### PR TITLE
Specify metric name/tags via annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Changes by Version
 
 ##### Breaking Changes
 
-- Consolidate query metrics and include result tag ([#1075](https://github.com/jaegertracing/jaeger/pull/1075), [@objectiser](https://github.com/objectiser)
-- Make the metrics produced by jaeger query scoped to the query component, and generated for all span readers (not just ES) ([#1074](https://github.com/jaegertracing/jaeger/pull/1074), [@objectiser](https://github.com/objectiser)
+- Consolidate query metrics and include result tag ([#1075](https://github.com/jaegertracing/jaeger/pull/1075) and [#1096](https://github.com/jaegertracing/jaeger/pull/1096), [@objectiser](https://github.com/objectiser))
+- Make the metrics produced by jaeger query scoped to the query component, and generated for all span readers (not just ES) ([#1074](https://github.com/jaegertracing/jaeger/pull/1074), [@objectiser](https://github.com/objectiser))
 
 
 1.7.0 (2018-09-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,28 @@ Changes by Version
 
 ##### Breaking Changes
 
-- Consolidate query metrics and include result tag ([#1075](https://github.com/jaegertracing/jaeger/pull/1075) and [#1096](https://github.com/jaegertracing/jaeger/pull/1096), [@objectiser](https://github.com/objectiser))
-- Make the metrics produced by jaeger query scoped to the query component, and generated for all span readers (not just ES) ([#1074](https://github.com/jaegertracing/jaeger/pull/1074), [@objectiser](https://github.com/objectiser))
+- Various changes around metrics produced by jaeger-query: Names scoped to the query component, generated for all span readers (not just ES), consolidate query metrics and include result tag ([#1074](https://github.com/jaegertracing/jaeger/pull/1074), [#1075](https://github.com/jaegertracing/jaeger/pull/1075) and [#1096](https://github.com/jaegertracing/jaeger/pull/1096), [@objectiser](https://github.com/objectiser))
+
+For example, sample of metrics produced for `find_traces` operation before:
+
+```
+jaeger_find_traces_attempts 1
+jaeger_find_traces_errLatency_bucket{le="0.005"} 0
+jaeger_find_traces_errors 0
+jaeger_find_traces_okLatency_bucket{le="0.005"} 0
+jaeger_find_traces_responses_bucket{le="0.005"} 1
+jaeger_find_traces_successes 1
+```
+
+And now:
+
+```
+jaeger_query_latency_bucket{operation="find_traces",result="err",le="0.005"} 0
+jaeger_query_latency_bucket{operation="find_traces",result="ok",le="0.005"} 2
+jaeger_query_requests{operation="find_traces",result="err"} 0
+jaeger_query_requests{operation="find_traces",result="ok"} 2
+jaeger_query_responses_bucket{operation="find_traces",le="0.005"} 2
+```
 
 
 1.7.0 (2018-09-19)

--- a/storage/spanstore/metrics/decorator.go
+++ b/storage/spanstore/metrics/decorator.go
@@ -34,8 +34,8 @@ type ReadMetricsDecorator struct {
 }
 
 type queryMetrics struct {
-	Errors     metrics.Counter `metric:"calls" tags:"result=err"`
-	Successes  metrics.Counter `metric:"calls" tags:"result=ok"`
+	Errors     metrics.Counter `metric:"requests" tags:"result=err"`
+	Successes  metrics.Counter `metric:"requests" tags:"result=ok"`
 	Responses  metrics.Timer   `metric:"responses"` //used as a histogram, not necessary for GetTrace
 	ErrLatency metrics.Timer   `metric:"latency" tags:"result=err"`
 	OKLatency  metrics.Timer   `metric:"latency" tags:"result=ok"`
@@ -63,9 +63,9 @@ func NewReadMetricsDecorator(spanReader spanstore.Reader, metricsFactory metrics
 	}
 }
 
-func buildQueryMetrics(namespace string, metricsFactory metrics.Factory) *queryMetrics {
+func buildQueryMetrics(operation string, metricsFactory metrics.Factory) *queryMetrics {
 	qMetrics := &queryMetrics{}
-	scoped := metricsFactory.Namespace(namespace, nil)
+	scoped := metricsFactory.Namespace("", map[string]string{"operation": operation})
 	metrics.Init(qMetrics, scoped, nil)
 	return qMetrics
 }

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -43,14 +43,14 @@ func TestSuccessfulUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations|result=ok":  1,
-		"get_operations|result=err": 0,
-		"get_trace|result=ok":       1,
-		"get_trace|result=err":      0,
-		"find_traces|result=ok":     1,
-		"find_traces|result=err":    0,
-		"get_services|result=ok":    1,
-		"get_services|result=err":   0,
+		"get_operations.calls|result=ok":  1,
+		"get_operations.calls|result=err": 0,
+		"get_trace.calls|result=ok":       1,
+		"get_trace.calls|result=err":      0,
+		"find_traces.calls|result=ok":     1,
+		"find_traces.calls|result=err":    0,
+		"get_services.calls|result=ok":    1,
+		"get_services.calls|result=err":   0,
 	}
 
 	existingKeys := []string{
@@ -96,14 +96,14 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations|result=ok":  0,
-		"get_operations|result=err": 1,
-		"get_trace|result=ok":       0,
-		"get_trace|result=err":      1,
-		"find_traces|result=ok":     0,
-		"find_traces|result=err":    1,
-		"get_services|result=ok":    0,
-		"get_services|result=err":   1,
+		"get_operations.calls|result=ok":  0,
+		"get_operations.calls|result=err": 1,
+		"get_trace.calls|result=ok":       0,
+		"get_trace.calls|result=err":      1,
+		"find_traces.calls|result=ok":     0,
+		"find_traces.calls|result=err":    1,
+		"get_services.calls|result=ok":    0,
+		"get_services.calls|result=err":   1,
 	}
 
 	existingKeys := []string{

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -43,23 +43,23 @@ func TestSuccessfulUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations.calls|result=ok":  1,
-		"get_operations.calls|result=err": 0,
-		"get_trace.calls|result=ok":       1,
-		"get_trace.calls|result=err":      0,
-		"find_traces.calls|result=ok":     1,
-		"find_traces.calls|result=err":    0,
-		"get_services.calls|result=ok":    1,
-		"get_services.calls|result=err":   0,
+		"requests|operation=get_operations|result=ok":  1,
+		"requests|operation=get_operations|result=err": 0,
+		"requests|operation=get_trace|result=ok":       1,
+		"requests|operation=get_trace|result=err":      0,
+		"requests|operation=find_traces|result=ok":     1,
+		"requests|operation=find_traces|result=err":    0,
+		"requests|operation=get_services|result=ok":    1,
+		"requests|operation=get_services|result=err":   0,
 	}
 
 	existingKeys := []string{
-		"get_operations.latency|result=ok.P50",
-		"get_trace.responses.P50",
-		"find_traces.latency|result=ok.P50", // this is not exhaustive
+		"latency|operation=get_operations|result=ok.P50",
+		"responses|operation=get_trace.P50",
+		"latency|operation=find_traces|result=ok.P50", // this is not exhaustive
 	}
 	nonExistentKeys := []string{
-		"get_operations.latency|result=err.P50",
+		"latency|operation=get_operations|result=err.P50",
 	}
 
 	checkExpectedExistingAndNonExistentCounters(t, counters, expecteds, gauges, existingKeys, nonExistentKeys)
@@ -96,24 +96,24 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 	mrs.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 	counters, gauges := mf.Snapshot()
 	expecteds := map[string]int64{
-		"get_operations.calls|result=ok":  0,
-		"get_operations.calls|result=err": 1,
-		"get_trace.calls|result=ok":       0,
-		"get_trace.calls|result=err":      1,
-		"find_traces.calls|result=ok":     0,
-		"find_traces.calls|result=err":    1,
-		"get_services.calls|result=ok":    0,
-		"get_services.calls|result=err":   1,
+		"requests|operation=get_operations|result=ok":  0,
+		"requests|operation=get_operations|result=err": 1,
+		"requests|operation=get_trace|result=ok":       0,
+		"requests|operation=get_trace|result=err":      1,
+		"requests|operation=find_traces|result=ok":     0,
+		"requests|operation=find_traces|result=err":    1,
+		"requests|operation=get_services|result=ok":    0,
+		"requests|operation=get_services|result=err":   1,
 	}
 
 	existingKeys := []string{
-		"get_operations.latency|result=err.P50",
+		"latency|operation=get_operations|result=err.P50",
 	}
 
 	nonExistentKeys := []string{
-		"get_operations.latency|result=ok.P50",
-		"get_trace.responses.P50",
-		"query.latency|result=ok.P50", // this is not exhaustive
+		"latency|operation=get_operations|result=ok.P50",
+		"responses|operation=get_trace.P50",
+		"latency|operation=query|result=ok.P50", // this is not exhaustive
 	}
 
 	checkExpectedExistingAndNonExistentCounters(t, counters, expecteds, gauges, existingKeys, nonExistentKeys)


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Addresses https://github.com/jaegertracing/jaeger/pull/1075#discussion_r221322279

Only issue is that the metric field needs a name, empty string does not work, so have called the overall counter(success/error) 'calls'. If another word is preferred let me know.

## Short description of the changes
Revert to using the annotation approach for defining metrics.
