### PR TITLE
WIP: Change ES tag schema to support tag search in Kibana

### DIFF
--- a/model/json/model.go
+++ b/model/json/model.go
@@ -61,19 +61,20 @@ type Trace struct {
 // When converting to ES model, ProcessID and Warnings should be omitted. Even if
 // included, ES with dynamic settings off will automatically ignore unneeded fields.
 type Span struct {
-	TraceID       TraceID     `json:"traceID"`
-	SpanID        SpanID      `json:"spanID"`
-	ParentSpanID  SpanID      `json:"parentSpanID,omitempty"` // deprecated
-	Flags         uint32      `json:"flags,omitempty"`
-	OperationName string      `json:"operationName"`
-	References    []Reference `json:"references"`
-	StartTime     uint64      `json:"startTime"` // microseconds since Unix epoch
-	Duration      uint64      `json:"duration"`  // microseconds
-	Tags          []KeyValue  `json:"tags"`
-	Logs          []Log       `json:"logs"`
-	ProcessID     ProcessID   `json:"processID,omitempty"`
-	Process       *Process    `json:"process,omitempty"`
-	Warnings      []string    `json:"warnings"`
+	TraceID       TraceID           `json:"traceID"`
+	SpanID        SpanID            `json:"spanID"`
+	ParentSpanID  SpanID            `json:"parentSpanID,omitempty"` // deprecated
+	Flags         uint32            `json:"flags,omitempty"`
+	OperationName string            `json:"operationName"`
+	References    []Reference       `json:"references"`
+	StartTime     uint64            `json:"startTime"` // microseconds since Unix epoch
+	Duration      uint64            `json:"duration"`  // microseconds
+	Tags          []KeyValue        `json:"tags"`
+	TagsMap       map[string]string `json:"tagsMap,omitempty"`
+	Logs          []Log             `json:"logs"`
+	ProcessID     ProcessID         `json:"processID,omitempty"`
+	Process       *Process          `json:"process,omitempty"`
+	Warnings      []string          `json:"warnings"`
 }
 
 // Reference is a reference from one span to another
@@ -85,8 +86,9 @@ type Reference struct {
 
 // Process is the process emitting a set of spans
 type Process struct {
-	ServiceName string     `json:"serviceName"`
-	Tags        []KeyValue `json:"tags"`
+	ServiceName string            `json:"serviceName"`
+	Tags        []KeyValue        `json:"tags"`
+	TagsMap     map[string]string `json:"tagsMap,omitempty"`
 }
 
 // Log is a log emitted in a span

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -43,8 +44,8 @@ const (
 	startTimeField     = "startTime"
 	serviceNameField   = "process.serviceName"
 	operationNameField = "operationName"
-	tagsField          = "tags"
-	processTagsField   = "process.tags"
+	tagsField          = "tagsMap"
+	processTagsField   = "process.tagsMap"
 	logFieldsField     = "logs.fields"
 	tagKeyField        = "key"
 	tagValueField      = "value"
@@ -76,7 +77,7 @@ var (
 
 	defaultMaxDuration = model.DurationAsMicroseconds(time.Hour * 24)
 
-	tagFieldList = []string{tagsField, processTagsField, logFieldsField}
+	objectTagFieldList = []string{tagsField, processTagsField}
 )
 
 // SpanReader can query for and load traces from ElasticSearch
@@ -127,6 +128,8 @@ func (s *SpanReader) collectSpans(esSpansRaw []*elastic.SearchHit) ([]*model.Spa
 		if err != nil {
 			return nil, errors.Wrap(err, "Marshalling JSON to span object failed")
 		}
+		jsonSpan.Tags = fromMapTagsToKeyValues(jsonSpan.TagsMap)
+		jsonSpan.Process.Tags = fromMapTagsToKeyValues(jsonSpan.Process.TagsMap)
 		span, err := jConverter.SpanToDomain(jsonSpan)
 		if err != nil {
 			return nil, errors.Wrap(err, "Converting JSONSpan to domain Span failed")
@@ -134,6 +137,16 @@ func (s *SpanReader) collectSpans(esSpansRaw []*elastic.SearchHit) ([]*model.Spa
 		spans[i] = span
 	}
 	return spans, nil
+}
+
+func fromMapTagsToKeyValues(tagMap map[string]string) []jModel.KeyValue {
+	var kvs []jModel.KeyValue
+	for key, value := range tagMap {
+		dKey := strings.Replace(key, ":", ".", -1)
+		kv := jModel.KeyValue{Key: dKey, Value: value, Type: jModel.StringType}
+		kvs = append(kvs, kv)
+	}
+	return kvs
 }
 
 func (s *SpanReader) unmarshalJSONSpan(esSpanRaw *elastic.SearchHit) (*jModel.Span, error) {
@@ -441,10 +454,12 @@ func (s *SpanReader) buildOperationNameQuery(operationName string) elastic.Query
 }
 
 func (s *SpanReader) buildTagQuery(k string, v string) elastic.Query {
-	queries := make([]elastic.Query, len(tagFieldList))
-	for i := range queries {
-		queries[i] = s.buildNestedQuery(tagFieldList[i], k, v)
+	queries := make([]elastic.Query, len(objectTagFieldList)+1)
+	kd := strings.Replace(k, ".", ":", -1)
+	for i := range objectTagFieldList {
+		queries[i] = s.buildObjectQuery(objectTagFieldList[i], kd, v)
 	}
+	queries[len(objectTagFieldList)] = s.buildNestedQuery(logFieldsField, k, v)
 	return elastic.NewBoolQuery().Should(queries...)
 }
 
@@ -455,4 +470,10 @@ func (s *SpanReader) buildNestedQuery(field string, k string, v string) elastic.
 	valueQuery := elastic.NewMatchQuery(valueField, v)
 	tagBoolQuery := elastic.NewBoolQuery().Must(keyQuery, valueQuery)
 	return elastic.NewNestedQuery(field, tagBoolQuery)
+}
+
+func (s *SpanReader) buildObjectQuery(field string, k string, v string) elastic.Query {
+	keyField := fmt.Sprintf("%s.%s", field, k)
+	keyQuery := elastic.NewMatchQuery(keyField, v)
+	return elastic.NewBoolQuery().Must(keyQuery)
 }

--- a/plugin/storage/es/spanstore/schema.go
+++ b/plugin/storage/es/spanstore/schema.go
@@ -101,6 +101,9 @@ var (
 					"type": "keyword",
 					"ignore_above": 256
 				},
+				"tagsMap": {
+					"type": "object"
+				},
 				"tags": {
 					"type": "nested",
 					"dynamic": false,
@@ -138,6 +141,9 @@ var (
 					"ignore_above": 256
 				}
 			}
+		},
+		"tagsMap": {
+			"type": "object"
 		},
 		"tags": {
 			"type": "nested",

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -129,8 +129,21 @@ func (s *SpanWriter) WriteSpan(span *model.Span) error {
 	if err := s.createIndex(spanIndexName, spanMapping, jsonSpan); err != nil {
 		return err
 	}
+	jsonSpan.TagsMap = tagsToMap(span.Tags)
+	jsonSpan.Tags = nil
+	jsonSpan.Process.TagsMap = tagsToMap(span.Process.Tags)
+	jsonSpan.Process.Tags = nil
 	s.writeSpan(spanIndexName, jsonSpan)
 	return nil
+}
+
+func tagsToMap(kvs []model.KeyValue) map[string]string {
+	tags := map[string]string{}
+	for _, tag := range kvs {
+		key := strings.Replace(tag.Key, ".", ":", -1)
+		tags[key] = tag.AsString()
+	}
+	return tags
 }
 
 // Close closes SpanWriter

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -129,17 +129,20 @@ func (s *SpanWriter) WriteSpan(span *model.Span) error {
 	if err := s.createIndex(spanIndexName, spanMapping, jsonSpan); err != nil {
 		return err
 	}
-	jsonSpan.TagsMap = tagsToMap(span.Tags)
+	jsonSpan.TagsMap = s.tagsToMap(span.Tags)
 	jsonSpan.Tags = nil
-	jsonSpan.Process.TagsMap = tagsToMap(span.Process.Tags)
+	jsonSpan.Process.TagsMap = s.tagsToMap(span.Process.Tags)
 	jsonSpan.Process.Tags = nil
 	s.writeSpan(spanIndexName, jsonSpan)
 	return nil
 }
 
-func tagsToMap(kvs []model.KeyValue) map[string]string {
+func (s *SpanWriter) tagsToMap(kvs []model.KeyValue) map[string]string {
 	tags := map[string]string{}
 	for _, tag := range kvs {
+		if strings.Contains(tag.Key, ":") {
+			s.logger.Warn("Tag key contains \\':\\', at the query time it will be transformed to \\'.\\'")
+		}
 		key := strings.Replace(tag.Key, ".", ":", -1)
 		tags[key] = tag.AsString()
 	}


### PR DESCRIPTION
Resolves #906 

Example of the index:
```
tags: {
  "http:method": "GET",
}
```

Significant changes
*  defines span and process tags as object datatype https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html
* dots in tag keys are replaced with `:`



Limitations:
* by default ~1000 unique keys per index `index.mapping.total_fields.limit` https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping.html#mapping-limit-settings. The count includes also meta fields https://github.com/elastic/elasticsearch/issues/24096
* issues if tag key contains `:`

#### TODO

- [x] performance comparison. 
- [ ]  fix `index.mapping.total_fields.limit` - we could count unique tag names, wait for failed PUT and then store following tags differently - array/nested object
- [ ] store type of the tag