### PR TITLE
Pin cql version to a versin used before migraiton to dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -244,8 +244,7 @@
   version = "v0.17.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:1a5f28249f1a5b118994359a1c7b8c53ee1ff47aa7fe65884fbd20cd237001f4"
+  digest = "1:2dd4729330a990761f321b89db505906de5cfe912014e51e99669fd99ace99b4"
   name = "github.com/gocql/gocql"
   packages = [
     ".",
@@ -254,7 +253,7 @@
     "internal/streams",
   ]
   pruneopts = "UT"
-  revision = "70385f88b28b43805bd83d212169ab2d38810b15"
+  revision = "181004e14a3fb735efcc826a4256369d0c96747b"
 
 [[projects]]
   digest = "1:08fc980336305dcf34156af60e58073ba8326437d64d027fe624fdd9c4ff0ae6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -105,7 +105,7 @@ required = [
 
 [[constraint]]
   name = "github.com/gocql/gocql"
-  branch = "master"
+  revision = "181004e14a3fb735efcc826a4256369d0c96747b"
 
 [[constraint]]
   name = "github.com/gogo/googleapis"


### PR DESCRIPTION
The current version of CQL causes failures in spark-dependencies https://github.com/jaegertracing/spark-dependencies/pull/51#issuecomment-454820619. The tests with Jaeger 1.8.1 passes without problems See the build https://github.com/jaegertracing/spark-dependencies/pull/53

``
19/01/16 14:54:09 INFO CassandraDependenciesJobTest: STDERR: {"level":"error","ts":1547650449.1140292,"caller":"metrics/table.go:48","msg":"Failed to exec query","query":"[query statement=\"\\n\\t\\tINSERT\\n\\t\\tINTO service_name_index(service_name, bucket, start_time, trace_id)\\n\\t\\tVALUES (?, ?, ?, ?)\" values=[10fae286a78f4f64a04619e13b2d3e8f 0 1547650448754000 96591cdbaf960a86] consistency=LOCAL_ONE]","error":"read tcp 172.18.0.3:48606->172.18.0.2:9042: i/o timeout","stacktrace":"github.com/jaegertracing/jaeger/pkg/cassandra/metrics.(*Table).Exec\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/pkg/cassandra/metrics/table.go:48\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).indexByService\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:243\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).writeIndexes\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:184\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).WriteSpan\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:144\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).saveSpan\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:101\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).saveSpan-fm\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:88\ngithub.com/jaegertracing/jaeger/cmd/collector/app.ChainedProcessSpan.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/model_consumer.go:34\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).processItemFromQueue\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:127\ngithub.com/jaegertracing/jaeger/cmd/collector/app.NewSpanProcessor.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:56\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/pkg/queue/bounded_queue.go:65"}
19/01/16 14:54:09 INFO CassandraDependenciesJobTest: STDERR: {"level":"error","ts":1547650449.1144202,"caller":"spanstore/writer.go:272","msg":"Failed to index service name","trace_id":"96591cdbaf960a86","span_id":6762871210571195514,"error":"failed to Exec query '[query statement=\"\\n\\t\\tINSERT\\n\\t\\tINTO service_name_index(service_name, bucket, start_time, trace_id)\\n\\t\\tVALUES (?, ?, ?, ?)\" values=[10fae286a78f4f64a04619e13b2d3e8f 0 1547650448754000 96591cdbaf960a86] consistency=LOCAL_ONE]': read tcp 172.18.0.3:48606->172.18.0.2:9042: i/o timeout","errorVerbose":"read tcp 172.18.0.3:48606->172.18.0.2:9042: i/o timeout\nfailed to Exec query '[query statement=\"\\n\\t\\tINSERT\\n\\t\\tINTO service_name_index(service_name, bucket, start_time, trace_id)\\n\\t\\tVALUES (?, ?, ?, ?)\" values=[10fae286a78f4f64a04619e13b2d3e8f 0 1547650448754000 96591cdbaf960a86] consistency=LOCAL_ONE]'\ngithub.com/jaegertracing/jaeger/pkg/cassandra/metrics.(*Table).Exec\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/pkg/cassandra/metrics/table.go:50\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).indexByService\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:243\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).writeIndexes\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:184\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).WriteSpan\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:144\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).saveSpan\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:101\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).saveSpan-fm\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:88\ngithub.com/jaegertracing/jaeger/cmd/collector/app.ChainedProcessSpan.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/model_consumer.go:34\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).processItemFromQueue\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:127\ngithub.com/jaegertracing/jaeger/cmd/collector/app.NewSpanProcessor.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:56\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/pkg/queue/bounded_queue.go:65\nruntime.goexit\n\t/home/travis/.gimme/versions/go1.11.1.linux.amd64/src/runtime/asm_amd64.s:1333","stacktrace":"github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).logError\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:272\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).writeIndexes\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:185\ngithub.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore.(*SpanWriter).WriteSpan\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/writer.go:144\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).saveSpan\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:101\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).saveSpan-fm\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:88\ngithub.com/jaegertracing/jaeger/cmd/collector/app.ChainedProcessSpan.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/model_consumer.go:34\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).processItemFromQueue\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:127\ngithub.com/jaegertracing/jaeger/cmd/collector/app.NewSpanProcessor.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:56\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/home/travis/gopath/src/github.com/jaegertracing/jaeger/pkg/queue/bounded_queue.go:65"}
``

Version used before https://github.com/jaegertracing/jaeger/pull/1240/files#diff-f16a80eae23d5b298c2652448ec420cfL72

Signed-off-by: Pavol Loffay <ploffay@redhat.com>

