### PR TITLE
Fix some misspells in comment

### DIFF
--- a/thrift-gen/zipkincore/ttypes.go
+++ b/thrift-gen/zipkincore/ttypes.go
@@ -730,7 +730,7 @@ func (p *BinaryAnnotation) String() string {
 // precise value possible. For example, gettimeofday or syncing nanoTime
 // against a tick of currentTimeMillis.
 //
-// For compatibilty with instrumentation that precede this field, collectors
+// For compatibility with instrumentation that precede this field, collectors
 // or span stores can derive this via Annotation.timestamp.
 // For example, SERVER_RECV.timestamp or CLIENT_SEND.timestamp.
 //
@@ -742,7 +742,7 @@ func (p *BinaryAnnotation) String() string {
 // precise measurement decoupled from problems of clocks, such as skew or NTP
 // updates causing time to move backwards.
 //
-// For compatibilty with instrumentation that precede this field, collectors
+// For compatibility with instrumentation that precede this field, collectors
 // or span stores can derive this by subtracting Annotation.timestamp.
 // For example, SERVER_SEND.timestamp - SERVER_RECV.timestamp.
 //


### PR DESCRIPTION
"compatibilty" to "compatibility" in line 733 and 745.