### PR TITLE
use RawMessage in check of value for being json

### DIFF
--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -252,7 +252,7 @@ func (s *SpanWriter) indexByOperation(span *dbmodel.Span) error {
 // shouldIndexTag checks to see if the tag is json or not, if it's UTF8 valid and it's not too large
 func (s *SpanWriter) shouldIndexTag(tag dbmodel.TagInsertion) bool {
 	isJSON := func(s string) bool {
-		var js map[string]interface{}
+		var js json.RawMessage
 		// poor man's string-is-a-json check shortcircuits full unmarshalling
 		return strings.HasPrefix(s, "{") && json.Unmarshal([]byte(s), &js) == nil
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
Optimizes a bit "isJSON" check for tag value.

## Short description of the changes
RawMessage replaces `map[string]interface{}` as a target for json.Unmarshal.
Unmarshalling checks JSON validity even when unmarshal to RawMessage.