### PR TITLE
Rename SPAN_STORAGE to SPAN_STORAGE_TYPE to be backwards compatible

### DIFF
--- a/cmd/env/command.go
+++ b/cmd/env/command.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/spf13/pflag"
 
 	"github.com/spf13/cobra"
@@ -42,8 +43,8 @@ their names to upper case and replacing punctuation with underscores. For exampl
 The following configuration options are only available via environment variables:
 `)
 			fs := new(pflag.FlagSet)
-			fs.String("SPAN_STORAGE", "cassandra", "The type of backend (cassandra, elasticsearch, memory) used for trace storage.")
-			fs.String("DEPENDENCY_STORAGE", "${SPAN_STORAGE}", "The type of backend used for service dependencies storage.")
+			fs.String(storage.SpanStorageTypeEnvVar, "cassandra", "The type of backend (cassandra, elasticsearch, memory) used for trace storage.")
+			fs.String(storage.DependencyStorageTypeEnvVar, "${SPAN_STORAGE}", "The type of backend used for service dependencies storage.")
 			fmt.Fprintln(cmd.OutOrStdout(), strings.Replace(fs.FlagUsages(), "      --", "      ", -1))
 		},
 	}

--- a/cmd/env/command.go
+++ b/cmd/env/command.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jaegertracing/jaeger/plugin/storage"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/spf13/cobra"
+	"github.com/jaegertracing/jaeger/plugin/storage"
 )
 
 // Command creates `env` command

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -54,8 +54,8 @@ import (
 
 // standalone/main is a standalone full-stack jaeger backend, backed by a memory store
 func main() {
-	if os.Getenv(storage.SpanStorageEnvVar) == "" {
-		os.Setenv(storage.SpanStorageEnvVar, "memory") // other storage types default to SpanStorage
+	if os.Getenv(storage.SpanStorageTypeEnvVar) == "" {
+		os.Setenv(storage.SpanStorageTypeEnvVar, "memory") // other storage types default to SpanStorage
 	}
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
 	if err != nil {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,7 +90,7 @@ Port  | Protocol | Function
 
 Collectors require a persistent storage backend. Cassandra and ElasticSearch are the primary supported storage backends. Additional backends are [discussed here](https://github.com/jaegertracing/jaeger/issues/638).
 
-The storage type can be passed via `SPAN_STORAGE` environment variable. Valid values are `cassandra`, `elasticsearch`, and `memory` (only for all-in-one binary).
+The storage type can be passed via `SPAN_STORAGE_TYPE` environment variable. Valid values are `cassandra`, `elasticsearch`, and `memory` (only for all-in-one binary).
 
 ### Cassandra
 

--- a/plugin/storage/factory_config.go
+++ b/plugin/storage/factory_config.go
@@ -22,9 +22,11 @@ import (
 )
 
 const (
-	// SpanStorageEnvVar is the name of the env var that defines the type of backend used for span storage.
-	SpanStorageEnvVar       = "SPAN_STORAGE"
-	dependencyStorageEnvVar = "DEPENDENCY_STORAGE"
+	// SpanStorageTypeEnvVar is the name of the env var that defines the type of backend used for span storage.
+	SpanStorageTypeEnvVar = "SPAN_STORAGE_TYPE"
+
+	// DependencyStorageTypeEnvVar is the name of the env var that defines the type of backend used for dependencies storage.
+	DependencyStorageTypeEnvVar = "DEPENDENCY_STORAGE_TYPE"
 
 	spanStorageFlag = "--span-storage.type"
 )
@@ -45,7 +47,7 @@ type FactoryConfig struct {
 // For backwards compatibility it also parses the args looking for deprecated --span-storage.type flag.
 // If found, it writes a deprecation warning to the log.
 func FactoryConfigFromEnvAndCLI(args []string, log io.Writer) FactoryConfig {
-	spanStorageType := os.Getenv(SpanStorageEnvVar)
+	spanStorageType := os.Getenv(SpanStorageTypeEnvVar)
 	if spanStorageType == "" {
 		// for backwards compatibility check command line for --span-storage.type flag
 		spanStorageType = spanStorageTypeFromArgs(args, log)
@@ -53,7 +55,7 @@ func FactoryConfigFromEnvAndCLI(args []string, log io.Writer) FactoryConfig {
 	if spanStorageType == "" {
 		spanStorageType = cassandraStorageType
 	}
-	depStoreType := os.Getenv(dependencyStorageEnvVar)
+	depStoreType := os.Getenv(DependencyStorageTypeEnvVar)
 	if depStoreType == "" {
 		depStoreType = spanStorageType
 	}
@@ -75,7 +77,7 @@ func spanStorageTypeFromArgs(args []string, log io.Writer) string {
 			log,
 			"WARNING: found deprecated command line option %s, please use environment variable %s instead\n",
 			token,
-			SpanStorageEnvVar,
+			SpanStorageTypeEnvVar,
 		)
 		if token == spanStorageFlag && i < len(args)-1 {
 			return args[i+1]

--- a/plugin/storage/factory_config_test.go
+++ b/plugin/storage/factory_config_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func clearEnv() {
-	os.Setenv(SpanStorageEnvVar, "")
-	os.Setenv(dependencyStorageEnvVar, "")
+	os.Setenv(SpanStorageTypeEnvVar, "")
+	os.Setenv(DependencyStorageTypeEnvVar, "")
 }
 
 func TestFactoryConfigFromEnv(t *testing.T) {
@@ -35,8 +35,8 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	assert.Equal(t, cassandraStorageType, f.SpanStorageType)
 	assert.Equal(t, cassandraStorageType, f.DependenciesStorageType)
 
-	os.Setenv(SpanStorageEnvVar, elasticsearchStorageType)
-	os.Setenv(dependencyStorageEnvVar, memoryStorageType)
+	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType)
+	os.Setenv(DependencyStorageTypeEnvVar, memoryStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, nil)
 	assert.Equal(t, elasticsearchStorageType, f.SpanStorageType)


### PR DESCRIPTION
Resolves #642 

```
$ go run ./cmd/query/main.go env

All command line options can be provided via environment variables by converting
their names to upper case and replacing punctuation with underscores. For example,

      command line option                 environment variable
      ------------------------------------------------------------------
      --cassandra.connections-per-host    CASSANDRA_CONNECTIONS_PER_HOST
      --metrics-backend                   METRICS_BACKEND

The following configuration options are only available via environment variables:

      SPAN_STORAGE_TYPE string         The type of backend (cassandra, elasticsearch, memory) used for trace storage. (default "cassandra")
      DEPENDENCY_STORAGE_TYPE string   The type of backend used for service dependencies storage. (default "${SPAN_STORAGE}")
```

Signed-off-by: Yuri Shkuro <ys@uber.com>