### PR TITLE
Query service: fix logging errors on SIGINT

### DIFF
--- a/cmd/flags/admin.go
+++ b/cmd/flags/admin.go
@@ -113,7 +113,10 @@ func (s *AdminServer) serveWithListener(l net.Listener) {
 	s.server = &http.Server{Handler: recoveryHandler(s.mux)}
 	s.logger.Info("Starting admin HTTP server", zap.Int("http-port", s.adminPort))
 	go func() {
-		if err := s.server.Serve(l); err != nil {
+		switch err := s.server.Serve(l); err {
+		case nil, http.ErrServerClosed:
+			// normal exit, nothing to do
+		default:
 			s.logger.Error("failed to serve", zap.Error(err))
 			s.hc.Set(healthcheck.Broken)
 		}


### PR DESCRIPTION
Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #1542

## Short description of the changes
- Query service servers return errors on SIGINT (when we call `Close()` on them). This PR handles such errors correctly and stops from logging

Previously merged PR: #1598 - I think, fixed the similar issue, but solving for SIGTERM. So it stopped from logging errors when i tested rebuilt query image inside a [all-in-one](https://github.com/jaegertracing/jaeger-kubernetes/blob/master/all-in-one/jaeger-all-in-one-template.yml) pod
