### PR TITLE
Change index prefix from : to -

### DIFF
--- a/plugin/storage/es/esCleaner.py
+++ b/plugin/storage/es/esCleaner.py
@@ -21,7 +21,7 @@ def main():
 
     prefix = os.getenv("INDEX_PREFIX", '')
     if prefix != '':
-        prefix += ':'
+        prefix += '-'
     prefix += 'jaeger'
 
     ilo.filter_by_regex(kind='prefix', value=prefix)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -175,7 +175,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.String(
 		nsConfig.namespace+suffixIndexPrefix,
 		nsConfig.IndexPrefix,
-		"Optional prefix of Jaeger indices. For example \"production\" creates \"production:jaeger-*\".")
+		"Optional prefix of Jaeger indices. For example \"production\" creates \"production-jaeger-*\".")
 	flagSet.Bool(
 		nsConfig.namespace+suffixTagsAsFieldsAll,
 		nsConfig.AllTagsAsFields,

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -117,12 +117,13 @@ func TestNewSpanReader(t *testing.T) {
 
 func TestNewSpanReaderIndexPrefix(t *testing.T) {
 	testCases := []struct {
-		prefix   string
-		expected string
+		prefix            string
+		expectedSpanIndex []string
+		expectedServiceIndex []string
 	}{
-		{prefix: "", expected: ""},
-		{prefix: "foo", expected: "foo:"},
-		{prefix: ":", expected: "::"},
+		{prefix: "", expectedSpanIndex: []string{spanIndex}, expectedServiceIndex: []string{serviceIndex}},
+		{prefix: "foo", expectedSpanIndex: []string{"foo-"+spanIndex, "foo:"+spanIndex}, expectedServiceIndex: []string{"foo-"+serviceIndex, "foo:"+serviceIndex}},
+		{prefix: ":", expectedSpanIndex: []string{":-"+spanIndex, "::"+spanIndex}, expectedServiceIndex: []string{":-"+serviceIndex, "::"+serviceIndex}},
 	}
 	for _, testCase := range testCases {
 		client := &mocks.Client{}
@@ -131,8 +132,8 @@ func TestNewSpanReaderIndexPrefix(t *testing.T) {
 			Logger:      zap.NewNop(),
 			MaxSpanAge:  0,
 			IndexPrefix: testCase.prefix})
-		assert.Equal(t, testCase.expected+spanIndex, r.spanIndexPrefix)
-		assert.Equal(t, testCase.expected+serviceIndex, r.serviceIndexPrefix)
+		assert.Equal(t, testCase.expectedSpanIndex, r.spanIndexPrefix)
+		assert.Equal(t, testCase.expectedServiceIndex, r.serviceIndexPrefix)
 	}
 }
 
@@ -343,7 +344,7 @@ func TestSpanReaderFindIndices(t *testing.T) {
 	}
 	withSpanReader(func(r *spanReaderTest) {
 		for _, testCase := range testCases {
-			actual := r.reader.indicesForTimeRange(spanIndex, testCase.startTime, testCase.endTime)
+			actual := r.reader.indicesForTimeRange([]string{spanIndex}, testCase.startTime, testCase.endTime)
 			assert.EqualValues(t, testCase.expected, actual)
 		}
 	})

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -83,7 +83,7 @@ func NewSpanWriter(p SpanWriterParams) *SpanWriter {
 	// TODO: Configurable TTL
 	serviceOperationStorage := NewServiceOperationStorage(ctx, p.Client, p.Logger, time.Hour*12)
 	if p.IndexPrefix != "" {
-		p.IndexPrefix += ":"
+		p.IndexPrefix += indexPrefixSeparator
 	}
 	return &SpanWriter{
 		ctx:    ctx,

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -61,8 +61,8 @@ func TestNewSpanWriterIndexPrefix(t *testing.T) {
 		expected string
 	}{
 		{prefix: "", expected: ""},
-		{prefix: "foo", expected: "foo:"},
-		{prefix: ":", expected: "::"},
+		{prefix: "foo", expected: "foo-"},
+		{prefix: ":", expected: ":-"},
 	}
 	client := &mocks.Client{}
 	logger, _ := testutils.NewLogger()


### PR DESCRIPTION
Resolves #1238 

Spark dependencies: https://github.com/jaegertracing/spark-dependencies/pull/52

The readers will still read from indices containing prefix "prefix:"
to keep backward compability.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>
