### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/scripts/travis/install-ui-deps.sh
+++ b/scripts/travis/install-ui-deps.sh
@@ -6,8 +6,8 @@ set -e
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 
 # Repo for Yarn (https://yarnpkg.com/en/docs/install-ci#travis-tab)
-sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt-key adv --fetch-keys https://dl.yarnpkg.com/debian/pubkey.gpg
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update -qq
 sudo apt-get install -y -qq yarn
 


### PR DESCRIPTION
Currently, when we access the modified pages with **HTTP**, it is
redirected to **HTTPS** automatically. So this commit aims to
replace **HTTP** to **HTTPs** for security.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>


## Which problem is this PR solving?
- Replacing HTTP by HTTPS for deprecated links

## Short description of the changes
- Minor changes
