### PR TITLE
Fix the threshold precision issue

### DIFF
--- a/storage/spanstore/downsampling_writer_test.go
+++ b/storage/spanstore/downsampling_writer_test.go
@@ -16,6 +16,7 @@ package spanstore
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,4 +80,9 @@ func TestDownSamplingWriter_hashBytes(t *testing.T) {
 	_, _ = span.TraceID.MarshalTo(h.buffer)
 	// Same traceID should always be hashed to same uint64 in DownSamplingWriter.
 	assert.Equal(t, h.hashBytes(), h.hashBytes())
+}
+
+func TestDownsamplingWriter_calculateThreshold(t *testing.T) {
+	var maxUint64 uint64 = math.MaxUint64
+	assert.Equal(t, maxUint64, calculateThreshold(1.0))
 }


### PR DESCRIPTION
Signed-off-by: Jude Wang <judew@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #1664 

## Short description of the changes
- It's potential for conversion from an uint64 traceid to float64 number to lose precision.
