### PR TITLE
fix panic: duplicate metrics collector registration attempted

### DIFF
--- a/cmd/ingester/app/consumer/offset/manager.go
+++ b/cmd/ingester/app/consumer/offset/manager.go
@@ -54,8 +54,8 @@ func NewManager(minOffset int64, markOffset MarkOffset, partition int32, factory
 	return &Manager{
 		markOffsetFunction:  markOffset,
 		close:               make(chan struct{}),
-		offsetCommitCount:   factory.Counter("offset-commit-count", map[string]string{"partition": strconv.Itoa(int(partition))}),
-		lastCommittedOffset: factory.Gauge("offset-commit", map[string]string{"partition": strconv.Itoa(int(partition))}),
+		offsetCommitCount:   factory.Counter("offset-commits-total", map[string]string{"partition": strconv.Itoa(int(partition))}),
+		lastCommittedOffset: factory.Gauge("last-committed-offset", map[string]string{"partition": strconv.Itoa(int(partition))}),
 		list:                newConcurrentList(minOffset),
 	}
 }

--- a/cmd/ingester/app/consumer/offset/manager.go
+++ b/cmd/ingester/app/consumer/offset/manager.go
@@ -54,7 +54,7 @@ func NewManager(minOffset int64, markOffset MarkOffset, partition int32, factory
 	return &Manager{
 		markOffsetFunction:  markOffset,
 		close:               make(chan struct{}),
-		offsetCommitCount:   factory.Counter("offset-commit", map[string]string{"partition": strconv.Itoa(int(partition))}),
+		offsetCommitCount:   factory.Counter("offset-commit-count", map[string]string{"partition": strconv.Itoa(int(partition))}),
 		lastCommittedOffset: factory.Gauge("offset-commit", map[string]string{"partition": strconv.Itoa(int(partition))}),
 		list:                newConcurrentList(minOffset),
 	}

--- a/cmd/ingester/app/consumer/offset/manager_test.go
+++ b/cmd/ingester/app/consumer/offset/manager_test.go
@@ -44,6 +44,6 @@ func TestHandleReset(t *testing.T) {
 
 	assert.Equal(t, offset, captureOffset)
 	cnt, g := m.Snapshot()
-	assert.Equal(t, int64(1), cnt["offset-commit|partition=1"])
-	assert.Equal(t, int64(offset), g["offset-commit|partition=1"])
+	assert.Equal(t, int64(1), cnt["offset-commits-total|partition=1"])
+	assert.Equal(t, int64(offset), g["last-committed-offset|partition=1"])
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
fix duplicate metrics collector registration attempted panic

## Short description of the changes
use different names for counter and gauge metrics collector.
