### PR TITLE
Fix a typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,7 @@ Changes by Version
         If you don't run the migration script, nothing will break, the system will used the old table 
         `operation_names` and set empty `spanKind` in the response.  
         Steps to get the updated functionality:
-        1.  You will need to run below command on the host you can use `cqlsh` to connect the the cassandra contact
-         point
+        1.  You will need to run the command below on the host where you can use `cqlsh` to connect to Cassandra:
             ```
             KEYSPACE=jaeger_v1 CQL_CMD='cqlsh host 9042 -u test_user -p test_password --request-timeout=3000' 
             bash ./v002tov003.sh


### PR DESCRIPTION
Fix a typo "the the" -> "the"

Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- 

## Short description of the changes
- 
