### PR TITLE
Log debug message when span reported

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -141,7 +141,7 @@ func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
 		reps := append([]reporter.Reporter{mainReporter}, b.otherReporters...)
 		rep = reporter.NewMultiReporter(reps...)
 	}
-	processors, err := b.GetProcessors(rep, mFactory)
+	processors, err := b.GetProcessors(rep, mFactory, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
 }
 
 // GetProcessors creates Processors with attached Reporter
-func (b *Builder) GetProcessors(rep reporter.Reporter, mFactory metrics.Factory) ([]processors.Processor, error) {
+func (b *Builder) GetProcessors(rep reporter.Reporter, mFactory metrics.Factory, logger *zap.Logger) ([]processors.Processor, error) {
 	retMe := make([]processors.Processor, len(b.Processors))
 	for idx, cfg := range b.Processors {
 		protoFactory, ok := protocolFactoryMap[cfg.Protocol]
@@ -173,7 +173,7 @@ func (b *Builder) GetProcessors(rep reporter.Reporter, mFactory metrics.Factory)
 			"protocol": string(cfg.Protocol),
 			"model":    string(cfg.Model),
 		})
-		processor, err := cfg.GetThriftProcessor(metrics, protoFactory, handler)
+		processor, err := cfg.GetThriftProcessor(metrics, protoFactory, handler, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -196,6 +196,7 @@ func (c *ProcessorConfiguration) GetThriftProcessor(
 	mFactory metrics.Factory,
 	factory thrift.TProtocolFactory,
 	handler processors.AgentProcessor,
+	logger *zap.Logger,
 ) (processors.Processor, error) {
 	c.applyDefaults()
 
@@ -204,7 +205,7 @@ func (c *ProcessorConfiguration) GetThriftProcessor(
 		return nil, err
 	}
 
-	return processors.NewThriftProcessor(server, c.Workers, mFactory, factory, handler)
+	return processors.NewThriftProcessor(server, c.Workers, mFactory, factory, handler, logger)
 }
 
 func (c *ProcessorConfiguration) applyDefaults() {

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -61,7 +61,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 	require.NoError(t, err)
 
 	numProcessors := 1
-	processor, err := NewThriftProcessor(server, numProcessors, mFactory, tFactory, handler)
+	processor, err := NewThriftProcessor(server, numProcessors, mFactory, tFactory, handler, zap.NewNop())
 	require.NoError(t, err)
 
 	go processor.Serve()
@@ -83,7 +83,7 @@ func initCollectorAndReporter(t *testing.T) (*metrics.LocalFactory, *testutils.M
 }
 
 func TestNewThriftProcessor_ZeroCount(t *testing.T) {
-	_, err := NewThriftProcessor(nil, 0, nil, nil, nil)
+	_, err := NewThriftProcessor(nil, 0, nil, nil, nil, zap.NewNop())
 	assert.EqualError(t, err, "Number of processors must be greater than 0, called with 0")
 }
 

--- a/cmd/agent/app/reporter/tchannel/reporter.go
+++ b/cmd/agent/app/reporter/tchannel/reporter.go
@@ -131,6 +131,8 @@ func (r *Reporter) submitAndReport(submissionFunc func(ctx thrift.Context) error
 		r.logger.Error(errMsg, zap.Error(err))
 		return err
 	}
+
+	r.logger.Debug("Span batch submitted by the agent", zap.Int64("span-count", size))
 	batchMetrics.BatchSize.Update(size)
 	batchMetrics.BatchesSubmitted.Inc(1)
 	batchMetrics.SpansSubmitted.Inc(size)

--- a/cmd/collector/app/span_handler.go
+++ b/cmd/collector/app/span_handler.go
@@ -76,6 +76,7 @@ func (jbh *jaegerBatchesHandler) SubmitBatches(ctx thrift.Context, batches []*ja
 		}
 		oks, err := jbh.modelProcessor.ProcessSpans(mSpans, JaegerFormatType)
 		if err != nil {
+			jbh.logger.Error("Collector failed to process span batch", zap.Error(err))
 			return nil, err
 		}
 		batchOk := true
@@ -85,6 +86,8 @@ func (jbh *jaegerBatchesHandler) SubmitBatches(ctx thrift.Context, batches []*ja
 				break
 			}
 		}
+
+		jbh.logger.Debug("Span batch processed by the collector.", zap.Bool("ok", batchOk))
 		res := &jaeger.BatchSubmitResponse{
 			Ok: batchOk,
 		}
@@ -117,6 +120,7 @@ func (h *zipkinSpanHandler) SubmitZipkinBatch(ctx thrift.Context, spans []*zipki
 	}
 	bools, err := h.modelProcessor.ProcessSpans(mSpans, ZipkinFormatType)
 	if err != nil {
+		h.logger.Error("Collector failed to process Zipkin span batch", zap.Error(err))
 		return nil, err
 	}
 	responses := make([]*zipkincore.Response, len(spans))
@@ -125,6 +129,8 @@ func (h *zipkinSpanHandler) SubmitZipkinBatch(ctx thrift.Context, spans []*zipki
 		res.Ok = ok
 		responses[i] = res
 	}
+
+	h.logger.Debug("Zipkin span batch processed by the collector.", zap.Int("span-count", len(spans)))
 	return responses, nil
 }
 

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -101,6 +101,8 @@ func (sp *spanProcessor) saveSpan(span *model.Span) {
 	if err := sp.spanWriter.WriteSpan(span); err != nil {
 		sp.logger.Error("Failed to save span", zap.Error(err))
 	} else {
+		sp.logger.Debug("Span written to the storage by the collector",
+			zap.Stringer("trace-id", span.TraceID), zap.Stringer("span-id", span.SpanID))
 		sp.metrics.SavedBySvc.ReportServiceNameForSpan(span)
 	}
 	sp.metrics.SaveLatency.Record(time.Now().Sub(startTime))


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Resolves #867

## Short description of the changes
- Added a few `logger.Debug()` statements on the path from the agent's incoming span processor down to the collector's span writer. The logger had to be passed down in some places, whereas others had a logger instance by default.

When running the `standalone` with the `--log-level debug`  set, this is seen upon visiting the Jaeger's Query UI for the first time:

```
{"level":"debug","ts":1529666719.3805306,"caller":"processors/thrift_processor.go:113","msg":"Span(s) received by the agent"}
{"level":"debug","ts":1529666719.3815565,"caller":"app/span_handler.go:90","msg":"Span batch processed by the collector.","ok":true}
{"level":"debug","ts":1529666719.3816545,"caller":"app/span_processor.go:104","msg":"Span wrote to storage by the collector","span-id":"92eefadeebebd8b"}
{"level":"debug","ts":1529666719.3816547,"caller":"app/span_processor.go:104","msg":"Span wrote to storage by the collector","span-id":"56bcbb4313670f6e"}
{"level":"debug","ts":1529666719.3819387,"caller":"tchannel/reporter.go:135","msg":"Span batch submitted by the agent","batch-size":2}
```

Without the flag set, there's no change from the current behavior.