### PR TITLE
Avoid process crash when elasticsearch response is nil

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -128,20 +128,17 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 			sm.Emit(err, time.Since(start.(time.Time)))
 			if err != nil {
 				var failed int
-				var respval interface{}
 				if response == nil {
 					failed = 0
-					respval = "nil"
 				} else {
 					failed = len(response.Failed())
-					respval = response
 				}
 				total := len(requests)
 				logger.Error("Elasticsearch could not process bulk request",
 					zap.Int("request_count", total),
 					zap.Int("failed_count", failed),
 					zap.Error(err),
-					zap.Any("response", respval))
+					zap.Any("response", response))
 			}
 		}).
 		BulkSize(c.BulkSize).


### PR DESCRIPTION
Add nil pointer check in elasticsearch bulkprocessor's
after callback, defined inside pkg/es/config/config.go.
In some rare cases, elasticsearch request will return
error with nil response, and then nil response will
be passed into after callback, and using of nil pointer
will cause process crash.
Signed-off-by: YEXINGZHE54 <429567185@qq.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #1440 

## Short description of the changes
- Add nil pointer check inside es after callback
