### PR TITLE
Add Dockerfile for OTEL collector and publish latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ else
 endif
 
 .PHONY: build-otel-collector
-build-otel-collector:
+build-otel-collector: elasticsearch-mappings
 ifeq ($(GOARCH), s390x)
 	cd ${OTEL_COLLECTOR_DIR} && $(GOBUILD) -o ./opentelemetry-collector-$(GOOS)-$(GOARCH) $(BUILD_INFO) main.go
 else
@@ -310,7 +310,7 @@ docker-images-elastic:
 
 .PHONY: docker-images-jaeger-backend
 docker-images-jaeger-backend:
-	for component in agent collector query ingester ; do \
+	for component in agent collector query ingester opentelemetry-collector ; do \
 		docker build -t $(DOCKER_NAMESPACE)/jaeger-$$component:${DOCKER_TAG} cmd/$$component ; \
 		echo "Finished building $$component ==============" ; \
 	done

--- a/cmd/opentelemetry-collector/Dockerfile
+++ b/cmd/opentelemetry-collector/Dockerfile
@@ -6,4 +6,3 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 
 COPY opentelemetry-collector-linux /go/bin/
 ENTRYPOINT ["/go/bin/opentelemetry-collector-linux"]
-

--- a/cmd/opentelemetry-collector/Dockerfile
+++ b/cmd/opentelemetry-collector/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest as certs
-RUN apk --update add ca-certificates
+RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/cmd/opentelemetry-collector/Dockerfile
+++ b/cmd/opentelemetry-collector/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
+FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+COPY opentelemetry-collector-linux /go/bin/
+ENTRYPOINT ["/go/bin/opentelemetry-collector-linux"]
+

--- a/scripts/travis/upload-all-docker-images.sh
+++ b/scripts/travis/upload-all-docker-images.sh
@@ -20,7 +20,7 @@ else
 fi
 
 export DOCKER_NAMESPACE=jaegertracing
-for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester tracegen
+for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester tracegen opentelemetry-collector
 do
   export REPO="jaegertracing/jaeger-${component}"
   bash ./scripts/travis/upload-to-docker.sh

--- a/scripts/travis/upload-to-docker.sh
+++ b/scripts/travis/upload-to-docker.sh
@@ -34,8 +34,13 @@ fi
 # Do not enable echo before the `docker login` command to avoid revealing the password.
 set -x
 docker login -u $DOCKER_USER -p $DOCKER_PASS
-# push all tags, therefore push to repo
-docker push $REPO
+if [[ "${REPO}" == "jaegertracing/jaeger-opentelemetry-collector" ]]; then
+  # TODO remove once Jaeger OTEL collector is stable
+  docker push $REPO:latest
+else
+  # push all tags, therefore push to repo
+  docker push $REPO
+fi
 
 SNAPSHOT_IMAGE="$REPO-snapshot:$TRAVIS_COMMIT"
 echo "Pushing snapshot image $SNAPSHOT_IMAGE"


### PR DESCRIPTION
The container name for OTEL collector is `jaegertracing/jaeger-opentelemetry-collector`.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>
