### PR TITLE
[agent] Make timeout for reporting configurable

### DIFF
--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -77,7 +77,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 
 func initCollectorAndReporter(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, reporter.Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
-	reporter := reporter.WrapWithMetrics(tchreporter.New("jaeger-collector", collector.Channel, nil, zap.NewNop()), metricsFactory)
+	reporter := reporter.WrapWithMetrics(tchreporter.New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop()), metricsFactory)
 	return metricsFactory, collector, reporter
 }
 

--- a/cmd/agent/app/reporter/tchannel/flags.go
+++ b/cmd/agent/app/reporter/tchannel/flags.go
@@ -30,6 +30,7 @@ const (
 	hostPort                  = "host-port"
 	discoveryMinPeers         = "discovery.min-peers"
 	discoveryConnCheckTimeout = "discovery.conn-check-timeout"
+	reportTimeout             = "report-timeout"
 )
 
 // AddFlags adds flags for Builder.
@@ -46,6 +47,10 @@ func AddFlags(flags *flag.FlagSet) {
 		tchannelPrefix+discoveryConnCheckTimeout,
 		defaultConnCheckTimeout,
 		"sets the timeout used when establishing new connections")
+	flags.Duration(
+		tchannelPrefix+reportTimeout,
+		time.Second,
+		"sets the timeout used when reporting spans")
 	// TODO remove deprecated in 1.9
 	flags.String(
 		collectorHostPort,
@@ -81,5 +86,6 @@ func (b *Builder) InitFromViper(v *viper.Viper, logger *zap.Logger) *Builder {
 	}
 	b.DiscoveryMinPeers = v.GetInt(tchannelPrefix + discoveryMinPeers)
 	b.ConnCheckTimeout = v.GetDuration(tchannelPrefix + discoveryConnCheckTimeout)
+	b.ReportTimeout = v.GetDuration(tchannelPrefix + reportTimeout)
 	return b
 }

--- a/cmd/agent/app/reporter/tchannel/flags.go
+++ b/cmd/agent/app/reporter/tchannel/flags.go
@@ -84,8 +84,13 @@ func (b *Builder) InitFromViper(v *viper.Viper, logger *zap.Logger) *Builder {
 	if len(v.GetString(tchannelPrefix+hostPort)) > 0 {
 		b.CollectorHostPorts = strings.Split(v.GetString(tchannelPrefix+hostPort), ",")
 	}
-	b.DiscoveryMinPeers = v.GetInt(tchannelPrefix + discoveryMinPeers)
-	b.ConnCheckTimeout = v.GetDuration(tchannelPrefix + discoveryConnCheckTimeout)
+
+	if value := v.GetInt(tchannelPrefix + discoveryMinPeers); value != defaultMinPeers {
+		b.DiscoveryMinPeers = value
+	}
+	if value := v.GetDuration(tchannelPrefix + discoveryConnCheckTimeout); value != defaultConnCheckTimeout {
+		b.ConnCheckTimeout = value
+	}
 	b.ReportTimeout = v.GetDuration(tchannelPrefix + reportTimeout)
 	return b
 }

--- a/cmd/agent/app/reporter/tchannel/flags_test.go
+++ b/cmd/agent/app/reporter/tchannel/flags_test.go
@@ -27,13 +27,6 @@ import (
 )
 
 func TestBingFlags(t *testing.T) {
-	v := viper.New()
-	command := cobra.Command{}
-	flags := &flag.FlagSet{}
-	AddFlags(flags)
-	command.PersistentFlags().AddGoFlagSet(flags)
-	v.BindPFlags(command.PersistentFlags())
-
 	tests := []struct {
 		flags   []string
 		builder Builder
@@ -47,14 +40,14 @@ func TestBingFlags(t *testing.T) {
 		},
 		{flags: []string{
 			"--collector.host-port=1.2.3.4:555,1.2.3.4:666",
-			"--discovery.min-peers=42",
+			"--discovery.min-peers=45",
 			"--discovery.conn-check-timeout=85s",
 		},
-			builder: Builder{ConnCheckTimeout: time.Second * 85, ReportTimeout: defaultReportTimeout, DiscoveryMinPeers: 42, CollectorHostPorts: []string{"1.2.3.4:555", "1.2.3.4:666"}},
+			builder: Builder{ConnCheckTimeout: time.Second * 85, ReportTimeout: defaultReportTimeout, DiscoveryMinPeers: 45, CollectorHostPorts: []string{"1.2.3.4:555", "1.2.3.4:666"}},
 		},
 		{flags: []string{
 			"--collector.host-port=1.2.3.4:555,1.2.3.4:666",
-			"--discovery.min-peers=42",
+			"--discovery.min-peers=46",
 			"--discovery.conn-check-timeout=85s",
 			"--reporter.tchannel.host-port=1.2.3.4:5556,1.2.3.4:6667",
 			"--reporter.tchannel.discovery.min-peers=43",
@@ -64,6 +57,16 @@ func TestBingFlags(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		// Reset flags every iteration.
+		v := viper.New()
+		command := cobra.Command{}
+
+		flags := &flag.FlagSet{}
+		AddFlags(flags)
+		command.ResetFlags()
+		command.PersistentFlags().AddGoFlagSet(flags)
+		v.BindPFlags(command.PersistentFlags())
+
 		err := command.ParseFlags(test.flags)
 		require.NoError(t, err)
 		b := Builder{}

--- a/cmd/agent/app/reporter/tchannel/flags_test.go
+++ b/cmd/agent/app/reporter/tchannel/flags_test.go
@@ -42,14 +42,15 @@ func TestBingFlags(t *testing.T) {
 			"--reporter.tchannel.host-port=1.2.3.4:555,1.2.3.4:666",
 			"--reporter.tchannel.discovery.min-peers=42",
 			"--reporter.tchannel.discovery.conn-check-timeout=85s",
-		}, builder: Builder{ConnCheckTimeout: time.Second * 85, DiscoveryMinPeers: 42, CollectorHostPorts: []string{"1.2.3.4:555", "1.2.3.4:666"}},
+			"--reporter.tchannel.report-timeout=80s",
+		}, builder: Builder{ConnCheckTimeout: time.Second * 85, ReportTimeout: time.Second * 80, DiscoveryMinPeers: 42, CollectorHostPorts: []string{"1.2.3.4:555", "1.2.3.4:666"}},
 		},
 		{flags: []string{
 			"--collector.host-port=1.2.3.4:555,1.2.3.4:666",
 			"--discovery.min-peers=42",
 			"--discovery.conn-check-timeout=85s",
 		},
-			builder: Builder{ConnCheckTimeout: time.Second * 85, DiscoveryMinPeers: 42, CollectorHostPorts: []string{"1.2.3.4:555", "1.2.3.4:666"}},
+			builder: Builder{ConnCheckTimeout: time.Second * 85, ReportTimeout: defaultReportTimeout, DiscoveryMinPeers: 42, CollectorHostPorts: []string{"1.2.3.4:555", "1.2.3.4:666"}},
 		},
 		{flags: []string{
 			"--collector.host-port=1.2.3.4:555,1.2.3.4:666",
@@ -59,7 +60,7 @@ func TestBingFlags(t *testing.T) {
 			"--reporter.tchannel.discovery.min-peers=43",
 			"--reporter.tchannel.discovery.conn-check-timeout=86s",
 		},
-			builder: Builder{ConnCheckTimeout: time.Second * 86, DiscoveryMinPeers: 43, CollectorHostPorts: []string{"1.2.3.4:5556", "1.2.3.4:6667"}},
+			builder: Builder{ConnCheckTimeout: time.Second * 86, ReportTimeout: defaultReportTimeout, DiscoveryMinPeers: 43, CollectorHostPorts: []string{"1.2.3.4:5556", "1.2.3.4:6667"}},
 		},
 	}
 	for _, test := range tests {

--- a/cmd/agent/app/reporter/tchannel/reporter_test.go
+++ b/cmd/agent/app/reporter/tchannel/reporter_test.go
@@ -30,7 +30,7 @@ import (
 
 func initRequirements(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, *Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
-	reporter := New("jaeger-collector", collector.Channel, nil, zap.NewNop())
+	reporter := New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop())
 	return metricsFactory, collector, reporter
 }
 


### PR DESCRIPTION
So, this is less a fix for #1026 but more to kick off the discussion around: https://github.com/jaegertracing/jaeger/issues/927

While the original proposal has:
```
reporters:
    - kind: tchannel
      # tchannel-specific parameters, e.g.
      collector:
        hostPort: ...
      discovery:
        minPeers: 10
    - kind: grps
      # grpc-specific parameters
```

I kind of like:
```
tchannel:
# tchannel-config

grpc:
# grpc-config
```

I took a stab at implementing my version and turns out it's super straight forward and is very little changed code. But if the preference is to have the originally proposed format, I'll make the changes. But now I'm curious, can we 2 different `tchannel` reporters?

Note: This will be a breaking change.