### PR TITLE
Remove golang.org/x/sys pin

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 524d05684b3bab1a1ba0b172a2a523d247a2dea24e7c8038a526b69f75122bb0
-updated: 2018-06-14T14:54:45.091736102-04:00
+hash: f821e88548fe126d174c800f7c3a4a076cb01391f3f4f1e091cc5b24819fbf58
+updated: 2018-06-14T17:56:36.870952443-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -81,7 +81,7 @@ imports:
   subpackages:
   - google/api
 - name: github.com/gogo/protobuf
-  version: 30cf7ac33676b5786e78c746683f0d4cd64fa75b
+  version: fd9a4790f3963525fb889cc00e0a8f828e0b3a29
   subpackages:
   - gogoproto
   - jsonpb

--- a/glide.yaml
+++ b/glide.yaml
@@ -57,10 +57,6 @@ import:
 - package: github.com/elazarl/go-bindata-assetfs
 - package: github.com/Shopify/sarama
   version: ^1.16.0
-- package: golang.org/x/sys
-  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
-  subpackages:
-  - unix
 # gogo/protobuf dependencies
 - package: github.com/gogo/googleapis
   version: master


### PR DESCRIPTION
## Which problem is this PR solving?
- In the previous PR (https://github.com/jaegertracing/jaeger/pull/862), we had to pin a repo because the builds were failing. We were unable to ascertain why it was failing. However, now that I've removed it, the builds are passing. 🤷‍♂️ 