### PR TITLE
Use new jaeger-lib metricstest

### DIFF
--- a/cmd/agent/app/httpserver/collector_proxy_test.go
+++ b/cmd/agent/app/httpserver/collector_proxy_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"github.com/uber/tchannel-go/thrift"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
@@ -59,7 +59,7 @@ func TestCollectorProxy(t *testing.T) {
 	assert.EqualValues(t, 10, bResp[0].MaxValueLength)
 
 	// must emit metrics
-	mTestutils.AssertCounterMetrics(t, metricsFactory, []mTestutils.ExpectedMetric{
+	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 		{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "sampling"}, Value: 1},
 		{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "sampling"}, Value: 0},
 		{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "baggage"}, Value: 1},
@@ -68,14 +68,14 @@ func TestCollectorProxy(t *testing.T) {
 }
 
 func TestTCollectorProxyClientErrorPropagates(t *testing.T) {
-	mFactory := metrics.NewLocalFactory(time.Minute)
+	mFactory := metricstest.NewFactory(time.Minute)
 	proxy := &collectorProxy{samplingClient: &failingClient{}, baggageClient: &failingClient{}}
 	metrics.Init(&proxy.metrics, mFactory, nil)
 	_, err := proxy.GetSamplingStrategy("test")
 	require.EqualError(t, err, "error")
 	_, err = proxy.GetBaggageRestrictions("test")
 	require.EqualError(t, err, "error")
-	mTestutils.AssertCounterMetrics(t, mFactory, []mTestutils.ExpectedMetric{
+	mFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 		{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "sampling"}, Value: 1},
 		{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "baggage"}, Value: 1},
 	}...)

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
@@ -75,7 +75,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 	return transport.Addr().String(), processor
 }
 
-func initCollectorAndReporter(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, reporter.Reporter) {
+func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.MockTCollector, reporter.Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
 	reporter := tchreporter.New("jaeger-collector", collector.Channel, nil, metricsFactory, zap.NewNop())
 	return metricsFactory, collector, reporter
@@ -115,7 +115,7 @@ func (h failingHandler) Process(iprot, oprot thrift.TProtocol) (success bool, er
 }
 
 func TestProcessor_HandlerError(t *testing.T) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	handler := failingHandler{err: errors.New("doh")}
 
@@ -137,9 +137,9 @@ func TestProcessor_HandlerError(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	mTestutils.AssertCounterMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.t-processor.handler-errors", Value: 1},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
+	metricsFactory.AssertCounterMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.t-processor.handler-errors", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
 	)
 }
 
@@ -170,7 +170,7 @@ func TestJaegerProcessor(t *testing.T) {
 	}
 }
 
-func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metrics.LocalFactory) {
+func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metricstest.Factory) {
 	sizeF := func() int {
 		return len(collector.GetJaegerBatches())
 	}
@@ -180,7 +180,7 @@ func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCo
 	assertProcessorCorrectness(t, metricsFactory, sizeF, nameF, "jaeger")
 }
 
-func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metrics.LocalFactory) {
+func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metricstest.Factory) {
 	sizeF := func() int {
 		return len(collector.GetZipkinSpans())
 	}
@@ -192,7 +192,7 @@ func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCo
 
 func assertProcessorCorrectness(
 	t *testing.T,
-	metricsFactory *metrics.LocalFactory,
+	metricsFactory *metricstest.Factory,
 	sizeF func() int,
 	nameF func() string,
 	format string,
@@ -218,7 +218,7 @@ func assertProcessorCorrectness(
 	}
 
 	// agentReporter must emit metrics
-	mTestutils.AssertCounterMetrics(t, metricsFactory, []mTestutils.ExpectedMetric{
+	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 		{Name: "tchannel-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "tchannel-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "thrift.udp.server.packets.processed", Value: 1},

--- a/cmd/agent/app/reporter/tchannel/reporter_test.go
+++ b/cmd/agent/app/reporter/tchannel/reporter_test.go
@@ -20,8 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
@@ -29,7 +28,7 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
-func initRequirements(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, *Reporter) {
+func initRequirements(t *testing.T) (*metricstest.Factory, *testutils.MockTCollector, *Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
 	reporter := New("jaeger-collector", collector.Channel, nil, metricsFactory, zap.NewNop())
 	return metricsFactory, collector, reporter
@@ -104,8 +103,8 @@ func submitTestJaegerBatch(reporter *Reporter) error {
 	return reporter.EmitBatch(batch)
 }
 
-func checkCounters(t *testing.T, mf *metrics.LocalFactory, batchesSubmitted, spansSubmitted, batchesFailures, spansFailures int, format string) {
-	mTestutils.AssertCounterMetrics(t, mf, []mTestutils.ExpectedMetric{
+func checkCounters(t *testing.T, mf *metricstest.Factory, batchesSubmitted, spansSubmitted, batchesFailures, spansFailures int, format string) {
+	mf.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 		{Name: "tchannel-reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: batchesSubmitted},
 		{Name: "tchannel-reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: spansSubmitted},
 		{Name: "tchannel-reporter.batches.failures", Tags: map[string]string{"format": format}, Value: batchesFailures},

--- a/cmd/agent/app/servers/tbuffered_server_test.go
+++ b/cmd/agent/app/servers/tbuffered_server_test.go
@@ -21,8 +21,7 @@ import (
 	athrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
@@ -41,7 +40,7 @@ func TestTBufferedServer(t *testing.T) {
 }
 
 func testTBufferedServer(t *testing.T, queueSize int, testDroppedPackets bool) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	transport, err := thriftudp.NewTUDPServerTransport("127.0.0.1:0")
 	require.NoError(t, err)
@@ -100,12 +99,12 @@ func testTBufferedServer(t *testing.T, queueSize int, testDroppedPackets bool) {
 	assert.Equal(t, "span1", inMemReporter.ZipkinSpans()[0].Name)
 
 	// server must emit metrics
-	mTestutils.AssertCounterMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 0},
+	metricsFactory.AssertCounterMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 0},
 	)
-	mTestutils.AssertGaugeMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 38},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
+	metricsFactory.AssertGaugeMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 38},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
 	)
 }

--- a/cmd/agent/app/testutils/fixture.go
+++ b/cmd/agent/app/testutils/fixture.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 // InitMockCollector initializes a MockTCollector fixture
-func InitMockCollector(t *testing.T) (*metrics.LocalFactory, *MockTCollector) {
-	factory := metrics.NewLocalFactory(0)
+func InitMockCollector(t *testing.T) (*metricstest.Factory, *MockTCollector) {
+	factory := metricstest.NewFactory(0)
 	collector, err := StartMockTCollector()
 	require.NoError(t, err)
 

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -19,13 +19,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	jaegerM "github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 )
 
 func TestProcessorMetrics(t *testing.T) {
-	baseMetrics := jaegerM.NewLocalFactory(time.Hour)
+	baseMetrics := metricstest.NewFactory(time.Hour)
 	serviceMetrics := baseMetrics.Namespace("service", nil)
 	hostMetrics := baseMetrics.Namespace("host", nil)
 	spm := NewSpanProcessorMetrics(serviceMetrics, hostMetrics, []string{"scruffy"})
@@ -46,7 +46,7 @@ func TestProcessorMetrics(t *testing.T) {
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	mSpan.ReplaceParentID(1234)
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
-	counters, gauges := baseMetrics.LocalBackend.Snapshot()
+	counters, gauges := baseMetrics.Snapshot()
 
 	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|svc=fry"])
 	assert.EqualValues(t, 2, counters["service.spans.received|debug=true|format=jaeger|svc=fry"])
@@ -56,7 +56,7 @@ func TestProcessorMetrics(t *testing.T) {
 }
 
 func TestNewCountsBySvc(t *testing.T) {
-	baseMetrics := jaegerM.NewLocalFactory(time.Hour)
+	baseMetrics := metricstest.NewFactory(time.Hour)
 	metrics := newCountsBySvc(baseMetrics, "not_on_my_level", 3)
 
 	metrics.countByServiceName("fry", false)
@@ -64,7 +64,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("bender", false)
 	metrics.countByServiceName("zoidberg", false)
 
-	counters, _ := baseMetrics.LocalBackend.Snapshot()
+	counters, _ := baseMetrics.Snapshot()
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|svc=fry"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|svc=leela"])
 	assert.EqualValues(t, 2, counters["not_on_my_level|debug=false|svc=other-services"])
@@ -74,7 +74,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("leela", true)
 	metrics.countByServiceName("fry", true)
 
-	counters, _ = baseMetrics.LocalBackend.Snapshot()
+	counters, _ = baseMetrics.Snapshot()
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|svc=zoidberg"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|svc=bender"])
 	assert.EqualValues(t, 2, counters["not_on_my_level|debug=true|svc=other-services"])

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -21,8 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
-	metricsTest "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
@@ -69,7 +68,7 @@ func TestBySvcMetrics(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mb := metrics.NewLocalFactory(time.Hour)
+		mb := metricstest.NewFactory(time.Hour)
 		logger := zap.NewNop()
 		serviceMetrics := mb.Namespace("service", nil)
 		hostMetrics := mb.Namespace("host", nil)
@@ -109,23 +108,23 @@ func TestBySvcMetrics(t *testing.T) {
 		} else {
 			panic("Unknown format")
 		}
-		expected := []metricsTest.ExpectedMetric{}
+		expected := []metricstest.ExpectedMetric{}
 		if test.debug {
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: metricPrefix + ".spans.received|debug=true|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		} else {
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: metricPrefix + ".spans.received|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		}
 		if test.rootSpan {
 			if test.debug {
-				expected = append(expected, metricsTest.ExpectedMetric{
+				expected = append(expected, metricstest.ExpectedMetric{
 					Name: metricPrefix + ".traces.received|debug=true|format=" + format + "|svc=" + test.serviceName, Value: 2,
 				})
 			} else {
-				expected = append(expected, metricsTest.ExpectedMetric{
+				expected = append(expected, metricstest.ExpectedMetric{
 					Name: metricPrefix + ".traces.received|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 				})
 			}
@@ -135,17 +134,17 @@ func TestBySvcMetrics(t *testing.T) {
 			// because both are emitted when attempting to add span to the queue, and since
 			// we defined the queue capacity as 0, all submitted items are dropped.
 			// The debug spans are always accepted.
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: "host.error.busy", Value: 2,
-			}, metricsTest.ExpectedMetric{
+			}, metricstest.ExpectedMetric{
 				Name: "host.spans.dropped", Value: 2,
 			})
 		} else {
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: metricPrefix + ".spans.rejected|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		}
-		metricsTest.AssertCounterMetrics(t, mb, expected...)
+		mb.AssertCounterMetrics(t, expected...)
 	}
 }
 
@@ -228,7 +227,7 @@ func TestSpanProcessorErrors(t *testing.T) {
 	w := &fakeSpanWriter{
 		err: fmt.Errorf("some-error"),
 	}
-	mb := metrics.NewLocalFactory(time.Hour)
+	mb := metricstest.NewFactory(time.Hour)
 	serviceMetrics := mb.Namespace("service", nil)
 	p := NewSpanProcessor(w,
 		Options.Logger(logger),
@@ -254,10 +253,10 @@ func TestSpanProcessorErrors(t *testing.T) {
 		"error": "some-error",
 	}, logBuf.JSONLine(0))
 
-	expected := []metricsTest.ExpectedMetric{{
+	expected := []metricstest.ExpectedMetric{{
 		Name: "service.spans.saved-by-svc|debug=false|result=err|svc=x", Value: 1,
 	}}
-	metricsTest.AssertCounterMetrics(t, mb, expected...)
+	mb.AssertCounterMetrics(t, expected...)
 }
 
 type blockingWriter struct {

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	kmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/mocks"
@@ -116,7 +116,7 @@ func TestSaramaConsumerWrapper_MarkPartitionOffset(t *testing.T) {
 }
 
 func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
-	localFactory := metrics.NewLocalFactory(0)
+	localFactory := metricstest.NewFactory(0)
 
 	msg := &sarama.ConsumerMessage{}
 
@@ -159,22 +159,22 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 	undertest.Close()
 
 	partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.messages",
 		Tags:  partitionTag,
 		Value: 1,
 	})
-	testutils.AssertGaugeMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.current-offset",
 		Tags:  partitionTag,
 		Value: 1,
 	})
-	testutils.AssertGaugeMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.offset-lag",
 		Tags:  partitionTag,
 		Value: 0,
 	})
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partition-start",
 		Tags:  partitionTag,
 		Value: 1,
@@ -182,7 +182,7 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 }
 
 func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
-	localFactory := metrics.NewLocalFactory(0)
+	localFactory := metricstest.NewFactory(0)
 
 	saramaConsumer := smocks.NewConsumer(t, &sarama.Config{})
 	mc := saramaConsumer.ExpectConsumePartition(topic, partition, msgOffset)
@@ -205,7 +205,7 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 		}
 
 		partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
-		testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+		localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 			Name:  "sarama-consumer.errors",
 			Tags:  partitionTag,
 			Value: 1,
@@ -218,7 +218,7 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 }
 
 func TestHandleClosePartition(t *testing.T) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	mp := &pmocks.SpanProcessor{}
 	saramaConsumer := smocks.NewConsumer(t, &sarama.Config{})

--- a/cmd/ingester/app/consumer/deadlock_detector_test.go
+++ b/cmd/ingester/app/consumer/deadlock_detector_test.go
@@ -21,13 +21,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 )
 
 func TestClosingSignalEmitted(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 	l, _ := zap.NewDevelopment()
 	f := newDeadlockDetector(mf, l, time.Millisecond)
 	w := f.startMonitoringForPartition(1)
@@ -36,7 +35,7 @@ func TestClosingSignalEmitted(t *testing.T) {
 }
 
 func TestNoClosingSignalIfMessagesProcessedInInterval(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 	l, _ := zap.NewDevelopment()
 	f := newDeadlockDetector(mf, l, time.Second)
 	f.start()
@@ -50,7 +49,7 @@ func TestNoClosingSignalIfMessagesProcessedInInterval(t *testing.T) {
 }
 
 func TestResetMsgCount(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 	l, _ := zap.NewDevelopment()
 	f := newDeadlockDetector(mf, l, 50*time.Millisecond)
 	f.start()
@@ -64,7 +63,7 @@ func TestResetMsgCount(t *testing.T) {
 }
 
 func TestPanicFunc(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 	l, _ := zap.NewDevelopment()
 	f := newDeadlockDetector(mf, l, time.Minute)
 
@@ -72,7 +71,7 @@ func TestPanicFunc(t *testing.T) {
 		f.panicFunc(1)
 	})
 
-	testutils.AssertCounterMetrics(t, mf, testutils.ExpectedMetric{
+	mf.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "deadlockdetector.panic-issued",
 		Tags:  map[string]string{"partition": "1"},
 		Value: 1,
@@ -84,7 +83,7 @@ func TestPanicForPartition(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	d := deadlockDetector{
-		metricsFactory: metrics.NewLocalFactory(0),
+		metricsFactory: metricstest.NewFactory(0),
 		logger:         l,
 		interval:       1,
 		panicFunc: func(partition int32) {
@@ -101,7 +100,7 @@ func TestGlobalPanic(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	d := deadlockDetector{
-		metricsFactory: metrics.NewLocalFactory(0),
+		metricsFactory: metricstest.NewFactory(0),
 		logger:         l,
 		interval:       1,
 		panicFunc: func(partition int32) {

--- a/cmd/ingester/app/consumer/offset/manager_test.go
+++ b/cmd/ingester/app/consumer/offset/manager_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 func TestHandleReset(t *testing.T) {
 	offset := int64(1498)
 	minOffset := offset - 1
 
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/cmd/ingester/app/processor/decorator/retry_test.go
+++ b/cmd/ingester/app/processor/decorator/retry_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
 )
@@ -34,7 +35,7 @@ func TestNewRetryingProcessor(t *testing.T) {
 	mockProcessor := &mocks.SpanProcessor{}
 	msg := &fakeMsg{}
 	mockProcessor.On("Process", msg).Return(nil)
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor)
 
 	assert.NoError(t, rp.Process(msg))
@@ -55,7 +56,7 @@ func TestNewRetryingProcessorError(t *testing.T) {
 		MaxAttempts(2),
 		PropagateError(true),
 		Rand(&fakeRand{})}
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
 	assert.Error(t, rp.Process(msg))
@@ -77,7 +78,7 @@ func TestNewRetryingProcessorNoErrorPropagation(t *testing.T) {
 		PropagateError(false),
 		Rand(&fakeRand{})}
 
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
 	assert.NoError(t, rp.Process(msg))

--- a/cmd/ingester/app/processor/metrics_decorator_test.go
+++ b/cmd/ingester/app/processor/metrics_decorator_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
@@ -35,7 +35,7 @@ func TestProcess(t *testing.T) {
 	p := &mocks.SpanProcessor{}
 	msg := fakeMsg{}
 	p.On("Process", msg).Return(nil)
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 	proc := processor.NewDecoratedProcessor(m, p)
 
 	proc.Process(msg)
@@ -48,7 +48,7 @@ func TestProcessErr(t *testing.T) {
 	p := &mocks.SpanProcessor{}
 	msg := fakeMsg{}
 	p.On("Process", msg).Return(errors.New("err"))
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 	proc := processor.NewDecoratedProcessor(m, p)
 
 	proc.Process(msg)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: eb96c7fd56c8c6523990c19ba5bcf0d826922569a16e1019a88de57d46675775
-updated: 2018-10-12T23:27:30.163799+09:00
+hash: d419ce51a469b2daea964abfd92ebe34826d46ec7cfbb6e8dc88124f1507b0c9
+updated: 2018-10-18T13:53:48.186535-07:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -254,15 +254,17 @@ imports:
   - transport/zipkin
   - utils
 - name: github.com/uber/jaeger-lib
-  version: ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5
+  version: 4aa908b951cc7516c61cf001ddca1118d02d243e
+  repo: https://github.com/isaachier/jaeger-lib
   subpackages:
   - metrics
   - metrics/adapters
   - metrics/expvar
   - metrics/go-kit
   - metrics/go-kit/expvar
+  - metrics/metricstest
   - metrics/prometheus
-  - metrics/testutils
+  - utils
 - name: github.com/uber/tchannel-go
   version: 1a0e35378f6f721bc07f6c4466bc9701ed70b506
   subpackages:
@@ -293,7 +295,7 @@ imports:
   - zapcore
   - zaptest
 - name: golang.org/x/net
-  version: 49bb7cea24b1df9410e1712aa6433dae904ff66a
+  version: 04a2e542c03f1d053ab3e4d6e5abcd4b66e2be8e
   subpackages:
   - context
   - context/ctxhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,9 +17,7 @@ import:
   subpackages:
   - transport
 - package: github.com/uber/jaeger-lib
-  repo: https://github.com/isaachier/jaeger-lib
-  version: 4aa908b951cc7516c61cf001ddca1118d02d243e
-  #version: ^1.5.0
+  version: e0a812eccf5a8ac943db957a823bed43b346d654
 - package: github.com/uber/tchannel-go
   version: v1.1.0
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,7 +17,9 @@ import:
   subpackages:
   - transport
 - package: github.com/uber/jaeger-lib
-  version: ^1.5.0
+  repo: https://github.com/isaachier/jaeger-lib
+  version: 4aa908b951cc7516c61cf001ddca1118d02d243e
+  #version: ^1.5.0
 - package: github.com/uber/tchannel-go
   version: v1.1.0
   subpackages:

--- a/pkg/cassandra/metrics/table_test.go
+++ b/pkg/cassandra/metrics/table_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
@@ -63,7 +63,7 @@ func TestTableEmit(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(time.Second)
+		mf := metricstest.NewFactory(time.Second)
 		tm := NewTable(mf, "a_table")
 		tm.Emit(tc.err, 50*time.Millisecond)
 		counts, gauges := mf.Snapshot()
@@ -110,7 +110,7 @@ func TestTableExec(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(0)
+		mf := metricstest.NewFactory(0)
 		tm := NewTable(mf, "a_table")
 		logger, logBuf := testutils.NewLogger()
 

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -23,14 +23,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 // In this test we run a queue with capacity 1 and a single consumer.
 // We want to test the overflow behavior, so we block the consumer
 // by holding a startLock before submitting items to the queue.
 func TestBoundedQueue(t *testing.T) {
-	mFact := metrics.NewLocalFactory(0)
+	mFact := metricstest.NewFactory(0)
 	counter := mFact.Counter("dropped", nil)
 	gauge := mFact.Gauge("size", nil)
 

--- a/plugin/storage/cassandra/dependencystore/storage_test.go
+++ b/plugin/storage/cassandra/dependencystore/storage_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -42,7 +42,7 @@ type depStorageTest struct {
 func withDepStore(fn func(s *depStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(time.Second)
+	metricsFactory := metricstest.NewFactory(time.Second)
 	defer metricsFactory.Stop()
 	s := &depStorageTest{
 		session:   session,

--- a/plugin/storage/cassandra/samplingstore/storage_test.go
+++ b/plugin/storage/cassandra/samplingstore/storage_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
@@ -45,7 +45,7 @@ type samplingStoreTest struct {
 func withSamplingStore(fn func(r *samplingStoreTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	r := &samplingStoreTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
@@ -32,7 +32,7 @@ import (
 type operationNameStorageTest struct {
 	session        *mocks.Session
 	writeCacheTTL  time.Duration
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	logger         *zap.Logger
 	logBuffer      *testutils.Buffer
 	storage        *OperationNamesStorage
@@ -41,7 +41,7 @@ type operationNameStorageTest struct {
 func withOperationNamesStorage(writeCacheTTL time.Duration, fn func(s *operationNameStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	s := &operationNameStorageTest{
 		session:        session,
 		writeCacheTTL:  writeCacheTTL,

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -45,7 +45,7 @@ type spanReaderTest struct {
 func withSpanReader(fn func(r *spanReaderTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	r := &spanReaderTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/cassandra/spanstore/service_names_test.go
+++ b/plugin/storage/cassandra/spanstore/service_names_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
@@ -32,7 +32,7 @@ import (
 type serviceNameStorageTest struct {
 	session        *mocks.Session
 	writeCacheTTL  time.Duration
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	logger         *zap.Logger
 	logBuffer      *testutils.Buffer
 	storage        *ServiceNamesStorage
@@ -41,7 +41,7 @@ type serviceNameStorageTest struct {
 func withServiceNamesStorage(writeCacheTTL time.Duration, fn func(s *serviceNameStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(time.Second)
+	metricsFactory := metricstest.NewFactory(time.Second)
 	defer metricsFactory.Stop()
 	s := &serviceNameStorageTest{
 		session:        session,

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -42,7 +42,7 @@ func withSpanWriter(writeCacheTTL time.Duration, fn func(w *spanWriterTest), opt
 ) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	w := &spanWriterTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -43,7 +43,7 @@ type spanWriterTest struct {
 func withSpanWriter(fn func(w *spanWriterTest)) {
 	client := &mocks.Client{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	w := &spanWriterTest{
 		client:    client,
 		logger:    logger,
@@ -66,7 +66,7 @@ func TestNewSpanWriterIndexPrefix(t *testing.T) {
 	}
 	client := &mocks.Client{}
 	logger, _ := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	for _, testCase := range testCases {
 		w := NewSpanWriter(SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: testCase.prefix})
@@ -311,7 +311,7 @@ func TestWriteSpanInternalError(t *testing.T) {
 func TestNewSpanTags(t *testing.T) {
 	client := &mocks.Client{}
 	logger, _ := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	testCases := []struct {
 		writer   *SpanWriter
 		expected dbmodel.Span

--- a/plugin/storage/kafka/writer_test.go
+++ b/plugin/storage/kafka/writer_test.go
@@ -23,8 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -67,7 +66,7 @@ var (
 type spanWriterTest struct {
 	producer       *saramaMocks.AsyncProducer
 	marshaller     *mocks.Marshaller
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 
 	writer *SpanWriter
 }
@@ -76,7 +75,7 @@ type spanWriterTest struct {
 var _ spanstore.Writer = &SpanWriter{}
 
 func withSpanWriter(t *testing.T, fn func(span *model.Span, w *spanWriterTest)) {
-	serviceMetrics := metrics.NewLocalFactory(100 * time.Millisecond)
+	serviceMetrics := metricstest.NewFactory(100 * time.Millisecond)
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Producer.Return.Successes = true
 	producer := saramaMocks.NewAsyncProducer(t, saramaConfig)
@@ -110,15 +109,15 @@ func TestKafkaWriter(t *testing.T) {
 		}
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 1,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 0,
@@ -142,15 +141,15 @@ func TestKafkaWriterErr(t *testing.T) {
 		}
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 0,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 1,
@@ -170,15 +169,15 @@ func TestMarshallerErr(t *testing.T) {
 
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 0,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 1,

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -29,7 +29,7 @@ import (
 )
 
 func TestSuccessfulUnderlyingCalls(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 
 	mockReader := mocks.Reader{}
 	mrs := NewReadMetricsDecorator(&mockReader, mf)
@@ -82,7 +82,7 @@ func checkExpectedExistingAndNonExistentCounters(t *testing.T, actualCounters, e
 }
 
 func TestFailingUnderlyingCalls(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 
 	mockReader := mocks.Reader{}
 	mrs := NewReadMetricsDecorator(&mockReader, mf)

--- a/storage/spanstore/metrics/write_metrics_test.go
+++ b/storage/spanstore/metrics/write_metrics_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 func TestTableEmit(t *testing.T) {
@@ -61,7 +61,7 @@ func TestTableEmit(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(time.Second)
+		mf := metricstest.NewFactory(time.Second)
 		tm := NewWriteMetrics(mf, "a_table")
 		tm.Emit(tc.err, 50*time.Millisecond)
 		counts, gauges := mf.Snapshot()


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1140. 

## Short description of the changes
- Replace old jaeger-lib API with new jaeger-lib API.
