### PR TITLE
Use CQLSH_HOST in final call to cqlsh as well

### DIFF
--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -31,4 +31,4 @@ done
 
 echo "Generating the schema for the keyspace ${KEYSPACE} and datacenter ${DATACENTER}"
 
-MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh "${TEMPLATE}" | ${CQLSH} ${CQLSH_SSL}
+MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh "${TEMPLATE}" | ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST}


### PR DESCRIPTION
## Which problem is this PR solving?
- docker script doesn't use CQLSH_HOST variable for final call to cqlsh
I suppose, it makes impossible to use docker image on other host that is not part of cassandra cluster.

## Short description of the changes
- add CQLSH_HOST variable in place of host argument