### PR TITLE
Add connect-timeout for Cassandra

### DIFF
--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -32,6 +32,7 @@ type Configuration struct {
 	LocalDC              string        `yaml:"local_dc"`
 	ConnectionsPerHost   int           `validate:"min=1" yaml:"connections_per_host"`
 	Timeout              time.Duration `validate:"min=500"`
+	ConnectTimeout       time.Duration `validate:"min=600"`
 	ReconnectInterval    time.Duration `validate:"min=500" yaml:"reconnect_interval"`
 	SocketKeepAlive      time.Duration `validate:"min=0" yaml:"socket_keep_alive"`
 	MaxRetryAttempts     int           `validate:"min=0" yaml:"max_retry_attempt"`
@@ -115,6 +116,7 @@ func (c *Configuration) NewCluster() *gocql.ClusterConfig {
 	cluster.Keyspace = c.Keyspace
 	cluster.NumConns = c.ConnectionsPerHost
 	cluster.Timeout = c.Timeout
+	cluster.ConnectTimeout = c.ConnectTimeout
 	cluster.ReconnectInterval = c.ReconnectInterval
 	cluster.SocketKeepalive = c.SocketKeepAlive
 	if c.ProtoVersion > 0 {

--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -32,7 +32,7 @@ type Configuration struct {
 	LocalDC              string        `yaml:"local_dc"`
 	ConnectionsPerHost   int           `validate:"min=1" yaml:"connections_per_host"`
 	Timeout              time.Duration `validate:"min=500"`
-	ConnectTimeout       time.Duration `validate:"min=600"`
+	ConnectTimeout       time.Duration `yaml:"connect_timeout"`
 	ReconnectInterval    time.Duration `validate:"min=500" yaml:"reconnect_interval"`
 	SocketKeepAlive      time.Duration `validate:"min=0" yaml:"socket_keep_alive"`
 	MaxRetryAttempts     int           `validate:"min=0" yaml:"max_retry_attempt"`

--- a/plugin/storage/cassandra/options.go
+++ b/plugin/storage/cassandra/options.go
@@ -30,6 +30,7 @@ const (
 	suffixConnPerHost          = ".connections-per-host"
 	suffixMaxRetryAttempts     = ".max-retry-attempts"
 	suffixTimeout              = ".timeout"
+	suffixConnectTimeout       = ".connect-timeout"
 	suffixReconnectInterval    = ".reconnect-interval"
 	suffixServers              = ".servers"
 	suffixPort                 = ".port"
@@ -135,6 +136,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.Timeout,
 		"Timeout used for queries. A Timeout of zero means no timeout")
 	flagSet.Duration(
+		nsConfig.namespace+suffixConnectTimeout,
+		nsConfig.ConnectTimeout,
+		"Timeout used for connections to Cassandra Servers")
+	flagSet.Duration(
 		nsConfig.namespace+suffixReconnectInterval,
 		nsConfig.ReconnectInterval,
 		"Reconnect interval to retry connecting to downed hosts")
@@ -220,6 +225,7 @@ func (cfg *namespaceConfig) initFromViper(v *viper.Viper) {
 	cfg.ConnectionsPerHost = v.GetInt(cfg.namespace + suffixConnPerHost)
 	cfg.MaxRetryAttempts = v.GetInt(cfg.namespace + suffixMaxRetryAttempts)
 	cfg.Timeout = v.GetDuration(cfg.namespace + suffixTimeout)
+	cfg.ConnectTimeout = v.GetDuration(cfg.namespace + suffixConnectTimeout)
 	cfg.ReconnectInterval = v.GetDuration(cfg.namespace + suffixReconnectInterval)
 	cfg.servers = stripWhiteSpace(v.GetString(cfg.namespace + suffixServers))
 	cfg.Port = v.GetInt(cfg.namespace + suffixPort)


### PR DESCRIPTION
Signed-off-by: Sagar Anand <sagar.anand015@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #1472 

## Short description of the changes
- Added connect-timeout as a flag in cassandra storage config which is then used by gocql for connecting to the Cassandra Servers
