### PR TITLE
Push compression of api/static routes to handlers

### DIFF
--- a/cmd/query/app/handler.go
+++ b/cmd/query/app/handler.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
@@ -137,7 +138,7 @@ func (aH *APIHandler) handleFunc(
 		nethttp.OperationNameFunc(func(r *http.Request) string {
 			return route
 		}))
-	return router.HandleFunc(route, traceMiddleware.ServeHTTP)
+	return router.Handle(route, handlers.CompressHandler(traceMiddleware))
 }
 
 func (aH *APIHandler) route(route string, args ...interface{}) string {

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -120,7 +119,7 @@ func main() {
 				apiHandlerOptions...)
 			r := mux.NewRouter()
 			apiHandler.RegisterRoutes(r)
-			registerStaticHandler(r, logger, queryOpts)
+			app.RegisterStaticHandler(r, logger, queryOpts)
 
 			if h := mBldr.Handler(); h != nil {
 				logger.Info("Registering metrics handler with HTTP server", zap.String("route", mBldr.HTTPRoute))
@@ -128,12 +127,11 @@ func main() {
 			}
 
 			portStr := ":" + strconv.Itoa(queryOpts.Port)
-			compressHandler := handlers.CompressHandler(r)
 			recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
 
 			go func() {
 				logger.Info("Starting jaeger-query HTTP server", zap.Int("port", queryOpts.Port))
-				if err := http.ListenAndServe(portStr, recoveryHandler(compressHandler)); err != nil {
+				if err := http.ListenAndServe(portStr, recoveryHandler(r)); err != nil {
 					logger.Fatal("Could not launch service", zap.Error(err))
 				}
 				hc.Set(healthcheck.Unavailable)
@@ -165,18 +163,6 @@ func main() {
 	if error := command.Execute(); error != nil {
 		fmt.Println(error.Error())
 		os.Exit(1)
-	}
-}
-
-func registerStaticHandler(r *mux.Router, logger *zap.Logger, qOpts *app.QueryOptions) {
-	staticHandler, err := app.NewStaticAssetsHandler(qOpts.StaticAssets, qOpts.UIConfig)
-	if err != nil {
-		logger.Fatal("Could not create static assets handler", zap.Error(err))
-	}
-	if staticHandler != nil {
-		staticHandler.RegisterRoutes(r)
-	} else {
-		logger.Info("Static handler is not registered")
 	}
 }
 

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -272,7 +272,7 @@ func startQuery(
 
 	r := mux.NewRouter()
 	apiHandler.RegisterRoutes(r)
-	registerStaticHandler(r, logger, qOpts)
+	queryApp.RegisterStaticHandler(r, logger, qOpts)
 
 	if h := metricsBuilder.Handler(); h != nil {
 		logger.Info("Registering metrics handler with jaeger-query HTTP server", zap.String("route", metricsBuilder.HTTPRoute))
@@ -288,18 +288,6 @@ func startQuery(
 			logger.Fatal("Could not launch jaeger-query service", zap.Error(err))
 		}
 	}()
-}
-
-func registerStaticHandler(r *mux.Router, logger *zap.Logger, qOpts *queryApp.QueryOptions) {
-	staticHandler, err := queryApp.NewStaticAssetsHandler(qOpts.StaticAssets, qOpts.UIConfig)
-	if err != nil {
-		logger.Fatal("Could not create static assets handler", zap.Error(err))
-	}
-	if staticHandler != nil {
-		staticHandler.RegisterRoutes(r)
-	} else {
-		logger.Info("Static handler is not registered")
-	}
 }
 
 func initializeSamplingHandler(


### PR DESCRIPTION
Fixes #697

The problem was that the handler performing gzip compression was added to the top level Router (#545), and it applied to the `/metrics` endpoint. This change pushes the compression down to individual `/static` and `/api` handlers.

Signed-off-by: Yuri Shkuro <ys@uber.com>