### PR TITLE
Enable staticcheck linter and fix warnings

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   revision = "e2d15f34fcf99d5dbb871c820ec73f710fca9815"
 
 [[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:6d8a3b164679872fa5a4c44559235f7fb109c7b5cd0f456a2159d579b76cc9ba"
   name = "github.com/DataDog/zstd"
   packages = ["."]
@@ -1051,6 +1059,36 @@
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
+[[projects]]
+  digest = "1:e7f29d557575410f09b303a6270a20f17b2dcb69d3bbc4d71d89f5d8e927416d"
+  name = "honnef.co/go/tools"
+  packages = [
+    "arg",
+    "callgraph",
+    "callgraph/static",
+    "cmd/staticcheck",
+    "config",
+    "deprecated",
+    "functions",
+    "internal/sharedcheck",
+    "lint",
+    "lint/lintdsl",
+    "lint/lintutil",
+    "lint/lintutil/format",
+    "simple",
+    "ssa",
+    "ssa/ssautil",
+    "ssautil",
+    "staticcheck",
+    "staticcheck/vrp",
+    "stylecheck",
+    "unused",
+    "version",
+  ]
+  pruneopts = "UT"
+  revision = "95959eaf5e3c41c66151dcfd91779616b84077a8"
+  version = "2019.1.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -1133,6 +1171,7 @@
     "google.golang.org/grpc/test/bufconn",
     "gopkg.in/olivere/elastic.v5",
     "gopkg.in/yaml.v2",
+    "honnef.co/go/tools/cmd/staticcheck",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,7 @@ required = [
 
 [[constraint]]
   name = "honnef.co/go/tools"
-  version = "=2019.1.1"
+  version = "2019.1.1"
 
 [[constraint]]
   name = "github.com/apache/thrift"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,6 @@ required = [
 
 [[constraint]]
   name = "honnef.co/go/tools"
-  # branch = "incr"
   version = "=2019.1.1"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,6 +26,7 @@
 
 required = [
     "github.com/securego/gosec/cmd/gosec",
+    "honnef.co/go/tools/cmd/staticcheck",
     "github.com/golang/protobuf/protoc-gen-go",
     "github.com/gogo/protobuf/protoc-gen-gogo",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
@@ -35,6 +36,11 @@ required = [
 [[constraint]]
   name = "github.com/securego/gosec"
   version = "1.3.0"
+
+[[constraint]]
+  name = "honnef.co/go/tools"
+  # branch = "incr"
+  version = "=2019.1.1"
 
 [[constraint]]
   name = "github.com/apache/thrift"

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ nocover:
 .PHONY: fmt
 fmt:
 	./scripts/import-order-cleanup.sh inplace
-	$(GOFMT) -e -s -l -w $(ALL_SRC)
+	@echo Running go fmt...
+	@$(GOFMT) -e -s -l -w $(ALL_SRC)
 	./scripts/updateLicenses.sh
 
 .PHONY: lint-gosec
@@ -286,7 +287,6 @@ install-tools:
 	go get -u golang.org/x/tools/cmd/cover
 	go get -u golang.org/x/lint/golint
 	go get -u github.com/sectioneight/md-to-godoc
-	go get -u honnef.co/go/tools/cmd/gosimple
 	go get -u github.com/mjibson/esc
 	go install ./vendor/github.com/securego/gosec/cmd/gosec/
 	go install ./vendor/honnef.co/go/tools/cmd/staticcheck/

--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -46,6 +46,7 @@ func TestAgentSamplingEndpoint(t *testing.T) {
 		httpClient := &http.Client{
 			Timeout: 100 * time.Millisecond,
 		}
+	wait_loop:
 		for i := 0; i < 1000; i++ {
 			_, err := httpClient.Get(url)
 			if err == nil {
@@ -56,7 +57,7 @@ func TestAgentSamplingEndpoint(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error from agent: %s", err)
 				}
-				break
+				break wait_loop
 			default:
 				time.Sleep(time.Millisecond)
 			}

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -43,10 +43,10 @@ const (
 	defaultServerWorkers = 10
 
 	jaegerModel Model = "jaeger"
-	zipkinModel       = "zipkin"
+	zipkinModel Model = "zipkin"
 
 	compactProtocol Protocol = "compact"
-	binaryProtocol           = "binary"
+	binaryProtocol  Protocol = "binary"
 )
 
 var defaultHTTPServerHostPort = ":" + strconv.Itoa(ports.AgentConfigServerHTTP)
@@ -58,8 +58,6 @@ type Model string
 type Protocol string
 
 var (
-	errNoReporters = errors.New("agent requires at least one Reporter")
-
 	protocolFactoryMap = map[Protocol]thrift.TProtocolFactory{
 		compactProtocol: thrift.NewTCompactProtocolFactory(),
 		binaryProtocol:  thrift.NewTBinaryProtocolFactoryDefault(),

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -32,6 +32,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 		api_v2.RegisterSamplingManagerServer(s, &mockSamplingHandler{})
 	})
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
 	defer s.GracefulStop()
@@ -43,6 +44,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 
 func TestSamplingManager_GetSamplingStrategy_error(t *testing.T) {
 	conn, err := grpc.Dial("foo", grpc.WithInsecure())
+	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
 	manager := NewConfigManager(conn)

--- a/cmd/agent/app/httpserver/server.go
+++ b/cmd/agent/app/httpserver/server.go
@@ -30,7 +30,7 @@ import (
 const mimeTypeApplicationJSON = "application/json"
 
 var (
-	errBadRequest = errors.New("Bad request")
+	errBadRequest = errors.New("bad request")
 )
 
 // NewHTTPServer creates a new server that hosts an HTTP/JSON endpoint for clients

--- a/cmd/agent/app/processors/thrift_processor.go
+++ b/cmd/agent/app/processors/thrift_processor.go
@@ -59,7 +59,7 @@ func NewThriftProcessor(
 ) (*ThriftProcessor, error) {
 	if numProcessors <= 0 {
 		return nil, fmt.Errorf(
-			"Number of processors must be greater than 0, called with %d", numProcessors)
+			"number of processors must be greater than 0, called with %d", numProcessors)
 	}
 	var protocolPool = &sync.Pool{
 		New: func() interface{} {

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -83,7 +83,7 @@ func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.Mo
 
 func TestNewThriftProcessor_ZeroCount(t *testing.T) {
 	_, err := NewThriftProcessor(nil, 0, nil, nil, nil, zap.NewNop())
-	assert.EqualError(t, err, "Number of processors must be greater than 0, called with 0")
+	assert.EqualError(t, err, "number of processors must be greater than 0, called with 0")
 }
 
 func TestProcessorWithCompactZipkin(t *testing.T) {

--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -40,7 +40,6 @@ type ConnBuilder struct {
 	TLSServerName string
 
 	notifier discovery.Notifier
-	resolver resolver.Builder
 }
 
 // WithDiscoveryNotifier sets service discovery notifier

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -54,8 +54,8 @@ func (r *Reporter) EmitBatch(b *thrift.Batch) error {
 
 // EmitZipkinBatch implements EmitZipkinBatch() of Reporter
 func (r *Reporter) EmitZipkinBatch(zSpans []*zipkincore.Span) error {
-	for _, zSpan := range zSpans {
-		zSpan = r.sanitizer.Sanitize(zSpan)
+	for i := range zSpans {
+		zSpans[i] = r.sanitizer.Sanitize(zSpans[i])
 	}
 	trace, err := zipkin.ToDomain(zSpans)
 	if err != nil {

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -56,6 +56,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 	})
 	defer s.Stop()
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
 
@@ -93,6 +94,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 	})
 	defer s.Stop()
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
 	rep := NewReporter(conn, nil, zap.NewNop())
@@ -133,15 +135,15 @@ func TestReporter_AddProcessTags_EmptyTags(t *testing.T) {
 }
 
 func TestReporter_AddProcessTags_ZipkinBatch(t *testing.T) {
-	tags := map[string]string{ "key" : "value" }
+	tags := map[string]string{"key": "value"}
 	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan", Process: &model.Process{ServiceName: "spring"}}}
 
 	expectedSpans := []*model.Span{
 		{
-			TraceID: model.NewTraceID(0, 1),
-			SpanID: model.NewSpanID(2),
+			TraceID:       model.NewTraceID(0, 1),
+			SpanID:        model.NewSpanID(2),
 			OperationName: "jonatan",
-			Process: &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}},
+			Process:       &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}},
 		},
 	}
 	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags))
@@ -150,7 +152,7 @@ func TestReporter_AddProcessTags_ZipkinBatch(t *testing.T) {
 }
 
 func TestReporter_AddProcessTags_JaegerBatch(t *testing.T) {
-	tags := map[string]string{ "key" : "value" }
+	tags := map[string]string{"key": "value"}
 	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
 	process := &model.Process{ServiceName: "spring"}
 
@@ -162,7 +164,7 @@ func TestReporter_AddProcessTags_JaegerBatch(t *testing.T) {
 
 func TestReporter_MakeModelKeyValue(t *testing.T) {
 	expectedTags := []model.KeyValue{model.String("key", "value")}
-	stringTags := map[string]string{ "key" : "value" }
+	stringTags := map[string]string{"key": "value"}
 	actualTags := makeModelKeyValue(stringTags)
 
 	assert.Equal(t, expectedTags, actualTags)

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -69,7 +69,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 		expected model.Batch
 		err      string
 	}{
-		{in: &zipkincore.Span{}, err: "Cannot find service name in Zipkin span [traceID=0, spanID=0]"},
+		{in: &zipkincore.Span{}, err: "cannot find service name in Zipkin span [traceID=0, spanID=0]"},
 		{in: &zipkincore.Span{Name: "jonatan", TraceID: 1, ID: 2, Timestamp: &a, Annotations: []*zipkincore.Annotation{{Value: zipkincore.CLIENT_SEND, Host: &zipkincore.Endpoint{ServiceName: "spring"}}}},
 			expected: model.Batch{
 				Spans: []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan", Duration: time.Microsecond * 1,

--- a/cmd/agent/app/reporter/metrics_test.go
+++ b/cmd/agent/app/reporter/metrics_test.go
@@ -26,10 +26,6 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
-const (
-	namespace = "reporter"
-)
-
 type noopReporter struct {
 	err error
 }

--- a/cmd/agent/app/testutils/mock_collector.go
+++ b/cmd/agent/app/testutils/mock_collector.go
@@ -125,7 +125,7 @@ func (s *MockTCollector) SubmitZipkinBatch(
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if s.ReturnErr {
-		return []*zipkincore.Response{{Ok: false}}, errors.New("Returning error from MockTCollector")
+		return []*zipkincore.Response{{Ok: false}}, errors.New("returning error from MockTCollector")
 	}
 	s.zipkinSpans = append(s.zipkinSpans, spans...)
 	return []*zipkincore.Response{{Ok: true}}, nil
@@ -139,7 +139,7 @@ func (s *MockTCollector) SubmitBatches(
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if s.ReturnErr {
-		return []*jaeger.BatchSubmitResponse{{Ok: false}}, errors.New("Returning error from MockTCollector")
+		return []*jaeger.BatchSubmitResponse{{Ok: false}}, errors.New("returning error from MockTCollector")
 	}
 	s.jaegerBatches = append(s.jaegerBatches, batches...)
 	return []*jaeger.BatchSubmitResponse{{Ok: true}}, nil

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -66,12 +66,12 @@ func main() {
 			builder := new(app.Builder).InitFromViper(v)
 			agent, err := builder.CreateAgent(cp, logger, mFactory)
 			if err != nil {
-				return errors.Wrap(err, "Unable to initialize Jaeger Agent")
+				return errors.Wrap(err, "unable to initialize Jaeger Agent")
 			}
 
 			logger.Info("Starting agent")
 			if err := agent.Run(); err != nil {
-				return errors.Wrap(err, "Failed to run the agent")
+				return errors.Wrap(err, "failed to run the agent")
 			}
 			svc.RunAndThen(func() {
 				if closer, ok := cp.(io.Closer); ok {

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -303,13 +303,13 @@ func startQuery(
 	queryOpts querysvc.QueryServiceOptions,
 ) {
 	tracer, closer, err := jaegerClientConfig.Configuration{
+		ServiceName: "jaeger-query",
 		Sampler: &jaegerClientConfig.SamplerConfig{
 			Type:  "const",
 			Param: 1.0,
 		},
 		RPCMetrics: true,
-	}.New(
-		"jaeger-query",
+	}.NewTracer(
 		jaegerClientConfig.Metrics(rootFactory),
 		jaegerClientConfig.Logger(jaegerClientZapLog.NewLogger(logger)),
 	)

--- a/cmd/collector/app/builder/span_handler_builder.go
+++ b/cmd/collector/app/builder/span_handler_builder.go
@@ -15,7 +15,6 @@
 package builder
 
 import (
-	"errors"
 	"os"
 
 	"github.com/uber/jaeger-lib/metrics"
@@ -26,12 +25,6 @@ import (
 	zs "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
-)
-
-var (
-	errMissingCassandraConfig     = errors.New("Cassandra not configured")
-	errMissingMemoryStore         = errors.New("MemoryStore is not provided")
-	errMissingElasticSearchConfig = errors.New("ElasticSearch not configured")
 )
 
 // SpanHandlerBuilder holds configuration required for handlers

--- a/cmd/collector/app/grpcserver/grpc_server.go
+++ b/cmd/collector/app/grpcserver/grpc_server.go
@@ -43,7 +43,7 @@ func StartGRPCCollector(
 	grpcPortStr := ":" + strconv.Itoa(port)
 	lis, err := net.Listen("tcp", grpcPortStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to listen on gRPC port")
+		return nil, errors.Wrap(err, "failed to listen on gRPC port")
 	}
 
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))

--- a/cmd/collector/app/grpcserver/grpc_server_test.go
+++ b/cmd/collector/app/grpcserver/grpc_server_test.go
@@ -68,6 +68,7 @@ func TestSpanCollector(t *testing.T) {
 	require.NoError(t, err)
 
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	defer server.Stop()
 	require.NoError(t, err)

--- a/cmd/collector/app/grpcserver/grpc_server_test.go
+++ b/cmd/collector/app/grpcserver/grpc_server_test.go
@@ -42,7 +42,7 @@ func TestFailToListen(t *testing.T) {
 	addr, err := StartGRPCCollector(invalidPort, server, handler, &mockSamplingStore{}, l, func(e error) {
 	})
 	assert.Nil(t, addr)
-	assert.EqualError(t, err, "Failed to listen on gRPC port: listen tcp: address -1: invalid port")
+	assert.EqualError(t, err, "failed to listen on gRPC port: listen tcp: address -1: invalid port")
 }
 
 func TestFailServe(t *testing.T) {

--- a/cmd/collector/app/sanitizer/cache/auto_refresh_cache_test.go
+++ b/cmd/collector/app/sanitizer/cache/auto_refresh_cache_test.go
@@ -29,7 +29,7 @@ import (
 var (
 	testCache1 = map[string]string{"supply": "rt-supply"}
 	testCache2 = map[string]string{"demand": "rt-demand"}
-	errDefault = errors.New("Test error")
+	errDefault = errors.New("test error")
 )
 
 // Generate the serviceAliasMapping mocks using go generate. Run "make build-mocks" to regenerate mocks

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -43,7 +43,7 @@ func TryLoadConfigFile(v *viper.Viper) error {
 		v.SetConfigFile(file)
 		err := v.ReadInConfig()
 		if err != nil {
-			return errors.Wrapf(err, "Error loading config file %s", file)
+			return errors.Wrapf(err, "cannot load config file %s", file)
 		}
 	}
 	return nil

--- a/cmd/flags/service.go
+++ b/cmd/flags/service.go
@@ -55,7 +55,7 @@ type Service struct {
 
 // NewService creates a new Service.
 func NewService(adminPort int) *Service {
-	signalsChannel := make(chan os.Signal)
+	signalsChannel := make(chan os.Signal, 1)
 	hcStatusChannel := make(chan healthcheck.Status)
 	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)
 
@@ -88,7 +88,7 @@ func (s *Service) SetHealthCheckStatus(status healthcheck.Status) {
 // Start bootstraps the service and starts the admin server.
 func (s *Service) Start(v *viper.Viper) error {
 	if err := TryLoadConfigFile(v); err != nil {
-		return errors.Wrap(err, "Cannot load config file")
+		return errors.Wrap(err, "cannot load config file")
 	}
 
 	sFlags := new(SharedFlags).InitFromViper(v)
@@ -97,13 +97,13 @@ func (s *Service) Start(v *viper.Viper) error {
 	if logger, err := sFlags.NewLogger(newProdConfig); err == nil {
 		s.Logger = logger
 	} else {
-		return errors.Wrap(err, "Cannot create logger")
+		return errors.Wrap(err, "cannot create logger")
 	}
 
 	metricsBuilder := new(pMetrics.Builder).InitFromViper(v)
 	metricsFactory, err := metricsBuilder.CreateMetricsFactory("")
 	if err != nil {
-		return errors.Wrap(err, "Cannot create metrics factory")
+		return errors.Wrap(err, "cannot create metrics factory")
 	}
 	s.MetricsFactory = metricsFactory
 
@@ -114,7 +114,7 @@ func (s *Service) Start(v *viper.Viper) error {
 		s.Admin.Handle(route, h)
 	}
 	if err := s.Admin.Serve(); err != nil {
-		return errors.Wrap(err, "Cannot start the admin server")
+		return errors.Wrap(err, "cannot start the admin server")
 	}
 
 	return nil

--- a/cmd/ingester/app/consumer/deadlock_detector.go
+++ b/cmd/ingester/app/consumer/deadlock_detector.go
@@ -89,7 +89,7 @@ func (s *deadlockDetector) startMonitoringForPartition(partition int32) *partiti
 		closePartition: make(chan struct{}, 1),
 		done:           make(chan struct{}),
 		logger:         s.logger,
-		disabled:       0 == s.interval,
+		disabled:       s.interval == 0,
 
 		incrementAllPartitionMsgCount: func() {
 			s.allPartitionsDeadlockDetector.incrementMsgCount()
@@ -142,7 +142,7 @@ func (s *deadlockDetector) start() {
 		msgConsumed: &msgConsumed,
 		done:        make(chan struct{}),
 		logger:      s.logger,
-		disabled:    0 == s.interval,
+		disabled:    s.interval == 0,
 	}
 
 	if detector.disabled {

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -242,13 +242,13 @@ func (aH *APIHandler) tracesByIDs(ctx context.Context, traceIDs []model.TraceID)
 
 func (aH *APIHandler) dependencies(w http.ResponseWriter, r *http.Request) {
 	endTsMillis, err := strconv.ParseInt(r.FormValue(endTsParam), 10, 64)
-	if aH.handleError(w, errors.Wrapf(err, "Unable to parse %s", endTimeParam), http.StatusBadRequest) {
+	if aH.handleError(w, errors.Wrapf(err, "unable to parse %s", endTimeParam), http.StatusBadRequest) {
 		return
 	}
 	var lookback time.Duration
 	if formValue := r.FormValue(lookbackParam); len(formValue) > 0 {
 		lookback, err = time.ParseDuration(formValue + "ms")
-		if aH.handleError(w, errors.Wrapf(err, "Unable to parse %s", lookbackParam), http.StatusBadRequest) {
+		if aH.handleError(w, errors.Wrapf(err, "unable to parse %s", lookbackParam), http.StatusBadRequest) {
 			return
 		}
 	}

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -430,7 +430,7 @@ func TestSearchFailures(t *testing.T) {
 	}{
 		{
 			`/api/traces?start=0&end=0&operation=operation&limit=200&minDuration=20ms`,
-			parsedError(400, "Parameter 'service' is required"),
+			parsedError(400, "parameter 'service' is required"),
 		},
 		{
 			`/api/traces?service=service&start=0&end=0&operation=operation&maxDuration=10ms&limit=200&minDuration=20ms`,

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -47,9 +47,9 @@ import (
 const millisToNanosMultiplier = int64(time.Millisecond / time.Nanosecond)
 
 var (
-	errStorageMsg = "Storage error"
+	errStorageMsg = "storage error"
 	errStorage    = errors.New(errStorageMsg)
-	errAdjustment = errors.New("Adjustment error")
+	errAdjustment = errors.New("adjustment error")
 
 	httpClient = &http.Client{
 		Timeout: 2 * time.Second,

--- a/cmd/query/app/query_parser.go
+++ b/cmd/query/app/query_parser.go
@@ -47,7 +47,7 @@ var (
 	errMaxDurationGreaterThanMin = fmt.Errorf("'%s' should be greater than '%s'", maxDurationParam, minDurationParam)
 
 	// ErrServiceParameterRequired occurs when no service name is defined
-	ErrServiceParameterRequired = fmt.Errorf("Parameter '%s' is required", serviceParam)
+	ErrServiceParameterRequired = fmt.Errorf("parameter '%s' is required", serviceParam)
 )
 
 // queryParser handles the parsing of query parameters for traces
@@ -163,7 +163,7 @@ func (p *queryParser) parseDuration(durationParam string, r *http.Request) (time
 	if len(durationInput) > 0 {
 		duration, err := time.ParseDuration(durationInput)
 		if err != nil {
-			return 0, errors.Wrapf(err, "Could not parse %s", durationParam)
+			return 0, errors.Wrapf(err, "cannot not parse %s", durationParam)
 		}
 		return duration, nil
 	}
@@ -189,13 +189,13 @@ func (p *queryParser) parseTags(simpleTags []string, jsonTags []string) (map[str
 		if l := len(keyAndValue); l > 1 {
 			retMe[keyAndValue[0]] = strings.Join(keyAndValue[1:], ":")
 		} else {
-			return nil, fmt.Errorf("Malformed 'tag' parameter, expecting key:value, received: %s", tag)
+			return nil, fmt.Errorf("malformed 'tag' parameter, expecting key:value, received: %s", tag)
 		}
 	}
 	for _, tags := range jsonTags {
 		var fromJSON map[string]string
 		if err := json.Unmarshal([]byte(tags), &fromJSON); err != nil {
-			return nil, fmt.Errorf("Malformed 'tags' parameter, cannot unmarshal JSON: %s", err)
+			return nil, fmt.Errorf("malformed 'tags' parameter, cannot unmarshal JSON: %s", err)
 		}
 		for k, v := range fromJSON {
 			retMe[k] = v

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -36,13 +36,13 @@ func TestParseTraceQuery(t *testing.T) {
 		errMsg        string
 		expectedQuery *traceQueryParameters
 	}{
-		{"", "Parameter 'service' is required", nil},
+		{"", "parameter 'service' is required", nil},
 		{"x?service=service&start=string", errParseInt, nil},
 		{"x?service=service&end=string", errParseInt, nil},
 		{"x?service=service&limit=string", errParseInt, nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", "Could not parse minDuration: time: missing unit in duration 20", nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", "Could not parse maxDuration: time: missing unit in duration 30", nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `Malformed 'tag' parameter, expecting key:value, received: k`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", "cannot not parse minDuration: time: missing unit in duration 20", nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", "cannot not parse maxDuration: time: missing unit in duration 30", nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `malformed 'tag' parameter, expecting key:value, received: k`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=25s&maxDuration=1s", `'maxDuration' should be greater than 'minDuration'`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
 			&traceQueryParameters{
@@ -57,7 +57,7 @@ func TestParseTraceQuery(t *testing.T) {
 			},
 		},
 		// tags=JSON with a non-string value 123
-		{`x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tags={"x":123}`, "Malformed 'tags' parameter, cannot unmarshal JSON: json: cannot unmarshal number into Go value of type string", nil},
+		{`x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tags={"x":123}`, "malformed 'tags' parameter, cannot unmarshal JSON: json: cannot unmarshal number into Go value of type string", nil},
 		// tags=JSON
 		{`x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tags={"x":"y"}`, noErr,
 			&traceQueryParameters{

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -33,9 +33,7 @@ import (
 const millisToNanosMultiplier = int64(time.Millisecond / time.Nanosecond)
 
 var (
-	errStorageMsg = "Storage error"
-	errStorage    = errors.New(errStorageMsg)
-	errAdjustment = errors.New("Adjustment error")
+	errAdjustment = errors.New("adjustment error")
 
 	defaultDependencyLookbackDuration = time.Hour * 24
 
@@ -165,11 +163,11 @@ func TestFindTraces(t *testing.T) {
 	ctx := context.Background()
 	duration, _ := time.ParseDuration("20ms")
 	params := &spanstore.TraceQueryParameters{
-		ServiceName: "service",
+		ServiceName:   "service",
 		OperationName: "operation",
-		StartTimeMax: time.Now(),
-		DurationMin: duration,
-		NumTraces: 200,
+		StartTimeMax:  time.Now(),
+		DurationMin:   duration,
+		NumTraces:     200,
 	}
 	traces, err := qs.FindTraces(context.WithValue(ctx, contextKey("foo"), "bar"), params)
 	assert.NoError(t, err)
@@ -244,8 +242,8 @@ func TestGetDependencies(t *testing.T) {
 	qs, _, depsMock := initializeTestService()
 	expectedDependencies := []model.DependencyLink{
 		{
-			Parent: "killer",
-			Child: "queen",
+			Parent:    "killer",
+			Child:     "queen",
 			CallCount: 12,
 		},
 	}

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -72,7 +72,7 @@ func NewStaticAssetsHandler(staticAssetsRoot string, options StaticAssetsHandler
 	}
 	indexBytes, err := loadIndexHTML(assetsFS.Open)
 	if err != nil {
-		return nil, errors.Wrap(err, "Cannot load index.html")
+		return nil, errors.Wrap(err, "cannot load index.html")
 	}
 	configString := "JAEGER_CONFIG = DEFAULT_CONFIG"
 	if config, err := loadUIConfig(options.UIConfigPath); err != nil {
@@ -104,12 +104,12 @@ func NewStaticAssetsHandler(staticAssetsRoot string, options StaticAssetsHandler
 func loadIndexHTML(open func(string) (http.File, error)) ([]byte, error) {
 	indexFile, err := open("/index.html")
 	if err != nil {
-		return nil, errors.Wrap(err, "Cannot open index.html")
+		return nil, errors.Wrap(err, "cannot open index.html")
 	}
 	defer indexFile.Close()
 	indexBytes, err := ioutil.ReadAll(indexFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "Cannot read from index.html")
+		return nil, errors.Wrap(err, "cannot read from index.html")
 	}
 	return indexBytes, nil
 }
@@ -121,7 +121,7 @@ func loadUIConfig(uiConfig string) (map[string]interface{}, error) {
 	ext := filepath.Ext(uiConfig)
 	bytes, err := ioutil.ReadFile(uiConfig) /* nolint #nosec , this comes from an admin, not user */
 	if err != nil {
-		return nil, errors.Wrapf(err, "Cannot read UI config file %v", uiConfig)
+		return nil, errors.Wrapf(err, "cannot read UI config file %v", uiConfig)
 	}
 
 	var c map[string]interface{}
@@ -131,11 +131,11 @@ func loadUIConfig(uiConfig string) (map[string]interface{}, error) {
 	case ".json":
 		unmarshal = json.Unmarshal
 	default:
-		return nil, fmt.Errorf("Unrecognized UI config file format %v", uiConfig)
+		return nil, fmt.Errorf("unrecognized UI config file format %v", uiConfig)
 	}
 
 	if err := unmarshal(bytes, &c); err != nil {
-		return nil, errors.Wrapf(err, "Cannot parse UI config file %v", uiConfig)
+		return nil, errors.Wrapf(err, "cannot parse UI config file %v", uiConfig)
 	}
 	return c, nil
 }

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -135,15 +135,15 @@ func TestLoadUIConfig(t *testing.T) {
 	run("no config", testCase{})
 	run("invalid config", testCase{
 		configFile:    "invalid",
-		expectedError: "Cannot read UI config file invalid: open invalid: no such file or directory",
+		expectedError: "cannot read UI config file invalid: open invalid: no such file or directory",
 	})
 	run("unsupported type", testCase{
 		configFile:    "fixture/ui-config.toml",
-		expectedError: "Unrecognized UI config file format fixture/ui-config.toml",
+		expectedError: "unrecognized UI config file format fixture/ui-config.toml",
 	})
 	run("malformed", testCase{
 		configFile:    "fixture/ui-config-malformed.json",
-		expectedError: "Cannot parse UI config file fixture/ui-config-malformed.json: invalid character '=' after object key",
+		expectedError: "cannot parse UI config file fixture/ui-config-malformed.json: invalid character '=' after object key",
 	})
 	run("json", testCase{
 		configFile: "fixture/ui-config.json",

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -61,13 +61,13 @@ func main() {
 			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "query"})
 
 			tracer, closer, err := jaegerClientConfig.Configuration{
+				ServiceName: "jaeger-query",
 				Sampler: &jaegerClientConfig.SamplerConfig{
 					Type:  "probabilistic",
 					Param: 1.0,
 				},
 				RPCMetrics: true,
-			}.New(
-				"jaeger-query",
+			}.NewTracer(
 				jaegerClientConfig.Metrics(svc.MetricsFactory),
 				jaegerClientConfig.Logger(jaegerClientZapLog.NewLogger(logger)),
 			)

--- a/examples/hotrod/pkg/tracing/mutex.go
+++ b/examples/hotrod/pkg/tracing/mutex.go
@@ -62,8 +62,8 @@ func (sm *Mutex) Lock(ctx context.Context) {
 	sm.waitersLock.Unlock()
 
 	if activeSpan != nil {
-		activeSpan.LogEvent(
-			fmt.Sprintf("Acquired lock with %d transactions waiting behind", behindLen))
+		activeSpan.LogFields(log.String("event",
+			fmt.Sprintf("Acquired lock with %d transactions waiting behind", behindLen)))
 	}
 }
 

--- a/examples/hotrod/services/frontend/best_eta.go
+++ b/examples/hotrod/services/frontend/best_eta.go
@@ -38,7 +38,6 @@ type bestETA struct {
 	route    route.Interface
 	pool     *pool.Pool
 	logger   log.Factory
-	options	 ConfigOptions
 }
 
 // Response contains ETA for a trip.
@@ -100,7 +99,7 @@ func (eta *bestETA) Get(ctx context.Context, customerID string) (*Response, erro
 		}
 	}
 	if resp.Driver == "" {
-		return nil, errors.New("No routes found")
+		return nil, errors.New("no routes found")
 	}
 
 	eta.logger.For(ctx).Info("Dispatch successful", zap.String("driver", resp.Driver), zap.String("eta", resp.ETA.String()))

--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -49,7 +49,7 @@ func Run(c *Config, logger *zap.Logger) error {
 	if c.Duration > 0 {
 		c.Traces = 0
 	} else if c.Traces <= 0 {
-		return fmt.Errorf("Either `traces` or `duration` must be greater than 0")
+		return fmt.Errorf("either `traces` or `duration` must be greater than 0")
 	}
 
 	wg := sync.WaitGroup{}

--- a/model/converter/thrift/jaeger/from_domain_test.go
+++ b/model/converter/thrift/jaeger/from_domain_test.go
@@ -20,25 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jaegertracing/jaeger/model"
-	j "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
-
-const (
-	millisecondsConversion = 1000
-)
-
-func spanRefsEqual(refs []*j.SpanRef, otherRefs []*j.SpanRef) bool {
-	if len(refs) != len(otherRefs) {
-		return false
-	}
-
-	for idx, ref := range refs {
-		if *ref != *otherRefs[idx] {
-			return false
-		}
-	}
-	return true
-}
 
 func TestFromDomainOneSpan(t *testing.T) {
 	spanFile := "fixtures/domain_01.json"

--- a/model/converter/thrift/zipkin/to_domain.go
+++ b/model/converter/thrift/zipkin/to_domain.go
@@ -253,7 +253,7 @@ func (td toDomain) findServiceNameAndIP(zSpan *zipkincore.Span) (string, int32, 
 		}
 	}
 	err := fmt.Errorf(
-		"Cannot find service name in Zipkin span [traceID=%x, spanID=%x]",
+		"cannot find service name in Zipkin span [traceID=%x, spanID=%x]",
 		uint64(zSpan.TraceID), uint64(zSpan.ID))
 	return UnknownServiceName, 0, err
 }
@@ -336,7 +336,7 @@ func (td toDomain) transformBinaryAnnotation(binaryAnnotation *zipkincore.Binary
 	case zipkincore.AnnotationType_STRING:
 		return model.String(binaryAnnotation.Key, string(binaryAnnotation.Value)), nil
 	}
-	return model.KeyValue{}, fmt.Errorf("Unknown zipkin annotation type: %d", binaryAnnotation.AnnotationType)
+	return model.KeyValue{}, fmt.Errorf("unknown zipkin annotation type: %d", binaryAnnotation.AnnotationType)
 }
 
 func bytesToNumber(b []byte, number interface{}) error {

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -77,7 +77,7 @@ func TestToDomain(t *testing.T) {
 func TestToDomainNoServiceNameError(t *testing.T) {
 	zSpans := getZipkinSpans(t, `[{ "trace_id": -1, "id": 31 }]`)
 	trace, err := ToDomain(zSpans)
-	assert.EqualError(t, err, "Cannot find service name in Zipkin span [traceID=ffffffffffffffff, spanID=1f]")
+	assert.EqualError(t, err, "cannot find service name in Zipkin span [traceID=ffffffffffffffff, spanID=1f]")
 	assert.Equal(t, 1, len(trace.Spans))
 	assert.Equal(t, "unknown-service-name", trace.Spans[0].Process.ServiceName)
 }
@@ -157,7 +157,7 @@ func TestInvalidAnnotationTypeError(t *testing.T) {
 	_, err := toDomain{}.transformBinaryAnnotation(&z.BinaryAnnotation{
 		AnnotationType: -1,
 	})
-	assert.EqualError(t, err, "Unknown zipkin annotation type: -1")
+	assert.EqualError(t, err, "unknown zipkin annotation type: -1")
 }
 
 // TestZipkinEncoding is just for reference to explain the base64 strings

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -71,8 +71,7 @@ func TestTraceIDMarshalJSONPB(t *testing.T) {
 
 func TestTraceIDUnmarshalJSONPBErrors(t *testing.T) {
 	testCases := []struct {
-		in     string
-		hi, lo uint64
+		in string
 	}{
 		{in: ""},
 		{in: "x"},

--- a/pkg/cassandra/gocql/testutils/udt.go
+++ b/pkg/cassandra/gocql/testutils/udt.go
@@ -46,9 +46,9 @@ func (testCase UDTTestCase) Run(t *testing.T) {
 			// To test MarshalUDT we need a gocql.NativeType struct whose fields private.
 			// Instead we create a structural copy that we cast to gocql.NativeType using unsafe.Pointer
 			nt := struct {
-				proto  byte
-				typ    gocql.Type
-				custom string
+				proto byte
+				typ   gocql.Type
+				_     string
 			}{
 				proto: 0x03,
 				typ:   field.Type,

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -50,6 +50,7 @@ func TestBoundedQueue(t *testing.T) {
 
 		// block further processing until startLock is released
 		startLock.Lock()
+		//lint:ignore SA2001 empty section is ok
 		startLock.Unlock()
 	})
 

--- a/plugin/sampling/internal/leaderelection/leader_election_test.go
+++ b/plugin/sampling/internal/leaderelection/leader_election_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	errTestLock = errors.New("Lock error")
+	errTestLock = errors.New("lock error")
 )
 
 var _ io.Closer = &electionParticipant{}

--- a/plugin/sampling/strategystore/adaptive/options.go
+++ b/plugin/sampling/strategystore/adaptive/options.go
@@ -45,8 +45,6 @@ const (
 	defaultMinSamplesPerSecond          = 1.0 / float64(time.Minute/time.Second) // once every 1 minute
 	defaultLeaderLeaseRefreshInterval   = 5 * time.Second
 	defaultFollowerLeaseRefreshInterval = 60 * time.Second
-
-	samplingLock = "sampling_lock"
 )
 
 // Options holds configuration for the adaptive sampling strategy store.

--- a/plugin/sampling/strategystore/adaptive/processor_test.go
+++ b/plugin/sampling/strategystore/adaptive/processor_test.go
@@ -71,7 +71,7 @@ var (
 		},
 	}
 
-	errTestStorage = errors.New("Storage error")
+	errTestStorage = errors.New("storage error")
 
 	testCalculator = calculationstrategy.CalculateFunc(func(targetQPS, qps, oldProbability float64) float64 {
 		factor := targetQPS / qps

--- a/plugin/sampling/strategystore/factory.go
+++ b/plugin/sampling/strategystore/factory.go
@@ -63,7 +63,7 @@ func (f *Factory) getFactoryOfType(factoryType string) (strategystore.Factory, e
 	case staticStrategyStoreType:
 		return static.NewFactory(), nil
 	default:
-		return nil, fmt.Errorf("Unknown sampling strategy store type %s. Valid types are %v", factoryType, allSamplingTypes)
+		return nil, fmt.Errorf("unknown sampling strategy store type %s. Valid types are %v", factoryType, allSamplingTypes)
 	}
 }
 
@@ -99,7 +99,7 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 func (f *Factory) CreateStrategyStore() (strategystore.StrategyStore, error) {
 	factory, ok := f.factories[f.StrategyStoreType]
 	if !ok {
-		return nil, fmt.Errorf("No %s strategy store registered", f.StrategyStoreType)
+		return nil, fmt.Errorf("no %s strategy store registered", f.StrategyStoreType)
 	}
 	return factory.CreateStrategyStore()
 }

--- a/plugin/sampling/strategystore/factory.go
+++ b/plugin/sampling/strategystore/factory.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	staticStrategyStoreType   = "static"
-	adaptiveStrategyStoreType = "adaptive"
+	staticStrategyStoreType = "static"
 )
 
 var allSamplingTypes = []string{staticStrategyStoreType} // TODO support adaptive

--- a/plugin/sampling/strategystore/factory_test.go
+++ b/plugin/sampling/strategystore/factory_test.go
@@ -54,11 +54,11 @@ func TestNewFactory(t *testing.T) {
 
 	f.StrategyStoreType = "nonsense"
 	_, err = f.CreateStrategyStore()
-	assert.EqualError(t, err, "No nonsense strategy store registered")
+	assert.EqualError(t, err, "no nonsense strategy store registered")
 
 	_, err = NewFactory(FactoryConfig{StrategyStoreType: "nonsense"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Unknown sampling strategy store type")
+	assert.Contains(t, err.Error(), "unknown sampling strategy store type")
 }
 
 func TestConfigurable(t *testing.T) {

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -113,7 +113,7 @@ func TestMaintenanceRun(t *testing.T) {
 	currSize := vlogSize.Value()
 	vlogSize.Set(currSize + 1<<31)
 
-	runtime = waiter(runtime)
+	waiter(runtime)
 	_, gs = mFactory.Snapshot()
 	assert.True(t, gs[lastValueLogCleanedName] > 0)
 

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -99,32 +99,32 @@ func TestValidation(t *testing.T) {
 
 		params.OperationName = "no-service"
 		_, err := sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "Service Name must be set")
+		assert.EqualError(t, err, "service name must be set")
 		params.ServiceName = "find-service"
 
 		_, err = sr.FindTraces(context.Background(), nil)
-		assert.EqualError(t, err, "Malformed request object")
+		assert.EqualError(t, err, "malformed request object")
 
 		params.StartTimeMin = params.StartTimeMax.Add(1 * time.Hour)
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "Start Time Minimum is above Maximum")
+		assert.EqualError(t, err, "min start time is above max")
 		params.StartTimeMin = tid
 
 		params.DurationMax = time.Duration(1 * time.Millisecond)
 		params.DurationMin = time.Duration(1 * time.Minute)
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "Duration Minimum is above Maximum")
+		assert.EqualError(t, err, "min duration is above max")
 
 		params = &spanstore.TraceQueryParameters{
 			StartTimeMin: tid,
 		}
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "Start and End Time must be set")
+		assert.EqualError(t, err, "start and end time must be set")
 
 		params.StartTimeMax = tid.Add(1 * time.Minute)
 		params.Tags = map[string]string{"A": "B"}
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "Service Name must be set")
+		assert.EqualError(t, err, "service name must be set")
 
 		// Only StartTimeMin and Max (not supported yet)
 		// _, err := sr.FindTraces(context.Background(), params)

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -35,29 +35,25 @@ import (
 
 var (
 	// ErrServiceNameNotSet occurs when attempting to query with an empty service name
-	ErrServiceNameNotSet = errors.New("Service Name must be set")
+	ErrServiceNameNotSet = errors.New("service name must be set")
 
 	// ErrStartTimeMinGreaterThanMax occurs when start time min is above start time max
-	ErrStartTimeMinGreaterThanMax = errors.New("Start Time Minimum is above Maximum")
+	ErrStartTimeMinGreaterThanMax = errors.New("min start time is above max")
 
 	// ErrDurationMinGreaterThanMax occurs when duration min is above duration max
-	ErrDurationMinGreaterThanMax = errors.New("Duration Minimum is above Maximum")
+	ErrDurationMinGreaterThanMax = errors.New("min duration is above max")
 
 	// ErrMalformedRequestObject occurs when a request object is nil
-	ErrMalformedRequestObject = errors.New("Malformed request object")
+	ErrMalformedRequestObject = errors.New("malformed request object")
 
 	// ErrStartAndEndTimeNotSet occurs when start time and end time are not set
-	ErrStartAndEndTimeNotSet = errors.New("Start and End Time must be set")
+	ErrStartAndEndTimeNotSet = errors.New("start and end time must be set")
 
 	// ErrUnableToFindTraceIDAggregation occurs when an aggregation query for TraceIDs fail.
-	ErrUnableToFindTraceIDAggregation = errors.New("Could not find aggregation of traceIDs")
+	ErrUnableToFindTraceIDAggregation = errors.New("could not find aggregation of traceIDs")
 
 	// ErrNotSupported during development, don't support every option - yet
-	ErrNotSupported = errors.New("This query parameter is not supported yet")
-
-	errNoTraces = errors.New("No trace with that ID found")
-
-	defaultMaxDuration = model.DurationAsMicroseconds(time.Hour * 24)
+	ErrNotSupported = errors.New("this query parameter is not supported yet")
 )
 
 const (
@@ -92,7 +88,7 @@ func decodeValue(val []byte, encodeType byte) (*model.Span, error) {
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("Unknown encoding type: %#02x", encodeType)
+		return nil, fmt.Errorf("unknown encoding type: %#02x", encodeType)
 	}
 	return &sp, nil
 }

--- a/plugin/storage/badger/spanstore/rw_internal_test.go
+++ b/plugin/storage/badger/spanstore/rw_internal_test.go
@@ -81,7 +81,7 @@ func TestEncodingTypes(t *testing.T) {
 
 		sw.encodingType = 0x04
 		err := sw.WriteSpan(&testSpan)
-		assert.EqualError(t, err, "Unknown encoding type: 0x04")
+		assert.EqualError(t, err, "unknown encoding type: 0x04")
 	})
 
 	// Unknown encoding reader
@@ -106,7 +106,7 @@ func TestEncodingTypes(t *testing.T) {
 		})
 
 		_, err = rw.GetTrace(context.Background(), model.TraceID{Low: 0, High: 1})
-		assert.EqualError(t, err, "Unknown encoding type: 0x04")
+		assert.EqualError(t, err, "unknown encoding type: 0x04")
 	})
 }
 

--- a/plugin/storage/badger/spanstore/writer.go
+++ b/plugin/storage/badger/spanstore/writer.go
@@ -183,7 +183,7 @@ func createTraceKV(span *model.Span, encodingType byte) ([]byte, []byte, error) 
 	case jsonEncoding:
 		bb, err = json.Marshal(span)
 	default:
-		return nil, nil, fmt.Errorf("Unknown encoding type: %#02x", encodingType)
+		return nil, nil, fmt.Errorf("unknown encoding type: %#02x", encodingType)
 	}
 
 	return buf.Bytes(), bb, err

--- a/plugin/storage/badger/spanstore/writer.go
+++ b/plugin/storage/badger/spanstore/writer.go
@@ -37,15 +37,11 @@ import (
 
 const (
 	spanKeyPrefix         byte = 0x80 // All span keys should have first bit set to 1
-	dependencyKeyPrefix   byte = 0xC0 // Dependency keys have first two bits set to 1 (documented here only)
-	secondaryBytePrefix   byte = 0x10 // Reserved, prefix uses more than one byte
 	indexKeyRange         byte = 0x0F // Secondary indexes use last 4 bits
-	primaryKeyPrefix      byte = 0x00 // Primary keys have last 4 bits set to 0
 	serviceNameIndexKey   byte = 0x81
 	operationNameIndexKey byte = 0x82
 	tagIndexKey           byte = 0x83
 	durationIndexKey      byte = 0x84
-	startTimeIndexKey     byte = 0x85 // Reserved
 	jsonEncoding          byte = 0x01 // Last 4 bits of the meta byte are for encoding type
 	protoEncoding         byte = 0x02 // Last 4 bits of the meta byte are for encoding type
 	defaultEncoding       byte = protoEncoding

--- a/plugin/storage/cassandra/factory_test.go
+++ b/plugin/storage/cassandra/factory_test.go
@@ -85,10 +85,10 @@ func TestCassandraFactory(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = f.CreateArchiveSpanReader()
-	assert.EqualError(t, err, "Archive storage not configured")
+	assert.EqualError(t, err, "archive storage not configured")
 
 	_, err = f.CreateArchiveSpanWriter()
-	assert.EqualError(t, err, "Archive storage not configured")
+	assert.EqualError(t, err, "archive storage not configured")
 
 	f.archiveConfig = &mockSessionBuilder{}
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))

--- a/plugin/storage/cassandra/samplingstore/storage_test.go
+++ b/plugin/storage/cassandra/samplingstore/storage_test.go
@@ -366,13 +366,13 @@ func TestThroughputToString(t *testing.T) {
 		{Service: "svc2", Operation: "op2", Count: 2, Probabilities: map[string]struct{}{}},
 	}
 	str := throughputToString(throughput)
-	assert.True(t, "svc1,\"op,1\",1,1\nsvc2,op2,2,\n" == str || "svc2,op2,2,\nsvc1,1\"op,1\",1,1\n" == str)
+	assert.True(t, str == "svc1,\"op,1\",1,1\nsvc2,op2,2,\n" || str == "svc2,op2,2,\nsvc1,1\"op,1\",1,1\n")
 
 	throughput = []*model.Throughput{
 		{Service: "svc1", Operation: "op,1", Count: 1, Probabilities: map[string]struct{}{"1": {}, "2": {}}},
 	}
 	str = throughputToString(throughput)
-	assert.True(t, "svc1,\"op,1\",1,\"1,2\"\n" == str || "svc1,\"op,1\",1,\"2,1\"\n" == str)
+	assert.True(t, str == "svc1,\"op,1\",1,\"1,2\"\n" || str == "svc1,\"op,1\",1,\"2,1\"\n")
 }
 
 func TestStringToThroughput(t *testing.T) {
@@ -450,6 +450,6 @@ func TestStringToProbabilities(t *testing.T) {
 
 func TestProbabilitiesSetToString(t *testing.T) {
 	s := probabilitiesSetToString(map[string]struct{}{"0.000001": {}, "0.000002": {}})
-	assert.True(t, "0.000001,0.000002" == s || "0.000002,0.000001" == s)
+	assert.True(t, s == "0.000001,0.000002" || s == "0.000002,0.000001")
 	assert.Equal(t, "", probabilitiesSetToString(nil))
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/log_fields_filter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/log_fields_filter_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var filter TagFilter = &LogFieldsFilter{} // Check API compliance
+var _ TagFilter = &LogFieldsFilter{} // Check API compliance
 
 func TestFilterLogTags(t *testing.T) {
 	span := getTestJaegerSpan()

--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -372,6 +372,7 @@ func (s *SpanReader) queryByDuration(ctx context.Context, traceQuery *spanstore.
 }
 
 func (s *SpanReader) queryByServiceNameAndOperation(ctx context.Context, tq *spanstore.TraceQueryParameters) (dbmodel.UniqueTraceIDs, error) {
+	//lint:ignore SA4006 failing to re-assign context is worse than unused variable
 	span, ctx := startSpanForQuery(ctx, "queryByServiceNameAndOperation", queryByServiceAndOperationName)
 	defer span.Finish()
 	query := s.session.Query(
@@ -386,6 +387,7 @@ func (s *SpanReader) queryByServiceNameAndOperation(ctx context.Context, tq *spa
 }
 
 func (s *SpanReader) queryByService(ctx context.Context, tq *spanstore.TraceQueryParameters) (dbmodel.UniqueTraceIDs, error) {
+	//lint:ignore SA4006 failing to re-assign context is worse than unused variable
 	span, ctx := startSpanForQuery(ctx, "queryByService", queryByServiceName)
 	defer span.Finish()
 	query := s.session.Query(

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -105,16 +105,15 @@ type SpanReader struct {
 
 // SpanReaderParams holds constructor params for NewSpanReader
 type SpanReaderParams struct {
-	Client                  es.Client
-	Logger                  *zap.Logger
-	MaxSpanAge              time.Duration
-	MaxNumSpans             int
-	MetricsFactory          metrics.Factory
-	serviceOperationStorage *ServiceOperationStorage
-	IndexPrefix             string
-	TagDotReplacement       string
-	Archive                 bool
-	UseReadWriteAliases     bool
+	Client              es.Client
+	Logger              *zap.Logger
+	MaxSpanAge          time.Duration
+	MaxNumSpans         int
+	MetricsFactory      metrics.Factory
+	IndexPrefix         string
+	TagDotReplacement   string
+	Archive             bool
+	UseReadWriteAliases bool
 }
 
 // NewSpanReader returns a new SpanReader with a metrics.
@@ -227,6 +226,7 @@ func (s *SpanReader) unmarshalJSONSpan(esSpanRaw *elastic.SearchHit) (*dbmodel.S
 
 // GetServices returns all services traced by Jaeger, ordered by frequency
 func (s *SpanReader) GetServices(ctx context.Context) ([]string, error) {
+	//lint:ignore SA4006 failing to re-assign context is worse than unused variable
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GetServices")
 	defer span.Finish()
 	currentTime := time.Now()
@@ -236,6 +236,7 @@ func (s *SpanReader) GetServices(ctx context.Context) ([]string, error) {
 
 // GetOperations returns all operations for a specific service traced by Jaeger
 func (s *SpanReader) GetOperations(ctx context.Context, service string) ([]string, error) {
+	//lint:ignore SA4006 failing to re-assign context is worse than unused variable
 	span, ctx := opentracing.StartSpanFromContext(ctx, "GetOperations")
 	defer span.Finish()
 	currentTime := time.Now()

--- a/plugin/storage/es/spanstore/service_operation.go
+++ b/plugin/storage/es/spanstore/service_operation.go
@@ -27,7 +27,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/cache"
 	"github.com/jaegertracing/jaeger/pkg/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
-	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
 )
 
 const (
@@ -41,7 +40,6 @@ const (
 type ServiceOperationStorage struct {
 	ctx          context.Context
 	client       es.Client
-	metrics      *storageMetrics.WriteMetrics
 	logger       *zap.Logger
 	serviceCache cache.Cache
 }

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -49,8 +49,6 @@ type SpanWriter struct {
 	writerMetrics    spanWriterMetrics // TODO: build functions to wrap around each Do fn
 	indexCache       cache.Cache
 	serviceWriter    serviceWriter
-	numShards        int64
-	numReplicas      int64
 	spanConverter    dbmodel.FromDomain
 	spanServiceIndex spanAndServiceIndexFn
 	spanMapping      string

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -65,27 +65,27 @@ func TestSpanWriterIndices(t *testing.T) {
 		indices []string
 		params  SpanWriterParams
 	}{
-		{params:SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+		{params: SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", Archive: false},
-			indices:[]string{spanIndex+dateFormat, serviceIndex+dateFormat}},
-		{params:SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			indices: []string{spanIndex + dateFormat, serviceIndex + dateFormat}},
+		{params: SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", UseReadWriteAliases: true},
-			indices:[]string{spanIndex+"write", serviceIndex+"write"}},
-		{params:SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			indices: []string{spanIndex + "write", serviceIndex + "write"}},
+		{params: SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: false},
-			indices:[]string{"foo:"+indexPrefixSeparator+spanIndex+dateFormat, "foo:"+indexPrefixSeparator+serviceIndex+dateFormat}},
-		{params:SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + dateFormat, "foo:" + indexPrefixSeparator + serviceIndex + dateFormat}},
+		{params: SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", UseReadWriteAliases: true},
-			indices:[]string{"foo:-"+spanIndex+"write", "foo:-"+serviceIndex+"write"}},
-		{params:SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			indices: []string{"foo:-" + spanIndex + "write", "foo:-" + serviceIndex + "write"}},
+		{params: SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", Archive: true},
-			indices:[]string{spanIndex+archiveIndexSuffix, ""}},
-		{params:SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			indices: []string{spanIndex + archiveIndexSuffix, ""}},
+		{params: SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: true},
-			indices:[]string{"foo:"+indexPrefixSeparator+spanIndex+archiveIndexSuffix, ""}},
-		{params:SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveIndexSuffix, ""}},
+		{params: SpanWriterParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: true, UseReadWriteAliases: true},
-			indices:[]string{"foo:"+indexPrefixSeparator+spanIndex+archiveWriteIndexSuffix, ""}},
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveWriteIndexSuffix, ""}},
 	}
 	for _, testCase := range testCases {
 		w := NewSpanWriter(testCase.params)
@@ -111,8 +111,6 @@ func TestSpanWriter_WriteSpan(t *testing.T) {
 		spanIndexExists         bool
 		serviceIndexCreateError error
 		spanIndexCreateError    error
-		servicePutError         error
-		spanPutError            error
 		expectedError           string
 		expectedLogs            []string
 	}{

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -91,7 +91,7 @@ func (f *Factory) getFactoryOfType(factoryType string) (storage.Factory, error) 
 	case badgerStorageType:
 		return badger.NewFactory(), nil
 	default:
-		return nil, fmt.Errorf("Unknown storage type %s. Valid types are %v", factoryType, allStorageTypes)
+		return nil, fmt.Errorf("unknown storage type %s. Valid types are %v", factoryType, allStorageTypes)
 	}
 }
 
@@ -110,7 +110,7 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
 	factory, ok := f.factories[f.SpanReaderType]
 	if !ok {
-		return nil, fmt.Errorf("No %s backend registered for span store", f.SpanReaderType)
+		return nil, fmt.Errorf("no %s backend registered for span store", f.SpanReaderType)
 	}
 	return factory.CreateSpanReader()
 }
@@ -121,7 +121,7 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 	for _, storageType := range f.SpanWriterTypes {
 		factory, ok := f.factories[storageType]
 		if !ok {
-			return nil, fmt.Errorf("No %s backend registered for span store", storageType)
+			return nil, fmt.Errorf("no %s backend registered for span store", storageType)
 		}
 		writer, err := factory.CreateSpanWriter()
 		if err != nil {
@@ -150,7 +150,7 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
 	factory, ok := f.factories[f.DependenciesStorageType]
 	if !ok {
-		return nil, fmt.Errorf("No %s backend registered for span store", f.DependenciesStorageType)
+		return nil, fmt.Errorf("no %s backend registered for span store", f.DependenciesStorageType)
 	}
 	return factory.CreateDependencyReader()
 }
@@ -202,7 +202,7 @@ func (f *Factory) initDownsamplingFromViper(v *viper.Viper) {
 func (f *Factory) CreateArchiveSpanReader() (spanstore.Reader, error) {
 	factory, ok := f.factories[f.SpanReaderType]
 	if !ok {
-		return nil, fmt.Errorf("No %s backend registered for span store", f.SpanReaderType)
+		return nil, fmt.Errorf("no %s backend registered for span store", f.SpanReaderType)
 	}
 	archive, ok := factory.(storage.ArchiveFactory)
 	if !ok {
@@ -215,7 +215,7 @@ func (f *Factory) CreateArchiveSpanReader() (spanstore.Reader, error) {
 func (f *Factory) CreateArchiveSpanWriter() (spanstore.Writer, error) {
 	factory, ok := f.factories[f.SpanWriterTypes[0]]
 	if !ok {
-		return nil, fmt.Errorf("No %s backend registered for span store", f.SpanWriterTypes[0])
+		return nil, fmt.Errorf("no %s backend registered for span store", f.SpanWriterTypes[0])
 	}
 	archive, ok := factory.(storage.ArchiveFactory)
 	if !ok {

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -74,7 +74,7 @@ func TestNewFactory(t *testing.T) {
 
 	_, err = NewFactory(FactoryConfig{SpanWriterTypes: []string{"x"}, DependenciesStorageType: "y", SpanReaderType: "z"})
 	require.Error(t, err)
-	expected := "Unknown storage type" // could be 'x' or 'y' since code iterates through map.
+	expected := "unknown storage type" // could be 'x' or 'y' since code iterates through map.
 	assert.Equal(t, expected, err.Error()[0:len(expected)])
 }
 
@@ -128,10 +128,10 @@ func TestCreate(t *testing.T) {
 	assert.EqualError(t, err, "dep-reader-error")
 
 	_, err = f.CreateArchiveSpanReader()
-	assert.EqualError(t, err, "Archive storage not supported")
+	assert.EqualError(t, err, "archive storage not supported")
 
 	_, err = f.CreateArchiveSpanWriter()
-	assert.EqualError(t, err, "Archive storage not supported")
+	assert.EqualError(t, err, "archive storage not supported")
 
 	mock.On("CreateSpanWriter").Return(spanWriter, nil)
 	m := metrics.NullFactory
@@ -242,7 +242,7 @@ func TestCreateError(t *testing.T) {
 	assert.NotEmpty(t, f.factories[cassandraStorageType])
 	delete(f.factories, cassandraStorageType)
 
-	expectedErr := "No cassandra backend registered for span store"
+	expectedErr := "no cassandra backend registered for span store"
 	// scope the vars to avoid bugs in the test
 	{
 		r, err := f.CreateSpanReader()

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -72,7 +72,7 @@ func TestNewFactory(t *testing.T) {
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
 	assert.Equal(t, memoryStorageType, f.DependenciesStorageType)
 
-	f, err = NewFactory(FactoryConfig{SpanWriterTypes: []string{"x"}, DependenciesStorageType: "y", SpanReaderType: "z"})
+	_, err = NewFactory(FactoryConfig{SpanWriterTypes: []string{"x"}, DependenciesStorageType: "y", SpanReaderType: "z"})
 	require.Error(t, err)
 	expected := "Unknown storage type" // could be 'x' or 'y' since code iterates through map.
 	assert.Equal(t, expected, err.Error()[0:len(expected)])

--- a/plugin/storage/integration/integration_test.go
+++ b/plugin/storage/integration/integration_test.go
@@ -236,15 +236,6 @@ func (s *StorageIntegration) findTracesByQuery(t *testing.T, query *spanstore.Tr
 	return traces
 }
 
-func (s *StorageIntegration) writeTraces(t *testing.T, traces []*model.Trace) error {
-	for _, trace := range traces {
-		if err := s.writeTrace(t, trace); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (s *StorageIntegration) writeTrace(t *testing.T, trace *model.Trace) error {
 	for _, span := range trace.Spans {
 		if err := s.SpanWriter.WriteSpan(span); err != nil {

--- a/plugin/storage/kafka/writer.go
+++ b/plugin/storage/kafka/writer.go
@@ -33,7 +33,6 @@ type SpanWriter struct {
 	producer   sarama.AsyncProducer
 	marshaller Marshaller
 	topic      string
-	logger     *zap.Logger
 }
 
 // NewSpanWriter initiates and returns a new kafka spanwriter

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
-var errTraceNotFound = errors.New("Trace was not found")
+var errTraceNotFound = errors.New("trace was not found")
 
 // Store is an in-memory store of traces
 type Store struct {

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -47,10 +47,10 @@ type Factory interface {
 
 var (
 	// ErrArchiveStorageNotConfigured can be returned by the ArchiveFactory when the archive storage is not configured.
-	ErrArchiveStorageNotConfigured = errors.New("Archive storage not configured")
+	ErrArchiveStorageNotConfigured = errors.New("archive storage not configured")
 
 	// ErrArchiveStorageNotSupported can be returned by the ArchiveFactory when the archive storage is not supported by the backend.
-	ErrArchiveStorageNotSupported = errors.New("Archive storage not supported")
+	ErrArchiveStorageNotSupported = errors.New("archive storage not supported")
 )
 
 // ArchiveFactory is an additional interface that can be implemented by a factory to support trace archiving.


### PR DESCRIPTION
Replace deprecated gosimple with staticcheck and fix all warnings.

Resolves #1271.