### PR TITLE
support jaeger.tags when calling 'GetSamplingStrategy', e.g. return R…

### DIFF
--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -46,7 +46,7 @@ func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFacto
 	return &ProxyBuilder{
 		conn:     conn,
 		reporter: reporter.WrapWithMetrics(NewReporter(conn, agentTags, logger), grpcMetrics),
-		manager:  configmanager.WrapWithMetrics(grpcManager.NewConfigManager(conn), grpcMetrics),
+		manager:  configmanager.WrapWithMetrics(grpcManager.NewConfigManager(conn, agentTags), grpcMetrics),
 	}, nil
 }
 


### PR DESCRIPTION
…ATE_LIMITING when jaeger.tags = {region,CA}

Signed-off-by: osfriend <osfriend@163.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
SamplingStrategy support for agent level tag
e.g. return RATE_LIMITING when jaeger.tags = {"region","CA"}

## Short description of the changes 
transparent metadata which converted from 'jaeger.tags' to collector service