### PR TITLE
Tracegen supports generating firehose spans

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -97,7 +97,7 @@ required = [
 
 [[constraint]]
   name = "github.com/uber/jaeger-client-go"
-  version = "^2.17.0"
+  version = "^2.18.0"
 
 [[constraint]]
   name = "github.com/uber/jaeger-lib"

--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Traces   int
 	Marshal  bool
 	Debug    bool
+	Firehose bool
 	Pause    time.Duration
 	Duration time.Duration
 }
@@ -40,6 +41,7 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.IntVar(&c.Traces, "traces", 1, "Number of traces to generate in each worker (ignored if duration is provided")
 	fs.BoolVar(&c.Marshal, "marshal", false, "Whether to marshal trace context via HTTP headers")
 	fs.BoolVar(&c.Debug, "debug", false, "Whether to set DEBUG flag on the spans to force sampling")
+	fs.BoolVar(&c.Firehose, "firehose", false, "Whether to set FIREHOSE flag on the spans to skip indexing")
 	fs.DurationVar(&c.Pause, "pause", time.Microsecond, "How long to pause before finishing trace")
 	fs.DurationVar(&c.Duration, "duration", 0, "For how long to run the test")
 }
@@ -61,6 +63,7 @@ func Run(c *Config, logger *zap.Logger) error {
 			traces:   c.Traces,
 			marshal:  c.Marshal,
 			debug:    c.Debug,
+			firehose: c.Firehose,
 			pause:    c.Pause,
 			duration: c.Duration,
 			running:  &running,


### PR DESCRIPTION
- add 'firehose' flag for tracegen
- upgrade jaeger-client-go version to 2.18.0

Signed-off-by: jung <jung@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Relates to #1731 

## Short description of the changes
- 
