### PR TITLE
Decouple storage dependencies and bump Go to 1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ services:
 
 env:
   global:
+    - GO111MODULE=off
     - DOCKER_COMPOSE_VERSION=1.8.0
     - COMMIT=${TRAVIS_COMMIT::8}
     # DOCKER_USER

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,43 +7,43 @@ dist: trusty
 
 jobs:
   include:
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - TESTS=true
     - COVERAGE=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - PROTO_GEN_TEST=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - ALL_IN_ONE=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - CROSSDOCK=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - DOCKER=true
     - DEPLOY=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - ES_INTEGRATION_TEST=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - KAFKA_INTEGRATION_TEST=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - CASSANDRA_INTEGRATION_TEST=true
-  - go: "1.12.1"
+  - go: "1.13.x"
     env:
     - HOTROD=true
   - stage: Fuzz regression
     dist: bionic
-    go: 1.12.x
+    go: "1.13.x"
     script: ./scripts/travis/fuzzit.sh local-regression
   - stage: Fuzz
     if: branch = master AND type IN (push)
     dist: bionic
-    go: 1.12.x
+    go: "1.13.x"
     script: ./scripts/travis/fuzzit.sh fuzzing
 
 services:

--- a/Makefile
+++ b/Makefile
@@ -136,13 +136,13 @@ fmt:
 
 .PHONY: lint-gosec
 lint-gosec:
-	$(GOSEC) ./...
+	time $(GOSEC) ./...
 
 .PHONY: lint-staticcheck
 lint-staticcheck:
 	@echo Running staticcheck...
 	@cat /dev/null > $(LINT_LOG)
-	@$(STATICCHECK) ./... \
+	@time $(STATICCHECK) ./... \
 		| grep -v \
 			-e model/model.pb.go \
 			-e thrift-gen/ \

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -17,14 +17,10 @@ package flags
 
 import (
 	"flag"
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/jaegertracing/jaeger/plugin/storage"
 )
 
 const (
@@ -62,7 +58,7 @@ type logging struct {
 
 // AddFlags adds flags for SharedFlags
 func AddFlags(flagSet *flag.FlagSet) {
-	flagSet.String(spanStorageType, "", "(deprecated) please use SPAN_STORAGE_TYPE environment variable. Run this binary with "env" command for help.")
+	flagSet.String(spanStorageType, "", "(deprecated) please use SPAN_STORAGE_TYPE environment variable. Run this binary with the 'env' command for help.")
 	AddLoggingFlag(flagSet)
 }
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -62,7 +62,7 @@ type logging struct {
 
 // AddFlags adds flags for SharedFlags
 func AddFlags(flagSet *flag.FlagSet) {
-	flagSet.String(spanStorageType, "", fmt.Sprintf(`(deprecated) please use %s environment variable. Run this binary with "env" command for help.`, storage.SpanStorageTypeEnvVar))
+	flagSet.String(spanStorageType, "", "(deprecated) please use SPAN_STORAGE_TYPE environment variable. Run this binary with "env" command for help.")
 	AddLoggingFlag(flagSet)
 }
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -17,6 +17,7 @@ package flags
 
 import (
 	"flag"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -150,11 +150,19 @@ func (m *Store) WriteSpan(span *model.Span) error {
 func (m *Store) GetTrace(ctx context.Context, traceID model.TraceID) (*model.Trace, error) {
 	m.RLock()
 	defer m.RUnlock()
-	retMe := m.traces[traceID]
-	if retMe == nil {
+	trace, ok := m.traces[traceID]
+	if !ok {
 		return nil, spanstore.ErrTraceNotFound
 	}
-	return retMe, nil
+	return m.copyTrace(trace), nil
+}
+
+// Spans may still be added to traces after they are returned to user code, so make copies.
+func (m *Store) copyTrace(trace *model.Trace) *model.Trace {
+	return &model.Trace{
+		Spans:    append([]*model.Span(nil), trace.Spans...),
+		Warnings: append([]string(nil), trace.Warnings...),
+	}
 }
 
 // GetServices returns a list of all known services
@@ -172,14 +180,13 @@ func (m *Store) GetServices(ctx context.Context) ([]string, error) {
 func (m *Store) GetOperations(ctx context.Context, service string) ([]string, error) {
 	m.RLock()
 	defer m.RUnlock()
+	var retMe []string
 	if operations, ok := m.operations[service]; ok {
-		var retMe []string
 		for ops := range operations {
 			retMe = append(retMe, ops)
 		}
-		return retMe, nil
 	}
-	return []string{}, nil
+	return retMe, nil
 }
 
 // FindTraces returns all traces in the query parameters are satisfied by a trace's span
@@ -189,7 +196,7 @@ func (m *Store) FindTraces(ctx context.Context, query *spanstore.TraceQueryParam
 	var retMe []*model.Trace
 	for _, trace := range m.traces {
 		if m.validTrace(trace, query) {
-			retMe = append(retMe, trace)
+			retMe = append(retMe, m.copyTrace(trace))
 		}
 	}
 


### PR DESCRIPTION
this little dependency pulls all storage implementations into custom builds, not worth it.

The Go bump is needed as staticcheck is failing on 1.12