### PR TITLE
Update README and docs with new C++ client lib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Jaeger is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CN
  * [Java client](https://github.com/uber/jaeger-client-java)
  * [Python client](https://github.com/uber/jaeger-client-python)
  * [Node.js client](https://github.com/uber/jaeger-client-node)
+ * [C++ client](https://github.com/jaegertracing/cpp-client)
 
 ### Contributions
 

--- a/docs/client_libraries.md
+++ b/docs/client_libraries.md
@@ -8,6 +8,7 @@
 | java     | [jaeger-client-java](https://github.com/uber/jaeger-client-java)    |
 | node     | [jaeger-client-node](https://github.com/uber/jaeger-client-node)    |
 | python   | [jaeger-client-python](https://github.com/uber/jaeger-client-python)|
+| C++      | [cpp-client](https://github.com/jaegertracing/cpp-client)           |
 
 For a deep dive into how to instrument a Go service, look at [Tracing HTTP request latency](https://medium.com/@YuriShkuro/tracing-http-request-latency-in-go-with-opentracing-7cc1282a100a).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,8 @@ for the architectural choices made in Jaeger.
 ## Features
 
   * [OpenTracing](http://opentracing.io/) compatible data model and instrumentation libraries
-    * in [Go](https://github.com/uber/jaeger-client-go), [Java](https://github.com/uber/jaeger-client-java), [Node](https://github.com/uber/jaeger-client-node) and [Python](https://github.com/uber/jaeger-client-python)
+    * in [Go](https://github.com/uber/jaeger-client-go), [Java](https://github.com/uber/jaeger-client-java), [Node](https://github.com/uber/jaeger-client-node), [Python](https://github.com/uber/jaeger-client-python)
+    and [C++](https://github.com/jaegertracing/cpp-client)
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Adaptive sampling (coming soon)
   * Post-collection data processing pipeline (coming soon)


### PR DESCRIPTION
Hi, 

with the new [C++ client](https://github.com/jaegertracing/cpp-client) merged, maybe it would be nice to expose it into the document materials of Jaeger.
Let me know if you find this useful or maybe premature.
I also wanted to update [this image](https://github.com/jaegertracing/jaeger/blob/master/docs/images/architecture.png) by adding C++ but I could not find the source.

Thanks !