### PR TITLE
Remove deprecated index prefix separator : from Elastic

### DIFF
--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -297,7 +297,6 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []model.TraceID, st
 	// i.e starts in one and ends in another.
 	indices := s.timeRangeIndices(s.spanIndexPrefix, startTime.Add(-time.Hour), endTime.Add(time.Hour))
 	nextTime := model.TimeAsEpochMicroseconds(startTime.Add(-time.Hour))
-	fmt.Println(indices)
 
 	searchAfterTime := make(map[model.TraceID]uint64)
 	totalDocumentsFetched := make(map[model.TraceID]int)

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -35,14 +35,13 @@ import (
 )
 
 const (
-	spanIndex                      = "jaeger-span-"
-	serviceIndex                   = "jaeger-service-"
-	archiveIndexSuffix             = "archive"
-	archiveReadIndexSuffix         = archiveIndexSuffix + "-read"
-	archiveWriteIndexSuffix        = archiveIndexSuffix + "-write"
-	traceIDAggregation             = "traceIDs"
-	indexPrefixSeparator           = "-"
-	indexPrefixSeparatorDeprecated = ":"
+	spanIndex               = "jaeger-span-"
+	serviceIndex            = "jaeger-service-"
+	archiveIndexSuffix      = "archive"
+	archiveReadIndexSuffix  = archiveIndexSuffix + "-read"
+	archiveWriteIndexSuffix = archiveIndexSuffix + "-write"
+	traceIDAggregation      = "traceIDs"
+	indexPrefixSeparator    = "-"
 
 	traceIDField           = "traceID"
 	durationField          = "duration"
@@ -97,8 +96,8 @@ type SpanReader struct {
 	maxSpanAge              time.Duration
 	maxNumSpans             int
 	serviceOperationStorage *ServiceOperationStorage
-	spanIndexPrefix         []string
-	serviceIndexPrefix      []string
+	spanIndexPrefix         string
+	serviceIndexPrefix      string
 	spanConverter           dbmodel.ToDomain
 	timeRangeIndices        timeRangeIndexFn
 }
@@ -133,7 +132,7 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 	}
 }
 
-type timeRangeIndexFn func(indexName []string, startTime time.Time, endTime time.Time) []string
+type timeRangeIndexFn func(indexName string, startTime time.Time, endTime time.Time) []string
 
 func getTimeRangeIndexFn(archive, useReadWriteAliases bool) timeRangeIndexFn {
 	if archive {
@@ -143,43 +142,37 @@ func getTimeRangeIndexFn(archive, useReadWriteAliases bool) timeRangeIndexFn {
 		} else {
 			archivePrefix = archiveIndexSuffix
 		}
-		return func(indexName []string, startTime time.Time, endTime time.Time) []string {
-			return []string{archiveIndex(indexName[0], archivePrefix)}
+		return func(indexName string, startTime time.Time, endTime time.Time) []string {
+			return []string{archiveIndex(indexName, archivePrefix)}
 		}
 	}
 	if useReadWriteAliases {
-		return func(indices []string, startTime time.Time, endTime time.Time) []string {
-			var indexAliases []string
-			for _, n := range indices {
-				indexAliases = append(indexAliases, n+"read")
-			}
-			return indexAliases
+		return func(indices string, startTime time.Time, endTime time.Time) []string {
+			return []string{indices + "read"}
 		}
 	}
 	return timeRangeIndices
 }
 
 // timeRangeIndices returns the array of indices that we need to query, based on query params
-func timeRangeIndices(indexNames []string, startTime time.Time, endTime time.Time) []string {
+func timeRangeIndices(indexName string, startTime time.Time, endTime time.Time) []string {
 	var indices []string
-	for _, indexName := range indexNames {
-		firstIndex := indexWithDate(indexName, startTime)
-		currentIndex := indexWithDate(indexName, endTime)
-		for currentIndex != firstIndex {
-			indices = append(indices, currentIndex)
-			endTime = endTime.Add(-24 * time.Hour)
-			currentIndex = indexWithDate(indexName, endTime)
-		}
-		indices = append(indices, firstIndex)
+	firstIndex := indexWithDate(indexName, startTime)
+	currentIndex := indexWithDate(indexName, endTime)
+	for currentIndex != firstIndex {
+		indices = append(indices, currentIndex)
+		endTime = endTime.Add(-24 * time.Hour)
+		currentIndex = indexWithDate(indexName, endTime)
 	}
+	indices = append(indices, firstIndex)
 	return indices
 }
 
-func indexNames(prefix, index string) []string {
+func indexNames(prefix, index string) string {
 	if prefix != "" {
-		return []string{prefix + indexPrefixSeparator + index, prefix + indexPrefixSeparatorDeprecated + index}
+		return prefix + indexPrefixSeparator + index
 	}
-	return []string{index}
+	return index
 }
 
 // GetTrace takes a traceID and returns a Trace associated with that traceID
@@ -304,6 +297,7 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []model.TraceID, st
 	// i.e starts in one and ends in another.
 	indices := s.timeRangeIndices(s.spanIndexPrefix, startTime.Add(-time.Hour), endTime.Add(time.Hour))
 	nextTime := model.TimeAsEpochMicroseconds(startTime.Add(-time.Hour))
+	fmt.Println(indices)
 
 	searchAfterTime := make(map[model.TraceID]uint64)
 	totalDocumentsFetched := make(map[model.TraceID]int)

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -144,35 +144,35 @@ func TestSpanReaderIndices(t *testing.T) {
 	date := time.Now()
 	dateFormat := date.UTC().Format("2006-01-02")
 	testCases := []struct {
-		indices []string
+		index string
 		params  SpanReaderParams
 	}{
 		{params:SpanReaderParams{Client:client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix:"", Archive: false},
-			indices: []string{spanIndex+dateFormat}},
+			index: spanIndex+dateFormat},
 		{params:SpanReaderParams{Client:client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix:"", UseReadWriteAliases: true},
-			indices: []string{spanIndex+"read"}},
+			index: spanIndex+"read"},
 		{params:SpanReaderParams{Client:client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix:"foo:", Archive: false},
-			indices: []string{"foo:"+indexPrefixSeparator+spanIndex+dateFormat,"foo:"+indexPrefixSeparatorDeprecated+spanIndex+dateFormat}},
+			index: "foo:"+indexPrefixSeparator+spanIndex+dateFormat},
 		{params:SpanReaderParams{Client:client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix:"foo:", UseReadWriteAliases: true},
-			indices: []string{"foo:-"+spanIndex+"read", "foo::"+spanIndex+"read"}},
+			index: "foo:-"+spanIndex+"read"},
 		{params:SpanReaderParams{Client:client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix:"", Archive: true},
-			indices: []string{spanIndex+archiveIndexSuffix}},
+			index: spanIndex+archiveIndexSuffix},
 		{params:SpanReaderParams{Client:client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix:"foo:", Archive: true},
-			indices: []string{"foo:"+indexPrefixSeparator+spanIndex+archiveIndexSuffix}},
+			index: "foo:"+indexPrefixSeparator+spanIndex+archiveIndexSuffix},
 		{params:SpanReaderParams{Client:client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix:"foo:", Archive: true, UseReadWriteAliases:true},
-			indices: []string{"foo:"+indexPrefixSeparator+spanIndex+archiveReadIndexSuffix}},
+			index: "foo:"+indexPrefixSeparator+spanIndex+archiveReadIndexSuffix},
 	}
 	for _, testCase := range testCases {
 		r := NewSpanReader(testCase.params)
 		actual := r.timeRangeIndices(r.spanIndexPrefix, date, date)
-		assert.Equal(t, testCase.indices, actual)
+		assert.Equal(t, []string{testCase.index}, actual)
 	}
 }
 
@@ -383,7 +383,7 @@ func TestSpanReaderFindIndices(t *testing.T) {
 	}
 	withSpanReader(func(r *spanReaderTest) {
 		for _, testCase := range testCases {
-			actual := r.reader.timeRangeIndices([]string{spanIndex}, testCase.startTime, testCase.endTime)
+			actual := r.reader.timeRangeIndices(spanIndex, testCase.startTime, testCase.endTime)
 			assert.EqualValues(t, testCase.expected, actual)
 		}
 	})


### PR DESCRIPTION
In Jaeger 1.9.0 the index prefix separator was changed from ":" (not allowed in ES7) to "-". However query still reads from deprecated indices to keep backward compatibility. After half year old indices should be expired so safe to remove.

https://github.com/jaegertracing/jaeger/blob/master/CHANGELOG.md#190-2019-01-21