### PR TITLE
Allow overriding base path for UI/API routes; rm --query.prefix

### DIFF
--- a/cmd/query/app/fixture/index.html
+++ b/cmd/query/app/fixture/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <meta charset="UTF-8">
+    <base href="/" data-inject-target="BASE_URL"/>
     <title>Test Page</title>
     <!-- JAEGER_CONFIG=DEFAULT_CONFIG; -->
 </html>

--- a/cmd/query/app/fixture/static/asset.txt
+++ b/cmd/query/app/fixture/static/asset.txt
@@ -1,0 +1,1 @@
+some asset

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	queryPort                = "query.port"
-	queryPrefix              = "query.prefix"
+	queryBasePath            = "query.base-path"
 	queryStaticFiles         = "query.static-files"
 	queryUIConfig            = "query.ui-config"
 	queryHealthCheckHTTPPort = "query.health-check-http-port"
@@ -32,8 +32,8 @@ const (
 type QueryOptions struct {
 	// Port is the port that the query service listens in on
 	Port int
-	// Prefix is the prefix of the query service api
-	Prefix string
+	// BasePath is the prefix for all UI and API HTTP routes
+	BasePath string
 	// StaticAssets is the path for the static assets for the UI (https://github.com/uber/jaeger-ui)
 	StaticAssets string
 	// UIConfig is the path to a configuration file for the UI
@@ -45,8 +45,8 @@ type QueryOptions struct {
 // AddFlags adds flags for QueryOptions
 func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Int(queryPort, 16686, "The port for the query service")
-	flagSet.String(queryPrefix, "api", "The prefix for the url of the query service")
-	flagSet.String(queryStaticFiles, "jaeger-ui-build/build/", "The path for the static assets for the UI")
+	flagSet.String(queryBasePath, "/", "The base path for all HTTP routes, e.g. /jaeger; useful when running behind a reverse proxy")
+	flagSet.String(queryStaticFiles, "jaeger-ui-build/build/", "The directory path for the static assets for the UI")
 	flagSet.String(queryUIConfig, "", "The path to the UI configuration file in JSON format")
 	flagSet.Int(queryHealthCheckHTTPPort, 16687, "The http port for the health check service")
 }
@@ -54,7 +54,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 // InitFromViper initializes QueryOptions with properties from viper
 func (qOpts *QueryOptions) InitFromViper(v *viper.Viper) *QueryOptions {
 	qOpts.Port = v.GetInt(queryPort)
-	qOpts.Prefix = v.GetString(queryPrefix)
+	qOpts.BasePath = v.GetString(queryBasePath)
 	qOpts.StaticAssets = v.GetString(queryStaticFiles)
 	qOpts.UIConfig = v.GetString(queryUIConfig)
 	qOpts.HealthCheckHTTPPort = v.GetInt(queryHealthCheckHTTPPort)

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -27,12 +27,12 @@ func TestQueryBuilderFlags(t *testing.T) {
 	command.ParseFlags([]string{
 		"--query.static-files=/dev/null",
 		"--query.ui-config=some.json",
-		"--query.prefix=api",
+		"--query.base-path=/jaeger",
 		"--query.port=80",
 	})
 	qOpts := new(QueryOptions).InitFromViper(v)
 	assert.Equal(t, "/dev/null", qOpts.StaticAssets)
 	assert.Equal(t, "some.json", qOpts.UIConfig)
-	assert.Equal(t, "api", qOpts.Prefix)
+	assert.Equal(t, "/jaeger", qOpts.BasePath)
 	assert.Equal(t, 80, qOpts.Port)
 }

--- a/cmd/query/app/handler.go
+++ b/cmd/query/app/handler.go
@@ -43,7 +43,7 @@ const (
 
 	defaultDependencyLookbackDuration = time.Hour * 24
 	defaultTraceQueryLookbackDuration = time.Hour * 24 * 2
-	defaultHTTPPrefix                 = "api"
+	defaultAPIPrefix                  = "api"
 )
 
 var (
@@ -78,7 +78,8 @@ type APIHandler struct {
 	adjuster          adjuster.Adjuster
 	logger            *zap.Logger
 	queryParser       queryParser
-	httpPrefix        string
+	basePath          string
+	apiPrefix         string
 	tracer            opentracing.Tracer
 }
 
@@ -96,8 +97,8 @@ func NewAPIHandler(spanReader spanstore.Reader, dependencyReader dependencystore
 	for _, option := range options {
 		option(aH)
 	}
-	if aH.httpPrefix == "" {
-		aH.httpPrefix = defaultHTTPPrefix
+	if aH.apiPrefix == "" {
+		aH.apiPrefix = defaultAPIPrefix
 	}
 	if aH.adjuster == nil {
 		aH.adjuster = adjuster.Sequence(StandardAdjusters...)
@@ -141,7 +142,7 @@ func (aH *APIHandler) handleFunc(
 }
 
 func (aH *APIHandler) route(route string, args ...interface{}) string {
-	args = append([]interface{}{aH.httpPrefix}, args...)
+	args = append([]interface{}{aH.apiPrefix}, args...)
 	return fmt.Sprintf("/%s"+route, args...)
 }
 

--- a/cmd/query/app/handler_options.go
+++ b/cmd/query/app/handler_options.go
@@ -47,10 +47,17 @@ func (handlerOptions) Adjusters(adjusters ...adjuster.Adjuster) HandlerOption {
 	}
 }
 
-// Prefix creates a HandlerOption that initializes prefix HTTP prefix of the API
+// BasePath creates a HandlerOption that initializes the base path for all HTTP routes
+func (handlerOptions) BasePath(prefix string) HandlerOption {
+	return func(apiHandler *APIHandler) {
+		apiHandler.basePath = prefix
+	}
+}
+
+// Prefix creates a HandlerOption that initializes the HTTP prefix for API routes
 func (handlerOptions) Prefix(prefix string) HandlerOption {
 	return func(apiHandler *APIHandler) {
-		apiHandler.httpPrefix = prefix
+		apiHandler.apiPrefix = prefix
 	}
 }
 

--- a/cmd/query/app/handler_test.go
+++ b/cmd/query/app/handler_test.go
@@ -85,7 +85,7 @@ func initializeTestServerWithHandler(options ...HandlerOption) (*httptest.Server
 		append(
 			[]HandlerOption{
 				HandlerOptions.Logger(zap.NewNop()),
-				HandlerOptions.Prefix(defaultHTTPPrefix),
+				HandlerOptions.Prefix(defaultAPIPrefix),
 				HandlerOptions.QueryLookbackDuration(defaultTraceQueryLookbackDuration),
 			},
 			options...,

--- a/cmd/query/app/handler_test.go
+++ b/cmd/query/app/handler_test.go
@@ -85,7 +85,9 @@ func initializeTestServerWithHandler(options ...HandlerOption) (*httptest.Server
 		append(
 			[]HandlerOption{
 				HandlerOptions.Logger(zap.NewNop()),
+				// add options for test coverage
 				HandlerOptions.Prefix(defaultAPIPrefix),
+				HandlerOptions.BasePath("/"),
 				HandlerOptions.QueryLookbackDuration(defaultTraceQueryLookbackDuration),
 			},
 			options...,

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -29,7 +29,8 @@ import (
 )
 
 var (
-	staticRootFiles = []string{"favicon.ico"}
+	favoriteIcon    = "favicon.ico"
+	staticRootFiles = []string{favoriteIcon}
 	configPattern   = regexp.MustCompile("JAEGER_CONFIG *= *DEFAULT_CONFIG;")
 	basePathPattern = regexp.MustCompile(`<base href="/"`)
 	basePathReplace = `<base href="%s/"`
@@ -132,7 +133,6 @@ func loadUIConfig(uiConfig string) (map[string]interface{}, error) {
 
 // RegisterRoutes registers routes for this handler on the given router
 func (sH *StaticAssetsHandler) RegisterRoutes(router *mux.Router) {
-	// router.PathPrefix("/static").Handler(http.FileServer(http.Dir(sH.staticAssetsRoot)))
 	router.PathPrefix("/static").Handler(sH.fileHandler())
 	for _, file := range staticRootFiles {
 		router.Path("/" + file).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -150,6 +150,8 @@ func (sH *StaticAssetsHandler) fileHandler() http.Handler {
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, base) {
+			// gorilla Subroute() is a bit odd, it keeps the base path in the URL,
+			// which prevents the FileServer from locating the files, so we strip the prefix.
 			r.URL.Path = r.URL.Path[len(base):]
 		}
 		fs.ServeHTTP(w, r)

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -34,7 +34,7 @@ var (
 	configPattern   = regexp.MustCompile("JAEGER_CONFIG *= *DEFAULT_CONFIG;")
 	basePathPattern = regexp.MustCompile(`<base href="/"`)
 	basePathReplace = `<base href="%s/"`
-	errBadBasePath  = "Invalid base path '%s'. Must start with / but not end with /, e.g. /jaeger/ui."
+	errBadBasePath  = "Invalid base path '%s'. Must start but not end with a slash '/', e.g. '/jaeger/ui'"
 )
 
 // RegisterStaticHandler adds handler for static assets to the router.

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -33,7 +33,7 @@ var (
 	configPattern   = regexp.MustCompile("JAEGER_CONFIG *= *DEFAULT_CONFIG;")
 	basePathPattern = regexp.MustCompile(`<base href="/"`)
 	basePathReplace = `<base href="%s/"`
-	errBadBasePath  = errors.New("Base path must start with / but not end with /; valid path: /jaeger/ui")
+	errBadBasePath  = "Invalid base path '%s'. Must start with / but not end with /, e.g. /jaeger/ui."
 )
 
 // RegisterStaticHandler adds handler for static assets to the router.
@@ -88,9 +88,12 @@ func NewStaticAssetsHandler(staticAssetsRoot string, options StaticAssetsHandler
 		configString = fmt.Sprintf("JAEGER_CONFIG = %v", string(bytes))
 	}
 	indexBytes = configPattern.ReplaceAll(indexBytes, []byte(configString+";"))
+	if options.BasePath == "" {
+		options.BasePath = "/"
+	}
 	if options.BasePath != "/" {
 		if !strings.HasPrefix(options.BasePath, "/") || strings.HasSuffix(options.BasePath, "/") {
-			return nil, errBadBasePath
+			return nil, fmt.Errorf(errBadBasePath, options.BasePath)
 		}
 		indexBytes = basePathPattern.ReplaceAll(indexBytes, []byte(fmt.Sprintf(basePathReplace, options.BasePath)))
 	}

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestStaticAssetsHandler(t *testing.T) {
 	r := mux.NewRouter()
-	handler, err := NewStaticAssetsHandler("fixture", "")
+	handler, err := NewStaticAssetsHandler("fixture", StaticAssetsHandlerOptions{})
 	require.NoError(t, err)
 	handler.RegisterRoutes(r)
 	server := httptest.NewServer(r)
@@ -49,13 +49,13 @@ func TestStaticAssetsHandler(t *testing.T) {
 }
 
 func TestDefaultStaticAssetsRoot(t *testing.T) {
-	handler, err := NewStaticAssetsHandler("", "")
+	handler, err := NewStaticAssetsHandler("", StaticAssetsHandlerOptions{})
 	assert.Nil(t, handler)
 	assert.Nil(t, err)
 }
 
 func TestNotExistingUiConfig(t *testing.T) {
-	handler, err := NewStaticAssetsHandler("/foo/bar", "")
+	handler, err := NewStaticAssetsHandler("/foo/bar", StaticAssetsHandlerOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Cannot read UI static assets")
 	assert.Nil(t, handler)
@@ -103,10 +103,10 @@ func TestRegisterStaticHandler(t *testing.T) {
 }
 
 func TestNewStaticAssetsHandlerWithConfig(t *testing.T) {
-	_, err := NewStaticAssetsHandler("fixture", "fixture/invalid-config")
+	_, err := NewStaticAssetsHandler("fixture", StaticAssetsHandlerOptions{UIConfigPath: "fixture/invalid-config"})
 	assert.Error(t, err)
 
-	handler, err := NewStaticAssetsHandler("fixture", "fixture/ui-config.json")
+	handler, err := NewStaticAssetsHandler("fixture", StaticAssetsHandlerOptions{UIConfigPath: "fixture/ui-config.json"})
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 	html := string(handler.indexHTML)

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -132,30 +132,6 @@ func TestRegisterStaticHandler(t *testing.T) {
 	}
 }
 
-func TestNewStaticAssetsHandlerSubstitutions(t *testing.T) {
-	testCases := []struct {
-		base     string
-		expected string
-	}{
-		{base: "", expected: `<base href="/"`},
-		{base: "/", expected: `<base href="/"`},
-		{base: "/jaeger", expected: `<base href="/jaeger/"`},
-	}
-	for _, testCase := range testCases {
-		handler, err := NewStaticAssetsHandler(
-			"fixture",
-			StaticAssetsHandlerOptions{
-				UIConfigPath: "fixture/ui-config.json",
-				BasePath:     testCase.base,
-			})
-		require.NoError(t, err)
-		require.NotNil(t, handler)
-		html := string(handler.indexHTML)
-		assert.Contains(t, html, `JAEGER_CONFIG = {"x":"y"};`, "actual: %v", html)
-		assert.Contains(t, html, testCase.expected, "actual: %v", html)
-	}
-}
-
 func TestNewStaticAssetsHandlerErrors(t *testing.T) {
 	_, err := NewStaticAssetsHandler("fixture", StaticAssetsHandlerOptions{UIConfigPath: "fixture/invalid-config"})
 	assert.Error(t, err)

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -130,8 +130,7 @@ func main() {
 			}
 
 			portStr := ":" + strconv.Itoa(queryOpts.Port)
-			loggingHandler := handlers.LoggingHandler(os.Stdout, r)
-			compressHandler := handlers.CompressHandler(loggingHandler)
+			compressHandler := handlers.CompressHandler(r)
 			recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
 
 			go func() {

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -109,7 +109,6 @@ func main() {
 			}
 
 			apiHandlerOptions := []app.HandlerOption{
-				app.HandlerOptions.Prefix(queryOpts.Prefix),
 				app.HandlerOptions.Logger(logger),
 				app.HandlerOptions.Tracer(tracer),
 			}
@@ -119,6 +118,9 @@ func main() {
 				dependencyReader,
 				apiHandlerOptions...)
 			r := mux.NewRouter()
+			if queryOpts.BasePath != "/" {
+				r = r.PathPrefix(queryOpts.BasePath).Subrouter()
+			}
 			apiHandler.RegisterRoutes(r)
 			app.RegisterStaticHandler(r, logger, queryOpts)
 
@@ -128,7 +130,8 @@ func main() {
 			}
 
 			portStr := ":" + strconv.Itoa(queryOpts.Port)
-			compressHandler := handlers.CompressHandler(r)
+			loggingHandler := handlers.LoggingHandler(os.Stdout, r)
+			compressHandler := handlers.CompressHandler(loggingHandler)
 			recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
 
 			go func() {

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -266,11 +266,13 @@ func startQuery(
 	apiHandler := queryApp.NewAPIHandler(
 		spanReader,
 		depReader,
-		queryApp.HandlerOptions.Prefix(qOpts.Prefix),
 		queryApp.HandlerOptions.Logger(logger),
 		queryApp.HandlerOptions.Tracer(tracer))
 
 	r := mux.NewRouter()
+	if qOpts.BasePath != "/" {
+		r = r.PathPrefix(qOpts.BasePath).Subrouter()
+	}
 	apiHandler.RegisterRoutes(r)
 	queryApp.RegisterStaticHandler(r, logger, qOpts)
 


### PR DESCRIPTION
Resolves #745 **Provide a means to define a path-prefix for the UI**
Resolves #746 **Remove --query.prefix option**

* [ ] depends on https://github.com/jaegertracing/jaeger-ui/pull/198 merged