### PR TITLE
Added support for hot reload of UI config

### DIFF
--- a/cmd/query/app/fixture/ui-config-hotreload.json
+++ b/cmd/query/app/fixture/ui-config-hotreload.json
@@ -1,0 +1,8 @@
+{
+  "menu": [
+    {
+      "label": "About Jaeger"
+    }
+  ]
+}
+

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -22,7 +22,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -44,17 +46,20 @@ func RegisterStaticHandler(r *mux.Router, logger *zap.Logger, qOpts *QueryOption
 	staticHandler, err := NewStaticAssetsHandler(qOpts.StaticAssets, StaticAssetsHandlerOptions{
 		BasePath:     qOpts.BasePath,
 		UIConfigPath: qOpts.UIConfig,
+		Logger:       logger,
 	})
+
 	if err != nil {
 		logger.Panic("Could not create static assets handler", zap.Error(err))
 	}
+
 	staticHandler.RegisterRoutes(r)
 }
 
 // StaticAssetsHandler handles static assets
 type StaticAssetsHandler struct {
 	options   StaticAssetsHandlerOptions
-	indexHTML []byte
+	indexHTML atomic.Value // stores []byte
 	assetsFS  http.FileSystem
 }
 
@@ -62,6 +67,7 @@ type StaticAssetsHandler struct {
 type StaticAssetsHandlerOptions struct {
 	BasePath     string
 	UIConfigPath string
+	Logger       *zap.Logger
 }
 
 // NewStaticAssetsHandler returns a StaticAssetsHandler
@@ -70,7 +76,29 @@ func NewStaticAssetsHandler(staticAssetsRoot string, options StaticAssetsHandler
 	if staticAssetsRoot != "" {
 		assetsFS = http.Dir(staticAssetsRoot)
 	}
-	indexBytes, err := loadIndexHTML(assetsFS.Open)
+
+	if options.Logger == nil {
+		options.Logger = zap.NewNop()
+	}
+
+	indexHTML, err := loadIndexBytes(assetsFS.Open, options)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &StaticAssetsHandler{
+		options:  options,
+		assetsFS: assetsFS,
+	}
+
+	h.indexHTML.Store(indexHTML)
+	h.watch()
+
+	return h, nil
+}
+
+func loadIndexBytes(open func(string) (http.File, error), options StaticAssetsHandlerOptions) ([]byte, error) {
+	indexBytes, err := loadIndexHTML(open)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot load index.html")
 	}
@@ -94,11 +122,66 @@ func NewStaticAssetsHandler(staticAssetsRoot string, options StaticAssetsHandler
 		}
 		indexBytes = basePathPattern.ReplaceAll(indexBytes, []byte(fmt.Sprintf(basePathReplace, options.BasePath)))
 	}
-	return &StaticAssetsHandler{
-		options:   options,
-		indexHTML: indexBytes,
-		assetsFS:  assetsFS,
-	}, nil
+
+	return indexBytes, nil
+}
+
+func (sH *StaticAssetsHandler) watch() {
+	if sH.options.UIConfigPath == "" {
+		return
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		sH.options.Logger.Error("failed to create a new watcher for the UI config", zap.Error(err))
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case event := <-watcher.Events:
+				if event.Op&fsnotify.Remove == fsnotify.Remove {
+					// this might be related to a file inside the dir, so, just log a warn if this is about the file we care about
+					// otherwise, just ignore the event
+					if event.Name == sH.options.UIConfigPath {
+						sH.options.Logger.Warn("the UI config file has been removed, using the last known version")
+					}
+					continue
+				}
+
+				// this will catch events for all files inside the same directory, which is OK if we don't have many changes
+				sH.options.Logger.Info("reloading UI config", zap.String("filename", sH.options.UIConfigPath))
+
+				content, err := loadIndexBytes(sH.assetsFS.Open, sH.options)
+				if err != nil {
+					sH.options.Logger.Error("error while reloading the UI config", zap.Error(err))
+				}
+
+				sH.indexHTML.Store(content)
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				sH.options.Logger.Error("event", zap.Error(err))
+			}
+		}
+	}()
+
+	err = watcher.Add(sH.options.UIConfigPath)
+	if err != nil {
+		sH.options.Logger.Error("error adding watcher to file", zap.String("file", sH.options.UIConfigPath), zap.Error(err))
+	} else {
+		sH.options.Logger.Info("watching", zap.String("file", sH.options.UIConfigPath))
+	}
+
+	dir := filepath.Dir(sH.options.UIConfigPath)
+	err = watcher.Add(dir)
+	if err != nil {
+		sH.options.Logger.Error("error adding watcher to dir", zap.String("dir", dir), zap.Error(err))
+	} else {
+		sH.options.Logger.Info("watching", zap.String("dir", dir))
+	}
 }
 
 func loadIndexHTML(open func(string) (http.File, error)) ([]byte, error) {
@@ -155,5 +238,5 @@ func (sH *StaticAssetsHandler) RegisterRoutes(router *mux.Router) {
 
 func (sH *StaticAssetsHandler) notFound(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(sH.indexHTML)
+	w.Write(sH.indexHTML.Load().([]byte))
 }


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?

- As seen on jaegertracing/jaeger-operator#533, changing the UI configuration requires the Jaeger Query to be stopped and started again. As the file is sent as is inside the HTML that is requested by the browser, it's safe to simply watch the file for changes and replace the internal `indexHTML` property.
