### PR TITLE
Consolidate query metrics and include result tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changes by Version
 ==================
 
+1.8.0 (unreleased)
+------------------
+
+#### Backend Changes
+
+##### Breaking Changes
+
+- Consolidate query metrics and include result tag ([#1075](https://github.com/jaegertracing/jaeger/pull/1075), [@objectiser](https://github.com/objectiser)
+- Make the metrics produced by jaeger query scoped to the query component, and generated for all span readers (not just ES) ([#1074](https://github.com/jaegertracing/jaeger/pull/1074), [@objectiser](https://github.com/objectiser)
+
+
 1.7.0 (2018-09-19)
 ------------------
 

--- a/storage/spanstore/metrics/decorator.go
+++ b/storage/spanstore/metrics/decorator.go
@@ -66,8 +66,8 @@ func NewReadMetricsDecorator(spanReader spanstore.Reader, metricsFactory metrics
 func buildQueryMetrics(namespace string, metricsFactory metrics.Factory) *queryMetrics {
 	scoped := metricsFactory.Namespace(namespace, nil)
 	qMetrics := &queryMetrics{
-		Errors:     scoped.Counter("requests", map[string]string{"result": "err"}),
-		Successes:  scoped.Counter("requests", map[string]string{"result": "ok"}),
+		Errors:     scoped.Counter("", map[string]string{"result": "err"}),
+		Successes:  scoped.Counter("", map[string]string{"result": "ok"}),
 		Responses:  scoped.Timer("responses", nil),
 		ErrLatency: scoped.Timer("latency", map[string]string{"result": "err"}),
 		OKLatency:  scoped.Timer("latency", map[string]string{"result": "ok"}),

--- a/storage/spanstore/metrics/decorator.go
+++ b/storage/spanstore/metrics/decorator.go
@@ -35,7 +35,6 @@ type ReadMetricsDecorator struct {
 
 type queryMetrics struct {
 	Errors     metrics.Counter
-	Attempts   metrics.Counter
 	Successes  metrics.Counter
 	Responses  metrics.Timer //used as a histogram, not necessary for GetTrace
 	ErrLatency metrics.Timer

--- a/storage/spanstore/metrics/decorator.go
+++ b/storage/spanstore/metrics/decorator.go
@@ -34,16 +34,15 @@ type ReadMetricsDecorator struct {
 }
 
 type queryMetrics struct {
-	Errors     metrics.Counter `metric:"errors"`
-	Attempts   metrics.Counter `metric:"attempts"`
-	Successes  metrics.Counter `metric:"successes"`
-	Responses  metrics.Timer   `metric:"responses"` //used as a histogram, not necessary for GetTrace
-	ErrLatency metrics.Timer   `metric:"errLatency"`
-	OKLatency  metrics.Timer   `metric:"okLatency"`
+	Errors     metrics.Counter
+	Attempts   metrics.Counter
+	Successes  metrics.Counter
+	Responses  metrics.Timer //used as a histogram, not necessary for GetTrace
+	ErrLatency metrics.Timer
+	OKLatency  metrics.Timer
 }
 
 func (q *queryMetrics) emit(err error, latency time.Duration, responses int) {
-	q.Attempts.Inc(1)
 	if err != nil {
 		q.Errors.Inc(1)
 		q.ErrLatency.Record(latency)
@@ -66,9 +65,14 @@ func NewReadMetricsDecorator(spanReader spanstore.Reader, metricsFactory metrics
 }
 
 func buildQueryMetrics(namespace string, metricsFactory metrics.Factory) *queryMetrics {
-	qMetrics := &queryMetrics{}
 	scoped := metricsFactory.Namespace(namespace, nil)
-	metrics.Init(qMetrics, scoped, nil)
+	qMetrics := &queryMetrics{
+		Errors:     scoped.Counter("requests", map[string]string{"result": "err"}),
+		Successes:  scoped.Counter("requests", map[string]string{"result": "ok"}),
+		Responses:  scoped.Timer("responses", nil),
+		ErrLatency: scoped.Timer("latency", map[string]string{"result": "err"}),
+		OKLatency:  scoped.Timer("latency", map[string]string{"result": "ok"}),
+	}
 	return qMetrics
 }
 

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -43,27 +43,23 @@ func TestSuccessfulUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations.attempts":  1,
-		"get_operations.successes": 1,
-		"get_operations.errors":    0,
-		"get_trace.attempts":       1,
-		"get_trace.successes":      1,
-		"get_trace.errors":         0,
-		"find_traces.attempts":     1,
-		"find_traces.successes":    1,
-		"find_traces.errors":       0,
-		"get_services.attempts":    1,
-		"get_services.successes":   1,
-		"get_services.errors":      0,
+		"get_operations.requests|result=ok":  1,
+		"get_operations.requests|result=err": 0,
+		"get_trace.requests|result=ok":       1,
+		"get_trace.requests|result=err":      0,
+		"find_traces.requests|result=ok":     1,
+		"find_traces.requests|result=err":    0,
+		"get_services.requests|result=ok":    1,
+		"get_services.requests|result=err":   0,
 	}
 
 	existingKeys := []string{
-		"get_operations.okLatency.P50",
+		"get_operations.latency|result=ok.P50",
 		"get_trace.responses.P50",
-		"find_traces.okLatency.P50", // this is not exhaustive
+		"find_traces.latency|result=ok.P50", // this is not exhaustive
 	}
 	nonExistentKeys := []string{
-		"get_operations.errLatency.P50",
+		"get_operations.latency|result=err.P50",
 	}
 
 	checkExpectedExistingAndNonExistentCounters(t, counters, expecteds, gauges, existingKeys, nonExistentKeys)
@@ -100,28 +96,24 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations.attempts":  1,
-		"get_operations.successes": 0,
-		"get_operations.errors":    1,
-		"get_trace.attempts":       1,
-		"get_trace.successes":      0,
-		"get_trace.errors":         1,
-		"find_traces.attempts":     1,
-		"find_traces.successes":    0,
-		"find_traces.errors":       1,
-		"get_services.attempts":    1,
-		"get_services.successes":   0,
-		"get_services.errors":      1,
+		"get_operations.requests|result=ok":  0,
+		"get_operations.requests|result=err": 1,
+		"get_trace.requests|result=ok":       0,
+		"get_trace.requests|result=err":      1,
+		"find_traces.requests|result=ok":     0,
+		"find_traces.requests|result=err":    1,
+		"get_services.requests|result=ok":    0,
+		"get_services.requests|result=err":   1,
 	}
 
 	existingKeys := []string{
-		"get_operations.errLatency.P50",
+		"get_operations.latency|result=err.P50",
 	}
 
 	nonExistentKeys := []string{
-		"get_operations.okLatency.P50",
+		"get_operations.latency|result=ok.P50",
 		"get_trace.responses.P50",
-		"query.okLatency.P50", // this is not exhaustive
+		"query.latency|result=ok.P50", // this is not exhaustive
 	}
 
 	checkExpectedExistingAndNonExistentCounters(t, counters, expecteds, gauges, existingKeys, nonExistentKeys)

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -43,14 +43,14 @@ func TestSuccessfulUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations.requests|result=ok":  1,
-		"get_operations.requests|result=err": 0,
-		"get_trace.requests|result=ok":       1,
-		"get_trace.requests|result=err":      0,
-		"find_traces.requests|result=ok":     1,
-		"find_traces.requests|result=err":    0,
-		"get_services.requests|result=ok":    1,
-		"get_services.requests|result=err":   0,
+		"get_operations|result=ok":  1,
+		"get_operations|result=err": 0,
+		"get_trace|result=ok":       1,
+		"get_trace|result=err":      0,
+		"find_traces|result=ok":     1,
+		"find_traces|result=err":    0,
+		"get_services|result=ok":    1,
+		"get_services|result=err":   0,
 	}
 
 	existingKeys := []string{
@@ -96,14 +96,14 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations.requests|result=ok":  0,
-		"get_operations.requests|result=err": 1,
-		"get_trace.requests|result=ok":       0,
-		"get_trace.requests|result=err":      1,
-		"find_traces.requests|result=ok":     0,
-		"find_traces.requests|result=err":    1,
-		"get_services.requests|result=ok":    0,
-		"get_services.requests|result=err":   1,
+		"get_operations|result=ok":  0,
+		"get_operations|result=err": 1,
+		"get_trace|result=ok":       0,
+		"get_trace|result=err":      1,
+		"find_traces|result=ok":     0,
+		"find_traces|result=err":    1,
+		"get_services|result=ok":    0,
+		"get_services|result=err":   1,
 	}
 
 	existingKeys := []string{


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Currently jaeger-query produces a set of metrics for the following operations: find traces, get operations, get services and get trace.

The set of metrics are (only showing one bucket for histograms):
```
jaeger_find_traces_attempts 1
jaeger_find_traces_errLatency_bucket{le="0.005"} 0
jaeger_find_traces_errors 0
jaeger_find_traces_okLatency_bucket{le="0.005"} 0
jaeger_find_traces_responses_bucket{le="0.005"} 1
jaeger_find_traces_successes 1
```
Errors and successes for latency and counters are separated out (including a further counter representing the total counts).

This PR consolidates the metrics to use common name with a `result` tag representing ok or err states.

## Short description of the changes
Have a single counter `find_traces_requests` with tag result (ok, err) to replace the attempts/errors/successes counters. So total (successes) is the count(find_traces_requests) and errors/successes can be determined by querying based on the tag.

Also combined the two latency based metrics and added a tag for result (ok/err).

```
jaeger_query_find_traces_latency_bucket{result="err",le="0.005"} 0
jaeger_query_find_traces_latency_bucket{result="ok",le="0.005"} 0
jaeger_query_find_traces_requests{result="err"} 0
jaeger_query_find_traces_requests{result="ok"} 0
jaeger_query_find_traces_responses_bucket{le="0.005"} 0
```
NOTE: Have not included the `sum` and `count` values for the histograms.