### PR TITLE
Log internal server errors in http handler

### DIFF
--- a/cmd/query/app/handler.go
+++ b/cmd/query/app/handler.go
@@ -448,6 +448,9 @@ func (aH *APIHandler) handleError(w http.ResponseWriter, err error, statusCode i
 	if err == nil {
 		return false
 	}
+	if statusCode == http.StatusInternalServerError {
+		aH.logger.Error("HTTP handler, Internal Server Error", zap.Error(err))
+	}
 	structuredResp := structuredResponse{
 		Errors: []structuredError{
 			{

--- a/cmd/query/app/handler_test.go
+++ b/cmd/query/app/handler_test.go
@@ -28,10 +28,12 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/stretchr/testify/assert"
+	testHttp "github.com/stretchr/testify/http"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	jaeger "github.com/uber/jaeger-client-go"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/adjuster"
@@ -138,6 +140,42 @@ func TestGetTraceSuccess(t *testing.T) {
 	err := getJSON(server.URL+`/api/traces/123456`, &response)
 	assert.NoError(t, err)
 	assert.Len(t, response.Errors, 0)
+}
+
+type logData struct {
+	e zapcore.Entry
+	f []zapcore.Field
+}
+
+type testLogger struct {
+	logs *[]logData
+}
+
+func (testLogger) Enabled(zapcore.Level) bool          { return true }
+func (l testLogger) With([]zapcore.Field) zapcore.Core { return l }
+func (testLogger) Sync() error                         { return nil }
+func (l testLogger) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(e, l)
+}
+func (l testLogger) Write(e zapcore.Entry, f []zapcore.Field) error {
+	*l.logs = append(*l.logs, logData{e: e, f: f})
+	return nil
+}
+
+func TestLogOnServerError(t *testing.T) {
+	l := &testLogger{
+		logs: &[]logData{},
+	}
+	apiHandlerOptions := []HandlerOption{
+		HandlerOptions.Logger(zap.New(l)),
+	}
+	h := NewAPIHandler(&spanstoremocks.Reader{}, &depsmocks.Reader{}, apiHandlerOptions...)
+	e := errors.New("test error")
+	h.handleError(&testHttp.TestResponseWriter{}, e, http.StatusInternalServerError)
+	require.Equal(t, 1, len(*l.logs))
+	assert.Equal(t, "HTTP handler, Internal Server Error", (*l.logs)[0].e.Message)
+	assert.Equal(t, 1, len((*l.logs)[0].f))
+	assert.Equal(t, e, (*l.logs)[0].f[0].Interface)
 }
 
 func TestPrettyPrint(t *testing.T) {


### PR DESCRIPTION
Internal server errors are not being logged. For example ES might crash and on the jaeger server side this info is completelly missing. Just the client get:

```
{"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"Search service failed: elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]"}]}
```

An example of server log
```
SPAN_STORAGE_TYPE=elasticsearch  go run -tags ui cmd/query/main.go   --log-level=debug                              5:48 
{"level":"info","ts":1532620123.9571958,"caller":"healthcheck/handler.go:99","msg":"Health Check server started","http-port":16687,"status":"unavailable"}
{"level":"info","ts":1532620123.960481,"caller":"query/main.go:180","msg":"Archive storage not created","reason":"Archive storage not supported"}
{"level":"info","ts":1532620124.123846,"caller":"query/main.go:125","msg":"Registering metrics handler with HTTP server","route":"/metrics"}
{"level":"info","ts":1532620124.1238933,"caller":"healthcheck/handler.go:133","msg":"Health Check state change","status":"ready"}
{"level":"info","ts":1532620124.1239398,"caller":"query/main.go:134","msg":"Starting jaeger-query HTTP server","port":16686}
{"level":"error","ts":1532620127.4582376,"caller":"app/handler.go:452","msg":"HTTP handler, Internal Server Error","error":"Search service failed: elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]","errorVerbose":"elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]\nSearch service failed\ngithub.com/jaegertracing/jaeger/plugin/storage/es/spanstore.(*SpanReader).findTraceIDs\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/reader.go:361\ngithub.com/jaegertracing/jaeger/plugin/storage/es/spanstore.(*SpanReader).FindTraces\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/reader.go:200\ngithub.com/jaegertracing/jaeger/storage/spanstore/metrics.(*ReadMetricsDecorator).FindTraces\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/storage/spanstore/metrics/decorator.go:77\ngithub.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).search\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/query/app/handler.go:214\ngithub.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).(github.com/jaegertracing/jaeger/cmd/query/app.search)-fm\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/query/app/handler.go:125\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\ngithub.com/jaegertracing/jaeger/vendor/github.com/opentracing-contrib/go-stdlib/nethttp.Middleware.func2\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:90\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\nnet/http.(Handler).ServeHTTP-fm\n\t/home/ploffay/bin/go/src/net/http/h2_bundle.go:5475\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\ngithub.com/jaegertracing/jaeger/vendor/github.com/gorilla/mux.(*Router).ServeHTTP\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/gorilla/mux/mux.go:114\ngithub.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers.CompressHandlerLevel.func1\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers/compress.go:146\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\ngithub.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers.recoveryHandler.ServeHTTP\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers/recovery.go:78\ngithub.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers.(*recoveryHandler).ServeHTTP\n\t<autogenerated>:1\nnet/http.serverHandler.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:2694\nnet/http.(*conn).serve\n\t/home/ploffay/bin/go/src/net/http/server.go:1830\nruntime.goexit\n\t/home/ploffay/bin/go/src/runtime/asm_amd64.s:2361","stacktrace":"github.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).handleError\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/query/app/handler.go:452\ngithub.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).search\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/query/app/handler.go:215\ngithub.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).(github.com/jaegertracing/jaeger/cmd/query/app.search)-fm\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/query/app/handler.go:125\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\ngithub.com/jaegertracing/jaeger/vendor/github.com/opentracing-contrib/go-stdlib/nethttp.Middleware.func2\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:90\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\nnet/http.(Handler).ServeHTTP-fm\n\t/home/ploffay/bin/go/src/net/http/h2_bundle.go:5475\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\ngithub.com/jaegertracing/jaeger/vendor/github.com/gorilla/mux.(*Router).ServeHTTP\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/gorilla/mux/mux.go:114\ngithub.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers.CompressHandlerLevel.func1\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers/compress.go:146\nnet/http.HandlerFunc.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:1947\ngithub.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers.recoveryHandler.ServeHTTP\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/vendor/github.com/gorilla/handlers/recovery.go:78\nnet/http.serverHandler.ServeHTTP\n\t/home/ploffay/bin/go/src/net/http/server.go:2694\nnet/http.(*conn).serve\n\t/home/ploffay/bin/go/src/net/http/server.go:1830"}

```