### PR TITLE
Use memory size flag to activate dyn queue size feature

### DIFF
--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -125,7 +125,7 @@ func newSpanProcessor(spanWriter spanstore.Writer, opts ...Option) *spanProcesso
 	}
 
 	processSpanFuncs := []ProcessSpan{options.preSave, sp.saveSpan}
-	if options.dynQueueSizeWarmup > 0 {
+	if options.dynQueueSizeMemory > 0 {
 		// add to processSpanFuncs
 		options.logger.Info("Dynamically adjusting the queue size at runtime.",
 			zap.Uint("memory-mib", options.dynQueueSizeMemory/1024/1024),

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -353,7 +353,7 @@ func TestSpanProcessorCountSpan(t *testing.T) {
 	m := mb.Namespace(metrics.NSOptions{})
 
 	w := &fakeSpanWriter{}
-	p := NewSpanProcessor(w, Options.HostMetrics(m), Options.DynQueueSizeWarmup(1000)).(*spanProcessor)
+	p := NewSpanProcessor(w, Options.HostMetrics(m), Options.DynQueueSizeMemory(1000)).(*spanProcessor)
 	p.background(10*time.Millisecond, p.updateGauges)
 	defer p.Stop()
 


### PR DESCRIPTION
## Which problem is this PR solving?
- One more place was using the warmup flag to activate the dynamic queue size. This PR changes that to use the `dynQueueSizeMemory` value instead, as it's the only one explicitly set by users.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>