### PR TITLE
Warn about time adjustment in tags

### DIFF
--- a/model/adjuster/clockskew.go
+++ b/model/adjuster/clockskew.go
@@ -173,7 +173,13 @@ func (a *clockSkewAdjuster) calculateSkew(child *node, parent *node) time.Durati
 }
 
 func (a *clockSkewAdjuster) adjustTimestamps(n *node, skew clockSkew) {
+	if skew.delta == 0 {
+		return
+	}
+
 	n.span.StartTime = n.span.StartTime.Add(skew.delta)
+	n.span.Warnings = append(n.span.Warnings, fmt.Sprintf("This span's timestamps were adjusted by %v", skew.delta))
+
 	for i := range n.span.Logs {
 		n.span.Logs[i].Timestamp = n.span.Logs[i].Timestamp.Add(skew.delta)
 	}

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -175,8 +175,12 @@ func TestClockSkewAdjuster(t *testing.T) {
 				}
 				assert.Equal(t, err, testCase.err)
 			} else {
-				for _, span := range trace.Spans {
-					assert.Len(t, span.Warnings, 0, "no warnings in span %s", span.SpanID)
+				for i, span := range trace.Spans {
+					if testCase.trace[i].adjusted == testCase.trace[i].startTime {
+						assert.Len(t, span.Warnings, 0, "no warnings in span %s", span.SpanID)
+					} else {
+						assert.Len(t, span.Warnings, 1, "warning about adjutment added to span %s", span.SpanID)
+					}
 				}
 			}
 			for _, proto := range testCase.trace {


### PR DESCRIPTION
Time adjustment is confusing to many people, as you can see in #961.

This change adds a warning if we do any time adjustments, so that it's at least clear that adjustments happened.