### PR TITLE
Avoid race condition on logging the buffer size

### DIFF
--- a/cmd/agent/app/processors/thrift_processor.go
+++ b/cmd/agent/app/processors/thrift_processor.go
@@ -110,8 +110,8 @@ func (s *ThriftProcessor) processBuffer() {
 		protocol := s.protocolPool.Get().(thrift.TProtocol)
 		payload := readBuf.GetBytes()
 		protocol.Transport().Write(payload)
-		s.server.DataRecd(readBuf) // acknowledge receipt and release the buffer
 		s.logger.Debug("Span(s) received by the agent", zap.Int("bytes-received", len(payload)))
+		s.server.DataRecd(readBuf) // acknowledge receipt and release the buffer
 
 		if ok, _ := s.handler.Process(protocol, protocol); !ok {
 			// TODO log the error


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Follow-up PR from #879. As [commented](https://github.com/jaegertracing/jaeger/pull/879/files#r197501562) by @yurishkuro, it's possible to have a race condition when logging the buffer size, as it has been released already by the previous statement.

## Short description of the changes
- Log the buffer size before the buffer is released
