### PR TITLE
Fix missing Zipkin error messages

### DIFF
--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
@@ -173,8 +173,9 @@ func (s *errorTagSanitizer) Sanitize(span *zc.Span) *zc.Span {
 			} else {
 				// value is different to true/false, create another bin annotation with error message
 				annoErrorMsg := &zc.BinaryAnnotation{
-					Key:   "error.message",
-					Value: binAnno.Value,
+					Key:            "error.message",
+					Value:          binAnno.Value,
+					AnnotationType: zc.AnnotationType_STRING,
 				}
 				span.BinaryAnnotations = append(span.BinaryAnnotations, annoErrorMsg)
 				binAnno.Value = []byte{1}

--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
@@ -151,6 +151,8 @@ func TestSpanErrorSanitizer(t *testing.T) {
 			if test.addErrMsgAnno {
 				assert.Equal(t, 2, len(sanitized.BinaryAnnotations))
 				assert.Equal(t, "error.message", sanitized.BinaryAnnotations[1].Key)
+				assert.Equal(t, "message", string(sanitized.BinaryAnnotations[1].Value))
+				assert.Equal(t, zipkincore.AnnotationType_STRING, sanitized.BinaryAnnotations[1].AnnotationType)
 			} else {
 				assert.Equal(t, 1, len(sanitized.BinaryAnnotations))
 			}


### PR DESCRIPTION
Currently a Zipkin error tag of type string shows up in
Jaeger UI as an error.message tag with the value "False"
instead of the string value. The sanitizer is missing
annotationType on the new tag that holds error.message

Resolves #890 

Signed-off-by: Hananiel Sarella <hananiel@gmail.com> 