### PR TITLE
Add Admin port and group all ports in one file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,3 +115,25 @@ import (
 )
 ```
 
+## Testing guidelines
+
+We strive to maintain as high code coverage as possible. Since `go test` command does not generate
+code coverage information for packages that have no test files, we have a build step (`make nocover`)
+that breaks the build when such packages are discovered, with an error like this:
+
+```
+error: at least one *_test.go file must be in all directories with go files
+       so that they are counted for code coverage.
+       If no tests are possible for a package (e.g. it only defines types), create empty_test.go
+```
+
+There are conditions that cannot be tested without external dependencies, such as a function that
+creates a gocql.Session, because it requires an active connection to Cassandra database. It is
+recommended to isolate such functions in a separate package with bare minimum of code and add a
+file `.nocover` to exclude the package from coverage calculations. The file should contain
+a comment explaining why it is there, for example:
+
+```
+$ cat ./pkg/cassandra/config/.nocover
+requires connection to Cassandra
+```

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -17,6 +17,7 @@ package app
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/pkg/errors"
@@ -31,6 +32,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
+	"github.com/jaegertracing/jaeger/ports"
 	zipkinThrift "github.com/jaegertracing/jaeger/thrift-gen/agent"
 	jaegerThrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
@@ -40,14 +42,14 @@ const (
 	defaultMaxPacketSize = 65000
 	defaultServerWorkers = 10
 
-	defaultHTTPServerHostPort = ":5778"
-
 	jaegerModel Model = "jaeger"
 	zipkinModel       = "zipkin"
 
 	compactProtocol Protocol = "compact"
 	binaryProtocol           = "binary"
 )
+
+var defaultHTTPServerHostPort = ":" + strconv.Itoa(ports.AgentConfigServerHTTP)
 
 // Model used to distinguish the data transfer model
 type Model string

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -17,8 +17,11 @@ package app
 import (
 	"flag"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/viper"
+
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 const (
@@ -32,21 +35,21 @@ const (
 var defaultProcessors = []struct {
 	model    Model
 	protocol Protocol
-	hostPort string
+	port     int
 }{
-	{model: "zipkin", protocol: "compact", hostPort: ":5775"},
-	{model: "jaeger", protocol: "compact", hostPort: ":6831"},
-	{model: "jaeger", protocol: "binary", hostPort: ":6832"},
+	{model: "zipkin", protocol: "compact", port: ports.AgentZipkinThriftCompactUDP},
+	{model: "jaeger", protocol: "compact", port: ports.AgentJaegerThriftCompactUDP},
+	{model: "jaeger", protocol: "binary", port: ports.AgentJaegerThriftBinaryUDP},
 }
 
 // AddFlags adds flags for Builder.
 func AddFlags(flags *flag.FlagSet) {
-	for _, processor := range defaultProcessors {
-		prefix := fmt.Sprintf("processor.%s-%s.", processor.model, processor.protocol)
+	for _, p := range defaultProcessors {
+		prefix := fmt.Sprintf("processor.%s-%s.", p.model, p.protocol)
 		flags.Int(prefix+suffixWorkers, defaultServerWorkers, "how many workers the processor should run")
 		flags.Int(prefix+suffixServerQueueSize, defaultQueueSize, "length of the queue for the UDP server")
 		flags.Int(prefix+suffixServerMaxPacketSize, defaultMaxPacketSize, "max packet size for the UDP server")
-		flags.String(prefix+suffixServerHostPort, processor.hostPort, "host:port for the UDP server")
+		flags.String(prefix+suffixServerHostPort, ":"+strconv.Itoa(p.port), "host:port for the UDP server")
 	}
 	flags.String(
 		httpServerHostPort,

--- a/cmd/agent/app/reporter/tchannel/flags.go
+++ b/cmd/agent/app/reporter/tchannel/flags.go
@@ -55,15 +55,15 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.String(
 		collectorHostPort,
 		"",
-		"Deprecated; comma-separated string representing host:ports of a static list of collectors to connect to directly (e.g. when not using service discovery)")
+		"(deprecated) see --"+tchannelPrefix+hostPort)
 	flags.Int(
 		discoveryMinPeers,
 		defaultMinPeers,
-		"Deprecated; if using service discovery, the min number of connections to maintain to the backend")
+		"(deprecated) see --"+tchannelPrefix+discoveryMinPeers)
 	flags.Duration(
 		discoveryConnCheckTimeout,
 		defaultConnCheckTimeout,
-		"Deprecated; sets the timeout used when establishing new connections")
+		"(deprecated) see --"+tchannelPrefix+discoveryConnCheckTimeout)
 }
 
 // InitFromViper initializes Builder with properties retrieved from Viper.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -49,7 +49,9 @@ func main() {
 				return err
 			}
 			logger := svc.Logger // shortcut
-			mFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "agent"})
+			mFactory := svc.MetricsFactory.
+				Namespace(metrics.NSOptions{Name: "jaeger"}).
+				Namespace(metrics.NSOptions{Name: "agent"})
 
 			rOpts := new(reporter.Options).InitFromViper(v)
 			tChanOpts := new(tchannel.Builder).InitFromViper(v, logger)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -17,18 +17,13 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	jMetrics "github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
@@ -36,15 +31,13 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/version"
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 func main() {
-	var signalsChannel = make(chan os.Signal)
-	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
-
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
+	svc := flags.NewService(ports.AgentAdminHTTP)
+	svc.NoStorage = true
 
 	v := viper.New()
 	var command = &cobra.Command{
@@ -52,25 +45,11 @@ func main() {
 		Short: "Jaeger agent is a local daemon program which collects tracing data.",
 		Long:  `Jaeger agent is a daemon program that runs on every host and receives tracing data submitted by Jaeger client libraries.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := flags.TryLoadConfigFile(v)
-			if err != nil {
+			if err := svc.Start(v); err != nil {
 				return err
 			}
-
-			sFlags := new(flags.SharedFlags).InitFromViper(v)
-			logger, err := sFlags.NewLogger(zap.NewProductionConfig())
-			if err != nil {
-				return err
-			}
-
-			builder := new(app.Builder).InitFromViper(v)
-			mBldr := new(metrics.Builder).InitFromViper(v)
-
-			mFactory, err := mBldr.CreateMetricsFactory("jaeger")
-			if err != nil {
-				logger.Fatal("Could not create metrics", zap.Error(err))
-			}
-			mFactory = mFactory.Namespace(jMetrics.NSOptions{Name: "agent", Tags: nil})
+			logger := svc.Logger // shortcut
+			mFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "agent"})
 
 			rOpts := new(reporter.Options).InitFromViper(v)
 			tChanOpts := new(tchannel.Builder).InitFromViper(v, logger)
@@ -82,26 +61,21 @@ func main() {
 
 			// TODO illustrate discovery service wiring
 
+			builder := new(app.Builder).InitFromViper(v)
 			agent, err := builder.CreateAgent(cp, logger, mFactory)
 			if err != nil {
 				return errors.Wrap(err, "Unable to initialize Jaeger Agent")
-			}
-
-			if h := mBldr.Handler(); mFactory != nil && h != nil {
-				logger.Info("Registering metrics handler with HTTP server", zap.String("route", mBldr.HTTPRoute))
-				agent.GetServer().Handler.(*http.ServeMux).Handle(mBldr.HTTPRoute, h)
 			}
 
 			logger.Info("Starting agent")
 			if err := agent.Run(); err != nil {
 				return errors.Wrap(err, "Failed to run the agent")
 			}
-			<-signalsChannel
-			logger.Info("Shutting down")
-			if closer, ok := cp.(io.Closer); ok {
-				closer.Close()
-			}
-			logger.Info("Shutdown complete")
+			svc.RunAndThen(func() {
+				if closer, ok := cp.(io.Closer); ok {
+					closer.Close()
+				}
+			})
 			return nil
 		},
 	}
@@ -111,13 +85,11 @@ func main() {
 	config.AddFlags(
 		v,
 		command,
-		flags.AddConfigFileFlag,
-		flags.AddLoggingFlag,
+		svc.AddFlags,
 		app.AddFlags,
 		reporter.AddFlags,
 		tchannel.AddFlags,
 		grpc.AddFlags,
-		metrics.AddFlags,
 	)
 
 	if err := command.Execute(); err != nil {

--- a/cmd/builder/builder_options.go
+++ b/cmd/builder/builder_options.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// TODO combine with SharedFlags
+// TODO nothing but Collector uses this, move to cmd/collector/builder
 
 // BasicOptions is a set of basic building blocks for most Jaeger executables
 type BasicOptions struct {

--- a/cmd/collector/app/builder/builder_flags.go
+++ b/cmd/collector/app/builder/builder_flags.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app"
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 const (
@@ -32,12 +33,6 @@ const (
 	collectorGRPCCert      = "collector.grpc.tls.cert"
 	collectorGRPCKey       = "collector.grpc.tls.key"
 	collectorZipkinHTTPort = "collector.zipkin.http-port"
-
-	defaultTChannelPort = 14267
-	defaultHTTPPort     = 14268
-	defaultGRPCPort     = 14250
-	// CollectorDefaultHealthCheckHTTPPort is the default HTTP Port for health check
-	CollectorDefaultHealthCheckHTTPPort = 14269
 )
 
 // CollectorOptions holds configuration for collector
@@ -66,9 +61,9 @@ type CollectorOptions struct {
 func AddFlags(flags *flag.FlagSet) {
 	flags.Int(collectorQueueSize, app.DefaultQueueSize, "The queue size of the collector")
 	flags.Int(collectorNumWorkers, app.DefaultNumWorkers, "The number of workers pulling items from the queue")
-	flags.Int(collectorPort, defaultTChannelPort, "The TChannel port for the collector service")
-	flags.Int(collectorHTTPPort, defaultHTTPPort, "The HTTP port for the collector service")
-	flags.Int(collectorGRPCPort, defaultGRPCPort, "The gRPC port for the collector service")
+	flags.Int(collectorPort, ports.CollectorTChannel, "The TChannel port for the collector service")
+	flags.Int(collectorHTTPPort, ports.CollectorHTTP, "The HTTP port for the collector service")
+	flags.Int(collectorGRPCPort, ports.CollectorGRPC, "The gRPC port for the collector service")
 	flags.Int(collectorZipkinHTTPort, 0, "The HTTP port for the Zipkin collector service e.g. 9411")
 	flags.Bool(collectorGRPCTLS, false, "Enable TLS")
 	flags.String(collectorGRPCCert, "", "Path to TLS certificate file")

--- a/cmd/flags/admin.go
+++ b/cmd/flags/admin.go
@@ -1,0 +1,107 @@
+package flags
+
+import (
+	"context"
+	"flag"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/pkg/healthcheck"
+	"github.com/jaegertracing/jaeger/pkg/recoveryhandler"
+)
+
+const (
+	adminHTTPPort       = "admin-http-port"
+	healthCheckHTTPPort = "health-check-http-port"
+)
+
+// AdminServer runs an HTTP server with admin endpoints, such as healthcheck at /, /metrics, etc.
+type AdminServer struct {
+	logger    *zap.Logger
+	adminPort int
+
+	hc *healthcheck.HealthCheck
+
+	mux    *http.ServeMux
+	server *http.Server
+}
+
+// NewAdminServer creates a new admin server.
+func NewAdminServer(defaultPort int) *AdminServer {
+	return &AdminServer{
+		adminPort: defaultPort,
+		logger:    zap.NewNop(),
+		hc:        healthcheck.New(),
+		mux:       http.NewServeMux(),
+	}
+}
+
+// HC returns the reference to HeathCheck.
+func (s *AdminServer) HC() *healthcheck.HealthCheck {
+	return s.hc
+}
+
+// SetLogger initializes logger.
+func (s *AdminServer) SetLogger(logger *zap.Logger) {
+	s.logger = logger
+	s.hc.SetLogger(logger)
+}
+
+// AddFlags registers CLI flags.
+func (s *AdminServer) AddFlags(flagSet *flag.FlagSet) {
+	flagSet.Int(healthCheckHTTPPort, 0, "(deprecated) The http port for the health check service")
+	flagSet.Int(adminHTTPPort, s.adminPort, "The http port for the admin server, including health check, /metrics, etc.")
+}
+
+// InitFromViper initializes the server with properties retrieved from Viper.
+func (s *AdminServer) initFromViper(v *viper.Viper, logger *zap.Logger) {
+	s.SetLogger(logger)
+	s.adminPort = v.GetInt(adminHTTPPort)
+	if v := v.GetInt(healthCheckHTTPPort); v != 0 {
+		logger.Sugar().Warnf("Using deprecated flag %s, please upgrade to %s", healthCheckHTTPPort, adminHTTPPort)
+		s.adminPort = v
+	}
+}
+
+// Handle adds a new handler to the admin server.
+func (s *AdminServer) Handle(path string, handler http.Handler) {
+	s.mux.Handle(path, handler)
+}
+
+// Serve starts HTTP server.
+func (s *AdminServer) Serve() error {
+	s.logger.Info("Starting admin HTTP server", zap.Int("http-port", s.adminPort))
+	portStr := ":" + strconv.Itoa(s.adminPort)
+	l, err := net.Listen("tcp", portStr)
+	if err != nil {
+		s.logger.Error("Admin server failed to listen", zap.Error(err))
+		return err
+	}
+	s.serveWithListener(l)
+	s.logger.Info(
+		"Admin server started",
+		zap.Int("http-port", s.adminPort),
+		zap.Stringer("health-status", s.hc.Get()))
+	return nil
+}
+
+func (s *AdminServer) serveWithListener(l net.Listener) {
+	s.mux.Handle("/", s.hc.Handler())
+	recoveryHandler := recoveryhandler.NewRecoveryHandler(s.logger, true)
+	s.server = &http.Server{Handler: recoveryHandler(s.mux)}
+	go func() {
+		if err := s.server.Serve(l); err != nil {
+			s.logger.Error("failed to serve", zap.Error(err))
+			s.hc.Set(healthcheck.Broken)
+		}
+	}()
+}
+
+// Close stops the HTTP server
+func (s *AdminServer) Close() error {
+	return s.server.Shutdown(context.Background())
+}

--- a/cmd/flags/admin.go
+++ b/cmd/flags/admin.go
@@ -68,7 +68,7 @@ func (s *AdminServer) setLogger(logger *zap.Logger) {
 
 // AddFlags registers CLI flags.
 func (s *AdminServer) AddFlags(flagSet *flag.FlagSet) {
-	flagSet.Int(healthCheckHTTPPort, 0, "(deprecated) The http port for the health check service")
+	flagSet.Int(healthCheckHTTPPort, 0, "(deprecated) see --"+adminHTTPPort)
 	flagSet.Int(adminHTTPPort, s.adminPort, "The http port for the admin server, including health check, /metrics, etc.")
 }
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -61,7 +61,7 @@ type logging struct {
 
 // AddFlags adds flags for SharedFlags
 func AddFlags(flagSet *flag.FlagSet) {
-	flagSet.String(spanStorageType, "", fmt.Sprintf(`Deprecated; please use %s environment variable. Run this binary with "env" command for help.`, storage.SpanStorageTypeEnvVar))
+	flagSet.String(spanStorageType, "", fmt.Sprintf(`(deprecated) please use %s environment variable. Run this binary with "env" command for help.`, storage.SpanStorageTypeEnvVar))
 	AddLoggingFlag(flagSet)
 }
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -23,18 +23,14 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	hc "github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/plugin/storage"
 )
 
 const (
-	spanStorageType     = "span-storage.type" // deprecated
-	logLevel            = "log-level"
-	configFile          = "config-file"
-	healthCheckHTTPPort = "health-check-http-port"
+	spanStorageType = "span-storage.type" // deprecated
+	logLevel        = "log-level"
+	configFile      = "config-file"
 )
-
-var defaultHealthCheckPort int
 
 // AddConfigFileFlag adds flags for ExternalConfFlags
 func AddConfigFileFlag(flagSet *flag.FlagSet) {
@@ -57,27 +53,15 @@ func TryLoadConfigFile(v *viper.Viper) error {
 type SharedFlags struct {
 	// Logging holds logging configuration
 	Logging logging
-	// HealthCheck holds health check configuration
-	HealthCheck healthCheck
 }
 
 type logging struct {
 	Level string
 }
 
-type healthCheck struct {
-	Port int
-}
-
-// SetDefaultHealthCheckPort sets the default port for health check. Must be called before AddFlags
-func SetDefaultHealthCheckPort(port int) {
-	defaultHealthCheckPort = port
-}
-
 // AddFlags adds flags for SharedFlags
 func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(spanStorageType, "", fmt.Sprintf(`Deprecated; please use %s environment variable. Run this binary with "env" command for help.`, storage.SpanStorageTypeEnvVar))
-	flagSet.Int(healthCheckHTTPPort, defaultHealthCheckPort, "The http port for the health check service")
 	AddLoggingFlag(flagSet)
 }
 
@@ -89,7 +73,6 @@ func AddLoggingFlag(flagSet *flag.FlagSet) {
 // InitFromViper initializes SharedFlags with properties from viper
 func (flags *SharedFlags) InitFromViper(v *viper.Viper) *SharedFlags {
 	flags.Logging.Level = v.GetString(logLevel)
-	flags.HealthCheck.Port = v.GetInt(healthCheckHTTPPort)
 	return flags
 }
 
@@ -102,13 +85,4 @@ func (flags *SharedFlags) NewLogger(conf zap.Config, options ...zap.Option) (*za
 	}
 	conf.Level = zap.NewAtomicLevelAt(level)
 	return conf.Build(options...)
-}
-
-// NewHealthCheck returns health check based on configuration in SharedFlags
-func (flags *SharedFlags) NewHealthCheck(logger *zap.Logger) (*hc.HealthCheck, error) {
-	if flags.HealthCheck.Port == 0 {
-		return nil, errors.New("port not specified")
-	}
-	return hc.New(hc.Unavailable, hc.Logger(logger)).
-		Serve(flags.HealthCheck.Port)
 }

--- a/cmd/flags/service.go
+++ b/cmd/flags/service.go
@@ -1,0 +1,115 @@
+package flags
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"github.com/uber/jaeger-lib/metrics"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/grpclog"
+
+	"github.com/jaegertracing/jaeger/pkg/healthcheck"
+	pMetrics "github.com/jaegertracing/jaeger/pkg/metrics"
+)
+
+// Service represents an abstract Jaeger backend component with some basic shared functionality.
+type Service struct {
+	// AdminPort is the HTTP port number for admin server.
+	AdminPort int
+
+	// NoStorage indicates that storage type CLI flag is not applicable
+	NoStorage bool
+
+	// Admin is the admin server that hosts the health check and metrics endpoints.
+	Admin *AdminServer
+
+	// Logger is initialized after parsing Viper flags like --log-level.
+	Logger *zap.Logger
+
+	// MetricsFactory is the root factory without a namespace.
+	MetricsFactory metrics.Factory
+
+	signalsChannel chan os.Signal
+}
+
+// NewService creates a new Service.
+func NewService(adminPort int) *Service {
+	signalsChannel := make(chan os.Signal)
+	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
+
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
+
+	return &Service{
+		Admin:          NewAdminServer(adminPort),
+		signalsChannel: signalsChannel,
+	}
+}
+
+// AddFlags registers CLI flags.
+func (s *Service) AddFlags(flagSet *flag.FlagSet) {
+	AddConfigFileFlag(flagSet)
+	if s.NoStorage {
+		AddLoggingFlag(flagSet)
+	} else {
+		AddFlags(flagSet)
+	}
+	pMetrics.AddFlags(flagSet)
+	s.Admin.AddFlags(flagSet)
+}
+
+// Start bootstraps the service and starts the admin server.
+func (s *Service) Start(v *viper.Viper) error {
+	if err := TryLoadConfigFile(v); err != nil {
+		return errors.Wrap(err, "Cannot load config file")
+	}
+
+	sFlags := new(SharedFlags).InitFromViper(v)
+	if logger, err := sFlags.NewLogger(zap.NewProductionConfig()); err == nil {
+		s.Logger = logger
+	} else {
+		return errors.Wrap(err, "Cannot create logger")
+	}
+
+	metricsBuilder := new(pMetrics.Builder).InitFromViper(v)
+	metricsFactory, err := metricsBuilder.CreateMetricsFactory("")
+	if err != nil {
+		return errors.Wrap(err, "Cannot create metrics factory")
+	}
+	s.MetricsFactory = metricsFactory
+
+	s.Admin.initFromViper(v, s.Logger)
+	if h := metricsBuilder.Handler(); h != nil {
+		route := metricsBuilder.HTTPRoute
+		s.Logger.Info("Registering metrics handler with admin server", zap.String("route", route))
+		s.Admin.Handle(route, h)
+	}
+	if err := s.Admin.Serve(); err != nil {
+		return errors.Wrap(err, "Cannot start the admin server")
+	}
+
+	return nil
+}
+
+// HC returns the reference to HeathCheck.
+func (s *Service) HC() *healthcheck.HealthCheck {
+	return s.Admin.HC()
+}
+
+// RunAndThen sets the health check to Ready and blocks until SIGTERM is received.
+// If then runs the shutdown function and exits.
+func (s *Service) RunAndThen(shutdown func()) {
+	s.HC().Ready()
+	<-s.signalsChannel
+	s.Logger.Info("Shutting down")
+
+	if shutdown != nil {
+		shutdown()
+	}
+
+	s.Logger.Info("Shutdown complete")
+}

--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -25,7 +25,6 @@ import (
 
 	kafkaConsumer "github.com/jaegertracing/jaeger/pkg/kafka/consumer"
 	"github.com/jaegertracing/jaeger/plugin/storage/kafka"
-	"github.com/jaegertracing/jaeger/ports"
 )
 
 const (
@@ -65,10 +64,8 @@ const (
 // Options stores the configuration options for the Ingester
 type Options struct {
 	kafkaConsumer.Configuration
-	Parallelism int
-	Encoding    string
-	// IngesterHTTPPort is the port that the ingester service listens in on for http requests
-	// IngesterHTTPPort int
+	Parallelism      int
+	Encoding         string
 	DeadlockInterval time.Duration
 }
 
@@ -94,10 +91,6 @@ func AddFlags(flagSet *flag.FlagSet) {
 		ConfigPrefix+SuffixParallelism,
 		strconv.Itoa(DefaultParallelism),
 		"The number of messages to process in parallel")
-	flagSet.Int(
-		ConfigPrefix+SuffixHTTPPort,
-		ports.IngesterAdminHTTP,
-		"The admin http port for the ingester service (health check, /metrics, etc.)")
 	flagSet.Duration(
 		ConfigPrefix+SuffixDeadlockInterval,
 		DefaultDeadlockInterval,
@@ -112,8 +105,6 @@ func (o *Options) InitFromViper(v *viper.Viper) {
 	o.Encoding = v.GetString(KafkaConsumerConfigPrefix + SuffixEncoding)
 
 	o.Parallelism = v.GetInt(ConfigPrefix + SuffixParallelism)
-	//o.IngesterHTTPPort = v.GetInt(ConfigPrefix + SuffixHTTPPort)
-
 	o.DeadlockInterval = v.GetDuration(ConfigPrefix + SuffixDeadlockInterval)
 }
 

--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -25,6 +25,7 @@ import (
 
 	kafkaConsumer "github.com/jaegertracing/jaeger/pkg/kafka/consumer"
 	"github.com/jaegertracing/jaeger/plugin/storage/kafka"
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 const (
@@ -59,10 +60,6 @@ const (
 	DefaultEncoding = kafka.EncodingProto
 	// DefaultDeadlockInterval is the default deadlock interval
 	DefaultDeadlockInterval = 1 * time.Minute
-	// DefaultHTTPPort is the default HTTP port (e.g. for /metrics)
-	DefaultHTTPPort = 14271
-	// IngesterDefaultHealthCheckHTTPPort is the default HTTP Port for health check
-	IngesterDefaultHealthCheckHTTPPort = 14270
 )
 
 // Options stores the configuration options for the Ingester
@@ -71,7 +68,7 @@ type Options struct {
 	Parallelism int
 	Encoding    string
 	// IngesterHTTPPort is the port that the ingester service listens in on for http requests
-	IngesterHTTPPort int
+	// IngesterHTTPPort int
 	DeadlockInterval time.Duration
 }
 
@@ -99,8 +96,8 @@ func AddFlags(flagSet *flag.FlagSet) {
 		"The number of messages to process in parallel")
 	flagSet.Int(
 		ConfigPrefix+SuffixHTTPPort,
-		DefaultHTTPPort,
-		"The http port for the ingester service")
+		ports.IngesterAdminHTTP,
+		"The admin http port for the ingester service (health check, /metrics, etc.)")
 	flagSet.Duration(
 		ConfigPrefix+SuffixDeadlockInterval,
 		DefaultDeadlockInterval,
@@ -115,7 +112,7 @@ func (o *Options) InitFromViper(v *viper.Viper) {
 	o.Encoding = v.GetString(KafkaConsumerConfigPrefix + SuffixEncoding)
 
 	o.Parallelism = v.GetInt(ConfigPrefix + SuffixParallelism)
-	o.IngesterHTTPPort = v.GetInt(ConfigPrefix + SuffixHTTPPort)
+	//o.IngesterHTTPPort = v.GetInt(ConfigPrefix + SuffixHTTPPort)
 
 	o.DeadlockInterval = v.GetDuration(ConfigPrefix + SuffixDeadlockInterval)
 }

--- a/cmd/ingester/app/flags_test.go
+++ b/cmd/ingester/app/flags_test.go
@@ -34,7 +34,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--kafka.consumer.encoding=json",
 		"--ingester.parallelism=5",
 		"--ingester.deadlockInterval=2m",
-		"--ingester.http-port=2345"})
+	})
 	o.InitFromViper(v)
 
 	assert.Equal(t, "topic1", o.Topic)
@@ -43,7 +43,6 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, 5, o.Parallelism)
 	assert.Equal(t, 2*time.Minute, o.DeadlockInterval)
 	assert.Equal(t, kafka.EncodingJSON, o.Encoding)
-	assert.Equal(t, 2345, o.IngesterHTTPPort)
 }
 
 func TestFlagDefaults(t *testing.T) {

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -17,38 +17,26 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
-	"os/signal"
-	"strconv"
-	"syscall"
 
-	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/jaegertracing/jaeger/cmd/env"
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/builder"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/healthcheck"
-	pMetrics "github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/recoveryhandler"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/plugin/storage"
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 func main() {
-	var signalsChannel = make(chan os.Signal)
-	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
-
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
+	svc := flags.NewService(ports.IngesterAdminHTTP)
 
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
 	if err != nil {
@@ -61,27 +49,12 @@ func main() {
 		Short: "Jaeger ingester consumes from Kafka and writes to storage",
 		Long:  `Jaeger ingester consumes spans from a particular Kafka topic and writes them to all configured storage types.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := flags.TryLoadConfigFile(v)
-			if err != nil {
+			if err := svc.Start(v); err != nil {
 				return err
 			}
-
-			sFlags := new(flags.SharedFlags).InitFromViper(v)
-			logger, err := sFlags.NewLogger(zap.NewProductionConfig())
-			if err != nil {
-				return err
-			}
-			hc, err := sFlags.NewHealthCheck(logger)
-			if err != nil {
-				logger.Fatal("Could not start the health check server.", zap.Error(err))
-			}
-
-			mBldr := new(pMetrics.Builder).InitFromViper(v)
-			baseFactory, err := mBldr.CreateMetricsFactory("jaeger")
-			if err != nil {
-				logger.Fatal("Cannot create metrics factory.", zap.Error(err))
-			}
-			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "ingester", Tags: nil})
+			logger := svc.Logger // shortcut
+			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
+			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "ingester"})
 
 			storageFactory.InitFromViper(v)
 			if err := storageFactory.Initialize(baseFactory, logger); err != nil {
@@ -100,37 +73,17 @@ func main() {
 			}
 			consumer.Start()
 
-			r := mux.NewRouter()
-			if h := mBldr.Handler(); h != nil {
-				logger.Info("Registering metrics handler with HTTP server", zap.String("route", mBldr.HTTPRoute))
-				r.Handle(mBldr.HTTPRoute, h)
-			}
-			httpPortStr := ":" + strconv.Itoa(options.IngesterHTTPPort)
-			recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
-
-			logger.Info("Starting HTTP server", zap.Int("http-port", options.IngesterHTTPPort))
-
-			go func() {
-				if err := http.ListenAndServe(httpPortStr, recoveryHandler(r)); err != nil {
-					logger.Fatal("Could not launch service", zap.Error(err))
+			svc.RunAndThen(func() {
+				if err = consumer.Close(); err != nil {
+					logger.Error("Failed to close consumer", zap.Error(err))
 				}
-				hc.Set(healthcheck.Unavailable)
-			}()
-
-			hc.Ready()
-			<-signalsChannel
-			logger.Info("Shutting down")
-			err = consumer.Close()
-			if err != nil {
-				logger.Error("Failed to close consumer", zap.Error(err))
-			}
-			if closer, ok := spanWriter.(io.Closer); ok {
-				err := closer.Close()
-				if err != nil {
-					logger.Error("Failed to close span writer", zap.Error(err))
+				if closer, ok := spanWriter.(io.Closer); ok {
+					err := closer.Close()
+					if err != nil {
+						logger.Error("Failed to close span writer", zap.Error(err))
+					}
 				}
-			}
-			logger.Info("Shutdown complete")
+			})
 			return nil
 		},
 	}
@@ -138,15 +91,11 @@ func main() {
 	command.AddCommand(version.Command())
 	command.AddCommand(env.Command())
 
-	flags.SetDefaultHealthCheckPort(app.IngesterDefaultHealthCheckHTTPPort)
-
 	config.AddFlags(
 		v,
 		command,
-		flags.AddConfigFileFlag,
-		flags.AddFlags,
+		svc.AddFlags,
 		storageFactory.AddFlags,
-		pMetrics.AddFlags,
 		app.AddFlags,
 	)
 

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -18,6 +18,8 @@ import (
 	"flag"
 
 	"github.com/spf13/viper"
+
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 const (
@@ -25,8 +27,6 @@ const (
 	queryBasePath    = "query.base-path"
 	queryStaticFiles = "query.static-files"
 	queryUIConfig    = "query.ui-config"
-	// QueryDefaultHealthCheckHTTPPort is the default HTTP Port for health check
-	QueryDefaultHealthCheckHTTPPort = 16687
 )
 
 // QueryOptions holds configuration for query service
@@ -43,7 +43,7 @@ type QueryOptions struct {
 
 // AddFlags adds flags for QueryOptions
 func AddFlags(flagSet *flag.FlagSet) {
-	flagSet.Int(queryPort, 16686, "The port for the query service")
+	flagSet.Int(queryPort, ports.QueryHTTP, "The port for the query service")
 	flagSet.String(queryBasePath, "/", "The base path for all HTTP routes, e.g. /jaeger; useful when running behind a reverse proxy")
 	flagSet.String(queryStaticFiles, "", "The directory path override for the static assets for the UI")
 	flagSet.String(queryUIConfig, "", "The path to the UI configuration file in JSON format")

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -139,6 +139,7 @@ func main() {
 	config.AddFlags(
 		v,
 		command,
+		svc.AddFlags,
 		storageFactory.AddFlags,
 		app.AddFlags,
 	)

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -63,6 +63,7 @@ func main() {
 			}
 			logger := svc.Logger // shortcut
 			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
+			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "query"})
 
 			tracer, closer, err := jaegerClientConfig.Configuration{
 				Sampler: &jaegerClientConfig.SamplerConfig{
@@ -89,7 +90,7 @@ func main() {
 			if err != nil {
 				logger.Fatal("Failed to create span reader", zap.Error(err))
 			}
-			spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, baseFactory.Namespace(metrics.NSOptions{Name: "query", Tags: nil}))
+			spanReader = storageMetrics.NewReadMetricsDecorator(spanReader, metricsFactory)
 			dependencyReader, err := storageFactory.CreateDependencyReader()
 			if err != nil {
 				logger.Fatal("Failed to create dependency reader", zap.Error(err))

--- a/examples/hotrod/services/frontend/gen_assets.go
+++ b/examples/hotrod/services/frontend/gen_assets.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    "index.html",
 		local:   "examples/hotrod/services/frontend/web_assets/index.html",
 		size:    3384,
-		modtime: 1533134850,
+		modtime: 1491239234,
 		compressed: `
 H4sIAAAAAAAC/9RX/1PbOBb/PX/FG23v7FywnRAoNMS54UiX0r0uvUC709vpD7L0YivYkivJgSzD/34j
 2wkJlJv9cZsZQHrfP++LXhhntsgnHYBxgZYCy6g2aGNycXUZHB8fvgkG5JEraYExWQq8LZW2BJiSFqWN

--- a/pkg/healthcheck/handler_test.go
+++ b/pkg/healthcheck/handler_test.go
@@ -15,11 +15,9 @@
 package healthcheck_test
 
 import (
-	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	. "github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
@@ -38,32 +36,15 @@ func TestStatusString(t *testing.T) {
 }
 
 func TestStatusSetGet(t *testing.T) {
-	hc := New(Unavailable)
+	hc := New()
 	assert.Equal(t, Unavailable, hc.Get())
 
 	logger, logBuf := testutils.NewLogger()
-	hc = New(Unavailable, Logger(logger))
+	hc = New()
+	hc.SetLogger(logger)
 	assert.Equal(t, Unavailable, hc.Get())
 
 	hc.Ready()
 	assert.Equal(t, Ready, hc.Get())
 	assert.Equal(t, map[string]string{"level": "info", "msg": "Health Check state change", "status": "ready"}, logBuf.JSONLine(0))
-}
-
-func TestPortBusy(t *testing.T) {
-	l, err := net.Listen("tcp", ":0")
-	require.NoError(t, err)
-	defer l.Close()
-	port := l.Addr().(*net.TCPAddr).Port
-
-	logger, logBuf := testutils.NewLogger()
-	_, err = New(Unavailable, Logger(logger)).Serve(port)
-	assert.Error(t, err)
-	assert.Equal(t, "Health Check server failed to listen", logBuf.JSONLine(0)["msg"])
-}
-
-func TestServeHandler(t *testing.T) {
-	hc, err := New(Ready).Serve(0)
-	require.NoError(t, err)
-	defer hc.Close()
 }

--- a/plugin/storage/cassandra/options.go
+++ b/plugin/storage/cassandra/options.go
@@ -201,7 +201,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Bool(
 		nsConfig.namespace+suffixEnableDependenciesV2,
 		nsConfig.EnableDependenciesV2,
-		"DEPRECATED: Jaeger will automatically detect the version of the dependencies table")
+		"(deprecated) Jaeger will automatically detect the version of the dependencies table")
 }
 
 // InitFromViper initializes Options with properties from viper

--- a/plugin/storage/es/mappings/gen_assets.go
+++ b/plugin/storage/es/mappings/gen_assets.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    ".nocover",
 		local:   "plugin/storage/es/mappings/.nocover",
 		size:    43,
-		modtime: 1549990175,
+		modtime: 1551113375,
 		compressed: `
 H4sIAAAAAAAC/youSSzJzFYoSEzOTkxPVcjILy4pVkgsLcnXTU/NSy1KLElNUUjLzEkt1uMCBAAA//8y
 IKK1KwAAAA==
@@ -224,7 +224,7 @@ IKK1KwAAAA==
 		name:    "jaeger-service.json",
 		local:   "plugin/storage/es/mappings/jaeger-service.json",
 		size:    1060,
-		modtime: 1549990175,
+		modtime: 1551113375,
 		compressed: `
 H4sIAAAAAAAC/8yTT2/UMBDF7/kU1ojTamshpHLwrUARSFDQVpwQGs3Gs1mD7RjbKayqfHfk4pKkW+2J
 Q3PIn/F78/xz7NtGCMjsgqXMoASsvhN3HM8SxxvT8tkK1kWSOGfjuwSqOIQA4zX/ln5wW47Y7zDtKeoE
@@ -240,7 +240,7 @@ TmGdQJrhQAmkbHr//7o382e5j83Y/AkAAP//qd2MzCQEAAA=
 		name:    "jaeger-span.json",
 		local:   "plugin/storage/es/mappings/jaeger-span.json",
 		size:    3776,
-		modtime: 1549990175,
+		modtime: 1551113375,
 		compressed: `
 H4sIAAAAAAAC/+xWUW/TMBB+z6+ITjxNW4SQxkPeBhtiEhtoG08IWdfkknpzbGNfB9XU/47SZLRZnHRI
 DUKCPayN7e+7+3x3X/MQxTEwVVYhE6QxHNwileSOvEV9dACH9b4nZqlLD2l9PI5B6px+JHpRzcgJUwg/

--- a/plugin/storage/es/mappings/gen_assets.go
+++ b/plugin/storage/es/mappings/gen_assets.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    ".nocover",
 		local:   "plugin/storage/es/mappings/.nocover",
 		size:    43,
-		modtime: 1551113375,
+		modtime: 1549990175,
 		compressed: `
 H4sIAAAAAAAC/youSSzJzFYoSEzOTkxPVcjILy4pVkgsLcnXTU/NSy1KLElNUUjLzEkt1uMCBAAA//8y
 IKK1KwAAAA==
@@ -224,7 +224,7 @@ IKK1KwAAAA==
 		name:    "jaeger-service.json",
 		local:   "plugin/storage/es/mappings/jaeger-service.json",
 		size:    1060,
-		modtime: 1551113375,
+		modtime: 1549990175,
 		compressed: `
 H4sIAAAAAAAC/8yTT2/UMBDF7/kU1ojTamshpHLwrUARSFDQVpwQGs3Gs1mD7RjbKayqfHfk4pKkW+2J
 Q3PIn/F78/xz7NtGCMjsgqXMoASsvhN3HM8SxxvT8tkK1kWSOGfjuwSqOIQA4zX/ln5wW47Y7zDtKeoE
@@ -240,7 +240,7 @@ TmGdQJrhQAmkbHr//7o382e5j83Y/AkAAP//qd2MzCQEAAA=
 		name:    "jaeger-span.json",
 		local:   "plugin/storage/es/mappings/jaeger-span.json",
 		size:    3776,
-		modtime: 1551113375,
+		modtime: 1549990175,
 		compressed: `
 H4sIAAAAAAAC/+xWUW/TMBB+z6+ITjxNW4SQxkPeBhtiEhtoG08IWdfkknpzbGNfB9XU/47SZLRZnHRI
 DUKCPayN7e+7+3x3X/MQxTEwVVYhE6QxHNwileSOvEV9dACH9b4nZqlLD2l9PI5B6px+JHpRzcgJUwg/

--- a/plugin/storage/memory/factory.go
+++ b/plugin/storage/memory/factory.go
@@ -52,7 +52,7 @@ func (f *Factory) InitFromViper(v *viper.Viper) {
 func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
 	f.metricsFactory, f.logger = metricsFactory, logger
 	f.store = WithConfiguration(f.options.Configuration)
-	logger.Info("Memory storage configuration", zap.Any("configuration", f.store.config))
+	logger.Info("Memory storage initialized", zap.Any("configuration", f.store.config))
 	return nil
 }
 

--- a/ports/empty_test.go
+++ b/ports/empty_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ports

--- a/ports/ports.go
+++ b/ports/ports.go
@@ -1,0 +1,31 @@
+package ports
+
+const (
+	// AgentJaegerThriftCompactUDP is the default port for receiving Jaeger Thrift over UDP in compact encoding
+	AgentJaegerThriftCompactUDP = 6831
+	// AgentJaegerThriftBinaryUDP is the default port for receiving Jaeger Thrift over UDP in binary encoding
+	AgentJaegerThriftBinaryUDP = 6832
+	// AgentZipkinThriftCompactUDP is the default port for receiving Zipkin Thrift over UDP in binary encoding
+	AgentZipkinThriftCompactUDP = 5775
+	// AgentConfigServerHTTP is the default port for the agent's HTTP config server (e.g. /sampling endpoint)
+	AgentConfigServerHTTP = 5778
+	// AgentAdminHTTP is the default admin HTTP port (health check, metrics, etc.)
+	AgentAdminHTTP = 14271
+
+	// CollectorGRPC is the default port for gRPC server for sending spans
+	CollectorGRPC = 14250
+	// CollectorTChannel is the default port for TChannel server for sending spans
+	CollectorTChannel = 14267
+	// CollectorHTTP is the default port for HTTP server for sending spans (e.g. /api/traces endpoint)
+	CollectorHTTP = 14268
+	// CollectorAdminHTTP is the default admin HTTP port (health check, metrics, etc.)
+	CollectorAdminHTTP = 14269
+
+	// QueryHTTP is the default port for UI and Query API (e.g. /api/* endpoints)
+	QueryHTTP = 16686
+	// QueryAdminHTTP is the default admin HTTP port (health check, metrics, etc.)
+	QueryAdminHTTP = 16687
+
+	// IngesterAdminHTTP is the default admin HTTP port (health check, metrics, etc.)
+	IngesterAdminHTTP = 14270
+)

--- a/ports/ports.go
+++ b/ports/ports.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ports
 
 const (


### PR DESCRIPTION
## Which problem is this PR solving?

Health checks, metrics, and other housekeeping data should not be exposed on the ports that also serve public APIs

* Partially supersedes #1375.
* Resolves #1428
* Resolves #1332

## Short description of the changes

* combines health check and metrics handlers on a single admin port. There are **breaking changes**:
  * agent metrics move from /sampling config port to the new admin port 14271
  * query metrics move from /api port to the former health check port 16687
  * collector metrics move from HTTP API port to the former health check port 14269
  * ingestor metrics move from standalone port 14271 to the health check port 14270
* groups all numeric port numbers in a single file `ports/ports.go` for easier reference
* consolidates common boilerplate code in all binaries into a Service type
* flag `health-check-http-port` is deprecated and replaced by `admin-http-port`
* ingester's `DefaultHTTPPort = 14271` is deprecated and repurposed as the agent's admin port

