### PR TITLE
use utc time zone in es storage getIndices test

### DIFF
--- a/plugin/storage/es/dependencystore/storage_test.go
+++ b/plugin/storage/es/dependencystore/storage_test.go
@@ -174,7 +174,7 @@ func createSearchResult(dependencyLink string) *elastic.SearchResult {
 }
 
 func TestGetIndices(t *testing.T) {
-	fixedTime := time.Date(1995, time.April, 21, 4, 12, 19, 95, time.Local)
+	fixedTime := time.Date(1995, time.April, 21, 4, 12, 19, 95, time.UTC)
 	testCases := []struct {
 		expected []string
 		lookback time.Duration


### PR DESCRIPTION
I changed test `TestGetIndices` to use UTC timezone instead of local
Fixes #557 