### PR TITLE
Add support for dynamically reloading sampling strategies

### DIFF
--- a/plugin/sampling/strategystore/static/fixtures/strategies-hot-reload.json
+++ b/plugin/sampling/strategystore/static/fixtures/strategies-hot-reload.json
@@ -1,0 +1,11 @@
+{
+  "default_strategy": {
+  },
+  "service_strategies": [
+    {
+      "service": "foo",
+      "type": "probabilistic",
+      "param": 0.5
+    }
+  ]
+}

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -44,11 +44,10 @@ type strategyStore struct {
 func (h *strategyStore) loadAndParseStrategies(strategiesFile string) error {
 	s, err := loadStrategies(strategiesFile)
 	if err != nil {
-		h.logger.Warn("Using the last saved configuration for sampling strategies.", zap.Error(err))
+		h.logger.Warn("using the last saved configuration for sampling strategies.", zap.Error(err))
 		return err
 	}
 
-	h.logger.Info("Updating sampling strategies file!", zap.Any("Strategies", s))
 	h.parseStrategies(s)
 	return nil
 }

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -125,6 +125,8 @@ func (h *strategyStore) parseStrategies(strategies *strategies) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
+	h.defaultStrategy = defaultStrategyResponse()
+
 	if strategies == nil {
 		h.logger.Info("No sampling strategies provided, using defaults")
 		return

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -72,8 +72,7 @@ func NewStrategyStore(options Options, logger *zap.Logger) (ss.StrategyStore, er
 
 	go h.runWatcherLoop(watcher, options.StrategiesFile)
 
-	err = watcher.Add(options.StrategiesFile)
-	if err != nil {
+	if err = watcher.Add(options.StrategiesFile); err != nil {
 		logger.Error("error adding watcher to file", zap.String("file", options.StrategiesFile), zap.Error(err))
 	} else {
 		logger.Info("watching", zap.String("file", options.StrategiesFile))

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -79,7 +79,6 @@ func NewStrategyStore(options Options, logger *zap.Logger) (ss.StrategyStore, er
 	}
 
 	dir := filepath.Dir(options.StrategiesFile)
-	err = watcher.Add(dir)
 	if err := watcher.Add(dir); err != nil {
 		h.logger.Error("error adding watcher to dir", zap.String("dir", dir), zap.Error(err))
 	} else {

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -73,7 +73,7 @@ func NewStrategyStore(options Options, logger *zap.Logger) (ss.StrategyStore, er
 
 	go h.runWatcherLoop(watcher, options.StrategiesFile)
 
-	if err = watcher.Add(options.StrategiesFile); err != nil {
+	if err := watcher.Add(options.StrategiesFile); err != nil {
 		logger.Error("error adding watcher to file", zap.String("file", options.StrategiesFile), zap.Error(err))
 	} else {
 		logger.Info("watching", zap.String("file", options.StrategiesFile))
@@ -81,7 +81,7 @@ func NewStrategyStore(options Options, logger *zap.Logger) (ss.StrategyStore, er
 
 	dir := filepath.Dir(options.StrategiesFile)
 	err = watcher.Add(dir)
-	if err != nil {
+	if err := watcher.Add(dir); err != nil {
 		h.logger.Error("error adding watcher to dir", zap.String("dir", dir), zap.Error(err))
 	} else {
 		h.logger.Info("watching", zap.String("dir", dir))
@@ -102,7 +102,7 @@ func (h *strategyStore) runWatcherLoop(watcher *fsnotify.Watcher, strategiesFile
 					// symlinked files within the containers, changes to the configmap register
 					// as `fsnotify.Remove` events.
 					if err := watcher.Add(strategiesFile); err != nil {
-						h.logger.Warn("Error adding sampling strategy config file to fsnotify watcher", zap.Error(err))
+						h.logger.Warn("cannot watch sampling strategy config file", zap.Error(err))
 					}
 
 					h.loadAndParseStrategies(strategiesFile)
@@ -116,7 +116,7 @@ func (h *strategyStore) runWatcherLoop(watcher *fsnotify.Watcher, strategiesFile
 			if !ok {
 				return
 			}
-			h.logger.Error("event", zap.Error(err))
+			h.logger.Error("file watcher error", zap.Error(err))
 		}
 	}
 }

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -72,8 +72,9 @@ func NewStrategyStore(options Options, logger *zap.Logger) (ss.StrategyStore, er
 				s, err := loadStrategies(options.StrategiesFile)
 				if err != nil {
 					logger.Warn("Error while parsing strategies file", zap.Error(err))
+				} else {
+					h.parseStrategies(s)
 				}
-				h.parseStrategies(s)
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					return

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -223,16 +221,21 @@ func TestParseStrategy(t *testing.T) {
 	assert.Contains(t, buf.String(), "Failed to parse sampling strategy")
 }
 
-func testHotReloadRunner(t *testing.T, tmpFileName, symlink string) {
-	var watchFileName string
-	if symlink == "" {
-		watchFileName = tmpFileName
-	} else {
-		watchFileName = symlink
-	}
+func TestHotReloadSamplingStrategiesTempFile(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("fixtures", "strategies-hot-reload.*.json")
+	assert.NoError(t, err)
+
+	tmpFileName := tmpfile.Name()
+	defer os.Remove(tmpFileName)
+
+	content, err := ioutil.ReadFile("fixtures/strategies-hot-reload.json")
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(tmpFileName, content, 0644)
+	assert.NoError(t, err)
 
 	logger, _ := testutils.NewLogger()
-	store, err := NewStrategyStore(Options{StrategiesFile: watchFileName}, logger)
+	store, err := NewStrategyStore(Options{StrategiesFile: tmpFileName}, logger)
 	assert.NoError(t, err)
 
 	s, err := store.GetSamplingStrategy("foo")
@@ -241,7 +244,6 @@ func testHotReloadRunner(t *testing.T, tmpFileName, symlink string) {
 
 	newContent, err := ioutil.ReadFile("fixtures/strategies.json")
 	assert.NoError(t, err)
-	// Even if its a symlink, write to tmp file
 	err = ioutil.WriteFile(tmpFileName, newContent, 0644)
 	assert.NoError(t, err)
 
@@ -265,49 +267,6 @@ func testHotReloadRunner(t *testing.T, tmpFileName, symlink string) {
 	case <-time.After(time.Second):
 		assert.Fail(t, "timed out waiting for the hot reload to kick in")
 	}
-}
-
-func TestHotReloadSamplingStrategiesTempFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("fixtures", "strategies-hot-reload.*.json")
-	assert.NoError(t, err)
-
-	tmpFileName := tmpfile.Name()
-	defer os.Remove(tmpFileName)
-
-	content, err := ioutil.ReadFile("fixtures/strategies-hot-reload.json")
-	assert.NoError(t, err)
-
-	err = ioutil.WriteFile(tmpFileName, content, 0644)
-	assert.NoError(t, err)
-
-	testHotReloadRunner(t, tmpFileName, "")
-}
-
-func TestHotReloadSamplingStrategiesTempFileWithSymlink(t *testing.T) {
-	// skip if not executed on Linux
-	if runtime.GOOS != "linux" {
-		t.Skipf("Skipping test as symlink replacements don't work on non-linux environment...")
-	}
-
-	tmpfile, err := ioutil.TempFile("fixtures", "strategies-hot-reload.*.json")
-	assert.NoError(t, err)
-
-	tmpFileName := tmpfile.Name()
-	defer os.Remove(tmpFileName)
-
-	content, err := ioutil.ReadFile("fixtures/strategies-hot-reload.json")
-	assert.NoError(t, err)
-
-	err = ioutil.WriteFile(tmpFileName, content, 0644)
-	assert.NoError(t, err)
-
-	// create symlink
-	symlink := filepath.Join("fixtures", "symlink")
-	err = os.Symlink(tmpFileName, symlink)
-	defer os.Remove(symlink)
-	assert.NoError(t, err)
-
-	testHotReloadRunner(t, tmpFileName, symlink)
 }
 
 func makeResponse(samplerType sampling.SamplingStrategyType, param float64) (resp sampling.SamplingStrategyResponse) {

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -243,6 +243,7 @@ func TestHotReloadSamplingStrategiesTempFile(t *testing.T) {
 	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.5), *s)
 
 	newContent, err := ioutil.ReadFile("fixtures/strategies.json")
+	assert.NoError(t, err)
 	err = ioutil.WriteFile(tmpFileName, newContent, 0644)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Add support for dynamically reloading sampling strategies, resolves #1058 

## Short description of the changes
- Create new viper instance to watch changes to the sampling strategies file
- Wrap the sampling strategy store in a `RWMutex` for concurrent access.
