### PR TITLE
Speed up SpanReader::findTraceIDs() for Elasticsearch

### DIFF
--- a/pkg/es/client.go
+++ b/pkg/es/client.go
@@ -66,6 +66,7 @@ type SearchService interface {
 	Aggregation(name string, aggregation elastic.Aggregation) SearchService
 	IgnoreUnavailable(ignoreUnavailable bool) SearchService
 	Query(query elastic.Query) SearchService
+	Source(source interface{}) SearchService
 	Do(ctx context.Context) (*elastic.SearchResult, error)
 }
 

--- a/pkg/es/mocks/SearchService.go
+++ b/pkg/es/mocks/SearchService.go
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package mocks
 
 import (
@@ -93,6 +92,22 @@ func (_m *SearchService) Query(query elastic.Query) es.SearchService {
 	var r0 es.SearchService
 	if rf, ok := ret.Get(0).(func(elastic.Query) es.SearchService); ok {
 		r0 = rf(query)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(es.SearchService)
+		}
+	}
+
+	return r0
+}
+
+// Sort provides a mock function with given fields: source
+func (_m *SearchService) Source(source interface{}) es.SearchService {
+	ret := _m.Called(source)
+
+	var r0 es.SearchService
+	if rf, ok := ret.Get(0).(func(interface{}) es.SearchService); ok {
+		r0 = rf(source)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(es.SearchService)

--- a/pkg/es/wrapper/wrapper.go
+++ b/pkg/es/wrapper/wrapper.go
@@ -210,6 +210,11 @@ func (s SearchServiceWrapper) Query(query elastic.Query) es.SearchService {
 	return WrapESSearchService(s.searchService.Query(query))
 }
 
+// Source calls this function to internal service.
+func (s SearchServiceWrapper) Source(source interface{}) es.SearchService {
+	return WrapESSearchService(s.searchService.Source(source))
+}
+
 // Do calls this function to internal service.
 func (s SearchServiceWrapper) Do(ctx context.Context) (*elastic.SearchResult, error) {
 	return s.searchService.Do(ctx)

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -133,7 +133,8 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		Logger:            s.logger,
 		MetricsFactory:    metrics.NullFactory,
 		IndexPrefix:       indexPrefix,
-		MaxSpanAge:        maxSpanAge,
+		MaxNumSpans:       1000,
+		MaxSpanAge:        72 * time.Hour,
 		TagDotReplacement: tagKeyDeDotChar,
 		Archive:           archive,
 	})


### PR DESCRIPTION
We have a service that generates two spans per trace, around 4K spans per second. It's very slow to query for the latest traces in this service.

This is the default query that is currently generated:

```json
{
  "aggregations": {
    "traceIDs": {
      "aggregations": {
        "startTime": {
          "max": {
            "field": "startTime"
          }
        }
      },
      "terms": {
        "field": "traceID",
        "order": [
          {
            "startTime": "desc"
          }
        ],
        "size": 20
      }
    }
  },
  "query": {
    "bool": {
      "must": [
        {
          "range": {
            "startTime": {
              "from": 1555437540000000,
              "include_lower": true,
              "include_upper": true,
              "to": 1555437600000000
            }
          }
        },
        {
          "match": {
            "process.serviceName": {
              "query": "nginx-ssl"
            }
          }
        }
      ]
    }
  },
  "size": 0
}
```

This takes pretty much forever if there are many spans to aggregate:

```json
{
  "took": 38372,
  "timed_out": false,
  "_shards": {
    "total": 5,
    "successful": 5,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": 331761,
    "max_score": 0,
    "hits": []
  },
  "other": "stuff"
}
```

Presumably, because ES takes full window, then sorts as many buckets
as there are traces.

Instead, we can pull the last X spans, and find unique traceIDs there:

```json
{
  "query": {
    "bool": {
      "must": [
        {
          "range": {
            "startTime": {
              "from": 1555437540000000,
              "include_lower": true,
              "include_upper": true,
              "to": 1555437600000000
            }
          }
        },
        {
          "match": {
            "process.serviceName": {
              "query": "nginx-ssl"
            }
          }
        }
      ]
    }
  },
  "size": 100,
  "sort": [
    {
      "startTime": "desc"
    }
  ]
}
```

This is a whole lot faster:

```json
{
  "took": 26,
  "timed_out": false,
  "_shards": {
    "total": 5,
    "successful": 5,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": 331761,
    "max_score": null,
    "hits": [
      "100 hits here"
    ]
  },
  "other": "stuff"
}
```

So this is 38372 / 26 = 1475x faster, which is pretty nice. Generally speedup is under 1000x, though.