### PR TITLE
Use the default metricsFactory if not provided

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -140,7 +140,7 @@ func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
 		return nil, err
 	}
 	httpServer := b.HTTPServer.GetHTTPServer(b.CollectorServiceName, mainReporter.Channel(), mFactory)
-	if h := b.Metrics.Handler(); b.metricsFactory != nil && h != nil {
+	if h := b.Metrics.Handler(); mFactory != nil && h != nil {
 		httpServer.Handler.(*http.ServeMux).Handle(b.Metrics.HTTPRoute, h)
 	}
 	return NewAgent(processors, httpServer, logger), nil


### PR DESCRIPTION
This will fix #738 

I'm looking at adding a test to ensure the functionality will stay over time. I'll update the PR