### PR TITLE
Update gopkg.in/yaml.v2 dependency to v2.2.4

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1251,12 +1251,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
+  digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
-  version = "v2.2.2"
+  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+  version = "v2.2.4"
 
 [[projects]]
   digest = "1:131158a88aad1f94854d0aa21a64af2802d0a470fb0f01cb33c04fafd2047111"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -116,6 +116,10 @@ required = [
   version = "^1.20.1"
 
 [[constraint]]
+  name = "gopkg.in/yaml.v2"
+  version = "^2.2.4"
+
+[[constraint]]
   name = "github.com/olivere/elastic"
   version = "^6.2.22"
 


### PR DESCRIPTION
Updates gopkg.in/yaml.v2 dependency to be greater or equal to v2.2.4.

Signed-off-by: Gary Brown <gary@brownuk.com>
