### PR TITLE
Fix lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,9 @@ lint: lint-gosec
 go-lint:
 	@cat /dev/null > $(LINT_LOG)
 	$(GOLINT) $(ALL_PKGS) \
-		| grep -E -v 'pkg/es/wrapper.go:\d+:\d+: method Id should be ID' \
-		| grep -E -v 'pkg/es/wrapper.go:\d+:\d+: method BodyJson should be BodyJSON' \
+		| grep -v -E \
+			-e 'pkg\/es\/wrapper.go:\d+:\d+: method Id should be ID' \
+			-e 'pkg\/es\/wrapper.go:\d+:\d+: method BodyJson should be BodyJSON' \
 		>> $(LINT_LOG) || true;
 	@[ ! -s "$(LINT_LOG)" ] || (echo "Lint Failures" | cat - $(LINT_LOG) && false)
 

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,7 @@ lint: lint-gosec
 go-lint:
 	@cat /dev/null > $(LINT_LOG)
 	$(GOLINT) $(ALL_PKGS) \
-		| grep -v -E \
-			-e 'pkg\/es\/wrapper.go:\d+:\d+: method Id should be ID' \
-			-e 'pkg\/es\/wrapper.go:\d+:\d+: method BodyJson should be BodyJSON' \
+		| grep -v _nolint.go \
 		>> $(LINT_LOG) || true;
 	@[ ! -s "$(LINT_LOG)" ] || (echo "Lint Failures" | cat - $(LINT_LOG) && false)
 

--- a/cmd/collector/app/zipkin/http_handler_test.go
+++ b/cmd/collector/app/zipkin/http_handler_test.go
@@ -105,7 +105,7 @@ func waitForSpans(t *testing.T, handler *mockZipkinHandler, expecting int) {
 func TestThriftFormat(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
-	bodyBytes := zipkinTrift.ZipkinSerialize([]*zipkincore.Span{{}})
+	bodyBytes := zipkinTrift.SerializeThrift([]*zipkincore.Span{{}})
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, bodyBytes, createHeader("application/x-thrift"))
 	assert.NoError(t, err)
 	assert.EqualValues(t, http.StatusAccepted, statusCode)
@@ -178,7 +178,7 @@ func TestJsonFormat(t *testing.T) {
 func TestGzipEncoding(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
-	bodyBytes := zipkinTrift.ZipkinSerialize([]*zipkincore.Span{{}})
+	bodyBytes := zipkinTrift.SerializeThrift([]*zipkincore.Span{{}})
 	header := createHeader("application/x-thrift")
 	header.Add("Content-Encoding", "gzip")
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, gzipEncode(bodyBytes), header)

--- a/crossdock/jaeger-docker-compose.yml
+++ b/crossdock/jaeger-docker-compose.yml
@@ -10,6 +10,8 @@ services:
         - "14267"
         - "14250"
         - "9411:9411"
+      environment:
+        - LOG_LEVEL=debug
       restart: on-failure
       depends_on:
         - cassandra-schema
@@ -20,6 +22,8 @@ services:
       ports:
         - "16686:16686"
         - "16687"
+      environment:
+        - LOG_LEVEL=debug
       restart: on-failure
       depends_on:
         - cassandra-schema
@@ -34,6 +38,8 @@ services:
         - "6831:6831/udp"
         - "6832:6832/udp"
         - "5778:5778"
+      environment:
+        - LOG_LEVEL=debug
       restart: on-failure
       depends_on:
         - jaeger-collector

--- a/model/converter/thrift/zipkin/deserialize.go
+++ b/model/converter/thrift/zipkin/deserialize.go
@@ -20,8 +20,8 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
-// Function used for testing purposes
-func ZipkinSerialize(spans []*zipkincore.Span) []byte {
+// SerializeThrift is only used in tests.
+func SerializeThrift(spans []*zipkincore.Span) []byte {
 	t := thrift.NewTMemoryBuffer()
 	p := thrift.NewTBinaryProtocolTransport(t)
 	p.WriteListBegin(thrift.STRUCT, len(spans))
@@ -32,6 +32,7 @@ func ZipkinSerialize(spans []*zipkincore.Span) []byte {
 	return t.Buffer.Bytes()
 }
 
+// DeserializeThrift decodes Thrift bytes to a list of spans.
 func DeserializeThrift(b []byte) ([]*zipkincore.Span, error) {
 	buffer := thrift.NewTMemoryBuffer()
 	buffer.Write(b)

--- a/model/converter/thrift/zipkin/deserialize_test.go
+++ b/model/converter/thrift/zipkin/deserialize_test.go
@@ -23,20 +23,20 @@ import (
 )
 
 func TestDeserializeWithBadListStart(t *testing.T) {
-	spanBytes := ZipkinSerialize([]*zipkincore.Span{{}})
+	spanBytes := SerializeThrift([]*zipkincore.Span{{}})
 	_, err := DeserializeThrift(append([]byte{0, 255, 255}, spanBytes...))
 	assert.Error(t, err)
 }
 
 func TestDeserializeWithCorruptedList(t *testing.T) {
-	spanBytes := ZipkinSerialize([]*zipkincore.Span{{}})
+	spanBytes := SerializeThrift([]*zipkincore.Span{{}})
 	spanBytes[2] = 255
 	_, err := DeserializeThrift(spanBytes)
 	assert.Error(t, err)
 }
 
 func TestDeserialize(t *testing.T) {
-	spanBytes := ZipkinSerialize([]*zipkincore.Span{{}})
+	spanBytes := SerializeThrift([]*zipkincore.Span{{}})
 	_, err := DeserializeThrift(spanBytes)
 	assert.NoError(t, err)
 }

--- a/pkg/es/wrapper.go
+++ b/pkg/es/wrapper.go
@@ -22,188 +22,188 @@ import (
 
 // This file avoids lint because the Id and Json are required to be capitalized, but must match an outside library.
 
-// ESClient is a wrapper around elastic.Client
-type ESClient struct {
+// ClientWrapper is a wrapper around elastic.Client
+type ClientWrapper struct {
 	client      *elastic.Client
 	bulkService *elastic.BulkProcessor
 }
 
 // WrapESClient creates a ESClient out of *elastic.Client.
-func WrapESClient(client *elastic.Client, s *elastic.BulkProcessor) ESClient {
-	return ESClient{client: client, bulkService: s}
+func WrapESClient(client *elastic.Client, s *elastic.BulkProcessor) ClientWrapper {
+	return ClientWrapper{client: client, bulkService: s}
 }
 
 // IndexExists calls this function to internal client.
-func (c ESClient) IndexExists(index string) IndicesExistsService {
+func (c ClientWrapper) IndexExists(index string) IndicesExistsService {
 	return WrapESIndicesExistsService(c.client.IndexExists(index))
 }
 
 // CreateIndex calls this function to internal client.
-func (c ESClient) CreateIndex(index string) IndicesCreateService {
+func (c ClientWrapper) CreateIndex(index string) IndicesCreateService {
 	return WrapESIndicesCreateService(c.client.CreateIndex(index))
 }
 
 // Index calls this function to internal client.
-func (c ESClient) Index() IndexService {
+func (c ClientWrapper) Index() IndexService {
 	r := elastic.NewBulkIndexRequest()
 	return WrapESIndexService(r, c.bulkService)
 }
 
 // Search calls this function to internal client.
-func (c ESClient) Search(indices ...string) SearchService {
+func (c ClientWrapper) Search(indices ...string) SearchService {
 	return WrapESSearchService(c.client.Search(indices...))
 }
 
 // MultiSearch calls this function to internal client.
-func (c ESClient) MultiSearch() MultiSearchService {
+func (c ClientWrapper) MultiSearch() MultiSearchService {
 	return WrapESMultiSearchService(c.client.MultiSearch())
 }
 
 // Close closes ESClient and flushes all data to the storage.
-func (c ESClient) Close() error {
+func (c ClientWrapper) Close() error {
 	return c.bulkService.Close()
 }
 
 // ---
 
-// ESIndicesExistsService is a wrapper around elastic.IndicesExistsService
-type ESIndicesExistsService struct {
+// IndicesExistsServiceWrapper is a wrapper around elastic.IndicesExistsService
+type IndicesExistsServiceWrapper struct {
 	indicesExistsService *elastic.IndicesExistsService
 }
 
 // WrapESIndicesExistsService creates an ESIndicesExistsService out of *elastic.IndicesExistsService.
-func WrapESIndicesExistsService(indicesExistsService *elastic.IndicesExistsService) ESIndicesExistsService {
-	return ESIndicesExistsService{indicesExistsService: indicesExistsService}
+func WrapESIndicesExistsService(indicesExistsService *elastic.IndicesExistsService) IndicesExistsServiceWrapper {
+	return IndicesExistsServiceWrapper{indicesExistsService: indicesExistsService}
 }
 
 // Do calls this function to internal service.
-func (e ESIndicesExistsService) Do(ctx context.Context) (bool, error) {
+func (e IndicesExistsServiceWrapper) Do(ctx context.Context) (bool, error) {
 	return e.indicesExistsService.Do(ctx)
 }
 
 // ---
 
-// ESIndicesCreateService is a wrapper around elastic.IndicesCreateService
-type ESIndicesCreateService struct {
+// IndicesCreateServiceWrapper is a wrapper around elastic.IndicesCreateService
+type IndicesCreateServiceWrapper struct {
 	indicesCreateService *elastic.IndicesCreateService
 }
 
 // WrapESIndicesCreateService creates an ESIndicesCreateService out of *elastic.IndicesCreateService.
-func WrapESIndicesCreateService(indicesCreateService *elastic.IndicesCreateService) ESIndicesCreateService {
-	return ESIndicesCreateService{indicesCreateService: indicesCreateService}
+func WrapESIndicesCreateService(indicesCreateService *elastic.IndicesCreateService) IndicesCreateServiceWrapper {
+	return IndicesCreateServiceWrapper{indicesCreateService: indicesCreateService}
 }
 
 // Body calls this function to internal service.
-func (c ESIndicesCreateService) Body(mapping string) IndicesCreateService {
+func (c IndicesCreateServiceWrapper) Body(mapping string) IndicesCreateService {
 	return WrapESIndicesCreateService(c.indicesCreateService.Body(mapping))
 }
 
 // Do calls this function to internal service.
-func (c ESIndicesCreateService) Do(ctx context.Context) (*elastic.IndicesCreateResult, error) {
+func (c IndicesCreateServiceWrapper) Do(ctx context.Context) (*elastic.IndicesCreateResult, error) {
 	return c.indicesCreateService.Do(ctx)
 }
 
 // ---
 
-// ESIndexService is a wrapper around elastic.ESIndexService
-type ESIndexService struct {
+// IndexServiceWrapper is a wrapper around elastic.ESIndexService
+type IndexServiceWrapper struct {
 	bulkIndexReq *elastic.BulkIndexRequest
 	bulkService  *elastic.BulkProcessor
 }
 
 // WrapESIndexService creates an ESIndexService out of *elastic.ESIndexService.
-func WrapESIndexService(indexService *elastic.BulkIndexRequest, bulkService *elastic.BulkProcessor) ESIndexService {
-	return ESIndexService{bulkIndexReq: indexService, bulkService: bulkService}
+func WrapESIndexService(indexService *elastic.BulkIndexRequest, bulkService *elastic.BulkProcessor) IndexServiceWrapper {
+	return IndexServiceWrapper{bulkIndexReq: indexService, bulkService: bulkService}
 }
 
 // Index calls this function to internal service.
-func (i ESIndexService) Index(index string) IndexService {
+func (i IndexServiceWrapper) Index(index string) IndexService {
 	return WrapESIndexService(i.bulkIndexReq.Index(index), i.bulkService)
 }
 
 // Type calls this function to internal service.
-func (i ESIndexService) Type(typ string) IndexService {
+func (i IndexServiceWrapper) Type(typ string) IndexService {
 	return WrapESIndexService(i.bulkIndexReq.Type(typ), i.bulkService)
 }
 
 // Id calls this function to internal service.
-func (i ESIndexService) Id(id string) IndexService {
+func (i IndexServiceWrapper) Id(id string) IndexService {
 	return WrapESIndexService(i.bulkIndexReq.Id(id), i.bulkService)
 }
 
 // BodyJson calls this function to internal service.
-func (i ESIndexService) BodyJson(body interface{}) IndexService {
+func (i IndexServiceWrapper) BodyJson(body interface{}) IndexService {
 	return WrapESIndexService(i.bulkIndexReq.Doc(body), i.bulkService)
 }
 
 // Add adds the request to bulk service
-func (i ESIndexService) Add() {
+func (i IndexServiceWrapper) Add() {
 	i.bulkService.Add(i.bulkIndexReq)
 }
 
 // ---
 
-// ESSearchService is a wrapper around elastic.ESSearchService
-type ESSearchService struct {
+// SearchServiceWrapper is a wrapper around elastic.ESSearchService
+type SearchServiceWrapper struct {
 	searchService *elastic.SearchService
 }
 
 // WrapESSearchService creates an ESSearchService out of *elastic.ESSearchService.
-func WrapESSearchService(searchService *elastic.SearchService) ESSearchService {
-	return ESSearchService{searchService: searchService}
+func WrapESSearchService(searchService *elastic.SearchService) SearchServiceWrapper {
+	return SearchServiceWrapper{searchService: searchService}
 }
 
 // Type calls this function to internal service.
-func (s ESSearchService) Type(typ string) SearchService {
+func (s SearchServiceWrapper) Type(typ string) SearchService {
 	return WrapESSearchService(s.searchService.Type(typ))
 }
 
 // Size calls this function to internal service.
-func (s ESSearchService) Size(size int) SearchService {
+func (s SearchServiceWrapper) Size(size int) SearchService {
 	return WrapESSearchService(s.searchService.Size(size))
 }
 
 // Aggregation calls this function to internal service.
-func (s ESSearchService) Aggregation(name string, aggregation elastic.Aggregation) SearchService {
+func (s SearchServiceWrapper) Aggregation(name string, aggregation elastic.Aggregation) SearchService {
 	return WrapESSearchService(s.searchService.Aggregation(name, aggregation))
 }
 
 // IgnoreUnavailable calls this function to internal service.
-func (s ESSearchService) IgnoreUnavailable(ignoreUnavailable bool) SearchService {
+func (s SearchServiceWrapper) IgnoreUnavailable(ignoreUnavailable bool) SearchService {
 	return WrapESSearchService(s.searchService.IgnoreUnavailable(ignoreUnavailable))
 }
 
 // Query calls this function to internal service.
-func (s ESSearchService) Query(query elastic.Query) SearchService {
+func (s SearchServiceWrapper) Query(query elastic.Query) SearchService {
 	return WrapESSearchService(s.searchService.Query(query))
 }
 
 // Do calls this function to internal service.
-func (s ESSearchService) Do(ctx context.Context) (*elastic.SearchResult, error) {
+func (s SearchServiceWrapper) Do(ctx context.Context) (*elastic.SearchResult, error) {
 	return s.searchService.Do(ctx)
 }
 
-// ESMultiSearchService is a wrapper around elastic.ESMultiSearchService
-type ESMultiSearchService struct {
+// MultiSearchServiceWrapper is a wrapper around elastic.ESMultiSearchService
+type MultiSearchServiceWrapper struct {
 	multiSearchService *elastic.MultiSearchService
 }
 
 // WrapESMultiSearchService creates an ESSearchService out of *elastic.ESSearchService.
-func WrapESMultiSearchService(multiSearchService *elastic.MultiSearchService) ESMultiSearchService {
-	return ESMultiSearchService{multiSearchService: multiSearchService}
+func WrapESMultiSearchService(multiSearchService *elastic.MultiSearchService) MultiSearchServiceWrapper {
+	return MultiSearchServiceWrapper{multiSearchService: multiSearchService}
 }
 
 // Add calls this function to internal service.
-func (s ESMultiSearchService) Add(requests ...*elastic.SearchRequest) MultiSearchService {
+func (s MultiSearchServiceWrapper) Add(requests ...*elastic.SearchRequest) MultiSearchService {
 	return WrapESMultiSearchService(s.multiSearchService.Add(requests...))
 }
 
 // Index calls this function to internal service.
-func (s ESMultiSearchService) Index(indices ...string) MultiSearchService {
+func (s MultiSearchServiceWrapper) Index(indices ...string) MultiSearchService {
 	return WrapESMultiSearchService(s.multiSearchService.Index(indices...))
 }
 
 // Do calls this function to internal service.
-func (s ESMultiSearchService) Do(ctx context.Context) (*elastic.MultiSearchResult, error) {
+func (s MultiSearchServiceWrapper) Do(ctx context.Context) (*elastic.MultiSearchResult, error) {
 	return s.multiSearchService.Do(ctx)
 }

--- a/pkg/es/wrapper.go
+++ b/pkg/es/wrapper.go
@@ -105,7 +105,8 @@ func (c IndicesCreateServiceWrapper) Do(ctx context.Context) (*elastic.IndicesCr
 
 // ---
 
-// IndexServiceWrapper is a wrapper around elastic.ESIndexService
+// IndexServiceWrapper is a wrapper around elastic.ESIndexService.
+// See wrapper_nolint.go for more functions.
 type IndexServiceWrapper struct {
 	bulkIndexReq *elastic.BulkIndexRequest
 	bulkService  *elastic.BulkProcessor
@@ -124,16 +125,6 @@ func (i IndexServiceWrapper) Index(index string) IndexService {
 // Type calls this function to internal service.
 func (i IndexServiceWrapper) Type(typ string) IndexService {
 	return WrapESIndexService(i.bulkIndexReq.Type(typ), i.bulkService)
-}
-
-// Id calls this function to internal service.
-func (i IndexServiceWrapper) Id(id string) IndexService {
-	return WrapESIndexService(i.bulkIndexReq.Id(id), i.bulkService)
-}
-
-// BodyJson calls this function to internal service.
-func (i IndexServiceWrapper) BodyJson(body interface{}) IndexService {
-	return WrapESIndexService(i.bulkIndexReq.Doc(body), i.bulkService)
 }
 
 // Add adds the request to bulk service

--- a/pkg/es/wrapper_nolint.go
+++ b/pkg/es/wrapper_nolint.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package es
 
 // Some of the functions of elastic.BulkIndexRequest violate golint rules.

--- a/pkg/es/wrapper_nolint.go
+++ b/pkg/es/wrapper_nolint.go
@@ -1,0 +1,13 @@
+package es
+
+// Some of the functions of elastic.BulkIndexRequest violate golint rules.
+
+// Id calls this function to internal service.
+func (i IndexServiceWrapper) Id(id string) IndexService {
+	return WrapESIndexService(i.bulkIndexReq.Id(id), i.bulkService)
+}
+
+// BodyJson calls this function to internal service.
+func (i IndexServiceWrapper) BodyJson(body interface{}) IndexService {
+	return WrapESIndexService(i.bulkIndexReq.Doc(body), i.bulkService)
+}

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -234,6 +234,7 @@ func (s *SpanReader) FindTraces(ctx context.Context, traceQuery *spanstore.Trace
 	return s.multiRead(ctx, uniqueTraceIDs, traceQuery.StartTimeMin, traceQuery.StartTimeMax)
 }
 
+// FindTraceIDs is not implemented.
 func (s *SpanReader) FindTraceIDs(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) ([]model.TraceID, error) {
 	return nil, errors.New("not implemented") // TODO: Implement
 }

--- a/plugin/storage/kafka/marshalling_test.go
+++ b/plugin/storage/kafka/marshalling_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	"github.com/jaegertracing/jaeger/model/converter/thrift/zipkin"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
 func TestProtobufMarshallerAndUnmarshaller(t *testing.T) {
@@ -45,9 +45,9 @@ func testMarshallerAndUnmarshaller(t *testing.T, marshaller Marshaller, unmarsha
 
 func TestZipkinThriftUnmarshaller(t *testing.T) {
 	operationName := "foo"
-	bytes := zipkin.ZipkinSerialize([]*zipkincore.Span{
+	bytes := zipkin.SerializeThrift([]*zipkincore.Span{
 		{
-			ID: 12345,
+			ID:   12345,
 			Name: operationName,
 			Annotations: []*zipkincore.Annotation{
 				{Host: &zipkincore.Endpoint{ServiceName: "foobar"}},
@@ -62,9 +62,9 @@ func TestZipkinThriftUnmarshaller(t *testing.T) {
 }
 
 func TestZipkinThriftUnmarshallerErrorNoService(t *testing.T) {
-	bytes := zipkin.ZipkinSerialize([]*zipkincore.Span{
+	bytes := zipkin.SerializeThrift([]*zipkincore.Span{
 		{
-			ID: 12345,
+			ID:   12345,
 			Name: "foo",
 		},
 	})

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -30,8 +30,11 @@ const (
 	suffixTopic    = ".topic"
 	suffixEncoding = ".encoding"
 
-	EncodingJSON         = "json"
-	EncodingProto        = "protobuf"
+	// EncodingJSON is used for spans encoded as Protobuf-based JSON.
+	EncodingJSON = "json"
+	// EncodingProto is used for spans encoded as Protobuf.
+	EncodingProto = "protobuf"
+	// EncodingZipkinThrift is used for spans encoded as Zipkin Thrift.
 	EncodingZipkinThrift = "zipkin-thrift"
 
 	defaultBroker   = "127.0.0.1:9092"
@@ -40,7 +43,7 @@ const (
 )
 
 var (
-	AllEncodings = []string{EncodingJSON, EncodingProto, EncodingZipkinThrift}
+	allEncodings = []string{EncodingJSON, EncodingProto, EncodingZipkinThrift}
 )
 
 // Options stores the configuration options for Kafka

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -25,11 +25,6 @@ import (
 )
 
 const (
-	configPrefix   = "kafka"
-	suffixBrokers  = ".brokers"
-	suffixTopic    = ".topic"
-	suffixEncoding = ".encoding"
-
 	// EncodingJSON is used for spans encoded as Protobuf-based JSON.
 	EncodingJSON = "json"
 	// EncodingProto is used for spans encoded as Protobuf.
@@ -37,13 +32,19 @@ const (
 	// EncodingZipkinThrift is used for spans encoded as Zipkin Thrift.
 	EncodingZipkinThrift = "zipkin-thrift"
 
+	configPrefix   = "kafka"
+	suffixBrokers  = ".brokers"
+	suffixTopic    = ".topic"
+	suffixEncoding = ".encoding"
+
 	defaultBroker   = "127.0.0.1:9092"
 	defaultTopic    = "jaeger-spans"
 	defaultEncoding = EncodingProto
 )
 
 var (
-	allEncodings = []string{EncodingJSON, EncodingProto, EncodingZipkinThrift}
+	// AllEncodings is a list of all supported encodings.
+	AllEncodings = []string{EncodingJSON, EncodingProto, EncodingZipkinThrift}
 )
 
 // Options stores the configuration options for Kafka

--- a/plugin/storage/kafka/unmarshaller.go
+++ b/plugin/storage/kafka/unmarshaller.go
@@ -59,16 +59,16 @@ func (h *JSONUnmarshaller) Unmarshal(msg []byte) (*model.Span, error) {
 	return newSpan, err
 }
 
-// zipkinThriftUnmarshaller implements Unmarshaller
-type zipkinThriftUnmarshaller struct{}
+// ZipkinThriftUnmarshaller implements Unmarshaller
+type ZipkinThriftUnmarshaller struct{}
 
 // NewZipkinThriftUnmarshaller constructs a zipkinThriftUnmarshaller
-func NewZipkinThriftUnmarshaller() *zipkinThriftUnmarshaller {
-	return &zipkinThriftUnmarshaller{}
+func NewZipkinThriftUnmarshaller() *ZipkinThriftUnmarshaller {
+	return &ZipkinThriftUnmarshaller{}
 }
 
 // Unmarshal decodes a json byte array to a span
-func (h *zipkinThriftUnmarshaller) Unmarshal(msg []byte) (*model.Span, error) {
+func (h *ZipkinThriftUnmarshaller) Unmarshal(msg []byte) (*model.Span, error) {
 	tSpans, err := zipkin.DeserializeThrift(msg)
 	if err != nil {
 		return nil, err

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -198,6 +198,7 @@ func (m *Store) FindTraces(ctx context.Context, query *spanstore.TraceQueryParam
 	return retMe, nil
 }
 
+// FindTraceIDs is not implemented.
 func (m *Store) FindTraceIDs(ctx context.Context, query *spanstore.TraceQueryParameters) ([]model.TraceID, error) {
 	return nil, errors.New("not implemented")
 }


### PR DESCRIPTION
Recent changes prevented lint running on all packages, and the lint was also incorrectly failing (see https://github.com/jaegertracing/jaeger/pull/760#issuecomment-451319852).

This change replaces `lint $(ALL_SRCS)` with `lint $(ALL_PGKS)`. A few source files started failing with that, so needed to be fixed as well.