### PR TITLE
[WIP] Start work on sqlite plugin for Jaeger

### DIFF
--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/memory"
+	"github.com/jaegertracing/jaeger/plugin/storage/sqlite"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -35,9 +36,10 @@ const (
 	cassandraStorageType     = "cassandra"
 	elasticsearchStorageType = "elasticsearch"
 	memoryStorageType        = "memory"
+	sqliteStorageType        = "sqlite"
 )
 
-var allStorageTypes = []string{cassandraStorageType, elasticsearchStorageType, memoryStorageType}
+var allStorageTypes = []string{cassandraStorageType, elasticsearchStorageType, memoryStorageType, sqliteStorageType}
 
 // Factory implements storage.Factory interface as a meta-factory for storage components.
 type Factory struct {
@@ -72,6 +74,8 @@ func (f *Factory) getFactoryOfType(factoryType string) (storage.Factory, error) 
 		return es.NewFactory(), nil
 	case memoryStorageType:
 		return memory.NewFactory(), nil
+	case sqliteStorageType:
+		return sqlite.NewFactory(), nil
 	default:
 		return nil, fmt.Errorf("Unknown storage type %s. Valid types are %v", factoryType, allStorageTypes)
 	}

--- a/plugin/storage/sqlite/README.md
+++ b/plugin/storage/sqlite/README.md
@@ -1,0 +1,8 @@
+# Sqlite Support
+
+Sometimes you want something more beefy than *in-memory* but not as complicated
+as Cassandra / ElasticSearch -- welcome to SQLite
+
+```bash
+sqlite3 jaeger.db < sqlite.sql
+```

--- a/plugin/storage/sqlite/factory.go
+++ b/plugin/storage/sqlite/factory.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"database/sql"
+	"flag"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/viper"
+	"github.com/uber/jaeger-lib/metrics"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/storage/dependencystore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+// Factory implements storage.Factory and creates storage components backed by sqlite store.
+type Factory struct {
+	Options        *Options
+	metricsFactory metrics.Factory
+	logger         *zap.Logger
+	db             *sql.DB
+}
+
+// AddFlags implements plugin.Configurable
+func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
+	f.Options.AddFlags(flagSet)
+}
+
+// InitFromViper implements plugin.Configurable
+func (f *Factory) InitFromViper(v *viper.Viper) {
+	f.Options.InitFromViper(v)
+}
+
+// NewFactory creates a new Factory.
+func NewFactory() *Factory {
+	return &Factory{
+		Options: NewOptions(),
+	}
+}
+
+// Initialize implements storage.Factory
+func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
+	db, err := sql.Open("sqlite3", f.Options.file)
+	f.db = db
+	return err
+}
+
+// CreateSpanReader implements storage.Factory
+func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
+	return f.store, nil
+}
+
+// CreateSpanWriter implements storage.Factory
+func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
+	return f.store, nil
+}
+
+// CreateDependencyReader implements storage.Factory
+func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
+	return f.store, nil
+}

--- a/plugin/storage/sqlite/options.go
+++ b/plugin/storage/sqlite/options.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"flag"
+
+	"github.com/spf13/viper"
+)
+
+const defaultSqliteFilePath = "./jaeger.db"
+
+// Options contains various type of sqlite configuration
+type Options struct {
+	file string //the sqlite db file
+}
+
+// AddFlags adds flags for Options
+func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
+	addFlags(flagSet)
+}
+
+func addFlags(flagSet *flag.FlagSet) {
+	flagSet.String(
+		"file",
+		defaultSqliteFilePath,
+		"The sqlite file path is required by Sqlite")
+}
+
+// InitFromViper initializes Options with properties from viper
+func (opt *Options) InitFromViper(v *viper.Viper) {
+	opt.file = v.GetString("file")
+
+}
+
+// NewOptions creates a new Options struct.
+func NewOptions() *Options {
+	options := &Options{
+		file: defaultSqliteFilePath,
+	}
+	return options
+}

--- a/plugin/storage/sqlite/spanstore/reader.go
+++ b/plugin/storage/sqlite/spanstore/reader.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstore
+
+import (
+	"database/sql"
+	"encoding/binary"
+
+	"github.com/uber/jaeger-lib/metrics"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
+)
+
+// TraceID is a serializable form of model.TraceID
+type TraceID [16]byte
+
+type SpanReader struct {
+	logger *zap.Logger
+	db     *sql.DB
+}
+
+// NewSpanReader returns a new SpanReader with a metrics.
+func NewSpanReader(logger *zap.Logger, db *sql.DB, metricsFactory metrics.Factory) spanstore.Reader {
+	return storageMetrics.NewReadMetricsDecorator(newSpanReader(logger, db), metricsFactory)
+}
+
+func newSpanReader(logger *zap.Logger, db *sql.DB) *SpanReader {
+	return &SpanReader{
+		logger: logger,
+		db:     db,
+	}
+}
+
+const traceQuery = `SELECT trace_id,
+						   span_id,
+                           parent_id,
+  						   operation_name,
+  						   flags,
+  						   start_time,
+  						   duration,
+  						   service_name
+                    FROM traces WHERE trace_id = ?`
+
+// GetTrace takes a traceID and returns a Trace associated with that traceID
+func (s *SpanReader) GetTrace(traceID model.TraceID) (*model.Trace, error) {
+	dbTraceID := TraceID{}
+	binary.BigEndian.PutUint64(dbTraceID[:8], uint64(traceID.High))
+	binary.BigEndian.PutUint64(dbTraceID[8:], uint64(traceID.Low))
+	rows, err := s.db.Query(traceQuery, dbTraceID)
+	if err != nil {
+		return nil, err
+	}
+
+	var spans = make([]*model.Span, 0, 10)
+	var traceId TraceID
+	var spanId uint64
+	var parentId uint64
+	var operationName string
+	var flags uint32
+	var startTime uint64
+	var duration uint64
+	var serviceName string
+
+	for rows.Next() {
+		err = rows.Scan(&traceId, &spanId, &parentId, &operationName, &flags, &startTime, &duration, &serviceName)
+
+		traceIDHigh := binary.BigEndian.Uint64(traceId[:8])
+		traceIDLow := binary.BigEndian.Uint64(traceId[8:])
+
+		span := &model.Span{
+			TraceID:       model.TraceID{High: traceIDHigh, Low: traceIDLow},
+			SpanID:        model.SpanID(spanId),
+			ParentSpanID:  model.SpanID(parentId),
+			OperationName: operationName,
+			References:    nil, //TODO
+			Flags:         model.Flags(flags),
+			StartTime:     model.EpochMicrosecondsAsTime(startTime),
+			Duration:      model.MicrosecondsAsDuration(duration),
+			Tags:          nil, //TODO
+			Logs:          nil, //TODO
+			Process: &model.Process{
+				ServiceName: serviceName,
+			},
+		}
+
+		spans = append(spans, span)
+	}
+
+	return &model.Trace{
+		Spans: spans,
+	}, nil
+}
+
+// GetServices returns all services traced by Jaeger, ordered by frequency
+func (s *SpanReader) GetServices() ([]string, error) {
+	return nil, nil
+}
+
+// GetOperations returns all operations for a specific service traced by Jaeger
+func (s *SpanReader) GetOperations(service string) ([]string, error) {
+	return nil, nil
+}
+
+// FindTraces retrieves traces that match the traceQuery
+func (s *SpanReader) FindTraces(traceQuery *spanstore.TraceQueryParameters) ([]*model.Trace, error) {
+	return nil, nil
+}

--- a/plugin/storage/sqlite/sqlite.sql
+++ b/plugin/storage/sqlite/sqlite.sql
@@ -1,0 +1,20 @@
+
+/**
+ * The traces table holds basic information about the trace
+ */
+CREATE TABLE IF NOT EXISTS traces (
+  trace_id BLOB,
+  span_id  BIGINT,
+  parent_id BIGINT,
+  operation_name TEXT,
+  flags INT,
+  start_time BIGINT,
+  duration BIGINT,
+  service_name TEXT,
+  PRIMARY KEY (trace_id, span_id)
+);
+
+/**
+ * This index is needed so we can easily list all services or traces for a specific service
+ */
+CREATE INDEX IF NOT EXISTS service_name ON traces(service_name);


### PR DESCRIPTION
- Added beggining support for sqlite3 to Jaeger as a storage plugin.
- Library to use https://github.com/mattn/go-sqlite3 however requires
cgo
- Interfaces filled out but mostly default to nil

Signed-off-by: Farid Zakaria <farid.m.zakaria@gmail.com>

## Which problem is this PR solving?
For _proof of concept_ deployments of Jaeger, it would be great to have something in between memory (too simple) and Cassandra/ElasticSearch (too much overhead). 
Sqlite seems to fit the bill nicely here as it provides a high throughput durable storage. The work here can potentially be leveraged to other SQL compatible systems as well through Go's sql package.
(If we find commonality and use ANSI SQL types)

## Short description of the changes
- Add support for a new sqlite3 storage plugin.
