### PR TITLE
Require a slightly newer version of grpc-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -827,21 +827,30 @@
   revision = "bd91e49a0898e27abb88c339b432fa53d7497ac0"
 
 [[projects]]
-  digest = "1:977794f3a0427850b6f4cb87cb88869a1833cb9e3f8867938c87434e422b7aa0"
+  digest = "1:ac5d5b62a1c24b362ee6c1577af1c3e56f6e412e8d4f5edb9282d66a8e5402f9"
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
     "balancer/base",
     "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
     "codes",
     "connectivity",
     "credentials",
+    "credentials/internal",
     "encoding",
     "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "internal",
+    "internal/backoff",
+    "internal/binarylog",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
@@ -854,11 +863,10 @@
     "status",
     "tap",
     "test/bufconn",
-    "transport",
   ]
   pruneopts = "UT"
-  revision = "afc05b9e1d36f289ea16ba294894486a3e458246"
-  version = "v1.11.0"
+  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
+  version = "v1.18.0"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
@@ -961,6 +969,7 @@
     "google.golang.org/grpc",
     "google.golang.org/grpc/balancer/roundrobin",
     "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/resolver",
     "google.golang.org/grpc/resolver/manual",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -97,7 +97,7 @@ required = [
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "^1.11.0"
+  version = "^1.13.0"
 
 [[constraint]]
   name = "gopkg.in/olivere/elastic.v5"


### PR DESCRIPTION
## Which problem is this PR solving?
This includes the fix for https://github.com/grpc/grpc-go/issues/1928 (https://github.com/grpc/grpc-go/pull/2045), which makes jaeger-collector usable behind nginx (and probably other grpc/http2 implementations) as load balancers for its grpc endpoint.

More info: https://trac.nginx.org/nginx/ticket/1538

## Short description of the changes
Require grpc-go >=1.13 instead of >=1.11