### PR TITLE
Change default rollover conditions to 2 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changes by Version
 
 #### Breaking Changes
 
-* List of service operations can be classified by span kinds ([#1943](https://github.com/jaegertracing/jaeger/pull/1943), [@guo0693](https://github.com/guo0693))
+##### List of service operations can be classified by span kinds ([#1943](https://github.com/jaegertracing/jaeger/pull/1943), [@guo0693](https://github.com/guo0693))
 
     * Endpoint changes:
         * Both Http & gRPC servers now take new optional parameter `spanKind` in addition to `service`. When spanKind
@@ -56,7 +56,7 @@ Changes by Version
                 At the end, it will ask you whether you want to drop the old table or not.
             2. Restart ingester & query services so that they begin to use the new table
 
-* Trace and Span IDs are always padded to 32 or 16 hex characters with leading zeros ([#1956](https://github.com/jaegertracing/jaeger/pull/1956), [@yurishkuro](https://github.com/yurishkuro))
+##### Trace and Span IDs are always padded to 32 or 16 hex characters with leading zeros ([#1956](https://github.com/jaegertracing/jaeger/pull/1956), [@yurishkuro](https://github.com/yurishkuro))
 
     Previously, Jaeger backend always rendered trace and span IDs as  the shortest possible hex string, e.g. an ID
     with numeric value 255 would be rendered as a string `ff`. This change makes the IDs to always render as 16 or 32
@@ -79,7 +79,7 @@ Changes by Version
 
     However, some custom integration that rely on exact string matches of trace IDs may be broken.
 
-* Change default rollover conditions to 2 days ([#1963](https://github.com/jaegertracing/jaeger/pull/1963), [@pavolloffay](https://github.com/pavolloffay))
+##### Change default rollover conditions to 2 days ([#1963](https://github.com/jaegertracing/jaeger/pull/1963), [@pavolloffay](https://github.com/pavolloffay))
 
     Change default rollover conditions from 7 days to 2 days.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Changes by Version
 1.16.0 (unreleased)
 ------------------
 
-#### Backend Changes
+### Backend Changes
 
-##### Breaking Changes
+#### Breaking Changes
 
 * List of service operations can be classified by span kinds ([#1943](https://github.com/jaegertracing/jaeger/pull/1943), [@guo0693](https://github.com/guo0693))
 
@@ -88,11 +88,11 @@ Changes by Version
     running curator would immediately remove the old index.
 
 
-##### New Features
+#### New Features
 
-##### Bug fixes, Minor Improvements
+#### Bug fixes, Minor Improvements
 
-#### UI Changes
+### UI Changes
 
 
 1.15.1 (2019-11-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ Overall, the change is backward compatible:
 
 However, some custom integration that rely on exact string matches of trace IDs may be broken.
 
+#### Change default rollover conditions to 2 days
+
+([PR #1963](https://github.com/jaegertracing/jaeger/pull/1963), [@pavolloffay](https://github.com/pavolloffay))
+
+Change default rollover conditions from 7 days to 2 days.
+
+Given that by default Jaeger uses daily indices and some organizations do not keep data longer than 7 days
+the default of 7 days seems unreasonable - it might result in a too big index and
+running curator would immediately remove the old index.
+
 ### Backend Changes
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changes by Version
 1.16.0 (unreleased)
 ------------------
 
-### Breaking Changes
+#### Backend Changes
+
+##### Breaking Changes
 
 * List of service operations can be classified by span kinds ([#1943](https://github.com/jaegertracing/jaeger/pull/1943), [@guo0693](https://github.com/guo0693))
 
@@ -85,13 +87,12 @@ Changes by Version
     the default of 7 days seems unreasonable - it might result in a too big index and
     running curator would immediately remove the old index.
 
-### Backend Changes
 
-#### New Features
+##### New Features
 
-#### Bug fixes, Minor Improvements
+##### Bug fixes, Minor Improvements
 
-### UI Changes
+#### UI Changes
 
 
 1.15.1 (2019-11-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,82 +10,82 @@ Changes by Version
 
 ##### List of service operations can be classified by span kinds ([#1943](https://github.com/jaegertracing/jaeger/pull/1943), [@guo0693](https://github.com/guo0693))
 
-    * Endpoint changes:
-        * Both Http & gRPC servers now take new optional parameter `spanKind` in addition to `service`. When spanKind
-         is absent or empty, operations from all kinds of spans will be returned.
-        * Instead of returning a list of string, both Http & gRPC servers return a list of operation struct. Please 
-        update your client code to process the new response. Example response:
-            ```
-            curl 'http://localhost:6686/api/operations?service=UserService&spanKind=server' | jq
+* Endpoint changes:
+    * Both Http & gRPC servers now take new optional parameter `spanKind` in addition to `service`. When spanKind
+     is absent or empty, operations from all kinds of spans will be returned.
+    * Instead of returning a list of string, both Http & gRPC servers return a list of operation struct. Please 
+    update your client code to process the new response. Example response:
+        ```
+        curl 'http://localhost:6686/api/operations?service=UserService&spanKind=server' | jq
+        {
+            "data": [{
+                "name": "UserService::getExtendedUser",
+                "spanKind": "server"
+            },
             {
-                "data": [{
-                    "name": "UserService::getExtendedUser",
-                    "spanKind": "server"
-                },
-                {
-                    "name": "UserService::getUserProfile",
-                    "spanKind": "server"
-                }],
-                "total": 2,
-                "limit": 0,
-                "offset": 0,
-                "errors": null
-            }
+                "name": "UserService::getUserProfile",
+                "spanKind": "server"
+            }],
+            "total": 2,
+            "limit": 0,
+            "offset": 0,
+            "errors": null
+        }
+        ```
+    * The legacy http endpoint stay untouched:
+        ```
+        /services/{%s}/operations
+        ```    
+* Storage plugin changes:
+    * Memory updated to support spanKind on write & read, no migration is required.
+    * [Badger](https://github.com/jaegertracing/jaeger/issues/1922) & [ElasticSearch](https://github.com/jaegertracing/jaeger/issues/1923) 
+    to be implemented:  
+    For now `spanKind` will be set as empty string during read & write, only `name` will be valid operation name.
+    * Cassandra updated to support spanKind on write & read ([#1937](https://github.com/jaegertracing/jaeger/pull/1937), [@guo0693](https://github.com/guo0693)):  
+        If you don't run the migration script, nothing will break, the system will used the old table 
+        `operation_names` and set empty `spanKind` in the response.  
+        Steps to get the updated functionality:
+        1.  You will need to run below command on the host you can use `cqlsh` to connect the the cassandra contact
+         point
             ```
-        * The legacy http endpoint stay untouched:
+            KEYSPACE=jaeger_v1 CQL_CMD='cqlsh host 9042 -u test_user -p test_password --request-timeout=3000' 
+            bash ./v002tov003.sh
             ```
-            /services/{%s}/operations
-            ```    
-    * Storage plugin changes:
-        * Memory updated to support spanKind on write & read, no migration is required.
-        * [Badger](https://github.com/jaegertracing/jaeger/issues/1922) & [ElasticSearch](https://github.com/jaegertracing/jaeger/issues/1923) 
-        to be implemented:  
-        For now `spanKind` will be set as empty string during read & write, only `name` will be valid operation name.
-        * Cassandra updated to support spanKind on write & read ([#1937](https://github.com/jaegertracing/jaeger/pull/1937), [@guo0693](https://github.com/guo0693)):  
-            If you don't run the migration script, nothing will break, the system will used the old table 
-            `operation_names` and set empty `spanKind` in the response.  
-            Steps to get the updated functionality:
-            1.  You will need to run below command on the host you can use `cqlsh` to connect the the cassandra contact
-             point
-                ```
-                KEYSPACE=jaeger_v1 CQL_CMD='cqlsh host 9042 -u test_user -p test_password --request-timeout=3000' 
-                bash ./v002tov003.sh
-                ```
-                The script will create new table `operation_names_v2` and migrate data from the old table.  
-                `spanKind` column will be empty for those data.  
-                At the end, it will ask you whether you want to drop the old table or not.
-            2. Restart ingester & query services so that they begin to use the new table
+            The script will create new table `operation_names_v2` and migrate data from the old table.  
+            `spanKind` column will be empty for those data.  
+            At the end, it will ask you whether you want to drop the old table or not.
+        2. Restart ingester & query services so that they begin to use the new table
 
 ##### Trace and Span IDs are always padded to 32 or 16 hex characters with leading zeros ([#1956](https://github.com/jaegertracing/jaeger/pull/1956), [@yurishkuro](https://github.com/yurishkuro))
 
-    Previously, Jaeger backend always rendered trace and span IDs as  the shortest possible hex string, e.g. an ID
-    with numeric value 255 would be rendered as a string `ff`. This change makes the IDs to always render as 16 or 32
-    characters long hex string, e.g. the same id=255 would render as `00000000000000ff`. It mostly affects how UI
-    displays the IDs, the URLs, and the JSON returned from `jaeger-query` service.
+Previously, Jaeger backend always rendered trace and span IDs as  the shortest possible hex string, e.g. an ID
+with numeric value 255 would be rendered as a string `ff`. This change makes the IDs to always render as 16 or 32
+characters long hex string, e.g. the same id=255 would render as `00000000000000ff`. It mostly affects how UI
+displays the IDs, the URLs, and the JSON returned from `jaeger-query` service.
 
-    Motivation: Among randomly generated and uniformly distributed trace IDs, only 1/16th of them start with 0
-    followed by a significant digit, 1/256th start with two 0s, and so on in decreasing geometric progression.
-    Therefore, trimming the leading 0s is a very modest optimization on the size of the data being transmitted or stored.
+Motivation: Among randomly generated and uniformly distributed trace IDs, only 1/16th of them start with 0
+followed by a significant digit, 1/256th start with two 0s, and so on in decreasing geometric progression.
+Therefore, trimming the leading 0s is a very modest optimization on the size of the data being transmitted or stored.
 
-    However, trimming 0s leads to ambiguities when the IDs are used as correlations with other monitoring systems,
-    such as logging, that treat the IDs as opaque strings and cannot establish the equivalence between padded and
-    unpadded IDs. It is also incompatible with W3C Trace Context and Zipkin B3 formats, both of which include all
-    leading 0s, so an application instrumented with OpenTelemetry SDKs may be logging different trace ID strings
-    than application instrumented with Jaeger SDKs (related issue #1657).
+However, trimming 0s leads to ambiguities when the IDs are used as correlations with other monitoring systems,
+such as logging, that treat the IDs as opaque strings and cannot establish the equivalence between padded and
+unpadded IDs. It is also incompatible with W3C Trace Context and Zipkin B3 formats, both of which include all
+leading 0s, so an application instrumented with OpenTelemetry SDKs may be logging different trace ID strings
+than application instrumented with Jaeger SDKs (related issue #1657).
 
-    Overall, the change is backward compatible:
-      * links with non-padded IDs in the UI will still work
-      * data stored in Elasticsearch (where IDs are represented as strings) is still readable
+Overall, the change is backward compatible:
+  * links with non-padded IDs in the UI will still work
+  * data stored in Elasticsearch (where IDs are represented as strings) is still readable
 
-    However, some custom integration that rely on exact string matches of trace IDs may be broken.
+However, some custom integration that rely on exact string matches of trace IDs may be broken.
 
 ##### Change default rollover conditions to 2 days ([#1963](https://github.com/jaegertracing/jaeger/pull/1963), [@pavolloffay](https://github.com/pavolloffay))
 
-    Change default rollover conditions from 7 days to 2 days.
+Change default rollover conditions from 7 days to 2 days.
 
-    Given that by default Jaeger uses daily indices and some organizations do not keep data longer than 7 days
-    the default of 7 days seems unreasonable - it might result in a too big index and
-    running curator would immediately remove the old index.
+Given that by default Jaeger uses daily indices and some organizations do not keep data longer than 7 days
+the default of 7 days seems unreasonable - it might result in a too big index and
+running curator would immediately remove the old index.
 
 
 #### New Features

--- a/plugin/storage/es/esRollover.py
+++ b/plugin/storage/es/esRollover.py
@@ -13,9 +13,9 @@ from requests.auth import HTTPBasicAuth
 
 
 ARCHIVE_INDEX = 'jaeger-span-archive'
-ROLLBACK_CONDITIONS = '{"max_age": "7d"}'
+ROLLBACK_CONDITIONS = '{"max_age": "2d"}'
 UNIT = 'days'
-UNIT_COUNT = 7
+UNIT_COUNT = 2
 SHARDS = 5
 REPLICAS = 1
 


### PR DESCRIPTION
Change default rollover conditions from 7 days to 2 days.

Given that by default Jaeger uses daily indices and some organizations do not keep data longer than 7 days the default of 7 days seems unreasonable - it might result in a too big index and running curator would immediatelly remove the old index.

 We should be more careful and change the default to 2 days - double the default daily indices. Is anybody from @jaegertracing/elasticsearch running rollover? Can anybody share the experience with this?

