### PR TITLE
Upgrade dependencies `dep ensure --update`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,12 +68,12 @@
   version = "0.9.3"
 
 [[projects]]
-  digest = "1:320e7ead93de9fd2b0e59b50fd92a4d50c1f8ab455d96bc2eb083267453a9709"
+  digest = "1:c68aba66f5db6052fd838d9a7d60d8859f8c11b8c1d9ac9758f69c7a51efc07a"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ccb8e960c48f04d6935e72476ae4a51028f9e22f"
-  version = "v9"
+  revision = "475eaeb164960a651e97470412a7d3b0c5036105"
+  version = "v10"
 
 [[projects]]
   digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
@@ -144,11 +144,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6e8109ce247a59ab1eeb5330166c12735f6590de99c9647b6162d11518d32c9a"
+  digest = "1:7b5b445d4d7b8d18eb794783e7559e90d1f1fca4bf3c2f1c249f11b582e6f546"
   name = "github.com/dgryski/go-farm"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6a90982ecee230ff6cba02d5bd386acc030be9d3"
+  revision = "c2139c5d712b01d0410c2e51d4bdc588b4eb6ca3"
 
 [[projects]]
   digest = "1:1f0c7ab489b407a7f8f9ad16c25a504d28ab461517a971d341388a56156c1bd7"
@@ -204,23 +204,23 @@
   version = "v0.9.0"
 
 [[projects]]
-  digest = "1:ec1763a0b23c3c610dc2a0310c9afd01513c9b95091c05a9207718a61181c276"
+  digest = "1:59e98a91b61e51b9457ee4e13a128f207bd66871cc84bef92a779a7d82711e93"
   name = "github.com/go-openapi/analysis"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "1024f3482ddc2c381cc918eb9eca596d51a70272"
-  version = "v0.19.6"
+  revision = "01a3bdad024cd0b80f267b070347538b6edb1c77"
+  version = "v0.19.7"
 
 [[projects]]
-  digest = "1:3bca1e4623bc7e1f9849a14fe730c093953727991f0592be3dad0168cb67758e"
+  digest = "1:dd9d7a334e7d246a8501ac0cf5d408024c91ff8b8308930cd98916629970da97"
   name = "github.com/go-openapi/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0b2a0a1f89aa2eec2d13e03cd80ab0fdaf01f8ce"
-  version = "v0.19.2"
+  revision = "9b273e805998abc751853b4e1574d66e5df888b4"
+  version = "v0.19.3"
 
 [[projects]]
   digest = "1:ed15647db08b6d63666bf9755d337725960c302bbfa5e23754b4b915a4797e42"
@@ -247,7 +247,7 @@
   version = "v0.19.4"
 
 [[projects]]
-  digest = "1:dce067db51b765f24e2588aff417b306c61fcacfca7f3fd71e129e67ef2e1e5f"
+  digest = "1:b2254eaaff849ab98571fd3c8800c110e23e4f17013a841a9d118547d458d969"
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
@@ -259,40 +259,40 @@
     "security",
   ]
   pruneopts = "UT"
-  revision = "553c9d1fb273d9550562d9f76949a413af265138"
-  version = "v0.19.7"
+  revision = "cc90213cf1bd091201a1f7ee230feeb7662c4a48"
+  version = "v0.19.9"
 
 [[projects]]
-  digest = "1:55d1c09fc8b3320b6842565249a9e4d0f363bead6f9b8be05c3b47f2c4264eda"
+  digest = "1:a60f47e736cc96075451c3c3502274d86ec6d96588c03d1ab56142ccbb8a5364"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8557d72e4f077c2dbe1e48df09e596b6fb9b7991"
-  version = "v0.19.4"
-
-[[projects]]
-  digest = "1:787b399bfeddd801aca6144bd9928f4fe1d40eadcb09c59fcbd421cc528ea11c"
-  name = "github.com/go-openapi/strfmt"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "6faa644e1cdafc07f7b38eb06c1af5f92128f289"
-  version = "v0.19.3"
-
-[[projects]]
-  digest = "1:43d0f99f53acce97119181dcd592321084690c2d462c57680ccb4472ae084949"
-  name = "github.com/go-openapi/swag"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "c3d0f7896d589f3babb99eea24bbc7de98108e72"
+  revision = "772572fd19ebcc983369e53bfaed4bde2077fe0c"
   version = "v0.19.5"
 
 [[projects]]
-  digest = "1:683e8ed8f90886b6338ab90d12aa8f4111383506313173ef02ad0724608512b5"
+  digest = "1:97d14436dd6f314edfd1cff0caae50342c5435718f0adfd7490db353342bfca4"
+  name = "github.com/go-openapi/strfmt"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1940fb2f8aba2045ae5493bd64b76ad4af8b5856"
+  version = "v0.19.4"
+
+[[projects]]
+  digest = "1:d79ccf65d7721efa48200dc7fc827f8fb29e1fba4db4d55be675fdec84e7cfe1"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8a84ec635f1b280a7062edeab609f0667a053248"
+  version = "v0.19.6"
+
+[[projects]]
+  digest = "1:313e98ecd90b82d00c6b480c7458602f2c669b93c396772680fd3a9bb9ad13c0"
   name = "github.com/go-openapi/validate"
   packages = ["."]
   pruneopts = "UT"
-  revision = "80d596e2af47cef147b636dfd76abce249d2b847"
-  version = "v0.19.4"
+  revision = "08232b6614a50c4f62d1efa77e966421d327d3d3"
+  version = "v0.19.5"
 
 [[projects]]
   digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
@@ -544,12 +544,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:ca955a9cd5b50b0f43d2cc3aeb35c951473eeca41b34eb67507f1dbcc0542394"
+  digest = "1:4cc7748b74453830951f95ddc3fd980387e7c13f77cc33d7cba54cd6b96dad26"
   name = "github.com/kr/pretty"
   packages = ["."]
   pruneopts = "UT"
-  revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
-  version = "v0.1.0"
+  revision = "4e0886370c3a67530192c6a238cff68f56c141b0"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:15b5cc79aad436d47019f814fde81a10221c740dc8ddf769221a65097fb6c2e9"
@@ -624,7 +624,7 @@
     "x86",
   ]
   pruneopts = "UT"
-  revision = "15d6a9a17e5386cb169227dd4dea9a23100a5029"
+  revision = "205fc6a3d76b01529817bc64d037340b558d2c05"
 
 [[projects]]
   digest = "1:66b0a65aba488ca6c72f77132d5b8d7e2c5baf07d577dee64502b69a2c90c791"
@@ -645,15 +645,15 @@
   version = "v0.1"
 
 [[projects]]
-  digest = "1:9ec6cf1df5ad1d55cf41a43b6b1e7e118a91bade4f68ff4303379343e40c0e25"
+  digest = "1:109a4e5eccbcaea2e63f89e2eccecbd7f427a893a8712defce705e14c1d51d3c"
   name = "github.com/oklog/run"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
-  version = "v1.0.0"
+  revision = "9c53bcd6fefd554246da88d55efcc283aff63659"
+  version = "v1.1.0"
 
 [[projects]]
-  digest = "1:4753e9dba3c4dea247a1b65b638d74561c2f3df47fbac74b704d2603bbb41974"
+  digest = "1:55222c9ad95811b5e0217a53bc4808a06549589b0026f0fdaf020ff34dd0c967"
   name = "github.com/olivere/elastic"
   packages = [
     ".",
@@ -661,8 +661,8 @@
     "uritemplates",
   ]
   pruneopts = "UT"
-  revision = "dc1492fc8d9d981e6a2e927933aac5546e473452"
-  version = "v6.2.26"
+  revision = "d7ed85d223ef32bd5ca4c324c444faf5001236fb"
+  version = "v6.2.27"
 
 [[projects]]
   branch = "master"
@@ -693,15 +693,15 @@
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:cef870622e603ac1305922eb5d380455cad27e354355ae7a855d8633ffa66197"
+  digest = "1:d843e9c8e27913780ac7a3d9014a19a4b2752d1dda1250e6fdba48bafe75fa6e"
   name = "github.com/pierrec/lz4"
   packages = [
     ".",
     "internal/xxh32",
   ]
   pruneopts = "UT"
-  revision = "645f9b948eee34cbcc335c70999f79c29c420fbf"
-  version = "v2.3.0"
+  revision = "9085dacd1e1eca033047a5514195779360363ced"
+  version = "v2.4.0"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
@@ -732,12 +732,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  digest = "1:982be0b5396e16a663697899ce69cc7b1e71ddcae4153af157578d4dc9bc3f88"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "UT"
-  revision = "14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016"
+  revision = "d1d2010b5beead3fa1c5f271a5cf626e40b3ad6e"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:f119e3205d3a1f0f19dbd7038eb37528e2c6f0933269dc344e305951fb87d632"
@@ -752,7 +752,7 @@
   version = "v0.7.0"
 
 [[projects]]
-  digest = "1:a210815b437763623ecca8eb91e6a0bf4f2d6773c5a6c9aec0e28f19e5fd6deb"
+  digest = "1:ec0ff4bd619a67065e34d6477711ed0117e335f99059a4c508e0fe21cfe7b304"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -760,8 +760,8 @@
     "internal/util",
   ]
   pruneopts = "UT"
-  revision = "499c85531f756d1129edd26485a5f73871eeb308"
-  version = "v0.0.5"
+  revision = "6d489fc7f1d9cd890a250f3ea3431b1744b9623f"
+  version = "v0.0.8"
 
 [[projects]]
   branch = "master"
@@ -828,12 +828,12 @@
   version = "v1.2.2"
 
 [[projects]]
-  digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
+  digest = "1:ff4cd55a3666b6ea3a876c9e133bfb54d6c812e725409a773f2c94a0b3a92f4f"
   name = "github.com/spf13/cast"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
-  version = "v1.3.0"
+  revision = "1ffadf551085444af981432dd0f6d1160c11ec64"
+  version = "v1.3.1"
 
 [[projects]]
   digest = "1:654214e86a044cfb1815afd41ff2a8e34402bdfafa0dd79fec5452ca1dc1f779"
@@ -863,12 +863,12 @@
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:0b60fc944fb6a7b6c985832bd341bdb7ed8fe894fea330414e7774bb24652962"
+  digest = "1:8d0b79a29be9946ea00b2f2b778ec5b36db07453d97abe9d754b25bc2cc49a0e"
   name = "github.com/spf13/viper"
   packages = ["."]
   pruneopts = "UT"
-  revision = "72b022eb357a56469725dcd03918449e2278d02e"
-  version = "v1.5.0"
+  revision = "eabbc68a3ecd5cf8c11a2f84dbda5e7a38493b2f"
+  version = "v1.6.1"
 
 [[projects]]
   digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
@@ -900,7 +900,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:ea9632313cd7ceffb62188cd5e4bf940e9b91446fc310f9a62372ae536011fdb"
+  digest = "1:b2871caffbaef2e8f6d6f42318b985a16297626df8669be365da99e9d4bab10f"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -924,8 +924,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "54da50209f6acdcb06df61e60eeda5b52a4ef47c"
-  version = "v2.20.0"
+  revision = "f2e1f58485aacf2975cdde9c9f5396e6d98c35ba"
+  version = "v2.21.1"
 
 [[projects]]
   digest = "1:abbb7762b4200f8b1d82193dcc02a3d8a62efc0a0ffc8ec4f4e9ef8abf797a9c"
@@ -968,27 +968,28 @@
   version = "v1.16.0"
 
 [[projects]]
-  digest = "1:8458b1a19a304c09d8f109a9463a419f703e3d1a81615afcaf3593dcce6749b9"
+  digest = "1:f15085b9880b96dc2c043eb279a11f88d80d3e24e3ba8ccbf8391a9a7ed1ba0f"
   name = "go.mongodb.org/mongo-driver"
   packages = [
     "bson",
     "bson/bsoncodec",
+    "bson/bsonoptions",
     "bson/bsonrw",
     "bson/bsontype",
     "bson/primitive",
     "x/bsonx/bsoncore",
   ]
   pruneopts = "UT"
-  revision = "797e0a635920c291b1808180bf7249eaac5eafed"
-  version = "v1.1.3"
+  revision = "55b507b3e45a2ef5dc1d5a4cba3333c45dce443c"
+  version = "v1.2.1"
 
 [[projects]]
-  digest = "1:0bdcb0c740d79d400bd3f7946ac22a715c94db62b20bfd2e01cd50693aba0600"
+  digest = "1:c708d00d1097e62bf4f3a72f239efa7dafc257581421b0b7d3789e1ff5299f30"
   name = "go.uber.org/atomic"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9dc4df04d0d1c39369750a9f6c32c39560672089"
-  version = "v1.5.0"
+  revision = "40ae6a40a970ef4cdbffa7b24b280e316db8accc"
+  version = "v1.5.1"
 
 [[projects]]
   digest = "1:a51a1c97b728b00cc514dfe5f78aad3354491792e69b881ea88176dd3fa30ef6"
@@ -1020,7 +1021,7 @@
   revision = "2cfd321de3ee5d5f8a5fda2521d1703478334d98"
 
 [[projects]]
-  digest = "1:d41c2589529fbacca8d78e18a7cc3e58304dc20735427838c25bb905a5a44e5d"
+  digest = "1:46ad3fed3cf8956a73166039328ab019c7ab9757a840488ee127d8b9b9a3178b"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -1034,8 +1035,8 @@
     "zaptest/observer",
   ]
   pruneopts = "UT"
-  revision = "a6015e13fab9b744d96085308ce4e8f11bad1996"
-  version = "v1.12.0"
+  revision = "33e58d4d0120aa28d4df84cd244838c490846c9d"
+  version = "v1.13.0"
 
 [[projects]]
   branch = "master"
@@ -1046,22 +1047,22 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "ed6320f186d4e69b2ba748dd0084746281301a8e"
+  revision = "5d647ca1575777a812e903a7e98177174d8c295a"
 
 [[projects]]
   branch = "master"
-  digest = "1:21d7bad9b7da270fd2d50aba8971a041bd691165c95096a2a4c68db823cbc86a"
+  digest = "1:334b27eac455cb6567ea28cd424230b07b1a64334a2f861a8075ac26ce10af43"
   name = "golang.org/x/lint"
   packages = [
     ".",
     "golint",
   ]
   pruneopts = "UT"
-  revision = "16217165b5de779cb6a5e4fc81fa9c1166fda457"
+  revision = "fdd1cda4f05fd1fd86124f0ef9ce31a0b72c8448"
 
 [[projects]]
   branch = "master"
-  digest = "1:ab87fcd483258ad8fb999dbd24d9175a7ce6b7630021a9a905bfbe6ef4783b96"
+  digest = "1:be532d3e419ae0a9001a05f78754b803473c76c55cfb94af715fc06eaf311b13"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -1081,18 +1082,18 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "a882066a44e04a21d46e51451c71e131344e830e"
+  revision = "c0dbc17a35534bf2e581d7a942408dc936316da4"
 
 [[projects]]
   branch = "master"
-  digest = "1:1017834f19e0d987e8b1b928f016b0a1186a202ec1867fee7112efd4b4475bd1"
+  digest = "1:c8faf148023f13e62a93d3ed6c01fc586b3c6b52a40c5c9b0f2220bae71f390a"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "c1f44814a5cd81a6d1cb589ef1e528bc5d305e07"
+  revision = "548cf772de5052aa878ccb47cdeb7d262b75c8ec"
 
 [[projects]]
   digest = "1:66a2f252a58b4fbbad0e4e180e1d85a83c222b6bce09c3dcdef3dc87c72eda7c"
@@ -1122,7 +1123,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:416b82a27fe1a8768ee1f2a143178cb5ca829b889081b66a096377e35fcdb6e4"
+  digest = "1:1025e9e880900028dc2ec8d648c486ba65e33c9bf1ce3498d3cc1984cd3a8a9c"
   name = "golang.org/x/tools"
   packages = [
     "go/analysis",
@@ -1141,10 +1142,9 @@
     "internal/fastwalk",
     "internal/gopathwalk",
     "internal/semver",
-    "internal/span",
   ]
   pruneopts = "UT"
-  revision = "0c330b00b1a74f19a7237de8f5c46b9483084fa2"
+  revision = "89082a3841783366cb82b3dc4ce9258fb3dad1a9"
 
 [[projects]]
   branch = "master"
@@ -1155,13 +1155,14 @@
     "googleapis/rpc/status",
   ]
   pruneopts = "UT"
-  revision = "919d9bdd9fe6f1a5dd95ce5d5e4cdb8fd3c516d0"
+  revision = "bd8f9a0ef82f9870cb10caef4f23c348069600cb"
 
 [[projects]]
-  digest = "1:55bc501ec595858b173f6bb7eb76af149c892a1708c1729204ccc80fd009015a"
+  digest = "1:b2c9ea388537a402c7f618e11eda34ec5358b67c3c6aef9df113c7022b46e0b1"
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "attributes",
     "backoff",
     "balancer",
     "balancer/base",
@@ -1203,8 +1204,8 @@
     "test/grpc_testing",
   ]
   pruneopts = "UT"
-  revision = "9d331e2b02dd47daeecae02790f61cc88dc75a64"
-  version = "v1.25.0"
+  revision = "f5b0812e6fe574d90da76b205e9eb51f6ddb1919"
+  version = "v1.26.0"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
@@ -1213,6 +1214,14 @@
   pruneopts = "UT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
+
+[[projects]]
+  digest = "1:c4b5592c342f273e18de68e16957f536f6648f2e90c9d7ece653ac90c22079a9"
+  name = "gopkg.in/ini.v1"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "94291fffe2b14f4632ec0e67c1bfecfc1287a168"
+  version = "v1.51.1"
 
 [[projects]]
   digest = "1:c902038ee2d6f964d3b9f2c718126571410c5d81251cbab9fe58abd37803513c"
@@ -1281,12 +1290,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:f26a5d382387e03a40d1471dddfba85dfff9bf05352d7e42d37612677c4d3c5c"
+  digest = "1:b75b3deb2bce8bc079e16bb2aecfe01eb80098f5650f9e93e5643ca8b7b73737"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f90ceb4f409096b60e2e9076b38b304b8246e5fa"
-  version = "v2.2.5"
+  revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
+  version = "v2.2.7"
 
 [[projects]]
   digest = "1:131158a88aad1f94854d0aa21a64af2802d0a470fb0f01cb33c04fafd2047111"

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -16,6 +16,7 @@ package grpc
 
 import (
 	"context"
+	"io"
 	"net"
 	"testing"
 
@@ -27,13 +28,16 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
+func closeCloser(t *testing.T, c io.Closer) {
+	require.NoError(t, c.Close())
+}
+
 func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 	s, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
 		api_v2.RegisterSamplingManagerServer(s, &mockSamplingHandler{})
 	})
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
-	//lint:ignore SA5001 don't care about errors
-	defer conn.Close()
+	defer closeCloser(t, conn)
 	require.NoError(t, err)
 	defer s.GracefulStop()
 	manager := NewConfigManager(conn)
@@ -44,13 +48,13 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 
 func TestSamplingManager_GetSamplingStrategy_error(t *testing.T) {
 	conn, err := grpc.Dial("foo", grpc.WithInsecure())
-	//lint:ignore SA5001 don't care about errors
-	defer conn.Close()
+	defer closeCloser(t, conn)
 	require.NoError(t, err)
 	manager := NewConfigManager(conn)
 	resp, err := manager.GetSamplingStrategy("any")
 	require.Nil(t, resp)
-	assert.EqualError(t, err, "rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: address foo: missing port in address\"")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Error while dialing dial tcp: address foo: missing port in address")
 }
 
 func TestSamplingManager_GetBaggageRestrictions(t *testing.T) {

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
-func closeCloser(t *testing.T, c io.Closer) {
+func close(t *testing.T, c io.Closer) {
 	require.NoError(t, c.Close())
 }
 
@@ -37,7 +37,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 		api_v2.RegisterSamplingManagerServer(s, &mockSamplingHandler{})
 	})
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
-	defer closeCloser(t, conn)
+	defer close(t, conn)
 	require.NoError(t, err)
 	defer s.GracefulStop()
 	manager := NewConfigManager(conn)
@@ -48,7 +48,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 
 func TestSamplingManager_GetSamplingStrategy_error(t *testing.T) {
 	conn, err := grpc.Dial("foo", grpc.WithInsecure())
-	defer closeCloser(t, conn)
+	defer close(t, conn)
 	require.NoError(t, err)
 	manager := NewConfigManager(conn)
 	resp, err := manager.GetSamplingStrategy("any")

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -124,7 +124,8 @@ func TestReporter_SendFailure(t *testing.T) {
 	require.NoError(t, err)
 	rep := NewReporter(conn, nil, zap.NewNop())
 	err = rep.send(nil, nil)
-	assert.EqualError(t, err, "rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: missing address\"")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transport: Error while dialing dial tcp: missing address")
 }
 
 func TestReporter_AddProcessTags_EmptyTags(t *testing.T) {

--- a/pkg/discovery/grpcresolver/grpc_resolver.go
+++ b/pkg/discovery/grpcresolver/grpc_resolver.go
@@ -85,7 +85,7 @@ func New(
 }
 
 // Build returns itself for Resolver, because it's both a builder and a resolver.
-func (r *Resolver) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+func (r *Resolver) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	r.cc = cc
 
 	// Update conn states if proactively updates already work
@@ -106,7 +106,7 @@ func (r *Resolver) Scheme() string {
 
 // ResolveNow is a noop for Resolver since resolver is already firing r.cc.UpdatesState every time
 // it receives updates of new instance from discoCh
-func (r *Resolver) ResolveNow(o resolver.ResolveNowOption) {}
+func (r *Resolver) ResolveNow(o resolver.ResolveNowOptions) {}
 
 func (r *Resolver) watcher() {
 	defer r.closing.Done()

--- a/pkg/discovery/grpcresolver/grpc_resolver_test.go
+++ b/pkg/discovery/grpcresolver/grpc_resolver_test.go
@@ -118,7 +118,7 @@ func TestErrorDiscoverer(t *testing.T) {
 		err: errMessage,
 	}
 	r := New(notifier, discoverer, zap.NewNop(), 2)
-	_, err := r.Build(resolver.Target{}, nil, resolver.BuildOption{})
+	_, err := r.Build(resolver.Target{}, nil, resolver.BuildOptions{})
 	assert.Equal(t, errMessage, err)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- gRPC deprecated some structs, causing CI breaks on other PRs (e.g. #2005 )

## Short description of the changes
- `dep ensure --update`
- use recommended structs
