### PR TITLE
Add before you push to the queue to prevent race condition on size

### DIFF
--- a/pkg/queue/bounded_queue.go
+++ b/pkg/queue/bounded_queue.go
@@ -105,12 +105,13 @@ func (q *BoundedQueue) Produce(item interface{}) bool {
 		return false
 	}
 
+	q.size.Add(1)
 	select {
 	case *q.items <- item:
-		q.size.Add(1)
 		return true
 	default:
 		// should not happen, as overflows should have been captured earlier
+		q.size.Sub(1)
 		if q.onDroppedItem != nil {
 			q.onDroppedItem(item)
 		}


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #2042 

## Short description of the changes
Adding to size before we put an item in the channel prevents `q.size.Sub(1)` hitting before the addition.  This prevents the uint from underflowing to max value.

This change fixed the issue described in #2042 in our environment.

cc @gouthamve