### PR TITLE
Alphabetically sorted modules import

### DIFF
--- a/plugin/storage/es/esCleaner.py
+++ b/plugin/storage/es/esCleaner.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import elasticsearch
 import curator
-import sys
+import elasticsearch
 import os
 import ssl
+import sys
 
 TIMEOUT=120
 

--- a/plugin/storage/es/esRollover.py
+++ b/plugin/storage/es/esRollover.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-import elasticsearch
-import curator
-import sys
-import os
 import ast
+import curator
+import elasticsearch
 import logging
-from pathlib import Path
+import os
 import requests
-from requests.auth import HTTPBasicAuth
 import ssl
+import sys
+from pathlib import Path
+from requests.auth import HTTPBasicAuth
 
 
 ARCHIVE_INDEX = 'jaeger-span-archive'

--- a/scripts/utils/ids-to-base64.py
+++ b/scripts/utils/ids-to-base64.py
@@ -1,6 +1,6 @@
 import base64
-import re
 import os
+import re
 import sys
 
 def trace_id_base64(match):


### PR DESCRIPTION
Modules which are imported to python are sorted alphabetically are
quicker to read and searchable.

Co-Authored-By: Dao Cong Tien tiendc@vn.fujitsu.com
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- 

## Short description of the changes
- 
