### PR TITLE
Tune create on custom index to not be created if it already exists.

### DIFF
--- a/plugin/storage/cassandra/schema/v001.cql.tmpl
+++ b/plugin/storage/cassandra/schema/v001.cql.tmpl
@@ -202,6 +202,6 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.dependencies (
     }
     AND default_time_to_live = ${dependencies_ttl};
 
-CREATE CUSTOM INDEX ON ${keyspace}.dependencies (ts_index) 
+CREATE CUSTOM INDEX IF NOT EXISTS ON ${keyspace}.dependencies (ts_index) 
     USING 'org.apache.cassandra.index.sasi.SASIIndex' 
     WITH OPTIONS = {'mode': 'SPARSE'};


### PR DESCRIPTION
This prevents schema upgrades or re-executions from erroring.

Closes jaegertracing/jaeger-openshift#79