### PR TITLE
Publish tracegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ cmd/ingester/ingester
 cmd/ingester/ingester-*
 cmd/query/query
 cmd/query/query-*
+cmd/tracegen/tracegen
+cmd/tracegen/tracegen-*
 cmd/docs/*.md
 cmd/docs/*.rst
 cmd/docs/*.1

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,10 @@ else
 	CGO_ENABLED=0 installsuffix=cgo go build -o ./examples/hotrod/hotrod-$(GOOS) ./examples/hotrod/main.go
 endif
 
+.PHONY: build-tracegen
+build-tracegen:
+	CGO_ENABLED=0 installsuffix=cgo go build -o ./cmd/tracegen/tracegen-$(GOOS) ./cmd/tracegen/main.go
+
 .PHONE: docker-hotrod
 docker-hotrod:
 	GOOS=linux $(MAKE) build-examples
@@ -277,7 +281,7 @@ build-binaries-s390x:
 	GOOS=linux GOARCH=s390x $(MAKE) build-platform-binaries
 
 .PHONY: build-platform-binaries
-build-platform-binaries: build-agent build-collector build-query build-ingester build-all-in-one build-examples
+build-platform-binaries: build-agent build-collector build-query build-ingester build-all-in-one build-examples build-tracegen
 
 .PHONY: build-all-platforms
 build-all-platforms: build-binaries-linux build-binaries-windows build-binaries-darwin build-binaries-s390x
@@ -300,8 +304,13 @@ docker-images-jaeger-backend:
 		echo "Finished building $$component ==============" ; \
 	done
 
+.PHONY: docker-images-tracegen
+docker-images-tracegen:
+	docker build -t $(DOCKER_NAMESPACE)/jaeger-tracegen:${DOCKER_TAG} cmd/tracegen/
+	@echo "Finished building jaeger-tracegen =============="
+
 .PHONY: docker-images-only
-docker-images-only: docker-images-cassandra docker-images-elastic docker-images-jaeger-backend
+docker-images-only: docker-images-cassandra docker-images-elastic docker-images-jaeger-backend docker-images-tracegen
 
 .PHONY: docker-push
 docker-push:
@@ -311,7 +320,7 @@ docker-push:
 	if [ $$CONFIRM != "y" ] && [ $$CONFIRM != "Y" ]; then \
 		echo "Exiting." ; exit 1 ; \
 	fi
-	for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester example-hotrod; do \
+	for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester example-hotrod tracegen; do \
 		docker push $(DOCKER_NAMESPACE)/jaeger-$$component ; \
 	done
 

--- a/cmd/tracegen/Dockerfile
+++ b/cmd/tracegen/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+COPY tracegen-linux /go/bin/
+ENTRYPOINT ["/go/bin/tracegen-linux"]

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -36,13 +36,20 @@ func main() {
 	flag.Parse()
 
 	metricsFactory := prometheus.New()
-	tracer, tCloser, err := jaegerConfig.Configuration{
+	traceCfg := &jaegerConfig.Configuration{
 		ServiceName: "tracegen",
 		Sampler: &jaegerConfig.SamplerConfig{
 			Type:  "const",
 			Param: 1,
 		},
-	}.NewTracer(
+		RPCMetrics: true,
+	}
+	traceCfg, err := traceCfg.FromEnv()
+	if err != nil {
+		logger.Fatal("failed to read tracer configuration", zap.Error(err))
+	}
+
+	tracer, tCloser, err := traceCfg.NewTracer(
 		jaegerConfig.Metrics(metricsFactory),
 		jaegerConfig.Logger(jaegerZap.NewLogger(logger)),
 	)

--- a/scripts/travis/upload-all-docker-images.sh
+++ b/scripts/travis/upload-all-docker-images.sh
@@ -20,7 +20,7 @@ else
 fi
 
 export DOCKER_NAMESPACE=jaegertracing
-for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester
+for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester tracegen
 do
   export REPO="jaegertracing/jaeger-${component}"
   bash ./scripts/travis/upload-to-docker.sh


### PR DESCRIPTION
## Which problem is this PR solving?
- I'm currently building an autoscaler for Jaeger in the Jaeger Operator. To test that, I could make use of a pod with the tracegen, and the first step is to get a container image built and published somewhere, addressed by this PR.

## Short description of the changes
- Added a build step for the trace gen, as well as a Dockerfile
- Changed the docker targets (build/push) to add tracegen
- Allows the tracegen utility to be configured from env