### PR TITLE
Do not create duplicate child-of reference from parentSpanId

### DIFF
--- a/model/converter/thrift/jaeger/fixtures/model_02.json
+++ b/model/converter/thrift/jaeger/fixtures/model_02.json
@@ -22,5 +22,22 @@
     "process":{
       "serviceName":"api"
     }
+  },
+  {
+    "traceID":"52969a8955571a3f",
+    "spanID":"647d99",
+    "operationName":"get",
+    "references": [
+        {
+          "refType": "follows-from",
+          "traceID": "52969a8955571a3f",
+          "spanID": "68c4e3"
+        }
+      ],
+    "startTime":"2017-01-26T16:46:31.639875-05:00",
+    "duration":22938000,
+    "process":{
+      "serviceName":"api"
+    }
   }
 ]

--- a/model/converter/thrift/jaeger/fixtures/thrift_batch_02.json
+++ b/model/converter/thrift/jaeger/fixtures/thrift_batch_02.json
@@ -18,6 +18,21 @@
           "vBinary": "AAAAAAAAMDk="
         }
       ]
-    }
-  ]
+    },
+    {
+        "traceIdLow": 5951113872249657919,
+        "spanId": 6585753,
+        "parentSpanId": 6866147,
+        "operationName": "get",
+        "references": [
+            {
+                "refType": "FOLLOWS_FROM",
+                "traceIdLow": 5951113872249657919,
+                "spanId": 6866147
+            }
+        ],
+        "startTime": 1485467191639875,
+        "duration": 22938
+      }
+    ]
 }

--- a/model/converter/thrift/jaeger/to_domain.go
+++ b/model/converter/thrift/jaeger/to_domain.go
@@ -64,9 +64,7 @@ func (td toDomain) transformSpan(jSpan *jaeger.Span, mProcess *model.Process) *m
 	// convert it back into child-of reference.
 	if jSpan.ParentSpanId != 0 {
 		parentSpanID := model.SpanID(jSpan.ParentSpanId)
-		if !td.duplicateParentID(traceID, parentSpanID, refs) {
-			refs = model.MaybeAddParentSpanID(traceID, parentSpanID, refs)
-		}
+		refs = model.MaybeAddParentSpanID(traceID, parentSpanID, refs)
 	}
 	return &model.Span{
 		TraceID:       traceID,
@@ -80,16 +78,6 @@ func (td toDomain) transformSpan(jSpan *jaeger.Span, mProcess *model.Process) *m
 		Logs:          td.getLogs(jSpan.Logs),
 		Process:       mProcess,
 	}
-}
-
-func (td toDomain) duplicateParentID(traceID model.TraceID, parentSpanID model.SpanID, refs []model.SpanRef) bool {
-	for i := range refs {
-		r := &refs[i]
-		if r.TraceID == traceID && r.SpanID == parentSpanID {
-			return true
-		}
-	}
-	return false
 }
 
 func (td toDomain) getReferences(jRefs []*jaeger.SpanRef) []model.SpanRef {

--- a/model/spanref.go
+++ b/model/spanref.go
@@ -87,7 +87,7 @@ func MaybeAddParentSpanID(traceID TraceID, parentSpanID SpanID, refs []SpanRef) 
 	}
 	for i := range refs {
 		r := &refs[i]
-		if r.SpanID == parentSpanID && r.TraceID == traceID && r.RefType == ChildOf {
+		if r.SpanID == parentSpanID && r.TraceID == traceID {
 			return refs
 		}
 	}


### PR DESCRIPTION
Fixes a bug introduced in #831. Resolves #859.

Issue: some Jaeger clients specify parent span via both `parentSpanId` field and a span reference. The new method `model.MaybeAddParentSpanID(traceID, parentSpanID, refs)` was checking for duplicate reference, but only of child-of type, which was incorrect, since there should be no situations when the same parent span is linked via two reference types.
