### PR TITLE
Export SaveSpan to enable multiplexing (#1967)

### DIFF
--- a/cmd/collector/app/http_handler.go
+++ b/cmd/collector/app/http_handler.go
@@ -55,10 +55,11 @@ func NewAPIHandler(
 
 // RegisterRoutes registers routes for this handler on the given router
 func (aH *APIHandler) RegisterRoutes(router *mux.Router) {
-	router.HandleFunc("/api/traces", aH.saveSpan).Methods(http.MethodPost)
+	router.HandleFunc("/api/traces", aH.SaveSpan).Methods(http.MethodPost)
 }
 
-func (aH *APIHandler) saveSpan(w http.ResponseWriter, r *http.Request) {
+// SaveSpan submits the span provided in the request body to the JaegerBatchesHandler
+func (aH *APIHandler) SaveSpan(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {

--- a/cmd/collector/app/http_handler_test.go
+++ b/cmd/collector/app/http_handler_test.go
@@ -162,7 +162,7 @@ func TestCannotReadBodyFromRequest(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, "whatever", &errReader{})
 	assert.NoError(t, err)
 	rw := dummyResponseWriter{}
-	handler.saveSpan(&rw, req)
+	handler.SaveSpan(&rw, req)
 	assert.EqualValues(t, http.StatusInternalServerError, rw.myStatusCode)
 	assert.EqualValues(t, "Unable to process request body: Simulated error reading body\n", rw.myBody)
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves #1967 where it is not possible to add new endpoints that call the same "SaveSpan" function. This is required for differentiating authenticated "external" endpoints from "internal" endpoints that do not require (and cannot provide) authentication.

## Short description of the changes
Export the `saveSpan` function in `cmd/collector/app/http_handler.go` to `SaveSpan` which allows for embedding the `APIHandler` into a struct for extending.

