### PR TITLE
Add script that auto orders imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.xml
 *.swp
 fmt.log
+import.log
 lint.log
 cover.html
 .envrc

--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ lint:
 	@[ ! -s "$(LINT_LOG)" ] || (echo "Lint Failures" | cat - $(LINT_LOG) && false)
 	@$(GOFMT) -e -s -l $(ALL_SRC) > $(FMT_LOG)
 	@./scripts/updateLicenses.sh >> $(FMT_LOG)
-	@./scripts/import-order-cleanup.sh stdout > $(IMPORT_LOG)
-	@[ ! -s "$(FMT_LOG)" ] || (echo "Go fmt or license check failures, run 'make fmt'" | cat - $(FMT_LOG) && false)
+	@./scripts/import-order-cleanup.sh stdout >> $(IMPORT_LOG)
+	@[[ ! -s "$(FMT_LOG)" && ! -s "$(IMPORT_LOG)" ]] || (echo "Go fmt, license check, or import ordering failures, run 'make fmt'" | cat - $(FMT_LOG) && false)
 
 .PHONY: install-glide
 install-glide:

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,9 @@ nocover:
 
 .PHONY: fmt
 fmt:
+	./scripts/import-order-cleanup.sh inplace
 	$(GOFMT) -e -s -l -w $(ALL_SRC)
 	./scripts/updateLicenses.sh
-	./scripts/import-order-cleanup.sh inplace
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ nocover:
 fmt:
 	$(GOFMT) -e -s -l -w $(ALL_SRC)
 	./scripts/updateLicenses.sh
-	./scripts/import-order-cleanup.sh
+	./scripts/import-order-cleanup.sh inplace
 
 .PHONY: lint
 lint:
@@ -110,6 +110,7 @@ lint:
 	@[ ! -s "$(LINT_LOG)" ] || (echo "Lint Failures" | cat - $(LINT_LOG) && false)
 	@$(GOFMT) -e -s -l $(ALL_SRC) > $(FMT_LOG)
 	@./scripts/updateLicenses.sh >> $(FMT_LOG)
+	@./scripts/import-order-cleanup.sh stdout >> $(FMT_LOG)
 	@[ ! -s "$(FMT_LOG)" ] || (echo "Go fmt or license check failures, run 'make fmt'" | cat - $(FMT_LOG) && false)
 
 .PHONY: install-glide

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ GOVET=go vet
 GOFMT=gofmt
 FMT_LOG=fmt.log
 LINT_LOG=lint.log
+IMPORT_LOG=import.log
 
 GIT_SHA=$(shell git rev-parse HEAD)
 GIT_CLOSEST_TAG=$(shell git describe --abbrev=0 --tags)
@@ -110,7 +111,7 @@ lint:
 	@[ ! -s "$(LINT_LOG)" ] || (echo "Lint Failures" | cat - $(LINT_LOG) && false)
 	@$(GOFMT) -e -s -l $(ALL_SRC) > $(FMT_LOG)
 	@./scripts/updateLicenses.sh >> $(FMT_LOG)
-	@./scripts/import-order-cleanup.sh stdout >> $(FMT_LOG)
+	@./scripts/import-order-cleanup.sh stdout > $(IMPORT_LOG)
 	@[ ! -s "$(FMT_LOG)" ] || (echo "Go fmt or license check failures, run 'make fmt'" | cat - $(FMT_LOG) && false)
 
 .PHONY: install-glide

--- a/Makefile
+++ b/Makefile
@@ -249,4 +249,4 @@ generate-mocks: install-mockery
 
 .PHONY: fix-imports
 fix-imports:
-	./scripts/import_order_cleanup.py -o inplace -t $(ALL_SRC)
+	./scripts/import-order-cleanup.sh

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ nocover:
 	@scripts/check-test-files.sh $(subst github.com/jaegertracing/jaeger/,./,$(ALL_PKGS)) | $(SED) ''/FIXME/s//$(FIXME)/''
 
 .PHONY: fmt
-fmt:
+fmt: fix-imports
 	$(GOFMT) -e -s -l -w $(ALL_SRC)
 	./scripts/updateLicenses.sh
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ lint:
 	@[ ! -s "$(LINT_LOG)" ] || (echo "Lint Failures" | cat - $(LINT_LOG) && false)
 	@$(GOFMT) -e -s -l $(ALL_SRC) > $(FMT_LOG)
 	@./scripts/updateLicenses.sh >> $(FMT_LOG)
-	@./scripts/import-order-cleanup.sh stdout >> $(IMPORT_LOG)
+	@./scripts/import-order-cleanup.sh stdout > $(IMPORT_LOG)
 	@[[ ! -s "$(FMT_LOG)" && ! -s "$(IMPORT_LOG)" ]] || (echo "Go fmt, license check, or import ordering failures, run 'make fmt'" | cat - $(FMT_LOG) && false)
 
 .PHONY: install-glide

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ lint:
 	@$(GOFMT) -e -s -l $(ALL_SRC) > $(FMT_LOG)
 	@./scripts/updateLicenses.sh >> $(FMT_LOG)
 	@./scripts/import-order-cleanup.sh stdout > $(IMPORT_LOG)
-	@[[ ! -s "$(FMT_LOG)" && ! -s "$(IMPORT_LOG)" ]] || (echo "Go fmt, license check, or import ordering failures, run 'make fmt'" | cat - $(FMT_LOG) && false)
+	@[ ! -s "$(FMT_LOG)" -a ! -s "$(IMPORT_LOG)" ] || (echo "Go fmt, license check, or import ordering failures, run 'make fmt'" | cat - $(FMT_LOG) && false)
 
 .PHONY: install-glide
 install-glide:

--- a/Makefile
+++ b/Makefile
@@ -246,3 +246,7 @@ install-mockery:
 .PHONY: generate-mocks
 generate-mocks: install-mockery
 	$(MOCKERY) -all -dir ./pkg/es/ -output ./pkg/es/mocks && rm pkg/es/mocks/ClientBuilder.go
+
+.PHONY: fix-imports
+fix-imports:
+	./scripts/import_order_cleanup.py -o inplace -t $(ALL_SRC)

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,10 @@ nocover:
 	@scripts/check-test-files.sh $(subst github.com/jaegertracing/jaeger/,./,$(ALL_PKGS)) | $(SED) ''/FIXME/s//$(FIXME)/''
 
 .PHONY: fmt
-fmt: fix-imports
+fmt:
 	$(GOFMT) -e -s -l -w $(ALL_SRC)
 	./scripts/updateLicenses.sh
+	./scripts/import-order-cleanup.sh
 
 .PHONY: lint
 lint:
@@ -246,7 +247,3 @@ install-mockery:
 .PHONY: generate-mocks
 generate-mocks: install-mockery
 	$(MOCKERY) -all -dir ./pkg/es/ -output ./pkg/es/mocks && rm pkg/es/mocks/ClientBuilder.go
-
-.PHONY: fix-imports
-fix-imports:
-	./scripts/import-order-cleanup.sh

--- a/cmd/agent/app/reporter/reporter_test.go
+++ b/cmd/agent/app/reporter/reporter_test.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
-	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
 func TestMultiReporter(t *testing.T) {

--- a/cmd/agent/app/servers/tbuffered_server_test.go
+++ b/cmd/agent/app/servers/tbuffered_server_test.go
@@ -24,12 +24,11 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/agent"
-	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
-
 	"github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
+	"github.com/jaegertracing/jaeger/thrift-gen/agent"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
 func TestTBufferedServer(t *testing.T) {

--- a/cmd/builder/builder_options_test.go
+++ b/cmd/builder/builder_options_test.go
@@ -18,9 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-
 	"github.com/uber/jaeger-lib/metrics"
+	"go.uber.org/zap"
 )
 
 func TestApplyOptions(t *testing.T) {

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -17,8 +17,9 @@ package app
 import (
 	"sync"
 
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/uber/jaeger-lib/metrics"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 const (

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	jaegerM "github.com/uber/jaeger-lib/metrics"
 
 	"github.com/jaegertracing/jaeger/model"
-	jaegerM "github.com/uber/jaeger-lib/metrics"
 )
 
 func TestProcessorMetrics(t *testing.T) {

--- a/cmd/collector/app/options.go
+++ b/cmd/collector/app/options.go
@@ -15,12 +15,11 @@
 package app
 
 import (
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/model"
-	"github.com/uber/jaeger-lib/metrics"
-
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer"
+	"github.com/jaegertracing/jaeger/model"
 )
 
 const (

--- a/cmd/collector/app/options_test.go
+++ b/cmd/collector/app/options_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/uber/jaeger-lib/metrics"
 )
 
 func TestAllOptionSet(t *testing.T) {

--- a/cmd/collector/app/sanitizer/service_name_sanitizer_test.go
+++ b/cmd/collector/app/sanitizer/service_name_sanitizer_test.go
@@ -17,8 +17,9 @@ package sanitizer
 import (
 	"testing"
 
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 var (

--- a/cmd/collector/app/sanitizer/utf8_sanitizer.go
+++ b/cmd/collector/app/sanitizer/utf8_sanitizer.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"unicode/utf8"
 
-	"github.com/jaegertracing/jaeger/model"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 const (

--- a/cmd/collector/app/sanitizer/utf8_sanitizer_test.go
+++ b/cmd/collector/app/sanitizer/utf8_sanitizer_test.go
@@ -18,9 +18,10 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 func invalidUTF8() string {

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -20,11 +20,10 @@ import (
 	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/model"
-	"github.com/jaegertracing/jaeger/storage/spanstore"
-
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer"
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/queue"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 type spanProcessor struct {

--- a/cmd/collector/app/zipkin/json_test.go
+++ b/cmd/collector/app/zipkin/json_test.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
 var endpointFmt = `{"serviceName": "%s", "ipv4": "%s", "ipv6": "%s", "port": %d}`

--- a/cmd/query/app/handler_test.go
+++ b/cmd/query/app/handler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	jaeger "github.com/uber/jaeger-client-go"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -38,7 +39,6 @@ import (
 	depsmocks "github.com/jaegertracing/jaeger/storage/dependencystore/mocks"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	spanstoremocks "github.com/jaegertracing/jaeger/storage/spanstore/mocks"
-	jaeger "github.com/uber/jaeger-client-go"
 )
 
 const millisToNanosMultiplier = int64(time.Millisecond / time.Nanosecond)

--- a/examples/hotrod/services/customer/database.go
+++ b/examples/hotrod/services/customer/database.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 
 	"go.uber.org/zap"
-
 	"github.com/opentracing/opentracing-go"
 	tags "github.com/opentracing/opentracing-go/ext"
 

--- a/model/converter/json/process_hashtable_test.go
+++ b/model/converter/json/process_hashtable_test.go
@@ -17,8 +17,9 @@ package json
 import (
 	"testing"
 
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 func TestProcessHashtable(t *testing.T) {

--- a/model/converter/json/to_domain.go
+++ b/model/converter/json/to_domain.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/json"
-	"github.com/pkg/errors"
 )
 
 // SpanToDomain converts json.Span with embedded Process into model.Span format.

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -25,13 +25,13 @@ import (
 	"time"
 
 	"github.com/kr/pretty"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	z "github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 )
 
 const NumberOfFixtures = 3

--- a/model/hash_test.go
+++ b/model/hash_test.go
@@ -20,8 +20,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 type mockHashWwiterAnswer struct {

--- a/model/keyvalue_test.go
+++ b/model/keyvalue_test.go
@@ -15,11 +15,10 @@
 package model_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"encoding/json"
 
 	"github.com/jaegertracing/jaeger/model"
 )

--- a/model/process_test.go
+++ b/model/process_test.go
@@ -15,16 +15,15 @@
 package model_test
 
 import (
+	"errors"
 	"hash/fnv"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/stretchr/testify/require"
 )
 
 func TestProcessEqual(t *testing.T) {

--- a/model/span.go
+++ b/model/span.go
@@ -15,12 +15,11 @@
 package model
 
 import (
+	"encoding/gob"
 	"fmt"
 	"io"
 	"strconv"
 	"time"
-
-	"encoding/gob"
 
 	"github.com/opentracing/opentracing-go/ext"
 )

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -15,17 +15,16 @@
 package model_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
-
-	"bytes"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/stretchr/testify/require"
 )
 
 type TraceIDContainer struct {

--- a/pkg/cassandra/metrics/table_test.go
+++ b/pkg/cassandra/metrics/table_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 func TestTableEmit(t *testing.T) {

--- a/pkg/discovery/notifier_test.go
+++ b/pkg/discovery/notifier_test.go
@@ -15,9 +15,8 @@
 package discovery
 
 import (
-	"testing"
-
 	"sync"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/healthcheck/internal_test.go
+++ b/pkg/healthcheck/internal_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 func TestHttpCall(t *testing.T) {

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -15,12 +15,11 @@
 package queue
 
 import (
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"reflect"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/plugin/storage/cassandra/factory_test.go
+++ b/plugin/storage/cassandra/factory_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
 	"github.com/jaegertracing/jaeger/pkg/config"
-
 	"github.com/jaegertracing/jaeger/storage"
 )
 

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"gopkg.in/olivere/elastic.v5"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/es/mocks"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
-	"github.com/uber/jaeger-lib/metrics"
 )
 
 var exampleESSpan = []byte(

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -1,8 +1,6 @@
 import argparse
-import fnmatch
-import os
 import sys
-from os import path
+# from os import path
 
 def cleanup_imports_and_return(imports):
     os_packages = []
@@ -69,21 +67,13 @@ def main():
                         help='output target [default: stdout]')
 
     parser.add_argument('-t', '--target',
-                        help='comma seperated filenames to operate upon',
-                        nargs='+')
+                        help='list of filenames to operate upon',
+                        nargs='+',
+                        required=True)
 
     args = parser.parse_args()
     output = args.output
-
-    go_files = []
-    target = args.target
-    if target:
-        go_files = target
-        print target
-    else:
-        print >>sys.stderr, "No input specified, operating upon all *.go files in local dir"
-        dirs = get_local_packages()
-        go_files = get_go_files(dirs)
+    go_files = args.target
 
     for f in go_files:
         print >>sys.stderr, "Parsing ", f

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -29,7 +29,7 @@ def cleanup_imports_and_return(imports):
             l.append("")
         l.extend(jaeger_packages)
 
-    imports_reordered = imports == l
+    imports_reordered = imports != l
     l.insert(0, "import (")
     l.append(")")
     return l, imports_reordered

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -14,7 +14,7 @@ def cleanup_imports_and_return(imports):
         else:
             os_packages.append(i)
 
-    l = [""]
+    l = []
     needs_new_line = False
     if os_packages:
         l.extend(os_packages)

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -4,18 +4,6 @@ import os
 import sys
 from os import path
 
-def get_local_packages():
-    for (dirpath, dirnames, filenames) in os.walk('.'):
-        return [d for d in dirnames if d != 'vendor' and d != 'thrift-gen' and d != 'swagger-gen' and d != 'thrift-0.9.2' and d[0] != '.']
-
-def get_go_files(dirs):
-    matches = set()
-    for d in dirs:
-        for root, dirnames, filenames in os.walk(d):
-            for filename in fnmatch.filter(filenames, '*.go'):
-                matches.add(os.path.join(root, filename))
-    return list(matches)
-
 def cleanup_imports_and_return(imports):
     os_packages = []
     jaeger_packages = []
@@ -80,9 +68,6 @@ def main():
                         choices=['inplace', 'stdout'],
                         help='output target [default: stdout]')
 
-    parser.add_argument('-i', '--input',
-                        help='file with list of go src files to operate upon, operates on all non-vendor dirs by default')
-
     parser.add_argument('-t', '--target',
                         help='comma seperated filenames to operate upon',
                         nargs='+')
@@ -91,13 +76,10 @@ def main():
     output = args.output
 
     go_files = []
-    input = args.input
     target = args.target
     if target:
-        go_files = [i.strip() for i in target.split(" ")]
-    elif input:
-        with open(input, 'r') as go_files_list:
-            go_files = [i.strip() for i in go_files_list.readlines()]
+        go_files = target
+        print target
     else:
         print >>sys.stderr, "No input specified, operating upon all *.go files in local dir"
         dirs = get_local_packages()

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 
 def cleanup_imports_and_return(imports):
     os_packages = []

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import argparse
 import fnmatch
 import os
@@ -86,7 +84,8 @@ def main():
                         help='file with list of go src files to operate upon, operates on all non-vendor dirs by default')
 
     parser.add_argument('-t', '--target',
-                        help='comma seperated filenames to operate upon')
+                        help='comma seperated filenames to operate upon',
+                        nargs='+')
 
     args = parser.parse_args()
     output = args.output
@@ -95,7 +94,7 @@ def main():
     input = args.input
     target = args.target
     if target:
-        go_files = [i.strip() for i in target.split(",")]
+        go_files = [i.strip() for i in target.split(" ")]
     elif input:
         with open(input, 'r') as go_files_list:
             go_files = [i.strip() for i in go_files_list.readlines()]

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -81,7 +81,7 @@ def main():
     for f in go_files:
         parsed, imports_reordered = parse_go_file(f)
         if output == "stdout" and imports_reordered:
-            print f + " imports reordered"
+            print f + " imports out of order"
         else:
             with open(f, 'w') as ofile:
                 ofile.write(parsed)

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -1,6 +1,5 @@
 import argparse
 import sys
-# from os import path
 
 def cleanup_imports_and_return(imports):
     os_packages = []
@@ -76,14 +75,12 @@ def main():
     go_files = args.target
 
     for f in go_files:
-        print >>sys.stderr, "Parsing ", f
         parsed = parse_go_file(f)
         if output == "stdout":
             print parsed
         else:
             with open(f, 'w') as ofile:
                 ofile.write(parsed)
-            print >>sys.stderr, "updated in place"
 
 if __name__ == '__main__':
     main()

--- a/scripts/import-order-cleanup.sh
+++ b/scripts/import-order-cleanup.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-python scripts/import-order-cleanup.py -o inplace -t $(git ls-files "*\.go" | grep -v -e thrift-gen -e swagger-gen -e thrift-0.9.2)
+python scripts/import-order-cleanup.py -o $1 -t $(git ls-files "*\.go" | grep -v -e thrift-gen -e swagger-gen -e thrift-0.9.2)

--- a/scripts/import-order-cleanup.sh
+++ b/scripts/import-order-cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+python scripts/import-order-cleanup.py -o inplace -t $(git ls-files "*\.go" | grep -v -e thrift-gen -e swagger-gen)

--- a/scripts/import-order-cleanup.sh
+++ b/scripts/import-order-cleanup.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-python scripts/import-order-cleanup.py -o inplace -t $(git ls-files "*\.go" | grep -v -e thrift-gen -e swagger-gen)
+python scripts/import-order-cleanup.py -o inplace -t $(git ls-files "*\.go" | grep -v -e thrift-gen -e swagger-gen -e thrift-0.9.2)

--- a/scripts/import_order_cleanup.py
+++ b/scripts/import_order_cleanup.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import argparse
+import fnmatch
+import os
+import sys
+from os import path
+
+def get_local_packages():
+    for (dirpath, dirnames, filenames) in os.walk('.'):
+        return [d for d in dirnames if d != 'vendor' and d != 'thrift-gen' and d[0] != '.']
+
+def get_go_files(dirs):
+    matches = set()
+    for d in dirs:
+        for root, dirnames, filenames in os.walk(d):
+            for filename in fnmatch.filter(filenames, '*.go'):
+                matches.add(os.path.join(root, filename))
+    return list(matches)
+
+def cleanup_imports_and_return(imports):
+    os_packages = []
+    jaeger_packages = []
+    thirdparty_packages = []
+    for i in imports:
+        if i.strip() == "":
+            continue
+        if i.find("github.com/jaegertracing/jaeger/") != -1:
+            jaeger_packages.append(i)
+        elif i.find(".com") != -1 or i.find(".net") != -1 or i.find(".org") != -1 or i.find(".in") != -1:
+            thirdparty_packages.append(i)
+        else:
+            os_packages.append(i)
+
+    l = ["import ("]
+    needs_new_line = False
+    if os_packages:
+        l.extend(os_packages)
+        needs_new_line = True
+    if thirdparty_packages:
+        if needs_new_line:
+            l.append("")
+        l.extend(thirdparty_packages)
+        needs_new_line = True
+    if jaeger_packages:
+        if needs_new_line:
+            l.append("")
+        l.extend(jaeger_packages)
+    l.append(")")
+    return l
+
+def parse_go_file(f):
+    with open(f, 'r') as go_file:
+        lines = [i.rstrip() for i in go_file.readlines()]
+        in_import_block = False
+        imports = []
+        output_lines = []
+        for line in lines:
+            if in_import_block:
+                endIdx = line.find(")")
+                if endIdx != -1:
+                    in_import_block = False
+                    output_lines.extend(cleanup_imports_and_return(imports))
+                    imports = []
+                    continue
+                imports.append(line)
+            else:
+                importIdx = line.find("import (")
+                if importIdx != -1:
+                    in_import_block = True
+                    continue
+                output_lines.append(line)
+        output_lines.append("")
+        return "\n".join(output_lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Tool to make cleaning up import orders easily')
+
+    parser.add_argument('-o', '--output', default='stdout',
+                        choices=['inplace', 'stdout'],
+                        help='output target [default: stdout]')
+
+    parser.add_argument('-i', '--input',
+                        help='file with list of go src files to operate upon, operates on all non-vendor dirs by default')
+
+    parser.add_argument('-t', '--target',
+                        help='comma seperated filenames to operate upon')
+
+    args = parser.parse_args()
+    output = args.output
+
+    go_files = []
+    input = args.input
+    target = args.target
+    if target:
+        go_files = [i.strip() for i in target.split(",")]
+    elif input:
+        with open(input, 'r') as go_files_list:
+            go_files = [i.strip() for i in go_files_list.readlines()]
+    else:
+        print >>sys.stderr, "No input specified, operating upon all *.go files in local dir"
+        dirs = get_local_packages()
+        go_files = get_go_files(dirs)
+
+    for f in go_files:
+        print >>sys.stderr, "Parsing ", f
+        parsed = parse_go_file(f)
+        if output == "stdout":
+            print parsed
+        else:
+            with open(f, 'w') as ofile:
+                ofile.write(parsed)
+            print >>sys.stderr, "updated in place"
+
+if __name__ == '__main__':
+    main()

--- a/scripts/import_order_cleanup.py
+++ b/scripts/import_order_cleanup.py
@@ -8,7 +8,7 @@ from os import path
 
 def get_local_packages():
     for (dirpath, dirnames, filenames) in os.walk('.'):
-        return [d for d in dirnames if d != 'vendor' and d != 'thrift-gen' and d != 'swagger-gen' and d[0] != '.']
+        return [d for d in dirnames if d != 'vendor' and d != 'thrift-gen' and d != 'swagger-gen' and d != 'thrift-0.9.2' and d[0] != '.']
 
 def get_go_files(dirs):
     matches = set()

--- a/scripts/import_order_cleanup.py
+++ b/scripts/import_order_cleanup.py
@@ -8,7 +8,7 @@ from os import path
 
 def get_local_packages():
     for (dirpath, dirnames, filenames) in os.walk('.'):
-        return [d for d in dirnames if d != 'vendor' and d != 'thrift-gen' and d[0] != '.']
+        return [d for d in dirnames if d != 'vendor' and d != 'thrift-gen' and d != 'swagger-gen' and d[0] != '.']
 
 def get_go_files(dirs):
     matches = set()


### PR DESCRIPTION
Shamelessly "borrowed" from: https://github.com/m3db/ci-scripts/pull/29

`make fmt` will automatically order the imports and `make lint` will fail if the imports are out of order. Maybe I'll do a commit hook after.