### PR TITLE
Adding warnings field to Cassandra traces table

### DIFF
--- a/plugin/storage/cassandra/schema/migration/v002tov003part1.sh
+++ b/plugin/storage/cassandra/schema/migration/v002tov003part1.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Corresponds to migration changes in v003.cql.tmpl (addition of warnings field to the traces table). This script backs up
+# all the existing data, creates the traces_v2 table and dumps all the data into traces_v2. This should be followed by
+# v002tov003part2.sh which truncates the old traces table and deletes it.
+
+set -euo pipefail
+
+function usage {
+    >&2 echo "Error: $1"
+    >&2 echo ""
+    >&2 echo "Usage: KEYSPACE={keyspace} $0"
+    >&2 echo ""
+    >&2 echo "The following parameters can be set via environment:"
+    >&2 echo "  KEYSPACE           - keyspace"
+    >&2 echo "  TIMEOUT            - cqlsh request timeout"
+    >&2 echo ""
+    exit 1
+}
+
+confirm() {
+    read -r -p "${1:-Are you sure? [y/N]} " response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            true
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+}
+
+keyspace=${KEYSPACE}
+timeout=${TIMEOUT:-"60"}
+cqlsh_cmd="cqlsh --request-timeout=$timeout"
+
+if [[ ${keyspace} == "" ]]; then
+   usage "missing KEYSPACE parameter"
+fi
+
+if [[ ${keyspace} =~ [^a-zA-Z0-9_] ]]; then
+    usage "invalid characters in KEYSPACE=$keyspace parameter, please use letters, digits or underscores"
+fi
+
+row_count=$($cqlsh_cmd -e "select count(*) from $keyspace.traces;"|head -4|tail -1| tr -d ' ')
+
+echo "About to copy $row_count rows."
+confirm
+
+$cqlsh_cmd -e "COPY $keyspace.traces to 'existing_traces.csv';"
+
+if [ ! -f existing_traces.csv ]; then
+    echo "Could not find existing_traces.csv. Backup of existing traces from cassandra was probably not successful"
+    exit 1
+fi
+
+if [ ${row_count} -ne $(wc -l existing_traces.csv | cut -f 1 -d ' ') ]; then
+    echo "Number of rows in file is not equal to number of rows in cassandra"
+    exit 1
+fi
+
+traces_ttl=$($cqlsh_cmd -e "select default_time_to_live from system_schema.tables WHERE keyspace_name='$keyspace' AND table_name='traces';" | head -4 | tail -1 | tr -d ' ')
+
+echo "Setting traces_ttl to $traces_ttl"
+
+$cqlsh_cmd -e "ALTER TYPE $keyspace.traces ADD warnings list<frozen<text>>;"
+
+$cqlsh_cmd -e "CREATE TABLE IF NOT EXISTS ${keyspace}.traces_v2 (
+    trace_id        blob,
+    span_id         bigint,
+    span_hash       bigint,
+    parent_id       bigint,
+    operation_name  text,
+    flags           int,
+    start_time      bigint,
+    duration        bigint,
+    tags            list<frozen<keyvalue>>,
+    logs            list<frozen<log>>,
+    refs            list<frozen<span_ref>>,
+    process         frozen<process>,
+    warnings        list<text>,
+    PRIMARY KEY (trace_id, span_id, span_hash)
+)
+    WITH compaction = {
+        'compaction_window_size': '1',
+        'compaction_window_unit': 'HOURS',
+        'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = $traces_ttl
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800;
+"
+
+$cqlsh_cmd -e "COPY $keyspace.traces_v2 (trace_id, span_id, span_hash, parent_id, operation_name, flags, start_time, duration, tags, logs, refs, process) FROM 'existing_traces.csv';"

--- a/plugin/storage/cassandra/schema/migration/v002tov003part2.sh
+++ b/plugin/storage/cassandra/schema/migration/v002tov003part2.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# This is the follow up to v002tov003part2.sh. It truncates and deletes the old traces table.
+
+set -euo pipefail
+
+function usage {
+    >&2 echo "Error: $1"
+    >&2 echo ""
+    >&2 echo "Usage: KEYSPACE={keyspace} $0"
+    >&2 echo ""
+    >&2 echo "The following parameters can be set via environment:"
+    >&2 echo "  KEYSPACE           - keyspace"
+    >&2 echo "  TIMEOUT            - cqlsh request timeout"
+    >&2 echo ""
+    exit 1
+}
+
+confirm() {
+    read -r -p "${1:-Are you sure? [y/N]} " response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            true
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+}
+
+keyspace=${KEYSPACE}
+timeout=${TIMEOUT}
+cqlsh_cmd=cqlsh --request-timeout=$timeout
+
+if [[ ${keyspace} == "" ]]; then
+   usage "missing KEYSPACE parameter"
+fi
+
+if [[ ${keyspace} =~ [^a-zA-Z0-9_] ]]; then
+    usage "invalid characters in KEYSPACE=$keyspace parameter, please use letters, digits or underscores"
+fi
+
+
+row_count=$($cqlsh_cmd -e "select count(*) from $keyspace.traces;"|head -4|tail -1| tr -d ' ')
+
+echo "About to delete $row_count rows."
+confirm
+
+$cqlsh_cmd -e "DROP TABLE IF EXISTS $keyspace.traces;"

--- a/plugin/storage/cassandra/schema/v003.cql.tmpl
+++ b/plugin/storage/cassandra/schema/v003.cql.tmpl
@@ -1,0 +1,204 @@
+--
+-- Creates Cassandra keyspace with tables for traces and dependencies.
+--
+-- Required parameters:
+--
+--   keyspace
+--     name of the keyspace
+--   replication
+--     replication strategy for the keyspace, such as
+--       for prod environments
+--         {'class': 'NetworkTopologyStrategy', '$datacenter': '${replication_factor}' }
+--       for test environments
+--         {'class': 'SimpleStrategy', 'replication_factor': '1'}
+--   trace_ttl
+--     default time to live for trace data, in seconds
+--   dependencies_ttl
+--     default time to live for dependencies data, in seconds (0 for no TTL)
+--
+-- Non-configurable settings:
+--   gc_grace_seconds is non-zero, see: http://www.uberobert.com/cassandra_gc_grace_disables_hinted_handoff/
+--   For TTL of 2 days, compaction window is 1 hour, rule of thumb here: http://thelastpickle.com/blog/2016/12/08/TWCS-part1.html
+
+CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = ${replication};
+
+CREATE TYPE IF NOT EXISTS ${keyspace}.keyvalue (
+    key             text,
+    value_type      text,
+    value_string    text,
+    value_bool      boolean,
+    value_long      bigint,
+    value_double    double,
+    value_binary    blob,
+);
+
+CREATE TYPE IF NOT EXISTS ${keyspace}.log (
+    ts      bigint,
+    fields  list<frozen<keyvalue>>,
+);
+
+CREATE TYPE IF NOT EXISTS ${keyspace}.span_ref (
+    ref_type        text,
+    trace_id        blob,
+    span_id         bigint,
+);
+
+CREATE TYPE IF NOT EXISTS ${keyspace}.process (
+    service_name    text,
+    tags            list<frozen<keyvalue>>,
+);
+
+-- Notice we have span_hash. This exists only for zipkin backwards compat. Zipkin allows spans with the same ID.
+-- Note: Cassandra re-orders non-PK columns alphabetically, so the table looks differently in CQLSH "describe table".
+-- start_time is bigint instead of timestamp as we require microsecond precision
+CREATE TABLE IF NOT EXISTS ${keyspace}.traces_v2 (
+    trace_id        blob,
+    span_id         bigint,
+    span_hash       bigint,
+    parent_id       bigint,
+    operation_name  text,
+    flags           int,
+    start_time      bigint,
+    duration        bigint,
+    tags            list<frozen<keyvalue>>,
+    logs            list<frozen<log>>,
+    refs            list<frozen<span_ref>>,
+    process         frozen<process>,
+    warnings        list<text>,
+    PRIMARY KEY (trace_id, span_id, span_hash)
+)
+    WITH compaction = {
+        'compaction_window_size': '1',
+        'compaction_window_unit': 'HOURS',
+        'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = ${trace_ttl}
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800; -- 3 hours of downtime acceptable on nodes
+
+CREATE TABLE IF NOT EXISTS ${keyspace}.service_names (
+    service_name text,
+    PRIMARY KEY (service_name)
+)
+    WITH compaction = {
+        'min_threshold': '4',
+        'max_threshold': '32',
+        'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = ${trace_ttl}
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800; -- 3 hours of downtime acceptable on nodes
+
+CREATE TABLE IF NOT EXISTS ${keyspace}.operation_names (
+    service_name        text,
+    operation_name      text,
+    PRIMARY KEY ((service_name), operation_name)
+)
+    WITH compaction = {
+        'min_threshold': '4',
+        'max_threshold': '32',
+        'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = ${trace_ttl}
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800; -- 3 hours of downtime acceptable on nodes
+
+-- index of trace IDs by service + operation names, sorted by span start_time.
+CREATE TABLE IF NOT EXISTS ${keyspace}.service_operation_index (
+    service_name        text,
+    operation_name      text,
+    start_time          bigint,
+    trace_id            blob,
+    PRIMARY KEY ((service_name, operation_name), start_time)
+) WITH CLUSTERING ORDER BY (start_time DESC)
+    AND compaction = {
+        'compaction_window_size': '1',
+        'compaction_window_unit': 'HOURS',
+        'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = ${trace_ttl}
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800; -- 3 hours of downtime acceptable on nodes
+
+CREATE TABLE IF NOT EXISTS ${keyspace}.service_name_index (
+    service_name      text,
+    bucket            int,
+    start_time        bigint,
+    trace_id          blob,
+    PRIMARY KEY ((service_name, bucket), start_time)
+) WITH CLUSTERING ORDER BY (start_time DESC)
+    AND compaction = {
+        'compaction_window_size': '1',
+        'compaction_window_unit': 'HOURS',
+        'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = ${trace_ttl}
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800; -- 3 hours of downtime acceptable on nodes
+
+CREATE TABLE IF NOT EXISTS ${keyspace}.duration_index (
+    service_name    text,      // service name
+    operation_name  text,      // operation name, or blank for queries without span name
+    bucket          timestamp, // time bucket, - the start_time of the given span rounded to an hour
+    duration        bigint,    // span duration, in microseconds
+    start_time      bigint,
+    trace_id        blob,
+    PRIMARY KEY ((service_name, operation_name, bucket), duration, start_time, trace_id)
+) WITH CLUSTERING ORDER BY (duration DESC, start_time DESC)
+    AND compaction = {
+        'compaction_window_size': '1',
+        'compaction_window_unit': 'HOURS',
+        'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = ${trace_ttl}
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800; -- 3 hours of downtime acceptable on nodes
+
+-- a bucketing strategy may have to be added for tag queries
+-- we can make this table even better by adding a timestamp to it
+CREATE TABLE IF NOT EXISTS ${keyspace}.tag_index (
+    service_name    text,
+    tag_key         text,
+    tag_value       text,
+    start_time      bigint,
+    trace_id        blob,
+    span_id         bigint,
+    PRIMARY KEY ((service_name, tag_key, tag_value), start_time, trace_id, span_id)
+)
+    WITH CLUSTERING ORDER BY (start_time DESC)
+    AND compaction = {
+        'compaction_window_size': '1',
+        'compaction_window_unit': 'HOURS',
+        'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'
+    }
+    AND dclocal_read_repair_chance = 0.0
+    AND default_time_to_live = ${trace_ttl}
+    AND speculative_retry = 'NONE'
+    AND gc_grace_seconds = 10800; -- 3 hours of downtime acceptable on nodes
+
+CREATE TYPE IF NOT EXISTS ${keyspace}.dependency (
+    parent          text,
+    child           text,
+    call_count      bigint,
+    source          text,
+);
+
+-- compaction strategy is intentionally different as compared to other tables due to the size of dependencies data
+CREATE TABLE IF NOT EXISTS ${keyspace}.dependencies_v2 (
+    ts_bucket    timestamp,
+    ts           timestamp,
+    dependencies list<frozen<dependency>>,
+    PRIMARY KEY (ts_bucket, ts)
+) WITH CLUSTERING ORDER BY (ts DESC)
+    AND compaction = {
+        'min_threshold': '4',
+        'max_threshold': '32',
+        'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'
+    }
+    AND default_time_to_live = ${dependencies_ttl};

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -75,6 +75,7 @@ func (c converter) fromDomain(span *model.Span) *Span {
 		Process:       udtProcess,
 		ServiceName:   span.Process.ServiceName,
 		SpanHash:      int64(spanHash),
+		Warnings:      span.Warnings,
 	}
 }
 
@@ -107,6 +108,7 @@ func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 		Tags:          tags,
 		Logs:          logs,
 		Process:       process,
+		Warnings:      dbSpan.Warnings,
 	}
 	return span, nil
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -117,6 +117,10 @@ var (
 			TraceID: someDBTraceID,
 		},
 	}
+	someWarnings = []string{
+		"warning 1",
+		"warning 2",
+	}
 	notValidTagTypeErrStr = "invalid ValueType in"
 )
 
@@ -132,6 +136,7 @@ func getTestJaegerSpan() *model.Span {
 		Tags:          someTags,
 		Logs:          someLogs,
 		Process:       getTestJaegerProcess(),
+		Warnings:      someWarnings,
 	}
 }
 
@@ -155,6 +160,7 @@ func getTestSpan() *Span {
 		Refs:          someDBRefs,
 		Process:       someDBProcess,
 		ServiceName:   someServiceName,
+		Warnings:      someWarnings,
 	}
 	// there is no way to validate if the hash code is "correct" or not,
 	// other than comparing it with some magic number that keeps changing
@@ -271,6 +277,9 @@ func TestFailingFromDBLogs(t *testing.T) {
 
 func TestDBTagTypeError(t *testing.T) {
 	_, err := converter{}.fromDBTag(&KeyValue{ValueType: "x"})
+	if err == nil {
+		t.Fatalf("expected error here")
+	}
 	assert.Contains(t, err.Error(), notValidTagTypeErrStr)
 }
 

--- a/plugin/storage/cassandra/spanstore/dbmodel/model.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/model.go
@@ -51,6 +51,7 @@ type Span struct {
 	Process       Process
 	ServiceName   string
 	SpanHash      int64
+	Warnings      []string
 }
 
 // KeyValue is the UDT representation of a Jaeger KeyValue.

--- a/plugin/storage/cassandra/spanstore/dbmodel/version.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/version.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbmodel
+
+// TraceVersion indicates the version of the main traces table.
+type TraceVersion int
+
+const (
+	// V1 first version of the traces table (corresponds to traces in schema/v001.cql.tmpl)
+	V1 TraceVersion = iota + 1
+
+	// V2 traces table with warnings field (corresponds to traces_v2 in schema/v001.cql.tmpl)
+	V2
+)

--- a/plugin/storage/cassandra/spanstore/table_version.go
+++ b/plugin/storage/cassandra/spanstore/table_version.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstore
+
+import (
+	"context"
+	"fmt"
+
+	otlog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/jaegertracing/jaeger/pkg/cassandra"
+	"github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/dbmodel"
+)
+
+const queryTraceTableVersion = `SELECT * FROM traces_v2 LIMIT 1;`
+
+// Returns the version of trace table used in the jaeger cassandra backend. Remove this after we permanently switch to traces_v2.
+func getTraceTableVersion(ctx context.Context, s cassandra.Session) dbmodel.TraceVersion {
+	span, _ := startSpanForQuery(ctx, "traceTableVersion", queryTraceTableVersion)
+	defer span.Finish()
+	if err := s.Query(queryTraceTableVersion).Exec(); err != nil {
+		span.LogFields(otlog.String("event", fmt.Sprintf("trace table version : %v", dbmodel.V1)))
+		return dbmodel.V1
+	}
+	span.LogFields(otlog.String("event", fmt.Sprintf("trace table version : %v", dbmodel.V2)))
+	return dbmodel.V2
+}

--- a/plugin/storage/cassandra/spanstore/table_version_test.go
+++ b/plugin/storage/cassandra/spanstore/table_version_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
+	"github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/dbmodel"
+)
+
+func TestTraceVersion_V1(t *testing.T) {
+	versionQuery := func() *mocks.Query {
+		query := &mocks.Query{}
+		query.On("Exec").Return(errors.New("version read error"))
+		return query
+	}
+
+	mockSession := &mocks.Session{}
+	mockSession.On("Query", stringMatcher(queryTraceTableVersion), matchEverything()).Return(versionQuery())
+	version := getTraceTableVersion(context.Background(), mockSession)
+	assert.EqualValues(t, dbmodel.V1, version)
+}
+
+func TestTraceVersion_V2(t *testing.T) {
+	versionQuery := func() *mocks.Query {
+		query := &mocks.Query{}
+		query.On("Exec").Return(nil)
+		return query
+	}
+
+	mockSession := &mocks.Session{}
+	mockSession.On("Query", stringMatcher(queryTraceTableVersion), matchEverything()).Return(versionQuery())
+	version := getTraceTableVersion(context.Background(), mockSession)
+	assert.EqualValues(t, dbmodel.V2, version)
+}


### PR DESCRIPTION
Signed-off-by: Aditya Kumar Praharaj <adityakumarpraharaj@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #705 - namely adds the field `Warnings` to the `traces` table in jaeger's cassandra keyspace.

## Short description of the changes
- This diff adds the `Warnings` field in `traces` table and renames the subsequent table to `traces_v2`. It accompanies migrations `v003.cql.tmpl` which is the CQL schema files and two subsequent migration scripts from moving to `traces_v2` from `traces`:
  - `migration/v002tov003part1.sh`: Alters existing `traces` table to add the column and creates a new `traces_v2` table as well. Copies existing data from `traces` to `traces_v2`.
  - `migration/v002tov003part2.sh`: Truncates and deletes `traces` table.
- It makes changes to `SpanReader` and `SpanWriter` to actually read from `traces_v2`. This is backwards compatible and falls back to using `traces` if the `traces_v2` table actually doesn't exist (which means the migrations have not been carried out).

## Followup

- Create the same changes for Elasticsearch Backend.
- Propagating and showing these in the UI.
