### PR TITLE
Do not keep old key versions on disk in Badger

### DIFF
--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -91,6 +91,8 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 
 	opts := badger.DefaultOptions
 	opts.TableLoadingMode = options.MemoryMap
+	// This is important. Without this Badger would keep atleast 1 version of very key.
+	opts.NumVersionsToKeep = 0
 
 	if f.Options.primary.Ephemeral {
 		opts.SyncWrites = false


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #1916

## Short description of the changes
set NumVersionsToKeep to 0 instead of default 1 acording to https://github.com/dgraph-io/badger/issues/1228

