### PR TITLE
export model and protocol type

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -43,20 +43,23 @@ const (
 
 	defaultHTTPServerHostPort = ":5778"
 
-	jaegerModel model = "jaeger"
+	jaegerModel Model = "jaeger"
 	zipkinModel       = "zipkin"
 
-	compactProtocol protocol = "compact"
+	compactProtocol Protocol = "compact"
 	binaryProtocol           = "binary"
 )
 
-type model string
-type protocol string
+// Model used to distinguish the data transfer model
+type Model string
+
+// Protocol used to distinguish the data transfer protocol
+type Protocol string
 
 var (
 	errNoReporters = errors.New("agent requires at least one Reporter")
 
-	protocolFactoryMap = map[protocol]thrift.TProtocolFactory{
+	protocolFactoryMap = map[Protocol]thrift.TProtocolFactory{
 		compactProtocol: thrift.NewTCompactProtocolFactory(),
 		binaryProtocol:  thrift.NewTBinaryProtocolFactoryDefault(),
 	}
@@ -77,8 +80,8 @@ type Builder struct {
 // ProcessorConfiguration holds config for a processor that receives spans from Server
 type ProcessorConfiguration struct {
 	Workers  int                 `yaml:"workers"`
-	Model    model               `yaml:"model"`
-	Protocol protocol            `yaml:"protocol"`
+	Model    Model               `yaml:"model"`
+	Protocol Protocol            `yaml:"protocol"`
 	Server   ServerConfiguration `yaml:"server"`
 }
 

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -156,14 +156,14 @@ func TestBuilderWithDiscoveryError(t *testing.T) {
 
 func TestBuilderWithProcessorErrors(t *testing.T) {
 	testCases := []struct {
-		model       model
-		protocol    protocol
+		model       Model
+		protocol    Protocol
 		hostPort    string
 		err         string
 		errContains string
 	}{
-		{protocol: protocol("bad"), err: "cannot find protocol factory for protocol bad"},
-		{protocol: compactProtocol, model: model("bad"), err: "cannot find agent processor for data model bad"},
+		{protocol: Protocol("bad"), err: "cannot find protocol factory for protocol bad"},
+		{protocol: compactProtocol, model: Model("bad"), err: "cannot find agent processor for data model bad"},
 		{protocol: compactProtocol, model: jaegerModel, err: "no host:port provided for udp server: {QueueSize:1000 MaxPacketSize:65000 HostPort:}"},
 		{protocol: compactProtocol, model: zipkinModel, hostPort: "bad-host-port", errContains: "bad-host-port"},
 	}

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -33,8 +33,8 @@ const (
 )
 
 var defaultProcessors = []struct {
-	model    model
-	protocol protocol
+	model    Model
+	protocol Protocol
 	hostPort string
 }{
 	{model: "zipkin", protocol: "compact", hostPort: ":5775"},


### PR DESCRIPTION
The `ProcessorConfiguration` can be exported, but the custom type `model` and `protocol` can not, so it's hard to new a `ProcessorConfiguration` outside the package.

Signed-off-by: kun <oiooj@qq.com>