### PR TITLE
Klarrio storage

### DIFF
--- a/plugin/storage/authorizingproxy/README.md
+++ b/plugin/storage/authorizingproxy/README.md
@@ -1,0 +1,38 @@
+# Authorizing proxy collector storage
+
+The collector storage which takes spans and, given a condition, forwards to another collector if condition is met.  
+
+## Enabling
+
+    <collector-command> --span-storage.type=authorizingproxy \
+      --authorizingproxy.proxy-host-port 10.0.100.1:14267,... \
+      --authorizingproxy.proxy-batch-size 500 \
+      --authorizingproxy.proxy-batch-flush-interval-ms 500 \
+      --authorizingproxy.proxy-if <authorizing-condition>
+
+### authorizingproxy.proxy-host-port
+
+Comma-delimited list of collector host port strings to which spans should be forwarded.  
+No default, use `JAEGER_STORAGE_PROXY_HOST_PORT` environment variable.
+
+### authorizingproxy.proxy-batch-size
+
+Maximum number of elements per source agent to wait for before forwarding to the collectors.  
+Default value is `50`, use `JAEGER_STORAGE_PROXY_BATCH_SIZE` environment variable.
+
+### authorizingproxy.proxy-batch-flush-interval-ms
+
+Maximum time to wait for a complete `proxy-batch-size` before forwarding the batches to the collectors. If the `proxy-batch-size` has not been reached, all elements received will be forwarded.  
+Default value is `500`, use `JAEGER_STORAGE_PROXY_FLUSH_INTERVAL_MS` environment variable.
+
+### authorizingproxy.proxy-if
+
+Optional condition for the spans to be forwarded. If condition is empty, all spans will be forwarded. Authorizing conditions can be:
+
+    # forward if a given tag matches:
+    tag.<tag-name>==string-value
+
+    # forward if a baggage item matches:
+    baggage.<key-name>==string-value
+
+No default, use `JAEGER_STORAGE_PROXY_IF` environment variable.

--- a/plugin/storage/authorizingproxy/config/config.go
+++ b/plugin/storage/authorizingproxy/config/config.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+  "time"
+
+  "github.com/pkg/errors"
+  "go.uber.org/zap"
+  jaegerClient "github.com/uber/jaeger-client-go"
+  jaegerClientLogger "github.com/uber/jaeger-client-go/log"
+)
+
+// Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
+type Configuration struct {
+  ProxyHostPort              string
+  ProxyIf                    string
+  ProxyQueueSize             int
+  ProxyBufferFlushIntervalMs int
+
+}
+
+// ClientBuilder creates new es.Client
+type ClientBuilder interface {
+  NewClient(logger *zap.Logger) (jaegerClient.Reporter, error)
+  GetProxyHostPort() string
+  GetProxyIf() string
+  GetProxyQueueSize() int
+  GetProxyBufferFlushIntervalMs() time.Duration
+}
+
+// NewClient creates a new ElasticSearch client
+func (c *Configuration) NewClient(logger *zap.Logger) (jaegerClient.Reporter, error) {
+
+  if c.ProxyHostPort == "" {
+    return nil, errors.New("Host port empty")
+  }
+
+  transport, err := jaegerClient.NewUDPTransport(c.GetProxyHostPort(), 0)
+  if err != nil {
+    return nil, err
+  }
+
+  reporter := jaegerClient.NewRemoteReporter(
+    transport,
+    jaegerClient.ReporterOptions.QueueSize(c.GetProxyQueueSize()),
+    jaegerClient.ReporterOptions.BufferFlushInterval(c.GetProxyBufferFlushIntervalMs()),
+    jaegerClient.ReporterOptions.Logger(jaegerClientLogger.StdLogger),
+    jaegerClient.ReporterOptions.Metrics(nil))
+
+  return reporter, nil
+}
+
+// ApplyDefaults copies settings from source unless its own value is non-zero.
+func (c *Configuration) ApplyDefaults(source *Configuration) {
+  if c.ProxyHostPort == "" {
+    c.ProxyHostPort = source.ProxyHostPort
+  }
+  if c.ProxyIf == "" {
+    c.ProxyIf = source.ProxyIf
+  }
+  if c.ProxyQueueSize == 0 {
+    c.ProxyQueueSize = source.ProxyQueueSize
+  }
+  if c.ProxyBufferFlushIntervalMs == 0 {
+    c.ProxyBufferFlushIntervalMs = source.ProxyBufferFlushIntervalMs
+  }
+}
+
+func (c *Configuration) GetProxyHostPort() string {
+  return c.ProxyHostPort
+}
+
+func (c *Configuration) GetProxyIf() string {
+  return c.ProxyIf
+}
+
+func (c *Configuration) GetProxyQueueSize() int {
+  return c.ProxyQueueSize
+}
+
+func (c *Configuration) GetProxyBufferFlushIntervalMs() time.Duration {
+  return time.Duration(c.ProxyBufferFlushIntervalMs) * time.Millisecond
+}

--- a/plugin/storage/authorizingproxy/config/config.go
+++ b/plugin/storage/authorizingproxy/config/config.go
@@ -13,7 +13,7 @@ import (
   "github.com/jaegertracing/jaeger/pkg/discovery"
 )
 
-// Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
+// Configuration describes the configuration properties needed to connect to a proxy collector
 type Configuration struct {
   ProxyHostPort              string
   ProxyIf                    *proxy_if.ProxyIf
@@ -31,7 +31,7 @@ type ClientBuilder interface {
   GetProxyBatchFlushIntervalMs() time.Duration
 }
 
-// NewClient creates a new ElasticSearch client
+// NewClient creates a new jaeger agent (client)
 func (c *Configuration) NewClient(metricsFactory metrics.Factory, logger *zap.Logger) (*agentReporter.Reporter, error) {
 
   if c.ProxyHostPort == "" {

--- a/plugin/storage/authorizingproxy/config/config.go
+++ b/plugin/storage/authorizingproxy/config/config.go
@@ -8,6 +8,7 @@ import (
   "github.com/uber/jaeger-lib/metrics"
   "go.uber.org/zap"
 
+  "github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy/proxy_if"
   agentReporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
   "github.com/jaegertracing/jaeger/pkg/discovery"
 )
@@ -15,7 +16,7 @@ import (
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
   ProxyHostPort              string
-  ProxyIf                    string
+  ProxyIf                    *proxy_if.ProxyIf
   ProxyBatchSize             int
   ProxyBatchFlushIntervalMs  int
 
@@ -25,7 +26,7 @@ type Configuration struct {
 type ClientBuilder interface {
   NewClient(metricsFactory metrics.Factory, logger *zap.Logger) (*agentReporter.Reporter, error)
   GetProxyHostPort() string
-  GetProxyIf() string
+  GetProxyIf() *proxy_if.ProxyIf
   GetProxyBatchSize() int
   GetProxyBatchFlushIntervalMs() time.Duration
 }
@@ -52,7 +53,7 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
   if c.ProxyHostPort == "" {
     c.ProxyHostPort = source.ProxyHostPort
   }
-  if c.ProxyIf == "" {
+  if c.ProxyIf.IsEmpty() {
     c.ProxyIf = source.ProxyIf
   }
   if c.ProxyBatchSize == 0 {
@@ -67,7 +68,7 @@ func (c *Configuration) GetProxyHostPort() string {
   return c.ProxyHostPort
 }
 
-func (c *Configuration) GetProxyIf() string {
+func (c *Configuration) GetProxyIf() *proxy_if.ProxyIf {
   return c.ProxyIf
 }
 

--- a/plugin/storage/authorizingproxy/dependencystore/storage.go
+++ b/plugin/storage/authorizingproxy/dependencystore/storage.go
@@ -14,7 +14,7 @@ import (
   agentReporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
 )
 
-// DependencyStore handles all queries and insertions to ElasticSearch dependencies
+// DependencyStore handles all queries and insertions of dependencies
 type DependencyStore struct {
   ctx    context.Context
   client *agentReporter.Reporter

--- a/plugin/storage/authorizingproxy/dependencystore/storage.go
+++ b/plugin/storage/authorizingproxy/dependencystore/storage.go
@@ -11,18 +11,18 @@ import (
 
   "github.com/jaegertracing/jaeger/model"
 
-  jaegerClient "github.com/uber/jaeger-client-go"
+  agentReporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
 )
 
 // DependencyStore handles all queries and insertions to ElasticSearch dependencies
 type DependencyStore struct {
   ctx    context.Context
-  client jaegerClient.Reporter
+  client *agentReporter.Reporter
   logger *zap.Logger
 }
 
 // NewDependencyStore returns a DependencyStore
-func NewDependencyStore(client jaegerClient.Reporter, logger *zap.Logger) *DependencyStore {
+func NewDependencyStore(client *agentReporter.Reporter, logger *zap.Logger) *DependencyStore {
   return &DependencyStore{
     ctx:    context.Background(),
     client: client,

--- a/plugin/storage/authorizingproxy/dependencystore/storage.go
+++ b/plugin/storage/authorizingproxy/dependencystore/storage.go
@@ -1,0 +1,43 @@
+package dependencystore
+
+import (
+  "fmt"
+
+  "context"
+  "time"
+
+  "github.com/pkg/errors"
+  "go.uber.org/zap"
+
+  "github.com/jaegertracing/jaeger/model"
+
+  jaegerClient "github.com/uber/jaeger-client-go"
+)
+
+// DependencyStore handles all queries and insertions to ElasticSearch dependencies
+type DependencyStore struct {
+  ctx    context.Context
+  client jaegerClient.Reporter
+  logger *zap.Logger
+}
+
+// NewDependencyStore returns a DependencyStore
+func NewDependencyStore(client jaegerClient.Reporter, logger *zap.Logger) *DependencyStore {
+  return &DependencyStore{
+    ctx:    context.Background(),
+    client: client,
+    logger: logger,
+  }
+}
+
+// WriteDependencies implements dependencystore.Writer#WriteDependencies.
+func (s *DependencyStore) WriteDependencies(ts time.Time, dependencies []model.DependencyLink) error {
+  s.logger.Info(fmt.Sprintf("%+v", dependencies))
+  return nil
+}
+
+
+// GetDependencies returns all interservice dependencies
+func (s *DependencyStore) GetDependencies(endTs time.Time, lookback time.Duration) ([]model.DependencyLink, error) {
+  return nil, errors.New("Reading not supported.")
+}

--- a/plugin/storage/authorizingproxy/factory.go
+++ b/plugin/storage/authorizingproxy/factory.go
@@ -65,7 +65,12 @@ func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
 // CreateSpanWriter implements storage.Factory
 func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
   cfg := f.primaryConfig
-  return proxySpanStore.NewSpanWriter(f.primaryClient, f.logger, f.metricsFactory, cfg.GetProxyBatchSize(), cfg.GetProxyBatchFlushIntervalMs()), nil
+  return proxySpanStore.NewSpanWriter(f.primaryClient,
+    f.logger,
+    f.metricsFactory,
+    cfg.GetProxyBatchSize(),
+    cfg.GetProxyBatchFlushIntervalMs(),
+    cfg.GetProxyIf()), nil
 }
 
 // CreateDependencyReader implements storage.Factory

--- a/plugin/storage/authorizingproxy/factory.go
+++ b/plugin/storage/authorizingproxy/factory.go
@@ -1,0 +1,73 @@
+package authorizingproxy
+
+import (
+  "flag"
+
+  "github.com/spf13/viper"
+  "github.com/uber/jaeger-lib/metrics"
+  "go.uber.org/zap"
+
+  "github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy/config"
+  proxyDepStore "github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy/dependencystore"
+  proxySpanStore "github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy/spanstore"
+  "github.com/jaegertracing/jaeger/storage/dependencystore"
+  "github.com/jaegertracing/jaeger/storage/spanstore"
+
+  jaegerClient "github.com/uber/jaeger-client-go"
+)
+
+type Factory struct {
+  Options *Options
+
+  metricsFactory metrics.Factory
+  logger         *zap.Logger
+
+  primaryConfig config.ClientBuilder
+  primaryClient jaegerClient.Reporter
+}
+
+// NewFactory creates a new Factory.
+func NewFactory() *Factory {
+  return &Factory{
+    Options: NewOptions("authorizingproxy"),
+  }
+}
+
+// AddFlags implements plugin.Configurable
+func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
+  f.Options.AddFlags(flagSet)
+}
+
+// InitFromViper implements plugin.Configurable
+func (f *Factory) InitFromViper(v *viper.Viper) {
+  f.Options.InitFromViper(v)
+  f.primaryConfig = f.Options.GetPrimary()
+}
+
+// Initialize implements storage.Factory
+func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
+  f.metricsFactory, f.logger = metricsFactory, logger
+
+  primaryClient, err := f.primaryConfig.NewClient(logger)
+  if err != nil {
+    return err
+  }
+  f.primaryClient = primaryClient
+  // TODO init archive (cf. https://github.com/jaegertracing/jaeger/pull/604)
+  return nil
+}
+
+// CreateSpanReader implements storage.Factory
+func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
+  return proxySpanStore.NewSpanReader(f.primaryClient, f.logger, f.metricsFactory), nil
+}
+
+// CreateSpanWriter implements storage.Factory
+func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
+  return proxySpanStore.NewSpanWriter(f.primaryClient, f.logger, f.metricsFactory), nil
+}
+
+// CreateDependencyReader implements storage.Factory
+func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
+  return proxyDepStore.NewDependencyStore(f.primaryClient, f.logger), nil
+}

--- a/plugin/storage/authorizingproxy/factory_test.go
+++ b/plugin/storage/authorizingproxy/factory_test.go
@@ -1,0 +1,228 @@
+package authorizingproxy
+
+import (
+  "fmt"
+  "log"
+  "net"
+  "net/http"
+  "strconv"
+  "testing"
+  "time"
+
+  "github.com/gorilla/mux"
+  "github.com/spf13/viper"
+  "github.com/uber/tchannel-go"
+  "github.com/uber/tchannel-go/thrift"
+  "go.uber.org/zap"
+
+  "github.com/uber/jaeger-lib/metrics"
+
+  collectorApp "github.com/jaegertracing/jaeger/cmd/collector/app"
+  agentReporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
+  basicB "github.com/jaegertracing/jaeger/cmd/builder"
+  "github.com/jaegertracing/jaeger/cmd/collector/app/builder"
+  "github.com/jaegertracing/jaeger/cmd/flags"
+  "github.com/jaegertracing/jaeger/plugin/storage"
+  pMetrics "github.com/jaegertracing/jaeger/pkg/metrics"
+  "github.com/jaegertracing/jaeger/pkg/healthcheck"
+  "github.com/jaegertracing/jaeger/storage/spanstore"
+  "github.com/jaegertracing/jaeger/pkg/recoveryhandler"
+
+  "github.com/jaegertracing/jaeger/pkg/discovery"
+
+  jc "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+  zc "github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+
+  jaegerThrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+)
+
+var (
+  CollectorTChannelPort = 14267
+  CollectorHTTPPort = 14268
+  CollectorZipkinHTTPPort = 14269
+)
+
+func startCollector() spanstore.Writer {
+
+  serviceName := "jaeger-collector"
+
+  v := viper.New()
+  v.Set("collector.host-port", "127.0.0.1:" + strconv.Itoa(CollectorTChannelPort))
+  v.Set("authorizingproxy.proxy-hostport", "127.0.0.1:10000")
+
+  builderOpts := new(builder.CollectorOptions).InitFromViper(v)
+
+  storageFactory, err := storage.NewFactory(storage.FactoryConfig{ "authorizing_proxy", "authorizing_proxy" })
+  if err != nil {
+    log.Fatalf("Cannot initialize storage factory: %v", err)
+    return nil
+  }
+
+  sFlags := new(flags.SharedFlags).InitFromViper(v)
+  logger, err := sFlags.NewLogger(zap.NewProductionConfig())
+  if err != nil {
+    return nil
+  }
+
+  hc, err := healthcheck.
+    New(healthcheck.Unavailable, healthcheck.Logger(logger)).
+    Serve(builderOpts.CollectorHealthCheckHTTPPort)
+  if err != nil {
+    logger.Fatal("Could not start the health check server.", zap.Error(err))
+  }
+
+  mBldr := new(pMetrics.Builder).InitFromViper(v)
+  //metricsFactory, err := mBldr.CreateMetricsFactory("jaeger-collector")
+  //if err != nil {
+  //  logger.Fatal("Cannot create metrics factory.", zap.Error(err))
+  //  return nil
+  //}
+
+  storageFactory.InitFromViper(v)
+  if err := storageFactory.Initialize(metrics.NullFactory, logger); err != nil {
+    logger.Fatal("Failed to init storage factory", zap.Error(err))
+    return nil
+  }
+
+  spanWriter, err := storageFactory.CreateSpanWriter()
+  if err != nil {
+    logger.Fatal("Failed to create span writer", zap.Error(err))
+    return nil
+  }
+
+  handlerBuilder, err := builder.NewSpanHandlerBuilder(
+    builderOpts,
+    spanWriter,
+    basicB.Options.LoggerOption(logger),
+    basicB.Options.MetricsFactoryOption(metrics.NullFactory),
+  )
+  if err != nil {
+    logger.Fatal("Unable to set up builder", zap.Error(err))
+    return nil
+  }
+
+  ch, err := tchannel.NewChannel(serviceName, &tchannel.ChannelOptions{})
+  if err != nil {
+    logger.Fatal("Unable to create new TChannel", zap.Error(err))
+    return nil
+  }
+  server := thrift.NewServer(ch)
+  zipkinSpansHandler, jaegerBatchesHandler := handlerBuilder.BuildHandlers()
+  server.Register(jc.NewTChanCollectorServer(jaegerBatchesHandler))
+  server.Register(zc.NewTChanZipkinCollectorServer(zipkinSpansHandler))
+
+  portStr := ":" + strconv.Itoa(CollectorTChannelPort)
+  listener, err := net.Listen("tcp", portStr)
+  if err != nil {
+    logger.Fatal("Unable to start listening on channel", zap.Error(err))
+    return nil
+  }
+  ch.Serve(listener)
+
+      r := mux.NewRouter()
+      apiHandler := collectorApp.NewAPIHandler(jaegerBatchesHandler)
+      apiHandler.RegisterRoutes(r)
+      if h := mBldr.Handler(); h != nil {
+        logger.Info("Registering metrics handler with HTTP server", zap.String("route", mBldr.HTTPRoute))
+        r.Handle(mBldr.HTTPRoute, h)
+      }
+      httpPortStr := ":" + strconv.Itoa(CollectorHTTPPort)
+      recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
+
+      //go startZipkinHTTPAPI(logger, CollectorZipkinHTTPPort, zipkinSpansHandler, recoveryHandler)
+
+      logger.Info("Starting Jaeger Collector HTTP server", zap.Int("http-port", CollectorHTTPPort))
+
+      go func() {
+        if err := http.ListenAndServe(httpPortStr, recoveryHandler(r)); err != nil {
+          logger.Fatal("Could not launch service", zap.Error(err))
+        }
+        hc.Set(healthcheck.Unavailable)
+      }()
+
+      hc.Ready()
+
+  return spanWriter
+}
+
+func createAgentReporter() (*agentReporter.Reporter, error) {
+  v := viper.New()
+  sFlags := new(flags.SharedFlags).InitFromViper(v)
+  logger, err := sFlags.NewLogger(zap.NewProductionConfig())
+  if err != nil {
+    return nil, err
+  }
+
+  discoverer := discovery.FixedDiscoverer([]string{ "127.0.0.1:" + strconv.Itoa(CollectorTChannelPort) })
+  notifier := &discovery.Dispatcher{}
+
+  builder := agentReporter.NewBuilder()
+  builder.WithDiscoverer(discoverer)
+  builder.WithDiscoveryNotifier(notifier)
+
+  return builder.CreateReporter(metrics.NullFactory, logger)
+
+}
+
+func strToRef(s string) *string {
+  return &s
+}
+
+func TestBasics(t *testing.T) {
+
+  spanWriter := startCollector()
+  if spanWriter == nil {
+    t.Error("Expected factory to be not nil")
+  }
+
+  reporter, err := createAgentReporter()
+  if err != nil {
+    t.Error(fmt.Sprintf("%+v", err))
+  }
+
+  batch := &jaegerThrift.Batch{}
+  batch.Process = &jaegerThrift.Process{
+    "integration-test-service",
+    make([]*jaegerThrift.Tag, 0) }
+
+  span := jaegerThrift.Span{
+    int64(0),
+    int64(1),
+    int64(100),
+    int64(0),
+    "integration-test-operation",
+    make([]*jaegerThrift.SpanRef, 0),
+    int32(0),
+    int64(1234567890),
+    int64(1000),
+    make([]*jaegerThrift.Tag, 0),
+    []*jaegerThrift.Log{
+      &jaegerThrift.Log{
+        int64(1234567890),
+        []*jaegerThrift.Tag{
+          &jaegerThrift.Tag{
+            Key: "event",
+            VType: jaegerThrift.TagType_STRING,
+            VStr: strToRef("baggage"),
+          },
+          &jaegerThrift.Tag{
+            Key: "key",
+            VType: jaegerThrift.TagType_STRING,
+            VStr: strToRef("x-klarrio-auth-key"),
+          },
+          &jaegerThrift.Tag{
+            Key: "value",
+            VType: jaegerThrift.TagType_STRING,
+            VStr: strToRef("mmmm"),
+          },
+        },
+      },
+    },
+  }
+  batch.Spans = []*jaegerThrift.Span{ &span }
+
+  reporter.EmitBatch(batch)
+
+  time.Sleep(time.Duration(5) * time.Second)
+
+}

--- a/plugin/storage/authorizingproxy/factory_test.go
+++ b/plugin/storage/authorizingproxy/factory_test.go
@@ -48,7 +48,9 @@ func startCollector() spanstore.Writer {
 
   v := viper.New()
   v.Set("collector.host-port", "127.0.0.1:" + strconv.Itoa(CollectorTChannelPort))
-  v.Set("authorizingproxy.proxy-hostport", "127.0.0.1:10000")
+  v.Set("authorizingproxy.proxy-host-port", "127.0.0.1:10000")
+  v.Set("authorizingproxy.proxy-batch-size", "50")
+  v.Set("authorizingproxy.proxy-batch-flush-interval-ms", "500")
 
   builderOpts := new(builder.CollectorOptions).InitFromViper(v)
 

--- a/plugin/storage/authorizingproxy/options.go
+++ b/plugin/storage/authorizingproxy/options.go
@@ -1,0 +1,97 @@
+package authorizingproxy
+
+import (
+  "flag"
+  "github.com/spf13/viper"
+  "github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy/config"
+)
+
+const (
+  suffixProxyHostPort              = ".proxy-hostport"
+  suffixProxyIf                    = ".proxy-if"
+  suffixProxyQueueSize             = ".proxy-queue-size"
+  suffixProxyBufferFlushIntervalMs = ".proxy-buffer-flush-interval-ms"
+)
+
+type Options struct {
+  primary *namespaceConfig
+  others map[string]*namespaceConfig
+}
+
+// the Servers field in config.Configuration is a list, which we cannot represent with flags.
+// This struct adds a plain string field that can be bound to flags and is then parsed when
+// preparing the actual config.Configuration.
+type namespaceConfig struct {
+  config.Configuration
+  namespace string
+}
+
+// NewOptions creates a new Options struct.
+func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
+  // TODO all default values should be defined via cobra flags
+  options := &Options{
+    primary: &namespaceConfig{
+      Configuration: config.Configuration{
+        ProxyHostPort:              "",
+        ProxyIf:                    "",
+        ProxyQueueSize:             0,
+        ProxyBufferFlushIntervalMs: 0,
+      },
+      namespace: primaryNamespace,
+    },
+    others: make(map[string]*namespaceConfig, len(otherNamespaces)),
+  }
+
+  for _, namespace := range otherNamespaces {
+    options.others[namespace] = &namespaceConfig{namespace: namespace}
+  }
+
+  return options
+}
+
+// AddFlags adds flags for Options
+func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
+  addFlags(flagSet, opt.primary)
+  for _, cfg := range opt.others {
+    addFlags(flagSet, cfg)
+  }
+}
+
+func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
+  flagSet.String(
+    nsConfig.namespace+suffixProxyHostPort,
+    nsConfig.ProxyHostPort,
+    "The host port string of the collector to proxy the requests to")
+  flagSet.String(
+    nsConfig.namespace+suffixProxyIf,
+    nsConfig.ProxyIf,
+    "The condition under which the requests should be proxied")
+  flagSet.Int(
+    nsConfig.namespace+suffixProxyQueueSize,
+    nsConfig.ProxyQueueSize,
+    "queue size - TODO figure out")
+  flagSet.Int(
+    nsConfig.namespace+suffixProxyBufferFlushIntervalMs,
+    nsConfig.ProxyBufferFlushIntervalMs,
+    "buffer flush interval - TODO figure out")
+}
+
+// InitFromViper initializes Options with properties from viper
+func (opt *Options) InitFromViper(v *viper.Viper) {
+  initFromViper(opt.primary, v)
+  for _, cfg := range opt.others {
+    initFromViper(cfg, v)
+  }
+}
+
+func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
+  cfg.ProxyHostPort = v.GetString(cfg.namespace + suffixProxyHostPort)
+  cfg.ProxyIf = v.GetString(cfg.namespace + suffixProxyIf)
+  cfg.ProxyQueueSize = v.GetInt(cfg.namespace + suffixProxyQueueSize)
+  cfg.ProxyBufferFlushIntervalMs = v.GetInt(cfg.namespace + suffixProxyBufferFlushIntervalMs)
+}
+
+// GetPrimary returns primary configuration.
+func (opt *Options) GetPrimary() *config.Configuration {
+  return &opt.primary.Configuration
+}

--- a/plugin/storage/authorizingproxy/options.go
+++ b/plugin/storage/authorizingproxy/options.go
@@ -2,15 +2,17 @@ package authorizingproxy
 
 import (
   "flag"
+
   "github.com/spf13/viper"
+  
   "github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy/config"
 )
 
 const (
-  suffixProxyHostPort              = ".proxy-hostport"
+  suffixProxyHostPort              = ".proxy-host-port"
   suffixProxyIf                    = ".proxy-if"
-  suffixProxyQueueSize             = ".proxy-queue-size"
-  suffixProxyBufferFlushIntervalMs = ".proxy-buffer-flush-interval-ms"
+  suffixProxyBatchSize             = ".proxy-batch-size"
+  suffixProxyBatchFlushIntervalMs  = ".proxy-batch-flush-interval-ms"
 )
 
 type Options struct {
@@ -34,8 +36,8 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
       Configuration: config.Configuration{
         ProxyHostPort:              "",
         ProxyIf:                    "",
-        ProxyQueueSize:             0,
-        ProxyBufferFlushIntervalMs: 0,
+        ProxyBatchSize:             50,
+        ProxyBatchFlushIntervalMs:  500,
       },
       namespace: primaryNamespace,
     },
@@ -61,19 +63,19 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
   flagSet.String(
     nsConfig.namespace+suffixProxyHostPort,
     nsConfig.ProxyHostPort,
-    "The host port string of the collector to proxy the requests to")
+    "The host port string of the collector to proxy the requests to. Can be comma delimited list.")
   flagSet.String(
     nsConfig.namespace+suffixProxyIf,
     nsConfig.ProxyIf,
-    "The condition under which the requests should be proxied")
+    "The condition under which the requests should be proxied.")
   flagSet.Int(
-    nsConfig.namespace+suffixProxyQueueSize,
-    nsConfig.ProxyQueueSize,
-    "queue size - TODO figure out")
+    nsConfig.namespace+suffixProxyBatchSize,
+    nsConfig.ProxyBatchSize,
+    "Batch size - maximum number of items to send to a collector in a single batch.")
   flagSet.Int(
-    nsConfig.namespace+suffixProxyBufferFlushIntervalMs,
-    nsConfig.ProxyBufferFlushIntervalMs,
-    "buffer flush interval - TODO figure out")
+    nsConfig.namespace+suffixProxyBatchFlushIntervalMs,
+    nsConfig.ProxyBatchFlushIntervalMs,
+    "Batch flush interval - maximum number of milliseconds to wait until flushing a batch, even if batch size hasn't been reached.")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -87,8 +89,8 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
   cfg.ProxyHostPort = v.GetString(cfg.namespace + suffixProxyHostPort)
   cfg.ProxyIf = v.GetString(cfg.namespace + suffixProxyIf)
-  cfg.ProxyQueueSize = v.GetInt(cfg.namespace + suffixProxyQueueSize)
-  cfg.ProxyBufferFlushIntervalMs = v.GetInt(cfg.namespace + suffixProxyBufferFlushIntervalMs)
+  cfg.ProxyBatchSize = v.GetInt(cfg.namespace + suffixProxyBatchSize)
+  cfg.ProxyBatchFlushIntervalMs = v.GetInt(cfg.namespace + suffixProxyBatchFlushIntervalMs)
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/authorizingproxy/proxy_if/proxy_if.go
+++ b/plugin/storage/authorizingproxy/proxy_if/proxy_if.go
@@ -1,0 +1,99 @@
+package proxy_if
+
+import (
+  "errors"
+  "fmt"
+  "regexp"
+  "strings"
+)
+
+const (
+  ProxyIfType_Baggage string = "baggage"
+  ProxyIfType_Tag string = "tag"
+)
+
+type ProxyIf struct {
+  input string
+  errors []string
+  ttype string
+  key string
+  value string
+}
+
+func NewProxyIf(input string) *ProxyIf {
+  p := &ProxyIf{
+    input: strings.TrimSpace(input),
+    errors: make([]string, 0),
+    ttype: "",
+    key: "",
+    value: "",
+  }
+  p.parseInput()
+  return p
+}
+
+func (pi *ProxyIf) Errors() []string {
+  return pi.errors
+}
+
+func (pi *ProxyIf) IsEmpty() bool {
+  return pi.IsValid() && pi.input == ""
+}
+
+func (pi *ProxyIf) IsValid() bool {
+  return len(pi.errors) == 0
+}
+
+func (pi *ProxyIf) IsBaggage() bool {
+  return pi.ttype == ProxyIfType_Baggage
+}
+
+func (pi *ProxyIf) IsTag() bool {
+  return pi.ttype == ProxyIfType_Tag
+}
+
+func (pi *ProxyIf) Key() string {
+  return pi.key
+}
+
+func (pi *ProxyIf) Value() string {
+  return pi.value
+}
+
+func (pi *ProxyIf) parseInput() {
+  re := regexp.MustCompile("(baggage|tag)\\.(.[^=]*)==(.*)")
+  if pi.input != "" {
+    matches := re.FindAllStringSubmatch(pi.input, -1)
+    if len(matches) != 1 {
+      pi.errors = append(pi.errors, fmt.Sprintf("Input '%+v' not valid proxy-if expression.", pi.input))
+    } else {
+      if ttype, key, value, err := pi.unpack(matches[0]); err == nil {
+        pi.ttype = ttype
+        pi.key = key
+        pi.value = value
+      } else {
+        pi.errors = append(pi.errors, fmt.Sprintf("%+v", err))
+      }
+    }
+  }
+}
+
+func (pi *ProxyIf) unpack(input []string) (string, string, string, error) {
+  if len(input) != 4 {
+    return "", "", "", errors.New("Input length must be 4 items.")
+  } else {
+    complete := input[0]
+    ttype := input[1]
+    key := input[2]
+    value := input[3]
+    if complete != fmt.Sprintf("%s.%s==%s", ttype, key, value) {
+      return "", "", "", errors.New("Input not in the correct format.")
+    } else {
+      if ttype != ProxyIfType_Baggage && ttype != ProxyIfType_Tag {
+        return "", "", "", errors.New("Input type must be either baggage or tag.")
+      } else {
+        return ttype, key, value, nil
+      }
+    }
+  }
+}

--- a/plugin/storage/authorizingproxy/proxy_if/proxy_if_test.go
+++ b/plugin/storage/authorizingproxy/proxy_if/proxy_if_test.go
@@ -1,0 +1,52 @@
+package proxy_if
+
+import (
+  "testing"
+  "github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy/proxy_if"
+)
+
+func TestValidBaggage(t *testing.T) {
+  proxyIf := proxy_if.NewProxyIf("baggage.x-test-key==test-value")
+  if !proxyIf.IsValid() {
+    t.Error("Expected the input to be valid.")
+  }
+  if !proxyIf.IsBaggage() {
+    t.Error("Expected the input to be a baggage.")
+  }
+  if proxyIf.Key() != "x-test-key" {
+    t.Error("Invalid key.")
+  }
+  if proxyIf.Value() != "test-value" {
+    t.Error("Invalid value.")
+  }
+}
+
+func TestValidTag(t *testing.T) {
+  proxyIf := proxy_if.NewProxyIf("tag.x-test-key==test-value")
+  if !proxyIf.IsValid() {
+    t.Error("Expected the input to be valid.")
+  }
+  if !proxyIf.IsTag() {
+    t.Error("Expected the input to be a tag.")
+  }
+  if proxyIf.Key() != "x-test-key" {
+    t.Error("Invalid key.")
+  }
+  if proxyIf.Value() != "test-value" {
+    t.Error("Invalid value.")
+  }
+}
+
+func TestInvalidInputType(t *testing.T) {
+  proxyIf := proxy_if.NewProxyIf("invalid-type.x-test-key==value")
+  if proxyIf.IsValid() {
+    t.Error("Expected the input to be invalid.")
+  }
+}
+
+func TestIncompleteInput(t *testing.T) {
+  proxyIf := proxy_if.NewProxyIf("baggage.x-test-key=")
+  if proxyIf.IsValid() {
+    t.Error("Expected the input to be invalid.")
+  }
+}

--- a/plugin/storage/authorizingproxy/spanstore/reader.go
+++ b/plugin/storage/authorizingproxy/spanstore/reader.go
@@ -10,21 +10,21 @@ import (
 
   "github.com/jaegertracing/jaeger/storage/spanstore"
   storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
-  jaegerClient "github.com/uber/jaeger-client-go"
+  agentReporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
 )
 
 type SpanReader struct {
   ctx    context.Context
-  client jaegerClient.Reporter
+  client *agentReporter.Reporter
   logger *zap.Logger
 }
 
 // NewSpanReader returns a new SpanReader with a metrics.
-func NewSpanReader(client jaegerClient.Reporter, logger *zap.Logger, metricsFactory metrics.Factory) spanstore.Reader {
+func NewSpanReader(client *agentReporter.Reporter, logger *zap.Logger, metricsFactory metrics.Factory) spanstore.Reader {
   return storageMetrics.NewReadMetricsDecorator(newSpanReader(client, logger), metricsFactory)
 }
 
-func newSpanReader(client jaegerClient.Reporter, logger *zap.Logger) *SpanReader {
+func newSpanReader(client *agentReporter.Reporter, logger *zap.Logger) *SpanReader {
   ctx := context.Background()
   return &SpanReader{
     ctx:                     ctx,

--- a/plugin/storage/authorizingproxy/spanstore/reader.go
+++ b/plugin/storage/authorizingproxy/spanstore/reader.go
@@ -1,0 +1,54 @@
+package spanstore
+
+import (
+  "context"
+
+  "github.com/pkg/errors"
+  "github.com/jaegertracing/jaeger/model"
+  "github.com/uber/jaeger-lib/metrics"
+  "go.uber.org/zap"
+
+  "github.com/jaegertracing/jaeger/storage/spanstore"
+  storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
+  jaegerClient "github.com/uber/jaeger-client-go"
+)
+
+type SpanReader struct {
+  ctx    context.Context
+  client jaegerClient.Reporter
+  logger *zap.Logger
+}
+
+// NewSpanReader returns a new SpanReader with a metrics.
+func NewSpanReader(client jaegerClient.Reporter, logger *zap.Logger, metricsFactory metrics.Factory) spanstore.Reader {
+  return storageMetrics.NewReadMetricsDecorator(newSpanReader(client, logger), metricsFactory)
+}
+
+func newSpanReader(client jaegerClient.Reporter, logger *zap.Logger) *SpanReader {
+  ctx := context.Background()
+  return &SpanReader{
+    ctx:                     ctx,
+    client:                  client,
+    logger:                  logger,
+  }
+}
+
+// GetTrace takes a traceID and returns a Trace associated with that traceID
+func (s *SpanReader) GetTrace(traceID model.TraceID) (*model.Trace, error) {
+  return nil, errors.New("Reading not supported.")
+}
+
+// FindTraces retrieves traces that match the traceQuery
+func (s *SpanReader) FindTraces(traceQuery *spanstore.TraceQueryParameters) ([]*model.Trace, error) {
+  return nil, errors.New("Reading not supported.")
+}
+
+// GetServices returns all services traced by Jaeger, ordered by frequency
+func (s *SpanReader) GetServices() ([]string, error) {
+  return nil, errors.New("Reading not supported.")
+}
+
+// GetOperations returns all operations for a specific service traced by Jaeger
+func (s *SpanReader) GetOperations(service string) ([]string, error) {
+  return nil, errors.New("Reading not supported.")
+}

--- a/plugin/storage/authorizingproxy/spanstore/writer.go
+++ b/plugin/storage/authorizingproxy/spanstore/writer.go
@@ -62,7 +62,7 @@ func NewSpanWriter(
   return spanWriter
 }
 
-// WriteSpan writes a span and its corresponding service:operation in ElasticSearch
+// WriteSpan writes a span and its corresponding service:operation to a proxied collector
 func (s *SpanWriter) WriteSpan(span *model.Span) error {
   
   forwardable := false

--- a/plugin/storage/authorizingproxy/spanstore/writer.go
+++ b/plugin/storage/authorizingproxy/spanstore/writer.go
@@ -2,51 +2,99 @@ package spanstore
 
 import (
   "fmt"
+  "sync"
+  "time"
   
   "github.com/jaegertracing/jaeger/model"
-  //"github.com/jaegertracing/jaeger/model/converter/json"
   "github.com/uber/jaeger-lib/metrics"
   "go.uber.org/zap"
   
-  jaegerClient "github.com/uber/jaeger-client-go"
+  agentReporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
+  jaegerThrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+  thriftConverter "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
 )
 
 type SpanWriter struct {
-  client        jaegerClient.Reporter
-  logger        *zap.Logger
+  client             *agentReporter.Reporter
+  logger             *zap.Logger
+  memory             map[*model.Process][]*model.Span
+  lock               *sync.Mutex
+  maxBatchSize       int
+  commitBatchesEvery time.Duration
+  batchCommiter      *time.Ticker
 }
 
 func NewSpanWriter(
-  client jaegerClient.Reporter,
+  client *agentReporter.Reporter,
   logger *zap.Logger,
   metricsFactory metrics.Factory,
+  maxBatchSize int,
+  commitBatchesEvery time.Duration,
 ) *SpanWriter {
-  return &SpanWriter{
-    client: client,
-    logger: logger,
+
+  ticker := time.NewTicker(commitBatchesEvery)
+
+  spanWriter := &SpanWriter{
+    client:             client,
+    logger:             logger,
+    memory:             make(map[*model.Process][]*model.Span),
+    lock:               &sync.Mutex{},
+    maxBatchSize:       maxBatchSize,
+    commitBatchesEvery: commitBatchesEvery,
+    batchCommiter:      ticker,
   }
+
+  go func() {
+    for range ticker.C {
+      spanWriter.submitAll()
+    }
+  }()
+
+  return spanWriter
 }
 
 // WriteSpan writes a span and its corresponding service:operation in ElasticSearch
 func (s *SpanWriter) WriteSpan(span *model.Span) error {
   
-  // Convert model.Span into json.Span
-  //jsonSpan := json.FromDomainEmbedProcess(span)
+  forwardable := false
+  spans := make([]*model.Span, 0)
 
   for _, log := range span.Logs {
     isBaggage, k, v := s.maybeGetBaggage(log)
-    fmt.Println(fmt.Sprintf(" =====================> got a span log %+v, %+v, %+v", isBaggage, k, v))
+    if isBaggage == true && k != v { // TODO: condition
+      forwardable = true
+      break
+    }
   }
 
-  // TODO: implement
-  //s.logger.Info(fmt.Sprintf("%+v", jsonSpan))
+  if forwardable == true {
+    
+    spans = []*model.Span{ span }
+    
+    s.lock.Lock()
+    if val, ok := s.memory[span.Process]; ok {
+      spans = append(val, span)
+    }
+    s.lock.Unlock()
+
+    if len(spans) < s.maxBatchSize {
+      s.lock.Lock()
+      s.memory[span.Process] = spans
+      fmt.Println(fmt.Sprintf("Updating batch for %+v to %+v items.", &span.Process, len(s.memory[span.Process])))
+      s.lock.Unlock()
+    } else {
+      fmt.Println(fmt.Sprintf("Immediately submitting batch of %+v items for process %+v (%+v).", len(spans), &span.Process, s.maxBatchSize))
+      s.submitBatch(span.Process, spans)
+    }
+
+  }
 
   return nil
 }
 
 // Close closes SpanWriter
 func (s *SpanWriter) Close() error {
-  s.client.Close()
+  s.batchCommiter.Stop()
   return nil
 }
 
@@ -64,4 +112,103 @@ func (s *SpanWriter) maybeGetBaggage(log model.Log) (bool, string, string) {
     }
   }
   return (event == "baggage" && key != "" && value != ""), key, value
+}
+
+func (s *SpanWriter) submitAll() {
+  copied := make(map[*model.Process][]*model.Span)
+  s.lock.Lock()
+  for k, v := range s.memory {
+    copied[k] = v
+  }
+  s.lock.Unlock()
+  for k, v := range copied {
+    s.submitBatch(k, v)
+  }
+}
+
+func (s *SpanWriter) submitBatch(process *model.Process, spans []*model.Span) {
+
+  batch := &jaegerThrift.Batch{}
+  batch.Process = &jaegerThrift.Process{
+    process.ServiceName,
+    s.convertProcessTagsToDomain(process.Tags) }
+  batch.Spans = thriftConverter.FromDomain(spans)
+
+  if err := s.client.EmitBatch(batch); err != nil {
+    fmt.Println(fmt.Sprintf("Error while submitting batch of %+v items for process %+v.", len(spans), process))
+  } else {
+    fmt.Println(fmt.Sprintf("Batch of %+v items for process %+v submitted.", len(spans), process))
+    s.lock.Lock()
+    delete(s.memory, process)
+    s.lock.Unlock()
+  }
+
+}
+
+func (s *SpanWriter) convertProcessTagsToDomain(keyValues model.KeyValues) []*jaegerThrift.Tag {
+  tags := make([]*jaegerThrift.Tag, 0)
+  for _, kv := range keyValues {
+    tags = append(tags, s.convertProcessTagToDomain(kv))
+  }
+  return tags
+}
+
+func (s *SpanWriter) convertProcessTagToDomain(kv model.KeyValue) *jaegerThrift.Tag {
+
+  if kv.VType == model.StringType {
+    stringValue := string(kv.VStr)
+    return &jaegerThrift.Tag{
+      Key:   kv.Key,
+      VType: jaegerThrift.TagType_STRING,
+      VStr:  &stringValue,
+    }
+  }
+
+  if kv.VType == model.Int64Type {
+    intValue := kv.Int64()
+    return &jaegerThrift.Tag{
+      Key:   kv.Key,
+      VType: jaegerThrift.TagType_LONG,
+      VLong: &intValue,
+    }
+  }
+
+  if kv.VType == model.BinaryType {
+    binaryValue := kv.Binary()
+    return &jaegerThrift.Tag{
+      Key:     kv.Key,
+      VType:   jaegerThrift.TagType_BINARY,
+      VBinary: binaryValue,
+    }
+  }
+
+  if kv.VType == model.BoolType {
+    boolValue := false
+    if kv.VNum > 0 {
+      boolValue = true
+    }
+    return &jaegerThrift.Tag{
+      Key:   kv.Key,
+      VType: jaegerThrift.TagType_BOOL,
+      VBool: &boolValue,
+    }
+  }
+
+  if kv.VType == model.Float64Type {
+    floatValue := kv.Float64()
+    return &jaegerThrift.Tag{
+      Key:     kv.Key,
+      VType:   jaegerThrift.TagType_DOUBLE,
+      VDouble: &floatValue,
+    }
+  }
+
+  errString := fmt.Sprintf("No suitable tag type found for: %#v", kv.VType)
+  errTag := &jaegerThrift.Tag{
+    Key:   "Error",
+    VType: jaegerThrift.TagType_STRING,
+    VStr:  &errString,
+  }
+
+  return errTag
 }

--- a/plugin/storage/authorizingproxy/spanstore/writer.go
+++ b/plugin/storage/authorizingproxy/spanstore/writer.go
@@ -1,0 +1,67 @@
+package spanstore
+
+import (
+  "fmt"
+  
+  "github.com/jaegertracing/jaeger/model"
+  //"github.com/jaegertracing/jaeger/model/converter/json"
+  "github.com/uber/jaeger-lib/metrics"
+  "go.uber.org/zap"
+  
+  jaegerClient "github.com/uber/jaeger-client-go"
+)
+
+type SpanWriter struct {
+  client        jaegerClient.Reporter
+  logger        *zap.Logger
+}
+
+func NewSpanWriter(
+  client jaegerClient.Reporter,
+  logger *zap.Logger,
+  metricsFactory metrics.Factory,
+) *SpanWriter {
+  return &SpanWriter{
+    client: client,
+    logger: logger,
+  }
+}
+
+// WriteSpan writes a span and its corresponding service:operation in ElasticSearch
+func (s *SpanWriter) WriteSpan(span *model.Span) error {
+  
+  // Convert model.Span into json.Span
+  //jsonSpan := json.FromDomainEmbedProcess(span)
+
+  for _, log := range span.Logs {
+    isBaggage, k, v := s.maybeGetBaggage(log)
+    fmt.Println(fmt.Sprintf(" =====================> got a span log %+v, %+v, %+v", isBaggage, k, v))
+  }
+
+  // TODO: implement
+  //s.logger.Info(fmt.Sprintf("%+v", jsonSpan))
+
+  return nil
+}
+
+// Close closes SpanWriter
+func (s *SpanWriter) Close() error {
+  s.client.Close()
+  return nil
+}
+
+func (s *SpanWriter) maybeGetBaggage(log model.Log) (bool, string, string) {
+  event, key, value := "", "", ""
+  for _, tag := range log.Fields {
+    if tag.Key == "event" && tag.VType == model.StringType {
+      event = tag.VStr
+    }
+    if tag.Key == "key" && tag.VType == model.StringType {
+      key = tag.VStr
+    }
+    if tag.Key == "value" && tag.VType == model.StringType {
+      value = tag.VStr
+    }
+  }
+  return (event == "baggage" && key != "" && value != ""), key, value
+}

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/plugin"
+	"github.com/jaegertracing/jaeger/plugin/storage/authorizingproxy"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/memory"
@@ -32,12 +33,13 @@ import (
 )
 
 const (
-	cassandraStorageType     = "cassandra"
-	elasticsearchStorageType = "elasticsearch"
-	memoryStorageType        = "memory"
+	authorizingProxyStorageType = "authorizing_proxy"
+	cassandraStorageType        = "cassandra"
+	elasticsearchStorageType    = "elasticsearch"
+	memoryStorageType           = "memory"
 )
 
-var allStorageTypes = []string{cassandraStorageType, elasticsearchStorageType, memoryStorageType}
+var allStorageTypes = []string{authorizingProxyStorageType, cassandraStorageType, elasticsearchStorageType, memoryStorageType}
 
 // Factory implements storage.Factory interface as a meta-factory for storage components.
 type Factory struct {
@@ -66,6 +68,8 @@ func NewFactory(config FactoryConfig) (*Factory, error) {
 
 func (f *Factory) getFactoryOfType(factoryType string) (storage.Factory, error) {
 	switch factoryType {
+	case authorizingProxyStorageType:
+		return authorizingproxy.NewFactory(), nil
 	case cassandraStorageType:
 		return cassandra.NewFactory(), nil
 	case elasticsearchStorageType:

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	authorizingProxyStorageType = "authorizing_proxy"
+	authorizingProxyStorageType = "authorizingproxy"
 	cassandraStorageType        = "cassandra"
 	elasticsearchStorageType    = "elasticsearch"
 	memoryStorageType           = "memory"


### PR DESCRIPTION
PR will extra jaeger storage types. Klarrio specific.

Storage 1: `authorizingproxy`
---
Given a collector with --span-storage.type=authorizingproxy (or whatever it will be called when complete), forward spans to another collector using an embedded agent reporter.
Optionally, forward only if a certain condition is met.