### PR TITLE
Do not add indices to not empty alias

### DIFF
--- a/plugin/storage/es/esRollover.py
+++ b/plugin/storage/es/esRollover.py
@@ -85,9 +85,9 @@ def perform_action(action, client, write_alias, read_alias, index_to_rollover, t
 
         index = index_to_rollover + '-000001'
         create_index(client, index)
-        if alias_is_not_empty(client, read_alias):
+        if is_alias_empty(client, read_alias):
             create_aliases(client, read_alias, index)
-        if alias_is_not_empty(client, write_alias):
+        if is_alias_empty(client, write_alias):
             create_aliases(client, write_alias, index)
     elif action == 'rollover':
         cond = ast.literal_eval(os.getenv('CONDITIONS', ROLLBACK_CONDITIONS))
@@ -134,7 +134,7 @@ def create_aliases(client, alias_name, archive_index_name):
     alias.do_action()
 
 
-def alias_is_not_empty(client, alias_name):
+def is_alias_empty(client, alias_name):
     """"
     Checks whether alias is empty or not
     """

--- a/plugin/storage/es/esRollover.py
+++ b/plugin/storage/es/esRollover.py
@@ -85,8 +85,10 @@ def perform_action(action, client, write_alias, read_alias, index_to_rollover, t
 
         index = index_to_rollover + '-000001'
         create_index(client, index)
-        create_aliases(client, read_alias, index)
-        create_aliases(client, write_alias, index)
+        if alias_is_not_empty(client, read_alias):
+            create_aliases(client, read_alias, index)
+        if alias_is_not_empty(client, write_alias):
+            create_aliases(client, write_alias, index)
     elif action == 'rollover':
         cond = ast.literal_eval(os.getenv('CONDITIONS', ROLLBACK_CONDITIONS))
         rollover(client, write_alias, read_alias, cond)
@@ -130,6 +132,18 @@ def create_aliases(client, alias_name, archive_index_name):
         print("Adding index {} to alias {}".format(index, alias_name))
     alias.add(ilo)
     alias.do_action()
+
+
+def alias_is_not_empty(client, alias_name):
+    """"
+    Checks whether alias is empty or not
+    """
+    ilo = curator.IndexList(client)
+    ilo.filter_by_alias(aliases=alias_name)
+    if len(ilo.working_list()) > 0:
+        print("Alias {} is not empty. Not adding indices to it.".format(alias_name))
+        return False
+    return True
 
 
 def rollover(client, write_alias, read_alias, conditions):


### PR DESCRIPTION
Related to #1407 

If the init was run after rollover action it would add indices to read and more importantly write alias. The write alias can contain only one index. 

```
python3  esRollover.py init http://localhost:9200
CONDITIONS='{"max_age": "1s"}' python3  esRollover.py rollover http://localhost:9200
python3  esRollover.py init http://localhost:9200
```

Signed-off-by: Pavol Loffay <ploffay@redhat.com>
