### PR TITLE
[bug fix] Pass TTL as int, not as float64

### DIFF
--- a/plugin/pkg/distributedlock/cassandra/lock.go
+++ b/plugin/pkg/distributedlock/cassandra/lock.go
@@ -54,8 +54,9 @@ func (l *Lock) Acquire(resource string, ttl time.Duration) (bool, error) {
 	if ttl == 0 {
 		ttl = defaultTTL
 	}
+	ttlSec := int(ttl.Seconds())
 	var name, owner string
-	applied, err := l.session.Query(cqlInsertLock, resource, l.tenantID, ttl.Seconds()).ScanCAS(&name, &owner)
+	applied, err := l.session.Query(cqlInsertLock, resource, l.tenantID, ttlSec).ScanCAS(&name, &owner)
 	if err != nil {
 		return false, errors.Wrap(err, "Failed to acquire resource lock due to cassandra error")
 	}
@@ -89,8 +90,9 @@ func (l *Lock) Forfeit(resource string) (bool, error) {
 
 // extendLease will attempt to extend the lease of an existing lock on a given resource.
 func (l *Lock) extendLease(resource string, ttl time.Duration) error {
+	ttlSec := int(ttl.Seconds())
 	var owner string
-	applied, err := l.session.Query(cqlUpdateLock, ttl.Seconds(), l.tenantID, resource, l.tenantID).ScanCAS(&owner)
+	applied, err := l.session.Query(cqlUpdateLock, ttlSec, l.tenantID, resource, l.tenantID).ScanCAS(&owner)
 	if err != nil {
 		return err
 	}

--- a/plugin/pkg/distributedlock/cassandra/lock_test.go
+++ b/plugin/pkg/distributedlock/cassandra/lock_test.go
@@ -92,27 +92,8 @@ func TestExtendLease(t *testing.T) {
 					assert.EqualError(t, err, testCase.expectedErrMsg)
 				}
 
-				assert.Len(t, args, 4)
-				if d, ok := args[0].(float64); ok {
-					assert.EqualValues(t, 60, d)
-				} else {
-					assert.Fail(t, "expecting first arg as int64", "received: %+v", args)
-				}
-				if d, ok := args[1].(string); ok {
-					assert.Equal(t, localhost, d)
-				} else {
-					assert.Fail(t, "expecting second arg as string", "received: %+v", args)
-				}
-				if d, ok := args[2].(string); ok {
-					assert.Equal(t, samplingLock, d)
-				} else {
-					assert.Fail(t, "expecting third arg as string", "received: %+v", args)
-				}
-				if d, ok := args[3].(string); ok {
-					assert.Equal(t, localhost, d)
-				} else {
-					assert.Fail(t, "expecting fourth arg as string", "received: %+v", args)
-				}
+				expectedArgs := []interface{}{60, localhost, samplingLock, localhost}
+				assert.Equal(t, expectedArgs, args)
 			})
 		})
 	}


### PR DESCRIPTION
Discovered during internal testing while consolidating oss and internal adaptive sampling code.

Unfortunately, we don't have a good integration tests for this yet.