### PR TITLE
Zipkin use net.parseIP and model functions for IDs

### DIFF
--- a/cmd/collector/app/zipkin/http_handler_test.go
+++ b/cmd/collector/app/zipkin/http_handler_test.go
@@ -154,12 +154,12 @@ func TestJsonFormat(t *testing.T) {
 		},
 		{
 			payload:    createSpan("bar", "", "1", "1", 156, 15145, false, annoJSON, binAnnoJSON),
-			expected:   "Unable to process request body: id is not an unsigned long\n",
+			expected:   "Unable to process request body: strconv.ParseUint: parsing \"\": invalid syntax\n",
 			statusCode: http.StatusBadRequest,
 		},
 		{
 			payload:    createSpan("bar", "ZTA", "1", "1", 156, 15145, false, "", ""),
-			expected:   "Unable to process request body: id is not an unsigned long\n",
+			expected:   "Unable to process request body: strconv.ParseUint: parsing \"ZTA\": invalid syntax\n",
 			statusCode: http.StatusBadRequest,
 		},
 		{

--- a/cmd/collector/app/zipkin/json.go
+++ b/cmd/collector/app/zipkin/json.go
@@ -92,8 +92,7 @@ func spansToThrift(spans []zipkinSpan) ([]*zipkincore.Span, error) {
 }
 
 func spanToThrift(s zipkinSpan) (*zipkincore.Span, error) {
-	// id can be padded with zeros
-	id, err := model.SpanIDFromString(s.ID[:16])
+	id, err := model.SpanIDFromString(cutLongID(s.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +115,7 @@ func spanToThrift(s zipkinSpan) (*zipkincore.Span, error) {
 	}
 
 	if len(s.ParentID) > 0 {
-		parentID, err := model.SpanIDFromString(s.ParentID[:16])
+		parentID, err := model.SpanIDFromString(cutLongID(s.ParentID))
 		if err != nil {
 			return nil, err
 		}
@@ -140,6 +139,15 @@ func spanToThrift(s zipkinSpan) (*zipkincore.Span, error) {
 	}
 
 	return tSpan, nil
+}
+
+// id can be padded with zeros. We let it fail later in case it's longer than 32
+func cutLongID(id string) string {
+	l := len(id)
+	if l > 16 && l <= 32 {
+		return id[:16]
+	}
+	return id
 }
 
 func endpointToThrift(e endpoint) (*zipkincore.Endpoint, error) {

--- a/cmd/collector/app/zipkin/json.go
+++ b/cmd/collector/app/zipkin/json.go
@@ -22,9 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
-	"strings"
+	"net"
 
+	"github.com/uber/jaeger/model"
 	"github.com/uber/jaeger/thrift-gen/zipkincore"
 )
 
@@ -58,8 +58,7 @@ type zipkinSpan struct {
 }
 
 var (
-	errIsNotUnsignedLog = errors.New("id is not an unsigned long")
-	errWrongIpv4        = errors.New("wrong ipv4")
+	errWrongIpv4 = errors.New("wrong ipv4")
 )
 
 // DeserializeJSON deserialize zipkin v1 json spans into zipkin thrift
@@ -93,37 +92,31 @@ func spansToThrift(spans []zipkinSpan) ([]*zipkincore.Span, error) {
 }
 
 func spanToThrift(s zipkinSpan) (*zipkincore.Span, error) {
-	// TODO use model.SpanIDFromString and model.TraceIDFromString
-	id, err := hexToUnsignedLong(s.ID)
+	// id can be padded with zeros
+	id, err := model.SpanIDFromString(s.ID[:16])
 	if err != nil {
 		return nil, err
 	}
-	traceID, err := hexToUnsignedLong(s.TraceID)
+	traceID, err := model.TraceIDFromString(s.TraceID)
 	if err != nil {
 		return nil, err
 	}
 
 	tSpan := &zipkincore.Span{
 		ID:        int64(id),
-		TraceID:   int64(traceID),
+		TraceID:   int64(traceID.Low),
 		Name:      s.Name,
 		Debug:     s.Debug,
 		Timestamp: s.Timestamp,
 		Duration:  s.Duration,
 	}
-
-	if len(s.TraceID) == 32 {
-		// take 0-16
-		traceIDHigh, err := hexToUnsignedLong(s.TraceID[:16])
-		if err != nil {
-			return nil, err
-		}
-		help := int64(traceIDHigh)
+	if traceID.High != 0 {
+		help := int64(traceID.High)
 		tSpan.TraceIDHigh = &help
 	}
 
 	if len(s.ParentID) > 0 {
-		parentID, err := hexToUnsignedLong(s.ParentID)
+		parentID, err := model.SpanIDFromString(s.ParentID[:16])
 		if err != nil {
 			return nil, err
 		}
@@ -248,49 +241,20 @@ func float64bytes(float float64) []byte {
 }
 
 func parseIpv4(str string) (int32, error) {
-	// TODO use net.ParseIP
-	segments := strings.Split(str, ".")
-	if len(segments) == 1 {
+	if str == "" {
 		return 0, nil
 	}
 
+	ip := net.ParseIP(str).To4()
+	if ip == nil {
+		return 0, errWrongIpv4
+	}
+
 	var ipv4 int32
-	for _, segment := range segments {
-		parsed, err := strconv.ParseInt(segment, 10, 32)
-		if err != nil {
-			return 0, errWrongIpv4
-		}
-		parsed32 := int32(parsed)
+	for _, segment := range ip {
+		parsed32 := int32(segment)
 		ipv4 = ipv4<<8 | (parsed32 & 0xff)
 	}
 
 	return ipv4, nil
-}
-
-func hexToUnsignedLong(hex string) (uint64, error) {
-	// TODO remove this func in favor of model.XxxFromString methods
-	len := len(hex)
-	if len < 1 || len > 32 {
-		return 0, errIsNotUnsignedLog
-	}
-
-	start := 0
-	if len > 16 {
-		start = len - 16
-	}
-
-	var result uint64
-	for i := start; i < len; i++ {
-		c := hex[i]
-		result <<= 4
-		if c >= '0' && c <= '9' {
-			result = result | uint64(c-'0')
-		} else if c >= 'a' && c <= 'f' {
-			result = result | uint64(c-'a'+10)
-		} else {
-			return 0, errIsNotUnsignedLog
-		}
-	}
-
-	return result, nil
 }

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -18,12 +18,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger/model"
 	"github.com/uber/jaeger/thrift-gen/zipkincore"
 )
 

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -243,6 +243,16 @@ func TestEndpointToThrift(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, errWrongIpv4, err)
 	assert.Nil(t, tEndpoint)
+
+	endp = endpoint{
+		ServiceName: "foo",
+		Port:        80,
+		IPv6:        "::R",
+	}
+	tEndpoint, err = endpointToThrift(endp)
+	require.Error(t, err)
+	assert.Equal(t, errWrongIpv6, err)
+	assert.Nil(t, tEndpoint)
 }
 
 func TestAnnotationToThrift(t *testing.T) {
@@ -322,7 +332,7 @@ func TestSpanToThrift(t *testing.T) {
 	span := zipkinSpan{
 		ID:                "bd7a977555f6b982",
 		TraceID:           "bd7a974555f6b982bd71977555f6b981",
-		ParentID:          "1",
+		ParentID:          "00000000000000001",
 		Name:              "foo",
 		Annotations:       []annotation{anno},
 		BinaryAnnotations: []binaryAnnotation{binAnno},

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger/model"
 	"github.com/uber/jaeger/thrift-gen/zipkincore"
 )
 
@@ -182,21 +183,21 @@ func TestIncorrectSpanIds(t *testing.T) {
 	spanJSON := createSpan("bar", "", "1", "2", 156, 15145, false, "", "")
 	spans, err := DeserializeJSON([]byte(spanJSON))
 	require.Error(t, err)
-	assert.Equal(t, errIsNotUnsignedLog, err)
+	assert.Equal(t, "strconv.ParseUint: parsing \"\": invalid syntax", err.Error())
 	assert.Nil(t, spans)
 	// id longer than 32
 	spanJSON = createSpan("bar", "123456789123456712345678912345678", "1", "2",
 		156, 15145, false, "", "")
 	spans, err = DeserializeJSON([]byte(spanJSON))
 	require.Error(t, err)
-	assert.Equal(t, errIsNotUnsignedLog, err)
+	assert.Equal(t, "SpanID cannot be longer than 16 hex characters: 123456789123456712345678912345678", err.Error())
 	assert.Nil(t, spans)
 	// traceId missing
 	spanJSON = createSpan("bar", "2", "1", "", 156, 15145, false,
 		"", "")
 	spans, err = DeserializeJSON([]byte(spanJSON))
 	require.Error(t, err)
-	assert.Equal(t, errIsNotUnsignedLog, err)
+	assert.Equal(t, "strconv.ParseUint: parsing \"\": invalid syntax", err.Error())
 	assert.Nil(t, spans)
 	// 128 bit traceId
 	spanJSON = createSpan("bar", "2", "1", "12345678912345671234567891234567", 156, 15145, false,
@@ -343,71 +344,34 @@ func TestSpanToThrift(t *testing.T) {
 
 	tests := []struct {
 		span zipkinSpan
-		err  error
+		err  string
 	}{
 		{
 			span: zipkinSpan{ID: "zd7a977555f6b982", TraceID: "bd7a977555f6b982"},
-			err:  errIsNotUnsignedLog,
+			err:  "strconv.ParseUint: parsing \"zd7a977555f6b982\": invalid syntax",
 		},
 		{
 			span: zipkinSpan{ID: "ad7a977555f6b982", TraceID: "zd7a977555f6b982"},
-			err:  errIsNotUnsignedLog,
+			err:  "strconv.ParseUint: parsing \"zd7a977555f6b982\": invalid syntax",
 		},
 		{
 			span: zipkinSpan{ID: "ad7a977555f6b982", TraceID: "ad7a977555f6b982", ParentID: "zd7a977555f6b982"},
-			err:  errIsNotUnsignedLog,
+			err:  "strconv.ParseUint: parsing \"zd7a977555f6b982\": invalid syntax",
 		},
 		{
 			span: zipkinSpan{ID: "1", TraceID: "1", Annotations: []annotation{{Endpoint: endpoint{IPv4: "127.0.0.A"}}}},
-			err:  errWrongIpv4,
+			err:  errWrongIpv4.Error(),
 		},
 		{
 			span: zipkinSpan{ID: "1", TraceID: "1", BinaryAnnotations: []binaryAnnotation{{Endpoint: endpoint{IPv4: "127.0.0.A"}}}},
-			err:  errWrongIpv4,
+			err:  errWrongIpv4.Error(),
 		},
 	}
 
 	for _, test := range tests {
 		tSpan, err = spanToThrift(test.span)
 		require.Error(t, err)
-		assert.Equal(t, test.err, err)
+		assert.Equal(t, test.err, err.Error())
 		assert.Nil(t, tSpan)
-	}
-}
-
-func TestHexToUnsignedLong(t *testing.T) {
-	okTests := []struct {
-		hex      string
-		expected uint64
-	}{
-		{hex: "0", expected: 0},
-		{hex: "ffffffffffffffff", expected: math.MaxUint64},
-		{hex: "00000000000000001", expected: 1},
-	}
-	for _, test := range okTests {
-		num, err := hexToUnsignedLong(test.hex)
-		require.NoError(t, err)
-		assert.Equal(t, test.expected, num)
-	}
-
-	// drop higher bits
-	num, err := hexToUnsignedLong("463ac35c9f6413ad48485a3953bb6124")
-	num2, err2 := hexToUnsignedLong("48485a3953bb6124")
-	require.NoError(t, err)
-	require.NoError(t, err2)
-	assert.Equal(t, num, num2)
-
-	errTests := []struct {
-		hex string
-	}{
-		{hex: "fffffffffffffffffffffffffffffffff"},
-		{hex: ""},
-		{hex: "po"},
-	}
-	for _, test := range errTests {
-		num, err = hexToUnsignedLong(test.hex)
-		require.Error(t, err)
-		assert.Equal(t, errIsNotUnsignedLog, err)
-		assert.Equal(t, uint64(0), num)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>