### PR TITLE
Add hyperlink to OpenTracing specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For example, any given Jaeger installation at Uber is typically processing sever
 
 ### Native support for OpenTracing
 
-Jaeger backend, Web UI, and instrumentation libraries have been designed from ground up to support the OpenTracing standard.
+Jaeger backend, Web UI, and instrumentation libraries have been designed from ground up to support the [OpenTracing standard](https://opentracing.io/specification/).
   * Represent traces as directed acyclic graphs (not just trees) via [span references](https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans)
   * Support strongly typed span _tags_ and _structured logs_
   * Support general distributed context propagation mechanism via _baggage_


### PR DESCRIPTION
It would be helpful to be able to jump from this readme to the OpenTracing specification.

Signed-off-by: Bert Roos <bert@famroos.nu>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Quickly get to the OpenTracing specification

## Short description of the changes
- Added a link to the OpenTracing specification
