### PR TITLE
Actually log the error

### DIFF
--- a/cmd/agent/app/processors/thrift_processor.go
+++ b/cmd/agent/app/processors/thrift_processor.go
@@ -114,7 +114,7 @@ func (s *ThriftProcessor) processBuffer() {
 		s.server.DataRecd(readBuf) // acknowledge receipt and release the buffer
 
 		if ok, _ := s.handler.Process(protocol, protocol); !ok {
-			// TODO log the error
+			s.logger.Error("error: %v", zap.Error(e))
 			s.metrics.HandlerProcessError.Inc(1)
 		}
 		s.protocolPool.Put(protocol)


### PR DESCRIPTION
Hi,
It's useful to log eventual thrift protocol errors. In my case, I needed to fix the protocol from normal to compact to fix an issue between the nodejs client and the jaeger agent.
In my case, adding this log printed
"Expected protocol id 82 but got 80"
which was really useful to change my client's thrift configuration
Thx @nathis690 for help

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- 

## Short description of the changes
- 
