### PR TITLE
Make the metrics produced by jaeger query scoped to the query compone…

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
+	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
 	jc "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	sc "github.com/jaegertracing/jaeger/thrift-gen/sampling"
 	zc "github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -285,6 +286,8 @@ func startQuery(
 		logger.Fatal("Failed to initialize tracer", zap.Error(err))
 	}
 	opentracing.SetGlobalTracer(tracer)
+
+	spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace("query", nil))
 
 	apiHandler := queryApp.NewAPIHandler(
 		spanReader,

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/plugin/storage"
 	istorage "github.com/jaegertracing/jaeger/storage"
+	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
 )
 
 func main() {
@@ -107,6 +108,7 @@ func main() {
 			if err != nil {
 				logger.Fatal("Failed to create span reader", zap.Error(err))
 			}
+			spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace("query", nil))
 			dependencyReader, err := storageFactory.CreateDependencyReader()
 			if err != nil {
 				logger.Fatal("Failed to create dependency reader", zap.Error(err))

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -29,7 +29,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
-	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
 )
 
 const (
@@ -109,7 +108,7 @@ type SpanReaderParams struct {
 
 // NewSpanReader returns a new SpanReader with a metrics.
 func NewSpanReader(p SpanReaderParams) spanstore.Reader {
-	return storageMetrics.NewReadMetricsDecorator(newSpanReader(p), p.MetricsFactory)
+	return newSpanReader(p)
 }
 
 func newSpanReader(p SpanReaderParams) *SpanReader {


### PR DESCRIPTION
…nt, and generated for all span readers (not just ES)

Signed-off-by: Gary Brown <gary@brownuk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Two problems:
1) metrics provided by collector, agent and client are all scoped to the component name - the query metrics were not, so the 'query' component has now been added
2) metrics were only being generated when the ES storage was used - the metrics decorator now wraps any span reader impl. 

## Short description of the changes
Moved use of the span reader decorator to the `all-in-one` and `query` mains, so it wraps any span reader impl. Added namespace scope 'query' to be consistent with metrics reported for other components.
