### PR TITLE
Add cassandra index filter

### DIFF
--- a/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbmodel
+
+// IndexFilter filters out any spans that should not be indexed.
+type IndexFilter interface {
+	IndexByDuration(span *Span) bool
+	IndexByService(span *Span) bool
+	IndexByOperation(span *Span) bool
+}
+
+// DefaultIndexFilter returns a filter that indexes everything.
+var DefaultIndexFilter = indexFilterImpl{}
+
+type indexFilterImpl struct{}
+
+func (f indexFilterImpl) IndexByDuration(span *Span) bool {
+	return true
+}
+
+func (f indexFilterImpl) IndexByService(span *Span) bool {
+	return true
+}
+
+func (f indexFilterImpl) IndexByOperation(span *Span) bool {
+	return true
+}

--- a/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
@@ -15,20 +15,20 @@
 package dbmodel
 
 const (
-	// DurationIndex represents the flag for indexing by duration
+	// DurationIndex represents the flag for indexing by duration.
 	DurationIndex = iota
 
-	// ServiceIndex represents the flag for indexing by service
+	// ServiceIndex represents the flag for indexing by service.
 	ServiceIndex
 
-	// OperationIndex represents the flag for indexing by service-operation
+	// OperationIndex represents the flag for indexing by service-operation.
 	OperationIndex
 )
 
-// IndexFilter filters out any spans that should not be indexed.
+// IndexFilter filters out any spans that should not be indexed depending on the index specified.
 type IndexFilter func(span *Span, index int) bool
 
-// DefaultIndexFilter returns a filter that indexes everything.
+// DefaultIndexFilter is a filter that indexes everything.
 var DefaultIndexFilter = func(span *Span, index int) bool {
 	return true
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
@@ -15,13 +15,13 @@
 package dbmodel
 
 const (
-	// Index by duration
+	// DurationIndex represents the flag for indexing by duration
 	DurationIndex = iota
 
-	// Index by service
+	// ServiceIndex represents the flag for indexing by service
 	ServiceIndex
 
-	// Index by service-operation
+	// OperationIndex represents the flag for indexing by service-operation
 	OperationIndex
 )
 

--- a/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/index_filter.go
@@ -14,26 +14,21 @@
 
 package dbmodel
 
+const (
+	// Index by duration
+	DurationIndex = iota
+
+	// Index by service
+	ServiceIndex
+
+	// Index by service-operation
+	OperationIndex
+)
+
 // IndexFilter filters out any spans that should not be indexed.
-type IndexFilter interface {
-	IndexByDuration(span *Span) bool
-	IndexByService(span *Span) bool
-	IndexByOperation(span *Span) bool
-}
+type IndexFilter func(span *Span, index int) bool
 
 // DefaultIndexFilter returns a filter that indexes everything.
-var DefaultIndexFilter = indexFilterImpl{}
-
-type indexFilterImpl struct{}
-
-func (f indexFilterImpl) IndexByDuration(span *Span) bool {
-	return true
-}
-
-func (f indexFilterImpl) IndexByService(span *Span) bool {
-	return true
-}
-
-func (f indexFilterImpl) IndexByOperation(span *Span) bool {
+var DefaultIndexFilter = func(span *Span, index int) bool {
 	return true
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/index_filter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/index_filter_test.go
@@ -23,7 +23,7 @@ import (
 func TestDefaultIndexFilter(t *testing.T) {
 	span := &Span{}
 	filter := DefaultIndexFilter
-	assert.True(t, filter.IndexByDuration(span))
-	assert.True(t, filter.IndexByService(span))
-	assert.True(t, filter.IndexByOperation(span))
+	assert.True(t, filter(span, DurationIndex))
+	assert.True(t, filter(span, ServiceIndex))
+	assert.True(t, filter(span, OperationIndex))
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/index_filter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/index_filter_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultIndexFilter(t *testing.T) {
+	span := &Span{}
+	filter := DefaultIndexFilter
+	assert.True(t, filter.IndexByDuration(span))
+	assert.True(t, filter.IndexByService(span))
+	assert.True(t, filter.IndexByOperation(span))
+}

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -180,19 +180,19 @@ func (s *SpanWriter) writeIndexes(span *model.Span, ds *dbmodel.Span) error {
 		return s.logError(ds, err, "Failed to index tags", s.logger)
 	}
 
-	if s.indexFilter.IndexByService(ds) {
+	if s.indexFilter(ds, dbmodel.ServiceIndex) {
 		if err := s.indexByService(ds); err != nil {
 			return s.logError(ds, err, "Failed to index service name", s.logger)
 		}
 	}
 
-	if s.indexFilter.IndexByOperation(ds) {
+	if s.indexFilter(ds, dbmodel.OperationIndex) {
 		if err := s.indexByOperation(ds); err != nil {
 			return s.logError(ds, err, "Failed to index operation name", s.logger)
 		}
 	}
 
-	if s.indexFilter.IndexByDuration(ds) {
+	if s.indexFilter(ds, dbmodel.DurationIndex) {
 		if err := s.indexByDuration(ds, span.StartTime); err != nil {
 			return s.logError(ds, err, "Failed to index duration", s.logger)
 		}

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -92,6 +92,7 @@ type SpanWriter struct {
 	tagIndexSkipped      metrics.Counter
 	tagFilter            dbmodel.TagFilter
 	storageMode          storageMode
+	indexFilter          dbmodel.IndexFilter
 }
 
 // NewSpanWriter returns a SpanWriter
@@ -121,6 +122,7 @@ func NewSpanWriter(
 		tagIndexSkipped: tagIndexSkipped,
 		tagFilter:       opts.tagFilter,
 		storageMode:     opts.storageMode,
+		indexFilter:     opts.indexFilter,
 	}
 }
 
@@ -178,16 +180,22 @@ func (s *SpanWriter) writeIndexes(span *model.Span, ds *dbmodel.Span) error {
 		return s.logError(ds, err, "Failed to index tags", s.logger)
 	}
 
-	if err := s.indexByService(span.TraceID, ds); err != nil {
-		return s.logError(ds, err, "Failed to index service name", s.logger)
+	if s.indexFilter.IndexByService(ds) {
+		if err := s.indexByService(ds); err != nil {
+			return s.logError(ds, err, "Failed to index service name", s.logger)
+		}
 	}
 
-	if err := s.indexByOperation(span.TraceID, ds); err != nil {
-		return s.logError(ds, err, "Failed to index operation name", s.logger)
+	if s.indexFilter.IndexByOperation(ds) {
+		if err := s.indexByOperation(ds); err != nil {
+			return s.logError(ds, err, "Failed to index operation name", s.logger)
+		}
 	}
 
-	if err := s.indexByDuration(ds, span.StartTime); err != nil {
-		return s.logError(ds, err, "Failed to index duration", s.logger)
+	if s.indexFilter.IndexByDuration(ds) {
+		if err := s.indexByDuration(ds, span.StartTime); err != nil {
+			return s.logError(ds, err, "Failed to index duration", s.logger)
+		}
 	}
 	return nil
 }
@@ -228,14 +236,14 @@ func (s *SpanWriter) indexByDuration(span *dbmodel.Span, startTime time.Time) er
 	return err
 }
 
-func (s *SpanWriter) indexByService(traceID model.TraceID, span *dbmodel.Span) error {
+func (s *SpanWriter) indexByService(span *dbmodel.Span) error {
 	bucketNo := uint64(span.SpanHash) % defaultNumBuckets
 	query := s.session.Query(serviceNameIndex)
 	q := query.Bind(span.Process.ServiceName, bucketNo, span.StartTime, span.TraceID)
 	return s.writerMetrics.serviceNameIndex.Exec(q, s.logger)
 }
 
-func (s *SpanWriter) indexByOperation(traceID model.TraceID, span *dbmodel.Span) error {
+func (s *SpanWriter) indexByOperation(span *dbmodel.Span) error {
 	query := s.session.Query(serviceOperationIndex)
 	q := query.Bind(span.Process.ServiceName, span.OperationName, span.StartTime, span.TraceID)
 	return s.writerMetrics.serviceOperationIndex.Exec(q, s.logger)

--- a/plugin/storage/cassandra/spanstore/writer_options.go
+++ b/plugin/storage/cassandra/spanstore/writer_options.go
@@ -25,6 +25,7 @@ type Option func(c *Options)
 type Options struct {
 	tagFilter   dbmodel.TagFilter
 	storageMode storageMode
+	indexFilter dbmodel.IndexFilter
 }
 
 // TagFilter can be provided to filter any tags that should not be indexed.
@@ -48,6 +49,13 @@ func StoreWithoutIndexing() Option {
 	}
 }
 
+// IndexFilter can be provided to filter certain spans that should not be indexed.
+func IndexFilter(indexFilter dbmodel.IndexFilter) Option {
+	return func(o *Options) {
+		o.indexFilter = indexFilter
+	}
+}
+
 func applyOptions(opts ...Option) Options {
 	o := Options{}
 	for _, opt := range opts {
@@ -58,6 +66,9 @@ func applyOptions(opts ...Option) Options {
 	}
 	if o.storageMode == 0 {
 		o.storageMode = storeFlag | indexFlag
+	}
+	if o.indexFilter == nil {
+		o.indexFilter = dbmodel.DefaultIndexFilter
 	}
 	return o
 }

--- a/plugin/storage/cassandra/spanstore/writer_options_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_options_test.go
@@ -25,7 +25,7 @@ import (
 func TestWriterOptions(t *testing.T) {
 	opts := applyOptions(TagFilter(dbmodel.DefaultTagFilter), IndexFilter(dbmodel.DefaultIndexFilter))
 	assert.Equal(t, dbmodel.DefaultTagFilter, opts.tagFilter)
-	assert.Equal(t, dbmodel.DefaultIndexFilter, opts.indexFilter)
+	assert.ObjectsAreEqual(dbmodel.DefaultIndexFilter, opts.indexFilter)
 }
 
 func TestWriterOptions_StorageMode(t *testing.T) {

--- a/plugin/storage/cassandra/spanstore/writer_options_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_options_test.go
@@ -23,8 +23,9 @@ import (
 )
 
 func TestWriterOptions(t *testing.T) {
-	opts := applyOptions(TagFilter(dbmodel.DefaultTagFilter))
+	opts := applyOptions(TagFilter(dbmodel.DefaultTagFilter), IndexFilter(dbmodel.DefaultIndexFilter))
 	assert.Equal(t, dbmodel.DefaultTagFilter, opts.tagFilter)
+	assert.Equal(t, dbmodel.DefaultIndexFilter, opts.indexFilter)
 }
 
 func TestWriterOptions_StorageMode(t *testing.T) {

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -314,23 +314,13 @@ func TestStorageMode_IndexOnly(t *testing.T) {
 	}, StoreIndexesOnly())
 }
 
-type indexFilter struct{}
-
-func (f indexFilter) IndexByDuration(span *dbmodel.Span) bool {
-	return false
-}
-
-func (f indexFilter) IndexByService(span *dbmodel.Span) bool {
-	return false
-}
-
-func (f indexFilter) IndexByOperation(span *dbmodel.Span) bool {
+var filterEverything = func(*dbmodel.Span, int) bool {
 	return false
 }
 
 func TestStorageMode_IndexOnly_WithFilter(t *testing.T) {
 	withSpanWriter(0, func(w *spanWriterTest) {
-		w.writer.indexFilter = indexFilter{}
+		w.writer.indexFilter = filterEverything
 		w.writer.serviceNamesWriter = func(serviceName string) error { return nil }
 		w.writer.operationNamesWriter = func(serviceName, operationName string) error { return nil }
 		span := &model.Span{


### PR DESCRIPTION
Signed-off-by: Won Jun Jang <wjang@uber.com>

## Which problem is this PR solving?
- There are certain times when you want to skip indexing a certain span. ie for debug spans, the most common use case is that the user will use the traceid directly to find the trace, there's no need to index it by duration, etc.

## Short description of the changes
- Add a new IndexFilter which checks the span and determines whether it should be indexed or not. Defaults to indexing everything
