### PR TITLE
Refactor badger storage dependency parsing for better performance

### DIFF
--- a/plugin/storage/badger/dependencystore/storage.go
+++ b/plugin/storage/badger/dependencystore/storage.go
@@ -15,10 +15,10 @@
 package dependencystore
 
 import (
-	"context"
 	"time"
 
 	"github.com/jaegertracing/jaeger/model"
+	badgerStore "github.com/jaegertracing/jaeger/plugin/storage/badger/spanstore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
@@ -36,64 +36,21 @@ func NewDependencyStore(store spanstore.Reader) *DependencyStore {
 
 // GetDependencies returns all interservice dependencies, implements DependencyReader
 func (s *DependencyStore) GetDependencies(endTs time.Time, lookback time.Duration) ([]model.DependencyLink, error) {
-	deps := map[string]*model.DependencyLink{}
-
-	params := &spanstore.TraceQueryParameters{
-		StartTimeMin: endTs.Add(-1 * lookback),
-		StartTimeMax: endTs,
-	}
-
-	// We need to do a full table scan - if this becomes a bottleneck, we can write write an index that describes
-	// dependencyKeyPrefix + timestamp + parent + child key and do a key-only seek (which is fast - but requires additional writes)
-
-	// GetDependencies is not shipped with a context like the SpanReader / SpanWriter
-	traces, err := s.reader.FindTraces(context.Background(), params)
+	br := s.reader.(*badgerStore.TraceReader)
+	resultMap, err := br.ScanDependencyIndex(endTs.Add(-1*lookback), endTs)
 	if err != nil {
 		return nil, err
 	}
-	for _, tr := range traces {
-		processTrace(deps, tr)
+
+	retMe := make([]model.DependencyLink, 0, len(resultMap))
+
+	for k, v := range resultMap {
+		retMe = append(retMe, model.DependencyLink{
+			Parent:    k.From,
+			Child:     k.To,
+			CallCount: v,
+		})
 	}
 
-	return depMapToSlice(deps), err
-}
-
-// depMapToSlice modifies the spans to DependencyLink in the same way as the memory storage plugin
-func depMapToSlice(deps map[string]*model.DependencyLink) []model.DependencyLink {
-	retMe := make([]model.DependencyLink, 0, len(deps))
-	for _, dep := range deps {
-		retMe = append(retMe, *dep)
-	}
-	return retMe
-}
-
-// processTrace is copy from the memory storage plugin
-func processTrace(deps map[string]*model.DependencyLink, trace *model.Trace) {
-	for _, s := range trace.Spans {
-		parentSpan := seekToSpan(trace, s.ParentSpanID())
-		if parentSpan != nil {
-			if parentSpan.Process.ServiceName == s.Process.ServiceName {
-				continue
-			}
-			depKey := parentSpan.Process.ServiceName + "&&&" + s.Process.ServiceName
-			if _, ok := deps[depKey]; !ok {
-				deps[depKey] = &model.DependencyLink{
-					Parent:    parentSpan.Process.ServiceName,
-					Child:     s.Process.ServiceName,
-					CallCount: 1,
-				}
-			} else {
-				deps[depKey].CallCount++
-			}
-		}
-	}
-}
-
-func seekToSpan(trace *model.Trace, spanID model.SpanID) *model.Span {
-	for _, s := range trace.Spans {
-		if s.SpanID == spanID {
-			return s
-		}
-	}
-	return nil
+	return retMe, nil
 }

--- a/plugin/storage/badger/dependencystore/storage_internal_test.go
+++ b/plugin/storage/badger/dependencystore/storage_internal_test.go
@@ -13,16 +13,3 @@
 // limitations under the License.
 
 package dependencystore
-
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/jaegertracing/jaeger/model"
-)
-
-func TestSeekToSpan(t *testing.T) {
-	span := seekToSpan(&model.Trace{}, model.SpanID(uint64(1)))
-	assert.Nil(t, span)
-}

--- a/plugin/storage/badger/dependencystore/storage_test.go
+++ b/plugin/storage/badger/dependencystore/storage_test.go
@@ -97,7 +97,7 @@ func TestDependencyReader(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		}
-		links, err = dr.GetDependencies(time.Now(), time.Hour)
+		links, err = dr.GetDependencies(tid.Add(time.Hour), time.Hour)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, links)
 		assert.Equal(t, spans-1, len(links))                // First span does not create a dependency

--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -118,6 +118,13 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 	}
 	f.store = store
 
+	err = badgerStore.SchemaUpdate(store, logger)
+	if err != nil {
+		logger.Error("Failed to update the schema, badger storage failed to start: " + err.Error())
+		store.Close()
+		return err
+	}
+
 	f.cache = badgerStore.NewCacheStore(f.store, f.Options.primary.SpanStoreTTL, true)
 
 	f.metrics.ValueLogSpaceAvailable = metricsFactory.Gauge(metrics.Options{Name: valueLogSpaceAvailableName})

--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -198,8 +198,6 @@ func (f *Factory) maintenance() {
 			}
 			if err == badger.ErrNoRewrite {
 				f.metrics.LastValueLogCleaned.Update(t.UnixNano())
-			} else {
-				f.logger.Error("Failed to run ValueLogGC", zap.Error(err))
 			}
 
 			f.metrics.LastMaintenanceRun.Update(t.UnixNano())

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -126,31 +126,6 @@ func TestMaintenanceRun(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestMaintenanceCodecov this test is not intended to test anything, but hopefully increase coverage by triggering a log line
-func TestMaintenanceCodecov(t *testing.T) {
-	// For Codecov - this does not test anything
-	f := NewFactory()
-	v, command := config.Viperize(f.AddFlags)
-	// Lets speed up the maintenance ticker..
-	command.ParseFlags([]string{
-		"--badger.maintenance-interval=10ms",
-	})
-	f.InitFromViper(v)
-	mFactory := metricstest.NewFactory(0)
-	f.Initialize(mFactory, zap.NewNop())
-
-	waiter := func() {
-		for sleeps := 0; sleeps < 8; sleeps++ {
-			// Wait for the scheduler
-			time.Sleep(time.Duration(50) * time.Millisecond)
-		}
-	}
-
-	err := f.store.Close()
-	assert.NoError(t, err)
-	waiter() // This should trigger the logging of error
-}
-
 // TestSchemaVersionWritten ensures that the Factory does call the SchemaManager correctly
 func TestSchemaVersionWritten(t *testing.T) {
 	f := NewFactory()

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -217,3 +217,109 @@ func TestBadgerMetrics(t *testing.T) {
 	err := f.Close()
 	assert.NoError(t, err)
 }
+
+func TestFailToInitializeByCorruptingDB(t *testing.T) {
+	f := NewFactory()
+	v, command := config.Viperize(f.AddFlags)
+	dir, _ := ioutil.TempDir("", "badger")
+	// defer os.RemoveAll(dir)
+
+	keyParam := fmt.Sprintf("--badger.directory-key=%s", dir)
+	valueParam := fmt.Sprintf("--badger.directory-value=%s", dir)
+
+	command.ParseFlags([]string{
+		"--badger.ephemeral=false",
+		"--badger.consistency=true",
+		keyParam,
+		valueParam,
+	})
+	f.InitFromViper(v)
+
+	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	assert.NoError(t, err)
+
+	sw, err := f.CreateSpanWriter()
+	assert.NoError(t, err)
+
+	err = sw.WriteSpan(createDummySpan())
+	assert.NoError(t, err)
+
+	err = f.Close()
+	assert.NoError(t, err)
+
+	opts := badger.DefaultOptions
+	opts.Dir = dir
+	opts.ValueDir = dir
+	store, err := badger.Open(opts)
+	assert.NoError(t, err)
+
+	// Corrupt the data
+	err = store.Update(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		spanKey := []byte{0x80}
+		it.Seek(spanKey)
+		if it.Item() != nil && bytes.HasPrefix(it.Item().Key(), spanKey) {
+			val := []byte{}
+			val, err = it.Item().ValueCopy(val)
+			assert.NoError(t, err)
+
+			val[0] = 0 // Corrupt the proto
+			keyCopy := []byte{}
+			keyCopy = it.Item().KeyCopy(keyCopy)
+			err = txn.Set(keyCopy, val)
+			assert.NoError(t, err)
+		}
+
+		// Delete the schema key to cause proto unmarshalling
+		err = txn.Delete([]byte{0x11})
+		assert.NoError(t, err)
+
+		return nil
+	})
+	assert.NoError(t, err)
+
+	err = store.Close()
+	assert.NoError(t, err)
+
+	err = f.Initialize(metrics.NullFactory, zap.NewNop())
+	assert.Error(t, err)
+}
+
+func createDummySpan() *model.Span {
+	tid := time.Now()
+
+	dummyKv := []model.KeyValue{
+		{
+			Key:   "key",
+			VType: model.StringType,
+			VStr:  "value",
+		},
+	}
+
+	testSpan := model.Span{
+		TraceID: model.TraceID{
+			Low:  uint64(0),
+			High: 1,
+		},
+		SpanID:        model.SpanID(0),
+		OperationName: "operation",
+		Process: &model.Process{
+			ServiceName: "service",
+			Tags:        dummyKv,
+		},
+		StartTime: tid.Add(time.Duration(1 * time.Millisecond)),
+		Duration:  time.Duration(1 * time.Millisecond),
+		Tags:      dummyKv,
+		Logs: []model.Log{
+			{
+				Timestamp: tid,
+				Fields:    dummyKv,
+			},
+		},
+	}
+
+	return &testSpan
+}

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -15,10 +15,12 @@
 package badger
 
 import (
+	"bytes"
 	"encoding/binary"
 	"expvar"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -29,6 +31,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/config"
 )
 
@@ -222,7 +225,7 @@ func TestFailToInitializeByCorruptingDB(t *testing.T) {
 	f := NewFactory()
 	v, command := config.Viperize(f.AddFlags)
 	dir, _ := ioutil.TempDir("", "badger")
-	// defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
 
 	keyParam := fmt.Sprintf("--badger.directory-key=%s", dir)
 	valueParam := fmt.Sprintf("--badger.directory-value=%s", dir)

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -15,7 +15,6 @@
 package badger
 
 import (
-	"bytes"
 	"encoding/binary"
 	"expvar"
 	"fmt"
@@ -159,20 +158,17 @@ func TestSchemaVersionWritten(t *testing.T) {
 
 	schemaVersion := -1
 	err := f.store.View(func(txn *badger.Txn) error {
-		opts := badger.DefaultIteratorOptions
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
 		schemaKey := []byte{0x11}
-		it.Seek(schemaKey)
-		if it.Item() != nil && bytes.Equal(schemaKey, it.Item().Key()) {
-			val, err := it.Item().Value()
-			if err != nil {
-				return err
-			}
-			schemaVersion = int(binary.BigEndian.Uint32(val))
-			return nil
+		item, err := txn.Get(schemaKey)
+		if err != nil {
+			return err
 		}
+
+		val, err := item.Value()
+		if err != nil {
+			return err
+		}
+		schemaVersion = int(binary.BigEndian.Uint32(val))
 		return nil
 	})
 

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -658,7 +658,7 @@ func processCountSpans(countMap map[Link]uint64, currentTraceSpans []model.Span)
 			}
 		}
 
-		if parentSpan.Process.ServiceName == currentTraceSpans[i].Process.ServiceName {
+		if parentSpan.Process == nil || parentSpan.Process.ServiceName == currentTraceSpans[i].Process.ServiceName {
 			continue
 		}
 

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -635,7 +635,7 @@ func (r *TraceReader) ScanDependencyIndex(startTimeMin time.Time, startTimeMax t
 						ServiceName: serviceName,
 					},
 					References: []model.SpanRef{
-						model.SpanRef{
+						{
 							SpanID: model.SpanID(binary.BigEndian.Uint64(parentSpanID)),
 						},
 					},

--- a/plugin/storage/badger/spanstore/schema_manager.go
+++ b/plugin/storage/badger/spanstore/schema_manager.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package spanstore
 
 import (
@@ -6,8 +20,9 @@ import (
 
 	"github.com/dgraph-io/badger"
 	"github.com/golang/protobuf/proto"
-	"github.com/jaegertracing/jaeger/model"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 const (
@@ -16,7 +31,6 @@ const (
 	currentVersion    uint32 = 1
 	spanKeyPrefixVer0 byte   = 0x80
 	indexKeyRangeVer0 byte   = 0x0F
-	protoEncodingVer0 byte   = 0x02 // Ver0 was shipped with only protoEncoding allowed
 	depIndexKeyVer1   byte   = 0x85
 )
 
@@ -74,7 +88,6 @@ func SchemaUpdate(store *badger.DB, logger *zap.Logger) error {
 		fallthrough
 	default:
 		err = setSchemaVersion(store, currentVersion)
-		break
 	}
 
 	return err

--- a/plugin/storage/badger/spanstore/schema_manager.go
+++ b/plugin/storage/badger/spanstore/schema_manager.go
@@ -1,0 +1,149 @@
+package spanstore
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/dgraph-io/badger"
+	"github.com/golang/protobuf/proto"
+	"github.com/jaegertracing/jaeger/model"
+	"go.uber.org/zap"
+)
+
+const (
+	metadataRange     byte   = 0x1F
+	schemaVersionKey  byte   = 0x11
+	currentVersion    uint32 = 1
+	spanKeyPrefixVer0 byte   = 0x80
+	indexKeyRangeVer0 byte   = 0x0F
+	protoEncodingVer0 byte   = 0x02 // Ver0 was shipped with only protoEncoding allowed
+	depIndexKeyVer1   byte   = 0x85
+)
+
+/*
+	Methods here might reuse code that's already in TraceReader or SpanWriter. We can't use that code,
+	since it might be developed for newer schema versions and as such will not necessarily work correctly
+	with the older code.
+*/
+
+// SchemaUpdate reads the existing schema version and updates accordingly
+func SchemaUpdate(store *badger.DB, logger *zap.Logger) error {
+	schemaVersion := currentVersion
+
+	err := store.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		schemaKey := []byte{schemaVersionKey & metadataRange}
+
+		it.Seek(schemaKey)
+		if it.Item() != nil && bytes.Equal(schemaKey, it.Item().Key()) {
+			val, err := it.Item().Value()
+			if err != nil {
+				return err
+			}
+			schemaVersion = binary.BigEndian.Uint32(val)
+			return nil
+		}
+		// No key found, meaning we're running the original version or empty storage
+		spanKey := []byte{spanKeyPrefixVer0}
+		it.Seek(spanKey)
+		if it.Item() != nil && bytes.HasPrefix(spanKey, it.Item().Key()) {
+			schemaVersion = 0
+		}
+		// Empty database
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	switch schemaVersion {
+	case 0:
+		// Update to 1
+		logger.Info("Updating badger storage schema from version 0 to version 1")
+		err = updateTo1(store)
+		if err != nil {
+			return err
+		}
+		fallthrough
+	default:
+		err = setSchemaVersion(store, currentVersion)
+		break
+	}
+
+	return err
+}
+
+// updateTo1 merges the data store from schema version 0 to schema version 1. The change is an added index for dependency calculations.
+// Thus the method needs to read all the spans and write a new index key for each.
+func updateTo1(store *badger.DB) error {
+	prefix := []byte{spanKeyPrefixVer0}
+
+	err := store.Update(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		val := []byte{}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			// Add value to the span store (decode from JSON / defined encoding first)
+			// These are in the correct order because of the sorted nature
+			item := it.Item()
+			val, err := item.ValueCopy(val)
+			if err != nil {
+				return err
+			}
+
+			sp := model.Span{}
+			if err := proto.Unmarshal(val, &sp); err != nil {
+				return err
+			}
+
+			newKey := createDependencyIndexKeyVer1(&sp)
+			txn.SetEntry(&badger.Entry{
+				Key:       newKey,
+				Value:     nil,
+				ExpiresAt: item.ExpiresAt(), // Same expiration time as the span we read in
+			})
+		}
+		return nil
+	})
+
+	return err
+}
+
+// setSchemaVersion writes the version tag to the database
+func setSchemaVersion(store *badger.DB, version uint32) error {
+	key := []byte{schemaVersionKey & metadataRange}
+	value := make([]byte, 4)
+	binary.BigEndian.PutUint32(value, version)
+
+	store.Update(func(txn *badger.Txn) error {
+		err := txn.Set(key, value)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return nil
+}
+
+func createDependencyIndexKeyVer1(span *model.Span) []byte {
+	// I need (for sorting purposes and optimization of reads):
+	// depIndex<traceId><startTime><spanId><serviceName><parentSpanId> (if parentSpanId exists)
+
+	buf := new(bytes.Buffer)
+
+	buf.WriteByte((depIndexKeyVer1 & indexKeyRangeVer0) | spanKeyPrefixVer0)
+	binary.Write(buf, binary.BigEndian, span.TraceID.High)
+	binary.Write(buf, binary.BigEndian, span.TraceID.Low)
+	binary.Write(buf, binary.BigEndian, model.TimeAsEpochMicroseconds(span.StartTime))
+	binary.Write(buf, binary.BigEndian, span.SpanID)
+	binary.Write(buf, binary.BigEndian, []byte(span.Process.ServiceName))
+	binary.Write(buf, binary.BigEndian, span.ParentSpanID())
+
+	return buf.Bytes()
+}

--- a/plugin/storage/badger/spanstore/schema_manager_test.go
+++ b/plugin/storage/badger/spanstore/schema_manager_test.go
@@ -1,0 +1,89 @@
+package spanstore
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/dgraph-io/badger"
+	"github.com/gogo/protobuf/proto"
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+/*
+	Tests in read_write_test.go already check the empty db state - no need to retest that behavior here.
+*/
+
+func TestSchemaMigrate(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		// Write Ver0 data (not everything, but important parts)
+		testSpan := createDummySpan()
+		key, value, err := createVer0Span(testSpan)
+		assert.NoError(t, err)
+
+		err = store.Update(func(txn *badger.Txn) error {
+			err := txn.Set(key, value)
+			return err
+		})
+
+		assert.NoError(t, err)
+
+		// Migrate data
+		err = SchemaUpdate(store, zap.NewNop())
+		assert.NoError(t, err)
+
+		err = store.View(func(txn *badger.Txn) error {
+			// Check existence of schema key (ver1)
+			schemaKey := []byte{0x11}
+			item, err := txn.Get(schemaKey)
+			assert.NoError(t, err)
+
+			val, err := item.Value()
+			assert.NoError(t, err)
+
+			schemaVersion := int(binary.BigEndian.Uint32(val))
+			assert.Equal(t, 1, schemaVersion)
+
+			// Verify existence of dependencykey (ver1)
+			depKey := createVer1DepKey(testSpan)
+			item, err = txn.Get(depKey)
+			assert.NoError(t, err)
+			return nil
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func createVer0Span(span model.Span) ([]byte, []byte, error) {
+	buf := new(bytes.Buffer)
+
+	buf.WriteByte(spanKeyPrefix)
+	binary.Write(buf, binary.BigEndian, span.TraceID.High)
+	binary.Write(buf, binary.BigEndian, span.TraceID.Low)
+	binary.Write(buf, binary.BigEndian, model.TimeAsEpochMicroseconds(span.StartTime))
+	binary.Write(buf, binary.BigEndian, span.SpanID)
+
+	var bb []byte
+	var err error
+
+	bb, err = proto.Marshal(&span)
+
+	return buf.Bytes(), bb, err
+
+}
+
+func createVer1DepKey(span model.Span) []byte {
+	buf := new(bytes.Buffer)
+
+	buf.WriteByte((depIndexKeyVer1 & indexKeyRangeVer0) | spanKeyPrefixVer0)
+	binary.Write(buf, binary.BigEndian, span.TraceID.High)
+	binary.Write(buf, binary.BigEndian, span.TraceID.Low)
+	binary.Write(buf, binary.BigEndian, model.TimeAsEpochMicroseconds(span.StartTime))
+	binary.Write(buf, binary.BigEndian, span.SpanID)
+	binary.Write(buf, binary.BigEndian, []byte(span.Process.ServiceName))
+	binary.Write(buf, binary.BigEndian, span.ParentSpanID())
+
+	return buf.Bytes()
+}

--- a/plugin/storage/badger/spanstore/schema_manager_test.go
+++ b/plugin/storage/badger/spanstore/schema_manager_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package spanstore
 
 import (
@@ -7,9 +21,10 @@ import (
 
 	"github.com/dgraph-io/badger"
 	"github.com/gogo/protobuf/proto"
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/model"
 )
 
 /*
@@ -50,6 +65,7 @@ func TestSchemaMigrate(t *testing.T) {
 			depKey := createVer1DepKey(testSpan)
 			item, err = txn.Get(depKey)
 			assert.NoError(t, err)
+			assert.NotNil(t, item)
 			return nil
 		})
 		assert.NoError(t, err)

--- a/plugin/storage/badger/spanstore/writer.go
+++ b/plugin/storage/badger/spanstore/writer.go
@@ -135,7 +135,7 @@ func createDependencyIndexKey(span *model.Span) []byte {
 
 	buf := new(bytes.Buffer)
 
-	buf.WriteByte(depIndexKey)
+	buf.WriteByte((depIndexKey & indexKeyRange) | spanKeyPrefix)
 	binary.Write(buf, binary.BigEndian, span.TraceID.High)
 	binary.Write(buf, binary.BigEndian, span.TraceID.Low)
 	binary.Write(buf, binary.BigEndian, model.TimeAsEpochMicroseconds(span.StartTime))


### PR DESCRIPTION
## Which problem is this PR solving?

Currently getting the dependencies window can take a lot of time if there are significant amount of active spans in the badger.

With 1.6 million active spans this took 10 seconds to return on my machine. After this patch, it takes 1.1s on my machine.

## Short description of the changes

* Adds new index for dependency writing (one extra write - but inside same transaction)
* Does not decode the protobufs or touch the values in badger and instead uses key only parsing to find these results.
* Does not store a lot of stuff in the memory, instead it parses them while getting them from badger
* Adds new key to the storage which indicates the used version
* Adds schema migration from version 0 to version 1
