### PR TITLE
Use tags in agent metrics

### DIFF
--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -219,8 +219,8 @@ func assertProcessorCorrectness(
 
 	// agentReporter must emit metrics
 	mTestutils.AssertCounterMetrics(t, metricsFactory, []mTestutils.ExpectedMetric{
-		{Name: "tc-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: 1},
-		{Name: "tc-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: 1},
+		{Name: "tchannel-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: 1},
+		{Name: "tchannel-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "thrift.udp.server.packets.processed", Value: 1},
 	}...)
 }

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -16,7 +16,6 @@ package processors
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -196,7 +195,7 @@ func assertProcessorCorrectness(
 	metricsFactory *metrics.LocalFactory,
 	sizeF func() int,
 	nameF func() string,
-	counterType string,
+	format string,
 ) {
 	// wait for server to receive
 	for i := 0; i < 1000; i++ {
@@ -219,11 +218,9 @@ func assertProcessorCorrectness(
 	}
 
 	// agentReporter must emit metrics
-	batchesSubmittedCounter := fmt.Sprintf("tc-reporter.%s.batches.submitted", counterType)
-	spansSubmittedCounter := fmt.Sprintf("tc-reporter.%s.spans.submitted", counterType)
 	mTestutils.AssertCounterMetrics(t, metricsFactory, []mTestutils.ExpectedMetric{
-		{Name: batchesSubmittedCounter, Value: 1},
-		{Name: spansSubmittedCounter, Value: 1},
+		{Name: "tc-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: 1},
+		{Name: "tc-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "thrift.udp.server.packets.processed", Value: 1},
 	}...)
 }

--- a/cmd/agent/app/reporter/tchannel/reporter.go
+++ b/cmd/agent/app/reporter/tchannel/reporter.go
@@ -34,19 +34,19 @@ const (
 
 type batchMetrics struct {
 	// Number of successful batch submissions to collector
-	BatchesSubmitted metrics.Counter `metric:"tc-reporter.batches.submitted"`
+	BatchesSubmitted metrics.Counter `metric:"batches.submitted"`
 
 	// Number of failed batch submissions to collector
-	BatchesFailures metrics.Counter `metric:"tc-reporter.batches.failures"`
+	BatchesFailures metrics.Counter `metric:"batches.failures"`
 
 	// Number of spans in a batch submitted to collector
-	BatchSize metrics.Gauge `metric:"tc-reporter.batch_size"`
+	BatchSize metrics.Gauge `metric:"batch_size"`
 
 	// Number of successful span submissions to collector
-	SpansSubmitted metrics.Counter `metric:"tc-reporter.spans.submitted"`
+	SpansSubmitted metrics.Counter `metric:"spans.submitted"`
 
 	// Number of failed span submissions to collector
-	SpansFailures metrics.Counter `metric:"tc-reporter.spans.failures"`
+	SpansFailures metrics.Counter `metric:"spans.failures"`
 }
 
 // Reporter forwards received spans to central collector tier over TChannel.
@@ -73,7 +73,7 @@ func New(
 	batchesMetrics := map[string]batchMetrics{}
 	for _, s := range []string{zipkinBatches, jaegerBatches} {
 		bm := batchMetrics{}
-		metrics.Init(&bm, mFactory.Namespace("", map[string]string{"format": s}), nil)
+		metrics.Init(&bm, mFactory.Namespace("tchannel-reporter", map[string]string{"format": s}), nil)
 		batchesMetrics[s] = bm
 	}
 	return &Reporter{

--- a/cmd/agent/app/reporter/tchannel/reporter.go
+++ b/cmd/agent/app/reporter/tchannel/reporter.go
@@ -34,19 +34,19 @@ const (
 
 type batchMetrics struct {
 	// Number of successful batch submissions to collector
-	BatchesSubmitted metrics.Counter `metric:"batches.submitted"`
+	BatchesSubmitted metrics.Counter `metric:"tc-reporter.batches.submitted"`
 
 	// Number of failed batch submissions to collector
-	BatchesFailures metrics.Counter `metric:"batches.failures"`
+	BatchesFailures metrics.Counter `metric:"tc-reporter.batches.failures"`
 
 	// Number of spans in a batch submitted to collector
-	BatchSize metrics.Gauge `metric:"batch_size"`
+	BatchSize metrics.Gauge `metric:"tc-reporter.batch_size"`
 
 	// Number of successful span submissions to collector
-	SpansSubmitted metrics.Counter `metric:"spans.submitted"`
+	SpansSubmitted metrics.Counter `metric:"tc-reporter.spans.submitted"`
 
 	// Number of failed span submissions to collector
-	SpansFailures metrics.Counter `metric:"spans.failures"`
+	SpansFailures metrics.Counter `metric:"tc-reporter.spans.failures"`
 }
 
 // Reporter forwards received spans to central collector tier over TChannel.
@@ -71,11 +71,9 @@ func New(
 	zClient := zipkincore.NewTChanZipkinCollectorClient(thriftClient)
 	jClient := jaeger.NewTChanCollectorClient(thriftClient)
 	batchesMetrics := map[string]batchMetrics{}
-	tcReporterNS := mFactory.Namespace("tc-reporter", nil)
 	for _, s := range []string{zipkinBatches, jaegerBatches} {
-		nsByType := tcReporterNS.Namespace(s, nil)
 		bm := batchMetrics{}
-		metrics.Init(&bm, nsByType, nil)
+		metrics.Init(&bm, mFactory.Namespace("", map[string]string{"format": s}), nil)
 		batchesMetrics[s] = bm
 	}
 	return &Reporter{

--- a/cmd/agent/app/reporter/tchannel/reporter_test.go
+++ b/cmd/agent/app/reporter/tchannel/reporter_test.go
@@ -15,7 +15,6 @@
 package tchannel
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -105,16 +104,11 @@ func submitTestJaegerBatch(reporter *Reporter) error {
 	return reporter.EmitBatch(batch)
 }
 
-func checkCounters(t *testing.T, mf *metrics.LocalFactory, batchesSubmitted, spansSubmitted, batchesFailures, spansFailures int, prefix string) {
-	batchesCounter := fmt.Sprintf("tc-reporter.%s.batches.submitted", prefix)
-	batchesFailureCounter := fmt.Sprintf("tc-reporter.%s.batches.failures", prefix)
-	spansCounter := fmt.Sprintf("tc-reporter.%s.spans.submitted", prefix)
-	spansFailureCounter := fmt.Sprintf("tc-reporter.%s.spans.failures", prefix)
-
+func checkCounters(t *testing.T, mf *metrics.LocalFactory, batchesSubmitted, spansSubmitted, batchesFailures, spansFailures int, format string) {
 	mTestutils.AssertCounterMetrics(t, mf, []mTestutils.ExpectedMetric{
-		{Name: batchesCounter, Value: batchesSubmitted},
-		{Name: spansCounter, Value: spansSubmitted},
-		{Name: batchesFailureCounter, Value: batchesFailures},
-		{Name: spansFailureCounter, Value: spansFailures},
+		{Name: "tc-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: batchesSubmitted},
+		{Name: "tc-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: spansSubmitted},
+		{Name: "tc-reporter.batches.failures", Tags: map[string]string{"format": format}, Value: batchesFailures},
+		{Name: "tc-reporter.spans.failures", Tags: map[string]string{"format": format}, Value: spansFailures},
 	}...)
 }

--- a/cmd/agent/app/reporter/tchannel/reporter_test.go
+++ b/cmd/agent/app/reporter/tchannel/reporter_test.go
@@ -106,9 +106,9 @@ func submitTestJaegerBatch(reporter *Reporter) error {
 
 func checkCounters(t *testing.T, mf *metrics.LocalFactory, batchesSubmitted, spansSubmitted, batchesFailures, spansFailures int, format string) {
 	mTestutils.AssertCounterMetrics(t, mf, []mTestutils.ExpectedMetric{
-		{Name: "tc-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: batchesSubmitted},
-		{Name: "tc-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: spansSubmitted},
-		{Name: "tc-reporter.batches.failures", Tags: map[string]string{"format": format}, Value: batchesFailures},
-		{Name: "tc-reporter.spans.failures", Tags: map[string]string{"format": format}, Value: spansFailures},
+		{Name: "tchannel-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: batchesSubmitted},
+		{Name: "tchannel-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: spansSubmitted},
+		{Name: "tchannel-reporter.batches.failures", Tags: map[string]string{"format": format}, Value: batchesFailures},
+		{Name: "tchannel-reporter.spans.failures", Tags: map[string]string{"format": format}, Value: spansFailures},
 	}...)
 }


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Change  path-based metrics to new format in agent.
- Resolves: #850 

## Short description of the changes
- jaeger and zipkin are pulled into format tag.
- Gist : https://gist.github.com/eundoosong/8d3e06a259b60ce0ff346799dd3f7f22
```
jaeger_agent_tc_reporter_batch_size{format="jaeger"} 0
jaeger_agent_tc_reporter_batch_size{format="zipkin"} 0
jaeger_agent_tc_reporter_batches_failures{format="jaeger"} 0
jaeger_agent_tc_reporter_batches_failures{format="zipkin"} 0
jaeger_agent_tc_reporter_batches_submitted{format="jaeger"} 0
jaeger_agent_tc_reporter_batches_submitted{format="zipkin"} 0
jaeger_agent_tc_reporter_spans_failures{format="jaeger"} 0
jaeger_agent_tc_reporter_spans_failures{format="zipkin"} 0
jaeger_agent_tc_reporter_spans_submitted{format="jaeger"} 0
jaeger_agent_tc_reporter_spans_submitted{format="zipkin"} 0
```