### PR TITLE
Add retries for apt-get in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ env:
 install:
   - docker rmi $(docker images -q) || true
   - make install-ci
-  - if [ "$ALL_IN_ONE" == true ]; then bash ./travis/install-ui-deps.sh ; fi
-  - if [ "$DOCKER" == true ]; then bash ./travis/install-ui-deps.sh ; fi
+  - if [ "$ALL_IN_ONE" == true ]; then travis_retry bash ./travis/install-ui-deps.sh ; fi
+  - if [ "$DOCKER" == true ]; then travis_retry bash ./travis/install-ui-deps.sh ; fi
   - if [ "$CROSSDOCK" == true ]; then bash ./travis/install-crossdock-deps.sh ; fi
 
 script:


### PR DESCRIPTION
Not sure if it will help with the errors like below
```
Hit:31 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty InRelease
Hit:32 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty Release
Fetched 7,048 B in 1s (4,254 B/s)
Reading package lists...
W: http://dl.hhvm.com/ubuntu/dists/trusty/InRelease: Signature by key 36AEF64D0207E7EEE352D4875A16E7281BE7A449 uses weak digest algorithm (SHA1)
W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
E: Failed to fetch http://dl.hhvm.com/ubuntu/dists/trusty/main/binary-i386/Packages  404  Not Found [IP: 52.84.14.161 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
Error executing command, exiting
```