### PR TITLE
Passthrough OAuth bearer token supplied to Query service through to ES storage

### DIFF
--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	queryPort        = "query.port"
-	queryBasePath    = "query.base-path"
-	queryStaticFiles = "query.static-files"
-	queryUIConfig    = "query.ui-config"
+	queryPort             = "query.port"
+	queryBasePath         = "query.base-path"
+	queryStaticFiles      = "query.static-files"
+	queryUIConfig         = "query.ui-config"
+	queryTokenPropagation = "query.bearer-token-propagation"
 )
 
 // QueryOptions holds configuration for query service
@@ -39,6 +40,8 @@ type QueryOptions struct {
 	StaticAssets string
 	// UIConfig is the path to a configuration file for the UI
 	UIConfig string
+	// BearerTokenPropagation activate/deactivate bearer token propagation to storage
+	BearerTokenPropagation bool
 }
 
 // AddFlags adds flags for QueryOptions
@@ -47,6 +50,8 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(queryBasePath, "/", "The base path for all HTTP routes, e.g. /jaeger; useful when running behind a reverse proxy")
 	flagSet.String(queryStaticFiles, "", "The directory path override for the static assets for the UI")
 	flagSet.String(queryUIConfig, "", "The path to the UI configuration file in JSON format")
+	flagSet.Bool(queryTokenPropagation, true, "Allow propagation of bearer token to be used by storage plugins")
+
 }
 
 // InitFromViper initializes QueryOptions with properties from viper
@@ -55,5 +60,6 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper) *QueryOptions {
 	qOpts.BasePath = v.GetString(queryBasePath)
 	qOpts.StaticAssets = v.GetString(queryStaticFiles)
 	qOpts.UIConfig = v.GetString(queryUIConfig)
+	qOpts.BearerTokenPropagation = v.GetBool(queryTokenPropagation)
 	return qOpts
 }

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -46,7 +46,8 @@ func TestServer(t *testing.T) {
 	querySvc := &querysvc.QueryService{}
 	tracer := opentracing.NoopTracer{}
 
-	server := NewServer(flagsSvc, querySvc, &QueryOptions{Port: ports.QueryAdminHTTP}, tracer)
+	server := NewServer(flagsSvc, querySvc, &QueryOptions{Port: ports.QueryAdminHTTP,
+		BearerTokenPropagation: true}, tracer)
 	assert.NoError(t, server.Start())
 
 	// TODO wait for servers to come up and test http and grpc endpoints

--- a/cmd/query/app/token_propagation_hander_test.go
+++ b/cmd/query/app/token_propagation_hander_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+
+func Test_bearTokenPropagationHandler(t *testing.T)  {
+	logger := zap.NewNop()
+	bearerToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI"
+
+	validTokenHandler := func(stop *sync.WaitGroup) http.HandlerFunc {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			token, ok := spanstore.GetBearerToken(ctx)
+			assert.Equal(t, token, bearerToken)
+			assert.True(t, ok)
+			stop.Done()
+		})
+	}
+
+	emptyHandler := func(stop *sync.WaitGroup) http.HandlerFunc {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			token, _ := spanstore.GetBearerToken(ctx)
+			assert.Empty(t, token, bearerToken)
+			stop.Done()
+		})
+	}
+
+	testCases := []struct {
+		name		string
+		sendHeader bool
+		header 		string
+		handler 	func(stop *sync.WaitGroup) http.HandlerFunc
+	}{
+		{ name:"Bearer token", sendHeader: true, header: "Bearer " + bearerToken, handler:validTokenHandler},
+		{ name:"Invalid header",sendHeader: true, header: bearerToken, handler:emptyHandler},
+		{ name:"No header", sendHeader: false, handler:emptyHandler},
+		{ name:"Basic Auth", sendHeader: true, header: "Basic " + bearerToken, handler:emptyHandler},
+		{ name:"X-Forwarded-Access-Token", sendHeader: true, header: "Bearer " + bearerToken, handler:validTokenHandler},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stop := sync.WaitGroup{}
+			stop.Add(1)
+			r := bearerTokenPropagationHandler(logger, testCase.handler(&stop))
+			server := httptest.NewServer(r)
+			defer server.Close()
+			req , err := http.NewRequest("GET", server.URL, nil)
+			assert.Nil(t,err)
+			if testCase.sendHeader {
+				req.Header.Add("Authorization", testCase.header)
+			}
+			_, err = httpClient.Do(req)
+			assert.Nil(t, err)
+			stop.Wait()
+		})
+	}
+
+}

--- a/cmd/query/app/token_propagation_handler.go
+++ b/cmd/query/app/token_propagation_handler.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+func bearerTokenPropagationHandler(logger *zap.Logger, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		authHeaderValue := r.Header.Get("Authorization")
+		// If no Authorization header is present, try with X-Forwarded-Access-Token
+		if authHeaderValue == "" {
+			authHeaderValue = r.Header.Get("X-Forwarded-Access-Token")
+		}
+		if authHeaderValue != "" {
+			headerValue := strings.Split(authHeaderValue, " ")
+			token := ""
+			if len(headerValue) == 2 {
+				// Make sure we only capture bearer token , not other types like Basic auth.
+				if headerValue[0] == "Bearer" {
+					token = headerValue[1]
+				}
+			} else {
+				logger.Warn("Invalid authorization header, skipping bearer token propagation")
+			}
+			h.ServeHTTP(w, r.WithContext(spanstore.ContextWithBearerToken(ctx, token)))
+		} else {
+			h.ServeHTTP(w, r.WithContext(ctx))
+		}
+	})
+
+}

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -32,32 +32,34 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/es"
 	"github.com/jaegertracing/jaeger/pkg/es/wrapper"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 	storageMetrics "github.com/jaegertracing/jaeger/storage/spanstore/metrics"
 )
 
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
-	Servers             []string
-	Username            string
-	Password            string
-	TokenFilePath       string
-	Sniffer             bool          // https://github.com/olivere/elastic/wiki/Sniffing
-	MaxNumSpans         int           // defines maximum number of spans to fetch from storage per query
-	MaxSpanAge          time.Duration `yaml:"max_span_age"` // configures the maximum lookback on span reads
-	NumShards           int64         `yaml:"shards"`
-	NumReplicas         int64         `yaml:"replicas"`
-	Timeout             time.Duration `validate:"min=500"`
-	BulkSize            int
-	BulkWorkers         int
-	BulkActions         int
-	BulkFlushInterval   time.Duration
-	IndexPrefix         string
-	TagsFilePath        string
-	AllTagsAsFields     bool
-	TagDotReplacement   string
-	Enabled             bool
-	TLS                 TLSConfig
-	UseReadWriteAliases bool
+	Servers               []string
+	Username              string
+	Password              string
+	TokenFilePath         string
+	AllowTokenFromContext bool
+	Sniffer               bool          // https://github.com/olivere/elastic/wiki/Sniffing
+	MaxNumSpans           int           // defines maximum number of spans to fetch from storage per query
+	MaxSpanAge            time.Duration `yaml:"max_span_age"` // configures the maximum lookback on span reads
+	NumShards             int64         `yaml:"shards"`
+	NumReplicas           int64         `yaml:"replicas"`
+	Timeout               time.Duration `validate:"min=500"`
+	BulkSize              int
+	BulkWorkers           int
+	BulkActions           int
+	BulkFlushInterval     time.Duration
+	IndexPrefix           string
+	TagsFilePath          string
+	AllTagsAsFields       bool
+	TagDotReplacement     string
+	Enabled               bool
+	TLS                   TLSConfig
+	UseReadWriteAliases   bool
 }
 
 // TLSConfig describes the configuration properties to connect tls enabled ElasticSearch cluster
@@ -90,7 +92,7 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 	if len(c.Servers) < 1 {
 		return nil, errors.New("No servers specified")
 	}
-	options, err := c.getConfigOptions()
+	options, err := c.getConfigOptions(logger)
 	if err != nil {
 		return nil, err
 	}
@@ -247,8 +249,13 @@ func (c *Configuration) IsEnabled() bool {
 }
 
 // getConfigOptions wraps the configs to feed to the ElasticSearch client init
-func (c *Configuration) getConfigOptions() ([]elastic.ClientOptionFunc, error) {
-	options := []elastic.ClientOptionFunc{elastic.SetURL(c.Servers...), elastic.SetSniff(c.Sniffer)}
+func (c *Configuration) getConfigOptions(logger *zap.Logger) ([]elastic.ClientOptionFunc, error) {
+
+	options := []elastic.ClientOptionFunc{elastic.SetURL(c.Servers...), elastic.SetSniff(c.Sniffer),
+		// Disable health check when token from context is allowed, this is because at this time
+		// we don' have a valid token to do the check ad if we don't disable the check the service that
+		// uses this won't start.
+		elastic.SetHealthcheck(!c.AllowTokenFromContext)}
 	httpClient := &http.Client{
 		Timeout: c.Timeout,
 	}
@@ -271,14 +278,24 @@ func (c *Configuration) getConfigOptions() ([]elastic.ClientOptionFunc, error) {
 			}
 			httpTransport.TLSClientConfig = &tls.Config{RootCAs: ca}
 		}
+
+		token := ""
 		if c.TokenFilePath != "" {
-			token, err := loadToken(c.TokenFilePath)
+			if c.AllowTokenFromContext {
+				logger.Warn("Token file and token propagation are both enabled, token from file won't be used")
+			}
+			tokenFromFile, err := loadToken(c.TokenFilePath)
 			if err != nil {
 				return nil, err
 			}
+			token = tokenFromFile
+		}
+
+		if token != "" || c.AllowTokenFromContext {
 			httpClient.Transport = &tokenAuthTransport{
-				token:   token,
-				wrapped: httpTransport,
+				token:                token,
+				allowOverrideFromCtx: c.AllowTokenFromContext,
+				wrapped:              httpTransport,
 			}
 		} else {
 			httpClient.Transport = httpTransport
@@ -329,12 +346,20 @@ func (tlsConfig *TLSConfig) loadPrivateKey() (*tls.Certificate, error) {
 
 // TokenAuthTransport
 type tokenAuthTransport struct {
-	token   string
-	wrapped *http.Transport
+	token                string
+	allowOverrideFromCtx bool
+	wrapped              *http.Transport
 }
 
 func (tr *tokenAuthTransport) RoundTrip(r *http.Request) (*http.Response, error) {
-	r.Header.Set("Authorization", "Bearer "+tr.token)
+	token := tr.token
+	if tr.allowOverrideFromCtx {
+		headerToken, _ := spanstore.GetBearerToken(r.Context())
+		if headerToken != "" {
+			token = headerToken
+		}
+	}
+	r.Header.Set("Authorization", "Bearer "+token)
 	return tr.wrapped.RoundTrip(r)
 }
 

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/pkg/es/config"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 const (
@@ -255,6 +256,8 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.TagDotReplacement = v.GetString(cfg.namespace + suffixTagDeDotChar)
 	cfg.UseReadWriteAliases = v.GetBool(cfg.namespace + suffixReadAlias)
 	cfg.Enabled = v.GetBool(cfg.namespace + suffixEnabled)
+	// TODO: Need to figure out a better way for do this.
+	cfg.AllowTokenFromContext = v.GetBool(spanstore.StoragePropagationKey)
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"testing"
 	"time"
 
@@ -749,7 +750,10 @@ func mockSearchService(r *spanReaderTest) *mock.Call {
 	searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(traceIDAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)
 	r.client.On("Search", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(searchService)
-	return searchService.On("Do", mock.AnythingOfType("*context.emptyCtx"))
+	return searchService.On("Do", mock.MatchedBy(func(ctx context.Context) bool{
+		t :=  reflect.TypeOf(ctx).String()
+		return t == "*context.valueCtx" || t == "*context.emptyCtx"
+	}))
 }
 
 func TestTraceQueryParameterValidation(t *testing.T) {

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -77,7 +77,7 @@ func NewSpanWriter(p SpanWriterParams) *SpanWriter {
 	ctx := context.Background()
 
 	// TODO: Configurable TTL
-	serviceOperationStorage := NewServiceOperationStorage(ctx, p.Client, p.Logger, time.Hour*12)
+	serviceOperationStorage := NewServiceOperationStorage(p.Client, p.Logger, time.Hour*12)
 	return &SpanWriter{
 		ctx:    ctx,
 		client: p.Client,

--- a/storage/spanstore/token_propagation.go
+++ b/storage/spanstore/token_propagation.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstore
+
+import "context"
+
+type contextKey string
+
+const bearerToken = contextKey("bearer.token")
+
+// StoragePropagationKey is a key for viper configuration to pass this option to storage plugins.
+const StoragePropagationKey = "storage.propagate.token"
+
+// ContextWithBearerToken set bearer token in context
+func ContextWithBearerToken(ctx context.Context, token string) context.Context {
+	if token == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, bearerToken, token)
+
+}
+
+// GetBearerToken from context, or empty string if there is no token
+func GetBearerToken(ctx context.Context) (string, bool) {
+	val, ok := ctx.Value(bearerToken).(string)
+	return val, ok
+}

--- a/storage/spanstore/token_propagation_test.go
+++ b/storage/spanstore/token_propagation_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetBearerToken(t *testing.T)  {
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI"
+	ctx := context.Background()
+	ctx = ContextWithBearerToken(ctx, token)
+	contextToken, ok := GetBearerToken(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, contextToken, token)
+}


### PR DESCRIPTION


## Which problem is this PR solving?
- To provide fine grained visibility of tracing information stored in Elasticsearch, protected using tools like SearchGuard, it would be useful if the OAuth bearer token for the authenticated user could be passed through the Query service to the ES storage plugin and then propagated to the ES cluster.
To enable users to disable the propagation, this PR includes the possibility of enable/disable this behavior using a flag.


## Short description of the changes

- I injected the token in the context, and used it on ES plugin, also included a flag, but not sure if the flag should be at the query level, I put it the query level because this behavior only makes sense there. (IMHO). Also I did some changes to disable health check on plugin because the token is provided on each request, so I cannot check health of ES cluster when query service starts.


