### PR TITLE
Fixed typo in the ES 'flush-interval' option.

### DIFF
--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -54,7 +54,7 @@ const (
 
 // TODO this should be moved next to config.Configuration struct (maybe ./flags package)
 
-// Options contains various type of ElasticSearch configs and provides the ability
+// Options contains various type of Elasticsearch configs and provides the ability
 // to bind them to command line flag and apply overlays, so that some configurations
 // (e.g. archive) may be underspecified and infer the rest of its parameters from primary.
 type Options struct {
@@ -117,11 +117,11 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.String(
 		nsConfig.namespace+suffixUsername,
 		nsConfig.Username,
-		"The username required by ElasticSearch. The basic authentication also loads CA if it is specified.")
+		"The username required by Elasticsearch. The basic authentication also loads CA if it is specified.")
 	flagSet.String(
 		nsConfig.namespace+suffixPassword,
 		nsConfig.Password,
-		"The password required by ElasticSearch")
+		"The password required by Elasticsearch")
 	flagSet.String(
 		nsConfig.namespace+suffixTokenPath,
 		nsConfig.TokenFilePath,
@@ -129,11 +129,11 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Bool(
 		nsConfig.namespace+suffixSniffer,
 		nsConfig.Sniffer,
-		"The sniffer config for ElasticSearch; client uses sniffing process to find all nodes automatically, disable if not required")
+		"The sniffer config for Elasticsearch; client uses sniffing process to find all nodes automatically, disable if not required")
 	flagSet.String(
 		nsConfig.namespace+suffixServerURLs,
 		nsConfig.servers,
-		"The comma-separated list of ElasticSearch servers, must be full url i.e. http://localhost:9200")
+		"The comma-separated list of Elasticsearch servers, must be full url i.e. http://localhost:9200")
 	flagSet.Duration(
 		nsConfig.namespace+suffixTimeout,
 		nsConfig.Timeout,
@@ -141,7 +141,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Duration(
 		nsConfig.namespace+suffixMaxSpanAge,
 		nsConfig.MaxSpanAge,
-		"The maximum lookback for spans in ElasticSearch")
+		"The maximum lookback for spans in Elasticsearch")
 	flagSet.Int(
 		nsConfig.namespace+suffixMaxNumSpans,
 		nsConfig.MaxNumSpans,
@@ -149,11 +149,11 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Int64(
 		nsConfig.namespace+suffixNumShards,
 		nsConfig.NumShards,
-		"The number of shards per index in ElasticSearch")
+		"The number of shards per index in Elasticsearch")
 	flagSet.Int64(
 		nsConfig.namespace+suffixNumReplicas,
 		nsConfig.NumReplicas,
-		"The number of replicas per index in ElasticSearch")
+		"The number of replicas per index in Elasticsearch")
 	flagSet.Int(
 		nsConfig.namespace+suffixBulkSize,
 		nsConfig.BulkSize,
@@ -169,7 +169,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Duration(
 		nsConfig.namespace+suffixBulkFlushInterval,
 		nsConfig.BulkFlushInterval,
-		"A time.Duration after which bulk requests are committed, regardless of other tresholds. Set to zero to disable. By default, this is disabled.")
+		"A time.Duration after which bulk requests are committed, regardless of other thresholds. Set to zero to disable. By default, this is disabled.")
 	flagSet.Bool(
 		nsConfig.namespace+suffixTLS,
 		nsConfig.TLS.Enabled,


### PR DESCRIPTION
Additionally, replaced `ElasticSearch` by `Elasticsearch`

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
