### PR TITLE
Return info msg for `/health` endpoint

### DIFF
--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -105,7 +105,7 @@ func (h *clientHandler) isInitialized() bool {
 func httpHealthCheck(logger *zap.Logger, service, healthURL string) {
 	for i := 0; i < 240; i++ {
 		res, err := http.Get(healthURL)
-		if err == nil && res.StatusCode == 204 {
+		if err == nil && res.StatusCode == 200 {
 			logger.Info("Health check successful", zap.String("service", service))
 			return
 		}

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -102,10 +102,14 @@ func (h *clientHandler) isInitialized() bool {
 	return atomic.LoadUint64(&h.initialized) != 0
 }
 
+func is2xxStatusCode(statusCode int) bool {
+	return statusCode >= 200 && statusCode <= 299
+}
+
 func httpHealthCheck(logger *zap.Logger, service, healthURL string) {
 	for i := 0; i < 240; i++ {
 		res, err := http.Get(healthURL)
-		if err == nil && res.StatusCode == 200 {
+		if err == nil && is2xxStatusCode(res.StatusCode) {
 			logger.Info("Health check successful", zap.String("service", service))
 			return
 		}

--- a/pkg/healthcheck/handler.go
+++ b/pkg/healthcheck/handler.go
@@ -72,10 +72,7 @@ type HealthCheck struct {
 // New creates a HealthCheck with the specified initial state.
 func New() *HealthCheck {
 	hc := &HealthCheck{
-		state: int32(Unavailable),
-		upTimeStats: upTimeStats{
-			StartedAt: time.Now(),
-		},
+		state:  int32(Unavailable),
 		logger: zap.NewNop(),
 		mapping: map[Status]healthCheckResponse{
 			Unavailable: {
@@ -84,7 +81,7 @@ func New() *HealthCheck {
 			},
 			Ready: {
 				statusCode: http.StatusOK,
-				StatusMsg:  "up",
+				StatusMsg:  "Server available",
 			},
 		},
 		server: nil,
@@ -110,7 +107,6 @@ func (hc *HealthCheck) Handler() http.Handler {
 }
 
 func (hc *HealthCheck) createRespBody(resp healthCheckResponse) []byte {
-
 	timeStats := hc.upTimeStats
 	if resp.statusCode == http.StatusOK {
 		timeStats.UpTime = upTime(timeStats.StartedAt)
@@ -140,5 +136,8 @@ func (hc *HealthCheck) Get() Status {
 
 // Ready is a shortcut for Set(Ready) (kept for backwards compatibility)
 func (hc *HealthCheck) Ready() {
+	hc.upTimeStats = upTimeStats{
+		StartedAt: time.Now(),
+	}
 	hc.Set(Ready)
 }

--- a/pkg/healthcheck/handler.go
+++ b/pkg/healthcheck/handler.go
@@ -16,6 +16,7 @@ package healthcheck
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -48,33 +49,31 @@ func (s Status) String() string {
 	}
 }
 
-type upTimeStats struct {
-	StartedAt time.Time `json:"startedAt"`
-	UpTime    string    `json:"upTime"`
-}
-
 type healthCheckResponse struct {
 	statusCode int
-	StatusMsg  string `json:"status"`
-	upTimeStats
+	StatusMsg  string    `json:"status"`
+	UpSince    time.Time `json:"upSince"`
+	Uptime     string    `json:"uptime"`
+}
+
+type state struct {
+	status  Status
+	upSince time.Time
 }
 
 // HealthCheck provides an HTTP endpoint that returns the health status of the service
 type HealthCheck struct {
-	state       int32 // atomic, keep at the top to be word-aligned
-	status      string
-	upTimeStats upTimeStats
-	logger      *zap.Logger
-	mapping     map[Status]healthCheckResponse
-	server      *http.Server
+	state     atomic.Value // stores state struct
+	logger    *zap.Logger
+	responses map[Status]healthCheckResponse
+	server    *http.Server
 }
 
 // New creates a HealthCheck with the specified initial state.
 func New() *HealthCheck {
 	hc := &HealthCheck{
-		state:  int32(Unavailable),
 		logger: zap.NewNop(),
-		mapping: map[Status]healthCheckResponse{
+		responses: map[Status]healthCheckResponse{
 			Unavailable: {
 				statusCode: http.StatusServiceUnavailable,
 				StatusMsg:  "Server not available",
@@ -86,6 +85,7 @@ func New() *HealthCheck {
 		},
 		server: nil,
 	}
+	hc.state.Store(state{status: Unavailable})
 	return hc
 }
 
@@ -97,47 +97,48 @@ func (hc *HealthCheck) SetLogger(logger *zap.Logger) {
 // Handler creates a new HTTP handler.
 func (hc *HealthCheck) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-
-		resp := hc.mapping[hc.Get()]
-		w.WriteHeader(resp.statusCode)
+		state := hc.getState()
+		template := hc.responses[state.status]
+		w.WriteHeader(template.statusCode)
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(hc.createRespBody(resp))
+		w.Write(hc.createRespBody(state, template))
 	})
 }
 
-func (hc *HealthCheck) createRespBody(resp healthCheckResponse) []byte {
-	timeStats := hc.upTimeStats
-	if resp.statusCode == http.StatusOK {
-		timeStats.UpTime = upTime(timeStats.StartedAt)
+func (hc *HealthCheck) createRespBody(state state, template healthCheckResponse) []byte {
+	resp := template // clone
+	if state.status == Ready {
+		resp.UpSince = state.upSince
+		resp.Uptime = fmt.Sprintf("%v", time.Since(state.upSince))
 	}
-
-	hc.upTimeStats = timeStats
-	resp.upTimeStats = timeStats
-
 	healthCheckStatus, _ := json.Marshal(resp)
 	return healthCheckStatus
 }
 
-func upTime(startTime time.Time) string {
-	return time.Since(startTime).String()
-}
-
 // Set a new health check status
-func (hc *HealthCheck) Set(state Status) {
-	atomic.StoreInt32(&hc.state, int32(state))
-	hc.logger.Info("Health Check state change", zap.Stringer("status", hc.Get()))
+func (hc *HealthCheck) Set(status Status) {
+	oldState := hc.getState()
+	newState := state{status: status}
+	if status == Ready {
+		if oldState.status != Ready {
+			newState.upSince = time.Now()
+		}
+	}
+	hc.state.Store(newState)
+	hc.logger.Info("Health Check state change", zap.Stringer("status", status))
 }
 
 // Get the current status of this health check
 func (hc *HealthCheck) Get() Status {
-	return Status(atomic.LoadInt32(&hc.state))
+	return hc.getState().status
+}
+
+func (hc *HealthCheck) getState() state {
+	return hc.state.Load().(state)
 }
 
 // Ready is a shortcut for Set(Ready) (kept for backwards compatibility)
 func (hc *HealthCheck) Ready() {
-	hc.upTimeStats = upTimeStats{
-		StartedAt: time.Now(),
-	}
 	hc.Set(Ready)
 }

--- a/pkg/healthcheck/internal_test.go
+++ b/pkg/healthcheck/internal_test.go
@@ -41,7 +41,7 @@ func TestHttpCall(t *testing.T) {
 
 	hr := getHealthCheckResponse(t, resp, )
 
-	assert.Equal(t, "up", hr.StatusMsg)
+	assert.Equal(t, "Server available", hr.StatusMsg)
 	assert.Equal(t, hc.upTimeStats.UpTime, hr.upTimeStats.UpTime)
 	assert.True(t, hc.upTimeStats.StartedAt.Equal(hr.upTimeStats.StartedAt))
 


### PR DESCRIPTION
## Short description of the changes
- Return 200 OK for status `ready`
- Return Json containing time `startedAt` and `upTime` statistics

Resolves #1450
