### PR TITLE
Collect metrics from ES bulk service

### DIFF
--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -62,7 +62,7 @@ func (f *Factory) InitFromViper(v *viper.Viper) {
 func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
 	f.metricsFactory, f.logger = metricsFactory, logger
 
-	primaryClient, err := f.primaryConfig.NewClient(logger)
+	primaryClient, err := f.primaryConfig.NewClient(logger, metricsFactory)
 	if err != nil {
 		return err
 	}

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -36,7 +36,7 @@ type mockClientBuilder struct {
 	err error
 }
 
-func (m *mockClientBuilder) NewClient(logger *zap.Logger) (es.Client, error) {
+func (m *mockClientBuilder) NewClient(logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
 	if m.err == nil {
 		return &mocks.Client{}, nil
 	}


### PR DESCRIPTION
Related to #662 

This is not sending bulk stats https://github.com/olivere/elastic/wiki/BulkProcessor#stats to our metrics but just emitting additional duration metrics. Bulk stats does not provide this duration metrics.