### PR TITLE
Update OTEL exporters to use new API

### DIFF
--- a/cmd/opentelemetry-collector/app/defaults/default_config.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config.go
@@ -60,7 +60,7 @@ func Config(storageType string, zipkinHostPort string, factories config.Factorie
 					InputType:  configmodels.TracesDataType,
 					Receivers:  recTypes,
 					Exporters:  expTypes,
-					Processors: []string{"batch"},
+					Processors: []string{},
 				},
 			},
 		},

--- a/cmd/opentelemetry-collector/app/defaults/default_config.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
-	"github.com/open-telemetry/opentelemetry-collector/processor/batchprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
@@ -51,16 +50,14 @@ func Config(storageType string, zipkinHostPort string, factories config.Factorie
 	return &configmodels.Config{
 		Receivers:  receivers,
 		Exporters:  exporters,
-		Processors: createProcessors(factories),
 		Extensions: configmodels.Extensions{"health_check": hc},
 		Service: configmodels.Service{
 			Extensions: []string{"health_check"},
 			Pipelines: map[string]*configmodels.Pipeline{
 				"traces": {
-					InputType:  configmodels.TracesDataType,
-					Receivers:  recTypes,
-					Exporters:  expTypes,
-					Processors: []string{},
+					InputType: configmodels.TracesDataType,
+					Receivers: recTypes,
+					Exporters: expTypes,
 				},
 			},
 		},
@@ -122,11 +119,4 @@ func createExporters(storageTypes string, factories config.Factories) (configmod
 		}
 	}
 	return exporters, nil
-}
-
-func createProcessors(factories config.Factories) configmodels.Processors {
-	batch := factories.Processors["batch"].CreateDefaultConfig().(*batchprocessor.Config)
-	return map[string]configmodels.Processor{
-		"batch": batch,
-	}
 }

--- a/cmd/opentelemetry-collector/app/defaults/default_config.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config.go
@@ -40,12 +40,12 @@ func Config(storageType string, zipkinHostPort string, factories config.Factorie
 	}
 	expTypes := []string{}
 	for _, v := range exporters {
-		expTypes = append(expTypes, v.Type())
+		expTypes = append(expTypes, string(v.Type()))
 	}
 	receivers := createReceivers(zipkinHostPort, factories)
 	recTypes := []string{}
 	for _, v := range receivers {
-		recTypes = append(recTypes, v.Type())
+		recTypes = append(recTypes, string(v.Type()))
 	}
 	hc := factories.Extensions["health_check"].CreateDefaultConfig()
 	return &configmodels.Config{

--- a/cmd/opentelemetry-collector/app/defaults/default_config_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config_test.go
@@ -134,7 +134,7 @@ func TestDefaultConfig(t *testing.T) {
 
 			types := []string{}
 			for _, v := range cfg.Exporters {
-				types = append(types, v.Type())
+				types = append(types, string(v.Type()))
 			}
 			sort.Strings(types)
 			assert.Equal(t, test.exporterTypes, types)

--- a/cmd/opentelemetry-collector/app/defaults/default_config_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config_test.go
@@ -47,10 +47,9 @@ func TestDefaultConfig(t *testing.T) {
 			exporterTypes:  []string{elasticsearch.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
-					InputType:  configmodels.TracesDataType,
-					Receivers:  []string{"jaeger"},
-					Exporters:  []string{elasticsearch.TypeStr},
-					Processors: []string{"batch"},
+					InputType: configmodels.TracesDataType,
+					Receivers: []string{"jaeger"},
+					Exporters: []string{elasticsearch.TypeStr},
 				},
 			},
 		},
@@ -60,10 +59,9 @@ func TestDefaultConfig(t *testing.T) {
 			exporterTypes:  []string{cassandra.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
-					InputType:  configmodels.TracesDataType,
-					Receivers:  []string{"jaeger"},
-					Exporters:  []string{cassandra.TypeStr},
-					Processors: []string{"batch"},
+					InputType: configmodels.TracesDataType,
+					Receivers: []string{"jaeger"},
+					Exporters: []string{cassandra.TypeStr},
 				},
 			},
 		},
@@ -73,10 +71,9 @@ func TestDefaultConfig(t *testing.T) {
 			exporterTypes:  []string{kafka.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
-					InputType:  configmodels.TracesDataType,
-					Receivers:  []string{"jaeger"},
-					Exporters:  []string{kafka.TypeStr},
-					Processors: []string{"batch"},
+					InputType: configmodels.TracesDataType,
+					Receivers: []string{"jaeger"},
+					Exporters: []string{kafka.TypeStr},
 				},
 			},
 		},
@@ -86,10 +83,9 @@ func TestDefaultConfig(t *testing.T) {
 			exporterTypes:  []string{cassandra.TypeStr, elasticsearch.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
-					InputType:  configmodels.TracesDataType,
-					Receivers:  []string{"jaeger"},
-					Exporters:  []string{cassandra.TypeStr, elasticsearch.TypeStr},
-					Processors: []string{"batch"},
+					InputType: configmodels.TracesDataType,
+					Receivers: []string{"jaeger"},
+					Exporters: []string{cassandra.TypeStr, elasticsearch.TypeStr},
 				},
 			},
 		},
@@ -99,10 +95,9 @@ func TestDefaultConfig(t *testing.T) {
 			exporterTypes:  []string{cassandra.TypeStr},
 			pipeline: map[string]*configmodels.Pipeline{
 				"traces": {
-					InputType:  configmodels.TracesDataType,
-					Receivers:  []string{"jaeger", "zipkin"},
-					Exporters:  []string{cassandra.TypeStr},
-					Processors: []string{"batch"},
+					InputType: configmodels.TracesDataType,
+					Receivers: []string{"jaeger", "zipkin"},
+					Exporters: []string{cassandra.TypeStr},
 				},
 			},
 		},
@@ -128,8 +123,6 @@ func TestDefaultConfig(t *testing.T) {
 			assert.Equal(t, "health_check", cfg.Extensions["health_check"].Name())
 			assert.Equal(t, len(test.pipeline["traces"].Receivers), len(cfg.Receivers))
 			assert.Equal(t, "jaeger", cfg.Receivers["jaeger"].Name())
-			assert.Equal(t, 1, len(cfg.Processors))
-			assert.Equal(t, "batch", cfg.Processors["batch"].Name())
 			assert.Equal(t, len(test.exporterTypes), len(cfg.Exporters))
 
 			types := []string{}

--- a/cmd/opentelemetry-collector/app/defaults/defaults_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/magiconair/properties/assert"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
@@ -28,9 +29,9 @@ import (
 func TestComponents(t *testing.T) {
 	v, _ := jConfig.Viperize(kafka.DefaultOptions().AddFlags, cassandra.DefaultOptions().AddFlags, elasticsearch.DefaultOptions().AddFlags)
 	factories := Components(v)
-	assert.Equal(t, "jaeger_kafka", factories.Exporters[kafka.TypeStr].Type())
-	assert.Equal(t, "jaeger_cassandra", factories.Exporters[cassandra.TypeStr].Type())
-	assert.Equal(t, "jaeger_elasticsearch", factories.Exporters[elasticsearch.TypeStr].Type())
+	assert.Equal(t, configmodels.Type("jaeger_kafka"), factories.Exporters[kafka.TypeStr].Type())
+	assert.Equal(t, configmodels.Type("jaeger_cassandra"), factories.Exporters[cassandra.TypeStr].Type())
+	assert.Equal(t, configmodels.Type("jaeger_elasticsearch"), factories.Exporters[elasticsearch.TypeStr].Type())
 
 	kafkaFactory := factories.Exporters[kafka.TypeStr]
 	kc := kafkaFactory.CreateDefaultConfig().(*kafka.Config)

--- a/cmd/opentelemetry-collector/app/exporter/cassandra/exporter.go
+++ b/cmd/opentelemetry-collector/app/exporter/cassandra/exporter.go
@@ -17,18 +17,17 @@ package cassandra
 import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/uber/jaeger-lib/metrics"
-	"go.uber.org/zap"
 
 	storageOtelExporter "github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 )
 
 // New creates Cassandra exporter/storage
-func New(config *Config, log *zap.Logger) (component.TraceExporterOld, error) {
+func New(config *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
 	f := cassandra.NewFactory()
 	f.InitFromOptions(&config.Options)
 
-	err := f.Initialize(metrics.NullFactory, log)
+	err := f.Initialize(metrics.NullFactory, params.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/opentelemetry-collector/app/exporter/cassandra/factory.go
+++ b/cmd/opentelemetry-collector/app/exporter/cassandra/factory.go
@@ -15,12 +15,12 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
-	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 )
@@ -43,13 +43,15 @@ type Factory struct {
 	OptionsFactory OptionsFactory
 }
 
+var _ component.ExporterFactory = (*Factory)(nil)
+
 // Type gets the type of exporter.
-func (Factory) Type() string {
+func (Factory) Type() configmodels.Type {
 	return TypeStr
 }
 
 // CreateDefaultConfig returns default configuration of Factory.
-// This function implements OTEL component.BaseFactory interface.
+// This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 	opts := f.OptionsFactory()
 	return &Config{
@@ -62,17 +64,25 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 }
 
 // CreateTraceExporter creates Jaeger Cassandra trace exporter.
-// This function implements OTEL component.Factory interface.
-func (Factory) CreateTraceExporter(log *zap.Logger, cfg configmodels.Exporter) (component.TraceExporterOld, error) {
+// This function implements OTEL component.ExporterFactory interface.
+func (f Factory) CreateTraceExporter(
+	_ context.Context,
+	params component.ExporterCreateParams,
+	cfg configmodels.Exporter,
+) (component.TraceExporter, error) {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return nil, fmt.Errorf("could not cast configuration to %s", TypeStr)
 	}
-	return New(config, log)
+	return New(config, params)
 }
 
 // CreateMetricsExporter is not implemented.
-// This function implements OTEL component.Factory interface.
-func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.MetricsExporterOld, error) {
+// This function implements OTEL component.ExporterFactory interface.
+func (Factory) CreateMetricsExporter(
+	_ context.Context,
+	_ component.ExporterCreateParams,
+	_ configmodels.Exporter,
+) (component.MetricsExporter, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }

--- a/cmd/opentelemetry-collector/app/exporter/cassandra/factory_test.go
+++ b/cmd/opentelemetry-collector/app/exporter/cassandra/factory_test.go
@@ -15,13 +15,15 @@
 package cassandra
 
 import (
+	"context"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
@@ -34,14 +36,14 @@ func TestCreateTraceExporter(t *testing.T) {
 	factory := Factory{OptionsFactory: func() *cassandra.Options {
 		return opts
 	}}
-	exporter, err := factory.CreateTraceExporter(zap.NewNop(), factory.CreateDefaultConfig())
+	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, factory.CreateDefaultConfig())
 	require.Nil(t, exporter)
 	assert.EqualError(t, err, "gocql: unable to create session: control: unable to connect to initial hosts: dial tcp 127.0.0.1:9042: connect: connection refused")
 }
 
 func TestCreateTraceExporter_NilConfig(t *testing.T) {
 	factory := Factory{}
-	exporter, err := factory.CreateTraceExporter(zap.NewNop(), nil)
+	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, nil)
 	require.Nil(t, exporter)
 	assert.EqualError(t, err, "could not cast configuration to jaeger_cassandra")
 }
@@ -55,12 +57,12 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestCreateMetricsExporter(t *testing.T) {
 	f := Factory{OptionsFactory: DefaultOptions}
-	mReceiver, err := f.CreateMetricsExporter(zap.NewNop(), f.CreateDefaultConfig())
+	mReceiver, err := f.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, f.CreateDefaultConfig())
 	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }
 
 func TestType(t *testing.T) {
 	factory := Factory{}
-	assert.Equal(t, TypeStr, factory.Type())
+	assert.Equal(t, configmodels.Type(TypeStr), factory.Type())
 }

--- a/cmd/opentelemetry-collector/app/exporter/elasticsearch/exporter.go
+++ b/cmd/opentelemetry-collector/app/exporter/elasticsearch/exporter.go
@@ -17,17 +17,16 @@ package elasticsearch
 import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/uber/jaeger-lib/metrics"
-	"go.uber.org/zap"
 
 	storageOtelExporter "github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 )
 
 // New creates Elasticsearch exporter/storage.
-func New(config *Config, log *zap.Logger) (component.TraceExporterOld, error) {
+func New(config *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
 	factory := es.NewFactory()
 	factory.InitFromOptions(config.Options)
-	err := factory.Initialize(metrics.NullFactory, log)
+	err := factory.Initialize(metrics.NullFactory, params.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory.go
+++ b/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory.go
@@ -64,7 +64,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 }
 
 // CreateTraceExporter creates Jaeger Elasticsearch trace exporter.
-// This function implements OTEL exporter.ExporterFactory interface.
+// This function implements OTEL component.ExporterFactory interface.
 func (Factory) CreateTraceExporter(
 	_ context.Context,
 	params component.ExporterCreateParams,
@@ -78,7 +78,7 @@ func (Factory) CreateTraceExporter(
 }
 
 // CreateMetricsExporter is not implemented.
-// This function implements OTEL exporter.ExporterFactory interface.
+// This function implements OTEL component.ExporterFactory interface.
 func (Factory) CreateMetricsExporter(
 	_ context.Context,
 	_ component.ExporterCreateParams,

--- a/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory.go
+++ b/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory.go
@@ -15,12 +15,12 @@
 package elasticsearch
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
-	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 )
@@ -44,12 +44,14 @@ type Factory struct {
 }
 
 // Type gets the type of exporter.
-func (Factory) Type() string {
+func (Factory) Type() configmodels.Type {
 	return TypeStr
 }
 
+var _ component.ExporterFactory = (*Factory)(nil)
+
 // CreateDefaultConfig returns default configuration of Factory.
-// This function implements OTEL component.BaseFactory interface.
+// This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 	opts := f.OptionsFactory()
 	return &Config{
@@ -62,17 +64,25 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 }
 
 // CreateTraceExporter creates Jaeger Elasticsearch trace exporter.
-// This function implements OTEL exporter.Factory interface.
-func (Factory) CreateTraceExporter(log *zap.Logger, cfg configmodels.Exporter) (component.TraceExporterOld, error) {
+// This function implements OTEL exporter.ExporterFactory interface.
+func (Factory) CreateTraceExporter(
+	_ context.Context,
+	params component.ExporterCreateParams,
+	cfg configmodels.Exporter,
+) (component.TraceExporter, error) {
 	esCfg, ok := cfg.(*Config)
 	if !ok {
 		return nil, fmt.Errorf("could not cast configuration to %s", TypeStr)
 	}
-	return New(esCfg, log)
+	return New(esCfg, params)
 }
 
 // CreateMetricsExporter is not implemented.
-// This function implements OTEL exporter.Factory interface.
-func (Factory) CreateMetricsExporter(*zap.Logger, configmodels.Exporter) (component.MetricsExporterOld, error) {
+// This function implements OTEL exporter.ExporterFactory interface.
+func (Factory) CreateMetricsExporter(
+	_ context.Context,
+	_ component.ExporterCreateParams,
+	_ configmodels.Exporter,
+) (component.MetricsExporter, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }

--- a/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory_test.go
+++ b/cmd/opentelemetry-collector/app/exporter/elasticsearch/factory_test.go
@@ -15,13 +15,15 @@
 package elasticsearch
 
 import (
+	"context"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
@@ -34,21 +36,21 @@ func TestCreateTraceExporter(t *testing.T) {
 	factory := &Factory{OptionsFactory: func() *es.Options {
 		return opts
 	}}
-	exporter, err := factory.CreateTraceExporter(zap.NewNop(), factory.CreateDefaultConfig())
+	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, factory.CreateDefaultConfig())
 	require.Nil(t, exporter)
 	assert.EqualError(t, err, "failed to create primary Elasticsearch client: health check timeout: Head http://127.0.0.1:9200: dial tcp 127.0.0.1:9200: connect: connection refused: no Elasticsearch node available")
 }
 
 func TestCreateTraceExporter_nilConfig(t *testing.T) {
 	factory := &Factory{}
-	exporter, err := factory.CreateTraceExporter(zap.NewNop(), nil)
+	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, nil)
 	require.Nil(t, exporter)
 	assert.EqualError(t, err, "could not cast configuration to jaeger_elasticsearch")
 }
 
 func TestCreateMetricsExporter(t *testing.T) {
 	f := Factory{OptionsFactory: DefaultOptions}
-	mReceiver, err := f.CreateMetricsExporter(zap.NewNop(), f.CreateDefaultConfig())
+	mReceiver, err := f.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, f.CreateDefaultConfig())
 	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }
@@ -62,5 +64,5 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestType(t *testing.T) {
 	factory := Factory{OptionsFactory: DefaultOptions}
-	assert.Equal(t, TypeStr, factory.Type())
+	assert.Equal(t, configmodels.Type(TypeStr), factory.Type())
 }

--- a/cmd/opentelemetry-collector/app/exporter/kafka/exporter.go
+++ b/cmd/opentelemetry-collector/app/exporter/kafka/exporter.go
@@ -17,17 +17,16 @@ package kafka
 import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/uber/jaeger-lib/metrics"
-	"go.uber.org/zap"
 
 	storageOtelExporter "github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter"
 	"github.com/jaegertracing/jaeger/plugin/storage/kafka"
 )
 
 // New creates new Kafka exporter
-func New(config *Config, log *zap.Logger) (component.TraceExporterOld, error) {
+func New(config *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
 	f := kafka.NewFactory()
 	f.InitFromOptions(config.Options)
-	err := f.Initialize(metrics.NullFactory, log)
+	err := f.Initialize(metrics.NullFactory, params.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/opentelemetry-collector/app/exporter/kafka/factory.go
+++ b/cmd/opentelemetry-collector/app/exporter/kafka/factory.go
@@ -50,7 +50,7 @@ func (Factory) Type() configmodels.Type {
 }
 
 // CreateDefaultConfig returns default configuration of Factory.
-// This function implements OTEL exporter.ExporterFactoryBase interface.
+// This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 	opts := f.OptionsFactory()
 	return &Config{

--- a/cmd/opentelemetry-collector/app/exporter/kafka/factory_test.go
+++ b/cmd/opentelemetry-collector/app/exporter/kafka/factory_test.go
@@ -15,10 +15,13 @@
 package kafka
 
 import (
+	"context"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -34,21 +37,21 @@ func TestCreateTraceExporter(t *testing.T) {
 	factory := &Factory{OptionsFactory: func() *kafka.Options {
 		return opts
 	}}
-	exporter, err := factory.CreateTraceExporter(zap.NewNop(), factory.CreateDefaultConfig())
+	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, factory.CreateDefaultConfig())
 	require.Nil(t, exporter)
 	assert.EqualError(t, err, "kafka: client has run out of available brokers to talk to (Is your cluster reachable?)")
 }
 
 func TestCreateTraceExporter_nilConfig(t *testing.T) {
 	factory := &Factory{}
-	exporter, err := factory.CreateTraceExporter(zap.NewNop(), nil)
+	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, nil)
 	require.Nil(t, exporter)
 	assert.EqualError(t, err, "could not cast configuration to jaeger_kafka")
 }
 
 func TestCreateMetricsExporter(t *testing.T) {
 	f := Factory{OptionsFactory: DefaultOptions}
-	mReceiver, err := f.CreateMetricsExporter(zap.NewNop(), f.CreateDefaultConfig())
+	mReceiver, err := f.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, f.CreateDefaultConfig())
 	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }
@@ -62,5 +65,5 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestType(t *testing.T) {
 	factory := Factory{OptionsFactory: DefaultOptions}
-	assert.Equal(t, TypeStr, factory.Type())
+	assert.Equal(t, configmodels.Type(TypeStr), factory.Type())
 }

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver.go
@@ -22,7 +22,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
 )
@@ -36,10 +35,10 @@ type Factory struct {
 	Viper *viper.Viper
 }
 
-var _ component.ReceiverFactoryOld = (*Factory)(nil)
+var _ component.ReceiverFactory = (*Factory)(nil)
 
 // Type gets the type of exporter.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return f.Wrapped.Type()
 }
 
@@ -62,11 +61,11 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 // This function implements OTEL component.ReceiverFactory interface.
 func (f *Factory) CreateTraceReceiver(
 	ctx context.Context,
-	log *zap.Logger,
+	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
-	nextConsumer consumer.TraceConsumerOld,
+	nextConsumer consumer.TraceConsumer,
 ) (component.TraceReceiver, error) {
-	return f.Wrapped.CreateTraceReceiver(ctx, log, cfg, nextConsumer)
+	return f.Wrapped.CreateTraceReceiver(ctx, params, cfg, nextConsumer)
 }
 
 // CustomUnmarshaler creates custom unmarshaller for Jaeger receiver config.
@@ -78,9 +77,10 @@ func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
 // This function implements component.ReceiverFactory.
 func (f *Factory) CreateMetricsReceiver(
-	logger *zap.Logger,
-	receiver configmodels.Receiver,
-	consumer consumer.MetricsConsumerOld,
+	ctx context.Context,
+	params component.ReceiverCreateParams,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
-	return f.Wrapped.CreateMetricsReceiver(logger, receiver, consumer)
+	return f.Wrapped.CreateMetricsReceiver(ctx, params, cfg, nextConsumer)
 }

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
@@ -15,16 +15,18 @@
 package jaegerreceiver
 
 import (
+	"context"
 	"path"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
@@ -78,14 +80,14 @@ func TestType(t *testing.T) {
 	f := &Factory{
 		Wrapped: &jaegerreceiver.Factory{},
 	}
-	assert.Equal(t, "jaeger", f.Type())
+	assert.Equal(t, configmodels.Type("jaeger"), f.Type())
 }
 
 func TestCreateMetricsExporter(t *testing.T) {
 	f := &Factory{
 		Wrapped: &jaegerreceiver.Factory{},
 	}
-	mReceiver, err := f.CreateMetricsReceiver(zap.NewNop(), nil, nil)
+	mReceiver, err := f.CreateMetricsReceiver(context.Background(), component.ReceiverCreateParams{}, nil, nil)
 	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }

--- a/cmd/opentelemetry-collector/go.mod
+++ b/cmd/opentelemetry-collector/go.mod
@@ -12,10 +12,11 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/jaegertracing/jaeger v1.17.0
 	github.com/magiconair/properties v1.8.1
-	github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200420175007-048d7d257824
+	github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200428040525-c7c58b3d1319
+	github.com/open-telemetry/opentelemetry-proto v0.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
-	github.com/stretchr/testify v1.5.0
+	github.com/stretchr/testify v1.5.1
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	go.uber.org/zap v1.13.0
 	k8s.io/client-go v12.0.0+incompatible // indirect

--- a/cmd/opentelemetry-collector/go.sum
+++ b/cmd/opentelemetry-collector/go.sum
@@ -972,8 +972,8 @@ github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200323151927-794a2b
 github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200323151927-794a2b689bd9/go.mod h1:7Sxe+ROKhJSqPZqsKnvb/y5EbEsjbkDTbQ2sS7cF9rY=
 github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200408203355-0e1b2e323d39 h1:D8QuOoh7ImcWA/o0RJ8s7M4QojCWSgiK9LBhYONDD1E=
 github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200408203355-0e1b2e323d39/go.mod h1:aZAL+YwTtk+1YkTj8dDgTvv06dU8twzOdRowRtBfEKo=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200420175007-048d7d257824 h1:3FftRuw4Hqe1X2mG1z+0nJHyhjsAOrE6qZXXB45B86Q=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200420175007-048d7d257824/go.mod h1:aZAL+YwTtk+1YkTj8dDgTvv06dU8twzOdRowRtBfEKo=
+github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200428040525-c7c58b3d1319 h1:/XRxzEE2VrsPMrGxSaOVM2rKzaznfWRRiuXcTaytCls=
+github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200428040525-c7c58b3d1319/go.mod h1:2cAmeCWbS3FK4ZGTT+PPiXrQdW7b2VGw7H966KMi9WY=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c h1:nDOtl6j2Ei16tlnx/o4qKEelpHtGoZ9ArwU+tux4Ia8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d h1:hZcHR0at6tb3jBjaPHlfLr6yK7rTrA8xGCS6jlUSLcU=
@@ -1221,6 +1221,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.0 h1:DMOzIV76tmoDNE9pX6RSN0aDtCYeCg5VueieJaAo1uw=
 github.com/stretchr/testify v1.5.0/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.1.1/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -30,7 +30,11 @@ services:
         ports:
             - "8080-8082"
         depends_on:
+            #        UDP sender needs to know agent's address
             - jaeger-agent
+        environment:
+            - AGENT_HOST_PORT=jaeger-agent:6831
+            - SAMPLING_SERVER_URL:http://jaeger-agent:5778/sampling
 
     node:
         image: jaegertracing/xdock-node

--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -29,6 +29,8 @@ services:
         image: jaegertracing/xdock-go
         ports:
             - "8080-8082"
+        environment:
+            - AGENT_HOST_PORT=jaeger-agent:6831
 
     node:
         image: jaegertracing/xdock-node

--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -29,12 +29,6 @@ services:
         image: jaegertracing/xdock-go
         ports:
             - "8080-8082"
-        depends_on:
-            #        UDP sender needs to know agent's address
-            - jaeger-agent
-        environment:
-            - AGENT_HOST_PORT=jaeger-agent:6831
-            - SAMPLING_SERVER_URL:http://jaeger-agent:5778/sampling
 
     node:
         image: jaegertracing/xdock-node

--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -29,8 +29,8 @@ services:
         image: jaegertracing/xdock-go
         ports:
             - "8080-8082"
-        environment:
-            - AGENT_HOST_PORT=jaeger-agent:6831
+        depends_on:
+            - jaeger-agent
 
     node:
         image: jaegertracing/xdock-node

--- a/crossdock/otel-agent-config.yml
+++ b/crossdock/otel-agent-config.yml
@@ -15,5 +15,4 @@ service:
   pipelines:
     traces:
       receivers: [jaeger]
-      processors: []
       exporters: [jaeger]

--- a/crossdock/otel-agent-config.yml
+++ b/crossdock/otel-agent-config.yml
@@ -7,9 +7,6 @@ receivers:
       thrift_compact:
       thrift_binary:
 
-processors:
-  queued_retry: {}
-
 exporters:
   jaeger:
     endpoint: jaeger-collector:14250
@@ -18,5 +15,5 @@ service:
   pipelines:
     traces:
       receivers: [jaeger]
-      processors: [queued_retry]
+      processors: []
       exporters: [jaeger]


### PR DESCRIPTION
~Currently blocked by https://github.com/open-telemetry/opentelemetry-collector/issues/872 as we need a new translator from `pdata.Traces` to Jaeger data model.~