### PR TITLE
Support configuration files

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -61,7 +61,7 @@ func main() {
 	config.AddFlags(
 		v,
 		command,
-		flags.AddConfFileFlag,
+		flags.AddConfigFileFlag,
 		app.AddFlags,
 		metrics.AddFlags,
 	)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"runtime"
 
 	"github.com/pkg/errors"
@@ -37,13 +36,7 @@ func main() {
 		Short: "Jaeger agent is a local daemon program which collects tracing data.",
 		Long:  `Jaeger agent is a daemon program that runs on every host and receives tracing data submitted by Jaeger client libraries.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if c := new(flags.ExternalConfFlags).InitFromViper(v); c.ConfigFile != "" {
-				v.SetConfigFile(c.ConfigFile)
-				err := v.ReadInConfig()
-				if err != nil {
-					logger.Fatal(fmt.Sprintf("Fatal error config file: %s \n", c.ConfigFile), zap.Error(err))
-				}
-			}
+			flags.TryLoadConfigFile(v, logger)
 
 			builder := &app.Builder{}
 			builder.InitFromViper(v)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"runtime"
 
 	"github.com/pkg/errors"
@@ -23,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/uber/jaeger/cmd/agent/app"
+	"github.com/uber/jaeger/cmd/flags"
 	"github.com/uber/jaeger/pkg/config"
 	"github.com/uber/jaeger/pkg/metrics"
 )
@@ -35,6 +37,14 @@ func main() {
 		Short: "Jaeger agent is a local daemon program which collects tracing data.",
 		Long:  `Jaeger agent is a daemon program that runs on every host and receives tracing data submitted by Jaeger client libraries.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if c := new(flags.ExternalConfFlags).InitFromViper(v); c.ConfigFile != "" {
+				v.SetConfigFile(c.ConfigFile)
+				err := v.ReadInConfig()
+				if err != nil {
+					logger.Fatal(fmt.Sprintf("Fatal error config file: %s \n", c.ConfigFile), zap.Error(err))
+				}
+			}
+
 			builder := &app.Builder{}
 			builder.InitFromViper(v)
 			runtime.GOMAXPROCS(runtime.NumCPU())
@@ -58,6 +68,7 @@ func main() {
 	config.AddFlags(
 		v,
 		command,
+		flags.AddConfFileFlag,
 		app.AddFlags,
 		metrics.AddFlags,
 	)

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -132,7 +132,7 @@ func main() {
 	config.AddFlags(
 		v,
 		command,
-		flags.AddConfFileFlag,
+		flags.AddConfigFileFlag,
 		flags.AddFlags,
 		builder.AddFlags,
 		casOptions.AddFlags,

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -62,13 +61,7 @@ func main() {
 		Long: `Jaeger collector receives traces from Jaeger agents and agent and runs them through
 				a processing pipeline.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if c := new(flags.ExternalConfFlags).InitFromViper(v); c.ConfigFile != "" {
-				v.SetConfigFile(c.ConfigFile)
-				err := v.ReadInConfig()
-				if err != nil {
-					logger.Fatal(fmt.Sprintf("Fatal error config file: %s \n", c.ConfigFile), zap.Error(err))
-				}
-			}
+			flags.TryLoadConfigFile(v, logger)
 
 			sFlags := new(flags.SharedFlags).InitFromViper(v)
 			casOptions.InitFromViper(v)

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -36,7 +36,24 @@ const (
 	logLevel                       = "log-level"
 	dependencyStorageType          = "dependency-storage.type"
 	dependencyStorageDataFrequency = "dependency-storage.data-frequency"
+	configFile                     = "config-file"
 )
+
+// ExternalConfFlags holds configuration for external sources like configuration files
+type ExternalConfFlags struct {
+	ConfigFile string
+}
+
+// AddConfFileFlag adds flags for ExternalConfFlags
+func AddConfFileFlag(flagSet *flag.FlagSet) {
+	flagSet.String(configFile, "", "Configuration file in JSON, TOML, YAML, HCL, or Java properties formats (default none). See spf13/viper for precedence.")
+}
+
+// InitFromViper initializes ExternalConfFlags with properties from viper
+func (flags *ExternalConfFlags) InitFromViper(v *viper.Viper) *ExternalConfFlags {
+	flags.ConfigFile = v.GetString(configFile)
+	return flags
+}
 
 // SharedFlags holds flags configuration
 type SharedFlags struct {

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -51,7 +51,7 @@ func TryLoadConfigFile(v *viper.Viper, logger *zap.Logger) {
 		v.SetConfigFile(file)
 		err := v.ReadInConfig()
 		if err != nil {
-			logger.Fatal("Error loading config file", zap.Error(err))
+			logger.Fatal("Error loading config file", zap.Error(err), zap.String(configFile, file))
 		}
 	}
 }

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
 )
 
 const (
@@ -39,20 +40,20 @@ const (
 	configFile                     = "config-file"
 )
 
-// ExternalConfFlags holds configuration for external sources like configuration files
-type ExternalConfFlags struct {
-	ConfigFile string
-}
-
 // AddConfFileFlag adds flags for ExternalConfFlags
 func AddConfFileFlag(flagSet *flag.FlagSet) {
 	flagSet.String(configFile, "", "Configuration file in JSON, TOML, YAML, HCL, or Java properties formats (default none). See spf13/viper for precedence.")
 }
 
-// InitFromViper initializes ExternalConfFlags with properties from viper
-func (flags *ExternalConfFlags) InitFromViper(v *viper.Viper) *ExternalConfFlags {
-	flags.ConfigFile = v.GetString(configFile)
-	return flags
+// TryLoadConfigFile initializes viper with config file specified as flag
+func TryLoadConfigFile(v *viper.Viper, logger *zap.Logger) {
+	if file := v.GetString(configFile); file != "" {
+		v.SetConfigFile(file)
+		err := v.ReadInConfig()
+		if err != nil {
+			logger.Fatal(fmt.Sprintf("Fatal error config file: %s \n", file), zap.Error(err))
+		}
+	}
 }
 
 // SharedFlags holds flags configuration

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -40,8 +40,8 @@ const (
 	configFile                     = "config-file"
 )
 
-// AddConfFileFlag adds flags for ExternalConfFlags
-func AddConfFileFlag(flagSet *flag.FlagSet) {
+// AddConfigFileFlag adds flags for ExternalConfFlags
+func AddConfigFileFlag(flagSet *flag.FlagSet) {
 	flagSet.String(configFile, "", "Configuration file in JSON, TOML, YAML, HCL, or Java properties formats (default none). See spf13/viper for precedence.")
 }
 
@@ -51,7 +51,7 @@ func TryLoadConfigFile(v *viper.Viper, logger *zap.Logger) {
 		v.SetConfigFile(file)
 		err := v.ReadInConfig()
 		if err != nil {
-			logger.Fatal(fmt.Sprintf("Fatal error config file: %s \n", file), zap.Error(err))
+			logger.Fatal("Error loading config file", zap.Error(err))
 		}
 	}
 }

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -125,7 +125,7 @@ func main() {
 	config.AddFlags(
 		v,
 		command,
-		flags.AddConfFileFlag,
+		flags.AddConfigFileFlag,
 		flags.AddFlags,
 		casOptions.AddFlags,
 		esOptions.AddFlags,

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -55,13 +54,7 @@ func main() {
 		Short: "Jaeger query is a service to access tracing data",
 		Long:  `Jaeger query is a service to access tracing data and host UI.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if c := new(flags.ExternalConfFlags).InitFromViper(v); c.ConfigFile != "" {
-				v.SetConfigFile(c.ConfigFile)
-				err := v.ReadInConfig()
-				if err != nil {
-					logger.Fatal(fmt.Sprintf("Fatal error config file: %s \n", c.ConfigFile), zap.Error(err))
-				}
-			}
+			flags.TryLoadConfigFile(v, logger)
 
 			sFlags := new(flags.SharedFlags).InitFromViper(v)
 			casOptions.InitFromViper(v)

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -59,13 +59,7 @@ func main() {
 		Long: `Jaeger all-in-one distribution with agent, collector and query. Use with caution this version
 		 uses only in-memory database.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if c := new(flags.ExternalConfFlags).InitFromViper(v); c.ConfigFile != "" {
-				v.SetConfigFile(c.ConfigFile)
-				err := v.ReadInConfig()
-				if err != nil {
-					logger.Fatal(fmt.Sprintf("Fatal error config file: %s \n", c.ConfigFile), zap.Error(err))
-				}
-			}
+			flags.TryLoadConfigFile(v, logger)
 
 			runtime.GOMAXPROCS(runtime.NumCPU())
 			sFlags := new(flags.SharedFlags).InitFromViper(v)

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -81,7 +81,7 @@ func main() {
 	config.AddFlags(
 		v,
 		command,
-		flags.AddConfFileFlag,
+		flags.AddConfigFileFlag,
 		flags.AddFlags,
 		collector.AddFlags,
 		query.AddFlags,


### PR DESCRIPTION
Support configuration files. This allows us to configure Jaeger with kubernetes config maps. 

By default configuration files are disabled. Lists are currently not handled because we parse them manually. For instance `cassandra.servers` requires a string with comma separated values. 

Follows some examples. Note that flags with dots can be written as nested objects.
```json
{
  "query": {
    "prefix": "prefix",
    "static-files": "static"
  },
  "cassandra": {
    "keyspace": "from_file",
    "password": "pas_from_file",
    "servers": "localhost,localhost2",
    "archive": {
      "keyspace": "archive_keyspace"
    }
  },
  "es.archive.max-span-age": "75h0m0s"
}
```
```yml
query:
  prefix: prefix
  static-files: static
cassandra:
  keyspace: from_file
  password: pas_from_file
  servers: localhost,localhost2
  archive:
    keyspace: archive_keyspace
es.archive.max-span-age: 75h0m0s
```