### PR TITLE
Expose missing port on docker run inside hotrod example

### DIFF
--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -24,7 +24,7 @@ to view the traces. A tutorial / walkthough is available:
 An all-in-one Jaeger backend is packaged as a Docker container with in-memory storage.
 
 ```
-docker run -d -p6831:6831/udp -p16686:16686 jaegertracing/all-in-one:latest
+docker run -d -p6831:6831/udp -p5775:5775/udp -p16686:16686 jaegertracing/all-in-one:latest
 ```
 
 Jaeger UI can be accessed at http://localhost:16686.


### PR DESCRIPTION
I ran into this error message when following the README instructions on the hotrod example. Exposing the 5775 port fixes the issue.
```
ERROR	log/logger.go:42	write udp 127.0.0.1:63246->127.0.0.1:5775: write: connection refused	{"service": "customer"}
```
