### PR TITLE
Use netcat to detect when Kafka is up

### DIFF
--- a/scripts/travis/kafka-integration-test.sh
+++ b/scripts/travis/kafka-integration-test.sh
@@ -4,6 +4,14 @@ set -e
 
 docker pull spotify/kafka
 CID=$(docker run -d -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=localhost --env ADVERTISED_PORT=9092 --rm spotify/kafka)
+
+# Guarantees no matter what happens, docker will remove the instance at the end.
+trap 'docker rm -f $CID 2>/dev/null' EXIT INT TERM
+
 export STORAGE=kafka
+while true; do
+    if nc -z localhost 9092; then
+        break
+    fi
+done
 make storage-integration-test
-docker kill $CID


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #1004 (hopefully). 

## Short description of the changes
- Use netcat to wait until Kafka is up before beginning integration test.
