### PR TITLE
Set an empty value when a default env var value is missing

### DIFF
--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -69,6 +69,11 @@ func parseAgentTags(agentTags string) map[string]string {
 
 		if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") {
 			ed := strings.SplitN(string(v[2:len(v)-1]), ":", 2)
+			if (len(ed) == 1) {
+				// no default value specified, set to empty
+				ed = append(ed, "")
+			}
+
 			e, d := ed[0], ed[1]
 			v = os.Getenv(e)
 			if v == "" && d != "" {

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -68,9 +68,12 @@ func parseAgentTags(agentTags string) map[string]string {
 		k, v := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
 
 		if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") {
+			skipWhenEmpty := false
+
 			ed := strings.SplitN(string(v[2:len(v)-1]), ":", 2)
-			if (len(ed) == 1) {
+			if len(ed) == 1 {
 				// no default value specified, set to empty
+				skipWhenEmpty = true
 				ed = append(ed, "")
 			}
 
@@ -78,6 +81,11 @@ func parseAgentTags(agentTags string) map[string]string {
 			v = os.Getenv(e)
 			if v == "" && d != "" {
 				v = d
+			}
+
+			// no value is set, skip this entry
+			if v == "" && skipWhenEmpty {
+				continue
 			}
 		}
 

--- a/cmd/agent/app/reporter/flags_test.go
+++ b/cmd/agent/app/reporter/flags_test.go
@@ -16,6 +16,7 @@ package reporter
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
@@ -52,22 +53,36 @@ func TestBindFlags(t *testing.T) {
 	command.PersistentFlags().AddGoFlagSet(flags)
 	v.BindPFlags(command.PersistentFlags())
 
+	jaegerTags := fmt.Sprintf("%s,%s,%s,%s,%s,%s",
+		"key=value",
+		"envVar1=${envKey1:defaultVal1}",
+		"envVar2=${envKey2:defaultVal2}",
+		"envVar3=${envKey3}",
+		"envVar4=${envKey4}",
+		"envVar5=${envVar5:}",
+	)
+
 	err := command.ParseFlags([]string{
 		"--reporter.type=grpc",
-		"--jaeger.tags=key=value,envVar1=${envKey1:defaultVal1},envVar2=${envKey2:defaultVal2},envVar3=${envKey3}",
+		"--jaeger.tags=" + jaegerTags,
 	})
 	require.NoError(t, err)
 
 	b := &Options{}
 	os.Setenv("envKey1", "envVal1")
 	defer os.Unsetenv("envKey1")
+
+	os.Setenv("envKey4", "envVal4")
+	defer os.Unsetenv("envKey4")
+
 	b.InitFromViper(v)
 
 	expectedTags := map[string]string{
 		"key":     "value",
 		"envVar1": "envVal1",
 		"envVar2": "defaultVal2",
-		"envVar3": "",
+		"envVar4": "envVal4",
+		"envVar5": "",
 	}
 
 	assert.Equal(t, Type("grpc"), b.ReporterType)

--- a/cmd/agent/app/reporter/flags_test.go
+++ b/cmd/agent/app/reporter/flags_test.go
@@ -54,21 +54,22 @@ func TestBindFlags(t *testing.T) {
 
 	err := command.ParseFlags([]string{
 		"--reporter.type=grpc",
-		"--jaeger.tags=key=value,envVar1=${envKey1:defaultVal1},envVar2=${envKey2:defaultVal2}",
+		"--jaeger.tags=key=value,envVar1=${envKey1:defaultVal1},envVar2=${envKey2:defaultVal2},envVar3=${envKey3}",
 	})
 	require.NoError(t, err)
 
 	b := &Options{}
 	os.Setenv("envKey1", "envVal1")
+	defer os.Unsetenv("envKey1")
 	b.InitFromViper(v)
 
 	expectedTags := map[string]string{
 		"key":     "value",
 		"envVar1": "envVal1",
 		"envVar2": "defaultVal2",
+		"envVar3": "",
 	}
 
 	assert.Equal(t, Type("grpc"), b.ReporterType)
 	assert.Equal(t, expectedTags, b.AgentTags)
-	os.Unsetenv("envKey1")
 }


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Fixes #1776 by setting an empty value to the tag when an env var is being used without explicit default value.
