### PR TITLE
Remove agent's hostPort env var from go service in xdock

### DIFF
--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -29,8 +29,6 @@ services:
         image: jaegertracing/xdock-go
         ports:
             - "8080-8082"
-        environment:
-            - AGENT_HOST_PORT=jaeger-agent:6831
 
     node:
         image: jaegertracing/xdock-node


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

