### PR TITLE
Add Zipkin Thrift as kafka ingestion format

### DIFF
--- a/cmd/ingester/app/builder/builder.go
+++ b/cmd/ingester/app/builder/builder.go
@@ -35,9 +35,11 @@ func CreateConsumer(logger *zap.Logger, metricsFactory metrics.Factory, spanWrit
 		unmarshaller = kafka.NewJSONUnmarshaller()
 	} else if options.Encoding == app.EncodingProto {
 		unmarshaller = kafka.NewProtobufUnmarshaller()
+	} else if options.Encoding == app.EncodingZipkinT {
+		unmarshaller = kafka.NewZipkinThriftUnmarshaller()
 	} else {
-		return nil, fmt.Errorf(`encoding '%s' not recognised, use one of ("%s" or "%s")`,
-			options.Encoding, app.EncodingProto, app.EncodingJSON)
+		return nil, fmt.Errorf(`encoding '%s' not recognised, use one of ("%s", "%s" or "%s")`,
+			options.Encoding, app.EncodingProto, app.EncodingJSON, app.EncodingZipkinT)
 	}
 
 	spParams := processor.SpanProcessorParams{

--- a/cmd/ingester/app/builder/builder.go
+++ b/cmd/ingester/app/builder/builder.go
@@ -16,6 +16,7 @@ package builder
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
@@ -31,15 +32,15 @@ import (
 // CreateConsumer creates a new span consumer for the ingester
 func CreateConsumer(logger *zap.Logger, metricsFactory metrics.Factory, spanWriter spanstore.Writer, options app.Options) (*consumer.Consumer, error) {
 	var unmarshaller kafka.Unmarshaller
-	if options.Encoding == app.EncodingJSON {
+	if options.Encoding == kafka.EncodingJSON {
 		unmarshaller = kafka.NewJSONUnmarshaller()
-	} else if options.Encoding == app.EncodingProto {
+	} else if options.Encoding == kafka.EncodingProto {
 		unmarshaller = kafka.NewProtobufUnmarshaller()
-	} else if options.Encoding == app.EncodingZipkinT {
+	} else if options.Encoding == kafka.EncodingZipkinThrift {
 		unmarshaller = kafka.NewZipkinThriftUnmarshaller()
 	} else {
-		return nil, fmt.Errorf(`encoding '%s' not recognised, use one of ("%s", "%s" or "%s")`,
-			options.Encoding, app.EncodingProto, app.EncodingJSON, app.EncodingZipkinT)
+		return nil, fmt.Errorf(`encoding '%s' not recognised, use one of ("%s")`,
+			options.Encoding, strings.Join(kafka.AllEncodings, "\", \""))
 	}
 
 	spParams := processor.SpanProcessorParams{

--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -24,16 +24,10 @@ import (
 	"github.com/spf13/viper"
 
 	kafkaConsumer "github.com/jaegertracing/jaeger/pkg/kafka/consumer"
+	"github.com/jaegertracing/jaeger/plugin/storage/kafka"
 )
 
 const (
-	// EncodingJSON indicates spans are encoded as a json byte array
-	EncodingJSON = "json"
-	// EncodingProto indicates spans are encoded as a protobuf byte array
-	EncodingProto = "protobuf"
-	// EncodingZipkinT indicates spans are encoded as a Zipkin thrift byte array
-	EncodingZipkinT = "zipkinThrift"
-
 	// ConfigPrefix is a prefix for the ingester flags
 	ConfigPrefix = "ingester"
 	// KafkaConfigPrefix is a prefix for the Kafka flags
@@ -62,7 +56,7 @@ const (
 	// DefaultParallelism is the default parallelism for the span processor
 	DefaultParallelism = 1000
 	// DefaultEncoding is the default span encoding
-	DefaultEncoding = EncodingProto
+	DefaultEncoding = kafka.EncodingProto
 	// DefaultDeadlockInterval is the default deadlock interval
 	DefaultDeadlockInterval = 1 * time.Minute
 	// DefaultHTTPPort is the default HTTP port (e.g. for /metrics)
@@ -98,7 +92,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(
 		KafkaConfigPrefix+SuffixEncoding,
 		DefaultEncoding,
-		fmt.Sprintf(`The encoding of spans ("%s", "%s" or "%s") consumed from kafka`, EncodingProto, EncodingJSON, EncodingZipkinT))
+		fmt.Sprintf(`The encoding of spans ("%s") consumed from kafka`, strings.Join(kafka.AllEncodings, "\", \"")))
 	flagSet.String(
 		ConfigPrefix+SuffixParallelism,
 		strconv.Itoa(DefaultParallelism),

--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -31,6 +31,8 @@ const (
 	EncodingJSON = "json"
 	// EncodingProto indicates spans are encoded as a protobuf byte array
 	EncodingProto = "protobuf"
+	// EncodingZipkinT indicates spans are encoded as a Zipkin thrift byte array
+	EncodingZipkinT = "zipkinThrift"
 
 	// ConfigPrefix is a prefix for the ingester flags
 	ConfigPrefix = "ingester"
@@ -96,7 +98,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(
 		KafkaConfigPrefix+SuffixEncoding,
 		DefaultEncoding,
-		fmt.Sprintf(`The encoding of spans ("%s" or "%s") consumed from kafka`, EncodingProto, EncodingJSON))
+		fmt.Sprintf(`The encoding of spans ("%s", "%s" or "%s") consumed from kafka`, EncodingProto, EncodingJSON, EncodingZipkinT))
 	flagSet.String(
 		ConfigPrefix+SuffixParallelism,
 		strconv.Itoa(DefaultParallelism),

--- a/cmd/ingester/app/flags_test.go
+++ b/cmd/ingester/app/flags_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/plugin/storage/kafka"
 )
 
 func TestOptionsWithFlags(t *testing.T) {
@@ -41,7 +42,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "group1", o.GroupID)
 	assert.Equal(t, 5, o.Parallelism)
 	assert.Equal(t, 2*time.Minute, o.DeadlockInterval)
-	assert.Equal(t, EncodingJSON, o.Encoding)
+	assert.Equal(t, kafka.EncodingJSON, o.Encoding)
 	assert.Equal(t, 2345, o.IngesterHTTPPort)
 }
 

--- a/model/converter/thrift/zipkin/deserialize.go
+++ b/model/converter/thrift/zipkin/deserialize.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import (
+	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+)
+
+// Function used for testing purposes
+func ZipkinSerialize(spans []*zipkincore.Span) []byte {
+	t := thrift.NewTMemoryBuffer()
+	p := thrift.NewTBinaryProtocolTransport(t)
+	p.WriteListBegin(thrift.STRUCT, len(spans))
+	for _, s := range spans {
+		s.Write(p)
+	}
+	p.WriteListEnd()
+	return t.Buffer.Bytes()
+}
+
+func DeserializeThrift(b []byte) ([]*zipkincore.Span, error) {
+	buffer := thrift.NewTMemoryBuffer()
+	buffer.Write(b)
+
+	transport := thrift.NewTBinaryProtocolTransport(buffer)
+	_, size, err := transport.ReadListBegin() // Ignore the returned element type
+	if err != nil {
+		return nil, err
+	}
+
+	// We don't depend on the size returned by ReadListBegin to preallocate the array because it
+	// sometimes returns a nil error on bad input and provides an unreasonably large int for size
+	var spans []*zipkincore.Span
+	for i := 0; i < size; i++ {
+		zs := &zipkincore.Span{}
+		if err = zs.Read(transport); err != nil {
+			return nil, err
+		}
+		spans = append(spans, zs)
+	}
+
+	return spans, nil
+}

--- a/model/converter/thrift/zipkin/deserialize_test.go
+++ b/model/converter/thrift/zipkin/deserialize_test.go
@@ -27,3 +27,16 @@ func TestDeserializeWithBadListStart(t *testing.T) {
 	_, err := DeserializeThrift(append([]byte{0, 255, 255}, spanBytes...))
 	assert.Error(t, err)
 }
+
+func TestDeserializeWithCorruptedList(t *testing.T) {
+	spanBytes := ZipkinSerialize([]*zipkincore.Span{{}})
+	spanBytes[2] = 255
+	_, err := DeserializeThrift(spanBytes)
+	assert.Error(t, err)
+}
+
+func TestDeserialize(t *testing.T) {
+	spanBytes := ZipkinSerialize([]*zipkincore.Span{{}})
+	_, err := DeserializeThrift(spanBytes)
+	assert.NoError(t, err)
+}

--- a/model/converter/thrift/zipkin/deserialize_test.go
+++ b/model/converter/thrift/zipkin/deserialize_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+)
+
+func TestDeserializeWithBadListStart(t *testing.T) {
+	spanBytes := ZipkinSerialize([]*zipkincore.Span{{}})
+	_, err := DeserializeThrift(append([]byte{0, 255, 255}, spanBytes...))
+	assert.Error(t, err)
+}

--- a/plugin/storage/kafka/factory.go
+++ b/plugin/storage/kafka/factory.go
@@ -68,12 +68,12 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 	}
 	f.producer = p
 	switch f.options.encoding {
-	case encodingProto:
+	case EncodingProto:
 		f.marshaller = newProtobufMarshaller()
-	case encodingJSON:
+	case EncodingJSON:
 		f.marshaller = newJSONMarshaller()
 	default:
-		return errors.New("kafka encoding is not one of '" + encodingJSON + "' or '" + encodingProto + "'")
+		return errors.New("kafka encoding is not one of '" + EncodingJSON + "' or '" + EncodingProto + "'")
 	}
 	return nil
 }

--- a/plugin/storage/kafka/marshalling_test.go
+++ b/plugin/storage/kafka/marshalling_test.go
@@ -44,18 +44,21 @@ func testMarshallerAndUnmarshaller(t *testing.T, marshaller Marshaller, unmarsha
 }
 
 func TestZipkinThriftUnmarshaller(t *testing.T) {
+	operationName := "foo"
 	bytes := zipkin.ZipkinSerialize([]*zipkincore.Span{
 		{
 			ID: 12345,
-			Name: "foo",
+			Name: operationName,
 			Annotations: []*zipkincore.Annotation{
-				{Host: &zipkincore.Endpoint{ServiceName: "foo"}},
+				{Host: &zipkincore.Endpoint{ServiceName: "foobar"}},
 			},
 		},
 	})
 	unmarshaller := NewZipkinThriftUnmarshaller()
-	_, err := unmarshaller.Unmarshal(bytes)
+	resultSpan, err := unmarshaller.Unmarshal(bytes)
+
 	assert.NoError(t, err)
+	assert.Equal(t, operationName, resultSpan.OperationName)
 }
 
 func TestZipkinThriftUnmarshallerErrorNoService(t *testing.T) {

--- a/plugin/storage/kafka/marshalling_test.go
+++ b/plugin/storage/kafka/marshalling_test.go
@@ -18,6 +18,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+	"github.com/jaegertracing/jaeger/model/converter/thrift/zipkin"
 )
 
 func TestProtobufMarshallerAndUnmarshaller(t *testing.T) {
@@ -38,4 +41,19 @@ func testMarshallerAndUnmarshaller(t *testing.T, marshaller Marshaller, unmarsha
 
 	assert.NoError(t, err)
 	assert.Equal(t, sampleSpan, resultSpan)
+}
+
+func TestZipkinThriftUnmarshaller(t *testing.T) {
+	bytes := zipkin.ZipkinSerialize([]*zipkincore.Span{
+		{
+			ID: 12345,
+			Name: "foo",
+			Annotations: []*zipkincore.Annotation{
+				{Host: &zipkincore.Endpoint{ServiceName: "foo"}},
+			},
+		},
+	})
+	unmarshaller := NewZipkinThriftUnmarshaller()
+	_, err := unmarshaller.Unmarshal(bytes)
+	assert.NoError(t, err)
 }

--- a/plugin/storage/kafka/marshalling_test.go
+++ b/plugin/storage/kafka/marshalling_test.go
@@ -57,3 +57,22 @@ func TestZipkinThriftUnmarshaller(t *testing.T) {
 	_, err := unmarshaller.Unmarshal(bytes)
 	assert.NoError(t, err)
 }
+
+func TestZipkinThriftUnmarshallerErrorNoService(t *testing.T) {
+	bytes := zipkin.ZipkinSerialize([]*zipkincore.Span{
+		{
+			ID: 12345,
+			Name: "foo",
+		},
+	})
+	unmarshaller := NewZipkinThriftUnmarshaller()
+	_, err := unmarshaller.Unmarshal(bytes)
+	assert.Error(t, err)
+}
+
+func TestZipkinThriftUnmarshallerErrorCorrupted(t *testing.T) {
+	bytes := []byte("foo")
+	unmarshaller := NewZipkinThriftUnmarshaller()
+	_, err := unmarshaller.Unmarshal(bytes)
+	assert.Error(t, err)
+}

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -30,8 +30,9 @@ const (
 	suffixTopic    = ".topic"
 	suffixEncoding = ".encoding"
 
-	encodingJSON  = "json"
-	encodingProto = "protobuf"
+	encodingJSON  	= "json"
+	encodingProto 	= "protobuf"
+	EncodingZipkinT = "zipkinThrift"
 
 	defaultBroker   = "127.0.0.1:9092"
 	defaultTopic    = "jaeger-spans"
@@ -58,7 +59,7 @@ func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(
 		configPrefix+suffixEncoding,
 		defaultEncoding,
-		fmt.Sprintf(`(experimental) Encoding of spans ("%s" or "%s") sent to kafka.`, encodingProto, encodingJSON),
+		fmt.Sprintf(`(experimental) Encoding of spans ("%s", "%s" or "%s") sent to kafka.`, encodingProto, encodingJSON, EncodingZipkinT),
 	)
 }
 

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -30,13 +30,17 @@ const (
 	suffixTopic    = ".topic"
 	suffixEncoding = ".encoding"
 
-	encodingJSON    = "json"
-	encodingProto   = "protobuf"
-	EncodingZipkinT = "zipkinThrift"
+	EncodingJSON         = "json"
+	EncodingProto        = "protobuf"
+	EncodingZipkinThrift = "zipkin-thrift"
 
 	defaultBroker   = "127.0.0.1:9092"
 	defaultTopic    = "jaeger-spans"
-	defaultEncoding = encodingProto
+	defaultEncoding = EncodingProto
+)
+
+var (
+	AllEncodings = []string{EncodingJSON, EncodingProto, EncodingZipkinThrift}
 )
 
 // Options stores the configuration options for Kafka
@@ -59,7 +63,7 @@ func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(
 		configPrefix+suffixEncoding,
 		defaultEncoding,
-		fmt.Sprintf(`(experimental) Encoding of spans ("%s", "%s" or "%s") sent to kafka.`, encodingProto, encodingJSON, EncodingZipkinT),
+		fmt.Sprintf(`(experimental) Encoding of spans ("%s" or "%s") sent to kafka.`, EncodingJSON, EncodingProto),
 	)
 }
 

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -30,8 +30,8 @@ const (
 	suffixTopic    = ".topic"
 	suffixEncoding = ".encoding"
 
-	encodingJSON  	= "json"
-	encodingProto 	= "protobuf"
+	encodingJSON    = "json"
+	encodingProto   = "protobuf"
 	EncodingZipkinT = "zipkinThrift"
 
 	defaultBroker   = "127.0.0.1:9092"

--- a/plugin/storage/kafka/unmarshaller.go
+++ b/plugin/storage/kafka/unmarshaller.go
@@ -21,9 +21,9 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
-	"github.com/jaegertracing/jaeger/model/converter/thrift/zipkin"
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/model/converter/thrift/zipkin"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
 // Unmarshaller decodes a byte array to a span


### PR DESCRIPTION
## Which problem is this PR solving?
- Ingesting Zipkin thrift span from Kafka: This is useful for a seamless migration from Zipkin. It is mentioned in #171

## Short description of the changes
- Add an unmarshaller to process spans in zipkin thrift using what was used for collector zipkin API
