### PR TITLE
Replace glide novendor, fix gosec lint to exclude crossdock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,6 @@
 PROJECT_ROOT=github.com/jaegertracing/jaeger
 # TOP_PKGS is used with 'go test'
-# TODO: try to do this without glide, since it may not be installed initially
-TOP_PKGS := $(shell glide novendor | \
-	sort | \
-	grep -v \
-		-e ./thrift-gen/... \
-		-e ./swagger-gen/... \
-		-e ./examples/... \
-		-e ./scripts/...\
-	)
+TOP_PKGS := $(shell ./scripts/list-packages.sh .)
 STORAGE_PKGS = ./plugin/storage/integration/...
 
 # all .go files that are not auto-generated and should be auto-formatted and linted.
@@ -128,7 +120,7 @@ fmt:
 
 .PHONY: lint-gosec
 lint-gosec:
-	$(GOSEC) $(TOP_PKGS)
+	$(GOSEC) $(filter-out ./crossdock/...,$(TOP_PKGS))
 
 .PHONY: lint
 lint: lint-gosec

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_ROOT=github.com/jaegertracing/jaeger
 # TOP_PKGS is used with 'go test'
-TOP_PKGS := $(shell ./scripts/list-packages.sh .) .
+TOP_PKGS := . $(shell ./scripts/list-packages.sh . | tr '\n' ' ')
 STORAGE_PKGS = ./plugin/storage/integration/...
 
 # all .go files that are not auto-generated and should be auto-formatted and linted.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_ROOT=github.com/jaegertracing/jaeger
 # TOP_PKGS is used with 'go test'
-TOP_PKGS := $(shell ./scripts/list-packages.sh .)
+TOP_PKGS := $(shell ./scripts/list-packages.sh .) .
 STORAGE_PKGS = ./plugin/storage/integration/...
 
 # all .go files that are not auto-generated and should be auto-formatted and linted.
@@ -26,7 +26,7 @@ GOTEST=go test -v $(RACE)
 GOLINT=golint
 GOVET=go vet
 GOFMT=gofmt
-GOSEC=gosec -quiet -exclude=G104,G107
+GOSEC=gosec -quiet -exclude=G104
 GOSIMPLE=gosimple
 FMT_LOG=fmt.log
 LINT_LOG=lint.log

--- a/scripts/list-packages.sh
+++ b/scripts/list-packages.sh
@@ -5,9 +5,14 @@ set -euo pipefail
 function listPackages() {
 	local d
 	local dirs
-	dirs=$(find -E . -mindepth 1 -maxdepth 1 -type d -not -regex '\./(vendor|thrift-gen|swagger-gen|examples|scripts)' | sed 's|^./||g')
+	dirs=$(find . -mindepth 1 -maxdepth 1 -type d \
+		-not -path './vendor' \
+		-not -path './thrift-gen' \
+		-not -path './swagger-gen' \
+		-not -path './examples' \
+		-not -path './scripts')
 	for d in $dirs; do
-		find "$d" -name '*.go' -type f -exec echo "./$d/..." \; -quit
+		find "$d" -name '*.go' -type f -exec echo "$d/..." \; -quit
 	done
 }
 

--- a/scripts/list-packages.sh
+++ b/scripts/list-packages.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function listPackages() {
+	local d
+	local dirs
+	dirs=$(find -E . -mindepth 1 -maxdepth 1 -type d -not -regex '\./(vendor|thrift-gen|swagger-gen|examples|scripts)' | sed 's|^./||g')
+	for d in $dirs; do
+		find "$d" -name '*.go' -type f -exec echo "./$d/..." \; -quit | sed -e 's|^\./\./|./|g'
+	done
+}
+
+listPackages "$1"

--- a/scripts/list-packages.sh
+++ b/scripts/list-packages.sh
@@ -7,7 +7,7 @@ function listPackages() {
 	local dirs
 	dirs=$(find -E . -mindepth 1 -maxdepth 1 -type d -not -regex '\./(vendor|thrift-gen|swagger-gen|examples|scripts)' | sed 's|^./||g')
 	for d in $dirs; do
-		find "$d" -name '*.go' -type f -exec echo "./$d/..." \; -quit | sed -e 's|^\./\./|./|g'
+		find "$d" -name '*.go' -type f -exec echo "./$d/..." \; -quit
 	done
 }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

- Resolves #1097.

- Exclude crossdock from gosec
- Replace `glide novendor` with custom bash script