### PR TITLE
Bypassing building UI altogether on non-master PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
 
 script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  - export SKIP_UI=$(if [ "$BRANCH" == "master" ]; then echo "true"; fi)
+  - export SKIP_UI=$(if [ "$BRANCH" != "master" ]; then echo "true"; fi)
   - if [ "$TESTS" == true ]; then make test-ci ; else echo 'skipping tests'; fi
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/build-all-in-one-image.sh ; else echo 'skipping all_in_one'; fi
   - if [ "$CROSSDOCK" == true ]; then bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script:
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/build-all-in-one-image.sh ; else echo 'skipping all_in_one'; fi
   - if [ "$CROSSDOCK" == true ]; then bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping build-docker-images'; fi
-  - if [ "$DEPLOY" == true ]; then make build-all-platforms ; else echo 'skipping build-all-platforms'; fi
+  - if [ "$DEPLOY" == true ]; then bash ./scripts/travis/build-all-platform-binaries.sh ; else echo 'skipping build-all-platforms'; fi
   - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$KAFKA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/kafka-integration-test.sh ; else echo 'skipping kafka integration test'; fi
   - if [ "$CASSANDRA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/cassandra-integration-test.sh ; else echo 'skipping cassandra integration test'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ install:
 
 script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - export SKIP_UI=$(if [ "$BRANCH" == "master" ]; then echo "true"; fi)
   - if [ "$TESTS" == true ]; then make test-ci ; else echo 'skipping tests'; fi
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/build-all-in-one-image.sh ; else echo 'skipping all_in_one'; fi
   - if [ "$CROSSDOCK" == true ]; then bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ include crossdock/rules.mk
 # Crossdock tests do not require fully functioning UI, so we skip it to speed up the build.
 .PHONY: build-crossdock-ui-placeholder
 build-crossdock-ui-placeholder:
-	mkdir -p cmd/query/app/u	i/actual
+	mkdir -p cmd/query/app/ui/actual
 	[ -e cmd/query/app/ui/actual/gen_assets.go ] || cp cmd/query/app/ui/placeholder/gen_assets.go cmd/query/app/ui/actual/gen_assets.go
 
 .PHONY: build-crossdock

--- a/Makefile
+++ b/Makefile
@@ -211,9 +211,17 @@ build-all-in-one-linux: build-ui
 build-all-in-one: elasticsearch-mappings
 	CGO_ENABLED=0 installsuffix=cgo go build -tags ui -o ./cmd/all-in-one/all-in-one-$(GOOS) $(BUILD_INFO) ./cmd/all-in-one/main.go
 
+.PHONY: build-all-in-one-without-ui
+build-all-in-one-without-ui: elasticsearch-mappings
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/all-in-one/all-in-one-$(GOOS) $(BUILD_INFO) ./cmd/all-in-one/main.go
+
 .PHONY: build-agent
 build-agent:
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/agent/agent-$(GOOS) $(BUILD_INFO) ./cmd/agent/main.go
+
+.PHONY: build-query-without-ui
+build-query-without-ui:
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/query/query-$(GOOS) $(BUILD_INFO) ./cmd/query/main.go
 
 .PHONY: build-query
 build-query:
@@ -230,9 +238,16 @@ build-ingester:
 .PHONY: docker
 docker: build-ui build-binaries-linux docker-images-only
 
+.PHONY: docker-without-ui
+docker-without-ui: build-platform-binaries-without-ui docker-images-only
+
 .PHONY: build-binaries-linux
 build-binaries-linux:
 	GOOS=linux $(MAKE) build-platform-binaries
+
+.PHONY: build-binaries-linux-without-ui
+build-binaries-linux:
+	GOOS=linux $(MAKE) build-platform-binaries-without-ui
 
 .PHONY: build-binaries-windows
 build-binaries-windows:
@@ -244,6 +259,9 @@ build-binaries-darwin:
 
 .PHONY: build-platform-binaries
 build-platform-binaries: build-agent build-collector build-query build-ingester build-all-in-one build-examples
+
+.PHONY: build-platform-binaries-without-ui
+build-platform-binaries-without-ui: build-agent build-collector build-query-without-ui build-ingester build-all-in-one-without-ui build-examples
 
 .PHONY: build-all-platforms
 build-all-platforms: build-binaries-linux build-binaries-windows build-binaries-darwin
@@ -290,7 +308,7 @@ include crossdock/rules.mk
 # Crossdock tests do not require fully functioning UI, so we skip it to speed up the build.
 .PHONY: build-crossdock-ui-placeholder
 build-crossdock-ui-placeholder:
-	mkdir -p cmd/query/app/ui/actual
+	mkdir -p cmd/query/app/u	i/actual
 	[ -e cmd/query/app/ui/actual/gen_assets.go ] || cp cmd/query/app/ui/placeholder/gen_assets.go cmd/query/app/ui/actual/gen_assets.go
 
 .PHONY: build-crossdock

--- a/Makefile
+++ b/Makefile
@@ -239,14 +239,14 @@ build-ingester:
 docker: build-ui build-binaries-linux docker-images-only
 
 .PHONY: docker-without-ui
-docker-without-ui: build-platform-binaries-without-ui docker-images-only
+docker-without-ui: build-binaries-linux-without-ui docker-images-only
 
 .PHONY: build-binaries-linux
 build-binaries-linux:
 	GOOS=linux $(MAKE) build-platform-binaries
 
 .PHONY: build-binaries-linux-without-ui
-build-binaries-linux:
+build-binaries-linux-without-ui:
 	GOOS=linux $(MAKE) build-platform-binaries-without-ui
 
 .PHONY: build-binaries-windows

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -4,13 +4,17 @@ set -e
 
 BRANCH=${BRANCH:?'missing BRANCH env var'}
 
-source ~/.nvm/nvm.sh
-nvm use 10
-make build-ui
+if [[ $BRANCH == "master" ]]; then
+  # Only build the UI on master branch.
+  source ~/.nvm/nvm.sh
+  nvm use 10
+  make build-ui
+  make build-all-in-one GOOS=linux
+else
+  make build-all-in-one-without-ui GOOS=linux
+fi
 
 set -x
-
-make build-all-in-one GOOS=linux
 
 export REPO=jaegertracing/all-in-one
 docker build -f cmd/all-in-one/Dockerfile -t $REPO:latest cmd/all-in-one

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -7,14 +7,16 @@ if [[ -z "$BRANCH" ]]; then
   echo "BRANCH env var not defined, using current branch $BRANCH instead ..."
 fi
 
-if [[ (-z "$SKIP_UI") || ($SKIP_UI == false) ]]; then
-  # Only build the UI on master branch.
+set -x
+
+if [[ "$SKIP_UI" == "true" ]]; then
+  echo "Skipping UI build because \$SKIP_UI is set to true"
+  make build-all-in-one-without-ui GOOS=linux
+else
   source ~/.nvm/nvm.sh
   nvm use 10
   make build-ui
   make build-all-in-one GOOS=linux
-else
-  make build-all-in-one-without-ui GOOS=linux
 fi
 
 set -x

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -2,9 +2,12 @@
 
 set -e
 
-BRANCH=${BRANCH:?'missing BRANCH env var'}
+if [[ -z "$BRANCH" ]]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  echo "BRANCH env var not defined, using current branch $BRANCH instead ..."
+fi
 
-if [[ $BRANCH == "master" ]]; then
+if [[ (-z "$SKIP_UI") || ($SKIP_UI == false) ]]; then
   # Only build the UI on master branch.
   source ~/.nvm/nvm.sh
   nvm use 10

--- a/scripts/travis/build-all-platform-binaries.sh
+++ b/scripts/travis/build-all-platform-binaries.sh
@@ -3,11 +3,14 @@
 # Builds all platform binaries.
 set -e
 
-BRANCH=${BRANCH:?'missing BRANCH env var'}
+if [[ -z "$BRANCH" ]]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  echo "BRANCH env var not defined, using current branch $BRANCH instead ..."
+fi
 
 set -x
 
-if [[ $BRANCH == "master" ]]; then
+if [[ (-z "$SKIP_UI") || ($SKIP_UI == false) ]]; then
   # Only build the UI on master branch.
   source ~/.nvm/nvm.sh
   nvm use 10

--- a/scripts/travis/build-all-platform-binaries.sh
+++ b/scripts/travis/build-all-platform-binaries.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Builds all platform binaries.
 set -e
 
 BRANCH=${BRANCH:?'missing BRANCH env var'}

--- a/scripts/travis/build-all-platform-binaries.sh
+++ b/scripts/travis/build-all-platform-binaries.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Builds all platform binaries.
 set -x
 
 if [[ "$SKIP_UI" == "true" ]]; then

--- a/scripts/travis/build-all-platform-binaries.sh
+++ b/scripts/travis/build-all-platform-binaries.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+BRANCH=${BRANCH:?'missing BRANCH env var'}
+
+set -x
+
+if [[ $BRANCH == "master" ]]; then
+  # Only build the UI on master branch.
+  source ~/.nvm/nvm.sh
+  nvm use 10
+  make build-ui
+  make build-platform-binaries
+else
+  echo "Skipping UI build because current branch $BRANCH is a PR branch"
+  make build-platform-binaries-without-ui
+fi
+

--- a/scripts/travis/build-all-platform-binaries.sh
+++ b/scripts/travis/build-all-platform-binaries.sh
@@ -1,23 +1,15 @@
 #!/bin/bash
 
 # Builds all platform binaries.
-set -e
-
-if [[ -z "$BRANCH" ]]; then
-  BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  echo "BRANCH env var not defined, using current branch $BRANCH instead ..."
-fi
-
 set -x
 
-if [[ (-z "$SKIP_UI") || ($SKIP_UI == false) ]]; then
-  # Only build the UI on master branch.
+if [[ "$SKIP_UI" == "true" ]]; then
+  echo "Skipping UI build because \$SKIP_UI is set to true"
+  make build-platform-binaries-without-ui
+else
   source ~/.nvm/nvm.sh
   nvm use 10
   make build-ui
   make build-platform-binaries
-else
-  echo "Skipping UI build because current branch $BRANCH is a PR branch"
-  make build-platform-binaries-without-ui
 fi
 

--- a/scripts/travis/build-crossdock.sh
+++ b/scripts/travis/build-crossdock.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-BRANCH=${BRANCH:?'missing BRANCH env var'}
+if [[ -z "$BRANCH" ]]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  echo "BRANCH env var not defined, using current branch $BRANCH instead ..."
+fi
 
 make build-and-run-crossdock
 

--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -4,17 +4,12 @@
 
 set -e
 
-if [[ -z "$BRANCH" ]]; then
-  BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  echo "BRANCH env var not defined, using current branch $BRANCH instead ..."
-fi
-
 export DOCKER_NAMESPACE=jaegertracing
-if [[ (-z "$SKIP_UI") || ($SKIP_UI == false) ]]; then
+if [[ "$SKIP_UI" == "true" ]]; then
+  echo "Skipping UI build because \$SKIP_UI is set to true"
+  make docker-without-ui
+else
   source ~/.nvm/nvm.sh
   nvm use 10
   make docker
-else
-  echo "Skipping UI build because the current branch $BRANCH is a PR branch"
-  make docker-without-ui
 fi

--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -14,5 +14,3 @@ else
   echo "Skipping UI build because the current branch $BRANCH is a PR branch"
   make docker-without-ui
 fi
-
-

--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -4,9 +4,15 @@
 
 set -e
 
-# TODO avoid building the UI when on a PR branch: https://github.com/jaegertracing/jaeger/issues/1908
-source ~/.nvm/nvm.sh
-nvm use 10
-
+BRANCH=${BRANCH:?'missing BRANCH env var'}
 export DOCKER_NAMESPACE=jaegertracing
-make docker
+if [[ $BRANCH == "master" ]]; then
+  source ~/.nvm/nvm.sh
+  nvm use 10
+  make docker
+else
+  echo "Skipping UI build because the current branch $BRANCH is a PR branch"
+  make docker-without-ui
+fi
+
+

--- a/scripts/travis/build-docker-images.sh
+++ b/scripts/travis/build-docker-images.sh
@@ -4,9 +4,13 @@
 
 set -e
 
-BRANCH=${BRANCH:?'missing BRANCH env var'}
+if [[ -z "$BRANCH" ]]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  echo "BRANCH env var not defined, using current branch $BRANCH instead ..."
+fi
+
 export DOCKER_NAMESPACE=jaegertracing
-if [[ $BRANCH == "master" ]]; then
+if [[ (-z "$SKIP_UI") || ($SKIP_UI == false) ]]; then
   source ~/.nvm/nvm.sh
   nvm use 10
   make docker


### PR DESCRIPTION
Signed-off-by: Aditya Kumar Praharaj <adityakumarpraharaj@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #1908  by bypassing building UI altogether for PR branches.

## Short description of the changes
- This diff adds support for skipping the make build-ui stage which builds the UI when the current branch is a PR-branch (non-master). 
