### PR TITLE
Add metric for debug traces

### DIFF
--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	maxServiceNames = 2000
-	otherServices = "other-services"
+	otherServices   = "other-services"
 )
 
 // SpanProcessorMetrics contains all the necessary metrics for the SpanProcessor
@@ -48,10 +48,10 @@ type SpanProcessorMetrics struct { //TODO - initialize metrics in the traditiona
 }
 
 type countsBySvc struct {
-	counts      map[string]metrics.Counter // counters per service
-	debugCounts map[string]metrics.Counter // debug counters per service
-	factory     metrics.Factory
-	lock        *sync.Mutex
+	counts          map[string]metrics.Counter // counters per service
+	debugCounts     map[string]metrics.Counter // debug counters per service
+	factory         metrics.Factory
+	lock            *sync.Mutex
 	maxServiceNames int
 }
 
@@ -97,21 +97,21 @@ func newMetricsBySvc(factory metrics.Factory, category string) metricsBySvc {
 	spansFactory := factory.Namespace("spans."+category, nil)
 	tracesFactory := factory.Namespace("traces."+category, nil)
 	return metricsBySvc{
-		spans: newCountsBySvc(spansFactory, maxServiceNames),
+		spans:  newCountsBySvc(spansFactory, maxServiceNames),
 		traces: newCountsBySvc(tracesFactory, maxServiceNames),
 	}
 }
 
 func newCountsBySvc(factory metrics.Factory, maxServiceNames int) countsBySvc {
 	return countsBySvc{
-		counts:      map[string]metrics.Counter{
+		counts: map[string]metrics.Counter{
 			otherServices: factory.Counter(otherServices, map[string]string{"debug": "false"}),
 		},
 		debugCounts: map[string]metrics.Counter{
 			otherServices: factory.Counter(otherServices, map[string]string{"debug": "true"}),
 		},
-		factory:     factory,
-		lock:        &sync.Mutex{},
+		factory:         factory,
+		lock:            &sync.Mutex{},
 		maxServiceNames: maxServiceNames,
 	}
 }

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -168,19 +168,19 @@ func (m metricsBySvc) countTracesByServiceName(serviceName string, isDebug bool)
 // service names.
 func (m *countsBySvc) countByServiceName(serviceName string, isDebug bool) {
 	serviceName = NormalizeServiceName(serviceName)
+	counts := m.counts
 	if isDebug {
-		m.x(serviceName, "true", m.debugCounts)
-	} else {
-		m.x(serviceName, "false", m.counts)
+		counts = m.debugCounts
 	}
-}
-
-func (m *countsBySvc) x(serviceName, debugStr string, counts map[string]metrics.Counter) {
 	var counter metrics.Counter
 	m.lock.Lock()
 	if c, ok := counts[serviceName]; ok {
 		counter = c
 	} else if len(counts) < m.maxServiceNames {
+		debugStr := "false"
+		if isDebug {
+			debugStr = "true"
+		}
 		c := m.factory.Counter("", map[string]string{"service": serviceName, "debug": debugStr})
 		counts[serviceName] = c
 		counter = c

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -105,10 +105,10 @@ func newMetricsBySvc(factory metrics.Factory, category string) metricsBySvc {
 func newCountsBySvc(factory metrics.Factory, maxServiceNames int) countsBySvc {
 	return countsBySvc{
 		counts: map[string]metrics.Counter{
-			otherServices: factory.Counter(otherServices, map[string]string{"debug": "false"}),
+			otherServices: factory.Counter("", map[string]string{"service": otherServices, "debug": "false"}),
 		},
 		debugCounts: map[string]metrics.Counter{
-			otherServices: factory.Counter(otherServices, map[string]string{"debug": "true"}),
+			otherServices: factory.Counter("", map[string]string{"service": otherServices, "debug": "true"}),
 		},
 		factory:         factory,
 		lock:            &sync.Mutex{},

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -47,8 +47,8 @@ func TestProcessorMetrics(t *testing.T) {
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	counters, gauges := baseMetrics.LocalBackend.Snapshot()
 
-	assert.EqualValues(t, 2, counters["service.spans.received|format=jaeger|service=fry"])
-	assert.EqualValues(t, 1, counters["service.traces.received|format=jaeger|service=fry"])
-	assert.EqualValues(t, 1, counters["service.debug-spans.received|format=jaeger|service=fry"])
+	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|service=fry"])
+	assert.EqualValues(t, 1, counters["service.traces.received|debug=false|format=jaeger|service=fry"])
+	assert.EqualValues(t, 1, counters["service.spans.received|debug=true|format=jaeger|service=fry"])
 	assert.Empty(t, gauges)
 }

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -43,12 +43,14 @@ func TestProcessorMetrics(t *testing.T) {
 	}
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	mSpan.Flags.SetDebug()
+	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	mSpan.ReplaceParentID(1234)
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	counters, gauges := baseMetrics.LocalBackend.Snapshot()
 
 	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|service=fry"])
+	assert.EqualValues(t, 2, counters["service.spans.received|debug=true|format=jaeger|service=fry"])
 	assert.EqualValues(t, 1, counters["service.traces.received|debug=false|format=jaeger|service=fry"])
-	assert.EqualValues(t, 1, counters["service.spans.received|debug=true|format=jaeger|service=fry"])
+	assert.EqualValues(t, 1, counters["service.traces.received|debug=true|format=jaeger|service=fry"])
 	assert.Empty(t, gauges)
 }

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -65,9 +65,9 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("zoidberg", false)
 
 	counters, _ := baseMetrics.LocalBackend.Snapshot()
-	assert.EqualValues(t, 1, counters["fry|debug=false"])
-	assert.EqualValues(t, 1, counters["leela|debug=false"])
-	assert.EqualValues(t, 2, counters["other-services|debug=false"])
+	assert.EqualValues(t, 1, counters["|debug=false|service=fry"])
+	assert.EqualValues(t, 1, counters["|debug=false|service=leela"])
+	assert.EqualValues(t, 2, counters["|debug=false|service=other-services"])
 
 	metrics.countByServiceName("zoidberg", true)
 	metrics.countByServiceName("bender", true)
@@ -75,7 +75,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("fry", true)
 
 	counters, _ = baseMetrics.LocalBackend.Snapshot()
-	assert.EqualValues(t, 1, counters["zoidberg|debug=true"])
-	assert.EqualValues(t, 1, counters["bender|debug=true"])
-	assert.EqualValues(t, 2, counters["other-services|debug=true"])
+	assert.EqualValues(t, 1, counters["|debug=true|service=zoidberg"])
+	assert.EqualValues(t, 1, counters["|debug=true|service=bender"])
+	assert.EqualValues(t, 2, counters["|debug=true|service=other-services"])
 }

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -109,18 +109,26 @@ func TestBySvcMetrics(t *testing.T) {
 		} else {
 			panic("Unknown format")
 		}
-		expected := []metricsTest.ExpectedMetric{
-			{Name: metricPrefix + ".spans.received|format=" + format + "|service=" + test.serviceName, Value: 2},
-		}
+		expected := []metricsTest.ExpectedMetric{}
 		if test.debug {
 			expected = append(expected, metricsTest.ExpectedMetric{
-				Name: metricPrefix + ".debug-spans.received|format=" + format + "|service=" + test.serviceName, Value: 2,
+				Name: metricPrefix + ".spans.received|debug=true|format=" + format + "|service=" + test.serviceName, Value: 2,
+			})
+		} else {
+			expected = append(expected, metricsTest.ExpectedMetric{
+				Name: metricPrefix + ".spans.received|debug=false|format=" + format + "|service=" + test.serviceName, Value: 2,
 			})
 		}
 		if test.rootSpan {
-			expected = append(expected, metricsTest.ExpectedMetric{
-				Name: metricPrefix + ".traces.received|format=" + format + "|service=" + test.serviceName, Value: 2,
-			})
+			if test.debug {
+				expected = append(expected, metricsTest.ExpectedMetric{
+					Name: metricPrefix + ".traces.received|debug=true|format=" + format + "|service=" + test.serviceName, Value: 2,
+				})
+			} else {
+				expected = append(expected, metricsTest.ExpectedMetric{
+					Name: metricPrefix + ".traces.received|debug=false|format=" + format + "|service=" + test.serviceName, Value: 2,
+				})
+			}
 		}
 		if test.serviceName != blackListedService || test.debug {
 			// "error.busy" and "spans.dropped" are both equivalent to a span being accepted,
@@ -134,7 +142,7 @@ func TestBySvcMetrics(t *testing.T) {
 			})
 		} else {
 			expected = append(expected, metricsTest.ExpectedMetric{
-				Name: metricPrefix + ".spans.rejected|format=" + format + "|service=" + test.serviceName, Value: 2,
+				Name: metricPrefix + ".spans.rejected|debug=false|format=" + format + "|service=" + test.serviceName, Value: 2,
 			})
 		}
 		metricsTest.AssertCounterMetrics(t, mb, expected...)


### PR DESCRIPTION
Currently, we support metrics for the total number of debug spans but another useful metric to have is the debug traces (services that initiate the debug trace). Since debug traces aren't downsampled (this isn't technically true here in OSS...) having metrics to observe which service is creating more debug traces than necessary is useful.

Signed-off-by: Won Jun Jang <wjang@uber.com>