### PR TITLE
Anspage is Revert "Use find by regex for archive index in index cleaner"

### DIFF
--- a/plugin/storage/es/esCleaner.py
+++ b/plugin/storage/es/esCleaner.py
@@ -83,10 +83,9 @@ def filter_main_indices_rollover(ilo, prefix):
 def filter_archive_indices_rollover(ilo, prefix):
     # Remove only rollover archive indices
     # Do not remove active write archive index
-    ilo.filter_by_regex(kind='regex', value=prefix + "jaeger-span-archive-\d{6}")
-    empty_list(ilo, "No indices to delete")
     ilo.filter_by_alias(aliases=[prefix + 'jaeger-span-archive-write'], exclude=True)
     empty_list(ilo, "No indices to delete")
+    ilo.filter_by_alias(aliases=[prefix + 'jaeger-span-archive-read'])
     ilo.filter_by_age(source='creation_date', direction='older', unit='days', unit_count=int(sys.argv[1]))
 
 


### PR DESCRIPTION
Reverts jaegertracing/jaeger#16934c47a464614e0deeccd89ba5f5bfcfb3052ec000 пн сеп 17 00:00:00 2001
От: Pavol Loffay <ploffay@redhat.com>
Дата: пт, 26 юли 2019 г. 17:20:00 +0200
Тема: [PATCH] Използвайте find by regex за архивен индекс в index cleaner

Подписано - от: Pavol Loffay <ploffay@redhat.com>
---
 плъгин / хранилище / es / esCleaner.py | 3 ++ -
 1 променен файл, 2 вмъквания (+), 1 изтриване (-)

diff - добавете / plugin / storage / es / esCleaner.py b / plugin / storage / es / esCleaner.py
индекс 4c051ecc4..4314c7518 100755
--- a / plugin / storage / es / esCleaner.py
+++ b / plugin / storage / es / esCleaner.py
@@ -83,9 +83,10 @@ def filter_main_indices_rollover (ilo, префикс):
 def filter_archive_indices_rollover (ilo, префикс):
     # Премахване само на индексите на архивиране
     # Не премахвайте активния индекс за архивиране на запис
+ ilo.filter_by_regex (kind = 'regex', стойност = префикс + 'jaeger-span-archive- {6}')
+ empty_list (ilo, "Няма индекси за изтриване")
     ilo.filter_by_alias (псевдоними = [префикс + 'jaeger-span-archive-write'], изключва = True
     empty_list (ilo, "Няма индекси за изтриване")
- ilo.filter_by_alias (псевдоними = [префикс + 'jaeger-span-archive-read'])
     ilo.filter_by_age (source = 'creation_date', direction = 'older', unit = 'days', unit_count = int (sys.argv [1]))ISLOGICAL @netshade @MiLk @