### PR TITLE
model.NewProcess no longer sorts tags

### DIFF
--- a/model/converter/thrift/zipkin/fixtures/jaeger_02.json
+++ b/model/converter/thrift/zipkin/fixtures/jaeger_02.json
@@ -9,6 +9,10 @@
         "serviceName": "service-x",
         "tags": [
           {
+            "key": "jaeger.version",
+            "vStr": "Go-1.1"
+          },
+          {
             "key": "hostname",
             "vStr": "some-host.com"
           },
@@ -16,10 +20,6 @@
             "key": "ip",
             "vNum": 12345,
             "vType": "int64"
-          },
-          {
-            "key": "jaeger.version",
-            "vStr": "Go-1.1"
           }
         ]
       },

--- a/model/process.go
+++ b/model/process.go
@@ -23,12 +23,8 @@ type Process struct {
 }
 
 // NewProcess creates a new Process for given serviceName and tags.
-// The tags are sorted in place and kept in the the same array/slice,
-// in order to store the Process in a canonical form that is relied
-// upon by the Equal and Hash functions.
 func NewProcess(serviceName string, tags []KeyValue) *Process {
 	typedTags := KeyValues(tags)
-	typedTags.Sort()
 	return &Process{ServiceName: serviceName, Tags: typedTags}
 }
 

--- a/model/process_test.go
+++ b/model/process_test.go
@@ -28,8 +28,8 @@ import (
 
 func TestProcessEqual(t *testing.T) {
 	p1 := model.NewProcess("s1", []model.KeyValue{
-		model.String("x", "y"),
 		model.Int64("a", 1),
+		model.String("x", "y"),
 	})
 	p2 := model.NewProcess("s1", []model.KeyValue{
 		model.Int64("a", 1),


### PR DESCRIPTION
- model.NewProcess sorts tags and claims that sorted process tags
  are the canonical form. This claim is incorrect, and is violated
  in the jaeger to model convertors.

- Because the claim has no merit, and leads to inconsistencies in
  convertors that use model.NewProcess as opposed to &model.Process{},
  the sorting has been removed, and tests updated.

- fixes #682

Signed-off-by: Prithvi Raj <p.r@uber.com>