### PR TITLE
Count received batches from conforming clients

### DIFF
--- a/cmd/agent/app/reporter/client_metrics.go
+++ b/cmd/agent/app/reporter/client_metrics.go
@@ -33,6 +33,7 @@ const (
 
 // clientMetrics are maintained only for data submitted in Jaeger Thrift format.
 type clientMetrics struct {
+	BatchesReceived  metrics.Counter `metric:"batches_received" help:"Total count of batches received from conforming clients"`
 	BatchesSent      metrics.Counter `metric:"batches_sent" help:"Total count of batches sent by clients"`
 	ConnectedClients metrics.Gauge   `metric:"connected_clients" help:"Total count of unique clients sending data to the agent"`
 
@@ -188,6 +189,8 @@ func (s *lastReceivedClientStats) update(
 ) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	metrics.BatchesReceived.Inc(1)
 
 	if s.batchSeqNo >= batchSeqNo {
 		// Ignore out of order batches. Once we receive a batch with a larger-than-seen number,

--- a/cmd/agent/app/reporter/client_metrics_test.go
+++ b/cmd/agent/app/reporter/client_metrics_test.go
@@ -112,6 +112,7 @@ func TestClientMetricsReporter_Jaeger(t *testing.T) {
 				runExpire: true,
 				// first batch cannot increment counters, only capture the baseline
 				expCounters: []metricstest.ExpectedMetric{
+					{Name: prefix + "batches_received", Value: 1},
 					{Name: prefix + "batches_sent", Value: 0},
 					{Name: prefix + "spans_dropped", Tags: tag("cause", "full-queue"), Value: 0},
 					{Name: prefix + "spans_dropped", Tags: tag("cause", "too-large"), Value: 0},
@@ -130,6 +131,7 @@ func TestClientMetricsReporter_Jaeger(t *testing.T) {
 					FailedToEmitSpans:     15,
 				},
 				expCounters: []metricstest.ExpectedMetric{
+					{Name: prefix + "batches_received", Value: 2},
 					{Name: prefix + "batches_sent", Value: 5},
 					{Name: prefix + "spans_dropped", Tags: tag("cause", "full-queue"), Value: 5},
 					{Name: prefix + "spans_dropped", Tags: tag("cause", "too-large"), Value: 5},
@@ -140,6 +142,7 @@ func TestClientMetricsReporter_Jaeger(t *testing.T) {
 				clientUUID: &clientUUID,
 				seqNo:      nPtr(90), // out of order batch will be ignored
 				expCounters: []metricstest.ExpectedMetric{
+					{Name: prefix + "batches_received", Value: 3},
 					{Name: prefix + "batches_sent", Value: 5}, // unchanged!
 				},
 			},
@@ -152,6 +155,7 @@ func TestClientMetricsReporter_Jaeger(t *testing.T) {
 					TooLargeDroppedSpans:  18,
 					FailedToEmitSpans:     19,
 				}, expCounters: []metricstest.ExpectedMetric{
+					{Name: prefix + "batches_received", Value: 4},
 					{Name: prefix + "batches_sent", Value: 10},
 					{Name: prefix + "spans_dropped", Tags: tag("cause", "full-queue"), Value: 7},
 					{Name: prefix + "spans_dropped", Tags: tag("cause", "too-large"), Value: 8},


### PR DESCRIPTION
## Which problem is this PR solving?
- The data loss metrics introduced in #2010 cannot be compared with the existing `batches.submitted` metrics unless all connected clients are emitting the new stats.

## Short description of the changes
- Emit a separate `client_stats.batches_received` counter that only counts batches from "conforming" clients (those that provide clientUUID and batchSeqNo). Then the difference between `client_stats.batches_sent` and `client_stats.batches_received` counters reflects the data loss due to UDP packet loss.
