### PR TITLE
Add options to Cassandra to control indexing

### DIFF
--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -66,9 +66,8 @@ const (
 )
 
 const (
-	indexAndStore = storageMode(iota)
-	indexOnly
-	storeOnly
+	storeFlag = storageMode(1 << iota)
+	indexFlag
 )
 
 type storageMode uint8
@@ -134,19 +133,12 @@ func (s *SpanWriter) Close() error {
 // WriteSpan saves the span into Cassandra
 func (s *SpanWriter) WriteSpan(span *model.Span) error {
 	ds := dbmodel.FromDomain(span)
-	switch s.storageMode {
-	case storeOnly:
+	if s.storageMode&storeFlag == storeFlag {
 		if err := s.writeSpan(span, ds); err != nil {
 			return err
 		}
-	case indexOnly:
-		if err := s.writeIndexes(span, ds); err != nil {
-			return err
-		}
-	default:
-		if err := s.writeSpan(span, ds); err != nil {
-			return err
-		}
+	}
+	if s.storageMode&indexFlag == indexFlag {
 		if err := s.writeIndexes(span, ds); err != nil {
 			return err
 		}

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -67,8 +67,8 @@ const (
 
 const (
 	indexAndStore = storageMode(iota)
-	indexOnly     = storageMode(iota)
-	storeOnly     = storageMode(iota)
+	indexOnly
+	storeOnly
 )
 
 type storageMode uint8

--- a/plugin/storage/cassandra/spanstore/writer_options.go
+++ b/plugin/storage/cassandra/spanstore/writer_options.go
@@ -23,13 +23,28 @@ type Option func(c *Options)
 
 // Options control behavior of the writer.
 type Options struct {
-	tagFilter dbmodel.TagFilter
+	tagFilter   dbmodel.TagFilter
+	storageMode storageMode
 }
 
 // TagFilter can be provided to filter any tags that should not be indexed.
 func TagFilter(tagFilter dbmodel.TagFilter) Option {
 	return func(o *Options) {
 		o.tagFilter = tagFilter
+	}
+}
+
+// StoreIndexesOnly can be provided to skip storing spans, and only store span indexes.
+func StoreIndexesOnly() Option {
+	return func(o *Options) {
+		o.storageMode = indexOnly
+	}
+}
+
+// StoreWithoutIndexing can be provided to store spans without indexing them.
+func StoreWithoutIndexing() Option {
+	return func(o *Options) {
+		o.storageMode = storeOnly
 	}
 }
 
@@ -40,6 +55,9 @@ func applyOptions(opts ...Option) Options {
 	}
 	if o.tagFilter == nil {
 		o.tagFilter = dbmodel.DefaultTagFilter
+	}
+	if o.storageMode == 0 {
+		o.storageMode = indexAndStore
 	}
 	return o
 }

--- a/plugin/storage/cassandra/spanstore/writer_options.go
+++ b/plugin/storage/cassandra/spanstore/writer_options.go
@@ -37,14 +37,14 @@ func TagFilter(tagFilter dbmodel.TagFilter) Option {
 // StoreIndexesOnly can be provided to skip storing spans, and only store span indexes.
 func StoreIndexesOnly() Option {
 	return func(o *Options) {
-		o.storageMode = indexOnly
+		o.storageMode = indexFlag
 	}
 }
 
 // StoreWithoutIndexing can be provided to store spans without indexing them.
 func StoreWithoutIndexing() Option {
 	return func(o *Options) {
-		o.storageMode = storeOnly
+		o.storageMode = storeFlag
 	}
 }
 
@@ -55,6 +55,9 @@ func applyOptions(opts ...Option) Options {
 	}
 	if o.tagFilter == nil {
 		o.tagFilter = dbmodel.DefaultTagFilter
+	}
+	if o.storageMode == 0 {
+		o.storageMode = storeFlag | indexFlag
 	}
 	return o
 }

--- a/plugin/storage/cassandra/spanstore/writer_options.go
+++ b/plugin/storage/cassandra/spanstore/writer_options.go
@@ -56,8 +56,5 @@ func applyOptions(opts ...Option) Options {
 	if o.tagFilter == nil {
 		o.tagFilter = dbmodel.DefaultTagFilter
 	}
-	if o.storageMode == 0 {
-		o.storageMode = indexAndStore
-	}
 	return o
 }

--- a/plugin/storage/cassandra/spanstore/writer_options_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_options_test.go
@@ -22,7 +22,36 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/dbmodel"
 )
 
-func TestWriterOpetions(t *testing.T) {
+func TestWriterOptions(t *testing.T) {
 	opts := applyOptions(TagFilter(dbmodel.DefaultTagFilter))
 	assert.Equal(t, dbmodel.DefaultTagFilter, opts.tagFilter)
+}
+
+func TestWriterOptions_StorageMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected storageMode
+		opts     Options
+	}{
+		{
+			name:     "Default",
+			expected: indexAndStore,
+			opts:     applyOptions(),
+		},
+		{
+			name:     "Index Only",
+			expected: indexOnly,
+			opts:     applyOptions(StoreIndexesOnly()),
+		},
+		{
+			name:     "Store Only",
+			expected: storeOnly,
+			opts:     applyOptions(StoreWithoutIndexing()),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.opts.storageMode)
+		})
+	}
 }

--- a/plugin/storage/cassandra/spanstore/writer_options_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_options_test.go
@@ -35,17 +35,17 @@ func TestWriterOptions_StorageMode(t *testing.T) {
 	}{
 		{
 			name:     "Default",
-			expected: indexAndStore,
+			expected: indexFlag | storeFlag,
 			opts:     applyOptions(),
 		},
 		{
 			name:     "Index Only",
-			expected: indexOnly,
+			expected: indexFlag,
 			opts:     applyOptions(StoreIndexesOnly()),
 		},
 		{
 			name:     "Store Only",
-			expected: storeOnly,
+			expected: storeFlag,
 			opts:     applyOptions(StoreWithoutIndexing()),
 		},
 	}


### PR DESCRIPTION
- Add `StoreIndexesOnly` and `StoreWithoutIndexing` options to the cassandra
  storage which controls whether indexes are written along with spans.

- This allows us to deploy, scale, and prioritize  writers independently for
  indexing and storage workloads.

Signed-off-by: Prithvi Raj <p.r@uber.com>