### PR TITLE
Add CA certs to all-in-one image

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -1,4 +1,9 @@
+FROM alpine:latest as certs
+RUN apk add --update --no-cache ca-certificates
+
 FROM scratch
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Agent zipkin.thrift compact
 EXPOSE 5775/udp


### PR DESCRIPTION
…sticsearch backend. (#1545)

Signed-off-by: chandresh-pancholi <chandreshpancholi007@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- all-in-one image misses ca-certs - can not connect to cloud-based elasticsearch backend 

## Short description of the changes
- NA
