### PR TITLE
Log configuration options for memory storage

### DIFF
--- a/plugin/storage/memory/factory.go
+++ b/plugin/storage/memory/factory.go
@@ -52,6 +52,7 @@ func (f *Factory) InitFromViper(v *viper.Viper) {
 func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
 	f.metricsFactory, f.logger = metricsFactory, logger
 	f.store = WithConfiguration(f.options.Configuration)
+	logger.Info("Memory storage configuration", zap.Any("configuration", f.store.config))
 	return nil
 }
 

--- a/plugin/storage/memory/factory_test.go
+++ b/plugin/storage/memory/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/storage"
@@ -27,7 +28,7 @@ var _ storage.Factory = new(Factory)
 
 func TestMemoryStorageFactory(t *testing.T) {
 	f := NewFactory()
-	assert.NoError(t, f.Initialize(nil, nil))
+	assert.NoError(t, f.Initialize(nil, zap.NewNop()))
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateSpanReader()
 	assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- With #845, there's now a configuration option to set the maximum number of traces to store in memory, but there's no positive feedback about the actual value of this configuration option during runtime. This PR adds a log statement with the configuration option, like:

```
$ MEMORY_MAX_TRACES=100 go run cmd/standalone/main.go
{"level":"info","ts":1527668119.7661645,"caller":"memory/factory.go:55","msg":"Memory storage configuration","configuration":{"MaxTraces":100}}
```

## Short description of the changes
- Added log statement with the contents of the configuration object
