### PR TITLE
Return appropriate gRPC errors/codes to indicate request status

### DIFF
--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -133,7 +133,7 @@ func (g *GRPCHandler) GetServices(ctx context.Context, r *api_v2.GetServicesRequ
 	return &api_v2.GetServicesResponse{Services: services}, nil
 }
 
-// GetOperations is the GRPC handler to fetch operations.
+// GetOperations is the gRPC handler to fetch operations.
 func (g *GRPCHandler) GetOperations(
 	ctx context.Context,
 	r *api_v2.GetOperationsRequest,
@@ -161,7 +161,7 @@ func (g *GRPCHandler) GetOperations(
 	}, nil
 }
 
-// GetDependencies is the GRPC handler to fetch dependencies.
+// GetDependencies is the gRPC handler to fetch dependencies.
 func (g *GRPCHandler) GetDependencies(ctx context.Context, r *api_v2.GetDependenciesRequest) (*api_v2.GetDependenciesResponse, error) {
 	startTime := r.StartTime
 	endTime := r.EndTime

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -256,10 +256,8 @@ func TestGetTraceNotFoundGRPC(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		spanResChunk, err := res.Recv()
-
-		assert.Errorf(t, err, spanstore.ErrTraceNotFound.Error())
+		assertGRPCError(t, err, codes.NotFound, "trace not found")
 		assert.Nil(t, spanResChunk)
-
 	})
 }
 
@@ -289,8 +287,7 @@ func TestArchiveTraceNotFoundGRPC(t *testing.T) {
 			TraceID: mockTraceIDgrpc,
 		})
 
-		assert.Errorf(t, err, spanstore.ErrTraceNotFound.Error())
-
+		assertGRPCError(t, err, codes.NotFound, "trace not found")
 	})
 }
 

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -41,10 +41,9 @@ import (
 )
 
 var (
-	errStorageGRPC = errors.New("Storage error")
+	errStorageGRPC = errors.New("storage error")
 
-	mockTraceIDgrpc = model.NewTraceID(0, 123456)
-	mockTraceGRPC   = &model.Trace{
+	mockTraceGRPC = &model.Trace{
 		Spans: []*model.Span{
 			{
 				TraceID: mockTraceID,
@@ -206,7 +205,7 @@ func TestGetTraceSuccessGRPC(t *testing.T) {
 			Return(mockTrace, nil).Once()
 
 		res, err := client.GetTrace(context.Background(), &api_v2.GetTraceRequest{
-			TraceID: mockTraceIDgrpc,
+			TraceID: mockTraceID,
 		})
 
 		spanResChunk, _ := res.Recv()
@@ -231,7 +230,7 @@ func TestGetTraceDBFailureGRPC(t *testing.T) {
 			Return(nil, errStorageGRPC).Once()
 
 		res, err := client.GetTrace(context.Background(), &api_v2.GetTraceRequest{
-			TraceID: mockTraceIDgrpc,
+			TraceID: mockTraceID,
 		})
 		assert.NoError(t, err)
 
@@ -252,7 +251,7 @@ func TestGetTraceNotFoundGRPC(t *testing.T) {
 			Return(nil, spanstore.ErrTraceNotFound).Once()
 
 		res, err := client.GetTrace(context.Background(), &api_v2.GetTraceRequest{
-			TraceID: mockTraceIDgrpc,
+			TraceID: mockTraceID,
 		})
 		assert.NoError(t, err)
 		spanResChunk, err := res.Recv()
@@ -269,7 +268,7 @@ func TestArchiveTraceSuccessGRPC(t *testing.T) {
 			Return(nil).Times(2)
 
 		_, err := client.ArchiveTrace(context.Background(), &api_v2.ArchiveTraceRequest{
-			TraceID: mockTraceIDgrpc,
+			TraceID: mockTraceID,
 		})
 
 		assert.NoError(t, err)
@@ -284,7 +283,7 @@ func TestArchiveTraceNotFoundGRPC(t *testing.T) {
 			Return(nil, spanstore.ErrTraceNotFound).Once()
 
 		_, err := client.ArchiveTrace(context.Background(), &api_v2.ArchiveTraceRequest{
-			TraceID: mockTraceIDgrpc,
+			TraceID: mockTraceID,
 		})
 
 		assertGRPCError(t, err, codes.NotFound, "trace not found")
@@ -300,7 +299,7 @@ func TestArchiveTraceFailureGRPC(t *testing.T) {
 			Return(errStorageGRPC).Times(2)
 
 		_, err := client.ArchiveTrace(context.Background(), &api_v2.ArchiveTraceRequest{
-			TraceID: mockTraceIDgrpc,
+			TraceID: mockTraceID,
 		})
 
 		assertGRPCError(t, err, codes.Internal, "failed to archive trace")

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867
-	golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d
+	golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d // indirect
 	google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/ini.v1 v1.52.0 // indirect


### PR DESCRIPTION
## Which problem is this PR solving?
- When using HTTP query API, we get a clear 404 when trace is not found. But gRPC API always returns Unknown gRPC code.

## Short description of the changes
- Return appropriate gRPC errors and codes.
