### PR TITLE
Add --es.disable-basic-auth option

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -31,6 +31,7 @@ type Configuration struct {
 	Servers           []string
 	Username          string
 	Password          string
+	DisableBasicAuth  bool
 	Sniffer           bool          // https://github.com/olivere/elastic/wiki/Sniffing
 	MaxSpanAge        time.Duration `yaml:"max_span_age"` // configures the maximum lookback on span reads
 	NumShards         int64         `yaml:"shards"`
@@ -134,9 +135,11 @@ func (c *Configuration) GetMaxSpanAge() time.Duration {
 
 // GetConfigs wraps the configs to feed to the ElasticSearch client init
 func (c *Configuration) GetConfigs() []elastic.ClientOptionFunc {
-	options := make([]elastic.ClientOptionFunc, 3)
-	options[0] = elastic.SetURL(c.Servers...)
-	options[1] = elastic.SetBasicAuth(c.Username, c.Password)
-	options[2] = elastic.SetSniff(c.Sniffer)
+	options := make([]elastic.ClientOptionFunc, 0, 3)
+	options = append(options, elastic.SetURL(c.Servers...))
+	options = append(options, elastic.SetSniff(c.Sniffer))
+	if !c.DisableBasicAuth {
+		options = append(options, elastic.SetBasicAuth(c.Username, c.Password))
+	}
 	return options
 }

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -27,6 +27,7 @@ import (
 const (
 	suffixUsername          = ".username"
 	suffixPassword          = ".password"
+	suffixDisableBasicAuth  = ".disable-basic-auth"
 	suffixSniffer           = ".sniffer"
 	suffixServerURLs        = ".server-urls"
 	suffixMaxSpanAge        = ".max-span-age"
@@ -66,6 +67,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 			Configuration: config.Configuration{
 				Username:          "",
 				Password:          "",
+				DisableBasicAuth:  false,
 				Sniffer:           false,
 				MaxSpanAge:        72 * time.Hour,
 				NumShards:         5,
@@ -105,6 +107,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixPassword,
 		nsConfig.Password,
 		"The password required by ElasticSearch")
+	flagSet.Bool(
+		nsConfig.namespace+suffixDisableBasicAuth,
+		nsConfig.DisableBasicAuth,
+		"Don't use basic auth to connect to ES. username and password will be ignored")
 	flagSet.Bool(
 		nsConfig.namespace+suffixSniffer,
 		nsConfig.Sniffer,
@@ -154,6 +160,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Username = v.GetString(cfg.namespace + suffixUsername)
 	cfg.Password = v.GetString(cfg.namespace + suffixPassword)
+	cfg.DisableBasicAuth = v.GetBool(cfg.namespace + suffixDisableBasicAuth)
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
 	cfg.servers = v.GetString(cfg.namespace + suffixServerURLs)
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)


### PR DESCRIPTION
This is useful when using Amazon's Elasticsearch service with a VPC
endpoint and ip-based access control.

I also considered automatically skipping the `SetBasicAuth` option if username and password were empty but it seems nicer to make it explicit.