### PR TITLE
Update to jaeger-lib 2 and latest sha for jaeger-client-go, to pick u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Changes by Version
 
 ##### Breaking Changes
 
+- Update to jaeger-lib 2 and latest sha for jaeger-client-go, to pick up refactored metric names ([#1282](https://github.com/jaegertracing/jaeger/pull/1282), [@objectiser](https://github.com/objectiser))
+
+Update to latest version of `jaeger-lib`, which includes a change to the naming of counters exported to
+prometheus, to follow the convention of using a `_total` suffix, e.g. `jaeger_query_requests` is now
+`jaeger_query_requests_total`.
+
+Jaeger go client metrics, previously under the namespace `jaeger_client_jaeger_` are now under
+`jaeger_tracer_`.
+
+
 - Add gRPC metrics to agent ([#1180](https://github.com/jaegertracing/jaeger/pull/1180), [@pavolloffay](https://github.com/pavolloffay))
 
 The following metrics:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -663,7 +663,7 @@
   version = "v1.3.2"
 
 [[projects]]
-  digest = "1:473fbf1a56c0b116352cbaaa7e3b6d012fbfe5b00194341a8c3ffd1de5fb74ff"
+  digest = "1:7c11980280dde910d2559041cc22a5a97630d889a692d2ee9e5155743245df9f"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -687,11 +687,10 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "1a782e2da844727691fef1757c72eb190c2909f0"
-  version = "v2.15.0"
+  revision = "cd507787f07ecb833e0f2df888e074f45a0dca74"
 
 [[projects]]
-  digest = "1:872d648d95d0d62c2a67d4f5f09c31752588705c4482bc8b4f52015e0495a6d5"
+  digest = "1:1aca23d09c5fd39cd9d630ad84aa6fb7d04aa0278dcf078257e45586b545d4b8"
   name = "github.com/uber/jaeger-lib"
   packages = [
     "metrics",
@@ -699,12 +698,12 @@
     "metrics/expvar",
     "metrics/go-kit",
     "metrics/go-kit/expvar",
+    "metrics/metricstest",
     "metrics/prometheus",
-    "metrics/testutils",
   ]
   pruneopts = "UT"
-  revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
-  version = "v1.5.0"
+  revision = "0e30338a695636fe5bcf7301e8030ce8dd2a8530"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:9c231161ce5a181c5782f73f443933b928b631d988f705dafc070f83aa79f4e9"
@@ -940,8 +939,8 @@
     "github.com/uber/jaeger-client-go/transport/zipkin",
     "github.com/uber/jaeger-lib/metrics",
     "github.com/uber/jaeger-lib/metrics/expvar",
+    "github.com/uber/jaeger-lib/metrics/metricstest",
     "github.com/uber/jaeger-lib/metrics/prometheus",
-    "github.com/uber/jaeger-lib/metrics/testutils",
     "github.com/uber/tchannel-go",
     "github.com/uber/tchannel-go/raw",
     "github.com/uber/tchannel-go/testutils",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -663,7 +663,7 @@
   version = "v1.3.2"
 
 [[projects]]
-  digest = "1:7c11980280dde910d2559041cc22a5a97630d889a692d2ee9e5155743245df9f"
+  digest = "1:359519fad3780843e57c5117ddf751284a9e0e3c050753ad362476cf1e10ef49"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -687,7 +687,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "cd507787f07ecb833e0f2df888e074f45a0dca74"
+  revision = "6733ee486c780528f2c8088305e16fdb685134c7"
 
 [[projects]]
   digest = "1:1aca23d09c5fd39cd9d630ad84aa6fb7d04aa0278dcf078257e45586b545d4b8"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,11 +81,11 @@ required = [
 
 [[constraint]]
   name = "github.com/uber/jaeger-client-go"
-  version = "^2.15.0"
+  revision = "cd507787f07ecb833e0f2df888e074f45a0dca74"
 
 [[constraint]]
   name = "github.com/uber/jaeger-lib"
-  version = "^1.5.0"
+  version = "^2.0.0"
 
 [[constraint]]
   name = "github.com/uber/tchannel-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,7 +81,7 @@ required = [
 
 [[constraint]]
   name = "github.com/uber/jaeger-client-go"
-  revision = "cd507787f07ecb833e0f2df888e074f45a0dca74"
+  revision = "6733ee486c780528f2c8088305e16fdb685134c7"
 
 [[constraint]]
   name = "github.com/uber/jaeger-lib"

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -141,10 +141,10 @@ func (b *Builder) getProcessors(rep reporter.Reporter, mFactory metrics.Factory,
 		default:
 			return nil, fmt.Errorf("cannot find agent processor for data model %v", cfg.Model)
 		}
-		metrics := mFactory.Namespace("", map[string]string{
+		metrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{
 			"protocol": string(cfg.Protocol),
 			"model":    string(cfg.Model),
-		})
+		}})
 		processor, err := cfg.GetThriftProcessor(metrics, protoFactory, handler, logger)
 		if err != nil {
 			return nil, err

--- a/cmd/agent/app/configmanager/metrics_test.go
+++ b/cmd/agent/app/configmanager/metrics_test.go
@@ -21,8 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
 	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
@@ -46,16 +45,16 @@ func (noopManager) GetBaggageRestrictions(s string) ([]*baggage.BaggageRestricti
 
 func TestMetrics(t *testing.T) {
 	tests := []struct {
-		expected []mTestutils.ExpectedMetric
+		expected []metricstest.ExpectedMetric
 		err      error
 	}{
-		{expected: []mTestutils.ExpectedMetric{
+		{expected: []metricstest.ExpectedMetric{
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "sampling"}, Value: 1},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "sampling"}, Value: 0},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "baggage"}, Value: 1},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "baggage"}, Value: 0},
 		}},
-		{expected: []mTestutils.ExpectedMetric{
+		{expected: []metricstest.ExpectedMetric{
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "sampling"}, Value: 0},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "err", "endpoint": "sampling"}, Value: 1},
 			{Name: "collector-proxy", Tags: map[string]string{"result": "ok", "endpoint": "baggage"}, Value: 0},
@@ -64,7 +63,7 @@ func TestMetrics(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		metricsFactory := metrics.NewLocalFactory(time.Microsecond)
+		metricsFactory := metricstest.NewFactory(time.Microsecond)
 		mgr := WrapWithMetrics(&noopManager{}, metricsFactory)
 
 		if test.err != nil {
@@ -82,6 +81,6 @@ func TestMetrics(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, b)
 		}
-		mTestutils.AssertCounterMetrics(t, metricsFactory, test.expected...)
+		metricsFactory.AssertCounterMetrics(t, test.expected...)
 	}
 }

--- a/cmd/agent/app/httpserver/server_test.go
+++ b/cmd/agent/app/httpserver/server_test.go
@@ -25,9 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	tSampling092 "github.com/jaegertracing/jaeger/cmd/agent/app/httpserver/thrift-0.9.2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
@@ -35,7 +33,7 @@ import (
 )
 
 type testServer struct {
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	mgr            *mockManager
 	server         *httptest.Server
 }
@@ -45,7 +43,7 @@ func withServer(
 	mockBaggageResponse []*baggage.BaggageRestriction,
 	runTest func(server *testServer),
 ) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	mgr := &mockManager{
 		samplingResponse: mockSamplingResponse,
 		baggageResponse:  mockBaggageResponse,
@@ -100,7 +98,7 @@ func TestHTTPHandler(t *testing.T) {
 		})
 
 		// handler must emit metrics
-		testutils.AssertCounterMetrics(t, ts.metricsFactory, []testutils.ExpectedMetric{
+		ts.metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 			{Name: "http-server.requests", Tags: map[string]string{"type": "sampling"}, Value: 1},
 			{Name: "http-server.requests", Tags: map[string]string{"type": "sampling-legacy"}, Value: 1},
 			{Name: "http-server.requests", Tags: map[string]string{"type": "baggage"}, Value: 1},
@@ -116,14 +114,14 @@ func TestHTTPHandlerErrors(t *testing.T) {
 		url                  string
 		statusCode           int
 		body                 string
-		metrics              []mTestutils.ExpectedMetric
+		metrics              []metricstest.ExpectedMetric
 	}{
 		{
 			description: "no service name",
 			url:         "",
 			statusCode:  http.StatusBadRequest,
 			body:        "'service' parameter must be provided once\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "all", "status": "4xx"}, Value: 1},
 			},
 		},
@@ -132,7 +130,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "?service=Y&service=Y",
 			statusCode:  http.StatusBadRequest,
 			body:        "'service' parameter must be provided once\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "all", "status": "4xx"}, Value: 1},
 			},
 		},
@@ -141,7 +139,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "/baggageRestrictions?service=Y&service=Y",
 			statusCode:  http.StatusBadRequest,
 			body:        "'service' parameter must be provided once\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "all", "status": "4xx"}, Value: 1},
 			},
 		},
@@ -150,7 +148,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "?service=Y",
 			statusCode:  http.StatusInternalServerError,
 			body:        "collector error: no mock response provided\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "collector-proxy", "status": "5xx"}, Value: 1},
 			},
 		},
@@ -159,7 +157,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:         "/baggageRestrictions?service=Y",
 			statusCode:  http.StatusInternalServerError,
 			body:        "collector error: no mock response provided\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "collector-proxy", "status": "5xx"}, Value: 1},
 			},
 		},
@@ -169,7 +167,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			url:                  "?service=Y",
 			statusCode:           http.StatusInternalServerError,
 			body:                 "Cannot marshall Thrift to JSON\n",
-			metrics: []mTestutils.ExpectedMetric{
+			metrics: []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "thrift", "status": "5xx"}, Value: 1},
 			},
 		},
@@ -188,7 +186,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 				}
 
 				if len(testCase.metrics) > 0 {
-					mTestutils.AssertCounterMetrics(t, ts.metricsFactory, testCase.metrics...)
+					ts.metricsFactory.AssertCounterMetrics(t, testCase.metrics...)
 				}
 			})
 		})
@@ -202,14 +200,14 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			w := &mockWriter{header: make(http.Header)}
 			handler.serveSamplingHTTP(w, req, false)
 
-			mTestutils.AssertCounterMetrics(t, ts.metricsFactory,
-				mTestutils.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 1})
+			ts.metricsFactory.AssertCounterMetrics(t,
+				metricstest.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 1})
 
 			req = httptest.NewRequest("GET", "http://localhost:80/baggageRestrictions?service=X", nil)
 			handler.serveBaggageHTTP(w, req)
 
-			mTestutils.AssertCounterMetrics(t, ts.metricsFactory,
-				mTestutils.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 2})
+			ts.metricsFactory.AssertCounterMetrics(t,
+				metricstest.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 2})
 		})
 	})
 }

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
@@ -75,7 +75,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 	return transport.Addr().String(), processor
 }
 
-func initCollectorAndReporter(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, reporter.Reporter) {
+func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.MockTCollector, reporter.Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
 	reporter := reporter.WrapWithMetrics(tchreporter.New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop()), metricsFactory)
 	return metricsFactory, collector, reporter
@@ -115,7 +115,7 @@ func (h failingHandler) Process(iprot, oprot thrift.TProtocol) (success bool, er
 }
 
 func TestProcessor_HandlerError(t *testing.T) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	handler := failingHandler{err: errors.New("doh")}
 
@@ -137,9 +137,9 @@ func TestProcessor_HandlerError(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	mTestutils.AssertCounterMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.t-processor.handler-errors", Value: 1},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
+	metricsFactory.AssertCounterMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.t-processor.handler-errors", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
 	)
 }
 
@@ -170,7 +170,7 @@ func TestJaegerProcessor(t *testing.T) {
 	}
 }
 
-func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metrics.LocalFactory) {
+func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metricstest.Factory) {
 	sizeF := func() int {
 		return len(collector.GetJaegerBatches())
 	}
@@ -180,7 +180,7 @@ func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.MockTCo
 	assertProcessorCorrectness(t, metricsFactory, sizeF, nameF, "jaeger")
 }
 
-func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metrics.LocalFactory) {
+func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCollector, metricsFactory *metricstest.Factory) {
 	sizeF := func() int {
 		return len(collector.GetZipkinSpans())
 	}
@@ -192,7 +192,7 @@ func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.MockTCo
 
 func assertProcessorCorrectness(
 	t *testing.T,
-	metricsFactory *metrics.LocalFactory,
+	metricsFactory *metricstest.Factory,
 	sizeF func() int,
 	nameF func() string,
 	format string,
@@ -218,7 +218,7 @@ func assertProcessorCorrectness(
 	}
 
 	// agentReporter must emit metrics
-	mTestutils.AssertCounterMetrics(t, metricsFactory, []mTestutils.ExpectedMetric{
+	metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 		{Name: "reporter.batches.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "reporter.spans.submitted", Tags: map[string]string{"format": format}, Value: 1},
 		{Name: "thrift.udp.server.packets.processed", Value: 1},

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -54,7 +54,7 @@ func NewCollectorProxy(o *Options, mFactory metrics.Factory, logger *zap.Logger)
 		// It does not return error if the collector is not running
 		conn, _ = grpc.Dial(o.CollectorHostPort[0], grpc.WithInsecure())
 	}
-	grpcMetrics := mFactory.Namespace("", map[string]string{"protocol": "grpc"})
+	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
 	return &ProxyBuilder{
 		conn:     conn,
 		reporter: aReporter.WrapWithMetrics(NewReporter(conn, logger), grpcMetrics),

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
@@ -57,7 +58,7 @@ func TestMultipleCollectors(t *testing.T) {
 	})
 	defer s2.Stop()
 
-	mFactory := metrics.NewLocalFactory(time.Microsecond)
+	mFactory := metricstest.NewFactory(time.Microsecond)
 	proxy, err := NewCollectorProxy(&Options{CollectorHostPort: []string{addr1.String(), addr2.String()}}, mFactory, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, proxy)

--- a/cmd/agent/app/reporter/metrics.go
+++ b/cmd/agent/app/reporter/metrics.go
@@ -55,7 +55,7 @@ func WrapWithMetrics(reporter Reporter, mFactory metrics.Factory) *MetricsReport
 	batchesMetrics := map[string]batchMetrics{}
 	for _, s := range []string{zipkinBatches, jaegerBatches} {
 		bm := batchMetrics{}
-		metrics.Init(&bm, mFactory.Namespace("reporter", map[string]string{"format": s}), nil)
+		metrics.Init(&bm, mFactory.Namespace(metrics.NSOptions{Name: "reporter", Tags: map[string]string{"format": s}}), nil)
 		batchesMetrics[s] = bm
 	}
 	return &MetricsReporter{wrapped: reporter, metrics: batchesMetrics}

--- a/cmd/agent/app/reporter/metrics_test.go
+++ b/cmd/agent/app/reporter/metrics_test.go
@@ -20,8 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -45,70 +44,70 @@ func (r *noopReporter) EmitBatch(batch *jaeger.Batch) error {
 
 func TestMetricsReporter(t *testing.T) {
 	tests := []struct {
-		expectedCounters []mTestutils.ExpectedMetric
-		expectedGauges   []mTestutils.ExpectedMetric
+		expectedCounters []metricstest.ExpectedMetric
+		expectedGauges   []metricstest.ExpectedMetric
 		action           func(reporter Reporter)
 		rep              *noopReporter
 	}{
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitBatch(nil)
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitBatch(&jaeger.Batch{Spans: []*jaeger.Span{{}}})
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitZipkinBatch(nil)
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "zipkin"}, Value: 0},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitZipkinBatch([]*zipkincore.Span{{}})
 			require.NoError(t, err)
 		}, rep: &noopReporter{}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "jaeger"}, Value: 1},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "jaeger"}, Value: 1},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitBatch(&jaeger.Batch{Spans: []*jaeger.Span{{}}})
 			require.Error(t, err)
 		}, rep: &noopReporter{err: errors.New("foo")}},
-		{expectedCounters: []mTestutils.ExpectedMetric{
+		{expectedCounters: []metricstest.ExpectedMetric{
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "zipkin"}, Value: 1},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "zipkin"}, Value: 2},
-		}, expectedGauges: []mTestutils.ExpectedMetric{
+		}, expectedGauges: []metricstest.ExpectedMetric{
 			{Name: "reporter.batch_size", Tags: map[string]string{"format": "zipkin"}, Value: 0},
 		}, action: func(reporter Reporter) {
 			err := reporter.EmitZipkinBatch([]*zipkincore.Span{{}, {}})
@@ -117,10 +116,10 @@ func TestMetricsReporter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		metricsFactory := metrics.NewLocalFactory(time.Microsecond)
+		metricsFactory := metricstest.NewFactory(time.Microsecond)
 		r := WrapWithMetrics(test.rep, metricsFactory)
 		test.action(r)
-		mTestutils.AssertCounterMetrics(t, metricsFactory, test.expectedCounters...)
-		mTestutils.AssertGaugeMetrics(t, metricsFactory, test.expectedGauges...)
+		metricsFactory.AssertCounterMetrics(t, test.expectedCounters...)
+		metricsFactory.AssertGaugeMetrics(t, test.expectedGauges...)
 	}
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy.go
@@ -36,7 +36,7 @@ func NewCollectorProxy(builder *Builder, mFactory metrics.Factory, logger *zap.L
 	if err != nil {
 		return nil, err
 	}
-	tchannelMetrics := mFactory.Namespace("", map[string]string{"protocol": "tchannel"})
+	tchannelMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "tchannel"}})
 	return &ProxyBuilder{
 		tchanRep: r,
 		reporter: reporter.WrapWithMetrics(r, tchannelMetrics),

--- a/cmd/agent/app/reporter/tchannel/reporter_test.go
+++ b/cmd/agent/app/reporter/tchannel/reporter_test.go
@@ -20,15 +20,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
-func initRequirements(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, *Reporter) {
+func initRequirements(t *testing.T) (*metricstest.Factory, *testutils.MockTCollector, *Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
 	reporter := New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop())
 	return metricsFactory, collector, reporter

--- a/cmd/agent/app/servers/tbuffered_server_test.go
+++ b/cmd/agent/app/servers/tbuffered_server_test.go
@@ -21,8 +21,7 @@ import (
 	athrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
-	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
@@ -41,7 +40,7 @@ func TestTBufferedServer(t *testing.T) {
 }
 
 func testTBufferedServer(t *testing.T, queueSize int, testDroppedPackets bool) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	transport, err := thriftudp.NewTUDPServerTransport("127.0.0.1:0")
 	require.NoError(t, err)
@@ -100,12 +99,12 @@ func testTBufferedServer(t *testing.T, queueSize int, testDroppedPackets bool) {
 	assert.Equal(t, "span1", inMemReporter.ZipkinSpans()[0].Name)
 
 	// server must emit metrics
-	mTestutils.AssertCounterMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 0},
+	metricsFactory.AssertCounterMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 0},
 	)
-	mTestutils.AssertGaugeMetrics(t, metricsFactory,
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 38},
-		mTestutils.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
+	metricsFactory.AssertGaugeMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 38},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
 	)
 }

--- a/cmd/agent/app/testutils/fixture.go
+++ b/cmd/agent/app/testutils/fixture.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 // InitMockCollector initializes a MockTCollector fixture
-func InitMockCollector(t *testing.T) (*metrics.LocalFactory, *MockTCollector) {
-	factory := metrics.NewLocalFactory(0)
+func InitMockCollector(t *testing.T) (*metricstest.Factory, *MockTCollector) {
+	factory := metricstest.NewFactory(0)
 	collector, err := StartMockTCollector()
 	require.NoError(t, err)
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -68,7 +68,7 @@ func main() {
 			if err != nil {
 				logger.Fatal("Could not create metrics", zap.Error(err))
 			}
-			mFactory = mFactory.Namespace("agent", nil)
+			mFactory = mFactory.Namespace(jMetrics.NSOptions{Name: "agent", Tags: nil})
 
 			rOpts := new(reporter.Options).InitFromViper(v)
 			tChanOpts := new(tchannel.Builder).InitFromViper(v, logger)

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -193,7 +193,7 @@ func startAgent(
 	logger *zap.Logger,
 	baseFactory metrics.Factory,
 ) {
-	metricsFactory := baseFactory.Namespace("agent", nil)
+	metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "agent", Tags: nil})
 
 	cp, err := createCollectorProxy(cOpts, repOpts, tchanRep, grpcRepOpts, logger, metricsFactory)
 	if err != nil {
@@ -239,7 +239,7 @@ func startCollector(
 	strategyStore strategystore.StrategyStore,
 	hc *healthcheck.HealthCheck,
 ) *grpc.Server {
-	metricsFactory := baseFactory.Namespace("collector", nil)
+	metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "collector", Tags: nil})
 
 	spanBuilder, err := collector.NewSpanHandlerBuilder(
 		cOpts,
@@ -349,7 +349,7 @@ func startQuery(
 		RPCMetrics: true,
 	}.New(
 		"jaeger-query",
-		jaegerClientConfig.Metrics(baseFactory.Namespace("client", nil)),
+		jaegerClientConfig.Metrics(baseFactory.Namespace(metrics.NSOptions{Name: "client", Tags: nil})),
 		jaegerClientConfig.Logger(jaegerClientZapLog.NewLogger(logger)),
 	)
 	if err != nil {
@@ -357,7 +357,7 @@ func startQuery(
 	}
 	opentracing.SetGlobalTracer(tracer)
 
-	spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace("query", nil))
+	spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace(metrics.NSOptions{Name: "query", Tags: nil}))
 
 	handlerOpts = append(handlerOpts, queryApp.HandlerOptions.Logger(logger), queryApp.HandlerOptions.Tracer(tracer))
 	apiHandler := queryApp.NewAPIHandler(

--- a/cmd/collector/app/builder/span_handler_builder.go
+++ b/cmd/collector/app/builder/span_handler_builder.go
@@ -63,7 +63,7 @@ func (spanHb *SpanHandlerBuilder) BuildHandlers() (
 	*app.GRPCHandler,
 ) {
 	hostname, _ := os.Hostname()
-	hostMetrics := spanHb.metricsFactory.Namespace("", map[string]string{"host": hostname})
+	hostMetrics := spanHb.metricsFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"host": hostname}})
 
 	spanProcessor := app.NewSpanProcessor(
 		spanHb.spanWriter,

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -74,32 +74,32 @@ type CountsBySpanType struct {
 // NewSpanProcessorMetrics returns a SpanProcessorMetrics
 func NewSpanProcessorMetrics(serviceMetrics metrics.Factory, hostMetrics metrics.Factory, otherFormatTypes []string) *SpanProcessorMetrics {
 	spanCounts := map[string]CountsBySpanType{
-		ZipkinFormatType:  newCountsBySpanType(serviceMetrics.Namespace("", map[string]string{"format": ZipkinFormatType})),
-		JaegerFormatType:  newCountsBySpanType(serviceMetrics.Namespace("", map[string]string{"format": JaegerFormatType})),
-		UnknownFormatType: newCountsBySpanType(serviceMetrics.Namespace("", map[string]string{"format": UnknownFormatType})),
+		ZipkinFormatType:  newCountsBySpanType(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"format": ZipkinFormatType}})),
+		JaegerFormatType:  newCountsBySpanType(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"format": JaegerFormatType}})),
+		UnknownFormatType: newCountsBySpanType(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"format": UnknownFormatType}})),
 	}
 	for _, otherFormatType := range otherFormatTypes {
-		spanCounts[otherFormatType] = newCountsBySpanType(serviceMetrics.Namespace("", map[string]string{"format": otherFormatType}))
+		spanCounts[otherFormatType] = newCountsBySpanType(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"format": otherFormatType}}))
 	}
 	m := &SpanProcessorMetrics{
-		SaveLatency:    hostMetrics.Timer("save-latency", nil),
-		InQueueLatency: hostMetrics.Timer("in-queue-latency", nil),
-		SpansDropped:   hostMetrics.Counter("spans.dropped", nil),
-		BatchSize:      hostMetrics.Gauge("batch-size", nil),
-		QueueLength:    hostMetrics.Gauge("queue-length", nil),
-		ErrorBusy:      hostMetrics.Counter("error.busy", nil),
-		SavedOkBySvc:   newMetricsBySvc(serviceMetrics.Namespace("", map[string]string{"result": "ok"}), "saved-by-svc"),
-		SavedErrBySvc:  newMetricsBySvc(serviceMetrics.Namespace("", map[string]string{"result": "err"}), "saved-by-svc"),
+		SaveLatency:    hostMetrics.Timer(metrics.TimerOptions{Name: "save-latency", Tags: nil}),
+		InQueueLatency: hostMetrics.Timer(metrics.TimerOptions{Name: "in-queue-latency", Tags: nil}),
+		SpansDropped:   hostMetrics.Counter(metrics.Options{Name: "spans.dropped", Tags: nil}),
+		BatchSize:      hostMetrics.Gauge(metrics.Options{Name: "batch-size", Tags: nil}),
+		QueueLength:    hostMetrics.Gauge(metrics.Options{Name: "queue-length", Tags: nil}),
+		ErrorBusy:      hostMetrics.Counter(metrics.Options{Name: "error.busy", Tags: nil}),
+		SavedOkBySvc:   newMetricsBySvc(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"result": "ok"}}), "saved-by-svc"),
+		SavedErrBySvc:  newMetricsBySvc(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"result": "err"}}), "saved-by-svc"),
 		spanCounts:     spanCounts,
-		serviceNames:   hostMetrics.Gauge("spans.serviceNames", nil),
+		serviceNames:   hostMetrics.Gauge(metrics.Options{Name: "spans.serviceNames", Tags: nil}),
 	}
 
 	return m
 }
 
 func newMetricsBySvc(factory metrics.Factory, category string) metricsBySvc {
-	spansFactory := factory.Namespace("spans", nil)
-	tracesFactory := factory.Namespace("traces", nil)
+	spansFactory := factory.Namespace(metrics.NSOptions{Name: "spans", Tags: nil})
+	tracesFactory := factory.Namespace(metrics.NSOptions{Name: "traces", Tags: nil})
 	return metricsBySvc{
 		spans:  newCountsBySvc(spansFactory, category, maxServiceNames),
 		traces: newCountsBySvc(tracesFactory, category, maxServiceNames),
@@ -109,10 +109,10 @@ func newMetricsBySvc(factory metrics.Factory, category string) metricsBySvc {
 func newCountsBySvc(factory metrics.Factory, category string, maxServiceNames int) countsBySvc {
 	return countsBySvc{
 		counts: map[string]metrics.Counter{
-			otherServices: factory.Counter(category, map[string]string{"svc": otherServices, "debug": "false"}),
+			otherServices: factory.Counter(metrics.Options{Name: category, Tags: map[string]string{"svc": otherServices, "debug": "false"}}),
 		},
 		debugCounts: map[string]metrics.Counter{
-			otherServices: factory.Counter(category, map[string]string{"svc": otherServices, "debug": "true"}),
+			otherServices: factory.Counter(metrics.Options{Name: category, Tags: map[string]string{"svc": otherServices, "debug": "true"}}),
 		},
 		factory:         factory,
 		lock:            &sync.Mutex{},
@@ -186,7 +186,7 @@ func (m *countsBySvc) countByServiceName(serviceName string, isDebug bool) {
 		if isDebug {
 			debugStr = "true"
 		}
-		c := m.factory.Counter(m.category, map[string]string{"svc": serviceName, "debug": debugStr})
+		c := m.factory.Counter(metrics.Options{Name: m.category, Tags: map[string]string{"svc": serviceName, "debug": debugStr}})
 		counts[serviceName] = c
 		counter = c
 	} else {

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -20,14 +20,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	jaegerM "github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 )
 
 func TestProcessorMetrics(t *testing.T) {
-	baseMetrics := jaegerM.NewLocalFactory(time.Hour)
-	serviceMetrics := baseMetrics.Namespace("service", nil)
-	hostMetrics := baseMetrics.Namespace("host", nil)
+	baseMetrics := metricstest.NewFactory(time.Hour)
+	serviceMetrics := baseMetrics.Namespace(jaegerM.NSOptions{Name: "service", Tags: nil})
+	hostMetrics := baseMetrics.Namespace(jaegerM.NSOptions{Name: "host", Tags: nil})
 	spm := NewSpanProcessorMetrics(serviceMetrics, hostMetrics, []string{"scruffy"})
 	benderFormatMetrics := spm.GetCountsForFormat("bender")
 	assert.NotNil(t, benderFormatMetrics)
@@ -46,7 +47,7 @@ func TestProcessorMetrics(t *testing.T) {
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
 	mSpan.ReplaceParentID(1234)
 	jFormat.ReceivedBySvc.ReportServiceNameForSpan(&mSpan)
-	counters, gauges := baseMetrics.LocalBackend.Snapshot()
+	counters, gauges := baseMetrics.Backend.Snapshot()
 
 	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|svc=fry"])
 	assert.EqualValues(t, 2, counters["service.spans.received|debug=true|format=jaeger|svc=fry"])
@@ -56,7 +57,7 @@ func TestProcessorMetrics(t *testing.T) {
 }
 
 func TestNewCountsBySvc(t *testing.T) {
-	baseMetrics := jaegerM.NewLocalFactory(time.Hour)
+	baseMetrics := metricstest.NewFactory(time.Hour)
 	metrics := newCountsBySvc(baseMetrics, "not_on_my_level", 3)
 
 	metrics.countByServiceName("fry", false)
@@ -64,7 +65,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("bender", false)
 	metrics.countByServiceName("zoidberg", false)
 
-	counters, _ := baseMetrics.LocalBackend.Snapshot()
+	counters, _ := baseMetrics.Backend.Snapshot()
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|svc=fry"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|svc=leela"])
 	assert.EqualValues(t, 2, counters["not_on_my_level|debug=false|svc=other-services"])
@@ -74,7 +75,7 @@ func TestNewCountsBySvc(t *testing.T) {
 	metrics.countByServiceName("leela", true)
 	metrics.countByServiceName("fry", true)
 
-	counters, _ = baseMetrics.LocalBackend.Snapshot()
+	counters, _ = baseMetrics.Backend.Snapshot()
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|svc=zoidberg"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|svc=bender"])
 	assert.EqualValues(t, 2, counters["not_on_my_level|debug=true|svc=other-services"])

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -107,7 +107,7 @@ func main() {
 				logger.Fatal("Failed to create span writer", zap.Error(err))
 			}
 
-			metricsFactory := baseFactory.Namespace("collector", nil)
+			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "collector", Tags: nil})
 			handlerBuilder, err := builder.NewSpanHandlerBuilder(
 				builderOpts,
 				spanWriter,

--- a/cmd/ingester/app/consumer/consumer_metrics.go
+++ b/cmd/ingester/app/consumer/consumer_metrics.go
@@ -38,29 +38,29 @@ type partitionMetrics struct {
 }
 
 func (c *Consumer) namespace(partition int32) metrics.Factory {
-	return c.metricsFactory.Namespace(consumerNamespace, map[string]string{"partition": strconv.Itoa(int(partition))})
+	return c.metricsFactory.Namespace(metrics.NSOptions{Name: consumerNamespace, Tags: map[string]string{"partition": strconv.Itoa(int(partition))}})
 }
 
 func (c *Consumer) newMsgMetrics(partition int32) msgMetrics {
 	f := c.namespace(partition)
 	return msgMetrics{
-		counter:     f.Counter("messages", nil),
-		offsetGauge: f.Gauge("current-offset", nil),
-		lagGauge:    f.Gauge("offset-lag", nil),
+		counter:     f.Counter(metrics.Options{Name: "messages", Tags: nil}),
+		offsetGauge: f.Gauge(metrics.Options{Name: "current-offset", Tags: nil}),
+		lagGauge:    f.Gauge(metrics.Options{Name: "offset-lag", Tags: nil}),
 	}
 }
 
 func (c *Consumer) newErrMetrics(partition int32) errMetrics {
-	return errMetrics{errCounter: c.namespace(partition).Counter("errors", nil)}
+	return errMetrics{errCounter: c.namespace(partition).Counter(metrics.Options{Name: "errors", Tags: nil})}
 }
 
 func (c *Consumer) partitionMetrics(partition int32) partitionMetrics {
 	f := c.namespace(partition)
 	return partitionMetrics{
-		closeCounter: f.Counter("partition-close", nil),
-		startCounter: f.Counter("partition-start", nil)}
+		closeCounter: f.Counter(metrics.Options{Name: "partition-close", Tags: nil}),
+		startCounter: f.Counter(metrics.Options{Name: "partition-start", Tags: nil})}
 }
 
 func partitionsHeld(metricsFactory metrics.Factory) metrics.Counter {
-	return metricsFactory.Namespace(consumerNamespace, nil).Counter("partitions-held", nil)
+	return metricsFactory.Namespace(metrics.NSOptions{Name: consumerNamespace, Tags: nil}).Counter(metrics.Options{Name: "partitions-held", Tags: nil})
 }

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	kmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/mocks"
@@ -117,7 +117,7 @@ func TestSaramaConsumerWrapper_MarkPartitionOffset(t *testing.T) {
 }
 
 func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
-	localFactory := metrics.NewLocalFactory(0)
+	localFactory := metricstest.NewFactory(0)
 
 	msg := &sarama.ConsumerMessage{}
 
@@ -153,7 +153,7 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 	mc.YieldMessage(msg)
 	isProcessed.Wait()
 
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partitions-held",
 		Value: 1,
 	})
@@ -164,28 +164,28 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 		undertest.partitionIDToState[partition].partitionConsumer.HighWaterMarkOffset())
 	undertest.Close()
 
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partitions-held",
 		Value: 0,
 	})
 
 	partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.messages",
 		Tags:  partitionTag,
 		Value: 1,
 	})
-	testutils.AssertGaugeMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.current-offset",
 		Tags:  partitionTag,
 		Value: 1,
 	})
-	testutils.AssertGaugeMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.offset-lag",
 		Tags:  partitionTag,
 		Value: 0,
 	})
-	testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partition-start",
 		Tags:  partitionTag,
 		Value: 1,
@@ -193,7 +193,7 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 }
 
 func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
-	localFactory := metrics.NewLocalFactory(0)
+	localFactory := metricstest.NewFactory(0)
 
 	saramaConsumer := smocks.NewConsumer(t, &sarama.Config{})
 	mc := saramaConsumer.ExpectConsumePartition(topic, partition, msgOffset)
@@ -216,7 +216,7 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 		}
 
 		partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
-		testutils.AssertCounterMetrics(t, localFactory, testutils.ExpectedMetric{
+		localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 			Name:  "sarama-consumer.errors",
 			Tags:  partitionTag,
 			Value: 1,
@@ -229,7 +229,7 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 }
 
 func TestHandleClosePartition(t *testing.T) {
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 
 	mp := &pmocks.SpanProcessor{}
 	saramaConsumer := smocks.NewConsumer(t, &sarama.Config{})

--- a/cmd/ingester/app/consumer/deadlock_detector.go
+++ b/cmd/ingester/app/consumer/deadlock_detector.go
@@ -64,7 +64,7 @@ type allPartitionsDeadlockDetector struct {
 
 func newDeadlockDetector(metricsFactory metrics.Factory, logger *zap.Logger, interval time.Duration) deadlockDetector {
 	panicFunc := func(partition int32) {
-		metricsFactory.Counter("deadlockdetector.panic-issued", map[string]string{"partition": strconv.Itoa(int(partition))}).Inc(1)
+		metricsFactory.Counter(metrics.Options{Name: "deadlockdetector.panic-issued", Tags: map[string]string{"partition": strconv.Itoa(int(partition))}}).Inc(1)
 		time.Sleep(time.Second) // Allow time to flush metric
 
 		buf := make([]byte, 1<<20)
@@ -118,7 +118,7 @@ func (s *deadlockDetector) monitorForPartition(w *partitionDeadlockDetector, par
 			if atomic.LoadUint64(w.msgConsumed) == 0 {
 				select {
 				case w.closePartition <- struct{}{}:
-					s.metricsFactory.Counter("deadlockdetector.close-signalled", map[string]string{"partition": strconv.Itoa(int(partition))}).Inc(1)
+					s.metricsFactory.Counter(metrics.Options{Name: "deadlockdetector.close-signalled", Tags: map[string]string{"partition": strconv.Itoa(int(partition))}}).Inc(1)
 					s.logger.Warn("Signalling partition close due to inactivity", zap.Int32("partition", partition))
 				default:
 					// If closePartition is blocked, the consumer might have deadlocked - kill the process

--- a/cmd/ingester/app/consumer/offset/manager.go
+++ b/cmd/ingester/app/consumer/offset/manager.go
@@ -55,8 +55,8 @@ func NewManager(minOffset int64, markOffset MarkOffset, partition int32, factory
 	return &Manager{
 		markOffsetFunction:  markOffset,
 		close:               make(chan struct{}),
-		offsetCommitCount:   factory.Counter("offset-commits-total", map[string]string{"partition": strconv.Itoa(int(partition))}),
-		lastCommittedOffset: factory.Gauge("last-committed-offset", map[string]string{"partition": strconv.Itoa(int(partition))}),
+		offsetCommitCount:   factory.Counter(metrics.Options{Name: "offset-commits-total", Tags: map[string]string{"partition": strconv.Itoa(int(partition))}}),
+		lastCommittedOffset: factory.Gauge(metrics.Options{Name: "last-committed-offset", Tags: map[string]string{"partition": strconv.Itoa(int(partition))}}),
 		list:                newConcurrentList(minOffset),
 		minOffset:           minOffset,
 	}

--- a/cmd/ingester/app/consumer/offset/manager_test.go
+++ b/cmd/ingester/app/consumer/offset/manager_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 func TestHandleReset(t *testing.T) {
 	offset := int64(1498)
 	minOffset := offset - 1
 
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/cmd/ingester/app/processor/decorator/retry.go
+++ b/cmd/ingester/app/processor/decorator/retry.go
@@ -97,10 +97,10 @@ func NewRetryingProcessor(f metrics.Factory, processor processor.SpanProcessor, 
 		opt(&options)
 	}
 
-	m := f.Namespace("span-processor", nil)
+	m := f.Namespace(metrics.NSOptions{Name: "span-processor", Tags: nil})
 	return &retryDecorator{
-		retryAttempts: m.Counter("retry-attempts", nil),
-		exhausted:     m.Counter("retry-exhausted", nil),
+		retryAttempts: m.Counter(metrics.Options{Name: "retry-attempts", Tags: nil}),
+		exhausted:     m.Counter(metrics.Options{Name: "retry-exhausted", Tags: nil}),
 		processor:     processor,
 		options:       options,
 	}

--- a/cmd/ingester/app/processor/decorator/retry_test.go
+++ b/cmd/ingester/app/processor/decorator/retry_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
 )
@@ -34,7 +35,7 @@ func TestNewRetryingProcessor(t *testing.T) {
 	mockProcessor := &mocks.SpanProcessor{}
 	msg := &fakeMsg{}
 	mockProcessor.On("Process", msg).Return(nil)
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor)
 
 	assert.NoError(t, rp.Process(msg))
@@ -55,7 +56,7 @@ func TestNewRetryingProcessorError(t *testing.T) {
 		MaxAttempts(2),
 		PropagateError(true),
 		Rand(&fakeRand{})}
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
 	assert.Error(t, rp.Process(msg))
@@ -77,7 +78,7 @@ func TestNewRetryingProcessorNoErrorPropagation(t *testing.T) {
 		PropagateError(false),
 		Rand(&fakeRand{})}
 
-	lf := metrics.NewLocalFactory(0)
+	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
 	assert.NoError(t, rp.Process(msg))

--- a/cmd/ingester/app/processor/metrics_decorator.go
+++ b/cmd/ingester/app/processor/metrics_decorator.go
@@ -30,10 +30,10 @@ type metricsDecorator struct {
 
 // NewDecoratedProcessor returns a processor with metrics
 func NewDecoratedProcessor(f metrics.Factory, processor SpanProcessor) SpanProcessor {
-	m := f.Namespace("span-processor", nil)
+	m := f.Namespace(metrics.NSOptions{Name: "span-processor", Tags: nil})
 	return &metricsDecorator{
-		errors:    m.Counter("errors", nil),
-		latency:   m.Timer("latency", nil),
+		errors:    m.Counter(metrics.Options{Name: "errors", Tags: nil}),
+		latency:   m.Timer(metrics.TimerOptions{Name: "latency", Tags: nil}),
 		processor: processor,
 	}
 }

--- a/cmd/ingester/app/processor/metrics_decorator_test.go
+++ b/cmd/ingester/app/processor/metrics_decorator_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
@@ -35,7 +35,7 @@ func TestProcess(t *testing.T) {
 	p := &mocks.SpanProcessor{}
 	msg := fakeMsg{}
 	p.On("Process", msg).Return(nil)
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 	proc := processor.NewDecoratedProcessor(m, p)
 
 	proc.Process(msg)
@@ -48,7 +48,7 @@ func TestProcessErr(t *testing.T) {
 	p := &mocks.SpanProcessor{}
 	msg := fakeMsg{}
 	p.On("Process", msg).Return(errors.New("err"))
-	m := metrics.NewLocalFactory(0)
+	m := metricstest.NewFactory(0)
 	proc := processor.NewDecoratedProcessor(m, p)
 
 	proc.Process(msg)

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/env"
@@ -76,7 +77,7 @@ func main() {
 			if err != nil {
 				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
 			}
-			metricsFactory := baseFactory.Namespace("ingester", nil)
+			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "ingester", Tags: nil})
 
 			storageFactory.InitFromViper(v)
 			if err := storageFactory.Initialize(baseFactory, logger); err != nil {

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -79,10 +79,11 @@ func main() {
 			queryOpts := new(app.QueryOptions).InitFromViper(v)
 
 			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			baseFactory, err := mBldr.CreateMetricsFactory("jaeger")
+			rootFactory, err := mBldr.CreateMetricsFactory("")
 			if err != nil {
 				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
 			}
+			baseFactory := rootFactory.Namespace(metrics.NSOptions{Name: "jaeger", Tags: nil})
 
 			tracer, closer, err := jaegerClientConfig.Configuration{
 				Sampler: &jaegerClientConfig.SamplerConfig{
@@ -92,7 +93,7 @@ func main() {
 				RPCMetrics: true,
 			}.New(
 				"jaeger-query",
-				jaegerClientConfig.Metrics(baseFactory.Namespace(metrics.NSOptions{Name: "client", Tags: nil})),
+				jaegerClientConfig.Metrics(rootFactory),
 				jaegerClientConfig.Logger(jaegerClientZapLog.NewLogger(logger)),
 			)
 			if err != nil {

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/viper"
 	jaegerClientConfig "github.com/uber/jaeger-client-go/config"
 	jaegerClientZapLog "github.com/uber/jaeger-client-go/log/zap"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/env"
@@ -91,7 +92,7 @@ func main() {
 				RPCMetrics: true,
 			}.New(
 				"jaeger-query",
-				jaegerClientConfig.Metrics(baseFactory.Namespace("client", nil)),
+				jaegerClientConfig.Metrics(baseFactory.Namespace(metrics.NSOptions{Name: "client", Tags: nil})),
 				jaegerClientConfig.Logger(jaegerClientZapLog.NewLogger(logger)),
 			)
 			if err != nil {
@@ -108,7 +109,7 @@ func main() {
 			if err != nil {
 				logger.Fatal("Failed to create span reader", zap.Error(err))
 			}
-			spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace("query", nil))
+			spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace(metrics.NSOptions{Name: "query", Tags: nil}))
 			dependencyReader, err := storageFactory.CreateDependencyReader()
 			if err != nil {
 				logger.Fatal("Failed to create dependency reader", zap.Error(err))

--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -83,7 +83,7 @@ func onInitialize() {
 		metricsFactory = jexpvar.NewFactory(10) // 10 buckets for histograms
 		logger.Info("Using expvar as metrics backend")
 	} else if metricsBackend == "prometheus" {
-		metricsFactory = jprom.New().Namespace("hotrod", nil)
+		metricsFactory = jprom.New().Namespace(metrics.NSOptions{Name: "hotrod", Tags: nil})
 		logger.Info("Using Prometheus as metrics backend")
 	} else {
 		logger.Fatal("unsupported metrics backend " + metricsBackend)

--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -41,7 +41,7 @@ func Init(serviceName string, metricsFactory metrics.Factory, logger log.Factory
 	time.Sleep(100 * time.Millisecond)
 	jaegerLogger := jaegerLoggerAdapter{logger.Bg()}
 
-	metricsFactory = metricsFactory.Namespace(serviceName, nil)
+	metricsFactory = metricsFactory.Namespace(metrics.NSOptions{Name: serviceName, Tags: nil})
 	tracer, _, err := cfg.NewTracer(
 		config.Logger(jaegerLogger),
 		config.Metrics(metricsFactory),

--- a/pkg/cassandra/metrics/table.go
+++ b/pkg/cassandra/metrics/table.go
@@ -33,7 +33,7 @@ type Table struct {
 // NewTable takes a metrics scope and creates a table metrics struct
 func NewTable(factory metrics.Factory, tableName string) *Table {
 	t := storageMetrics.WriteMetrics{}
-	metrics.Init(&t, factory.Namespace("", map[string]string{"table": tableName}), nil)
+	metrics.Init(&t, factory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"table": tableName}}), nil)
 	return &Table{t}
 }
 

--- a/pkg/cassandra/metrics/table_test.go
+++ b/pkg/cassandra/metrics/table_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
@@ -63,7 +63,7 @@ func TestTableEmit(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(time.Second)
+		mf := metricstest.NewFactory(time.Second)
 		tm := NewTable(mf, "a_table")
 		tm.Emit(tc.err, 50*time.Millisecond)
 		counts, gauges := mf.Snapshot()
@@ -110,7 +110,7 @@ func TestTableExec(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(0)
+		mf := metricstest.NewFactory(0)
 		tm := NewTable(mf, "a_table")
 		logger, logBuf := testutils.NewLogger()
 

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -68,12 +68,12 @@ func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
 // can be later added by RegisterHandler function.
 func (b *Builder) CreateMetricsFactory(namespace string) (metrics.Factory, error) {
 	if b.Backend == "prometheus" {
-		metricsFactory := jprom.New().Namespace(namespace, nil)
+		metricsFactory := jprom.New().Namespace(metrics.NSOptions{Name: namespace, Tags: nil})
 		b.handler = promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{DisableCompression: true})
 		return metricsFactory, nil
 	}
 	if b.Backend == "expvar" {
-		metricsFactory := jexpvar.NewFactory(10).Namespace(namespace, nil)
+		metricsFactory := jexpvar.NewFactory(10).Namespace(metrics.NSOptions{Name: namespace, Tags: nil})
 		b.handler = expvar.Handler()
 		return metricsFactory, nil
 	}

--- a/pkg/metrics/builder_test.go
+++ b/pkg/metrics/builder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-lib/metrics"
 )
 
 func TestAddFlags(t *testing.T) {
@@ -51,7 +52,7 @@ func TestBuilder(t *testing.T) {
 		families, err := prometheus.DefaultGatherer.Gather()
 		require.NoError(t, err)
 		for _, mf := range families {
-			if mf.GetName() == "foo_counter" {
+			if mf.GetName() == "foo_counter_total" {
 				return
 			}
 		}
@@ -112,7 +113,7 @@ func TestBuilder(t *testing.T) {
 			continue
 		}
 		require.NotNil(t, mf)
-		mf.Counter("counter", nil).Inc(1)
+		mf.Counter(metrics.Options{Name: "counter", Tags: nil}).Inc(1)
 		if testCase.assert != nil {
 			testCase.assert()
 		}

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -24,15 +24,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 // In this test we run a queue with capacity 1 and a single consumer.
 // We want to test the overflow behavior, so we block the consumer
 // by holding a startLock before submitting items to the queue.
 func TestBoundedQueue(t *testing.T) {
-	mFact := metrics.NewLocalFactory(0)
-	counter := mFact.Counter("dropped", nil)
-	gauge := mFact.Gauge("size", nil)
+	mFact := metricstest.NewFactory(0)
+	counter := mFact.Counter(metrics.Options{Name: "dropped", Tags: nil})
+	gauge := mFact.Gauge(metrics.Options{Name: "size", Tags: nil})
 
 	q := NewBoundedQueue(1, func(item interface{}) {
 		counter.Inc(1)

--- a/plugin/storage/cassandra/dependencystore/storage_test.go
+++ b/plugin/storage/cassandra/dependencystore/storage_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
@@ -42,7 +42,7 @@ type depStorageTest struct {
 func withDepStore(fn func(s *depStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(time.Second)
+	metricsFactory := metricstest.NewFactory(time.Second)
 	defer metricsFactory.Stop()
 	s := &depStorageTest{
 		session:   session,

--- a/plugin/storage/cassandra/factory.go
+++ b/plugin/storage/cassandra/factory.go
@@ -72,8 +72,8 @@ func (f *Factory) InitFromViper(v *viper.Viper) {
 
 // Initialize implements storage.Factory
 func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
-	f.primaryMetricsFactory = metricsFactory.Namespace("cassandra", nil)
-	f.archiveMetricsFactory = metricsFactory.Namespace("cassandra-archive", nil)
+	f.primaryMetricsFactory = metricsFactory.Namespace(metrics.NSOptions{Name: "cassandra", Tags: nil})
+	f.archiveMetricsFactory = metricsFactory.Namespace(metrics.NSOptions{Name: "cassandra-archive", Tags: nil})
 	f.logger = logger
 
 	primarySession, err := f.primaryConfig.NewSession()

--- a/plugin/storage/cassandra/samplingstore/storage_test.go
+++ b/plugin/storage/cassandra/samplingstore/storage_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
@@ -45,7 +45,7 @@ type samplingStoreTest struct {
 func withSamplingStore(fn func(r *samplingStoreTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	r := &samplingStoreTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
@@ -32,7 +32,7 @@ import (
 type operationNameStorageTest struct {
 	session        *mocks.Session
 	writeCacheTTL  time.Duration
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	logger         *zap.Logger
 	logBuffer      *testutils.Buffer
 	storage        *OperationNamesStorage
@@ -41,7 +41,7 @@ type operationNameStorageTest struct {
 func withOperationNamesStorage(writeCacheTTL time.Duration, fn func(s *operationNameStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	s := &operationNameStorageTest{
 		session:        session,
 		writeCacheTTL:  writeCacheTTL,

--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -116,7 +116,7 @@ func NewSpanReader(
 	metricsFactory metrics.Factory,
 	logger *zap.Logger,
 ) *SpanReader {
-	readFactory := metricsFactory.Namespace("read", nil)
+	readFactory := metricsFactory.Namespace(metrics.NSOptions{Name: "read", Tags: nil})
 	serviceNamesStorage := NewServiceNamesStorage(session, 0, metricsFactory, logger)
 	operationNamesStorage := NewOperationNamesStorage(session, 0, metricsFactory, logger)
 	return &SpanReader{

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
@@ -45,7 +45,7 @@ type spanReaderTest struct {
 func withSpanReader(fn func(r *spanReaderTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	r := &spanReaderTest{
 		session:   session,
 		logger:    logger,

--- a/plugin/storage/cassandra/spanstore/service_names_test.go
+++ b/plugin/storage/cassandra/spanstore/service_names_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
@@ -32,7 +32,7 @@ import (
 type serviceNameStorageTest struct {
 	session        *mocks.Session
 	writeCacheTTL  time.Duration
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 	logger         *zap.Logger
 	logBuffer      *testutils.Buffer
 	storage        *ServiceNamesStorage
@@ -41,7 +41,7 @@ type serviceNameStorageTest struct {
 func withServiceNamesStorage(writeCacheTTL time.Duration, fn func(s *serviceNameStorageTest)) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(time.Second)
+	metricsFactory := metricstest.NewFactory(time.Second)
 	defer metricsFactory.Stop()
 	s := &serviceNameStorageTest{
 		session:        session,

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -105,7 +105,7 @@ func NewSpanWriter(
 ) *SpanWriter {
 	serviceNamesStorage := NewServiceNamesStorage(session, writeCacheTTL, metricsFactory, logger)
 	operationNamesStorage := NewOperationNamesStorage(session, writeCacheTTL, metricsFactory, logger)
-	tagIndexSkipped := metricsFactory.Counter("tag_index_skipped", nil)
+	tagIndexSkipped := metricsFactory.Counter(metrics.Options{Name: "tag_index_skipped", Tags: nil})
 	opts := applyOptions(options...)
 	return &SpanWriter{
 		session:              session,

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
@@ -42,7 +42,7 @@ func withSpanWriter(writeCacheTTL time.Duration, fn func(w *spanWriterTest), opt
 ) {
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	w := &spanWriterTest{
 		session:   session,
 		logger:    logger,
@@ -122,7 +122,7 @@ func TestSpanWriter(t *testing.T) {
 			},
 		},
 		{
-			caption:                        "add span to operation name index",
+			caption: "add span to operation name index",
 			serviceOperationNameQueryError: errors.New("serviceOperationNameQueryError"),
 			expectedError:                  "Failed to index operation name: failed to Exec query 'select from service_operation_index': serviceOperationNameQueryError",
 			expectedLogs: []string{
@@ -132,7 +132,7 @@ func TestSpanWriter(t *testing.T) {
 			},
 		},
 		{
-			caption:                       "add duration with no operation name",
+			caption: "add duration with no operation name",
 			durationNoOperationQueryError: errors.New("durationNoOperationError"),
 			expectedError:                 "Failed to index duration: failed to Exec query 'select from duration_index': durationNoOperationError",
 			expectedLogs: []string{

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/mocks"
@@ -43,7 +43,7 @@ type spanWriterTest struct {
 func withSpanWriter(fn func(w *spanWriterTest)) {
 	client := &mocks.Client{}
 	logger, logBuffer := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	w := &spanWriterTest{
 		client:    client,
 		logger:    logger,
@@ -66,7 +66,7 @@ func TestNewSpanWriterIndexPrefix(t *testing.T) {
 	}
 	client := &mocks.Client{}
 	logger, _ := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	for _, testCase := range testCases {
 		w := NewSpanWriter(SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: testCase.prefix})
@@ -311,7 +311,7 @@ func TestWriteSpanInternalError(t *testing.T) {
 func TestNewSpanTags(t *testing.T) {
 	client := &mocks.Client{}
 	logger, _ := testutils.NewLogger()
-	metricsFactory := metrics.NewLocalFactory(0)
+	metricsFactory := metricstest.NewFactory(0)
 	testCases := []struct {
 		writer   *SpanWriter
 		expected dbmodel.Span

--- a/plugin/storage/kafka/writer.go
+++ b/plugin/storage/kafka/writer.go
@@ -45,8 +45,8 @@ func NewSpanWriter(
 	logger *zap.Logger,
 ) *SpanWriter {
 	writeMetrics := spanWriterMetrics{
-		SpansWrittenSuccess: factory.Counter("kafka_spans_written", map[string]string{"status": "success"}),
-		SpansWrittenFailure: factory.Counter("kafka_spans_written", map[string]string{"status": "failure"}),
+		SpansWrittenSuccess: factory.Counter(metrics.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "success"}}),
+		SpansWrittenFailure: factory.Counter(metrics.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "failure"}}),
 	}
 
 	go func() {

--- a/plugin/storage/kafka/writer_test.go
+++ b/plugin/storage/kafka/writer_test.go
@@ -23,8 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -67,7 +66,7 @@ var (
 type spanWriterTest struct {
 	producer       *saramaMocks.AsyncProducer
 	marshaller     *mocks.Marshaller
-	metricsFactory *metrics.LocalFactory
+	metricsFactory *metricstest.Factory
 
 	writer *SpanWriter
 }
@@ -76,7 +75,7 @@ type spanWriterTest struct {
 var _ spanstore.Writer = &SpanWriter{}
 
 func withSpanWriter(t *testing.T, fn func(span *model.Span, w *spanWriterTest)) {
-	serviceMetrics := metrics.NewLocalFactory(100 * time.Millisecond)
+	serviceMetrics := metricstest.NewFactory(100 * time.Millisecond)
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Producer.Return.Successes = true
 	producer := saramaMocks.NewAsyncProducer(t, saramaConfig)
@@ -110,15 +109,15 @@ func TestKafkaWriter(t *testing.T) {
 		}
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 1,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 0,
@@ -142,15 +141,15 @@ func TestKafkaWriterErr(t *testing.T) {
 		}
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 0,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 1,
@@ -170,15 +169,15 @@ func TestMarshallerErr(t *testing.T) {
 
 		w.writer.Close()
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "success"},
 				Value: 0,
 			})
 
-		testutils.AssertCounterMetrics(t, w.metricsFactory,
-			testutils.ExpectedMetric{
+		w.metricsFactory.AssertCounterMetrics(t,
+			metricstest.ExpectedMetric{
 				Name:  "kafka_spans_written",
 				Tags:  map[string]string{"status": "failure"},
 				Value: 1,

--- a/storage/spanstore/metrics/decorator.go
+++ b/storage/spanstore/metrics/decorator.go
@@ -67,7 +67,7 @@ func NewReadMetricsDecorator(spanReader spanstore.Reader, metricsFactory metrics
 
 func buildQueryMetrics(operation string, metricsFactory metrics.Factory) *queryMetrics {
 	qMetrics := &queryMetrics{}
-	scoped := metricsFactory.Namespace("", map[string]string{"operation": operation})
+	scoped := metricsFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"operation": operation}})
 	metrics.Init(qMetrics, scoped, nil)
 	return qMetrics
 }

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -29,7 +29,7 @@ import (
 )
 
 func TestSuccessfulUnderlyingCalls(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 
 	mockReader := mocks.Reader{}
 	mrs := NewReadMetricsDecorator(&mockReader, mf)
@@ -86,7 +86,7 @@ func checkExpectedExistingAndNonExistentCounters(t *testing.T, actualCounters, e
 }
 
 func TestFailingUnderlyingCalls(t *testing.T) {
-	mf := metrics.NewLocalFactory(0)
+	mf := metricstest.NewFactory(0)
 
 	mockReader := mocks.Reader{}
 	mrs := NewReadMetricsDecorator(&mockReader, mf)
@@ -108,8 +108,8 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 		"requests|operation=get_trace|result=err":      1,
 		"requests|operation=find_traces|result=ok":     0,
 		"requests|operation=find_traces|result=err":    1,
-		"requests|operation=find_trace_ids|result=ok":   0,
-		"requests|operation=find_trace_ids|result=err":  1,
+		"requests|operation=find_trace_ids|result=ok":  0,
+		"requests|operation=find_trace_ids|result=err": 1,
 		"requests|operation=get_services|result=ok":    0,
 		"requests|operation=get_services|result=err":   1,
 	}

--- a/storage/spanstore/metrics/write_metrics.go
+++ b/storage/spanstore/metrics/write_metrics.go
@@ -32,7 +32,7 @@ type WriteMetrics struct {
 // NewWriteMetrics takes a metrics scope and creates a metrics struct
 func NewWriteMetrics(factory metrics.Factory, tableName string) *WriteMetrics {
 	t := &WriteMetrics{}
-	metrics.Init(t, factory.Namespace(tableName, nil), nil)
+	metrics.Init(t, factory.Namespace(metrics.NSOptions{Name: tableName, Tags: nil}), nil)
 	return t
 }
 

--- a/storage/spanstore/metrics/write_metrics_test.go
+++ b/storage/spanstore/metrics/write_metrics_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
 func TestTableEmit(t *testing.T) {
@@ -61,7 +61,7 @@ func TestTableEmit(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mf := metrics.NewLocalFactory(time.Second)
+		mf := metricstest.NewFactory(time.Second)
 		tm := NewWriteMetrics(mf, "a_table")
 		tm.Emit(tc.err, 50*time.Millisecond)
 		counts, gauges := mf.Snapshot()


### PR DESCRIPTION
…p refactored metric names

Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Updating to latest jaeger-lib (version 2) and jaeger-client-go (sha currently as not yet released). This is to pick up changes to the metric names.

## Short description of the changes
Updated versions - as the metrics factory approach changed in jaeger-lib 2 this required updates throughout the code.

NOTE: Will need to change the namespace used with the go client, to use the base metrics factory, to avoid `jaeger_client_jaeger_tracer....` prefix and instead just have `jaeger_tracer....`. Should this be added to this PR or be done separately?