### PR TITLE
Finish replacing uber/jaeger with jaegertracing/jaeger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,11 @@ file for details.
 
 This library uses [glide](https://github.com/Masterminds/glide) to manage dependencies.
 
-To get started, make sure you clone the Git repository into the correct location `github.com/uber/jaeger` relative to `$GOPATH`:
+To get started, make sure you clone the Git repository into the correct location `github.com/jaegertracing/jaeger` relative to `$GOPATH`:
 
 ```
-mkdir -p $GOPATH/src/github.com/uber
-cd $GOPATH/src/github.com/uber
+mkdir -p $GOPATH/src/github.com/jaegertracing
+cd $GOPATH/src/github.com/jaegertracing
 git clone git@github.com:jaegertracing/jaeger.git jaeger
 cd jaeger
 ```
@@ -43,7 +43,7 @@ make test
 These are general guidelines on how to organize source code in this repository.
 
 ```
-github.com/uber/jaeger
+github.com/jaegertracing/jaeger
   cmd/                      - All binaries go here
     agent/
       app/                  - The actual code for the binary
@@ -102,15 +102,15 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
-	"github.com/uber/jaeger/cmd/agent/app"
-	"github.com/uber/jaeger/cmd/collector/app/builder"
+	"github.com/jaegertracing/jaeger/cmd/agent/app"
+	"github.com/jaegertracing/jaeger/cmd/collector/app/builder"
 )
 ```
 
 ## Making A Change
 
 *Before making any significant changes, please [open an
-issue](https://github.com/uber/jaeger/issues).* Discussing your proposed
+issue](https://github.com/jaegertracing/jaeger/issues).* Discussing your proposed
 changes ahead of time will make the contribution process smooth for everyone.
 
 Once we've discussed your changes and you've got your code ready, make sure

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Jaeger is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CN
 
 ### Instrumentation Libraries
 
- * [Go client](https://github.com/uber/jaeger-client-go)
- * [Java client](https://github.com/uber/jaeger-client-java)
- * [Python client](https://github.com/uber/jaeger-client-python)
- * [Node.js client](https://github.com/uber/jaeger-client-node)
+ * [Go client](https://github.com/jaegertracing/jaeger-client-go)
+ * [Java client](https://github.com/jaegertracing/jaeger-client-java)
+ * [Python client](https://github.com/jaegertracing/jaeger-client-python)
+ * [Node.js client](https://github.com/jaegertracing/jaeger-client-node)
  * [C++ client](https://github.com/jaegertracing/cpp-client)
 
 ### Contributions
@@ -43,8 +43,8 @@ Jaeger is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CN
 
 ### Components
 
- * [UI](https://github.com/uber/jaeger-ui)
- * [Data model](https://github.com/uber/jaeger-idl)
+ * [UI](https://github.com/jaegertracing/jaeger-ui)
+ * [Data model](https://github.com/jaegertracing/jaeger-idl)
 
 ## Building From Source
 
@@ -69,7 +69,7 @@ Reach project contributors via these channels:
 
  * [jaeger-tracing mail group](https://groups.google.com/forum/#!forum/jaeger-tracing)
  * [Gitter chat room](https://gitter.im/jaegertracing/Lobby)
- * [Github issues](https://github.com/uber/jaeger/issues)
+ * [Github issues](https://github.com/jaegertracing/jaeger/issues)
 
 ## Adopters
 
@@ -79,7 +79,7 @@ whether it runs in production or you use it to troubleshoot issues in developmen
 
 Please see [ADOPTERS.md](./ADOPTERS.md) for some of the organizations using Jaeger today.
 If you would like to add your organization to the list, please comment on our
-[survey issue](https://github.com/uber/jaeger/issues/207).
+[survey issue](https://github.com/jaegertracing/jaeger/issues/207).
 
 ## License
 
@@ -87,8 +87,8 @@ If you would like to add your organization to the list, please comment on our
 
 [doc-img]: https://readthedocs.org/projects/jaeger/badge/?version=latest
 [doc]: http://jaeger.readthedocs.org/en/latest/
-[godoc-img]: https://godoc.org/github.com/uber/jaeger?status.svg
-[godoc]: https://godoc.org/github.com/uber/jaeger
+[godoc-img]: https://godoc.org/github.com/jaegertracing/jaeger?status.svg
+[godoc]: https://godoc.org/github.com/jaegertracing/jaeger
 [ci-img]: https://travis-ci.org/jaegertracing/jaeger.svg?branch=master
 [ci]: https://travis-ci.org/jaegertracing/jaeger
 [cov-img]: https://coveralls.io/repos/jaegertracing/jaeger/badge.svg?branch=master

--- a/doc.go
+++ b/doc.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaeger contains the code for Jaeger backend.
 // Do not delete this file, it's needed for `go get` to work.
+
+// Package jaeger contains the code for Jaeger backend.
 package jaeger

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,7 +58,7 @@ docker run \
 ```
 
 In the future we will support different service discovery systems to dynamically load balance
-across several collectors ([issue 213](https://github.com/uber/jaeger/issues/213)).
+across several collectors ([issue 213](https://github.com/jaegertracing/jaeger/issues/213)).
 
 ## Collectors
 
@@ -183,7 +183,7 @@ Links can either be members of the `menu` Array, directly, or they can be groupe
 
 The `items` Array should contain one or more link configurations.
 
-TODO: Swagger and GraphQL API ([issue 158](https://github.com/uber/jaeger/issues/158)).
+TODO: Swagger and GraphQL API ([issue 158](https://github.com/jaegertracing/jaeger/issues/158)).
 
 ## Aggregation Jobs for Service Dependencies
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,8 +44,10 @@ traces.
 #### Running
 
 ```bash
-go get github.com/uber/jaeger
-cd $GOPATH/src/github.com/uber/jaeger
+mkdir -p $GOPATH/src/github.com/jaegertracing
+cd $GOPATH/src/github.com/jaegertracing
+git clone git@github.com:jaegertracing/jaeger.git jaeger
+cd jaeger
 make install
 cd examples/hotrod
 go run ./main.go all
@@ -83,8 +85,10 @@ Individual Jaeger backend components can be run from source.
 They all have their `main.go` in the `cmd` folder. For example, to run the `jaeger-agent`:
 
 ```bash
-go get github.com/uber/jaeger
-cd $GOPATH/src/github.com/uber/jaeger
+mkdir -p $GOPATH/src/github.com/jaegertracing
+cd $GOPATH/src/github.com/jaegertracing
+git clone git@github.com:jaegertracing/jaeger.git jaeger
+cd jaeger
 make install
 go run ./cmd/agent/main.go
 ```
@@ -98,7 +102,7 @@ Collector service exposes Zipkin compatible REST API `/api/v1/spans` and can be 
 `--collector.zipkin.http-port=9411`. It supports Thrift and JSON format.
 Agent uses `TBinaryProtocol` and is available on `UDP` port `5775`.
 
-Zipkin Thrift IDL file can be found [here](https://github.com/uber/jaeger-idl/blob/master/thrift/zipkincore.thrift).
+Zipkin Thrift IDL file can be found [here](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/zipkincore.thrift).
 It's compatible with [zipkinCore.thrift](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift)
 
 [hotrod-tutorial]: https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 Welcome to Jaeger's documentation portal! Below, you'll find information for beginners and experienced Jaeger users.
 
-If you can't find what you are looking for, or have an issue not covered here, we'd love to hear from you either on [Github](https://github.com/uber/jaeger/issues), [Gitter chat](https://gitter.im/jaegertracing/Lobby), or on our [mailing list](https://groups.google.com/forum/#!forum/jaeger-tracing).
+If you can't find what you are looking for, or have an issue not covered here, we'd love to hear from you either on [Github](https://github.com/jaegertracing/jaeger/issues), [Gitter chat](https://gitter.im/jaegertracing/Lobby), or on our [mailing list](https://groups.google.com/forum/#!forum/jaeger-tracing).
 
 ## About
 Jaeger, inspired by [Dapper][dapper] and [OpenZipkin](http://zipkin.io),
@@ -23,7 +23,7 @@ for the architectural choices made in Jaeger.
 ## Features
 
   * [OpenTracing](http://opentracing.io/) compatible data model and instrumentation libraries
-    * in [Go](https://github.com/uber/jaeger-client-go), [Java](https://github.com/uber/jaeger-client-java), [Node](https://github.com/uber/jaeger-client-node), [Python](https://github.com/uber/jaeger-client-python)
+    * in [Go](https://github.com/jaegertracing/jaeger-client-go), [Java](https://github.com/jaegertracing/jaeger-client-java), [Node](https://github.com/jaegertracing/jaeger-client-node), [Python](https://github.com/jaegertracing/jaeger-client-python)
     and [C++](https://github.com/jaegertracing/cpp-client)
   * Uses consistent upfront sampling with individual per service/endpoint probabilities
   * Adaptive sampling (coming soon)
@@ -33,7 +33,7 @@ for the architectural choices made in Jaeger.
 
   * Backend components implemented in Go
   * React/Javascript UI
-  * [Cassandra 3.x](https://github.com/uber/jaeger/tree/master/plugin/storage/cassandra), [ElasticSearch](https://github.com/uber/jaeger/tree/master/plugin/storage/es) as persistent storage (more storage backends coming soon)
+  * [Cassandra 3.x](https://github.com/jaegertracing/jaeger/tree/master/plugin/storage/cassandra), [ElasticSearch](https://github.com/jaegertracing/jaeger/tree/master/plugin/storage/es) as persistent storage (more storage backends coming soon)
 
 ## Quick Start
 See [running a docker all in one image](getting_started.md#all-in-one-docker-image).

--- a/docs/news.md
+++ b/docs/news.md
@@ -20,9 +20,9 @@ News coverage:
 <img align="right" src="../images/jaeger-vector.svg" width=400>
 Uber is pleased to announce the open source release of Jaeger, a distributed tracing system, used to monitor, profile, and troubleshoot microservices.
 
-Jaeger is written in Go, with OpenTracing compatible client libraries in [Go](https://github.com/uber/jaeger-client-go), [Java](https://github.com/uber/jaeger-client-java), [Node](https://github.com/uber/jaeger-client-node), and [Python](https://github.com/uber/jaeger-client-python). It allows service owners to instrument their services to get insights into what their architecture is doing.
+Jaeger is written in Go, with OpenTracing compatible client libraries in [Go](https://github.com/jaegertracing/jaeger-client-go), [Java](https://github.com/jaegertracing/jaeger-client-java), [Node](https://github.com/jaegertracing/jaeger-client-node), and [Python](https://github.com/jaegertracing/jaeger-client-python). It allows service owners to instrument their services to get insights into what their architecture is doing.
 
-Jaeger is available now on [Github](https://github.com/uber/jaeger) as a public beta. Try it out by running the complete backend using the [Docker image](http://jaeger.readthedocs.io/en/latest/getting_started/#all-in-one-docker-image) along with a sample application, [HotROD](http://jaeger.readthedocs.io/en/latest/getting_started/#sample-application), to generate interesting traces.
+Jaeger is available now on [Github](https://github.com/jaegertracing/jaeger) as a public beta. Try it out by running the complete backend using the [Docker image](http://jaeger.readthedocs.io/en/latest/getting_started/#all-in-one-docker-image) along with a sample application, [HotROD](http://jaeger.readthedocs.io/en/latest/getting_started/#sample-application), to generate interesting traces.
 
 We hope that other organizations find Jaeger to be a useful tool, and we welcome contributions.
 Keep up to date by subscribing to our [mailing list](https://groups.google.com/forum/#!forum/jaeger-tracing).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 The following is only a selection of some of the major features we plan to implement in the near future (6-12 months).
 To get a more complete overview of planned features and current work, see the issue trackers for the various repositories,
-for example, the [Jaeger backend](https://github.com/uber/jaeger/issues/).
+for example, the [Jaeger backend](https://github.com/jaegertracing/jaeger/issues/).
 
 ## Adaptive Sampling
 
@@ -18,15 +18,15 @@ the storage backend. There are two issues with the current approach:
      endpoint never sampled. For example, if the QPS of the endpoints is different by a factor of 100, and the
      probability is set to 0.001, then the low QPS traffic will have only 1 in 100,000 chance to be sampled.
 
-See issue tracker for more info: [jaeger/issues/365](https://github.com/uber/jaeger/issues/365).
+See issue tracker for more info: [jaeger/issues/365](https://github.com/jaegertracing/jaeger/issues/365).
 
 ## Support for Large Traces in the UI
 
-[jaeger-ui/milestone/1](https://github.com/uber/jaeger-ui/milestone/1)
+[jaeger-ui/milestone/1](https://github.com/jaegertracing/jaeger-ui/milestone/1)
 
 ## Instrumentation Libraries in More Languages
 
-[jaeger/issues/366](https://github.com/uber/jaeger/issues/366)
+[jaeger/issues/366](https://github.com/jaegertracing/jaeger/issues/366)
 
 ## Data Pipeline
 
@@ -36,7 +36,7 @@ Post-collection data pipeline for trace aggregation and data mining based on Apa
 
 Features for Jaeger backend to be a drop-in replacement for Zipkin backend.
 
-[jaeger/milestone/2](https://github.com/uber/jaeger/milestone/2)
+[jaeger/milestone/2](https://github.com/jaegertracing/jaeger/milestone/2)
 
 ## Path-Based Dependency Diagrams
 
@@ -74,14 +74,14 @@ there are always questions about how much of the architecture is integrated
 with tracing, what is the quality of the instrumentation, are there microservices
 that are using stale versions of instrumentation libraries, etc.
 
-Trace Quality engine ([jaeger/issues/367](https://github.com/uber/jaeger/issues/367))
+Trace Quality engine ([jaeger/issues/367](https://github.com/jaegertracing/jaeger/issues/367))
 runs analysis on all traces collected in the backend, inspects them for known completeness
 and quality problems, and provides summary reports to service owners with suggestions on
 improving the quality metrics and links to sample traces that exhibit the issues.
 
 ## Dynamic Configuration
 
-We need a dynamic configuration solution ([jaeger/issues/355](https://github.com/uber/jaeger/issues/355))
+We need a dynamic configuration solution ([jaeger/issues/355](https://github.com/jaegertracing/jaeger/issues/355))
 that comes in handy in various scenarios:
 
   * Blacklisting services,

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/uber/jaeger
+package: github.com/jaegertracing/jaeger
 import:
 - package: github.com/apache/thrift
   version: 0.9.3


### PR DESCRIPTION
After #528 many instructions still incorrectly refer to `uber`