### PR TITLE
WIP integration-test fixtures should use internal model 

### DIFF
--- a/plugin/storage/integration/fixtures/traces/default.json
+++ b/plugin/storage/integration/fixtures/traces/default.json
@@ -4,13 +4,10 @@
       "traceID": "11",
       "spanID": "3",
       "operationName": "",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "query11-service",
-        "tags": []
+        "serviceName": "query11-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/dur_trace.json
@@ -4,13 +4,10 @@
       "traceID": "9",
       "spanID": "3",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
-        "serviceName": "query09-service",
-        "tags": []
+        "serviceName": "query09-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/example_trace.json
+++ b/plugin/storage/integration/fixtures/traces/example_trace.json
@@ -4,13 +4,10 @@
       "traceID": "11",
       "spanID": "3",
       "operationName": "example-operation-1",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "example-service-1",
-        "tags": []
+        "serviceName": "example-service-1"
       },
       "logs": [
         {
@@ -27,13 +24,10 @@
       "traceID": "11",
       "spanID": "4",
       "operationName": "example-operation-2",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "example-service-2",
-        "tags": []
+        "serviceName": "example-service-2"
       },
       "logs": [
         {
@@ -50,13 +44,10 @@
       "traceID": "11",
       "spanID": "5",
       "operationName": "example-operation-1",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "example-service-3",
-        "tags": []
+        "serviceName": "example-service-3"
       },
       "logs": [
         {
@@ -73,13 +64,10 @@
       "traceID": "11",
       "spanID": "6",
       "operationName": "example-operation-3",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "example-service-1",
-        "tags": []
+        "serviceName": "example-service-1"
       },
       "logs": [
         {
@@ -96,13 +84,10 @@
       "traceID": "11",
       "spanID": "7",
       "operationName": "example-operation-4",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "example-service-1",
-        "tags": []
+        "serviceName": "example-service-1"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/log_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/log_tags_trace.json
@@ -4,13 +4,10 @@
       "traceID": "2",
       "spanID": "1",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
-        "serviceName": "query02-service",
-        "tags": []
+        "serviceName": "query02-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/max_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/max_dur_trace.json
@@ -4,13 +4,10 @@
       "traceID": "10",
       "spanID": "2",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 1000,
-      "tags": [],
       "process": {
-        "serviceName": "query10-service",
-        "tags": []
+        "serviceName": "query10-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/multi_index_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multi_index_trace.json
@@ -4,13 +4,10 @@
       "traceID": "5",
       "spanID": "1",
       "operationName": "operation-list-test2",
-      "references": [],
       "startTime": "2017-01-26T00:03:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
-        "serviceName": "query05-service",
-        "tags": []
+        "serviceName": "query05-service"
       },
       "logs": [
         {
@@ -27,13 +24,10 @@
       "traceID": "5",
       "spanID": "2",
       "operationName": "operation-list-test3",
-      "references": [],
       "startTime": "2017-01-25T23:56:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
-        "serviceName": "query05-service",
-        "tags": []
+        "serviceName": "query05-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/multi_spot_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multi_spot_tags_trace.json
@@ -4,7 +4,6 @@
       "traceID": "4",
       "spanID": "1",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/multiple1_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple1_trace.json
@@ -4,13 +4,10 @@
       "traceID": "221",
       "spanID": "3",
       "operationName": "",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "query22-service",
-        "tags": []
+        "serviceName": "query22-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/multiple2_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple2_trace.json
@@ -4,13 +4,10 @@
       "traceID": "222",
       "spanID": "3",
       "operationName": "",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "query22-service",
-        "tags": []
+        "serviceName": "query22-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/multiple3_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple3_trace.json
@@ -4,13 +4,10 @@
       "traceID": "223",
       "spanID": "3",
       "operationName": "",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 100000,
-      "tags": [],
       "process": {
-        "serviceName": "query22-service",
-        "tags": []
+        "serviceName": "query22-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/multispottag_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_dur_trace.json
@@ -4,7 +4,6 @@
       "traceID": "20",
       "spanID": "3",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/multispottag_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_maxdur_trace.json
@@ -4,7 +4,6 @@
       "traceID": "21",
       "spanID": "5",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 1000,
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/multispottag_opname_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_opname_dur_trace.json
@@ -4,7 +4,6 @@
       "traceID": "19",
       "spanID": "5",
       "operationName": "query19-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/multispottag_opname_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_opname_maxdur_trace.json
@@ -4,7 +4,6 @@
       "traceID": "18",
       "spanID": "4",
       "operationName": "query18-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 1000,
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/multispottag_opname_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_opname_trace.json
@@ -4,7 +4,6 @@
       "traceID": "17",
       "spanID": "4",
       "operationName": "query17-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/opname_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/opname_dur_trace.json
@@ -4,13 +4,10 @@
       "traceID": "8",
       "spanID": "2",
       "operationName": "query08-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
-        "serviceName": "query08-service",
-        "tags": []
+        "serviceName": "query08-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/opname_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/opname_maxdur_trace.json
@@ -5,27 +5,20 @@
       "spanID": "3",
       "parentSpanID": "2",
       "operationName": "query07-operation",
-      "tags": [],
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 1000,
       "process": {
-        "serviceName": "query07-service",
-        "tags": []
-      },
-      "logs": []
+        "serviceName": "query07-service"
+      }
     },
     {
       "traceID": "7",
       "spanID": "2",
       "operationName": "query07-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 2000,
-      "tags": [],
       "process": {
-        "serviceName": "query07-service",
-        "tags": []
+        "serviceName": "query07-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/opname_trace.json
+++ b/plugin/storage/integration/fixtures/traces/opname_trace.json
@@ -4,13 +4,10 @@
       "traceID": "6",
       "spanID": "1",
       "operationName": "query06-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
-        "serviceName": "query06-service",
-        "tags": []
+        "serviceName": "query06-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/process_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/process_tags_trace.json
@@ -4,10 +4,8 @@
       "traceID": "3",
       "spanID": "1",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
         "serviceName": "query03-service",
         "tags": [

--- a/plugin/storage/integration/fixtures/traces/span_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/span_tags_trace.json
@@ -4,7 +4,6 @@
       "traceID": "1",
       "spanID": "2",
       "operationName": "some-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 7000,
       "tags": [
@@ -35,10 +34,8 @@
         }
       ],
       "process": {
-        "serviceName": "query01-service",
-        "tags": []
-      },
-      "logs": []
+        "serviceName": "query01-service"
+      }
     }
   ]
 }

--- a/plugin/storage/integration/fixtures/traces/tags_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_dur_trace.json
@@ -4,7 +4,6 @@
       "traceID": "15",
       "spanID": "4",
       "operationName": "placeholder",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
       "tags": [
@@ -35,8 +34,7 @@
         }
       ],
       "process": {
-        "serviceName": "query15-service",
-        "tags": []
+        "serviceName": "query15-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/tags_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_maxdur_trace.json
@@ -4,10 +4,8 @@
       "traceID": "16",
       "spanID": "5",
       "operationName": "",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 1000,
-      "tags": [],
       "process": {
         "serviceName": "query16-service",
         "tags": [

--- a/plugin/storage/integration/fixtures/traces/tags_opname_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_opname_dur_trace.json
@@ -4,13 +4,10 @@
       "traceID": "14",
       "spanID": "3",
       "operationName": "query14-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 5000,
-      "tags": [],
       "process": {
-        "serviceName": "query14-service",
-        "tags": []
+        "serviceName": "query14-service"
       },
       "logs": [
         {

--- a/plugin/storage/integration/fixtures/traces/tags_opname_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_opname_maxdur_trace.json
@@ -4,7 +4,6 @@
       "traceID": "13",
       "spanID": "7",
       "operationName": "query13-operation",
-      "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 1000,
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/tags_opname_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_opname_trace.json
@@ -51,10 +51,8 @@
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": 2000,
       "process": {
-        "serviceName": "query12-service",
-        "tags": []
-      },
-      "logs": []
+        "serviceName": "query12-service"
+      }
     }
   ]
 }


### PR DESCRIPTION
Integration-test fixtures should use internal model and not domain model for comparison purposes since these storage backends don't deal with the UI data models.

This commit is also available in the PR #760 but I figured another PR would be suitable for this. Can be closed if merging with the #760 is enough. 

Signed-off-by: Michael Burman <miburman@redhat.com>