### PR TITLE
Make agent tests more robust

### DIFF
--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -22,10 +22,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 func TestAgentStartError(t *testing.T) {
@@ -113,5 +114,5 @@ func TestAgentStartStop(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
-	t.Fatalf("Expecting log %s", "agent's http server exiting")
+	t.Fatal("Expecting server exist log")
 }

--- a/pkg/testutils/logger.go
+++ b/pkg/testutils/logger.go
@@ -75,6 +75,13 @@ func (b *Buffer) Stripped() string {
 	return b.Buffer.Stripped()
 }
 
+// String overwrites zaptest.Buffer.String() to make it thread safe
+func (b *Buffer) String() string {
+	b.RLock()
+	defer b.RUnlock()
+	return b.Buffer.String()
+}
+
 // Write overwrites zaptest.Buffer.bytes.Buffer.Write() to make it thread safe
 func (b *Buffer) Write(p []byte) (int, error) {
 	b.Lock()

--- a/pkg/testutils/logger_test.go
+++ b/pkg/testutils/logger_test.go
@@ -59,7 +59,7 @@ func TestRaceCondition(t *testing.T) {
 		_ = <-start
 		buffer.Lines()
 		buffer.Stripped()
-		buffer.String()
+		_ = buffer.String()
 		finish.Done()
 	}()
 

--- a/pkg/testutils/logger_test.go
+++ b/pkg/testutils/logger_test.go
@@ -59,6 +59,7 @@ func TestRaceCondition(t *testing.T) {
 		_ = <-start
 		buffer.Lines()
 		buffer.Stripped()
+		buffer.String()
 		finish.Done()
 	}()
 


### PR DESCRIPTION
1. The test was using default HTTP port instead of ephemeral port, which lead to unexpected failures if you happen to run some other jaeger components locally
1. The coverage was unstable because there was no waiting for the http server to shutdown and execute the error handler