### PR TITLE
Regenerate grpc-gateway code

### DIFF
--- a/proto-gen/openapi/api_v2.swagger.json
+++ b/proto-gen/openapi/api_v2.swagger.json
@@ -20,7 +20,7 @@
         "operationId": "GetSamplingStrategy",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/api_v2SamplingStrategyResponse"
             }
@@ -46,7 +46,7 @@
         "operationId": "PostSpans",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/api_v2PostSpansResponse"
             }


### PR DESCRIPTION
The grpc-gateway files are out of sync with its current version in the Gopkg. We're not actually using them, but this is needed before fixing #1431.