### PR TITLE
Correct typo: Isio -> Istio

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ See [running a docker all in one image](getting_started.md#all-in-one-docker-ima
 - [Evolving Distributed tracing At Uber Engineering](https://eng.uber.com/distributed-tracing/)
 - [Tracing HTTP request latency in Go with OpenTracing](https://medium.com/opentracing/tracing-http-request-latency-in-go-with-opentracing-7cc1282a100a)
 - [Distributed Tracing with Jaeger & Prometheus on Kubernetes](https://blog.openshift.com/openshift-commons-briefing-82-distributed-tracing-with-jaeger-prometheus-on-kubernetes/)
-- [Using Jaeger with Isio](https://istio.io/docs/tasks/telemetry/distributed-tracing.html)
+- [Using Jaeger with Istio](https://istio.io/docs/tasks/telemetry/distributed-tracing.html)
 - [Using Jaeger with Envoy](https://envoyproxy.github.io/envoy/install/sandboxes/jaeger_tracing.html)
 
 [dapper]: https://research.google.com/pubs/pub36356.html


### PR DESCRIPTION
PR changes text for "Using Jaeger with Istio" link in "Related links" section. It adds the missing "t".