### PR TITLE
Configure cqlsh for TLS for schema setup.

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -129,6 +129,30 @@ docker run \
   jaegertracing/jaeger-collector
 ```
 
+The schema tool also supports TLS. You need to make a custom cqlshrc file like
+so:
+
+```
+# Creating schema in a cassandra cluster requiring client TLS certificates.
+#
+# Create a volume for the schema docker container containing four files:
+# cqlshrc: this file
+# ca-cert: the cert authority for your keys
+# client-key: the keyfile for your client
+# client-cert: the cert file matching client-key
+#
+# if there is any sort of DNS mismatch and you want to ignore server validation
+# issues, then uncomment validate = false below.
+#
+# When running the container, map this volume to /root/.cassandra and set the
+# environment variable CQLSH_SSL=--ssl
+[ssl]
+certfile = ~/.cassandra/ca-cert
+userkey = ~/.cassandra/client-key
+usercert = ~/.cassandra/client-cert
+# validate = false
+```
+
 ### ElasticSearch
 
 ElasticSearch does not require initialization other than

--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -5,6 +5,7 @@
 
 CQLSH=${CQLSH:-"/usr/bin/cqlsh"}
 CQLSH_HOST=${CQLSH_HOST:-"cassandra"}
+CQLSH_SSL=${CQLSH_SSL:-""}
 CASSANDRA_WAIT_TIMEOUT=${CASSANDRA_WAIT_TIMEOUT:-"60"}
 DATACENTER=${DATACENTER:-"dc1"}
 KEYSPACE=${KEYSPACE:-"jaeger_v1_${DATACENTER}"}
@@ -13,7 +14,7 @@ MODE=${MODE:-"test"}
 total_wait=0
 while true
 do
-  ${CQLSH} -e "describe keyspaces"
+  ${CQLSH} ${CQLSH_SSL} -e "describe keyspaces"
   if (( $? == 0 )); then
     break
   else
@@ -29,4 +30,4 @@ done
 
 echo "Generating the schema for the keyspace ${KEYSPACE} and datacenter ${DATACENTER}"
 
-MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh | ${CQLSH}
+MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh | ${CQLSH} ${CQLSH_SSL}


### PR DESCRIPTION
We can configure most of cqlsh externally, but we do need to pass --ssl in to enable the SSL support. Here's a trivial patch to do that plus docs to make it easy for others.