### PR TITLE
Fix the bug that operation_name table can not be init more than once

### DIFF
--- a/plugin/storage/cassandra/spanstore/operation_names.go
+++ b/plugin/storage/cassandra/spanstore/operation_names.go
@@ -63,7 +63,7 @@ func (t *tableMeta) materialize() {
 	t.queryStmt = fmt.Sprintf(t.queryStmt, t.tableName)
 }
 
-var schemas = map[schemaVersion]*tableMeta{
+var schemas = map[schemaVersion]tableMeta{
 	previousVersion: {
 		tableName:       "operation_names",
 		insertStmt:      "INSERT INTO %s(service_name, operation_name) VALUES (?, ?)",
@@ -90,7 +90,7 @@ var schemas = map[schemaVersion]*tableMeta{
 type OperationNamesStorage struct {
 	// CQL statements are public so that Cassandra2 storage can override them
 	schemaVersion  schemaVersion
-	table          *tableMeta
+	table          tableMeta
 	session        cassandra.Session
 	writeCacheTTL  time.Duration
 	metrics        *casMetrics.Table


### PR DESCRIPTION
Signed-off-by: Jun Guo <guo0693@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- If we materialize the operation_names schema more than once, the original query template will be changed to something like 
`INSERT INTO operation_names_v2(service_name, span_kind, operation_name) VALUES (?, ?, ?)%!!(string=operation_names_v2)(EXTRA string=operation_names_v2)`

## Short description of the changes
- Do not use pointer for schemas map. Always materialize the copied struct for the storage use
