### PR TITLE
Use NewSpanID()/NewTraceID() instead of type-specific intializations

### DIFF
--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -48,7 +48,7 @@ func TestGetArchivedTrace_NotFound(t *testing.T) {
 }
 
 func TestGetArchivedTraceSuccess(t *testing.T) {
-	traceID := model.TraceID{Low: 123456}
+	traceID := model.NewTraceID(0, 123456)
 	mockReader := &spanstoremocks.Reader{}
 	mockReader.On("GetTrace", mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Once()

--- a/cmd/query/app/handler_test.go
+++ b/cmd/query/app/handler_test.go
@@ -56,12 +56,12 @@ var (
 		Spans: []*model.Span{
 			{
 				TraceID: mockTraceID,
-				SpanID:  model.SpanID(1),
+				SpanID:  model.NewSpanID(1),
 				Process: &model.Process{},
 			},
 			{
 				TraceID: mockTraceID,
-				SpanID:  model.SpanID(2),
+				SpanID:  model.NewSpanID(2),
 				Process: &model.Process{},
 			},
 		},

--- a/cmd/query/app/handler_test.go
+++ b/cmd/query/app/handler_test.go
@@ -51,7 +51,7 @@ var (
 		Timeout: 2 * time.Second,
 	}
 
-	mockTraceID = model.TraceID{Low: 123456}
+	mockTraceID = model.NewTraceID(0, 123456)
 	mockTrace   = &model.Trace{
 		Spans: []*model.Span{
 			{
@@ -188,7 +188,7 @@ func TestGetTrace(t *testing.T) {
 		var trace *model.Trace
 		require.NoError(t, json.Unmarshal(bytes, &trace))
 		trace.Spans[1].References = []model.SpanRef{
-			{TraceID: model.TraceID{High: 0, Low: 0}},
+			{TraceID: model.NewTraceID(0, 0)},
 		}
 		return trace
 	}
@@ -212,7 +212,7 @@ func TestGetTrace(t *testing.T) {
 			server, readMock, _ := initializeTestServer(HandlerOptions.Tracer(jaegerTracer))
 			defer server.Close()
 
-			readMock.On("GetTrace", model.TraceID{Low: 0x123456abc}).
+			readMock.On("GetTrace", model.NewTraceID(0, 0x123456abc)).
 				Return(makeMockTrace(t), nil).Once()
 
 			var response structuredResponse

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -122,8 +122,8 @@ func TestParseTraceQuery(t *testing.T) {
 					Tags:         make(map[string]string),
 				},
 				traceIDs: []model.TraceID{
-					{Low: 0x1f00},
-					{Low: 0x1e00},
+					model.NewTraceID(0, 0x1f00),
+					model.NewTraceID(0, 0x1e00),
 				},
 			},
 		},
@@ -136,8 +136,8 @@ func TestParseTraceQuery(t *testing.T) {
 					Tags:         make(map[string]string),
 				},
 				traceIDs: []model.TraceID{
-					{Low: 0x100},
-					{Low: 0x200},
+					model.NewTraceID(0, 0x100),
+					model.NewTraceID(0, 0x200),
 				},
 			},
 		},

--- a/model/adjuster/bad_span_references_test.go
+++ b/model/adjuster/bad_span_references_test.go
@@ -31,9 +31,9 @@ func TestSpanReferencesAdjuster(t *testing.T) {
 			},
 			{
 				References: []model.SpanRef{
-					{TraceID: model.TraceID{High: 0, Low: 1}},
-					{TraceID: model.TraceID{High: 1, Low: 0}},
-					{TraceID: model.TraceID{High: 0, Low: 0}},
+					{TraceID: model.NewTraceID(0, 1)},
+					{TraceID: model.NewTraceID(1, 0)},
+					{TraceID: model.NewTraceID(0, 0)},
 				},
 			},
 		},

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -56,8 +56,8 @@ func TestClockSkewAdjuster(t *testing.T) {
 			traceID := model.TraceID{Low: 1}
 			span := &model.Span{
 				TraceID:    traceID,
-				SpanID:     model.SpanID(spanProto.id),
-				References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(spanProto.parent))},
+				SpanID:     model.NewSpanID(uint64(spanProto.id)),
+				References: []model.SpanRef{model.NewChildOfRef(traceID, model.NewSpanID(uint64(spanProto.parent)))},
 				StartTime:  toTime(spanProto.startTime),
 				Duration:   toDuration(spanProto.duration),
 				Logs:       logs,
@@ -180,7 +180,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 			}
 			for _, proto := range testCase.trace {
 				id := proto.id
-				span := trace.FindSpanByID(model.SpanID(uint64(id)))
+				span := trace.FindSpanByID(model.NewSpanID(uint64(id)))
 				require.NotNil(t, span, "expecting span with span ID = %d", id)
 				// compare values as int because assert.Equal prints uint64 as hex
 				assert.Equal(

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -53,7 +53,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 					Fields:    []model.KeyValue{model.String("event", "some event")},
 				})
 			}
-			traceID := model.TraceID{Low: 1}
+			traceID := model.NewTraceID(0, 1)
 			span := &model.Span{
 				TraceID:    traceID,
 				SpanID:     model.NewSpanID(uint64(spanProto.id)),

--- a/model/adjuster/span_id_deduper.go
+++ b/model/adjuster/span_id_deduper.go
@@ -39,7 +39,10 @@ func SpanIDDeduper() Adjuster {
 
 const (
 	warningTooManySpans = "cannot assign unique span ID, too many spans in the trace"
-	maxSpanID           = model.SpanID(0xffffffffffffffff)
+)
+
+var (
+	maxSpanID = model.NewSpanID(0xffffffffffffffff)
 )
 
 type spanIDDeduper struct {

--- a/model/adjuster/span_id_deduper_test.go
+++ b/model/adjuster/span_id_deduper_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 )
 
-const (
-	clientSpanID  = model.SpanID(1)
-	anotherSpanID = model.SpanID(11)
+var (
+	clientSpanID  = model.NewSpanID(1)
+	anotherSpanID = model.NewSpanID(11)
 )
 
 func newTrace() *model.Trace {
@@ -99,7 +99,7 @@ func TestSpanIDDeduperError(t *testing.T) {
 	trace := newTrace()
 
 	maxID := int64(-1)
-	assert.Equal(t, maxSpanID, model.SpanID(maxID), "maxSpanID must be 2^64-1")
+	assert.Equal(t, maxSpanID, model.NewSpanID(uint64(maxID)), "maxSpanID must be 2^64-1")
 
 	deduper := &spanIDDeduper{trace: trace}
 	deduper.groupSpansByID()

--- a/model/adjuster/span_id_deduper_test.go
+++ b/model/adjuster/span_id_deduper_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 func newTrace() *model.Trace {
-	traceID := model.TraceID{Low: 42}
+	traceID := model.NewTraceID(0, 42)
 	return &model.Trace{
 		Spans: []*model.Span{
 			{

--- a/model/converter/json/to_domain.go
+++ b/model/converter/json/to_domain.go
@@ -69,7 +69,7 @@ func (td toDomain) spanToDomain(dbSpan *json.Span) (*model.Span, error) {
 
 	span := &model.Span{
 		TraceID:       traceID,
-		SpanID:        model.SpanID(spanIDInt),
+		SpanID:        model.NewSpanID(uint64(spanIDInt)),
 		OperationName: dbSpan.OperationName,
 		References:    refs,
 		Flags:         model.Flags(uint32(dbSpan.Flags)),
@@ -108,7 +108,7 @@ func (td toDomain) convertRefs(refs []json.Reference) ([]model.SpanRef, error) {
 		retMe[i] = model.SpanRef{
 			RefType: refType,
 			TraceID: traceID,
-			SpanID:  model.SpanID(spanID),
+			SpanID:  model.NewSpanID(spanID),
 		}
 	}
 	return retMe, nil

--- a/model/converter/thrift/jaeger/to_domain.go
+++ b/model/converter/thrift/jaeger/to_domain.go
@@ -53,10 +53,7 @@ func (td toDomain) ToDomainSpan(jSpan *jaeger.Span, jProcess *jaeger.Process) *m
 }
 
 func (td toDomain) transformSpan(jSpan *jaeger.Span, mProcess *model.Process) *model.Span {
-	traceID := model.TraceID{
-		High: uint64(jSpan.TraceIdHigh),
-		Low:  uint64(jSpan.TraceIdLow),
-	}
+	traceID := model.NewTraceID(uint64(jSpan.TraceIdHigh), uint64(jSpan.TraceIdLow))
 	tags := td.getTags(jSpan.Tags)
 	refs := td.getReferences(jSpan.References)
 	// We no longer store ParentSpanID in the domain model, but the data in Thrift model
@@ -89,7 +86,7 @@ func (td toDomain) getReferences(jRefs []*jaeger.SpanRef) []model.SpanRef {
 	for idx, jRef := range jRefs {
 		mRefs[idx] = model.SpanRef{
 			RefType: model.SpanRefType(int(jRef.RefType)),
-			TraceID: model.TraceID{High: uint64(jRef.TraceIdHigh), Low: uint64(jRef.TraceIdLow)},
+			TraceID: model.NewTraceID(uint64(jRef.TraceIdHigh), uint64(jRef.TraceIdLow)),
 			SpanID:  model.NewSpanID(uint64(jRef.SpanId)),
 		}
 	}

--- a/model/converter/thrift/jaeger/to_domain.go
+++ b/model/converter/thrift/jaeger/to_domain.go
@@ -63,12 +63,12 @@ func (td toDomain) transformSpan(jSpan *jaeger.Span, mProcess *model.Process) *m
 	// might still have these IDs without representing them in the References, so we
 	// convert it back into child-of reference.
 	if jSpan.ParentSpanId != 0 {
-		parentSpanID := model.SpanID(jSpan.ParentSpanId)
+		parentSpanID := model.NewSpanID(uint64(jSpan.ParentSpanId))
 		refs = model.MaybeAddParentSpanID(traceID, parentSpanID, refs)
 	}
 	return &model.Span{
 		TraceID:       traceID,
-		SpanID:        model.SpanID(jSpan.SpanId),
+		SpanID:        model.NewSpanID(uint64(jSpan.SpanId)),
 		OperationName: jSpan.OperationName,
 		References:    refs,
 		Flags:         model.Flags(jSpan.Flags),
@@ -90,7 +90,7 @@ func (td toDomain) getReferences(jRefs []*jaeger.SpanRef) []model.SpanRef {
 		mRefs[idx] = model.SpanRef{
 			RefType: model.SpanRefType(int(jRef.RefType)),
 			TraceID: model.TraceID{High: uint64(jRef.TraceIdHigh), Low: uint64(jRef.TraceIdLow)},
-			SpanID:  model.SpanID(uint64(jRef.SpanId)),
+			SpanID:  model.NewSpanID(uint64(jRef.SpanId)),
 		}
 	}
 

--- a/model/converter/thrift/zipkin/to_domain.go
+++ b/model/converter/thrift/zipkin/to_domain.go
@@ -131,14 +131,14 @@ func (td toDomain) transformSpan(zSpan *zipkincore.Span) []*model.Span {
 	traceID := model.TraceID{High: uint64(traceIDHigh), Low: uint64(zSpan.TraceID)}
 	var refs []model.SpanRef
 	if zSpan.ParentID != nil {
-		parentSpanID := model.SpanID(*zSpan.ParentID)
+		parentSpanID := model.NewSpanID(uint64(*zSpan.ParentID))
 		refs = model.MaybeAddParentSpanID(traceID, parentSpanID, refs)
 	}
 
 	flags := td.getFlags(zSpan)
 	result := []*model.Span{{
 		TraceID:       traceID,
-		SpanID:        model.SpanID(zSpan.ID),
+		SpanID:        model.NewSpanID(uint64(zSpan.ID)),
 		OperationName: zSpan.Name,
 		References:    refs,
 		Flags:         flags,
@@ -154,7 +154,7 @@ func (td toDomain) transformSpan(zSpan *zipkincore.Span) []*model.Span {
 		// if the span is client and server we split it into two separate spans
 		s := &model.Span{
 			TraceID:       traceID,
-			SpanID:        model.SpanID(zSpan.ID),
+			SpanID:        model.NewSpanID(uint64(zSpan.ID)),
 			OperationName: zSpan.Name,
 			References:    refs,
 			Flags:         flags,

--- a/model/converter/thrift/zipkin/to_domain.go
+++ b/model/converter/thrift/zipkin/to_domain.go
@@ -128,7 +128,7 @@ func (td toDomain) transformSpan(zSpan *zipkincore.Span) []*model.Span {
 	if zSpan.TraceIDHigh != nil {
 		traceIDHigh = *zSpan.TraceIDHigh
 	}
-	traceID := model.TraceID{High: uint64(traceIDHigh), Low: uint64(zSpan.TraceID)}
+	traceID := model.NewTraceID(uint64(traceIDHigh), uint64(zSpan.TraceID))
 	var refs []model.SpanRef
 	if zSpan.ParentID != nil {
 		parentSpanID := model.NewSpanID(uint64(*zSpan.ParentID))

--- a/model/ids.go
+++ b/model/ids.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// TraceID is a random 128bit identifier for a trace
+type TraceID struct {
+	Low  uint64 `json:"lo"`
+	High uint64 `json:"hi"`
+}
+
+// SpanID is a random 64bit identifier for a span
+type SpanID uint64
+
+// ------- TraceID -------
+
+// NewTraceID creates a new TraceID from two 64bit unsigned ints.
+func NewTraceID(high, low uint64) TraceID {
+	return TraceID{High: high, Low: low}
+}
+
+func (t TraceID) String() string {
+	if t.High == 0 {
+		return fmt.Sprintf("%x", t.Low)
+	}
+	return fmt.Sprintf("%x%016x", t.High, t.Low)
+}
+
+// TraceIDFromString creates a TraceID from a hexadecimal string
+func TraceIDFromString(s string) (TraceID, error) {
+	var hi, lo uint64
+	var err error
+	if len(s) > 32 {
+		return TraceID{}, fmt.Errorf("TraceID cannot be longer than 32 hex characters: %s", s)
+	} else if len(s) > 16 {
+		hiLen := len(s) - 16
+		if hi, err = strconv.ParseUint(s[0:hiLen], 16, 64); err != nil {
+			return TraceID{}, err
+		}
+		if lo, err = strconv.ParseUint(s[hiLen:], 16, 64); err != nil {
+			return TraceID{}, err
+		}
+	} else {
+		if lo, err = strconv.ParseUint(s, 16, 64); err != nil {
+			return TraceID{}, err
+		}
+	}
+	return TraceID{High: hi, Low: lo}, nil
+}
+
+// MarshalText allows TraceID to serialize itself in JSON as a string.
+func (t TraceID) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalText allows TraceID to deserialize itself from a JSON string.
+func (t *TraceID) UnmarshalText(text []byte) error {
+	q, err := TraceIDFromString(string(text))
+	if err != nil {
+		return err
+	}
+	*t = q
+	return nil
+}
+
+// ------- SpanID -------
+
+// NewSpanID creates a new SpanID from a 64bit unsigned int.
+func NewSpanID(v uint64) SpanID {
+	return SpanID(v)
+}
+
+func (s SpanID) String() string {
+	return fmt.Sprintf("%x", uint64(s))
+}
+
+// SpanIDFromString creates a SpanID from a hexadecimal string
+func SpanIDFromString(s string) (SpanID, error) {
+	if len(s) > 16 {
+		return SpanID(0), fmt.Errorf("SpanID cannot be longer than 16 hex characters: %s", s)
+	}
+	id, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return SpanID(0), err
+	}
+	return SpanID(id), nil
+}
+
+// MarshalText allows SpanID to serialize itself in JSON as a string.
+func (s SpanID) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// UnmarshalText allows SpanID to deserialize itself from a JSON string.
+func (s *SpanID) UnmarshalText(text []byte) error {
+	q, err := SpanIDFromString(string(text))
+	if err != nil {
+		return err
+	}
+	*s = q
+	return nil
+}

--- a/model/span.go
+++ b/model/span.go
@@ -16,9 +16,7 @@ package model
 
 import (
 	"encoding/gob"
-	"fmt"
 	"io"
-	"strconv"
 	"time"
 
 	"github.com/opentracing/opentracing-go/ext"
@@ -31,17 +29,8 @@ const (
 	debugFlag = Flags(2)
 )
 
-// TraceID is a random 128bit identifier for a trace
-type TraceID struct {
-	Low  uint64 `json:"lo"`
-	High uint64 `json:"hi"`
-}
-
 // Flags is a bit map of flags for a span
 type Flags uint32
-
-// SpanID is a random 64bit identifier for a span
-type SpanID uint64
 
 // Span represents a unit of work in an application, such as an RPC, a database call, etc.
 type Span struct {
@@ -148,83 +137,4 @@ func (f Flags) IsDebug() bool {
 
 func (f Flags) checkFlags(bit Flags) bool {
 	return f&bit == bit
-}
-
-// ------- TraceID -------
-
-func (t TraceID) String() string {
-	if t.High == 0 {
-		return fmt.Sprintf("%x", t.Low)
-	}
-	return fmt.Sprintf("%x%016x", t.High, t.Low)
-}
-
-// TraceIDFromString creates a TraceID from a hexadecimal string
-func TraceIDFromString(s string) (TraceID, error) {
-	var hi, lo uint64
-	var err error
-	if len(s) > 32 {
-		return TraceID{}, fmt.Errorf("TraceID cannot be longer than 32 hex characters: %s", s)
-	} else if len(s) > 16 {
-		hiLen := len(s) - 16
-		if hi, err = strconv.ParseUint(s[0:hiLen], 16, 64); err != nil {
-			return TraceID{}, err
-		}
-		if lo, err = strconv.ParseUint(s[hiLen:], 16, 64); err != nil {
-			return TraceID{}, err
-		}
-	} else {
-		if lo, err = strconv.ParseUint(s, 16, 64); err != nil {
-			return TraceID{}, err
-		}
-	}
-	return TraceID{High: hi, Low: lo}, nil
-}
-
-// MarshalText allows TraceID to serialize itself in JSON as a string.
-func (t TraceID) MarshalText() ([]byte, error) {
-	return []byte(t.String()), nil
-}
-
-// UnmarshalText allows TraceID to deserialize itself from a JSON string.
-func (t *TraceID) UnmarshalText(text []byte) error {
-	q, err := TraceIDFromString(string(text))
-	if err != nil {
-		return err
-	}
-	*t = q
-	return nil
-}
-
-// ------- SpanID -------
-
-func (s SpanID) String() string {
-	return fmt.Sprintf("%x", uint64(s))
-}
-
-// SpanIDFromString creates a SpanID from a hexadecimal string
-func SpanIDFromString(s string) (SpanID, error) {
-	if len(s) > 16 {
-		return SpanID(0), fmt.Errorf("SpanID cannot be longer than 16 hex characters: %s", s)
-	}
-	id, err := strconv.ParseUint(s, 16, 64)
-	if err != nil {
-		return SpanID(0), err
-	}
-	return SpanID(id), nil
-}
-
-// MarshalText allows SpanID to serialize itself in JSON as a string.
-func (s SpanID) MarshalText() ([]byte, error) {
-	return []byte(s.String()), nil
-}
-
-// UnmarshalText allows SpanID to deserialize itself from a JSON string.
-func (s *SpanID) UnmarshalText(text []byte) error {
-	q, err := SpanIDFromString(string(text))
-	if err != nil {
-		return err
-	}
-	*s = q
-	return nil
 }

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -44,7 +44,7 @@ func TestTraceIDMarshalText(t *testing.T) {
 		{hi: 257, lo: 1, out: `{"id":"1010000000000000001"}`},
 	}
 	for _, testCase := range testCases {
-		c := TraceIDContainer{TraceID: model.TraceID{High: testCase.hi, Low: testCase.lo}}
+		c := TraceIDContainer{TraceID: model.NewTraceID(testCase.hi, testCase.lo)}
 		out, err := json.Marshal(&c)
 		if assert.NoError(t, err) {
 			assert.Equal(t, testCase.out, string(out))
@@ -196,13 +196,13 @@ func TestParentSpanID(t *testing.T) {
 	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
 	span.References = []model.SpanRef{
-		model.NewFollowsFromRef(span.TraceID, 777),
-		model.NewChildOfRef(span.TraceID, 888),
+		model.NewFollowsFromRef(span.TraceID, model.NewSpanID(777)),
+		model.NewChildOfRef(span.TraceID, model.NewSpanID(888)),
 	}
 	assert.Equal(t, model.NewSpanID(888), span.ParentSpanID())
 
 	span.References = []model.SpanRef{
-		model.NewChildOfRef(model.TraceID{High: 321}, 999),
+		model.NewChildOfRef(model.NewTraceID(321, 0), model.NewSpanID(999)),
 	}
 	assert.Equal(t, model.NewSpanID(0), span.ParentSpanID())
 }
@@ -215,19 +215,19 @@ func TestReplaceParentSpanID(t *testing.T) {
 	assert.Equal(t, model.NewSpanID(789), span.ParentSpanID())
 
 	span.References = []model.SpanRef{
-		model.NewChildOfRef(model.TraceID{High: 321}, 999),
+		model.NewChildOfRef(model.NewTraceID(321, 0), model.NewSpanID(999)),
 	}
 	span.ReplaceParentID(789)
 	assert.Equal(t, model.NewSpanID(789), span.ParentSpanID())
 }
 
 func makeSpan(someKV model.KeyValue) *model.Span {
-	traceID := model.TraceID{Low: 123}
+	traceID := model.NewTraceID(0, 123)
 	return &model.Span{
 		TraceID:       traceID,
 		SpanID:        model.NewSpanID(567),
 		OperationName: "hi",
-		References:    []model.SpanRef{model.NewChildOfRef(traceID, 123)},
+		References:    []model.SpanRef{model.NewChildOfRef(traceID, model.NewSpanID(123))},
 		StartTime:     time.Unix(0, 1000),
 		Duration:      5000,
 		Tags:          model.KeyValues{someKV},

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -101,7 +101,7 @@ func TestSpanIDMarshalText(t *testing.T) {
 		{id: uint64(max), out: `{"id":"ffffffffffffffff"}`},
 	}
 	for _, testCase := range testCases {
-		c := SpanIDContainer{SpanID: model.SpanID(testCase.id)}
+		c := SpanIDContainer{SpanID: model.NewSpanID(testCase.id)}
 		out, err := json.Marshal(&c)
 		if assert.NoError(t, err) {
 			assert.Equal(t, testCase.out, string(out))
@@ -193,39 +193,39 @@ func TestSpanHash(t *testing.T) {
 
 func TestParentSpanID(t *testing.T) {
 	span := makeSpan(model.String("k", "v"))
-	assert.Equal(t, model.SpanID(123), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
 	span.References = []model.SpanRef{
 		model.NewFollowsFromRef(span.TraceID, 777),
 		model.NewChildOfRef(span.TraceID, 888),
 	}
-	assert.Equal(t, model.SpanID(888), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(888), span.ParentSpanID())
 
 	span.References = []model.SpanRef{
 		model.NewChildOfRef(model.TraceID{High: 321}, 999),
 	}
-	assert.Equal(t, model.SpanID(0), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(0), span.ParentSpanID())
 }
 
 func TestReplaceParentSpanID(t *testing.T) {
 	span := makeSpan(model.String("k", "v"))
-	assert.Equal(t, model.SpanID(123), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
 	span.ReplaceParentID(789)
-	assert.Equal(t, model.SpanID(789), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(789), span.ParentSpanID())
 
 	span.References = []model.SpanRef{
 		model.NewChildOfRef(model.TraceID{High: 321}, 999),
 	}
 	span.ReplaceParentID(789)
-	assert.Equal(t, model.SpanID(789), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(789), span.ParentSpanID())
 }
 
 func makeSpan(someKV model.KeyValue) *model.Span {
 	traceID := model.TraceID{Low: 123}
 	return &model.Span{
 		TraceID:       traceID,
-		SpanID:        model.SpanID(567),
+		SpanID:        model.NewSpanID(567),
 		OperationName: "hi",
 		References:    []model.SpanRef{model.NewChildOfRef(traceID, 123)},
 		StartTime:     time.Unix(0, 1000),

--- a/model/spanref_test.go
+++ b/model/spanref_test.go
@@ -65,16 +65,16 @@ func TestMaybeAddParentSpanID(t *testing.T) {
 	span := makeSpan(model.String("k", "v"))
 	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
-	span.References = model.MaybeAddParentSpanID(span.TraceID, 0, span.References)
+	span.References = model.MaybeAddParentSpanID(span.TraceID, model.NewSpanID(0), span.References)
 	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
-	span.References = model.MaybeAddParentSpanID(span.TraceID, 123, span.References)
+	span.References = model.MaybeAddParentSpanID(span.TraceID, model.NewSpanID(123), span.References)
 	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
-	span.References = model.MaybeAddParentSpanID(span.TraceID, 123, []model.SpanRef{})
+	span.References = model.MaybeAddParentSpanID(span.TraceID, model.NewSpanID(123), []model.SpanRef{})
 	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
-	span.References = []model.SpanRef{model.NewChildOfRef(model.TraceID{High: 42}, 789)}
-	span.References = model.MaybeAddParentSpanID(span.TraceID, 123, span.References)
+	span.References = []model.SpanRef{model.NewChildOfRef(model.NewTraceID(42, 0), model.NewSpanID(789))}
+	span.References = model.MaybeAddParentSpanID(span.TraceID, model.NewSpanID(123), span.References)
 	assert.Equal(t, model.NewSpanID(123), span.References[0].SpanID, "parent added as first reference")
 }

--- a/model/spanref_test.go
+++ b/model/spanref_test.go
@@ -63,18 +63,18 @@ func TestSpanRefTypeToFromJSON(t *testing.T) {
 
 func TestMaybeAddParentSpanID(t *testing.T) {
 	span := makeSpan(model.String("k", "v"))
-	assert.Equal(t, model.SpanID(123), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
 	span.References = model.MaybeAddParentSpanID(span.TraceID, 0, span.References)
-	assert.Equal(t, model.SpanID(123), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
 	span.References = model.MaybeAddParentSpanID(span.TraceID, 123, span.References)
-	assert.Equal(t, model.SpanID(123), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
 	span.References = model.MaybeAddParentSpanID(span.TraceID, 123, []model.SpanRef{})
-	assert.Equal(t, model.SpanID(123), span.ParentSpanID())
+	assert.Equal(t, model.NewSpanID(123), span.ParentSpanID())
 
 	span.References = []model.SpanRef{model.NewChildOfRef(model.TraceID{High: 42}, 789)}
 	span.References = model.MaybeAddParentSpanID(span.TraceID, 123, span.References)
-	assert.Equal(t, model.SpanID(123), span.References[0].SpanID, "parent added as first reference")
+	assert.Equal(t, model.NewSpanID(123), span.References[0].SpanID, "parent added as first reference")
 }

--- a/model/trace_test.go
+++ b/model/trace_test.go
@@ -26,18 +26,18 @@ import (
 func TestTraceFindSpanByID(t *testing.T) {
 	trace := &model.Trace{
 		Spans: []*model.Span{
-			{SpanID: model.SpanID(1), OperationName: "x"},
-			{SpanID: model.SpanID(2), OperationName: "y"},
-			{SpanID: model.SpanID(1), OperationName: "z"}, // same span ID
+			{SpanID: model.NewSpanID(1), OperationName: "x"},
+			{SpanID: model.NewSpanID(2), OperationName: "y"},
+			{SpanID: model.NewSpanID(1), OperationName: "z"}, // same span ID
 		},
 	}
-	s1 := trace.FindSpanByID(model.SpanID(1))
+	s1 := trace.FindSpanByID(model.NewSpanID(1))
 	assert.NotNil(t, s1)
 	assert.Equal(t, "x", s1.OperationName)
-	s2 := trace.FindSpanByID(model.SpanID(2))
+	s2 := trace.FindSpanByID(model.NewSpanID(2))
 	assert.NotNil(t, s2)
 	assert.Equal(t, "y", s2.OperationName)
-	s3 := trace.FindSpanByID(model.SpanID(3))
+	s3 := trace.FindSpanByID(model.NewSpanID(3))
 	assert.Nil(t, s3)
 }
 

--- a/plugin/storage/cassandra/savetracetest/main.go
+++ b/plugin/storage/cassandra/savetracetest/main.go
@@ -102,7 +102,7 @@ func getSomeProcess() *model.Process {
 }
 
 func getSomeSpan() *model.Span {
-	traceID := model.TraceID{High: 1, Low: 2}
+	traceID := model.NewTraceID(1, 2)
 	return &model.Span{
 		TraceID:       traceID,
 		SpanID:        model.NewSpanID(3),
@@ -121,7 +121,7 @@ func getReferences() []model.SpanRef {
 	return []model.SpanRef{
 		{
 			RefType: model.ChildOf,
-			TraceID: model.TraceID{High: 1, Low: 1},
+			TraceID: model.NewTraceID(1, 1),
 			SpanID:  model.NewSpanID(4),
 		},
 	}

--- a/plugin/storage/cassandra/savetracetest/main.go
+++ b/plugin/storage/cassandra/savetracetest/main.go
@@ -105,7 +105,7 @@ func getSomeSpan() *model.Span {
 	traceID := model.TraceID{High: 1, Low: 2}
 	return &model.Span{
 		TraceID:       traceID,
-		SpanID:        model.SpanID(3),
+		SpanID:        model.NewSpanID(3),
 		OperationName: "opName",
 		References:    model.MaybeAddParentSpanID(traceID, 4, getReferences()),
 		Flags:         model.Flags(uint32(5)),
@@ -122,7 +122,7 @@ func getReferences() []model.SpanRef {
 		{
 			RefType: model.ChildOf,
 			TraceID: model.TraceID{High: 1, Low: 1},
-			SpanID:  model.SpanID(4),
+			SpanID:  model.NewSpanID(4),
 		},
 	}
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -80,9 +80,9 @@ func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 	traceID := dbSpan.TraceID.ToDomain()
 	span := &model.Span{
 		TraceID:       traceID,
-		SpanID:        model.SpanID(dbSpan.SpanID),
+		SpanID:        model.NewSpanID(uint64(dbSpan.SpanID)),
 		OperationName: dbSpan.OperationName,
-		References:    model.MaybeAddParentSpanID(traceID, model.SpanID(dbSpan.ParentID), refs),
+		References:    model.MaybeAddParentSpanID(traceID, model.NewSpanID(uint64(dbSpan.ParentID)), refs),
 		Flags:         model.Flags(uint32(dbSpan.Flags)),
 		StartTime:     model.EpochMicrosecondsAsTime(uint64(dbSpan.StartTime)),
 		Duration:      model.MicrosecondsAsDuration(uint64(dbSpan.Duration)),
@@ -154,7 +154,7 @@ func (c converter) fromDBRefs(refs []SpanRef) ([]model.SpanRef, error) {
 		retMe[i] = model.SpanRef{
 			RefType: refType,
 			TraceID: r.TraceID.ToDomain(),
-			SpanID:  model.SpanID(r.SpanID),
+			SpanID:  model.NewSpanID(uint64(r.SpanID)),
 		}
 	}
 	return retMe, nil

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	someTraceID       = model.TraceID{High: 22222, Low: 44444}
+	someTraceID       = model.NewTraceID(22222, 44444)
 	someSpanID        = model.SpanID(3333)
 	someParentSpanID  = model.SpanID(11111)
 	someOperationName = "someOperationName"

--- a/plugin/storage/cassandra/spanstore/dbmodel/cql_udt_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/cql_udt_test.go
@@ -47,7 +47,7 @@ func TestDBModelUDTMarshall(t *testing.T) {
 
 	spanRef := &SpanRef{
 		RefType: "childOf",
-		TraceID: TraceIDFromDomain(model.TraceID{Low: 1}),
+		TraceID: TraceIDFromDomain(model.NewTraceID(0, 1)),
 		SpanID:  123,
 	}
 

--- a/plugin/storage/cassandra/spanstore/dbmodel/model.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/model.go
@@ -101,7 +101,7 @@ func TraceIDFromDomain(traceID model.TraceID) TraceID {
 func (dbTraceID TraceID) ToDomain() model.TraceID {
 	traceIDHigh := binary.BigEndian.Uint64(dbTraceID[:8])
 	traceIDLow := binary.BigEndian.Uint64(dbTraceID[8:])
-	return model.TraceID{High: traceIDHigh, Low: traceIDLow}
+	return model.NewTraceID(traceIDHigh, traceIDLow)
 }
 
 // String returns hex string representation of the trace ID.

--- a/plugin/storage/cassandra/spanstore/dbmodel/model_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/model_test.go
@@ -28,6 +28,6 @@ func TestTagInsertionString(t *testing.T) {
 }
 
 func TestTraceIDString(t *testing.T) {
-	id := TraceIDFromDomain(model.TraceID{High: 1, Low: 1})
+	id := TraceIDFromDomain(model.NewTraceID(1, 1))
 	assert.Equal(t, "10000000000000001", id.String())
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/unique_ids_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/unique_ids_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestGetIntersectedTraceIDs(t *testing.T) {
-	firstTraceID := TraceIDFromDomain(model.TraceID{High: 1, Low: 1})
-	secondTraceID := TraceIDFromDomain(model.TraceID{High: 2, Low: 2})
+	firstTraceID := TraceIDFromDomain(model.NewTraceID(1, 1))
+	secondTraceID := TraceIDFromDomain(model.NewTraceID(2, 2))
 	listOfUniqueTraceIDs := []UniqueTraceIDs{
 		{
 			firstTraceID:  struct{}{},
@@ -47,13 +47,13 @@ func TestGetIntersectedTraceIDs(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	u := UniqueTraceIDs{}
-	someID := TraceIDFromDomain(model.TraceID{High: 1, Low: 1})
+	someID := TraceIDFromDomain(model.NewTraceID(1, 1))
 	u.Add(someID)
 	assert.Contains(t, u, someID)
 }
 
 func TestFromList(t *testing.T) {
-	someID := TraceIDFromDomain(model.TraceID{High: 1, Low: 1})
+	someID := TraceIDFromDomain(model.NewTraceID(1, 1))
 	traceIDList := []TraceID{
 		someID,
 	}

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -272,8 +272,8 @@ func TestSpanReaderFindTraces(t *testing.T) {
 				// scanMatcher can match Iter.Scan() parameters and set trace ID fields
 				scanMatcher := func(name string) interface{} {
 					traceIDs := []dbmodel.TraceID{
-						dbmodel.TraceIDFromDomain(model.TraceID{Low: 1}),
-						dbmodel.TraceIDFromDomain(model.TraceID{Low: 2}),
+						dbmodel.TraceIDFromDomain(model.NewTraceID(0, 1)),
+						dbmodel.TraceIDFromDomain(model.NewTraceID(0, 2)),
 					}
 					scanFunc := func(args []interface{}) bool {
 						if len(traceIDs) == 0 {

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -147,7 +147,7 @@ func TestSpanWriter(t *testing.T) {
 		t.Run(testCase.caption, func(t *testing.T) {
 			withSpanWriter(0, func(w *spanWriterTest) {
 				span := &model.Span{
-					TraceID:       model.TraceID{Low: 1},
+					TraceID:       model.NewTraceID(0, 1),
 					OperationName: "operation-a",
 					Tags: model.KeyValues{
 						model.String("x", "y"),
@@ -281,7 +281,7 @@ func TestStorageMode_IndexOnly(t *testing.T) {
 		w.writer.serviceNamesWriter = func(serviceName string) error { return nil }
 		w.writer.operationNamesWriter = func(serviceName, operationName string) error { return nil }
 		span := &model.Span{
-			TraceID: model.TraceID{Low: 1},
+			TraceID: model.NewTraceID(0, 1),
 			Process: &model.Process{
 				ServiceName: "service-a",
 			},
@@ -323,7 +323,7 @@ func TestStorageMode_StoreWithoutIndexing(t *testing.T) {
 				return nil
 			}
 		span := &model.Span{
-			TraceID: model.TraceID{Low: 1},
+			TraceID: model.NewTraceID(0, 1),
 			Process: &model.Process{
 				ServiceName: "service-a",
 			},

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -118,7 +118,7 @@ func TestSpanReader_GetTrace(t *testing.T) {
 				},
 			}, nil)
 
-		trace, err := r.reader.GetTrace(model.TraceID{Low: 1})
+		trace, err := r.reader.GetTrace(model.NewTraceID(0, 1))
 		require.NoError(t, err)
 		require.NotNil(t, trace)
 
@@ -149,7 +149,7 @@ func TestSpanReader_SearchAfter(t *testing.T) {
 				},
 			}, nil).Times(2)
 
-		trace, err := r.reader.GetTrace(model.TraceID{Low: 1})
+		trace, err := r.reader.GetTrace(model.NewTraceID(0, 1))
 		require.NoError(t, err)
 		require.NotNil(t, trace)
 
@@ -168,7 +168,7 @@ func TestSpanReader_GetTraceQueryError(t *testing.T) {
 			Return(&elastic.MultiSearchResult{
 				Responses: []*elastic.SearchResult{},
 			}, nil)
-		trace, err := r.reader.GetTrace(model.TraceID{Low: 1})
+		trace, err := r.reader.GetTrace(model.NewTraceID(0, 1))
 		require.EqualError(t, err, "No trace with that ID found")
 		require.Nil(t, trace)
 	})
@@ -187,7 +187,7 @@ func TestSpanReader_GetTraceNilHits(t *testing.T) {
 				},
 			}, nil)
 
-		trace, err := r.reader.GetTrace(model.TraceID{Low: 1})
+		trace, err := r.reader.GetTrace(model.NewTraceID(0, 1))
 		require.EqualError(t, err, "No trace with that ID found")
 		require.Nil(t, trace)
 	})
@@ -210,7 +210,7 @@ func TestSpanReader_GetTraceInvalidSpanError(t *testing.T) {
 				},
 			}, nil)
 
-		trace, err := r.reader.GetTrace(model.TraceID{Low: 1})
+		trace, err := r.reader.GetTrace(model.NewTraceID(0, 1))
 		require.Error(t, err, "invalid span")
 		require.Nil(t, trace)
 	})
@@ -234,7 +234,7 @@ func TestSpanReader_GetTraceSpanConversionError(t *testing.T) {
 				},
 			}, nil)
 
-		trace, err := r.reader.GetTrace(model.TraceID{Low: 1})
+		trace, err := r.reader.GetTrace(model.NewTraceID(0, 1))
 		require.Error(t, err, "span conversion error, because lacks elements")
 		require.Nil(t, trace)
 	})

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -124,7 +124,7 @@ func TestSpanWriter_WriteSpan(t *testing.T) {
 
 				span := &model.Span{
 					TraceID:       model.TraceID{Low: 1},
-					SpanID:        model.SpanID(0),
+					SpanID:        model.NewSpanID(0),
 					OperationName: "operation",
 					Process: &model.Process{
 						ServiceName: "service",

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -123,7 +123,7 @@ func TestSpanWriter_WriteSpan(t *testing.T) {
 				require.NoError(t, err)
 
 				span := &model.Span{
-					TraceID:       model.TraceID{Low: 1},
+					TraceID:       model.NewTraceID(0, 1),
 					SpanID:        model.NewSpanID(0),
 					OperationName: "operation",
 					Process: &model.Process{

--- a/plugin/storage/memory/memory_test.go
+++ b/plugin/storage/memory/memory_test.go
@@ -25,10 +25,7 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
-var traceID = model.TraceID{
-	Low:  1,
-	High: 2,
-}
+var traceID = model.NewTraceID(1, 2)
 
 var testingSpan = &model.Span{
 	TraceID: traceID,
@@ -175,9 +172,9 @@ func TestStoreWithLimit(t *testing.T) {
 	store := WithConfiguration(config.Configuration{MaxTraces: maxTraces})
 
 	for i := 0; i < maxTraces*2; i++ {
-		id := &model.TraceID{High: 1, Low: uint64(i)}
+		id := model.NewTraceID(1, uint64(i))
 		err := store.WriteSpan(&model.Span{
-			TraceID: *id,
+			TraceID: id,
 			Process: &model.Process{
 				ServiceName: "TestStoreWithLimit",
 			},
@@ -185,7 +182,7 @@ func TestStoreWithLimit(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = store.WriteSpan(&model.Span{
-			TraceID: *id,
+			TraceID: id,
 			SpanID:  model.NewSpanID(uint64(i)),
 			Process: &model.Process{
 				ServiceName: "TestStoreWithLimit",

--- a/plugin/storage/memory/memory_test.go
+++ b/plugin/storage/memory/memory_test.go
@@ -32,7 +32,7 @@ var traceID = model.TraceID{
 
 var testingSpan = &model.Span{
 	TraceID: traceID,
-	SpanID:  model.SpanID(1),
+	SpanID:  model.NewSpanID(1),
 	Process: &model.Process{
 		ServiceName: "serviceName",
 		Tags:        model.KeyValues{},
@@ -55,8 +55,8 @@ var testingSpan = &model.Span{
 
 var childSpan1 = &model.Span{
 	TraceID:    traceID,
-	SpanID:     model.SpanID(2),
-	References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(1))},
+	SpanID:     model.NewSpanID(2),
+	References: []model.SpanRef{model.NewChildOfRef(traceID, model.NewSpanID(1))},
 	Process: &model.Process{
 		ServiceName: "childService",
 		Tags:        model.KeyValues{},
@@ -79,8 +79,8 @@ var childSpan1 = &model.Span{
 
 var childSpan2 = &model.Span{
 	TraceID:    traceID,
-	SpanID:     model.SpanID(3),
-	References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(1))},
+	SpanID:     model.NewSpanID(3),
+	References: []model.SpanRef{model.NewChildOfRef(traceID, model.NewSpanID(1))},
 	Process: &model.Process{
 		ServiceName: "childService",
 		Tags:        model.KeyValues{},
@@ -103,9 +103,9 @@ var childSpan2 = &model.Span{
 
 var childSpan2_1 = &model.Span{
 	TraceID: traceID,
-	SpanID:  model.SpanID(4),
+	SpanID:  model.NewSpanID(4),
 	// child of childSpan2, but with the same service name
-	References: []model.SpanRef{model.NewChildOfRef(traceID, model.SpanID(3))},
+	References: []model.SpanRef{model.NewChildOfRef(traceID, model.NewSpanID(3))},
 	Process: &model.Process{
 		ServiceName: "childService",
 		Tags:        model.KeyValues{},
@@ -186,7 +186,7 @@ func TestStoreWithLimit(t *testing.T) {
 
 		err = store.WriteSpan(&model.Span{
 			TraceID: *id,
-			SpanID:  model.SpanID(i),
+			SpanID:  model.NewSpanID(uint64(i)),
 			Process: &model.Process{
 				ServiceName: "TestStoreWithLimit",
 			},


### PR DESCRIPTION
#856 may change the SpanID type alias from uint64 to `[8]byte`. It would make the change smaller if we didn't assume that int values can be converted directly to SpanID, so this change replaces instantiations with a call to `NewSpanID()` function. It decouples the usage from the actual implementation of SpanID type.

Similar change for TraceID.

