### PR TITLE
Fix metrics handler registration in agent

### DIFF
--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -49,6 +49,11 @@ func NewAgent(
 	return a
 }
 
+// GetServer returns HTTP server used by the agent.
+func (a *Agent) GetServer() *http.Server {
+	return a.httpServer
+}
+
 // Run runs all of agent UDP and HTTP servers in separate go-routines.
 // It returns an error when it's immediately apparent on startup, but
 // any errors happening after starting the servers are only logged.
@@ -60,6 +65,7 @@ func (a *Agent) Run() error {
 	a.httpAddr.Store(listener.Addr().String())
 	a.closer = listener
 	go func() {
+		a.logger.Info("Starting jaeger-agent HTTP server", zap.Int("http-port", listener.Addr().(*net.TCPAddr).Port))
 		if err := a.httpServer.Serve(listener); err != nil {
 			a.logger.Error("http server failure", zap.Error(err))
 		}

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -107,15 +107,6 @@ func TestBuilderWithExtraReporter(t *testing.T) {
 	assert.NotNil(t, agent)
 }
 
-func TestBuilderMetricsHandler(t *testing.T) {
-	b := &Builder{}
-	b.Metrics.Backend = "expvar"
-	b.Metrics.HTTPRoute = "/expvar"
-	agent, err := b.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
-	assert.NoError(t, err)
-	assert.NotNil(t, agent)
-}
-
 func TestBuilderWithProcessorErrors(t *testing.T) {
 	testCases := []struct {
 		model       Model

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -56,8 +56,6 @@ func AddFlags(flags *flag.FlagSet) {
 
 // InitFromViper initializes Builder with properties retrieved from Viper.
 func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
-	b.Metrics.InitFromViper(v)
-
 	for _, processor := range defaultProcessors {
 		prefix := fmt.Sprintf("processor.%s-%s.", processor.model, processor.protocol)
 		p := &ProcessorConfiguration{Model: processor.model, Protocol: processor.protocol}


### PR DESCRIPTION
Resolves #1177 

I have removed metrics registration from agent. now following the same approach as in query, collector and allinone.