### PR TITLE
Split zipkin span which contains server and client annotations

### DIFF
--- a/cmd/collector/app/span_handler.go
+++ b/cmd/collector/app/span_handler.go
@@ -110,10 +110,10 @@ func NewZipkinSpanHandler(logger *zap.Logger, modelHandler SpanProcessor, saniti
 
 // SubmitZipkinBatch records a batch of spans already in Zipkin Thrift format.
 func (h *zipkinSpanHandler) SubmitZipkinBatch(ctx thrift.Context, spans []*zipkincore.Span) ([]*zipkincore.Response, error) {
-	mSpans := make([]*model.Span, len(spans))
-	for i, span := range spans {
+	mSpans := make([]*model.Span, 0, len(spans))
+	for _, span := range spans {
 		sanitized := h.sanitizer.Sanitize(span)
-		mSpans[i] = ConvertZipkinToModel(sanitized, h.logger)
+		mSpans = append(mSpans, convertZipkinToModel(sanitized, h.logger)...)
 	}
 	bools, err := h.modelProcessor.ProcessSpans(mSpans, ZipkinFormatType)
 	if err != nil {
@@ -129,7 +129,7 @@ func (h *zipkinSpanHandler) SubmitZipkinBatch(ctx thrift.Context, spans []*zipki
 }
 
 // ConvertZipkinToModel is a helper function that logs warnings during conversion
-func ConvertZipkinToModel(zSpan *zipkincore.Span, logger *zap.Logger) *model.Span {
+func convertZipkinToModel(zSpan *zipkincore.Span, logger *zap.Logger) []*model.Span {
 	mSpan, err := zipkin.ToDomainSpan(zSpan)
 	if err != nil {
 		logger.Warn("Warning while converting zipkin to domain span", zap.Error(err))

--- a/cmd/collector/app/span_handler.go
+++ b/cmd/collector/app/span_handler.go
@@ -130,9 +130,9 @@ func (h *zipkinSpanHandler) SubmitZipkinBatch(ctx thrift.Context, spans []*zipki
 
 // ConvertZipkinToModel is a helper function that logs warnings during conversion
 func convertZipkinToModel(zSpan *zipkincore.Span, logger *zap.Logger) []*model.Span {
-	mSpan, err := zipkin.ToDomainSpan(zSpan)
+	mSpans, err := zipkin.ToDomainSpan(zSpan)
 	if err != nil {
 		logger.Warn("Warning while converting zipkin to domain span", zap.Error(err))
 	}
-	return mSpan
+	return mSpans
 }

--- a/model/converter/thrift/zipkin/to_domain.go
+++ b/model/converter/thrift/zipkin/to_domain.go
@@ -35,10 +35,10 @@ const (
 
 var (
 	coreAnnotations = map[string]string{
-		zipkincore.CLIENT_RECV: string(ext.SpanKindRPCClientEnum),
-		zipkincore.CLIENT_SEND: string(ext.SpanKindRPCClientEnum),
 		zipkincore.SERVER_RECV: string(ext.SpanKindRPCServerEnum),
 		zipkincore.SERVER_SEND: string(ext.SpanKindRPCServerEnum),
+		zipkincore.CLIENT_RECV: string(ext.SpanKindRPCClientEnum),
+		zipkincore.CLIENT_SEND: string(ext.SpanKindRPCClientEnum),
 	}
 
 	// Some tags on Zipkin spans really describe the process emitting them rather than an individual span.

--- a/model/converter/thrift/zipkin/to_domain.go
+++ b/model/converter/thrift/zipkin/to_domain.go
@@ -158,13 +158,13 @@ func (td toDomain) transformSpan(zSpan *zipkincore.Span) []*model.Span {
 		}
 		// if the first span is a client span we create server span and vice-versa.
 		if result[0].IsRPCClient() {
-			s.Tags = []model.KeyValue{model.String(ext.SpanKindRPCServer.Key, string(ext.SpanKindRPCServer.Value.(ext.SpanKindEnum)))}
+			s.Tags = []model.KeyValue{model.String(string(ext.SpanKind), string(ext.SpanKindRPCServerEnum))}
 			s.StartTime = model.EpochMicrosecondsAsTime(uint64(sr.Timestamp))
 			if ss := td.findAnnotation(zSpan, zipkincore.SERVER_SEND); ss != nil {
 				s.Duration = model.MicrosecondsAsDuration(uint64(ss.Timestamp - sr.Timestamp))
 			}
 		} else {
-			s.Tags = []model.KeyValue{model.String(ext.SpanKindRPCClient.Key, string(ext.SpanKindRPCClient.Value.(ext.SpanKindEnum)))}
+			s.Tags = []model.KeyValue{model.String(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum))}
 			s.StartTime = model.EpochMicrosecondsAsTime(uint64(cs.Timestamp))
 			if cr := td.findAnnotation(zSpan, zipkincore.CLIENT_RECV); cr != nil {
 				s.Duration = model.MicrosecondsAsDuration(uint64(cr.Timestamp - cs.Timestamp))

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
@@ -93,15 +94,19 @@ func TestToDomainMultipleSpanKinds(t *testing.T) {
 		tagFirst  opentracing.Tag
 		tagSecond opentracing.Tag
 	}{
-		{json: `[{ "trace_id": -1, "id": 31,
-	"annotations": [{"value": "cs", "host": {"service_name": "bar", "ipv4": 23456}},
-		{"value": "sr", "host": {"service_name": "bar", "ipv4": 23456}}] }]`,
+		{json: `[{ "trace_id": -1, "id": 31, "annotations": [
+		{"value": "cs", "host": {"service_name": "bar", "ipv4": 23456}},
+		{"value": "sr", "timestamp": 1, "host": {"service_name": "bar", "ipv4": 23456}},
+		{"value": "ss", "timestamp": 2, "host": {"service_name": "bar", "ipv4": 23456}}
+		]}]`,
 			tagFirst:  ext.SpanKindRPCClient,
 			tagSecond: ext.SpanKindRPCServer,
 		},
-		{json: `[{ "trace_id": -1, "id": 31,
-	"annotations": [{"value": "sr", "host": {"service_name": "bar", "ipv4": 23456}},
-		{"value": "cs", "host": {"service_name": "bar", "ipv4": 23456}}] }]`,
+		{json: `[{ "trace_id": -1, "id": 31, "annotations": [
+		{"value": "sr", "host": {"service_name": "bar", "ipv4": 23456}},
+		{"value": "cs", "timestamp": 1, "host": {"service_name": "bar", "ipv4": 23456}},
+		{"value": "cr", "timestamp": 2, "host": {"service_name": "bar", "ipv4": 23456}}
+		]}]`,
 			tagFirst:  ext.SpanKindRPCServer,
 			tagSecond: ext.SpanKindRPCClient,
 		},
@@ -119,6 +124,7 @@ func TestToDomainMultipleSpanKinds(t *testing.T) {
 
 		assert.Equal(t, 1, trace.Spans[1].Tags.Len())
 		assert.Equal(t, test.tagSecond.Key, trace.Spans[1].Tags[0].Key)
+		assert.Equal(t, time.Duration(1000), trace.Spans[1].Duration)
 		assert.Equal(t, string(test.tagSecond.Value.(ext.SpanKindEnum)), trace.Spans[1].Tags[0].VStr)
 	}
 }

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -57,7 +57,7 @@ func TestToDomain(t *testing.T) {
 			}
 		})
 		if i == 1 {
-			t.Run("ToDomainSpan", func(t *testing.T) {
+			t.Run("ToDomainSpans", func(t *testing.T) {
 				zSpan := zSpans[0]
 				jSpans, err := ToDomainSpan(zSpan)
 				assert.NoError(t, err)

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/uber/jaeger/model"
 	z "github.com/uber/jaeger/thrift-gen/zipkincore"
 )
@@ -57,10 +59,12 @@ func TestToDomain(t *testing.T) {
 		if i == 1 {
 			t.Run("ToDomainSpan", func(t *testing.T) {
 				zSpan := zSpans[0]
-				jSpan, err := ToDomainSpan(zSpan)
+				jSpans, err := ToDomainSpan(zSpan)
 				assert.NoError(t, err)
-				jSpan.NormalizeTimestamps()
-				assert.Equal(t, expectedTrace.Spans[0], jSpan)
+				for _, jSpan := range jSpans {
+					jSpan.NormalizeTimestamps()
+					assert.Equal(t, expectedTrace.Spans[0], jSpan)
+				}
 			})
 		}
 	}
@@ -81,6 +85,42 @@ func TestToDomainServiceNameInBinAnnotation(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(trace.Spans))
 	assert.Equal(t, "bar", trace.Spans[0].Process.ServiceName)
+}
+
+func TestToDomainMultipleSpanKinds(t *testing.T) {
+	tests := []struct {
+		json      string
+		tagFirst  opentracing.Tag
+		tagSecond opentracing.Tag
+	}{
+		{json: `[{ "trace_id": -1, "id": 31,
+	"annotations": [{"value": "cs", "host": {"service_name": "bar", "ipv4": 23456}},
+		{"value": "sr", "host": {"service_name": "bar", "ipv4": 23456}}] }]`,
+			tagFirst:  ext.SpanKindRPCClient,
+			tagSecond: ext.SpanKindRPCServer,
+		},
+		{json: `[{ "trace_id": -1, "id": 31,
+	"annotations": [{"value": "sr", "host": {"service_name": "bar", "ipv4": 23456}},
+		{"value": "cs", "host": {"service_name": "bar", "ipv4": 23456}}] }]`,
+			tagFirst:  ext.SpanKindRPCServer,
+			tagSecond: ext.SpanKindRPCClient,
+		},
+	}
+
+	for _, test := range tests {
+		fmt.Println(test.json)
+		trace, err := ToDomain(getZipkinSpans(t, test.json))
+		require.Nil(t, err)
+
+		assert.Equal(t, 2, len(trace.Spans))
+		assert.Equal(t, 1, trace.Spans[0].Tags.Len())
+		assert.Equal(t, test.tagFirst.Key, trace.Spans[0].Tags[0].Key)
+		assert.Equal(t, string(test.tagFirst.Value.(ext.SpanKindEnum)), trace.Spans[0].Tags[0].VStr)
+
+		assert.Equal(t, 1, trace.Spans[1].Tags.Len())
+		assert.Equal(t, test.tagSecond.Key, trace.Spans[1].Tags[0].Key)
+		assert.Equal(t, string(test.tagSecond.Value.(ext.SpanKindEnum)), trace.Spans[1].Tags[0].VStr)
+	}
 }
 
 func TestInvalidAnnotationTypeError(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Fixes #451 

Zipkin logic is here: 
Collector: https://github.com/openzipkin/zipkin/blob/5c8a17620674ada895acf05038bfdb209924a47d/zipkin/src/main/java/zipkin/collector/Collector.java#L143
v1 to v2 model: https://github.com/openzipkin/zipkin/blob/eeeeb3c02b0e0c578eb36c08d80cf2bf400067fc/zipkin/src/main/java/zipkin/internal/V2SpanConverter.java#L46