### PR TITLE
Use protobuf marshaller

### DIFF
--- a/plugin/storage/kafka/factory.go
+++ b/plugin/storage/kafka/factory.go
@@ -67,14 +67,7 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 		return err
 	}
 	f.producer = p
-	switch f.options.encoding {
-	case encodingThrift:
-		f.marshaller = newThriftMarshaller()
-	case encodingJSON:
-		f.marshaller = newJSONMarshaller()
-	default:
-		return errors.New("kafka encoding is not one of '" + encodingJSON + "' or '" + encodingThrift + "'")
-	}
+	f.marshaller = newJSONMarshaller()
 	return nil
 }
 

--- a/plugin/storage/kafka/factory.go
+++ b/plugin/storage/kafka/factory.go
@@ -67,7 +67,14 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 		return err
 	}
 	f.producer = p
-	f.marshaller = newJSONMarshaller()
+	switch f.options.encoding {
+	case encodingProto:
+		f.marshaller = newProtobufMarshaller()
+	case encodingJSON:
+		f.marshaller = newJSONMarshaller()
+	default:
+		return errors.New("kafka encoding is not one of '" + encodingJSON + "' or '" + encodingProto + "'")
+	}
 	return nil
 }
 

--- a/plugin/storage/kafka/factory_test.go
+++ b/plugin/storage/kafka/factory_test.go
@@ -59,7 +59,6 @@ func TestKafkaFactory(t *testing.T) {
 
 	f.config = &mockProducerBuilder{t: t}
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
-	assert.IsType(t, &jsonMarshaller{}, f.marshaller)
 
 	_, err := f.CreateSpanWriter()
 	assert.NoError(t, err)
@@ -69,25 +68,4 @@ func TestKafkaFactory(t *testing.T) {
 
 	_, err = f.CreateDependencyReader()
 	assert.Error(t, err)
-}
-
-func TestKafkaFactoryThrift(t *testing.T) {
-	f := NewFactory()
-	v, command := config.Viperize(f.AddFlags)
-	command.ParseFlags([]string{"--kafka.encoding=thrift"})
-	f.InitFromViper(v)
-
-	f.config = &mockProducerBuilder{t: t}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
-	assert.IsType(t, &thriftMarshaller{}, f.marshaller)
-}
-
-func TestKafkaFactoryMarshallerErr(t *testing.T) {
-	f := NewFactory()
-	v, command := config.Viperize(f.AddFlags)
-	command.ParseFlags([]string{"--kafka.encoding=bad-input"})
-	f.InitFromViper(v)
-
-	f.config = &mockProducerBuilder{t: t}
-	assert.Error(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 }

--- a/plugin/storage/kafka/marshaller.go
+++ b/plugin/storage/kafka/marshaller.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -27,20 +28,28 @@ type Marshaller interface {
 	Marshal(*model.Span) ([]byte, error)
 }
 
+type protobufMarshaller struct{}
+
+func newProtobufMarshaller() *protobufMarshaller {
+	return &protobufMarshaller{}
+}
+
+// Marshall encodes a span as a protobuf byte array
+func (h *protobufMarshaller) Marshal(span *model.Span) ([]byte, error) {
+	return proto.Marshal(span)
+}
+
 type jsonMarshaller struct {
-	pbMarshaller jsonpb.Marshaler
+	pbMarshaller *jsonpb.Marshaler
 }
 
 func newJSONMarshaller() *jsonMarshaller {
-	return &jsonMarshaller{}
+	return &jsonMarshaller{&jsonpb.Marshaler{}}
 }
 
 // Marshall encodes a span as a json byte array
 func (h *jsonMarshaller) Marshal(span *model.Span) ([]byte, error) {
 	out := new(bytes.Buffer)
 	err := h.pbMarshaller.Marshal(out, span)
-	if err != nil {
-		return nil, err
-	}
-	return out.Bytes(), nil
+	return out.Bytes(), err
 }

--- a/plugin/storage/kafka/marshaller.go
+++ b/plugin/storage/kafka/marshaller.go
@@ -15,12 +15,11 @@
 package kafka
 
 import (
-	"encoding/json"
+	"bytes"
 
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/gogo/protobuf/jsonpb"
 
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
 )
 
 // Marshaller encodes a span into a byte array to be sent to Kafka
@@ -28,25 +27,9 @@ type Marshaller interface {
 	Marshal(*model.Span) ([]byte, error)
 }
 
-type thriftMarshaller struct {
-	tProtocolFactory *thrift.TBinaryProtocolFactory
+type jsonMarshaller struct {
+	pbMarshaller jsonpb.Marshaler
 }
-
-func newThriftMarshaller() *thriftMarshaller {
-	return &thriftMarshaller{thrift.NewTBinaryProtocolFactoryDefault()}
-}
-
-// Marshall encodes a span as a thrift byte array
-func (h *thriftMarshaller) Marshal(span *model.Span) ([]byte, error) {
-	thriftSpan := jaeger.FromDomainSpan(span)
-
-	memBuffer := thrift.NewTMemoryBuffer()
-	thriftSpan.Write(h.tProtocolFactory.GetProtocol(memBuffer))
-
-	return memBuffer.Bytes(), nil
-}
-
-type jsonMarshaller struct{}
 
 func newJSONMarshaller() *jsonMarshaller {
 	return &jsonMarshaller{}
@@ -54,5 +37,10 @@ func newJSONMarshaller() *jsonMarshaller {
 
 // Marshall encodes a span as a json byte array
 func (h *jsonMarshaller) Marshal(span *model.Span) ([]byte, error) {
-	return json.Marshal(span)
+	out := new(bytes.Buffer)
+	err := h.pbMarshaller.Marshal(out, span)
+	if err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
 }

--- a/plugin/storage/kafka/marshaller_test.go
+++ b/plugin/storage/kafka/marshaller_test.go
@@ -20,15 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestThriftMarshaller(t *testing.T) {
-	marshaller := newThriftMarshaller()
-
-	bytes, err := marshaller.Marshal(sampleSpan)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, bytes)
-}
-
 func TestJSONMarshaller(t *testing.T) {
 	marshaller := newJSONMarshaller()
 

--- a/plugin/storage/kafka/marshaller_test.go
+++ b/plugin/storage/kafka/marshaller_test.go
@@ -20,6 +20,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestProtoMarshaller(t *testing.T) {
+	marshaller := newProtobufMarshaller()
+
+	bytes, err := marshaller.Marshal(sampleSpan)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, bytes)
+}
+
 func TestJSONMarshaller(t *testing.T) {
 	marshaller := newJSONMarshaller()
 

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -24,18 +24,24 @@ import (
 )
 
 const (
-	configPrefix  = "kafka"
-	suffixBrokers = ".brokers"
-	suffixTopic   = ".topic"
+	configPrefix   = "kafka"
+	suffixBrokers  = ".brokers"
+	suffixTopic    = ".topic"
+	suffixEncoding = ".encoding"
 
-	defaultBroker = "127.0.0.1:9092"
-	defaultTopic  = "jaeger-spans"
+	defaultBroker   = "127.0.0.1:9092"
+	defaultTopic    = "jaeger-spans"
+	defaultEncoding = encodingJSON
+
+	encodingJSON  = "json"
+	encodingProto = "protobuf"
 )
 
 // Options stores the configuration options for Kafka
 type Options struct {
-	config config.Configuration
-	topic  string
+	config   config.Configuration
+	topic    string
+	encoding string
 }
 
 // AddFlags adds flags for Options
@@ -48,6 +54,10 @@ func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 		configPrefix+suffixTopic,
 		defaultTopic,
 		"The name of the kafka topic")
+	flagSet.String(
+		configPrefix+suffixEncoding,
+		defaultEncoding,
+		"Encoding of spans sent to kafka. Either '"+encodingJSON+"' or '"+encodingProto+"'")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -56,4 +66,5 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 		Brokers: strings.Split(v.GetString(configPrefix+suffixBrokers), ","),
 	}
 	opt.topic = v.GetString(configPrefix + suffixTopic)
+	opt.encoding = v.GetString(configPrefix + suffixEncoding)
 }

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -24,24 +24,18 @@ import (
 )
 
 const (
-	configPrefix   = "kafka"
-	suffixBrokers  = ".brokers"
-	suffixTopic    = ".topic"
-	suffixEncoding = ".encoding"
+	configPrefix  = "kafka"
+	suffixBrokers = ".brokers"
+	suffixTopic   = ".topic"
 
-	defaultBroker   = "127.0.0.1:9092"
-	defaultTopic    = "jaeger-spans"
-	defaultEncoding = encodingJSON
-
-	encodingJSON   = "json"
-	encodingThrift = "thrift"
+	defaultBroker = "127.0.0.1:9092"
+	defaultTopic  = "jaeger-spans"
 )
 
 // Options stores the configuration options for Kafka
 type Options struct {
-	config   config.Configuration
-	topic    string
-	encoding string
+	config config.Configuration
+	topic  string
 }
 
 // AddFlags adds flags for Options
@@ -54,10 +48,6 @@ func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 		configPrefix+suffixTopic,
 		defaultTopic,
 		"The name of the kafka topic")
-	flagSet.String(
-		configPrefix+suffixEncoding,
-		defaultEncoding,
-		"Encoding of spans sent to kafka. Either '"+encodingJSON+"' or '"+encodingThrift+"'")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -66,5 +56,4 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 		Brokers: strings.Split(v.GetString(configPrefix+suffixBrokers), ","),
 	}
 	opt.topic = v.GetString(configPrefix + suffixTopic)
-	opt.encoding = v.GetString(configPrefix + suffixEncoding)
 }

--- a/plugin/storage/kafka/options_test.go
+++ b/plugin/storage/kafka/options_test.go
@@ -25,11 +25,15 @@ import (
 func TestOptionsWithFlags(t *testing.T) {
 	opts := &Options{}
 	v, command := config.Viperize(opts.AddFlags)
-	command.ParseFlags([]string{"--kafka.topic=topic1", "--kafka.brokers=127.0.0.1:9092,0.0.0:1234"})
+	command.ParseFlags([]string{
+		"--kafka.topic=topic1",
+		"--kafka.brokers=127.0.0.1:9092,0.0.0:1234",
+		"--kafka.encoding=protobuf"})
 	opts.InitFromViper(v)
 
 	assert.Equal(t, "topic1", opts.topic)
 	assert.Equal(t, []string{"127.0.0.1:9092", "0.0.0:1234"}, opts.config.Brokers)
+	assert.Equal(t, "protobuf", opts.encoding)
 }
 
 func TestFlagDefaults(t *testing.T) {
@@ -40,4 +44,5 @@ func TestFlagDefaults(t *testing.T) {
 
 	assert.Equal(t, defaultTopic, opts.topic)
 	assert.Equal(t, []string{defaultBroker}, opts.config.Brokers)
+	assert.Equal(t, defaultEncoding, opts.encoding)
 }

--- a/plugin/storage/kafka/options_test.go
+++ b/plugin/storage/kafka/options_test.go
@@ -25,15 +25,11 @@ import (
 func TestOptionsWithFlags(t *testing.T) {
 	opts := &Options{}
 	v, command := config.Viperize(opts.AddFlags)
-	command.ParseFlags([]string{
-		"--kafka.topic=topic1",
-		"--kafka.brokers=127.0.0.1:9092,0.0.0:1234",
-		"--kafka.encoding=thrift"})
+	command.ParseFlags([]string{"--kafka.topic=topic1", "--kafka.brokers=127.0.0.1:9092,0.0.0:1234"})
 	opts.InitFromViper(v)
 
 	assert.Equal(t, "topic1", opts.topic)
 	assert.Equal(t, []string{"127.0.0.1:9092", "0.0.0:1234"}, opts.config.Brokers)
-	assert.Equal(t, "thrift", opts.encoding)
 }
 
 func TestFlagDefaults(t *testing.T) {
@@ -44,5 +40,4 @@ func TestFlagDefaults(t *testing.T) {
 
 	assert.Equal(t, defaultTopic, opts.topic)
 	assert.Equal(t, []string{defaultBroker}, opts.config.Brokers)
-	assert.Equal(t, defaultEncoding, opts.encoding)
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
https://github.com/jaegertracing/jaeger/pull/862#discussion_r195198455
- Standard JSON encoding is not optimal for sending spans
- Thrift model doesn't have the process in the definition, therefore encoding causes loss of data when writing

## Short description of the changes
- JSON Marshaller now uses protobuf to encode spans
- Thrift Marshaller has been replaced by a ProtobufMarshaller
