### PR TITLE
Update query handler to read from archive reader when multiple traceI…

### DIFF
--- a/cmd/query/app/handler.go
+++ b/cmd/query/app/handler.go
@@ -237,7 +237,7 @@ func (aH *APIHandler) tracesByIDs(traceIDs []model.TraceID) ([]*model.Trace, []s
 	var errors []structuredError
 	retMe := make([]*model.Trace, 0, len(traceIDs))
 	for _, traceID := range traceIDs {
-		if trace, err := aH.spanReader.GetTrace(traceID); err != nil {
+		if trace, err := trace(traceID, aH.spanReader, aH.archiveSpanReader); err != nil {
 			if err != spanstore.ErrTraceNotFound {
 				return nil, nil, err
 			}
@@ -399,22 +399,30 @@ func (aH *APIHandler) withTraceFromReader(
 	if !ok {
 		return
 	}
-	trace, err := reader.GetTrace(traceID)
+	trace, err := trace(traceID, reader, backupReader)
 	if err == spanstore.ErrTraceNotFound {
-		if backupReader == nil {
-			aH.handleError(w, err, http.StatusNotFound)
-			return
-		}
-		trace, err = backupReader.GetTrace(traceID)
-		if err == spanstore.ErrTraceNotFound {
-			aH.handleError(w, err, http.StatusNotFound)
-			return
-		}
+		aH.handleError(w, err, http.StatusNotFound)
+		return
 	}
 	if aH.handleError(w, err, http.StatusInternalServerError) {
 		return
 	}
 	process(trace)
+}
+
+func trace(
+	traceID model.TraceID,
+	reader spanstore.Reader,
+	backupReader spanstore.Reader,
+) (*model.Trace, error) {
+	trace, err := reader.GetTrace(traceID)
+	if err == spanstore.ErrTraceNotFound {
+		if backupReader == nil {
+			return nil, err
+		}
+		trace, err = backupReader.GetTrace(traceID)
+	}
+	return trace, err
 }
 
 // archiveTrace implements the REST API POST:/archive/{trace-id}.

--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -53,7 +53,7 @@ func TestGetArchivedTraceSuccess(t *testing.T) {
 	mockReader.On("GetTrace", mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Once()
 	withTestServer(t, func(ts *testServer) {
-		// maeke main reader return NotFound
+		// make main reader return NotFound
 		ts.spanReader.On("GetTrace", mock.AnythingOfType("model.TraceID")).
 			Return(nil, spanstore.ErrTraceNotFound).Once()
 		var response structuredTraceResponse


### PR DESCRIPTION
…Ds are passed as parameters

Signed-off-by: Won Jun Jang <wjang@uber.com>

## Which problem is this PR solving?
- When multiple traceIDs are passed to the query service, it only reads the traces from the reader, not the archiveReader.
