### PR TITLE
Add error logging for individual ES bulk reposes

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/es"
 	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
-)
+	)
 
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
@@ -75,18 +75,28 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 			}
 			m.Delete(id)
 
-			duration := time.Since(start.(time.Time))
-			sm.Emit(err, duration)
-
-			if err != nil {
-				failed := len(response.Failed())
-				total := len(requests)
-				logger.Error("Elasticsearch could not process bulk request",
-					zap.Int("request_count", total),
-					zap.Int("failed_count", failed),
-					zap.Error(err),
-					zap.Any("response", response))
+			// log individual errors, note that err might be false and these errors still present
+			if response.Errors {
+				for _, it := range response.Items {
+					for key, val := range it {
+						if val.Error != nil {
+							logger.Error("Elasticsearch part of bulk request failed", zap.String("map-key",key),
+								zap.Reflect("response", val))
+						}
+					}
+				}
 			}
+
+			sm.Emit(err, time.Since(start.(time.Time)))
+				if err != nil {
+					failed := len(response.Failed())
+					total := len(requests)
+					logger.Error("Elasticsearch could not process bulk request",
+						zap.Int("request_count", total),
+						zap.Int("failed_count", failed),
+						zap.Error(err),
+						zap.Any("response", response))
+				}
 		}).
 		BulkSize(c.BulkSize).
 		Workers(c.BulkWorkers).

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/es"
 	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
-	)
+)
 
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
@@ -80,7 +80,7 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 				for _, it := range response.Items {
 					for key, val := range it {
 						if val.Error != nil {
-							logger.Error("Elasticsearch part of bulk request failed", zap.String("map-key",key),
+							logger.Error("Elasticsearch part of bulk request failed", zap.String("map-key", key),
 								zap.Reflect("response", val))
 						}
 					}
@@ -88,15 +88,15 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 			}
 
 			sm.Emit(err, time.Since(start.(time.Time)))
-				if err != nil {
-					failed := len(response.Failed())
-					total := len(requests)
-					logger.Error("Elasticsearch could not process bulk request",
-						zap.Int("request_count", total),
-						zap.Int("failed_count", failed),
-						zap.Error(err),
-						zap.Any("response", response))
-				}
+			if err != nil {
+				failed := len(response.Failed())
+				total := len(requests)
+				logger.Error("Elasticsearch could not process bulk request",
+					zap.Int("request_count", total),
+					zap.Int("failed_count", failed),
+					zap.Error(err),
+					zap.Any("response", response))
+			}
 		}).
 		BulkSize(c.BulkSize).
 		Workers(c.BulkWorkers).


### PR DESCRIPTION
It's important to check every bulk response because
root error can be nil even when some response failed.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>
