### PR TITLE
ES storage: not logging requests on error

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -80,15 +79,8 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 			sm.Emit(err, duration)
 
 			if err != nil {
-				var buffer bytes.Buffer
-				for i, r := range requests {
-					buffer.WriteString(r.String())
-					if i+1 < len(requests) {
-						buffer.WriteByte('\n')
-					}
-				}
 				logger.Error("Elasticsearch could not process bulk request", zap.Error(err),
-					zap.Any("response", response), zap.String("requests", buffer.String()))
+					zap.Any("response", response))
 			}
 		}).
 		BulkSize(c.BulkSize).


### PR DESCRIPTION
## Which problem is this PR solving?
- #896 

## Short description of the changes
- Because failed requests buffer can get very big it can make error logs impossible to parse (e.g. by ELK stack) so that it is harder to debug the actual problem.
