### PR TITLE
Changed the default value for the flag 'ingester.deadlockInterval'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changes by Version
 
 ##### Breaking Changes
 
+* The default value for the Ingester's flag `ingester.deadlockInterval` has been changed to `0`. With the new default, the ingester won't `panic` if there are no messages for the last minute. To restore the previous behavior, set the flag's value to `1m`.
+
 ##### New Features
 
 ##### Bug fixes, Minor Improvements

--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -64,7 +64,7 @@ const (
 	// DefaultEncoding is the default span encoding
 	DefaultEncoding = kafka.EncodingProto
 	// DefaultDeadlockInterval is the default deadlock interval
-	DefaultDeadlockInterval = 1 * time.Minute
+	DefaultDeadlockInterval = time.Duration(0)
 )
 
 // Options stores the configuration options for the Ingester


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Resolves #1867 by changing the default value for the flag `ingester.deadlockInterval` to `0`
