### PR TITLE
WIP: Add Duplicate Tags Policy to Reporter

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -230,7 +230,8 @@ func CreateCollectorProxy(
 	}
 	switch opts.ReporterType {
 	case reporter.GRPC:
-		return grpc.NewCollectorProxy(grpcBuilder, opts.AgentTags, opts.DuplicateTagsPolicy, mFactory, logger)
+		params := grpc.CollectorProxyParams{Builder: grpcBuilder, AgentTags: opts.AgentTags, DedupeTagPolicy: opts.DuplicateTagsPolicy, MFactory: mFactory, Logger: logger}
+		return grpc.NewCollectorProxy(params)
 	case reporter.TCHANNEL:
 		return tchannel.NewCollectorProxy(tchanBuilder, mFactory, logger)
 	default:

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -230,7 +230,13 @@ func CreateCollectorProxy(
 	}
 	switch opts.ReporterType {
 	case reporter.GRPC:
-		params := grpc.CollectorProxyParams{Builder: grpcBuilder, AgentTags: opts.AgentTags, DedupeTagPolicy: opts.DuplicateTagsPolicy, MFactory: mFactory, Logger: logger}
+		params := grpc.CollectorProxyParams{
+			Builder:         grpcBuilder,
+			AgentTags:       opts.AgentTags,
+			DedupeTagPolicy: opts.DuplicateTagsPolicy,
+			MFactory:        mFactory,
+			Logger:          logger,
+		}
 		return grpc.NewCollectorProxy(params)
 	case reporter.TCHANNEL:
 		return tchannel.NewCollectorProxy(tchanBuilder, mFactory, logger)

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -230,7 +230,7 @@ func CreateCollectorProxy(
 	}
 	switch opts.ReporterType {
 	case reporter.GRPC:
-		return grpc.NewCollectorProxy(grpcBuilder, opts.AgentTags, mFactory, logger)
+		return grpc.NewCollectorProxy(grpcBuilder, opts.AgentTags, opts.DuplicateTagsPolicy, mFactory, logger)
 	case reporter.TCHANNEL:
 		return tchannel.NewCollectorProxy(tchanBuilder, mFactory, logger)
 	default:

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -29,7 +29,7 @@ const (
 	// Agent tags
 	agentTags = "jaeger.tags"
 	// duplicateTags is the override policy for tags when duplicates are present
-	duplicateTags = "jaeger.duplicate-tags"
+	duplicateTags = "dedupe-tags"
 	// Client to honour client's i.e library's tag
 	Client string = "client"
 	// Agent to honour agent's tag
@@ -54,7 +54,7 @@ type Options struct {
 
 // AddFlags adds flags for Options.
 func AddFlags(flags *flag.FlagSet) {
-	flags.String(duplicateTags, Client, "Jaeger Tags override policy. Accepted values are client, agent, duplicate.")
+	flags.String(duplicateTags, Duplicate, "The tag override policy, defining what to do when the same process tag is added by the client and the agent. Accepted values are 'client' (keep client's value), 'agent' (keep agent's value) and 'duplicate' (keep both).")
 	flags.String(reporterType, string(GRPC), fmt.Sprintf("Reporter type to use e.g. %s, %s", string(GRPC), string(TCHANNEL)))
 	flags.String(agentTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
 }

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -28,11 +28,13 @@ const (
 	reporterType = "reporter.type"
 	// Agent tags
 	agentTags = "jaeger.tags"
-	// Jaeger Tags override policy
+	// duplicateTags is the override policy for tags when duplicates are present
 	duplicateTags = "jaeger.duplicate-tags"
-	// Options for Jaeger Tag override policy
+	// Client to honour client's i.e library's tag
 	Client    string = "client"
+	// Agent to honour agent's tag
 	Agent     string = "agent"
+	// Duplicate to keep both
 	Duplicate string = "duplicate"
 	// TCHANNEL is name of tchannel reporter.
 	TCHANNEL Type = "tchannel"

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -28,8 +28,8 @@ const (
 	reporterType = "reporter.type"
 	// Agent tags
 	agentTags = "jaeger.tags"
-	// duplicateTags is the override policy for tags when duplicates are present
-	duplicateTags = "dedupe-tags"
+	// dedupeTags is the override policy for tags when duplicates are present
+	dedupeTags = "dedupe-tags"
 	// Client to honour client's i.e library's tag
 	Client string = "client"
 	// Agent to honour agent's tag
@@ -54,7 +54,7 @@ type Options struct {
 
 // AddFlags adds flags for Options.
 func AddFlags(flags *flag.FlagSet) {
-	flags.String(duplicateTags, Duplicate, "The tag override policy, defining what to do when the same process tag is added by the client and the agent. Accepted values are 'client' (keep client's value), 'agent' (keep agent's value) and 'duplicate' (keep both).")
+	flags.String(dedupeTags, Duplicate, "The tag override policy, defining what to do when the same process tag is added by the client and the agent. Accepted values are 'client' (keep client's value), 'agent' (keep agent's value) and 'duplicate' (keep both).")
 	flags.String(reporterType, string(GRPC), fmt.Sprintf("Reporter type to use e.g. %s, %s", string(GRPC), string(TCHANNEL)))
 	flags.String(agentTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
 }
@@ -63,7 +63,7 @@ func AddFlags(flags *flag.FlagSet) {
 func (b *Options) InitFromViper(v *viper.Viper) *Options {
 	b.ReporterType = Type(v.GetString(reporterType))
 	b.AgentTags = parseAgentTags(v.GetString(agentTags))
-	b.DuplicateTagsPolicy = v.GetString(duplicateTags)
+	b.DuplicateTagsPolicy = v.GetString(dedupeTags)
 	return b
 }
 

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -28,6 +28,12 @@ const (
 	reporterType = "reporter.type"
 	// Agent tags
 	agentTags = "jaeger.tags"
+	// Jaeger Tags override policy
+	duplicateTags = "jaeger.duplicate-tags"
+	// Options for Jaeger Tag override policy
+	Client    string = "client"
+	Agent     string = "agent"
+	Duplicate string = "duplicate"
 	// TCHANNEL is name of tchannel reporter.
 	TCHANNEL Type = "tchannel"
 	// GRPC is name of gRPC reporter.
@@ -39,12 +45,14 @@ type Type string
 
 // Options holds generic reporter configuration.
 type Options struct {
-	ReporterType Type
-	AgentTags    map[string]string
+	ReporterType        Type
+	DuplicateTagsPolicy string
+	AgentTags           map[string]string
 }
 
 // AddFlags adds flags for Options.
 func AddFlags(flags *flag.FlagSet) {
+	flags.String(duplicateTags, Client, "Jaeger Tags override policy. Accepted values are client, agent, duplicate.")
 	flags.String(reporterType, string(GRPC), fmt.Sprintf("Reporter type to use e.g. %s, %s", string(GRPC), string(TCHANNEL)))
 	flags.String(agentTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
 }
@@ -53,6 +61,7 @@ func AddFlags(flags *flag.FlagSet) {
 func (b *Options) InitFromViper(v *viper.Viper) *Options {
 	b.ReporterType = Type(v.GetString(reporterType))
 	b.AgentTags = parseAgentTags(v.GetString(agentTags))
+	b.DuplicateTagsPolicy = v.GetString(duplicateTags)
 	return b
 }
 

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -31,9 +31,9 @@ const (
 	// duplicateTags is the override policy for tags when duplicates are present
 	duplicateTags = "jaeger.duplicate-tags"
 	// Client to honour client's i.e library's tag
-	Client    string = "client"
+	Client string = "client"
 	// Agent to honour agent's tag
-	Agent     string = "agent"
+	Agent string = "agent"
 	// Duplicate to keep both
 	Duplicate string = "duplicate"
 	// TCHANNEL is name of tchannel reporter.

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -173,7 +173,8 @@ func TestProxyBuilder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			proxy, err := NewCollectorProxy(test.grpcBuilder, nil, reporter.Duplicate, metrics.NullFactory, zap.NewNop())
+			params := CollectorProxyParams{Builder: test.grpcBuilder, AgentTags: nil, DedupeTagPolicy: reporter.Duplicate, MFactory: metrics.NullFactory, Logger: zap.NewNop()}
+			proxy, err := NewCollectorProxy(params)
 			if test.expectError {
 				require.Error(t, err)
 			} else {
@@ -318,13 +319,15 @@ func TestProxyClientTLS(t *testing.T) {
 				CollectorHostPorts: []string{net.JoinHostPort("localhost", port)},
 				TLS:                test.clientTLS,
 			}
-			proxy, err := NewCollectorProxy(
-				grpcBuilder,
-				nil,
-				reporter.Duplicate,
-				mFactory,
-				zap.NewNop())
+			params := CollectorProxyParams{
+				Builder:         grpcBuilder,
+				AgentTags:       nil,
+				DedupeTagPolicy: reporter.Duplicate,
+				MFactory:        mFactory,
+				Logger:          zap.NewNop(),
+			}
 
+			proxy, err := NewCollectorProxy(params)
 			require.NoError(t, err)
 			require.NotNil(t, proxy)
 			assert.NotNil(t, proxy.GetReporter())

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
@@ -173,7 +175,7 @@ func TestProxyBuilder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			proxy, err := NewCollectorProxy(test.grpcBuilder, nil, metrics.NullFactory, zap.NewNop())
+			proxy, err := NewCollectorProxy(test.grpcBuilder, nil, reporter.Duplicate, metrics.NullFactory, zap.NewNop())
 			if test.expectError {
 				require.Error(t, err)
 			} else {
@@ -321,6 +323,7 @@ func TestProxyClientTLS(t *testing.T) {
 			proxy, err := NewCollectorProxy(
 				grpcBuilder,
 				nil,
+				reporter.Duplicate,
 				mFactory,
 				zap.NewNop())
 

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -20,7 +20,10 @@ import (
 	"time"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
-
+	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
+	"github.com/jaegertracing/jaeger/pkg/discovery"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
@@ -29,11 +32,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	yaml "gopkg.in/yaml.v2"
-
-	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
-	"github.com/jaegertracing/jaeger/pkg/discovery"
-	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
 
 var yamlConfig = `

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -41,7 +41,7 @@ func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, duplic
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
 	return &ProxyBuilder{
 		conn:     conn,
-		reporter: reporter.WrapWithMetrics(NewReporter(conn, agentTags, duplicateTagsPolicy, logger), grpcMetrics),
+		reporter: reporter.WrapWithMetrics(NewReporter(conn, &tagsMerger{agentTags: makeModelKeyValue(agentTags), duplicateTagsPolicy: duplicateTagsPolicy}, logger), grpcMetrics),
 		manager:  configmanager.WrapWithMetrics(grpcManager.NewConfigManager(conn), grpcMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -33,7 +33,7 @@ type ProxyBuilder struct {
 }
 
 // NewCollectorProxy creates ProxyBuilder
-func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
+func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, duplicateTagsPolicy string, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
 	conn, err := builder.CreateConnection(logger)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFacto
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
 	return &ProxyBuilder{
 		conn:     conn,
-		reporter: reporter.WrapWithMetrics(NewReporter(conn, agentTags, logger), grpcMetrics),
+		reporter: reporter.WrapWithMetrics(NewReporter(conn, agentTags, duplicateTagsPolicy, logger), grpcMetrics),
 		manager:  configmanager.WrapWithMetrics(grpcManager.NewConfigManager(conn), grpcMetrics),
 	}, nil
 }

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -19,14 +19,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -43,7 +43,14 @@ func TestMultipleCollectors(t *testing.T) {
 	defer s2.Stop()
 
 	mFactory := metricstest.NewFactory(time.Microsecond)
-	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, reporter.Duplicate, mFactory, zap.NewNop())
+	params := CollectorProxyParams{
+		Builder:         &ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}},
+		AgentTags:       nil,
+		DedupeTagPolicy: reporter.Duplicate,
+		MFactory:        mFactory,
+		Logger:          zap.NewNop(),
+	}
+	proxy, err := NewCollectorProxy(params)
 	require.NoError(t, err)
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics/metricstest"
@@ -42,7 +44,7 @@ func TestMultipleCollectors(t *testing.T) {
 	defer s2.Stop()
 
 	mFactory := metricstest.NewFactory(time.Microsecond)
-	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, mFactory, zap.NewNop())
+	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, reporter.Duplicate, mFactory, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -21,7 +21,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	zipkin2 "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
 	"github.com/jaegertracing/jaeger/model"
 	jConverter "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
@@ -33,21 +32,19 @@ import (
 
 // Reporter reports data to collector over gRPC.
 type Reporter struct {
-	collector           api_v2.CollectorServiceClient
-	agentTags           []model.KeyValue
-	duplicateTagsPolicy string
-	logger              *zap.Logger
-	sanitizer           zipkin2.Sanitizer
+	collector  api_v2.CollectorServiceClient
+	tagsMerger TagsMerger
+	logger     *zap.Logger
+	sanitizer  zipkin2.Sanitizer
 }
 
 // NewReporter creates gRPC reporter.
-func NewReporter(conn *grpc.ClientConn, agentTags map[string]string, duplicateTagsPolicy string, logger *zap.Logger) *Reporter {
+func NewReporter(conn *grpc.ClientConn, tagsMerger TagsMerger, logger *zap.Logger) *Reporter {
 	return &Reporter{
-		collector:           api_v2.NewCollectorServiceClient(conn),
-		agentTags:           makeModelKeyValue(agentTags),
-		duplicateTagsPolicy: duplicateTagsPolicy,
-		logger:              logger,
-		sanitizer:           zipkin2.NewChainedSanitizer(zipkin2.StandardSanitizers...),
+		collector:  api_v2.NewCollectorServiceClient(conn),
+		tagsMerger: tagsMerger,
+		logger:     logger,
+		sanitizer:  zipkin2.NewChainedSanitizer(zipkin2.StandardSanitizers...),
 	}
 }
 
@@ -69,7 +66,7 @@ func (r *Reporter) EmitZipkinBatch(zSpans []*zipkincore.Span) error {
 }
 
 func (r *Reporter) send(spans []*model.Span, process *model.Process) error {
-	spans, process = addProcessTags(spans, process, r.agentTags, r.duplicateTagsPolicy)
+	spans, process = r.tagsMerger.Merge(spans, process)
 	batch := model.Batch{Spans: spans, Process: process}
 	req := &api_v2.PostSpansRequest{Batch: batch}
 	_, err := r.collector.PostSpans(context.Background(), req)
@@ -77,38 +74,6 @@ func (r *Reporter) send(spans []*model.Span, process *model.Process) error {
 		r.logger.Error("Could not send spans over gRPC", zap.Error(err))
 	}
 	return err
-}
-
-// addTags appends jaeger tags for the agent to every span it sends to the collector.
-func addProcessTags(spans []*model.Span, process *model.Process, agentTags []model.KeyValue, duplicateTagsPolicy string) ([]*model.Span, *model.Process) {
-	if len(agentTags) == 0 {
-		return spans, process
-	}
-	if process != nil {
-		process.Tags = append(process.Tags, agentTags...)
-	}
-	for _, span := range spans {
-		if span.Process != nil {
-			if duplicateTagsPolicy != reporter.Duplicate {
-				for _, agentTag := range agentTags {
-					index, alreadyPresent := checkIfPresentAlready(span.Process.Tags, agentTag)
-					if alreadyPresent {
-						// If Policy is to keep agent tags, purge duplicate client tag and add AgentTag. Else Do Nothing
-						if duplicateTagsPolicy == reporter.Agent {
-							// remove index from Tags and add agentTag
-							span.Process.Tags = append(span.Process.Tags[:index], span.Process.Tags[index+1:]...)
-							span.Process.Tags = append(span.Process.Tags, agentTag)
-						}
-					} else {
-						span.Process.Tags = append(span.Process.Tags, agentTag)
-					}
-				}
-			} else {
-				span.Process.Tags = append(span.Process.Tags, agentTags...)
-			}
-		}
-	}
-	return spans, process
 }
 
 func checkIfPresentAlready(tags []model.KeyValue, agentTag model.KeyValue) (int, bool) {

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -93,9 +93,9 @@ func addProcessTags(spans []*model.Span, process *model.Process, agentTags []mod
 				for _, agentTag := range agentTags {
 					index, alreadyPresent := checkIfPresentAlready(span.Process.Tags, agentTag)
 					if alreadyPresent {
-						// If Policy is Agent, remove and add else do nothing as client is already present
+						// If Policy is to keep agent tags, purge duplicate client tag and add AgentTag. Else Do Nothing
 						if duplicateTagsPolicy == reporter.Agent {
-							// remove i from Tags and add agentTag
+							// remove index from Tags and add agentTag
 							span.Process.Tags = append(span.Process.Tags[:index], span.Process.Tags[index+1:]...)
 							span.Process.Tags = append(span.Process.Tags, agentTag)
 						}

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -18,11 +18,10 @@ package grpc
 import (
 	"context"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
-
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	zipkin2 "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
 	"github.com/jaegertracing/jaeger/model"
 	jConverter "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	jThrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -60,7 +62,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 	defer conn.Close()
 	require.NoError(t, err)
 
-	rep := NewReporter(conn, nil, zap.NewNop())
+	rep := NewReporter(conn, nil, reporter.Duplicate, zap.NewNop())
 
 	tm := time.Unix(158, 0)
 	a := tm.Unix() * 1000 * 1000
@@ -97,7 +99,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
-	rep := NewReporter(conn, nil, zap.NewNop())
+	rep := NewReporter(conn, nil, reporter.Duplicate, zap.NewNop())
 
 	tm := time.Unix(158, 0)
 	tests := []struct {
@@ -122,7 +124,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 func TestReporter_SendFailure(t *testing.T) {
 	conn, err := grpc.Dial("", grpc.WithInsecure())
 	require.NoError(t, err)
-	rep := NewReporter(conn, nil, zap.NewNop())
+	rep := NewReporter(conn, nil, reporter.Duplicate, zap.NewNop())
 	err = rep.send(nil, nil)
 	assert.EqualError(t, err, "rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: missing address\"")
 }
@@ -130,7 +132,7 @@ func TestReporter_SendFailure(t *testing.T) {
 func TestReporter_AddProcessTags_EmptyTags(t *testing.T) {
 	tags := map[string]string{}
 	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
-	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags))
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags), reporter.Duplicate)
 	assert.Equal(t, spans, actualSpans)
 }
 
@@ -146,7 +148,7 @@ func TestReporter_AddProcessTags_ZipkinBatch(t *testing.T) {
 			Process:       &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}},
 		},
 	}
-	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags))
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags), reporter.Duplicate)
 
 	assert.Equal(t, expectedSpans, actualSpans)
 }
@@ -157,9 +159,52 @@ func TestReporter_AddProcessTags_JaegerBatch(t *testing.T) {
 	process := &model.Process{ServiceName: "spring"}
 
 	expectedProcess := &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}}
-	_, actualProcess := addProcessTags(spans, process, makeModelKeyValue(tags))
+	_, actualProcess := addProcessTags(spans, process, makeModelKeyValue(tags), reporter.Duplicate)
 
 	assert.Equal(t, expectedProcess, actualProcess)
+}
+
+func TestReporter_AddProcessTags_JaegerBatchWithClientOverride(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2", "agentKey1": "agentValue1"}
+
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(agentTags), reporter.Client)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+}
+
+func TestReporter_AddProcessTags_JaegerBatchWithAgentOverride(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue1", "agentKey1": "agentValue1"}
+
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(agentTags), reporter.Agent)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+}
+
+func TestReporter_AddProcessTags_JaegerBatchWithDuplicates(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	expectedModelKeyValue := append(makeModelKeyValue(expectedTags), []model.KeyValue{model.String("commonKey", "commonValue2")}...)
+
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(agentTags), reporter.Duplicate)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, expectedModelKeyValue)
 }
 
 func TestReporter_MakeModelKeyValue(t *testing.T) {

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -20,16 +20,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	jThrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
 )
 
 type mockSpanHandler struct {
@@ -61,7 +59,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 	defer conn.Close()
 	require.NoError(t, err)
 
-	rep := NewReporter(conn, &tagsMerger{nil, reporter.Duplicate}, zap.NewNop())
+	rep := NewReporter(conn, nil, SimpleTagsMerger(), zap.NewNop())
 
 	tm := time.Unix(158, 0)
 	a := tm.Unix() * 1000 * 1000
@@ -98,7 +96,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 	//lint:ignore SA5001 don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
-	rep := NewReporter(conn, &tagsMerger{nil, reporter.Duplicate}, zap.NewNop())
+	rep := NewReporter(conn, nil, SimpleTagsMerger(), zap.NewNop())
 
 	tm := time.Unix(158, 0)
 	tests := []struct {
@@ -123,9 +121,91 @@ func TestReporter_EmitBatch(t *testing.T) {
 func TestReporter_SendFailure(t *testing.T) {
 	conn, err := grpc.Dial("", grpc.WithInsecure())
 	require.NoError(t, err)
-	rep := NewReporter(conn, &tagsMerger{nil, reporter.Duplicate}, zap.NewNop())
+	rep := NewReporter(conn, nil, SimpleTagsMerger(), zap.NewNop())
 	err = rep.send(nil, nil)
 	assert.EqualError(t, err, "rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: missing address\"")
+}
+
+func TestReporter_AddProcessTags_EmptyTags(t *testing.T) {
+	tags := map[string]string{}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
+	tagsMerger := SimpleTagsMerger()
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags), tagsMerger)
+	assert.Equal(t, spans, actualSpans)
+}
+
+func TestReporter_AddProcessTags_ZipkinBatch(t *testing.T) {
+	tags := map[string]string{"key": "value"}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan", Process: &model.Process{ServiceName: "spring"}}}
+
+	expectedSpans := []*model.Span{
+		{
+			TraceID:       model.NewTraceID(0, 1),
+			SpanID:        model.NewSpanID(2),
+			OperationName: "jonatan",
+			Process:       &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}},
+		},
+	}
+	tagsMerger := SimpleTagsMerger()
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(tags), tagsMerger)
+
+	assert.Equal(t, expectedSpans, actualSpans)
+}
+
+func TestReporter_AddProcessTags_JaegerBatch(t *testing.T) {
+	tags := map[string]string{"key": "value"}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
+	process := &model.Process{ServiceName: "spring"}
+
+	expectedProcess := &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}}
+	tagsMerger := SimpleTagsMerger()
+	_, actualProcess := addProcessTags(spans, process, makeModelKeyValue(tags), tagsMerger)
+
+	assert.Equal(t, expectedProcess, actualProcess)
+}
+
+func TestReporter_AddProcessTags_JaegerBatchWithClientOverride(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2", "agentKey1": "agentValue1"}
+	tagsMerger := DeDupeClientTagsMerger()
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(agentTags), tagsMerger)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+}
+
+func TestReporter_AddProcessTags_JaegerBatchWithAgentOverride(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue1", "agentKey1": "agentValue1"}
+	tagsMerger := DeDupeAgentTagsMerger()
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(agentTags), tagsMerger)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+}
+
+func TestReporter_AddProcessTags_JaegerBatchWithDuplicates(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	expectedModelKeyValue := append(makeModelKeyValue(expectedTags), []model.KeyValue{model.String("commonKey", "commonValue2")}...)
+
+	tagsMerger := SimpleTagsMerger()
+	actualSpans, _ := addProcessTags(spans, nil, makeModelKeyValue(agentTags), tagsMerger)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, expectedModelKeyValue)
 }
 
 func TestReporter_MakeModelKeyValue(t *testing.T) {

--- a/cmd/agent/app/reporter/grpc/tags_merger.go
+++ b/cmd/agent/app/reporter/grpc/tags_merger.go
@@ -7,49 +7,64 @@ import (
 
 type TagsMerger interface {
 	// Merge merges jaeger tags for the agent to every span it sends to the collector based on a policy
-	Merge(spans []*model.Span, process *model.Process) ([]*model.Span, *model.Process)
+	Merge(spanTags, agentTags []model.KeyValue) []model.KeyValue
 }
 
 type tagsMerger struct {
-	agentTags           []model.KeyValue
 	duplicateTagsPolicy string
 }
 
-func NewTagsMerger(agentTags []model.KeyValue, duplicateTagsPolicy string) TagsMerger {
+// DeDupeAgentTagsMerger creates a TagsMerger with Agent dedupe policy
+func DeDupeAgentTagsMerger() TagsMerger {
+	return NewTagsMerger(reporter.Agent)
+}
+
+// DeDupeClientTagsMerger creates a TagsMerger with Client dedupe policy
+func DeDupeClientTagsMerger() TagsMerger {
+	return NewTagsMerger(reporter.Client)
+}
+
+// SimpleTagsMerger creates a TagsMerger with Duplicate dedupe policy
+func SimpleTagsMerger() TagsMerger {
+	return NewTagsMerger(reporter.Duplicate)
+}
+
+// NewTagsMerger returns a TagsMerger based on the policy
+func NewTagsMerger(duplicateTagsPolicy string) TagsMerger {
 	return &tagsMerger{
-		agentTags:           agentTags,
 		duplicateTagsPolicy: duplicateTagsPolicy,
 	}
 }
 
 // Merge merges jaeger tags for the agent to every span it sends to the collector based on a policy
-func (tm *tagsMerger) Merge(spans []*model.Span, process *model.Process) ([]*model.Span, *model.Process) {
-	if len(tm.agentTags) == 0 {
-		return spans, process
-	}
-	if process != nil {
-		process.Tags = append(process.Tags, tm.agentTags...)
-	}
-	for _, span := range spans {
-		if span.Process != nil {
-			if tm.duplicateTagsPolicy != reporter.Duplicate {
-				for _, agentTag := range tm.agentTags {
-					index, alreadyPresent := checkIfPresentAlready(span.Process.Tags, agentTag)
-					if alreadyPresent {
-						// If Policy is to keep agent tags, purge duplicate client tag and add AgentTag. Else Do Nothing
-						if tm.duplicateTagsPolicy == reporter.Agent {
-							// remove index from Tags and add agentTag
-							span.Process.Tags = append(span.Process.Tags[:index], span.Process.Tags[index+1:]...)
-							span.Process.Tags = append(span.Process.Tags, agentTag)
-						}
-					} else {
-						span.Process.Tags = append(span.Process.Tags, agentTag)
-					}
+func (tm *tagsMerger) Merge(spanTags, agentTags []model.KeyValue) []model.KeyValue {
+
+	if tm.duplicateTagsPolicy != reporter.Duplicate {
+		for _, agentTag := range agentTags {
+			index, alreadyPresent := checkIfPresentAlready(spanTags, agentTag)
+			if alreadyPresent {
+				// If Policy is to keep agent tags, purge duplicate client tag and add AgentTag. Else Do Nothing
+				if tm.duplicateTagsPolicy == reporter.Agent {
+					// remove index from Tags and add agentTag
+					spanTags = append(spanTags[:index], spanTags[index+1:]...)
+					spanTags = append(spanTags, agentTag)
 				}
 			} else {
-				span.Process.Tags = append(span.Process.Tags, tm.agentTags...)
+				spanTags = append(spanTags, agentTag)
 			}
 		}
+	} else {
+		spanTags = append(spanTags, agentTags...)
 	}
-	return spans, process
+
+	return spanTags
+}
+
+func checkIfPresentAlready(tags []model.KeyValue, agentTag model.KeyValue) (int, bool) {
+	for i := range tags {
+		if tags[i].Key == agentTag.Key {
+			return i, true
+		}
+	}
+	return 0, false
 }

--- a/cmd/agent/app/reporter/grpc/tags_merger.go
+++ b/cmd/agent/app/reporter/grpc/tags_merger.go
@@ -1,0 +1,55 @@
+package grpc
+
+import (
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
+	"github.com/jaegertracing/jaeger/model"
+)
+
+type TagsMerger interface {
+	// Merge merges jaeger tags for the agent to every span it sends to the collector based on a policy
+	Merge(spans []*model.Span, process *model.Process) ([]*model.Span, *model.Process)
+}
+
+type tagsMerger struct {
+	agentTags           []model.KeyValue
+	duplicateTagsPolicy string
+}
+
+func NewTagsMerger(agentTags []model.KeyValue, duplicateTagsPolicy string) TagsMerger {
+	return &tagsMerger{
+		agentTags:           agentTags,
+		duplicateTagsPolicy: duplicateTagsPolicy,
+	}
+}
+
+// Merge merges jaeger tags for the agent to every span it sends to the collector based on a policy
+func (tm *tagsMerger) Merge(spans []*model.Span, process *model.Process) ([]*model.Span, *model.Process) {
+	if len(tm.agentTags) == 0 {
+		return spans, process
+	}
+	if process != nil {
+		process.Tags = append(process.Tags, tm.agentTags...)
+	}
+	for _, span := range spans {
+		if span.Process != nil {
+			if tm.duplicateTagsPolicy != reporter.Duplicate {
+				for _, agentTag := range tm.agentTags {
+					index, alreadyPresent := checkIfPresentAlready(span.Process.Tags, agentTag)
+					if alreadyPresent {
+						// If Policy is to keep agent tags, purge duplicate client tag and add AgentTag. Else Do Nothing
+						if tm.duplicateTagsPolicy == reporter.Agent {
+							// remove index from Tags and add agentTag
+							span.Process.Tags = append(span.Process.Tags[:index], span.Process.Tags[index+1:]...)
+							span.Process.Tags = append(span.Process.Tags, agentTag)
+						}
+					} else {
+						span.Process.Tags = append(span.Process.Tags, agentTag)
+					}
+				}
+			} else {
+				span.Process.Tags = append(span.Process.Tags, tm.agentTags...)
+			}
+		}
+	}
+	return spans, process
+}

--- a/cmd/agent/app/reporter/grpc/tags_merger_test.go
+++ b/cmd/agent/app/reporter/grpc/tags_merger_test.go
@@ -3,91 +3,41 @@ package grpc
 import (
 	"testing"
 
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTagsMerger_Merge_EmptyTags(t *testing.T) {
-	tags := map[string]string{}
-	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
-	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(tags), duplicateTagsPolicy: reporter.Duplicate}
-	actualSpans, _ := tagsMerger.Merge(spans, nil)
-	assert.Equal(t, spans, actualSpans)
-}
-
-func TestTagsMerger_Merge_ZipkinBatch(t *testing.T) {
-	tags := map[string]string{"key": "value"}
-	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan", Process: &model.Process{ServiceName: "spring"}}}
-
-	expectedSpans := []*model.Span{
-		{
-			TraceID:       model.NewTraceID(0, 1),
-			SpanID:        model.NewSpanID(2),
-			OperationName: "jonatan",
-			Process:       &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}},
-		},
-	}
-	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(tags), duplicateTagsPolicy: reporter.Duplicate}
-	actualSpans, _ := tagsMerger.Merge(spans, nil)
-
-	assert.Equal(t, expectedSpans, actualSpans)
-}
-
-func TestTagsMerger_Merge_JaegerBatch(t *testing.T) {
-	tags := map[string]string{"key": "value"}
-	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
-	process := &model.Process{ServiceName: "spring"}
-
-	expectedProcess := &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}}
-	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(tags), duplicateTagsPolicy: reporter.Duplicate}
-	_, actualProcess := tagsMerger.Merge(spans, process)
-
-	assert.Equal(t, expectedProcess, actualProcess)
-}
-
-func TestTagsMerger_Merge_JaegerBatchWithClientOverride(t *testing.T) {
+func TestTagsMerger_Merge_ClientOverride(t *testing.T) {
 	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
 	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
 
-	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
-	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
-
 	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2", "agentKey1": "agentValue1"}
+	tagsMerger := DeDupeClientTagsMerger()
+	actualSpans := tagsMerger.Merge(makeModelKeyValue(clientTags), makeModelKeyValue(agentTags))
 
-	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(agentTags), duplicateTagsPolicy: reporter.Client}
-	actualSpans, _ := tagsMerger.Merge(spans, nil)
-
-	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+	assert.ElementsMatch(t, actualSpans, makeModelKeyValue(expectedTags))
 }
 
 func TestTagsMerger_Merge_JaegerBatchWithAgentOverride(t *testing.T) {
 	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
 	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
 
-	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
-	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
-
 	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue1", "agentKey1": "agentValue1"}
+	tagsMerger := DeDupeAgentTagsMerger()
+	actualSpans := tagsMerger.Merge(makeModelKeyValue(clientTags), makeModelKeyValue(agentTags))
 
-	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(agentTags), duplicateTagsPolicy: reporter.Agent}
-	actualSpans, _ := tagsMerger.Merge(spans, nil)
-
-	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+	assert.ElementsMatch(t, actualSpans, makeModelKeyValue(expectedTags))
 }
 
 func TestTagsMerger_Merge_JaegerBatchWithDuplicates(t *testing.T) {
 	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
 	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
 
-	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
-	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
-
 	expectedTags := map[string]string{"clientKey1": "clientValue1", "agentKey1": "agentValue1", "commonKey": "commonValue1"}
 	expectedModelKeyValue := append(makeModelKeyValue(expectedTags), []model.KeyValue{model.String("commonKey", "commonValue2")}...)
 
-	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(agentTags), duplicateTagsPolicy: reporter.Duplicate}
-	actualSpans, _ := tagsMerger.Merge(spans, nil)
+	tagsMerger := SimpleTagsMerger()
+	actualSpans := tagsMerger.Merge(makeModelKeyValue(clientTags), makeModelKeyValue(agentTags))
 
-	assert.ElementsMatch(t, actualSpans[0].Process.Tags, expectedModelKeyValue)
+	assert.ElementsMatch(t, actualSpans, expectedModelKeyValue)
 }

--- a/cmd/agent/app/reporter/grpc/tags_merger_test.go
+++ b/cmd/agent/app/reporter/grpc/tags_merger_test.go
@@ -1,0 +1,93 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsMerger_Merge_EmptyTags(t *testing.T) {
+	tags := map[string]string{}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
+	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(tags), duplicateTagsPolicy: reporter.Duplicate}
+	actualSpans, _ := tagsMerger.Merge(spans, nil)
+	assert.Equal(t, spans, actualSpans)
+}
+
+func TestTagsMerger_Merge_ZipkinBatch(t *testing.T) {
+	tags := map[string]string{"key": "value"}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan", Process: &model.Process{ServiceName: "spring"}}}
+
+	expectedSpans := []*model.Span{
+		{
+			TraceID:       model.NewTraceID(0, 1),
+			SpanID:        model.NewSpanID(2),
+			OperationName: "jonatan",
+			Process:       &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}},
+		},
+	}
+	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(tags), duplicateTagsPolicy: reporter.Duplicate}
+	actualSpans, _ := tagsMerger.Merge(spans, nil)
+
+	assert.Equal(t, expectedSpans, actualSpans)
+}
+
+func TestTagsMerger_Merge_JaegerBatch(t *testing.T) {
+	tags := map[string]string{"key": "value"}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), OperationName: "jonatan"}}
+	process := &model.Process{ServiceName: "spring"}
+
+	expectedProcess := &model.Process{ServiceName: "spring", Tags: []model.KeyValue{model.String("key", "value")}}
+	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(tags), duplicateTagsPolicy: reporter.Duplicate}
+	_, actualProcess := tagsMerger.Merge(spans, process)
+
+	assert.Equal(t, expectedProcess, actualProcess)
+}
+
+func TestTagsMerger_Merge_JaegerBatchWithClientOverride(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2", "agentKey1": "agentValue1"}
+
+	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(agentTags), duplicateTagsPolicy: reporter.Client}
+	actualSpans, _ := tagsMerger.Merge(spans, nil)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+}
+
+func TestTagsMerger_Merge_JaegerBatchWithAgentOverride(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue1", "agentKey1": "agentValue1"}
+
+	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(agentTags), duplicateTagsPolicy: reporter.Agent}
+	actualSpans, _ := tagsMerger.Merge(spans, nil)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, makeModelKeyValue(expectedTags))
+}
+
+func TestTagsMerger_Merge_JaegerBatchWithDuplicates(t *testing.T) {
+	agentTags := map[string]string{"agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	clientTags := map[string]string{"clientKey1": "clientValue1", "commonKey": "commonValue2"}
+
+	process := &model.Process{Tags: makeModelKeyValue(clientTags)}
+	spans := []*model.Span{{TraceID: model.NewTraceID(0, 1), SpanID: model.NewSpanID(2), Process: process, OperationName: "jonatan"}}
+
+	expectedTags := map[string]string{"clientKey1": "clientValue1", "agentKey1": "agentValue1", "commonKey": "commonValue1"}
+	expectedModelKeyValue := append(makeModelKeyValue(expectedTags), []model.KeyValue{model.String("commonKey", "commonValue2")}...)
+
+	tagsMerger := tagsMerger{agentTags: makeModelKeyValue(agentTags), duplicateTagsPolicy: reporter.Duplicate}
+	actualSpans, _ := tagsMerger.Merge(spans, nil)
+
+	assert.ElementsMatch(t, actualSpans[0].Process.Tags, expectedModelKeyValue)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Partially addresses #1778 by adding a `jaeger.duplicate-tags` flag. 

## Short description of the changes
- Adds `jaeger.duplicate-tags` to the command line flags.
- Adds a `DuplicateTagsPolicy` field to Reporter
- Adds relevant Unit tests to check the elements.
- Update other Reporter Tests to use `DuplicateTagsPolicy` `duplicate`


@jpkrohling @annanay25 
