### PR TITLE
Fix ordering of indexScanKeys after TraceID parsing, closes #1808

### DIFF
--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -25,7 +25,8 @@ import (
 	"testing"
 	"time"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
@@ -587,7 +588,7 @@ func BenchmarkServiceIndexLimitFetch(b *testing.B) {
 
 // Opens a badger db and runs a test on it.
 func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
-	assert := assert.New(tb)
+	assert := require.New(tb)
 	f := badger.NewFactory()
 	opts := badger.NewOptions("badger")
 	v, command := config.Viperize(opts.AddFlags)
@@ -687,8 +688,6 @@ func TestRandomTraceID(t *testing.T) {
 		}
 		traces, err := sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-
-		// failed with `second` tag query, but success with `first`
 		assert.Equal(t, 1, len(traces))
 	})
 }

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
@@ -588,7 +587,7 @@ func BenchmarkServiceIndexLimitFetch(b *testing.B) {
 
 // Opens a badger db and runs a test on it.
 func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
-	assert := require.New(tb)
+	assert := assert.New(tb)
 	f := badger.NewFactory()
 	opts := badger.NewOptions("badger")
 	v, command := config.Viperize(opts.AddFlags)

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/dgraph-io/badger"
@@ -291,6 +292,9 @@ func (r *TraceReader) indexSeeksToTraceIDs(query *spanstore.TraceQueryParameters
 				prevTraceID = traceID
 			}
 		}
+		sort.Slice(ids[i], func(k, h int) bool {
+			return bytes.Compare(ids[i][k], ids[i][h]) < 0
+		})
 	}
 	return ids, nil
 }
@@ -522,6 +526,7 @@ func (r *TraceReader) scanIndexKeys(indexKeyValue []byte, startTimeMin time.Time
 		}
 		return nil
 	})
+
 	return indexResults, err
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Bug #1808 ``indexSeeksToTraceIDs`` returns keys in wrong order after parsing the TraceID, while ``durationQueries`` returned them in correct order.

## Short description of the changes

Add slice sorting after TraceID parsing to ensure the order is correct. Also add read-order test for this method.