### PR TITLE
Detect HTTP payload format from Content-Type

### DIFF
--- a/cmd/collector/app/http_handler.go
+++ b/cmd/collector/app/http_handler.go
@@ -34,8 +34,8 @@ const (
 
 var (
 	acceptedThriftFormats = map[string]struct{}{
-		"application/x-thrift":                 struct{}{},
-		"application/vnd.apache.thrift.binary": struct{}{},
+		"application/x-thrift":                 {},
+		"application/vnd.apache.thrift.binary": {},
 	}
 )
 


### PR DESCRIPTION
Since Zipkin HTTP endpoint has been moved to another port, the only format that Collector HTTP handler recognizes is Thrift, which makes the `?format=` URL parameter redundant since the payload type can be inferred from the `Content-Type` header.

This change removes the `format` URL parameter and only looks at the `Content-Type`.