### PR TITLE
Allow configurable elasticsearch index date format

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -42,11 +42,13 @@ type Configuration struct {
 	BulkWorkers       int
 	BulkActions       int
 	BulkFlushInterval time.Duration
+	IndexDateFormat   string
 }
 
 // ClientBuilder creates new es.Client
 type ClientBuilder interface {
 	NewClient(logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error)
+	GetIndexDateFormat() string
 	GetNumShards() int64
 	GetNumReplicas() int64
 	GetMaxSpanAge() time.Duration
@@ -134,6 +136,14 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.BulkFlushInterval == 0 {
 		c.BulkFlushInterval = source.BulkFlushInterval
 	}
+	if c.IndexDateFormat == "" {
+		c.IndexDateFormat = source.IndexDateFormat
+	}
+}
+
+// GetIndexDateFormat returns the Elasticsearch index name date format
+func (c *Configuration) GetIndexDateFormat() string {
+	return c.IndexDateFormat
 }
 
 // GetNumShards returns number of shards from Configuration

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -80,7 +80,7 @@ func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
 // CreateSpanWriter implements storage.Factory
 func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 	cfg := f.primaryConfig
-	return esSpanStore.NewSpanWriter(f.primaryClient, f.logger, f.metricsFactory, cfg.GetNumShards(), cfg.GetNumReplicas()), nil
+	return esSpanStore.NewSpanWriter(f.primaryClient, cfg.GetIndexDateFormat(), f.logger, f.metricsFactory, cfg.GetNumShards(), cfg.GetNumReplicas()), nil
 }
 
 // CreateDependencyReader implements storage.Factory

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -36,6 +36,7 @@ const (
 	suffixBulkWorkers       = ".bulk.workers"
 	suffixBulkActions       = ".bulk.actions"
 	suffixBulkFlushInterval = ".bulk.flush-interval"
+	suffixIndexDateFortmat  = ".index.date-format"
 )
 
 // TODO this should be moved next to config.Configuration struct (maybe ./flags package)
@@ -74,6 +75,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				BulkWorkers:       1,
 				BulkActions:       1000,
 				BulkFlushInterval: time.Millisecond * 200,
+				IndexDateFormat:   "2006-01-02",
 			},
 			servers:   "http://127.0.0.1:9200",
 			namespace: primaryNamespace,
@@ -141,6 +143,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixBulkFlushInterval,
 		nsConfig.BulkFlushInterval,
 		"A time.Duration after which bulk requests are committed, regardless of other tresholds. Set to zero to disable. By default, this is disabled.")
+	flagSet.String(
+		nsConfig.namespace+suffixIndexDateFortmat,
+		nsConfig.IndexDateFormat,
+		"The date format of the Elasticsearch index names suffix, using Golang date format - https://golang.org/pkg/time/#example_Time_Format")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -163,6 +169,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.BulkWorkers = v.GetInt(cfg.namespace + suffixBulkWorkers)
 	cfg.BulkActions = v.GetInt(cfg.namespace + suffixBulkActions)
 	cfg.BulkFlushInterval = v.GetDuration(cfg.namespace + suffixBulkFlushInterval)
+	cfg.IndexDateFormat = v.GetString(cfg.namespace + suffixIndexDateFortmat)
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -81,7 +81,7 @@ func (s *ESStorageIntegration) esCleanUp() error {
 func (s *ESStorageIntegration) initSpanstore() {
 	bp, _ := s.client.BulkProcessor().BulkActions(1).FlushInterval(time.Nanosecond).Do(context.Background())
 	client := es.WrapESClient(s.client, bp)
-	s.SpanWriter = spanstore.NewSpanWriter(client, s.logger, metrics.NullFactory, 0, 0)
+	s.SpanWriter = spanstore.NewSpanWriter(client, "2006-01-02", s.logger, metrics.NullFactory, 0, 0)
 	s.SpanReader = spanstore.NewSpanReader(client, s.logger, 72*time.Hour, metrics.NullFactory)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #628

## Short description of the changes
- This PR allows overriding the Elasticsearch index date format. There is a new flag when using `SPAN_STORAGE_TYPE=elasticsearch`:

```
--es.index.date-format string       The date format of the Elasticsearch index names suffix, using Golang date format. https://golang.org/pkg/time/#example_Time_Format (default "2006-01-02")
```
