### PR TITLE
Only support the Kafka storage in Collector

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -68,6 +68,8 @@ import (
 	zc "github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
+var unsupportedTypes = []string{storage.KafkaStorageType}
+
 // all-in-one/main is a standalone full-stack jaeger backend, backed by a memory store
 func main() {
 	var signalsChannel = make(chan os.Signal)
@@ -77,7 +79,7 @@ func main() {
 		os.Setenv(storage.SpanStorageTypeEnvVar, "memory") // other storage types default to SpanStorage
 	}
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr),
-		[]string{storage.KafkaStorageType})
+		storage.Options{UnsupportedTypes: unsupportedTypes})
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -76,7 +76,8 @@ func main() {
 	if os.Getenv(storage.SpanStorageTypeEnvVar) == "" {
 		os.Setenv(storage.SpanStorageTypeEnvVar, "memory") // other storage types default to SpanStorage
 	}
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr),
+		[]string{storage.KafkaStorageType})
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -61,7 +61,7 @@ func main() {
 	var signalsChannel = make(chan os.Signal)
 	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
 
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr), nil)
+	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr), storage.Options{})
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -61,7 +61,7 @@ func main() {
 	var signalsChannel = make(chan os.Signal)
 	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
 
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr), nil)
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -45,7 +45,8 @@ func main() {
 	var signalsChannel = make(chan os.Signal)
 	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
 
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr),
+		[]string{storage.KafkaStorageType})
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -41,12 +41,14 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage"
 )
 
+var unsupportedTypes = []string{storage.KafkaStorageType}
+
 func main() {
 	var signalsChannel = make(chan os.Signal)
 	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
 
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr),
-		[]string{storage.KafkaStorageType})
+		storage.Options{UnsupportedTypes: unsupportedTypes})
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -44,12 +44,14 @@ import (
 	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
 )
 
+var unsupportedTypes = []string{storage.KafkaStorageType}
+
 func main() {
 	var serverChannel = make(chan os.Signal)
 	signal.Notify(serverChannel, os.Interrupt, syscall.SIGTERM)
 
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr),
-		[]string{storage.KafkaStorageType})
+		storage.Options{UnsupportedTypes: unsupportedTypes})
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -48,7 +48,8 @@ func main() {
 	var serverChannel = make(chan os.Signal)
 	signal.Notify(serverChannel, os.Interrupt, syscall.SIGTERM)
 
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr),
+		[]string{storage.KafkaStorageType})
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -48,14 +48,13 @@ var allStorageTypes = []string{CassandraStorageType, ElasticsearchStorageType, M
 // Factory implements storage.Factory interface as a meta-factory for storage components.
 type Factory struct {
 	FactoryConfig
-
-	unsupportedTypes []string
-	factories        map[string]storage.Factory
+	Options
+	factories map[string]storage.Factory
 }
 
 // NewFactory creates the meta-factory.
-func NewFactory(config FactoryConfig, unsupportedTypes []string) (*Factory, error) {
-	f := &Factory{FactoryConfig: config, unsupportedTypes: unsupportedTypes}
+func NewFactory(config FactoryConfig, opts Options) (*Factory, error) {
+	f := &Factory{FactoryConfig: config, Options: opts}
 	uniqueTypes := map[string]struct{}{
 		f.SpanReaderType:          {},
 		f.DependenciesStorageType: {},
@@ -78,7 +77,7 @@ func NewFactory(config FactoryConfig, unsupportedTypes []string) (*Factory, erro
 }
 
 func (f *Factory) isUnsupportedType(factoryType string) bool {
-	for _, t := range f.unsupportedTypes {
+	for _, t := range f.Options.UnsupportedTypes {
 		if t == factoryType {
 			return true
 		}

--- a/plugin/storage/factory_config.go
+++ b/plugin/storage/factory_config.go
@@ -55,7 +55,7 @@ func FactoryConfigFromEnvAndCLI(args []string, log io.Writer) FactoryConfig {
 		spanStorageType = spanStorageTypeFromArgs(args, log)
 	}
 	if spanStorageType == "" {
-		spanStorageType = cassandraStorageType
+		spanStorageType = CassandraStorageType
 	}
 	spanWriterTypes := strings.Split(spanStorageType, ",")
 	if len(spanWriterTypes) > 1 {

--- a/plugin/storage/factory_config_test.go
+++ b/plugin/storage/factory_config_test.go
@@ -33,25 +33,25 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 
 	f := FactoryConfigFromEnvAndCLI(nil, nil)
 	assert.Equal(t, 1, len(f.SpanWriterTypes))
-	assert.Equal(t, cassandraStorageType, f.SpanWriterTypes[0])
-	assert.Equal(t, cassandraStorageType, f.SpanReaderType)
-	assert.Equal(t, cassandraStorageType, f.DependenciesStorageType)
+	assert.Equal(t, CassandraStorageType, f.SpanWriterTypes[0])
+	assert.Equal(t, CassandraStorageType, f.SpanReaderType)
+	assert.Equal(t, CassandraStorageType, f.DependenciesStorageType)
 
-	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType)
-	os.Setenv(DependencyStorageTypeEnvVar, memoryStorageType)
+	os.Setenv(SpanStorageTypeEnvVar, ElasticsearchStorageType)
+	os.Setenv(DependencyStorageTypeEnvVar, MemoryStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, nil)
 	assert.Equal(t, 1, len(f.SpanWriterTypes))
-	assert.Equal(t, elasticsearchStorageType, f.SpanWriterTypes[0])
-	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
-	assert.Equal(t, memoryStorageType, f.DependenciesStorageType)
+	assert.Equal(t, ElasticsearchStorageType, f.SpanWriterTypes[0])
+	assert.Equal(t, ElasticsearchStorageType, f.SpanReaderType)
+	assert.Equal(t, MemoryStorageType, f.DependenciesStorageType)
 
-	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType+","+kafkaStorageType)
+	os.Setenv(SpanStorageTypeEnvVar, ElasticsearchStorageType+","+KafkaStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Equal(t, 2, len(f.SpanWriterTypes))
-	assert.Equal(t, []string{elasticsearchStorageType, kafkaStorageType}, f.SpanWriterTypes)
-	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
+	assert.Equal(t, []string{ElasticsearchStorageType, KafkaStorageType}, f.SpanWriterTypes)
+	assert.Equal(t, ElasticsearchStorageType, f.SpanReaderType)
 }
 
 func TestFactoryConfigFromEnvDeprecated(t *testing.T) {

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -44,7 +44,7 @@ func defaultCfg() FactoryConfig {
 }
 
 func TestNewFactory(t *testing.T) {
-	f, err := NewFactory(defaultCfg(), nil)
+	f, err := NewFactory(defaultCfg(), Options{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)
 	assert.NotEmpty(t, f.factories[CassandraStorageType])
@@ -56,7 +56,7 @@ func TestNewFactory(t *testing.T) {
 		SpanWriterTypes:         []string{CassandraStorageType, KafkaStorageType},
 		SpanReaderType:          ElasticsearchStorageType,
 		DependenciesStorageType: MemoryStorageType,
-	}, nil)
+	}, Options{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)
 	assert.NotEmpty(t, f.factories[CassandraStorageType])
@@ -67,20 +67,20 @@ func TestNewFactory(t *testing.T) {
 	assert.Equal(t, ElasticsearchStorageType, f.SpanReaderType)
 	assert.Equal(t, MemoryStorageType, f.DependenciesStorageType)
 
-	f, err = NewFactory(FactoryConfig{SpanWriterTypes: []string{"x"}, DependenciesStorageType: "y", SpanReaderType: "z"}, nil)
+	f, err = NewFactory(FactoryConfig{SpanWriterTypes: []string{"x"}, DependenciesStorageType: "y", SpanReaderType: "z"}, Options{})
 	require.Error(t, err)
 	expected := "Unknown storage type" // could be 'x' or 'y' since code iterates through map.
 	assert.Equal(t, expected, err.Error()[0:len(expected)])
 }
 
 func TestNewFactoryWithUnsupportedType(t *testing.T) {
-	_, err := NewFactory(defaultCfg(), []string{CassandraStorageType})
+	_, err := NewFactory(defaultCfg(), Options{UnsupportedTypes: []string{CassandraStorageType}})
 
 	assert.EqualError(t, err, "The cassandra storage type is unsupported by this command")
 }
 
 func TestInitialize(t *testing.T) {
-	f, err := NewFactory(defaultCfg(), nil)
+	f, err := NewFactory(defaultCfg(), Options{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)
 	assert.NotEmpty(t, f.factories[CassandraStorageType])
@@ -100,7 +100,7 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	f, err := NewFactory(defaultCfg(), nil)
+	f, err := NewFactory(defaultCfg(), Options{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)
 	assert.NotEmpty(t, f.factories[CassandraStorageType])
@@ -143,7 +143,7 @@ func TestCreate(t *testing.T) {
 func TestCreateMulti(t *testing.T) {
 	cfg := defaultCfg()
 	cfg.SpanWriterTypes = append(cfg.SpanWriterTypes, ElasticsearchStorageType)
-	f, err := NewFactory(cfg, nil)
+	f, err := NewFactory(cfg, Options{})
 	require.NoError(t, err)
 
 	mock := new(mocks.Factory)
@@ -168,7 +168,7 @@ func TestCreateMulti(t *testing.T) {
 }
 
 func TestCreateArchive(t *testing.T) {
-	f, err := NewFactory(defaultCfg(), nil)
+	f, err := NewFactory(defaultCfg(), Options{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories[CassandraStorageType])
 
@@ -194,7 +194,7 @@ func TestCreateArchive(t *testing.T) {
 }
 
 func TestCreateError(t *testing.T) {
-	f, err := NewFactory(defaultCfg(), nil)
+	f, err := NewFactory(defaultCfg(), Options{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)
 	assert.NotEmpty(t, f.factories[CassandraStorageType])
@@ -253,7 +253,7 @@ func TestConfigurable(t *testing.T) {
 	clearEnv()
 	defer clearEnv()
 
-	f, err := NewFactory(defaultCfg(), nil)
+	f, err := NewFactory(defaultCfg(), Options{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)
 	assert.NotEmpty(t, f.factories[CassandraStorageType])

--- a/plugin/storage/options.go
+++ b/plugin/storage/options.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2018 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+// Options allow the different commands to control certain behavior of storage.Factory
+type Options struct {
+	// UnsupportedTypes prevents the usage of the provided storage types
+	UnsupportedTypes []string
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Solves https://github.com/jaegertracing/jaeger/issues/1190

## Short description of the changes
- Add an unsupported list to the storage factory
- Make Kafka as unsupported in Ingester, Query, all-in-one (because Ingester is not started anyway)