### PR TITLE
Fix issue where Domain to UI model converter double reports the same …

### DIFF
--- a/model/converter/json/fixtures/domain_01.json
+++ b/model/converter/json/fixtures/domain_01.json
@@ -107,6 +107,27 @@
       "warnings": [
         "some span warning"
       ]
+    },
+    {
+      "traceID": "1",
+      "spanID": "5",
+      "parentSpanID": "4",
+      "operationName": "preserveParentID-test",
+      "references": [
+        {
+          "refType": "child-of",
+          "traceID": "1",
+          "spanID": "4"
+        }
+      ],
+      "startTime": "2017-01-26T16:46:31.639875139-05:00",
+      "duration": 4000,
+      "process": {
+        "serviceName": "service-y"
+      },
+      "warnings": [
+        "some span warning"
+      ]
     }
   ],
   "warnings": [

--- a/model/converter/json/fixtures/ui_01.json
+++ b/model/converter/json/fixtures/ui_01.json
@@ -119,6 +119,26 @@
       "warnings": [
         "some span warning"
       ]
+    },
+    {
+      "traceID": "1",
+      "spanID": "5",
+      "operationName": "preserveParentID-test",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "1",
+          "spanID": "4"
+        }
+      ],
+      "startTime": 1485467191639875,
+      "duration": 4,
+      "tags": [],
+      "logs": [],
+      "processID": "p2",
+      "warnings": [
+        "some span warning"
+      ]
     }
   ],
   "processes": {

--- a/model/converter/json/from_domain.go
+++ b/model/converter/json/from_domain.go
@@ -105,7 +105,6 @@ func (fd fromDomain) convertReferences(span *model.Span, preserveParentID bool) 
 			SpanID:  json.SpanID(ref.SpanID.String()),
 		})
 		if ref.TraceID == span.TraceID && ref.SpanID == span.ParentSpanID {
-			// Check if the parent reference already exists
 			parentRefAdded = true
 		}
 	}

--- a/model/converter/json/from_domain.go
+++ b/model/converter/json/from_domain.go
@@ -97,19 +97,27 @@ func (fd fromDomain) convertReferences(span *model.Span, preserveParentID bool) 
 		length++
 	}
 	out := make([]json.Reference, 0, length)
+	var parentRef json.Reference
 	if span.ParentSpanID != 0 && !preserveParentID {
-		out = append(out, json.Reference{
+		// TODO this (wrongly) assumes that the reference type is always ChildOf
+		parentRef = json.Reference{
 			RefType: json.ChildOf,
 			TraceID: json.TraceID(span.TraceID.String()),
 			SpanID:  json.SpanID(span.ParentSpanID.String()),
-		})
+		}
+		out = append(out, parentRef)
 	}
 	for _, ref := range span.References {
-		out = append(out, json.Reference{
+		// TODO if the parentRef was wrongly added as a ChildOf ref above, this could
+		// potentially add a FollowsFrom ref and still keep the ChildOf ref
+		newRef := json.Reference{
 			RefType: fd.convertRefType(ref.RefType),
 			TraceID: json.TraceID(ref.TraceID.String()),
 			SpanID:  json.SpanID(ref.SpanID.String()),
-		})
+		}
+		if newRef != parentRef {
+			out = append(out, newRef)
+		}
 	}
 	return out
 }

--- a/model/converter/json/from_domain.go
+++ b/model/converter/json/from_domain.go
@@ -99,20 +99,19 @@ func (fd fromDomain) convertReferences(span *model.Span, preserveParentID bool) 
 	out := make([]json.Reference, 0, length)
 	var parentRefAdded bool
 	for _, ref := range span.References {
-		newRef := json.Reference{
+		out = append(out, json.Reference{
 			RefType: fd.convertRefType(ref.RefType),
 			TraceID: json.TraceID(ref.TraceID.String()),
 			SpanID:  json.SpanID(ref.SpanID.String()),
-		}
-		out = append(out, newRef)
-		if newRef.TraceID == json.TraceID(span.TraceID.String()) &&
-			newRef.SpanID == json.SpanID(span.ParentSpanID.String()) {
+		})
+		if ref.TraceID == span.TraceID && ref.SpanID == span.ParentSpanID {
 			// Check if the parent reference already exists
 			parentRefAdded = true
 		}
 	}
 	if span.ParentSpanID != 0 && !preserveParentID && !parentRefAdded {
-		// TODO this (wrongly) assumes that the reference type is always ChildOf
+		// By this point, if ParentSpanID != 0 but there are no other references,
+		// then the ParentSpanID does refer to child-of type
 		out = append(out, json.Reference{
 			RefType: json.ChildOf,
 			TraceID: json.TraceID(span.TraceID.String()),


### PR DESCRIPTION
…Span Reference

Problem was that the converter removes the parentSpanID and replaces it with a parent child-of Reference. But if the child-of reference is already present in the model span, it gets double reported.

It seems like the whole `if span.ParentSpanID != 0 && !preserveParentID {` code path could be removed. Can any part of the jaeger system send in a span where ParentSpanID is filled out but the child-of reference is not present? Also, the logic here makes a couple of faulty assumptions.

Signed-off-by: Won Jun Jang <wjang@uber.com>