### PR TITLE
Remove the override of GOMAXPROCS

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -51,7 +50,6 @@ func main() {
 
 			builder := &app.Builder{}
 			builder.InitFromViper(v)
-			runtime.GOMAXPROCS(runtime.NumCPU())
 
 			// TODO illustrate discovery service wiring
 			// TODO illustrate additional reporter

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"syscall"
 
@@ -83,8 +82,6 @@ func main() {
 			if err != nil {
 				return err
 			}
-
-			runtime.GOMAXPROCS(runtime.NumCPU())
 
 			mBldr := new(pMetrics.Builder).InitFromViper(v)
 			metricsFactory, err := mBldr.CreateMetricsFactory("jaeger-standalone")

--- a/examples/hotrod/main.go
+++ b/examples/hotrod/main.go
@@ -3,12 +3,9 @@
 package main
 
 import (
-	"runtime"
-
 	"github.com/jaegertracing/jaeger/examples/hotrod/cmd"
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	cmd.Execute()
 }


### PR DESCRIPTION
From Go 1.5, the default setting of `GOMAXPROCS` is the number of
CPUs available. we might as well remove this so people can set
GOMAXPROCS to a custom value using environment variables.

> https://golang.org/doc/go1.5#runtime

Signed-off-by: kun <oiooj@qq.com>