### PR TITLE
Update codeowners to jaeger-maintainers team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 
-* @black-adder @jpkrohling @objectiser @pavolloffay @tiffon @vprithvi @yurishkuro 
-
+* @jaegertracing/jaeger-maintainers


### PR DESCRIPTION
Signed-off-by: Prithvi Raj <p.r@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

- Use group membership to determine CODEOWNERS instead of explicitly managing users
- This would allow us to use Github's code review [auto-assignment](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/managing-code-review-assignment-for-your-team).
