### PR TITLE
Fix Running Instructions

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -46,7 +46,7 @@ traces.
 ```bash
 go get github.com/uber/jaeger
 cd $GOPATH/src/github.com/uber/jaeger
-make install_examples
+make install
 cd examples/hotrod
 go run ./main.go all
 ```


### PR DESCRIPTION
Change `make install_examples` to `make install`.