### PR TITLE
Expose tls.InsecureSkipVerify to es.tls.* CLI flags

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -298,6 +298,7 @@ func (tlsConfig *TLSConfig) createTLSConfig() (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	// #nosec
 	return &tls.Config{
 		RootCAs:            rootCerts,
 		Certificates:       []tls.Certificate{*clientPrivateKey},

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -62,10 +62,11 @@ type Configuration struct {
 
 // TLSConfig describes the configuration properties to connect tls enabled ElasticSearch cluster
 type TLSConfig struct {
-	Enabled  bool
-	CertPath string
-	KeyPath  string
-	CaPath   string
+	Enabled        bool
+	SkipHostVerify bool
+	CertPath       string
+	KeyPath        string
+	CaPath         string
 }
 
 // ClientBuilder creates new es.Client
@@ -298,8 +299,9 @@ func (tlsConfig *TLSConfig) createTLSConfig() (*tls.Config, error) {
 		return nil, err
 	}
 	return &tls.Config{
-		RootCAs:      rootCerts,
-		Certificates: []tls.Certificate{*clientPrivateKey},
+		RootCAs:            rootCerts,
+		Certificates:       []tls.Certificate{*clientPrivateKey},
+		InsecureSkipVerify: tlsConfig.SkipHostVerify,
 	}, nil
 
 }

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -43,6 +43,7 @@ const (
 	suffixCert              = ".tls.cert"
 	suffixKey               = ".tls.key"
 	suffixCA                = ".tls.ca"
+	suffixSkipHostVerify    = ".tls.skip-host-verify"
 	suffixIndexPrefix       = ".index-prefix"
 	suffixTagsAsFields      = ".tags-as-fields"
 	suffixTagsAsFieldsAll   = suffixTagsAsFields + ".all"
@@ -174,6 +175,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixTLS,
 		nsConfig.TLS.Enabled,
 		"Enable TLS with client certificates.")
+	flagSet.Bool(
+		nsConfig.namespace+suffixSkipHostVerify,
+		nsConfig.TLS.SkipHostVerify,
+		"Skip server's certificate chain and host name verification")
 	flagSet.String(
 		nsConfig.namespace+suffixCert,
 		nsConfig.TLS.CertPath,
@@ -240,6 +245,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.BulkFlushInterval = v.GetDuration(cfg.namespace + suffixBulkFlushInterval)
 	cfg.Timeout = v.GetDuration(cfg.namespace + suffixTimeout)
 	cfg.TLS.Enabled = v.GetBool(cfg.namespace + suffixTLS)
+	cfg.TLS.SkipHostVerify = v.GetBool(cfg.namespace + suffixSkipHostVerify)
 	cfg.TLS.CertPath = v.GetString(cfg.namespace + suffixCert)
 	cfg.TLS.KeyPath = v.GetString(cfg.namespace + suffixKey)
 	cfg.TLS.CaPath = v.GetString(cfg.namespace + suffixCA)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -178,7 +178,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Bool(
 		nsConfig.namespace+suffixSkipHostVerify,
 		nsConfig.TLS.SkipHostVerify,
-		"Skip server's certificate chain and host name verification")
+		"(insecure) Skip server's certificate chain and host name verification")
 	flagSet.String(
 		nsConfig.namespace+suffixCert,
 		nsConfig.TLS.CertPath,

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -56,6 +56,8 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.aux.server-urls=3.3.3.3, 4.4.4.4",
 		"--es.aux.max-span-age=24h",
 		"--es.aux.num-replicas=10",
+		"--es.tls=true",
+		"--es.tls.skip-host-verify=true",
 	})
 	opts.InitFromViper(v)
 
@@ -65,6 +67,8 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, primary.Servers)
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
 	assert.True(t, primary.Sniffer)
+	assert.Equal(t, true, primary.TLS.Enabled)
+	assert.Equal(t, true, primary.TLS.SkipHostVerify)
 
 	aux := opts.Get("es.aux")
 	assert.Equal(t, []string{"3.3.3.3", "4.4.4.4"}, aux.Servers)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1471

## Short description of the changes
- Add `SkipHostVerify` field to `TLSConfig` struct, exposed by `.tls.skip-host-verify`CLI flag
