### PR TITLE
Add support for ES index aliases / rollover to the dependency store (Resolves #2143)

### DIFF
--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -49,7 +49,7 @@ func (i *IndexFilter) filter(indices []client.Index) []client.Index {
 		// archive works only for rollover
 		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-span-archive-\\d{6}", i.IndexPrefix))
 	} else if i.Rollover {
-		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service)-\\d{6}", i.IndexPrefix))
+		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies)-\\d{6}", i.IndexPrefix))
 	} else {
 		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies)-\\d{4}%s\\d{2}%s\\d{2}", i.IndexPrefix, i.IndexDateSeparator, i.IndexDateSeparator))
 	}
@@ -58,7 +58,10 @@ func (i *IndexFilter) filter(indices []client.Index) []client.Index {
 	for _, in := range indices {
 		if reg.MatchString(in.Index) {
 			// index in write alias cannot be removed
-			if in.Aliases[i.IndexPrefix+"jaeger-span-write"] || in.Aliases[i.IndexPrefix+"jaeger-service-write"] || in.Aliases[i.IndexPrefix+"jaeger-span-archive-write"] {
+			if in.Aliases[i.IndexPrefix+"jaeger-span-write"] ||
+				in.Aliases[i.IndexPrefix+"jaeger-service-write"] ||
+				in.Aliases[i.IndexPrefix+"jaeger-span-archive-write"] ||
+				in.Aliases[i.IndexPrefix+"jaeger-dependencies-write"] {
 				continue
 			}
 			filtered = append(filtered, in)

--- a/cmd/es-rollover/app/index_options.go
+++ b/cmd/es-rollover/app/index_options.go
@@ -52,6 +52,11 @@ func RolloverIndices(archive bool, prefix string) []IndexOption {
 			Mapping:   "jaeger-service",
 			indexType: "jaeger-service",
 		},
+		{
+			prefix:    prefix,
+			Mapping:   "jaeger-dependencies",
+			indexType: "jaeger-dependencies",
+		},
 	}
 }
 

--- a/cmd/es-rollover/app/index_options_test.go
+++ b/cmd/es-rollover/app/index_options_test.go
@@ -52,6 +52,13 @@ func TestRolloverIndices(t *testing.T) {
 					writeAliasName:       "jaeger-service-write",
 					initialRolloverIndex: "jaeger-service-000001",
 				},
+				{
+					templateName:         "jaeger-dependencies",
+					mapping:              "jaeger-dependencies",
+					readAliasName:        "jaeger-dependencies-read",
+					writeAliasName:       "jaeger-dependencies-write",
+					initialRolloverIndex: "jaeger-dependencies-000001",
+				},
 			},
 		},
 		{
@@ -98,6 +105,13 @@ func TestRolloverIndices(t *testing.T) {
 					readAliasName:        "mytenant-jaeger-service-read",
 					writeAliasName:       "mytenant-jaeger-service-write",
 					initialRolloverIndex: "mytenant-jaeger-service-000001",
+				},
+				{
+					mapping:              "jaeger-dependencies",
+					templateName:         "mytenant-jaeger-dependencies",
+					readAliasName:        "mytenant-jaeger-dependencies-read",
+					writeAliasName:       "mytenant-jaeger-dependencies-write",
+					initialRolloverIndex: "mytenant-jaeger-dependencies-000001",
 				},
 			},
 		},

--- a/cmd/esmapping-generator/app/renderer/render.go
+++ b/cmd/esmapping-generator/app/renderer/render.go
@@ -23,8 +23,9 @@ import (
 )
 
 var supportedMappings = map[string]struct{}{
-	"jaeger-span":    {},
-	"jaeger-service": {},
+	"jaeger-span":         {},
+	"jaeger-service":      {},
+	"jaeger-dependencies": {},
 }
 
 // GetMappingAsString returns rendered index templates as string

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -109,9 +109,7 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 
 // CreateDependencyReader implements storage.Factory
 func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
-	reader := esDepStore.NewDependencyStore(f.primaryClient, f.logger, f.primaryConfig.GetIndexPrefix(),
-		f.primaryConfig.GetIndexDateLayoutDependencies(), f.primaryConfig.GetMaxDocCount())
-	return reader, nil
+	return createDependencyReader(f.logger, f.primaryClient, f.primaryConfig)
 }
 
 // CreateArchiveSpanReader implements storage.ArchiveFactory
@@ -208,6 +206,22 @@ func createSpanWriter(
 		}
 	}
 	return writer, nil
+}
+
+func createDependencyReader(
+	logger *zap.Logger,
+	client es.Client,
+	cfg config.ClientBuilder,
+) (dependencystore.Reader, error) {
+
+	reader := esDepStore.NewDependencyStore(esDepStore.DependencyStoreParams{
+		Client:              client,
+		Logger:              logger,
+		IndexPrefix:         cfg.GetIndexPrefix(),
+		MaxDocCount:         cfg.GetMaxDocCount(),
+		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
+	})
+	return reader, nil
 }
 
 var _ io.Closer = (*Factory)(nil)

--- a/plugin/storage/es/mappings/fixtures/jaeger-dependencies-7.json
+++ b/plugin/storage/es/mappings/fixtures/jaeger-dependencies-7.json
@@ -1,10 +1,17 @@
 {
   "index_patterns": "*jaeger-dependencies-*",
+  "aliases": {
+    "test-jaeger-dependencies-read" : {}
+  },
   "settings":{
     "index.number_of_shards": 3,
     "index.number_of_replicas": 3,
     "index.mapping.nested_fields.limit":50,
     "index.requests.cache.enable":true
+    ,"lifecycle": {
+        "name": "jaeger-test-policy",
+        "rollover_alias": "test-jaeger-dependencies-write"
+    }
   },
   "mappings":{}
 }

--- a/plugin/storage/es/mappings/jaeger-dependencies-7.json
+++ b/plugin/storage/es/mappings/jaeger-dependencies-7.json
@@ -1,10 +1,21 @@
 {
   "index_patterns": "*jaeger-dependencies-*",
+  {{- if .UseILM }}
+  "aliases": {
+    "{{ .IndexPrefix }}jaeger-dependencies-read" : {}
+  },
+  {{- end }}
   "settings":{
     "index.number_of_shards": {{ .Shards }},
     "index.number_of_replicas": {{ .Replicas }},
     "index.mapping.nested_fields.limit":50,
     "index.requests.cache.enable":true
+  {{- if .UseILM }}
+    ,"lifecycle": {
+        "name": "{{ .ILMPolicyName }}",
+        "rollover_alias": "{{ .IndexPrefix }}jaeger-dependencies-write"
+    }
+  {{- end }}
   },
   "mappings":{}
 }

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -152,7 +152,14 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		Archive:           archive,
 		MaxDocCount:       defaultMaxDocCount,
 	})
-	dependencyStore := dependencystore.NewDependencyStore(client, s.logger, indexPrefix, indexDateLayout, defaultMaxDocCount)
+	dependencyStore := dependencystore.NewDependencyStore(dependencystore.DependencyStoreParams{
+		Client:          client,
+		Logger:          s.logger,
+		IndexPrefix:     indexPrefix,
+		IndexDateLayout: indexDateLayout,
+		MaxDocCount:     defaultMaxDocCount,
+	})
+
 	depMapping, err := mappingBuilder.GetDependenciesMappings()
 	if err != nil {
 		return err

--- a/plugin/storage/integration/es_index_cleaner_test.go
+++ b/plugin/storage/integration/es_index_cleaner_test.go
@@ -91,7 +91,7 @@ func TestIndexCleaner(t *testing.T) {
 			envVars: []string{},
 			expectedIndices: []string{
 				archiveIndexName,
-				"jaeger-span-000001", "jaeger-service-000001", "jaeger-span-000002", "jaeger-service-000002",
+				"jaeger-span-000001", "jaeger-service-000001", "jaeger-dependencies-000001", "jaeger-span-000002", "jaeger-service-000002", "jaeger-dependencies-000002",
 				"jaeger-span-archive-000001", "jaeger-span-archive-000002",
 			},
 		},
@@ -100,7 +100,7 @@ func TestIndexCleaner(t *testing.T) {
 			envVars: []string{"ROLLOVER=true"},
 			expectedIndices: []string{
 				archiveIndexName, spanIndexName, serviceIndexName, dependenciesIndexName,
-				"jaeger-span-000002", "jaeger-service-000002",
+				"jaeger-span-000002", "jaeger-service-000002", "jaeger-dependencies-000002",
 				"jaeger-span-archive-000001", "jaeger-span-archive-000002",
 			},
 		},
@@ -109,7 +109,7 @@ func TestIndexCleaner(t *testing.T) {
 			envVars: []string{"ARCHIVE=true"},
 			expectedIndices: []string{
 				archiveIndexName, spanIndexName, serviceIndexName, dependenciesIndexName,
-				"jaeger-span-000001", "jaeger-service-000001", "jaeger-span-000002", "jaeger-service-000002",
+				"jaeger-span-000001", "jaeger-service-000001", "jaeger-dependencies-000001", "jaeger-span-000002", "jaeger-service-000002", "jaeger-dependencies-000002",
 				"jaeger-span-archive-000002",
 			},
 		},

--- a/plugin/storage/integration/es_index_rollover_test.go
+++ b/plugin/storage/integration/es_index_rollover_test.go
@@ -90,7 +90,7 @@ func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 		assert.Empty(t, indices)
 
 	} else {
-		expectedIndices := []string{"jaeger-span-000001", "jaeger-service-000001"}
+		expectedIndices := []string{"jaeger-span-000001", "jaeger-service-000001", "jaeger-dependencies-000001"}
 		t.Run(fmt.Sprintf("NoPrefix"), func(t *testing.T) {
 			runIndexRolloverWithILMTest(t, client, "", expectedIndices, envVars, ilmPolicyName)
 		})
@@ -101,7 +101,7 @@ func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 }
 
 func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, prefix string, expectedIndices, envVars []string, ilmPolicyName string) {
-	writeAliases := []string{"jaeger-service-write", "jaeger-span-write"}
+	writeAliases := []string{"jaeger-service-write", "jaeger-span-write", "jaeger-dependencies-write"}
 
 	// make sure ES is cleaned before test
 	cleanES(t, client, ilmPolicyName)


### PR DESCRIPTION
## Which problem is this PR solving?
Currently the dependency store has no support for index aliases / rollover indices.
Resolves https://github.com/jaegertracing/jaeger/issues/2143#

## Short description of the changes
Use the already existing and used config variable `UseReadWriteAliases` to switch between the current behavior and using non-dated "-read" and "-write" index names. This aligns with the behavior that is already in place for spans and services.
