### PR TITLE
Small memory optimizations in badger write-path

### DIFF
--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -220,11 +220,14 @@ func (r *TraceReader) scanTimeRange(startTime time.Time, endTime time.Time) ([]*
 }
 
 func createPrimaryKeySeekPrefix(traceID model.TraceID) []byte {
-	buf := new(bytes.Buffer)
-	buf.WriteByte(spanKeyPrefix)
-	binary.Write(buf, binary.BigEndian, traceID.High)
-	binary.Write(buf, binary.BigEndian, traceID.Low)
-	return buf.Bytes()
+	key := make([]byte, 1+sizeOfTraceID)
+	key[0] = spanKeyPrefix
+	pos := 1
+	binary.BigEndian.PutUint64(key[pos:], traceID.High)
+	pos += 8
+	binary.BigEndian.PutUint64(key[pos:], traceID.Low)
+
+	return key
 }
 
 // GetServices fetches the sorted service list that have not expired
@@ -378,7 +381,6 @@ func mergeJoinIds(left, right [][]byte) [][]byte {
 // sortMergeIds does a sort-merge join operation to the list of TraceIDs to remove duplicates
 func sortMergeIds(query *spanstore.TraceQueryParameters, ids [][][]byte) []model.TraceID {
 	// Key only scan is a lot faster in the badger - use sort-merge join algorithm instead of hash join since we have the keys in sorted order already
-
 	var merged [][]byte
 
 	if len(ids) > 1 {
@@ -501,19 +503,20 @@ func (r *TraceReader) scanIndexKeys(indexKeyValue []byte, startTimeMin time.Time
 		defer it.Close()
 
 		// Create starting point for sorted index scan
-		startIndex := make([]byte, 0, len(indexKeyValue)+len(startStampBytes))
-		startIndex = append(startIndex, indexKeyValue...)
-		startIndex = append(startIndex, startStampBytes...)
+		startIndex := make([]byte, len(indexKeyValue)+len(startStampBytes))
+		copy(startIndex, indexKeyValue)
+		copy(startIndex[len(indexKeyValue):], startStampBytes)
 
-		for it.Seek(startIndex); scanFunction(it, indexKeyValue, model.TimeAsEpochMicroseconds(startTimeMax)); it.Next() {
+		timeMax := model.TimeAsEpochMicroseconds(startTimeMax)
+		for it.Seek(startIndex); scanFunction(it, indexKeyValue, timeMax); it.Next() {
 			item := it.Item()
 
 			// ScanFunction is a prefix scanning (since we could have for example service1 & service12)
 			// Now we need to match only the exact key if we want to add it
 			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // timestamp is stored with 8 bytes
 			if bytes.Equal(indexKeyValue, it.Item().Key()[:timestampStartIndex]) {
-				key := []byte{}
-				key = append(key, item.Key()...) // badger reuses underlying slices so we have to copy the key
+				key := make([]byte, len(item.Key()))
+				copy(key, item.Key())
 				indexResults = append(indexResults, key)
 			}
 		}
@@ -548,9 +551,9 @@ func (r *TraceReader) scanRangeIndex(indexStartValue []byte, indexEndValue []byt
 		defer it.Close()
 
 		// Create starting point for sorted index scan
-		startIndex := make([]byte, 0, len(indexStartValue)+len(startStampBytes))
-		startIndex = append(startIndex, indexStartValue...)
-		startIndex = append(startIndex, startStampBytes...)
+		startIndex := make([]byte, len(indexStartValue)+len(startStampBytes))
+		copy(startIndex, indexStartValue)
+		copy(startIndex[len(indexStartValue):], startStampBytes)
 
 		timeIndexEnd := model.TimeAsEpochMicroseconds(startTimeMax)
 
@@ -562,9 +565,8 @@ func (r *TraceReader) scanRangeIndex(indexStartValue []byte, indexEndValue []byt
 			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // timestamp is stored with 8 bytes
 			timestamp := binary.BigEndian.Uint64(it.Item().Key()[timestampStartIndex : timestampStartIndex+8])
 			if timestamp <= timeIndexEnd {
-				key := []byte{}
-				key = item.KeyCopy(key)
-				key = append(key, item.Key()...) // badger reuses underlying slices so we have to copy the key
+				key := make([]byte, len(item.Key()))
+				copy(key, item.Key())
 				indexResults = append(indexResults, key)
 			}
 		}
@@ -584,10 +586,8 @@ func scanRangeFunction(it *badger.Iterator, indexEndValue []byte) bool {
 
 // traceIDToComparableBytes transforms model.TraceID to BigEndian sorted []byte
 func traceIDToComparableBytes(traceID *model.TraceID) []byte {
-	buf := new(bytes.Buffer)
-
-	binary.Write(buf, binary.BigEndian, traceID.High)
-	binary.Write(buf, binary.BigEndian, traceID.Low)
-
-	return buf.Bytes()
+	traceIDBytes := make([]byte, sizeOfTraceID)
+	binary.BigEndian.PutUint64(traceIDBytes, traceID.High)
+	binary.BigEndian.PutUint64(traceIDBytes[8:], traceID.Low)
+	return traceIDBytes
 }

--- a/plugin/storage/badger/spanstore/rw_internal_test.go
+++ b/plugin/storage/badger/spanstore/rw_internal_test.go
@@ -69,7 +69,9 @@ func TestEncodingTypes(t *testing.T) {
 		err := sw.WriteSpan(&testSpan)
 		assert.NoError(t, err)
 
-		key, _, _ := createTraceKV(&testSpan, protoEncoding)
+		startTime := model.TimeAsEpochMicroseconds(testSpan.StartTime)
+
+		key, _, _ := createTraceKV(&testSpan, protoEncoding, startTime)
 		e := &badger.Entry{
 			Key:       key,
 			ExpiresAt: uint64(time.Now().Add(1 * time.Hour).Unix()),


### PR DESCRIPTION
## Which problem is this PR solving?

This is work from another unfinished PR ported as standalone. Adds benchmarks for profiling purposes and removes some unnecessary duplicate processing and memory pressure from the write-path mostly. 

Improves perf slightly:

```
benchmark                                           old ns/op      new ns/op      delta
BenchmarkWrites-8                                   8365954405     7515525425     -10.17%
BenchmarkServiceTagsRangeQueryLimitIndexFetch-8     61905754       59933936       -3.19%
BenchmarkServiceIndexLimitFetch-8                   41341527       39249518       -5.06%
```

But more interesting, reduces memory pressure towards GC when writing:

```
benchmark             old allocs     new allocs     delta
BenchmarkWrites-8     49572552       36456074       -26.46%

benchmark             old bytes      new bytes      delta
BenchmarkWrites-8     2080032376     1853283416     -10.90%
```

## Short description of the changes

time-package calls are reduced, bytes.Buffer is replaced with writing to slice directly and copy() is used instead of append( ...)
