### PR TITLE
Provide the ability to define the default strategy for one service

### DIFF
--- a/plugin/sampling/strategystore/static/options.go
+++ b/plugin/sampling/strategystore/static/options.go
@@ -24,6 +24,7 @@ import (
 const (
 	SamplingStrategiesFile           = "sampling.strategies-file"
 	samplingStrategiesReloadInterval = "sampling.strategies-reload-interval"
+	samplingDisableMergeStrategies   = "sampling.disable-merge-strategies"
 )
 
 // Options holds configuration for the static sampling strategy store.
@@ -32,17 +33,21 @@ type Options struct {
 	StrategiesFile string
 	// ReloadInterval is the time interval to check and reload sampling strategies file
 	ReloadInterval time.Duration
+	// DisableMerge disables the merging of default strategies
+	DisableMerge bool
 }
 
 // AddFlags adds flags for Options
 func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(SamplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
 	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
+	flagSet.Bool(samplingDisableMergeStrategies, false, "Disables the merging of default strategies")
 }
 
 // InitFromViper initializes Options with properties from viper
 func (opts *Options) InitFromViper(v *viper.Viper) *Options {
 	opts.StrategiesFile = v.GetString(SamplingStrategiesFile)
 	opts.ReloadInterval = v.GetDuration(samplingStrategiesReloadInterval)
+	opts.DisableMerge = v.GetBool(samplingDisableMergeStrategies)
 	return opts
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fix #2171

## Short description of the changes
- Add a bool flag --sampling.disable-merge-strategies to provide the ability to define the default strategy for one service.
