### PR TITLE
Add Jaeger related istio and envoy links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,8 @@ See [running a docker all in one image](getting_started.md#all-in-one-docker-ima
 - [Evolving Distributed tracing At Uber Engineering](https://eng.uber.com/distributed-tracing/)
 - [Tracing HTTP request latency in Go with OpenTracing](https://medium.com/opentracing/tracing-http-request-latency-in-go-with-opentracing-7cc1282a100a)
 - [Distributed Tracing with Jaeger & Prometheus on Kubernetes](https://blog.openshift.com/openshift-commons-briefing-82-distributed-tracing-with-jaeger-prometheus-on-kubernetes/)
+- [Using Jaeger with Isio](https://istio.io/docs/tasks/telemetry/distributed-tracing.html)
+- [Using Jaeger with Envoy](https://envoyproxy.github.io/envoy/install/sandboxes/jaeger_tracing.html)
 
 [dapper]: https://research.google.com/pubs/pub36356.html
 [ubeross]: http://uber.github.io


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

Provide links to how Jaeger can be used with Istio and Envoy. When/if the documentation is restructured we could have a think about best way to describe such use cases.