### PR TITLE
[feat] Support periodic refresh of sampling strategies

### DIFF
--- a/plugin/sampling/strategystore/static/constants.go
+++ b/plugin/sampling/strategystore/static/constants.go
@@ -42,3 +42,11 @@ func defaultStrategyResponse() *sampling.SamplingStrategyResponse {
 		},
 	}
 }
+
+func defaultStrategies() *storedStrategies {
+	s := &storedStrategies{
+		serviceStrategies: make(map[string]*sampling.SamplingStrategyResponse),
+	}
+	s.defaultStrategy = defaultStrategyResponse()
+	return s
+}

--- a/plugin/sampling/strategystore/static/options.go
+++ b/plugin/sampling/strategystore/static/options.go
@@ -16,27 +16,33 @@ package static
 
 import (
 	"flag"
+	"time"
 
 	"github.com/spf13/viper"
 )
 
 const (
-	samplingStrategiesFile = "sampling.strategies-file"
+	samplingStrategiesFile           = "sampling.strategies-file"
+	samplingStrategiesReloadInterval = "sampling.strategies-reload-interval"
 )
 
 // Options holds configuration for the static sampling strategy store.
 type Options struct {
 	// StrategiesFile is the path for the sampling strategies file in JSON format
 	StrategiesFile string
+	// ReloadInterval is the time interval to check and reload sampling strategies file
+	ReloadInterval time.Duration
 }
 
 // AddFlags adds flags for Options
 func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(samplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
+	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
 }
 
 // InitFromViper initializes Options with properties from viper
 func (opts *Options) InitFromViper(v *viper.Viper) *Options {
 	opts.StrategiesFile = v.GetString(samplingStrategiesFile)
+	opts.ReloadInterval = v.GetDuration(samplingStrategiesReloadInterval)
 	return opts
 }

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -15,8 +15,11 @@
 package static
 
 import (
-	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,7 +82,7 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 	os := s.OperationSampling
 	assert.EqualValues(t, os.DefaultSamplingProbability, 0.8)
 	require.Len(t, os.PerOperationStrategies, 4)
-	fmt.Println(os)
+
 	assert.Equal(t, "op6", os.PerOperationStrategies[0].Operation)
 	assert.EqualValues(t, 0.5, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)
 	assert.Equal(t, "op1", os.PerOperationStrategies[1].Operation)
@@ -242,4 +245,52 @@ func TestDeepCopy(t *testing.T) {
 	copy := deepCopy(s)
 	assert.False(t, copy == s)
 	assert.EqualValues(t, copy, s)
+}
+
+func TestAutoUpdateStrategy(t *testing.T) {
+	// copy from fixtures/strategies.json
+	tempFile, _ := ioutil.TempFile("", "for_go_test_*.json")
+	tempFile.Close()
+
+	srcFile, dstFile := "fixtures/strategies.json", tempFile.Name()
+	srcBytes, err := ioutil.ReadFile(srcFile)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(dstFile, srcBytes, 0644)
+	require.NoError(t, err)
+
+	interval := time.Millisecond * 10
+	store, err := NewStrategyStore(Options{
+		StrategiesFile: dstFile,
+		ReloadInterval: interval,
+	}, zap.NewNop())
+	require.NoError(t, err)
+	defer store.(*strategyStore).StopUpdateStrategy()
+
+	s, err := store.GetSamplingStrategy("foo")
+	require.NoError(t, err)
+	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
+
+	// update file
+	newStr := strings.Replace(string(srcBytes), "0.8", "0.9", 1)
+	err = ioutil.WriteFile(dstFile, []byte(newStr), 0644)
+	require.NoError(t, err)
+
+	// wait for reload
+	time.Sleep(interval * 2)
+
+	// verity reloading
+	s, err = store.GetSamplingStrategy("foo")
+	require.NoError(t, err)
+	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.9), *s)
+
+	// check bad file content
+	_ = ioutil.WriteFile(dstFile, []byte("bad value"), 0644)
+	time.Sleep(interval * 2)
+
+	// check file not exist
+	os.Remove(dstFile)
+
+	// wait for delete and update failed
+	time.Sleep(interval * 2)
+
 }

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -264,7 +264,7 @@ func TestAutoUpdateStrategy(t *testing.T) {
 		ReloadInterval: interval,
 	}, zap.NewNop())
 	require.NoError(t, err)
-	defer store.(*strategyStore).StopUpdateStrategy()
+	defer store.(*strategyStore).Close()
 
 	s, err := store.GetSamplingStrategy("foo")
 	require.NoError(t, err)
@@ -275,8 +275,8 @@ func TestAutoUpdateStrategy(t *testing.T) {
 	err = ioutil.WriteFile(dstFile, []byte(newStr), 0644)
 	require.NoError(t, err)
 
-	// wait for reload
-	time.Sleep(interval * 2)
+	// wait for reloading
+	time.Sleep(interval * 4)
 
 	// verity reloading
 	s, err = store.GetSamplingStrategy("foo")
@@ -287,10 +287,9 @@ func TestAutoUpdateStrategy(t *testing.T) {
 	_ = ioutil.WriteFile(dstFile, []byte("bad value"), 0644)
 	time.Sleep(interval * 2)
 
-	// check file not exist
-	os.Remove(dstFile)
-
-	// wait for delete and update failed
+	// remove file(test read file failure)
+	_ = os.Remove(dstFile)
+	// wait for delete and update failure
 	time.Sleep(interval * 2)
 
 }


### PR DESCRIPTION
PR for #2186 

Signed-off-by: defool <defool@foxmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Add CLI option to refresh sampling strategies file.

## Short description of the changes
- Add --strategies-reload-interval option for updating strategies periodically.
