### PR TITLE
Update a deprecated link in test file

### DIFF
--- a/model/spanref_test.go
+++ b/model/spanref_test.go
@@ -27,7 +27,7 @@ import (
 func TestSpanRefTypeToFromJSON(t *testing.T) {
 	// base64(0x42, 16 bytes) == AAAAAAAAAAAAAAAAAAAAQg==
 	// base64(0x43, 8 bytes) == AAAAAAAAAEM=
-	// Verify: https://cryptii.com/base64-to-hex
+	// Verify: https://cryptii.com/pipes/base64-to-hex
 	sr := model.SpanRef{
 		TraceID: model.NewTraceID(0, 0x42),
 		SpanID:  model.NewSpanID(0x43),


### PR DESCRIPTION
Currently, the URL of converter between **base64** and **HEX** is out of date.
This commit intends to update this URL to the working one.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Update the deprecated URL

## Short description of the changes
- A minor change
