### PR TITLE
Normalize CLI flags to use host:port addresses

### DIFF
--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -17,7 +17,6 @@ package app
 
 import (
 	"flag"
-	"strings"
 
 	"github.com/spf13/viper"
 
@@ -104,25 +103,12 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
 	cOpts.DynQueueSizeMemory = v.GetUint(collectorDynQueueSizeMemory) * 1024 * 1024 // we receive in MiB and store in bytes
 	cOpts.QueueSize = v.GetInt(collectorQueueSize)
 	cOpts.NumWorkers = v.GetInt(collectorNumWorkers)
-	cOpts.CollectorHTTPHostPort = getAddressFromCLIOptions(v.GetInt(collectorHTTPPort), v.GetString(CollectorHTTPHostPort))
-	cOpts.CollectorGRPCHostPort = getAddressFromCLIOptions(v.GetInt(collectorGRPCPort), v.GetString(CollectorGRPCHostPort))
-	cOpts.CollectorZipkinHTTPHostPort = getAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(collectorZipkinHTTPHostPort))
+	cOpts.CollectorHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorHTTPPort), v.GetString(CollectorHTTPHostPort))
+	cOpts.CollectorGRPCHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorGRPCPort), v.GetString(CollectorGRPCHostPort))
+	cOpts.CollectorZipkinHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(collectorZipkinHTTPHostPort))
 	cOpts.CollectorTags = flags.ParseJaegerTags(v.GetString(collectorTags))
 	cOpts.CollectorZipkinAllowedOrigins = v.GetString(collectorZipkinAllowedOrigins)
 	cOpts.CollectorZipkinAllowedHeaders = v.GetString(collectorZipkinAllowedHeaders)
 	cOpts.TLS = tlsFlagsConfig.InitFromViper(v)
 	return cOpts
-}
-
-// Utility function to get listening address based on port (deprecated flags) or host:port (new flags)
-func getAddressFromCLIOptions(port int, hostPort string) string {
-	if port != 0 {
-		return ports.PortToHostPort(port)
-	}
-
-	if strings.Contains(hostPort, ":") {
-		return hostPort
-	}
-
-	return ":" + hostPort
 }

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -111,7 +111,7 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
 	cOpts.NumWorkers = v.GetInt(collectorNumWorkers)
 	cOpts.CollectorHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorHTTPPort), v.GetString(CollectorHTTPHostPort))
 	cOpts.CollectorGRPCHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorGRPCPort), v.GetString(CollectorGRPCHostPort))
-	cOpts.CollectorZipkinHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(collectorZipkinHTTPHostPort))
+	cOpts.CollectorZipkinHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(CollectorZipkinHTTPHostPort))
 	cOpts.CollectorTags = flags.ParseJaegerTags(v.GetString(collectorTags))
 	cOpts.CollectorZipkinAllowedOrigins = v.GetString(collectorZipkinAllowedOrigins)
 	cOpts.CollectorZipkinAllowedHeaders = v.GetString(collectorZipkinAllowedHeaders)

--- a/cmd/collector/app/builder_flags_test.go
+++ b/cmd/collector/app/builder_flags_test.go
@@ -51,7 +51,3 @@ func TestCollectorOptionsWithFlags_CheckFullHostPort(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:1234", c.CollectorGRPCHostPort)
 	assert.Equal(t, "0.0.0.0:3456", c.CollectorZipkinHTTPHostPort)
 }
-
-func Test_getAddressFromCLIOptions(t *testing.T) {
-	assert.Equal(t, ":123", getAddressFromCLIOptions(123, ""))
-}

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -38,13 +38,13 @@ import (
 const (
 	queryHostPort           = "query.host-port"
 	queryPort               = "query.port"
+	queryPortWarning        = "(deprecated, will be removed after 2020-08-31 or in release v1.20.0, whichever is later)"
 	queryBasePath           = "query.base-path"
 	queryStaticFiles        = "query.static-files"
 	queryUIConfig           = "query.ui-config"
 	queryTokenPropagation   = "query.bearer-token-propagation"
 	queryAdditionalHeaders  = "query.additional-headers"
 	queryMaxClockSkewAdjust = "query.max-clock-skew-adjustment"
-	queryPortWarning        = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
 )
 
 // QueryOptions holds configuration for query service

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -51,8 +51,6 @@ const (
 type QueryOptions struct {
 	// HostPort is the host:port address that the query service listens o n
 	HostPort string
-	// Port is the port that the query service listens in on (deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)
-	Port int
 	// BasePath is the prefix for all UI and API HTTP routes
 	BasePath string
 	// StaticAssets is the path for the static assets for the UI (https://github.com/uber/jaeger-ui)

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -51,9 +51,9 @@ const (
 type QueryOptions struct {
 	// HostPort is the host:port address that the query service listens o n
 	HostPort string
-	// Port is the port that the query service listens in on ()
+	// Port is the port that the query service listens in on (deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)
 	Port int
-	// BasePath is the prefix for all UI and API HTTP routes (deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)
+	// BasePath is the prefix for all UI and API HTTP routes
 	BasePath string
 	// StaticAssets is the path for the static assets for the UI (https://github.com/uber/jaeger-ui)
 	StaticAssets string
@@ -81,7 +81,6 @@ func AddFlags(flagSet *flag.FlagSet) {
 
 // InitFromViper initializes QueryOptions with properties from viper
 func (qOpts *QueryOptions) InitFromViper(v *viper.Viper, logger *zap.Logger) *QueryOptions {
-	// qOpts.Port = v.GetInt(queryPort)
 	qOpts.HostPort = ports.GetAddressFromCLIOptions(v.GetInt(queryPort), v.GetString(queryHostPort))
 	qOpts.BasePath = v.GetString(queryBasePath)
 	qOpts.StaticAssets = v.GetString(queryStaticFiles)

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -82,7 +82,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 // InitFromViper initializes QueryOptions with properties from viper
 func (qOpts *QueryOptions) InitFromViper(v *viper.Viper, logger *zap.Logger) *QueryOptions {
 	// qOpts.Port = v.GetInt(queryPort)
-	qOpts.HostPort = getAddressFromCLIOptions(v.GetInt(queryPort), v.GetString(queryHostPort))
+	qOpts.HostPort = ports.GetAddressFromCLIOptions(v.GetInt(queryPort), v.GetString(queryHostPort))
 	qOpts.BasePath = v.GetString(queryBasePath)
 	qOpts.StaticAssets = v.GetString(queryStaticFiles)
 	qOpts.UIConfig = v.GetString(queryUIConfig)
@@ -97,19 +97,6 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper, logger *zap.Logger) *Qu
 		qOpts.AdditionalHeaders = headers
 	}
 	return qOpts
-}
-
-// Utility function to get listening address based on port (deprecated flags) or host:port (new flags)
-func getAddressFromCLIOptions(port int, hostPort string) string {
-	if port != 0 {
-		return ports.PortToHostPort(port)
-	}
-
-	if strings.Contains(hostPort, ":") {
-		return hostPort
-	}
-
-	return ":" + hostPort
 }
 
 // BuildQueryServiceOptions creates a QueryServiceOptions struct with appropriate adjusters and archive config

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -31,24 +31,10 @@ import (
 func TestQueryBuilderFlagsDeprecation(t *testing.T) {
 	v, command := config.Viperize(AddFlags)
 	command.ParseFlags([]string{
-		"--query.static-files=/dev/null",
-		"--query.ui-config=some.json",
-		"--query.base-path=/jaeger",
 		"--query.port=80",
-		"--query.additional-headers=access-control-allow-origin:blerg",
-		"--query.additional-headers=whatever:thing",
-		"--query.max-clock-skew-adjustment=10s",
 	})
 	qOpts := new(QueryOptions).InitFromViper(v, zap.NewNop())
-	assert.Equal(t, "/dev/null", qOpts.StaticAssets)
-	assert.Equal(t, "some.json", qOpts.UIConfig)
-	assert.Equal(t, "/jaeger", qOpts.BasePath)
 	assert.Equal(t, ":80", qOpts.HostPort)
-	assert.Equal(t, http.Header{
-		"Access-Control-Allow-Origin": []string{"blerg"},
-		"Whatever":                    []string{"thing"},
-	}, qOpts.AdditionalHeaders)
-	assert.Equal(t, 10*time.Second, qOpts.MaxClockSkewAdjust)
 }
 
 func TestQueryBuilderFlags(t *testing.T) {
@@ -93,17 +79,6 @@ func TestQueryOptionsWithFlags_CheckHostPort(t *testing.T) {
 	q.InitFromViper(v, zap.NewNop())
 
 	assert.Equal(t, ":8080", q.HostPort)
-}
-
-func TestQueryOptionsWithFlags_CheckFullHostPort(t *testing.T) {
-	q := &QueryOptions{}
-	v, command := config.Viperize(AddFlags)
-	command.ParseFlags([]string{
-		"--query.host-port=127.0.0.1:1234",
-	})
-	q.InitFromViper(v, zap.NewNop())
-
-	assert.Equal(t, "127.0.0.1:1234", q.HostPort)
 }
 
 func TestStringSliceAsHeader(t *testing.T) {

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -52,7 +52,6 @@ func TestQueryBuilderFlags(t *testing.T) {
 	assert.Equal(t, "/dev/null", qOpts.StaticAssets)
 	assert.Equal(t, "some.json", qOpts.UIConfig)
 	assert.Equal(t, "/jaeger", qOpts.BasePath)
-	//assert.Equal(t, 80, qOpts.Port)
 	assert.Equal(t, "127.0.0.1:8080", qOpts.HostPort)
 	assert.Equal(t, http.Header{
 		"Access-Control-Allow-Origin": []string{"blerg"},
@@ -68,17 +67,6 @@ func TestQueryBuilderBadHeadersFlags(t *testing.T) {
 	})
 	qOpts := new(QueryOptions).InitFromViper(v, zap.NewNop())
 	assert.Nil(t, qOpts.AdditionalHeaders)
-}
-
-func TestQueryOptionsWithFlags_CheckHostPort(t *testing.T) {
-	q := &QueryOptions{}
-	v, command := config.Viperize(AddFlags)
-	command.ParseFlags([]string{
-		"--query.host-port=8080",
-	})
-	q.InitFromViper(v, zap.NewNop())
-
-	assert.Equal(t, ":8080", q.HostPort)
 }
 
 func TestStringSliceAsHeader(t *testing.T) {

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -100,7 +100,7 @@ func (s *Server) Start() error {
 	}
 	s.conn = conn
 
-	tcpPort := s.queryOptions.Port
+	var tcpPort int
 	if port, err := netutils.GetPort(s.conn.Addr()); err == nil {
 		tcpPort = port
 	}

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2020 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package app
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -95,7 +94,7 @@ func createHTTPServer(querySvc *querysvc.QueryService, queryOpts *QueryOptions, 
 
 // Start http, GRPC and cmux servers concurrently
 func (s *Server) Start() error {
-	conn, err := net.Listen("tcp", fmt.Sprintf(":%d", s.queryOptions.Port))
+	conn, err := net.Listen("tcp", s.queryOptions.HostPort)
 	if err != nil {
 		return err
 	}
@@ -105,10 +104,11 @@ func (s *Server) Start() error {
 	if port, err := netutils.GetPort(s.conn.Addr()); err == nil {
 		tcpPort = port
 	}
+	s.svc.Logger.Info("addr", zap.Int("port", tcpPort))
 
 	s.svc.Logger.Info(
 		"Query server started",
-		zap.Int("port", tcpPort))
+		zap.String("addr", s.queryOptions.HostPort))
 
 	// cmux server acts as a reverse-proxy between HTTP and GRPC backends.
 	cmuxServer := cmux.New(s.conn)
@@ -120,7 +120,7 @@ func (s *Server) Start() error {
 	httpListener := cmuxServer.Match(cmux.Any())
 
 	go func() {
-		s.svc.Logger.Info("Starting HTTP server", zap.Int("port", tcpPort))
+		s.svc.Logger.Info("Starting HTTP server", zap.String("addr", s.queryOptions.HostPort))
 
 		switch err := s.httpServer.Serve(httpListener); err {
 		case nil, http.ErrServerClosed, cmux.ErrListenerClosed:
@@ -133,7 +133,7 @@ func (s *Server) Start() error {
 
 	// Start GRPC server concurrently
 	go func() {
-		s.svc.Logger.Info("Starting GRPC server", zap.Int("port", tcpPort))
+		s.svc.Logger.Info("Starting GRPC server", zap.String("addr", s.queryOptions.HostPort))
 
 		if err := s.grpcServer.Serve(grpcListener); err != nil {
 			s.svc.Logger.Error("Could not start GRPC server", zap.Error(err))
@@ -143,7 +143,7 @@ func (s *Server) Start() error {
 
 	// Start cmux server concurrently.
 	go func() {
-		s.svc.Logger.Info("Starting CMUX server", zap.Int("port", tcpPort))
+		s.svc.Logger.Info("Starting CMUX server", zap.String("addr", s.queryOptions.HostPort))
 
 		err := cmuxServer.Serve()
 		// TODO: Remove string comparison when https://github.com/soheilhy/cmux/pull/69 is merged

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Jaeger Authors.
+// Copyright (c) 2019,2020 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,10 +104,10 @@ func (s *Server) Start() error {
 	if port, err := netutils.GetPort(s.conn.Addr()); err == nil {
 		tcpPort = port
 	}
-	s.svc.Logger.Info("addr", zap.Int("port", tcpPort))
 
 	s.svc.Logger.Info(
 		"Query server started",
+		zap.Int("port", tcpPort),
 		zap.String("addr", s.queryOptions.HostPort))
 
 	// cmux server acts as a reverse-proxy between HTTP and GRPC backends.
@@ -120,7 +120,7 @@ func (s *Server) Start() error {
 	httpListener := cmuxServer.Match(cmux.Any())
 
 	go func() {
-		s.svc.Logger.Info("Starting HTTP server", zap.String("addr", s.queryOptions.HostPort))
+		s.svc.Logger.Info("Starting HTTP server", zap.Int("port", tcpPort), zap.String("addr", s.queryOptions.HostPort))
 
 		switch err := s.httpServer.Serve(httpListener); err {
 		case nil, http.ErrServerClosed, cmux.ErrListenerClosed:
@@ -133,7 +133,7 @@ func (s *Server) Start() error {
 
 	// Start GRPC server concurrently
 	go func() {
-		s.svc.Logger.Info("Starting GRPC server", zap.String("addr", s.queryOptions.HostPort))
+		s.svc.Logger.Info("Starting GRPC server", zap.Int("port", tcpPort), zap.String("addr", s.queryOptions.HostPort))
 
 		if err := s.grpcServer.Serve(grpcListener); err != nil {
 			s.svc.Logger.Error("Could not start GRPC server", zap.Error(err))
@@ -143,7 +143,7 @@ func (s *Server) Start() error {
 
 	// Start cmux server concurrently.
 	go func() {
-		s.svc.Logger.Info("Starting CMUX server", zap.String("addr", s.queryOptions.HostPort))
+		s.svc.Logger.Info("Starting CMUX server", zap.Int("port", tcpPort), zap.String("addr", s.queryOptions.HostPort))
 
 		err := cmuxServer.Serve()
 		// TODO: Remove string comparison when https://github.com/soheilhy/cmux/pull/69 is merged

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -111,7 +111,7 @@ func TestServerHandlesPortZero(t *testing.T) {
 
 	querySvc := &querysvc.QueryService{}
 	tracer := opentracing.NoopTracer{}
-	server := NewServer(flagsSvc, querySvc, &QueryOptions{HostPort: ":0"}, tracer) //Change me
+	server := NewServer(flagsSvc, querySvc, &QueryOptions{HostPort: ":0"}, tracer)
 	assert.NoError(t, server.Start())
 	server.Close()
 

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Jaeger Authors.
+// Copyright (c) 2019,2020 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ func TestServerHandlesPortZero(t *testing.T) {
 
 	querySvc := &querysvc.QueryService{}
 	tracer := opentracing.NoopTracer{}
-	server := NewServer(flagsSvc, querySvc, &QueryOptions{Port: 0}, tracer) //Change me
+	server := NewServer(flagsSvc, querySvc, &QueryOptions{HostPort: ":0"}, tracer) //Change me
 	assert.NoError(t, server.Start())
 	server.Close()
 
@@ -119,6 +119,6 @@ func TestServerHandlesPortZero(t *testing.T) {
 	assert.Equal(t, 1, message.Len(), "Expected query started log message.")
 
 	onlyEntry := message.All()[0]
-	port := onlyEntry.ContextMap()["port"].(int64)
+	port := onlyEntry.ContextMap()["port"]
 	assert.Greater(t, port, int64(0))
 }

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -46,7 +46,7 @@ func TestServerError(t *testing.T) {
 func TestServer(t *testing.T) {
 	flagsSvc := flags.NewService(ports.QueryAdminHTTP)
 	flagsSvc.Logger = zap.NewNop()
-	hostPort := getAddressFromCLIOptions(ports.QueryHTTP, "")
+	hostPort := ports.GetAddressFromCLIOptions(ports.QueryHTTP, "")
 
 	spanReader := &spanstoremocks.Reader{}
 	dependencyReader := &depsmocks.Reader{}

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -90,7 +90,7 @@ func TestServerGracefulExit(t *testing.T) {
 
 	querySvc := &querysvc.QueryService{}
 	tracer := opentracing.NoopTracer{}
-	server := NewServer(flagsSvc, querySvc, &QueryOptions{Port: ports.QueryAdminHTTP}, tracer)
+	server := NewServer(flagsSvc, querySvc, &QueryOptions{HostPort: ports.PortToHostPort(ports.QueryAdminHTTP)}, tracer)
 	assert.NoError(t, server.Start())
 
 	// Wait for servers to come up before we can call .Close()

--- a/cmd/query/app/ui/placeholder/gen_assets.go
+++ b/cmd/query/app/ui/placeholder/gen_assets.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    "index.html",
 		local:   "cmd/query/app/ui/placeholder/public/index.html",
 		size:    376,
-		modtime: 1547655513,
+		modtime: 1586972220,
 		compressed: `
 H4sIAAAAAAAC/zyQQW/CMAyF7/yKR8/Lep20FolBQSA0EGsPOyHTmiZTm6DECPHvpyrQXGK/56fPcjZd
 7hfl76GAlr6bTbLhQ0e2zRO2yWwCAFnPQqg1+cCSJ1W5Uh8v60yBoT1f8iRN0JCQMvaPa1FCvh3Gv+Y/

--- a/cmd/query/app/ui/placeholder/gen_assets.go
+++ b/cmd/query/app/ui/placeholder/gen_assets.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    "index.html",
 		local:   "cmd/query/app/ui/placeholder/public/index.html",
 		size:    376,
-		modtime: 1586972220,
+		modtime: 1547655513,
 		compressed: `
 H4sIAAAAAAAC/zyQQW/CMAyF7/yKR8/Lep20FolBQSA0EGsPOyHTmiZTm6DECPHvpyrQXGK/56fPcjZd
 7hfl76GAlr6bTbLhQ0e2zRO2yWwCAFnPQqg1+cCSJ1W5Uh8v60yBoT1f8iRN0JCQMvaPa1FCvh3Gv+Y/

--- a/ports/ports.go
+++ b/ports/ports.go
@@ -16,6 +16,7 @@ package ports
 
 import (
 	"strconv"
+	"strings"
 )
 
 const (
@@ -49,4 +50,17 @@ const (
 // PortToHostPort converts the port into a host:port address string
 func PortToHostPort(port int) string {
 	return ":" + strconv.Itoa(port)
+}
+
+// GetAddressFromCLIOptions gets listening address based on port (deprecated flags) or host:port (new flags)
+func GetAddressFromCLIOptions(port int, hostPort string) string {
+	if port != 0 {
+		return PortToHostPort(port)
+	}
+
+	if strings.Contains(hostPort, ":") {
+		return hostPort
+	}
+
+	return ":" + hostPort
 }

--- a/ports/ports_test.go
+++ b/ports/ports_test.go
@@ -35,3 +35,7 @@ func TestGetAddressFromCLIOptionHostPort(t *testing.T) {
 func TestGetAddressFromCLIOptionOnlyPort(t *testing.T) {
 	assert.Equal(t, ":123", GetAddressFromCLIOptions(0, ":123"))
 }
+
+func TestGetAddressFromCLIOptionOnlyPortWithoutColon(t *testing.T) {
+	assert.Equal(t, ":123", GetAddressFromCLIOptions(0, "123"))
+}

--- a/ports/ports_test.go
+++ b/ports/ports_test.go
@@ -24,6 +24,14 @@ func TestPortToHostPort(t *testing.T) {
 	assert.Equal(t, ":42", PortToHostPort(42))
 }
 
-func TestGetAddressFromCLIOptions(t *testing.T) {
+func TestGetAddressFromCLIOptionsLegacy(t *testing.T) {
 	assert.Equal(t, ":123", GetAddressFromCLIOptions(123, ""))
+}
+
+func TestGetAddressFromCLIOptionHostPort(t *testing.T) {
+	assert.Equal(t, "127.0.0.1:123", GetAddressFromCLIOptions(0, "127.0.0.1:123"))
+}
+
+func TestGetAddressFromCLIOptionOnlyPort(t *testing.T) {
+	assert.Equal(t, ":123", GetAddressFromCLIOptions(0, ":123"))
 }

--- a/ports/ports_test.go
+++ b/ports/ports_test.go
@@ -23,3 +23,7 @@ import (
 func TestPortToHostPort(t *testing.T) {
 	assert.Equal(t, ":42", PortToHostPort(42))
 }
+
+func TestGetAddressFromCLIOptions(t *testing.T) {
+	assert.Equal(t, ":123", GetAddressFromCLIOptions(123, ""))
+}


### PR DESCRIPTION
Signed-off-by: Jonas Reindl <j-reindl@live.at>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #1447


## Short description of the changes
- Normalize CLI flags to use host:port address format
- Add HostPort Flag to query app as it was left out
