### PR TITLE
WIP: Use json number as timestamp in Zipkin v2 json

### DIFF
--- a/cmd/collector/app/zipkin/jsonv2.go
+++ b/cmd/collector/app/zipkin/jsonv2.go
@@ -41,12 +41,20 @@ func spanV2ToThrift(s *models.Span) (*zipkincore.Span, error) {
 	if err != nil {
 		return nil, err
 	}
+	ts, err := s.Timestamp.Int64()
+	if err != nil {
+		tsF, err :=  s.Timestamp.Float64()
+		if err != nil {
+		} else {
+			ts = int64(tsF)
+		}
+	}
 	tSpan := &zipkincore.Span{
 		ID:        int64(id),
 		TraceID:   int64(traceID.Low),
 		Name:      s.Name,
 		Debug:     s.Debug,
-		Timestamp: &s.Timestamp,
+		Timestamp: &ts,
 		Duration:  &s.Duration,
 	}
 	if traceID.High != 0 {
@@ -77,7 +85,7 @@ func spanV2ToThrift(s *models.Span) (*zipkincore.Span, error) {
 	}
 
 	tSpan.BinaryAnnotations = append(tSpan.BinaryAnnotations, tagsToThrift(s.Tags, localE)...)
-	tSpan.Annotations = append(tSpan.Annotations, kindToThrift(s.Timestamp, s.Duration, s.Kind, localE)...)
+	tSpan.Annotations = append(tSpan.Annotations, kindToThrift(ts, s.Duration, s.Kind, localE)...)
 
 	if s.RemoteEndpoint != nil {
 		rAddrAnno, err := remoteEndpToThrift(s.RemoteEndpoint, s.Kind)

--- a/cmd/collector/app/zipkin/jsonv2.go
+++ b/cmd/collector/app/zipkin/jsonv2.go
@@ -43,7 +43,7 @@ func spanV2ToThrift(s *models.Span) (*zipkincore.Span, error) {
 	}
 	ts, err := s.Timestamp.Int64()
 	if err != nil {
-		tsF, err :=  s.Timestamp.Float64()
+		tsF, err := s.Timestamp.Float64()
 		if err != nil {
 		} else {
 			ts = int64(tsF)

--- a/swagger-gen/models/span.go
+++ b/swagger-gen/models/span.go
@@ -118,7 +118,7 @@ type Span struct {
 	//  * The span's start event was lost
 	//  * Data about a completed span (ex tags) were sent after the fact
 	//
-	Timestamp int64 `json:"timestamp,omitempty"`
+	Timestamp json.Number `json:"timestamp,omitempty"`
 
 	// Randomly generated, unique identifier for a trace, set on all spans within it.
 	//


### PR DESCRIPTION
Resolves #895 

Note that zipkin schema defines timestamp as `in64`, so it shouldn't come as a float. https://github.com/openzipkin/zipkin-api/blob/master/zipkin2-api.yaml#L421

Signed-off-by: Pavol Loffay <ploffay@redhat.com>

