### PR TITLE
Document timestamp/duration precision in Cassandra schema

### DIFF
--- a/plugin/storage/cassandra/schema/v001.cql.tmpl
+++ b/plugin/storage/cassandra/schema/v001.cql.tmpl
@@ -33,7 +33,7 @@ CREATE TYPE IF NOT EXISTS ${keyspace}.keyvalue (
 );
 
 CREATE TYPE IF NOT EXISTS ${keyspace}.log (
-    ts      bigint,
+    ts      bigint, // microseconds since epoch
     fields  list<frozen<keyvalue>>,
 );
 
@@ -58,8 +58,8 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.traces (
     parent_id       bigint,
     operation_name  text,
     flags           int,
-    start_time      bigint,
-    duration        bigint,
+    start_time      bigint, // microseconds since epoch
+    duration        bigint, // microseconds
     tags            list<frozen<keyvalue>>,
     logs            list<frozen<log>>,
     refs            list<frozen<span_ref>>,
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.operation_names (
 CREATE TABLE IF NOT EXISTS ${keyspace}.service_operation_index (
     service_name        text,
     operation_name      text,
-    start_time          bigint,
+    start_time          bigint, // microseconds since epoch
     trace_id            blob,
     PRIMARY KEY ((service_name, operation_name), start_time)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.service_operation_index (
 CREATE TABLE IF NOT EXISTS ${keyspace}.service_name_index (
     service_name      text,
     bucket            int,
-    start_time        bigint,
+    start_time        bigint, // microseconds since epoch
     trace_id          blob,
     PRIMARY KEY ((service_name, bucket), start_time)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.duration_index (
     operation_name  text,      // operation name, or blank for queries without span name
     bucket          timestamp, // time bucket, - the start_time of the given span rounded to an hour
     duration        bigint,    // span duration, in microseconds
-    start_time      bigint,
+    start_time      bigint,    // microseconds since epoch
     trace_id        blob,
     PRIMARY KEY ((service_name, operation_name, bucket), duration, start_time, trace_id)
 ) WITH CLUSTERING ORDER BY (duration DESC, start_time DESC)
@@ -165,7 +165,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.tag_index (
     service_name    text,
     tag_key         text,
     tag_value       text,
-    start_time      bigint,
+    start_time      bigint, // microseconds since epoch
     trace_id        blob,
     span_id         bigint,
     PRIMARY KEY ((service_name, tag_key, tag_value), start_time, trace_id, span_id)

--- a/plugin/storage/cassandra/schema/v002.cql.tmpl
+++ b/plugin/storage/cassandra/schema/v002.cql.tmpl
@@ -33,7 +33,7 @@ CREATE TYPE IF NOT EXISTS ${keyspace}.keyvalue (
 );
 
 CREATE TYPE IF NOT EXISTS ${keyspace}.log (
-    ts      bigint,
+    ts      bigint, // microseconds since epoch
     fields  list<frozen<keyvalue>>,
 );
 
@@ -58,8 +58,8 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.traces (
     parent_id       bigint,
     operation_name  text,
     flags           int,
-    start_time      bigint,
-    duration        bigint,
+    start_time      bigint, // microseconds since epoch
+    duration        bigint, // microseconds
     tags            list<frozen<keyvalue>>,
     logs            list<frozen<log>>,
     refs            list<frozen<span_ref>>,
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.operation_names (
 CREATE TABLE IF NOT EXISTS ${keyspace}.service_operation_index (
     service_name        text,
     operation_name      text,
-    start_time          bigint,
+    start_time          bigint, // microseconds since epoch
     trace_id            blob,
     PRIMARY KEY ((service_name, operation_name), start_time)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.service_operation_index (
 CREATE TABLE IF NOT EXISTS ${keyspace}.service_name_index (
     service_name      text,
     bucket            int,
-    start_time        bigint,
+    start_time        bigint, // microseconds since epoch
     trace_id          blob,
     PRIMARY KEY ((service_name, bucket), start_time)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.duration_index (
     operation_name  text,      // operation name, or blank for queries without span name
     bucket          timestamp, // time bucket, - the start_time of the given span rounded to an hour
     duration        bigint,    // span duration, in microseconds
-    start_time      bigint,
+    start_time      bigint,    // microseconds since epoch
     trace_id        blob,
     PRIMARY KEY ((service_name, operation_name, bucket), duration, start_time, trace_id)
 ) WITH CLUSTERING ORDER BY (duration DESC, start_time DESC)
@@ -165,7 +165,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.tag_index (
     service_name    text,
     tag_key         text,
     tag_value       text,
-    start_time      bigint,
+    start_time      bigint, // microseconds since epoch
     trace_id        blob,
     span_id         bigint,
     PRIMARY KEY ((service_name, tag_key, tag_value), start_time, trace_id, span_id)

--- a/plugin/storage/cassandra/schema/v003.cql.tmpl
+++ b/plugin/storage/cassandra/schema/v003.cql.tmpl
@@ -33,7 +33,7 @@ CREATE TYPE IF NOT EXISTS ${keyspace}.keyvalue (
 );
 
 CREATE TYPE IF NOT EXISTS ${keyspace}.log (
-    ts      bigint,
+    ts      bigint, // microseconds since epoch
     fields  list<frozen<keyvalue>>,
 );
 
@@ -58,8 +58,8 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.traces (
     parent_id       bigint,
     operation_name  text,
     flags           int,
-    start_time      bigint,
-    duration        bigint,
+    start_time      bigint, // microseconds since epoch
+    duration        bigint, // microseconds
     tags            list<frozen<keyvalue>>,
     logs            list<frozen<log>>,
     refs            list<frozen<span_ref>>,
@@ -110,7 +110,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.operation_names_v2 (
 CREATE TABLE IF NOT EXISTS ${keyspace}.service_operation_index (
     service_name        text,
     operation_name      text,
-    start_time          bigint,
+    start_time          bigint, // microseconds since epoch
     trace_id            blob,
     PRIMARY KEY ((service_name, operation_name), start_time)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.service_operation_index (
 CREATE TABLE IF NOT EXISTS ${keyspace}.service_name_index (
     service_name      text,
     bucket            int,
-    start_time        bigint,
+    start_time        bigint, // microseconds since epoch
     trace_id          blob,
     PRIMARY KEY ((service_name, bucket), start_time)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
@@ -146,7 +146,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.duration_index (
     operation_name  text,      // operation name, or blank for queries without span name
     bucket          timestamp, // time bucket, - the start_time of the given span rounded to an hour
     duration        bigint,    // span duration, in microseconds
-    start_time      bigint,
+    start_time      bigint,    // microseconds since epoch
     trace_id        blob,
     PRIMARY KEY ((service_name, operation_name, bucket), duration, start_time, trace_id)
 ) WITH CLUSTERING ORDER BY (duration DESC, start_time DESC)
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.tag_index (
     service_name    text,
     tag_key         text,
     tag_value       text,
-    start_time      bigint,
+    start_time      bigint, // microseconds since epoch
     trace_id        blob,
     span_id         bigint,
     PRIMARY KEY ((service_name, tag_key, tag_value), start_time, trace_id, span_id)

--- a/plugin/storage/cassandra/spanstore/dbmodel/model.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/model.go
@@ -43,8 +43,8 @@ type Span struct {
 	ParentID      int64 // deprecated
 	OperationName string
 	Flags         int32
-	StartTime     int64
-	Duration      int64
+	StartTime     int64 // microseconds since epoch
+	Duration      int64 // microseconds
 	Tags          []KeyValue
 	Logs          []Log
 	Refs          []SpanRef
@@ -66,7 +66,7 @@ type KeyValue struct {
 
 // Log is the UDT representation of a Jaeger Log.
 type Log struct {
-	Timestamp int64      `cql:"ts"`
+	Timestamp int64      `cql:"ts"` // microseconds since epoch
 	Fields    []KeyValue `cql:"fields"`
 }
 


### PR DESCRIPTION
Add comments that `bigint` fields for timestamps and durations are in microseconds.