### PR TITLE
Use UTC for model timezone

### DIFF
--- a/model/time.go
+++ b/model/time.go
@@ -20,7 +20,7 @@ import "time"
 func EpochMicrosecondsAsTime(ts uint64) time.Time {
 	seconds := ts / 1000000
 	nanos := 1000 * (ts % 1000000)
-	return time.Unix(int64(seconds), int64(nanos))
+	return time.Unix(int64(seconds), int64(nanos)).UTC()
 }
 
 // TimeAsEpochMicroseconds converts time.Time to microseconds since epoch,

--- a/model/time_test.go
+++ b/model/time_test.go
@@ -26,11 +26,16 @@ import (
 func TestTimeConversion(t *testing.T) {
 	s := model.TimeAsEpochMicroseconds(time.Unix(100, 2000))
 	assert.Equal(t, uint64(100000002), s)
-	assert.Equal(t, time.Unix(100, 2000), model.EpochMicrosecondsAsTime(s))
+	assert.True(t, time.Unix(100, 2000).Equal(model.EpochMicrosecondsAsTime(s)))
 }
 
 func TestDurationConversion(t *testing.T) {
 	d := model.DurationAsMicroseconds(12345 * time.Microsecond)
 	assert.Equal(t, 12345*time.Microsecond, model.MicrosecondsAsDuration(d))
 	assert.Equal(t, uint64(12345), d)
+}
+
+func TestTimeZoneUTC(t *testing.T) {
+	ts := model.EpochMicrosecondsAsTime(10000100)
+	assert.Equal(t, time.UTC, ts.Location())
 }


### PR DESCRIPTION
- standardize on UTC for time representation
- the wire format for everything is microseconds since epoch, so this change does not effect data transfer over rpcs. 

Signed-off-by: Prithvi Raj <p.r@uber.com>