### PR TITLE
Do not skip service/operation indexing for firehose spans + a couple fixes

### DIFF
--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -3,7 +3,7 @@
 # This script is used in the Docker image jaegertracing/jaeger-cassandra-schema
 # that allows installing Jaeger keyspace and schema without installing cqlsh.
 
-CQLSH=${CQLSH:-"/usr/bin/cqlsh"}
+CQLSH=${CQLSH:-"cqlsh"}
 CQLSH_HOST=${CQLSH_HOST:-"cassandra"}
 CQLSH_SSL=${CQLSH_SSL:-""}
 CASSANDRA_WAIT_TIMEOUT=${CASSANDRA_WAIT_TIMEOUT:-"60"}

--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -3,7 +3,7 @@
 # This script is used in the Docker image jaegertracing/jaeger-cassandra-schema
 # that allows installing Jaeger keyspace and schema without installing cqlsh.
 
-CQLSH=${CQLSH:-"cqlsh"}
+CQLSH=${CQLSH:-"/opt/cassandra/bin/cqlsh"}
 CQLSH_HOST=${CQLSH_HOST:-"cassandra"}
 CQLSH_SSL=${CQLSH_SSL:-""}
 CASSANDRA_WAIT_TIMEOUT=${CASSANDRA_WAIT_TIMEOUT:-"60"}

--- a/scripts/travis/cassandra-integration-test.sh
+++ b/scripts/travis/cassandra-integration-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # Clean up before starting.
 docker rm -f cassandra || true


### PR DESCRIPTION
## Which problem is this PR solving?
The transitive dep graphs view uses service & operation index to populate the dropdown. However, when traces are stored in the firehose mode, they are excluded from indexing (to reduce the load on storage), including the service/operation tables, which are actually very inexpensive to write because writes only happen once per 12hr period due to a cache in front of them.

## Short description of the changes
Allow service/operation tables to be written even in firehose mode.
