### PR TITLE
Add service as a command line option

### DIFF
--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	metricsFactory := prometheus.New()
 	traceCfg := &jaegerConfig.Configuration{
-		ServiceName: "tracegen",
+		ServiceName: cfg.Service,
 		Sampler: &jaegerConfig.SamplerConfig{
 			Type:  "const",
 			Param: 1,

--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Firehose bool
 	Pause    time.Duration
 	Duration time.Duration
+	Service  string
 }
 
 // Flags registers config flags.
@@ -44,6 +45,7 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.Firehose, "firehose", false, "Whether to set FIREHOSE flag on the spans to skip indexing")
 	fs.DurationVar(&c.Pause, "pause", time.Microsecond, "How long to pause before finishing trace")
 	fs.DurationVar(&c.Duration, "duration", 0, "For how long to run the test")
+	fs.StringVar(&c.Service, "service", "tracegen", "Service name to use")
 }
 
 // Run executes the test scenario.


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- This PR adds a command line option to tracegen for service name.  This will help support some more complex test scenarios.

## Short description of the changes
- "-service" has been added as a command line flag

