### PR TITLE
Make sure different tracers in HotROD process use different RNG seeds

### DIFF
--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -37,9 +37,11 @@ func Init(serviceName string, metricsFactory metrics.Factory, logger log.Factory
 		Reporter: &config.ReporterConfig{
 			LogSpans:            false,
 			BufferFlushInterval: 1 * time.Second,
-			LocalAgentHostPort: hostPort,
+			LocalAgentHostPort:  hostPort,
 		},
 	}
+	// TODO(ys) a quick hack to ensure random generators get different seeds, which are based on current time.
+	time.Sleep(100 * time.Millisecond)
 	tracer, _, err := cfg.New(
 		serviceName,
 		config.Logger(jaegerLoggerAdapter{logger.Bg()}),


### PR DESCRIPTION
I ran into a case where trace had spans with the same IDs. The RNG is seeded with time.Now().UnixNano(), which potentially can give identical values over several calls (since the clock precision is not actually nanos).

This is a quick (hacky) workaround. A proper fix needs to be in the Jaeger client.

Signed-off-by: Yuri Shkuro <ys@uber.com>