### PR TITLE
gocql: use NewNativeType instead of unsafe hacks

### DIFF
--- a/pkg/cassandra/gocql/testutils/udt.go
+++ b/pkg/cassandra/gocql/testutils/udt.go
@@ -16,7 +16,6 @@ package testutils
 
 import (
 	"testing"
-	"unsafe"
 
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
@@ -43,17 +42,7 @@ func (testCase UDTTestCase) Run(t *testing.T) {
 	for _, ff := range testCase.Fields {
 		field := ff // capture loop var
 		t.Run(testCase.ObjName+"-"+field.Name, func(t *testing.T) {
-			// To test MarshalUDT we need a gocql.NativeType struct whose fields private.
-			// Instead we create a structural copy that we cast to gocql.NativeType using unsafe.Pointer
-			nt := struct {
-				proto  byte
-				typ    gocql.Type
-				custom string
-			}{
-				proto: 0x03,
-				typ:   field.Type,
-			}
-			typeInfo := *(*gocql.NativeType)(unsafe.Pointer(&nt))
+			typeInfo := gocql.NewNativeType(0x03, field.Type, "") 
 			data, err := testCase.Obj.MarshalUDT(field.Name, typeInfo)
 			if field.Err {
 				assert.Error(t, err)


### PR DESCRIPTION
Use gocql.NewNativeType instead of unsafe hacks to produce a NativeType

Signed-off-by: Chris Bannister <c.bannister@gmail.com>