### PR TITLE
Add a 'save failed by service' metric, as currently a counter is only…

### DIFF
--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -42,9 +42,10 @@ type SpanProcessorMetrics struct { //TODO - initialize metrics in the traditiona
 	// ErrorBusy counts number of return ErrServerBusy
 	ErrorBusy metrics.Counter
 	// SavedBySvc contains span and trace counts by service
-	SavedBySvc   metricsBySvc  // spans actually saved
-	serviceNames metrics.Gauge // total number of unique service name metrics reported by this collector
-	spanCounts   map[string]CountsBySpanType
+	SavedBySvc      metricsBySvc  // spans actually saved
+	SaveFailedBySvc metricsBySvc  // spans failed to save
+	serviceNames    metrics.Gauge // total number of unique service name metrics reported by this collector
+	spanCounts      map[string]CountsBySpanType
 }
 
 type countsBySvc struct {
@@ -80,15 +81,16 @@ func NewSpanProcessorMetrics(serviceMetrics metrics.Factory, hostMetrics metrics
 		spanCounts[otherFormatType] = newCountsBySpanType(serviceMetrics.Namespace("", map[string]string{"format": otherFormatType}))
 	}
 	m := &SpanProcessorMetrics{
-		SaveLatency:    hostMetrics.Timer("save-latency", nil),
-		InQueueLatency: hostMetrics.Timer("in-queue-latency", nil),
-		SpansDropped:   hostMetrics.Counter("spans.dropped", nil),
-		BatchSize:      hostMetrics.Gauge("batch-size", nil),
-		QueueLength:    hostMetrics.Gauge("queue-length", nil),
-		ErrorBusy:      hostMetrics.Counter("error.busy", nil),
-		SavedBySvc:     newMetricsBySvc(serviceMetrics, "saved-by-svc"),
-		spanCounts:     spanCounts,
-		serviceNames:   hostMetrics.Gauge("spans.serviceNames", nil),
+		SaveLatency:     hostMetrics.Timer("save-latency", nil),
+		InQueueLatency:  hostMetrics.Timer("in-queue-latency", nil),
+		SpansDropped:    hostMetrics.Counter("spans.dropped", nil),
+		BatchSize:       hostMetrics.Gauge("batch-size", nil),
+		QueueLength:     hostMetrics.Gauge("queue-length", nil),
+		ErrorBusy:       hostMetrics.Counter("error.busy", nil),
+		SavedBySvc:      newMetricsBySvc(serviceMetrics, "saved-by-svc"),
+		SaveFailedBySvc: newMetricsBySvc(serviceMetrics, "save-failed-by-svc"),
+		spanCounts:      spanCounts,
+		serviceNames:    hostMetrics.Gauge("spans.serviceNames", nil),
 	}
 
 	return m

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -41,11 +41,11 @@ type SpanProcessorMetrics struct { //TODO - initialize metrics in the traditiona
 	QueueLength metrics.Gauge
 	// ErrorBusy counts number of return ErrServerBusy
 	ErrorBusy metrics.Counter
-	// SavedBySvc contains span and trace counts by service
-	SavedBySvc      metricsBySvc  // spans actually saved
-	SaveFailedBySvc metricsBySvc  // spans failed to save
-	serviceNames    metrics.Gauge // total number of unique service name metrics reported by this collector
-	spanCounts      map[string]CountsBySpanType
+	// SavedOkBySvc contains span and trace counts by service
+	SavedOkBySvc  metricsBySvc  // spans actually saved
+	SavedErrBySvc metricsBySvc  // spans failed to save
+	serviceNames  metrics.Gauge // total number of unique service name metrics reported by this collector
+	spanCounts    map[string]CountsBySpanType
 }
 
 type countsBySvc struct {
@@ -81,16 +81,16 @@ func NewSpanProcessorMetrics(serviceMetrics metrics.Factory, hostMetrics metrics
 		spanCounts[otherFormatType] = newCountsBySpanType(serviceMetrics.Namespace("", map[string]string{"format": otherFormatType}))
 	}
 	m := &SpanProcessorMetrics{
-		SaveLatency:     hostMetrics.Timer("save-latency", nil),
-		InQueueLatency:  hostMetrics.Timer("in-queue-latency", nil),
-		SpansDropped:    hostMetrics.Counter("spans.dropped", nil),
-		BatchSize:       hostMetrics.Gauge("batch-size", nil),
-		QueueLength:     hostMetrics.Gauge("queue-length", nil),
-		ErrorBusy:       hostMetrics.Counter("error.busy", nil),
-		SavedBySvc:      newMetricsBySvc(serviceMetrics, "saved-by-svc"),
-		SaveFailedBySvc: newMetricsBySvc(serviceMetrics, "save-failed-by-svc"),
-		spanCounts:      spanCounts,
-		serviceNames:    hostMetrics.Gauge("spans.serviceNames", nil),
+		SaveLatency:    hostMetrics.Timer("save-latency", nil),
+		InQueueLatency: hostMetrics.Timer("in-queue-latency", nil),
+		SpansDropped:   hostMetrics.Counter("spans.dropped", nil),
+		BatchSize:      hostMetrics.Gauge("batch-size", nil),
+		QueueLength:    hostMetrics.Gauge("queue-length", nil),
+		ErrorBusy:      hostMetrics.Counter("error.busy", nil),
+		SavedOkBySvc:   newMetricsBySvc(serviceMetrics.Namespace("", map[string]string{"result": "ok"}), "saved-by-svc"),
+		SavedErrBySvc:  newMetricsBySvc(serviceMetrics.Namespace("", map[string]string{"result": "err"}), "saved-by-svc"),
+		spanCounts:     spanCounts,
+		serviceNames:   hostMetrics.Gauge("spans.serviceNames", nil),
 	}
 
 	return m

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -100,11 +100,11 @@ func (sp *spanProcessor) saveSpan(span *model.Span) {
 	startTime := time.Now()
 	if err := sp.spanWriter.WriteSpan(span); err != nil {
 		sp.logger.Error("Failed to save span", zap.Error(err))
-		sp.metrics.SaveFailedBySvc.ReportServiceNameForSpan(span)
+		sp.metrics.SavedErrBySvc.ReportServiceNameForSpan(span)
 	} else {
 		sp.logger.Debug("Span written to the storage by the collector",
 			zap.Stringer("trace-id", span.TraceID), zap.Stringer("span-id", span.SpanID))
-		sp.metrics.SavedBySvc.ReportServiceNameForSpan(span)
+		sp.metrics.SavedOkBySvc.ReportServiceNameForSpan(span)
 	}
 	sp.metrics.SaveLatency.Record(time.Since(startTime))
 }

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -100,6 +100,7 @@ func (sp *spanProcessor) saveSpan(span *model.Span) {
 	startTime := time.Now()
 	if err := sp.spanWriter.WriteSpan(span); err != nil {
 		sp.logger.Error("Failed to save span", zap.Error(err))
+		sp.metrics.SaveFailedBySvc.ReportServiceNameForSpan(span)
 	} else {
 		sp.logger.Debug("Span written to the storage by the collector",
 			zap.Stringer("trace-id", span.TraceID), zap.Stringer("span-id", span.SpanID))

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -255,7 +255,7 @@ func TestSpanProcessorErrors(t *testing.T) {
 	}, logBuf.JSONLine(0))
 
 	expected := []metricsTest.ExpectedMetric{{
-		Name: "service.spans.save-failed-by-svc|debug=false|svc=x", Value: 1,
+		Name: "service.spans.saved-by-svc|debug=false|result=err|svc=x", Value: 1,
 	}}
 	metricsTest.AssertCounterMetrics(t, mb, expected...)
 }


### PR DESCRIPTION
… used to keep track of successful span saves

Signed-off-by: Gary Brown <gary@brownuk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Currently a counter is only available to record successfully saved spans. An error is reported if the write fails, but no counter is provided.

## Short description of the changes
Add a counter to record the number of span write failures.
