### PR TITLE
fix StartTimeMin

### DIFF
--- a/plugin/storage/badger/dependencystore/storage.go
+++ b/plugin/storage/badger/dependencystore/storage.go
@@ -39,7 +39,7 @@ func (s *DependencyStore) GetDependencies(endTs time.Time, lookback time.Duratio
 	deps := map[string]*model.DependencyLink{}
 
 	params := &spanstore.TraceQueryParameters{
-		StartTimeMin: endTs.Add(-1 * lookback),
+		StartTimeMin: endTs.Add(time.Duration(-1*lookback) * time.Millisecond),
 		StartTimeMax: endTs,
 	}
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Per https://www.jaegertracing.io/docs/1.17/apis/#service-dependencies-graph-internal lookback is in milliseconds. However, badger plugin fails to account for it.

## Short description of the changes
Fix timing unit.
