### PR TITLE
Achieve parity b/w C* write and read metrics

### DIFF
--- a/plugin/storage/cassandra/dependencystore/storage.go
+++ b/plugin/storage/cassandra/dependencystore/storage.go
@@ -46,7 +46,7 @@ func NewDependencyStore(
 ) *DependencyStore {
 	return &DependencyStore{
 		session:                  session,
-		dependenciesTableMetrics: casMetrics.NewTable(metricsFactory, "dependencies"),
+		dependenciesTableMetrics: casMetrics.NewTable(metricsFactory.Namespace("write", nil), "dependencies"),
 		logger:                   logger,
 	}
 }

--- a/plugin/storage/cassandra/spanstore/operation_names.go
+++ b/plugin/storage/cassandra/spanstore/operation_names.go
@@ -54,7 +54,7 @@ func NewOperationNamesStorage(
 		session:       session,
 		InsertStmt:    insertOperationName,
 		QueryStmt:     queryOperationNames,
-		metrics:       casMetrics.NewTable(metricsFactory, "operation_names"),
+		metrics:       casMetrics.NewTable(metricsFactory.Namespace("write", nil), "operation_names"),
 		writeCacheTTL: writeCacheTTL,
 		logger:        logger,
 		operationNames: cache.NewLRUWithOptions(

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -85,7 +85,7 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 
 				counts, _ := s.metricsFactory.Snapshot()
 				assert.Equal(t, map[string]int64{
-					"attempts|table=operation_names": 2, "inserts|table=operation_names": 1, "errors|table=operation_names": 1,
+					"write.attempts|table=operation_names": 2, "write.inserts|table=operation_names": 1, "write.errors|table=operation_names": 1,
 				}, counts, "after first two writes")
 
 				// write again
@@ -96,8 +96,8 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 				expCounts := counts
 				if writeCacheTTL == 0 {
 					// without write cache, the second write must succeed
-					expCounts["attempts|table=operation_names"]++
-					expCounts["inserts|table=operation_names"]++
+					expCounts["write.attempts|table=operation_names"]++
+					expCounts["write.inserts|table=operation_names"]++
 				}
 				assert.Equal(t, expCounts, counts2)
 			})

--- a/plugin/storage/cassandra/spanstore/service_names.go
+++ b/plugin/storage/cassandra/spanstore/service_names.go
@@ -53,7 +53,7 @@ func NewServiceNamesStorage(
 		session:       session,
 		InsertStmt:    insertServiceName,
 		QueryStmt:     queryServiceNames,
-		metrics:       casMetrics.NewTable(metricsFactory, "service_names"),
+		metrics:       casMetrics.NewTable(metricsFactory.Namespace("write", nil), "service_names"),
 		writeCacheTTL: writeCacheTTL,
 		logger:        logger,
 		serviceNames: cache.NewLRUWithOptions(

--- a/plugin/storage/cassandra/spanstore/service_names_test.go
+++ b/plugin/storage/cassandra/spanstore/service_names_test.go
@@ -85,7 +85,7 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 
 				counts, _ := s.metricsFactory.Snapshot()
 				assert.Equal(t, map[string]int64{
-					"attempts|table=service_names": 2, "inserts|table=service_names": 1, "errors|table=service_names": 1,
+					"write.attempts|table=service_names": 2, "write.inserts|table=service_names": 1, "write.errors|table=service_names": 1,
 				}, counts)
 
 				// write again
@@ -96,8 +96,8 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 				expCounts := counts
 				if writeCacheTTL == 0 {
 					// without write cache, the second write must succeed
-					expCounts["attempts|table=service_names"]++
-					expCounts["inserts|table=service_names"]++
+					expCounts["write.attempts|table=service_names"]++
+					expCounts["write.inserts|table=service_names"]++
 				}
 				assert.Equal(t, expCounts, counts2)
 			})

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -103,6 +103,7 @@ func NewSpanWriter(
 	logger *zap.Logger,
 	options ...Option,
 ) *SpanWriter {
+	writeFactory := metricsFactory.Namespace("write", nil)
 	serviceNamesStorage := NewServiceNamesStorage(session, writeCacheTTL, metricsFactory, logger)
 	operationNamesStorage := NewOperationNamesStorage(session, writeCacheTTL, metricsFactory, logger)
 	tagIndexSkipped := metricsFactory.Counter("tag_index_skipped", nil)
@@ -112,11 +113,11 @@ func NewSpanWriter(
 		serviceNamesWriter:   serviceNamesStorage.Write,
 		operationNamesWriter: operationNamesStorage.Write,
 		writerMetrics: spanWriterMetrics{
-			traces:                casMetrics.NewTable(metricsFactory, "traces"),
-			tagIndex:              casMetrics.NewTable(metricsFactory, "tag_index"),
-			serviceNameIndex:      casMetrics.NewTable(metricsFactory, "service_name_index"),
-			serviceOperationIndex: casMetrics.NewTable(metricsFactory, "service_operation_index"),
-			durationIndex:         casMetrics.NewTable(metricsFactory, "duration_index"),
+			traces:                casMetrics.NewTable(writeFactory, "traces"),
+			tagIndex:              casMetrics.NewTable(writeFactory, "tag_index"),
+			serviceNameIndex:      casMetrics.NewTable(writeFactory, "service_name_index"),
+			serviceOperationIndex: casMetrics.NewTable(writeFactory, "service_operation_index"),
+			durationIndex:         casMetrics.NewTable(writeFactory, "duration_index"),
 		},
 		logger:          logger,
 		tagIndexSkipped: tagIndexSkipped,


### PR DESCRIPTION
Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>

## Which problem is this PR solving?
The jaeger C* metrics are confusing. 
`jaeger_cassandra_attempts` for writes and `jaeger_cassandra_read_attempts` for reads. 

## Short description of the changes
This just renames `jaeger_cassandra_attempts` to `jaeger_cassandra_write_attempts` 
