### PR TITLE
Change metric tag from "service" to "svc"

### DIFF
--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -105,10 +105,10 @@ func newMetricsBySvc(factory metrics.Factory, category string) metricsBySvc {
 func newCountsBySvc(factory metrics.Factory, maxServiceNames int) countsBySvc {
 	return countsBySvc{
 		counts: map[string]metrics.Counter{
-			otherServices: factory.Counter("", map[string]string{"service": otherServices, "debug": "false"}),
+			otherServices: factory.Counter("", map[string]string{"svc": otherServices, "debug": "false"}),
 		},
 		debugCounts: map[string]metrics.Counter{
-			otherServices: factory.Counter("", map[string]string{"service": otherServices, "debug": "true"}),
+			otherServices: factory.Counter("", map[string]string{"svc": otherServices, "debug": "true"}),
 		},
 		factory:         factory,
 		lock:            &sync.Mutex{},
@@ -181,7 +181,7 @@ func (m *countsBySvc) countByServiceName(serviceName string, isDebug bool) {
 		if isDebug {
 			debugStr = "true"
 		}
-		c := m.factory.Counter("", map[string]string{"service": serviceName, "debug": debugStr})
+		c := m.factory.Counter("", map[string]string{"svc": serviceName, "debug": debugStr})
 		counts[serviceName] = c
 		counter = c
 	} else {

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -48,10 +48,10 @@ func TestProcessorMetrics(t *testing.T) {
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	counters, gauges := baseMetrics.LocalBackend.Snapshot()
 
-	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|service=fry"])
-	assert.EqualValues(t, 2, counters["service.spans.received|debug=true|format=jaeger|service=fry"])
-	assert.EqualValues(t, 1, counters["service.traces.received|debug=false|format=jaeger|service=fry"])
-	assert.EqualValues(t, 1, counters["service.traces.received|debug=true|format=jaeger|service=fry"])
+	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|svc=fry"])
+	assert.EqualValues(t, 2, counters["service.spans.received|debug=true|format=jaeger|svc=fry"])
+	assert.EqualValues(t, 1, counters["service.traces.received|debug=false|format=jaeger|svc=fry"])
+	assert.EqualValues(t, 1, counters["service.traces.received|debug=true|format=jaeger|svc=fry"])
 	assert.Empty(t, gauges)
 }
 
@@ -65,9 +65,9 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("zoidberg", false)
 
 	counters, _ := baseMetrics.LocalBackend.Snapshot()
-	assert.EqualValues(t, 1, counters["|debug=false|service=fry"])
-	assert.EqualValues(t, 1, counters["|debug=false|service=leela"])
-	assert.EqualValues(t, 2, counters["|debug=false|service=other-services"])
+	assert.EqualValues(t, 1, counters["|debug=false|svc=fry"])
+	assert.EqualValues(t, 1, counters["|debug=false|svc=leela"])
+	assert.EqualValues(t, 2, counters["|debug=false|svc=other-services"])
 
 	metrics.countByServiceName("zoidberg", true)
 	metrics.countByServiceName("bender", true)
@@ -75,7 +75,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("fry", true)
 
 	counters, _ = baseMetrics.LocalBackend.Snapshot()
-	assert.EqualValues(t, 1, counters["|debug=true|service=zoidberg"])
-	assert.EqualValues(t, 1, counters["|debug=true|service=bender"])
-	assert.EqualValues(t, 2, counters["|debug=true|service=other-services"])
+	assert.EqualValues(t, 1, counters["|debug=true|svc=zoidberg"])
+	assert.EqualValues(t, 1, counters["|debug=true|svc=bender"])
+	assert.EqualValues(t, 2, counters["|debug=true|svc=other-services"])
 }

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -112,21 +112,21 @@ func TestBySvcMetrics(t *testing.T) {
 		expected := []metricsTest.ExpectedMetric{}
 		if test.debug {
 			expected = append(expected, metricsTest.ExpectedMetric{
-				Name: metricPrefix + ".spans.received|debug=true|format=" + format + "|service=" + test.serviceName, Value: 2,
+				Name: metricPrefix + ".spans.received|debug=true|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		} else {
 			expected = append(expected, metricsTest.ExpectedMetric{
-				Name: metricPrefix + ".spans.received|debug=false|format=" + format + "|service=" + test.serviceName, Value: 2,
+				Name: metricPrefix + ".spans.received|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		}
 		if test.rootSpan {
 			if test.debug {
 				expected = append(expected, metricsTest.ExpectedMetric{
-					Name: metricPrefix + ".traces.received|debug=true|format=" + format + "|service=" + test.serviceName, Value: 2,
+					Name: metricPrefix + ".traces.received|debug=true|format=" + format + "|svc=" + test.serviceName, Value: 2,
 				})
 			} else {
 				expected = append(expected, metricsTest.ExpectedMetric{
-					Name: metricPrefix + ".traces.received|debug=false|format=" + format + "|service=" + test.serviceName, Value: 2,
+					Name: metricPrefix + ".traces.received|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 				})
 			}
 		}
@@ -142,7 +142,7 @@ func TestBySvcMetrics(t *testing.T) {
 			})
 		} else {
 			expected = append(expected, metricsTest.ExpectedMetric{
-				Name: metricPrefix + ".spans.rejected|debug=false|format=" + format + "|service=" + test.serviceName, Value: 2,
+				Name: metricPrefix + ".spans.rejected|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		}
 		metricsTest.AssertCounterMetrics(t, mb, expected...)


### PR DESCRIPTION
Signed-off-by: Won Jun Jang <wjang@uber.com>

## Which problem is this PR solving?
- I just realized that the "service" tag is pretty common, internally we deployed the newest version of jaeger with the new tag based metrics and the "service" metric tag was overwriting the actual service tag (jaeger-collector) so we were emitting metrics for every other service at Uber except jaeger-collector (oops). I changed the tag to the shorthand "svc" but I'm open to suggestions.  

## Short description of the changes
- service -> svc
