### PR TITLE
Parse media types in the Content-Type header correctly

### DIFF
--- a/cmd/collector/app/http_handler.go
+++ b/cmd/collector/app/http_handler.go
@@ -67,7 +67,12 @@ func (aH *APIHandler) saveSpan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Cannot parse content type: %v", err), http.StatusBadRequest)
+		return
+	}
 
 	if _, ok := acceptedThriftFormats[contentType]; !ok {
 		http.Error(w, fmt.Sprintf("Unsupported content type: %v", contentType), http.StatusBadRequest)

--- a/cmd/collector/app/http_handler.go
+++ b/cmd/collector/app/http_handler.go
@@ -17,6 +17,7 @@ package app
 import (
 	"fmt"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"time"
 
@@ -66,7 +67,8 @@ func (aH *APIHandler) saveSpan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType := r.Header.Get("Content-Type")
+	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+
 	if _, ok := acceptedThriftFormats[contentType]; !ok {
 		http.Error(w, fmt.Sprintf("Unsupported content type: %v", contentType), http.StatusBadRequest)
 		return

--- a/cmd/collector/app/http_handler_test.go
+++ b/cmd/collector/app/http_handler_test.go
@@ -148,6 +148,15 @@ func TestWrongFormat(t *testing.T) {
 	assert.EqualValues(t, "Unsupported content type: nosoupforyou\n", resBodyStr)
 }
 
+func TestMalformedFormat(t *testing.T) {
+	server, _ := initializeTestServer(nil)
+	defer server.Close()
+	statusCode, resBodyStr, err := postBytes("application/json; =iammalformed", server.URL+`/api/traces`, []byte{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, http.StatusBadRequest, statusCode)
+	assert.EqualValues(t, "Cannot parse content type: mime: invalid media parameter\n", resBodyStr)
+}
+
 func TestCannotReadBodyFromRequest(t *testing.T) {
 	handler := NewAPIHandler(&mockJaegerHandler{})
 	req, err := http.NewRequest(http.MethodPost, "whatever", &errReader{})

--- a/cmd/collector/app/http_handler_test.go
+++ b/cmd/collector/app/http_handler_test.go
@@ -83,6 +83,11 @@ func TestThriftFormat(t *testing.T) {
 	assert.EqualValues(t, http.StatusAccepted, statusCode)
 	assert.EqualValues(t, "", resBodyStr)
 
+	statusCode, resBodyStr, err = postBytes("application/x-thrift; charset=utf-8", server.URL+`/api/traces`, someBytes)
+	assert.NoError(t, err)
+	assert.EqualValues(t, http.StatusAccepted, statusCode)
+	assert.EqualValues(t, "", resBodyStr)
+
 	handler.jaegerBatchesHandler.(*mockJaegerHandler).err = fmt.Errorf("Bad times ahead")
 	statusCode, resBodyStr, err = postBytes("application/vnd.apache.thrift.binary", server.URL+`/api/traces`, someBytes)
 	assert.NoError(t, err)

--- a/cmd/collector/app/zipkin/http_handler.go
+++ b/cmd/collector/app/zipkin/http_handler.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strings"
 	"time"
@@ -79,7 +80,8 @@ func (aH *APIHandler) saveSpans(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType := r.Header.Get("Content-Type")
+	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+
 	var tSpans []*zipkincore.Span
 	if contentType == "application/x-thrift" {
 		tSpans, err = deserializeThrift(bodyBytes)
@@ -121,7 +123,8 @@ func (aH *APIHandler) saveSpansV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType := r.Header.Get("Content-Type")
+	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+
 	if contentType != "application/json" {
 		http.Error(w, "Unsupported Content-Type", http.StatusBadRequest)
 		return

--- a/cmd/collector/app/zipkin/http_handler.go
+++ b/cmd/collector/app/zipkin/http_handler.go
@@ -80,7 +80,12 @@ func (aH *APIHandler) saveSpans(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Cannot parse Content-Type: %v", err), http.StatusBadRequest)
+		return
+	}
 
 	var tSpans []*zipkincore.Span
 	if contentType == "application/x-thrift" {
@@ -123,7 +128,12 @@ func (aH *APIHandler) saveSpansV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Cannot parse Content-Type: %v", err), http.StatusBadRequest)
+		return
+	}
 
 	if contentType != "application/json" {
 		http.Error(w, "Unsupported Content-Type", http.StatusBadRequest)

--- a/cmd/collector/app/zipkin/http_handler_test.go
+++ b/cmd/collector/app/zipkin/http_handler_test.go
@@ -131,6 +131,11 @@ func TestJsonFormat(t *testing.T) {
 	require.NotNil(t, recdSpan.Annotations[0].Host)
 	assert.EqualValues(t, -1, recdSpan.Annotations[0].Host.Port, "Port 65535 must be represented as -1 in zipkin.thrift")
 
+	statusCode, resBodyStr, err = postBytes(server.URL+`/api/v1/spans`, []byte(spanJSON), createHeader("application/json; charset=utf-8"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, http.StatusAccepted, statusCode)
+	assert.EqualValues(t, "", resBodyStr)
+
 	endpErrJSON := createEndpoint("", "127.0.0.A", "", 80)
 
 	// error zipkinSpanHandler
@@ -245,6 +250,7 @@ func TestSaveSpansV2(t *testing.T) {
 		headers map[string]string
 	}{
 		{body: []byte("[]"), code: http.StatusAccepted},
+		{body: []byte("[]"), code: http.StatusAccepted, headers: map[string]string{"Content-Type": "application/json; charset=utf-8"}},
 		{body: gzipEncode([]byte("[]")), code: http.StatusAccepted, headers: map[string]string{"Content-Encoding": "gzip"}},
 		{body: []byte("[]"), code: http.StatusBadRequest, headers: map[string]string{"Content-Type": "text/html"}, resBody: "Unsupported Content-Type\n"},
 		{body: []byte("[]"), code: http.StatusBadRequest, headers: map[string]string{"Content-Encoding": "gzip"}, resBody: "Unable to process request body: unexpected EOF\n"},


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #963 , in which `Content-Type` extraction was using the raw value of the `Content-Type` header, rather than extracting it from the containing Media Type.

## Short description of the changes
- Imports the `mime` module into the HTTP Thrift endpoint as well as the Zipkin endpoints and resolves the `Content-Type` using the `mime` package's [`ParseMediaType`](https://golang.org/pkg/mime/#ParseMediaType) method. 
