### PR TITLE
Allow Cassandra schema builder to use credentials

### DIFF
--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -34,7 +34,7 @@ done
 echo "Generating the schema for the keyspace ${KEYSPACE} and datacenter ${DATACENTER}"
 
 
-if [ -z "$PASSWORD" ] then
+if [ -z "$PASSWORD" ]; then
   MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh "${TEMPLATE}" | ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST}
 else
   MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh "${TEMPLATE}" | ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST} -u ${USER} -p ${PASSWORD}

--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -11,6 +11,8 @@ DATACENTER=${DATACENTER:-"dc1"}
 KEYSPACE=${KEYSPACE:-"jaeger_v1_${DATACENTER}"}
 MODE=${MODE:-"test"}
 TEMPLATE=${TEMPLATE:-""}
+USER=${CASSANDRA_USERNAME:-""}
+PASSWORD=${CASSANDRA_PASSWORD:-""}
 
 total_wait=0
 while true
@@ -31,4 +33,9 @@ done
 
 echo "Generating the schema for the keyspace ${KEYSPACE} and datacenter ${DATACENTER}"
 
-MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh "${TEMPLATE}" | ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST}
+
+if [ -z "$PASSWORD" ] then
+  MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh "${TEMPLATE}" | ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST}
+else
+  MODE="${MODE}" DATACENTER="${DATACENTER}" KEYSPACE="${KEYSPACE}" /cassandra-schema/create.sh "${TEMPLATE}" | ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST} -u ${USER} -p ${PASSWORD}
+fi


### PR DESCRIPTION
Currently the Cassandra schema builder job only works on open Cassandra installations. This PR fixes this by modifying the script so that two environmental variables, CASSANDRA_USER and CASSANDRA_PASSWORD, could be passed in to supply these credentials.

Signed-off-by: E.G. Hornbostel <eg.hornbostel@pricespider.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Currently the Cassandra schema builder job only works on open Cassandra installations. This PR fixes this by modifying the script so that two environmental variables, CASSANDRA_USER and CASSANDRA_PASSWORD, could be passed in to supply these credentials.

## Short description of the changes
- Modify docker.sh script to allow for credentials to be assed in to cqlsh