### PR TITLE
Build binaries for Linux on IBM Z / s390x architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,13 @@ dist: trusty
 
 matrix:
   include:
-  - arch: s390x
-    go: 1.13.x
+  - go: "1.13.x"
     env:
     - TESTS=true
     - COVERAGE=true
-    addons:
-      apt:
-        packages:
-        - jq
-        - time
-  - arch: amd64
-    go: 1.13.x
+  - go: "1.13.x"
     env:
-    - TESTS=true
-    - COVERAGE=true  
+    - PROTO_GEN_TEST=true
   - go: "1.13.x"
     env:
     - ALL_IN_ONE=true
@@ -62,7 +54,6 @@ env:
 
 install:
   - docker rmi $(docker images -q) || true
-  - if [ "$HOSTTYPE" == "s390x" ]; then mkdir -p $HOME/gopath/bin; fi
   - travis_retry make install-ci
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/install-ui-deps.sh ; fi
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/install-ui-deps.sh ; fi
@@ -70,8 +61,8 @@ install:
   - |
     if [ "$PROTO_GEN_TEST" == true ]; then
         make proto-install
-        curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip;
-        unzip /tmp/protoc.zip -d "$HOME"/protoc   
+        curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip
+        unzip /tmp/protoc.zip -d "$HOME"/protoc
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,70 +7,44 @@ dist: trusty
 
 matrix:
   include:
-    - arch: s390x
-      go: 1.13.x
-      env:
-      - TESTS=true
-      - COVERAGE=true
-      addons:
-        apt:
-          packages:
-          - jq
-          - time
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - TESTS=true
-      - COVERAGE=true   
+  - arch: s390x
+    go: 1.13.x
+    env:
+    - TESTS=true
+    - COVERAGE=true
+    addons:
+      apt:
+        packages:
+        - jq
+        - time
+  - arch: amd64
+    go: 1.13.x
+    env:
+    - TESTS=true
+    - COVERAGE=true  
+  - go: "1.13.x"
+    env:
+    - ALL_IN_ONE=true
+  - go: "1.13.x"
+    env:
+    - CROSSDOCK=true
+  - go: "1.13.x"
+    env:
+    - DOCKER=true
+    - DEPLOY=true
+  - go: "1.13.x"
+    env:
+    - ES_INTEGRATION_TEST=true
+  - go: "1.13.x"
+    env:
+    - KAFKA_INTEGRATION_TEST=true
+  - go: "1.13.x"
+    env:
+    - CASSANDRA_INTEGRATION_TEST=true
+  - go: "1.13.x"
+    env:
+    - HOTROD=true
 
-    - arch: s390x
-      go: 1.13.x
-      env:
-      - PROTO_GEN_TEST=true
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - PROTO_GEN_TEST=true
-
-    - arch: s390x
-      go: 1.13.x
-      env:
-      - ALL_IN_ONE=true  
-
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - ALL_IN_ONE=true  
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - CROSSDOCK=true 
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - DOCKER=true
-      - DEPLOY=true
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - ES_INTEGRATION_TEST=true
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - KAFKA_INTEGRATION_TEST=true
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - CASSANDRA_INTEGRATION_TEST=true
-    - arch: s390x
-      go: 1.13.x
-      env:
-      - HOTROD=true
-    - arch: amd64
-      go: 1.13.x
-      env:
-      - HOTROD=true
-      
 services:
   - docker
 
@@ -96,15 +70,8 @@ install:
   - |
     if [ "$PROTO_GEN_TEST" == true ]; then
         make proto-install
-        if [[ $(uname -m) == 's390x' ]]; then
-            wget https://raw.githubusercontent.com/linux-on-ibm-z/scripts/master/Protobuf/3.10.0/build_protobuf.sh ;
-            bash build_protobuf.sh -y;
-            mkdir -p "$HOME"/protoc/bin;
-            cp /usr/local/bin/protoc "$HOME"/protoc/bin/ ;
-        else
-            curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip;
-            unzip /tmp/protoc.zip -d "$HOME"/protoc      
-        fi
+        curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip;
+        unzip /tmp/protoc.zip -d "$HOME"/protoc   
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,36 +7,70 @@ dist: trusty
 
 matrix:
   include:
-  - go: "1.13.x"
-    env:
-    - TESTS=true
-    - COVERAGE=true
-  - go: "1.13.x"
-    env:
-    - PROTO_GEN_TEST=true
-  - go: "1.13.x"
-    env:
-    - ALL_IN_ONE=true
-  - go: "1.13.x"
-    env:
-    - CROSSDOCK=true
-  - go: "1.13.x"
-    env:
-    - DOCKER=true
-    - DEPLOY=true
-  - go: "1.13.x"
-    env:
-    - ES_INTEGRATION_TEST=true
-  - go: "1.13.x"
-    env:
-    - KAFKA_INTEGRATION_TEST=true
-  - go: "1.13.x"
-    env:
-    - CASSANDRA_INTEGRATION_TEST=true
-  - go: "1.13.x"
-    env:
-    - HOTROD=true
+    - arch: s390x
+      go: 1.13.x
+      env:
+      - TESTS=true
+      - COVERAGE=true
+      addons:
+        apt:
+          packages:
+          - jq
+          - time
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - TESTS=true
+      - COVERAGE=true   
 
+    - arch: s390x
+      go: 1.13.x
+      env:
+      - PROTO_GEN_TEST=true
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - PROTO_GEN_TEST=true
+
+    - arch: s390x
+      go: 1.13.x
+      env:
+      - ALL_IN_ONE=true  
+
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - ALL_IN_ONE=true  
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - CROSSDOCK=true 
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - DOCKER=true
+      - DEPLOY=true
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - ES_INTEGRATION_TEST=true
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - KAFKA_INTEGRATION_TEST=true
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - CASSANDRA_INTEGRATION_TEST=true
+    - arch: s390x
+      go: 1.13.x
+      env:
+      - HOTROD=true
+    - arch: amd64
+      go: 1.13.x
+      env:
+      - HOTROD=true
+      
 services:
   - docker
 
@@ -54,6 +88,7 @@ env:
 
 install:
   - docker rmi $(docker images -q) || true
+  - if [ "$HOSTTYPE" == "s390x" ]; then mkdir -p $HOME/gopath/bin; fi
   - travis_retry make install-ci
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/install-ui-deps.sh ; fi
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/install-ui-deps.sh ; fi
@@ -61,8 +96,15 @@ install:
   - |
     if [ "$PROTO_GEN_TEST" == true ]; then
         make proto-install
-        curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip
-        unzip /tmp/protoc.zip -d "$HOME"/protoc
+        if [[ $(uname -m) == 's390x' ]]; then
+            wget https://raw.githubusercontent.com/linux-on-ibm-z/scripts/master/Protobuf/3.10.0/build_protobuf.sh ;
+            bash build_protobuf.sh -y;
+            mkdir -p "$HOME"/protoc/bin;
+            cp /usr/local/bin/protoc "$HOME"/protoc/bin/ ;
+        else
+            curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip;
+            unzip /tmp/protoc.zip -d "$HOME"/protoc      
+        fi
     fi
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,11 @@ elasticsearch-mappings:
 .PHONY: build-examples
 build-examples:
 	esc -pkg frontend -o examples/hotrod/services/frontend/gen_assets.go  -prefix examples/hotrod/services/frontend/web_assets examples/hotrod/services/frontend/web_assets
+ifeq ($(GOARCH), s390x)
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./examples/hotrod/hotrod-$(GOOS)-$(GOARCH) ./examples/hotrod/main.go
+else
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./examples/hotrod/hotrod-$(GOOS) ./examples/hotrod/main.go
+endif
 
 .PHONE: docker-hotrod
 docker-hotrod:
@@ -214,23 +218,43 @@ build-all-in-one-linux: build-ui
 
 .PHONY: build-all-in-one
 build-all-in-one: elasticsearch-mappings
+ifeq ($(GOARCH), s390x)
+	CGO_ENABLED=0 installsuffix=cgo go build -tags ui -o ./cmd/all-in-one/all-in-one-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/all-in-one/main.go
+else	
 	CGO_ENABLED=0 installsuffix=cgo go build -tags ui -o ./cmd/all-in-one/all-in-one-$(GOOS) $(BUILD_INFO) ./cmd/all-in-one/main.go
+endif
 
 .PHONY: build-agent
 build-agent:
+ifeq ($(GOARCH), s390x)
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/agent/agent-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/agent/main.go
+else
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/agent/agent-$(GOOS) $(BUILD_INFO) ./cmd/agent/main.go
+endif
 
 .PHONY: build-query
 build-query:
+ifeq ($(GOARCH), s390x)
+	CGO_ENABLED=0 installsuffix=cgo go build -tags ui -o ./cmd/query/query-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/query/main.go
+else
 	CGO_ENABLED=0 installsuffix=cgo go build -tags ui -o ./cmd/query/query-$(GOOS) $(BUILD_INFO) ./cmd/query/main.go
+endif
 
 .PHONY: build-collector
 build-collector: elasticsearch-mappings
+ifeq ($(GOARCH), s390x)
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/collector/collector-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/collector/main.go
+else
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/collector/collector-$(GOOS) $(BUILD_INFO) ./cmd/collector/main.go
+endif
 
 .PHONY: build-ingester
 build-ingester:
+ifeq ($(GOARCH), s390x)
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/ingester/ingester-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/ingester/main.go
+else
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/ingester/ingester-$(GOOS) $(BUILD_INFO) ./cmd/ingester/main.go
+endif
 
 .PHONY: docker
 docker: build-ui build-binaries-linux docker-images-only
@@ -247,11 +271,15 @@ build-binaries-windows:
 build-binaries-darwin:
 	GOOS=darwin $(MAKE) build-platform-binaries
 
+.PHONY: build-binaries-s390x
+build-binaries-s390x:
+	GOOS=linux GOARCH=s390x $(MAKE) build-platform-binaries
+
 .PHONY: build-platform-binaries
 build-platform-binaries: build-agent build-collector build-query build-ingester build-all-in-one build-examples
 
 .PHONY: build-all-platforms
-build-all-platforms: build-binaries-linux build-binaries-windows build-binaries-darwin
+build-all-platforms: build-binaries-linux build-binaries-windows build-binaries-darwin build-binaries-s390x
 
 .PHONY: docker-images-cassandra
 docker-images-cassandra:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,13 @@ ALL_SRC := $(shell find . -name '*.go' \
 
 # ALL_PKGS is used with 'go cover' and 'golint'
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
-
-RACE=-race
+UNAME := $(shell uname -m)
+#Race flag is not supported on s390x architecture
+ifeq ($(UNAME), s390x)
+	RACE=
+else
+	RACE=-race
+endif
 GOTEST=go test -v $(RACE)
 GOLINT=golint
 GOVET=go vet

--- a/plugin/storage/badger/stats_linux.go
+++ b/plugin/storage/badger/stats_linux.go
@@ -30,8 +30,8 @@ func (f *Factory) diskStatisticsUpdate() error {
 	_ = unix.Statfs(f.Options.GetPrimary().ValueDirectory, &valDirStatfs)
 
 	// Using Bavail instead of Bfree to get non-priviledged user space available
-	f.metrics.ValueLogSpaceAvailable.Update(int64(valDirStatfs.Bavail) * valDirStatfs.Bsize)
-	f.metrics.KeyLogSpaceAvailable.Update(int64(keyDirStatfs.Bavail) * keyDirStatfs.Bsize)
+	f.metrics.ValueLogSpaceAvailable.Update(int64(valDirStatfs.Bavail) * int64(valDirStatfs.Bsize))
+	f.metrics.KeyLogSpaceAvailable.Update(int64(keyDirStatfs.Bavail) * int64(keyDirStatfs.Bsize))
 
 	/*
 	 TODO If we wanted to clean up oldest data to free up diskspace, we need at a minimum an index to the StartTime

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -52,8 +52,13 @@ for pkg in "$@"; do
 		args="-coverprofile $COVER/cover.${i}.out" # -coverpkg $coverpkg
 	fi
 
-	echo go test $args -v -race "$pkg"
-	go test $args -v -race "$pkg"
+	if [[ $(uname -m) == 's390x' ]]; then
+		echo go test $args -v "$pkg"
+		go test $args -v "$pkg"
+	else
+		echo go test $args -v -race "$pkg"
+		go test $args -v -race "$pkg"
+	fi
 done
 
 gocovmerge "$COVER"/*.out > cover.out

--- a/scripts/travis/package-deploy.sh
+++ b/scripts/travis/package-deploy.sh
@@ -33,8 +33,13 @@ function stage-platform-files {
 function package {
     local PLATFORM=$1
     local FILE_EXTENSION=$2
-
-    local PACKAGE_STAGING_DIR=jaeger-$VERSION-$PLATFORM-amd64
+    # script start
+    if [ "$PLATFORM" == "linux-s390x" ]; then
+        local PACKAGE_STAGING_DIR=jaeger-$VERSION-$PLATFORM
+    else
+        local PACKAGE_STAGING_DIR=jaeger-$VERSION-$PLATFORM-amd64
+    fi
+    
     mkdir $PACKAGE_STAGING_DIR
 
     stage-platform-files $PLATFORM $PACKAGE_STAGING_DIR $FILE_EXTENSION
@@ -64,3 +69,4 @@ mkdir $DEPLOY_STAGING_DIR
 package linux
 package darwin
 package windows .exe
+package linux-s390x


### PR DESCRIPTION
Signed-off-by: Prasanna Kelkar <Prasanna.Kelkar@ibm.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  PR not intended to resolve specific issue but As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.

## Short description of the changes
- Added s390x specific changes to skip usage of `RACE` flag as it is not supported on s390x architecture.
- Added type casting in `plugin/storage/badger/stats_linux.go` file to resolve `mismatched types int64 and uint32` issue on s390x platform.
