### PR TITLE
Fix processor overriding ReadBuf data

### DIFF
--- a/cmd/agent/app/processors/thrift_processor.go
+++ b/cmd/agent/app/processors/thrift_processor.go
@@ -111,13 +111,13 @@ func (s *ThriftProcessor) processBuffer() {
 		payload := readBuf.GetBytes()
 		protocol.Transport().Write(payload)
 		s.logger.Debug("Span(s) received by the agent", zap.Int("bytes-received", len(payload)))
-		s.server.DataRecd(readBuf) // acknowledge receipt and release the buffer
 
-		if ok, _ := s.handler.Process(protocol, protocol); !ok {
-			// TODO log the error
+		if ok, err := s.handler.Process(protocol, protocol); !ok {
+			s.logger.Error("Processor failed", zap.Error(err))
 			s.metrics.HandlerProcessError.Inc(1)
 		}
 		s.protocolPool.Put(protocol)
+		s.server.DataRecd(readBuf) // acknowledge receipt and release the buffer
 	}
 	s.processing.Done()
 }


### PR DESCRIPTION
ReadBuf byte slice can be overriden before processing in processor is finished.

```
{"level":"error","ts":1538663826.591028,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: *jaeger.Tag field 7 read error: don't know what type: %!s(thrift.tCompactType=14)","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663827.887695,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Log error reading struct: don't know what type: %!s(thrift.tCompactType=14)","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663827.9029524,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: error reading field 1: Invalid data length","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663827.9916568,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Log error reading struct: *jaeger.Tag error reading struct: error reading field 1: Invalid data length","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.0100384,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: *jaeger.Tag field -58 read error: don't know what type: %!s(thrift.tCompactType=13)","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.0260687,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: Required field VType is not set","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.0396416,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: Required field Key is not set","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.0613725,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: don't know what type: %!s(thrift.tCompactType=14)","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.0657265,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: Required field TraceIdLow is not set","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.1010654,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: Required field TraceIdHigh is not set","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.1204793,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: *jaeger.Tag field 13 read error: don't know what type: %!s(thrift.tCompactType=14)","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.1882222,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Log error reading struct: *jaeger.Tag error reading struct: don't know what type: %!s(thrift.tCompactType=14)","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.2727396,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Tag error reading struct: don't know what type: %!s(thrift.tCompactType=14)","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.3243358,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Log error reading struct: *jaeger.Tag error reading struct: error reading field 3: Invalid data length","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
{"level":"error","ts":1538663828.3399134,"caller":"processors/thrift_processor.go:117","msg":"Processor failed","error":"*jaeger.Batch error reading struct: *jaeger.Span error reading struct: *jaeger.Log error reading struct: Required field Timestamp is not set","stacktrace":"github.com/jaegertracing/jaeger/cmd/agent/app/processors.(*ThriftProcessor).processBuffer\n\t/home/ploffay/projects/golang/src/github.com/jaegertracing/jaeger/cmd/agent/app/processors/thrift_processor.go:117"}
^C{"level":"info","ts":1538663830.0657444,"caller":"all-in-one/main.go:135","msg":"Shutting down"}
{"level":"info","ts":1538663830.0658135,"caller":"all-in-one/main.go:142","msg":"Shutdown complete"}
```