### PR TITLE
Build platform binaries as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ script:
   - if [ "$TESTS" == true ]; then make test-ci ; else echo 'skipping tests'; fi
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/build-all-in-one-image.sh ; else echo 'skipping all_in_one'; fi
   - if [ "$CROSSDOCK" == true ]; then bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi
-  - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping docker images'; fi
+  - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping build-docker-images'; fi
   - if [ "$DEPLOY" == true ]; then make build-all-platforms ; else echo 'skipping build-all-platforms'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$KAFKA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/kafka-integration-test.sh ; else echo 'skipping kafka integration test'; fi
@@ -95,7 +95,8 @@ after_failure:
   - if [ "$CROSSDOCK" == true ]; then make crossdock-logs ; else echo 'skipping crossdock'; fi
 
 before_deploy:
-  - if [ "$DEPLOY" == true ]; then bash ./scripts/travis/package-deploy.sh ; else echo 'skipping deploy'; fi
+  - if [ "$DOCKER" == true ]; then bash ./scripts/travis/upload-all-docker-images.sh ; else echo 'skipping docker upload'; fi
+  - if [ "$DEPLOY" == true ]; then bash ./scripts/travis/package-deploy.sh ; else echo 'skipping deploying binaries'; fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ script:
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/build-all-in-one-image.sh ; else echo 'skipping all_in_one'; fi
   - if [ "$CROSSDOCK" == true ]; then bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping docker images'; fi
+  - if [ "$DEPLOY" == true ]; then make build-all-platforms ; else echo 'skipping build-all-platforms'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$KAFKA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/kafka-integration-test.sh ; else echo 'skipping kafka integration test'; fi
   - if [ "$CASSANDRA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/cassandra-integration-test.sh ; else echo 'skipping cassandra integration test'; fi
@@ -94,7 +95,7 @@ after_failure:
   - if [ "$CROSSDOCK" == true ]; then make crossdock-logs ; else echo 'skipping crossdock'; fi
 
 before_deploy:
-  - if [ "$DEPLOY" == true ]; then make build-all-platforms && bash ./scripts/travis/package-deploy.sh ; else echo 'skipping deploy'; fi
+  - if [ "$DEPLOY" == true ]; then bash ./scripts/travis/package-deploy.sh ; else echo 'skipping deploy'; fi
 
 deploy:
   provider: releases

--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -1,30 +1,12 @@
 #!/bin/bash
+#
+# Build UI and all Docker images
 
 set -e
 
-BRANCH=${BRANCH:?'missing BRANCH env var'}
-
-# Only push images to Docker Hub for master branch or for release tags vM.N.P
-if [[ "$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "upload to Docker Hub, BRANCH=$BRANCH"
-else
-  echo 'skip Docker upload, only allowed for tagged releases or master (latest tag)'
-  exit 0
-fi
-
+# TODO avoid building the UI when on a PR branch: https://github.com/jaegertracing/jaeger/issues/1908
 source ~/.nvm/nvm.sh
 nvm use 10
 
 export DOCKER_NAMESPACE=jaegertracing
 make docker
-
-if [[ "$TRAVIS_SECURE_ENV_VARS" == "false" ]]; then
-  echo "skip docker upload, TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS"
-  exit 0
-fi
-
-for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester
-do
-  export REPO="jaegertracing/jaeger-${component}"
-  bash ./scripts/travis/upload-to-docker.sh
-done

--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [[ "$TRAVIS_SECURE_ENV_VARS" == "false" ]]; then
-  echo "skip docker upload, TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS"
-  exit 0
-fi
-
 BRANCH=${BRANCH:?'missing BRANCH env var'}
 
 # Only push images to Docker Hub for master branch or for release tags vM.N.P
@@ -22,6 +17,11 @@ nvm use 10
 
 export DOCKER_NAMESPACE=jaegertracing
 make docker
+
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "false" ]]; then
+  echo "skip docker upload, TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS"
+  exit 0
+fi
 
 for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester
 do

--- a/scripts/travis/upload-all-docker-images.sh
+++ b/scripts/travis/upload-all-docker-images.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# this script should only be run after build-docker-images.sh
+
+set -e
+
+BRANCH=${BRANCH:?'missing BRANCH env var'}
+
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "false" ]]; then
+  echo "skip docker upload, TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS"
+  exit 0
+fi
+
+# Only push images to Docker Hub for master branch or for release tags vM.N.P
+if [[ "$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "upload to Docker Hub, BRANCH=$BRANCH"
+else
+  echo 'skip Docker upload, only allowed for tagged releases or master (latest tag)'
+  exit 0
+fi
+
+export DOCKER_NAMESPACE=jaegertracing
+for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester
+do
+  export REPO="jaegertracing/jaeger-${component}"
+  bash ./scripts/travis/upload-to-docker.sh
+done


### PR DESCRIPTION
As described in #1906, the release process failed to build Windows binaries.

This change makes sure that the build process is executed as part of the CI for all PRs, to allows catching these problems sooner.

This will increase the length of CI because the process needs to build the UI, which takes long time (to be addressed in #1908).