### PR TITLE
Fix typo in license URL

### DIFF
--- a/pkg/discovery/grpcresolver/grpc_resolver.go
+++ b/pkg/discovery/grpcresolver/grpc_resolver.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://wwr.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Fixes a typo in the license comments URL in one file.

Signed-off-by: Steve Winslow <swinslow@gmail.com>