### PR TITLE
[badger] Filter duplicate results from a single indexSeek [fixes #1604]

### DIFF
--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -278,9 +278,16 @@ func (r *TraceReader) indexSeeksToTraceIDs(query *spanstore.TraceQueryParameters
 		if err != nil {
 			return nil, err
 		}
+
+		// Same traceID can be returned multiple times, but always in sorted order so checking the previous key is enough
+		prevTraceID := []byte{}
 		ids = append(ids, make([][]byte, 0, len(indexResults)))
 		for _, k := range indexResults {
-			ids[i] = append(ids[i], k[len(k)-sizeOfTraceID:])
+			traceID := k[len(k)-sizeOfTraceID:]
+			if !bytes.Equal(prevTraceID, traceID) {
+				ids[i] = append(ids[i], traceID)
+				prevTraceID = traceID
+			}
 		}
 	}
 	return ids, nil


### PR DESCRIPTION
Signed-off-by: Michael Burman <yak@iki.fi>

## Which problem is this PR solving?

Resolves #1604, seeing multiple traces in the UI 

## Short description of the changes

Changes to the badger storage backend reader part (no changes to write path):

Filtering duplicates from the index key results when those occur in the same index seek. Previously only cross-index-seeks had their duplicates removed. Also added a test to ensure this does not break anymore.
