### PR TITLE
Set default zap sampling config to nil

### DIFF
--- a/cmd/flags/service.go
+++ b/cmd/flags/service.go
@@ -83,7 +83,9 @@ func (s *Service) Start(v *viper.Viper) error {
 	}
 
 	sFlags := new(SharedFlags).InitFromViper(v)
-	if logger, err := sFlags.NewLogger(zap.NewProductionConfig()); err == nil {
+	newProdConfig := zap.NewProductionConfig()
+	newProdConfig.Sampling = nil
+	if logger, err := sFlags.NewLogger(newProdConfig); err == nil {
 		s.Logger = logger
 	} else {
 		return errors.Wrap(err, "Cannot create logger")


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #160. Sets the default config behavior to no sampling for zap

## Short description of the changes
- Changes the default sampling config for the zap logger to nil
