### PR TITLE
temporarily expose grpc conn

### DIFF
--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -50,6 +50,11 @@ func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFacto
 	}, nil
 }
 
+// GetConn returns grpc conn
+func (b ProxyBuilder) GetConn() *grpc.ClientConn {
+	return b.conn
+}
+
 // GetReporter returns Reporter
 func (b ProxyBuilder) GetReporter() aReporter.Reporter {
 	return b.reporter

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -62,6 +62,7 @@ func TestMultipleCollectors(t *testing.T) {
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())
 	assert.NotNil(t, proxy.GetManager())
+	assert.NotNil(t, proxy.GetConn())
 
 	var bothServers = false
 	r := proxy.GetReporter()


### PR DESCRIPTION
Signed-off-by: Jude Wang <judew@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #1539 

## Short description of the changes
- Expose grpc conn for agent so it could register grpc client with it
   we should revert the change after baggage and throttler are fully migrated to oss
