### PR TITLE
add shared helper for stripping whitespace of storage host strings

### DIFF
--- a/plugin/storage/cassandra/options.go
+++ b/plugin/storage/cassandra/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/config"
+	"github.com/jaegertracing/jaeger/plugin/storage/helper"
 )
 
 const (
@@ -216,7 +217,7 @@ func (cfg *namespaceConfig) initFromViper(v *viper.Viper) {
 	cfg.MaxRetryAttempts = v.GetInt(cfg.namespace + suffixMaxRetryAttempts)
 	cfg.Timeout = v.GetDuration(cfg.namespace + suffixTimeout)
 	cfg.ReconnectInterval = v.GetDuration(cfg.namespace + suffixReconnectInterval)
-	cfg.servers = stripWhiteSpace(v.GetString(cfg.namespace + suffixServers))
+	cfg.servers = helper.StripWhiteSpace(v.GetString(cfg.namespace + suffixServers))
 	cfg.Port = v.GetInt(cfg.namespace + suffixPort)
 	cfg.Keyspace = v.GetString(cfg.namespace + suffixKeyspace)
 	cfg.LocalDC = v.GetString(cfg.namespace + suffixDC)
@@ -255,9 +256,4 @@ func (opt *Options) Get(namespace string) *config.Configuration {
 	}
 	nsCfg.Servers = strings.Split(nsCfg.servers, ",")
 	return &nsCfg.Configuration
-}
-
-// stripWhiteSpace removes all whitespace characters from a string
-func stripWhiteSpace(str string) string {
-	return strings.Replace(str, " ", "", -1)
 }

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/pkg/es/config"
+	"github.com/jaegertracing/jaeger/plugin/storage/helper"
 )
 
 const (
@@ -218,7 +219,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Username = v.GetString(cfg.namespace + suffixUsername)
 	cfg.Password = v.GetString(cfg.namespace + suffixPassword)
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
-	cfg.servers = v.GetString(cfg.namespace + suffixServerURLs)
+	cfg.servers = helper.StripWhiteSpace(v.GetString(cfg.namespace + suffixServerURLs))
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)
 	cfg.MaxNumSpans = v.GetInt(cfg.namespace + suffixMaxNumSpans)
 	cfg.NumShards = v.GetInt64(cfg.namespace + suffixNumShards)

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -44,7 +44,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	opts := NewOptions("es", "es.aux")
 	v, command := config.Viperize(opts.AddFlags)
 	command.ParseFlags([]string{
-		"--es.server-urls=1.1.1.1,2.2.2.2",
+		"--es.server-urls=1.1.1.1, 2.2.2.2",
 		"--es.username=hello",
 		"--es.password=world",
 		"--es.sniffer=true",
@@ -52,7 +52,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.num-shards=20",
 		"--es.num-replicas=10",
 		// a couple overrides
-		"--es.aux.server-urls=3.3.3.3,4.4.4.4",
+		"--es.aux.server-urls=3.3.3.3, 4.4.4.4",
 		"--es.aux.max-span-age=24h",
 		"--es.aux.num-replicas=10",
 	})

--- a/plugin/storage/helper/helper.go
+++ b/plugin/storage/helper/helper.go
@@ -1,0 +1,8 @@
+package helper
+
+import "strings"
+
+// stripWhiteSpace removes all whitespace characters from a string
+func StripWhiteSpace(str string) string {
+	return strings.Replace(str, " ", "", -1)
+}

--- a/plugin/storage/kafka/options.go
+++ b/plugin/storage/kafka/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/pkg/kafka/producer"
+	"github.com/jaegertracing/jaeger/plugin/storage/helper"
 )
 
 const (
@@ -74,7 +75,7 @@ func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 // InitFromViper initializes Options with properties from viper
 func (opt *Options) InitFromViper(v *viper.Viper) {
 	opt.config = producer.Configuration{
-		Brokers: strings.Split(v.GetString(configPrefix+suffixBrokers), ","),
+		Brokers: strings.Split(helper.StripWhiteSpace(v.GetString(configPrefix+suffixBrokers)), ","),
 	}
 	opt.topic = v.GetString(configPrefix + suffixTopic)
 	opt.encoding = v.GetString(configPrefix + suffixEncoding)

--- a/plugin/storage/kafka/options_test.go
+++ b/plugin/storage/kafka/options_test.go
@@ -27,7 +27,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	v, command := config.Viperize(opts.AddFlags)
 	command.ParseFlags([]string{
 		"--kafka.topic=topic1",
-		"--kafka.brokers=127.0.0.1:9092,0.0.0:1234",
+		"--kafka.brokers=127.0.0.1:9092, 0.0.0:1234",
 		"--kafka.encoding=protobuf"})
 	opts.InitFromViper(v)
 


### PR DESCRIPTION
Signed-off-by: Karl Pokus <karl.pokus@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #1302 

## Short description of the changes
- shared helper for stripping whitespace of storage host strings

Not sure of the quality of the solution. It works and the tests pass. Didn't have time to wrap the viper lib with the helper like was suggested in #1302.