### PR TITLE
Do not fail es-cleaner if there are no jaeger indices

### DIFF
--- a/plugin/storage/es/esCleaner.py
+++ b/plugin/storage/es/esCleaner.py
@@ -59,6 +59,7 @@ def main():
 
 def filter_main_indices(ilo, prefix):
     ilo.filter_by_regex(kind='prefix', value=prefix + "jaeger")
+    empty_list(ilo, "No indices to delete")
     # This excludes archive index as we use source='name'
     # source `creation_date` would include archive index
     ilo.filter_by_age(source='name', direction='older', timestring='%Y-%m-%d', unit='days', unit_count=int(sys.argv[1]))


### PR DESCRIPTION
Resolves #1468 


The original stacktrace
```
Traceback (most recent call last):
  File "plugin/storage/es/esCleaner.py", line 89, in <module>
    main()
  File "plugin/storage/es/esCleaner.py", line 49, in main
    filter_main_indices(ilo, prefix)
  File "plugin/storage/es/esCleaner.py", line 65, in filter_main_indices
    ilo.filter_by_age(source='name', direction='older', timestring='%Y-%m-%d', unit='days', unit_count=int(sys.argv[1]))
  File "/usr/local/lib/python3.6/site-packages/curator/indexlist.py", line 495, in filter_by_age
    stats_result=stats_result
  File "/usr/local/lib/python3.6/site-packages/curator/indexlist.py", line 356, in _calculate_ages
    self._get_name_based_ages(timestring)
  File "/usr/local/lib/python3.6/site-packages/curator/indexlist.py", line 279, in _get_name_based_ages
    self.empty_list_check()
  File "/usr/local/lib/python3.6/site-packages/curator/indexlist.py", line 226, in empty_list_check
    raise exceptions.NoIndices('index_list object is empty.')
curator.exceptions.NoIndices: index_list object is empty.
```

I have tested this with ES 5.x and 6.x. Archive storage works also fine.