### PR TITLE
Allow raw port numbers for UDP servers

### DIFF
--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -144,7 +144,7 @@ func TestBuilderWithProcessorErrors(t *testing.T) {
 		_, err := cfg.CreateAgent(&fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
 		assert.Error(t, err)
 		if testCase.err != "" {
-			assert.EqualError(t, err, testCase.err)
+			assert.Contains(t, err.Error(), testCase.err)
 		} else if testCase.errContains != "" {
 			assert.True(t, strings.Contains(err.Error(), testCase.errContains), "error must contain %s", testCase.errContains)
 		}

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/viper"
 
@@ -67,16 +66,18 @@ func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
 		p.Workers = v.GetInt(prefix + suffixWorkers)
 		p.Server.QueueSize = v.GetInt(prefix + suffixServerQueueSize)
 		p.Server.MaxPacketSize = v.GetInt(prefix + suffixServerMaxPacketSize)
-		p.Server.HostPort = toHostPort(v.GetString(prefix + suffixServerHostPort))
+		p.Server.HostPort = portNumToHostPort(v.GetString(prefix + suffixServerHostPort))
 		b.Processors = append(b.Processors, *p)
 	}
 
-	b.HTTPServer.HostPort = toHostPort(v.GetString(httpServerHostPort))
+	b.HTTPServer.HostPort = portNumToHostPort(v.GetString(httpServerHostPort))
 	return b
 }
 
-func toHostPort(v string) string {
-	if !strings.Contains(v, ":") {
+// portNumToHostPort checks if the value is a raw integer port number,
+// and converts it to ":{port}" host-port string, otherwise leaves it as is.
+func portNumToHostPort(v string) string {
+	if _, err := strconv.Atoi(v); err == nil {
 		return ":" + v
 	}
 	return v

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -66,10 +67,17 @@ func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
 		p.Workers = v.GetInt(prefix + suffixWorkers)
 		p.Server.QueueSize = v.GetInt(prefix + suffixServerQueueSize)
 		p.Server.MaxPacketSize = v.GetInt(prefix + suffixServerMaxPacketSize)
-		p.Server.HostPort = v.GetString(prefix + suffixServerHostPort)
+		p.Server.HostPort = toHostPort(v.GetString(prefix + suffixServerHostPort))
 		b.Processors = append(b.Processors, *p)
 	}
 
-	b.HTTPServer.HostPort = v.GetString(httpServerHostPort)
+	b.HTTPServer.HostPort = toHostPort(v.GetString(httpServerHostPort))
 	return b
+}
+
+func toHostPort(v string) string {
+	if !strings.Contains(v, ":") {
+		return ":" + v
+	}
+	return v
 }


### PR DESCRIPTION
Currently flags like `--processor.jaeger-binary.server-host-port 5001` result in a failure. I think we can be more flexible since in most cases the host is not required, just the port.