### PR TITLE
add make and travis options for building for windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
     - HOTROD=true
   - go: 1.9
     env:
+    - LINUX=true
+    - go: 1.9
+    env:
     - WINDOWS=true
   - go: 1.9
     env:
@@ -60,6 +63,7 @@ script:
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping docker images'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
+  - if [ "$LINUX" == true ]; make build-linux ; else echo 'skipping linux'; fi
   - if [ "$WINDOWS" == true ]; make build-windows ; else echo 'skipping windows'; fi
   - if [ "$DARWIN" == true ]; make build-darwin ; else echo 'skipping darwin'; fi
 
@@ -68,6 +72,9 @@ after_success:
 
 after_failure:
   - if [ "$CROSSDOCK" == true ]; then make crossdock-logs ; else echo 'skipping crossdock'; fi
+
+before_deploy:
+  - bash ./scripts/travis/package-deploy.sh
 
 deploy:
   provider: releases
@@ -86,3 +93,4 @@ deploy:
   on:
     tags: true
     repo: jaegertracing/jaeger
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ matrix:
   - go: 1.9
     env:
     - WINDOWS=true
+  - go: 1.9
+    env:
+    - DARWIN=true
 
 services:
   - docker
@@ -58,6 +61,7 @@ script:
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
   - if [ "$WINDOWS" == true ]; then bash ./scripts/travis/build-windows.sh ; else echo 'skipping windows'; fi
+  - if [ "$DARWIN" == true ]; make build-darwin ; else echo 'skipping darwin'; fi
 
 after_success:
   - if [ "$COVERAGE" == true ]; then travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true ; else echo 'skipping coverage'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
   - go: 1.9
     env:
     - HOTROD=true
+  - go: 1.9
+    env:
+    - WINDOWS=true
 
 services:
   - docker
@@ -54,9 +57,28 @@ script:
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping docker images'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
+  - if [ "$WINDOWS" == true ]; then bash ./scripts/travis/build-windows.sh ; else echo 'skipping windows'; fi
 
 after_success:
   - if [ "$COVERAGE" == true ]; then travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true ; else echo 'skipping coverage'; fi
 
 after_failure:
   - if [ "$CROSSDOCK" == true ]; then make crossdock-logs ; else echo 'skipping crossdock'; fi
+
+deploy:
+  provider: releases
+  api_key:
+    secure: YOUR_API_KEY_ENCRYPTED
+  file:
+    - "cmd/standalone/standalone-linux"
+    - "cmd/standalone/standalone-windows.exe"
+    - "cmd/agent/agent-linux"
+    - "cmd/agent/agent-windows.exe"
+    - "cmd/query/query-linux"
+    - "cmd/query/query-windows.exe"
+    - "cmd/collector/collector-linux"
+    - "cmd/collector/collector-windows.exe"
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: jaegertracing/jaeger

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,13 @@ matrix:
   - go: 1.9
     env:
     - DOCKER=true
+    - DEPLOY=true
   - go: 1.9
     env:
     - ES_INTEGRATION_TEST=true
   - go: 1.9
     env:
     - HOTROD=true
-  - go: 1.9
-    env:
-    - LINUX=true
-    - go: 1.9
-    env:
-    - WINDOWS=true
-  - go: 1.9
-    env:
-    - DARWIN=true
 
 services:
   - docker
@@ -63,9 +55,7 @@ script:
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping docker images'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
-  - if [ "$LINUX" == true ]; then make build-linux ; else echo 'skipping linux'; fi
-  - if [ "$WINDOWS" == true ]; then make build-windows ; else echo 'skipping windows'; fi
-  - if [ "$DARWIN" == true ]; then make build-darwin ; else echo 'skipping darwin'; fi
+  - if [ "$DEPLOY" == true ]; then make build-binaries-linux build-binaries-windows build-binaries-darwin ; else echo 'skipping linux'; fi
 
 after_success:
   - if [ "$COVERAGE" == true ]; then travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true ; else echo 'skipping coverage'; fi
@@ -80,15 +70,9 @@ deploy:
   provider: releases
   api_key:
     secure: YOUR_API_KEY_ENCRYPTED
+  file_glob: true
   file:
-    - "cmd/standalone/standalone-linux"
-    - "cmd/standalone/standalone-windows.exe"
-    - "cmd/agent/agent-linux"
-    - "cmd/agent/agent-windows.exe"
-    - "cmd/query/query-linux"
-    - "cmd/query/query-windows.exe"
-    - "cmd/collector/collector-linux"
-    - "cmd/collector/collector-windows.exe"
+    - deploy/*.tar.gz
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ script:
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping docker images'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
-  - if [ "$LINUX" == true ]; make build-linux ; else echo 'skipping linux'; fi
-  - if [ "$WINDOWS" == true ]; make build-windows ; else echo 'skipping windows'; fi
-  - if [ "$DARWIN" == true ]; make build-darwin ; else echo 'skipping darwin'; fi
+  - if [ "$LINUX" == true ]; then make build-linux ; else echo 'skipping linux'; fi
+  - if [ "$WINDOWS" == true ]; then make build-windows ; else echo 'skipping windows'; fi
+  - if [ "$DARWIN" == true ]; then make build-darwin ; else echo 'skipping darwin'; fi
 
 after_success:
   - if [ "$COVERAGE" == true ]; then travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true ; else echo 'skipping coverage'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping docker images'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
-  - if [ "$WINDOWS" == true ]; then bash ./scripts/travis/build-windows.sh ; else echo 'skipping windows'; fi
+  - if [ "$WINDOWS" == true ]; make build-windows ; else echo 'skipping windows'; fi
   - if [ "$DARWIN" == true ]; make build-darwin ; else echo 'skipping darwin'; fi
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -143,70 +143,45 @@ build_ui:
 	rm -rf jaeger-ui-build && mkdir jaeger-ui-build
 	cp -r jaeger-ui/build jaeger-ui-build/
 
+.PHONY: build-all-in-one
+build-all-in-one: build_ui
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/standalone/standalone-$(GOOS) $(BUILD_INFO) ./cmd/standalone/main.go
+
 .PHONY: build-all-in-one-linux
-build-all-in-one-linux: build_ui
-	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/standalone/standalone-linux $(BUILD_INFO) ./cmd/standalone/main.go
+build-all-in-one-linux: 
+	GOOS=linux $(MAKE) build-all-in-one
 
-.PHONY: build-all-in-one-windows
-build-all-in-one-windows: build_ui
-	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/standalone/standalone-windows.exe $(BUILD_INFO) ./cmd/standalone/main.go
+.PHONY: build-agent
+build-agent:
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/agent/agent-$(GOOS) $(BUILD_INFO) ./cmd/agent/main.go
 
-.PHONY: build-all-in-one-darwin
-build-all-in-one-darwin: build_ui
-	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/standalone/standalone-darwin $(BUILD_INFO) ./cmd/standalone/main.go
+.PHONY: build-query
+build-query:
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/query/query-$(GOOS) $(BUILD_INFO) ./cmd/query/main.go
 
-.PHONY: build-agent-linux
-build-agent-linux:
-	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/agent/agent-linux $(BUILD_INFO) ./cmd/agent/main.go
-
-.PHONY: build-agent-windows
-build-agent-windows:
-	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/agent/agent-windows.exe $(BUILD_INFO) ./cmd/agent/main.go
-
-.PHONY: build-agent-darwin
-build-agent-darwin:
-	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/agent/agent-darwin $(BUILD_INFO) ./cmd/agent/main.go
-
-.PHONY: build-query-linux
-build-query-linux:
-	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/query/query-linux $(BUILD_INFO) ./cmd/query/main.go
-
-.PHONY: build-query-windows
-build-query-windows:
-	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/query/query-windows.exe $(BUILD_INFO) ./cmd/query/main.go
-
-.PHONY: build-query-darwin
-build-query-darwin:
-	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/query/query-darwin $(BUILD_INFO) ./cmd/query/main.go
-
-.PHONY: build-collector-linux
-build-collector-linux:
-	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/collector/collector-linux $(BUILD_INFO) ./cmd/collector/main.go
-
-.PHONY: build-collector-windows
-build-collector-windows:
-	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/collector/collector-windows.exe $(BUILD_INFO) ./cmd/collector/main.go
-
-.PHONY: build-collector-darwin
-build-collector-darwin:
-	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/collector/collector-darwin $(BUILD_INFO) ./cmd/collector/main.go
+.PHONY: build-collector
+build-collector:
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/collector/collector-$(GOOS) $(BUILD_INFO) ./cmd/collector/main.go
 
 .PHONY: docker-no-ui
-docker-no-ui: build-agent-linux build-collector-linux build-query-linux build-crossdock-linux
+docker-no-ui: build-binaries-linux build-crossdock-linux
 	mkdir -p jaeger-ui-build/build/
 	make docker-images-only
 
 .PHONY: docker
 docker: build_ui docker-no-ui
 
-.PHONY: build-linux
-build-linux: build-agent-linux build-collector-linux build-query-linux build-all-in-one-linux
+.PHONY: build-binaries-linux
+build-binaries-linux:
+	GOOS=linux $(MAKE) build-agent build-collector build-query build-all-in-one
 
-.PHONY: build-windows
-build-windows: build-agent-windows build-collector-windows build-query-windows build-all-in-one-windows
+.PHONY: build-binaries-windows
+build-binaries-windows:
+	GOOS=windows $(MAKE) build-agent build-collector build-query build-all-in-one
 
-.PHONY: build-darwin
-build-darwin: build-agent-darwin build-collector-darwin build-query-darwin build-all-in-one-darwin
+.PHONY: build-binaries-darwin
+build-binaries-darwin:
+	GOOS=darwin $(MAKE) build-agent build-collector build-query build-all-in-one
 
 .PHONY: docker-images-only
 docker-images-only:

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ build-all-in-one-linux: build_ui
 build-all-in-one-windows: build_ui
 	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/standalone/standalone-windows.exe $(BUILD_INFO) ./cmd/standalone/main.go
 
+.PHONY: build-all-in-one-darwin
+build-all-in-one-darwin: build_ui
+	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/standalone/standalone-darwin $(BUILD_INFO) ./cmd/standalone/main.go
+
 .PHONY: build-agent-linux
 build-agent-linux:
 	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/agent/agent-linux $(BUILD_INFO) ./cmd/agent/main.go
@@ -158,6 +162,10 @@ build-agent-linux:
 .PHONY: build-agent-windows
 build-agent-windows:
 	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/agent/agent-windows.exe $(BUILD_INFO) ./cmd/agent/main.go
+
+.PHONY: build-agent-darwin
+build-agent-darwin:
+	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/agent/agent-darwin $(BUILD_INFO) ./cmd/agent/main.go
 
 .PHONY: build-query-linux
 build-query-linux:
@@ -167,6 +175,10 @@ build-query-linux:
 build-query-windows:
 	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/query/query-windows.exe $(BUILD_INFO) ./cmd/query/main.go
 
+.PHONY: build-query-darwin
+build-query-darwin:
+	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/query/query-darwin $(BUILD_INFO) ./cmd/query/main.go
+
 .PHONY: build-collector-linux
 build-collector-linux:
 	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/collector/collector-linux $(BUILD_INFO) ./cmd/collector/main.go
@@ -174,6 +186,10 @@ build-collector-linux:
 .PHONY: build-collector-windows
 build-collector-windows:
 	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/collector/collector-windows.exe $(BUILD_INFO) ./cmd/collector/main.go
+
+.PHONY: build-collector-darwin
+build-collector-darwin:
+	CGO_ENABLED=0 GOOS=darwin installsuffix=cgo go build -o ./cmd/collector/collector-darwin $(BUILD_INFO) ./cmd/collector/main.go
 
 .PHONY: docker-no-ui
 docker-no-ui: build-agent-linux build-collector-linux build-query-linux build-crossdock-linux
@@ -185,6 +201,9 @@ docker: build_ui docker-no-ui
 
 .PHONY: build-windows
 build-windows: build-agent-windows build-collector-windows build-query-windows build-all-in-one-windows
+
+.PHONY: build-darwin
+build-darwin: build-agent-darwin build-collector-darwin build-query-darwin build-all-in-one-darwin
 
 .PHONY: docker-images-only
 docker-images-only:
@@ -281,3 +300,7 @@ install-mockery:
 .PHONY: generate-mocks
 generate-mocks: install-mockery
 	$(MOCKERY) -all -dir ./pkg/es/ -output ./pkg/es/mocks && rm pkg/es/mocks/ClientBuilder.go
+
+.PHONY: echo-version
+echo-version:
+	@echo $(GIT_CLOSEST_TAG)

--- a/Makefile
+++ b/Makefile
@@ -147,17 +147,33 @@ build_ui:
 build-all-in-one-linux: build_ui
 	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/standalone/standalone-linux $(BUILD_INFO) ./cmd/standalone/main.go
 
+.PHONY: build-all-in-one-windows
+build-all-in-one-windows: build_ui
+	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/standalone/standalone-windows.exe $(BUILD_INFO) ./cmd/standalone/main.go
+
 .PHONY: build-agent-linux
 build-agent-linux:
 	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/agent/agent-linux $(BUILD_INFO) ./cmd/agent/main.go
+
+.PHONY: build-agent-windows
+build-agent-windows:
+	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/agent/agent-windows.exe $(BUILD_INFO) ./cmd/agent/main.go
 
 .PHONY: build-query-linux
 build-query-linux:
 	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/query/query-linux $(BUILD_INFO) ./cmd/query/main.go
 
+.PHONY: build-query-windows
+build-query-windows:
+	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/query/query-windows.exe $(BUILD_INFO) ./cmd/query/main.go
+
 .PHONY: build-collector-linux
 build-collector-linux:
 	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/collector/collector-linux $(BUILD_INFO) ./cmd/collector/main.go
+
+.PHONY: build-collector-windows
+build-collector-windows:
+	CGO_ENABLED=0 GOOS=windows installsuffix=cgo go build -o ./cmd/collector/collector-windows.exe $(BUILD_INFO) ./cmd/collector/main.go
 
 .PHONY: docker-no-ui
 docker-no-ui: build-agent-linux build-collector-linux build-query-linux build-crossdock-linux
@@ -166,6 +182,9 @@ docker-no-ui: build-agent-linux build-collector-linux build-query-linux build-cr
 
 .PHONY: docker
 docker: build_ui docker-no-ui
+
+.PHONY: build-windows
+build-windows: build-agent-windows build-collector-windows build-query-windows build-all-in-one-windows
 
 .PHONY: docker-images-only
 docker-images-only:

--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,9 @@ docker-no-ui: build-agent-linux build-collector-linux build-query-linux build-cr
 .PHONY: docker
 docker: build_ui docker-no-ui
 
+.PHONY: build-linux
+build-linux: build-agent-linux build-collector-linux build-query-linux build-all-in-one-linux
+
 .PHONY: build-windows
 build-windows: build-agent-windows build-collector-windows build-query-windows build-all-in-one-windows
 

--- a/scripts/travis/build-windows.sh
+++ b/scripts/travis/build-windows.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-make build-windows

--- a/scripts/travis/build-windows.sh
+++ b/scripts/travis/build-windows.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+make build-windows

--- a/scripts/travis/package-deploy.sh
+++ b/scripts/travis/package-deploy.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# stage-file copies the file $1 with the specified path $2
+# if no file exists it will silently continue
+function stage-file {
+    if [ -f $1 ]; then
+        echo "Copying $1 to $2"
+        cp $1 $2
+    else
+        echo "$1 does not exist. Continuing on."
+    fi
+}
+
+# stage-platform-files stages the different the platform ($1) into the package
+# staging dir ($2). If you pass in a file extension ($3) it will be used when 
+# copying on both the target and the source
+function stage-platform-files {
+    local PLATFORM=$1
+    local PACKAGE_STAGING_DIR=$2
+    local FILE_EXTENSION=$3
+    
+    stage-file ./cmd/standalone/standalone-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-standalone$FILE_EXTENSION
+    stage-file ./cmd/agent/agent-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
+    stage-file ./cmd/query/query-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
+    stage-file ./cmd/collector/collector-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
+
+}
+
+# package pulls built files for the platform ($1). If you pass in a file 
+# extension ($2) it will be used on the binaries
+function package {
+    local PLATFORM=$1
+    local FILE_EXTENSION=$2
+
+    local PACKAGE_STAGING_DIR=$DEPLOY_STAGING_DIR/$PLATFORM
+    mkdir $PACKAGE_STAGING_DIR
+
+    stage-platform-files $PLATFORM $PACKAGE_STAGING_DIR $FILE_EXTENSION
+
+    local PACKAGE_FILES=$(ls -A $PACKAGE_STAGING_DIR/*) 2>/dev/null
+
+    if [ "$PACKAGE_FILES" ]; then
+        local ARCHIVE_NAME="jaeger-$VERSION-$PLATFORM-amd64.tar.gz"
+        echo "Packaging the following files into $ARCHIVE_NAME:"
+        echo $PACKAGE_FILES
+        tar -czvf ./deploy/$ARCHIVE_NAME $PACKAGE_FILES
+    else
+        echo "Will not package or deploy $PLATFORM files as there are no files to package!"
+    fi
+}
+
+# script start
+
+DEPLOY_STAGING_DIR=./deploy-staging
+VERSION="$(make echo-version | awk 'match($0, /([0-9]*\.[0-9]*\.[0-9]*)$/) { print substr($0, RSTART, RLENGTH) }')"
+echo "Working on version: $VERSION"
+
+# make needed directories
+mkdir deploy
+mkdir $DEPLOY_STAGING_DIR
+
+# package linux
+if [ "$LINUX" = true ]; then
+    package linux
+else
+    echo "Skipping the packaging of linux binaries as \$LINUX was not true."
+fi
+
+# package darwin
+if [ "$DARWIN" = true ]; then
+    package darwin
+else
+    echo "Skipping the packaging of darwin binaries as \$DARWIN was not true."
+fi
+
+# package windows
+if [ "$WINDOWS" = true ]; then
+    package windows .exe
+else
+    echo "Skipping the packaging of windows binaries as \$LINUX was not true."
+fi

--- a/scripts/travis/package-deploy.sh
+++ b/scripts/travis/package-deploy.sh
@@ -13,16 +13,16 @@ function stage-file {
 
 # stage-platform-files stages the different the platform ($1) into the package
 # staging dir ($2). If you pass in a file extension ($3) it will be used when 
-# copying on both the target and the source
+# copying on the source
 function stage-platform-files {
     local PLATFORM=$1
     local PACKAGE_STAGING_DIR=$2
     local FILE_EXTENSION=$3
     
-    stage-file ./cmd/standalone/standalone-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-standalone$FILE_EXTENSION
-    stage-file ./cmd/agent/agent-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
-    stage-file ./cmd/query/query-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
-    stage-file ./cmd/collector/collector-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
+    stage-file ./cmd/standalone/standalone-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-standalone$FILE_EXTENSION
+    stage-file ./cmd/agent/agent-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
+    stage-file ./cmd/query/query-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
+    stage-file ./cmd/collector/collector-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
 }
 
 # package pulls built files for the platform ($1). If you pass in a file 
@@ -58,23 +58,10 @@ echo "Working on version: $VERSION"
 mkdir deploy
 mkdir $DEPLOY_STAGING_DIR
 
-# package linux
-if [ "$LINUX" = true ]; then
+if [ "$DEPLOY" = true ]; then
     package linux
-else
-    echo "Skipping the packaging of linux binaries as \$LINUX was not true."
-fi
-
-# package darwin
-if [ "$DARWIN" = true ]; then
     package darwin
-else
-    echo "Skipping the packaging of darwin binaries as \$DARWIN was not true."
-fi
-
-# package windows
-if [ "$WINDOWS" = true ]; then
     package windows .exe
 else
-    echo "Skipping the packaging of windows binaries as \$WINDOWS was not true."
+    echo "Skipping the packaging of binaries as \$DEPLOY was not true."
 fi

--- a/scripts/travis/package-deploy.sh
+++ b/scripts/travis/package-deploy.sh
@@ -23,7 +23,6 @@ function stage-platform-files {
     stage-file ./cmd/agent/agent-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
     stage-file ./cmd/query/query-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
     stage-file ./cmd/collector/collector-$PLATFORM$FILE_EXTENSION $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
-
 }
 
 # package pulls built files for the platform ($1). If you pass in a file 
@@ -77,5 +76,5 @@ fi
 if [ "$WINDOWS" = true ]; then
     package windows .exe
 else
-    echo "Skipping the packaging of windows binaries as \$LINUX was not true."
+    echo "Skipping the packaging of windows binaries as \$WINDOWS was not true."
 fi


### PR DESCRIPTION
This is for #765. It will build executables for windows and in the travis job it will publish the windows and linux binaries with the GitHub release when the build is tagged. Out of the box the standalone binary and the query binary won't work as they need the UI files location specified.

Also, before this is merged someone with access to the repo will have to add a secure key to the travis deploy so the files can be sent along to GitHub.