### PR TITLE
Use node 10 when building docker images

### DIFF
--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -18,7 +18,7 @@ else
 fi
 
 source ~/.nvm/nvm.sh
-nvm use 8
+nvm use 10
 
 export DOCKER_NAMESPACE=jaegertracing
 make docker


### PR DESCRIPTION
Fixes failing builds on the master branch:
https://travis-ci.org/jaegertracing/jaeger/jobs/599917635#L780
https://travis-ci.org/jaegertracing/jaeger/jobs/598603785#L780

@everett980 could you please review? I am not sure why UI repo is using node 8 https://github.com/jaegertracing/jaeger-ui/blob/master/.travis.yml#L3

 

 