### PR TITLE
[agent] Added ping endpoint to agent for connectivity check

### DIFF
--- a/cmd/agent/app/httpserver/server.go
+++ b/cmd/agent/app/httpserver/server.go
@@ -40,6 +40,9 @@ func NewHTTPServer(hostPort string, manager ClientConfigManager, mFactory metric
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		handler.serveSamplingHTTP(w, r, true /* thriftEnums092 */)
 	})
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		handler.servePingHTTP(w, r)
+	})
 	mux.HandleFunc("/sampling", func(w http.ResponseWriter, r *http.Request) {
 		handler.serveSamplingHTTP(w, r, false /* thriftEnums092 */)
 	})
@@ -128,6 +131,10 @@ func (h *httpHandler) serveSamplingHTTP(w http.ResponseWriter, r *http.Request, 
 	} else {
 		h.metrics.SamplingRequestSuccess.Inc(1)
 	}
+}
+
+func (h *httpHandler) servePingHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h *httpHandler) serveBaggageHTTP(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/app/httpserver/server_test.go
+++ b/cmd/agent/app/httpserver/server_test.go
@@ -87,6 +87,12 @@ func TestHTTPHandler(t *testing.T) {
 			})
 		}
 
+		t.Run("request against endpoint /ping", func(t *testing.T) {
+			resp, err := http.Get(ts.server.URL + "/ping?service=Y")
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
 		t.Run("request against endpoint /baggage", func(t *testing.T) {
 			resp, err := http.Get(ts.server.URL + "/baggageRestrictions?service=Y")
 			require.NoError(t, err)


### PR DESCRIPTION
Fixes #1007 

## Which problem is this PR solving?
- It is hard to know for sure that a trace generated at a client will reach the collector. 

## Short description of the changes
- This PR starts out by adding a ping endpoint to the agent that the client can check with before sending traces. Future commits will be aimed at extending this connectivity check to the collector.

Signed-off-by: Annanay Agarwal <agarwal.ansh@yahoo.co.in>
