### PR TITLE
Remove duplicated words in comments

### DIFF
--- a/model/process.go
+++ b/model/process.go
@@ -19,7 +19,7 @@ import (
 )
 
 // NewProcess creates a new Process for given serviceName and tags.
-// The tags are sorted in place and kept in the the same array/slice,
+// The tags are sorted in place and kept in the same array/slice,
 // in order to store the Process in a canonical form that is relied
 // upon by the Equal and Hash functions.
 func NewProcess(serviceName string, tags []KeyValue) *Process {

--- a/plugin/storage/es/spanstore/dbmodel/model.go
+++ b/plugin/storage/es/spanstore/dbmodel/model.go
@@ -86,7 +86,7 @@ type Log struct {
 	Fields    []KeyValue `json:"fields"`
 }
 
-// KeyValue is a a key-value pair with typed value.
+// KeyValue is a key-value pair with typed value.
 type KeyValue struct {
 	Key   string      `json:"key"`
 	Type  ValueType   `json:"type,omitempty"`


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects
while reading.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

