### PR TITLE
Make new proto RefType backwards compatible in cassandra

### DIFF
--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -22,14 +22,17 @@ import (
 )
 
 var (
-	dbToProtoRefMap = map[string]model.SpanRefType{
-		"child-of":     model.SpanRefType_CHILD_OF,
-		"follows-from": model.SpanRefType_FOLLOWS_FROM,
+	childOf     = "child-of"
+	followsFrom = "follows-from"
+
+	dbToDomainRefMap = map[string]model.SpanRefType{
+		childOf:     model.SpanRefType_CHILD_OF,
+		followsFrom: model.SpanRefType_FOLLOWS_FROM,
 	}
 
-	protoToDBRefMap = map[model.SpanRefType]string{
-		model.SpanRefType_CHILD_OF:     "child-of",
-		model.SpanRefType_FOLLOWS_FROM: "follows-from",
+	domainToDBRefMap = map[model.SpanRefType]string{
+		model.SpanRefType_CHILD_OF:     childOf,
+		model.SpanRefType_FOLLOWS_FROM: followsFrom,
 	}
 )
 
@@ -160,7 +163,7 @@ func (c converter) fromDBLogs(logs []Log) ([]model.Log, error) {
 func (c converter) fromDBRefs(refs []SpanRef) ([]model.SpanRef, error) {
 	retMe := make([]model.SpanRef, len(refs))
 	for i, r := range refs {
-		refType, ok := dbToProtoRefMap[r.RefType]
+		refType, ok := dbToDomainRefMap[r.RefType]
 		if !ok {
 			return nil, fmt.Errorf("not a valid SpanRefType string %s", r.RefType)
 		}
@@ -218,7 +221,7 @@ func (c converter) toDBRefs(refs []model.SpanRef) []SpanRef {
 		retMe[i] = SpanRef{
 			TraceID: TraceIDFromDomain(r.TraceID),
 			SpanID:  int64(r.SpanID),
-			RefType: protoToDBRefMap[r.RefType],
+			RefType: domainToDBRefMap[r.RefType],
 		}
 	}
 	return retMe

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -110,7 +110,7 @@ var (
 	someDBTraceID = TraceIDFromDomain(someTraceID)
 	someDBRefs    = []SpanRef{
 		{
-			RefType: model.ChildOf.String(),
+			RefType: "child-of",
 			SpanID:  int64(someParentSpanID),
 			TraceID: someDBTraceID,
 		},


### PR DESCRIPTION
## Which problem is this PR solving?
- The recent PR that changed the domain model to use proto added this change: https://github.com/jaegertracing/jaeger/pull/856/files#diff-96d29428fedf19815cb3671bba06767eL33. The issue is that previously we were storing "child-of" instead of "CHILD_OF" and doing a simple strings.Upper() isn't going to help.

With this fix, cassandra dbmodel will use it's own version of RefTypes so it's not affected by any outside changes.

## Short description of the changes
- 
