### PR TITLE
Rename gas to gosec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ GOTEST=go test -v $(RACE)
 GOLINT=golint
 GOVET=go vet
 GOFMT=gofmt
-GAS=gas -quiet -exclude=G104
+GOSEC=gosec -quiet -exclude=G104
 FMT_LOG=fmt.log
 LINT_LOG=lint.log
 IMPORT_LOG=import.log
@@ -125,12 +125,12 @@ fmt:
 	$(GOFMT) -e -s -l -w $(ALL_SRC)
 	./scripts/updateLicenses.sh
 
-.PHONY: lint-gas
-lint-gas:
-	$(GAS) $(TOP_PKGS)
+.PHONY: lint-gosec
+lint-gosec:
+	$(GOSEC) $(TOP_PKGS)
 
 .PHONY: lint
-lint: lint-gas
+lint: lint-gosec
 	$(GOVET) $(TOP_PKGS)
 	@cat /dev/null > $(LINT_LOG)
 	$(GOLINT) $(TOP_PKGS) | \
@@ -272,7 +272,7 @@ install-tools:
 	go get golang.org/x/tools/cmd/cover
 	go get github.com/golang/lint/golint
 	go get github.com/sectioneight/md-to-godoc
-	go get github.com/GoASTScanner/gas/cmd/gas/...
+	go get github.com/securego/gosec/cmd/gosec/...
 
 .PHONY: install-ci
 install-ci: install install-tools


### PR DESCRIPTION




<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- GoASTScanner/gas was renamed to gosec in securego/gosec#216 causing our
builds to break. 

## Short description of the changes
- Resolves #945 be renaming `gas` to `gosec`
Signed-off-by: Prithvi Raj <p.r@uber.com>
