### PR TITLE
Load elasticsearch auth token from file

### DIFF
--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -76,11 +76,13 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 
 	primaryClient, err := f.primaryConfig.NewClient(logger, metricsFactory)
 	if err != nil {
+		f.logger.Error("failed to create primary Elasticsearch client", zap.Error(err))
 		return err
 	}
 	f.primaryClient = primaryClient
 	archiveClient, err := f.archiveConfig.NewClient(logger, metricsFactory)
 	if err != nil {
+		f.logger.Error("failed to create archive Elasticsearch client", zap.Error(err))
 		return err
 	}
 	f.archiveClient = archiveClient

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
@@ -76,14 +77,12 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 
 	primaryClient, err := f.primaryConfig.NewClient(logger, metricsFactory)
 	if err != nil {
-		f.logger.Error("failed to create primary Elasticsearch client", zap.Error(err))
-		return err
+		return errors.Wrap(err, "failed to create primary Elasticsearch client")
 	}
 	f.primaryClient = primaryClient
 	archiveClient, err := f.archiveConfig.NewClient(logger, metricsFactory)
 	if err != nil {
-		f.logger.Error("failed to create archive Elasticsearch client", zap.Error(err))
-		return err
+		return errors.Wrap(err, "failed to create archive Elasticsearch client")
 	}
 	f.archiveClient = archiveClient
 	return nil

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -53,11 +53,11 @@ func TestElasticsearchFactory(t *testing.T) {
 	// after InitFromViper, f.primaryConfig points to a real session builder that will fail in unit tests,
 	// so we override it with a mock.
 	f.primaryConfig = &mockClientBuilder{err: errors.New("made-up error")}
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "failed to create primary Elasticsearch client: made-up error")
 
 	f.primaryConfig = &mockClientBuilder{}
 	f.archiveConfig = &mockClientBuilder{err: errors.New("made-up error2")}
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error2")
+	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "failed to create archive Elasticsearch client: made-up error2")
 
 	f.archiveConfig = &mockClientBuilder{}
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -28,7 +28,7 @@ const (
 	suffixUsername          = ".username"
 	suffixPassword          = ".password"
 	suffixSniffer           = ".sniffer"
-	suffixTokenPath         = ".token-file-path"
+	suffixTokenPath         = ".token-file"
 	suffixServerURLs        = ".server-urls"
 	suffixMaxSpanAge        = ".max-span-age"
 	suffixMaxNumSpans       = ".max-num-spans"

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -28,6 +28,7 @@ const (
 	suffixUsername          = ".username"
 	suffixPassword          = ".password"
 	suffixSniffer           = ".sniffer"
+	suffixTokenPath         = ".token-file-path"
 	suffixServerURLs        = ".server-urls"
 	suffixMaxSpanAge        = ".max-span-age"
 	suffixMaxNumSpans       = ".max-num-spans"
@@ -119,6 +120,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixPassword,
 		nsConfig.Password,
 		"The password required by ElasticSearch")
+	flagSet.String(
+		nsConfig.namespace+suffixTokenPath,
+		nsConfig.TokenFilePath,
+		"Path to a file containing bearer token. This flag also uses "+suffixCA+" if it is specified")
 	flagSet.Bool(
 		nsConfig.namespace+suffixSniffer,
 		nsConfig.Sniffer,
@@ -217,6 +222,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Username = v.GetString(cfg.namespace + suffixUsername)
 	cfg.Password = v.GetString(cfg.namespace + suffixPassword)
+	cfg.TokenFilePath = v.GetString(cfg.namespace + suffixTokenPath)
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
 	cfg.servers = stripWhiteSpace(v.GetString(cfg.namespace + suffixServerURLs))
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -123,7 +123,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.String(
 		nsConfig.namespace+suffixTokenPath,
 		nsConfig.TokenFilePath,
-		"Path to a file containing bearer token. This flag also uses "+suffixCA+" if it is specified")
+		"Path to a file containing bearer token. This flag also uses CA if it is specified")
 	flagSet.Bool(
 		nsConfig.namespace+suffixSniffer,
 		nsConfig.Sniffer,

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -47,7 +47,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.server-urls=1.1.1.1, 2.2.2.2",
 		"--es.username=hello",
 		"--es.password=world",
-		"--es.token-file-path=/foo/bar",
+		"--es.token-file=/foo/bar",
 		"--es.sniffer=true",
 		"--es.max-span-age=48h",
 		"--es.num-shards=20",

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -47,6 +47,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.server-urls=1.1.1.1, 2.2.2.2",
 		"--es.username=hello",
 		"--es.password=world",
+		"--es.token-file-path=/foo/bar",
 		"--es.sniffer=true",
 		"--es.max-span-age=48h",
 		"--es.num-shards=20",
@@ -60,6 +61,7 @@ func TestOptionsWithFlags(t *testing.T) {
 
 	primary := opts.GetPrimary()
 	assert.Equal(t, "hello", primary.Username)
+	assert.Equal(t, "/foo/bar", primary.TokenFilePath)
 	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, primary.Servers)
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
 	assert.True(t, primary.Sniffer)


### PR DESCRIPTION
In k8s the auth token (serviceaccount) is injected to pod. 

Signed-off-by: Pavol Loffay <ploffay@redhat.com>
