### PR TITLE
Make it possible for esCleaner.py to use a username/password

### DIFF
--- a/plugin/storage/es/README.md
+++ b/plugin/storage/es/README.md
@@ -14,6 +14,7 @@ The script is using `python3`. All dependencies can be installed with: `python3 
 
 Parameters:
  * Environment variable TIMEOUT that sets the timeout in seconds for indices deletion (default: 120)
+ * Optional environment variable ES_USERNAME and ES_PASSWORD
  * a number that will delete any indices older than that number in days
  * ElasticSearch hostnames
  * Example usage: `TIMEOUT=120 ./esCleaner.py 4 localhost:9200`

--- a/plugin/storage/es/esCleaner.py
+++ b/plugin/storage/es/esCleaner.py
@@ -15,7 +15,13 @@ def main():
         print('ARCHIVE ... specifies whether to remove archive indices. Use true or false')
         sys.exit(1)
 
-    client = elasticsearch.Elasticsearch(sys.argv[2:])
+    username = os.getenv("ES_USERNAME")
+    password = os.getenv("ES_PASSWORD")
+
+    if username is not None and password is not None:
+        client = elasticsearch.Elasticsearch(sys.argv[2:], http_auth=(username, password))
+    else:
+        client = elasticsearch.Elasticsearch(sys.argv[2:])
 
     ilo = curator.IndexList(client)
     empty_list(ilo, 'ElasticSearch has no indices')


### PR DESCRIPTION
Resolves https://github.com/jaegertracing/jaeger/issues/1317

Add optional ES_USERNAME and ES_PASSWORD environment variables in order that esCleaner.py can authenticate against elasticsearch clusters.