### PR TITLE
Added flags for driving cassandra connection compression through config

### DIFF
--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -38,6 +38,7 @@ type Configuration struct {
 	MaxRetryAttempts     int           `validate:"min=0" yaml:"max_retry_attempt"`
 	ProtoVersion         int           `yaml:"proto_version"`
 	Consistency          string        `yaml:"consistency"`
+	EnableCompression    bool          `yaml:"enable-compression"`
 	Port                 int           `yaml:"port"`
 	Authenticator        Authenticator `yaml:"authenticator"`
 	DisableAutoDiscovery bool          `yaml:"disable_auto_discovery"`
@@ -128,7 +129,11 @@ func (c *Configuration) NewCluster() *gocql.ClusterConfig {
 	if c.Port != 0 {
 		cluster.Port = c.Port
 	}
-	cluster.Compressor = gocql.SnappyCompressor{}
+
+	if c.EnableCompression {
+		cluster.Compressor = gocql.SnappyCompressor{}
+	}
+
 	if c.Consistency == "" {
 		cluster.Consistency = gocql.LocalOne
 	} else {

--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -38,7 +38,7 @@ type Configuration struct {
 	MaxRetryAttempts     int           `validate:"min=0" yaml:"max_retry_attempt"`
 	ProtoVersion         int           `yaml:"proto_version"`
 	Consistency          string        `yaml:"consistency"`
-	EnableCompression    bool          `yaml:"enable-compression"`
+	DisableCompression   bool          `yaml:"disable-compression"`
 	Port                 int           `yaml:"port"`
 	Authenticator        Authenticator `yaml:"authenticator"`
 	DisableAutoDiscovery bool          `yaml:"disable_auto_discovery"`
@@ -130,9 +130,14 @@ func (c *Configuration) NewCluster() *gocql.ClusterConfig {
 		cluster.Port = c.Port
 	}
 
-	if c.EnableCompression {
+	fmt.Println("Disable Compression Flag is: ")
+	fmt.Println(c.DisableCompression)
+	if !c.DisableCompression {
 		cluster.Compressor = gocql.SnappyCompressor{}
 	}
+
+	fmt.Println("Compression is:")
+	fmt.Println(cluster.Compressor)
 
 	if c.Consistency == "" {
 		cluster.Consistency = gocql.LocalOne

--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -130,14 +130,9 @@ func (c *Configuration) NewCluster() *gocql.ClusterConfig {
 		cluster.Port = c.Port
 	}
 
-	fmt.Println("Disable Compression Flag is: ")
-	fmt.Println(c.DisableCompression)
 	if !c.DisableCompression {
 		cluster.Compressor = gocql.SnappyCompressor{}
 	}
-
-	fmt.Println("Compression is:")
-	fmt.Println(cluster.Compressor)
 
 	if c.Consistency == "" {
 		cluster.Consistency = gocql.LocalOne

--- a/plugin/storage/cassandra/options.go
+++ b/plugin/storage/cassandra/options.go
@@ -37,6 +37,7 @@ const (
 	suffixKeyspace             = ".keyspace"
 	suffixDC                   = ".local-dc"
 	suffixConsistency          = ".consistency"
+	suffixEnableCompression    = ".enable-compression"
 	suffixProtoVer             = ".proto-version"
 	suffixSocketKeepAlive      = ".socket-keep-alive"
 	suffixUsername             = ".username"
@@ -163,6 +164,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixConsistency,
 		nsConfig.Consistency,
 		"The Cassandra consistency level, e.g. ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, LOCAL_ONE (default LOCAL_ONE)")
+	flagSet.Bool(
+		nsConfig.namespace+suffixEnableCompression,
+		true,
+		"Enable the use of Compression while connecting to Cassandra API based Storage backend. Uses SnappyCompression by default")
 	flagSet.Int(
 		nsConfig.namespace+suffixProtoVer,
 		nsConfig.ProtoVersion,
@@ -243,6 +248,7 @@ func (cfg *namespaceConfig) initFromViper(v *viper.Viper) {
 	cfg.TLS.ServerName = v.GetString(cfg.namespace + suffixServerName)
 	cfg.TLS.EnableHostVerification = v.GetBool(cfg.namespace + suffixVerifyHost)
 	cfg.EnableDependenciesV2 = v.GetBool(cfg.namespace + suffixEnableDependenciesV2)
+	cfg.EnableCompression = v.GetBool(cfg.namespace + suffixEnableCompression)
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/cassandra/options.go
+++ b/plugin/storage/cassandra/options.go
@@ -167,7 +167,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Bool(
 		nsConfig.namespace+suffixDisableCompression,
 		false,
-		"Disables the use of the default Snappy Compression while connecting to the Cassandra Cluster if set to true")
+		"Disables the use of the default Snappy Compression while connecting to the Cassandra Cluster if set to true. This is useful for connecting to Cassandra Clusters(like Azure Cosmos Db with Cassandra API) that do not support SnappyCompression")
 	flagSet.Int(
 		nsConfig.namespace+suffixProtoVer,
 		nsConfig.ProtoVersion,

--- a/plugin/storage/cassandra/options.go
+++ b/plugin/storage/cassandra/options.go
@@ -37,7 +37,7 @@ const (
 	suffixKeyspace             = ".keyspace"
 	suffixDC                   = ".local-dc"
 	suffixConsistency          = ".consistency"
-	suffixEnableCompression    = ".enable-compression"
+	suffixDisableCompression   = ".disable-compression"
 	suffixProtoVer             = ".proto-version"
 	suffixSocketKeepAlive      = ".socket-keep-alive"
 	suffixUsername             = ".username"
@@ -165,9 +165,9 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.Consistency,
 		"The Cassandra consistency level, e.g. ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, LOCAL_ONE (default LOCAL_ONE)")
 	flagSet.Bool(
-		nsConfig.namespace+suffixEnableCompression,
-		true,
-		"Enable the use of Compression while connecting to Cassandra API based Storage backend. Uses SnappyCompression by default")
+		nsConfig.namespace+suffixDisableCompression,
+		false,
+		"Disables the use of the default Snappy Compression while connecting to the Cassandra Cluster if set to true")
 	flagSet.Int(
 		nsConfig.namespace+suffixProtoVer,
 		nsConfig.ProtoVersion,
@@ -248,7 +248,7 @@ func (cfg *namespaceConfig) initFromViper(v *viper.Viper) {
 	cfg.TLS.ServerName = v.GetString(cfg.namespace + suffixServerName)
 	cfg.TLS.EnableHostVerification = v.GetBool(cfg.namespace + suffixVerifyHost)
 	cfg.EnableDependenciesV2 = v.GetBool(cfg.namespace + suffixEnableDependenciesV2)
-	cfg.EnableCompression = v.GetBool(cfg.namespace + suffixEnableCompression)
+	cfg.DisableCompression = v.GetBool(cfg.namespace + suffixDisableCompression)
 }
 
 // GetPrimary returns primary configuration.


### PR DESCRIPTION
Signed-off-by: Sagar  Anand <sagar.anand015@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/1667 and https://github.com/jaegertracing/jaeger/issues/1105

## Short description of the changes
- Added flag to drive the Cassandra Connection Compression from config. This will be use to use SnappyCompressor by default or opt out of using the SnappyCompressor
