### PR TITLE
Change dbmodel.TagFilter to take span as argument

### DIFF
--- a/plugin/storage/cassandra/spanstore/dbmodel/log_fields_filter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/log_fields_filter.go
@@ -27,6 +27,6 @@ func NewLogFieldsFilter() *LogFieldsFilter {
 }
 
 // FilterLogFields implements TagFilter#FilterLogFields
-func (f *LogFieldsFilter) FilterLogFields(logFields model.KeyValues) model.KeyValues {
+func (f *LogFieldsFilter) FilterLogFields(span *model.Span, logFields model.KeyValues) model.KeyValues {
 	return model.KeyValues{}
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/log_fields_filter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/log_fields_filter_test.go
@@ -27,10 +27,10 @@ func TestFilterLogTags(t *testing.T) {
 	span := getTestJaegerSpan()
 	filter := NewLogFieldsFilter()
 	expectedTags := append(someTags, someTags...)
-	filteredTags := filter.FilterProcessTags(span.Process.Tags)
-	filteredTags = append(filteredTags, filter.FilterTags(span.Tags)...)
+	filteredTags := filter.FilterProcessTags(span, span.Process.Tags)
+	filteredTags = append(filteredTags, filter.FilterTags(span, span.Tags)...)
 	for _, log := range span.Logs {
-		filteredTags = append(filteredTags, filter.FilterLogFields(log.Fields)...)
+		filteredTags = append(filteredTags, filter.FilterLogFields(span, log.Fields)...)
 	}
 	if !assert.EqualValues(t, expectedTags, filteredTags) {
 		for _, diff := range pretty.Diff(expectedTags, filteredTags) {

--- a/plugin/storage/cassandra/spanstore/dbmodel/tag_filter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/tag_filter.go
@@ -20,9 +20,9 @@ import (
 
 // TagFilter filters out any tags that should not be indexed.
 type TagFilter interface {
-	FilterProcessTags(processTags model.KeyValues) model.KeyValues
-	FilterTags(tags model.KeyValues) model.KeyValues
-	FilterLogFields(logFields model.KeyValues) model.KeyValues
+	FilterProcessTags(span *model.Span, processTags model.KeyValues) model.KeyValues
+	FilterTags(span *model.Span, tags model.KeyValues) model.KeyValues
+	FilterLogFields(span *model.Span, logFields model.KeyValues) model.KeyValues
 }
 
 // ChainedTagFilter applies multiple tag filters in serial fashion.
@@ -34,25 +34,25 @@ func NewChainedTagFilter(filters ...TagFilter) ChainedTagFilter {
 }
 
 // FilterProcessTags calls each FilterProcessTags.
-func (tf ChainedTagFilter) FilterProcessTags(processTags model.KeyValues) model.KeyValues {
+func (tf ChainedTagFilter) FilterProcessTags(span *model.Span, processTags model.KeyValues) model.KeyValues {
 	for _, f := range tf {
-		processTags = f.FilterProcessTags(processTags)
+		processTags = f.FilterProcessTags(span, processTags)
 	}
 	return processTags
 }
 
 // FilterTags calls each FilterTags
-func (tf ChainedTagFilter) FilterTags(tags model.KeyValues) model.KeyValues {
+func (tf ChainedTagFilter) FilterTags(span *model.Span, tags model.KeyValues) model.KeyValues {
 	for _, f := range tf {
-		tags = f.FilterTags(tags)
+		tags = f.FilterTags(span, tags)
 	}
 	return tags
 }
 
 // FilterLogFields calls each FilterLogFields
-func (tf ChainedTagFilter) FilterLogFields(logFields model.KeyValues) model.KeyValues {
+func (tf ChainedTagFilter) FilterLogFields(span *model.Span, logFields model.KeyValues) model.KeyValues {
 	for _, f := range tf {
-		logFields = f.FilterProcessTags(logFields)
+		logFields = f.FilterProcessTags(span, logFields)
 	}
 	return logFields
 }
@@ -62,14 +62,14 @@ var DefaultTagFilter = tagFilterImpl{}
 
 type tagFilterImpl struct{}
 
-func (f tagFilterImpl) FilterProcessTags(processTags model.KeyValues) model.KeyValues {
+func (f tagFilterImpl) FilterProcessTags(span *model.Span, processTags model.KeyValues) model.KeyValues {
 	return processTags
 }
 
-func (f tagFilterImpl) FilterTags(tags model.KeyValues) model.KeyValues {
+func (f tagFilterImpl) FilterTags(span *model.Span, tags model.KeyValues) model.KeyValues {
 	return tags
 }
 
-func (f tagFilterImpl) FilterLogFields(logFields model.KeyValues) model.KeyValues {
+func (f tagFilterImpl) FilterLogFields(span *model.Span, logFields model.KeyValues) model.KeyValues {
 	return logFields
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/tag_filter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/tag_filter_test.go
@@ -26,10 +26,10 @@ import (
 func TestDefaultTagFilter(t *testing.T) {
 	span := getTestJaegerSpan()
 	expectedTags := append(append(someTags, someTags...), someTags...)
-	filteredTags := DefaultTagFilter.FilterProcessTags(span.Process.Tags)
-	filteredTags = append(filteredTags, DefaultTagFilter.FilterTags(span.Tags)...)
+	filteredTags := DefaultTagFilter.FilterProcessTags(span, span.Process.Tags)
+	filteredTags = append(filteredTags, DefaultTagFilter.FilterTags(span, span.Tags)...)
 	for _, log := range span.Logs {
-		filteredTags = append(filteredTags, DefaultTagFilter.FilterLogFields(log.Fields)...)
+		filteredTags = append(filteredTags, DefaultTagFilter.FilterLogFields(span, log.Fields)...)
 	}
 	compareTags(t, expectedTags, filteredTags)
 }
@@ -46,26 +46,26 @@ func (f onlyStringsFilter) filterStringTags(tags model.KeyValues) model.KeyValue
 	return ret
 }
 
-func (f onlyStringsFilter) FilterProcessTags(processTags model.KeyValues) model.KeyValues {
+func (f onlyStringsFilter) FilterProcessTags(span *model.Span, processTags model.KeyValues) model.KeyValues {
 	return f.filterStringTags(processTags)
 }
 
-func (f onlyStringsFilter) FilterTags(tags model.KeyValues) model.KeyValues {
+func (f onlyStringsFilter) FilterTags(span *model.Span, tags model.KeyValues) model.KeyValues {
 	return f.filterStringTags(tags)
 }
 
-func (f onlyStringsFilter) FilterLogFields(logFields model.KeyValues) model.KeyValues {
+func (f onlyStringsFilter) FilterLogFields(span *model.Span, logFields model.KeyValues) model.KeyValues {
 	return f.filterStringTags(logFields)
 }
 
 func TestChainedTagFilter(t *testing.T) {
 	expectedTags := model.KeyValues{model.String(someStringTagKey, someStringTagValue)}
 	filter := NewChainedTagFilter(DefaultTagFilter, onlyStringsFilter{})
-	filteredTags := filter.FilterProcessTags(someTags)
+	filteredTags := filter.FilterProcessTags(nil, someTags)
 	compareTags(t, expectedTags, filteredTags)
-	filteredTags = filter.FilterTags(someTags)
+	filteredTags = filter.FilterTags(nil, someTags)
 	compareTags(t, expectedTags, filteredTags)
-	filteredTags = filter.FilterLogFields(someTags)
+	filteredTags = filter.FilterLogFields(nil, someTags)
 	compareTags(t, expectedTags, filteredTags)
 }
 

--- a/plugin/storage/cassandra/spanstore/dbmodel/unique_tags.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/unique_tags.go
@@ -18,10 +18,10 @@ import "github.com/jaegertracing/jaeger/model"
 
 // GetAllUniqueTags creates a list of all unique tags from a set of filtered tags.
 func GetAllUniqueTags(span *model.Span, tagFilter TagFilter) []TagInsertion {
-	allTags := append(model.KeyValues{}, tagFilter.FilterProcessTags(span.Process.Tags)...)
-	allTags = append(allTags, tagFilter.FilterTags(span.Tags)...)
+	allTags := append(model.KeyValues{}, tagFilter.FilterProcessTags(span, span.Process.Tags)...)
+	allTags = append(allTags, tagFilter.FilterTags(span, span.Tags)...)
 	for _, log := range span.Logs {
-		allTags = append(allTags, tagFilter.FilterLogFields(log.Fields)...)
+		allTags = append(allTags, tagFilter.FilterLogFields(span, log.Fields)...)
 	}
 	allTags.Sort()
 	uniqueTags := make([]TagInsertion, 0, len(allTags))


### PR DESCRIPTION
Because sometimes the filtering decision depends not only on the tags, but on the span itself, e.g. debug bit, or the service name.

Signed-off-by: Yuri Shkuro <ys@uber.com>