### PR TITLE
Support archive traces for ES storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ docker-images-only:
 	docker build -t $(DOCKER_NAMESPACE)/jaeger-cassandra-schema:${DOCKER_TAG} plugin/storage/cassandra/
 	@echo "Finished building jaeger-cassandra-schema =============="
 	docker build -t $(DOCKER_NAMESPACE)/jaeger-es-index-cleaner:${DOCKER_TAG} plugin/storage/es
+	docker build -t $(DOCKER_NAMESPACE)/jaeger-es-rollover:${DOCKER_TAG} plugin/storage/es -f plugin/storage/es/Dockerfile.rollover
 	@echo "Finished building jaeger-es-indices-clean =============="
 	for component in agent collector query ingester ; do \
 		docker build -t $(DOCKER_NAMESPACE)/jaeger-$$component:${DOCKER_TAG} cmd/$$component ; \
@@ -238,7 +239,7 @@ docker-push:
 	if [ $$CONFIRM != "y" ] && [ $$CONFIRM != "Y" ]; then \
 		echo "Exiting." ; exit 1 ; \
 	fi
-	for component in agent cassandra-schema es-index-cleaner collector query ingester example-hotrod; do \
+	for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester example-hotrod; do \
 		docker push $(DOCKER_NAMESPACE)/jaeger-$$component ; \
 	done
 

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -35,24 +35,25 @@ import (
 
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
-	Servers           []string
-	Username          string
-	Password          string
-	Sniffer           bool          // https://github.com/olivere/elastic/wiki/Sniffing
-	MaxNumSpans       int           // defines maximum number of spans to fetch from storage per query
-	MaxSpanAge        time.Duration `yaml:"max_span_age"` // configures the maximum lookback on span reads
-	NumShards         int64         `yaml:"shards"`
-	NumReplicas       int64         `yaml:"replicas"`
-	Timeout           time.Duration `validate:"min=500"`
-	BulkSize          int
-	BulkWorkers       int
-	BulkActions       int
-	BulkFlushInterval time.Duration
-	IndexPrefix       string
-	TagsFilePath      string
-	AllTagsAsFields   bool
-	TagDotReplacement string
-	TLS               TLSConfig
+	Servers             []string
+	Username            string
+	Password            string
+	Sniffer             bool          // https://github.com/olivere/elastic/wiki/Sniffing
+	MaxNumSpans         int           // defines maximum number of spans to fetch from storage per query
+	MaxSpanAge          time.Duration `yaml:"max_span_age"` // configures the maximum lookback on span reads
+	NumShards           int64         `yaml:"shards"`
+	NumReplicas         int64         `yaml:"replicas"`
+	Timeout             time.Duration `validate:"min=500"`
+	BulkSize            int
+	BulkWorkers         int
+	BulkActions         int
+	BulkFlushInterval   time.Duration
+	IndexPrefix         string
+	TagsFilePath        string
+	AllTagsAsFields     bool
+	TagDotReplacement   string
+	TLS                 TLSConfig
+	UseReadWriteAliases bool
 }
 
 // TLSConfig describes the configuration properties to connect tls enabled ElasticSearch cluster
@@ -74,6 +75,7 @@ type ClientBuilder interface {
 	GetTagsFilePath() string
 	GetAllTagsAsFields() bool
 	GetTagDotReplacement() string
+	GetUseReadWriteAliases() bool
 }
 
 // NewClient creates a new ElasticSearch client
@@ -215,6 +217,11 @@ func (c *Configuration) GetAllTagsAsFields() bool {
 // the tag is stored as object field.
 func (c *Configuration) GetTagDotReplacement() string {
 	return c.TagDotReplacement
+}
+
+// GetUseReadWriteAliases indicates whether read alias should be used
+func (c *Configuration) GetUseReadWriteAliases() bool {
+	return c.UseReadWriteAliases
 }
 
 // getConfigOptions wraps the configs to feed to the ElasticSearch client init

--- a/plugin/storage/es/Dockerfile.rollover
+++ b/plugin/storage/es/Dockerfile.rollover
@@ -1,0 +1,4 @@
+FROM python:3-alpine
+RUN pip install elasticsearch elasticsearch-curator
+COPY esRollover.py /es-rollover/
+ENTRYPOINT ["python3", "/es-rollover/esRollover.py"]

--- a/plugin/storage/es/esCleaner.py
+++ b/plugin/storage/es/esCleaner.py
@@ -8,10 +8,11 @@ import os
 
 def main():
     if len(sys.argv) == 1:
-        print('USAGE: [TIMEOUT=(default 120)] [INDEX_PREFIX=(default "")] %s NUM_OF_DAYS HOSTNAME[:PORT] ...' % sys.argv[0])
+        print('USAGE: [TIMEOUT=(default 120)] [INDEX_PREFIX=(default "")] [ARCHIVE=(default false)] {} NUM_OF_DAYS HOSTNAME[:PORT]'.format(sys.argv[0]))
         print('Specify a NUM_OF_DAYS that will delete indices that are older than the given NUM_OF_DAYS.')
         print('HOSTNAME ... specifies which ElasticSearch hosts to search and delete indices from.')
         print('INDEX_PREFIX ... specifies index prefix.')
+        print('ARCHIVE ... specifies whether to remove archive indices. Use true or false')
         sys.exit(1)
 
     client = elasticsearch.Elasticsearch(sys.argv[2:])
@@ -24,15 +25,33 @@ def main():
         prefix += '-'
     prefix += 'jaeger'
 
-    ilo.filter_by_regex(kind='prefix', value=prefix)
-    ilo.filter_by_age(source='name', direction='older', timestring='%Y-%m-%d', unit='days', unit_count=int(sys.argv[1]))
+    if str2bool(os.getenv("ARCHIVE", 'false')):
+        filter_archive_indices(ilo, prefix)
+    else:
+        filter_main_indices(ilo, prefix)
+
     empty_list(ilo, 'No indices to delete')
 
     for index in ilo.working_list():
         print("Removing", index)
     timeout = int(os.getenv("TIMEOUT", 120))
     delete_indices = curator.DeleteIndices(ilo, master_timeout=timeout)
-    delete_indices.do_action()
+    delete_indices.do_dry_run()
+
+
+def filter_main_indices(ilo, prefix):
+    ilo.filter_by_regex(kind='prefix', value=prefix + "jaeger")
+    # This excludes archive index as we use source='name'
+    # source `creation_date` would include archive index
+    ilo.filter_by_age(source='name', direction='older', timestring='%Y-%m-%d', unit='days', unit_count=int(sys.argv[1]))
+
+
+def filter_archive_indices(ilo, prefix):
+    # Remove only archive indices when aliases are used
+    # Do not remove active write archive index
+    ilo.filter_by_alias(aliases=[prefix + 'jaeger-span-archive-write'], exclude=True)
+    ilo.filter_by_alias(aliases=[prefix + 'jaeger-span-archive-read'])
+    ilo.filter_by_age(source='creation_date', direction='older', unit='days', unit_count=int(sys.argv[1]))
 
 
 def empty_list(ilo, error_msg):
@@ -41,6 +60,11 @@ def empty_list(ilo, error_msg):
     except curator.NoIndices:
         print(error_msg)
         sys.exit(0)
+
+
+def str2bool(v):
+    return v.lower() in ('true', '1')
+
 
 if __name__ == "__main__":
     main()

--- a/plugin/storage/es/esRollover.py
+++ b/plugin/storage/es/esRollover.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+import elasticsearch
+import curator
+import sys
+import os
+import ast
+import logging
+
+ARCHIVE_INDEX = 'jaeger-span-archive'
+ROLLBACK_CONDITIONS = '{"max_age": "7d"}'
+UNIT = 'days'
+UNIT_COUNT = 7
+
+def main():
+    if len(sys.argv) != 3:
+        print('USAGE: [INDEX_PREFIX=(default "")] [ARCHIVE=(default false)] [CONDITIONS=(default {})] [UNIT=(default {})] [UNIT_COUNT=(default {})] {} ACTION HOSTNAME[:PORT]'.format(ROLLBACK_CONDITIONS, UNIT, UNIT_COUNT, sys.argv[0]))
+        print('ACTION ... one of:')
+        print('\tinit - creates archive index and aliases')
+        print('\trollover - rollover to new write index')
+        print('\tlookback - removes old indices from read alias')
+        print('HOSTNAME ... specifies which ElasticSearch hosts to search and delete indices from.')
+        print('INDEX_PREFIX ... specifies index prefix.')
+        print('rollover configuration:')
+        print('\tCONDITIONS ... conditions used to rollover to a new write index e.g. \'{"max_age": "30d"}\'')
+        print('lookback configuration:')
+        print('\tUNIT ... used with lookback to remove indices from read alias e.g. ..., days, weeks, months, years')
+        print('\tUNIT_COUNT ... count of UNITs')
+        sys.exit(1)
+
+    # TODO add rollover for main indices https://github.com/jaegertracing/jaeger/issues/1242
+    if not str2bool(os.getenv('ARCHIVE', 'false')):
+        print('Rollover for main indices is not supported at the moment')
+        sys.exit(1)
+
+    client = elasticsearch.Elasticsearch(sys.argv[2:])
+    prefix = os.getenv('INDEX_PREFIX', '')
+    if prefix != '':
+        prefix += '-'
+    write_alias = prefix + ARCHIVE_INDEX + '-write'
+    read_alias = prefix + ARCHIVE_INDEX + '-read'
+
+    action = sys.argv[1]
+    if action == 'init':
+        index = prefix + ARCHIVE_INDEX + '-000001'
+        create_index(client, index)
+        create_aliases(client, read_alias, index)
+        create_aliases(client, write_alias, index)
+    elif action == 'rollover':
+        cond = ast.literal_eval(os.getenv('CONDITIONS', ROLLBACK_CONDITIONS))
+        rollover(client, write_alias, read_alias, cond)
+    elif action == 'lookback':
+        read_alias_lookback(client, write_alias, read_alias, os.getenv('UNIT', UNIT), int(os.getenv('UNIT_COUNT', UNIT_COUNT)))
+    else:
+        print('Unrecognized action {}'.format(action))
+        sys.exit(1)
+
+
+def create_index(client, name):
+    """
+    Create archive index
+    """
+    print('Creating index {}'.format(name))
+    create = curator.CreateIndex(client=client, name=name)
+    create.do_action()
+
+
+def create_aliases(client, alias_name, archive_index_name):
+    """"
+    Create read write aliases
+    """
+    ilo = curator.IndexList(client)
+    ilo.filter_by_regex(kind='regex', value='^'+archive_index_name+'$')
+    alias = curator.Alias(client=client, name=alias_name)
+    for index in ilo.working_list():
+        print("Adding index {} to {} alias".format(index, alias_name))
+    alias.add(ilo)
+    alias.do_action()
+
+
+def rollover(client, write_alias, read_alias, conditions):
+    """
+    Rollover to new index and put it into read alias
+    """
+    print("Rollover {}, based on conditions {}".format(write_alias, conditions))
+    roll = curator.Rollover(client=client, name=write_alias, conditions=conditions)
+    roll.do_action()
+    ilo = curator.IndexList(client)
+    ilo.filter_by_alias(aliases=[write_alias])
+    alias = curator.Alias(client=client, name=read_alias)
+    for index in ilo.working_list():
+        print("Adding index {} to {} alias".format(index, read_alias))
+    alias.add(ilo)
+    alias.do_action()
+
+
+def read_alias_lookback(client, write_alias, read_alias, unit, unit_count):
+    """
+    This is used to mimic --es.max-span-age - The maximum lookback for spans in Elasticsearch
+    by removing old indices from read alias
+    """
+    ilo = curator.IndexList(client)
+    ilo.filter_by_alias(aliases=[read_alias])
+    ilo.filter_by_alias(aliases=[write_alias], exclude=True)
+    ilo.filter_by_age(source='creation_date', direction='older', unit=unit, unit_count=unit_count)
+    empty_list(ilo, 'No indices to remove from alias {}'.format(read_alias))
+    for index in ilo.working_list():
+        print("Removing index {} from {} alias".format(index, read_alias))
+    alias = curator.Alias(client=client, name=read_alias)
+    alias.remove(ilo)
+    alias.do_action()
+
+
+def str2bool(v):
+    return v.lower() in ('true', '1')
+
+
+def empty_list(ilo, error_msg):
+    try:
+        ilo.empty_list_check()
+    except curator.NoIndices:
+        print(error_msg)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.DEBUG)
+    main()

--- a/plugin/storage/es/esRollover.py
+++ b/plugin/storage/es/esRollover.py
@@ -30,7 +30,7 @@ def main():
 
     # TODO add rollover for main indices https://github.com/jaegertracing/jaeger/issues/1242
     if not str2bool(os.getenv('ARCHIVE', 'false')):
-        print('Rollover for main indices is not supported at the moment')
+        print('Rollover for main indices is not supported')
         sys.exit(1)
 
     client = elasticsearch.Elasticsearch(sys.argv[2:])
@@ -73,7 +73,7 @@ def create_aliases(client, alias_name, archive_index_name):
     ilo.filter_by_regex(kind='regex', value='^'+archive_index_name+'$')
     alias = curator.Alias(client=client, name=alias_name)
     for index in ilo.working_list():
-        print("Adding index {} to {} alias".format(index, alias_name))
+        print("Adding index {} to alias {}".format(index, alias_name))
     alias.add(ilo)
     alias.do_action()
 
@@ -89,7 +89,7 @@ def rollover(client, write_alias, read_alias, conditions):
     ilo.filter_by_alias(aliases=[write_alias])
     alias = curator.Alias(client=client, name=read_alias)
     for index in ilo.working_list():
-        print("Adding index {} to {} alias".format(index, read_alias))
+        print("Adding index {} to alias {}".format(index, read_alias))
     alias.add(ilo)
     alias.do_action()
 
@@ -105,7 +105,7 @@ def read_alias_lookback(client, write_alias, read_alias, unit, unit_count):
     ilo.filter_by_age(source='creation_date', direction='older', unit=unit, unit_count=unit_count)
     empty_list(ilo, 'No indices to remove from alias {}'.format(read_alias))
     for index in ilo.working_list():
-        print("Removing index {} from {} alias".format(index, read_alias))
+        print("Removing index {} from alias {}".format(index, read_alias))
     alias = curator.Alias(client=client, name=read_alias)
     alias.remove(ilo)
     alias.do_action()

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -33,6 +33,11 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
+const (
+	primaryNamespace = "es"
+	archiveNamespace = "es-archive"
+)
+
 // Factory implements storage.Factory for Elasticsearch backend.
 type Factory struct {
 	Options *Options
@@ -42,12 +47,14 @@ type Factory struct {
 
 	primaryConfig config.ClientBuilder
 	primaryClient es.Client
+	archiveConfig config.ClientBuilder
+	archiveClient es.Client
 }
 
 // NewFactory creates a new Factory.
 func NewFactory() *Factory {
 	return &Factory{
-		Options: NewOptions("es"), // TODO add "es-archive" once supported
+		Options: NewOptions(primaryNamespace, archiveNamespace),
 	}
 }
 
@@ -60,6 +67,7 @@ func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
 func (f *Factory) InitFromViper(v *viper.Viper) {
 	f.Options.InitFromViper(v)
 	f.primaryConfig = f.Options.GetPrimary()
+	f.archiveConfig = f.Options.Get(archiveNamespace)
 }
 
 // Initialize implements storage.Factory
@@ -71,45 +79,22 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 		return err
 	}
 	f.primaryClient = primaryClient
-	// TODO init archive (cf. https://github.com/jaegertracing/jaeger/pull/604)
+	archiveClient, err := f.archiveConfig.NewClient(logger, metricsFactory)
+	if err != nil {
+		return err
+	}
+	f.archiveClient = archiveClient
 	return nil
 }
 
 // CreateSpanReader implements storage.Factory
 func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
-	cfg := f.primaryConfig
-	return esSpanStore.NewSpanReader(esSpanStore.SpanReaderParams{
-		Client:            f.primaryClient,
-		Logger:            f.logger,
-		MetricsFactory:    f.metricsFactory,
-		MaxSpanAge:        cfg.GetMaxSpanAge(),
-		MaxNumSpans:       cfg.GetMaxNumSpans(),
-		IndexPrefix:       cfg.GetIndexPrefix(),
-		TagDotReplacement: cfg.GetTagDotReplacement(),
-	}), nil
+	return createSpanReader(f.metricsFactory, f.logger, f.primaryClient, f.primaryConfig, false)
 }
 
 // CreateSpanWriter implements storage.Factory
 func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
-	cfg := f.primaryConfig
-	var tags []string
-	if cfg.GetTagsFilePath() != "" {
-		var err error
-		if tags, err = loadTagsFromFile(cfg.GetTagsFilePath()); err != nil {
-			f.logger.Error("Could not open file with tags", zap.Error(err))
-			return nil, err
-		}
-	}
-	return esSpanStore.NewSpanWriter(esSpanStore.SpanWriterParams{Client: f.primaryClient,
-		Logger:            f.logger,
-		MetricsFactory:    f.metricsFactory,
-		NumShards:         f.primaryConfig.GetNumShards(),
-		NumReplicas:       f.primaryConfig.GetNumReplicas(),
-		IndexPrefix:       f.primaryConfig.GetIndexPrefix(),
-		AllTagsAsFields:   f.primaryConfig.GetAllTagsAsFields(),
-		TagKeysAsFields:   tags,
-		TagDotReplacement: f.primaryConfig.GetTagDotReplacement(),
-	}), nil
+	return createSpanWriter(f.metricsFactory, f.logger, f.archiveClient, f.primaryConfig, false)
 }
 
 // CreateDependencyReader implements storage.Factory
@@ -133,4 +118,64 @@ func loadTagsFromFile(filePath string) ([]string, error) {
 		}
 	}
 	return tags, nil
+}
+
+// CreateArchiveSpanReader implements storage.ArchiveFactory
+func (f *Factory) CreateArchiveSpanReader() (spanstore.Reader, error) {
+	return createSpanReader(f.metricsFactory, f.logger, f.archiveClient, f.Options.Get(archiveNamespace), true)
+}
+
+// CreateArchiveSpanWriter implements storage.ArchiveFactory
+func (f *Factory) CreateArchiveSpanWriter() (spanstore.Writer, error) {
+	return createSpanWriter(f.metricsFactory, f.logger, f.archiveClient, f.Options.Get(archiveNamespace), true)
+}
+
+func createSpanReader(
+	mFactory metrics.Factory,
+	logger *zap.Logger,
+	client es.Client,
+	cfg config.ClientBuilder,
+	archive bool,
+) (spanstore.Reader, error) {
+	return esSpanStore.NewSpanReader(esSpanStore.SpanReaderParams{
+		Client:              client,
+		Logger:              logger,
+		MetricsFactory:      mFactory,
+		MaxNumSpans:         cfg.GetMaxNumSpans(),
+		MaxSpanAge:          cfg.GetMaxSpanAge(),
+		IndexPrefix:         cfg.GetIndexPrefix(),
+		TagDotReplacement:   cfg.GetTagDotReplacement(),
+		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
+		Archive:             archive,
+	}), nil
+}
+
+func createSpanWriter(
+	mFactory metrics.Factory,
+	logger *zap.Logger,
+	client es.Client,
+	cfg config.ClientBuilder,
+	archive bool,
+) (spanstore.Writer, error) {
+	var tags []string
+	if cfg.GetTagsFilePath() != "" {
+		var err error
+		if tags, err = loadTagsFromFile(cfg.GetTagsFilePath()); err != nil {
+			logger.Error("Could not open file with tags", zap.Error(err))
+			return nil, err
+		}
+	}
+	return esSpanStore.NewSpanWriter(esSpanStore.SpanWriterParams{
+		Client:              client,
+		Logger:              logger,
+		MetricsFactory:      mFactory,
+		NumShards:           cfg.GetNumShards(),
+		NumReplicas:         cfg.GetNumReplicas(),
+		IndexPrefix:         cfg.GetIndexPrefix(),
+		AllTagsAsFields:     cfg.GetAllTagsAsFields(),
+		TagKeysAsFields:     tags,
+		TagDotReplacement:   cfg.GetTagDotReplacement(),
+		Archive:             archive,
+		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
+	}), nil
 }

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -56,6 +56,10 @@ func TestElasticsearchFactory(t *testing.T) {
 	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
 
 	f.primaryConfig = &mockClientBuilder{}
+	f.archiveConfig = &mockClientBuilder{err: errors.New("made-up error2")}
+	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error2")
+
+	f.archiveConfig = &mockClientBuilder{}
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	_, err := f.CreateSpanReader()
@@ -66,6 +70,12 @@ func TestElasticsearchFactory(t *testing.T) {
 
 	_, err = f.CreateDependencyReader()
 	assert.NoError(t, err)
+
+	_, err = f.CreateArchiveSpanReader()
+	assert.NoError(t, err)
+
+	_, err = f.CreateArchiveSpanWriter()
+	assert.NoError(t, err)
 }
 
 func TestElasticsearchTagsFileDoNotExist(t *testing.T) {
@@ -73,6 +83,7 @@ func TestElasticsearchTagsFileDoNotExist(t *testing.T) {
 	mockConf := &mockClientBuilder{}
 	mockConf.TagsFilePath = "fixtures/tags_foo.txt"
 	f.primaryConfig = mockConf
+	f.archiveConfig = mockConf
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	r, err := f.CreateSpanWriter()
 	require.Error(t, err)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -47,6 +47,7 @@ const (
 	suffixTagsAsFieldsAll   = suffixTagsAsFields + ".all"
 	suffixTagsFile          = suffixTagsAsFields + ".config-file"
 	suffixTagDeDotChar      = suffixTagsAsFields + ".dot-replacement"
+	suffixReadAlias         = ".use-aliases"
 )
 
 // TODO this should be moved next to config.Configuration struct (maybe ./flags package)
@@ -194,6 +195,15 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixTagDeDotChar,
 		nsConfig.TagDotReplacement,
 		"(experimental) The character used to replace dots (\".\") in tag keys stored as object fields.")
+	// TODO add rollover support for main indices
+	if nsConfig.namespace == archiveNamespace {
+		flagSet.Bool(
+			nsConfig.namespace+suffixReadAlias,
+			nsConfig.UseReadWriteAliases,
+			"Use read and write aliases for indices. Use this option with Elasticsearch rollover "+
+				"API. It requires an external component to create aliases before startup and then performing its management. "+
+				"Note that "+nsConfig.namespace+suffixMaxSpanAge+" is not taken into the account and has to be substituted by external component managing read alias.")
+	}
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -226,6 +236,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.AllTagsAsFields = v.GetBool(cfg.namespace + suffixTagsAsFieldsAll)
 	cfg.TagsFilePath = v.GetString(cfg.namespace + suffixTagsFile)
 	cfg.TagDotReplacement = v.GetString(cfg.namespace + suffixTagDeDotChar)
+	cfg.UseReadWriteAliases = v.GetBool(cfg.namespace + suffixReadAlias)
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/es/spanstore/index_utils.go
+++ b/plugin/storage/es/spanstore/index_utils.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstore
+
+import (
+	"time"
+)
+
+// returns index name with date
+func indexWithDate(indexPrefix string, date time.Time) string {
+	spanDate := date.UTC().Format("2006-01-02")
+	return indexPrefix + spanDate
+}
+
+// returns archive index name
+func archiveIndex(indexPrefix, archiveSuffix string) string {
+	return indexPrefix + archiveSuffix
+}

--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -23,7 +23,7 @@ nvm use 8
 export DOCKER_NAMESPACE=jaegertracing
 make docker
 
-for component in agent cassandra-schema es-index-cleaner collector query ingester
+for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester
 do
   export REPO="jaegertracing/jaeger-${component}"
   bash ./scripts/travis/upload-to-docker.sh


### PR DESCRIPTION
Resolves https://github.com/jaegertracing/jaeger/issues/818
Related to https://github.com/jaegertracing/jaeger/issues/1242

This adds the implementation of archive storage for ES. There are two possible configurations how to use this feature:

* the default - it will store and read archived traces from `jaeger-archive-span` index.
* using rollover API - it writers spans to an alias `jaeger-span-archive-write` and reads from an alias `jaeger-span-archive-read`. This deployment requires an external component that performs index managent: creating index, creating alias, callig rollover API and managing `max-span-age` by removing indices from read alias. This component is `esRollover.py` available as `jaeger-es-rollover` docker image.

As the default index name does not collide with aliases used by rollover users can seameasly migrate from default deployment to rollover by putting  `jaeger-archive-span` index into the read alias.

### Default use case
It does not require any configuration just deploying jaeger.

### Rollover use case
It requires to create index `jaeger-span-archive-000001` and aliases `jaeger-span-archive-read`, `jaeger-span-archive-write`.

To enable rollover the following switch has to be enabled
```
--es-archive.use-aliases                                    Use read and write aliases for indices. Use this option with Elasticsearch rollover API. It requires an external component to create aliases before startup and then performing its management. Note that es-archive.max-span-age is not taken into the account and has to be substituted by external component managing read alias. (default false)
```

#### Initialization
Initialize - create index and aliases
```
ARCHIVE=true UNIT=seconds python3 esRollover.py init localhost:9200
```

#### Rollover
Now we can start jaeger and archive traces. The next step is to rollover to new write index:
```
ARCHIVE=true CONDITIONS='{"max_age": "1s"}'  python3 esRollover.py  rollover localhost:9200
```
I am using max age 1s to trigger the rollover immmediately. This step can be repeated multiple times, The read alias should always point to all created indices, whereas write alias only to the last one. 

#### Managing max-span-age and delete old indices
The last step is to remove old indices from read alias - to mimic `max-span-age`.
```
ARCHIVE=true  UNIT=minutes UNIT_COUNT=2  python3 esRollover.py  lookback localhost:9200
```
We can also delete the old indices entirely by running es-index-cleaner
```
ARCHIVE=true python3 esCleaner.py 1 localhost:9200
```
Note that it supports only days at unit.

#### Other
Indices: http://localhost:9200/_cat/indices
Aliases: http://localhost:9200/_cat/aliases

UI config to enable archive tab: `--query.ui-config ui-config.json`
```
{
    "archiveEnabled": true
}
```

ES 6.4.4 supports `is_write_index` - it means that a single alias can be used for reads and writes (it points to multiple indices from which only one is write). We can add support later by using a different flag.

The following command can be used to rollover and put the new index to read alias.
```bash
curl -ivX PUT -H "Content-Type: application/json" localhost:9200/jaeger-span-archive-000001 -d '{
  "aliases": {
    "jaeger-span-archive-write": {"is_write_index": true},
    "jaeger-span-archive-read": {}
  }
}'
```

Note that all actions provided by `esRollover.py` can be written declarativelly as yml files for curator. Here is a working examlple https://gist.github.com/pavolloffay/5ce3f59f0967aadd5b019be411121c6c. The problem is to support index prefix. Yaml approach is quite nice but does not satifly our requirements if we want to have some fields configurable.


