### PR TITLE
Fix sampling strategies overwriting service entry when no sampling ty…

### DIFF
--- a/plugin/sampling/strategystore/static/fixtures/missing-service-types.json
+++ b/plugin/sampling/strategystore/static/fixtures/missing-service-types.json
@@ -6,35 +6,21 @@
   "service_strategies": [
     {
       "service": "foo",
-      "type": "probabilistic",
-      "param": 0.8,
       "operation_strategies": [
         {
           "operation": "op1",
           "type": "probabilistic",
           "param": 0.2
-        },
-        {
-          "operation": "op2",
-          "type": "ratelimiting",
-          "param": 10
         }
       ]
     },
     {
       "service": "bar",
-      "type": "ratelimiting",
-      "param": 5,
       "operation_strategies": [
         {
           "operation": "op3",
           "type": "probabilistic",
           "param": 0.3
-        },
-        {
-          "operation": "op4",
-          "type": "ratelimiting",
-          "param": 100
         },
         {
           "operation": "op5",

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -136,6 +136,7 @@ func (h *strategyStore) parseStrategy(strategy *strategy) *sampling.SamplingStra
 		}
 	default:
 		h.logger.Warn("Failed to parse sampling strategy", zap.Any("strategy", strategy))
-		return &defaultStrategy
+		copyOfDefaultStrategy := defaultStrategy
+		return &copyOfDefaultStrategy
 	}
 }

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -15,6 +15,8 @@
 package static
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -136,7 +138,22 @@ func (h *strategyStore) parseStrategy(strategy *strategy) *sampling.SamplingStra
 		}
 	default:
 		h.logger.Warn("Failed to parse sampling strategy", zap.Any("strategy", strategy))
-		copyOfDefaultStrategy := defaultStrategy
-		return &copyOfDefaultStrategy
+		return deepCopy(&defaultStrategy)
 	}
+}
+
+func deepCopy(s *sampling.SamplingStrategyResponse) *sampling.SamplingStrategyResponse {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	dec := gob.NewDecoder(&buf)
+	err := enc.Encode(*s)
+	if err != nil {
+		return nil
+	}
+	var copy sampling.SamplingStrategyResponse
+	err = dec.Decode(&copy)
+	if err != nil {
+		return nil
+	}
+	return &copy
 }

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -146,14 +146,8 @@ func deepCopy(s *sampling.SamplingStrategyResponse) *sampling.SamplingStrategyRe
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
 	dec := gob.NewDecoder(&buf)
-	err := enc.Encode(*s)
-	if err != nil {
-		return nil
-	}
+	enc.Encode(*s)
 	var copy sampling.SamplingStrategyResponse
-	err = dec.Decode(&copy)
-	if err != nil {
-		return nil
-	}
+	dec.Decode(&copy)
 	return &copy
 }

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -193,3 +193,15 @@ func makeResponse(samplerType sampling.SamplingStrategyType, param float64) (res
 	}
 	return resp
 }
+
+func TestDeepCopy(t *testing.T) {
+	s := &sampling.SamplingStrategyResponse{
+		StrategyType: sampling.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+			SamplingRate: 0.5,
+		},
+	}
+	copy := deepCopy(s)
+	assert.False(t, copy == s)
+	assert.EqualValues(t, copy, s)
+}

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -91,9 +91,52 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 	require.NotNil(t, s.OperationSampling)
 	os = s.OperationSampling
 	assert.EqualValues(t, os.DefaultSamplingProbability, 0.001)
-	require.Len(t, os.PerOperationStrategies, 1)
+	require.Len(t, os.PerOperationStrategies, 2)
 	assert.Equal(t, "op3", os.PerOperationStrategies[0].Operation)
 	assert.EqualValues(t, 0.3, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)
+	assert.Equal(t, "op5", os.PerOperationStrategies[1].Operation)
+	assert.EqualValues(t, 0.4, os.PerOperationStrategies[1].ProbabilisticSampling.SamplingRate)
+
+	s, err = store.GetSamplingStrategy("default")
+	require.NoError(t, err)
+	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.5), *s)
+}
+
+func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
+	logger, buf := testutils.NewLogger()
+	store, err := NewStrategyStore(Options{StrategiesFile: "fixtures/missing-service-types.json"}, logger)
+	assert.Contains(t, buf.String(), "Failed to parse sampling strategy")
+	require.NoError(t, err)
+
+	expected := makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+
+	s, err := store.GetSamplingStrategy("foo")
+	require.NoError(t, err)
+	assert.Equal(t, sampling.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
+	assert.Equal(t, *expected.ProbabilisticSampling, *s.ProbabilisticSampling)
+
+	require.NotNil(t, s.OperationSampling)
+	os := s.OperationSampling
+	assert.EqualValues(t, os.DefaultSamplingProbability, defaultSamplingProbability)
+	require.Len(t, os.PerOperationStrategies, 1)
+	assert.Equal(t, "op1", os.PerOperationStrategies[0].Operation)
+	assert.EqualValues(t, 0.2, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)
+
+	expected = makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+
+	s, err = store.GetSamplingStrategy("bar")
+	require.NoError(t, err)
+	assert.Equal(t, sampling.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
+	assert.Equal(t, *expected.ProbabilisticSampling, *s.ProbabilisticSampling)
+
+	require.NotNil(t, s.OperationSampling)
+	os = s.OperationSampling
+	assert.EqualValues(t, os.DefaultSamplingProbability, 0.001)
+	require.Len(t, os.PerOperationStrategies, 2)
+	assert.Equal(t, "op3", os.PerOperationStrategies[0].Operation)
+	assert.EqualValues(t, 0.3, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)
+	assert.Equal(t, "op5", os.PerOperationStrategies[1].Operation)
+	assert.EqualValues(t, 0.4, os.PerOperationStrategies[1].ProbabilisticSampling.SamplingRate)
 
 	s, err = store.GetSamplingStrategy("default")
 	require.NoError(t, err)


### PR DESCRIPTION
…pe is specified

Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Resolves #1205 
If the service strategy does not define a sampling type, it reuses the default sampling strategy but applies the operation sampling strategies. End result is that all services (that don't define a sampling type) will share a single entry with identical details (i.e. the ones associated with the last initialised entry).

## Short description of the changes
Although it is an error state, if no sampling type is defined and the default sampling strategy is to be used, then it should return a copy.
