### PR TITLE
Remove check for tags + duration in query parser

### DIFF
--- a/cmd/query/app/query_parser.go
+++ b/cmd/query/app/query_parser.go
@@ -44,7 +44,6 @@ const (
 )
 
 var (
-	errCannotQueryTagAndDuration = fmt.Errorf("Cannot query for tags when '%s' is specified", minDurationParam)
 	errMaxDurationGreaterThanMin = fmt.Errorf("'%s' should be greater than '%s'", maxDurationParam, minDurationParam)
 
 	// ErrServiceParameterRequired occurs when no service name is defined
@@ -108,11 +107,6 @@ func (p *queryParser) parse(r *http.Request) (*traceQueryParameters, error) {
 	minDuration, err := p.parseDuration(minDurationParam, r)
 	if err != nil {
 		return nil, err
-	}
-
-	if minDuration != 0 && len(tags) > 0 {
-		// This is because querying for this almost certainly returns no results due to intersections
-		return nil, errCannotQueryTagAndDuration
 	}
 
 	maxDuration, err := p.parseDuration(maxDurationParam, r)

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -42,7 +42,6 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&limit=string", errParseInt, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", "Could not parse minDuration: time: missing unit in duration 20", nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", "Could not parse maxDuration: time: missing unit in duration 30", nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&minDuration=1s", `Cannot query for tags when 'minDuration' is specified`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `Malformed 'tag' parameter, expecting key:value, received: k`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=25s&maxDuration=1s", `'maxDuration' should be greater than 'minDuration'`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,


### PR DESCRIPTION
The check only applies to Cassandra backend, which already has the same check enabled.

Resolves #1047.

Signed-off-by: Ivan Babrou <ibobrik@gmail.com>