### PR TITLE
adding a wrapping writer that automatic drop spans before writing wit…

### DIFF
--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -118,9 +118,9 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 		writers = append(writers, writer)
 	}
 	if len(f.SpanWriterTypes) == 1 {
-		return writers[0], nil
+		return spanstore.NewAutomateDroppingWriter(writers[0], f.automateDropPercentage), nil
 	}
-	return spanstore.NewCompositeWriter(writers...), nil
+	return spanstore.NewAutomateDroppingWriter(spanstore.NewCompositeWriter(writers...), f.automateDropPercentage), nil
 }
 
 // CreateDependencyReader implements storage.Factory

--- a/plugin/storage/factory_config_test.go
+++ b/plugin/storage/factory_config_test.go
@@ -25,6 +25,7 @@ import (
 func clearEnv() {
 	os.Setenv(SpanStorageTypeEnvVar, "")
 	os.Setenv(DependencyStorageTypeEnvVar, "")
+	os.Setenv(AutomateDropPercentage, "")
 }
 
 func TestFactoryConfigFromEnv(t *testing.T) {
@@ -52,6 +53,10 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	assert.Equal(t, 2, len(f.SpanWriterTypes))
 	assert.Equal(t, []string{elasticsearchStorageType, kafkaStorageType}, f.SpanWriterTypes)
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
+
+	os.Setenv(AutomateDropPercentage, "0.5")
+	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
+	assert.Equal(t, 0.5, f.automateDropPercentage)
 }
 
 func TestFactoryConfigFromEnvDeprecated(t *testing.T) {

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -131,7 +131,7 @@ func TestCreate(t *testing.T) {
 	mock.On("CreateSpanWriter").Return(spanWriter, nil)
 	w, err = f.CreateSpanWriter()
 	assert.NoError(t, err)
-	assert.Equal(t, spanWriter, w)
+	assert.Equal(t, spanstore.NewAutomateDroppingWriter(spanWriter, 0), w)
 }
 
 func TestCreateMulti(t *testing.T) {
@@ -158,7 +158,7 @@ func TestCreateMulti(t *testing.T) {
 	mock2.On("CreateSpanWriter").Return(spanWriter2, nil)
 	w, err = f.CreateSpanWriter()
 	assert.NoError(t, err)
-	assert.Equal(t, spanstore.NewCompositeWriter(spanWriter, spanWriter2), w)
+	assert.Equal(t, spanstore.NewAutomateDroppingWriter(spanstore.NewCompositeWriter(spanWriter, spanWriter2), 0), w)
 }
 
 func TestCreateArchive(t *testing.T) {

--- a/storage/spanstore/automate_dropping_writer.go
+++ b/storage/spanstore/automate_dropping_writer.go
@@ -15,6 +15,7 @@ type AutomateDroppingWriter struct {
 
 // NewAutomateDroppingWriter creates a AutomateDroppingWriter
 func NewAutomateDroppingWriter(spanWriter Writer, percentage float64) *AutomateDroppingWriter {
+	// span with TraceID.Low below this threshold won't be written
 	threshold := uint64(percentage * float64(math.MaxUint64))
 	return &AutomateDroppingWriter{
 		spanWriter: spanWriter,

--- a/storage/spanstore/automate_dropping_writer.go
+++ b/storage/spanstore/automate_dropping_writer.go
@@ -1,0 +1,32 @@
+package spanstore
+
+import (
+	"math"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+// AutomateDroppingWriter is a span Writer that tries to tries to drop spans with
+// percentage set in config file
+type AutomateDroppingWriter struct {
+	spanWriter Writer
+	threshold  uint64
+}
+
+// NewAutomateDroppingWriter creates a AutomateDroppingWriter
+func NewAutomateDroppingWriter(spanWriter Writer, percentage float64) *AutomateDroppingWriter {
+	threshold := uint64(percentage * float64(math.MaxUint64))
+	return &AutomateDroppingWriter{
+		spanWriter: spanWriter,
+		threshold:  threshold,
+	}
+}
+
+// WriteSpan calls WriteSpan on wrapped span writer.
+func (c *AutomateDroppingWriter) WriteSpan(span *model.Span) error {
+	// TraceID consists of two random generated uint64, we use one of them to decide if span will be written
+	if c.threshold != 0 && span.TraceID.Low < c.threshold {
+		return nil
+	}
+	return c.spanWriter.WriteSpan(span)
+}

--- a/storage/spanstore/automate_dropping_writer_test.go
+++ b/storage/spanstore/automate_dropping_writer_test.go
@@ -1,0 +1,53 @@
+package spanstore
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+)
+
+type noopWriteSpanStore struct{}
+
+func (n *noopWriteSpanStore) WriteSpan(span *model.Span) error {
+	return nil
+}
+
+var errIWillAlwaysFail = errors.New("ErrProneWriteSpanStore will always fail")
+
+type errProneWriteSpanStore struct{}
+
+func (e *errProneWriteSpanStore) WriteSpan(span *model.Span) error {
+	return errIWillAlwaysFail
+}
+
+func TestNewAutomateDroppingWriter_DefaultConfig(t *testing.T) {
+	// In default config where the percentage is 0, newAutomateDroppingWriter will not work
+	c := NewAutomateDroppingWriter(&noopWriteSpanStore{}, 0)
+	assert.NoError(t, c.WriteSpan(nil))
+}
+
+func TestAutomateDroppingWriter_WriteSpan(t *testing.T) {
+	c := NewAutomateDroppingWriter(&errProneWriteSpanStore{}, 0.4)
+	fmt.Println(float64(math.MaxUint64))
+	// The TraceID.Low in this span is within the threshold, span will not be written
+	span := &model.Span{
+		TraceID: model.TraceID{
+			Low:  uint64(float64(math.MaxUint64) * 0.1),
+			High: math.MaxUint64,
+		},
+	}
+	assert.NoError(t, c.WriteSpan(span))
+
+	// The TraceID.Low in this span is beyond the threshold, span will be written
+	span = &model.Span{
+		TraceID: model.TraceID{
+			Low:  uint64(float64(math.MaxUint64) * 0.6),
+			High: math.MaxUint64,
+		},
+	}
+	assert.EqualError(t, c.WriteSpan(span), fmt.Sprintf("%s", errIWillAlwaysFail))
+}


### PR DESCRIPTION


## Which problem is this PR solving?

* Partially resolves #1100 

## Short description of the changes
* Instead of doing ratelimiting based on the volume, simply adding DownSamplingWriter to wrap other writers so user could specify a float ratio number between 0 ~ 1.0 to drop certain percentage of spans.

Ratio parameter is specified by passing `AUTOMATE_DROP_PERCENTAGE` as env variable.
