### PR TITLE
Added null guards to 'Process' when processing an incoming span

### DIFF
--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -244,10 +244,13 @@ func (m *SpanProcessorMetrics) GetCountsForFormat(spanFormat SpanFormat, transpo
 // reportServiceNameForSpan determines the name of the service that emitted
 // the span and reports a counter stat.
 func (m metricsBySvc) ReportServiceNameForSpan(span *model.Span) {
-	serviceName := span.Process.ServiceName
-	if serviceName == "" {
-		return
+	var serviceName string
+	if nil == span.Process || len(span.Process.ServiceName) == 0 {
+		serviceName = "__unknown"
+	} else {
+		serviceName = span.Process.ServiceName
 	}
+
 	m.countSpansByServiceName(serviceName, span.Flags.IsDebug())
 	if span.ParentSpanID() == 0 {
 

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -109,6 +109,12 @@ func (sp *spanProcessor) Stop() {
 }
 
 func (sp *spanProcessor) saveSpan(span *model.Span) {
+	if nil == span.Process {
+		sp.logger.Error("process is empty for the span")
+		sp.metrics.SavedErrBySvc.ReportServiceNameForSpan(span)
+		return
+	}
+
 	startTime := time.Now()
 	if err := sp.spanWriter.WriteSpan(span); err != nil {
 		sp.logger.Error("Failed to save span", zap.Error(err))


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #1722 by returning an error before attempting to write the span that has no process attached to it. For the metrics collection, the service name is set to `__unknown`. Previously, such problems were not apparent via metrics.

Before this PR, the collector would crash at different points (see #1722) depending on the storage being used. After this PR, the following message is shown in the logs:

```
{"level":"error","ts":1565269296.058833,"caller":"app/span_processor.go:114","msg":"Failed to save span","error":"process is empty for the span","stacktrace":"github.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).saveSpan\n\t/mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:114\ngithub.com/jaegertracing/jaeger/cmd/collector/app.ChainedProcessSpan.func1\n\t/mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger/cmd/collector/app/model_consumer.go:34\ngithub.com/jaegertracing/jaeger/cmd/collector/app.(*spanProcessor).processItemFromQueue\n\t/mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:139\ngithub.com/jaegertracing/jaeger/cmd/collector/app.NewSpanProcessor.func1\n\t/mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger/cmd/collector/app/span_processor.go:68\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger/pkg/queue/bounded_queue.go:65"}
```

And this counter is incremented:

```
jaeger_collector_spans_saved_by_svc_total{debug="false",result="err",svc="__unknown"} 1
```