### PR TITLE
Fix jaeger agent embedded reporter builder bug

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -43,9 +43,6 @@ const (
 
 	defaultHTTPServerHostPort = ":5778"
 
-	agentServiceName            = "jaeger-agent"
-	defaultCollectorServiceName = "jaeger-collector"
-
 	jaegerModel model = "jaeger"
 	zipkinModel       = "zipkin"
 
@@ -71,12 +68,7 @@ type Builder struct {
 	HTTPServer HTTPServerConfiguration  `yaml:"httpServer"`
 	Metrics    jmetrics.Builder         `yaml:"metrics"`
 
-	// These 3 fields are copied from tchreporter.Builder because yaml does not parse embedded structs
-	CollectorHostPorts   []string `yaml:"collectorHostPorts"`
-	DiscoveryMinPeers    int      `yaml:"minPeers"`
-	CollectorServiceName string   `yaml:"collectorServiceName"`
-
-	tchreporter.Builder
+	tchreporter.Builder `yaml:",inline"`
 
 	otherReporters []reporter.Reporter
 	metricsFactory metrics.Factory
@@ -115,16 +107,7 @@ func (b *Builder) WithMetricsFactory(mf metrics.Factory) *Builder {
 }
 
 func (b *Builder) createMainReporter(mFactory metrics.Factory, logger *zap.Logger) (*tchreporter.Reporter, error) {
-	if len(b.Builder.CollectorHostPorts) == 0 {
-		b.Builder.CollectorHostPorts = b.CollectorHostPorts
-	}
-	if b.Builder.CollectorServiceName == "" {
-		b.Builder.CollectorServiceName = b.CollectorServiceName
-	}
-	if b.Builder.DiscoveryMinPeers == 0 {
-		b.Builder.DiscoveryMinPeers = b.DiscoveryMinPeers
-	}
-	return b.Builder.CreateReporter(mFactory, logger)
+	return b.CreateReporter(mFactory, logger)
 }
 
 func (b *Builder) getMetricsFactory() (metrics.Factory, error) {


### PR DESCRIPTION
- When overriding the collector service name using the agent app builder's embedded
  `WithCollectorServiceName`, the service name is stored in the embedded struct and
  not in the outer struct.

- When constructing an agent using `createAgent`, `GetHttpServer` reads the outer
  struct leading to different behavior when reading configuration from a file, as
  opposed to using the builder.

- This change uses go-yaml's `inline` keyword to deserialize embedded structs.

Signed-off-by: Prithvi Raj <p.r@uber.com>