### PR TITLE
Added support for dynamic queue sizes

### DIFF
--- a/cmd/collector/app/builder/builder_flags.go
+++ b/cmd/collector/app/builder/builder_flags.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	collectorDynQueueSizeMemory   = "collector.queue-size-memory"
 	collectorQueueSize            = "collector.queue-size"
 	collectorNumWorkers           = "collector.num-workers"
 	collectorPort                 = "collector.port"
@@ -46,6 +47,8 @@ var tlsFlagsConfig = tlscfg.ServerFlagsConfig{
 
 // CollectorOptions holds configuration for collector
 type CollectorOptions struct {
+	// DynQueueSizeMemory determines how much memory to use for the queue
+	DynQueueSizeMemory uint
 	// QueueSize is the size of collector's queue
 	QueueSize int
 	// NumWorkers is the number of internal workers in a collector
@@ -70,6 +73,7 @@ type CollectorOptions struct {
 
 // AddFlags adds flags for CollectorOptions
 func AddFlags(flags *flag.FlagSet) {
+	flags.Uint(collectorDynQueueSizeMemory, 0, "(experimental) The max memory size in MiB to use for the dynamic queue.")
 	flags.Int(collectorQueueSize, app.DefaultQueueSize, "The queue size of the collector")
 	flags.Int(collectorNumWorkers, app.DefaultNumWorkers, "The number of workers pulling items from the queue")
 	flags.Int(collectorPort, ports.CollectorTChannel, "The TChannel port for the collector service")
@@ -84,6 +88,7 @@ func AddFlags(flags *flag.FlagSet) {
 
 // InitFromViper initializes CollectorOptions with properties from viper
 func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
+	cOpts.DynQueueSizeMemory = v.GetUint(collectorDynQueueSizeMemory) * 1024 * 1024 // we receive in MiB and store in bytes
 	cOpts.QueueSize = v.GetInt(collectorQueueSize)
 	cOpts.NumWorkers = v.GetInt(collectorNumWorkers)
 	cOpts.CollectorPort = v.GetInt(collectorPort)

--- a/cmd/collector/app/builder/span_handler_builder.go
+++ b/cmd/collector/app/builder/span_handler_builder.go
@@ -54,6 +54,8 @@ func (b *SpanHandlerBuilder) BuildHandlers() (
 		app.Options.NumWorkers(b.CollectorOpts.NumWorkers),
 		app.Options.QueueSize(b.CollectorOpts.QueueSize),
 		app.Options.CollectorTags(b.CollectorOpts.CollectorTags),
+		app.Options.DynQueueSizeWarmup(uint(b.CollectorOpts.QueueSize)), // same as queue size for now
+		app.Options.DynQueueSizeMemory(b.CollectorOpts.DynQueueSizeMemory),
 	)
 
 	return app.NewZipkinSpanHandler(b.Logger, spanProcessor, zs.NewChainedSanitizer(zs.StandardSanitizers...)),

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -58,9 +58,13 @@ type SpanProcessorMetrics struct {
 	InQueueLatency metrics.Timer
 	// SpansDropped measures the number of spans we discarded because the queue was full
 	SpansDropped metrics.Counter
+	// SpansBytes records how many bytes were processed
+	SpansBytes metrics.Gauge
 	// BatchSize measures the span batch size
 	BatchSize metrics.Gauge // size of span batch
-	// QueueLength measures the size of the internal span queue
+	// QueueCapacity measures the capacity of the internal span queue
+	QueueCapacity metrics.Gauge
+	// QueueLength measures the current number of elements in the internal span queue
 	QueueLength metrics.Gauge
 	// SavedOkBySvc contains span and trace counts by service
 	SavedOkBySvc  metricsBySvc  // spans actually saved
@@ -150,7 +154,9 @@ func NewSpanProcessorMetrics(serviceMetrics metrics.Factory, hostMetrics metrics
 		InQueueLatency: hostMetrics.Timer(metrics.TimerOptions{Name: "in-queue-latency", Tags: nil}),
 		SpansDropped:   hostMetrics.Counter(metrics.Options{Name: "spans.dropped", Tags: nil}),
 		BatchSize:      hostMetrics.Gauge(metrics.Options{Name: "batch-size", Tags: nil}),
+		QueueCapacity:  hostMetrics.Gauge(metrics.Options{Name: "queue-capacity", Tags: nil}),
 		QueueLength:    hostMetrics.Gauge(metrics.Options{Name: "queue-length", Tags: nil}),
+		SpansBytes:     hostMetrics.Gauge(metrics.Options{Name: "spans.bytes", Tags: nil}),
 		SavedOkBySvc:   newMetricsBySvc(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"result": "ok"}}), "saved-by-svc"),
 		SavedErrBySvc:  newMetricsBySvc(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"result": "err"}}), "saved-by-svc"),
 		spanCounts:     spanCounts,

--- a/cmd/collector/app/options.go
+++ b/cmd/collector/app/options.go
@@ -31,19 +31,21 @@ const (
 )
 
 type options struct {
-	logger           *zap.Logger
-	serviceMetrics   metrics.Factory
-	hostMetrics      metrics.Factory
-	preProcessSpans  ProcessSpans
-	sanitizer        sanitizer.SanitizeSpan
-	preSave          ProcessSpan
-	spanFilter       FilterSpan
-	numWorkers       int
-	blockingSubmit   bool
-	queueSize        int
-	reportBusy       bool
-	extraFormatTypes []SpanFormat
-	collectorTags    map[string]string
+	logger             *zap.Logger
+	serviceMetrics     metrics.Factory
+	hostMetrics        metrics.Factory
+	preProcessSpans    ProcessSpans
+	sanitizer          sanitizer.SanitizeSpan
+	preSave            ProcessSpan
+	spanFilter         FilterSpan
+	numWorkers         int
+	blockingSubmit     bool
+	queueSize          int
+	dynQueueSizeWarmup uint
+	dynQueueSizeMemory uint
+	reportBusy         bool
+	extraFormatTypes   []SpanFormat
+	collectorTags      map[string]string
 }
 
 // Option is a function that sets some option on StorageBuilder.
@@ -119,6 +121,20 @@ func (options) BlockingSubmit(blockingSubmit bool) Option {
 func (options) QueueSize(queueSize int) Option {
 	return func(b *options) {
 		b.queueSize = queueSize
+	}
+}
+
+// DynQueueSize creates an Option that initializes the queue size
+func (options) DynQueueSizeWarmup(dynQueueSizeWarmup uint) Option {
+	return func(b *options) {
+		b.dynQueueSizeWarmup = dynQueueSizeWarmup
+	}
+}
+
+// DynQueueSize creates an Option that initializes the queue size
+func (options) DynQueueSizeMemory(dynQueueSizeMemory uint) Option {
+	return func(b *options) {
+		b.dynQueueSizeMemory = dynQueueSizeMemory
 	}
 }
 

--- a/cmd/collector/app/options_test.go
+++ b/cmd/collector/app/options_test.go
@@ -39,12 +39,16 @@ func TestAllOptionSet(t *testing.T) {
 		Options.PreProcessSpans(func(spans []*model.Span) {}),
 		Options.Sanitizer(func(span *model.Span) *model.Span { return span }),
 		Options.QueueSize(10),
+		Options.DynQueueSizeWarmup(1000),
+		Options.DynQueueSizeMemory(1024),
 		Options.PreSave(func(span *model.Span) {}),
 		Options.CollectorTags(map[string]string{"extra": "tags"}),
 	)
 	assert.EqualValues(t, 5, opts.numWorkers)
 	assert.EqualValues(t, 10, opts.queueSize)
 	assert.EqualValues(t, map[string]string{"extra": "tags"}, opts.collectorTags)
+	assert.EqualValues(t, 1000, opts.dynQueueSizeWarmup)
+	assert.EqualValues(t, 1024, opts.dynQueueSizeMemory)
 }
 
 func TestNoOptionsSet(t *testing.T) {
@@ -59,4 +63,5 @@ func TestNoOptionsSet(t *testing.T) {
 	assert.True(t, opts.spanFilter(nil))
 	span := model.Span{}
 	assert.EqualValues(t, &span, opts.sanitizer(&span))
+	assert.EqualValues(t, 0, opts.dynQueueSizeWarmup)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #943

## Short description of the changes
* Introduces the new flags: `collector.dyn-queue-size-warmup` and `collector.dyn-queue-size-memory`.
* When the warm-up flag is set, the span processor starts a new background process to recalculate the queue capacity at regular intervals.
* The span processor now keeps track of the number of spans it has seen, as well as the total bytes it processed. That information allows to derive the average spans size that the collector has processed. Along with the memory to allocate, we can come up with the ideal queue size.
* New metrics: `jaeger_collector_queue_capacity` and `jaeger_collector_spans_bytes`.

This commit shouldn't cause performance degradation for instances not using the new options, except for a small memory overhead due to the new span tracker (quantity/size) and the new metrics.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

