### PR TITLE
add option to disable schema change events for gocql

### DIFF
--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -133,12 +133,7 @@ func (c *Configuration) NewCluster() *gocql.ClusterConfig {
 		cluster.Consistency = gocql.ParseConsistency(c.Consistency)
 	}
 
-	fallbackHostSelectionPolicy := gocql.RoundRobinHostPolicy()
-	if c.LocalDC != "" {
-		fallbackHostSelectionPolicy = gocql.DCAwareRoundRobinPolicy(c.LocalDC)
-	}
-	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(fallbackHostSelectionPolicy, gocql.ShuffleReplicas())
-
+	cluster.PoolConfig.HostSelectionPolicy = gocql.DCAwareRoundRobinPolicy(c.LocalDC)
 	if c.Authenticator.Basic.Username != "" && c.Authenticator.Basic.Password != "" {
 		cluster.Authenticator = gocql.PasswordAuthenticator{
 			Username: c.Authenticator.Basic.Username,


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- This change add the option to enable/disable schema events so #1373 could be avoided.

## Short description of the changes
- Sometimes gocql will panic which cause components using Cassandra to crash if schema change events (e.g Removing Keyspace in a multi-dc jaeger setup), We can disable this attribute to avoid the catastrophic crash.
