### PR TITLE
make cassandra service_name_index inserts idempotent

### DIFF
--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -147,7 +147,7 @@ func (s *SpanWriter) WriteSpan(span *model.Span) error {
 		return s.logError(ds, err, "Failed to index tags", s.logger)
 	}
 
-	if err := s.indexBySerice(span.TraceID, ds); err != nil {
+	if err := s.indexByService(span.TraceID, ds); err != nil {
 		return s.logError(ds, err, "Failed to index service name", s.logger)
 	}
 
@@ -197,7 +197,7 @@ func (s *SpanWriter) indexByDuration(span *dbmodel.Span, startTime time.Time) er
 	return err
 }
 
-func (s *SpanWriter) indexBySerice(traceID model.TraceID, span *dbmodel.Span) error {
+func (s *SpanWriter) indexByService(traceID model.TraceID, span *dbmodel.Span) error {
 	bucketNo := span.SpanHash % defaultNumBuckets
 	query := s.session.Query(serviceNameIndex)
 	q := query.Bind(span.Process.ServiceName, bucketNo, span.StartTime, span.TraceID)


### PR DESCRIPTION
Use the span hash as the source of variation for bucket choice instead of an atomic counter so that the inserts are idempotent.

Signed-off-by: Kevin Wojcik <kwojcik@uber.com>
