### PR TITLE
Close the span writer on main

### DIFF
--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -16,7 +16,6 @@ package app
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"time"
 
@@ -176,16 +175,6 @@ func (c *Collector) Close() error {
 
 	if err := c.spanProcessor.Close(); err != nil {
 		c.logger.Error("failed to close span processor.", zap.Error(err))
-	}
-
-	// the span processor is closed
-	if c.spanWriter != nil {
-		if closer, ok := c.spanWriter.(io.Closer); ok {
-			err := closer.Close() // SpanWriter
-			if err != nil {
-				c.logger.Error("failed to close span writer", zap.Error(err))
-			}
-		}
 	}
 
 	return nil

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -95,6 +96,12 @@ func main() {
 			c.Start(collectorOpts)
 
 			svc.RunAndThen(func() {
+				if closer, ok := spanWriter.(io.Closer); ok {
+					err := closer.Close()
+					if err != nil {
+						logger.Error("failed to close span writer", zap.Error(err))
+					}
+				}
 				c.Close()
 			})
 			return nil


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Fixes #2094 

## Short description of the changes
- Previously, the span writer was being closed twice when the all-in-one was being used: once from the all-in-one main, and one from the collector's `#Close`. This PR makes the party that creates the span writer responsible for closing it.
