### PR TITLE
Bump Jaeger dependency on badger to 1.6.0 and resolve breaking changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,19 +128,19 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:21ac9938fb1098b3a7b0dd909fb30878d33231177fac11a2821114eb9c1088ff"
+  digest = "1:6be8582a4f52ba2851d8a039eb9c3a3b90334b2820563d71e97de35580da128e"
   name = "github.com/dgraph-io/badger"
   packages = [
     ".",
     "options",
-    "protos",
+    "pb",
     "skl",
     "table",
     "y",
   ]
   pruneopts = "UT"
-  revision = "391b6d3b93e6014fe8c2971fcc0c1266e47dbbd9"
-  version = "v1.5.3"
+  revision = "2fa005c9d4bf695277ab5214c1fbce3735b9562a"
+  version = "v1.6.0"
 
 [[projects]]
   branch = "master"
@@ -149,6 +149,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "6a90982ecee230ff6cba02d5bd386acc030be9d3"
+
+[[projects]]
+  digest = "1:6f9339c912bbdda81302633ad7e99a28dfa5a639c864061f1929510a9a64aa74"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:1f0c7ab489b407a7f8f9ad16c25a504d28ab461517a971d341388a56156c1bd7"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1310,7 +1310,6 @@
     "github.com/bsm/sarama-cluster",
     "github.com/crossdock/crossdock-go",
     "github.com/dgraph-io/badger",
-    "github.com/dgraph-io/badger/options",
     "github.com/fsnotify/fsnotify",
     "github.com/go-openapi/errors",
     "github.com/go-openapi/loads",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -137,7 +137,7 @@ required = [
 
 [[constraint]]
   name = "github.com/dgraph-io/badger"
-  version = "^1.6.0"
+  version = "=1.6.0"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -121,7 +121,7 @@ required = [
 
 [[constraint]]
   name = "github.com/olivere/elastic"
-  version = "^6.2.23"
+  version = "^6.2.22"
 
 [[constraint]]
   name = "github.com/gocql/gocql"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -121,7 +121,7 @@ required = [
 
 [[constraint]]
   name = "github.com/olivere/elastic"
-  version = "^6.2.22"
+  version = "^6.2.23"
 
 [[constraint]]
   name = "github.com/gocql/gocql"
@@ -137,7 +137,7 @@ required = [
 
 [[constraint]]
   name = "github.com/dgraph-io/badger"
-  version = "=1.5.3"
+  version = "^1.6.0"
 
 [prune]
   go-tests = true

--- a/plugin/storage/badger/spanstore/cache_test.go
+++ b/plugin/storage/badger/spanstore/cache_test.go
@@ -107,12 +107,10 @@ func TestOldReads(t *testing.T) {
 
 // func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
 func runWithBadger(t *testing.T, test func(store *badger.DB, t *testing.T)) {
-	opts := badger.DefaultOptions
+	dir, _ := ioutil.TempDir("", "badger")
+	opts := badger.DefaultOptions(dir)
 
 	opts.SyncWrites = false
-	dir, _ := ioutil.TempDir("", "badger")
-	opts.Dir = dir
-	opts.ValueDir = dir
 
 	store, err := badger.Open(opts)
 	defer func() {

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -532,7 +532,7 @@ func (r *TraceReader) scanIndexKeys(indexKeyValue []byte, startTimeMin time.Time
 
 // scanFunction compares the index name as well as the time range in the index key
 func scanFunction(it *badger.Iterator, indexPrefix []byte, timeIndexEnd uint64) bool {
-	if it.Item() != nil {
+	if it.Valid() && it.Item() != nil {
 		// We can't use the indexPrefix length, because we might have the same prefixValue for non-matching cases also
 		timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // timestamp is stored with 8 bytes
 		timestamp := binary.BigEndian.Uint64(it.Item().Key()[timestampStartIndex : timestampStartIndex+8])
@@ -582,7 +582,7 @@ func (r *TraceReader) scanRangeIndex(indexStartValue []byte, indexEndValue []byt
 
 // scanRangeFunction seeks until the index end has been reached
 func scanRangeFunction(it *badger.Iterator, indexEndValue []byte) bool {
-	if it.Item() != nil {
+	if it.Valid() && it.Item() != nil {
 		compareSlice := it.Item().Key()[:len(indexEndValue)]
 		return bytes.Compare(indexEndValue, compareSlice) >= 0
 	}


### PR DESCRIPTION


<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Need to upgrade badger dependency to 1.6.0

## Short description of the changes
- DefaultOptions is now a function with path default passed in
- Iterator now seems unhappy when you do it.Item() != null and expects to be checked against .Valid()
