### PR TITLE
Replace coveralls badge with codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ If you would like to add your organization to the list, please comment on our
 [godoc]: https://godoc.org/github.com/jaegertracing/jaeger
 [ci-img]: https://travis-ci.org/jaegertracing/jaeger.svg?branch=master
 [ci]: https://travis-ci.org/jaegertracing/jaeger
-[cov-img]: https://coveralls.io/repos/jaegertracing/jaeger/badge.svg?branch=master
-[cov]: https://coveralls.io/github/jaegertracing/jaeger?branch=master
+[cov-img]: https://codecov.io/gh/jaegertracing/jaeger/branch/master/graph/badge.svg
+[cov]: https://codecov.io/gh/jaegertracing/jaeger/branch/master/
 [dapper]: https://research.google.com/pubs/pub36356.html
 [ubeross]: http://uber.github.io
 [ot-badge]: https://img.shields.io/badge/OpenTracing--1.x-inside-blue.svg


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Jaeger switched to codecov.io from coveralls from https://github.com/jaegertracing/jaeger/pull/857, but badges are not changed.

## Short description of the changes
- Replace coveralls badge with codecov badge
