### PR TITLE
Refactor zipkin/protov2.go

### DIFF
--- a/cmd/collector/app/zipkin/http_handler_test.go
+++ b/cmd/collector/app/zipkin/http_handler_test.go
@@ -295,9 +295,9 @@ func TestSaveProtoSpansV2(t *testing.T) {
 		resBody    string
 	}{
 		{Span: zipkinProto.Span{Id: validID, TraceId: validTraceID, LocalEndpoint: &zipkinProto.Endpoint{Ipv4: randBytesOfLen(4)}, Kind: zipkinProto.Span_CLIENT}, StatusCode: http.StatusAccepted},
-		{Span: zipkinProto.Span{Id: randBytesOfLen(4)}, StatusCode: http.StatusBadRequest, resBody: "Unable to process request body: invalid length for Span ID\n"},
-		{Span: zipkinProto.Span{Id: validID, TraceId: randBytesOfLen(32)}, StatusCode: http.StatusBadRequest, resBody: "Unable to process request body: invalid length for traceId\n"},
-		{Span: zipkinProto.Span{Id: validID, TraceId: validTraceID, ParentId: randBytesOfLen(16)}, StatusCode: http.StatusBadRequest, resBody: "Unable to process request body: invalid length for parentId\n"},
+		{Span: zipkinProto.Span{Id: randBytesOfLen(4)}, StatusCode: http.StatusBadRequest, resBody: "Unable to process request body: invalid length for SpanID\n"},
+		{Span: zipkinProto.Span{Id: validID, TraceId: randBytesOfLen(32)}, StatusCode: http.StatusBadRequest, resBody: "Unable to process request body: invalid length for TraceID\n"},
+		{Span: zipkinProto.Span{Id: validID, TraceId: validTraceID, ParentId: randBytesOfLen(16)}, StatusCode: http.StatusBadRequest, resBody: "Unable to process request body: invalid length for SpanID\n"},
 		{Span: zipkinProto.Span{Id: validID, TraceId: validTraceID, LocalEndpoint: &zipkinProto.Endpoint{Ipv4: randBytesOfLen(2)}}, StatusCode: http.StatusBadRequest, resBody: "Unable to process request body: wrong Ipv4\n"},
 	}
 	for _, test := range tests {

--- a/cmd/collector/app/zipkin/protov2.go
+++ b/cmd/collector/app/zipkin/protov2.go
@@ -42,7 +42,8 @@ func protoSpanV2ToThrift(s *zipkinProto.Span) (*zipkincore.Span, error) {
 		return nil, fmt.Errorf("invalid length for Span ID")
 	}
 	id := binary.BigEndian.Uint64(s.Id)
-	traceID, err := traceIDFromBytes(s.TraceId)
+	traceID := model.TraceID{}
+	err := traceID.Unmarshal(s.TraceId)
 	if err != nil {
 		return nil, err
 	}
@@ -103,21 +104,6 @@ func protoSpanV2ToThrift(s *zipkinProto.Span) (*zipkincore.Span, error) {
 		})
 	}
 	return tSpan, nil
-}
-
-func traceIDFromBytes(tid []byte) (model.TraceID, error) {
-	var hi, lo uint64
-	switch {
-	case len(tid) > model.TraceIDLongBytesLen:
-		return model.TraceID{}, fmt.Errorf("invalid length for traceId")
-	case len(tid) > model.TraceIDShortBytesLen:
-		hiLen := len(tid) - model.TraceIDShortBytesLen
-		hi = binary.BigEndian.Uint64(tid[:hiLen])
-		lo = binary.BigEndian.Uint64(tid[hiLen:])
-	default:
-		lo = binary.BigEndian.Uint64(tid)
-	}
-	return model.TraceID{High: hi, Low: lo}, nil
 }
 
 func protoRemoteEndpToAddrAnno(e *zipkinProto.Endpoint, kind zipkinProto.Span_Kind) (*zipkincore.BinaryAnnotation, error) {

--- a/cmd/collector/app/zipkin/protov2.go
+++ b/cmd/collector/app/zipkin/protov2.go
@@ -44,8 +44,8 @@ func protoSpanV2ToThrift(s *zipkinProto.Span) (*zipkincore.Span, error) {
 		return nil, err
 	}
 
-	traceID := model.TraceID{}
-	if err = traceID.Unmarshal(s.TraceId); err != nil {
+	var traceID model.TraceID
+	if traceID, err = model.TraceIDFromBytes(s.TraceId); err != nil {
 		return nil, err
 	}
 

--- a/cmd/collector/app/zipkin/protov2_test.go
+++ b/cmd/collector/app/zipkin/protov2_test.go
@@ -82,9 +82,9 @@ func TestIdErrs(t *testing.T) {
 		span   zipkinProto.Span
 		errMsg string
 	}{
-		{span: zipkinProto.Span{Id: randBytesOfLen(16)}, errMsg: "invalid length for Span ID"},
-		{span: zipkinProto.Span{Id: validID, TraceId: invalidTraceID}, errMsg: "invalid length for traceId"},
-		{span: zipkinProto.Span{Id: validID, TraceId: validTraceID, ParentId: invalidParentID}, errMsg: "invalid length for parentId"},
+		{span: zipkinProto.Span{Id: randBytesOfLen(16)}, errMsg: "invalid length for SpanID"},
+		{span: zipkinProto.Span{Id: validID, TraceId: invalidTraceID}, errMsg: "invalid length for TraceID"},
+		{span: zipkinProto.Span{Id: validID, TraceId: validTraceID, ParentId: invalidParentID}, errMsg: "invalid length for SpanID"},
 	}
 	for _, test := range tests {
 		_, err := protoSpanV2ToThrift(&test.span)

--- a/model/ids.go
+++ b/model/ids.go
@@ -173,6 +173,15 @@ func SpanIDFromString(s string) (SpanID, error) {
 	return SpanID(id), nil
 }
 
+// SpanIDFromBytes creates a SpandID from list of bytes
+func SpanIDFromBytes(data []byte) (SpanID, error) {
+	id := SpanID(0)
+	if err := id.Unmarshal(data); err != nil {
+		return SpanID(0), err
+	}
+	return id, nil
+}
+
 // MarshalText is called by encoding/json, which we do not want people to use.
 func (s SpanID) MarshalText() ([]byte, error) {
 	return nil, fmt.Errorf("unsupported method SpanID.MarshalText; please use github.com/gogo/protobuf/jsonpb for marshalling")
@@ -197,8 +206,8 @@ func (s *SpanID) MarshalTo(data []byte) (n int, err error) {
 
 // Unmarshal inflates span ID from a binary representation. Called by protobuf serialization.
 func (s *SpanID) Unmarshal(data []byte) error {
-	if len(data) < 8 {
-		return fmt.Errorf("buffer is too short")
+	if len(data) != traceIDShortBytesLen {
+		return fmt.Errorf("invalid length for SpanID")
 	}
 	*s = NewSpanID(binary.BigEndian.Uint64(data))
 	return nil

--- a/model/ids.go
+++ b/model/ids.go
@@ -117,12 +117,9 @@ func (t *TraceID) MarshalTo(data []byte) (n int, err error) {
 
 // Unmarshal inflates this trace ID from binary representation. Called by protobuf serialization.
 func (t *TraceID) Unmarshal(data []byte) error {
-	if len(data) < 16 {
-		return fmt.Errorf("buffer is too short")
-	}
-	t.High = binary.BigEndian.Uint64(data[:8])
-	t.Low = binary.BigEndian.Uint64(data[8:])
-	return nil
+	var err error
+	*t, err = TraceIDFromBytes(data)
+	return err
 }
 
 func marshalBytes(dst []byte, src []byte) (n int, err error) {
@@ -183,11 +180,10 @@ func SpanIDFromString(s string) (SpanID, error) {
 
 // SpanIDFromBytes creates a SpandID from list of bytes
 func SpanIDFromBytes(data []byte) (SpanID, error) {
-	id := SpanID(0)
-	if err := id.Unmarshal(data); err != nil {
-		return SpanID(0), err
+	if len(data) != traceIDShortBytesLen {
+		return SpanID(0), fmt.Errorf("invalid length for SpanID")
 	}
-	return id, nil
+	return NewSpanID(binary.BigEndian.Uint64(data)), nil
 }
 
 // MarshalText is called by encoding/json, which we do not want people to use.
@@ -214,11 +210,9 @@ func (s *SpanID) MarshalTo(data []byte) (n int, err error) {
 
 // Unmarshal inflates span ID from a binary representation. Called by protobuf serialization.
 func (s *SpanID) Unmarshal(data []byte) error {
-	if len(data) != traceIDShortBytesLen {
-		return fmt.Errorf("invalid length for SpanID")
-	}
-	*s = NewSpanID(binary.BigEndian.Uint64(data))
-	return nil
+	var err error
+	*s, err = SpanIDFromBytes(data)
+	return err
 }
 
 // MarshalJSON converts span id into a base64 string enclosed in quotes.

--- a/model/ids.go
+++ b/model/ids.go
@@ -80,18 +80,15 @@ func TraceIDFromString(s string) (TraceID, error) {
 // TraceIDFromBytes creates a TraceID from list of bytes
 func TraceIDFromBytes(data []byte) (TraceID, error) {
 	var t TraceID
-	var hi, lo uint64
 	switch {
-	case len(data) > traceIDLongBytesLen:
-		return TraceID{}, fmt.Errorf("invalid length for TraceID")
-	case len(data) > traceIDShortBytesLen:
-		hiLen := len(data) - traceIDShortBytesLen
-		hi = binary.BigEndian.Uint64(data[:hiLen])
-		lo = binary.BigEndian.Uint64(data[hiLen:])
+	case len(data) == traceIDLongBytesLen:
+		t.High = binary.BigEndian.Uint64(data[:traceIDShortBytesLen])
+		t.Low = binary.BigEndian.Uint64(data[traceIDShortBytesLen:])
+	case len(data) == traceIDShortBytesLen:
+		t.Low = binary.BigEndian.Uint64(data)
 	default:
-		lo = binary.BigEndian.Uint64(data)
+		return TraceID{}, fmt.Errorf("invalid length for TraceID")
 	}
-	t.High, t.Low = hi, lo
 	return t, nil
 }
 

--- a/model/ids_test.go
+++ b/model/ids_test.go
@@ -108,9 +108,9 @@ func TestSpanIDFromBytes(t *testing.T) {
 
 func TestTraceIDFromBytes(t *testing.T) {
 	errTests := [][]byte{
-		[]byte{0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 13},
-		[]byte{0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 13},
-		[]byte{0, 0, 0, 0, 0, 0, 13},
+		{0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 13},
+		{0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 13},
+		{0, 0, 0, 0, 0, 0, 13},
 	}
 	for _, data := range errTests {
 		_, err := model.TraceIDFromBytes(data)

--- a/model/ids_test.go
+++ b/model/ids_test.go
@@ -88,17 +88,14 @@ func TestTraceSpanIDMarshalProto(t *testing.T) {
 }
 
 func TestSpanIDFromBytes(t *testing.T) {
-	tests := []struct {
-		data   []byte
-		errMsg string
-	}{
-		{data: []byte{0, 0, 0, 0}, errMsg: "invalid length for SpanID"},
-		{data: []byte{0, 0, 0, 0, 0, 0, 0, 13, 0}, errMsg: "invalid length for SpanID"},
+	errTests := [][]byte{
+		{0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 0, 0, 13, 0},
 	}
-	for _, test := range tests {
-		_, err := model.SpanIDFromBytes(test.data)
+	for _, data := range errTests {
+		_, err := model.SpanIDFromBytes(data)
 		require.Error(t, err)
-		assert.Equal(t, err.Error(), test.errMsg)
+		assert.Equal(t, err.Error(), "invalid length for SpanID")
 	}
 
 	spanID, err := model.SpanIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 13})

--- a/model/ids_test.go
+++ b/model/ids_test.go
@@ -86,3 +86,48 @@ func TestTraceSpanIDMarshalProto(t *testing.T) {
 		})
 	}
 }
+
+func TestSpanIDFromBytes(t *testing.T) {
+	tests := []struct {
+		data   []byte
+		errMsg string
+	}{
+		{data: []byte{0, 0, 0, 0}, errMsg: "invalid length for SpanID"},
+		{data: []byte{0, 0, 0, 0, 0, 0, 0, 13, 0}, errMsg: "invalid length for SpanID"},
+	}
+	for _, test := range tests {
+		_, err := model.SpanIDFromBytes(test.data)
+		require.Error(t, err)
+		assert.Equal(t, err.Error(), test.errMsg)
+	}
+
+	spanID, err := model.SpanIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 13})
+	require.NoError(t, err)
+	assert.Equal(t, spanID, model.NewSpanID(13))
+}
+
+func TestTraceIDFromBytes(t *testing.T) {
+	errTests := [][]byte{
+		[]byte{0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 13},
+		[]byte{0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 13},
+		[]byte{0, 0, 0, 0, 0, 0, 13},
+	}
+	for _, data := range errTests {
+		_, err := model.TraceIDFromBytes(data)
+		require.Error(t, err)
+		assert.Equal(t, err.Error(), "invalid length for TraceID")
+	}
+
+	tests := []struct {
+		data     []byte
+		expected model.TraceID
+	}{
+		{data: []byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}, expected: model.NewTraceID(2, 3)},
+		{data: []byte{0, 0, 0, 0, 0, 0, 0, 2}, expected: model.NewTraceID(0, 2)},
+	}
+	for _, test := range tests {
+		traceID, err := model.TraceIDFromBytes(test.data)
+		require.NoError(t, err)
+		assert.Equal(t, traceID, test.expected)
+	}
+}

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -175,7 +175,7 @@ func TestSpanIDUnmarshalJSONErrors(t *testing.T) {
 
 	err = id.UnmarshalJSONPB(nil, []byte(""))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "buffer is too short")
+	assert.Contains(t, err.Error(), "invalid length for SpanID")
 	err = id.UnmarshalJSONPB(nil, []byte("123"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "illegal base64 data")


### PR DESCRIPTION
## Which problem is this PR solving?
- Related to https://github.com/jaegertracing/jaeger/pull/1695#discussion_r314391550 (from previously merged PR)
## Short description of the changes
- Improve `model/ids.go` to parse `[]byte` into SpanID/TraceID
- Use `model/ids.go` in `zipkin/protov2.go`