### PR TITLE
Zipkin json binAnnotation value number

### DIFF
--- a/cmd/collector/app/zipkin/http_handler.go
+++ b/cmd/collector/app/zipkin/http_handler.go
@@ -74,7 +74,7 @@ func (aH *APIHandler) saveSpans(w http.ResponseWriter, r *http.Request) {
 	if contentType == "application/x-thrift" {
 		tSpans, err = deserializeThrift(bodyBytes)
 	} else if contentType == "application/json" {
-		tSpans, err = deserializeJSON(bodyBytes)
+		tSpans, err = DeserializeJSON(bodyBytes)
 	} else {
 		http.Error(w, "Unsupported Content-Type", http.StatusBadRequest)
 		return

--- a/cmd/collector/app/zipkin/json.go
+++ b/cmd/collector/app/zipkin/json.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -186,10 +187,6 @@ func binAnnoToThrift(ba binaryAnnotation) (*zipkincore.BinaryAnnotation, error) 
 		return nil, err
 	}
 
-	if ba.Type == "" {
-		ba.Type = "STRING"
-	}
-
 	var val []byte
 	var valType zipkincore.AnnotationType
 	switch ba.Type {
@@ -200,42 +197,38 @@ func binAnnoToThrift(ba binaryAnnotation) (*zipkincore.BinaryAnnotation, error) 
 			val = []byte{0}
 		}
 		valType = zipkincore.AnnotationType_BOOL
-		break
 	case "I16":
 		buff := new(bytes.Buffer)
 		binary.Write(buff, binary.LittleEndian, int16(ba.Value.(float64)))
 		val = buff.Bytes()
 		valType = zipkincore.AnnotationType_I16
-		break
 	case "I32":
 		buff := new(bytes.Buffer)
 		binary.Write(buff, binary.LittleEndian, int32(ba.Value.(float64)))
 		val = buff.Bytes()
 		valType = zipkincore.AnnotationType_I32
-		break
 	case "I64":
 		buff := new(bytes.Buffer)
 		binary.Write(buff, binary.LittleEndian, int64(ba.Value.(float64)))
 		val = buff.Bytes()
 		valType = zipkincore.AnnotationType_I64
-		break
 	case "DOUBLE":
 		val = float64bytes(ba.Value.(float64))
 		valType = zipkincore.AnnotationType_DOUBLE
-		break
-	case "STRING":
-		val = []byte(ba.Value.(string))
-		valType = zipkincore.AnnotationType_STRING
-		break
 	case "BYTES":
 		val, err = base64.StdEncoding.DecodeString(ba.Value.(string))
 		if err != nil {
 			return nil, err
 		}
 		valType = zipkincore.AnnotationType_BYTES
-		break
+	case "STRING":
+		fallthrough
 	default:
-		break
+		str := fmt.Sprintf("%s", ba.Value)
+		val = []byte(str)
+		fmt.Println("default")
+		fmt.Println(str)
+		valType = zipkincore.AnnotationType_STRING
 	}
 
 	return &zipkincore.BinaryAnnotation{

--- a/cmd/collector/app/zipkin/json.go
+++ b/cmd/collector/app/zipkin/json.go
@@ -37,7 +37,7 @@ type annotation struct {
 type binaryAnnotation struct {
 	Endpoint endpoint `json:"endpoint"`
 	Key      string   `json:"key"`
-	Value    string   `json:"value"`
+	Value    json.Number   `json:"value"`
 }
 type zipkinSpan struct {
 	ID                string             `json:"id"`

--- a/cmd/collector/app/zipkin/json.go
+++ b/cmd/collector/app/zipkin/json.go
@@ -186,6 +186,10 @@ func binAnnoToThrift(ba binaryAnnotation) (*zipkincore.BinaryAnnotation, error) 
 		return nil, err
 	}
 
+	if ba.Type == "" {
+		ba.Type = "STRING"
+	}
+
 	var val []byte
 	var valType zipkincore.AnnotationType
 	switch ba.Type {

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -77,8 +77,18 @@ func TestUnmarshalBinAnnotation(t *testing.T) {
 	err := json.Unmarshal([]byte(createBinAnno("foo", "bar", endpointJSON)), binAnno)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", binAnno.Key)
-	assert.Equal(t, "bar", binAnno.Value)
+	assert.Equal(t, "bar", string(binAnno.Value))
 	assert.Equal(t, "foo", binAnno.Endpoint.ServiceName)
+}
+
+func TestUnmarshalBinAnnotationNumberValue(t *testing.T) {
+	jsonStr := `{"key":"http.status_code", "value": 200, "type": "I64"}`
+
+	binAnno := &binaryAnnotation{}
+	err := json.Unmarshal([]byte(jsonStr), binAnno)
+	require.NoError(t, err)
+	assert.Equal(t, "http.status_code", binAnno.Key)
+	assert.Equal(t, "200", string(binAnno.Value))
 }
 
 func TestUnmarshalSpan(t *testing.T) {
@@ -223,7 +233,7 @@ func TestBinaryAnnotationToThrift(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, binAnno.Key, tBinAnno.Key)
 	assert.Equal(t, binAnno.Endpoint.ServiceName, tBinAnno.Host.ServiceName)
-	assert.Equal(t, binAnno.Value, string(tBinAnno.Value))
+	assert.Equal(t, string(binAnno.Value), string(tBinAnno.Value))
 
 	endp = endpoint{
 		IPv4: "127.0.0.A",

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -15,8 +15,6 @@
 package zipkin
 
 import (
-	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -15,13 +15,17 @@
 package zipkin
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger/thrift-gen/zipkincore"
 )
 
 var endpointFmt = `{"serviceName": "%s", "ipv4": "%s", "ipv6": "%s", "port": %d}`
@@ -47,7 +51,7 @@ func createSpan(name string, id string, parentID string, traceID string, ts int6
 }
 
 func TestDecodeWrongJson(t *testing.T) {
-	spans, err := deserializeJSON([]byte(""))
+	spans, err := DeserializeJSON([]byte(""))
 	require.Error(t, err)
 	assert.Nil(t, spans)
 }
@@ -77,18 +81,70 @@ func TestUnmarshalBinAnnotation(t *testing.T) {
 	err := json.Unmarshal([]byte(createBinAnno("foo", "bar", endpointJSON)), binAnno)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", binAnno.Key)
-	assert.Equal(t, "bar", string(binAnno.Value))
+	assert.Equal(t, "bar", binAnno.Value.(string))
 	assert.Equal(t, "foo", binAnno.Endpoint.ServiceName)
 }
 
 func TestUnmarshalBinAnnotationNumberValue(t *testing.T) {
-	jsonStr := `{"key":"http.status_code", "value": 200, "type": "I64"}`
+	tests := []struct {
+		json     string
+		expected zipkincore.BinaryAnnotation
+		err      error
+	}{
+		{
+			json:     `{"key":"foo", "value": 32768, "type": "I16"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte{0x0, 0x80}, AnnotationType: zipkincore.AnnotationType_I16},
+		},
+		{
+			json:     `{"key":"foo", "value": 32768, "type": "I32"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte{0x00, 0x80, 0x00, 0x00}, AnnotationType: zipkincore.AnnotationType_I32},
+		},
+		{
+			json:     `{"key":"foo", "value": 32768, "type": "I64"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte{0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, AnnotationType: zipkincore.AnnotationType_I64},
+		},
+		{
+			json:     `{"key":"foo", "value": -12.666512, "type": "DOUBLE"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte{122, 200, 148, 15, 65, 85, 41, 192}, AnnotationType: zipkincore.AnnotationType_DOUBLE},
+		},
+		{
+			json:     `{"key":"foo", "value": true, "type": "BOOL"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte{1}, AnnotationType: zipkincore.AnnotationType_BOOL},
+		},
+		{
+			json:     `{"key":"foo", "value": false, "type": "BOOL"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte{0}, AnnotationType: zipkincore.AnnotationType_BOOL},
+		},
+		{
+			json:     `{"key":"foo", "value": "str", "type": "STRING"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte("str"), AnnotationType: zipkincore.AnnotationType_STRING},
+		},
+		{
+			json:     `{"key":"foo", "value": "c3Ry", "type": "BYTES"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte("str"), AnnotationType: zipkincore.AnnotationType_BYTES},
+		},
+		{
+			json: `{"key":"foo", "value": "^^^", "type": "BYTES"}`,
+			err:  errors.New("illegal base64 data at input byte 0"),
+			//expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte("str"), AnnotationType: zipkincore.AnnotationType_BYTES},
+		},
+	}
 
-	binAnno := &binaryAnnotation{}
-	err := json.Unmarshal([]byte(jsonStr), binAnno)
-	require.NoError(t, err)
-	assert.Equal(t, "http.status_code", binAnno.Key)
-	assert.Equal(t, "200", string(binAnno.Value))
+	for _, test := range tests {
+		binAnno := &binaryAnnotation{}
+		err := json.Unmarshal([]byte(test.json), binAnno)
+		require.NoError(t, err)
+		tBinAnno, err := binAnnoToThrift(*binAnno)
+		if test.err != nil {
+			require.Error(t, err, test.json)
+			require.Nil(t, tBinAnno)
+			assert.Equal(t, test.err.Error(), err.Error())
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, test.expected.Key, tBinAnno.Key)
+			assert.Equal(t, test.expected.Value, tBinAnno.Value)
+		}
+	}
 }
 
 func TestUnmarshalSpan(t *testing.T) {
@@ -123,34 +179,34 @@ func TestUnmarshalSpan(t *testing.T) {
 func TestIncorrectSpanIds(t *testing.T) {
 	// id missing
 	spanJSON := createSpan("bar", "", "1", "2", 156, 15145, false, "", "")
-	spans, err := deserializeJSON([]byte(spanJSON))
+	spans, err := DeserializeJSON([]byte(spanJSON))
 	require.Error(t, err)
 	assert.Equal(t, errIsNotUnsignedLog, err)
 	assert.Nil(t, spans)
 	// id longer than 32
 	spanJSON = createSpan("bar", "123456789123456712345678912345678", "1", "2",
 		156, 15145, false, "", "")
-	spans, err = deserializeJSON([]byte(spanJSON))
+	spans, err = DeserializeJSON([]byte(spanJSON))
 	require.Error(t, err)
 	assert.Equal(t, errIsNotUnsignedLog, err)
 	assert.Nil(t, spans)
 	// traceId missing
 	spanJSON = createSpan("bar", "2", "1", "", 156, 15145, false,
 		"", "")
-	spans, err = deserializeJSON([]byte(spanJSON))
+	spans, err = DeserializeJSON([]byte(spanJSON))
 	require.Error(t, err)
 	assert.Equal(t, errIsNotUnsignedLog, err)
 	assert.Nil(t, spans)
 	// 128 bit traceId
 	spanJSON = createSpan("bar", "2", "1", "12345678912345671234567891234567", 156, 15145, false,
 		"", "")
-	spans, err = deserializeJSON([]byte(spanJSON))
+	spans, err = DeserializeJSON([]byte(spanJSON))
 	require.NoError(t, err)
 	assert.NotNil(t, spans)
 	// wrong 128 bit traceId
 	spanJSON = createSpan("bar", "22", "12", "#2345678912345671234567891234562", 156, 15145, false,
 		"", "")
-	spans, err = deserializeJSON([]byte(spanJSON))
+	spans, err = DeserializeJSON([]byte(spanJSON))
 	require.Error(t, err)
 	assert.Nil(t, spans)
 }
@@ -228,12 +284,13 @@ func TestBinaryAnnotationToThrift(t *testing.T) {
 		Endpoint: endp,
 		Key:      "error",
 		Value:    "str",
+		Type:     "STRING",
 	}
 	tBinAnno, err := binAnnoToThrift(binAnno)
 	require.NoError(t, err)
 	assert.Equal(t, binAnno.Key, tBinAnno.Key)
 	assert.Equal(t, binAnno.Endpoint.ServiceName, tBinAnno.Host.ServiceName)
-	assert.Equal(t, string(binAnno.Value), string(tBinAnno.Value))
+	assert.Equal(t, binAnno.Value, string(tBinAnno.Value))
 
 	endp = endpoint{
 		IPv4: "127.0.0.A",

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -124,7 +124,10 @@ func TestUnmarshalBinAnnotationNumberValue(t *testing.T) {
 		{
 			json: `{"key":"foo", "value": "^^^", "type": "BYTES"}`,
 			err:  errors.New("illegal base64 data at input byte 0"),
-			//expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte("str"), AnnotationType: zipkincore.AnnotationType_BYTES},
+		},
+		{
+			json:     `{"key":"foo", "value": "733c374d736e41cc"}`,
+			expected: zipkincore.BinaryAnnotation{Key: "foo", Value: []byte("733c374d736e41cc"), AnnotationType: zipkincore.AnnotationType_STRING},
 		},
 	}
 


### PR DESCRIPTION
Fix deserialization of zipkin binary annotations values of number type. cc @golonzovsky 

The following json fails to deserialize with this error `Unable to process request body: json: cannot unmarshal number into Go value of type string`

```json
[
{
    "traceId": "7d3277b087a7c05a",
    "name": "/",
    "id": "3c1813d224db60fe",
    "parentId": "a50ac2ce7f3bf056",
    "timestamp": 1508924339988597,
    "duration": 1781,
    "annotations": [],
    "binaryAnnotations": [
      {
        "key": "http.status_code",
        "value": 200,
        "type": "I64"
      }
    ]
  }
]
```