### PR TITLE
Remove spances from ES schema

### DIFF
--- a/plugin/storage/es/spanstore/schema.go
+++ b/plugin/storage/es/spanstore/schema.go
@@ -18,21 +18,21 @@ import "fmt"
 
 // TODO: resolve traceID concerns (may not require any changes here)
 const mapping = `{
-   "settings":{
-      "index.number_of_shards": ${__NUMBER_OF_SHARDS__},
-      "index.number_of_replicas": ${__NUMBER_OF_REPLICAS__},
-      "index.mapping.nested_fields.limit":50,
-      "index.requests.cache.enable":true,
-      "index.mapper.dynamic":false
-   },
-   "mappings":{
-      "_default_":{
-         "_all":{
-            "enabled":false
-         }
-      },
-      "%s":%s
-   }
+	"settings":{
+		"index.number_of_shards": ${__NUMBER_OF_SHARDS__},
+		"index.number_of_replicas": ${__NUMBER_OF_REPLICAS__},
+		"index.mapping.nested_fields.limit":50,
+		"index.requests.cache.enable":true,
+		"index.mapper.dynamic":false
+	},
+	"mappings":{
+		"_default_":{
+			"_all":{
+				"enabled":false
+			}
+		},
+		"%s":%s
+	}
 }`
 
 var (
@@ -40,141 +40,139 @@ var (
 		mapping,
 		spanType,
 		`{
-		 "properties":{
-		    "traceID":{
-		       "type":"keyword",
-		       "ignore_above":256
-		    },
-		    "parentSpanID":{
-		       "type":"keyword",
-		       "ignore_above":256
-		    },
-		    "spanID":{
-		       "type":"keyword",
-		       "ignore_above":256
-		    },
-		    "operationName":{
-		       "type":"keyword",
-		       "ignore_above":256
-		    },
-		    "startTime":{
-		       "type":"long"
-		    },
-		    "startTimeMillis":{
-		       "type":"date",
-		       "format":"epoch_millis"
-		    },
-		    "duration":{
-		       "type":"long"
-		    },
-		    "flags":{
-		       "type":"integer"
-		    },
-		    "logs":{
-		       "properties":{
-			  "timestamp":{
-			     "type":"long"
-			  },
-			  "fields":{
-			     "type":"nested",
-			     "dynamic":false,
-			     "properties":{
-				"key":{
-				   "type":"keyword",
-				   "ignore_above":256
+	"properties": {
+		"traceID": {
+			"type": "keyword",
+			"ignore_above": 256
+		},
+		"parentSpanID": {
+			"type": "keyword",
+			"ignore_above": 256
+		},
+		"spanID": {
+			"type": "keyword",
+			"ignore_above": 256
+		},
+		"operationName": {
+			"type": "keyword",
+			"ignore_above": 256
+		},
+		"startTime": {
+			"type": "long"
+		},
+		"startTimeMillis": {
+			"type": "date",
+			"format": "epoch_millis"
+		},
+		"duration": {
+			"type": "long"
+		},
+		"flags": {
+			"type": "integer"
+		},
+		"logs": {
+			"properties": {
+				"timestamp": {
+					"type": "long"
 				},
-				"value":{
-				   "type":"keyword",
-				   "ignore_above":256
-				},
-				"tagType":{
-				   "type":"keyword",
-				   "ignore_above":256
+				"fields": {
+					"type": "nested",
+					"dynamic": false,
+					"properties": {
+						"key": {
+							"type": "keyword",
+							"ignore_above": 256
+						},
+						"value": {
+							"type": "keyword",
+							"ignore_above": 256
+						},
+						"tagType": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
 				}
-			     }
-			  }
-		       }
-		    },
-		    "process":{
-		       "properties":{
-			  "serviceName":{
-			     "type":"keyword",
-			     "ignore_above":256
-			  },
-			  "tags":{
-			     "type":"nested",
-			     "dynamic":false,
-			     "properties":{
-				"key":{
-				   "type":"keyword",
-				   "ignore_above":256
+			}
+		},
+		"process": {
+			"properties": {
+				"serviceName": {
+					"type": "keyword",
+					"ignore_above": 256
 				},
-				"value":{
-				   "type":"keyword",
-				   "ignore_above":256
-				},
-				"tagType":{
-				   "type":"keyword",
-				   "ignore_above":256
+				"tags": {
+					"type": "nested",
+					"dynamic": false,
+					"properties": {
+						"key": {
+							"type": "keyword",
+							"ignore_above": 256
+						},
+						"value": {
+							"type": "keyword",
+							"ignore_above": 256
+						},
+						"tagType": {
+							"type": "keyword",
+							"ignore_above": 256
+						}
+					}
 				}
-			     }
-			  }
-		       }
-		    },
-		    "references":{
-		       "type":"nested",
-		       "dynamic":false,
-		       "properties":{
-			  "refType":{
-			     "type":"keyword",
-			     "ignore_above":256
-			  },
-			  "traceID":{
-			     "type":"keyword",
-			     "ignore_above":256
-			  },
-			  "spanID":{
-			     "type":"keyword",
-			     "ignore_above":256
-			  }
-		       }
-		    },
-		    "tags":{
-		       "type":"nested",
-		       "dynamic":false,
-		       "properties":{
-			  "key":{
-			     "type":"keyword",
-			     "ignore_above":256
-			  },
-			  "value":{
-			     "type":"keyword",
-			     "ignore_above":256
-			  },
-			  "tagType":{
-			     "type":"keyword",
-			     "ignore_above":256
-			  }
-		       }
-		    }
-		 }
-	      }`,
-	)
+			}
+		},
+		"references": {
+			"type": "nested",
+			"dynamic": false,
+			"properties": {
+				"refType": {
+					"type": "keyword",
+					"ignore_above": 256
+				},
+				"traceID": {
+					"type": "keyword",
+					"ignore_above": 256
+				},
+				"spanID": {
+					"type": "keyword",
+					"ignore_above": 256
+				}
+			}
+		},
+		"tags": {
+			"type": "nested",
+			"dynamic": false,
+			"properties": {
+				"key": {
+					"type": "keyword",
+					"ignore_above": 256
+				},
+				"value": {
+					"type": "keyword",
+					"ignore_above": 256
+				},
+				"tagType": {
+					"type": "keyword",
+					"ignore_above": 256
+				}
+			}
+		}
+	}
+}`)
 
 	serviceMapping = fmt.Sprintf(
 		mapping,
 		serviceType,
 		`{
-		 "properties":{
-		    "serviceName":{
-		       "type":"keyword",
-		       "ignore_above":256
-		    },
-		    "operationName":{
-		       "type":"keyword",
-		       "ignore_above":256
-		    }
-		 }
-	      }`,
-	)
+	"properties":{
+		"serviceName":{
+			"type":"keyword",
+			"ignore_above":256
+		},
+		"operationName":{
+			"type":"keyword",
+			"ignore_above":256
+		}
+	}
+}`)
 )


### PR DESCRIPTION
Fixes indentation in ES schema. The file contained spaces and tags. Now the indentation is done only with tags.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>
