### PR TITLE
Change metrics naming scheme

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -117,7 +117,13 @@ func (b *Builder) getMetricsFactory() (metrics.Factory, error) {
 	if b.metricsFactory != nil {
 		return b.metricsFactory, nil
 	}
-	return b.Metrics.CreateMetricsFactory("jaeger_agent")
+
+	baseFactory, err := b.Metrics.CreateMetricsFactory("jaeger")
+	if err != nil {
+		return nil, err
+	}
+
+	return baseFactory.Namespace("agent", nil), nil
 }
 
 // CreateAgent creates the Agent

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -47,8 +47,8 @@ func TestProcessorMetrics(t *testing.T) {
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	counters, gauges := baseMetrics.LocalBackend.Snapshot()
 
-	assert.EqualValues(t, 2, counters["service.jaeger.spans.by-svc.fry"])
-	assert.EqualValues(t, 1, counters["service.jaeger.traces.by-svc.fry"])
-	assert.EqualValues(t, 1, counters["service.jaeger.debug-spans.by-svc.fry"])
+	assert.EqualValues(t, 2, counters["service.spans.received|format=jaeger|service=fry"])
+	assert.EqualValues(t, 1, counters["service.traces.received|format=jaeger|service=fry"])
+	assert.EqualValues(t, 1, counters["service.debug-spans.received|format=jaeger|service=fry"])
 	assert.Empty(t, gauges)
 }

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -108,7 +108,6 @@ func (sp *spanProcessor) saveSpan(span *model.Span) {
 
 func (sp *spanProcessor) ProcessSpans(mSpans []*model.Span, spanFormat string) ([]bool, error) {
 	sp.preProcessSpans(mSpans)
-	sp.metrics.GetCountsForFormat(spanFormat).Received.Inc(int64(len(mSpans)))
 	sp.metrics.BatchSize.Update(int64(len(mSpans)))
 	retMe := make([]bool, len(mSpans))
 	for i, mSpan := range mSpans {
@@ -131,7 +130,7 @@ func (sp *spanProcessor) enqueueSpan(span *model.Span, originalFormat string) bo
 	spanCounts.ReceivedBySvc.ReportServiceNameForSpan(span)
 
 	if !sp.filterSpan(span) {
-		spanCounts.Rejected.Inc(int64(1))
+		spanCounts.RejectedBySvc.ReportServiceNameForSpan(span)
 		return true // as in "not dropped", because it's actively rejected
 	}
 	item := &queueItem{

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -90,13 +90,13 @@ func main() {
 			builderOpts := new(builder.CollectorOptions).InitFromViper(v)
 
 			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			metricsFactory, err := mBldr.CreateMetricsFactory("jaeger-collector")
+			baseFactory, err := mBldr.CreateMetricsFactory("jaeger")
 			if err != nil {
 				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
 			}
 
 			storageFactory.InitFromViper(v)
-			if err := storageFactory.Initialize(metricsFactory, logger); err != nil {
+			if err := storageFactory.Initialize(baseFactory, logger); err != nil {
 				logger.Fatal("Failed to init storage factory", zap.Error(err))
 			}
 			spanWriter, err := storageFactory.CreateSpanWriter()
@@ -104,6 +104,7 @@ func main() {
 				logger.Fatal("Failed to create span writer", zap.Error(err))
 			}
 
+			metricsFactory := baseFactory.Namespace("collector", nil)
 			handlerBuilder, err := builder.NewSpanHandlerBuilder(
 				builderOpts,
 				spanWriter,

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -75,7 +75,7 @@ func main() {
 			queryOpts := new(app.QueryOptions).InitFromViper(v)
 
 			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			metricsFactory, err := mBldr.CreateMetricsFactory("jaeger-query")
+			baseFactory, err := mBldr.CreateMetricsFactory("jaeger")
 			if err != nil {
 				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
 			}
@@ -86,14 +86,14 @@ func main() {
 					Param: 1.0,
 				},
 				RPCMetrics: true,
-			}.New("jaeger-query", jaegerClientConfig.Metrics(metricsFactory))
+			}.New("jaeger-query", jaegerClientConfig.Metrics(baseFactory.Namespace("client", nil)))
 			if err != nil {
 				logger.Fatal("Failed to initialize tracer", zap.Error(err))
 			}
 			defer closer.Close()
 
 			storageFactory.InitFromViper(v)
-			if err := storageFactory.Initialize(metricsFactory, logger); err != nil {
+			if err := storageFactory.Initialize(baseFactory, logger); err != nil {
 				logger.Fatal("Failed to init storage factory", zap.Error(err))
 			}
 			spanReader, err := storageFactory.CreateSpanReader()

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -96,7 +96,7 @@ func main() {
 			}
 
 			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			metricsFactory, err := mBldr.CreateMetricsFactory("jaeger-standalone")
+			metricsFactory, err := mBldr.CreateMetricsFactory("jaeger")
 			if err != nil {
 				return errors.Wrap(err, "Cannot create metrics factory")
 			}
@@ -166,7 +166,7 @@ func startAgent(
 	logger *zap.Logger,
 	baseFactory metrics.Factory,
 ) {
-	metricsFactory := baseFactory.Namespace("jaeger-agent", nil)
+	metricsFactory := baseFactory.Namespace("agent", nil)
 
 	if len(b.CollectorHostPorts) == 0 {
 		b.CollectorHostPorts = append(b.CollectorHostPorts, fmt.Sprintf("127.0.0.1:%d", cOpts.CollectorPort))
@@ -190,7 +190,7 @@ func startCollector(
 	samplingHandler sampling.Handler,
 	hc *healthcheck.HealthCheck,
 ) {
-	metricsFactory := baseFactory.Namespace("jaeger-collector", nil)
+	metricsFactory := baseFactory.Namespace("collector", nil)
 
 	spanBuilder, err := collector.NewSpanHandlerBuilder(
 		cOpts,
@@ -269,7 +269,7 @@ func startQuery(
 			Param: 1.0,
 		},
 		RPCMetrics: true,
-	}.New("jaeger-query", jaegerClientConfig.Metrics(baseFactory))
+	}.New("jaeger-query", jaegerClientConfig.Metrics(baseFactory.Namespace("client", nil)))
 	if err != nil {
 		logger.Fatal("Failed to initialize tracer", zap.Error(err))
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -195,7 +195,7 @@ imports:
   - transport/zipkin
   - utils
 - name: github.com/uber/jaeger-lib
-  version: 4267858c0679cd4e47cefed8d7f70fd386cfb567
+  version: ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5
   subpackages:
   - metrics
   - metrics/adapters

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,7 +17,7 @@ import:
   subpackages:
   - transport
 - package: github.com/uber/jaeger-lib
-  version: ^1.4.0
+  version: ^1.5.0
 - package: github.com/uber/tchannel-go
   version: v1.1.0
   subpackages:

--- a/pkg/cassandra/metrics/table.go
+++ b/pkg/cassandra/metrics/table.go
@@ -33,7 +33,7 @@ type Table struct {
 // NewTable takes a metrics scope and creates a table metrics struct
 func NewTable(factory metrics.Factory, tableName string) *Table {
 	t := storageMetrics.WriteMetrics{}
-	metrics.Init(&t, factory.Namespace(tableName, nil), nil)
+	metrics.Init(&t, factory.Namespace("", map[string]string{"table": tableName}), nil)
 	return &Table{t}
 }
 

--- a/pkg/cassandra/metrics/table_test.go
+++ b/pkg/cassandra/metrics/table_test.go
@@ -34,31 +34,31 @@ func TestTableEmit(t *testing.T) {
 		{
 			err: nil,
 			counts: map[string]int64{
-				"a_table.attempts": 1,
-				"a_table.inserts":  1,
+				"attempts|table=a_table": 1,
+				"inserts|table=a_table":  1,
 			},
 			gauges: map[string]int64{
-				"a_table.latency-ok.P999": 51,
-				"a_table.latency-ok.P50":  51,
-				"a_table.latency-ok.P75":  51,
-				"a_table.latency-ok.P90":  51,
-				"a_table.latency-ok.P95":  51,
-				"a_table.latency-ok.P99":  51,
+				"latency-ok|table=a_table.P999": 51,
+				"latency-ok|table=a_table.P50":  51,
+				"latency-ok|table=a_table.P75":  51,
+				"latency-ok|table=a_table.P90":  51,
+				"latency-ok|table=a_table.P95":  51,
+				"latency-ok|table=a_table.P99":  51,
 			},
 		},
 		{
 			err: errors.New("some error"),
 			counts: map[string]int64{
-				"a_table.attempts": 1,
-				"a_table.errors":   1,
+				"attempts|table=a_table": 1,
+				"errors|table=a_table":   1,
 			},
 			gauges: map[string]int64{
-				"a_table.latency-err.P999": 51,
-				"a_table.latency-err.P50":  51,
-				"a_table.latency-err.P75":  51,
-				"a_table.latency-err.P90":  51,
-				"a_table.latency-err.P95":  51,
-				"a_table.latency-err.P99":  51,
+				"latency-err|table=a_table.P999": 51,
+				"latency-err|table=a_table.P50":  51,
+				"latency-err|table=a_table.P75":  51,
+				"latency-err|table=a_table.P90":  51,
+				"latency-err|table=a_table.P95":  51,
+				"latency-err|table=a_table.P99":  51,
 			},
 		},
 	}
@@ -82,8 +82,8 @@ func TestTableExec(t *testing.T) {
 		{
 			q: insertQuery{},
 			counts: map[string]int64{
-				"a_table.attempts": 1,
-				"a_table.inserts":  1,
+				"attempts|table=a_table": 1,
+				"inserts|table=a_table":  1,
 			},
 		},
 		{
@@ -92,8 +92,8 @@ func TestTableExec(t *testing.T) {
 				err: errors.New("failed"),
 			},
 			counts: map[string]int64{
-				"a_table.attempts": 1,
-				"a_table.errors":   1,
+				"attempts|table=a_table": 1,
+				"errors|table=a_table":   1,
 			},
 		},
 		{
@@ -103,8 +103,8 @@ func TestTableExec(t *testing.T) {
 			},
 			log: true,
 			counts: map[string]int64{
-				"a_table.attempts": 1,
-				"a_table.errors":   1,
+				"attempts|table=a_table": 1,
+				"errors|table=a_table":   1,
 			},
 		},
 	}

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -62,7 +62,7 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 		return nil, err
 	}
 
-	sm := storageMetrics.NewWriteMetrics(metricsFactory, "BulkIndex")
+	sm := storageMetrics.NewWriteMetrics(metricsFactory, "bulk_index")
 	m := sync.Map{}
 
 	service, err := rawClient.BulkProcessor().

--- a/pkg/metrics/builder_test.go
+++ b/pkg/metrics/builder_test.go
@@ -51,7 +51,7 @@ func TestBuilder(t *testing.T) {
 		families, err := prometheus.DefaultGatherer.Gather()
 		require.NoError(t, err)
 		for _, mf := range families {
-			if mf.GetName() == "foo:counter" {
+			if mf.GetName() == "foo_counter" {
 				return
 			}
 		}

--- a/plugin/storage/cassandra/dependencystore/storage.go
+++ b/plugin/storage/cassandra/dependencystore/storage.go
@@ -49,7 +49,7 @@ func NewDependencyStore(
 	return &DependencyStore{
 		session:                  session,
 		dependencyDataFrequency:  dependencyDataFrequency,
-		dependenciesTableMetrics: casMetrics.NewTable(metricsFactory, "Dependencies"),
+		dependenciesTableMetrics: casMetrics.NewTable(metricsFactory, "dependencies"),
 		logger: logger,
 	}
 }

--- a/plugin/storage/cassandra/samplingstore/storage.go
+++ b/plugin/storage/cassandra/samplingstore/storage.go
@@ -62,8 +62,8 @@ func New(session cassandra.Session, factory metrics.Factory, logger *zap.Logger)
 	return &SamplingStore{
 		session: session,
 		metrics: samplingStoreMetrics{
-			operationThroughput: casMetrics.NewTable(factory, "OperationThroughput"),
-			probabilities:       casMetrics.NewTable(factory, "Probabilities"),
+			operationThroughput: casMetrics.NewTable(factory, "operation_throughput"),
+			probabilities:       casMetrics.NewTable(factory, "probabilities"),
 		},
 		logger: logger,
 	}

--- a/plugin/storage/cassandra/spanstore/operation_names.go
+++ b/plugin/storage/cassandra/spanstore/operation_names.go
@@ -54,7 +54,7 @@ func NewOperationNamesStorage(
 		session:       session,
 		InsertStmt:    insertOperationName,
 		QueryStmt:     queryOperationNames,
-		metrics:       casMetrics.NewTable(metricsFactory, "OperationNames"),
+		metrics:       casMetrics.NewTable(metricsFactory, "operation_names"),
 		writeCacheTTL: writeCacheTTL,
 		logger:        logger,
 		operationNames: cache.NewLRUWithOptions(

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -85,7 +85,7 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 
 				counts, _ := s.metricsFactory.Snapshot()
 				assert.Equal(t, map[string]int64{
-					"OperationNames.attempts": 2, "OperationNames.inserts": 1, "OperationNames.errors": 1,
+					"attempts|table=operation_names": 2, "inserts|table=operation_names": 1, "errors|table=operation_names": 1,
 				}, counts, "after first two writes")
 
 				// write again
@@ -96,8 +96,8 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 				expCounts := counts
 				if writeCacheTTL == 0 {
 					// without write cache, the second write must succeed
-					expCounts["OperationNames.attempts"]++
-					expCounts["OperationNames.inserts"]++
+					expCounts["attempts|table=operation_names"]++
+					expCounts["inserts|table=operation_names"]++
 				}
 				assert.Equal(t, expCounts, counts2)
 			})

--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -113,7 +113,7 @@ func NewSpanReader(
 	metricsFactory metrics.Factory,
 	logger *zap.Logger,
 ) *SpanReader {
-	readFactory := metricsFactory.Namespace("Read", nil)
+	readFactory := metricsFactory.Namespace("read", nil)
 	serviceNamesStorage := NewServiceNamesStorage(session, 0, metricsFactory, logger)
 	operationNamesStorage := NewOperationNamesStorage(session, 0, metricsFactory, logger)
 	return &SpanReader{
@@ -122,12 +122,12 @@ func NewSpanReader(
 		serviceNamesReader:   serviceNamesStorage.GetServices,
 		operationNamesReader: operationNamesStorage.GetOperations,
 		metrics: spanReaderMetrics{
-			readTraces:                 casMetrics.NewTable(readFactory, "ReadTraces"),
-			queryTrace:                 casMetrics.NewTable(readFactory, "QueryTraces"),
-			queryTagIndex:              casMetrics.NewTable(readFactory, "TagIndex"),
-			queryDurationIndex:         casMetrics.NewTable(readFactory, "DurationIndex"),
-			queryServiceOperationIndex: casMetrics.NewTable(readFactory, "ServiceOperationIndex"),
-			queryServiceNameIndex:      casMetrics.NewTable(readFactory, "ServiceNameIndex"),
+			readTraces:                 casMetrics.NewTable(readFactory, "read_traces"),
+			queryTrace:                 casMetrics.NewTable(readFactory, "query_traces"),
+			queryTagIndex:              casMetrics.NewTable(readFactory, "tag_index"),
+			queryDurationIndex:         casMetrics.NewTable(readFactory, "duration_index"),
+			queryServiceOperationIndex: casMetrics.NewTable(readFactory, "service_operation_index"),
+			queryServiceNameIndex:      casMetrics.NewTable(readFactory, "service_name_index"),
 		},
 		logger: logger,
 	}

--- a/plugin/storage/cassandra/spanstore/service_names.go
+++ b/plugin/storage/cassandra/spanstore/service_names.go
@@ -53,7 +53,7 @@ func NewServiceNamesStorage(
 		session:       session,
 		InsertStmt:    insertServiceName,
 		QueryStmt:     queryServiceNames,
-		metrics:       casMetrics.NewTable(metricsFactory, "ServiceNames"),
+		metrics:       casMetrics.NewTable(metricsFactory, "service_names"),
 		writeCacheTTL: writeCacheTTL,
 		logger:        logger,
 		serviceNames: cache.NewLRUWithOptions(

--- a/plugin/storage/cassandra/spanstore/service_names_test.go
+++ b/plugin/storage/cassandra/spanstore/service_names_test.go
@@ -85,7 +85,7 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 
 				counts, _ := s.metricsFactory.Snapshot()
 				assert.Equal(t, map[string]int64{
-					"ServiceNames.attempts": 2, "ServiceNames.inserts": 1, "ServiceNames.errors": 1,
+					"attempts|table=service_names": 2, "inserts|table=service_names": 1, "errors|table=service_names": 1,
 				}, counts)
 
 				// write again
@@ -96,8 +96,8 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 				expCounts := counts
 				if writeCacheTTL == 0 {
 					// without write cache, the second write must succeed
-					expCounts["ServiceNames.attempts"]++
-					expCounts["ServiceNames.inserts"]++
+					expCounts["attempts|table=service_names"]++
+					expCounts["inserts|table=service_names"]++
 				}
 				assert.Equal(t, expCounts, counts2)
 			})

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -104,18 +104,18 @@ func NewSpanWriter(
 ) *SpanWriter {
 	serviceNamesStorage := NewServiceNamesStorage(session, writeCacheTTL, metricsFactory, logger)
 	operationNamesStorage := NewOperationNamesStorage(session, writeCacheTTL, metricsFactory, logger)
-	tagIndexSkipped := metricsFactory.Counter("tagIndexSkipped", nil)
+	tagIndexSkipped := metricsFactory.Counter("tag_index_skipped", nil)
 	opts := applyOptions(options...)
 	return &SpanWriter{
 		session:              session,
 		serviceNamesWriter:   serviceNamesStorage.Write,
 		operationNamesWriter: operationNamesStorage.Write,
 		writerMetrics: spanWriterMetrics{
-			traces:                casMetrics.NewTable(metricsFactory, "Traces"),
-			tagIndex:              casMetrics.NewTable(metricsFactory, "TagIndex"),
-			serviceNameIndex:      casMetrics.NewTable(metricsFactory, "ServiceNameIndex"),
-			serviceOperationIndex: casMetrics.NewTable(metricsFactory, "ServiceOperationIndex"),
-			durationIndex:         casMetrics.NewTable(metricsFactory, "DurationIndex"),
+			traces:                casMetrics.NewTable(metricsFactory, "traces"),
+			tagIndex:              casMetrics.NewTable(metricsFactory, "tag_index"),
+			serviceNameIndex:      casMetrics.NewTable(metricsFactory, "service_name_index"),
+			serviceOperationIndex: casMetrics.NewTable(metricsFactory, "service_operation_index"),
+			durationIndex:         casMetrics.NewTable(metricsFactory, "duration_index"),
 		},
 		logger:          logger,
 		tagIndexSkipped: tagIndexSkipped,

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -93,7 +93,7 @@ func NewSpanWriter(
 		client: client,
 		logger: logger,
 		writerMetrics: spanWriterMetrics{
-			indexCreate: storageMetrics.NewWriteMetrics(metricsFactory, "IndexCreate"),
+			indexCreate: storageMetrics.NewWriteMetrics(metricsFactory, "index_create"),
 		},
 		serviceWriter: serviceOperationStorage.Write,
 		indexCache: cache.NewLRUWithOptions(

--- a/storage/spanstore/metrics/decorator.go
+++ b/storage/spanstore/metrics/decorator.go
@@ -57,10 +57,10 @@ func (q *queryMetrics) emit(err error, latency time.Duration, responses int) {
 func NewReadMetricsDecorator(spanReader spanstore.Reader, metricsFactory metrics.Factory) *ReadMetricsDecorator {
 	return &ReadMetricsDecorator{
 		spanReader:           spanReader,
-		findTracesMetrics:    buildQueryMetrics("FindTraces", metricsFactory),
-		getTraceMetrics:      buildQueryMetrics("GetTrace", metricsFactory),
-		getServicesMetrics:   buildQueryMetrics("GetServices", metricsFactory),
-		getOperationsMetrics: buildQueryMetrics("GetOperations", metricsFactory),
+		findTracesMetrics:    buildQueryMetrics("find_traces", metricsFactory),
+		getTraceMetrics:      buildQueryMetrics("get_trace", metricsFactory),
+		getServicesMetrics:   buildQueryMetrics("get_services", metricsFactory),
+		getOperationsMetrics: buildQueryMetrics("get_operations", metricsFactory),
 	}
 }
 

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -42,27 +42,27 @@ func TestSuccessfulUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(&spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"GetOperations.attempts":  1,
-		"GetOperations.successes": 1,
-		"GetOperations.errors":    0,
-		"GetTrace.attempts":       1,
-		"GetTrace.successes":      1,
-		"GetTrace.errors":         0,
-		"FindTraces.attempts":     1,
-		"FindTraces.successes":    1,
-		"FindTraces.errors":       0,
-		"GetServices.attempts":    1,
-		"GetServices.successes":   1,
-		"GetServices.errors":      0,
+		"get_operations.attempts":  1,
+		"get_operations.successes": 1,
+		"get_operations.errors":    0,
+		"get_trace.attempts":       1,
+		"get_trace.successes":      1,
+		"get_trace.errors":         0,
+		"find_traces.attempts":     1,
+		"find_traces.successes":    1,
+		"find_traces.errors":       0,
+		"get_services.attempts":    1,
+		"get_services.successes":   1,
+		"get_services.errors":      0,
 	}
 
 	existingKeys := []string{
-		"GetOperations.okLatency.P50",
-		"GetTrace.responses.P50",
-		"FindTraces.okLatency.P50", // this is not exhaustive
+		"get_operations.okLatency.P50",
+		"get_trace.responses.P50",
+		"find_traces.okLatency.P50", // this is not exhaustive
 	}
 	nonExistentKeys := []string{
-		"GetOperations.errLatency.P50",
+		"get_operations.errLatency.P50",
 	}
 
 	checkExpectedExistingAndNonExistentCounters(t, counters, expecteds, gauges, existingKeys, nonExistentKeys)
@@ -99,28 +99,28 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(&spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"GetOperations.attempts":  1,
-		"GetOperations.successes": 0,
-		"GetOperations.errors":    1,
-		"GetTrace.attempts":       1,
-		"GetTrace.successes":      0,
-		"GetTrace.errors":         1,
-		"FindTraces.attempts":     1,
-		"FindTraces.successes":    0,
-		"FindTraces.errors":       1,
-		"GetServices.attempts":    1,
-		"GetServices.successes":   0,
-		"GetServices.errors":      1,
+		"get_operations.attempts":  1,
+		"get_operations.successes": 0,
+		"get_operations.errors":    1,
+		"get_trace.attempts":       1,
+		"get_trace.successes":      0,
+		"get_trace.errors":         1,
+		"find_traces.attempts":     1,
+		"find_traces.successes":    0,
+		"find_traces.errors":       1,
+		"get_services.attempts":    1,
+		"get_services.successes":   0,
+		"get_services.errors":      1,
 	}
 
 	existingKeys := []string{
-		"GetOperations.errLatency.P50",
+		"get_operations.errLatency.P50",
 	}
 
 	nonExistentKeys := []string{
-		"GetOperations.okLatency.P50",
-		"GetTrace.responses.P50",
-		"Query.okLatency.P50", // this is not exhaustive
+		"get_operations.okLatency.P50",
+		"get_trace.responses.P50",
+		"query.okLatency.P50", // this is not exhaustive
 	}
 
 	checkExpectedExistingAndNonExistentCounters(t, counters, expecteds, gauges, existingKeys, nonExistentKeys)


### PR DESCRIPTION
Tasks pending:

- [x] Use a proper version for `jaeger-lib`
- [x] Agree on keeping/removing `jaeger_collector_spans_recd` (see https://github.com/jaegertracing/jaeger/pull/776#issuecomment-383946237)

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>