### PR TITLE
Update dependencies, pin grpc<1.27

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -144,11 +144,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7b5b445d4d7b8d18eb794783e7559e90d1f1fca4bf3c2f1c249f11b582e6f546"
+  digest = "1:9dd8a8123991fd0ea3e4673e5b40dd569c426bfef3da1d28d78d4f066c67623c"
   name = "github.com/dgryski/go-farm"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c2139c5d712b01d0410c2e51d4bdc588b4eb6ca3"
+  revision = "a6ae2369ad13dc757768086f0cb902728c7e03e5"
 
 [[projects]]
   digest = "1:1f0c7ab489b407a7f8f9ad16c25a504d28ab461517a971d341388a56156c1bd7"
@@ -247,7 +247,7 @@
   version = "v0.19.4"
 
 [[projects]]
-  digest = "1:30d5aa62d498626e8ebd8d7ff2a7933fbd9a68cd08ab46f49b6d695a8dca41f6"
+  digest = "1:aa5d44be3752218d2b58edad48bf744ebafaa15a3c978627c04810e4eb30879f"
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
@@ -259,16 +259,16 @@
     "security",
   ]
   pruneopts = "UT"
-  revision = "d1fdda849ebf3073a1ca42082639b9aec7e9b15c"
-  version = "v0.19.10"
+  revision = "d5a301537e5208a4b0c720f36ba75c0fa802c7df"
+  version = "v0.19.11"
 
 [[projects]]
-  digest = "1:a60f47e736cc96075451c3c3502274d86ec6d96588c03d1ab56142ccbb8a5364"
+  digest = "1:97899a475b12f80513ede1ea1806dc3bd91380e233d463aff8360a2ac1bfb3b4"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = "UT"
-  revision = "772572fd19ebcc983369e53bfaed4bde2077fe0c"
-  version = "v0.19.5"
+  revision = "dce82e4362c708e636da7feb0831bd29efb5cd97"
+  version = "v0.19.6"
 
 [[projects]]
   digest = "1:97d14436dd6f314edfd1cff0caae50342c5435718f0adfd7490db353342bfca4"
@@ -367,7 +367,7 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:022f1a397b8ea7d77f27038cb90134e1cfcf012a40bdee0e4fd491aba5ab9291"
+  digest = "1:868284bb42c57c28e7915b5f856a920e15226577d1b5c3430b266d13026a4d63"
   name = "github.com/golang/protobuf"
   packages = [
     "descriptor",
@@ -386,8 +386,8 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
-  version = "v1.3.2"
+  revision = "d23c5127dc24889085f8ccea5c9d560a57a879d8"
+  version = "v1.3.3"
 
 [[projects]]
   digest = "1:e4f5819333ac698d294fe04dbf640f84719658d5c7ce195b10060cc37292ce79"
@@ -406,15 +406,15 @@
   version = "v1.4.2"
 
 [[projects]]
-  digest = "1:cbec35fe4d5a4fba369a656a8cd65e244ea2c743007d8f6c1ccb132acf9d1296"
+  digest = "1:25ebe6496abb289ef977c081b2d49f56dd97c32db4ca083d37f95923909ced02"
   name = "github.com/gorilla/mux"
   packages = ["."]
   pruneopts = "UT"
-  revision = "00bdffe0f3c77e27d2cf6f5c70232a2d3e4d9c15"
-  version = "v1.7.3"
+  revision = "75dcda0896e109a2a22c9315bca3bb21b87b2ba5"
+  version = "v1.7.4"
 
 [[projects]]
-  digest = "1:8319645ec0e09631f62b33f8e6d141296b41fc74a908b21465746180d535f3af"
+  digest = "1:1ec6527c66147536e0049c9d9daf8572dded623318ee3b5856f2ed85f6adb0b6"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
@@ -423,16 +423,15 @@
     "logging/zap/ctxzap",
     "retry",
     "tags",
-    "tags/zap",
     "util/backoffutils",
     "util/metautils",
   ]
   pruneopts = "UT"
-  revision = "dd15ed025b6054e5253963e355991f3070d4e593"
-  version = "v1.1.0"
+  revision = "3c51f7f332123e8be5a157c0802a228ac85bf9db"
+  version = "v1.2.0"
 
 [[projects]]
-  digest = "1:5aa5b00f687d0113ca052d4adf0d1f569295aea4f267236b3f7dca9157a8e63e"
+  digest = "1:e4395555aac92f5e5921722ec20d22c6f697ff2a2eae00ffc109165c22b32471"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
     "codegenerator",
@@ -448,8 +447,8 @@
     "utilities",
   ]
   pruneopts = "T"
-  revision = "e16fcd495a18ea01dbc6f5b6ac2956a94e1981a2"
-  version = "v1.12.2"
+  revision = "4c2cec4158f65aebe0290d3bee883b13f7b07c6f"
+  version = "v1.13.0"
 
 [[projects]]
   branch = "master"
@@ -552,12 +551,12 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:15b5cc79aad436d47019f814fde81a10221c740dc8ddf769221a65097fb6c2e9"
+  digest = "1:7218fd69ff5436d016101bbc6183cdc289aa45ac37b48e78846318e4ef389bea"
   name = "github.com/kr/text"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
-  version = "v0.1.0"
+  revision = "702c74938df48b97370179f33ce2107bd7ff3b3e"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:5a0ef768465592efca0412f7e838cdc0826712f8447e70e6ccc52eb441e9ab13"
@@ -606,7 +605,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2afb6599629db1eb814d894f0572663c04b19ef23e8544afd50e8ad92f8d2bb0"
+  digest = "1:82d921efdd06e4b160af837eeae468c4d915dbdf71b1a010c9bd1af4a44c9c97"
   name = "github.com/mmcloughlin/avo"
   packages = [
     "attr",
@@ -624,7 +623,7 @@
     "x86",
   ]
   pruneopts = "UT"
-  revision = "f40d60217016153df218454045f92dd37ba6bcea"
+  revision = "fb157e1de836bf0660e167f46a54e50b9289f6b9"
 
 [[projects]]
   digest = "1:66b0a65aba488ca6c72f77132d5b8d7e2c5baf07d577dee64502b69a2c90c791"
@@ -752,7 +751,7 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:ec0ff4bd619a67065e34d6477711ed0117e335f99059a4c508e0fe21cfe7b304"
+  digest = "1:6421995dc4b0cae1fc87b615c1b7eb22e87a6746b5ac1f73221879bd2f1f4fc1"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -760,8 +759,8 @@
     "internal/util",
   ]
   pruneopts = "UT"
-  revision = "6d489fc7f1d9cd890a250f3ea3431b1744b9623f"
-  version = "v0.0.8"
+  revision = "584181f8e7015e8fbd319be9a5a9341d8f3d64df"
+  version = "v0.0.9"
 
 [[projects]]
   branch = "master"
@@ -969,7 +968,7 @@
   version = "v1.16.0"
 
 [[projects]]
-  digest = "1:f15085b9880b96dc2c043eb279a11f88d80d3e24e3ba8ccbf8391a9a7ed1ba0f"
+  digest = "1:3f2695e75ed6dfa1187df6baf40a81d8dd47589e6fbfc4ccb748bceb3af8836c"
   name = "go.mongodb.org/mongo-driver"
   packages = [
     "bson",
@@ -981,8 +980,8 @@
     "x/bsonx/bsoncore",
   ]
   pruneopts = "UT"
-  revision = "55b507b3e45a2ef5dc1d5a4cba3333c45dce443c"
-  version = "v1.2.1"
+  revision = "f002b1fa256d7987c03274bab1f4263dbdff0f64"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:c708d00d1097e62bf4f3a72f239efa7dafc257581421b0b7d3789e1ff5299f30"
@@ -1048,18 +1047,18 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "530e935923ad688be97c15eeb8e5ee42ebf2b54a"
+  revision = "1d94cc7ab1c630336ab82ccb9c9cda72a875c382"
 
 [[projects]]
   branch = "master"
-  digest = "1:334b27eac455cb6567ea28cd424230b07b1a64334a2f861a8075ac26ce10af43"
+  digest = "1:802fc3c45ff4507b6e4a5c0c5ea55836242aeac3b8eddfe31d5d80a3cac50731"
   name = "golang.org/x/lint"
   packages = [
     ".",
     "golint",
   ]
   pruneopts = "UT"
-  revision = "fdd1cda4f05fd1fd86124f0ef9ce31a0b72c8448"
+  revision = "910be7a94367618fd0fd25eaabbee4fdc0ac7092"
 
 [[projects]]
   branch = "master"
@@ -1083,18 +1082,18 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "6afb5195e5aab057fda82e27171243402346b0ad"
+  revision = "16171245cfb220d5317888b716d69c1fb4e7992b"
 
 [[projects]]
   branch = "master"
-  digest = "1:6b58066101dc93c55b168b0c9f09b15ae700e6199709dfadddfc091413c6497f"
+  digest = "1:cc2f66816d35b969d6c72e63fed6d1e01b4c4c7ab2cadf4cf68346869358670b"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "9fbb57f87de9ccfe3a99d4e3270ce8a926ebba4f"
+  revision = "12a6c2dcc1e4cb348b57847c73987099e261714b"
 
 [[projects]]
   digest = "1:66a2f252a58b4fbbad0e4e180e1d85a83c222b6bce09c3dcdef3dc87c72eda7c"
@@ -1124,7 +1123,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7eabee30173eaf67532a2027e3b4ef8a0efd09ed0de782270341f46afdce85a3"
+  digest = "1:bd04eb4504594ed84c98f0fec0d1b45a096e92c7f470495d9de4184977d399ed"
   name = "golang.org/x/tools"
   packages = [
     "go/analysis",
@@ -1143,7 +1142,7 @@
     "internal/packagesinternal",
   ]
   pruneopts = "UT"
-  revision = "d33eef8e6825f50394356b51ff2bbbe3d30e07e7"
+  revision = "b320d3a0f5a29dea7f95f1ca5c4cbef0ac24a304"
 
 [[projects]]
   branch = "master"
@@ -1154,7 +1153,7 @@
     "googleapis/rpc/status",
   ]
   pruneopts = "UT"
-  revision = "0452cf42e150a6aeb2c8615de02e260ae83d9873"
+  revision = "66ed5ce911ce4978d229e861f15b63d8bf359acb"
 
 [[projects]]
   digest = "1:b2c9ea388537a402c7f618e11eda34ec5358b67c3c6aef9df113c7022b46e0b1"
@@ -1215,12 +1214,12 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:c4b5592c342f273e18de68e16957f536f6648f2e90c9d7ece653ac90c22079a9"
+  digest = "1:ef4bd1cd2563d93d3f48352fc24d499a4a2b54c11932814173653ece7db13800"
   name = "gopkg.in/ini.v1"
   packages = ["."]
   pruneopts = "UT"
-  revision = "94291fffe2b14f4632ec0e67c1bfecfc1287a168"
-  version = "v1.51.1"
+  revision = "32cf4f7e9c77f151e18b53067b55549b4d1d411d"
+  version = "v1.52.0"
 
 [[projects]]
   digest = "1:c902038ee2d6f964d3b9f2c718126571410c5d81251cbab9fe58abd37803513c"
@@ -1239,7 +1238,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:1d0a2dd8403cd5ee29761aadd7fd941be7dcf31e4ba77eeb923ac1d2b49611b6"
+  digest = "1:911d78367f4e572fbf4eaaebc6d5d4a65e4194f950aa1634420f9964d9b4c171"
   name = "gopkg.in/jcmturner/gokrb5.v7"
   packages = [
     "asn1tools",
@@ -1274,8 +1273,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "8a3a3d700460d6dee4e98b6c06bf26296d2fd2c8"
-  version = "v7.4.0"
+  revision = "0b0d9d762bbc834e1e14f3f39dcea984364e9d63"
+  version = "v7.5.0"
 
 [[projects]]
   digest = "1:0f16d9c577198e3b8d3209f5a89aabe679525b2aba2a7548714e973035c0e232"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -121,7 +121,7 @@ required = [
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "^1.20.1"
+  version = ">=1.20.1, <1.27"
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"


### PR DESCRIPTION
* Pin grpc to <1.27 (as a companion to #2018), to protect against breaking changes (https://github.com/grpc/grpc-go/pull/3309) to the `balancer` pkg which is considered "experimental"
* Run `dep ensure --update`

NB: I am checking when our internal monorepo is going to upgrade grpc version so that we can remove the pin.
