### PR TITLE
Xdock compose, test driver links jaeger services

### DIFF
--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     crossdock:
         image: crossdock/crossdock
         links:
-            - jaeger-query
-            - jaeger-collector
-            - jaeger-agent
             - test_driver
             - go
             - node
@@ -76,6 +73,10 @@ services:
         image: jaegertracing/test-driver
         ports:
             - "8080"
+        links:
+          - jaeger-query
+          - jaeger-collector
+          - jaeger-agent
 
     jaeger-query:
 #    override to disable static files


### PR DESCRIPTION
A minor improvement. `test-driver` should depend on jaeger services and not xdock.