### PR TITLE
Change Zipkin CORS origins and headers to comma separated list

### DIFF
--- a/cmd/collector/app/builder/builder_flags.go
+++ b/cmd/collector/app/builder/builder_flags.go
@@ -78,8 +78,8 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.String(collectorGRPCCert, "", "Path to TLS certificate for the gRPC collector TLS service")
 	flags.String(collectorGRPCKey, "", "Path to TLS key for the gRPC collector TLS cert")
 	flags.String(collectorGRPCClientCA, "", "Path to a TLS CA to verify certificates presented by clients (if unset, all clients are permitted)")
-	flags.String(collectorZipkinAllowedOrigins, "*", "Allowed origins for the Zipkin collector service, default accepts all")
-	flags.String(collectorZipkinAllowedHeaders, "content-type", "Allowed headers for the Zipkin collector service, default content-type")
+	flags.String(collectorZipkinAllowedOrigins, "*", "Comma separated list of allowed origins for the Zipkin collector service, default accepts all")
+	flags.String(collectorZipkinAllowedHeaders, "content-type", "Comma separated list of allowed headers for the Zipkin collector service, default content-type")
 }
 
 // InitFromViper initializes CollectorOptions with properties from viper

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
@@ -227,10 +228,13 @@ func startZipkinHTTPAPI(
 		r := mux.NewRouter()
 		zHandler.RegisterRoutes(r)
 
+		origins := strings.Split(strings.Replace(allowedOrigins, " ", "", -1), ",")
+		headers := strings.Split(strings.Replace(allowedHeaders, " ", "", -1), ",")
+
 		c := cors.New(cors.Options{
-			AllowedOrigins: []string{allowedOrigins},
+			AllowedOrigins: origins,
 			AllowedMethods: []string{"POST"}, // Allowing only POST, because that's the only handled one
-			AllowedHeaders: []string{allowedHeaders},
+			AllowedHeaders: headers,
 		})
 
 		httpPortStr := ":" + strconv.Itoa(zipkinPort)


### PR DESCRIPTION
Signed-off-by: Jonas Verhofsté <25819942+JonasVerhofste@users.noreply.github.com>

## Which problem is this PR solving?
When I implemented the CORS handling in f9702c4b03903601e752af784b50a66b49c6058f (#1463), I forgot that there can be more than one origin and one header. This adds the functionality of specifying multiple origins and headers as a comma separated list.
