### PR TITLE
Direct grpc logs to Zap logger

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -371,7 +371,8 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:e3bed20f553811662a2b5e6c0d40f1c837b2f1decace8afb1bb1778acb97fd04"
+  branch = "master"
+  digest = "1:5ab3bec64c76669f1d55ecc42e665350df94e5e1f8570a90715f3b7b024ea523"
   name = "github.com/golang/protobuf"
   packages = [
     "descriptor",
@@ -390,8 +391,7 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
-  version = "v1.3.1"
+  revision = "b285ee9cfc6c881bb20c0d8dc73370ea9b9ec90f"
 
 [[projects]]
   digest = "1:e4f5819333ac698d294fe04dbf640f84719658d5c7ce195b10060cc37292ce79"
@@ -418,10 +418,16 @@
   version = "v1.7.1"
 
 [[projects]]
-  digest = "1:d84c274ffdfd7ce6b4efd64ee776648459009d1f542440b1faa32cb7ed9aba84"
+  digest = "1:f053e09da1c565313cbe0f999af92a690b1e1f5709dfb9aca4dcf70cb89f3cec"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
+    ".",
+    "logging",
+    "logging/zap",
+    "logging/zap/ctxzap",
     "retry",
+    "tags",
+    "tags/zap",
     "util/backoffutils",
     "util/metautils",
   ]
@@ -1200,6 +1206,7 @@
     "github.com/golang/protobuf/protoc-gen-go",
     "github.com/gorilla/handlers",
     "github.com/gorilla/mux",
+    "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap",
     "github.com/grpc-ecosystem/go-grpc-middleware/retry",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",


### PR DESCRIPTION
Resolves #1602, supersedes #1330.

Sample output:
```
{"level":"info","ts":1560530693.131958,"caller":"grpc/clientconn.go:242","msg":"parsed scheme: \"\"","system":"grpc","grpc_log":true}
{"level":"info","ts":1560530693.1319869,"caller":"grpc/clientconn.go:248","msg":"scheme \"\" not registered, fallback to default scheme","system":"grpc","grpc_log":true}
{"level":"info","ts":1560530693.132017,"caller":"grpc/resolver_conn_wrapper.go:113","msg":"ccResolverWrapper: sending update to cc: {[{127.0.0.1:14250 0  <nil>}] }","system":"grpc","grpc_log":true}
{"level":"info","ts":1560530693.132215,"caller":"base/balancer.go:76","msg":"base.baseBalancer: got new resolver state: {[{127.0.0.1:14250 0  <nil>}] }","system":"grpc","grpc_log":true}
{"level":"info","ts":1560530693.1323001,"caller":"base/balancer.go:130","msg":"base.baseBalancer: handle SubConn state change: 0xc000256040, CONNECTING","system":"grpc","grpc_log":true}
{"level":"info","ts":1560530693.132832,"caller":"grpc/clientconn.go:1139","msg":"grpc: addrConn.createTransport failed to connect to {127.0.0.1:14250 0  <nil>}. Err :connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:14250: connect: connection refused\". Reconnecting...","system":"grpc","grpc_log":true}
{"level":"info","ts":1560530693.132919,"caller":"base/balancer.go:130","msg":"base.baseBalancer: handle SubConn state change: 0xc000256040, TRANSIENT_FAILURE","system":"grpc","grpc_log":true}
```