### PR TITLE
Update python pathlib to pathlib2

### DIFF
--- a/plugin/storage/es/Dockerfile.rollover
+++ b/plugin/storage/es/Dockerfile.rollover
@@ -3,7 +3,7 @@ FROM python:3-alpine
 # Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494
 RUN pip install urllib3==1.21.1
 
-RUN pip install elasticsearch elasticsearch-curator
+RUN pip install elasticsearch elasticsearch-curator pathlib2
 COPY ./mappings/* /mappings/
 COPY esRollover.py /es-rollover/
 

--- a/plugin/storage/es/esRollover.py
+++ b/plugin/storage/es/esRollover.py
@@ -8,7 +8,7 @@ import os
 import requests
 import ssl
 import sys
-from pathlib import Path
+from pathlib2 import Path
 from requests.auth import HTTPBasicAuth
 
 


### PR DESCRIPTION
Switch to pathlib2, which is an actively maintained version.

Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Pathlib is a very old python lib, which has a more actively maintained backward compatible version called pathlib2.

## Short description of the changes
Install pathlib2 within the rollover Dockerfile, and update the import in the rollover script.

Has been tested locally by running the rollover init command.
