### PR TITLE
Migrate query cache to open source

### DIFF
--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -16,15 +16,17 @@ package app
 
 import (
 	"flag"
+	"time"
 
 	"github.com/spf13/viper"
 )
 
 const (
-	queryPort        = "query.port"
-	queryBasePath    = "query.base-path"
-	queryStaticFiles = "query.static-files"
-	queryUIConfig    = "query.ui-config"
+	queryPort                 = "query.port"
+	queryBasePath             = "query.base-path"
+	queryStaticFiles          = "query.static-files"
+	queryUIConfig             = "query.ui-config"
+	queryCacheRefreshInterval = "query.cache-refresh-interval"
 	// QueryDefaultHealthCheckHTTPPort is the default HTTP Port for health check
 	QueryDefaultHealthCheckHTTPPort = 16687
 )
@@ -39,6 +41,8 @@ type QueryOptions struct {
 	StaticAssets string
 	// UIConfig is the path to a configuration file for the UI
 	UIConfig string
+	// CacheRefreshInterval is the refresh interval for read cache
+	CacheRefreshInterval time.Duration
 }
 
 // AddFlags adds flags for QueryOptions
@@ -47,6 +51,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(queryBasePath, "/", "The base path for all HTTP routes, e.g. /jaeger; useful when running behind a reverse proxy")
 	flagSet.String(queryStaticFiles, "", "The directory path override for the static assets for the UI")
 	flagSet.String(queryUIConfig, "", "The path to the UI configuration file in JSON format")
+	flagSet.Duration(queryCacheRefreshInterval, 2*time.Minute, "The duration between cache refreshes")
 }
 
 // InitFromViper initializes QueryOptions with properties from viper
@@ -55,5 +60,6 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper) *QueryOptions {
 	qOpts.BasePath = v.GetString(queryBasePath)
 	qOpts.StaticAssets = v.GetString(queryStaticFiles)
 	qOpts.UIConfig = v.GetString(queryUIConfig)
+	qOpts.CacheRefreshInterval = v.GetDuration(queryCacheRefreshInterval)
 	return qOpts
 }

--- a/cmd/query/app/storage/cache.go
+++ b/cmd/query/app/storage/cache.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+// Cache is used to read from the underlying data store
+type Cache struct {
+	storage spanstore.Reader
+	cache   *autoRefreshCache
+	logger  *zap.Logger
+}
+
+// autoRefreshCache cache that automatically refreshes itself
+type autoRefreshCache struct {
+	sync.RWMutex
+
+	cache           []string
+	refreshInterval time.Duration
+	storage         spanstore.Reader
+	stopRefreshChan chan struct{}
+	logger          *zap.Logger
+}
+
+// NewCache returns a new cache that caches services data and automatically refreshes the data
+func NewCache(storage spanstore.Reader, refreshInterval time.Duration, logger *zap.Logger) *Cache {
+	return &Cache{
+		storage: storage,
+		logger:  logger,
+		cache: &autoRefreshCache{
+			storage:         storage,
+			refreshInterval: refreshInterval,
+			stopRefreshChan: make(chan struct{}),
+			logger:          logger,
+		},
+	}
+}
+
+// FindTraces implements spanstore.Reader#FindTraces
+func (c *Cache) FindTraces(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) ([]*model.Trace, error) {
+	return c.storage.FindTraces(ctx, traceQuery)
+}
+
+// GetTrace is used to populate a single trace using its traceID
+func (c *Cache) GetTrace(ctx context.Context, traceID model.TraceID) (*model.Trace, error) {
+	return c.storage.GetTrace(ctx, traceID)
+}
+
+// GetServices returns all services traced by Jaeger
+func (c *Cache) GetServices(ctx context.Context) ([]string, error) {
+	return c.cache.get(), nil
+}
+
+// GetOperations returns all operations for a specific service traced by Jaeger
+func (c *Cache) GetOperations(ctx context.Context, service string) ([]string, error) {
+	return c.storage.GetOperations(ctx, service)
+}
+
+// Initialize warm the cache and start up the auto refresh cache
+func (c *Cache) Initialize() {
+	if err := c.cache.warmCache(); err != nil {
+		c.logger.Error("Cannot warm cache from storage", zap.Error(err))
+	}
+	c.cache.initializeCacheRefresh()
+}
+
+// Close stop refreshing the auto refresh cache
+func (c *Cache) Close() error {
+	close(c.cache.stopRefreshChan)
+	return nil
+}
+
+func (ac *autoRefreshCache) get() []string {
+	ac.RLock()
+	defer ac.RUnlock()
+	return ac.cache
+}
+
+func (ac *autoRefreshCache) put(value []string) {
+	ac.Lock()
+	defer ac.Unlock()
+	ac.cache = value
+}
+
+func (ac *autoRefreshCache) isEmpty() bool {
+	ac.RLock()
+	defer ac.RUnlock()
+	return len(ac.cache) == 0
+}
+
+func (ac *autoRefreshCache) initializeCacheRefresh() {
+	go ac.refreshFromStorage(ac.refreshInterval)
+}
+
+// refreshFromStorage retrieves data from storage and replaces the current cache
+func (ac *autoRefreshCache) refreshFromStorage(refreshInterval time.Duration) {
+	ticker := time.NewTicker(refreshInterval)
+	for {
+		select {
+		case <-ticker.C:
+			ac.logger.Info("Refreshing cache from storage")
+			if err := ac.warmCache(); err != nil {
+				ac.logger.Error("Failed to retrieve cache from storage", zap.Error(err))
+			}
+		case <-ac.stopRefreshChan:
+			return
+		}
+	}
+}
+
+// warmCache warm up the cache with data from storage
+func (ac *autoRefreshCache) warmCache() error {
+	services, err := ac.storage.GetServices(context.Background())
+	if err != nil {
+		return err
+	}
+	ac.put(services)
+	return nil
+}

--- a/cmd/query/app/storage/cache_test.go
+++ b/cmd/query/app/storage/cache_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+	spanstoremocks "github.com/jaegertracing/jaeger/storage/spanstore/mocks"
+)
+
+var _ io.Closer = &Cache{} // API compliance check
+
+func initializeCache() (*Cache, *spanstoremocks.Reader) {
+	mock := &spanstoremocks.Reader{}
+	return NewCache(mock, 50*time.Millisecond, zap.NewNop()), mock
+}
+
+func TestCacheInitialize(t *testing.T) {
+	goodCache, goodMock := initializeCache()
+	expectedServices := []string{"someService"}
+	goodMock.On("GetServices").Return(expectedServices, nil)
+	goodCache.Initialize()
+	goodMock.AssertCalled(t, "GetServices")
+
+	badCache, badMock := initializeCache()
+	err := fmt.Errorf("Why u no work")
+	badMock.On("GetServices").Return(nil, err)
+	badCache.Initialize()
+	badMock.AssertCalled(t, "GetServices")
+}
+
+func TestCacheQuery(t *testing.T) {
+	cache, mock := initializeCache()
+
+	expectedTraces := []*model.Trace{}
+	mock.On("FindTraces", &spanstore.TraceQueryParameters{}).Return(expectedTraces, nil).Times(1)
+
+	actualTraces, err := cache.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTraces, actualTraces)
+}
+
+func TestGetTrace(t *testing.T) {
+	cache, mock := initializeCache()
+
+	expectedTraces := &model.Trace{}
+	traceID := model.TraceID{
+		High: 1,
+		Low:  2,
+	}
+	mock.On("GetTrace", traceID).Return(expectedTraces, nil).Times(1)
+
+	actualTraces, err := cache.GetTrace(context.Background(), traceID)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTraces, actualTraces)
+}
+
+func TestGetOperations(t *testing.T) {
+	cache, mock := initializeCache()
+
+	expectedOperations := []string{"get", "post"}
+	service := "service"
+	mock.On("GetOperations", service).Return(expectedOperations, nil).Times(1)
+
+	actualTraces, err := cache.GetOperations(context.Background(), service)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOperations, actualTraces)
+}
+
+func TestWarmCache(t *testing.T) {
+	cache, mock := initializeCache()
+
+	expectedServices := []string{"someService"}
+	mock.On("GetServices").Return(expectedServices, nil).Times(1)
+
+	err := cache.cache.warmCache()
+	assert.NoError(t, err)
+
+	services, err := cache.GetServices(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedServices, services)
+}
+
+func TestRefreshFromStorage(t *testing.T) {
+	cache, mock := initializeCache()
+
+	expectedServices := []string{"someService"}
+	mock.On("GetServices").Return(expectedServices, nil).Times(1)
+
+	cache.cache.initializeCacheRefresh()
+
+	for i := 0; i < 100; i++ {
+		if !cache.cache.isEmpty() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	services, err := cache.GetServices(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedServices, services)
+
+	cache.Close()
+}

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/env"
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/cmd/query/app"
+	queryCache "github.com/jaegertracing/jaeger/cmd/query/app/storage"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	pMetrics "github.com/jaegertracing/jaeger/pkg/metrics"
@@ -109,6 +110,8 @@ func main() {
 				logger.Fatal("Failed to create span reader", zap.Error(err))
 			}
 			spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace("query", nil))
+			spanReader = queryCache.NewCache(spanReader, queryOpts.CacheRefreshInterval, logger)
+
 			dependencyReader, err := storageFactory.CreateDependencyReader()
 			if err != nil {
 				logger.Fatal("Failed to create dependency reader", zap.Error(err))


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1203.  

## Short description of the changes
- Migrates @black-adder's and @yurishkuro's changes from Uber internal repository to open source.
