### PR TITLE
Support samling startegies file flag in OTEL collector

### DIFF
--- a/cmd/opentelemetry-collector/app/defaults/defaults.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
+	otelJaegerreceiver "github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/service/defaultcomponents"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -25,6 +26,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/jaegerreceiver"
 	storageCassandra "github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	storageEs "github.com/jaegertracing/jaeger/plugin/storage/es"
 	storageKafka "github.com/jaegertracing/jaeger/plugin/storage/kafka"
@@ -56,6 +58,12 @@ func Components(v *viper.Viper) config.Factories {
 	factories.Exporters[kafkaExp.Type()] = kafkaExp
 	factories.Exporters[cassandraExp.Type()] = cassandraExp
 	factories.Exporters[esExp.Type()] = esExp
+
+	otelJRec := factories.Receivers["jaeger"].(*otelJaegerreceiver.Factory)
+	factories.Receivers["jaeger"] = &jaegerreceiver.Factory{
+		Wrapped: otelJRec,
+		Viper:   v,
+	}
 	return factories
 }
 

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
@@ -48,10 +48,6 @@ func (f *Factory) Type() string {
 func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	cfg := f.Wrapped.CreateDefaultConfig().(*jaegerreceiver.Config)
 	strategyFile := f.Viper.GetString(static.SamplingStrategiesFile)
-	// if remote sampling struct is not nil the factory will use default values for endpoints and enable remote sampling
-	// the problem is that flag will always return some default value
-	// so we cannot distinguish when it should be enabled and when not.
-	// Using default values makes sense when a component is enabled
 	var samplingConf *jaegerreceiver.RemoteSamplingConfig
 	if strategyFile != "" {
 		samplingConf = &jaegerreceiver.RemoteSamplingConfig{

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaegerreceiver
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
+)
+
+// Factory wraps jaegerreceiver.Factory and makes the default config configurable via viper.
+// For instance this enables using flags as default values in the config object.
+type Factory struct {
+	// Wrapped is Jaeger receiver.
+	Wrapped *jaegerreceiver.Factory
+	// Viper is used to get configuration values for default configuration
+	Viper *viper.Viper
+}
+
+var _ component.ReceiverFactoryOld = (*Factory)(nil)
+
+// Type gets the type of exporter.
+func (f *Factory) Type() string {
+	return f.Wrapped.Type()
+}
+
+// CreateDefaultConfig returns default configuration of Factory.
+// This function implements OTEL component.BaseFactory interface.
+func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
+	cfg := f.Wrapped.CreateDefaultConfig().(*jaegerreceiver.Config)
+	strategyFile := f.Viper.GetString(static.SamplingStrategiesFile)
+	// if remote sampling struct is not nil the factory will use default values for endpoints and enable remote sampling
+	// the problem is that flag will always return some default value
+	// so we cannot distinguish when it should be enabled and when not.
+	// Using default values makes sense when a component is enabled
+	var samplingConf *jaegerreceiver.RemoteSamplingConfig
+	if strategyFile != "" {
+		samplingConf = &jaegerreceiver.RemoteSamplingConfig{
+			StrategyFile: strategyFile,
+		}
+	}
+	cfg.RemoteSampling = samplingConf
+	return cfg
+}
+
+// CreateTraceReceiver creates Jaeger receiver trace receiver.
+// This function implements OTEL component.ReceiverFactory interface.
+func (f *Factory) CreateTraceReceiver(
+	ctx context.Context,
+	log *zap.Logger,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.TraceConsumerOld,
+) (component.TraceReceiver, error) {
+	return f.Wrapped.CreateTraceReceiver(ctx, log, cfg, nextConsumer)
+}
+
+// CustomUnmarshaler creates custom unmarshaller for Jaeger receiver config.
+// This function implements component.ReceiverFactoryBase interface.
+func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
+	return f.Wrapped.CustomUnmarshaler()
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on provided config.
+// This function implements component.ReceiverFactory.
+func (f *Factory) CreateMetricsReceiver(
+	_ *zap.Logger,
+	_ configmodels.Receiver,
+	_ consumer.MetricsConsumerOld,
+) (component.MetricsReceiver, error) {
+	return nil, configerror.ErrDataTypeIsNotSupported
+}

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
@@ -83,9 +82,9 @@ func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
 // This function implements component.ReceiverFactory.
 func (f *Factory) CreateMetricsReceiver(
-	_ *zap.Logger,
-	_ configmodels.Receiver,
-	_ consumer.MetricsConsumerOld,
+	logger *zap.Logger,
+	receiver configmodels.Receiver,
+	consumer consumer.MetricsConsumerOld,
 ) (component.MetricsReceiver, error) {
-	return nil, configerror.ErrDataTypeIsNotSupported
+	return f.Wrapped.CreateMetricsReceiver(logger, receiver, consumer)
 }

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaegerreceiver
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
+)
+
+func TestDefaultValueFromViper(t *testing.T) {
+	v := viper.New()
+	v.Set(static.SamplingStrategiesFile, "config.json")
+	jr := &jaegerreceiver.Factory{}
+
+	f := &Factory{
+		Wrapped: jr,
+		Viper:   v,
+	}
+
+	cfg := f.CreateDefaultConfig().(*jaegerreceiver.Config)
+	assert.Equal(t, "config.json", cfg.RemoteSampling.StrategyFile)
+}
+
+func TestType(t *testing.T) {
+	f := &Factory{
+		Wrapped: &jaegerreceiver.Factory{},
+	}
+	assert.Equal(t, "jaeger", f.Type())
+}
+
+func TestCreateMetricsExporter(t *testing.T) {
+	f := &Factory{
+		Wrapped: &jaegerreceiver.Factory{},
+	}
+	mReceiver, err := f.CreateMetricsReceiver(zap.NewNop(), nil, nil)
+	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
+	assert.Nil(t, mReceiver)
+}

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
@@ -15,18 +15,18 @@
 package jaegerreceiver
 
 import (
-	jConfig "github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/open-telemetry/opentelemetry-collector/config"
-	"github.com/stretchr/testify/require"
 	"path"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
 )
 
@@ -63,6 +63,7 @@ func TestLoadConfigAndFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	factory := &Factory{Viper: v, Wrapped: &jaegerreceiver.Factory{}}
+	assert.Equal(t, "bar.json", factory.CreateDefaultConfig().(*jaegerreceiver.Config).RemoteSampling.StrategyFile)
 
 	factories.Receivers["jaeger"] = factory
 	colConfig, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/testdata/config.yaml
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/testdata/config.yaml
@@ -1,0 +1,19 @@
+receivers:
+  jaeger:
+    remote_sampling:
+      strategy_file: foo.json
+    protocols:
+      grpc:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [jaeger]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/cmd/opentelemetry-collector/go.mod
+++ b/cmd/opentelemetry-collector/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/jaegertracing/jaeger v1.17.0
 	github.com/magiconair/properties v1.8.1
-	github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200408203355-0e1b2e323d39
+	github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200420175007-048d7d257824
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.0

--- a/cmd/opentelemetry-collector/go.sum
+++ b/cmd/opentelemetry-collector/go.sum
@@ -972,6 +972,8 @@ github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200323151927-794a2b
 github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200323151927-794a2b689bd9/go.mod h1:7Sxe+ROKhJSqPZqsKnvb/y5EbEsjbkDTbQ2sS7cF9rY=
 github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200408203355-0e1b2e323d39 h1:D8QuOoh7ImcWA/o0RJ8s7M4QojCWSgiK9LBhYONDD1E=
 github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200408203355-0e1b2e323d39/go.mod h1:aZAL+YwTtk+1YkTj8dDgTvv06dU8twzOdRowRtBfEKo=
+github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200420175007-048d7d257824 h1:3FftRuw4Hqe1X2mG1z+0nJHyhjsAOrE6qZXXB45B86Q=
+github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200420175007-048d7d257824/go.mod h1:aZAL+YwTtk+1YkTj8dDgTvv06dU8twzOdRowRtBfEKo=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c h1:nDOtl6j2Ei16tlnx/o4qKEelpHtGoZ9ArwU+tux4Ia8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d h1:hZcHR0at6tb3jBjaPHlfLr6yK7rTrA8xGCS6jlUSLcU=
@@ -1129,6 +1131,7 @@ github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c/go.mod h1:kJ9mm
 github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
+github.com/shirou/gopsutil v2.20.3+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt3d2aYa0SiNms/hFqC9qJYolM=

--- a/cmd/opentelemetry-collector/main.go
+++ b/cmd/opentelemetry-collector/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -34,6 +35,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
 	jconfig "github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
 	"github.com/jaegertracing/jaeger/plugin/storage"
 )
 
@@ -88,6 +90,7 @@ func main() {
 		collectorApp.AddFlags,
 		jflags.AddConfigFileFlag,
 		storageFlags,
+		static.AddFlags,
 	)
 
 	// parse flags to propagate Jaeger config file flag value to viper
@@ -104,6 +107,7 @@ func main() {
 // getOTELConfigFile returns name of OTEL config file.
 func getOTELConfigFile() string {
 	f := &flag.FlagSet{}
+	f.SetOutput(ioutil.Discard)
 	builder.Flags(f)
 	// parse flags to bind the value
 	f.Parse(os.Args[1:])

--- a/plugin/sampling/strategystore/static/options.go
+++ b/plugin/sampling/strategystore/static/options.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	samplingStrategiesFile           = "sampling.strategies-file"
+	SamplingStrategiesFile           = "sampling.strategies-file"
 	samplingStrategiesReloadInterval = "sampling.strategies-reload-interval"
 )
 
@@ -36,13 +36,13 @@ type Options struct {
 
 // AddFlags adds flags for Options
 func AddFlags(flagSet *flag.FlagSet) {
-	flagSet.String(samplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
+	flagSet.String(SamplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
 	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
 }
 
 // InitFromViper initializes Options with properties from viper
 func (opts *Options) InitFromViper(v *viper.Viper) *Options {
-	opts.StrategiesFile = v.GetString(samplingStrategiesFile)
+	opts.StrategiesFile = v.GetString(SamplingStrategiesFile)
 	opts.ReloadInterval = v.GetDuration(samplingStrategiesReloadInterval)
 	return opts
 }


### PR DESCRIPTION
Resolves #2154 

This patch showcases how upstream OTEL components can be extended to support additional means of configuration. In this case I have added `sampling.strategies-file` flag to Jaeger receiver. The configuration in OTEL config has higher precedence over the configuration in Viper (like we do for other jaeger flags).

* if the flag `sampling.strategies-file` is used and the sampling strategies in the OTEL config is missing it would enable it. e.g.: 

```
go run main.go --config=/home/ploffay/tmp/otel-config.yml  --sampling.strategies-file=/home/ploffay/tmp/sampling.json
receivers:
  jaeger:
    protocols:
      grpc:  
```


Now let's talk about how this approach could work for other flags. Flags that don't have a default value can be supported easily. However flags with a default value e.g. `--collector.http-server.host-port=:14268` are problematic. The problem is that when the default config is created we don't know whether this endpoint should be enabled or disabled as there is always a default value. When the collector is started without a configuration file it's not a problem because we enable all Jaeger endpoints. However when the collector is started with a configuration file the default value in the flag  always enables the endpoint - which might be problematic if users want to disable the endpoint.


