### PR TITLE
Added whitespace tolerance for value for ES servers and kafka brokers

### DIFF
--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -218,7 +218,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Username = v.GetString(cfg.namespace + suffixUsername)
 	cfg.Password = v.GetString(cfg.namespace + suffixPassword)
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
-	cfg.servers = v.GetString(cfg.namespace + suffixServerURLs)
+	cfg.servers = stripWhiteSpace(v.GetString(cfg.namespace + suffixServerURLs))
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)
 	cfg.MaxNumSpans = v.GetInt(cfg.namespace + suffixMaxNumSpans)
 	cfg.NumShards = v.GetInt64(cfg.namespace + suffixNumShards)
@@ -258,4 +258,9 @@ func (opt *Options) Get(namespace string) *config.Configuration {
 	}
 	nsCfg.Servers = strings.Split(nsCfg.servers, ",")
 	return &nsCfg.Configuration
+}
+
+// stripWhiteSpace removes all whitespace characters from a string
+func stripWhiteSpace(str string) string {
+	return strings.Replace(str, " ", "", -1)
 }

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -44,7 +44,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	opts := NewOptions("es", "es.aux")
 	v, command := config.Viperize(opts.AddFlags)
 	command.ParseFlags([]string{
-		"--es.server-urls=1.1.1.1,2.2.2.2",
+		"--es.server-urls=1.1.1.1, 2.2.2.2",
 		"--es.username=hello",
 		"--es.password=world",
 		"--es.sniffer=true",
@@ -52,7 +52,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.num-shards=20",
 		"--es.num-replicas=10",
 		// a couple overrides
-		"--es.aux.server-urls=3.3.3.3,4.4.4.4",
+		"--es.aux.server-urls=3.3.3.3, 4.4.4.4",
 		"--es.aux.max-span-age=24h",
 		"--es.aux.num-replicas=10",
 	})

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -74,8 +74,13 @@ func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 // InitFromViper initializes Options with properties from viper
 func (opt *Options) InitFromViper(v *viper.Viper) {
 	opt.config = producer.Configuration{
-		Brokers: strings.Split(v.GetString(configPrefix+suffixBrokers), ","),
+		Brokers: strings.Split(stripWhiteSpace(v.GetString(configPrefix+suffixBrokers)), ","),
 	}
 	opt.topic = v.GetString(configPrefix + suffixTopic)
 	opt.encoding = v.GetString(configPrefix + suffixEncoding)
+}
+
+// stripWhiteSpace removes all whitespace characters from a string
+func stripWhiteSpace(str string) string {
+	return strings.Replace(str, " ", "", -1)
 }

--- a/plugin/storage/kafka/options_test.go
+++ b/plugin/storage/kafka/options_test.go
@@ -27,7 +27,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	v, command := config.Viperize(opts.AddFlags)
 	command.ParseFlags([]string{
 		"--kafka.topic=topic1",
-		"--kafka.brokers=127.0.0.1:9092,0.0.0:1234",
+		"--kafka.brokers=127.0.0.1:9092, 0.0.0:1234",
 		"--kafka.encoding=protobuf"})
 	opts.InitFromViper(v)
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Addresses the issue #1302 

## Short description of the changes
- A stripWhiteSpace function is added for both ES and kafka 
- An additional whitespace is added to the strings used for testing 
