### PR TITLE
Refactor agent configuration

### DIFF
--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -33,6 +33,7 @@ import (
 
 func TestAgentStartError(t *testing.T) {
 	cfg := &Builder{}
+	configureSamplingManager(t, cfg)
 	agent, err := cfg.CreateAgent(zap.NewNop())
 	require.NoError(t, err)
 	agent.httpServer.Addr = "bad-address"
@@ -100,6 +101,7 @@ func withRunningAgent(t *testing.T, testcase func(string, chan error)) {
 		},
 	}
 	logger, logBuf := testutils.NewLogger()
+	configureSamplingManager(t, &cfg)
 	agent, err := cfg.CreateAgent(logger)
 	require.NoError(t, err)
 	ch := make(chan error, 2)

--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -34,8 +34,7 @@ import (
 
 func TestAgentStartError(t *testing.T) {
 	cfg := &Builder{}
-	configureSamplingManager(t, cfg, metrics.NullFactory)
-	agent, err := cfg.CreateAgent(zap.NewNop(), metrics.NullFactory)
+	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
 	require.NoError(t, err)
 	agent.httpServer.Addr = "bad-address"
 	assert.Error(t, agent.Run())
@@ -103,8 +102,7 @@ func withRunningAgent(t *testing.T, testcase func(string, chan error)) {
 	}
 	logger, logBuf := testutils.NewLogger()
 	f, _ := cfg.Metrics.CreateMetricsFactory("jaeger")
-	configureSamplingManager(t, &cfg, f)
-	agent, err := cfg.CreateAgent(logger, f)
+	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, logger, f)
 	require.NoError(t, err)
 	ch := make(chan error, 2)
 	go func() {

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -126,10 +126,6 @@ func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create metrics factory")
 	}
-
-	if err != nil {
-		return nil, err
-	}
 	r, err := b.getReporter(logger)
 	if err != nil {
 		return nil, err

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -68,9 +68,8 @@ type Builder struct {
 	HTTPServer HTTPServerConfiguration  `yaml:"httpServer"`
 	Metrics    jmetrics.Builder         `yaml:"metrics"`
 
-	reporters      []reporter.Reporter
-	metricsFactory metrics.Factory
-	configManager  httpserver.ClientConfigManager
+	reporters     []reporter.Reporter
+	configManager httpserver.ClientConfigManager
 }
 
 // ProcessorConfiguration holds config for a processor that receives spans from Server
@@ -99,33 +98,8 @@ func (b *Builder) WithReporters(r ...reporter.Reporter) *Builder {
 	return b
 }
 
-// WithMetricsFactory sets an externally initialized metrics factory.
-func (b *Builder) WithMetricsFactory(mf metrics.Factory) *Builder {
-	b.metricsFactory = mf
-	return b
-}
-
-// GetMetricsFactory returns metrics factory used by the agent.
-func (b *Builder) GetMetricsFactory() (metrics.Factory, error) {
-	if b.metricsFactory != nil {
-		return b.metricsFactory, nil
-	}
-
-	baseFactory, err := b.Metrics.CreateMetricsFactory("jaeger")
-	if err != nil {
-		return nil, err
-	}
-
-	b.metricsFactory = baseFactory.Namespace("agent", nil)
-	return b.metricsFactory, nil
-}
-
 // CreateAgent creates the Agent
-func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
-	mFactory, err := b.GetMetricsFactory()
-	if err != nil {
-		return nil, errors.Wrap(err, "cannot create metrics factory")
-	}
+func (b *Builder) CreateAgent(logger *zap.Logger, mFactory metrics.Factory) (*Agent, error) {
 	r, err := b.getReporter(logger)
 	if err != nil {
 		return nil, err

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -144,6 +144,8 @@ func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
 func (b *Builder) getReporter(logger *zap.Logger) (reporter.Reporter, error) {
 	if len(b.reporters) == 0 {
 		return nil, errors.New("Missing required reporters")
+	} else if len(b.reporters) == 1 {
+		return b.reporters[0], nil
 	}
 	return reporter.NewMultiReporter(b.reporters...), nil
 }

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -30,6 +30,23 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
+func TestDefault(t *testing.T) {
+	tests := []struct {
+		b      *Builder
+		errMsg string
+	}{
+		{b: &Builder{}, errMsg: "Missing required reporters"},
+		{b: (&Builder{}).WithReporters(&fakeReporter{}), errMsg: "Missing required Client config manager"},
+	}
+
+	for _, test := range tests {
+		a, err := test.b.CreateAgent(zap.NewNop())
+		require.Error(t, err)
+		assert.Equal(t, test.errMsg, err.Error())
+		assert.Nil(t, a)
+	}
+}
+
 var yamlConfig = `
 ignored: abcd
 
@@ -160,6 +177,7 @@ func TestBuilderWithProcessorErrors(t *testing.T) {
 				},
 			},
 		}
+		cfg.WithReporters(&fakeReporter{})
 		_, err := cfg.CreateAgent(zap.NewNop())
 		assert.Error(t, err)
 		if testCase.err != "" {

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -102,7 +102,6 @@ func TestBuilderFromConfig(t *testing.T) {
 
 func TestBuilderWithExtraReporter(t *testing.T) {
 	cfg := &Builder{}
-	//configureSamplingManager(t, cfg, metrics.NullFactory)
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
 	assert.NoError(t, err)
 	assert.NotNil(t, agent)
@@ -110,7 +109,6 @@ func TestBuilderWithExtraReporter(t *testing.T) {
 
 func TestBuilderMetricsHandler(t *testing.T) {
 	b := &Builder{}
-	//configureSamplingManager(t, b, metrics.NullFactory)
 	b.Metrics.Backend = "expvar"
 	b.Metrics.HTTPRoute = "/expvar"
 	agent, err := b.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -156,7 +156,7 @@ func TestMultipleCollectorProxies(t *testing.T) {
 	b := Builder{}
 	ra := fakeCollectorProxy{}
 	rb := fakeCollectorProxy{}
-	b.WithCollectorProxy(ra)
+	b.WithReporter(ra)
 	r := b.getReporter(rb)
 	mr, ok := r.(reporter.MultiReporter)
 	require.True(t, ok)

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -17,7 +17,6 @@ package app
 import (
 	"flag"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -27,10 +26,7 @@ const (
 	suffixServerQueueSize     = "server-queue-size"
 	suffixServerMaxPacketSize = "server-max-packet-size"
 	suffixServerHostPort      = "server-host-port"
-	collectorHostPort         = "collector.host-port"
 	httpServerHostPort        = "http-server.host-port"
-	discoveryMinPeers         = "discovery.min-peers"
-	discoveryConnCheckTimeout = "discovery.conn-check-timeout"
 )
 
 var defaultProcessors = []struct {
@@ -53,21 +49,9 @@ func AddFlags(flags *flag.FlagSet) {
 		flags.String(prefix+suffixServerHostPort, processor.hostPort, "host:port for the UDP server")
 	}
 	flags.String(
-		collectorHostPort,
-		"",
-		"comma-separated string representing host:ports of a static list of collectors to connect to directly (e.g. when not using service discovery)")
-	flags.String(
 		httpServerHostPort,
 		defaultHTTPServerHostPort,
 		"host:port of the http server (e.g. for /sampling point and /baggage endpoint)")
-	flags.Int(
-		discoveryMinPeers,
-		defaultMinPeers,
-		"if using service discovery, the min number of connections to maintain to the backend")
-	flags.Duration(
-		discoveryConnCheckTimeout,
-		defaultConnCheckTimeout,
-		"sets the timeout used when establishing new connections")
 }
 
 // InitFromViper initializes Builder with properties retrieved from Viper.
@@ -84,11 +68,6 @@ func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
 		b.Processors = append(b.Processors, *p)
 	}
 
-	if len(v.GetString(collectorHostPort)) > 0 {
-		b.CollectorHostPorts = strings.Split(v.GetString(collectorHostPort), ",")
-	}
 	b.HTTPServer.HostPort = v.GetString(httpServerHostPort)
-	b.DiscoveryMinPeers = v.GetInt(discoveryMinPeers)
-	b.ConnCheckTimeout = v.GetDuration(discoveryConnCheckTimeout)
 	return b
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tchannel
+
+import (
+	"github.com/uber/jaeger-lib/metrics"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/agent/app/httpserver"
+)
+
+// ProxyBuilder holds objects communicating with collector
+type ProxyBuilder struct {
+	reporter *Reporter
+	manager  httpserver.ClientConfigManager
+}
+
+// NewCollectorProxy creates ProxyBuilder
+func NewCollectorProxy(builder *Builder, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
+	b := &ProxyBuilder{}
+	r, err := builder.CreateReporter(mFactory, logger)
+	if err != nil {
+		return nil, err
+	}
+	b.reporter = r
+	b.manager = httpserver.NewCollectorProxy(b.reporter.CollectorServiceName(), b.reporter.Channel(), mFactory)
+	return b, nil
+}
+
+// GetReporter returns Reporter
+func (b *ProxyBuilder) GetReporter() *Reporter {
+	return b.reporter
+}
+
+// GetManager returns manager
+func (b *ProxyBuilder) GetManager() httpserver.ClientConfigManager {
+	return b.manager
+}

--- a/cmd/agent/app/reporter/tchannel/collector_proxy.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/httpserver"
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 )
 
 // ProxyBuilder holds objects communicating with collector
@@ -40,11 +41,11 @@ func NewCollectorProxy(builder *Builder, mFactory metrics.Factory, logger *zap.L
 }
 
 // GetReporter returns Reporter
-func (b *ProxyBuilder) GetReporter() *Reporter {
+func (b ProxyBuilder) GetReporter() reporter.Reporter {
 	return b.reporter
 }
 
 // GetManager returns manager
-func (b *ProxyBuilder) GetManager() httpserver.ClientConfigManager {
+func (b ProxyBuilder) GetManager() httpserver.ClientConfigManager {
 	return b.manager
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tchannel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-lib/metrics"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/agent/app/httpserver"
+)
+
+func TestErrorReporterBuilder(t *testing.T) {
+	tbuilder := NewBuilder().WithDiscoverer(fakeDiscoverer{})
+	b, err := NewCollectorProxy(tbuilder, metrics.NullFactory, zap.NewNop())
+	require.Error(t, err)
+	assert.Nil(t, b)
+}
+
+func TestCreate(t *testing.T) {
+	cfg := &Builder{}
+	mFactory := metrics.NullFactory
+	logger := zap.NewNop()
+	b, err := NewCollectorProxy(cfg, mFactory, logger)
+	require.NoError(t, err)
+	assert.NotNil(t, b)
+	r, _ := cfg.CreateReporter(mFactory, logger)
+	assert.Equal(t, r, b.GetReporter())
+	m := httpserver.NewCollectorProxy(r.CollectorServiceName(), r.Channel(), mFactory)
+	assert.Equal(t, m, b.GetManager())
+}

--- a/cmd/agent/app/reporter/tchannel/flags.go
+++ b/cmd/agent/app/reporter/tchannel/flags.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tchannel
+
+import (
+	"flag"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	defaultConnCheckTimeout   = 250 * time.Millisecond
+	tchannelPrefix            = "reporter.tchannel."
+	collectorHostPort         = tchannelPrefix + "collector.host-port"
+	discoveryMinPeers         = tchannelPrefix + "discovery.min-peers"
+	discoveryConnCheckTimeout = tchannelPrefix + "discovery.conn-check-timeout"
+)
+
+// AddFlags adds flags for Builder.
+func AddFlags(flags *flag.FlagSet) {
+	flags.String(
+		collectorHostPort,
+		"",
+		"comma-separated string representing host:ports of a static list of collectors to connect to directly (e.g. when not using service discovery)")
+	flags.Int(
+		discoveryMinPeers,
+		defaultMinPeers,
+		"if using service discovery, the min number of connections to maintain to the backend")
+	flags.Duration(
+		discoveryConnCheckTimeout,
+		defaultConnCheckTimeout,
+		"sets the timeout used when establishing new connections")
+}
+
+// InitFromViper initializes Builder with properties retrieved from Viper.
+func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
+	if len(v.GetString(collectorHostPort)) > 0 {
+		b.CollectorHostPorts = strings.Split(v.GetString(collectorHostPort), ",")
+	}
+	b.DiscoveryMinPeers = v.GetInt(discoveryMinPeers)
+	b.ConnCheckTimeout = v.GetDuration(discoveryConnCheckTimeout)
+	return b
+}

--- a/cmd/agent/app/reporter/tchannel/flags_test.go
+++ b/cmd/agent/app/reporter/tchannel/flags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2018 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package app
+package tchannel
 
 import (
 	"flag"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -34,19 +35,14 @@ func TestBingFlags(t *testing.T) {
 	v.BindPFlags(command.PersistentFlags())
 
 	err := command.ParseFlags([]string{
-		"--http-server.host-port=:8080",
-		"--processor.jaeger-binary.server-host-port=:1111",
-		"--processor.jaeger-binary.server-max-packet-size=4242",
-		"--processor.jaeger-binary.server-queue-size=42",
-		"--processor.jaeger-binary.workers=42",
+		"--reporter.tchannel.collector.host-port=1.2.3.4:555,1.2.3.4:666",
+		"--reporter.tchannel.discovery.min-peers=42",
+		"--reporter.tchannel.discovery.conn-check-timeout=85s",
 	})
 	require.NoError(t, err)
 
 	b.InitFromViper(v)
-	assert.Equal(t, 3, len(b.Processors))
-	assert.Equal(t, ":8080", b.HTTPServer.HostPort)
-	assert.Equal(t, ":1111", b.Processors[2].Server.HostPort)
-	assert.Equal(t, 4242, b.Processors[2].Server.MaxPacketSize)
-	assert.Equal(t, 42, b.Processors[2].Server.QueueSize)
-	assert.Equal(t, 42, b.Processors[2].Workers)
+	assert.Equal(t, 42, b.DiscoveryMinPeers)
+	assert.Equal(t, []string{"1.2.3.4:555", "1.2.3.4:666"}, b.CollectorHostPorts)
+	assert.Equal(t, time.Second*85, b.ConnCheckTimeout)
 }

--- a/cmd/agent/app/reporter/tchannel/reporter.go
+++ b/cmd/agent/app/reporter/tchannel/reporter.go
@@ -57,6 +57,7 @@ type Reporter struct {
 	peerListMgr    *peerlistmgr.PeerListManager
 	batchesMetrics map[string]batchMetrics
 	logger         *zap.Logger
+	serviceName    string
 }
 
 // New creates new TChannel-based Reporter.
@@ -83,6 +84,7 @@ func New(
 		peerListMgr:    peerListMgr,
 		logger:         zlogger,
 		batchesMetrics: batchesMetrics,
+		serviceName:    collectorServiceName,
 	}
 }
 
@@ -135,4 +137,9 @@ func (r *Reporter) submitAndReport(submissionFunc func(ctx thrift.Context) error
 	batchMetrics.BatchesSubmitted.Inc(1)
 	batchMetrics.SpansSubmitted.Inc(size)
 	return nil
+}
+
+// CollectorServiceName returns collector service name.
+func (r *Reporter) CollectorServiceName() string {
+	return r.serviceName
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app"
-	"github.com/jaegertracing/jaeger/cmd/agent/app/httpserver"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/pkg/config"
@@ -61,12 +60,12 @@ func main() {
 			}
 			mFactory = mFactory.Namespace("agent", nil)
 
-			r, err := tchanRep.CreateReporter(mFactory, logger)
+			cp, err := tchannel.NewCollectorProxy(tchanRep, mFactory, logger)
 			if err != nil {
-				logger.Fatal("Could not create tchannel reporter", zap.Error(err))
+				logger.Fatal("Could not create collector proxy", zap.Error(err))
 			}
-			builder.WithReporters(r)
-			builder.WithClientConfigManager(httpserver.NewCollectorProxy(r.CollectorServiceName(), r.Channel(), mFactory))
+			builder.WithReporters(cp.GetReporter())
+			builder.WithClientConfigManager(cp.GetManager())
 
 			// TODO illustrate discovery service wiring
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -64,12 +64,10 @@ func main() {
 			if err != nil {
 				logger.Fatal("Could not create collector proxy", zap.Error(err))
 			}
-			builder.WithReporters(cp.GetReporter())
-			builder.WithClientConfigManager(cp.GetManager())
 
 			// TODO illustrate discovery service wiring
 
-			agent, err := builder.CreateAgent(logger, mFactory)
+			agent, err := builder.CreateAgent(cp, logger, mFactory)
 			if err != nil {
 				return errors.Wrap(err, "Unable to initialize Jaeger Agent")
 			}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -52,7 +52,7 @@ func main() {
 
 			builder := &app.Builder{}
 			builder.InitFromViper(v)
-			tchanRep := tchannel.NewBuilder().InitFromViper(v)
+			tchanRep := tchannel.NewBuilder().InitFromViper(v, logger)
 			mFactory, err := builder.GetMetricsFactory()
 			if err != nil {
 				logger.Fatal("Could not create metrics", zap.Error(err))

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -53,10 +53,14 @@ func main() {
 			builder := &app.Builder{}
 			builder.InitFromViper(v)
 			tchanRep := tchannel.NewBuilder().InitFromViper(v, logger)
-			mFactory, err := builder.GetMetricsFactory()
+			mBldr := new(metrics.Builder).InitFromViper(v)
+
+			mFactory, err := mBldr.CreateMetricsFactory("jaeger")
 			if err != nil {
 				logger.Fatal("Could not create metrics", zap.Error(err))
 			}
+			mFactory = mFactory.Namespace("agent", nil)
+
 			r, err := tchanRep.CreateReporter(mFactory, logger)
 			if err != nil {
 				logger.Fatal("Could not create tchannel reporter", zap.Error(err))
@@ -66,7 +70,7 @@ func main() {
 
 			// TODO illustrate discovery service wiring
 
-			agent, err := builder.CreateAgent(logger)
+			agent, err := builder.CreateAgent(logger, mFactory)
 			if err != nil {
 				return errors.Wrap(err, "Unable to initialize Jaeger Agent")
 			}

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -184,10 +184,8 @@ func startAgent(
 	if err != nil {
 		logger.Fatal("Could not create collector proxy", zap.Error(err))
 	}
-	b.WithReporters(cp.GetReporter())
-	b.WithClientConfigManager(cp.GetManager())
 
-	agent, err := b.CreateAgent(logger, baseFactory)
+	agent, err := b.CreateAgent(cp, logger, baseFactory)
 	if err != nil {
 		logger.Fatal("Unable to initialize Jaeger Agent", zap.Error(err))
 	}

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -188,7 +188,7 @@ func startAgent(
 	b.WithReporters(r)
 	b.WithClientConfigManager(httpserver.NewCollectorProxy(r.CollectorServiceName(), r.Channel(), metricsFactory))
 
-	agent, err := b.WithMetricsFactory(metricsFactory).CreateAgent(logger)
+	agent, err := b.CreateAgent(logger, baseFactory)
 	if err != nil {
 		logger.Fatal("Unable to initialize Jaeger Agent", zap.Error(err))
 	}

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -180,6 +180,7 @@ func startAgent(
 ) {
 	metricsFactory := baseFactory.Namespace("agent", nil)
 
+	tchanRep.CollectorHostPorts = append(tchanRep.CollectorHostPorts, fmt.Sprintf("127.0.0.1:%d", cOpts.CollectorPort))
 	cp, err := agentTchanRep.NewCollectorProxy(tchanRep, metricsFactory, logger)
 	if err != nil {
 		logger.Fatal("Could not create collector proxy", zap.Error(err))

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -126,7 +126,7 @@ func main() {
 			samplingHandler := initializeSamplingHandler(strategyStoreFactory, v, metricsFactory, logger)
 
 			aOpts := new(agentApp.Builder).InitFromViper(v)
-			tchannelRep := agentTchanRep.NewBuilder().InitFromViper(v)
+			tchannelRep := agentTchanRep.NewBuilder().InitFromViper(v, logger)
 			cOpts := new(collector.CollectorOptions).InitFromViper(v)
 			qOpts := new(queryApp.QueryOptions).InitFromViper(v)
 

--- a/docker-compose/jaeger-docker-compose.yml
+++ b/docker-compose/jaeger-docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
     jaeger-agent:
       image: jaegertracing/jaeger-agent
-      command: ["--collector.host-port=jaeger-collector:14267"]
+      command: ["--reporter.tchannel.collector.host-port=jaeger-collector:14267"]
       ports:
         - "5775:5775/udp"
         - "6831:6831/udp"


### PR DESCRIPTION
Resolves: #927 

* agent tchannel flags moved to `reporter.tchannel.*`
* agent reporters have to be specified explicitly `b.WithReporters` - if none added create fails
* agent client configuration manager have to be specified explicitly `b.WithClientConfigManager` - if none added create fails

