### PR TITLE
Improve HotROD demo

### DIFF
--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	jexpvar "github.com/uber/jaeger-lib/metrics/expvar"
 	jprom "github.com/uber/jaeger-lib/metrics/prometheus"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -35,7 +36,7 @@ var (
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "jaeger-demo",
+	Use:   "examples-hotrod",
 	Short: "HotR.O.D. - A tracing demo application",
 	Long:  `HotR.O.D. - A tracing demo application.`,
 }
@@ -51,9 +52,9 @@ func Execute() {
 
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&metricsBackend, "metrics", "m", "expvar", "Metrics backend (expvar|prometheus)")
-	RootCmd.PersistentFlags().StringVarP(&jAgentHostPort, "jaeger-agent.host-port", "a", "0.0.0.0:6831", "String representing jaeger-agent host:port")
+	RootCmd.PersistentFlags().StringVarP(&jAgentHostPort, "jaeger-agent.host-port", "a", "0.0.0.0:6831", "String representing jaeger-agent UDP host:port")
 	rand.Seed(int64(time.Now().Nanosecond()))
-	logger, _ = zap.NewDevelopment()
+	logger, _ = zap.NewDevelopment(zap.AddStacktrace(zapcore.FatalLevel))
 	cobra.OnInitialize(initMetrics)
 }
 
@@ -63,7 +64,7 @@ func initMetrics() {
 		metricsFactory = jexpvar.NewFactory(10) // 10 buckets for histograms
 		logger.Info("Using expvar as metrics backend")
 	} else if metricsBackend == "prometheus" {
-		metricsFactory = jprom.New()
+		metricsFactory = jprom.New().Namespace("hotrod", nil)
 		logger.Info("Using Prometheus as metrics backend")
 	} else {
 		logger.Fatal("unsupported metrics backend " + metricsBackend)

--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -58,7 +58,7 @@ func Execute() {
 
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&metricsBackend, "metrics", "m", "expvar", "Metrics backend (expvar|prometheus)")
-	RootCmd.PersistentFlags().StringVarP(&jAgentHostPort, "jaeger-agent.host-port", "a", "0.0.0.0:6831", "String representing jaeger-agent UDP host:port")
+	RootCmd.PersistentFlags().StringVarP(&jAgentHostPort, "jaeger-agent.host-port", "a", "0.0.0.0:6831", "String representing jaeger-agent UDP host:port, or jaeger-collector HTTP endpoint address, e.g. http://localhost:14268/api/traces.")
 	RootCmd.PersistentFlags().DurationVarP(&fixDBConnDelay, "fix-db-query-delay", "D", 300*time.Millisecond, "Average lagency of MySQL DB query")
 	RootCmd.PersistentFlags().BoolVarP(&fixDBConnDisableMutex, "fix-disable-db-conn-mutex", "M", false, "Disables the mutex guarding db connection")
 	RootCmd.PersistentFlags().IntVarP(&fixRouteWorkerPoolSize, "fix-route-worker-pool-size", "W", 3, "Default worker pool size")

--- a/examples/hotrod/services/config/config.go
+++ b/examples/hotrod/services/config/config.go
@@ -21,8 +21,9 @@ import (
 var (
 	// 'frontend' service
 
-	// WorkerPoolSize is the size of goroutine pool used to query for routes
-	WorkerPoolSize = 3
+	// RouteWorkerPoolSize is the size of the worker pool used to query `route` service.
+	// Can be overwritten from command line.
+	RouteWorkerPoolSize = 3
 
 	// 'customer' service
 
@@ -33,18 +34,19 @@ var (
 	// MySQLGetDelayStdDev is standard deviation
 	MySQLGetDelayStdDev = MySQLGetDelay / 10
 
-	// RouteWorkerPoolSize is the size of the worker pool used to query `route` service
-	RouteWorkerPoolSize = 3
+	// MySQLMutexDisabled controls whether there is a mutex guarding db query execution.
+	// When not disabled it simulates a misconfigured connection pool of size 1.
+	MySQLMutexDisabled = false
 
 	// 'driver' service
 
-	// RedisFindDelay is how long finding closest drivers takes
+	// RedisFindDelay is how long finding closest drivers takes.
 	RedisFindDelay = 20 * time.Millisecond
 
-	// RedisFindDelayStdDev is standard deviation
+	// RedisFindDelayStdDev is standard deviation.
 	RedisFindDelayStdDev = RedisFindDelay / 4
 
-	// RedisGetDelay is how long retrieving a driver record takes
+	// RedisGetDelay is how long retrieving a driver record takes.
 	RedisGetDelay = 10 * time.Millisecond
 
 	// RedisGetDelayStdDev is standard deviation

--- a/examples/hotrod/services/customer/database.go
+++ b/examples/hotrod/services/customer/database.go
@@ -81,9 +81,11 @@ func (d *database) Get(ctx context.Context, customerID string) (*Customer, error
 		ctx = opentracing.ContextWithSpan(ctx, span)
 	}
 
-	// simulate misconfigured connection pool that only gives one connection at a time
-	d.lock.Lock(ctx)
-	defer d.lock.Unlock()
+	if !config.MySQLMutexDisabled {
+		// simulate misconfigured connection pool that only gives one connection at a time
+		d.lock.Lock(ctx)
+		defer d.lock.Unlock()
+	}
 
 	// simulate RPC delay
 	delay.Sleep(config.MySQLGetDelay, config.MySQLGetDelayStdDev)


### PR DESCRIPTION
* Allow controlling optimizations from cmd line
* Suppress logging of stack traces unless fatal
* Add `hotrod` namespace to all metrics
* Support HTTP or UDP senders

On the topic of senders, the Go client, unfortunately, does not support JAEGER_ENDPOINT env variable like Java client does, and the current CLI argument is called `--jaeger-agent.host-port`, even though it now accepts HTTP endpoint name.