### PR TITLE
Fix badger merge-join algorithm to correctly filter indexes

### DIFF
--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -161,6 +161,11 @@ func TestIndexSeeks(t *testing.T) {
 							VStr:  fmt.Sprintf("val%d", j),
 							VType: model.StringType,
 						},
+						{
+							Key:   "error",
+							VType: model.BoolType,
+							VBool: true,
+						},
 					},
 				}
 				err := sw.WriteSpan(&s)
@@ -200,6 +205,7 @@ func TestIndexSeeks(t *testing.T) {
 		params.OperationName = "operation-1"
 		tags := make(map[string]string)
 		tags["k11"] = "val0"
+		tags["error"] = "true"
 		params.Tags = tags
 		params.DurationMin = time.Duration(1 * time.Millisecond)
 		// params.DurationMax = time.Duration(1 * time.Hour)

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -346,7 +346,13 @@ func (r *TraceReader) durationQueries(query *spanstore.TraceQueryParameters, ids
 }
 
 func mergeJoinIds(left, right [][]byte) [][]byte {
-	merged := make([][]byte, 0, len(left)) // len(left) or len(right) is the maximum, whichever is smallest
+	// len(left) or len(right) is the maximum, whichever is the smallest
+	allocateSize := len(left)
+	if len(right) < allocateSize {
+		allocateSize = len(right)
+	}
+
+	merged := make([][]byte, 0, allocateSize)
 
 	lMax := len(left) - 1
 	rMax := len(right) - 1
@@ -382,7 +388,6 @@ func sortMergeIds(query *spanstore.TraceQueryParameters, ids [][][]byte) []model
 		}
 	} else {
 		merged = ids[0]
-
 	}
 
 	// Get top query.NumTraces results (order in DESC)

--- a/plugin/storage/badger/spanstore/rw_internal_test.go
+++ b/plugin/storage/badger/spanstore/rw_internal_test.go
@@ -176,3 +176,37 @@ func createDummySpan() model.Span {
 
 	return testSpan
 }
+
+func TestMergeJoin(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test equals
+
+	left := make([][]byte, 16)
+	right := make([][]byte, 16)
+
+	for i := 0; i < 16; i++ {
+		left[i] = make([]byte, 4)
+		binary.BigEndian.PutUint32(left[i], uint32(i))
+
+		right[i] = make([]byte, 4)
+		binary.BigEndian.PutUint32(right[i], uint32(i))
+	}
+
+	merged := mergeJoinIds(left, right)
+	assert.Equal(16, len(merged))
+
+	// Check order
+	assert.Equal(uint32(15), binary.BigEndian.Uint32(merged[15]))
+
+	// Test simple non-equality different size
+
+	merged = mergeJoinIds(left[1:2], right[13:])
+	assert.Empty(merged)
+
+	// Different size, some equalities
+
+	merged = mergeJoinIds(left[0:3], right[1:7])
+	assert.Equal(2, len(merged))
+	assert.Equal(uint32(2), binary.BigEndian.Uint32(merged[1]))
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #1719, the index seeks were not correctly merged and filtered. 

## Short description of the changes

Make the merge-join correctly update two indices when encountering equal items. Also, the input must be the output of previous merge. Also, changed ASC to DESC reversing to happen after the top query filtering - thus reducing unnecessary work.
