### PR TITLE
Fix flaky test

### DIFF
--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -62,7 +62,7 @@ func TestNewFactory(t *testing.T) {
 
 	f, err = NewFactory(FactoryConfig{SpanStorageType: "x", DependenciesStorageType: "y"})
 	require.Error(t, err)
-	expected := "Unknown storage type x."
+	expected := "Unknown storage type" // could be 'x' or 'y' since code iterates through map.
 	assert.Equal(t, expected, err.Error()[0:len(expected)])
 }
 


### PR DESCRIPTION
```
=== RUN   TestNewFactory
--- FAIL: TestNewFactory (0.00s)
	Error Trace:	factory_test.go:66
	Error:      	Not equal: 
	            	expected: "Unknown storage type x."
	            	actual: "Unknown storage type y."
```

Signed-off-by: Yuri Shkuro <ys@uber.com>