### PR TITLE
Add latency metrics per service

### DIFF
--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -118,6 +118,7 @@ func (sp *spanProcessor) saveSpan(span *model.Span) {
 			zap.Stringer("trace-id", span.TraceID), zap.Stringer("span-id", span.SpanID))
 		sp.metrics.SavedOkBySvc.ReportServiceNameForSpan(span)
 	}
+	sp.metrics.SvcLatency.RecordLatencyByServiceName(span)
 	sp.metrics.SaveLatency.Record(time.Since(startTime))
 }
 


### PR DESCRIPTION
Signed-off-by: Annanay <annanay.a@media.net>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- An open-for-discussion fix for #1570 

## Short description of the changes
-  The PR adds latency histograms metrics per service (exposed from the collector). For ex: New metrics from the HOTRoD application - 
```
# HELP jaeger_collector_svc_latency svc-latency
# TYPE jaeger_collector_svc_latency histogram
jaeger_collector_svc_latency_bucket{svc="customer",le="0.005"} 0
jaeger_collector_svc_latency_bucket{svc="customer",le="0.01"} 0
jaeger_collector_svc_latency_bucket{svc="customer",le="0.025"} 0
jaeger_collector_svc_latency_bucket{svc="customer",le="0.05"} 0
jaeger_collector_svc_latency_bucket{svc="customer",le="0.1"} 0
jaeger_collector_svc_latency_bucket{svc="customer",le="0.25"} 0
jaeger_collector_svc_latency_bucket{svc="customer",le="0.5"} 3
jaeger_collector_svc_latency_bucket{svc="customer",le="1"} 3
jaeger_collector_svc_latency_bucket{svc="customer",le="2.5"} 3
jaeger_collector_svc_latency_bucket{svc="customer",le="5"} 3
jaeger_collector_svc_latency_bucket{svc="customer",le="10"} 3
jaeger_collector_svc_latency_bucket{svc="customer",le="+Inf"} 3
jaeger_collector_svc_latency_sum{svc="customer"} 0.965474
jaeger_collector_svc_latency_count{svc="customer"} 3
jaeger_collector_svc_latency_bucket{svc="redis",le="0.005"} 0
jaeger_collector_svc_latency_bucket{svc="redis",le="0.01"} 2
jaeger_collector_svc_latency_bucket{svc="redis",le="0.025"} 32
jaeger_collector_svc_latency_bucket{svc="redis",le="0.05"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="0.1"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="0.25"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="0.5"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="1"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="2.5"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="5"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="10"} 40
jaeger_collector_svc_latency_bucket{svc="redis",le="+Inf"} 40
jaeger_collector_svc_latency_sum{svc="redis"} 0.7106460000000001
jaeger_collector_svc_latency_count{svc="redis"} 40
jaeger_collector_svc_latency_bucket{svc="route",le="0.005"} 0
jaeger_collector_svc_latency_bucket{svc="route",le="0.01"} 0
jaeger_collector_svc_latency_bucket{svc="route",le="0.025"} 0
jaeger_collector_svc_latency_bucket{svc="route",le="0.05"} 8
jaeger_collector_svc_latency_bucket{svc="route",le="0.1"} 20
jaeger_collector_svc_latency_bucket{svc="route",le="0.25"} 20
jaeger_collector_svc_latency_bucket{svc="route",le="0.5"} 20
jaeger_collector_svc_latency_bucket{svc="route",le="1"} 20
jaeger_collector_svc_latency_bucket{svc="route",le="2.5"} 20
jaeger_collector_svc_latency_bucket{svc="route",le="5"} 20
jaeger_collector_svc_latency_bucket{svc="route",le="10"} 20
jaeger_collector_svc_latency_bucket{svc="route",le="+Inf"} 20
jaeger_collector_svc_latency_sum{svc="route"} 1.034048
jaeger_collector_svc_latency_count{svc="route"} 20
```