### PR TITLE
Rewrite if-else to switch statements

### DIFF
--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
@@ -168,11 +168,12 @@ func (s *errorTagSanitizer) Sanitize(span *zc.Span) *zc.Span {
 		if binAnno.AnnotationType != zc.AnnotationType_BOOL && strings.EqualFold("error", binAnno.Key) {
 			binAnno.AnnotationType = zc.AnnotationType_BOOL
 
-			if strings.EqualFold("true", string(binAnno.Value)) || len(binAnno.Value) == 0 {
+			switch {
+			case len(binAnno.Value) == 0 || strings.EqualFold("true", string(binAnno.Value)):
 				binAnno.Value = []byte{1}
-			} else if strings.EqualFold("false", string(binAnno.Value)) {
+			case strings.EqualFold("false", string(binAnno.Value)):
 				binAnno.Value = []byte{0}
-			} else {
+			default:
 				// value is different to true/false, create another bin annotation with error message
 				annoErrorMsg := &zc.BinaryAnnotation{
 					Key:            "error.message",

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -86,13 +86,14 @@ func TestBySvcMetrics(t *testing.T) {
 		ctx := context.Background()
 		tctx := thrift.Wrap(ctx)
 		var metricPrefix, format string
-		if test.format == ZipkinFormatType {
+		switch test.format {
+		case ZipkinFormatType:
 			span := makeZipkinSpan(test.serviceName, test.rootSpan, test.debug)
 			zHandler := NewZipkinSpanHandler(logger, processor, zipkinSanitizer.NewParentIDSanitizer())
 			zHandler.SubmitZipkinBatch(tctx, []*zc.Span{span, span})
 			metricPrefix = "service"
 			format = "zipkin"
-		} else if test.format == JaegerFormatType {
+		case JaegerFormatType:
 			span, process := makeJaegerSpan(test.serviceName, test.rootSpan, test.debug)
 			jHandler := NewJaegerSpanHandler(logger, processor)
 			jHandler.SubmitBatches(tctx, []*jaeger.Batch{
@@ -106,7 +107,7 @@ func TestBySvcMetrics(t *testing.T) {
 			})
 			metricPrefix = "service"
 			format = "jaeger"
-		} else {
+		default:
 			panic("Unknown format")
 		}
 		expected := []metricstest.ExpectedMetric{}

--- a/cmd/collector/app/zipkin/http_handler.go
+++ b/cmd/collector/app/zipkin/http_handler.go
@@ -88,11 +88,12 @@ func (aH *APIHandler) saveSpans(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var tSpans []*zipkincore.Span
-	if contentType == "application/x-thrift" {
+	switch contentType {
+	case "application/x-thrift":
 		tSpans, err = zipkin.DeserializeThrift(bodyBytes)
-	} else if contentType == "application/json" {
+	case "application/json":
 		tSpans, err = DeserializeJSON(bodyBytes)
-	} else {
+	default:
 		http.Error(w, "Unsupported Content-Type", http.StatusBadRequest)
 		return
 	}

--- a/cmd/ingester/app/builder/builder.go
+++ b/cmd/ingester/app/builder/builder.go
@@ -32,13 +32,14 @@ import (
 // CreateConsumer creates a new span consumer for the ingester
 func CreateConsumer(logger *zap.Logger, metricsFactory metrics.Factory, spanWriter spanstore.Writer, options app.Options) (*consumer.Consumer, error) {
 	var unmarshaller kafka.Unmarshaller
-	if options.Encoding == kafka.EncodingJSON {
+	switch options.Encoding {
+	case kafka.EncodingJSON:
 		unmarshaller = kafka.NewJSONUnmarshaller()
-	} else if options.Encoding == kafka.EncodingProto {
+	case kafka.EncodingProto:
 		unmarshaller = kafka.NewProtobufUnmarshaller()
-	} else if options.Encoding == kafka.EncodingZipkinThrift {
+	case kafka.EncodingZipkinThrift:
 		unmarshaller = kafka.NewZipkinThriftUnmarshaller()
-	} else {
+	default:
 		return nil, fmt.Errorf(`encoding '%s' not recognised, use one of ("%s")`,
 			options.Encoding, strings.Join(kafka.AllEncodings, "\", \""))
 	}

--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -79,13 +79,14 @@ func init() {
 
 // onInitialize is called before the command is executed.
 func onInitialize() {
-	if metricsBackend == "expvar" {
+	switch metricsBackend {
+	case "expvar":
 		metricsFactory = jexpvar.NewFactory(10) // 10 buckets for histograms
 		logger.Info("Using expvar as metrics backend")
-	} else if metricsBackend == "prometheus" {
+	case "prometheus":
 		metricsFactory = jprom.New().Namespace(metrics.NSOptions{Name: "hotrod", Tags: nil})
 		logger.Info("Using Prometheus as metrics backend")
-	} else {
+	default:
 		logger.Fatal("unsupported metrics backend " + metricsBackend)
 	}
 	if config.MySQLGetDelay != fixDBConnDelay {

--- a/model/ids.go
+++ b/model/ids.go
@@ -50,9 +50,10 @@ func (t TraceID) String() string {
 func TraceIDFromString(s string) (TraceID, error) {
 	var hi, lo uint64
 	var err error
-	if len(s) > 32 {
+	switch {
+	case len(s) > 32:
 		return TraceID{}, fmt.Errorf("TraceID cannot be longer than 32 hex characters: %s", s)
-	} else if len(s) > 16 {
+	case len(s) > 16:
 		hiLen := len(s) - 16
 		if hi, err = strconv.ParseUint(s[0:hiLen], 16, 64); err != nil {
 			return TraceID{}, err
@@ -60,7 +61,7 @@ func TraceIDFromString(s string) (TraceID, error) {
 		if lo, err = strconv.ParseUint(s[hiLen:], 16, 64); err != nil {
 			return TraceID{}, err
 		}
-	} else {
+	default:
 		if lo, err = strconv.ParseUint(s, 16, 64); err != nil {
 			return TraceID{}, err
 		}

--- a/model/sort.go
+++ b/model/sort.go
@@ -23,11 +23,12 @@ type traceByTraceID []*Trace
 func (s traceByTraceID) Len() int      { return len(s) }
 func (s traceByTraceID) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s traceByTraceID) Less(i, j int) bool {
-	if len(s[i].Spans) == 0 {
+	switch {
+	case len(s[i].Spans) == 0:
 		return true
-	} else if len(s[j].Spans) == 0 {
+	case len(s[j].Spans) == 0:
 		return false
-	} else {
+	default:
 		return s[i].Spans[0].TraceID.Low < s[j].Spans[0].TraceID.Low
 	}
 }

--- a/plugin/storage/es/spanstore/dbmodel/to_domain.go
+++ b/plugin/storage/es/spanstore/dbmodel/to_domain.go
@@ -105,11 +105,12 @@ func (td ToDomain) convertRefs(refs []Reference) ([]model.SpanRef, error) {
 	for i, r := range refs {
 		// There are some inconsistencies with ReferenceTypes, hence the hacky fix.
 		var refType model.SpanRefType
-		if r.RefType == ChildOf {
+		switch r.RefType {
+		case ChildOf:
 			refType = model.ChildOf
-		} else if r.RefType == FollowsFrom {
+		case FollowsFrom:
 			refType = model.FollowsFrom
-		} else {
+		default:
 			return nil, fmt.Errorf("not a valid SpanRefType string %s", string(r.RefType))
 		}
 


### PR DESCRIPTION
This commit rewrites some if-else-if-else chains as a switch.
Based on Go style guide:
https://golang.org/doc/effective_go.html#switch

Signed-off-by: Kirill Motkov <motkov.kirill@gmail.com>
