### PR TITLE
Improve migration script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ Changes by Version
             1.  You will need to run below command on the host you can use `cqlsh` to connect the the cassandra contact
              point
                 ```
-                KEYSPACE=test_keyspace TIMEOUT=1000 CQL_CMD='cqlsh host 9042 -u test_user -p test_password' bash
-                ./plugin/storage/cassandra/schema/migration/v002tov003.sh
+                KEYSPACE=jaeger_v1 CQL_CMD='cqlsh host 9042 -u test_user -p test_password --request-timeout=3000' 
+                bash ./v002tov003.sh
                 ```
                 The script will create new table `operation_names_v2` and migrate data from the old table.  
                 `spanKind` column will be empty for those data.  

--- a/plugin/storage/cassandra/schema/migration/V002toV003.sh
+++ b/plugin/storage/cassandra/schema/migration/V002toV003.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Create a new operation_names_v2 table and copy all data from operation_names table
-# Sample usage: KEYSPACE=jaeger_v1 TIMEOUT=1000 CQL_CMD='cqlsh host 9042 -u test_user -p test_password' bash
+# Sample usage: KEYSPACE=jaeger_v1 CQL_CMD='cqlsh host 9042 -u test_user -p test_password --request-timeout=3000' bash
 # ./v002tov003.sh
 
 set -euo pipefail
@@ -9,7 +9,7 @@ set -euo pipefail
 function usage {
     >&2 echo "Error: $1"
     >&2 echo ""
-    >&2 echo "Usage: KEYSPACE={keyspace} TTL={ttl} CQL_CMD={cql_cmd}$0"
+    >&2 echo "Usage: KEYSPACE={keyspace} CQL_CMD={cql_cmd} $0"
     >&2 echo ""
     >&2 echo "The following parameters can be set via environment:"
     >&2 echo "  KEYSPACE           - keyspace"
@@ -63,11 +63,6 @@ if [[ ! -f ${old_table}.csv ]]; then
 fi
 
 csv_rows=$(wc -l ${old_table}.csv | tr -dc '0-9')
-
-if [[ ${row_count} -ne ${csv_rows} ]]; then
-    echo "Number of rows: $csv_rows in file is not equal to number of rows: $row_count in cassandra"
-    exit 1
-fi
 
 echo "Generating data for new table..."
 while IFS="," read service_name operation_name; do


### PR DESCRIPTION
- continue migration if number of rows changed during migration
- improve the sample command and remove unused TTL since it will be
copied from old table

Signed-off-by: Jun Guo <guo0693@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Relates to #1921 

## Short description of the changes
- continue migration if number of rows changed during migration since indexer will keep adding new rows which cause the actual ported rows > original number of rows at the beginning
- improve the sample command and remove unused TTL since it will be
copied from old table
