### PR TITLE
[badger] Make default dirs work in Windows

### DIFF
--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -96,6 +96,10 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 		f.Options.primary.KeyDirectory = f.tmpDir
 		f.Options.primary.ValueDirectory = f.tmpDir
 	} else {
+		// Errors are ignored as they're catched in the Open call
+		initializeDir(f.Options.primary.KeyDirectory)
+		initializeDir(f.Options.primary.ValueDirectory)
+
 		opts.SyncWrites = f.Options.primary.SyncWrites
 		opts.Dir = f.Options.primary.KeyDirectory
 		opts.ValueDir = f.Options.primary.ValueDirectory
@@ -119,6 +123,13 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 	logger.Info("Badger storage configuration", zap.Any("configuration", opts))
 
 	return nil
+}
+
+// initializeDir makes the directory and parent directories if the path doesn't exists yet.
+func initializeDir(path string) {
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		os.MkdirAll(path, 0700)
+	}
 }
 
 // CreateSpanReader implements storage.Factory

--- a/plugin/storage/badger/options.go
+++ b/plugin/storage/badger/options.go
@@ -52,14 +52,15 @@ const (
 	suffixSpanstoreTTL        = ".span-store-ttl"
 	suffixSyncWrite           = ".consistency"
 	suffixMaintenanceInterval = ".maintenance-interval"
-	defaultValueDir           = "/data/values"
-	defaultKeysDir            = "/data/keys"
+	defaultDataDir            = string(os.PathSeparator) + "data"
+	defaultValueDir           = defaultDataDir + string(os.PathSeparator) + "values"
+	defaultKeysDir            = defaultDataDir + string(os.PathSeparator) + "keys"
 )
 
 // NewOptions creates a new Options struct.
 func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 
-	defaultDataDir := getCurrentExecutableDir()
+	defaultBadgerDataDir := getCurrentExecutableDir()
 
 	options := &Options{
 		primary: &NamespaceConfig{
@@ -67,8 +68,8 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 			SpanStoreTTL:        defaultTTL,
 			SyncWrites:          false, // Performance over durability
 			Ephemeral:           true,  // Default is ephemeral storage
-			ValueDirectory:      defaultDataDir + defaultValueDir,
-			KeyDirectory:        defaultDataDir + defaultKeysDir,
+			ValueDirectory:      defaultBadgerDataDir + defaultValueDir,
+			KeyDirectory:        defaultBadgerDataDir + defaultKeysDir,
 			MaintenanceInterval: defaultMaintenanceInterval,
 		},
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #1652 (Windows default directories do not work), but also ensures that the directories are created successfully since badger only creates the last directory - not the missing parent directories. This is why default directory does not work unless ``data`` is created first.

## Short description of the changes

Use os.pathSeparator instead of hardcoded ``/`` and create directories if possible.
