### PR TITLE
Require 100% coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,12 +1,15 @@
-coverage:
-  range: 100..100
-  round: down
-  precision: 2
-
 codecov:
   notify:
     require_ci_to_pass: yes
+  strict_yaml_branch: master  # only use the latest copy on master branch
 
-# see https://docs.codecov.io/docs/ignoring-paths
-ignore:
-  - "model.pb*.go"
+coverage:
+  precision: 2
+  round: down
+  range: "100...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,7 @@ coverage:
   range: "100...100"
 
   status:
-    project: yes
+    project:
       default:
         target: 100
     patch: yes

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,6 +10,8 @@ coverage:
 
   status:
     project: yes
+      default:
+        target: 100
     patch: yes
     changes: no
 


### PR DESCRIPTION
Our codecov.io status no longer blocks PRs with less than 100% code coverage. Trying to fix that.