### PR TITLE
Add CNCF Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+## Community Code of Conduct
+
+Jaeger follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
All CNCF projects should have code of conduct.

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>