### PR TITLE
Use credentials when describing keyspaces in cassandra schema builder

### DIFF
--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -17,7 +17,11 @@ PASSWORD=${CASSANDRA_PASSWORD:-""}
 total_wait=0
 while true
 do
-  ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST} -e "describe keyspaces"
+  if [ -z "$PASSWORD" ]; then
+    ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST} -e "describe keyspaces"
+  else
+    ${CQLSH} ${CQLSH_SSL} ${CQLSH_HOST} -u ${USER} -p ${PASSWORD} -e "describe keyspaces"
+  fi
   if (( $? == 0 )); then
     break
   else


### PR DESCRIPTION
This follows #1635 in order to solve https://github.com/jaegertracing/jaeger-operator/issues/469

## Which problem is this PR solving?
- The cassandra-schema-builder is not using the provided credentials when trying to connect to cassandra to know if it's up.

## Short description of the changes
- The query describing the keyspaces (used to wait for cassandra) will use the credentials if any is provided.
