### PR TITLE
WIP: update uber/jaeger-lib to master

### DIFF
--- a/cmd/agent/app/configmanager/metrics_test.go
+++ b/cmd/agent/app/configmanager/metrics_test.go
@@ -21,8 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
 	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
@@ -46,16 +45,16 @@ func (noopManager) GetBaggageRestrictions(s string) ([]*baggage.BaggageRestricti
 
 func TestMetrics(t *testing.T) {
 	tests := []struct {
-		expected []mTestutils.ExpectedMetric
+		expected []metricstest.ExpectedMetric
 		err      error
 	}{
-		{expected: []mTestutils.ExpectedMetric{
+		{expected: []metricstest.ExpectedMetric{
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "sampling"}, Value: 1},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "sampling"}, Value: 0},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "baggage"}, Value: 1},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "baggage"}, Value: 0},
 		}},
-		{expected: []mTestutils.ExpectedMetric{
+		{expected: []metricstest.ExpectedMetric{
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "sampling"}, Value: 0},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "sampling"}, Value: 1},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "baggage"}, Value: 0},
@@ -64,7 +63,7 @@ func TestMetrics(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		metricsFactory := metrics.NewLocalFactory(time.Microsecond)
+		metricsFactory := metricstest.NewFactory(time.Microsecond)
 		mgr := WrapWithMetrics(&noopManager{}, metricsFactory)
 
 		if test.err != nil {
@@ -82,6 +81,6 @@ func TestMetrics(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, b)
 		}
-		mTestutils.AssertCounterMetrics(t, metricsFactory, test.expected...)
+		metricsFactory.AssertCounterMetrics(t, test.expected...)
 	}
 }

--- a/cmd/agent/app/httpserver/server_test.go
+++ b/cmd/agent/app/httpserver/server_test.go
@@ -25,9 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	tSampling092 "github.com/jaegertracing/jaeger/cmd/agent/app/httpserver/thrift-0.9.2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
@@ -35,7 +33,7 @@ import (
 )
 
 type testServer struct {
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	mgr            *mockManager
 	server         *httptest.Server
 }
@@ -45,7 +43,7 @@ func withServer(
 	mockBaggageResponse []*baggage.BaggageRestriction,
 	runTest func(server *testServer),
 ) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	mgr := &mockManager{
 		samplingResponse: mockSamplingResponse,
 		baggageResponse:  mockBaggageResponse,
@@ -100,7 +98,7 @@ func TestHTTPHandler(t *testing.T) {
 		})
 
 		// handler must emit metrics
-		testutils.AssertCounterMetrics(t, ts.metricsFactory, []testutils.ExpectedMetric{
+		ts.metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 			{Name: "http-server.requests", Tags: map[string]string{"type": "sampling"}, Value: 1},
 			{Name: "http-server.requests", Tags: map[string]string{"type": "sampling-legacy"}, Value: 1},
 			{Name: "http-server.requests", Tags: map[string]string{"type": "baggage"}, Value: 1},
@@ -116,14 +114,14 @@ func TestHTTPHandlerErrors(t *testing.T) {
 		url                  string
 		statusCode           int
 		body                 string
-		metrics              []mTestutils.ExpectedMetric
+		metrics              []metricstest.ExpectedMetric
 	}{
 		{
 			description: "no service name",
 			url:         "",
 			statusCode:  http.StatusBadRequest,
 			body:        "'service' parameter must be provided once\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "all", "status": "4xx"}, Value: 1},
 			},
 		},
@@ -132,7 +130,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "?service=Y&service=Y",
 			statusCode:  http.StatusBadRequest,
 			body:        "'service' parameter must be provided once\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "all", "status": "4xx"}, Value: 1},
 			},
 		},
@@ -141,7 +139,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "/baggageRestrictions?service=Y&service=Y",
 			statusCode:  http.StatusBadRequest,
 			body:        "'service' parameter must be provided once\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "all", "status": "4xx"}, Value: 1},
 			},
 		},
@@ -150,7 +148,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "?service=Y",
 			statusCode:  http.StatusInternalServerError,
 			body:        "collector error: no mock response provided\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "collector-proxy", "status": "5xx"}, Value: 1},
 			},
 		},
@@ -159,7 +157,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "/baggageRestrictions?service=Y",
 			statusCode:  http.StatusInternalServerError,
 			body:        "collector error: no mock response provided\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "collector-proxy", "status": "5xx"}, Value: 1},
 			},
 		},
@@ -169,7 +167,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:                  "?service=Y",
 			statusCode:           http.StatusInternalServerError,
 			body:                 "Cannot marshall Thrift to JSON\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "thrift", "status": "5xx"}, Value: 1},
 			},
 		},
@@ -188,7 +186,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 				}
 
 				if len(testCase.metrics) > 0 {
-					mTestutils.AssertCounterMetrics(t, ts.metricsFactory, testCase.metrics...)
+					ts.metricsFactory.AssertCounterMetrics(t, testCase.metrics...)
 				}
 			})
 		})
@@ -202,14 +200,14 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			w := &mockWriter{header: make(http.Header)}
 			handler.serveSamplingHTTP(w, req, false)
 
-			mTestutils.AssertCounterMetrics(t, ts.metricsFactory,
-				mTestutils.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 1})
+			ts.metricsFactory.AssertCounterMetrics(t,
+				metricstest.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 1})
 
 			req = httptest.NewRequest("GET", "http://localhost:80/baggageRestrictions?service=X", nil)
 			handler.serveBaggageHTTP(w, req)
 
-			mTestutils.AssertCounterMetrics(t, ts.metricsFactory,
-				mTestutils.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 2})
+			ts.metricsFactory.AssertCounterMetrics(t,
+				metricstest.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 2})
 		})
 	})
 }

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
@@ -75,7 +75,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 	return transport.Addr().String(), processor
 }
 
-func initCollectorAndReporter(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, reporter.Reporter) {
+func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.MockTCollector, reporter.Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
 	reporter := reporter.WrapWithMetrics(tchreporter.New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop()), metricsFactory)
 	return metricsFactory, collector, reporter
@@ -115,7 +115,7 @@ func (h failingHandler) Process(iprot, oprot thrift.TProtocol) (success bool, er
 }
 
 func TestProcessor_HandlerError(t *testing.T) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	handler := failingHandler{err: errors.New("doh")}
 
@@ -137,9 +137,9 @@ func TestProcessor_HandlerError(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	mTestutils.AssertCounterMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.t-processor.handler-errors", Value: 1},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
+	metricsFactory.AssertCounterMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.t-processor.handler-errors", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
 	)
 }
 
@@ -170,7 +170,7 @@ func TestJaegerProcessor(t *testing.T) {
 	}
 }
 
-func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metrics.LocalFactory) {
+func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metricstest.Factory) {
 	sizeF := func() int {
 		return len(collector.GetJaegerBatches())
 	}
@@ -180,7 +180,7 @@ func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCo
 	assertProcessorCorrectness(t, metricsFactory, sizeF, nameF, "jaeger")
 }
 
-func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metrics.LocalFactory) {
+func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metricstest.Factory) {
 	sizeF := func() int {
 		return len(collector.GetZipkinSpans())
 	}
@@ -192,7 +192,7 @@ func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCo
 
 func assertProcessorCorrectness(
 	t *testing.T,
-	metricsFactory *metrics.LocalFactory,
+	metricsFactory *metricstest.Factory,
 	sizeF func() int,
 	nameF func() string,
 	format string,
@@ -218,7 +218,7 @@ func assertProcessorCorrectness(
 	}
 
 	// agentReporter must emit metrics
-	mTestutils.AssertCounterMetrics(t, metricsFactory, []mTestutils.ExpectedMetric{
+	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 		{Name: "reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "thrift.udp.server.packets.processed", Value: 1},

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -57,7 +58,7 @@ func TestMultipleCollectors(t *testing.T) {
 	})
 	defer s2.Stop()
 
-	mFactory := metrics.NewLocalFactory(time.Microsecond)
+	mFactory := metricstest.NewFactory(time.Microsecond)
 	proxy, err := NewCollectorProxy(&Options{CollectorHostPort: []string{addr1.String(), addr2.String()}}, mFactory, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, proxy)

--- a/cmd/agent/app/reporter/metrics_test.go
+++ b/cmd/agent/app/reporter/metrics_test.go
@@ -20,8 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -45,70 +44,70 @@ func (r *noopReporter) EmitBatch(batch *jaeger.Batch) error {
 
 func TestMetricsReporter(t *testing.T) {
 	tests := []struct {
-		expectedCounters []mTestutils.ExpectedMetric
-		expectedGauges   []mTestutils.ExpectedMetric
+		expectedCounters []metricstest.ExpectedMetric
+		expectedGauges   []metricstest.ExpectedMetric
 		action           func(reporter Reporter)
 		rep              *noopReporter
 	}{
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitBatch(nil)
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitBatch(&jaeger.Batch{Spans: []*jaeger.Span{{}}})
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitZipkinBatch(nil)
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitZipkinBatch([]*zipkincore.Span{{}})
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "jaeger"}, Value: 1},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitBatch(&jaeger.Batch{Spans: []*jaeger.Span{{}}})
 			require.Error(t, err)
 		}, rep: &noopReporter{err: errors.New("foo")}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "zipkin"}, Value: 2},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitZipkinBatch([]*zipkincore.Span{{}, {}})
@@ -117,10 +116,10 @@ func TestMetricsReporter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		metricsFactory := metrics.NewLocalFactory(time.Microsecond)
+		metricsFactory := metricstest.NewFactory(time.Microsecond)
 		r := WrapWithMetrics(test.rep, metricsFactory)
 		test.action(r)
-		mTestutils.AssertCounterMetrics(t, metricsFactory, test.expectedCounters...)
-		mTestutils.AssertGaugeMetrics(t, metricsFactory, test.expectedGauges...)
+		metricsFactory.AssertCounterMetrics(t, test.expectedCounters...)
+		metricsFactory.AssertGaugeMetrics(t, test.expectedGauges...)
 	}
 }

--- a/cmd/agent/app/reporter/tchannel/reporter_test.go
+++ b/cmd/agent/app/reporter/tchannel/reporter_test.go
@@ -20,15 +20,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
-func initRequirements(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, *Reporter) {
+func initRequirements(t *testing.T) (*metricstest.Factory, *testutils.MockTCollector, *Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
 	reporter := New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop())
 	return metricsFactory, collector, reporter

--- a/cmd/agent/app/servers/tbuffered_server_test.go
+++ b/cmd/agent/app/servers/tbuffered_server_test.go
@@ -21,8 +21,7 @@ import (
 	athrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
@@ -41,7 +40,7 @@ func TestTBufferedServer(t *testing.T) {
 }
 
 func testTBufferedServer(t *testing.T, queueSize int, testDroppedPackets bool) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	transport, err := thriftudp.NewTUDPServerTransport("127.0.0.1:0")
 	require.NoError(t, err)
@@ -100,12 +99,12 @@ func testTBufferedServer(t *testing.T, queueSize int, testDroppedPackets bool) {
 	assert.Equal(t, "span1", inMemReporter.ZipkinSpans()[0].Name)
 
 	// server must emit metrics
-	mTestutils.AssertCounterMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 0},
+	metricsFactory.AssertCounterMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 0},
 	)
-	mTestutils.AssertGaugeMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 38},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
+	metricsFactory.AssertGaugeMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 38},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
 	)
 }

--- a/cmd/agent/app/testutils/fixture.go
+++ b/cmd/agent/app/testutils/fixture.go
@@ -17,13 +17,13 @@ package testutils
 import (
 	"testing"
 
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
 )
 
 // InitMockCollector initializes a MockTCollector fixture
-func InitMockCollector(t *testing.T) (*metrics.LocalFactory, *MockTCollector) {
-	factory := metrics.NewLocalFactory(0)
+func InitMockCollector(t *testing.T) (*metricstest.Factory, *MockTCollector) {
+	factory := metricstest.NewFactory(0)
 	collector, err := StartMockTCollector()
 	require.NoError(t, err)
 

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -18,14 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	jaegerM "github.com/uber/jaeger-lib/metrics"
-
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 func TestProcessorMetrics(t *testing.T) {
-	baseMetrics := jaegerM.NewLocalFactory(time.Hour)
+	baseMetrics := metricstest.NewFactory(time.Hour)
 	serviceMetrics := baseMetrics.Namespace("service", nil)
 	hostMetrics := baseMetrics.Namespace("host", nil)
 	spm := NewSpanProcessorMetrics(serviceMetrics, hostMetrics, []string{"scruffy"})
@@ -46,7 +45,7 @@ func TestProcessorMetrics(t *testing.T) {
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	mSpan.ReplaceParentID(1234)
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
-	counters, gauges := baseMetrics.LocalBackend.Snapshot()
+	counters, gauges := baseMetrics.Backend.Snapshot()
 
 	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|svc=fry"])
 	assert.EqualValues(t, 2, counters["service.spans.received|debug=true|format=jaeger|svc=fry"])
@@ -56,7 +55,7 @@ func TestProcessorMetrics(t *testing.T) {
 }
 
 func TestNewCountsBySvc(t *testing.T) {
-	baseMetrics := jaegerM.NewLocalFactory(time.Hour)
+	baseMetrics := metricstest.NewFactory(time.Hour)
 	metrics := newCountsBySvc(baseMetrics, "not_on_my_level", 3)
 
 	metrics.countByServiceName("fry", false)
@@ -64,7 +63,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("bender", false)
 	metrics.countByServiceName("zoidberg", false)
 
-	counters, _ := baseMetrics.LocalBackend.Snapshot()
+	counters, _ := baseMetrics.Backend.Snapshot()
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|svc=fry"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|svc=leela"])
 	assert.EqualValues(t, 2, counters["not_on_my_level|debug=false|svc=other-services"])
@@ -74,7 +73,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("leela", true)
 	metrics.countByServiceName("fry", true)
 
-	counters, _ = baseMetrics.LocalBackend.Snapshot()
+	counters, _ = baseMetrics.Backend.Snapshot()
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|svc=zoidberg"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|svc=bender"])
 	assert.EqualValues(t, 2, counters["not_on_my_level|debug=true|svc=other-services"])

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -21,8 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
-	metricsTest "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
@@ -69,7 +68,7 @@ func TestBySvcMetrics(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mb := metrics.NewLocalFactory(time.Hour)
+		mb := metricstest.NewFactory(time.Hour)
 		logger := zap.NewNop()
 		serviceMetrics := mb.Namespace("service", nil)
 		hostMetrics := mb.Namespace("host", nil)
@@ -109,23 +108,23 @@ func TestBySvcMetrics(t *testing.T) {
 		} else {
 			panic("Unknown format")
 		}
-		expected := []metricsTest.ExpectedMetric{}
+		expected := []metricstest.ExpectedMetric{}
 		if test.debug {
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: metricPrefix + ".spans.received|debug=true|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		} else {
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: metricPrefix + ".spans.received|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		}
 		if test.rootSpan {
 			if test.debug {
-				expected = append(expected, metricsTest.ExpectedMetric{
+				expected = append(expected, metricstest.ExpectedMetric{
 					Name: metricPrefix + ".traces.received|debug=true|format=" + format + "|svc=" + test.serviceName, Value: 2,
 				})
 			} else {
-				expected = append(expected, metricsTest.ExpectedMetric{
+				expected = append(expected, metricstest.ExpectedMetric{
 					Name: metricPrefix + ".traces.received|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 				})
 			}
@@ -135,17 +134,17 @@ func TestBySvcMetrics(t *testing.T) {
 			// because both are emitted when attempting to add span to the queue, and since
 			// we defined the queue capacity as 0, all submitted items are dropped.
 			// The debug spans are always accepted.
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: "host.error.busy", Value: 2,
-			}, metricsTest.ExpectedMetric{
+			}, metricstest.ExpectedMetric{
 				Name: "host.spans.dropped", Value: 2,
 			})
 		} else {
-			expected = append(expected, metricsTest.ExpectedMetric{
+			expected = append(expected, metricstest.ExpectedMetric{
 				Name: metricPrefix + ".spans.rejected|debug=false|format=" + format + "|svc=" + test.serviceName, Value: 2,
 			})
 		}
-		metricsTest.AssertCounterMetrics(t, mb, expected...)
+		mb.AssertCounterMetrics(t, expected...)
 	}
 }
 
@@ -228,7 +227,7 @@ func TestSpanProcessorErrors(t *testing.T) {
 	w := &fakeSpanWriter{
 		err: fmt.Errorf("some-error"),
 	}
-	mb := metrics.NewLocalFactory(time.Hour)
+	mb := metricstest.NewFactory(time.Hour)
 	serviceMetrics := mb.Namespace("service", nil)
 	p := NewSpanProcessor(w,
 		Options.Logger(logger),
@@ -254,10 +253,10 @@ func TestSpanProcessorErrors(t *testing.T) {
 		"error": "some-error",
 	}, logBuf.JSONLine(0))
 
-	expected := []metricsTest.ExpectedMetric{{
+	expected := []metricstest.ExpectedMetric{{
 		Name: "service.spans.saved-by-svc|debug=false|result=err|svc=x", Value: 1,
 	}}
-	metricsTest.AssertCounterMetrics(t, mb, expected...)
+	mb.AssertCounterMetrics(t, expected...)
 }
 
 type blockingWriter struct {

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	kmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/mocks"
@@ -117,7 +117,7 @@ func TestSaramaConsumerWrapper_MarkPartitionOffset(t *testing.T) {
 }
 
 func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
-	localFactory := metrics.NewLocalFactory(0)
+	localFactory := metricstest.NewFactory(0)
 
 	msg := &sarama.ConsumerMessage{}
 
@@ -153,7 +153,7 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 	mc.YieldMessage(msg)
 	isProcessed.Wait()
 
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partitions-held",
 		Value: 1,
 	})
@@ -164,28 +164,28 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 		undertest.partitionIDToState[partition].partitionConsumer.HighWaterMarkOffset())
 	undertest.Close()
 
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partitions-held",
 		Value: 0,
 	})
 
 	partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.messages",
 		Tags:  partitionTag,
 		Value: 1,
 	})
-	testutils.AssertGaugeMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.current-offset",
 		Tags:  partitionTag,
 		Value: 1,
 	})
-	testutils.AssertGaugeMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.offset-lag",
 		Tags:  partitionTag,
 		Value: 0,
 	})
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partition-start",
 		Tags:  partitionTag,
 		Value: 1,
@@ -193,7 +193,7 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 }
 
 func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
-	localFactory := metrics.NewLocalFactory(0)
+	localFactory := metricstest.NewFactory(0)
 
 	saramaConsumer := smocks.NewConsumer(t, &sarama.Config{})
 	mc := saramaConsumer.ExpectConsumePartition(topic, partition, msgOffset)
@@ -216,7 +216,7 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 		}
 
 		partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
-		testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+		localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 			Name:  "sarama-consumer.errors",
 			Tags:  partitionTag,
 			Value: 1,
@@ -229,7 +229,7 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 }
 
 func TestHandleClosePartition(t *testing.T) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	mp := &pmocks.SpanProcessor{}
 	saramaConsumer := smocks.NewConsumer(t, &sarama.Config{})

--- a/cmd/ingester/app/consumer/offset/manager_test.go
+++ b/cmd/ingester/app/consumer/offset/manager_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 func TestHandleReset(t *testing.T) {
 	offset := int64(1498)
 	minOffset := offset - 1
 
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/cmd/ingester/app/processor/decorator/retry_test.go
+++ b/cmd/ingester/app/processor/decorator/retry_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
 )
@@ -34,7 +35,7 @@ func TestNewRetryingProcessor(t *testing.T) {
 	mockProcessor := &mocks.SpanProcessor{}
 	msg := &fakeMsg{}
 	mockProcessor.On("Process", msg).Return(nil)
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor)
 
 	assert.NoError(t, rp.Process(msg))
@@ -55,7 +56,7 @@ func TestNewRetryingProcessorError(t *testing.T) {
 		MaxAttempts(2),
 		PropagateError(true),
 		Rand(&fakeRand{})}
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
 	assert.Error(t, rp.Process(msg))
@@ -77,7 +78,7 @@ func TestNewRetryingProcessorNoErrorPropagation(t *testing.T) {
 		PropagateError(false),
 		Rand(&fakeRand{})}
 
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
 	assert.NoError(t, rp.Process(msg))

--- a/cmd/ingester/app/processor/metrics_decorator_test.go
+++ b/cmd/ingester/app/processor/metrics_decorator_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
@@ -35,7 +35,7 @@ func TestProcess(t *testing.T) {
 	p := &mocks.SpanProcessor{}
 	msg := fakeMsg{}
 	p.On("Process", msg).Return(nil)
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 	proc := processor.NewDecoratedProcessor(m, p)
 
 	proc.Process(msg)
@@ -48,7 +48,7 @@ func TestProcessErr(t *testing.T) {
 	p := &mocks.SpanProcessor{}
 	msg := fakeMsg{}
 	p.On("Process", msg).Return(errors.New("err"))
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 	proc := processor.NewDecoratedProcessor(m, p)
 
 	proc.Process(msg)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: eb96c7fd56c8c6523990c19ba5bcf0d826922569a16e1019a88de57d46675775
-updated: 2018-10-12T23:27:30.163799+09:00
+hash: c989085653e341867354de5fa1993613baf10bedc72ba71e5d6388ab7d947d4d
+updated: 2018-11-24T16:00:17.164333289+05:30
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -254,15 +254,15 @@ imports:
   - transport/zipkin
   - utils
 - name: github.com/uber/jaeger-lib
-  version: ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5
+  version: 1fc5c315e03c871d98a3df762234414d185115d7
   subpackages:
   - metrics
   - metrics/adapters
   - metrics/expvar
   - metrics/go-kit
   - metrics/go-kit/expvar
+  - metrics/metricstest
   - metrics/prometheus
-  - metrics/testutils
 - name: github.com/uber/tchannel-go
   version: 1a0e35378f6f721bc07f6c4466bc9701ed70b506
   subpackages:
@@ -292,8 +292,9 @@ imports:
   - internal/ztest
   - zapcore
   - zaptest
+  - zaptest/observer
 - name: golang.org/x/net
-  version: 49bb7cea24b1df9410e1712aa6433dae904ff66a
+  version: adae6a3d119ae4890b46832a2e88a95adc62b8e7
   subpackages:
   - context
   - context/ctxhttp
@@ -339,10 +340,12 @@ imports:
   - peer
   - resolver
   - resolver/dns
+  - resolver/manual
   - resolver/passthrough
   - stats
   - status
   - tap
+  - test/bufconn
   - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
@@ -357,7 +360,7 @@ imports:
   - config
   - uritemplates
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/kr/text
   version: 7cafcd837844e784b526369c9bce262804aebc60

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,7 +17,7 @@ import:
   subpackages:
   - transport
 - package: github.com/uber/jaeger-lib
-  version: ^1.5.0
+  version: master 
 - package: github.com/uber/tchannel-go
   version: v1.1.0
   subpackages:

--- a/pkg/cassandra/metrics/table_test.go
+++ b/pkg/cassandra/metrics/table_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
@@ -63,7 +63,7 @@ func TestTableEmit(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(time.Second)
+		mf := metricstest.NewFactory(time.Second)
 		tm := NewTable(mf, "a_table")
 		tm.Emit(tc.err, 50*time.Millisecond)
 		counts, gauges := mf.Snapshot()
@@ -110,7 +110,7 @@ func TestTableExec(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(0)
+		mf := metricstest.NewFactory(0)
 		tm := NewTable(mf, "a_table")
 		logger, logBuf := testutils.NewLogger()
 

--- a/pkg/metrics/builder_test.go
+++ b/pkg/metrics/builder_test.go
@@ -51,7 +51,7 @@ func TestBuilder(t *testing.T) {
 		families, err := prometheus.DefaultGatherer.Gather()
 		require.NoError(t, err)
 		for _, mf := range families {
-			if mf.GetName() == "foo_counter" {
+			if mf.GetName() == "foo_counter_total" {
 				return
 			}
 		}

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -23,14 +23,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 // In this test we run a queue with capacity 1 and a single consumer.
 // We want to test the overflow behavior, so we block the consumer
 // by holding a startLock before submitting items to the queue.
 func TestBoundedQueue(t *testing.T) {
-	mFact := metrics.NewLocalFactory(0)
+	mFact := metricstest.NewFactory(0)
 	counter := mFact.Counter("dropped", nil)
 	gauge := mFact.Gauge("size", nil)
 

--- a/plugin/storage/cassandra/dependencystore/storage.go
+++ b/plugin/storage/cassandra/dependencystore/storage.go
@@ -46,7 +46,7 @@ func NewDependencyStore(
 ) *DependencyStore {
 	return &DependencyStore{
 		session:                  session,
-		dependenciesTableMetrics: casMetrics.NewTable(metricsFactory, "dependencies"),
+		dependenciesTableMetrics: casMetrics.NewTable(metricsFactory.Namespace("write", nil), "dependencies"),
 		logger:                   logger,
 	}
 }

--- a/plugin/storage/cassandra/dependencystore/storage_test.go
+++ b/plugin/storage/cassandra/dependencystore/storage_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -42,7 +42,7 @@ type depStorageTest struct {
 func withDepStore(fn func(s *depStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(time.Second)
+	metricsFactory := metricstest.NewFactory(time.Second)
 	defer metricsFactory.Stop()
 	s := &depStorageTest{
 		session:   session,

--- a/plugin/storage/cassandra/samplingstore/storage_test.go
+++ b/plugin/storage/cassandra/samplingstore/storage_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
@@ -45,7 +45,7 @@ type samplingStoreTest struct {
 func withSamplingStore(fn func(r *samplingStoreTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	r := &samplingStoreTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/cassandra/spanstore/operation_names.go
+++ b/plugin/storage/cassandra/spanstore/operation_names.go
@@ -54,7 +54,7 @@ func NewOperationNamesStorage(
 		session:       session,
 		InsertStmt:    insertOperationName,
 		QueryStmt:     queryOperationNames,
-		metrics:       casMetrics.NewTable(metricsFactory, "operation_names"),
+		metrics:       casMetrics.NewTable(metricsFactory.Namespace("write", nil), "operation_names"),
 		writeCacheTTL: writeCacheTTL,
 		logger:        logger,
 		operationNames: cache.NewLRUWithOptions(

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -85,7 +85,7 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 
 				counts, _ := s.metricsFactory.Snapshot()
 				assert.Equal(t, map[string]int64{
-					"attempts|table=operation_names": 2, "inserts|table=operation_names": 1, "errors|table=operation_names": 1,
+					"write.attempts|table=operation_names": 2, "write.inserts|table=operation_names": 1, "write.errors|table=operation_names": 1,
 				}, counts, "after first two writes")
 
 				// write again
@@ -96,8 +96,8 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 				expCounts := counts
 				if writeCacheTTL == 0 {
 					// without write cache, the second write must succeed
-					expCounts["attempts|table=operation_names"]++
-					expCounts["inserts|table=operation_names"]++
+					expCounts["write.attempts|table=operation_names"]++
+					expCounts["write.inserts|table=operation_names"]++
 				}
 				assert.Equal(t, expCounts, counts2)
 			})

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
@@ -32,7 +32,7 @@ import (
 type operationNameStorageTest struct {
 	session        *mocks.Session
 	writeCacheTTL  time.Duration
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	logger         *zap.Logger
 	logBuffer      *testutils.Buffer
 	storage        *OperationNamesStorage
@@ -41,7 +41,7 @@ type operationNameStorageTest struct {
 func withOperationNamesStorage(writeCacheTTL time.Duration, fn func(s *operationNameStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	s := &operationNameStorageTest{
 		session:        session,
 		writeCacheTTL:  writeCacheTTL,

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -45,7 +45,7 @@ type spanReaderTest struct {
 func withSpanReader(fn func(r *spanReaderTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	r := &spanReaderTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/cassandra/spanstore/service_names.go
+++ b/plugin/storage/cassandra/spanstore/service_names.go
@@ -53,7 +53,7 @@ func NewServiceNamesStorage(
 		session:       session,
 		InsertStmt:    insertServiceName,
 		QueryStmt:     queryServiceNames,
-		metrics:       casMetrics.NewTable(metricsFactory, "service_names"),
+		metrics:       casMetrics.NewTable(metricsFactory.Namespace("write", nil), "service_names"),
 		writeCacheTTL: writeCacheTTL,
 		logger:        logger,
 		serviceNames: cache.NewLRUWithOptions(

--- a/plugin/storage/cassandra/spanstore/service_names_test.go
+++ b/plugin/storage/cassandra/spanstore/service_names_test.go
@@ -85,7 +85,7 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 
 				counts, _ := s.metricsFactory.Snapshot()
 				assert.Equal(t, map[string]int64{
-					"attempts|table=service_names": 2, "inserts|table=service_names": 1, "errors|table=service_names": 1,
+					"write.attempts|table=service_names": 2, "write.inserts|table=service_names": 1, "write.errors|table=service_names": 1,
 				}, counts)
 
 				// write again
@@ -96,8 +96,8 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 				expCounts := counts
 				if writeCacheTTL == 0 {
 					// without write cache, the second write must succeed
-					expCounts["attempts|table=service_names"]++
-					expCounts["inserts|table=service_names"]++
+					expCounts["write.attempts|table=service_names"]++
+					expCounts["write.inserts|table=service_names"]++
 				}
 				assert.Equal(t, expCounts, counts2)
 			})

--- a/plugin/storage/cassandra/spanstore/service_names_test.go
+++ b/plugin/storage/cassandra/spanstore/service_names_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
@@ -32,7 +32,7 @@ import (
 type serviceNameStorageTest struct {
 	session        *mocks.Session
 	writeCacheTTL  time.Duration
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	logger         *zap.Logger
 	logBuffer      *testutils.Buffer
 	storage        *ServiceNamesStorage
@@ -41,7 +41,7 @@ type serviceNameStorageTest struct {
 func withServiceNamesStorage(writeCacheTTL time.Duration, fn func(s *serviceNameStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(time.Second)
+	metricsFactory := metricstest.NewFactory(time.Second)
 	defer metricsFactory.Stop()
 	s := &serviceNameStorageTest{
 		session:        session,

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -103,6 +103,7 @@ func NewSpanWriter(
 	logger *zap.Logger,
 	options ...Option,
 ) *SpanWriter {
+	writeFactory := metricsFactory.Namespace("write", nil)
 	serviceNamesStorage := NewServiceNamesStorage(session, writeCacheTTL, metricsFactory, logger)
 	operationNamesStorage := NewOperationNamesStorage(session, writeCacheTTL, metricsFactory, logger)
 	tagIndexSkipped := metricsFactory.Counter("tag_index_skipped", nil)
@@ -112,11 +113,11 @@ func NewSpanWriter(
 		serviceNamesWriter:   serviceNamesStorage.Write,
 		operationNamesWriter: operationNamesStorage.Write,
 		writerMetrics: spanWriterMetrics{
-			traces:                casMetrics.NewTable(metricsFactory, "traces"),
-			tagIndex:              casMetrics.NewTable(metricsFactory, "tag_index"),
-			serviceNameIndex:      casMetrics.NewTable(metricsFactory, "service_name_index"),
-			serviceOperationIndex: casMetrics.NewTable(metricsFactory, "service_operation_index"),
-			durationIndex:         casMetrics.NewTable(metricsFactory, "duration_index"),
+			traces:                casMetrics.NewTable(writeFactory, "traces"),
+			tagIndex:              casMetrics.NewTable(writeFactory, "tag_index"),
+			serviceNameIndex:      casMetrics.NewTable(writeFactory, "service_name_index"),
+			serviceOperationIndex: casMetrics.NewTable(writeFactory, "service_operation_index"),
+			durationIndex:         casMetrics.NewTable(writeFactory, "duration_index"),
 		},
 		logger:          logger,
 		tagIndexSkipped: tagIndexSkipped,

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -42,7 +42,7 @@ func withSpanWriter(writeCacheTTL time.Duration, fn func(w *spanWriterTest), opt
 ) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	w := &spanWriterTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -43,7 +43,7 @@ type spanWriterTest struct {
 func withSpanWriter(fn func(w *spanWriterTest)) {
 	client := &mocks.Client{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	w := &spanWriterTest{
 		client:    client,
 		logger:    logger,
@@ -66,7 +66,7 @@ func TestNewSpanWriterIndexPrefix(t *testing.T) {
 	}
 	client := &mocks.Client{}
 	logger, _ := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	for _, testCase := range testCases {
 		w := NewSpanWriter(SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: testCase.prefix})
@@ -311,7 +311,7 @@ func TestWriteSpanInternalError(t *testing.T) {
 func TestNewSpanTags(t *testing.T) {
 	client := &mocks.Client{}
 	logger, _ := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	testCases := []struct {
 		writer   *SpanWriter
 		expected dbmodel.Span

--- a/plugin/storage/kafka/writer_test.go
+++ b/plugin/storage/kafka/writer_test.go
@@ -23,8 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -67,7 +66,7 @@ var (
 type spanWriterTest struct {
 	producer       *saramaMocks.AsyncProducer
 	marshaller     *mocks.Marshaller
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 
 	writer *SpanWriter
 }
@@ -76,7 +75,7 @@ type spanWriterTest struct {
 var _ spanstore.Writer = &SpanWriter{}
 
 func withSpanWriter(t *testing.T, fn func(span *model.Span, w *spanWriterTest)) {
-	serviceMetrics := metrics.NewLocalFactory(100 * time.Millisecond)
+	serviceMetrics := metricstest.NewFactory(100 * time.Millisecond)
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Producer.Return.Successes = true
 	producer := saramaMocks.NewAsyncProducer(t, saramaConfig)
@@ -110,15 +109,15 @@ func TestKafkaWriter(t *testing.T) {
 		}
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 1,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 0,
@@ -142,15 +141,15 @@ func TestKafkaWriterErr(t *testing.T) {
 		}
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 0,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 1,
@@ -170,15 +169,15 @@ func TestMarshallerErr(t *testing.T) {
 
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 0,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 1,

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -29,7 +29,7 @@ import (
 )
 
 func TestSuccessfulUnderlyingCalls(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 
 	mockReader := mocks.Reader{}
 	mrs := NewReadMetricsDecorator(&mockReader, mf)
@@ -82,7 +82,7 @@ func checkExpectedExistingAndNonExistentCounters(t *testing.T, actualCounters, e
 }
 
 func TestFailingUnderlyingCalls(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 
 	mockReader := mocks.Reader{}
 	mrs := NewReadMetricsDecorator(&mockReader, mf)

--- a/storage/spanstore/metrics/write_metrics_test.go
+++ b/storage/spanstore/metrics/write_metrics_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 func TestTableEmit(t *testing.T) {
@@ -61,7 +61,7 @@ func TestTableEmit(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(time.Second)
+		mf := metricstest.NewFactory(time.Second)
 		tm := NewWriteMetrics(mf, "a_table")
 		tm.Emit(tc.err, 50*time.Millisecond)
 		counts, gauges := mf.Snapshot()


### PR DESCRIPTION
This is a don't merge PR. 

I understand that this will only make it in once `uber/jaeger-lib@v2.0` is released. But I spent the better part of 2hrs changing the APIs for the breaking changes, and I'm hoping it'll be useful for the person updating the dependency later :)