### PR TITLE
Change Composite Writer to Sequential Writer

### DIFF
--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -120,7 +120,7 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 	if len(f.SpanWriterTypes) == 1 {
 		return writers[0], nil
 	}
-	return spanstore.NewCompositeWriter(writers...), nil
+	return spanstore.NewSequentialWriter(writers...), nil
 }
 
 // CreateDependencyReader implements storage.Factory

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -158,7 +158,7 @@ func TestCreateMulti(t *testing.T) {
 	mock2.On("CreateSpanWriter").Return(spanWriter2, nil)
 	w, err = f.CreateSpanWriter()
 	assert.NoError(t, err)
-	assert.Equal(t, spanstore.NewCompositeWriter(spanWriter, spanWriter2), w)
+	assert.Equal(t, spanstore.NewSequentialWriter(spanWriter, spanWriter2), w)
 }
 
 func TestCreateArchive(t *testing.T) {

--- a/storage/spanstore/composite.go
+++ b/storage/spanstore/composite.go
@@ -16,7 +16,6 @@ package spanstore
 
 import (
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/jaegertracing/jaeger/pkg/multierror"
 )
 
 // CompositeWriter is a span Writer that tries to save spans into several underlying span Writers
@@ -31,13 +30,12 @@ func NewCompositeWriter(spanWriters ...Writer) *CompositeWriter {
 	}
 }
 
-// WriteSpan calls WriteSpan on each span writer. It will sum up failures, it is not transactional
+// WriteSpan calls WriteSpan on each span writer. It will fail at the first error
 func (c *CompositeWriter) WriteSpan(span *model.Span) error {
-	var errors []error
 	for _, writer := range c.spanWriters {
 		if err := writer.WriteSpan(span); err != nil {
-			errors = append(errors, err)
+			return err
 		}
 	}
-	return multierror.Wrap(errors)
+	return nil
 }

--- a/storage/spanstore/composite.go
+++ b/storage/spanstore/composite.go
@@ -18,20 +18,20 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 )
 
-// CompositeWriter is a span Writer that tries to save spans into several underlying span Writers
-type CompositeWriter struct {
+// SequentialWriter is a span Writer that tries to save spans into several underlying span Writers
+type SequentialWriter struct {
 	spanWriters []Writer
 }
 
-// NewCompositeWriter creates a CompositeWriter
-func NewCompositeWriter(spanWriters ...Writer) *CompositeWriter {
-	return &CompositeWriter{
+// NewSequentialWriter creates a SequentialWriter
+func NewSequentialWriter(spanWriters ...Writer) *SequentialWriter {
+	return &SequentialWriter{
 		spanWriters: spanWriters,
 	}
 }
 
 // WriteSpan calls WriteSpan on each span writer. It will fail at the first error
-func (c *CompositeWriter) WriteSpan(span *model.Span) error {
+func (c *SequentialWriter) WriteSpan(span *model.Span) error {
 	for _, writer := range c.spanWriters {
 		if err := writer.WriteSpan(span); err != nil {
 			return err

--- a/storage/spanstore/composite_test.go
+++ b/storage/spanstore/composite_test.go
@@ -39,16 +39,16 @@ func (n *noopWriteSpanStore) WriteSpan(span *model.Span) error {
 }
 
 func TestCompositeWriteSpanStoreSuccess(t *testing.T) {
-	c := NewCompositeWriter(&noopWriteSpanStore{}, &noopWriteSpanStore{})
+	c := NewSequentialWriter(&noopWriteSpanStore{}, &noopWriteSpanStore{})
 	assert.NoError(t, c.WriteSpan(nil))
 }
 
 func TestCompositeWriteSpanStoreSecondFailure(t *testing.T) {
-	c := NewCompositeWriter(&errProneWriteSpanStore{}, &errProneWriteSpanStore{})
+	c := NewSequentialWriter(&errProneWriteSpanStore{}, &errProneWriteSpanStore{})
 	assert.EqualError(t, c.WriteSpan(nil), errIWillAlwaysFail.Error())
 }
 
 func TestCompositeWriteSpanStoreFirstFailure(t *testing.T) {
-	c := NewCompositeWriter(&errProneWriteSpanStore{}, &noopWriteSpanStore{})
+	c := NewSequentialWriter(&errProneWriteSpanStore{}, &noopWriteSpanStore{})
 	assert.Equal(t, errIWillAlwaysFail, c.WriteSpan(nil))
 }

--- a/storage/spanstore/composite_test.go
+++ b/storage/spanstore/composite_test.go
@@ -16,7 +16,6 @@ package spanstore_test
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,7 +45,7 @@ func TestCompositeWriteSpanStoreSuccess(t *testing.T) {
 
 func TestCompositeWriteSpanStoreSecondFailure(t *testing.T) {
 	c := NewCompositeWriter(&errProneWriteSpanStore{}, &errProneWriteSpanStore{})
-	assert.EqualError(t, c.WriteSpan(nil), fmt.Sprintf("[%s, %s]", errIWillAlwaysFail, errIWillAlwaysFail))
+	assert.EqualError(t, c.WriteSpan(nil), errIWillAlwaysFail.Error())
 }
 
 func TestCompositeWriteSpanStoreFirstFailure(t *testing.T) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #929 

## Short description of the changes
- As part of the necessary changes to add the Ingester, the Composite Writer will fail at the first error when writing spans as opposed to continuing with the next storage type.
- Consider the case where the second storage type is not idempotent, and the first storage type fails to process a span. With a Composite Writer, on every retry, the second storage will have redundant spans written to it. With a Sequential Writer, the second storage type won't be attempted until the write to the first storage type succeeds.
