### PR TITLE
connCheckTimeout as flag

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -17,6 +17,7 @@ package app
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/pkg/errors"
@@ -36,10 +37,11 @@ import (
 )
 
 const (
-	defaultQueueSize     = 1000
-	defaultMaxPacketSize = 65000
-	defaultServerWorkers = 10
-	defaultMinPeers      = 3
+	defaultQueueSize        = 1000
+	defaultMaxPacketSize    = 65000
+	defaultServerWorkers    = 10
+	defaultMinPeers         = 3
+	defaultConnCheckTimeout = 250 * time.Millisecond
 
 	defaultHTTPServerHostPort = ":5778"
 

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -30,6 +30,7 @@ const (
 	collectorHostPort         = "collector.host-port"
 	httpServerHostPort        = "http-server.host-port"
 	discoveryMinPeers         = "discovery.min-peers"
+	discoveryConnCheckTimeout = "discovery.conn-check-timeout"
 )
 
 var defaultProcessors = []struct {
@@ -63,6 +64,10 @@ func AddFlags(flags *flag.FlagSet) {
 		discoveryMinPeers,
 		defaultMinPeers,
 		"if using service discovery, the min number of connections to maintain to the backend")
+	flags.Duration(
+		discoveryConnCheckTimeout,
+		defaultConnCheckTimeout,
+		"sets the timeout used when establishing new connections")
 }
 
 // InitFromViper initializes Builder with properties retrieved from Viper.
@@ -84,5 +89,6 @@ func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
 	}
 	b.HTTPServer.HostPort = v.GetString(httpServerHostPort)
 	b.DiscoveryMinPeers = v.GetInt(discoveryMinPeers)
+	b.ConnCheckTimeout = v.GetDuration(discoveryConnCheckTimeout)
 	return b
 }

--- a/cmd/agent/app/reporter/tchannel/builder.go
+++ b/cmd/agent/app/reporter/tchannel/builder.go
@@ -15,6 +15,8 @@
 package tchannel
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/uber/jaeger-lib/metrics"
 	"github.com/uber/tchannel-go"
@@ -43,6 +45,9 @@ type Builder struct {
 	// CollectorServiceName is the name that Jaeger Collector's TChannel server
 	// responds to.
 	CollectorServiceName string `yaml:"collectorServiceName"`
+
+	// ConnCheckTimeout is the timeout used when establishing new connections.
+	ConnCheckTimeout time.Duration
 
 	discoverer discovery.Discoverer
 	notifier   discovery.Notifier
@@ -92,7 +97,9 @@ func (b *Builder) enableDiscovery(channel *tchannel.Channel, logger *zap.Logger)
 	peers := subCh.Peers()
 	return peerlistmgr.New(peers, b.discoverer, b.notifier,
 		peerlistmgr.Options.MinPeers(defaultInt(b.DiscoveryMinPeers, defaultMinPeers)),
-		peerlistmgr.Options.Logger(logger))
+		peerlistmgr.Options.Logger(logger),
+		peerlistmgr.Options.ConnCheckTimeout(b.ConnCheckTimeout),
+	)
 }
 
 // CreateReporter creates the TChannel-based Reporter


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Adds a option to set connCheckTimeout. Now the value is hardcoded at 250ms. 

## Short description of the changes
Added a flag to accept a new timeout for connCheckTimeout (--discovery.conn-check-timeout) that receives a duration. Defaults to 250ms. 
