### PR TITLE
dump log if integration test fails

### DIFF
--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -14,9 +14,9 @@ docker build -f cmd/all-in-one/Dockerfile -t $REPO:latest cmd/all-in-one
 export CID=$(docker run -d -p 16686:16686 -p 5778:5778 $REPO:latest)
 make integration-test
 
-if [ -z "$( docker ps | grep jaeger )" ] ; then
-    echo "---- jaeger stopped unexpectedly during test ---------"
-    echo "---- please check the following log for details ----"
+if [ $? -ne 0 ] ; then
+    echo "---- integration test failed unexpectedly ----"
+    echo "--- check the docker log below for details ---"
     docker logs $CID
     exit 1
 fi

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -13,6 +13,14 @@ export REPO=jaegertracing/all-in-one
 docker build -f cmd/all-in-one/Dockerfile -t $REPO:latest cmd/all-in-one
 export CID=$(docker run -d -p 16686:16686 -p 5778:5778 $REPO:latest)
 make integration-test
+
+if [ -z "$( docker ps | grep jaeger )" ] ; then
+    echo "---- jaeger stopped unexpectedly during test ---------"
+    echo "---- please check the following log for details ----"
+    docker logs $CID
+    exit 1
+fi
+
 docker kill $CID
 
 # Only push the docker container to Docker Hub for master branch


### PR DESCRIPTION
Signed-off-by: Jude Wang <judew@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #1583 

## Short description of the changes
- Add additional bash script to dump docker log if docker integration test panic&fail
