### PR TITLE
Fix empty grpc address

### DIFF
--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -15,6 +15,8 @@
 package grpc
 
 import (
+	"errors"
+
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
@@ -32,7 +34,11 @@ type ProxyBuilder struct {
 }
 
 // NewCollectorProxy creates ProxyBuilder
-func NewCollectorProxy(o *Options, logger *zap.Logger) *ProxyBuilder {
+func NewCollectorProxy(o *Options, logger *zap.Logger) (*ProxyBuilder, error) {
+	if len(o.CollectorHostPort) == 0 {
+		return nil, errors.New("could not create collector proxy, address is missing")
+	}
+
 	// It does not return error if the collector is not running
 	// a way to fail immediately is to call WithBlock and WithTimeout
 	var conn *grpc.ClientConn
@@ -49,7 +55,7 @@ func NewCollectorProxy(o *Options, logger *zap.Logger) *ProxyBuilder {
 	}
 	return &ProxyBuilder{
 		reporter: NewReporter(conn, logger),
-		manager:  NewSamplingManager(conn)}
+		manager:  NewSamplingManager(conn)}, nil
 }
 
 // GetReporter returns Reporter

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -26,8 +26,15 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
 
+func TestProxyBuilderMissingAddress(t *testing.T) {
+	proxy, err := NewCollectorProxy(&Options{}, zap.NewNop())
+	require.Nil(t, proxy)
+	assert.EqualError(t, err, "could not create collector proxy, address is missing")
+}
+
 func TestProxyBuilder(t *testing.T) {
-	proxy := NewCollectorProxy(&Options{CollectorHostPort: []string{"localhost:0000"}}, zap.NewNop())
+	proxy, err := NewCollectorProxy(&Options{CollectorHostPort: []string{"localhost:0000"}}, zap.NewNop())
+	require.NoError(t, err)
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())
 	assert.NotNil(t, proxy.GetManager())
@@ -45,7 +52,8 @@ func TestMultipleCollectors(t *testing.T) {
 	})
 	defer s2.Stop()
 
-	proxy := NewCollectorProxy(&Options{CollectorHostPort: []string{addr1.String(), addr2.String()}}, zap.NewNop())
+	proxy, err := NewCollectorProxy(&Options{CollectorHostPort: []string{addr1.String(), addr2.String()}}, zap.NewNop())
+	require.NoError(t, err)
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())
 	assert.NotNil(t, proxy.GetManager())

--- a/cmd/agent/app/reporter/grpc/flags.go
+++ b/cmd/agent/app/reporter/grpc/flags.go
@@ -39,6 +39,9 @@ func AddFlags(flags *flag.FlagSet) {
 
 // InitFromViper initializes Options with properties retrieved from Viper.
 func (o *Options) InitFromViper(v *viper.Viper) *Options {
-	o.CollectorHostPort = strings.Split(v.GetString(collectorHostPort), ",")
+	hostPorts := v.GetString(collectorHostPort)
+	if hostPorts != "" {
+		o.CollectorHostPort = strings.Split(hostPorts, ",")
+	}
 	return o
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -117,7 +117,7 @@ func createCollectorProxy(
 	switch opts.ReporterType {
 	case reporter.GRPC:
 		grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
-		return grpc.NewCollectorProxy(grpcRepOpts, logger), nil
+		return grpc.NewCollectorProxy(grpcRepOpts, logger)
 	case reporter.TCHANNEL:
 		return tchannel.NewCollectorProxy(tchanRep, mFactory, logger)
 	default:

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -220,7 +220,7 @@ func createCollectorProxy(
 	switch repOpts.ReporterType {
 	case agentRep.GRPC:
 		grpcRepOpts.CollectorHostPort = append(grpcRepOpts.CollectorHostPort, fmt.Sprintf("127.0.0.1:%d", cOpts.CollectorGRPCPort))
-		return agentGrpcRep.NewCollectorProxy(grpcRepOpts, logger), nil
+		return agentGrpcRep.NewCollectorProxy(grpcRepOpts, logger)
 	case agentRep.TCHANNEL:
 		tchanRepOpts.CollectorHostPorts = append(tchanRepOpts.CollectorHostPorts, fmt.Sprintf("127.0.0.1:%d", cOpts.CollectorPort))
 		return agentTchanRep.NewCollectorProxy(tchanRepOpts, mFactory, logger)


### PR DESCRIPTION
`initFromViper` was adding an empty address if no address was provided. all-in-one main added another address causing failed to connect logs.

I think the current patch is better because it exists the agent if no grpc address was provided - before it was reconnecting on empty address.

```bash
go run -tags ui ./cmd/all-in-one/main.go   --reporter.type=grpc                                         2:33 
{"level":"info","ts":1542115995.914291,"caller":"healthcheck/handler.go:99","msg":"Health Check server started","http-port":14269,"status":"unavailable"}
{"level":"info","ts":1542115995.9144924,"caller":"memory/factory.go:55","msg":"Memory storage configuration","configuration":{"MaxTraces":0}}
{"level":"info","ts":1542115995.9145684,"caller":"static/strategy_store.go:77","msg":"No sampling strategies provided, using defaults"}
{"level":"info","ts":1542115995.9164443,"caller":"all-in-one/main.go:206","msg":"Starting agent"}
{"level":"info","ts":1542115995.9170663,"caller":"all-in-one/main.go:268","msg":"Starting jaeger-collector TChannel server","port":14267}
{"level":"info","ts":1542115995.917164,"caller":"grpcserver/grpc_server.go:64","msg":"Starting jaeger-collector gRPC server","grpc-port":"14250"}
{"level":"info","ts":1542115995.9172246,"caller":"all-in-one/main.go:288","msg":"Starting jaeger-collector HTTP server","http-port":14268}
{"level":"info","ts":1542115996.1725812,"caller":"all-in-one/main.go:358","msg":"Registering metrics handler with jaeger-query HTTP server","route":"/metrics"}
{"level":"info","ts":1542115996.172633,"caller":"all-in-one/main.go:364","msg":"Starting jaeger-query HTTP server","port":16686}
{"level":"info","ts":1542115996.1726682,"caller":"healthcheck/handler.go:133","msg":"Health Check state change","status":"ready"}
WARNING: 2018/11/13 14:33:16 grpc: addrConn.createTransport failed to connect to { 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp: missing address". Reconnecting...
WARNING: 2018/11/13 14:33:18 grpc: addrConn.createTransport failed to connect to { 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp: missing address". Reconnecting...
WARNING: 2018/11/13 14:33:21 grpc: addrConn.createTransport failed to connect to { 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp: missing address". Reconnecting...
WARNING: 2018/11/13 14:33:25 grpc: addrConn.createTransport failed to connect to { 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp: missing address". Reconnecting...
WARNING: 2018/11/13 14:33:31 grpc: addrConn.createTransport failed to connect to { 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp: missing address". Reconnecting...
```