### PR TITLE
Enable IAM based auth to ES for AWS clients (#465)

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 5ffbb7d077d2f42d30c8107c7c323b17e8fbc252fff78e24c5e19577cf942e04
-updated: 2018-08-13T15:02:55.899715-04:00
+updated: 2018-08-30T16:59:30.365812-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -7,12 +7,27 @@ imports:
   - lib/go/thrift
 - name: github.com/asaskevich/govalidator
   version: 852d82c746b23d9b357b210ea470d99f4e023b72
+- name: github.com/aws/aws-sdk-go
+  version: 65e0d510c9560c8d59b69ab2e9e1ded1d3c5ccac
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client/metadata
+  - aws/credentials
+  - aws/endpoints
+  - aws/request
+  - aws/signer/v4
+  - internal/sdkio
+  - internal/shareddefaults
+  - private/protocol
+  - private/protocol/rest
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/bsm/sarama-cluster
-  version: cf455bc755fe41ac9bb2861e7a961833d9c2ecc3
+  version: c618e605e15c0d7535f6c96ff8efbb0dba4fd66c
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/crossdock/crossdock-go
@@ -34,6 +49,8 @@ imports:
   version: 093482f3f8ce946c05bcba64badd2c82369e084d
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
+- name: github.com/go-ini/ini
+  version: 5cf292cae48347c2490ac1a58fe36735fb78df7e
 - name: github.com/go-kit/kit
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:
@@ -131,6 +148,8 @@ imports:
   - json/token
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/jmespath/go-jmespath
+  version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: github.com/kr/pretty
   version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 - name: github.com/magiconair/properties
@@ -203,6 +222,8 @@ imports:
   - fs
 - name: github.com/rcrowley/go-metrics
   version: e2704e165165ec55d062f5919b4b29494e9fa790
+- name: github.com/sha1sum/aws_signing_client
+  version: 9088e4c7b34b3174ae879fc975deb18ac62ac8d3
 - name: github.com/Shopify/sarama
   version: 35324cf48e33d8260e1c7c18854465a904ade249
   subpackages:
@@ -222,7 +243,7 @@ imports:
 - name: github.com/spf13/viper
   version: 907c19d40d9a6c9bb55f040ff4ae45271a4754b9
 - name: github.com/stretchr/objx
-  version: b8b73a35e9830ae509858c10dec5866b4d5c8bff
+  version: ef50b0de28773081167c97fc27cf29a0bf8b8c71
 - name: github.com/stretchr/testify
   version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
@@ -292,7 +313,7 @@ imports:
   - zapcore
   - zaptest
 - name: golang.org/x/net
-  version: c39426892332e1bb5ec0a434a079bf82f5d30c54
+  version: 8a410e7b638dca158bf9e766925842f6651ff828
   subpackages:
   - context
   - context/ctxhttp

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -19,7 +19,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/pkg/errors"
+	"github.com/sha1sum/aws_signing_client"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"gopkg.in/olivere/elastic.v5"
@@ -42,6 +45,12 @@ type Configuration struct {
 	BulkActions       int
 	BulkFlushInterval time.Duration
 	IndexPrefix       string
+	AwsIamConfig      AwsIamConfiguration
+}
+
+// AwsIamConfiguration describes the AWS-specific configuration needed to connect to ElasticSearch with IAM authn
+type AwsIamConfiguration struct {
+	Enabled bool
 }
 
 // ClientBuilder creates new es.Client
@@ -58,7 +67,13 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 	if len(c.Servers) < 1 {
 		return nil, errors.New("No servers specified")
 	}
-	rawClient, err := elastic.NewClient(c.GetConfigs()...)
+
+	clientOptionFuncs, err := c.GetConfigs()
+	if err != nil {
+		return nil, err
+	}
+
+	rawClient, err := elastic.NewClient(clientOptionFuncs...)
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +158,9 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.BulkFlushInterval == 0 {
 		c.BulkFlushInterval = source.BulkFlushInterval
 	}
+	if !c.AwsIamConfig.Enabled {
+		c.AwsIamConfig.Enabled = source.AwsIamConfig.Enabled
+	}
 }
 
 // GetNumShards returns number of shards from Configuration
@@ -166,10 +184,26 @@ func (c *Configuration) GetIndexPrefix() string {
 }
 
 // GetConfigs wraps the configs to feed to the ElasticSearch client init
-func (c *Configuration) GetConfigs() []elastic.ClientOptionFunc {
+func (c *Configuration) GetConfigs() ([]elastic.ClientOptionFunc, error) {
 	options := make([]elastic.ClientOptionFunc, 3)
 	options[0] = elastic.SetURL(c.Servers...)
 	options[1] = elastic.SetBasicAuth(c.Username, c.Password)
 	options[2] = elastic.SetSniff(c.Sniffer)
-	return options
+
+	// if AWS IAM is enabled, instantiate the elastic client with a signing client created via the AWS SDK
+	if c.AwsIamConfig.Enabled {
+		sess, err := session.NewSession()
+		if err != nil {
+			return nil, err
+		}
+
+		signer := v4.NewSigner(sess.Config.Credentials)
+		awsSigningClient, err := aws_signing_client.New(signer, nil, "es", *sess.Config.Region)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, elastic.SetHttpClient(awsSigningClient))
+	}
+
+	return options, nil
 }

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -37,6 +37,7 @@ const (
 	suffixBulkActions       = ".bulk.actions"
 	suffixBulkFlushInterval = ".bulk.flush-interval"
 	suffixIndexPrefix       = ".index-prefix"
+	suffixAwsIamEnabled     = ".aws.iam_enabled"
 )
 
 // TODO this should be moved next to config.Configuration struct (maybe ./flags package)
@@ -75,6 +76,9 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				BulkWorkers:       1,
 				BulkActions:       1000,
 				BulkFlushInterval: time.Millisecond * 200,
+				AwsIamConfig: config.AwsIamConfiguration{
+					Enabled: false,
+				},
 			},
 			servers:   "http://127.0.0.1:9200",
 			namespace: primaryNamespace,
@@ -146,6 +150,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixIndexPrefix,
 		nsConfig.IndexPrefix,
 		"Optional prefix of Jaeger indices. For example \"production\" creates \"production:jaeger-*\".")
+	flagSet.Bool(
+		nsConfig.namespace+suffixAwsIamEnabled,
+		nsConfig.AwsIamConfig.Enabled,
+		"Whether to connect to AWS ElasticSearch with IAM authentication. Requires the proper .aws/ files to be setup to connect.")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -169,6 +177,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.BulkActions = v.GetInt(cfg.namespace + suffixBulkActions)
 	cfg.BulkFlushInterval = v.GetDuration(cfg.namespace + suffixBulkFlushInterval)
 	cfg.IndexPrefix = v.GetString(cfg.namespace + suffixIndexPrefix)
+	cfg.AwsIamConfig.Enabled = v.GetBool(cfg.namespace + suffixAwsIamEnabled)
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -33,11 +33,13 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, int64(1), primary.NumReplicas)
 	assert.Equal(t, 72*time.Hour, primary.MaxSpanAge)
 	assert.False(t, primary.Sniffer)
+	assert.Equal(t, false, primary.AwsIamConfig.Enabled)
 
 	aux := opts.Get("archive")
 	assert.Equal(t, primary.Username, aux.Username)
 	assert.Equal(t, primary.Password, aux.Password)
 	assert.Equal(t, primary.Servers, aux.Servers)
+	assert.Equal(t, primary.AwsIamConfig, aux.AwsIamConfig)
 }
 
 func TestOptionsWithFlags(t *testing.T) {
@@ -50,7 +52,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.sniffer=true",
 		"--es.max-span-age=48h",
 		"--es.num-shards=20",
-		"--es.num-replicas=10",
+		"--es.aws.iam_enabled=true",
 		// a couple overrides
 		"--es.aux.server-urls=3.3.3.3,4.4.4.4",
 		"--es.aux.max-span-age=24h",
@@ -62,6 +64,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "hello", primary.Username)
 	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, primary.Servers)
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
+	assert.Equal(t, true, primary.AwsIamConfig.Enabled)
 	assert.True(t, primary.Sniffer)
 
 	aux := opts.Get("es.aux")


### PR DESCRIPTION
Allows clients to specify AWS IAM configuration
details for their connection to ElasticSearch.
We allow this to enable an additional layer
of security for those clients running on AWS.

More details on connecting to ElasticSearch
on AWS here: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html

Signed-off-by: Wesley Kim <wesley@squareup.com>