### PR TITLE
docs(example): fix go get url

### DIFF
--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -32,8 +32,8 @@ Jaeger UI can be accessed at http://localhost:16686.
 ### Run HotROD Application
 
 ```
-go get github.com/uber/jaeger
-cd $GOPATH/src/github.com/uber/jaeger
+go get github.com/jaegertracing/jaeger
+cd $GOPATH/src/github.com/jaegertracing/jaeger
 make install
 cd examples/hotrod
 go run ./main.go all


### PR DESCRIPTION
[minor] following the `README` you hit the following error:

```
 ~/go/src/github.com/uber/jaeger/examples/hotrod   master  go run ./main.go all
main.go:8:2: cannot find package "github.com/jaegertracing/jaeger/examples/hotrod/cmd" in any of:
        /Users/me/go/src/github.com/uber/jaeger/vendor/github.com/jaegertracing/jaeger/examples/hotrod/cmd (vendor tree)
        /usr/local/Cellar/go/1.9.2/libexec/src/github.com/jaegertracing/jaeger/examples/hotrod/cmd (from $GOROOT)
        /Users/me/go/src/github.com/jaegertracing/jaeger/examples/hotrod/cmd (from $GOPATH)
```