### PR TITLE
Fix FollowsFrom reference clock skew adjuster

### DIFF
--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -33,6 +33,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 		host                            string
 		adjusted                        int   // start time after adjustment
 		adjustedLogs                    []int // adjusted log timestamps
+		refs                            []model.SpanRef
 	}
 
 	toTime := func(t int) time.Time {
@@ -66,6 +67,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 						model.String("ip", spanProto.host),
 					},
 				},
+				References: spanProto.refs,
 			}
 			trace.Spans = append(trace.Spans, span)
 		}
@@ -110,6 +112,13 @@ func TestClockSkewAdjuster(t *testing.T) {
 			trace: []spanProto{
 				{id: 1, parent: 0, startTime: 10, duration: 100, host: "a", adjusted: 10},
 				{id: 2, parent: 1, startTime: 0, duration: 50, host: "a", adjusted: 0},
+			},
+		},
+		{
+			description: "do not adjust child that follows from parent",
+			trace: []spanProto{
+				{id: 1, parent: 0, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: 2, parent: 1, startTime: 110, duration: 100, host: "a", adjusted: 110, refs: []model.SpanRef{{RefType: model.FollowsFrom, SpanID: 1}}},
 			},
 		},
 		{


### PR DESCRIPTION
As stated by @black-adder in https://github.com/jaegertracing/jaeger/issues/448, the clockskew adjuster does not handle spans that reference the parent span using FollowsFrom reference. This PR tries to fix that by considering spans that have that reference as root spans. This way, the span will not be adjusted (specifically will be adjusted with a skew with `delta = 0`).

Note: if you find the use of labels ugly, please comment and I will change it to the alternative approach.