### PR TITLE
Fix data race between Agent.Run() and Agent.Stop()

### DIFF
--- a/cmd/agent/app/processors/thrift_processor.go
+++ b/cmd/agent/app/processors/thrift_processor.go
@@ -22,7 +22,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
+	customtransport "github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers"
 )
 
@@ -76,12 +76,12 @@ func NewThriftProcessor(
 		numProcessors: numProcessors,
 	}
 	metrics.Init(&res.metrics, mFactory, nil)
+	res.processing.Add(res.numProcessors)
 	return res, nil
 }
 
 // Serve initiates the readers and starts serving traffic
 func (s *ThriftProcessor) Serve() {
-	s.processing.Add(s.numProcessors)
 	for i := 0; i < s.numProcessors; i++ {
 		go s.processBuffer()
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

We had a data race with Agent.Stop() failing if called immediately
after Agent.Run() returns.

## Short description of the changes

The root cause of the race was that Stop() called WaitGroup.Wait()
before Run() called WaitGroup.Add() for the first time which is
prohibited: https://golang.org/pkg/sync/#WaitGroup.Add

This change moves WaitGroup.Add() to earlier stage which guarantees
that WaitGroup.Wait() will be called after that.

Github issue: https://github.com/jaegertracing/jaeger/issues/1624

Testing done:

Added an automated test which was failing before the bug was fixed
and does not fail any more after the fix.

Also verified that `make test` passes.

Signed-off-by: Tigran Najaryan <tigran@najaryan.net>
