### PR TITLE
Cleanup healthcheck struct, remove server

### DIFF
--- a/pkg/healthcheck/handler.go
+++ b/pkg/healthcheck/handler.go
@@ -67,7 +67,6 @@ type HealthCheck struct {
 	state     atomic.Value // stores state struct
 	logger    *zap.Logger
 	responses map[Status]healthCheckResponse
-	server    *http.Server
 }
 
 // New creates a HealthCheck with the specified initial state.
@@ -84,7 +83,6 @@ func New() *HealthCheck {
 				StatusMsg:  "Server available",
 			},
 		},
-		server: nil,
 	}
 	hc.state.Store(state{status: Unavailable})
 	return hc


### PR DESCRIPTION
Signed-off-by: Annanay <annanay.a@media.net>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Code refactoring

## Short description of the changes
- Healthcheck handler is now served through the `Adminserver` mux - 

https://github.com/jaegertracing/jaeger/blob/b8d21ac1093282c7769e6d3c4378780cc59f0e1d/cmd/flags/admin.go#L107-L110

