### PR TITLE
Add zipkin receiver to OTEL collector

### DIFF
--- a/cmd/opentelemetry-collector/app/defaults/default_config.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config.go
@@ -28,10 +28,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
-)
-
-const (
-	disabledZipkinHostPort = ":0"
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 // Config creates default configuration.
@@ -96,7 +93,7 @@ func createReceivers(zipkinHostPort string, factories config.Factories) configmo
 	recvs := map[string]configmodels.Receiver{
 		"jaeger": jaeger,
 	}
-	if zipkinHostPort != disabledZipkinHostPort {
+	if zipkinHostPort != ports.PortToHostPort(0) {
 		zipkin := factories.Receivers["zipkin"].CreateDefaultConfig().(*zipkinreceiver.Config)
 		zipkin.Endpoint = zipkinHostPort
 		recvs["zipkin"] = zipkin

--- a/cmd/opentelemetry-collector/app/defaults/default_config.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/processor/batchprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
@@ -31,25 +32,30 @@ import (
 
 // Config creates default configuration.
 // It enables default Jaeger receivers, processors and exporters.
-func Config(storageType string, factories config.Factories) (*configmodels.Config, error) {
+func Config(storageType string, zipkinPort string, factories config.Factories) (*configmodels.Config, error) {
 	exporters, err := createExporters(storageType, factories)
 	if err != nil {
 		return nil, err
 	}
-	types := []string{}
+	expTypes := []string{}
 	for _, v := range exporters {
-		types = append(types, v.Type())
+		expTypes = append(expTypes, v.Type())
+	}
+	receivers := createReceivers(zipkinPort, factories)
+	recTypes := []string{}
+	for _, v := range receivers {
+		recTypes = append(recTypes, v.Type())
 	}
 	return &configmodels.Config{
-		Receivers:  createReceivers(factories),
+		Receivers:  receivers,
 		Exporters:  exporters,
 		Processors: createProcessors(factories),
 		Service: configmodels.Service{
 			Pipelines: map[string]*configmodels.Pipeline{
 				"traces": {
 					InputType:  configmodels.TracesDataType,
-					Receivers:  []string{"jaeger"},
-					Exporters:  types,
+					Receivers:  recTypes,
+					Exporters:  expTypes,
 					Processors: []string{"batch"},
 				},
 			},
@@ -57,11 +63,11 @@ func Config(storageType string, factories config.Factories) (*configmodels.Confi
 	}, nil
 }
 
-func createReceivers(factories config.Factories) configmodels.Receivers {
-	rec := factories.Receivers["jaeger"].CreateDefaultConfig().(*jaegerreceiver.Config)
+func createReceivers(zipkinPort string, factories config.Factories) configmodels.Receivers {
+	jaeger := factories.Receivers["jaeger"].CreateDefaultConfig().(*jaegerreceiver.Config)
 	// TODO load and serve sampling strategies
 	// TODO bind sampling strategies file
-	rec.Protocols = map[string]*receiver.SecureReceiverSettings{
+	jaeger.Protocols = map[string]*receiver.SecureReceiverSettings{
 		"grpc": {
 			ReceiverSettings: configmodels.ReceiverSettings{
 				Endpoint: "localhost:14250",
@@ -83,9 +89,15 @@ func createReceivers(factories config.Factories) configmodels.Receivers {
 			},
 		},
 	}
-	return map[string]configmodels.Receiver{
-		"jaeger": rec,
+	recvs := map[string]configmodels.Receiver{
+		"jaeger": jaeger,
 	}
+	if zipkinPort != ":0" {
+		zipkin := factories.Receivers["zipkin"].CreateDefaultConfig().(*zipkinreceiver.Config)
+		zipkin.Endpoint = zipkinPort
+		recvs["zipkin"] = zipkin
+	}
+	return recvs
 }
 
 func createExporters(storageTypes string, factories config.Factories) (configmodels.Exporters, error) {

--- a/cmd/opentelemetry-collector/app/defaults/default_config.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config.go
@@ -30,9 +30,13 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
 )
 
+const (
+	disabledZipkinHostPort = ":0"
+)
+
 // Config creates default configuration.
 // It enables default Jaeger receivers, processors and exporters.
-func Config(storageType string, zipkinPort string, factories config.Factories) (*configmodels.Config, error) {
+func Config(storageType string, zipkinHostPort string, factories config.Factories) (*configmodels.Config, error) {
 	exporters, err := createExporters(storageType, factories)
 	if err != nil {
 		return nil, err
@@ -41,7 +45,7 @@ func Config(storageType string, zipkinPort string, factories config.Factories) (
 	for _, v := range exporters {
 		expTypes = append(expTypes, v.Type())
 	}
-	receivers := createReceivers(zipkinPort, factories)
+	receivers := createReceivers(zipkinHostPort, factories)
 	recTypes := []string{}
 	for _, v := range receivers {
 		recTypes = append(recTypes, v.Type())
@@ -63,7 +67,7 @@ func Config(storageType string, zipkinPort string, factories config.Factories) (
 	}, nil
 }
 
-func createReceivers(zipkinPort string, factories config.Factories) configmodels.Receivers {
+func createReceivers(zipkinHostPort string, factories config.Factories) configmodels.Receivers {
 	jaeger := factories.Receivers["jaeger"].CreateDefaultConfig().(*jaegerreceiver.Config)
 	// TODO load and serve sampling strategies
 	// TODO bind sampling strategies file
@@ -92,9 +96,9 @@ func createReceivers(zipkinPort string, factories config.Factories) configmodels
 	recvs := map[string]configmodels.Receiver{
 		"jaeger": jaeger,
 	}
-	if zipkinPort != ":0" {
+	if zipkinHostPort != disabledZipkinHostPort {
 		zipkin := factories.Receivers["zipkin"].CreateDefaultConfig().(*zipkinreceiver.Config)
-		zipkin.Endpoint = zipkinPort
+		zipkin.Endpoint = zipkinHostPort
 		recvs["zipkin"] = zipkin
 	}
 	return recvs

--- a/cmd/opentelemetry-collector/app/defaults/default_config_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config_test.go
@@ -28,10 +28,12 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 func TestDefaultConfig(t *testing.T) {
 	factories := Components(viper.New())
+	disabledHostPort := ports.PortToHostPort(0)
 	tests := []struct {
 		storageType    string
 		zipkinHostPort string
@@ -41,7 +43,7 @@ func TestDefaultConfig(t *testing.T) {
 	}{
 		{
 			storageType:    "elasticsearch",
-			zipkinHostPort: disabledZipkinHostPort,
+			zipkinHostPort: disabledHostPort,
 			exporterTypes:  []string{elasticsearch.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
@@ -54,7 +56,7 @@ func TestDefaultConfig(t *testing.T) {
 		},
 		{
 			storageType:    "cassandra",
-			zipkinHostPort: disabledZipkinHostPort,
+			zipkinHostPort: disabledHostPort,
 			exporterTypes:  []string{cassandra.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
@@ -67,7 +69,7 @@ func TestDefaultConfig(t *testing.T) {
 		},
 		{
 			storageType:    "kafka",
-			zipkinHostPort: disabledZipkinHostPort,
+			zipkinHostPort: disabledHostPort,
 			exporterTypes:  []string{kafka.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
@@ -80,7 +82,7 @@ func TestDefaultConfig(t *testing.T) {
 		},
 		{
 			storageType:    "cassandra,elasticsearch",
-			zipkinHostPort: disabledZipkinHostPort,
+			zipkinHostPort: disabledHostPort,
 			exporterTypes:  []string{cassandra.TypeStr, elasticsearch.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {

--- a/cmd/opentelemetry-collector/app/defaults/defaults.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults.go
@@ -15,8 +15,10 @@
 package defaults
 
 import (
+	"flag"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/service/defaultcomponents"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
@@ -29,6 +31,10 @@ import (
 
 // Components creates default and Jaeger factories
 func Components(v *viper.Viper) config.Factories {
+	// Add flags to viper to make the default values available.
+	// We have to add all storage flags to viper because any exporter can be specified in the OTEL config file.
+	// OTEL collector creates default configurations for all factories to verify they can be created.
+	addDefaultValuesToViper(v)
 	kafkaExp := kafka.Factory{OptionsFactory: func() *storageKafka.Options {
 		opts := kafka.DefaultOptions()
 		opts.InitFromViper(v)
@@ -50,4 +56,15 @@ func Components(v *viper.Viper) config.Factories {
 	factories.Exporters[cassandraExp.Type()] = cassandraExp
 	factories.Exporters[esExp.Type()] = esExp
 	return factories
+}
+
+// addDefaultValuesToViper adds Jaeger storage flags to viper to make the default values available.
+func addDefaultValuesToViper(v *viper.Viper) {
+	flagSet := &flag.FlagSet{}
+	kafka.DefaultOptions().AddFlags(flagSet)
+	elasticsearch.DefaultOptions().AddFlags(flagSet)
+	cassandra.DefaultOptions().AddFlags(flagSet)
+	pflagSet := &pflag.FlagSet{}
+	pflagSet.AddGoFlagSet(flagSet)
+	v.BindPFlags(pflagSet)
 }

--- a/cmd/opentelemetry-collector/app/defaults/defaults.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults.go
@@ -16,6 +16,7 @@ package defaults
 
 import (
 	"flag"
+
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/service/defaultcomponents"
 	"github.com/spf13/pflag"

--- a/cmd/opentelemetry-collector/app/exporter/cassandra/factory.go
+++ b/cmd/opentelemetry-collector/app/exporter/cassandra/factory.go
@@ -73,6 +73,6 @@ func (Factory) CreateTraceExporter(log *zap.Logger, cfg configmodels.Exporter) (
 
 // CreateMetricsExporter is not implemented.
 // This function implements OTEL component.Factory interface.
-func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.MetricsExporter, error) {
+func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.MetricsExporterOld, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }

--- a/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory.go
+++ b/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory.go
@@ -73,6 +73,6 @@ func (Factory) CreateTraceExporter(log *zap.Logger, cfg configmodels.Exporter) (
 
 // CreateMetricsExporter is not implemented.
 // This function implements OTEL exporter.Factory interface.
-func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.MetricsExporter, error) {
+func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.MetricsExporterOld, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }

--- a/cmd/opentelemetry-collector/app/exporter/kafka/factory.go
+++ b/cmd/opentelemetry-collector/app/exporter/kafka/factory.go
@@ -72,6 +72,6 @@ func (Factory) CreateTraceExporter(log *zap.Logger, cfg configmodels.Exporter) (
 
 // CreateMetricsExporter is not implemented.
 // This function implements OTEL component.Factory interface.
-func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.TraceExporterOld, error) {
+func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.MetricsExporterOld, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }

--- a/cmd/opentelemetry-collector/main.go
+++ b/cmd/opentelemetry-collector/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/service/builder"
 	"github.com/spf13/viper"
 
+	collectorApp "github.com/jaegertracing/jaeger/cmd/collector/app"
 	jflags "github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/defaults"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
@@ -62,7 +63,9 @@ func main() {
 	if getOTELConfigFile() == "" {
 		log.Println("Config file not provided, installing default Jaeger components")
 		cfgFactory = func(*viper.Viper, config.Factories) (*configmodels.Config, error) {
-			return defaults.Config(storageType, cmpts)
+			collectorOpts := &collectorApp.CollectorOptions{}
+			collectorOpts.InitFromViper(v)
+			return defaults.Config(storageType, collectorOpts.CollectorZipkinHTTPHostPort, cmpts)
 		}
 	}
 
@@ -82,6 +85,7 @@ func main() {
 	cmd := svc.Command()
 	jconfig.AddFlags(v,
 		cmd,
+		collectorApp.AddFlags,
 		jflags.AddConfigFileFlag,
 		storageFlags,
 	)


### PR DESCRIPTION
Add Zipkin receiver to OTEL collector.

The Zipkin receiver is disabled by default and it can be enabled by flags:

```
      --collector.zipkin.host-port string          The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's Zipkin server (default ":0")
      --collector.zipkin.http-port int             (deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later) see --collector.zipkin.host-port
```

Other notable changes:
* All collector flags are added to OTEL collector. Most of them are be noop exept zipkin. We could support other flags (grpc endpoint, HTTP endpoint) also but it will require changes in OTEL jaeger receiver.
```
      --collector.grpc-port int                    (deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later) see --collector.grpc-server.host-port
      --collector.grpc-server.host-port string     The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's GRPC server (default ":14250")
      --collector.grpc.tls                         (deprecated) see --collector.grpc.tls.enabled
      --collector.grpc.tls.cert string             Path to a TLS Certificate file, used to identify this server to clients
      --collector.grpc.tls.client-ca string        Path to a TLS CA (Certification Authority) file used to verify certificates presented by clients (if unset, all clients are permitted)
      --collector.grpc.tls.client.ca string        (deprecated) see --collector.grpc.tls.client-ca
      --collector.grpc.tls.enabled                 Enable TLS on the server
      --collector.grpc.tls.key string              Path to a TLS Private Key file, used to identify this server to clients
      --collector.http-port int                    (deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later) see --collector.http-server.host-port
      --collector.http-server.host-port string     The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's HTTP server (default ":14268")
      --collector.num-workers int                  The number of workers pulling items from the queue (default 50)
      --collector.queue-size int                   The queue size of the collector (default 2000)
      --collector.queue-size-memory uint           (experimental) The max memory size in MiB to use for the dynamic queue.
      --collector.tags string                      One or more tags to be added to the Process tags of all spans passing through this collector. Ex: key1=value1,key2=${envVar:defaultValue}
      --collector.zipkin.allowed-headers string    Comma separated list of allowed headers for the Zipkin collector service, default content-type (default "content-type")
      --collector.zipkin.allowed-origins string    Comma separated list of allowed origins for the Zipkin collector service, default accepts all (default "*")
      --collector.zipkin.host-port string          The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's Zipkin server (default ":0")
      --collector.zipkin.http-port int             (deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later) see --collector.zipkin.host-port
```



