### PR TITLE
Fix ES 6.x index already exists race condition

### DIFF
--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -148,8 +148,8 @@ func (s *SpanWriter) createIndex(indexName string, mapping string, jsonSpan *jMo
 				if !ok || eErr.Details != nil &&
 					// ES 5.x
 					(eErr.Details.Type != "index_already_exists_exception" &&
-					// ES 6.x
-					eErr.Details.Type != "resource_already_exists_exception") {
+						// ES 6.x
+						eErr.Details.Type != "resource_already_exists_exception") {
 					return s.logError(jsonSpan, err, "Failed to create index", s.logger)
 				}
 			}

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -145,7 +145,11 @@ func (s *SpanWriter) createIndex(indexName string, mapping string, jsonSpan *jMo
 			s.writerMetrics.indexCreate.Emit(err, time.Since(start))
 			if err != nil {
 				eErr, ok := err.(*elastic.Error)
-				if !ok || eErr.Details != nil && eErr.Details.Type != "index_already_exists_exception" {
+				if !ok || eErr.Details != nil &&
+					// ES 5.x
+					(eErr.Details.Type != "index_already_exists_exception" &&
+					// ES 6.x
+					eErr.Details.Type != "resource_already_exists_exception") {
 					return s.logError(jsonSpan, err, "Failed to create index", s.logger)
 				}
 			}


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #665

## Short description of the changes

Add `resource_already_exists_exception` used by ES 6.x. It has been renamed from `index_already_exists_exception` https://github.com/elastic/elasticsearch/blob/7d7ead95b2a3b967f788f1fa56f118ee77d857fe/server/src/main/java/org/elasticsearch/ElasticsearchException.java#L978
