### PR TITLE
Add changelog target to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,8 +291,8 @@ build-crossdock-fresh: build-crossdock-linux
 
 .PHONY: changelog
 changelog: changelog
-	@echo "Set env variable GH_TOKEN before invoking, https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token"
-	docker run --rm  -v "${PWD}:/app" pavolloffay/gch:latest --oauth-token ${GH_TOKEN} --owner jaegertracing --repo jaeger
+	@echo "Set env variable OAUTH_TOKEN before invoking, https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token"
+	docker run --rm  -v "${PWD}:/app" pavolloffay/gch:latest --oauth-token ${OAUTH_TOKEN} --owner jaegertracing --repo jaeger
 
 .PHONY: install-tools
 install-tools:

--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,11 @@ build-and-run-crossdock: build-crossdock
 build-crossdock-fresh: build-crossdock-linux
 	make crossdock-fresh
 
+.PHONY: changelog
+changelog: changelog
+	@echo "Set env variable GH_TOKEN before invoking, https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token"
+	docker run --rm  -v "${PWD}:/app" pavolloffay/gch:latest --oauth-token ${GH_TOKEN} --owner jaegertracing --repo jaeger
+
 .PHONY: install-tools
 install-tools:
 	go get -u github.com/wadey/gocovmerge

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,9 @@
 
 1. Create a PR "Preparing release X.Y.Z" against master or maintenance branch ([example](https://github.com/jaegertracing/jaeger/pull/543/files)) by updating CHANGELOG.md to include:
     * A new section with the header `<X.Y.Z> (YYYY-MM-DD)`
-    * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users.
     * The section can be split into sub-section if necessary, e.g. UI Changes, Backend Changes, Bug Fixes, etc.
+    * Run `make changelog` and manually select notable changes that affect users.
+    * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users. To obtain the list of all changes run `make changelog`
 2. After the PR is merged, create a release on Github:
     * Title "Release X.Y.Z" 
     * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 1. Create a PR "Preparing release X.Y.Z" against master or maintenance branch ([example](https://github.com/jaegertracing/jaeger/pull/543/files)) by updating CHANGELOG.md to include:
     * A new section with the header `<X.Y.Z> (YYYY-MM-DD)`
     * The section can be split into sub-section if necessary, e.g. UI Changes, Backend Changes, Bug Fixes, etc.
-    * Run `make changelog` and manually select notable changes that affect users.
+    * Run `make changelog` and manually select notable changes that affect users. The incorrect pull request titles can be changed on Github and changelog regenerated.
     * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users. To obtain the list of all changes run `make changelog`
 2. After the PR is merged, create a release on Github:
     * Title "Release X.Y.Z" 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,8 @@
 
 1. Create a PR "Preparing release X.Y.Z" against master or maintenance branch ([example](https://github.com/jaegertracing/jaeger/pull/543/files)) by updating CHANGELOG.md to include:
     * A new section with the header `<X.Y.Z> (YYYY-MM-DD)`
-    * The section can be split into sub-section if necessary, e.g. UI Changes, Backend Changes, Bug Fixes, etc.
     * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users. To obtain the list of all changes run `make changelog`.
+    * The section can be split into sub-section if necessary, e.g. UI Changes, Backend Changes, Bug Fixes, etc.
 2. After the PR is merged, create a release on Github:
     * Title "Release X.Y.Z" 
     * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,7 @@
 1. Create a PR "Preparing release X.Y.Z" against master or maintenance branch ([example](https://github.com/jaegertracing/jaeger/pull/543/files)) by updating CHANGELOG.md to include:
     * A new section with the header `<X.Y.Z> (YYYY-MM-DD)`
     * The section can be split into sub-section if necessary, e.g. UI Changes, Backend Changes, Bug Fixes, etc.
-    * Run `make changelog` and manually select notable changes that affect users. The incorrect pull request titles can be changed on Github and changelog regenerated.
-    * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users. To obtain the list of all changes run `make changelog`
+    * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users. To obtain the list of all changes run `make changelog`.
 2. After the PR is merged, create a release on Github:
     * Title "Release X.Y.Z" 
     * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch


### PR DESCRIPTION
I have written https://github.com/pavolloffay/github-changelog, I could not find anything good and customizable. Now it generates only non categorized changes. I will extend it to create categories based on labels on PRs.

```
# Changelog
 
* Use latest all-in-one image in hotrod ([#1555](https://github.com/jaegertracing/jaeger/pull/1555), [@everett980](https://github.com/everett980))
* Add CA certs to all-in-one image ([#1554](https://github.com/jaegertracing/jaeger/pull/1554), [@chandresh-pancholi](https://github.com/chandresh-pancholi))
* temporarily expose grpc conn ([#1547](https://github.com/jaegertracing/jaeger/pull/1547), [@guanw](https://github.com/guanw))
 
## v1.12.0 (2019-05-16)
* Add all storages to env command ([#1541](https://github.com/jaegertracing/jaeger/pull/1541), [@pavolloffay](https://github.com/pavolloffay))
* Prepare release 1.12.0 ([#1538](https://github.com/jaegertracing/jaeger/pull/1538), [@pavolloffay](https://github.com/pavolloffay))
* Bump UI to 1.2.0 ([#1536](https://github.com/jaegertracing/jaeger/pull/1536), [@pavolloffay](https://github.com/pavolloffay))
* Update python script shebang to explicitly reference used python vers… ([#1534](https://github.com/jaegertracing/jaeger/pull/1534), [@objectiser](https://github.com/objectiser))
* Memory store limit queries return most recent traces ([#1394](https://github.com/jaegertracing/jaeger/pull/1394), [@jacobmarble](https://github.com/jacobmarble))
* Add grpc_resolver using external discovery service ([#1498](https://github.com/jaegertracing/jaeger/pull/1498), [@guanw]
```
Full changelog https://pastebin.com/b8ezHg4s