### PR TITLE
Use unsigned for span hash

### DIFF
--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -57,7 +57,7 @@ func (c converter) fromDomain(span *model.Span) *Span {
 		Refs:          refs,
 		Process:       udtProcess,
 		ServiceName:   span.Process.ServiceName,
-		SpanHash:      int64(spanHash),
+		SpanHash:      spanHash,
 	}
 }
 

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -161,7 +161,7 @@ func getTestSpan() *Span {
 	// as the model changes. So let's just make sure the code is being
 	// calculated during the conversion.
 	spanHash, _ := model.HashCode(getTestJaegerSpan())
-	span.SpanHash = int64(spanHash)
+	span.SpanHash = spanHash
 	return span
 }
 

--- a/plugin/storage/cassandra/spanstore/dbmodel/model.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/model.go
@@ -38,7 +38,7 @@ type Span struct {
 	Refs          []SpanRef
 	Process       Process
 	ServiceName   string
-	SpanHash      int64
+	SpanHash      uint64
 }
 
 // KeyValue is the UDT representation of a Jaeger KeyValue.


### PR DESCRIPTION
span hash is used for cassandra buckets, with signed it produced
negative numbers


Related to https://github.com/jaegertracing/jaeger/pull/587 and fixes https://github.com/jaegertracing/spark-dependencies/issues/23