### PR TITLE
Deprecate tchannel

### DIFF
--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -48,7 +48,7 @@ type Options struct {
 
 // AddFlags adds flags for Options.
 func AddFlags(flags *flag.FlagSet) {
-	flags.String(reporterType, string(GRPC), fmt.Sprintf("Reporter type to use e.g. %s, %s", string(GRPC), string(TCHANNEL)))
+	flags.String(reporterType, string(GRPC), fmt.Sprintf("Reporter type to use e.g. %s, %s[%s]", string(GRPC), string(TCHANNEL), "NOTE: Deprecated since 1.16"))
 	if !setupcontext.IsAllInOne() {
 		flags.String(agentTagsDeprecated, "", "(deprecated) see --"+agentTags)
 		flags.String(agentTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
@@ -58,6 +58,9 @@ func AddFlags(flags *flag.FlagSet) {
 // InitFromViper initializes Options with properties retrieved from Viper.
 func (b *Options) InitFromViper(v *viper.Viper, logger *zap.Logger) *Options {
 	b.ReporterType = Type(v.GetString(reporterType))
+	if b.ReporterType == TCHANNEL {
+		logger.Warn("Using deprecated reporter type", zap.Any(reporterType, TCHANNEL))
+	}
 	if !setupcontext.IsAllInOne() {
 		if len(v.GetString(agentTagsDeprecated)) > 0 {
 			logger.Warn("Using deprecated configuration", zap.String("option", agentTagsDeprecated))

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -244,6 +244,7 @@ func startCollector(
 			logger.Fatal("Unable to start listening on channel", zap.Error(err))
 		}
 		logger.Info("Starting jaeger-collector TChannel server", zap.Int("port", cOpts.CollectorPort))
+		logger.Warn("TChannel has been deprecated and will be removed in a future release")
 		ch.Serve(listener)
 	}
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -126,6 +126,7 @@ func main() {
 					logger.Fatal("Unable to start listening on channel", zap.Error(err))
 				}
 				logger.Info("Starting jaeger-collector TChannel server", zap.Int("port", builderOpts.CollectorPort))
+				logger.Warn("TChannel has been deprecated and will be removed in a future release")
 				ch.Serve(listener)
 			}
 


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Deprecating tchannel so can be removed from future release.

## Short description of the changes
Added deprecation notice to agent flag and collector/all-in-one handler.
