### PR TITLE
Test that processes with identical tags are deduped

### DIFF
--- a/model/converter/json/process_hashtable_test.go
+++ b/model/converter/json/process_hashtable_test.go
@@ -26,10 +26,13 @@ func TestProcessHashtable(t *testing.T) {
 	ht := &processHashtable{}
 
 	p1 := model.NewProcess("s1", []model.KeyValue{
+		model.String("ip", "1.2.3.4"),
 		model.String("host", "google.com"),
 	})
+	// same process but with different order of tags
 	p1dup := model.NewProcess("s1", []model.KeyValue{
 		model.String("host", "google.com"),
+		model.String("ip", "1.2.3.4"),
 	})
 	p2 := model.NewProcess("s2", []model.KeyValue{
 		model.String("host", "facebook.com"),


### PR DESCRIPTION
The UI converter dedups Process objects using the hash code that is currently independent of the tags order (provided NewProcess ctor is used). Whether relying on NewProcess to sort the tags is the right or wrong thing, this PR simply enhances the tests to demonstrate the existing dependency.

Signed-off-by: Yuri Shkuro <ys@uber.com>