### PR TITLE
Add remote read clusters option to elasticsearch to enable cross-cluster querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changes by Version
 
 ##### New Features
 
+Add Elasticsearch remote read clusters setting that enables [cross-cluster querying](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cross-cluster-search.html) `--es.remote-read-clusters=cluster_one,cluster_two` [#1833](https://github.com/jaegertracing/jaeger/issues/1883)
+
 ##### Bug fixes, Minor Improvements
 
 #### UI Changes

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -41,6 +41,7 @@ import (
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
 	Servers               []string
+	RemoteReadClusters    []string
 	Username              string
 	Password              string
 	TokenFilePath         string
@@ -78,6 +79,7 @@ type TLSConfig struct {
 // ClientBuilder creates new es.Client
 type ClientBuilder interface {
 	NewClient(logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error)
+	GetRemoteReadClusters() []string
 	GetNumShards() int64
 	GetNumReplicas() int64
 	GetMaxSpanAge() time.Duration
@@ -178,6 +180,9 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 
 // ApplyDefaults copies settings from source unless its own value is non-zero.
 func (c *Configuration) ApplyDefaults(source *Configuration) {
+	if len(c.RemoteReadClusters) == 0 {
+		c.RemoteReadClusters = source.RemoteReadClusters
+	}
 	if c.Username == "" {
 		c.Username = source.Username
 	}
@@ -211,6 +216,11 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.BulkFlushInterval == 0 {
 		c.BulkFlushInterval = source.BulkFlushInterval
 	}
+}
+
+// GetRemoteReadClusters returns list of remote read clusters
+func (c *Configuration) GetRemoteReadClusters() []string {
+	return c.RemoteReadClusters
 }
 
 // GetNumShards returns number of shards from Configuration

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -158,6 +158,7 @@ func createSpanReader(
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 		Archive:             archive,
+		RemoteReadClusters:  cfg.GetRemoteReadClusters(),
 	}), nil
 }
 

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -30,6 +30,7 @@ func TestOptions(t *testing.T) {
 	assert.Empty(t, primary.Username)
 	assert.Empty(t, primary.Password)
 	assert.NotEmpty(t, primary.Servers)
+	assert.Equal(t, []string{}, primary.RemoteReadClusters)
 	assert.Equal(t, int64(5), primary.NumShards)
 	assert.Equal(t, int64(1), primary.NumReplicas)
 	assert.Equal(t, 72*time.Hour, primary.MaxSpanAge)
@@ -46,6 +47,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	v, command := config.Viperize(opts.AddFlags)
 	command.ParseFlags([]string{
 		"--es.server-urls=1.1.1.1, 2.2.2.2",
+		"--es.remote-read-clusters=cluster_one,cluster_two",
 		"--es.username=hello",
 		"--es.password=world",
 		"--es.token-file=/foo/bar",
@@ -66,6 +68,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "hello", primary.Username)
 	assert.Equal(t, "/foo/bar", primary.TokenFilePath)
 	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, primary.Servers)
+	assert.Equal(t, []string{"cluster_one", "cluster_two"}, primary.RemoteReadClusters)
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
 	assert.True(t, primary.Sniffer)
 	assert.Equal(t, true, primary.TLS.Enabled)

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -146,35 +146,38 @@ func TestSpanReaderIndices(t *testing.T) {
 	date := time.Date(2019, 10, 10, 5, 0, 0, 0, time.UTC)
 	dateFormat := date.UTC().Format("2006-01-02")
 	testCases := []struct {
-		index  string
-		params SpanReaderParams
+		indices []string
+		params  SpanReaderParams
 	}{
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", Archive: false},
-			index: spanIndex + dateFormat},
+			indices: []string{spanIndex + dateFormat}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", UseReadWriteAliases: true},
-			index: spanIndex + "read"},
+			indices: []string{spanIndex + "read"}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: false},
-			index: "foo:" + indexPrefixSeparator + spanIndex + dateFormat},
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + dateFormat}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", UseReadWriteAliases: true},
-			index: "foo:-" + spanIndex + "read"},
+			indices: []string{"foo:-" + spanIndex + "read"}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", Archive: true},
-			index: spanIndex + archiveIndexSuffix},
+			indices: []string{spanIndex + archiveIndexSuffix}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: true},
-			index: "foo:" + indexPrefixSeparator + spanIndex + archiveIndexSuffix},
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveIndexSuffix}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: true, UseReadWriteAliases: true},
-			index: "foo:" + indexPrefixSeparator + spanIndex + archiveReadIndexSuffix},
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveReadIndexSuffix}},
+		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			IndexPrefix: "", Archive: false, RemoteReadClusters: []string{"cluster_one", "cluster_two"}},
+			indices: []string{spanIndex + dateFormat, "cluster_one:" + spanIndex + dateFormat, "cluster_two:" + spanIndex + dateFormat}},
 	}
 	for _, testCase := range testCases {
 		r := NewSpanReader(testCase.params)
 		actual := r.timeRangeIndices(r.spanIndexPrefix, date, date)
-		assert.Equal(t, []string{testCase.index}, actual)
+		assert.Equal(t, testCase.indices, actual)
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
Enables elasticsearch [cross-cluster querying](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cross-cluster-search.html)

Resolves [#1883](https://github.com/jaegertracing/jaeger/issues/1883)

## Short description of the changes

The cross cluster query api functions by appending a pre-configured remote cluster to an index e.g. cluster_one:index_name. This change simply applies a prefix for each remote cluster and for each index. You will end up with `total_indicies = indicies * remote_clusters`. Also added a special case `local` which will not append a prefix and query the local cluster. 

This works with both standard and rollover indices since it mostly comes down to a simple string manipulation.


