### PR TITLE
Speed up building of all-in-one image by enclosing docker build context

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -26,8 +26,8 @@ EXPOSE 14250
 # Web HTTP
 EXPOSE 16686
 
-COPY ./cmd/all-in-one/all-in-one-linux /go/bin/
-COPY ./cmd/all-in-one/sampling_strategies.json /etc/jaeger/
+COPY all-in-one-linux /go/bin/
+COPY sampling_strategies.json /etc/jaeger/
 
 ENTRYPOINT ["/go/bin/all-in-one-linux"]
 CMD ["--sampling.strategies-file=/etc/jaeger/sampling_strategies.json"]

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -10,7 +10,7 @@ make build-all-in-one-linux
 
 export REPO=jaegertracing/all-in-one
 
-docker build -f cmd/all-in-one/Dockerfile -t $REPO:latest .
+docker build -f cmd/all-in-one/Dockerfile -t $REPO:latest cmd/all-in-one
 export CID=$(docker run -d -p 16686:16686 -p 5778:5778 $REPO:latest)
 make integration-test
 docker kill $CID


### PR DESCRIPTION
Signed-off-by: wxdao <waxiadao@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Before this PR building of all-in-one image uses the whole project directory as docker build context, while the artifacts needed for the image are all stored under cmd/all-in-one/. Since the former could take up as large as 1Gi after `make build`, most of the building time is consumed on `Sending build context to Docker daemon`.

## Short description of the changes

This PR tweaks Dockerfile in cmd/all-in-one and the build script in scripts/travis to limit docker build context to be cmd/all-in-one, where all the needed artifacts are stored after `make build-all-in-one-linux`.