### PR TITLE
Unpin dependencies in Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,92 +26,80 @@
 
 
 [[constraint]]
-  name = "github.com/Shopify/sarama"
-  version = "=1.16.0"
-
-[[constraint]]
   name = "github.com/apache/thrift"
   version = "=0.9.3"
 
 [[constraint]]
   name = "github.com/bsm/sarama-cluster"
-  version = "=2.1.13"
+  version = "^2.1.13"
 
 [[constraint]]
   branch = "master"
   name = "github.com/crossdock/crossdock-go"
 
 [[constraint]]
-  name = "github.com/go-openapi/loads"
-  version = "=0.16.0"
-
-[[constraint]]
   name = "github.com/gorilla/handlers"
-  version = "=1.2.0"
+  version = "^1.2.0"
 
 [[constraint]]
   name = "github.com/gorilla/mux"
-  version = "=1.3.0"
+  version = "^1.3.0"
 
 [[constraint]]
   name = "github.com/opentracing/opentracing-go"
-  version = "=1.0.2"
+  version = "^1.0.2"
 
 [[constraint]]
   name = "github.com/pkg/errors"
-  version = "=0.8.0"
+  version = "^0.8.0"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "=0.8.0"
+  version = "^0.8.0"
 
 [[constraint]]
   name = "github.com/spf13/cobra"
-  version = "0.0.1"
+  version = "^0.0.1"
 
 [[constraint]]
   name = "github.com/spf13/pflag"
-  version = "1.0.0"
+  version = "^1.0.0"
 
 [[constraint]]
   name = "github.com/spf13/viper"
-  version = "1.0.0"
+  version = "^1.0.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "=1.2.1"
+  version = "^1.2.1"
 
 [[constraint]]
   name = "github.com/uber/jaeger-client-go"
-  version = "2.15.0"
+  version = "^2.15.0"
 
 [[constraint]]
   name = "github.com/uber/jaeger-lib"
-  version = "1.5.0"
+  version = "^1.5.0"
 
 [[constraint]]
   name = "github.com/uber/tchannel-go"
-  version = "=1.1.0"
-
-[[constraint]]
-  name = "go.uber.org/atomic"
-  version = "=1.3.2"
+  version = "^1.1.0"
 
 [[constraint]]
   name = "go.uber.org/zap"
-  version = "1.0.0"
+  version = "^1.0.0"
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "=1.11.0"
+  version = "^1.11.0"
 
 [[constraint]]
   name = "gopkg.in/olivere/elastic.v5"
-  version = "=5.0.53"
+  version = "^5.0.53"
 
-[[constraint]]
-  name = "gopkg.in/yaml.v2"
-  version = "=2.0.0"
+ [[constraint]]
+  name = "github.com/gocql/gocql"
+  branch = "master"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
Signed-off-by: Prithvi Raj <p.r@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Pinning dependencies prevents causes the dep solver from trying other versions when solving. This is problematic when jaeger is imported alongside other projects.
- Because only specific dependencies in `Gopkg.toml` are updated when `dep ensure -update <dependency>` is executed, these pins are unnecessary. Unrelated version bumps cannot happen (as they used to with `glide`)

## Short description of the changes
- Unpin dependencies
