### PR TITLE
Add a span merger that merges spans read

### DIFF
--- a/model/adjuster/span_merger.go
+++ b/model/adjuster/span_merger.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adjuster
+
+import (
+	"sort"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+// MergeSpans returns an Adjuster that merges Jaeger spans with the same spanID.
+// It skips merging Zipkin spans. Zipkin spans are defined as spans sharing the spanID and containing
+// both client and server span.kind annotations.
+// As Zipkin spans are always reported in entirety, we can assume that that the span.kind annotations are present.
+// A drawback of this approach is that incomplete traces with duplicate Zipkin spans will be merged unnecessarily
+//
+// MergeSpans assumes that the duration field in a span is monotonically increasing for a spans with the
+// same spanID. The span with the longest spanID wins, and is selected in entirety.
+// TODO: Granular merging of spans
+func MergeSpans() Adjuster {
+	return Func(func(input *model.Trace) (*model.Trace, error) {
+
+		IDToSpans := groupByIDs(input.Spans)
+
+		if len(IDToSpans) == len(input.Spans) {
+			return input, nil
+		}
+
+		trace := &model.Trace{}
+		trace.Warnings = input.Warnings
+		for _, spans := range IDToSpans {
+			if isZipkin(spans) {
+				trace.Spans = append(trace.Spans, spans...)
+			} else {
+				trace.Spans = append(trace.Spans, mergeSpans(spans))
+			}
+		}
+		return trace, nil
+	})
+}
+
+func groupByIDs(spans []*model.Span) map[model.SpanID][]*model.Span {
+	IDToSpans := make(map[model.SpanID][]*model.Span)
+	for _, span := range spans {
+		if spans, ok := IDToSpans[span.SpanID]; ok {
+			IDToSpans[span.SpanID] = append(spans, span)
+		} else {
+			IDToSpans[span.SpanID] = []*model.Span{span}
+		}
+	}
+	return IDToSpans
+}
+
+func mergeSpans(spans []*model.Span) *model.Span {
+	// This assumes that the duration field in a span is monotonically increasing
+	// and uses it to break ties between spans.
+	sort.Slice(spans, func(i, j int) bool {
+		return spans[i].Duration > spans[j].Duration
+	})
+
+	return spans[0]
+}
+
+func isZipkin(spans []*model.Span) bool {
+	hasServer := false
+	hasClient := false
+	for _, span := range spans {
+		if span.IsRPCClient() {
+			hasClient = true
+		}
+		if span.IsRPCServer() {
+			hasServer = true
+		}
+	}
+	return hasServer && hasClient
+}

--- a/model/adjuster/span_merger_test.go
+++ b/model/adjuster/span_merger_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adjuster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_MergeAdjuster(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *model.Trace
+		expected *model.Trace
+	}{
+		{
+			name: "non duplicated spans: do nothing",
+			input: &model.Trace{
+				Spans: []*model.Span{
+					{
+						SpanID: model.SpanID(1),
+					},
+					{
+						SpanID: model.SpanID(2),
+					},
+					{
+						SpanID: model.SpanID(3),
+					},
+				},
+			},
+			expected: &model.Trace{
+				Spans: []*model.Span{
+					{
+						SpanID: model.SpanID(1),
+					},
+					{
+						SpanID: model.SpanID(2),
+					},
+					{
+						SpanID: model.SpanID(3),
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate Jaeger spans: select longest duration",
+			input: &model.Trace{
+				Spans: []*model.Span{
+					{
+						SpanID: model.SpanID(1),
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 1 * time.Microsecond,
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 5 * time.Microsecond,
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 5 * time.Microsecond,
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 2 * time.Microsecond,
+					},
+					{
+						SpanID: model.SpanID(2),
+					},
+				},
+			},
+			expected: &model.Trace{
+				Spans: []*model.Span{
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 5 * time.Microsecond,
+					},
+					{
+						SpanID: model.SpanID(2),
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate Zipkin spans: don't merge",
+			input: &model.Trace{
+				Spans: []*model.Span{
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 1 * time.Microsecond,
+						Tags: model.KeyValues{
+							model.String(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum)),
+						},
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 5 * time.Microsecond,
+						Tags: model.KeyValues{
+							model.String(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum)),
+						},
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 2 * time.Microsecond,
+						Tags: model.KeyValues{
+							model.String(string(ext.SpanKind), string(ext.SpanKindRPCServerEnum)),
+						},
+					},
+					{
+						SpanID: model.SpanID(2),
+					},
+				},
+			},
+			expected: &model.Trace{
+				Spans: []*model.Span{
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 1 * time.Microsecond,
+						Tags: model.KeyValues{
+							model.String(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum)),
+						},
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 5 * time.Microsecond,
+						Tags: model.KeyValues{
+							model.String(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum)),
+						},
+					},
+					{
+						SpanID:   model.SpanID(1),
+						Duration: 2 * time.Microsecond,
+						Tags: model.KeyValues{
+							model.String(string(ext.SpanKind), string(ext.SpanKindRPCServerEnum)),
+						},
+					},
+					{
+						SpanID: model.SpanID(2),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := MergeSpans().Adjust(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected.Warnings, actual.Warnings)
+			assert.ElementsMatch(t, tt.expected.Spans, actual.Spans)
+		})
+	}
+
+}

--- a/model/adjuster/span_merger_test.go
+++ b/model/adjuster/span_merger_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 func Test_MergeAdjuster(t *testing.T) {


### PR DESCRIPTION
- allows for partially written spans to be merged while querying by selecting
  the span with the longest duration.

See https://github.com/jaegertracing/jaeger-client-java/issues/231 for more discussion

Signed-off-by: Prithvi Raj <p.r@uber.com>