### PR TITLE
Elasticsearch 7 Support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -656,6 +656,18 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:2bf1079dc711508d423f2d1bcb97078f0a015152433b02858e681006fcb1147f"
+  name = "github.com/olivere/elastic"
+  packages = [
+    ".",
+    "config",
+    "uritemplates",
+  ]
+  pruneopts = "UT"
+  revision = "2ce6dee3af14e17dc059746a1de4f983169030e9"
+  version = "v6.2.21"
+
+[[projects]]
   branch = "master"
   digest = "1:bccaead3121ab7964fd80fab704f612e5893fb5a2c581d520ec847ed8cfac27e"
   name = "github.com/opentracing-contrib/go-stdlib"
@@ -1222,18 +1234,6 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:9a1d716749c77399bfa71792d77eef3278586423947f3431dbac6d6049c24787"
-  name = "gopkg.in/olivere/elastic.v5"
-  packages = [
-    ".",
-    "config",
-    "uritemplates",
-  ]
-  pruneopts = "UT"
-  revision = "f72acaba629a7ec879103d17b7426a31bc38e199"
-  version = "v5.0.80"
-
-[[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -1309,6 +1309,7 @@
     "github.com/hashicorp/go-hclog",
     "github.com/hashicorp/go-plugin",
     "github.com/kr/pretty",
+    "github.com/olivere/elastic",
     "github.com/opentracing-contrib/go-stdlib/nethttp",
     "github.com/opentracing/opentracing-go",
     "github.com/opentracing/opentracing-go/ext",
@@ -1361,7 +1362,6 @@
     "google.golang.org/grpc/status",
     "google.golang.org/grpc/test/bufconn",
     "google.golang.org/grpc/test/grpc_testing",
-    "gopkg.in/olivere/elastic.v5",
     "gopkg.in/yaml.v2",
     "honnef.co/go/tools/cmd/staticcheck",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -116,8 +116,8 @@ required = [
   version = "=1.20.1"
 
 [[constraint]]
-  name = "gopkg.in/olivere/elastic.v5"
-  version = "^5.0.53"
+  name = "github.com/olivere/elastic"
+  version = "^6.2.21"
 
 [[constraint]]
   name = "github.com/gocql/gocql"

--- a/pkg/es/client.go
+++ b/pkg/es/client.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"io"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 // Client is an abstraction for elastic.Client

--- a/pkg/es/client.go
+++ b/pkg/es/client.go
@@ -40,6 +40,7 @@ type IndicesExistsService interface {
 type IndicesCreateService interface {
 	Body(mapping string) IndicesCreateService
 	Do(ctx context.Context) (*elastic.IndicesCreateResult, error)
+	IncludeTypeName(include bool) IndicesCreateService
 }
 
 // IndexService is an abstraction for elastic BulkService

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/pkg/es"
 	"github.com/jaegertracing/jaeger/pkg/es/wrapper"

--- a/pkg/es/mocks/IndicesCreateService.go
+++ b/pkg/es/mocks/IndicesCreateService.go
@@ -17,7 +17,7 @@
 package mocks
 
 import context "context"
-import elastic "gopkg.in/olivere/elastic.v5"
+import elastic "github.com/olivere/elastic"
 import es "github.com/jaegertracing/jaeger/pkg/es"
 import mock "github.com/stretchr/testify/mock"
 

--- a/pkg/es/mocks/MultiSearchService.go
+++ b/pkg/es/mocks/MultiSearchService.go
@@ -17,7 +17,7 @@
 package mocks
 
 import context "context"
-import elastic "gopkg.in/olivere/elastic.v5"
+import elastic "github.com/olivere/elastic"
 import es "github.com/jaegertracing/jaeger/pkg/es"
 import mock "github.com/stretchr/testify/mock"
 

--- a/pkg/es/mocks/SearchService.go
+++ b/pkg/es/mocks/SearchService.go
@@ -17,7 +17,7 @@
 package mocks
 
 import context "context"
-import elastic "gopkg.in/olivere/elastic.v5"
+import elastic "github.com/olivere/elastic"
 import es "github.com/jaegertracing/jaeger/pkg/es"
 import mock "github.com/stretchr/testify/mock"
 

--- a/pkg/es/wrapper/wrapper.go
+++ b/pkg/es/wrapper/wrapper.go
@@ -17,7 +17,7 @@ package eswrapper
 import (
 	"context"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/pkg/es"
 )

--- a/pkg/es/wrapper/wrapper.go
+++ b/pkg/es/wrapper/wrapper.go
@@ -100,6 +100,11 @@ func (c IndicesCreateServiceWrapper) Body(mapping string) es.IndicesCreateServic
 	return WrapESIndicesCreateService(c.indicesCreateService.Body(mapping))
 }
 
+// IncludeTypeName calls this function to internal service.
+func (c IndicesCreateServiceWrapper) IncludeTypeName(include bool) es.IndicesCreateService {
+	return WrapESIndicesCreateService(c.indicesCreateService.IncludeTypeName(include))
+}
+
 // Do calls this function to internal service.
 func (c IndicesCreateServiceWrapper) Do(ctx context.Context) (*elastic.IndicesCreateResult, error) {
 	return c.indicesCreateService.Do(ctx)

--- a/plugin/storage/es/dependencystore/storage.go
+++ b/plugin/storage/es/dependencystore/storage.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es"

--- a/plugin/storage/es/dependencystore/storage.go
+++ b/plugin/storage/es/dependencystore/storage.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es"
@@ -66,7 +66,7 @@ func (s *DependencyStore) WriteDependencies(ts time.Time, dependencies []model.D
 }
 
 func (s *DependencyStore) createIndex(indexName string) error {
-	_, err := s.client.CreateIndex(indexName).Body(dependenciesMapping).Do(s.ctx)
+	_, err := s.client.CreateIndex(indexName).Body(dependenciesMapping).IncludeTypeName(true).Do(s.ctx)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create index")
 	}

--- a/plugin/storage/es/dependencystore/storage.go
+++ b/plugin/storage/es/dependencystore/storage.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	dependencyType  = "dependencies"
+	dependencyType  = "_doc"
 	dependencyIndex = "jaeger-dependencies-"
 )
 

--- a/plugin/storage/es/dependencystore/storage_test.go
+++ b/plugin/storage/es/dependencystore/storage_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/mocks"

--- a/plugin/storage/es/mappings/gen_assets.go
+++ b/plugin/storage/es/mappings/gen_assets.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    ".nocover",
 		local:   "plugin/storage/es/mappings/.nocover",
 		size:    43,
-		modtime: 1551270965,
+		modtime: 1563813000,
 		compressed: `
 H4sIAAAAAAAC/youSSzJzFYoSEzOTkxPVcjILy4pVkgsLcnXTU/NSy1KLElNUUjLzEkt1uMCBAAA//8y
 IKK1KwAAAA==
@@ -223,16 +223,16 @@ IKK1KwAAAA==
 	"/jaeger-service.json": {
 		name:    "jaeger-service.json",
 		local:   "plugin/storage/es/mappings/jaeger-service.json",
-		size:    1060,
-		modtime: 1551270965,
+		size:    1057,
+		modtime: 1563814977,
 		compressed: `
-H4sIAAAAAAAC/8yTT2/UMBDF7/kU1ojTamshpHLwrUARSFDQVpwQGs3Gs1mD7RjbKayqfHfk4pKkW+2J
-Q3PIn/F78/xz7NtGCMjsgqXMoASsvhN3HM8SxxvT8tkK1kWSOGfjuwSqOIQA4zX/ln5wW47Y7zDtKeoE
-Sjy7Rbz68vHV5QY/vcXrdxebN9eI4/pxW+RgTUvHxs3l5w/vX18cWR2FYHwnPafMGneGrU7SGmcyqPPn
-C23knwOnnGRL7Z4le9paBpXjwEc9OUp98ORMC2pHNnEjxF0y1MQJHTXvaLAZ7yulRtZOn0LA3zA9NStX
-RRECahbeL30C9fWfeWpTVj6Qx0xdQkdhHnE3Wif3sF5+6iEwKPjBh1991LB+OG4630dG2vY3DOrF+cuF
-YFzqIVDeo6Pc7kFBpk6uYCYYm0d8C4oQ+5ZTemIgdVbyFFB9+9bMukE9HbMNEGIfOGbDabENqvCKHC/R
-TmGdQJrhQAmkbHr//7o382e5j83Y/AkAAP//qd2MzCQEAAA=
+H4sIAAAAAAAC/8yTT28TMRDF7/sprBGnKLUQUjn4VqAIJCgoFSeERhN7sjH4H7ZTiKr97shlS3abKicO
+3cP+Gc97zz97fdsJAZV9clQZlIDFd+Ke81nhfGM1ny1g2VoK12pDX0A1hRBgg+HfMuz8mjPGDZYtZVNA
+iWe3iFdfPr66XOGnt3j97mL15hpxWD4uy5yc1XQsXF1+/vD+9cWR1FNKNvQycKlscGPZmSKd9baCOn8+
+6838c8elFqlJb1lyoLVjUDXv+MiTszT7QN5qUBtyhTsh7pJhTDygo+EN7VzF+0qrkXOHTyHgb5g5mLVr
+RBECxiy8X/oC6us/8cGmrXyigJX6gp7SNOJudJzcw3rb1H1iUPCD979iNrB8OG77EDMjreMNg3px/nLW
+MMz7IVHdoqeqt6CgUi8XMGkYukd0M4qUo+ZSnhjIOCt5Cmh8+9ZN3ABN1JPdTzkmztVymf0D4xm6Is9z
+rlNMJ3gmLNACqdoY/p97N322+9AN3Z8AAAD//8OVHf0hBAAA
 `,
 	},
 
@@ -240,19 +240,19 @@ TmGdQJrhQAmkbHr//7o382e5j83Y/AkAAP//qd2MzCQEAAA=
 		name:    "jaeger-span.json",
 		local:   "plugin/storage/es/mappings/jaeger-span.json",
 		size:    3830,
-		modtime: 1561117834,
+		modtime: 1563814989,
 		compressed: `
 H4sIAAAAAAAC/+xW0W/TPhB+z18RnX5PUxf9hDQe8jbYEJPYQNt4Qsi6JpfUm2Mb+zqopv7vKE1Lm9ZJ
 QGoQEvShbWx/391n333xcxTHwFRZhUyQxnDygFSSO/UW9ekJTOp5T8xSlx7Senkcg9Q5fUv0vJqSE6YQ
 foYu95DG/z0LcfPx+tXlrXj/Rty9Pb+9uBNiOQnDHFklMzwE3l5+eHf1+vwAWqG1UpeJJs+Ui0KSyn2i
 ZCUZ0rP/W2sdfZmTZ59kmM0oIY1TRZCym9MBJ7kkX2isZAZpgcpTFMeryLCOuJUucipwrlhsRuoxVGr7
 GMfQBMu3ZPVnLSWOYR1LbPbdQ/rpB3hLU++8RS0YSy8qtLshVrPr5PbH6xNdWIIUHmnx1bgcJvvzstTG
-kcCpeSJIX5y9bC1YtteDRZ6JCjmbQQqMZXICOwuWUQDXUmGdycj7P0zIOqukT9D63+doh211KDunb52x
-5FiSb9UAO8zo6qKtqU9Pj5YdHWDRkeY7i3oEcj8Obb1ByNLoG6zo+EkzOr6XXczK6BL6gddSKenD8Lw2
-xlZWhXEVMqRA1mQzUTXgYIR83uj+1cwKhWVHPlJzbdBhnDJdsMYy20LanjfZa9lAUTeEsiLPWNnudm0L
-C3ViY93dDIF0B1IeSHs1/UiL0Piwz/yE1wRUrlBPqOb026Mylvcr8jHjRn3Py6FXxMaA9+q1p/I8uSeZ
-0aGJjPCqYOx5HZnpA2UMQwT/6vuvrm9HBTnSGY1uyY6K8G4cuylCd5oR4oSuIccIM3hkB13f1fF7oNFP
-ONjZR971jk4+vrGOU6u9N/jmt/5eRsvoewAAAP//W45CgfYOAAA=
+kcCpeSJIX5y9bC1YtteDRZ6JCjmbQQqMZXICOwuWUQDXUmGdycj7P0zIOqukT9D63+dohw1EbrKd07fO
+WHIsybdqgB1mdHXR1tSnp0fLjg6w6EjznUU9Arkfh7beIGRp9A1WdPykGR3fyy5mZXQJ/cBrqZT0YXhe
+G2Mrq8K4ChlSIGuymagacDBCPm90/2pmhcKyIx+puTboME6ZLlhjmW0hbc+b7LVsoKgbQlmRZ6xsd7u2
+hYU6sbHuboZAugMpD6S9mn6kRWh82Gd+wmsCKleoJ1Rz+u1RGcv7FfmYcaO+5+XQK2JjwHv12lN5ntyT
+zOjQREZ4VTD2vI7M9IEyhiGCf/X9V9e3o4Ic6YxGt2RHRXg3jt0UoTvNCHFC15BjhBk8soOu7+r4PdDo
+Jxzs7CPvekcnH99Yx6nV3ht881t/L6Nl9D0AAP//2S76bfYOAAA=
 `,
 	},
 

--- a/plugin/storage/es/mappings/gen_assets.go
+++ b/plugin/storage/es/mappings/gen_assets.go
@@ -223,36 +223,34 @@ IKK1KwAAAA==
 	"/jaeger-service.json": {
 		name:    "jaeger-service.json",
 		local:   "plugin/storage/es/mappings/jaeger-service.json",
-		size:    988,
-		modtime: 1563815875,
+		size:    916,
+		modtime: 1563884923,
 		compressed: `
-H4sIAAAAAAAC/8yST2/UMBDF7/kU1ogTqiKEVA6+FSgCCQraihNCo1l7klj4H/aksKry3VFKYJO22hMH
-Lkn8/N7z/JLcNkpBZREX+wp6XioFLlr+2cYx7Llg6rAOVGwFrZ7cIl59/vDycocf3+D124vd62vE6ezx
-WOHsnaGHwd3lp/fvXl08iAbK2cW+jVyFLXaOva2td8EJ6PNnG2/h7yNXqa0hM3DLkfaeQUsZuVHqrheW
-viMYWu5o9IJ/lFkj749LpeB3lQXdka+86MugSoE9RArOoHDInoQr6C9/w8ea+b1miijUVwyU10fc7S7D
-3deVAjlkBg3f+PAjFQtn9/ddH1NhpH26YdDPz19sDNPWD5lkwEBiBtAg1LdPYWWYmkdyG4pckuFa/zOQ
-Zar2FNDy9LVZtQHaZFZfP5eUuYjjuvkHKpcbZ/iKAm+5TjGd4FmxwHwgiUvx37U36/t8nZqp+RUAAP//
-xyO7lNwDAAA=
+H4sIAAAAAAAC/8xQQUszMRC9768Iw3f6KIsI9ZBb1YqCVmnxJBKm2elucJONybRayv53Wdna3bb05MFL
+MpN578172SRCQCRm4/IIsmmFAOMy+kzd0s4pqGqhYoEhiyDFv41Sk+eHy/FUPd6o2e1oej1Tqh4cpwXy
+pdF4SJyOn+7vrkYHVIveG5enjiJTphaGyiympbGGQQ7PethA70uKHFONuqCUHM5LAslhSYkQ37rQ6u2C
+qazS20YIyNYOrdGKyfoSmSLIl3YmxOanar7Io1OMeVQW/U6hnbZ79t+FAF57AglvtP6oQgaD/bnJXRVI
+4bxaEcjz4UUPUPfx4JELZZF1ARIY8/Q/dAB1coTXS+FDpSnGPxakdZWeCtRWr1udhuQpsKHYNQuRwspo
+mqClfohTAU6Y7xiHZiGyqdzvqSfduznrpE6+AgAA//8cbA7YlAMAAA==
 `,
 	},
 
 	"/jaeger-span.json": {
 		name:    "jaeger-span.json",
 		local:   "plugin/storage/es/mappings/jaeger-span.json",
-		size:    3764,
-		modtime: 1563815872,
+		size:    3692,
+		modtime: 1563884910,
 		compressed: `
-H4sIAAAAAAAC/+xW0W/TPhB+z19hnX5PP00RQhoPeRtsiElsoG08IWRdk0tq5tjGvg6qqf87apPRpnUS
-kBqEBC9tfPb33X323dmPiRAQiFmZKkC2HgoByhT0LTWLekZe2lKGOfoiQCb+e5Ty+sPVy4sb+e61vH1z
-dnN+K+XqJA7z5LTK8RB4c/H+7eWrswNojc4pU6WGAlMhS0W6CKlWtWLITp911nr6sqDAIc0xn1NKBmea
-IGO/oESIDS+0fFthsqASF5rlk2VtQ623QyGgoSogK1EHau1toEJAsTRYq1wy1U4jU4Ds4w/wlma9rw6N
-ZKyCrNHtutjMtsHt24UAXjqCDO5p+dX6Ak7251VlrCeJM/tAkD0/fdFZsOquB4c8lzVyPocMGKv0f9hZ
-sEoiuI4K521OIfxhQtqo0iFB7denZIcNZGHzndN33jryrCh0coA95nR53tU0pGdAy44OcOjJ8K1DMwF5
-mIZ2vUHIypprrOn4QTN6vlN9zNqaCoaBV0prFeLwApm6UZXW18iQATmbz2XdgKMeikWj+1cjKzVWPfEo
-w1SRj+O07YM1DbErpO1DbZs62SvZSFI3hKqmwFi7/nLtCotVYtOY+xki4Y6EPBL2ZvqeljH7eJ/5iV4T
-UblBPaBe0G/3yljdbcin9JsMjVdjV8RTA97L14HMC+QfVE6HTWSCq4Jx4Dqys8+UM4wR/Mvvvzq/PZXk
-yeQ0eUv2VMZ349hFEXvTTOAn9gw5hpvRIzuo+r6K3wNNfsLRyj7yrvdU8vEb6zS5OviCb/7Xv6tklXwP
-AAD//+K4Q2G0DgAA
+H4sIAAAAAAAC/+xWT28TPxC951NYo9/pp2qFkMphb4UWUYkW1JYTQtbEO7sx9T/sSSGq8t1Rki3tJt4N
+SFmEBJdkvfZ788Y78+z7iRCQiFm7JkG5GgoB2lX0rXBzO6UofS3TDGOVoBT/3Ut5+eHi5dmVfPdaXr85
+uTq9lnJ5lIdFCkYr3AVenb1/e/7qZAdqMQTtmsJRYqpkrclUqTDaaoby+FlnbaQvc0qcCoVqRgU5nBqC
+kuOcJkKseaHle0xMVl49DISAauHQaiWZbDDIlKD82M4Jcf/jabVFAZ1kbJK0GB4Z2tk2zvZ7IYAXgaCE
+W1p89bGCo+153TgfSeLU3xGUz49fdBYsu+shIM+kRVYzKIGxKf6HJwuWkwyuk0WIXlFKf1girapiKKH2
+6dMDzwoUKLKm9FQscERF56fdBIbEDwh/IhoCRnJ8HdCNQJ7GoV1tELL27hItHV40Y+Qb3cdsvGtgGHih
+jdEpD6+Qqauq9tEiQwkUvJpJuwFnI1TzTd6/qqw22PTo0Y6poZjHGd8H2xhZN5HWdKCs0SQ62urPTFFv
+CLWlxGhDf292E8u13cZQ+xkycvdI3iN7PX1Li9z7/abyE8aSyXKNukMzp98elbG5WZOPGXcyNF7uOw8e
+3HarXgcqL1G804p2TWSEc4Fx4Ozx08+kGPYR/Kvvv7q+I9UUySka3ZIj1fndOHRT5O40I8TJXUMOEWbv
+J9vp+r6O3wKN/oWznX3gXe/p5MMb6zi1Onhd3/yvfpeT5eR7AAAA///c0Vx8bA4AAA==
 `,
 	},
 

--- a/plugin/storage/es/mappings/gen_assets.go
+++ b/plugin/storage/es/mappings/gen_assets.go
@@ -223,36 +223,36 @@ IKK1KwAAAA==
 	"/jaeger-service.json": {
 		name:    "jaeger-service.json",
 		local:   "plugin/storage/es/mappings/jaeger-service.json",
-		size:    1057,
-		modtime: 1563814977,
+		size:    988,
+		modtime: 1563815875,
 		compressed: `
-H4sIAAAAAAAC/8yTT28TMRDF7/sprBGnKLUQUjn4VqAIJCgoFSeERhN7sjH4H7ZTiKr97shlS3abKicO
-3cP+Gc97zz97fdsJAZV9clQZlIDFd+Ke81nhfGM1ny1g2VoK12pDX0A1hRBgg+HfMuz8mjPGDZYtZVNA
-iWe3iFdfPr66XOGnt3j97mL15hpxWD4uy5yc1XQsXF1+/vD+9cWR1FNKNvQycKlscGPZmSKd9baCOn8+
-6838c8elFqlJb1lyoLVjUDXv+MiTszT7QN5qUBtyhTsh7pJhTDygo+EN7VzF+0qrkXOHTyHgb5g5mLVr
-RBECxiy8X/oC6us/8cGmrXyigJX6gp7SNOJudJzcw3rb1H1iUPCD979iNrB8OG77EDMjreMNg3px/nLW
-MMz7IVHdoqeqt6CgUi8XMGkYukd0M4qUo+ZSnhjIOCt5Cmh8+9ZN3ABN1JPdTzkmztVymf0D4xm6Is9z
-rlNMJ3gmLNACqdoY/p97N322+9AN3Z8AAAD//8OVHf0hBAAA
+H4sIAAAAAAAC/8yST2/UMBDF7/kU1ogTqiKEVA6+FSgCCQraihNCo1l7klj4H/aksKry3VFKYJO22hMH
+Lkn8/N7z/JLcNkpBZREX+wp6XioFLlr+2cYx7Llg6rAOVGwFrZ7cIl59/vDycocf3+D124vd62vE6ezx
+WOHsnaGHwd3lp/fvXl08iAbK2cW+jVyFLXaOva2td8EJ6PNnG2/h7yNXqa0hM3DLkfaeQUsZuVHqrheW
+viMYWu5o9IJ/lFkj749LpeB3lQXdka+86MugSoE9RArOoHDInoQr6C9/w8ea+b1miijUVwyU10fc7S7D
+3deVAjlkBg3f+PAjFQtn9/ddH1NhpH26YdDPz19sDNPWD5lkwEBiBtAg1LdPYWWYmkdyG4pckuFa/zOQ
+Zar2FNDy9LVZtQHaZFZfP5eUuYjjuvkHKpcbZ/iKAm+5TjGd4FmxwHwgiUvx37U36/t8nZqp+RUAAP//
+xyO7lNwDAAA=
 `,
 	},
 
 	"/jaeger-span.json": {
 		name:    "jaeger-span.json",
 		local:   "plugin/storage/es/mappings/jaeger-span.json",
-		size:    3830,
-		modtime: 1563814989,
+		size:    3764,
+		modtime: 1563815872,
 		compressed: `
-H4sIAAAAAAAC/+xW0W/TPhB+z18RnX5PUxf9hDQe8jbYEJPYQNt4Qsi6JpfUm2Mb+zqopv7vKE1Lm9ZJ
-QGoQEvShbWx/391n333xcxTHwFRZhUyQxnDygFSSO/UW9ekJTOp5T8xSlx7Senkcg9Q5fUv0vJqSE6YQ
-foYu95DG/z0LcfPx+tXlrXj/Rty9Pb+9uBNiOQnDHFklMzwE3l5+eHf1+vwAWqG1UpeJJs+Ui0KSyn2i
-ZCUZ0rP/W2sdfZmTZ59kmM0oIY1TRZCym9MBJ7kkX2isZAZpgcpTFMeryLCOuJUucipwrlhsRuoxVGr7
-GMfQBMu3ZPVnLSWOYR1LbPbdQ/rpB3hLU++8RS0YSy8qtLshVrPr5PbH6xNdWIIUHmnx1bgcJvvzstTG
-kcCpeSJIX5y9bC1YtteDRZ6JCjmbQQqMZXICOwuWUQDXUmGdycj7P0zIOqukT9D63+dohw1EbrKd07fO
-WHIsybdqgB1mdHXR1tSnp0fLjg6w6EjznUU9Arkfh7beIGRp9A1WdPykGR3fyy5mZXQJ/cBrqZT0YXhe
-G2Mrq8K4ChlSIGuymagacDBCPm90/2pmhcKyIx+puTboME6ZLlhjmW0hbc+b7LVsoKgbQlmRZ6xsd7u2
-hYU6sbHuboZAugMpD6S9mn6kRWh82Gd+wmsCKleoJ1Rz+u1RGcv7FfmYcaO+5+XQK2JjwHv12lN5ntyT
-zOjQREZ4VTD2vI7M9IEyhiGCf/X9V9e3o4Ic6YxGt2RHRXg3jt0UoTvNCHFC15BjhBk8soOu7+r4PdDo
-Jxzs7CPvekcnH99Yx6nV3ht881t/L6Nl9D0AAP//2S76bfYOAAA=
+H4sIAAAAAAAC/+xW0W/TPhB+z19hnX5PP00RQhoPeRtsiElsoG08IWRdk0tq5tjGvg6qqf87apPRpnUS
+kBqEBC9tfPb33X323dmPiRAQiFmZKkC2HgoByhT0LTWLekZe2lKGOfoiQCb+e5Ty+sPVy4sb+e61vH1z
+dnN+K+XqJA7z5LTK8RB4c/H+7eWrswNojc4pU6WGAlMhS0W6CKlWtWLITp911nr6sqDAIc0xn1NKBmea
+IGO/oESIDS+0fFthsqASF5rlk2VtQ623QyGgoSogK1EHau1toEJAsTRYq1wy1U4jU4Ds4w/wlma9rw6N
+ZKyCrNHtutjMtsHt24UAXjqCDO5p+dX6Ak7251VlrCeJM/tAkD0/fdFZsOquB4c8lzVyPocMGKv0f9hZ
+sEoiuI4K521OIfxhQtqo0iFB7denZIcNZGHzndN33jryrCh0coA95nR53tU0pGdAy44OcOjJ8K1DMwF5
+mIZ2vUHIypprrOn4QTN6vlN9zNqaCoaBV0prFeLwApm6UZXW18iQATmbz2XdgKMeikWj+1cjKzVWPfEo
+w1SRj+O07YM1DbErpO1DbZs62SvZSFI3hKqmwFi7/nLtCotVYtOY+xki4Y6EPBL2ZvqeljH7eJ/5iV4T
+UblBPaBe0G/3yljdbcin9JsMjVdjV8RTA97L14HMC+QfVE6HTWSCq4Jx4Dqys8+UM4wR/Mvvvzq/PZXk
+yeQ0eUv2VMZ349hFEXvTTOAn9gw5hpvRIzuo+r6K3wNNfsLRyj7yrvdU8vEb6zS5OviCb/7Xv6tklXwP
+AAD//+K4Q2G0DgAA
 `,
 	},
 

--- a/plugin/storage/es/mappings/jaeger-service.json
+++ b/plugin/storage/es/mappings/jaeger-service.json
@@ -1,11 +1,9 @@
 {
-  "template": "*jaeger-service-*",
   "settings":{
     "index.number_of_shards": ${__NUMBER_OF_SHARDS__},
     "index.number_of_replicas": ${__NUMBER_OF_REPLICAS__},
     "index.mapping.nested_fields.limit":50,
-    "index.requests.cache.enable":true,
-    "index.mapper.dynamic":false
+    "index.requests.cache.enable":true
   },
   "mappings":{
     "_default_":{

--- a/plugin/storage/es/mappings/jaeger-service.json
+++ b/plugin/storage/es/mappings/jaeger-service.json
@@ -33,7 +33,7 @@
         }
       ]
     },
-    "service":{
+    "_doc":{
       "properties":{
         "serviceName":{
           "type":"keyword",

--- a/plugin/storage/es/mappings/jaeger-service.json
+++ b/plugin/storage/es/mappings/jaeger-service.json
@@ -6,10 +6,7 @@
     "index.requests.cache.enable":true
   },
   "mappings":{
-    "_default_":{
-      "_all":{
-        "enabled":false
-      },
+    "_doc":{
       "dynamic_templates":[
         {
           "span_tags_map":{
@@ -29,9 +26,7 @@
             "path_match":"process.tag.*"
           }
         }
-      ]
-    },
-    "_doc":{
+      ],
       "properties":{
         "serviceName":{
           "type":"keyword",

--- a/plugin/storage/es/mappings/jaeger-span.json
+++ b/plugin/storage/es/mappings/jaeger-span.json
@@ -33,7 +33,7 @@
         }
       ]
     },
-    "span":{
+    "_doc":{
       "properties":{
         "traceID":{
           "type":"keyword",

--- a/plugin/storage/es/mappings/jaeger-span.json
+++ b/plugin/storage/es/mappings/jaeger-span.json
@@ -6,10 +6,7 @@
     "index.requests.cache.enable":true
   },
   "mappings":{
-    "_default_":{
-      "_all":{
-        "enabled":false
-      },
+    "_doc":{
       "dynamic_templates":[
         {
           "span_tags_map":{
@@ -29,9 +26,7 @@
             "path_match":"process.tag.*"
           }
         }
-      ]
-    },
-    "_doc":{
+      ],
       "properties":{
         "traceID":{
           "type":"keyword",

--- a/plugin/storage/es/mappings/jaeger-span.json
+++ b/plugin/storage/es/mappings/jaeger-span.json
@@ -1,11 +1,9 @@
 {
-  "template": "*jaeger-span-*",
   "settings":{
     "index.number_of_shards": ${__NUMBER_OF_SHARDS__},
     "index.number_of_replicas": ${__NUMBER_OF_REPLICAS__},
     "index.mapping.nested_fields.limit":50,
-    "index.requests.cache.enable":true,
-    "index.mapper.dynamic":false
+    "index.requests.cache.enable":true
   },
   "mappings":{
     "_default_":{

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es"

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/mocks"

--- a/plugin/storage/es/spanstore/service_operation.go
+++ b/plugin/storage/es/spanstore/service_operation.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/pkg/cache"
 	"github.com/jaegertracing/jaeger/pkg/es"

--- a/plugin/storage/es/spanstore/service_operation_test.go
+++ b/plugin/storage/es/spanstore/service_operation_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/pkg/es/mocks"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -19,10 +19,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/pkg/errors"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
-	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cache"
@@ -164,7 +164,7 @@ func (s *SpanWriter) createIndex(indexName string, mapping string, jsonSpan *dbm
 		if !exists {
 			// if there are multiple collectors writing to the same elasticsearch host a race condition can occur - create the index multiple times
 			// we check for the error type to minimize errors
-			_, err := s.client.CreateIndex(indexName).Body(mapping).Do(s.ctx)
+			_, err := s.client.CreateIndex(indexName).Body(mapping).IncludeTypeName(true).Do(s.ctx)
 			s.writerMetrics.indexCreate.Emit(err, time.Since(start))
 			if err != nil {
 				eErr, ok := err.(*elastic.Error)

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -32,8 +32,8 @@ import (
 )
 
 const (
-	spanType    = "span"
-	serviceType = "service"
+	spanType    = "_doc"
+	serviceType = "_doc"
 )
 
 type spanWriterMetrics struct {

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cache"

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/wrapper"

--- a/scripts/travis/es-integration-test.sh
+++ b/scripts/travis/es-integration-test.sh
@@ -2,8 +2,11 @@
 
 set -e
 
-docker pull docker.elastic.co/elasticsearch/elasticsearch:5.6.12
-CID=$(docker run -d -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:5.6.12)
+# Default to elasticsearch 5.6.12 if ES_VERSION is not set
+ES_VERSION=${ES_VERSION:-5.6.12}
+
+docker pull docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+CID=$(docker run -d -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION})
 export STORAGE=elasticsearch
 make storage-integration-test
 docker kill $CID


### PR DESCRIPTION
Adds support for Elasticsearch 7.x

Resolves #1474

- Updates github.com/olivere/elastic to 6.2.21
- Removes the deprecated _default_ field from mappings
- Replaces document types with '_doc' as a transition step to removing them entirely
- Sets include_type_name for compatibility between elasticsearch 6.x and 7.x

rest_total_hits_as_int support is also required for compatibility between elasticsearch 6.x and 7.x (waiting for feature to be merged in github.com/olivere/elastic)