### PR TITLE
Support building just the ingester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ cmd/agent/agent
 cmd/agent/agent-linux
 cmd/collector/collector
 cmd/collector/collector-linux
+cmd/ingester/ingester
+cmd/ingester/ingester-linux
 cmd/query/query
 cmd/query/query-linux
 crossdock/crossdock-linux

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,14 @@ build-query:
 build-collector:
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/collector/collector-$(GOOS) $(BUILD_INFO) ./cmd/collector/main.go
 
+.PHONY: build-ingester
+build-ingester:
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/ingester/ingester-$(GOOS) $(BUILD_INFO) ./cmd/ingester/main.go
+
+.PHONY: build-ingester-linux
+build-ingester-linux:
+	GOOS=linux $(MAKE) build-ingester
+
 .PHONY: docker-no-ui
 docker-no-ui: build-binaries-linux build-crossdock-linux
 	make docker-images-only


### PR DESCRIPTION
## Which problem is this PR solving?
Wanting to build just the ingester

## Short description of the changes
-  Add `Makefile` job to just build the ingester
- Ignore the ingester binaries in the `.gitignore`
- Whitespace that my editor wanted at the end of the `Makefile` ( I can revert it)
