### PR TITLE
Use reliable bad address to guarantee failure

### DIFF
--- a/cmd/agent/app/testutils/mock_collector_test.go
+++ b/cmd/agent/app/testutils/mock_collector_test.go
@@ -158,6 +158,6 @@ func TestMockTCollectorErrors(t *testing.T) {
 	_, err := startMockTCollector("", "127.0.0.1:0")
 	assert.Error(t, err, "error because of empty service name")
 
-	_, err = startMockTCollector("test", "127.0.0:0")
+	_, err = startMockTCollector("test", "256.0.0:0")
 	assert.Error(t, err, "error because of bad address")
 }

--- a/cmd/agent/app/testutils/thriftudp_client_test.go
+++ b/cmd/agent/app/testutils/thriftudp_client_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestNewZipkinThriftUDPClient(t *testing.T) {
-	_, _, err := NewZipkinThriftUDPClient("1.2.3:0")
+	_, _, err := NewZipkinThriftUDPClient("256.2.3:0")
 	assert.Error(t, err)
 
 	_, cl, err := NewZipkinThriftUDPClient("127.0.0.1:12345")
@@ -34,7 +34,7 @@ func TestNewZipkinThriftUDPClient(t *testing.T) {
 func TestNewJaegerThriftUDPClient(t *testing.T) {
 	compactFactory := thrift.NewTCompactProtocolFactory()
 
-	_, _, err := NewJaegerThriftUDPClient("1.2.3:0", compactFactory)
+	_, _, err := NewJaegerThriftUDPClient("256.2.3:0", compactFactory)
 	assert.Error(t, err)
 
 	_, cl, err := NewJaegerThriftUDPClient("127.0.0.1:12345", compactFactory)


### PR DESCRIPTION
-  Resolves #1002.
- Use `256` to overflow IP address.