### PR TITLE
Supress the warn on queue-size-memory not being set

### DIFF
--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -88,7 +88,7 @@ func NewSpanProcessor(
 
 	sp.background(1*time.Second, sp.updateGauges)
 
-	if sp.dynQueueSizeWarmup > 0 {
+	if sp.dynQueueSizeMemory > 0 {
 		sp.background(1*time.Minute, sp.updateQueueSize)
 	}
 
@@ -236,7 +236,6 @@ func (sp *spanProcessor) updateQueueSize() {
 	}
 
 	if sp.dynQueueSizeMemory == 0 {
-		sp.logger.Warn("The dynamic queue size warmup value is set, but not the amount of memory to use. Skipping.")
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- #2041

## Short description of the changes
- Removed the warn log message. In a previous iteration of the PR that incorporated that change, the queue size in memory had to be set together with the warmup, which isn't the case anymore. The warmup assumes a default value, meaning that it might always be set, requiring only the queue-size-memory to be set to activate the feature.
