### PR TITLE
Added configuration for stale bot and needs-triage

### DIFF
--- a/.devbots/needs-triage.yml
+++ b/.devbots/needs-triage.yml
@@ -1,0 +1,2 @@
+enabled: true
+label: "needs-triage"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,4 @@
+daysUntilStale: 60
+daysUntilClose: 7
+onlyLabels:
+  - needs-info


### PR DESCRIPTION
## Which problem is this PR solving?
- Adds the bots discussed during today's bi-weekly meeting

## Short description of the changes
- Adds the configuration to both the stale bot and the "needs-triage" dev bot
