### PR TITLE
Fail test if the expected and actual traces differ (#777)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PROJECT_ROOT=github.com/jaegertracing/jaeger
 TOP_PKGS := $(shell glide novendor | grep -v -e ./thrift-gen/... -e swagger-gen... -e ./examples/... -e ./scripts/...)
+STORAGE_PKGS = ./plugin/storage/integration/...
 
 # all .go files that don't exist in hidden directories
 ALL_SRC := $(shell find . -name "*.go" | grep -v -e vendor -e thrift-gen -e swagger-gen -e examples -e doc.go \
@@ -77,7 +78,7 @@ integration-test: go-gen
 
 .PHONY: storage-integration-test
 storage-integration-test: go-gen
-	$(GOTEST) ./plugin/storage/integration/...
+	bash -c "set -e; set -o pipefail; $(GOTEST) $(STORAGE_PKGS) | $(COLORIZE)"
 
 all-pkgs:
 	@echo $(ALL_PKGS) | tr ' ' '\n' | sort

--- a/plugin/storage/integration/domain_trace_compare_test.go
+++ b/plugin/storage/integration/domain_trace_compare_test.go
@@ -50,13 +50,15 @@ func CompareTraces(t *testing.T, expected *model.Trace, actual *model.Trace) {
 	model.SortTrace(expected)
 	model.SortTrace(actual)
 	checkSize(t, expected, actual)
-	if !assert.EqualValues(t, expected, actual) {
-		for _, err := range pretty.Diff(expected, actual) {
-			t.Log(err)
+
+	if diff := pretty.Diff(expected, actual); len(diff) > 0 {
+		for _, d := range diff {
+			t.Logf("Expected and actual differ: %v\n", d)
 		}
 		out, err := json.Marshal(actual)
 		assert.NoError(t, err)
 		t.Logf("Actual trace: %s", string(out))
+		t.Fail()
 	}
 }
 


### PR DESCRIPTION
Use pretty.Diff(expected, actual) instead of reflect.DeepEqual(expected, actual) to check for equality between given and received trace. Also, if there is a difference, set the test to fail instead of only logging the failed trace.

And prettify the storage-integration-test output