### PR TITLE
Add grpc log level

### DIFF
--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -29,6 +29,7 @@ import (
 type Configuration struct {
 	PluginBinary            string `yaml:"binary"`
 	PluginConfigurationFile string `yaml:"configuration-file"`
+	PluginLogLevel 			string `yaml:"log-level"`
 }
 
 // Build instantiates a StoragePlugin
@@ -44,7 +45,7 @@ func (c *Configuration) Build() (shared.StoragePlugin, error) {
 		Cmd:              cmd,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger: hclog.New(&hclog.LoggerOptions{
-			Level: hclog.Warn,
+			Level: hclog.LevelFromString(c.PluginLogLevel),
 		}),
 	})
 

--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -29,7 +29,7 @@ import (
 type Configuration struct {
 	PluginBinary            string `yaml:"binary"`
 	PluginConfigurationFile string `yaml:"configuration-file"`
-	PluginLogLevel 			string `yaml:"log-level"`
+	PluginLogLevel          string `yaml:"log-level"`
 }
 
 // Build instantiates a StoragePlugin

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -103,8 +103,10 @@ func TestWithConfiguration(t *testing.T) {
 	command.ParseFlags([]string{
 		"--grpc-storage-plugin.binary=noop-grpc-plugin",
 		"--grpc-storage-plugin.configuration-file=config.json",
+		"--grpc-storage-plugin.log-level=debug",
 	})
 	f.InitFromViper(v)
 	assert.Equal(t, f.options.Configuration.PluginBinary, "noop-grpc-plugin")
 	assert.Equal(t, f.options.Configuration.PluginConfigurationFile, "config.json")
+	assert.Equal(t, f.options.Configuration.PluginLogLevel, "debug")
 }

--- a/plugin/storage/grpc/options.go
+++ b/plugin/storage/grpc/options.go
@@ -37,7 +37,7 @@ type Options struct {
 func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(pluginBinary, "", "The location of the plugin binary")
 	flagSet.String(pluginConfigurationFile, "", "A path pointing to the plugin's configuration file, made available to the plugin with the --config arg")
-	flagSet.String(pluginLogLevel, defaultPluginLogLevel, "A path pointing to the plugin's configuration file, made available to the plugin with the --config arg")
+	flagSet.String(pluginLogLevel, defaultPluginLogLevel, "Set the log level of the plugin's logger")
 }
 
 // InitFromViper initializes Options with properties from viper

--- a/plugin/storage/grpc/options.go
+++ b/plugin/storage/grpc/options.go
@@ -24,6 +24,8 @@ import (
 
 const pluginBinary = "grpc-storage-plugin.binary"
 const pluginConfigurationFile = "grpc-storage-plugin.configuration-file"
+const pluginLogLevel = "grpc-storage-plugin.log-level"
+const defaultPluginLogLevel = "warn"
 
 // Options contains GRPC plugins configs and provides the ability
 // to bind them to command line flags
@@ -35,10 +37,13 @@ type Options struct {
 func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(pluginBinary, "", "The location of the plugin binary")
 	flagSet.String(pluginConfigurationFile, "", "A path pointing to the plugin's configuration file, made available to the plugin with the --config arg")
+	flagSet.String(pluginLogLevel, defaultPluginLogLevel, "A path pointing to the plugin's configuration file, made available to the plugin with the --config arg")
 }
 
 // InitFromViper initializes Options with properties from viper
 func (opt *Options) InitFromViper(v *viper.Viper) {
 	opt.Configuration.PluginBinary = v.GetString(pluginBinary)
 	opt.Configuration.PluginConfigurationFile = v.GetString(pluginConfigurationFile)
+	opt.Configuration.PluginLogLevel = v.GetString(pluginLogLevel)
+
 }

--- a/plugin/storage/grpc/options.go
+++ b/plugin/storage/grpc/options.go
@@ -22,10 +22,12 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/config"
 )
 
-const pluginBinary = "grpc-storage-plugin.binary"
-const pluginConfigurationFile = "grpc-storage-plugin.configuration-file"
-const pluginLogLevel = "grpc-storage-plugin.log-level"
-const defaultPluginLogLevel = "warn"
+const (
+	pluginBinary            = "grpc-storage-plugin.binary"
+	pluginConfigurationFile = "grpc-storage-plugin.configuration-file"
+	pluginLogLevel          = "grpc-storage-plugin.log-level"
+	defaultPluginLogLevel   = "warn"
+)
 
 // Options contains GRPC plugins configs and provides the ability
 // to bind them to command line flags

--- a/plugin/storage/grpc/options_test.go
+++ b/plugin/storage/grpc/options_test.go
@@ -28,9 +28,11 @@ func TestOptionsWithFlags(t *testing.T) {
 	command.ParseFlags([]string{
 		"--grpc-storage-plugin.binary=noop-grpc-plugin",
 		"--grpc-storage-plugin.configuration-file=config.json",
+		"--grpc-storage-plugin.log-level=debug",
 	})
 	opts.InitFromViper(v)
 
 	assert.Equal(t, opts.Configuration.PluginBinary, "noop-grpc-plugin")
 	assert.Equal(t, opts.Configuration.PluginConfigurationFile, "config.json")
+	assert.Equal(t, opts.Configuration.PluginLogLevel, "debug")
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves [#1529](https://github.com/jaegertracing/jaeger/issues/1529)

## Short description of the changes
- Add flag grpc-storage-plugin.log-level to set the level of the grpc plugin logger
