### PR TITLE
skip nil and zero length hits, fix #556

### DIFF
--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -72,8 +72,6 @@ var (
 	// ErrUnableToFindTraceIDAggregation occurs when an aggregation query for TraceIDs fail.
 	ErrUnableToFindTraceIDAggregation = errors.New("Could not find aggregation of traceIDs")
 
-	errNilHits = errors.New("No hits in read results found")
-
 	errNoTraces = errors.New("No trace with that ID found")
 
 	defaultMaxDuration = model.DurationAsMicroseconds(time.Hour * 24)
@@ -232,8 +230,8 @@ func (s *SpanReader) multiRead(traceIDs []string, startTime, endTime time.Time) 
 
 	var traces []*model.Trace
 	for _, result := range results.Responses {
-		if result.Hits == nil {
-			return nil, errNilHits
+		if result.Hits == nil || len(result.Hits.Hits) == 0 {
+			continue
 		}
 		spans, err := s.collectSpans(result.Hits.Hits)
 		if err != nil {

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -144,7 +144,7 @@ func TestSpanReader_GetTraceQueryError(t *testing.T) {
 	})
 }
 
-func TestSpanReader_GetTraceNilHitsError(t *testing.T) {
+func TestSpanReader_GetTraceNilHits(t *testing.T) {
 	withSpanReader(func(r *spanReaderTest) {
 		var hits []*elastic.SearchHit
 		searchHits := &elastic.SearchHits{Hits: hits}
@@ -158,7 +158,7 @@ func TestSpanReader_GetTraceNilHitsError(t *testing.T) {
 			}, nil)
 
 		trace, err := r.reader.GetTrace(model.TraceID{Low: 1})
-		require.EqualError(t, err, "No hits in read results found")
+		require.EqualError(t, err, "No trace with that ID found")
 		require.Nil(t, trace)
 	})
 }


### PR DESCRIPTION
Focus on the flowing multiread function code snippet
```golang
	var traces []*model.Trace
	for _, result := range results.Responses {
		if result.Hits == nil {
			return nil, errNilHits
		}
		spans, err := s.collectSpans(result.Hits.Hits)
		if err != nil {
			return nil, err
		}
		traces = append(traces, &model.Trace{Spans: spans})
	}
	return traces, nil
```

when trace id is invalid or not in the es store, we got response json as follows:
```json
{
   "responses":[
      {
         "took":2,
         "timed_out":false,
         "_shards":{
            "total":15,
            "successful":15,
            "failed":0
         },
         "hits":{
            "total":0,
            "max_score":null,
            "hits":[]
         },
         "status":200
      }
   ]
}
```
and then the response json is unmarshalled to the `elastic.MultiSearchResult` struct, you will notice that the snippet
```json
"hits":{
    "total":0,
    "max_score":null,
    "hits":[]
},
```
will not get nil `result.Hits`, but a zero length `result.Hits.Hits`.

When `len(result.Hits.Hits) == 0`,  `collectSpans` will return `[]*model.Span` with zero length and no error. 

In this case, got result traces as
```
[]*model.Trace{
    &model.Trace{
        Spans: {
        },
        Warnings: nil,
    },
}
```
this results that `len(traces) == 0` not triggered, and then no `errNoTraces ` is returned.

As explained above, neither nil `result.Hits` nor zero length `result.Hits.Hits` should do the following `collectSpans`, just skip them.