### PR TITLE
 passes error message if KEYSPACE does not have valid character

### DIFF
--- a/plugin/storage/cassandra/schema/create.sh
+++ b/plugin/storage/cassandra/schema/create.sh
@@ -41,6 +41,7 @@ else
 fi
 
 keyspace=${KEYSPACE:-"jaeger_v1_${datacenter}"}
+if [[ $keyspace =~ [^a-zA-Z0-9_] ]]; then usage "invalid characters in KEYSPACE parameter, please use letters, digits or underscores(a-zA-Z0-9_)"; fi 
 
 >&2 cat <<EOF
 Using template file $template with parameters:


### PR DESCRIPTION
if cassandra fails because of using invalid character the user will now
know why, thus can make changes to KEYSPACE parameter

fixes: #445
Signed-off-by: Deepika Upadhyay <deepikaupadhyay01@gmail.com>