### PR TITLE
Replaces agent infinite block with agent.Stop()

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -63,7 +63,8 @@ func main() {
 			if err := agent.Run(); err != nil {
 				return errors.Wrap(err, "Failed to run the agent")
 			}
-			select {}
+			defer agent.Stop()
+			return nil
 		},
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?
- The `select {}` statement to place `agent` in an infinite loop is uncommon and causes confusion for new contributors.

## Short description of the changes
- The `agent.Stop()` method exists, so let's use it. Calling `defer` with the `agent.Stop()` method will stop `agent` only when the `agent.Start` go routine stops/fails and is easier for new contributors to understand.

Signed-off-by: Daneyon Hansen <danehans@cisco.com>
