### PR TITLE
Remove ParentSpanID from domain model

### DIFF
--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -141,7 +141,7 @@ func (m metricsBySvc) ReportServiceNameForSpan(span *model.Span) {
 	if span.Flags.IsDebug() {
 		m.countDebugSpansByServiceName(serviceName)
 	}
-	if span.ParentSpanID == 0 {
+	if span.ParentSpanID() == 0 {
 		m.countTracesByServiceName(serviceName)
 	}
 }

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -43,7 +43,7 @@ func TestProcessorMetrics(t *testing.T) {
 	}
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	mSpan.Flags.SetDebug()
-	mSpan.ParentSpanID = model.SpanID(1234)
+	mSpan.ReplaceParentID(1234)
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	counters, gauges := baseMetrics.LocalBackend.Snapshot()
 

--- a/model/adjuster/clockskew.go
+++ b/model/adjuster/clockskew.go
@@ -115,14 +115,14 @@ func (a *clockSkewAdjuster) buildSubGraphs() {
 	a.roots = make(map[model.SpanID]*node)
 	for _, n := range a.spans {
 		// TODO handle FOLLOWS_FROM references
-		if n.span.ParentSpanID == 0 {
+		if n.span.ParentSpanID() == 0 {
 			a.roots[n.span.SpanID] = n
 			continue
 		}
-		if p, ok := a.spans[n.span.ParentSpanID]; ok {
+		if p, ok := a.spans[n.span.ParentSpanID()]; ok {
 			p.children = append(p.children, n)
 		} else {
-			warning := fmt.Sprintf(warningFormatInvalidParentID, n.span.ParentSpanID)
+			warning := fmt.Sprintf(warningFormatInvalidParentID, n.span.ParentSpanID())
 			n.span.Warnings = append(n.span.Warnings, warning)
 			// Treat spans with invalid parent ID as root spans
 			a.roots[n.span.SpanID] = n

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -53,13 +53,14 @@ func TestClockSkewAdjuster(t *testing.T) {
 					Fields:    []model.KeyValue{model.String("event", "some event")},
 				})
 			}
+			traceID := model.TraceID{Low: 1}
 			span := &model.Span{
-				TraceID:      model.TraceID{Low: 1},
-				SpanID:       model.SpanID(spanProto.id),
-				ParentSpanID: model.SpanID(spanProto.parent),
-				StartTime:    toTime(spanProto.startTime),
-				Duration:     toDuration(spanProto.duration),
-				Logs:         logs,
+				TraceID:    traceID,
+				SpanID:     model.SpanID(spanProto.id),
+				References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(spanProto.parent))},
+				StartTime:  toTime(spanProto.startTime),
+				Duration:   toDuration(spanProto.duration),
+				Logs:       logs,
 				Process: &model.Process{
 					ServiceName: spanProto.host,
 					Tags: []model.KeyValue{

--- a/model/adjuster/span_id_deduper.go
+++ b/model/adjuster/span_id_deduper.go
@@ -82,7 +82,7 @@ func (d *spanIDDeduper) dedupeSpanIDs() {
 				continue
 			}
 			oldToNewSpanIDs[span.SpanID] = newID
-			span.ParentSpanID = span.SpanID // previously shared ID is the new parent
+			span.ReplaceParentID(span.SpanID) // previously shared ID is the new parent
 			span.SpanID = newID
 		}
 	}
@@ -93,9 +93,9 @@ func (d *spanIDDeduper) dedupeSpanIDs() {
 // spans whose IDs we deduped.
 func (d *spanIDDeduper) swapParentIDs(oldToNewSpanIDs map[model.SpanID]model.SpanID) {
 	for _, span := range d.trace.Spans {
-		if parentID, ok := oldToNewSpanIDs[span.ParentSpanID]; ok {
+		if parentID, ok := oldToNewSpanIDs[span.ParentSpanID()]; ok {
 			if span.SpanID != parentID {
-				span.ParentSpanID = parentID
+				span.ReplaceParentID(parentID)
 			}
 		}
 	}

--- a/model/converter/json/fixtures/domain_01.json
+++ b/model/converter/json/fixtures/domain_01.json
@@ -70,7 +70,13 @@
     {
       "traceID": "1",
       "spanID": "3",
-      "parentSpanID": "2",
+      "references": [
+          {
+              "refType": "child-of",
+              "traceID": "1",
+              "spanID": "2"
+          }
+      ],
       "operationName": "some-operation",
       "startTime": "2017-01-26T16:46:31.639875139-05:00",
       "duration": 5000,
@@ -111,7 +117,6 @@
     {
       "traceID": "1",
       "spanID": "5",
-      "parentSpanID": "4",
       "operationName": "preserveParentID-test",
       "references": [
         {

--- a/model/converter/json/fixtures/domain_es_01.json
+++ b/model/converter/json/fixtures/domain_es_01.json
@@ -1,7 +1,6 @@
 {
   "traceID": "1",
   "spanID": "2",
-  "parentSpanID": "3",
   "operationName": "test-general-conversion",
   "references": [
     {

--- a/model/converter/json/fixtures/domain_es_01.json
+++ b/model/converter/json/fixtures/domain_es_01.json
@@ -5,18 +5,18 @@
   "references": [
     {
       "refType": "child-of",
-      "traceID": "ff",
-      "spanID": "ff"
-    },
-    {
-      "refType": "child-of",
       "traceID": "1",
-      "spanID": "2"
+      "spanID": "3"
     },
     {
       "refType": "follows-from",
       "traceID": "1",
-      "spanID": "2"
+      "spanID": "4"
+    },
+    {
+      "refType": "child-of",
+      "traceID": "ff",
+      "spanID": "ff"
     }
   ],
   "flags": 1,

--- a/model/converter/json/fixtures/es_01.json
+++ b/model/converter/json/fixtures/es_01.json
@@ -6,18 +6,18 @@
   "references": [
     {
       "refType": "CHILD_OF",
-      "traceID": "ff",
-      "spanID": "ff"
-    },
-    {
-      "refType": "CHILD_OF",
       "traceID": "1",
-      "spanID": "2"
+      "spanID": "3"
     },
     {
       "refType": "FOLLOWS_FROM",
       "traceID": "1",
-      "spanID": "2"
+      "spanID": "4"
+    },
+    {
+      "refType": "CHILD_OF",
+      "traceID": "ff",
+      "spanID": "ff"
     }
   ],
   "startTime": 1485467191639875,

--- a/model/converter/json/fixtures/es_01.json
+++ b/model/converter/json/fixtures/es_01.json
@@ -1,7 +1,6 @@
 {
   "traceID": "1",
   "spanID": "2",
-  "parentSpanID": "3",
   "flags": 1,
   "operationName": "test-general-conversion",
   "references": [

--- a/model/converter/json/from_domain_test.go
+++ b/model/converter/json/from_domain_test.go
@@ -33,13 +33,13 @@ const NumberOfFixtures = 1
 
 func TestFromDomain(t *testing.T) {
 	for i := 1; i <= NumberOfFixtures; i++ {
-		inStr, outStr := testReadFixtures(t, i, false)
+		domainStr, jsonStr := testReadFixtures(t, i, false)
 
 		var trace model.Trace
-		require.NoError(t, json.Unmarshal(inStr, &trace))
+		require.NoError(t, json.Unmarshal(domainStr, &trace))
 		uiTrace := FromDomain(&trace)
 
-		testOutput(t, i, outStr, uiTrace, false)
+		testOutput(t, i, jsonStr, uiTrace, false)
 	}
 	// this is just to confirm the uint64 representation of float64(72.5) used as a "temperature" tag
 	assert.Equal(t, int64(4634802150889750528), int64(math.Float64bits(72.5)))
@@ -60,6 +60,7 @@ func TestFromDomainEmbedProcess(t *testing.T) {
 	}
 }
 
+// Loads and returns domain model and JSON model fixtures with given number i.
 func testReadFixtures(t *testing.T, i int, processEmbedded bool) ([]byte, []byte) {
 	var in string
 	if processEmbedded {
@@ -80,7 +81,7 @@ func testReadFixtures(t *testing.T, i int, processEmbedded bool) ([]byte, []byte
 	return inStr, outStr
 }
 
-func testOutput(t *testing.T, i int, outStr []byte, object interface{}, processEmbedded bool) {
+func testOutput(t *testing.T, i int, expectedStr []byte, object interface{}, processEmbedded bool) {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetIndent("", "  ")
@@ -94,7 +95,7 @@ func testOutput(t *testing.T, i int, outStr []byte, object interface{}, processE
 		require.NoError(t, enc.Encode(object.(*jModel.Trace)))
 	}
 
-	if !assert.Equal(t, string(outStr), string(buf.Bytes())) {
+	if !assert.Equal(t, string(expectedStr), string(buf.Bytes())) {
 		err := ioutil.WriteFile(outFile+"-actual.json", buf.Bytes(), 0644)
 		assert.NoError(t, err)
 	}

--- a/model/converter/json/to_domain.go
+++ b/model/converter/json/to_domain.go
@@ -58,15 +58,18 @@ func (td toDomain) spanToDomain(dbSpan *json.Span) (*model.Span, error) {
 	if err != nil {
 		return nil, err
 	}
-	parentSpanIDInt, err := model.SpanIDFromString(string(dbSpan.ParentSpanID))
-	if err != nil {
-		return nil, err
+
+	if dbSpan.ParentSpanID != "" {
+		parentSpanID, err := model.SpanIDFromString(string(dbSpan.ParentSpanID))
+		if err != nil {
+			return nil, err
+		}
+		refs = model.MaybeAddParentSpanID(traceID, parentSpanID, refs)
 	}
 
 	span := &model.Span{
 		TraceID:       traceID,
 		SpanID:        model.SpanID(spanIDInt),
-		ParentSpanID:  model.SpanID(parentSpanIDInt),
 		OperationName: dbSpan.OperationName,
 		References:    refs,
 		Flags:         model.Flags(uint32(dbSpan.Flags)),

--- a/model/converter/json/to_domain_test.go
+++ b/model/converter/json/to_domain_test.go
@@ -244,10 +244,3 @@ func TestFailureBadSpanID(t *testing.T) {
 	badSpanIDESSpan.SpanID = "zz"
 	failingSpanTransformAnyMsg(t, &badSpanIDESSpan)
 }
-
-func TestFailureBadParentSpanID(t *testing.T) {
-	badParentSpanIDESSpan, err := createGoodSpan(1)
-	require.NoError(t, err)
-	badParentSpanIDESSpan.ParentSpanID = "zz"
-	failingSpanTransformAnyMsg(t, &badParentSpanIDESSpan)
-}

--- a/model/converter/json/to_domain_test.go
+++ b/model/converter/json/to_domain_test.go
@@ -28,10 +28,20 @@ import (
 	jModel "github.com/jaegertracing/jaeger/model/json"
 )
 
-func TestToDomainEmbeddedProcess(t *testing.T) {
+func TestToDomain(t *testing.T) {
+	testToDomain(t, false)
+	testToDomain(t, true)
+	// this is just to confirm the uint64 representation of float64(72.5) used as a "temperature" tag
+	assert.Equal(t, int64(4634802150889750528), int64(math.Float64bits(72.5)))
+}
+
+func testToDomain(t *testing.T, testParentSpanID bool) {
 	for i := 1; i <= NumberOfFixtures; i++ {
-		span, err := createGoodSpan(i)
+		span, err := loadESSpanFixture(i)
 		require.NoError(t, err)
+		if testParentSpanID {
+			span.ParentSpanID = "3"
+		}
 
 		actualSpan, err := SpanToDomain(&span)
 		require.NoError(t, err)
@@ -44,11 +54,9 @@ func TestToDomainEmbeddedProcess(t *testing.T) {
 
 		CompareModelSpans(t, &expectedSpan, actualSpan)
 	}
-	// this is just to confirm the uint64 representation of float64(72.5) used as a "temperature" tag
-	assert.Equal(t, int64(4634802150889750528), int64(math.Float64bits(72.5)))
 }
 
-func createGoodSpan(i int) (jModel.Span, error) {
+func loadESSpanFixture(i int) (jModel.Span, error) {
 	in := fmt.Sprintf("fixtures/es_%02d.json", i)
 	inStr, err := ioutil.ReadFile(in)
 	if err != nil {
@@ -72,7 +80,7 @@ func failingSpanTransformAnyMsg(t *testing.T, embeddedSpan *jModel.Span) {
 }
 
 func TestFailureBadTypeTags(t *testing.T) {
-	badTagESSpan, err := createGoodSpan(1)
+	badTagESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 
 	badTagESSpan.Tags = []jModel.KeyValue{
@@ -85,7 +93,7 @@ func TestFailureBadTypeTags(t *testing.T) {
 }
 
 func TestFailureBadBoolTags(t *testing.T) {
-	badTagESSpan, err := createGoodSpan(1)
+	badTagESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 
 	badTagESSpan.Tags = []jModel.KeyValue{
@@ -99,7 +107,7 @@ func TestFailureBadBoolTags(t *testing.T) {
 }
 
 func TestFailureBadIntTags(t *testing.T) {
-	badTagESSpan, err := createGoodSpan(1)
+	badTagESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 
 	badTagESSpan.Tags = []jModel.KeyValue{
@@ -113,7 +121,7 @@ func TestFailureBadIntTags(t *testing.T) {
 }
 
 func TestFailureBadFloatTags(t *testing.T) {
-	badTagESSpan, err := createGoodSpan(1)
+	badTagESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 
 	badTagESSpan.Tags = []jModel.KeyValue{
@@ -127,7 +135,7 @@ func TestFailureBadFloatTags(t *testing.T) {
 }
 
 func TestFailureBadBinaryTags(t *testing.T) {
-	badTagESSpan, err := createGoodSpan(1)
+	badTagESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 
 	badTagESSpan.Tags = []jModel.KeyValue{
@@ -141,7 +149,7 @@ func TestFailureBadBinaryTags(t *testing.T) {
 }
 
 func TestFailureBadLogs(t *testing.T) {
-	badLogsESSpan, err := createGoodSpan(1)
+	badLogsESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 	badLogsESSpan.Logs = []jModel.Log{
 		{
@@ -169,7 +177,7 @@ func TestRevertKeyValueOfType(t *testing.T) {
 }
 
 func TestFailureBadRefs(t *testing.T) {
-	badRefsESSpan, err := createGoodSpan(1)
+	badRefsESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 	badRefsESSpan.References = []jModel.Reference{
 		{
@@ -181,7 +189,7 @@ func TestFailureBadRefs(t *testing.T) {
 }
 
 func TestFailureBadTraceIDRefs(t *testing.T) {
-	badRefsESSpan, err := createGoodSpan(1)
+	badRefsESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 	badRefsESSpan.References = []jModel.Reference{
 		{
@@ -194,7 +202,7 @@ func TestFailureBadTraceIDRefs(t *testing.T) {
 }
 
 func TestFailureBadSpanIDRefs(t *testing.T) {
-	badRefsESSpan, err := createGoodSpan(1)
+	badRefsESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 	badRefsESSpan.References = []jModel.Reference{
 		{
@@ -207,7 +215,7 @@ func TestFailureBadSpanIDRefs(t *testing.T) {
 }
 
 func TestFailureBadProcess(t *testing.T) {
-	badProcessESSpan, err := createGoodSpan(1)
+	badProcessESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 
 	badTags := []jModel.KeyValue{
@@ -224,7 +232,7 @@ func TestFailureBadProcess(t *testing.T) {
 }
 
 func TestProcessPointer(t *testing.T) {
-	badProcessESSpan, err := createGoodSpan(1)
+	badProcessESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 
 	badProcessESSpan.Process = nil
@@ -232,15 +240,22 @@ func TestProcessPointer(t *testing.T) {
 }
 
 func TestFailureBadTraceID(t *testing.T) {
-	badTraceIDESSpan, err := createGoodSpan(1)
+	badTraceIDESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 	badTraceIDESSpan.TraceID = "zz"
 	failingSpanTransformAnyMsg(t, &badTraceIDESSpan)
 }
 
 func TestFailureBadSpanID(t *testing.T) {
-	badSpanIDESSpan, err := createGoodSpan(1)
+	badSpanIDESSpan, err := loadESSpanFixture(1)
 	require.NoError(t, err)
 	badSpanIDESSpan.SpanID = "zz"
 	failingSpanTransformAnyMsg(t, &badSpanIDESSpan)
+}
+
+func TestFailureBadParentSpanID(t *testing.T) {
+	badParentSpanIDESSpan, err := loadESSpanFixture(1)
+	require.NoError(t, err)
+	badParentSpanIDESSpan.ParentSpanID = "zz"
+	failingSpanTransformAnyMsg(t, &badParentSpanIDESSpan)
 }

--- a/model/converter/thrift/jaeger/fixtures/model_01.json
+++ b/model/converter/thrift/jaeger/fixtures/model_01.json
@@ -2,8 +2,14 @@
   {
     "traceID":"52969a8955571a3f",
     "spanID":"647d98",
-    "parentSpanID":"68c4e3",
     "operationName":"get",
+    "references": [
+        {
+          "refType": "child-of",
+          "traceID": "52969a8955571a3f",
+          "spanID": "68c4e3"
+        }
+      ],
     "startTime":"2017-01-26T16:46:31.639875-05:00",
     "duration":22938000,
     "tags":[

--- a/model/converter/thrift/jaeger/fixtures/model_02.json
+++ b/model/converter/thrift/jaeger/fixtures/model_02.json
@@ -2,8 +2,14 @@
   {
     "traceID":"52969a8955571a3f",
     "spanID":"647d98",
-    "parentSpanID":"68c4e3",
     "operationName":"get",
+    "references": [
+        {
+          "refType": "child-of",
+          "traceID": "52969a8955571a3f",
+          "spanID": "68c4e3"
+        }
+      ],
     "startTime":"2017-01-26T16:46:31.639875-05:00",
     "duration":22938000,
     "tags":[

--- a/model/converter/thrift/jaeger/fixtures/model_03.json
+++ b/model/converter/thrift/jaeger/fixtures/model_03.json
@@ -2,7 +2,6 @@
   {
     "traceID":"52969a8955571a3f",
     "spanID":"52969a",
-    "parentSpanID":"52969a",
     "operationName":"get",
     "startTime":"2017-01-26T16:46:31.639875-05:00",
     "duration":22938000,
@@ -93,7 +92,6 @@
   {
     "traceID":"52969a8955571a3f",
     "spanID":"52947b",
-    "parentSpanID":"52969a",
     "operationName":"get",
     "startTime":"2017-01-26T16:46:31.639875-05:00",
     "duration":22938000,

--- a/model/converter/thrift/jaeger/from_domain.go
+++ b/model/converter/thrift/jaeger/from_domain.go
@@ -140,7 +140,7 @@ func (d domainToJaegerTransformer) transformSpan(span *model.Span) *jaeger.Span 
 		TraceIdLow:    int64(span.TraceID.Low),
 		TraceIdHigh:   int64(span.TraceID.High),
 		SpanId:        int64(span.SpanID),
-		ParentSpanId:  int64(span.ParentSpanID),
+		ParentSpanId:  int64(span.ParentSpanID()),
 		OperationName: span.OperationName,
 		References:    refs,
 		Flags:         int32(span.Flags),

--- a/model/converter/thrift/jaeger/to_domain.go
+++ b/model/converter/thrift/jaeger/to_domain.go
@@ -57,7 +57,6 @@ func (td toDomain) transformSpan(jSpan *jaeger.Span, mProcess *model.Process) *m
 		High: uint64(jSpan.TraceIdHigh),
 		Low:  uint64(jSpan.TraceIdLow),
 	}
-	spanID := model.SpanID(jSpan.SpanId)
 	tags := td.getTags(jSpan.Tags)
 	refs := td.getReferences(jSpan.References)
 	// We no longer store ParentSpanID in the domain model, but the data in Thrift model
@@ -69,7 +68,7 @@ func (td toDomain) transformSpan(jSpan *jaeger.Span, mProcess *model.Process) *m
 	}
 	return &model.Span{
 		TraceID:       traceID,
-		SpanID:        spanID,
+		SpanID:        model.SpanID(jSpan.SpanId),
 		OperationName: jSpan.OperationName,
 		References:    refs,
 		Flags:         model.Flags(jSpan.Flags),

--- a/model/converter/thrift/zipkin/fixtures/jaeger_01.json
+++ b/model/converter/thrift/zipkin/fixtures/jaeger_01.json
@@ -63,8 +63,14 @@
     {
       "traceID": "20000000000000001",
       "spanID": "3",
-      "parentSpanID": "2",
       "operationName": "some-operation",
+      "references": [
+        {
+          "refType": "child-of",
+          "traceID": "20000000000000001",
+          "spanID": "2"
+        }
+      ],
       "startTime": "1970-01-01T00:00:00-00:00",
       "tags": [
         {

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -114,7 +114,6 @@ func TestToDomainMultipleSpanKinds(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		fmt.Println(test.json)
 		trace, err := ToDomain(getZipkinSpans(t, test.json))
 		require.Nil(t, err)
 

--- a/model/json/model.go
+++ b/model/json/model.go
@@ -63,7 +63,7 @@ type Trace struct {
 type Span struct {
 	TraceID       TraceID     `json:"traceID"`
 	SpanID        SpanID      `json:"spanID"`
-	ParentSpanID  SpanID      `json:"parentSpanID,omitempty"`
+	ParentSpanID  SpanID      `json:"parentSpanID,omitempty"` // deprecated
 	Flags         uint32      `json:"flags,omitempty"`
 	OperationName string      `json:"operationName"`
 	References    []Reference `json:"references"`

--- a/model/spanref.go
+++ b/model/spanref.go
@@ -85,8 +85,9 @@ func MaybeAddParentSpanID(traceID TraceID, parentSpanID SpanID, refs []SpanRef) 
 	if parentSpanID == 0 {
 		return refs
 	}
-	for _, r := range refs {
-		if r.SpanID == parentSpanID && r.TraceID == traceID {
+	for i := range refs {
+		r := &refs[i]
+		if r.SpanID == parentSpanID && r.TraceID == traceID && r.RefType == ChildOf {
 			return refs
 		}
 	}
@@ -96,7 +97,7 @@ func MaybeAddParentSpanID(traceID TraceID, parentSpanID SpanID, refs []SpanRef) 
 		RefType: ChildOf,
 	}
 	if len(refs) == 0 {
-		return []SpanRef{newRef}
+		return append(refs, newRef)
 	}
 	newRefs := make([]SpanRef, len(refs)+1)
 	newRefs[0] = newRef
@@ -108,6 +109,15 @@ func MaybeAddParentSpanID(traceID TraceID, parentSpanID SpanID, refs []SpanRef) 
 func NewChildOfRef(traceID TraceID, spanID SpanID) SpanRef {
 	return SpanRef{
 		RefType: ChildOf,
+		TraceID: traceID,
+		SpanID:  spanID,
+	}
+}
+
+// NewFollowsFromRef creates a new follows-from span reference.
+func NewFollowsFromRef(traceID TraceID, spanID SpanID) SpanRef {
+	return SpanRef{
+		RefType: FollowsFrom,
 		TraceID: traceID,
 		SpanID:  spanID,
 	}

--- a/model/spanref.go
+++ b/model/spanref.go
@@ -14,7 +14,9 @@
 
 package model
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // SpanRefType describes the type of a span reference
 type SpanRefType int
@@ -73,4 +75,40 @@ func (p *SpanRefType) UnmarshalText(text []byte) error {
 	}
 	*p = q
 	return nil
+}
+
+// MaybeAddParentSpanID adds non-zero parentSpanID to refs as a child-of reference.
+// We no longer store ParentSpanID in the domain model, but the data in the database
+// or other formats might still have these IDs without representing them in the References,
+// so this converts parent IDs to canonical reference format.
+func MaybeAddParentSpanID(traceID TraceID, parentSpanID SpanID, refs []SpanRef) []SpanRef {
+	if parentSpanID == 0 {
+		return refs
+	}
+	for _, r := range refs {
+		if r.SpanID == parentSpanID && r.TraceID == traceID {
+			return refs
+		}
+	}
+	newRef := SpanRef{
+		TraceID: traceID,
+		SpanID:  parentSpanID,
+		RefType: ChildOf,
+	}
+	if len(refs) == 0 {
+		return []SpanRef{newRef}
+	}
+	newRefs := make([]SpanRef, len(refs)+1)
+	newRefs[0] = newRef
+	copy(newRefs[1:], refs)
+	return newRefs
+}
+
+// NewChildOfRef creates a new child-of span reference.
+func NewChildOfRef(traceID TraceID, spanID SpanID) SpanRef {
+	return SpanRef{
+		RefType: ChildOf,
+		TraceID: traceID,
+		SpanID:  spanID,
+	}
 }

--- a/plugin/storage/cassandra/savetracetest/main.go
+++ b/plugin/storage/cassandra/savetracetest/main.go
@@ -102,12 +102,12 @@ func getSomeProcess() *model.Process {
 }
 
 func getSomeSpan() *model.Span {
+	traceID := model.TraceID{High: 1, Low: 2}
 	return &model.Span{
-		TraceID:       model.TraceID{High: 1, Low: 2},
+		TraceID:       traceID,
 		SpanID:        model.SpanID(3),
-		ParentSpanID:  model.SpanID(4),
 		OperationName: "opName",
-		References:    getReferences(),
+		References:    append([]model.SpanRef{model.NewChildOfRef(traceID, 4)}, getReferences()...),
 		Flags:         model.Flags(uint32(5)),
 		StartTime:     time.Now(),
 		Duration:      50000 * time.Microsecond,

--- a/plugin/storage/cassandra/savetracetest/main.go
+++ b/plugin/storage/cassandra/savetracetest/main.go
@@ -107,7 +107,7 @@ func getSomeSpan() *model.Span {
 		TraceID:       traceID,
 		SpanID:        model.SpanID(3),
 		OperationName: "opName",
-		References:    append([]model.SpanRef{model.NewChildOfRef(traceID, 4)}, getReferences()...),
+		References:    model.MaybeAddParentSpanID(traceID, 4, getReferences()),
 		Flags:         model.Flags(uint32(5)),
 		StartTime:     time.Now(),
 		Duration:      50000 * time.Microsecond,

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -78,14 +78,11 @@ func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 		return nil, err
 	}
 	traceID := dbSpan.TraceID.ToDomain()
-	if dbSpan.ParentID != 0 {
-		refs = model.MaybeAddParentSpanID(traceID, model.SpanID(dbSpan.ParentID), refs)
-	}
 	span := &model.Span{
 		TraceID:       traceID,
 		SpanID:        model.SpanID(dbSpan.SpanID),
 		OperationName: dbSpan.OperationName,
-		References:    refs,
+		References:    model.MaybeAddParentSpanID(traceID, model.SpanID(dbSpan.ParentID), refs),
 		Flags:         model.Flags(uint32(dbSpan.Flags)),
 		StartTime:     model.EpochMicrosecondsAsTime(uint64(dbSpan.StartTime)),
 		Duration:      model.MicrosecondsAsDuration(uint64(dbSpan.Duration)),

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -122,7 +122,6 @@ func getTestJaegerSpan() *model.Span {
 	return &model.Span{
 		TraceID:       someTraceID,
 		SpanID:        someSpanID,
-		ParentSpanID:  someParentSpanID,
 		OperationName: someOperationName,
 		References:    someRefs,
 		Flags:         someFlags,
@@ -145,7 +144,6 @@ func getTestSpan() *Span {
 	span := &Span{
 		TraceID:       someDBTraceID,
 		SpanID:        int64(someSpanID),
-		ParentID:      int64(someParentSpanID),
 		OperationName: someOperationName,
 		Flags:         int32(someFlags),
 		StartTime:     int64(model.TimeAsEpochMicroseconds(someStartTime)),
@@ -194,8 +192,11 @@ func TestToSpan(t *testing.T) {
 }
 
 func TestFromSpan(t *testing.T) {
+	testDBSpan := getTestSpan()
+	testDBSpan.ParentID = testDBSpan.Refs[0].SpanID
+	testDBSpan.Refs = nil
 	expectedSpan := getTestJaegerSpan()
-	actualJSpan, err := ToDomain(getTestSpan())
+	actualJSpan, err := ToDomain(testDBSpan)
 	assert.NoError(t, err)
 	if !assert.EqualValues(t, expectedSpan, actualJSpan) {
 		for _, diff := range pretty.Diff(expectedSpan, actualJSpan) {

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -192,15 +192,19 @@ func TestToSpan(t *testing.T) {
 }
 
 func TestFromSpan(t *testing.T) {
-	testDBSpan := getTestSpan()
-	testDBSpan.ParentID = testDBSpan.Refs[0].SpanID
-	testDBSpan.Refs = nil
-	expectedSpan := getTestJaegerSpan()
-	actualJSpan, err := ToDomain(testDBSpan)
-	assert.NoError(t, err)
-	if !assert.EqualValues(t, expectedSpan, actualJSpan) {
-		for _, diff := range pretty.Diff(expectedSpan, actualJSpan) {
-			t.Log(diff)
+	for _, testParentID := range []bool{false, true} {
+		testDBSpan := getTestSpan()
+		if testParentID {
+			testDBSpan.ParentID = testDBSpan.Refs[0].SpanID
+			testDBSpan.Refs = nil
+		}
+		expectedSpan := getTestJaegerSpan()
+		actualJSpan, err := ToDomain(testDBSpan)
+		assert.NoError(t, err)
+		if !assert.EqualValues(t, expectedSpan, actualJSpan) {
+			for _, diff := range pretty.Diff(expectedSpan, actualJSpan) {
+				t.Log(diff)
+			}
 		}
 	}
 }

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -58,7 +58,7 @@ func (m *Store) GetDependencies(endTs time.Time, lookback time.Duration) ([]mode
 		trace, _ := m.deduper.Adjust(orig)
 		if m.traceIsBetweenStartAndEnd(startTs, endTs, trace) {
 			for _, s := range trace.Spans {
-				parentSpan := m.findSpan(trace, s.ParentSpanID)
+				parentSpan := m.findSpan(trace, s.ParentSpanID())
 				if parentSpan != nil {
 					if parentSpan.Process.ServiceName == s.Process.ServiceName {
 						continue

--- a/plugin/storage/memory/memory_test.go
+++ b/plugin/storage/memory/memory_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
+var traceID = model.TraceID{
+	Low:  1,
+	High: 2,
+}
+
 var testingSpan = &model.Span{
-	TraceID: model.TraceID{
-		Low:  1,
-		High: 2,
-	},
-	SpanID: model.SpanID(1),
+	TraceID: traceID,
+	SpanID:  model.SpanID(1),
 	Process: &model.Process{
 		ServiceName: "serviceName",
 		Tags:        model.KeyValues{},
@@ -51,12 +53,9 @@ var testingSpan = &model.Span{
 }
 
 var childSpan1 = &model.Span{
-	TraceID: model.TraceID{
-		Low:  1,
-		High: 2,
-	},
-	SpanID:       model.SpanID(2),
-	ParentSpanID: model.SpanID(1),
+	TraceID:    traceID,
+	SpanID:     model.SpanID(2),
+	References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(1))},
 	Process: &model.Process{
 		ServiceName: "childService",
 		Tags:        model.KeyValues{},
@@ -78,12 +77,9 @@ var childSpan1 = &model.Span{
 }
 
 var childSpan2 = &model.Span{
-	TraceID: model.TraceID{
-		Low:  1,
-		High: 2,
-	},
-	SpanID:       model.SpanID(3),
-	ParentSpanID: model.SpanID(1),
+	TraceID:    traceID,
+	SpanID:     model.SpanID(3),
+	References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(1))},
 	Process: &model.Process{
 		ServiceName: "childService",
 		Tags:        model.KeyValues{},
@@ -105,12 +101,10 @@ var childSpan2 = &model.Span{
 }
 
 var childSpan2_1 = &model.Span{
-	TraceID: model.TraceID{
-		Low:  1,
-		High: 2,
-	},
-	SpanID:       model.SpanID(4),
-	ParentSpanID: model.SpanID(3), // child of childSpan2, but with the same service name
+	TraceID: traceID,
+	SpanID:  model.SpanID(4),
+	// child of childSpan2, but with the same service name
+	References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(3))},
 	Process: &model.Process{
 		ServiceName: "childService",
 		Tags:        model.KeyValues{},


### PR DESCRIPTION
Resolves #824

This implements option 1 from #824 by removing ParentSpanID from the domain model and only using the References array. `ParentSpanID` is replaced with an accessor `ParentSpanID()` that returns the span ID of the first `child-of` reference for the same trace ID.

Once unfortunate discovery: both Cassandra and Elasticsearch models kept the ParentID field in their respective models. It is no longer populated in the domain->db model conversions, but still has to be taken into account in the dbmodel->domain conversion for backwards compatibility with existing data. I don't know of a better solution. 

A side effect of that is that we won't be able to use gogoprotobuf-generated model (from #773) to generate the JSON for Elasticsearch. The plan would be to move `model/converter/json` code into `plugin/storage/es/dbmodel`, similar to `plugin/storage/cassandra/dbmodel`, while the UI JSON model will be produced directly from protobuf model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaegertracing/jaeger/831)
<!-- Reviewable:end -->
