### PR TITLE
Place a queue infront of agent reporter to provide some resiliency

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -38,9 +38,7 @@ import (
 )
 
 const (
-	defaultQueueSize     = 1000
 	defaultMaxPacketSize = 65000
-	defaultServerWorkers = 10
 
 	jaegerModel Model = "jaeger"
 	zipkinModel Model = "zipkin"

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -18,7 +18,6 @@ package app
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -153,7 +152,6 @@ func TestMultipleCollectorProxies(t *testing.T) {
 	r := b.getReporter(rb)
 	mr, ok := r.(reporter.MultiReporter)
 	require.True(t, ok)
-	fmt.Println(mr)
 	assert.Equal(t, rb, mr[0])
 	assert.Equal(t, ra, mr[1])
 }
@@ -236,7 +234,7 @@ func TestCreateCollectorProxy(t *testing.T) {
 		err := command.ParseFlags(test.flags)
 		require.NoError(t, err)
 
-		rOpts := new(reporter.Options).InitFromViper(v)
+		rOpts := new(reporter.Options).InitFromViper(v, zap.NewNop())
 		tchan := tchannel.NewBuilder().InitFromViper(v, zap.NewNop())
 		grpcBuilder := grpc.NewConnBuilder().InitFromViper(v)
 

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -47,8 +47,8 @@ var defaultProcessors = []struct {
 func AddFlags(flags *flag.FlagSet) {
 	for _, p := range defaultProcessors {
 		prefix := fmt.Sprintf("processor.%s-%s.", p.model, p.protocol)
-		flags.Int(prefix+suffixWorkers, defaultServerWorkers, "how many workers the processor should run, deprecated - use reporter config")
-		flags.Int(prefix+suffixServerQueueSize, defaultQueueSize, "length of the queue for the UDP server, deprecated - use reporter config")
+		flags.Int(prefix+suffixWorkers, 0, "(deprecated) see --reporter.queue.workers")
+		flags.Int(prefix+suffixServerQueueSize, 0, "(deprecated) see --reporter.queue.memory.size")
 		flags.Int(prefix+suffixServerMaxPacketSize, defaultMaxPacketSize, "max packet size for the UDP server")
 		flags.String(prefix+suffixServerHostPort, ":"+strconv.Itoa(p.port), "host:port for the UDP server")
 	}

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -47,8 +47,8 @@ var defaultProcessors = []struct {
 func AddFlags(flags *flag.FlagSet) {
 	for _, p := range defaultProcessors {
 		prefix := fmt.Sprintf("processor.%s-%s.", p.model, p.protocol)
-		flags.Int(prefix+suffixWorkers, defaultServerWorkers, "how many workers the processor should run")
-		flags.Int(prefix+suffixServerQueueSize, defaultQueueSize, "length of the queue for the UDP server")
+		flags.Int(prefix+suffixWorkers, defaultServerWorkers, "how many workers the processor should run, deprecated - use reporter config")
+		flags.Int(prefix+suffixServerQueueSize, defaultQueueSize, "length of the queue for the UDP server, deprecated - use reporter config")
 		flags.Int(prefix+suffixServerMaxPacketSize, defaultMaxPacketSize, "max packet size for the UDP server")
 		flags.String(prefix+suffixServerHostPort, ":"+strconv.Itoa(p.port), "host:port for the UDP server")
 	}
@@ -63,8 +63,6 @@ func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
 	for _, processor := range defaultProcessors {
 		prefix := fmt.Sprintf("processor.%s-%s.", processor.model, processor.protocol)
 		p := &ProcessorConfiguration{Model: processor.model, Protocol: processor.protocol}
-		p.Workers = v.GetInt(prefix + suffixWorkers)
-		p.Server.QueueSize = v.GetInt(prefix + suffixServerQueueSize)
 		p.Server.MaxPacketSize = v.GetInt(prefix + suffixServerMaxPacketSize)
 		p.Server.HostPort = v.GetString(prefix + suffixServerHostPort)
 		b.Processors = append(b.Processors, *p)

--- a/cmd/agent/app/flags_test.go
+++ b/cmd/agent/app/flags_test.go
@@ -48,6 +48,4 @@ func TestBindFlags(t *testing.T) {
 	assert.Equal(t, ":8080", b.HTTPServer.HostPort)
 	assert.Equal(t, ":1111", b.Processors[2].Server.HostPort)
 	assert.Equal(t, 4242, b.Processors[2].Server.MaxPacketSize)
-	assert.Equal(t, 42, b.Processors[2].Server.QueueSize)
-	assert.Equal(t, 42, b.Processors[2].Workers)
 }

--- a/cmd/agent/app/processors/thrift_processor.go
+++ b/cmd/agent/app/processors/thrift_processor.go
@@ -23,7 +23,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
+	customtransport "github.com/jaegertracing/jaeger/cmd/agent/app/customtransports"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers"
 )
 

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -77,7 +77,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.MockTCollector, reporter.Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
 
-	reporter := reporter.WrapWithQueue(&reporter.Options{QueueType: reporter.DIRECT}, tchreporter.New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop()), zap.NewNop(), metricsFactory)
+	reporter := reporter.NewMetricsReporter(tchreporter.New("jaeger-collector", collector.Channel, time.Second, nil, zap.NewNop()), metricsFactory)
 
 	return metricsFactory, collector, reporter
 }

--- a/cmd/agent/app/reporter/common/domain_tools.go
+++ b/cmd/agent/app/reporter/common/domain_tools.go
@@ -12,21 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package queue
+package common
 
 import "github.com/jaegertracing/jaeger/model"
 
-// NonQueue sends stuff directly without queueing. Useful for testing purposes
-type NonQueue struct {
-	processor func(model.Batch) error
-}
-
-// NewNonQueue returns direct processing "queue"
-func NewNonQueue(processor func(model.Batch) error) *NonQueue {
-	return &NonQueue{processor}
-}
-
-// Enqueue calls processor instead of queueing
-func (n *NonQueue) Enqueue(batch model.Batch) error {
-	return n.processor(batch)
+// AddProcessTags appends jaeger tags for the agent to every span it sends to the collector.
+func AddProcessTags(spans []*model.Span, process *model.Process, agentTags []model.KeyValue) ([]*model.Span, *model.Process) {
+	if len(agentTags) == 0 {
+		return spans, process
+	}
+	if process != nil {
+		process.Tags = append(process.Tags, agentTags...)
+	}
+	for _, span := range spans {
+		if span.Process != nil {
+			span.Process.Tags = append(span.Process.Tags, agentTags...)
+		}
+	}
+	return spans, process
 }

--- a/cmd/agent/app/reporter/common/domain_tools_test.go
+++ b/cmd/agent/app/reporter/common/domain_tools_test.go
@@ -12,23 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package queue
+package common_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/common"
 	"github.com/jaegertracing/jaeger/model"
 )
 
-func TestDirectProcessing(t *testing.T) {
+func TestAddProcessTagsToAllParts(t *testing.T) {
 	assert := assert.New(t)
-	n := NewNonQueue(func(batch model.Batch) error {
-		return fmt.Errorf("Error")
-	})
 
-	err := n.Enqueue(model.Batch{})
-	assert.Error(err, "Error")
+	process := &model.Process{}
+
+	spans := []*model.Span{
+		{
+			Process: &model.Process{},
+		},
+	}
+
+	tags := map[string]string{
+		"a": "b",
+	}
+
+	spans2, process2 := common.AddProcessTags(spans, process, []model.KeyValue{})
+	assert.Equal(process, process2)
+	assert.Equal(spans, spans2)
+
+	_, process2 = common.AddProcessTags(spans, process, model.KeyValueFromMap(tags))
+	assert.Equal("b", process2.Tags[0].VStr)
 }

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -45,6 +45,9 @@ const (
 
 	// MEMORY is the default reporter queue
 	MEMORY QueueType = "memory"
+
+	// DIRECT is the reporter queue for testing (no queue at all)
+	DIRECT QueueType = "direct"
 )
 
 // Type defines type of reporter.

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -69,7 +69,7 @@ type Options struct {
 // AddFlags adds flags for Options.
 func AddFlags(flags *flag.FlagSet) {
 	flags.String(prefix+reporterType, string(GRPC), fmt.Sprintf("Reporter type to use e.g. %s, %s", string(GRPC), string(TCHANNEL)))
-	flags.String(prefix+reporterQueueType, string(MEMORY), "queue implementation to use in the reporter. Available options: memory")
+	flags.String(prefix+reporterQueueType, string(defaultQueueType), "queue implementation to use in the reporter. Available options: memory")
 	flags.Int(prefix+boundedQueueSize, defaultBoundedQueueSize, "maximum size of bounded in-memory queue")
 	flags.Int(prefix+reporterQueueWorkers, defaultQueueWorkers, "the amount of concurrent reporter connections to use")
 	flags.Duration(prefix+reporterMaxInterval, defaultMaxRetryInterval, "longest period of time to wait before retry. Format is time.Duration (https://golang.org/pkg/time/#Duration).")

--- a/cmd/agent/app/reporter/flags_test.go
+++ b/cmd/agent/app/reporter/flags_test.go
@@ -16,6 +16,7 @@ package reporter_test
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 )
 

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -143,10 +143,6 @@ func TestProxyBuilder(t *testing.T) {
 			name: "should pass with insecure grpc connection",
 			grpcBuilder: &ConnBuilder{
 				CollectorHostPorts: []string{"localhost:0000"},
-				TLS:                true,
-				TLSCA:              "testdata/testCA.pem",
-				TLSCert:            "testdata/client.jaeger.io-client.pem",
-				TLSKey:             "testdata/client.jaeger.io-client-key.pem",
 			},
 			expectError: false,
 		},
@@ -323,7 +319,7 @@ func TestProxyClientTLS(t *testing.T) {
 				TLS:                test.clientTLS,
 			}
 			proxy, err := NewCollectorProxy(
-				test.grpcBuilder,
+				grpcBuilder,
 				&reporter.Options{QueueType: reporter.DIRECT},
 				mFactory,
 				zap.NewNop())

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -189,7 +189,6 @@ func TestProxyBuilder(t *testing.T) {
 				assert.NotNil(t, proxy.GetManager())
 
 				assert.Nil(t, proxy.Close())
-				assert.EqualError(t, proxy.Close(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
 			}
 		})
 	}

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -33,15 +33,16 @@ type ProxyBuilder struct {
 }
 
 // NewCollectorProxy creates ProxyBuilder
-func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
+func NewCollectorProxy(builder *ConnBuilder, opts *reporter.Options, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
 	conn, err := builder.CreateConnection(logger)
 	if err != nil {
 		return nil, err
 	}
+	agentTags := opts.AgentTags
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
 	return &ProxyBuilder{
 		conn:     conn,
-		reporter: reporter.WrapWithQueue(NewReporter(conn, agentTags, logger), logger, grpcMetrics),
+		reporter: reporter.WrapWithQueue(opts, NewReporter(conn, agentTags, logger), logger, grpcMetrics),
 		manager:  configmanager.WrapWithMetrics(grpcManager.NewConfigManager(conn), grpcMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -41,7 +41,7 @@ func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFacto
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
 	return &ProxyBuilder{
 		conn:     conn,
-		reporter: reporter.WrapWithMetrics(NewReporter(conn, agentTags, logger), grpcMetrics),
+		reporter: reporter.WrapWithQueue(reporter.WrapWithMetrics(NewReporter(conn, agentTags, logger), grpcMetrics), logger),
 		manager:  configmanager.WrapWithMetrics(grpcManager.NewConfigManager(conn), grpcMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -41,7 +41,7 @@ func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFacto
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
 	return &ProxyBuilder{
 		conn:     conn,
-		reporter: reporter.WrapWithQueue(reporter.WrapWithMetrics(NewReporter(conn, agentTags, logger), grpcMetrics), logger),
+		reporter: reporter.WrapWithQueue(NewReporter(conn, agentTags, logger), logger, grpcMetrics),
 		manager:  configmanager.WrapWithMetrics(grpcManager.NewConfigManager(conn), grpcMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -15,6 +15,8 @@
 package grpc
 
 import (
+	"io"
+
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
@@ -42,7 +43,7 @@ func TestMultipleCollectors(t *testing.T) {
 	defer s2.Stop()
 
 	mFactory := metricstest.NewFactory(time.Microsecond)
-	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, mFactory, zap.NewNop())
+	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, &reporter.Options{QueueType: reporter.DIRECT}, mFactory, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -72,7 +72,10 @@ func (r *Reporter) send(spans []*model.Span, process *model.Process) error {
 	batch := model.Batch{Spans: spans, Process: process}
 	req := &api_v2.PostSpansRequest{Batch: batch}
 	_, err := r.collector.PostSpans(context.Background(), req)
-	return &gRPCReporterError{err}
+	if err != nil {
+		return &gRPCReporterError{err}
+	}
+	return nil
 }
 
 // addTags appends jaeger tags for the agent to every span it sends to the collector.

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/common"
 	zipkin2 "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
 	"github.com/jaegertracing/jaeger/model"
@@ -42,10 +43,10 @@ type Reporter struct {
 }
 
 // NewReporter creates gRPC reporter.
-func NewReporter(conn *grpc.ClientConn, agentTags map[string]string, logger *zap.Logger) *Reporter {
+func NewReporter(conn *grpc.ClientConn, opts *reporter.Options, logger *zap.Logger) *Reporter {
 	return &Reporter{
 		collector: api_v2.NewCollectorServiceClient(conn),
-		agentTags: model.KeyValueFromMap(agentTags),
+		agentTags: model.KeyValueFromMap(opts.AgentTags),
 		logger:    logger,
 		sanitizer: zipkin2.NewChainedSanitizer(zipkin2.StandardSanitizers...),
 	}

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/common"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
@@ -63,7 +64,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 	defer conn.Close()
 	require.NoError(t, err)
 
-	rep := NewReporter(conn, nil, zap.NewNop())
+	rep := NewReporter(conn, &reporter.Options{}, zap.NewNop())
 
 	tm := time.Unix(158, 0)
 	a := tm.Unix() * 1000 * 1000
@@ -100,7 +101,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
-	rep := NewReporter(conn, nil, zap.NewNop())
+	rep := NewReporter(conn, &reporter.Options{}, zap.NewNop())
 
 	tm := time.Unix(158, 0)
 	tests := []struct {
@@ -125,7 +126,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 func TestReporter_SendFailure(t *testing.T) {
 	conn, err := grpc.Dial("", grpc.WithInsecure())
 	require.NoError(t, err)
-	rep := NewReporter(conn, nil, zap.NewNop())
+	rep := NewReporter(conn, &reporter.Options{}, zap.NewNop())
 	err = rep.send(nil, nil)
 	assert.EqualError(t, err, "rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: missing address\"")
 }

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/common"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	jThrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
@@ -132,7 +133,7 @@ func TestReporter_SendFailure(t *testing.T) {
 func TestReporter_AddProcessTags_EmptyTags(t *testing.T) {
 	tags := map[string]string{}
 	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
-	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags))
+	actualSpans, _ := common.AddProcessTags(spans, nil, model.KeyValueFromMap(tags))
 	assert.Equal(t, spans, actualSpans)
 }
 
@@ -148,7 +149,7 @@ func TestReporter_AddProcessTags_ZipkinBatch(t *testing.T) {
 			Process:       &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}},
 		},
 	}
-	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags))
+	actualSpans, _ := common.AddProcessTags(spans, nil, model.KeyValueFromMap(tags))
 
 	assert.Equal(t, expectedSpans, actualSpans)
 }
@@ -159,7 +160,7 @@ func TestReporter_AddProcessTags_JaegerBatch(t *testing.T) {
 	process := &model.Process{ServiceName: "spring"}
 
 	expectedProcess := &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}}
-	_, actualProcess := addProcessTags(spans, process, makeModelKeyValue(tags))
+	_, actualProcess := common.AddProcessTags(spans, process, model.KeyValueFromMap(tags))
 
 	assert.Equal(t, expectedProcess, actualProcess)
 }
@@ -167,7 +168,7 @@ func TestReporter_AddProcessTags_JaegerBatch(t *testing.T) {
 func TestReporter_MakeModelKeyValue(t *testing.T) {
 	expectedTags := []model.KeyValue{model.String("key", "value")}
 	stringTags := map[string]string{"key": "value"}
-	actualTags := makeModelKeyValue(stringTags)
+	actualTags := model.KeyValueFromMap(stringTags)
 
 	assert.Equal(t, expectedTags, actualTags)
 }

--- a/cmd/agent/app/reporter/metrics.go
+++ b/cmd/agent/app/reporter/metrics.go
@@ -47,10 +47,10 @@ type batchMetrics struct {
 	BatchesRetries metrics.Counter `metric:"batches.retries"`
 
 	// Current queue size for reporter
-	QueueSize metrics.Gauge `metric:"reporter.queuesize"`
+	QueueSize metrics.Gauge `metric:"queuesize"`
 
 	// Current waiting time for reporter failures
-	RetryInterval metrics.Gauge `metric:"reporter.retry-interval-ns"`
+	RetryInterval metrics.Gauge `metric:"retry-interval-ns"`
 }
 
 // MetricsReporter is reporter with metrics integration.

--- a/cmd/agent/app/reporter/metrics.go
+++ b/cmd/agent/app/reporter/metrics.go
@@ -89,7 +89,3 @@ func withMetrics(m batchMetrics, size int64, err error) {
 		m.SpansSubmitted.Inc(size)
 	}
 }
-
-func (r *MetricsReporter) Retryable(err error) bool {
-	return r.wrapped.Retryable(err)
-}

--- a/cmd/agent/app/reporter/metrics.go
+++ b/cmd/agent/app/reporter/metrics.go
@@ -89,3 +89,7 @@ func withMetrics(m batchMetrics, size int64, err error) {
 		m.SpansSubmitted.Inc(size)
 	}
 }
+
+func (r *MetricsReporter) Retryable(err error) bool {
+	return r.wrapped.Retryable(err)
+}

--- a/cmd/agent/app/reporter/metrics_test.go
+++ b/cmd/agent/app/reporter/metrics_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics/metricstest"
+	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -46,7 +47,7 @@ func TestMetricsReporter(t *testing.T) {
 		rep              *noopReporter
 	}{
 		{expectedCounters: []metricstest.ExpectedMetric{
-			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 1},
+			{Name: "reporter.batches.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.batches.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.submitted", Tags: map[string]string{"format": "jaeger"}, Value: 0},
 			{Name: "reporter.spans.failures", Tags: map[string]string{"format": "jaeger"}, Value: 0},
@@ -113,7 +114,7 @@ func TestMetricsReporter(t *testing.T) {
 
 	for _, test := range tests {
 		metricsFactory := metricstest.NewFactory(time.Microsecond)
-		r := WrapWithMetrics(test.rep, metricsFactory)
+		r := WrapWithQueue(&Options{QueueType: DIRECT}, test.rep, zap.NewNop(), metricsFactory)
 		test.action(r)
 		metricsFactory.AssertCounterMetrics(t, test.expectedCounters...)
 		metricsFactory.AssertGaugeMetrics(t, test.expectedGauges...)

--- a/cmd/agent/app/reporter/metrics_test.go
+++ b/cmd/agent/app/reporter/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
@@ -36,6 +37,10 @@ func (r *noopReporter) EmitZipkinBatch(spans []*zipkincore.Span) error {
 }
 
 func (r *noopReporter) EmitBatch(batch *jaeger.Batch) error {
+	return r.err
+}
+
+func (r *noopReporter) ForwardBatch(batch model.Batch) error {
 	return r.err
 }
 

--- a/cmd/agent/app/reporter/queue.go
+++ b/cmd/agent/app/reporter/queue.go
@@ -1,0 +1,98 @@
+package reporter
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/queue"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+)
+
+type Queue interface {
+	Enqueue(*jaeger.Batch) error
+}
+
+type QueuedReporter struct {
+	wrapped Reporter
+	queue   Queue
+	logger  *zap.Logger
+
+	retryMutex sync.Mutex
+
+	retryTimerChange  time.Time
+	retryTimer        time.Duration
+	retryMaxWait      time.Duration
+	retryDefaultSleep time.Duration
+}
+
+func WrapWithQueue(reporter Reporter, logger *zap.Logger) *QueuedReporter {
+	q := &QueuedReporter{
+		wrapped:           reporter,
+		logger:            logger,
+		retryDefaultSleep: time.Millisecond * 100,
+		retryTimerChange:  time.Now(),
+		retryMaxWait:      20 * time.Second,
+	}
+	q.retryTimer = q.retryDefaultSleep
+	q.queue = queue.NewBoundQueue(1000, q.batchProcessor, logger)
+	return q
+}
+
+func (q *QueuedReporter) EmitZipkinBatch(spans []*zipkincore.Span) error {
+	return nil
+}
+
+func (q *QueuedReporter) EmitBatch(batch *jaeger.Batch) error {
+	return q.queue.Enqueue(batch)
+}
+
+func (q *QueuedReporter) backOffTimer() time.Duration {
+	// Has to be more than previous time from previous increase before we can reincrease
+	// otherwise simultaneous threads could race to increase the sleep time too quickly
+	t := time.Now()
+	if q.retryTimerChange.Add(q.retryTimer).Before(t) && q.retryTimer < q.retryMaxWait {
+		// We can increase, more than the previous timer has been spent
+		q.retryMutex.Lock()
+		if q.retryTimerChange.Add(q.retryTimer).Before(t) {
+			// We have to do the recheck because someone could have changed the time between check and mutex locking
+			newWait := q.retryTimer * 2
+			if newWait > q.retryMaxWait {
+				q.retryTimer = q.retryMaxWait
+			} else {
+				q.retryTimer = newWait
+			}
+		}
+		q.retryMutex.Unlock()
+	}
+
+	return q.retryTimer
+}
+
+func (q *QueuedReporter) batchProcessor(batch *jaeger.Batch) error {
+	err := q.wrapped.EmitBatch(batch)
+	if err != nil {
+		for q.wrapped.Retryable(err) {
+			// Block this processing instance before returning
+			sleepTime := q.backOffTimer()
+			q.logger.Info(fmt.Sprintf("Failed to contact the collector, waiting %s before retry", sleepTime.String()))
+			time.Sleep(sleepTime)
+			err = q.wrapped.EmitBatch(batch)
+			if err == nil {
+				q.retryMutex.Lock()
+				q.retryTimer = q.retryDefaultSleep
+				q.retryMutex.Unlock()
+				break
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func (q *QueuedReporter) Retryable(err error) bool {
+	return q.wrapped.Retryable(err)
+}

--- a/cmd/agent/app/reporter/queue.go
+++ b/cmd/agent/app/reporter/queue.go
@@ -23,27 +23,27 @@ type QueuedReporter struct {
 
 	retryMutex sync.Mutex
 
-	retryTimerChange  time.Time
-	retryTimer        time.Duration
-	retryMaxWait      time.Duration
-	retryDefaultSleep time.Duration
+	lastRetry            time.Time
+	currentRetryInterval time.Duration
+	maxRetryInterval     time.Duration
+	initialRetryInterval time.Duration
 }
 
 func WrapWithQueue(reporter Reporter, logger *zap.Logger) *QueuedReporter {
 	q := &QueuedReporter{
-		wrapped:           reporter,
-		logger:            logger,
-		retryDefaultSleep: time.Millisecond * 100,
-		retryTimerChange:  time.Now(),
-		retryMaxWait:      20 * time.Second,
+		wrapped:              reporter,
+		logger:               logger,
+		lastRetry:            time.Now(),
+		initialRetryInterval: time.Millisecond * 100,
+		maxRetryInterval:     20 * time.Second,
 	}
-	q.retryTimer = q.retryDefaultSleep
+	q.currentRetryInterval = q.initialRetryInterval
 	q.queue = queue.NewBoundQueue(1000, q.batchProcessor, logger)
 	return q
 }
 
 func (q *QueuedReporter) EmitZipkinBatch(spans []*zipkincore.Span) error {
-	return nil
+	return q.wrapped.EmitZipkinBatch(spans)
 }
 
 func (q *QueuedReporter) EmitBatch(batch *jaeger.Batch) error {
@@ -54,28 +54,28 @@ func (q *QueuedReporter) backOffTimer() time.Duration {
 	// Has to be more than previous time from previous increase before we can reincrease
 	// otherwise simultaneous threads could race to increase the sleep time too quickly
 	t := time.Now()
-	if q.retryTimerChange.Add(q.retryTimer).Before(t) && q.retryTimer < q.retryMaxWait {
+	if q.lastRetry.Add(q.currentRetryInterval).Before(t) && q.currentRetryInterval < q.maxRetryInterval {
 		// We can increase, more than the previous timer has been spent
 		q.retryMutex.Lock()
-		if q.retryTimerChange.Add(q.retryTimer).Before(t) {
+		if q.lastRetry.Add(q.currentRetryInterval).Before(t) {
 			// We have to do the recheck because someone could have changed the time between check and mutex locking
-			newWait := q.retryTimer * 2
-			if newWait > q.retryMaxWait {
-				q.retryTimer = q.retryMaxWait
+			newWait := q.currentRetryInterval * 2
+			if newWait > q.maxRetryInterval {
+				q.currentRetryInterval = q.maxRetryInterval
 			} else {
-				q.retryTimer = newWait
+				q.currentRetryInterval = newWait
 			}
 		}
 		q.retryMutex.Unlock()
 	}
 
-	return q.retryTimer
+	return q.currentRetryInterval
 }
 
 func (q *QueuedReporter) batchProcessor(batch *jaeger.Batch) error {
 	err := q.wrapped.EmitBatch(batch)
 	if err != nil {
-		for q.wrapped.Retryable(err) {
+		for IsRetryable(err) {
 			// Block this processing instance before returning
 			sleepTime := q.backOffTimer()
 			q.logger.Info(fmt.Sprintf("Failed to contact the collector, waiting %s before retry", sleepTime.String()))
@@ -83,16 +83,20 @@ func (q *QueuedReporter) batchProcessor(batch *jaeger.Batch) error {
 			err = q.wrapped.EmitBatch(batch)
 			if err == nil {
 				q.retryMutex.Lock()
-				q.retryTimer = q.retryDefaultSleep
+				q.currentRetryInterval = q.initialRetryInterval
 				q.retryMutex.Unlock()
-				break
+				return nil
 			}
 		}
+		q.logger.Error("Could not send batch", zap.Error(err))
 		return err
 	}
 	return nil
 }
 
-func (q *QueuedReporter) Retryable(err error) bool {
-	return q.wrapped.Retryable(err)
+func IsRetryable(err error) bool {
+	if r, ok := err.(RetryableError); ok {
+		return r.IsRetryable()
+	}
+	return false
 }

--- a/cmd/agent/app/reporter/queue.go
+++ b/cmd/agent/app/reporter/queue.go
@@ -15,7 +15,6 @@
 package reporter
 
 import (
-	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -155,7 +154,7 @@ func (q *QueuedReporter) batchProcessor(batch model.Batch) (bool, error) {
 			q.reporterMetrics.BatchMetrics.BatchesRetries.Inc(1)
 			// Block this processing instance before returning
 			sleepTime := q.backOffTimer()
-			q.logger.Error(fmt.Sprintf("Failed to contact the collector, waiting %s before retry", sleepTime.String()))
+			q.logger.Error("Failed to contact the collector, waiting before retry", zap.String("time", sleepTime.String()))
 			time.Sleep(sleepTime)
 			err = q.wrapped.ForwardBatch(batch)
 			if err == nil {

--- a/cmd/agent/app/reporter/queue.go
+++ b/cmd/agent/app/reporter/queue.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/queue"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
@@ -23,30 +24,39 @@ type QueuedReporter struct {
 
 	retryMutex sync.Mutex
 
-	lastRetry            time.Time
-	currentRetryInterval time.Duration
-	maxRetryInterval     time.Duration
-	initialRetryInterval time.Duration
+	lastRetryIntervalChange time.Time
+	currentRetryInterval    time.Duration
+	maxRetryInterval        time.Duration
+	initialRetryInterval    time.Duration
+
+	reporterMetrics *MetricsReporter
 }
 
-func WrapWithQueue(reporter Reporter, logger *zap.Logger) *QueuedReporter {
+// WrapWithQueue wraps the destination reporter with a queueing capabilities for retries
+func WrapWithQueue(reporter Reporter, logger *zap.Logger, mFactory metrics.Factory) *QueuedReporter {
 	q := &QueuedReporter{
-		wrapped:              reporter,
-		logger:               logger,
-		lastRetry:            time.Now(),
-		initialRetryInterval: time.Millisecond * 100,
-		maxRetryInterval:     20 * time.Second,
+		wrapped:                 reporter,
+		logger:                  logger,
+		lastRetryIntervalChange: time.Now(),
+		initialRetryInterval:    time.Millisecond * 100,
+		maxRetryInterval:        20 * time.Second,
+		reporterMetrics:         NewMetricsReporter(reporter, mFactory),
 	}
 	q.currentRetryInterval = q.initialRetryInterval
-	q.queue = queue.NewBoundQueue(1000, q.batchProcessor, logger)
+	q.queue = queue.NewBoundQueue(1000, q.batchProcessor, logger, mFactory)
 	return q
 }
 
+// EmitZipkinBatch forwards the spans to the wrapped reporter (without queue)
 func (q *QueuedReporter) EmitZipkinBatch(spans []*zipkincore.Span) error {
-	return q.wrapped.EmitZipkinBatch(spans)
+	// EmitZipkinBatch does not use queue, instead it uses the older metrics passthrough
+	return q.reporterMetrics.EmitZipkinBatch(spans)
 }
 
+// EmitBatch sends the batch to the queue for async processing
 func (q *QueuedReporter) EmitBatch(batch *jaeger.Batch) error {
+	spansCount := int64(len(batch.GetSpans()))
+	q.reporterMetrics.BatchMetrics.BatchSize.Update(spansCount)
 	return q.queue.Enqueue(batch)
 }
 
@@ -54,10 +64,10 @@ func (q *QueuedReporter) backOffTimer() time.Duration {
 	// Has to be more than previous time from previous increase before we can reincrease
 	// otherwise simultaneous threads could race to increase the sleep time too quickly
 	t := time.Now()
-	if q.lastRetry.Add(q.currentRetryInterval).Before(t) && q.currentRetryInterval < q.maxRetryInterval {
+	if q.lastRetryIntervalChange.Add(q.currentRetryInterval).Before(t) && q.currentRetryInterval < q.maxRetryInterval {
 		// We can increase, more than the previous timer has been spent
 		q.retryMutex.Lock()
-		if q.lastRetry.Add(q.currentRetryInterval).Before(t) {
+		if q.lastRetryIntervalChange.Add(q.currentRetryInterval).Before(t) {
 			// We have to do the recheck because someone could have changed the time between check and mutex locking
 			newWait := q.currentRetryInterval * 2
 			if newWait > q.maxRetryInterval {
@@ -65,6 +75,8 @@ func (q *QueuedReporter) backOffTimer() time.Duration {
 			} else {
 				q.currentRetryInterval = newWait
 			}
+			q.lastRetryIntervalChange = time.Now()
+			q.reporterMetrics.BatchMetrics.RetryInterval.Update(int64(q.currentRetryInterval))
 		}
 		q.retryMutex.Unlock()
 	}
@@ -73,9 +85,15 @@ func (q *QueuedReporter) backOffTimer() time.Duration {
 }
 
 func (q *QueuedReporter) batchProcessor(batch *jaeger.Batch) error {
+	spansCount := int64(len(batch.GetSpans()))
+
+	q.reporterMetrics.BatchMetrics.BatchesSubmitted.Inc(1)
+	q.reporterMetrics.BatchMetrics.SpansSubmitted.Inc(spansCount)
+
 	err := q.wrapped.EmitBatch(batch)
 	if err != nil {
 		for IsRetryable(err) {
+			q.reporterMetrics.BatchMetrics.BatchesRetries.Inc(1)
 			// Block this processing instance before returning
 			sleepTime := q.backOffTimer()
 			q.logger.Info(fmt.Sprintf("Failed to contact the collector, waiting %s before retry", sleepTime.String()))
@@ -84,10 +102,14 @@ func (q *QueuedReporter) batchProcessor(batch *jaeger.Batch) error {
 			if err == nil {
 				q.retryMutex.Lock()
 				q.currentRetryInterval = q.initialRetryInterval
+				q.reporterMetrics.BatchMetrics.RetryInterval.Update(int64(q.currentRetryInterval))
+				q.lastRetryIntervalChange = time.Now()
 				q.retryMutex.Unlock()
 				return nil
 			}
 		}
+		q.reporterMetrics.BatchMetrics.BatchesFailures.Inc(1)
+		q.reporterMetrics.BatchMetrics.SpansFailures.Inc(spansCount)
 		q.logger.Error("Could not send batch", zap.Error(err))
 		return err
 	}

--- a/cmd/agent/app/reporter/queue/bounded.go
+++ b/cmd/agent/app/reporter/queue/bounded.go
@@ -30,7 +30,7 @@ type queueMetrics struct {
 	QueueSize metrics.Gauge `metric:"boundqueue.queuesize"`
 
 	// BatchesDropped indicates the number of batches dropped by server
-	BatchesDropped metrics.Counter `metric:"reporter.batches.dropped"`
+	BatchesDropped metrics.Counter `metric:"batches.dropped"`
 }
 
 type Bound struct {
@@ -67,7 +67,7 @@ func (b *Bound) droppedItem(item interface{}) {
 func (b *Bound) Enqueue(batch *jaeger.Batch) error {
 	success := b.queue.Produce(batch)
 	if !success {
-		return fmt.Errorf("Destination queue could not accept new entries")
+		return fmt.Errorf("destination queue could not accept new entries")
 	}
 	return nil
 }

--- a/cmd/agent/app/reporter/queue/bounded.go
+++ b/cmd/agent/app/reporter/queue/bounded.go
@@ -1,0 +1,39 @@
+package queue
+
+import (
+	"fmt"
+
+	"github.com/jaegertracing/jaeger/pkg/queue"
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"go.uber.org/zap"
+)
+
+type Bound struct {
+	queue  *queue.BoundedQueue
+	logger *zap.Logger
+}
+
+func NewBoundQueue(bufSize int, processor func(*jaeger.Batch) error, logger *zap.Logger) *Bound {
+	b := &Bound{
+		queue:  queue.NewBoundedQueue(bufSize, nil),
+		logger: logger,
+	}
+
+	b.queue.StartConsumers(1, func(item interface{}) {
+		// This queue does not have persistence, thus we don't handle transactionality
+		err := processor(item.(*jaeger.Batch))
+		if err != nil {
+			b.logger.Error("Could not transmit span", zap.Error(err))
+		}
+	})
+
+	return b
+}
+
+func (q *Bound) Enqueue(batch *jaeger.Batch) error {
+	success := q.queue.Produce(batch)
+	if !success {
+		return fmt.Errorf("Destination queue could not accept new entries")
+	}
+	return nil
+}

--- a/cmd/agent/app/reporter/queue/bounded.go
+++ b/cmd/agent/app/reporter/queue/bounded.go
@@ -2,21 +2,30 @@ package queue
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jaegertracing/jaeger/pkg/queue"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 )
 
-type Bound struct {
-	queue  *queue.BoundedQueue
-	logger *zap.Logger
+type queueMetrics struct {
+	// queueSize is a counter indicating how many items are currently in the queue
+	QueueSize metrics.Gauge `metric:"boundqueue.queuesize"`
 }
 
-func NewBoundQueue(bufSize int, processor func(*jaeger.Batch) error, logger *zap.Logger) *Bound {
+type Bound struct {
+	queue   *queue.BoundedQueue
+	logger  *zap.Logger
+	metrics queueMetrics
+}
+
+func NewBoundQueue(bufSize int, processor func(*jaeger.Batch) error, logger *zap.Logger, mFactory metrics.Factory) *Bound {
 	b := &Bound{
-		queue:  queue.NewBoundedQueue(bufSize, nil),
-		logger: logger,
+		queue:   queue.NewBoundedQueue(bufSize, nil),
+		logger:  logger,
+		metrics: queueMetrics{},
 	}
 
 	b.queue.StartConsumers(1, func(item interface{}) {
@@ -27,11 +36,14 @@ func NewBoundQueue(bufSize int, processor func(*jaeger.Batch) error, logger *zap
 		}
 	})
 
+	metrics.Init(&b.metrics, mFactory.Namespace(metrics.NSOptions{Name: "reporter"}), nil)
+	b.queue.StartLengthReporting(1*time.Second, b.metrics.QueueSize)
+
 	return b
 }
 
-func (q *Bound) Enqueue(batch *jaeger.Batch) error {
-	success := q.queue.Produce(batch)
+func (b *Bound) Enqueue(batch *jaeger.Batch) error {
+	success := b.queue.Produce(batch)
 	if !success {
 		return fmt.Errorf("Destination queue could not accept new entries")
 	}

--- a/cmd/agent/app/reporter/queue/bounded.go
+++ b/cmd/agent/app/reporter/queue/bounded.go
@@ -33,12 +33,14 @@ type queueMetrics struct {
 	BatchesDropped metrics.Counter `metric:"batches.dropped"`
 }
 
+// Bound is using BoundedQueue (from bounded_queue.go) for QueueReporter
 type Bound struct {
 	queue   *queue.BoundedQueue
 	logger  *zap.Logger
 	metrics queueMetrics
 }
 
+// NewBoundQueue creates a new bounded queue with non-transactional processing
 func NewBoundQueue(bufSize, concurrency int, processor func(*jaeger.Batch) error, logger *zap.Logger, mFactory metrics.Factory) *Bound {
 	b := &Bound{
 		logger:  logger,
@@ -64,6 +66,7 @@ func (b *Bound) droppedItem(item interface{}) {
 	b.metrics.BatchesDropped.Inc(1)
 }
 
+// Enqueue pushes the batch to the queue or returns and error if the queue is full
 func (b *Bound) Enqueue(batch *jaeger.Batch) error {
 	success := b.queue.Produce(batch)
 	if !success {

--- a/cmd/agent/app/reporter/queue/bounded.go
+++ b/cmd/agent/app/reporter/queue/bounded.go
@@ -21,14 +21,14 @@ type Bound struct {
 	metrics queueMetrics
 }
 
-func NewBoundQueue(bufSize int, processor func(*jaeger.Batch) error, logger *zap.Logger, mFactory metrics.Factory) *Bound {
+func NewBoundQueue(bufSize, concurrency int, processor func(*jaeger.Batch) error, logger *zap.Logger, mFactory metrics.Factory) *Bound {
 	b := &Bound{
 		queue:   queue.NewBoundedQueue(bufSize, nil),
 		logger:  logger,
 		metrics: queueMetrics{},
 	}
 
-	b.queue.StartConsumers(1, func(item interface{}) {
+	b.queue.StartConsumers(concurrency, func(item interface{}) {
 		// This queue does not have persistence, thus we don't handle transactionality
 		err := processor(item.(*jaeger.Batch))
 		if err != nil {

--- a/cmd/agent/app/reporter/queue/bounded.go
+++ b/cmd/agent/app/reporter/queue/bounded.go
@@ -1,18 +1,36 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package queue
 
 import (
 	"fmt"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/queue"
-	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/pkg/queue"
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
 
 type queueMetrics struct {
-	// queueSize is a counter indicating how many items are currently in the queue
+	// QueueSize is a counter indicating how many items are currently in the queue
 	QueueSize metrics.Gauge `metric:"boundqueue.queuesize"`
+
+	// BatchesDropped indicates the number of batches dropped by server
+	BatchesDropped metrics.Counter `metric:"reporter.batches.dropped"`
 }
 
 type Bound struct {
@@ -23,10 +41,10 @@ type Bound struct {
 
 func NewBoundQueue(bufSize, concurrency int, processor func(*jaeger.Batch) error, logger *zap.Logger, mFactory metrics.Factory) *Bound {
 	b := &Bound{
-		queue:   queue.NewBoundedQueue(bufSize, nil),
 		logger:  logger,
 		metrics: queueMetrics{},
 	}
+	b.queue = queue.NewBoundedQueue(bufSize, b.droppedItem)
 
 	b.queue.StartConsumers(concurrency, func(item interface{}) {
 		// This queue does not have persistence, thus we don't handle transactionality
@@ -40,6 +58,10 @@ func NewBoundQueue(bufSize, concurrency int, processor func(*jaeger.Batch) error
 	b.queue.StartLengthReporting(1*time.Second, b.metrics.QueueSize)
 
 	return b
+}
+
+func (b *Bound) droppedItem(item interface{}) {
+	b.metrics.BatchesDropped.Inc(1)
 }
 
 func (b *Bound) Enqueue(batch *jaeger.Batch) error {

--- a/cmd/agent/app/reporter/queue/bounded.go
+++ b/cmd/agent/app/reporter/queue/bounded.go
@@ -23,7 +23,7 @@ func NewBoundQueue(bufSize int, processor func(*jaeger.Batch) error, logger *zap
 		// This queue does not have persistence, thus we don't handle transactionality
 		err := processor(item.(*jaeger.Batch))
 		if err != nil {
-			b.logger.Error("Could not transmit span", zap.Error(err))
+			b.logger.Error("Could not transmit batch", zap.Error(err))
 		}
 	})
 

--- a/cmd/agent/app/reporter/queue/bounded_test.go
+++ b/cmd/agent/app/reporter/queue/bounded_test.go
@@ -1,0 +1,77 @@
+package queue
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
+	"go.uber.org/zap"
+)
+
+func TestErrorConsumerLogging(t *testing.T) {
+	// For codecov
+	metricsFactory := metricstest.NewFactory(time.Microsecond)
+	b := NewBoundQueue(1, 1, func(batch *jaeger.Batch) error {
+		return fmt.Errorf("Logging error")
+	}, zap.NewNop(), metricsFactory)
+
+	for i := 0; i < 2; i++ {
+		b.Enqueue(&jaeger.Batch{
+			Process: &jaeger.Process{
+				ServiceName: fmt.Sprintf("error_%d", i),
+			},
+		})
+	}
+}
+
+func TestDroppedItems(t *testing.T) {
+	assert := assert.New(t)
+
+	mut := sync.Mutex{}
+	mut.Lock()
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	processNames := make([]string, 0, 2)
+
+	metricsFactory := metricstest.NewFactory(time.Microsecond)
+	b := NewBoundQueue(1, 1, func(batch *jaeger.Batch) error {
+		fmt.Printf("%s\n", batch.GetProcess().ServiceName)
+		mut.Lock() // Block processing until we let it go
+		processNames = append(processNames, batch.GetProcess().ServiceName)
+		mut.Unlock()
+		wg.Done()
+		return nil
+	}, zap.NewNop(), metricsFactory)
+
+	for i := 0; i < 2; i++ {
+		// First one goes to processing, second to queue..
+		assert.NoError(b.Enqueue(&jaeger.Batch{
+			Process: &jaeger.Process{
+				ServiceName: fmt.Sprintf("success_%d", i),
+			},
+		}))
+	}
+
+	// These should start throwing errors as the queue is full
+	for i := 0; i < 2; i++ {
+		assert.Error(b.Enqueue(&jaeger.Batch{
+			Process: &jaeger.Process{
+				ServiceName: fmt.Sprintf("error_%d", i),
+			},
+		}))
+	}
+
+	c, _ := metricsFactory.Snapshot()
+	assert.Equal(int64(2), c["reporter.batches.dropped"])
+
+	mut.Unlock()
+	wg.Wait()
+	assert.Equal(2, len(processNames))
+	assert.Equal("success_0", processNames[0])
+	assert.Equal("success_1", processNames[1])
+}

--- a/cmd/agent/app/reporter/queue/bounded_test.go
+++ b/cmd/agent/app/reporter/queue/bounded_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package queue
 
 import (
@@ -7,10 +21,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
 
 func TestErrorConsumerLogging(t *testing.T) {

--- a/cmd/agent/app/reporter/queue/nonqueue.go
+++ b/cmd/agent/app/reporter/queue/nonqueue.go
@@ -14,19 +14,27 @@
 
 package queue
 
-import "github.com/jaegertracing/jaeger/model"
+import (
+	"github.com/jaegertracing/jaeger/model"
+)
 
 // NonQueue sends stuff directly without queueing. Useful for testing purposes
 type NonQueue struct {
-	processor func(model.Batch) error
+	processor func(model.Batch) (bool, error)
 }
 
 // NewNonQueue returns direct processing "queue"
-func NewNonQueue(processor func(model.Batch) error) *NonQueue {
+func NewNonQueue(processor func(model.Batch) (bool, error)) *NonQueue {
 	return &NonQueue{processor}
 }
 
 // Enqueue calls processor instead of queueing
 func (n *NonQueue) Enqueue(batch model.Batch) error {
-	return n.processor(batch)
+	_, err := n.processor(batch)
+	return err
+}
+
+// Close implements io.Closer
+func (n *NonQueue) Close() error {
+	return nil
 }

--- a/cmd/agent/app/reporter/queue/nonqueue.go
+++ b/cmd/agent/app/reporter/queue/nonqueue.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package queue
 
 import (

--- a/cmd/agent/app/reporter/queue/nonqueue.go
+++ b/cmd/agent/app/reporter/queue/nonqueue.go
@@ -1,0 +1,20 @@
+package queue
+
+import (
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+)
+
+// NonQueue sends stuff directly without queueing. Useful for testing purposes
+type NonQueue struct {
+	processor func(*jaeger.Batch) error
+}
+
+// NewNonQueue returns direct processing "queue"
+func NewNonQueue(processor func(*jaeger.Batch) error) *NonQueue {
+	return &NonQueue{processor}
+}
+
+// Enqueue calls processor instead of queueing
+func (n *NonQueue) Enqueue(batch *jaeger.Batch) error {
+	return n.processor(batch)
+}

--- a/cmd/agent/app/reporter/queue/nonqueue_test.go
+++ b/cmd/agent/app/reporter/queue/nonqueue_test.go
@@ -1,0 +1,19 @@
+package queue
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirectProcessing(t *testing.T) {
+	assert := assert.New(t)
+	n := NewNonQueue(func(batch *jaeger.Batch) error {
+		return fmt.Errorf("Error")
+	})
+
+	err := n.Enqueue(&jaeger.Batch{})
+	assert.Error(err, "Error")
+}

--- a/cmd/agent/app/reporter/queue/nonqueue_test.go
+++ b/cmd/agent/app/reporter/queue/nonqueue_test.go
@@ -25,10 +25,12 @@ import (
 
 func TestDirectProcessing(t *testing.T) {
 	assert := assert.New(t)
-	n := NewNonQueue(func(batch model.Batch) error {
-		return fmt.Errorf("Error")
+	n := NewNonQueue(func(batch model.Batch) (bool, error) {
+		return false, fmt.Errorf("error")
 	})
 
 	err := n.Enqueue(model.Batch{})
-	assert.Error(err, "Error")
+	assert.Error(err)
+
+	assert.NoError(n.Close())
 }

--- a/cmd/agent/app/reporter/queue/nonqueue_test.go
+++ b/cmd/agent/app/reporter/queue/nonqueue_test.go
@@ -1,11 +1,26 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package queue
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
 
 func TestDirectProcessing(t *testing.T) {

--- a/cmd/agent/app/reporter/queue_test.go
+++ b/cmd/agent/app/reporter/queue_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reporter
 
 import (
@@ -7,12 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/queue"
-	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
-	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/queue"
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
 var _ Queue = &queue.NonQueue{}

--- a/cmd/agent/app/reporter/queue_test.go
+++ b/cmd/agent/app/reporter/queue_test.go
@@ -1,0 +1,183 @@
+package reporter
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/queue"
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
+	"go.uber.org/zap"
+)
+
+var _ Queue = &queue.NonQueue{}
+var _ Queue = &queue.Bound{}
+
+type gRPCErrorReporter struct {
+	createRetryError bool
+	createFatalError bool
+
+	retries   int32
+	processed int32
+	errors    int32
+
+	testMutex sync.Mutex
+}
+
+func (g *gRPCErrorReporter) EmitZipkinBatch(spans []*zipkincore.Span) error {
+	atomic.AddInt32(&g.processed, 1)
+	return nil
+}
+
+func (g *gRPCErrorReporter) EmitBatch(batch *jaeger.Batch) error {
+	g.testMutex.Lock()
+	defer g.testMutex.Unlock()
+
+	if g.createRetryError {
+		atomic.AddInt32(&g.retries, 1)
+		return &retryableError{fmt.Errorf("Error requested")}
+	} else if g.createFatalError {
+		atomic.AddInt32(&g.errors, 1)
+		return fmt.Errorf("Fatal error")
+	}
+	atomic.AddInt32(&g.processed, 1)
+	return nil
+}
+
+func TestMemoryQueue(t *testing.T) {
+	assert := assert.New(t)
+	gr := &gRPCErrorReporter{}
+	metricsFactory := metricstest.NewFactory(time.Microsecond)
+	q := WrapWithQueue(&Options{QueueType: MEMORY, BoundedQueueSize: defaultBoundedQueueSize, ReporterConcurrency: 1}, gr, zap.NewNop(), metricsFactory)
+
+	err := q.EmitZipkinBatch([]*zipkincore.Span{{}})
+	assert.NoError(err)
+	assert.Equal(int32(1), atomic.LoadInt32(&gr.processed))
+
+	_, g := metricsFactory.Snapshot()
+	assert.Equal(int64(1), g["reporter.batch_size|format=zipkin"])
+}
+
+func TestMemoryQueueSuccess(t *testing.T) {
+	assert := assert.New(t)
+	gr := &gRPCErrorReporter{}
+	metricsFactory := metricstest.NewFactory(time.Microsecond)
+	q := WrapWithQueue(&Options{QueueType: MEMORY, BoundedQueueSize: defaultBoundedQueueSize, ReporterConcurrency: 1}, gr, zap.NewNop(), metricsFactory)
+
+	err := q.EmitBatch(&jaeger.Batch{})
+	assert.NoError(err)
+
+	for i := 0; i < 100 && atomic.LoadInt32(&gr.processed) == 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Equal(int32(1), atomic.LoadInt32(&gr.processed))
+
+	c, _ := metricsFactory.Snapshot()
+	assert.Equal(int64(1), c["reporter.batches.submitted|format=jaeger"])
+}
+
+func TestMemoryQueueFail(t *testing.T) {
+	assert := assert.New(t)
+	gr := &gRPCErrorReporter{createFatalError: true}
+	metricsFactory := metricstest.NewFactory(time.Microsecond)
+	q := WrapWithQueue(&Options{QueueType: MEMORY, BoundedQueueSize: defaultBoundedQueueSize, ReporterConcurrency: 1}, gr, zap.NewNop(), metricsFactory)
+
+	err := q.EmitBatch(&jaeger.Batch{})
+	assert.NoError(err)
+
+	for i := 0; i < 100 && atomic.LoadInt32(&gr.errors) == 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Equal(int32(1), atomic.LoadInt32(&gr.errors))
+	assert.Equal(int32(0), atomic.LoadInt32(&gr.retries))
+
+	c, _ := metricsFactory.Snapshot()
+	assert.Equal(int64(1), c["reporter.batches.failures|format=jaeger"])
+}
+
+func TestMemoryQueueRetries(t *testing.T) {
+	assert := assert.New(t)
+	gr := &gRPCErrorReporter{}
+	metricsFactory := metricstest.NewFactory(time.Microsecond)
+	q := WrapWithQueue(&Options{QueueType: MEMORY, BoundedQueueSize: defaultBoundedQueueSize, ReporterConcurrency: 1}, gr, zap.NewNop(), metricsFactory)
+
+	gr.testMutex.Lock()
+	gr.createRetryError = true
+	gr.testMutex.Unlock()
+
+	err := q.EmitBatch(&jaeger.Batch{})
+	assert.NoError(err)
+
+	for i := 0; i < 100 && atomic.LoadInt32(&gr.retries) == 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	assert.True(atomic.LoadInt32(&gr.retries) > 0)
+
+	// Now verify it is resent
+	gr.testMutex.Lock()
+	gr.createRetryError = false
+	gr.testMutex.Unlock()
+
+	for i := 0; i < 100 && atomic.LoadInt32(&gr.processed) == 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Equal(int32(1), atomic.LoadInt32(&gr.processed))
+
+	c, _ := metricsFactory.Snapshot()
+	assert.True(c["reporter.batches.retries|format=jaeger"] > int64(0))
+}
+
+func TestBackoffTimer(t *testing.T) {
+	assert := assert.New(t)
+
+	metricsFactory := metricstest.NewFactory(time.Microsecond)
+	q := WrapWithQueue(&Options{QueueType: MEMORY, ReporterMaxRetryInterval: time.Duration(time.Second)}, nil, zap.NewNop(), metricsFactory)
+
+	dur := q.backOffTimer()
+	assert.True(q.initialRetryInterval == dur)
+
+	q.lastRetryIntervalChange = q.lastRetryIntervalChange.Add(-1 * time.Hour)
+
+	dur2 := q.backOffTimer()
+	assert.True(dur2 > dur)
+
+	// Reach the maximum time
+	for i := 0; i < 100; i++ {
+		q.lastRetryIntervalChange = q.lastRetryIntervalChange.Add(-1 * time.Hour)
+		assert.True(q.maxRetryInterval >= q.backOffTimer())
+	}
+	assert.Equal(q.maxRetryInterval, q.currentRetryInterval)
+
+	// Check metrics also
+	_, g := metricsFactory.Snapshot()
+	assert.Equal(int64(q.currentRetryInterval), g["reporter.retry-interval-ns|format=jaeger"])
+}
+
+func TestIsRetryable(t *testing.T) {
+	assert := assert.New(t)
+	err := fmt.Errorf("NoInterface")
+	assert.False(IsRetryable(err))
+
+	rerr := &retryableError{err}
+	assert.True(IsRetryable(rerr))
+}
+
+// gRPCReporterError is capsulated error coming from the gRPC interface
+type retryableError struct {
+	Err error
+}
+
+func (r *retryableError) Error() string {
+	return r.Err.Error()
+}
+
+// IsRetryable checks if the gRPC errors are temporary errors and are errors from the status package
+func (r *retryableError) IsRetryable() bool {
+	return true
+}

--- a/cmd/agent/app/reporter/queue_test.go
+++ b/cmd/agent/app/reporter/queue_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/queue"
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
@@ -50,6 +51,10 @@ func (g *gRPCErrorReporter) EmitZipkinBatch(spans []*zipkincore.Span) error {
 }
 
 func (g *gRPCErrorReporter) EmitBatch(batch *jaeger.Batch) error {
+	return g.ForwardBatch(model.Batch{})
+}
+
+func (g *gRPCErrorReporter) ForwardBatch(batch model.Batch) error {
 	g.testMutex.Lock()
 	defer g.testMutex.Unlock()
 

--- a/cmd/agent/app/reporter/reporter.go
+++ b/cmd/agent/app/reporter/reporter.go
@@ -26,7 +26,11 @@ import (
 type Reporter interface {
 	EmitZipkinBatch(spans []*zipkincore.Span) (err error)
 	EmitBatch(batch *jaeger.Batch) (err error)
-	Retryable(error) bool
+}
+
+// RetryableError indicates if the error coming from a reporter can be retried for sending
+type RetryableError interface {
+	IsRetryable() bool
 }
 
 // MultiReporter provides serial span emission to one or more reporters.  If
@@ -60,12 +64,4 @@ func (mr MultiReporter) EmitBatch(batch *jaeger.Batch) error {
 		}
 	}
 	return multierror.Wrap(errors)
-}
-
-func (mr MultiReporter) Retryable(err error) bool {
-	retry := false
-	for _, rep := range mr {
-		retry = retry && rep.Retryable(err)
-	}
-	return retry
 }

--- a/cmd/agent/app/reporter/reporter.go
+++ b/cmd/agent/app/reporter/reporter.go
@@ -16,6 +16,7 @@
 package reporter
 
 import (
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/multierror"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -26,6 +27,12 @@ import (
 type Reporter interface {
 	EmitZipkinBatch(spans []*zipkincore.Span) (err error)
 	EmitBatch(batch *jaeger.Batch) (err error)
+}
+
+// Forwarder is a replacement for Reporter interface, behind a retryable queue
+type Forwarder interface {
+	Reporter
+	ForwardBatch(batch model.Batch) error
 }
 
 // RetryableError indicates if the error coming from a reporter can be retried for sending

--- a/cmd/agent/app/reporter/reporter.go
+++ b/cmd/agent/app/reporter/reporter.go
@@ -26,6 +26,7 @@ import (
 type Reporter interface {
 	EmitZipkinBatch(spans []*zipkincore.Span) (err error)
 	EmitBatch(batch *jaeger.Batch) (err error)
+	Retryable(error) bool
 }
 
 // MultiReporter provides serial span emission to one or more reporters.  If
@@ -59,4 +60,12 @@ func (mr MultiReporter) EmitBatch(batch *jaeger.Batch) error {
 		}
 	}
 	return multierror.Wrap(errors)
+}
+
+func (mr MultiReporter) Retryable(err error) bool {
+	retry := false
+	for _, rep := range mr {
+		retry = retry && rep.Retryable(err)
+	}
+	return retry
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy.go
@@ -31,7 +31,7 @@ type ProxyBuilder struct {
 }
 
 // NewCollectorProxy creates ProxyBuilder
-func NewCollectorProxy(builder *Builder, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
+func NewCollectorProxy(builder *Builder, opts *reporter.Options, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
 	r, err := builder.CreateReporter(logger)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func NewCollectorProxy(builder *Builder, mFactory metrics.Factory, logger *zap.L
 	tchannelMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "tchannel"}})
 	return &ProxyBuilder{
 		tchanRep: r,
-		reporter: reporter.WrapWithQueue(r, logger, tchannelMetrics),
+		reporter: reporter.WrapWithQueue(opts, r, logger, tchannelMetrics),
 		manager:  configmanager.WrapWithMetrics(tchannel.NewConfigManager(r.CollectorServiceName(), r.Channel()), tchannelMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy.go
@@ -39,7 +39,7 @@ func NewCollectorProxy(builder *Builder, opts *reporter.Options, mFactory metric
 	tchannelMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "tchannel"}})
 	return &ProxyBuilder{
 		tchanRep: r,
-		reporter: reporter.WrapWithQueue(opts, r, logger, tchannelMetrics),
+		reporter: reporter.NewMetricsReporter(r, tchannelMetrics),
 		manager:  configmanager.WrapWithMetrics(tchannel.NewConfigManager(r.CollectorServiceName(), r.Channel()), tchannelMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy.go
@@ -39,7 +39,7 @@ func NewCollectorProxy(builder *Builder, mFactory metrics.Factory, logger *zap.L
 	tchannelMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "tchannel"}})
 	return &ProxyBuilder{
 		tchanRep: r,
-		reporter: reporter.WrapWithQueue(reporter.WrapWithMetrics(r, tchannelMetrics), logger),
+		reporter: reporter.WrapWithQueue(r, logger, tchannelMetrics),
 		manager:  configmanager.WrapWithMetrics(tchannel.NewConfigManager(r.CollectorServiceName(), r.Channel()), tchannelMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy.go
@@ -39,7 +39,7 @@ func NewCollectorProxy(builder *Builder, mFactory metrics.Factory, logger *zap.L
 	tchannelMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "tchannel"}})
 	return &ProxyBuilder{
 		tchanRep: r,
-		reporter: reporter.WrapWithMetrics(r, tchannelMetrics),
+		reporter: reporter.WrapWithQueue(reporter.WrapWithMetrics(r, tchannelMetrics), logger),
 		manager:  configmanager.WrapWithMetrics(tchannel.NewConfigManager(r.CollectorServiceName(), r.Channel()), tchannelMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/tchannel/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy_test.go
@@ -42,7 +42,7 @@ func TestCreate(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, b)
 	r, _ := cfg.CreateReporter(logger)
-	assert.IsType(t, &reporter.QueuedReporter{}, b.GetReporter())
+	assert.IsType(t, &reporter.MetricsReporter{}, b.GetReporter())
 	m := tchannel.NewConfigManager(r.CollectorServiceName(), r.Channel())
 	assert.Equal(t, configmanager.WrapWithMetrics(m, mFactory), b.GetManager())
 	assert.Nil(t, b.Close())

--- a/cmd/agent/app/reporter/tchannel/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/tchannel/collector_proxy_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestErrorReporterBuilder(t *testing.T) {
 	tbuilder := NewBuilder().WithDiscoverer(fakeDiscoverer{})
-	b, err := NewCollectorProxy(tbuilder, metrics.NullFactory, zap.NewNop())
+	b, err := NewCollectorProxy(tbuilder, &reporter.Options{}, metrics.NullFactory, zap.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, b)
 }
@@ -38,11 +38,11 @@ func TestCreate(t *testing.T) {
 	cfg := &Builder{}
 	mFactory := metrics.NullFactory
 	logger := zap.NewNop()
-	b, err := NewCollectorProxy(cfg, mFactory, logger)
+	b, err := NewCollectorProxy(cfg, &reporter.Options{}, mFactory, logger)
 	require.NoError(t, err)
 	assert.NotNil(t, b)
 	r, _ := cfg.CreateReporter(logger)
-	assert.Equal(t, reporter.WrapWithMetrics(r, mFactory), b.GetReporter())
+	assert.IsType(t, &reporter.QueuedReporter{}, b.GetReporter())
 	m := tchannel.NewConfigManager(r.CollectorServiceName(), r.Channel())
 	assert.Equal(t, configmanager.WrapWithMetrics(m, mFactory), b.GetManager())
 	assert.Nil(t, b.Close())

--- a/cmd/agent/app/reporter/tchannel/reporter.go
+++ b/cmd/agent/app/reporter/tchannel/reporter.go
@@ -18,7 +18,7 @@ package tchannel
 import (
 	"time"
 
-	"github.com/uber/tchannel-go"
+	tchannel "github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/zap"
 
@@ -106,4 +106,8 @@ func (r *Reporter) submitAndReport(submissionFunc func(ctx thrift.Context) error
 // CollectorServiceName returns collector service name.
 func (r *Reporter) CollectorServiceName() string {
 	return r.serviceName
+}
+
+func (r *Reporter) Retryable(err error) bool {
+	return false
 }

--- a/cmd/agent/app/reporter/tchannel/reporter.go
+++ b/cmd/agent/app/reporter/tchannel/reporter.go
@@ -107,7 +107,3 @@ func (r *Reporter) submitAndReport(submissionFunc func(ctx thrift.Context) error
 func (r *Reporter) CollectorServiceName() string {
 	return r.serviceName
 }
-
-func (r *Reporter) Retryable(err error) bool {
-	return false
-}

--- a/cmd/agent/app/servers/server.go
+++ b/cmd/agent/app/servers/server.go
@@ -24,8 +24,7 @@ type Server interface {
 	Serve()
 	IsServing() bool
 	Stop()
-	DataChan() chan *ReadBuf
-	DataRecd(*ReadBuf) // must be called by consumer after reading data from the ReadBuf
+	RegisterProcessor(func(*ReadBuf))
 }
 
 // ReadBuf is a structure that holds the bytes to read into as well as the number of bytes

--- a/cmd/agent/app/servers/tbuffered_server.go
+++ b/cmd/agent/app/servers/tbuffered_server.go
@@ -83,6 +83,7 @@ func (s *TBufferedServer) Serve() {
 			readBuf.n = n
 			s.metrics.PacketSize.Update(int64(n))
 			go func() {
+				s.metrics.PacketsProcessed.Inc(1)
 				s.processor(readBuf)
 				s.readBufPool.Put(readBuf)
 			}()

--- a/cmd/agent/app/servers/tbuffered_server.go
+++ b/cmd/agent/app/servers/tbuffered_server.go
@@ -104,6 +104,7 @@ func (s *TBufferedServer) Stop() {
 	s.transport.Close()
 }
 
+// RegisterProcessor sets a function that is run whenever there's a readable buffer received by the server
 func (s *TBufferedServer) RegisterProcessor(process func(*ReadBuf)) {
 	s.processor = process
 }

--- a/cmd/agent/app/servers/tbuffered_server.go
+++ b/cmd/agent/app/servers/tbuffered_server.go
@@ -28,7 +28,6 @@ import (
 type TBufferedServer struct {
 	// NB. queueLength HAS to be at the top of the struct or it will SIGSEV for certain architectures.
 	// See https://github.com/golang/go/issues/13868
-	queueSize     int64
 	processor     func(*ReadBuf)
 	maxPacketSize int
 	serving       uint32

--- a/cmd/agent/app/servers/tbuffered_server_test.go
+++ b/cmd/agent/app/servers/tbuffered_server_test.go
@@ -46,7 +46,6 @@ func TestTBufferedServer(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	pr := func(readBuf *ReadBuf) {
-		wg.Done()
 		assert.NotEqual(t, 0, len(readBuf.GetBytes()))
 		protoFact := athrift.NewTCompactProtocolFactory()
 		trans := &customtransport.TBufferedReadTransport{}
@@ -54,6 +53,7 @@ func TestTBufferedServer(t *testing.T) {
 		protocol.Transport().Write(readBuf.GetBytes())
 		handler := agent.NewAgentProcessor(inMemReporter)
 		handler.Process(protocol, protocol)
+		wg.Done()
 	}
 
 	server.RegisterProcessor(pr)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -56,7 +56,7 @@ func main() {
 				Namespace(metrics.NSOptions{Name: "jaeger"}).
 				Namespace(metrics.NSOptions{Name: "agent"})
 
-			rOpts := new(reporter.Options).InitFromViper(v)
+			rOpts := new(reporter.Options).InitFromViper(v, logger)
 			tchanBuilder := tchannel.NewBuilder().InitFromViper(v, logger)
 			grpcBuilder := grpc.NewConnBuilder().InitFromViper(v)
 			cp, err := app.CreateCollectorProxy(rOpts, tchanBuilder, grpcBuilder, logger, mFactory)

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -121,7 +121,7 @@ by default uses only in-memory database.`,
 			strategyStore := initSamplingStrategyStore(strategyStoreFactory, metricsFactory, logger)
 
 			aOpts := new(agentApp.Builder).InitFromViper(v)
-			repOpts := new(agentRep.Options).InitFromViper(v)
+			repOpts := new(agentRep.Options).InitFromViper(v, logger)
 			tchanBuilder := agentTchanRep.NewBuilder().InitFromViper(v, logger)
 			grpcBuilder := agentGrpcRep.NewConnBuilder().InitFromViper(v)
 			cOpts := new(collector.CollectorOptions).InitFromViper(v)

--- a/model/keyvalue.go
+++ b/model/keyvalue.go
@@ -221,3 +221,14 @@ func (kv KeyValue) Hash(w io.Writer) error {
 	}
 	return err
 }
+
+// KeyValueFromMap transforms map[string]string to []KeyValue
+func KeyValueFromMap(tags map[string]string) []KeyValue {
+	kvs := make([]KeyValue, 0, len(tags))
+	for k, v := range tags {
+		kv := String(k, v)
+		kvs = append(kvs, kv)
+	}
+
+	return kvs
+}

--- a/model/keyvalue_test.go
+++ b/model/keyvalue_test.go
@@ -159,3 +159,13 @@ func TestKeyValueHash(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyValueFromMap(t *testing.T) {
+	testMap := map[string]string{
+		"a": "b",
+		"c": "d",
+	}
+
+	kvMap := model.KeyValueFromMap(testMap)
+	assert.Equal(t, 2, len(kvMap))
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #1430 , by buffering incoming spans if the collector can't be reached. 

## Short description of the changes

This wraps the outbound reporter with a queue to which new spans are first pushed to and then pulled by the processing threads. If the collector can't be reached due to an error that's caused by network issues, the processing thread is put to sleep for a exponential time (until the maximum is hit).

The queue can be changed to a different one to provide features such as persistence to processed messages. The process should provide "at-least-once" delivery, not necessarily "only-once". 

Certain things omitted from this PR to get feedback if this was the intended approach, so no configuration options for amount of workers, times or which queue to be used.
