### PR TITLE
Allow tracer config via env vars

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -348,7 +348,7 @@ func initTracer(metricsFactory metrics.Factory, logger *zap.Logger) io.Closer {
 	traceCfg := &jaegerClientConfig.Configuration{
 		ServiceName: "jaeger-query",
 		Sampler: &jaegerClientConfig.SamplerConfig{
-			Type:  "probabilistic",
+			Type:  "const",
 			Param: 1.0,
 		},
 		RPCMetrics: true,

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -345,14 +345,19 @@ func archiveOptions(storageFactory istorage.Factory, logger *zap.Logger) *querys
 }
 
 func initTracer(metricsFactory metrics.Factory, logger *zap.Logger) io.Closer {
-	tracer, closer, err := jaegerClientConfig.Configuration{
+	traceCfg := &jaegerClientConfig.Configuration{
 		ServiceName: "jaeger-query",
 		Sampler: &jaegerClientConfig.SamplerConfig{
-			Type:  "const",
+			Type:  "probabilistic",
 			Param: 1.0,
 		},
 		RPCMetrics: true,
-	}.NewTracer(
+	}
+	traceCfg, err := traceCfg.FromEnv()
+	if err != nil {
+		logger.Fatal("Failed to read tracer configuration", zap.Error(err))
+	}
+	tracer, closer, err := traceCfg.NewTracer(
 		jaegerClientConfig.Metrics(metricsFactory),
 		jaegerClientConfig.Logger(jaegerClientZapLog.NewLogger(logger)),
 	)

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -67,7 +67,7 @@ func main() {
 			traceCfg := &jaegerClientConfig.Configuration{
 				ServiceName: "jaeger-query",
 				Sampler: &jaegerClientConfig.SamplerConfig{
-					Type:  "probabilistic",
+					Type:  "const",
 					Param: 1.0,
 				},
 				RPCMetrics: true,

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -64,14 +64,19 @@ func main() {
 			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
 			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "query"})
 
-			tracer, closer, err := jaegerClientConfig.Configuration{
+			traceCfg := &jaegerClientConfig.Configuration{
 				ServiceName: "jaeger-query",
 				Sampler: &jaegerClientConfig.SamplerConfig{
 					Type:  "probabilistic",
 					Param: 1.0,
 				},
 				RPCMetrics: true,
-			}.NewTracer(
+			}
+			traceCfg, err = traceCfg.FromEnv()
+			if err != nil {
+				logger.Fatal("Failed to read tracer configuration", zap.Error(err))
+			}
+			tracer, closer, err := traceCfg.NewTracer(
 				jaegerClientConfig.Metrics(svc.MetricsFactory),
 				jaegerClientConfig.Logger(jaegerClientZapLog.NewLogger(logger)),
 			)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #747

## Short description of the changes
- invoke FromEnv on the tracer configuration object before creating a tracer so that default configuration can be overwritten via environment variables.

Tested with all-in-one by running it on different port, re-pointing the tracer to the new port, and validating messages via tcpdump:
```
JAEGER_AGENT_PORT=7701 go run -tags=ui ./cmd/all-in-one \
    --processor.jaeger-binary.server-host-port :7700 \
    --processor.jaeger-compact.server-host-port :7701 \
    --processor.zipkin-compact.server-host-port :7702 \
    --http-server.host-port :7703

sudo tcpdump -i any -Z root "udp port 7701" -w out.cap
```
