### PR TITLE
[ingester] Add metrics& healthcheck, rename Kafka cli flags

### DIFF
--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -107,7 +107,7 @@ func (o *Options) InitFromViper(v *viper.Viper) {
 	o.Brokers = strings.Split(v.GetString(KafkaConfigPrefix+SuffixBrokers), ",")
 	o.Topic = v.GetString(KafkaConfigPrefix + SuffixTopic)
 	o.GroupID = v.GetString(KafkaConfigPrefix + SuffixGroupID)
+	o.Encoding = v.GetString(KafkaConfigPrefix + SuffixEncoding)
 	o.Parallelism = v.GetInt(ConfigPrefix + SuffixParallelism)
-	o.Encoding = v.GetString(ConfigPrefix + SuffixEncoding)
 	o.IngesterHTTPPort = v.GetInt(ConfigPrefix + SuffixHTTPPort)
 }

--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -33,7 +33,7 @@ const (
 
 	// ConfigPrefix is a prefix for the ingester flags
 	ConfigPrefix = "ingester"
-	// KafkaConfigPrefix is a prefix for the ingester flags
+	// KafkaConfigPrefix is a prefix for the Kafka flags
 	KafkaConfigPrefix = "kafka"
 	// SuffixBrokers is a suffix for the brokers flag
 	SuffixBrokers = ".brokers"

--- a/cmd/ingester/app/flags_test.go
+++ b/cmd/ingester/app/flags_test.go
@@ -26,11 +26,12 @@ func TestOptionsWithFlags(t *testing.T) {
 	o := &Options{}
 	v, command := config.Viperize(AddFlags)
 	command.ParseFlags([]string{
-		"--ingester.topic=topic1",
-		"--ingester.brokers=127.0.0.1:9092,0.0.0:1234",
-		"--ingester.group-id=group1",
+		"--kafka.topic=topic1",
+		"--kafka.brokers=127.0.0.1:9092,0.0.0:1234",
+		"--kafka.group-id=group1",
+		"--kafka.encoding=json",
 		"--ingester.parallelism=5",
-		"--ingester.encoding=json"})
+		"--ingester.http-port=2345"})
 	o.InitFromViper(v)
 
 	assert.Equal(t, "topic1", o.Topic)
@@ -38,6 +39,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "group1", o.GroupID)
 	assert.Equal(t, 5, o.Parallelism)
 	assert.Equal(t, EncodingJSON, o.Encoding)
+	assert.Equal(t, 2345, o.IngesterHTTPPort)
 }
 
 func TestFlagDefaults(t *testing.T) {

--- a/plugin/storage/integration/kafka_test.go
+++ b/plugin/storage/integration/kafka_test.go
@@ -48,7 +48,7 @@ func (s *KafkaIntegrationTestSuite) initialize() error {
 	topic := "jaeger-kafka-integration-test-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
 	f := kafka.NewFactory()
-	v, command := config.Viperize(f.AddFlags, app.AddFlags)
+	v, command := config.Viperize(app.AddFlags)
 	command.ParseFlags([]string{
 		"--kafka.topic",
 		topic,


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/jaeger/issues/1014
Resolves https://github.com/jaegertracing/jaeger/issues/1013
Resolves https://github.com/jaegertracing/jaeger/issues/1093

## Short description of the changes
- Add default healthcheck port (14270)
- Add a configurable metrics HTTP handler (default port is 14271)
- Make Kafka flags the same as in the Collector (prefix is `kafka` instead of `ingester`)

## Comments:
I wasn't sure if I should have refactor the following:
- Move the various Kafka flags under `/pkg`
 - I left it as is mainly because there's a mix of consumer vs producer flags and because the producer flags are under `plugins`

Also, should the `Parallelism` be under Kafka prefix? I felt it was more a `ingester` flags than a `kafka` one, but I don't have any strong opinion about it
