### PR TITLE
Fix for #1382 - logs are not easily queryable with es storage

### DIFF
--- a/plugin/storage/es/mappings/jaeger-span.json
+++ b/plugin/storage/es/mappings/jaeger-span.json
@@ -64,10 +64,10 @@
         "flags":{
           "type":"integer"
         },
-          "logs" : {
-            "type" : "nested",
-            "dynamic" : "false",
-            "properties":{
+        "logs" : {
+          "type" : "nested",
+          "dynamic" : "false",
+          "properties":{
             "timestamp":{
               "type":"long"
             },

--- a/plugin/storage/es/mappings/jaeger-span.json
+++ b/plugin/storage/es/mappings/jaeger-span.json
@@ -64,8 +64,10 @@
         "flags":{
           "type":"integer"
         },
-        "logs":{
-          "properties":{
+          "logs" : {
+            "type" : "nested",
+            "dynamic" : "false",
+            "properties":{
             "timestamp":{
               "type":"long"
             },


### PR DESCRIPTION
As logs was not defined as a nested object. Nested elastic query did not work for logs.fields either. This commit fixes this issue: 
resolves #1382

## Which problem is this PR solving?
 #1382 - Logs are not easily queryable from elasticsearch (ES6)

## Short description of the changes
Added two lines to elastic jaeger span index definition - see in changes.

## Note
I do not know how to create unit tests for this. If unit tests are needed for this PR and there is someone who can guide me a bit, I would really appreciate that.
