### PR TITLE
Update version in hotrod example

### DIFF
--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -29,7 +29,7 @@ docker run \
   --name jaeger \
   -p6831:6831/udp \
   -p16686:16686 \
-  jaegertracing/all-in-one:1.6
+  jaegertracing/all-in-one:latest
 ```
 
 Jaeger UI can be accessed at http://localhost:16686.


### PR DESCRIPTION
## Short description of the changes
The version in the `examples/hotrod/README.md` is quite old (~10 months I believe) and contains bugs that have been fixed. It seems to me that the example docs should use `latest`. If we don't want to use a dynamic version, this could be a more recent static version (`1.12` in particular).
