### PR TITLE
Prototype of a "relay" component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,10 @@ build-query:
 build-collector:
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/collector/collector-$(GOOS) $(BUILD_INFO) ./cmd/collector/main.go
 
+.PHONY: build-relay
+build-relay:
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/relay/relay-$(GOOS) $(BUILD_INFO) ./cmd/relay/main.go
+
 .PHONY: docker-no-ui
 docker-no-ui: build-binaries-linux build-crossdock-linux
 	make docker-images-only
@@ -218,7 +222,7 @@ build-binaries-darwin:
 	GOOS=darwin $(MAKE) build-platform-binaries
 
 .PHONY: build-platform-binaries
-build-platform-binaries: build-agent build-collector build-query build-all-in-one build-examples
+build-platform-binaries: build-agent build-relay build-collector build-query build-all-in-one build-examples
 
 .PHONY: build-all-platforms
 build-all-platforms: build-binaries-linux build-binaries-windows build-binaries-darwin
@@ -229,12 +233,17 @@ docker-images-only:
 	@echo "Finished building jaeger-cassandra-schema =============="
 	docker build -t $(DOCKER_NAMESPACE)/jaeger-es-index-cleaner:${DOCKER_TAG} plugin/storage/es
 	@echo "Finished building jaeger-es-indices-clean =============="
-	for component in agent collector query ; do \
+	for component in agent collector query relay ; do \
 		docker build -t $(DOCKER_NAMESPACE)/jaeger-$$component:${DOCKER_TAG} cmd/$$component ; \
 		echo "Finished building $$component ==============" ; \
 	done
 	docker build -t $(DOCKER_NAMESPACE)/test-driver:${DOCKER_TAG} crossdock/
 	@echo "Finished building test-driver ==============" ; \
+
+.PHONY: docker-relay
+docker-relay:
+	docker build -t $(DOCKER_NAMESPACE)/jaeger-relay:${DOCKER_TAG} cmd/relay ; \
+	echo "Finished building relay ==============" ; \
 
 .PHONY: docker-push
 docker-push:

--- a/cmd/relay/Dockerfile
+++ b/cmd/relay/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+EXPOSE 14267 14268 9411 14269
+COPY relay-linux /go/bin/
+ENTRYPOINT ["/go/bin/relay-linux"]

--- a/cmd/relay/app/builder/builder_flags.go
+++ b/cmd/relay/app/builder/builder_flags.go
@@ -1,0 +1,80 @@
+package builder
+
+import (
+	"flag"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	receiverJaegerTChannelPort = "receiver.jaeger.tchannel-port"
+	receiverJaegerHTTPPort     = "receiver.jaeger.http-port"
+	receiverZipkinHTTPort      = "receiver.zipkin.http-port"
+
+	reporterTChannelHostPort                  = "reporter.tchannel.host-port"
+	reporterTChannelDiscoveryMinPeers         = "reporter.tchannel.discovery.min-peers"
+	reporterTChannelDiscoveryConnCheckTimeout = "reporter.tchannel.discovery.conn-check-timeout"
+
+	// RelayDefaultHealthCheckHTTPPort is the default HTTP Port for health check
+	RelayDefaultHealthCheckHTTPPort = 14269
+
+	defaultMinPeers         = 3
+	defaultConnCheckTimeout = 250 * time.Millisecond
+)
+
+// ReceiverOptions holds configuration for receivers
+type ReceiverOptions struct {
+	// ReceiverJaegerTchannelPort is the port that the relay receives on for tchannel requests
+	ReceiverJaegerTChannelPort int
+	// ReceiverJaegerHTTPPort is the port that the relay receives on for http requests
+	ReceiverJaegerHTTPPort int
+	// ReceiverZipkinHTTPPort is the port that the relay receives on for zipkin http requests
+	ReceiverZipkinHTTPPort int
+}
+
+// ReporterOptions holds configuration for reporters
+type ReporterOptions struct {
+	ReporterTChannelHostPorts                 []string
+	ReporterTChannelDiscoveryMinPeers         int
+	ReporterTChannelDiscoveryConnCheckTimeout time.Duration
+}
+
+// AddFlags adds flags for ReceiverOptions
+func AddFlags(flags *flag.FlagSet) {
+	flags.Int(receiverJaegerTChannelPort, 14267, "The tchannel port for the Jaeger receiver service")
+	flags.Int(receiverJaegerHTTPPort, 14268, "The http port for the Jaeger receiver service")
+	flags.Int(receiverZipkinHTTPort, 9411, "The http port for the Zipkin reciver service e.g. 9411")
+
+	flags.String(
+		reporterTChannelHostPort,
+		"",
+		"comma-separated string representing host:ports of a static list of collectors to connect to directly (e.g. when not using service discovery)")
+	flags.Int(
+		reporterTChannelDiscoveryMinPeers,
+		defaultMinPeers,
+		"if using service discovery, the min number of connections to maintain to the backend")
+	flags.Duration(
+		reporterTChannelDiscoveryConnCheckTimeout,
+		defaultConnCheckTimeout,
+		"sets the timeout used when establishing new connections")
+}
+
+// InitFromViper initializes CollectorOptions with properties from viper
+func (rOpts *ReceiverOptions) InitFromViper(v *viper.Viper) *ReceiverOptions {
+	rOpts.ReceiverJaegerTChannelPort = v.GetInt(receiverJaegerTChannelPort)
+	rOpts.ReceiverJaegerHTTPPort = v.GetInt(receiverJaegerHTTPPort)
+	rOpts.ReceiverZipkinHTTPPort = v.GetInt(receiverZipkinHTTPort)
+	return rOpts
+}
+
+// InitFromViper initializes ReporterBuilder with properties from viper
+func (rOpts *ReporterOptions) InitFromViper(v *viper.Viper) *ReporterOptions {
+	if len(v.GetString(reporterTChannelHostPort)) > 0 {
+		rOpts.ReporterTChannelHostPorts = strings.Split(v.GetString(reporterTChannelHostPort), ",")
+	}
+	rOpts.ReporterTChannelDiscoveryMinPeers = v.GetInt(reporterTChannelDiscoveryMinPeers)
+	rOpts.ReporterTChannelDiscoveryConnCheckTimeout = v.GetDuration(reporterTChannelDiscoveryConnCheckTimeout)
+	return rOpts
+}

--- a/cmd/relay/app/span_batch_thrift_reporter.go
+++ b/cmd/relay/app/span_batch_thrift_reporter.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"github.com/uber/jaeger-lib/metrics"
+	"go.uber.org/zap"
+
+	reporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
+	"github.com/jaegertracing/jaeger/model"
+	jConv "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
+	tmodel "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+)
+
+type batchMetrics struct {
+	// Number of successful batch submissions to collector
+	BatchesSubmitted metrics.Counter `metric:"batches.submitted"`
+
+	// Number of failed batch submissions to collector
+	BatchesFailures metrics.Counter `metric:"batches.failures"`
+
+	// Number of spans in a batch submitted to collector
+	BatchSize metrics.Gauge `metric:"batch_size"`
+
+	// Number of successful span submissions to collector
+	SpansSubmitted metrics.Counter `metric:"spans.submitted"`
+
+	// Number of failed span submissions to collector
+	SpansFailures metrics.Counter `metric:"spans.failures"`
+}
+
+// SpanBatchThriftReporter takes jaeger model batches and sends them
+// out on tchannel
+type SpanBatchThriftReporter struct {
+	logger       *zap.Logger
+	reporter     reporter.Reporter
+	batchMetrics batchMetrics
+}
+
+// NewSpanBatchThriftReporter creates new TChannel-based Reporter.
+func NewSpanBatchThriftReporter(
+	reporter reporter.Reporter,
+	mFactory metrics.Factory,
+	zlogger *zap.Logger,
+) *SpanBatchThriftReporter {
+	bm := batchMetrics{}
+	metrics.Init(&bm, mFactory.Namespace("span-batch-thrift-reporter", nil), nil)
+	return &SpanBatchThriftReporter{
+		logger:       zlogger,
+		reporter:     reporter,
+		batchMetrics: bm,
+	}
+}
+
+// ProcessSpans implements SpanProcessor interface
+func (s *SpanBatchThriftReporter) ProcessSpans(mSpans []*model.Span, spanFormat string) ([]bool, error) {
+	tSpans := jConv.FromDomain(mSpans)
+	tBatch := &tmodel.Batch{Spans: tSpans}
+	oks := make([]bool, len(mSpans))
+	if err := s.reporter.EmitBatch(tBatch); err != nil {
+		s.logger.Error("Reporter failed to report span batch", zap.Error(err))
+		for i := range oks {
+			oks[i] = false
+		}
+		return oks, err
+	}
+	for i := range oks {
+		oks[i] = true
+	}
+	return oks, nil
+}

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	tchannel "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
+	"go.uber.org/zap"
+
+	tchReporter "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
+	collectorApp "github.com/jaegertracing/jaeger/cmd/collector/app"
+	zs "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
+	"github.com/jaegertracing/jaeger/cmd/collector/app/zipkin"
+	"github.com/jaegertracing/jaeger/cmd/env"
+	"github.com/jaegertracing/jaeger/cmd/flags"
+	"github.com/jaegertracing/jaeger/cmd/relay/app"
+	"github.com/jaegertracing/jaeger/cmd/relay/app/builder"
+	"github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/healthcheck"
+	"github.com/jaegertracing/jaeger/pkg/metrics"
+	pMetrics "github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/pkg/recoveryhandler"
+	"github.com/jaegertracing/jaeger/pkg/version"
+	jc "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	zc "github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+)
+
+const serviceName = "jaeger-relay"
+
+func main() {
+	var signalsChannel = make(chan os.Signal)
+	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
+
+	v := viper.New()
+	var command = &cobra.Command{
+		Use:   "jaeger-relay",
+		Short: "Jaeger relay is a utility program which relays span data.",
+		Long:  `Jaeger relay is a utility program that can receive data over thrift/grpc and relay to thrift/grpc receiver.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := flags.TryLoadConfigFile(v)
+			if err != nil {
+				return err
+			}
+
+			sFlags := new(flags.SharedFlags).InitFromViper(v)
+			logger, err := sFlags.NewLogger(zap.NewProductionConfig())
+			if err != nil {
+				return err
+			}
+			hc, err := sFlags.NewHealthCheck(logger)
+			if err != nil {
+				logger.Fatal("Could not start the health check server.", zap.Error(err))
+				return err
+			}
+
+			builderOpts := new(builder.ReceiverOptions).InitFromViper(v)
+			reporterOpts := new(builder.ReporterOptions).InitFromViper(v)
+
+			mBldr := new(pMetrics.Builder).InitFromViper(v)
+			baseFactory, err := mBldr.CreateMetricsFactory("jaeger")
+			if err != nil {
+				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
+				return err
+			}
+
+			metricsFactory := baseFactory.Namespace("relay", nil)
+			ch, err := tchannel.NewChannel(serviceName, &tchannel.ChannelOptions{})
+			if err != nil {
+				logger.Fatal("Unable to create new TChannel", zap.Error(err))
+				return err
+			}
+			server := thrift.NewServer(ch)
+			tchrepbuilder := &tchReporter.Builder{
+				CollectorHostPorts: reporterOpts.ReporterTChannelHostPorts,
+				ConnCheckTimeout:   reporterOpts.ReporterTChannelDiscoveryConnCheckTimeout,
+				DiscoveryMinPeers:  reporterOpts.ReporterTChannelDiscoveryMinPeers,
+			}
+			tchreporter, err := tchrepbuilder.CreateReporter(metricsFactory, logger)
+			if err != nil {
+				logger.Fatal("Cannot create tchannel reporter.", zap.Error(err))
+				return err
+			}
+			spanBatchReporter := app.NewSpanBatchThriftReporter(
+				tchreporter, metricsFactory, logger)
+			jaegerBatchesHandler := collectorApp.NewJaegerSpanHandler(logger, spanBatchReporter)
+			zSanitizer := zs.NewChainedSanitizer(
+				zs.NewSpanDurationSanitizer(),
+				zs.NewSpanStartTimeSanitizer(),
+				zs.NewParentIDSanitizer(),
+				zs.NewErrorTagSanitizer(),
+			)
+			zipkinSpansHandler := collectorApp.NewZipkinSpanHandler(logger, spanBatchReporter, zSanitizer)
+			server.Register(jc.NewTChanCollectorServer(jaegerBatchesHandler))
+			server.Register(zc.NewTChanZipkinCollectorServer(zipkinSpansHandler))
+
+			portStr := ":" + strconv.Itoa(builderOpts.ReceiverJaegerTChannelPort)
+			listener, err := net.Listen("tcp", portStr)
+			if err != nil {
+				logger.Fatal("Unable to start listening on channel", zap.Error(err))
+			}
+			ch.Serve(listener)
+
+			r := mux.NewRouter()
+			apiHandler := collectorApp.NewAPIHandler(jaegerBatchesHandler)
+			apiHandler.RegisterRoutes(r)
+			if h := mBldr.Handler(); h != nil {
+				logger.Info("Registering metrics handler with HTTP server", zap.String("route", mBldr.HTTPRoute))
+				r.Handle(mBldr.HTTPRoute, h)
+			}
+			httpPortStr := ":" + strconv.Itoa(builderOpts.ReceiverJaegerHTTPPort)
+			recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
+
+			go startZipkinHTTPAPI(logger, builderOpts.ReceiverZipkinHTTPPort, zipkinSpansHandler, recoveryHandler)
+
+			logger.Info("Starting HTTP server", zap.Int("http-port", builderOpts.ReceiverJaegerHTTPPort))
+
+			go func() {
+				if err := http.ListenAndServe(httpPortStr, recoveryHandler(r)); err != nil {
+					logger.Fatal("Could not launch service", zap.Error(err))
+				}
+				hc.Set(healthcheck.Unavailable)
+			}()
+
+			hc.Ready()
+			<-signalsChannel
+			logger.Info("Shutting down")
+
+			logger.Info("Shutdown complete")
+			return nil
+		},
+	}
+
+	command.AddCommand(version.Command())
+	command.AddCommand(env.Command())
+
+	flags.SetDefaultHealthCheckPort(builder.RelayDefaultHealthCheckHTTPPort)
+
+	config.AddFlags(
+		v,
+		command,
+		flags.AddConfigFileFlag,
+		flags.AddFlags,
+		flags.AddLoggingFlag,
+		builder.AddFlags,
+		metrics.AddFlags,
+	)
+
+	if err := command.Execute(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}
+
+func startZipkinHTTPAPI(
+	logger *zap.Logger,
+	zipkinPort int,
+	zipkinSpansHandler collectorApp.ZipkinSpansHandler,
+	recoveryHandler func(http.Handler) http.Handler,
+) {
+	if zipkinPort != 0 {
+		zHandler := zipkin.NewAPIHandler(zipkinSpansHandler)
+		r := mux.NewRouter()
+		zHandler.RegisterRoutes(r)
+
+		httpPortStr := ":" + strconv.Itoa(zipkinPort)
+		logger.Info("Listening for Zipkin HTTP traffic", zap.Int("zipkin.http-port", zipkinPort))
+
+		if err := http.ListenAndServe(httpPortStr, recoveryHandler(r)); err != nil {
+			logger.Fatal("Could not launch service", zap.Error(err))
+		}
+	}
+}


### PR DESCRIPTION
This change prototypes a relay component. The goal of this component
is to be a drop-in replacement for jaeger-collector, but instead of
writing to cassandra (or another writer) relay the spans to another
jaeger-collector (or compatible) instance.

Currently, the relay is its own component. In future, it could be
potentially merged into the jaeger-collector repo.

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- 

## Short description of the changes
- 
