### PR TITLE
[WIP] Influx metrics reporter

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -113,12 +113,12 @@ func (b *Builder) createMainReporter(mFactory metrics.Factory, logger *zap.Logge
 	return b.CreateReporter(mFactory, logger)
 }
 
-func (b *Builder) getMetricsFactory() (metrics.Factory, error) {
+func (b *Builder) getMetricsFactory(logger *zap.Logger) (metrics.Factory, error) {
 	if b.metricsFactory != nil {
 		return b.metricsFactory, nil
 	}
 
-	baseFactory, err := b.Metrics.CreateMetricsFactory("jaeger")
+	baseFactory, err := b.Metrics.CreateMetricsFactory("jaeger", logger)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (b *Builder) getMetricsFactory() (metrics.Factory, error) {
 
 // CreateAgent creates the Agent
 func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
-	mFactory, err := b.getMetricsFactory()
+	mFactory, err := b.getMetricsFactory(logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create metrics factory")
 	}

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -121,7 +121,7 @@ func TestBuilderWithExtraReporter(t *testing.T) {
 func TestBuilderMetrics(t *testing.T) {
 	mf := metrics.NullFactory
 	b := new(Builder).WithMetricsFactory(mf)
-	mf2, err := b.getMetricsFactory()
+	mf2, err := b.getMetricsFactory(zap.NewNop())
 	assert.NoError(t, err)
 	assert.Equal(t, mf, mf2)
 }
@@ -130,7 +130,7 @@ func TestBuilderMetricsHandler(t *testing.T) {
 	b := &Builder{}
 	b.Metrics.Backend = "expvar"
 	b.Metrics.HTTPRoute = "/expvar"
-	factory, err := b.Metrics.CreateMetricsFactory("test")
+	factory, err := b.Metrics.CreateMetricsFactory("test", zap.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, factory)
 	b.metricsFactory = factory

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -89,8 +89,12 @@ func main() {
 
 			builderOpts := new(builder.CollectorOptions).InitFromViper(v)
 
-			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			baseFactory, err := mBldr.CreateMetricsFactory("jaeger")
+			mBldr, err := new(pMetrics.Builder).InitFromViper(v)
+			if err != nil {
+				logger.Fatal("Cannot parse metrics flags.", zap.Error(err))
+			}
+
+			baseFactory, err := mBldr.CreateMetricsFactory("jaeger", logger)
 			if err != nil {
 				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
 			}

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -74,8 +74,12 @@ func main() {
 
 			queryOpts := new(app.QueryOptions).InitFromViper(v)
 
-			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			baseFactory, err := mBldr.CreateMetricsFactory("jaeger")
+			mBldr, err := new(pMetrics.Builder).InitFromViper(v)
+			if err != nil {
+				logger.Fatal("Cannot parse metrics flags.", zap.Error(err))
+			}
+
+			baseFactory, err := mBldr.CreateMetricsFactory("jaeger", logger)
 			if err != nil {
 				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
 			}

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -96,8 +96,15 @@ func main() {
 				logger.Fatal("Could not start the health check server.", zap.Error(err))
 			}
 
-			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			metricsFactory, err := mBldr.CreateMetricsFactory("jaeger")
+			mBldr, err := new(pMetrics.Builder).InitFromViper(v)
+			if err != nil {
+				logger.Fatal("Cannot parse metrics flags.", zap.Error(err))
+			}
+
+			metricsFactory, err := mBldr.CreateMetricsFactory("jaeger", logger)
+			if err != nil {
+				logger.Fatal("Cannot parse metrics flags.", zap.Error(err))
+			}
 			if err != nil {
 				return errors.Wrap(err, "Cannot create metrics factory")
 			}

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
-hash: d40883d6de90a4a415db54f472ac90c848b7503cbcd2f1251396e19e91f25745
-updated: 2018-04-03T13:20:02.642056-04:00
+hash: b484df02b699a918c87af8cb918126b06ade1eb4c311ccdfd1ebb0c53467db41
+updated: 2018-06-13T23:21:51.73548686+02:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
   subpackages:
   - lib/go/thrift
 - name: github.com/asaskevich/govalidator
-  version: 808e7b820405fbd763f8a3c95531df8f87e675f1
+  version: 7d2e70ef918f16bd6455529af38304d6d025c952
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/codahale/hdrhistogram
-  version: f8ad88b59a584afeee9d334eff879b104439117b
+  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/crossdock/crossdock-go
   version: 049aabb0122b03bc9bd30cab8f3f91fb60166361
   subpackages:
@@ -25,40 +25,47 @@ imports:
 - name: github.com/elazarl/go-bindata-assetfs
   version: 38087fe4dafb822e541b3f7955075cc1c30bd294
 - name: github.com/fsnotify/fsnotify
-  version: 30411dbcefb7a1da7e84f75530ad3abe4011b4f8
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/go-kit/kit
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:
+  - log
   - metrics
   - metrics/expvar
   - metrics/generic
+  - metrics/influx
   - metrics/internal/lv
+- name: github.com/go-logfmt/logfmt
+  version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-openapi/analysis
-  version: 8ed83f2ea9f00f945516462951a288eaa68bf0d6
+  version: 5957818e100395077187fb7ef3b8a28227af06c6
 - name: github.com/go-openapi/errors
-  version: 03cfca65330da08a5a440053faf994a3c682b5bf
+  version: b2b2befaf267d082d779bcef52d682a47c779517
 - name: github.com/go-openapi/jsonpointer
-  version: 779f45308c19820f1a69e9a4cd965f496e0da10f
+  version: 3a0015ad55fa9873f41605d3e8f28cd279c32ab2
 - name: github.com/go-openapi/jsonreference
-  version: 36d33bfe519efae5632669801b180bf1a245da3b
+  version: 3fb327e6747da3043567ee86abd02bb6376b6be2
 - name: github.com/go-openapi/loads
-  version: c3e1ca4c0b6160cac10aeef7e8b425cc95b9c820
+  version: 2a2b323bab96e6b1fdee110e57d959322446e9c9
 - name: github.com/go-openapi/runtime
-  version: e8231e16de5bcda9839e03ae07c5c96a1fd82041
+  version: 90c7afbb4bd8b22431e1c32d65caf405abf170c3
   subpackages:
+  - logger
   - middleware
   - middleware/denco
   - middleware/header
   - middleware/untyped
   - security
 - name: github.com/go-openapi/spec
-  version: a4fa9574c7aa73b2fc54e251eb9524d0482bb592
+  version: bcff419492eeeb01f76e77d2ebc714dc97b607f5
 - name: github.com/go-openapi/strfmt
-  version: 610b6cacdcde6852f4de68998bd20ce1dac85b22
+  version: 481808443b00a14745fada967cb5eeff0f9b1df2
 - name: github.com/go-openapi/swag
-  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
+  version: 811b1089cde9dad18d4d0c2d09fbdbf28dbd27a5
 - name: github.com/go-openapi/validate
-  version: a762d5dd38f7c7e9e1a13c3e98344cfbe4aa15d9
+  version: b0a3ed684d0fdd3e1eda00433382188ce8aa7169
+- name: github.com/go-stack/stack
+  version: 259ab82a6cad3992b4e21ff5cac294ccb06474bc
 - name: github.com/gocql/gocql
   version: 181004e14a3fb735efcc826a4256369d0c96747b
   subpackages:
@@ -66,13 +73,13 @@ imports:
   - internal/murmur
   - internal/streams
 - name: github.com/golang/protobuf
-  version: 7cc19b78d562895b13596ddce7aafb59dd789318
+  version: 925541529c1fa6821df4e44ce2723319eb2be768
   subpackages:
   - proto
 - name: github.com/golang/snappy
-  version: d7b1e156f50d3c4664f683603af70e3e47fa0aa2
+  version: 2e65f85255dbc3072edf28d6b5b8efc472979f5a
 - name: github.com/gorilla/context
-  version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/handlers
   version: 3a5767ca75ece5f7f1440b1d16975247f8d8b221
 - name: github.com/gorilla/mux
@@ -80,10 +87,11 @@ imports:
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/hashicorp/hcl
-  version: 80e628d796135357b3d2e33a985c666b9f35eee1
+  version: ef8a98b0bbce4a65b5aa4c368430a80ddc533168
   subpackages:
   - hcl/ast
   - hcl/parser
+  - hcl/printer
   - hcl/scanner
   - hcl/strconv
   - hcl/token
@@ -92,26 +100,34 @@ imports:
   - json/token
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/influxdata/influxdb
+  version: 2be1620c32dd422c91f41e27def0e67382cb346f
+  subpackages:
+  - client/v2
+  - models
+  - pkg/escape
+- name: github.com/kr/logfmt
+  version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/kr/pretty
-  version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
+  version: 73f6ac0b30a98e433b289500d779f50c1a6f0712
 - name: github.com/magiconair/properties
-  version: 9c47895dc1ce54302908ab8a43385d1f5df2c11c
+  version: c2353362d570a7bfa228149c62842019201cfb71
 - name: github.com/mailru/easyjson
-  version: 5f62e4f3afa2f576dc86531b7df4d966b19ef8f8
+  version: 3fdea8d05856a0c8df22ed4bc71b3219245e4485
   subpackages:
   - buffer
   - jlexer
   - jwriter
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  version: 3247c84500bff8d9fb6d579d800f20b3e091582c
   subpackages:
   - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: bfdb1a85537d60bc7e954e600c250219ea497417
+  version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
 - name: github.com/olivere/elastic
   version: f1fd7305d0b6270192b27010fe1193568b18e4b6
 - name: github.com/opentracing-contrib/go-stdlib
-  version: 1de4cc2120e71f745a5810488bf64b29b6d7d9f6
+  version: 36723135187404d2f4002f4f189938565e64cc5c
   subpackages:
   - nethttp
 - name: github.com/opentracing/opentracing-go
@@ -119,10 +135,8 @@ imports:
   subpackages:
   - ext
   - log
-- name: github.com/pelletier/go-buffruneio
-  version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: 439fbba1f887c286024370cb4f281ba815c4c7d7
+  version: c01d1270ff3e442a8a57cddc1c92dc1138598194
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
@@ -135,57 +149,61 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: e4aa40a9169a88835b849a6efb71e05dc04b88f0
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: 54d17b57dd7d4a3aa092476596b3f8a933bde349
   subpackages:
+  - internal/util
+  - nfs
   - xfs
 - name: github.com/PuerkitoBio/purell
-  version: fd18e053af8a4ff11039269006e8037ff374ce0e
+  version: 975f53781597ed779763b7b65566e74c4004d8de
 - name: github.com/PuerkitoBio/urlesc
   version: de5bf2ad457846296e2031421a34e2568e304e35
 - name: github.com/spf13/afero
-  version: 90dd71edc4d0a8b3511dc12ea15d617d03be09e0
+  version: 787d034dfe70e44075ccc060d346146ef53270ad
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: 56a7ecbeb18dde53c6db4bd96b541fd9741b8d44
+  version: 8965335b8c7107321228e3e3702cab9832751bac
 - name: github.com/spf13/cobra
   version: 7b2c5ac9fc04fc5efafb60700713d4fa609b777b
 - name: github.com/spf13/jwalterweatherman
-  version: bccdd23ae5e51bd2b081814db093646c7af3d34d
+  version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
 - name: github.com/spf13/pflag
-  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/spf13/viper
-  version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
+  version: b5e8006cbee93ec955a89ab31e0e3ce3204f3736
 - name: github.com/stretchr/objx
-  version: 8a3f7159479fbc75b30357fbc48f380b7320f08e
+  version: 0ab728f62c7f6fcd754334f7931c2dd659dce1d1
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - mock
   - require
 - name: github.com/uber-go/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: github.com/uber/jaeger-client-go
-  version: c107110d057826281414cb964f167bce5be17588
+  version: b043381d944715b469fd6b37addfd30145ca1758
   subpackages:
   - config
   - internal/baggage
   - internal/baggage/remote
   - internal/spanlog
   - internal/throttler
+  - internal/throttler/remote
   - log
   - rpcmetrics
+  - thrift
   - thrift-gen/agent
   - thrift-gen/baggage
   - thrift-gen/jaeger
@@ -202,6 +220,7 @@ imports:
   - metrics/expvar
   - metrics/go-kit
   - metrics/go-kit/expvar
+  - metrics/go-kit/influx
   - metrics/prometheus
   - metrics/testutils
 - name: github.com/uber/tchannel-go
@@ -220,30 +239,31 @@ imports:
 - name: github.com/VividCortex/gohistogram
   version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: 35aad584952c3e7020db7b839f6b102de6271f89
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool
   - internal/color
   - internal/exit
+  - internal/ztest
   - zapcore
   - zaptest
 - name: golang.org/x/net
-  version: b68f30494add4df6bd8ef5e82803f308e7f7c59c
+  version: db08ff08e8622530d9ed3a0e8ac279f6d4c02196
   subpackages:
   - context
   - context/ctxhttp
   - idna
 - name: golang.org/x/sys
-  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  version: d8e400bc7db4870d786864138af681469693d18c
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 44f4f658a783b0cee41fe0a23b8fc91d9c120558
+  version: f21a4dfb5e38f5895301dc265a8def02365cc3d0
   subpackages:
   - secure/bidirule
   - transform
@@ -251,18 +271,19 @@ imports:
   - unicode/norm
   - width
 - name: gopkg.in/inf.v0
-  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+  version: d2d2541c53f18d2a059457998ce2876cc8e67cbf
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
   - internal/json
 - name: gopkg.in/olivere/elastic.v5
-  version: f1fd7305d0b6270192b27010fe1193568b18e4b6
+  version: b708306d715bea9b983685e94ab4602cdc9f988b
   subpackages:
+  - config
   - uritemplates
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/kr/text
-  version: 7cafcd837844e784b526369c9bce262804aebc60
+  version: e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f

--- a/glide.yaml
+++ b/glide.yaml
@@ -55,3 +55,6 @@ import:
 - package: github.com/go-openapi/validate
 - package: github.com/go-openapi/loads
 - package: github.com/elazarl/go-bindata-assetfs
+- package: github.com/influxdata/influxdb
+  subpackages:
+  - client/v2

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -15,33 +15,61 @@
 package metrics
 
 import (
+	"encoding/json"
 	"errors"
 	"expvar"
 	"flag"
 	"net/http"
+	"time"
 
+	gokitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics/influx"
+	influxcli "github.com/influxdata/influxdb/client/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
 	jexpvar "github.com/uber/jaeger-lib/metrics/expvar"
+	"github.com/uber/jaeger-lib/metrics/go-kit"
+	jinfl "github.com/uber/jaeger-lib/metrics/go-kit/influx"
 	jprom "github.com/uber/jaeger-lib/metrics/prometheus"
+	"go.uber.org/zap"
 )
 
 const (
-	metricsBackend        = "metrics-backend"
-	metricsHTTPRoute      = "metrics-http-route"
-	defaultMetricsBackend = "prometheus"
-	defaultMetricsRoute   = "/metrics"
+	metricsBackend         = "metrics-backend"
+	metricsHTTPRoute       = "metrics-http-route"
+	metricsTags            = "metrics-tags"
+	metricsInfluxServerURL = "metrics-influx-server-url"
+	metricsInfluxDb        = "metrics-influx-db"
+	metricsInfluxFrequency = "metrics-influx-reporting-frequency"
+	metricsInfluxUser      = "metrics-influx-user"
+	metricsInfluxPass      = "metrics-influx-pass"
+
+	defaultMetricsBackend  = "prometheus"
+	defaultMetricsRoute    = "/metrics"
+	defaultMetricsTags     = "{}"
+	defaultInfluxURL       = "http://localhost:8086"
+	defaultInfluxDb        = "jaeger"
+	defaultInfluxFrequency = "10s"
+	defaultInfluxUser      = ""
+	defaultInfluxPass      = ""
 )
 
 var errUnknownBackend = errors.New("unknown metrics backend specified")
+var errMalformedMetricTags = errors.New("flag " + metricsTags + " is not a valid JSON map")
 
 // Builder provides command line options to configure metrics backend used by Jaeger executables.
 type Builder struct {
-	Backend   string
-	HTTPRoute string // endpoint name to expose metrics, e.g. for scraping
-	handler   http.Handler
+	Backend                  string
+	HTTPRoute                string // endpoint name to expose metrics, e.g. for scraping
+	tags                     map[string]string
+	handler                  http.Handler
+	influxServerURL          string
+	influxDb                 string
+	influxReportingFrequency time.Duration
+	influxUser               string
+	influxPass               string
 }
 
 // AddFlags adds flags for Builder.
@@ -49,24 +77,58 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.String(
 		metricsBackend,
 		defaultMetricsBackend,
-		"Defines which metrics backend to use for metrics reporting: expvar, prometheus, none")
+		"Defines which metrics backend to use for metrics reporting: expvar, prometheus, influx, none")
 	flags.String(
 		metricsHTTPRoute,
 		defaultMetricsRoute,
 		"Defines the route of HTTP endpoint for metrics backends that support scraping")
+	flags.String(
+		metricsTags,
+		defaultMetricsTags,
+		`Tags reported with each metric. JSON-formatted map. E.g. {"tag1": "a", "tag2": "b"}`)
+	flags.String(
+		metricsInfluxServerURL,
+		defaultInfluxURL,
+		"Influx server address")
+	flags.String(
+		metricsInfluxDb,
+		defaultInfluxDb,
+		"The Influx database name")
+	flags.String(
+		metricsInfluxFrequency,
+		defaultInfluxFrequency,
+		"The frequency of reporting metrics to Influx")
+	flags.String(
+		metricsInfluxUser,
+		defaultInfluxUser,
+		"Influx username")
+	flags.String(
+		metricsInfluxPass,
+		defaultInfluxPass,
+		"Influx password")
 }
 
 // InitFromViper initializes Builder with properties retrieved from Viper.
-func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
+func (b *Builder) InitFromViper(v *viper.Viper) (*Builder, error) {
 	b.Backend = v.GetString(metricsBackend)
 	b.HTTPRoute = v.GetString(metricsHTTPRoute)
-	return b
+	b.influxServerURL = v.GetString(metricsInfluxServerURL)
+	b.influxDb = v.GetString(metricsInfluxDb)
+	b.influxReportingFrequency = v.GetDuration(metricsInfluxFrequency)
+	b.influxUser = v.GetString(metricsInfluxUser)
+	b.influxPass = v.GetString(metricsInfluxPass)
+	tagsStr := v.GetString(metricsTags)
+	err := json.Unmarshal([]byte(tagsStr), &b.tags)
+	if err != nil {
+		return nil, errMalformedMetricTags
+	}
+	return b, nil
 }
 
 // CreateMetricsFactory creates a metrics factory based on the configured type of the backend.
 // If the metrics backend supports HTTP endpoint for scraping, it is stored in the builder and
 // can be later added by RegisterHandler function.
-func (b *Builder) CreateMetricsFactory(namespace string) (metrics.Factory, error) {
+func (b *Builder) CreateMetricsFactory(namespace string, logger *zap.Logger) (metrics.Factory, error) {
 	if b.Backend == "prometheus" {
 		metricsFactory := jprom.New().Namespace(namespace, nil)
 		b.handler = promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{DisableCompression: true})
@@ -75,6 +137,39 @@ func (b *Builder) CreateMetricsFactory(namespace string) (metrics.Factory, error
 	if b.Backend == "expvar" {
 		metricsFactory := jexpvar.NewFactory(10).Namespace(namespace, nil)
 		b.handler = expvar.Handler()
+		return metricsFactory, nil
+	}
+	if b.Backend == "influx" {
+		reporter, err := influxcli.NewHTTPClient(influxcli.HTTPConfig{
+			Addr:     b.influxServerURL,
+			Username: b.influxUser,
+			Password: b.influxPass,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		inf := influx.New(b.tags, influxcli.BatchPointsConfig{
+			Database: b.influxDb,
+		}, gokitlog.NewNopLogger()) // NopLogger is ok because we use our own reporting loop with zap logger
+
+		metricsFactory := xkit.Wrap(namespace, jinfl.NewFactory(inf))
+
+		go func() {
+			ticker := time.NewTicker(b.influxReportingFrequency)
+			for range ticker.C {
+				err := inf.WriteTo(reporter)
+				if err != nil {
+					logger.Warn("Failed to write to influx", zap.Error(err))
+				}
+			}
+		}()
+		logger.Info("Reporting metrics to influxdb",
+			zap.String("url", b.influxServerURL),
+			zap.String("username", b.influxUser),
+			zap.String("db", b.influxDb),
+			zap.Duration("frequency", b.influxReportingFrequency),
+			zap.Reflect("tags", b.tags))
 		return metricsFactory, nil
 	}
 	if b.Backend == "none" || b.Backend == "" {


### PR DESCRIPTION
This adds influx metrics reporter, it uses gokit wrapper added in https://github.com/jaegertracing/jaeger-lib/pull/23

I had to add a bunch of flags because (unlike prometheus/expvar) influx reporter requires at least url, credentials and database name. I also wanted to be able to add some predefined tags to be able to indicate the environment name.