### PR TITLE
Rename tcollector proxy metric in agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 Changes by Version
 ==================
 
+1.9.0 (unreleased)
+------------------
+
+#### Backend Changes
+
+##### Breaking Changes
+
+- Rename tcollector proxy metric in agent ([#1182](https://github.com/jaegertracing/jaeger/pull/1182), [@pavolloffay](https://github.com/pavolloffay))
+
+The following metric:
+```
+jaeger_http_server_errors{source="tcollector-proxy",status="5xx"}
+```
+has been renamed to:
+```
+jaeger_http_server_errors{source="collector-proxy",status="5xx"}
+```
+
+##### New Features
+
+##### Bug fixes, Minor Improvements
+
+#### UI Changes
+
+##### New Features
+
+##### Bug Fixes, Minor Improvements
+
+
 1.8.0 (2018-11-12)
 ------------------
 

--- a/cmd/agent/app/httpserver/server.go
+++ b/cmd/agent/app/httpserver/server.go
@@ -71,7 +71,7 @@ type httpHandler struct {
 		BadRequest metrics.Counter `metric:"http-server.errors" tags:"status=4xx,source=all"`
 
 		// Number of collector proxy failures
-		TCollectorProxyFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=tcollector-proxy"`
+		TCollectorProxyFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=collector-proxy"`
 
 		// Number of bad responses due to malformed thrift
 		BadThriftFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=thrift"`

--- a/cmd/agent/app/httpserver/server.go
+++ b/cmd/agent/app/httpserver/server.go
@@ -71,7 +71,7 @@ type httpHandler struct {
 		BadRequest metrics.Counter `metric:"http-server.errors" tags:"status=4xx,source=all"`
 
 		// Number of collector proxy failures
-		TCollectorProxyFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=collector-proxy"`
+		CollectorProxyFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=collector-proxy"`
 
 		// Number of bad responses due to malformed thrift
 		BadThriftFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=thrift"`
@@ -107,7 +107,7 @@ func (h *httpHandler) serveSamplingHTTP(w http.ResponseWriter, r *http.Request, 
 	}
 	resp, err := h.manager.GetSamplingStrategy(service)
 	if err != nil {
-		h.metrics.TCollectorProxyFailures.Inc(1)
+		h.metrics.CollectorProxyFailures.Inc(1)
 		http.Error(w, fmt.Sprintf("collector error: %+v", err), http.StatusInternalServerError)
 		return
 	}
@@ -137,7 +137,7 @@ func (h *httpHandler) serveBaggageHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := h.manager.GetBaggageRestrictions(service)
 	if err != nil {
-		h.metrics.TCollectorProxyFailures.Inc(1)
+		h.metrics.CollectorProxyFailures.Inc(1)
 		http.Error(w, fmt.Sprintf("collector error: %+v", err), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/agent/app/httpserver/server_test.go
+++ b/cmd/agent/app/httpserver/server_test.go
@@ -151,7 +151,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			statusCode:  http.StatusInternalServerError,
 			body:        "collector error: no mock response provided\n",
 			metrics: []mTestutils.ExpectedMetric{
-				{Name: "http-server.errors", Tags: map[string]string{"source": "tcollector-proxy", "status": "5xx"}, Value: 1},
+				{Name: "http-server.errors", Tags: map[string]string{"source": "collector-proxy", "status": "5xx"}, Value: 1},
 			},
 		},
 		{
@@ -160,7 +160,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			statusCode:  http.StatusInternalServerError,
 			body:        "collector error: no mock response provided\n",
 			metrics: []mTestutils.ExpectedMetric{
-				{Name: "http-server.errors", Tags: map[string]string{"source": "tcollector-proxy", "status": "5xx"}, Value: 1},
+				{Name: "http-server.errors", Tags: map[string]string{"source": "collector-proxy", "status": "5xx"}, Value: 1},
 			},
 		},
 		{


### PR DESCRIPTION
Related to https://github.com/jaegertracing/jaeger/issues/773#issuecomment-436602664


This is not something required but it seems wrong to have tag `tcollector-proxy` when the proxy can use any protocol.
