### PR TITLE
adds the gRPC port to the docker-all-in-one Dockerfile (#773)

### DIFF
--- a/cmd/standalone/Dockerfile
+++ b/cmd/standalone/Dockerfile
@@ -15,6 +15,9 @@ EXPOSE 5778
 # Collector HTTP
 EXPOSE 14268
 
+# Collector gRPC
+EXPOSE 14270
+
 # Web HTTP
 EXPOSE 16686
 


### PR DESCRIPTION
## Which problem is this PR solving?
- gRPC Prototype has all-in-one-support, but the dockerfile doesn't expose the port yet 

## Short description of the changes
- add the port to the all-in-one Dockerfile
