### PR TITLE
Add sasl plain auth kafka plugin

### DIFF
--- a/pkg/kafka/auth/config.go
+++ b/pkg/kafka/auth/config.go
@@ -23,15 +23,17 @@ import (
 )
 
 const (
-	none     = "none"
-	kerberos = "kerberos"
-	tls      = "tls"
+	none      = "none"
+	kerberos  = "kerberos"
+	tls       = "tls"
+	saslPlain = "plain"
 )
 
 var authTypes = []string{
 	none,
 	kerberos,
 	tls,
+	saslPlain,
 }
 
 // AuthenticationConfig describes the configuration properties needed authenticate with kafka cluster
@@ -39,6 +41,7 @@ type AuthenticationConfig struct {
 	Authentication string
 	Kerberos       KerberosConfig
 	TLS            TLSConfig
+	SASLPlain      SASLPlainConfig
 }
 
 //SetConfiguration set configure authentication into sarama config structure
@@ -55,6 +58,8 @@ func (config *AuthenticationConfig) SetConfiguration(saramaConfig *sarama.Config
 		return nil
 	case tls:
 		return setTLSConfiguration(&config.TLS, saramaConfig)
+	case saslPlain:
+		return setSASLPlainConfiguration(&config.SASLPlain, saramaConfig)
 	default:
 		return errors.Errorf("Unknown/Unsupported authentication method %s to kafka cluster.", config.Authentication)
 	}
@@ -74,4 +79,7 @@ func (config *AuthenticationConfig) InitFromViper(configPrefix string, v *viper.
 	config.TLS.CaPath = v.GetString(configPrefix + tlsPrefix + suffixTLSCA)
 	config.TLS.CertPath = v.GetString(configPrefix + tlsPrefix + suffixTLSCert)
 	config.TLS.KeyPath = v.GetString(configPrefix + tlsPrefix + suffixTLSKey)
+
+	config.SASLPlain.UserName = v.GetString(configPrefix + saslPlainPrefix + suffixSASLUsername)
+	config.SASLPlain.Password = v.GetString(configPrefix + saslPlainPrefix + suffixSASLPassword)
 }

--- a/pkg/kafka/auth/config.go
+++ b/pkg/kafka/auth/config.go
@@ -39,7 +39,6 @@ var authTypes = []string{
 // AuthenticationConfig describes the configuration properties needed authenticate with kafka cluster
 type AuthenticationConfig struct {
 	Authentication string
-	TlsEnabled	   bool
 	Kerberos       KerberosConfig
 	TLS            TLSConfig
 	SASLPlain      SASLPlainConfig
@@ -51,7 +50,6 @@ func (config *AuthenticationConfig) SetConfiguration(saramaConfig *sarama.Config
 	if strings.Trim(authentication, " ") == "" {
 		authentication = none
 	}
-	saramaConfig.Net.TLS.Enable = config.TlsEnabled
 	switch authentication {
 	case none:
 		return nil
@@ -70,7 +68,6 @@ func (config *AuthenticationConfig) SetConfiguration(saramaConfig *sarama.Config
 // InitFromViper loads authentication configuration from viper flags.
 func (config *AuthenticationConfig) InitFromViper(configPrefix string, v *viper.Viper) {
 	config.Authentication = v.GetString(configPrefix + suffixAuthentication)
-	config.TlsEnabled = v.GetBool(configPrefix+suffixTlsTransportEnabled)
 	config.Kerberos.ServiceName = v.GetString(configPrefix + kerberosPrefix + suffixKerberosServiceName)
 	config.Kerberos.Realm = v.GetString(configPrefix + kerberosPrefix + suffixKerberosRealm)
 	config.Kerberos.UseKeyTab = v.GetBool(configPrefix + kerberosPrefix + suffixKerberosUseKeyTab)

--- a/pkg/kafka/auth/config.go
+++ b/pkg/kafka/auth/config.go
@@ -39,6 +39,7 @@ var authTypes = []string{
 // AuthenticationConfig describes the configuration properties needed authenticate with kafka cluster
 type AuthenticationConfig struct {
 	Authentication string
+	TlsEnabled	   bool
 	Kerberos       KerberosConfig
 	TLS            TLSConfig
 	SASLPlain      SASLPlainConfig
@@ -50,6 +51,7 @@ func (config *AuthenticationConfig) SetConfiguration(saramaConfig *sarama.Config
 	if strings.Trim(authentication, " ") == "" {
 		authentication = none
 	}
+	saramaConfig.Net.TLS.Enable = config.TlsEnabled
 	switch authentication {
 	case none:
 		return nil
@@ -68,6 +70,7 @@ func (config *AuthenticationConfig) SetConfiguration(saramaConfig *sarama.Config
 // InitFromViper loads authentication configuration from viper flags.
 func (config *AuthenticationConfig) InitFromViper(configPrefix string, v *viper.Viper) {
 	config.Authentication = v.GetString(configPrefix + suffixAuthentication)
+	config.TlsEnabled = v.GetBool(configPrefix+suffixTlsTransportEnabled)
 	config.Kerberos.ServiceName = v.GetString(configPrefix + kerberosPrefix + suffixKerberosServiceName)
 	config.Kerberos.Realm = v.GetString(configPrefix + kerberosPrefix + suffixKerberosRealm)
 	config.Kerberos.UseKeyTab = v.GetBool(configPrefix + kerberosPrefix + suffixKerberosUseKeyTab)

--- a/pkg/kafka/auth/options.go
+++ b/pkg/kafka/auth/options.go
@@ -52,7 +52,7 @@ const (
 	defaultKeyPath  = ""
 
 	// SASL Plain configuration options
-	saslPlainPrefix           = ".plain"
+	saslPlainPrefix           = ".sasl.plain"
 	suffixSASLUsername 		  = ".username"
 	suffixSASLPassword 		  = ".password"
 	defaultSASLUsername       = ""

--- a/pkg/kafka/auth/options.go
+++ b/pkg/kafka/auth/options.go
@@ -52,11 +52,11 @@ const (
 	defaultKeyPath  = ""
 
 	// SASL Plain configuration options
-	saslPlainPrefix           = ".sasl.plain"
-	suffixSASLUsername 		  = ".username"
-	suffixSASLPassword 		  = ".password"
-	defaultSASLUsername       = ""
-	defaultSASLPassword       = ""
+	saslPlainPrefix     = ".sasl.plain"
+	suffixSASLUsername  = ".username"
+	suffixSASLPassword  = ".password"
+	defaultSASLUsername = ""
+	defaultSASLPassword = ""
 )
 
 func addKerberosFlags(configPrefix string, flagSet *flag.FlagSet) {

--- a/pkg/kafka/auth/options.go
+++ b/pkg/kafka/auth/options.go
@@ -20,8 +20,10 @@ import (
 )
 
 const (
-	suffixAuthentication  = ".authentication"
-	defaultAuthentication = none
+	suffixAuthentication      = ".authentication"
+	defaultAuthentication     = none
+	suffixTlsTransportEnabled = ".tls.enabled"
+	defaultTlsEnabled         = false
 
 	// Kerberos configuration options
 	kerberosPrefix            = ".kerberos"
@@ -125,6 +127,10 @@ func AddFlags(configPrefix string, flagSet *flag.FlagSet) {
 		defaultAuthentication,
 		"Authentication type used to authenticate with kafka cluster. e.g. "+strings.Join(authTypes, ", "),
 	)
+	flagSet.Bool(
+		configPrefix+suffixTlsTransportEnabled,
+		defaultTlsEnabled,
+		"TLS enabled or disabled for communication")
 	addKerberosFlags(configPrefix, flagSet)
 	addTLSFlags(configPrefix, flagSet)
 	addSASLPlainFlags(configPrefix, flagSet)

--- a/pkg/kafka/auth/options.go
+++ b/pkg/kafka/auth/options.go
@@ -20,10 +20,8 @@ import (
 )
 
 const (
-	suffixAuthentication      = ".authentication"
-	defaultAuthentication     = none
-	suffixTlsTransportEnabled = ".tls.enabled"
-	defaultTlsEnabled         = false
+	suffixAuthentication  = ".authentication"
+	defaultAuthentication = none
 
 	// Kerberos configuration options
 	kerberosPrefix            = ".kerberos"
@@ -127,10 +125,6 @@ func AddFlags(configPrefix string, flagSet *flag.FlagSet) {
 		defaultAuthentication,
 		"Authentication type used to authenticate with kafka cluster. e.g. "+strings.Join(authTypes, ", "),
 	)
-	flagSet.Bool(
-		configPrefix+suffixTlsTransportEnabled,
-		defaultTlsEnabled,
-		"TLS enabled or disabled for communication")
 	addKerberosFlags(configPrefix, flagSet)
 	addTLSFlags(configPrefix, flagSet)
 	addSASLPlainFlags(configPrefix, flagSet)

--- a/pkg/kafka/auth/options.go
+++ b/pkg/kafka/auth/options.go
@@ -50,6 +50,13 @@ const (
 	defaultCAPath   = ""
 	defaultCertPath = ""
 	defaultKeyPath  = ""
+
+	// SASL Plain configuration options
+	saslPlainPrefix           = ".plain"
+	suffixSASLUsername 		  = ".username"
+	suffixSASLPassword 		  = ".password"
+	defaultSASLUsername       = ""
+	defaultSASLPassword       = ""
 )
 
 func addKerberosFlags(configPrefix string, flagSet *flag.FlagSet) {
@@ -99,6 +106,18 @@ func addTLSFlags(configPrefix string, flagSet *flag.FlagSet) {
 		"Path to the TLS Key for the Kafka connection")
 }
 
+// Flags for SASL Plain authentication options
+func addSASLPlainFlags(configPrefix string, flagSet *flag.FlagSet) {
+	flagSet.String(
+		configPrefix+saslPlainPrefix+suffixSASLUsername,
+		defaultSASLUsername,
+		"Username for SASL Plain authentication")
+	flagSet.String(
+		configPrefix+saslPlainPrefix+suffixSASLPassword,
+		defaultSASLPassword,
+		"Password for SASL Plain authentication")
+}
+
 // AddFlags add configuration flags to a flagSet.
 func AddFlags(configPrefix string, flagSet *flag.FlagSet) {
 	flagSet.String(
@@ -108,4 +127,5 @@ func AddFlags(configPrefix string, flagSet *flag.FlagSet) {
 	)
 	addKerberosFlags(configPrefix, flagSet)
 	addTLSFlags(configPrefix, flagSet)
+	addSASLPlainFlags(configPrefix, flagSet)
 }

--- a/pkg/kafka/auth/sasl_plain.go
+++ b/pkg/kafka/auth/sasl_plain.go
@@ -26,15 +26,12 @@ type SASLPlainConfig struct {
 }
 
 func setSASLPlainConfiguration(config *SASLPlainConfig, saramaConfig *sarama.Config) error {
-	saramaConfig.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+	if len(config.UserName) == 0 || len(config.Password) == 0 {
+		return errors.New("invalid username/password supplied for SASL Plain authentication. username/password cannot be empty")
+	}
 	saramaConfig.Net.SASL.Enable = true
-	if len(config.UserName) == 0 {
-		return errors.New("no username provided for SASL Plain authentication")
-	}
+	saramaConfig.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 	saramaConfig.Net.SASL.User = config.UserName
-	if len(config.Password) == 0 {
-		return errors.New("no password provided for SASL Plain authentication")
-	}
 	saramaConfig.Net.SASL.Password = config.Password
 	return nil
 }

--- a/pkg/kafka/auth/sasl_plain.go
+++ b/pkg/kafka/auth/sasl_plain.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"errors"
+	"github.com/Shopify/sarama"
+)
+
+// SASLPlainConfig defines configurations required for SASL Plain authentication (Refer: https://kafka.apache.org/documentation/#security_sasl_plain)
+type SASLPlainConfig struct {
+	UserName string
+	Password string
+}
+
+func setSASLPlainConfiguration(config *SASLPlainConfig, saramaConfig *sarama.Config) error {
+	saramaConfig.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+	saramaConfig.Net.SASL.Enable = true
+	if len(config.UserName) == 0 {
+		return errors.New("no username provided for SASL Plain authentication")
+	}
+	saramaConfig.Net.SASL.User = config.UserName
+	if len(config.Password) == 0 {
+		return errors.New("no password provided for SASL Plain authentication")
+	}
+	saramaConfig.Net.SASL.Password = config.Password
+	return nil
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Issue #1845 As of today Jaeger Kafka plugin only supports SASL GSSPI (Kerberos) and certificate-based authentication (mutual TLS). However, not all Kafka deployments support this authentication mechanism.  we have a Kafka cluster deployed with TLS transport for communication however our authentication is set up to use SASL PLAIN. https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_plain.html#kafka-sasl-auth-plain

## Short description of the changes
Added new authentication configuration for SASL Plain.
```  
kafka.producer.authentication = "plain"
```
New SASL Plain configuration options
```
kafka.producer.sasl.plain.username = "username"
kafka.producer.sasl.plain.password = "password"
```