### PR TITLE
Add tmp-volume to all-in-one image, fixes #1543

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -29,5 +29,6 @@ EXPOSE 16686
 COPY all-in-one-linux /go/bin/
 COPY sampling_strategies.json /etc/jaeger/
 
+VOLUME ["/tmp"]
 ENTRYPOINT ["/go/bin/all-in-one-linux"]
 CMD ["--sampling.strategies-file=/etc/jaeger/sampling_strategies.json"]


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes issue #1543, badger does not start without mounting tmpfs.

## Short description of the changes

Adds /tmp volume to the container. This allows the badger storage to work with a simple command:

``docker run -e SPAN_STORAGE_TYPE=badger``

Which uses tmpfs in the container in this case. It does not prevent customization to the tmpfs, so user can still issue mount parameters for the tmpfs (such as limiting memory size) by overriding the /tmp mount.