### PR TITLE
Support elasticsearch index rollover by hour or quarter hour

### DIFF
--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -165,6 +165,7 @@ func createSpanReader(
 		IndexPrefix:         cfg.GetIndexPrefix(),
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
+		RolloverInterval:    cfg.GetRolloverInterval(),
 		Archive:             archive,
 	}), nil
 }
@@ -194,6 +195,7 @@ func createSpanWriter(
 		AllTagsAsFields:     cfg.GetAllTagsAsFields(),
 		TagKeysAsFields:     tags,
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
+		RolloverInterval:    cfg.GetRolloverInterval(),
 		Archive:             archive,
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 	})

--- a/plugin/storage/es/spanstore/index_utils.go
+++ b/plugin/storage/es/spanstore/index_utils.go
@@ -18,10 +18,23 @@ import (
 	"time"
 )
 
+var quarters = []string{"00", "15", "30", "45"}
+
 // returns index name with date
 func indexWithDate(indexPrefix string, date time.Time) string {
 	spanDate := date.UTC().Format("2006-01-02")
 	return indexPrefix + spanDate
+}
+
+// returns index name with hour
+func indexWithHour(indexPrefix string, date time.Time) string {
+	spanHour := date.UTC().Format("2006-01-02T15")
+	return indexPrefix + spanHour
+}
+
+// returns index name with quarter hour
+func indexWithQuarter(indexPrefix string, date time.Time) string {
+	return indexWithHour(indexPrefix, date) + "-" + quarters[date.Minute()/15]
 }
 
 // returns archive index name

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -258,6 +258,14 @@ func TestSpanIndexName(t *testing.T) {
 	serviceIndexName := indexWithDate(serviceIndex, span.StartTime)
 	assert.Equal(t, "jaeger-span-1995-04-21", spanIndexName)
 	assert.Equal(t, "jaeger-service-1995-04-21", serviceIndexName)
+	spanIndexName = indexWithHour(spanIndex, span.StartTime)
+	serviceIndexName = indexWithHour(serviceIndex, span.StartTime)
+	assert.Equal(t, "jaeger-span-1995-04-21T22", spanIndexName)
+	assert.Equal(t, "jaeger-service-1995-04-21T22", serviceIndexName)
+	spanIndexName = indexWithQuarter(spanIndex, span.StartTime)
+	serviceIndexName = indexWithQuarter(serviceIndex, span.StartTime)
+	assert.Equal(t, "jaeger-span-1995-04-21T22-00", spanIndexName)
+	assert.Equal(t, "jaeger-service-1995-04-21T22-00", serviceIndexName)
 }
 
 func TestWriteSpanInternal(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Xiaoguang Sun <sunxiaoguang@zhihu.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #2189

## Short description of the changes
- add new es.rollover-interval and es-archive.rollover-interval flag to specify if new index should be created at daily (default), hourly or even quarterly basis.
- change spanstore to support new rollover intervals
- change esCleanup.py to support new rollover intervals