### PR TITLE
Use proxy env vars if they're configured

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -300,7 +300,9 @@ func (c *Configuration) getConfigOptions(logger *zap.Logger) ([]elastic.ClientOp
 			TLSClientConfig: ctlsConfig,
 		}
 	} else {
-		httpTransport := &http.Transport{}
+		httpTransport := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
 		if c.TLS.CaPath != "" {
 			ctls := &TLSConfig{CaPath: c.TLS.CaPath}
 			ca, err := ctls.loadCertificate()


### PR DESCRIPTION
We use a custom `net/http` Transport for talking to Elastic Search that doesn't currently support `HTTP{,S}_PROXY` environment variables, but Elastic Search might be only accessible via a Proxy for some corporate enterprise reasons or because you're using something like Envoy as a proxy for egress for service discovery.