### PR TITLE
Add CA certificates to collector/query images

### DIFF
--- a/cmd/collector/Dockerfile
+++ b/cmd/collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as certs
+FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch

--- a/cmd/collector/Dockerfile
+++ b/cmd/collector/Dockerfile
@@ -3,8 +3,7 @@ RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
 
-COPY --from=certs /usr/share/ca-certificates/ /usr/share/ca-certificates/
-COPY --from=certs /etc/ssl/ /etc/ssl/
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 14267
 COPY collector-linux /go/bin/

--- a/cmd/collector/Dockerfile
+++ b/cmd/collector/Dockerfile
@@ -1,4 +1,10 @@
+FROM alpine as certs
+RUN apk add --update --no-cache ca-certificates
+
 FROM scratch
+
+COPY --from=certs /usr/share/ca-certificates/ /usr/share/ca-certificates/
+COPY --from=certs /etc/ssl/ /etc/ssl/
 
 EXPOSE 14267
 COPY collector-linux /go/bin/

--- a/cmd/query/Dockerfile
+++ b/cmd/query/Dockerfile
@@ -3,8 +3,7 @@ RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
 
-COPY --from=certs /usr/share/ca-certificates/ /usr/share/ca-certificates/
-COPY --from=certs /etc/ssl/ /etc/ssl/
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 16686
 COPY query-linux /go/bin/

--- a/cmd/query/Dockerfile
+++ b/cmd/query/Dockerfile
@@ -1,4 +1,10 @@
+FROM alpine as certs
+RUN apk add --update --no-cache ca-certificates
+
 FROM scratch
+
+COPY --from=certs /usr/share/ca-certificates/ /usr/share/ca-certificates/
+COPY --from=certs /etc/ssl/ /etc/ssl/
 
 EXPOSE 16686
 COPY query-linux /go/bin/

--- a/cmd/query/Dockerfile
+++ b/cmd/query/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as certs
+FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch


### PR DESCRIPTION
Resolves #485 

When connecting query/collector to storage backends that use TLS with certificates signed by public root CAs, it's useful to have those CA certificates in the Docker image.

On the other hand, the certificates can always be mounted from the host filesystem, which is necessary anyway when connecting to servers using self-signed certificates.

I think this is a nice to have so that people don't have to do extra work. For collector it increases the image size from 24.6MB to 25.3MB.