### PR TITLE
Shutdown sarama consumer cleanly

### DIFF
--- a/cmd/ingester/app/consumer/consumer.go
+++ b/cmd/ingester/app/consumer/consumer.go
@@ -15,6 +15,8 @@
 package consumer
 
 import (
+	"sync"
+
 	"github.com/Shopify/sarama"
 	sc "github.com/bsm/sarama-cluster"
 	"github.com/uber/jaeger-lib/metrics"
@@ -22,7 +24,6 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
 	"github.com/jaegertracing/jaeger/pkg/kafka/consumer"
-	"sync"
 )
 
 // Params are the parameters of a Consumer

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -154,7 +154,7 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 	mp.AssertExpectations(t)
 	// Ensure that the partition consumer was updated in the map
 	assert.Equal(t, saramaPartitionConsumer.HighWaterMarkOffset(),
-		            undertest.partitionIDToState[partition].partitionConsumer.HighWaterMarkOffset())
+		undertest.partitionIDToState[partition].partitionConsumer.HighWaterMarkOffset())
 	undertest.Close()
 
 	partitionTag := map[string]string{"partition": fmt.Sprint(partition)}

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
+
 	"github.com/Shopify/sarama"
 	smocks "github.com/Shopify/sarama/mocks"
 	"github.com/bsm/sarama-cluster"
@@ -33,7 +35,6 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
 	pmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
 	"github.com/jaegertracing/jaeger/pkg/kafka/consumer"
-	"time"
 )
 
 //go:generate mockery -dir ../../../../pkg/kafka/config/ -name Consumer
@@ -188,7 +189,6 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 
 	undertest.Start()
 	mc.YieldError(errors.New("Daisy, Daisy"))
-
 
 	for i := 0; i < 1000; i++ {
 		time.Sleep(time.Millisecond)


### PR DESCRIPTION
### Cleanly shutdown Sarama parent consumer

Shutdown all partitions before shutting down the sarama consumer. This sidesteps   https://github.com/bsm/sarama-cluster/issues/255 and ensures that the shutdown completes in a reasonable timeframe. 

### Wait for PartitionConsumer shutdown before consuming messages

A given host could be reassigned the same partition quickly. In this case, we wait for proper shutdown and draining of the messages queue to prevent committing offsets for more recent messages before processing older ones. 

While this solution works on one host, it doesn't scale to multiple hosts because `sarama-cluster` does not provide an API to complete actions after a rebalance is triggered, but before subscriptions are released. This is being addressed as part of https://github.com/Shopify/sarama/pull/1099. 

### Use Sarama's PartitionConsumer mock instead of relying on our own because it is richer and well tested. 

Signed-off-by: Prithvi Raj <p.r@uber.com>

