### PR TITLE
Support adding process tags in OTEL via env variable

### DIFF
--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -28,8 +28,8 @@ import (
 const (
 	// Whether to use grpc or tchannel reporter.
 	reporterType = "reporter.type"
-	// Agent tags
-	agentTagsDeprecated = "jaeger.tags"
+	// AgentTagsDeprecated is a configuration property name for adding process tags to incoming spans.
+	AgentTagsDeprecated = "jaeger.tags"
 	agentTags           = "agent.tags"
 	// GRPC is name of gRPC reporter.
 	GRPC Type = "grpc"
@@ -48,7 +48,7 @@ type Options struct {
 func AddFlags(flags *flag.FlagSet) {
 	flags.String(reporterType, string(GRPC), fmt.Sprintf("Reporter type to use e.g. %s", string(GRPC)))
 	if !setupcontext.IsAllInOne() {
-		flags.String(agentTagsDeprecated, "", "(deprecated) see --"+agentTags)
+		flags.String(AgentTagsDeprecated, "", "(deprecated) see --"+agentTags)
 		flags.String(agentTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
 	}
 }
@@ -57,9 +57,9 @@ func AddFlags(flags *flag.FlagSet) {
 func (b *Options) InitFromViper(v *viper.Viper, logger *zap.Logger) *Options {
 	b.ReporterType = Type(v.GetString(reporterType))
 	if !setupcontext.IsAllInOne() {
-		if len(v.GetString(agentTagsDeprecated)) > 0 {
-			logger.Warn("Using deprecated configuration", zap.String("option", agentTagsDeprecated))
-			b.AgentTags = flags.ParseJaegerTags(v.GetString(agentTagsDeprecated))
+		if len(v.GetString(AgentTagsDeprecated)) > 0 {
+			logger.Warn("Using deprecated configuration", zap.String("option", AgentTagsDeprecated))
+			b.AgentTags = flags.ParseJaegerTags(v.GetString(AgentTagsDeprecated))
 		}
 		if len(v.GetString(agentTags)) > 0 {
 			b.AgentTags = flags.ParseJaegerTags(v.GetString(agentTags))

--- a/cmd/opentelemetry-collector/app/defaults/default_config_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaegerexporter"
+	"github.com/open-telemetry/opentelemetry-collector/processor/resourceprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -51,9 +52,10 @@ func TestDefaultCollectorConfig(t *testing.T) {
 			exporterTypes:  []string{elasticsearch.TypeStr},
 			pipeline: configmodels.Pipelines{
 				"traces": {
-					InputType: configmodels.TracesDataType,
-					Receivers: []string{"jaeger"},
-					Exporters: []string{elasticsearch.TypeStr},
+					InputType:  configmodels.TracesDataType,
+					Receivers:  []string{"jaeger"},
+					Processors: []string{"resource"},
+					Exporters:  []string{elasticsearch.TypeStr},
 				},
 			},
 		},
@@ -63,9 +65,10 @@ func TestDefaultCollectorConfig(t *testing.T) {
 			exporterTypes:  []string{cassandra.TypeStr},
 			pipeline: configmodels.Pipelines{
 				"traces": {
-					InputType: configmodels.TracesDataType,
-					Receivers: []string{"jaeger"},
-					Exporters: []string{cassandra.TypeStr},
+					InputType:  configmodels.TracesDataType,
+					Receivers:  []string{"jaeger"},
+					Processors: []string{"resource"},
+					Exporters:  []string{cassandra.TypeStr},
 				},
 			},
 		},
@@ -75,9 +78,10 @@ func TestDefaultCollectorConfig(t *testing.T) {
 			exporterTypes:  []string{kafka.TypeStr},
 			pipeline: configmodels.Pipelines{
 				"traces": {
-					InputType: configmodels.TracesDataType,
-					Receivers: []string{"jaeger"},
-					Exporters: []string{kafka.TypeStr},
+					InputType:  configmodels.TracesDataType,
+					Receivers:  []string{"jaeger"},
+					Processors: []string{"resource"},
+					Exporters:  []string{kafka.TypeStr},
 				},
 			},
 		},
@@ -87,9 +91,10 @@ func TestDefaultCollectorConfig(t *testing.T) {
 			exporterTypes:  []string{cassandra.TypeStr, elasticsearch.TypeStr},
 			pipeline: configmodels.Pipelines{
 				"traces": {
-					InputType: configmodels.TracesDataType,
-					Receivers: []string{"jaeger"},
-					Exporters: []string{cassandra.TypeStr, elasticsearch.TypeStr},
+					InputType:  configmodels.TracesDataType,
+					Receivers:  []string{"jaeger"},
+					Processors: []string{"resource"},
+					Exporters:  []string{cassandra.TypeStr, elasticsearch.TypeStr},
 				},
 			},
 		},
@@ -99,9 +104,10 @@ func TestDefaultCollectorConfig(t *testing.T) {
 			exporterTypes:  []string{cassandra.TypeStr},
 			pipeline: configmodels.Pipelines{
 				"traces": {
-					InputType: configmodels.TracesDataType,
-					Receivers: []string{"jaeger", "zipkin"},
-					Exporters: []string{cassandra.TypeStr},
+					InputType:  configmodels.TracesDataType,
+					Receivers:  []string{"jaeger", "zipkin"},
+					Processors: []string{"resource"},
+					Exporters:  []string{cassandra.TypeStr},
 				},
 			},
 		},
@@ -128,6 +134,7 @@ func TestDefaultCollectorConfig(t *testing.T) {
 			assert.Equal(t, len(test.pipeline["traces"].Receivers), len(cfg.Receivers))
 			assert.Equal(t, "jaeger", cfg.Receivers["jaeger"].Name())
 			assert.Equal(t, len(test.exporterTypes), len(cfg.Exporters))
+			assert.IsType(t, &resourceprocessor.Config{}, cfg.Processors["resource"])
 
 			types := []string{}
 			for _, v := range cfg.Exporters {
@@ -148,13 +155,15 @@ func TestDefaultAgentConfig(t *testing.T) {
 		Extensions: []string{"health_check"},
 		Pipelines: configmodels.Pipelines{
 			"traces": &configmodels.Pipeline{
-				InputType: configmodels.TracesDataType,
-				Receivers: []string{"jaeger"},
-				Exporters: []string{"jaeger"},
+				InputType:  configmodels.TracesDataType,
+				Receivers:  []string{"jaeger"},
+				Processors: []string{"resource"},
+				Exporters:  []string{"jaeger"},
 			},
 		},
 	}, cfg.Service)
-	assert.Equal(t, 0, len(cfg.Processors))
+	assert.Equal(t, 1, len(cfg.Processors))
+	assert.IsType(t, &resourceprocessor.Config{}, cfg.Processors["resource"])
 	assert.Equal(t, 1, len(cfg.Receivers))
 	assert.IsType(t, &jaegerreceiver.Config{}, cfg.Receivers["jaeger"])
 	assert.Equal(t, 1, len(cfg.Exporters))

--- a/cmd/opentelemetry-collector/app/defaults/defaults.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults.go
@@ -18,8 +18,9 @@ import (
 	"flag"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
-	otelJaegerEexporter "github.com/open-telemetry/opentelemetry-collector/exporter/jaegerexporter"
-	otelJaegerreceiver "github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+	otelJaegerExporter "github.com/open-telemetry/opentelemetry-collector/exporter/jaegerexporter"
+	otelResourceProcessor "github.com/open-telemetry/opentelemetry-collector/processor/resourceprocessor"
+	otelJaegerReceiver "github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/service/defaultcomponents"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -28,6 +29,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/jaegerexporter"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/processor/resourceprocessor"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/jaegerreceiver"
 	storageCassandra "github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	storageEs "github.com/jaegertracing/jaeger/plugin/storage/es"
@@ -61,14 +63,20 @@ func Components(v *viper.Viper) config.Factories {
 	factories.Exporters[cassandraExp.Type()] = cassandraExp
 	factories.Exporters[esExp.Type()] = esExp
 
-	jaegerRec := factories.Receivers["jaeger"].(*otelJaegerreceiver.Factory)
+	jaegerRec := factories.Receivers["jaeger"].(*otelJaegerReceiver.Factory)
 	factories.Receivers["jaeger"] = &jaegerreceiver.Factory{
 		Wrapped: jaegerRec,
 		Viper:   v,
 	}
-	jaegerExp := factories.Exporters["jaeger"].(*otelJaegerEexporter.Factory)
+	jaegerExp := factories.Exporters["jaeger"].(*otelJaegerExporter.Factory)
 	factories.Exporters["jaeger"] = &jaegerexporter.Factory{
 		Wrapped: jaegerExp,
+		Viper:   v,
+	}
+
+	resourceProc := factories.Processors["resource"].(*otelResourceProcessor.Factory)
+	factories.Processors["resource"] = &resourceprocessor.Factory{
+		Wrapped: resourceProc,
 		Viper:   v,
 	}
 	return factories

--- a/cmd/opentelemetry-collector/app/defaults/defaults_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/jaegerexporter"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/processor/resourceprocessor"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/jaegerreceiver"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 )
@@ -51,4 +52,5 @@ func TestComponents(t *testing.T) {
 	assert.Equal(t, []string{"http://127.0.0.1:9200"}, ec.GetPrimary().Servers)
 	assert.IsType(t, &jaegerreceiver.Factory{}, factories.Receivers["jaeger"])
 	assert.IsType(t, &jaegerexporter.Factory{}, factories.Exporters["jaeger"])
+	assert.IsType(t, &resourceprocessor.Factory{}, factories.Processors["resource"])
 }

--- a/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor.go
+++ b/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor.go
@@ -16,6 +16,7 @@ package resourceprocessor
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
@@ -29,7 +30,7 @@ import (
 )
 
 const (
-	resourceTags = "resource.labels"
+	resourceLabels = "resource.labels"
 )
 
 // Factory wraps resourceprocessor.Factory and makes the default config configurable via viper.
@@ -58,7 +59,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Processor {
 
 func GetTags(v *viper.Viper) map[string]string {
 	tagsLegacy := flags.ParseJaegerTags(v.GetString(reporter.AgentTagsDeprecated))
-	tags := flags.ParseJaegerTags(v.GetString(resourceTags))
+	tags := flags.ParseJaegerTags(v.GetString(resourceLabels))
 	for k, v := range tagsLegacy {
 		if _, ok := tags[k]; !ok {
 			tags[k] = v
@@ -89,6 +90,6 @@ func (f Factory) CreateMetricsProcessor(
 
 // AddFlags adds flags for Options.
 func AddFlags(flags *flag.FlagSet) {
-	flags.String(reporter.AgentTagsDeprecated, "", "(deprecated, use --resource.tags) One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
-	flags.String(resourceTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
+	flags.String(reporter.AgentTagsDeprecated, "", fmt.Sprintf("(deprecated, use --%s) One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}", resourceLabels))
+	flags.String(resourceLabels, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
 }

--- a/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor.go
+++ b/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"flag"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/processor/resourceprocessor"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/flags"
+)
+
+const (
+	resourceTags       = "resource.tags"
+	resourceTagsLegacy = "jaeger.tags"
+)
+
+// Factory wraps resourceprocessor.Factory and makes the default config configurable via viper.
+// For instance this enables using flags as default values in the config object.
+type Factory struct {
+	Wrapped *resourceprocessor.Factory
+	Viper   *viper.Viper
+}
+
+var _ component.ProcessorFactoryOld = (*Factory)(nil)
+
+// Type returns the type of the receiver.
+func (f Factory) Type() configmodels.Type {
+	return f.Wrapped.Type()
+}
+
+// CreateDefaultConfig returns default configuration of Factory.
+// This function implements OTEL component.ProcessorFactoryBase interface.
+func (f Factory) CreateDefaultConfig() configmodels.Processor {
+	cfg := f.Wrapped.CreateDefaultConfig().(*resourceprocessor.Config)
+	for k, v := range getTags(f.Viper) {
+		cfg.Labels[k] = v
+	}
+	return cfg
+}
+
+func getTags(v *viper.Viper) map[string]string {
+	tagsLegacy := flags.ParseJaegerTags(v.GetString(resourceTagsLegacy))
+	tags := flags.ParseJaegerTags(v.GetString(resourceTags))
+	for k, v := range tagsLegacy {
+		if _, ok := tags[k]; !ok {
+			tags[k] = v
+		}
+	}
+	return tags
+}
+
+// CreateTraceProcessor creates resource processor.
+// This function implements OTEL component.ProcessorFactoryOld interface.
+func (f Factory) CreateTraceProcessor(
+	logger *zap.Logger,
+	nextConsumer consumer.TraceConsumerOld,
+	cfg configmodels.Processor,
+) (component.TraceProcessorOld, error) {
+	return f.Wrapped.CreateTraceProcessor(logger, nextConsumer, cfg)
+}
+
+// CreateMetricsProcessor creates a resource processor.
+// This function implements component.ProcessorFactoryOld.
+func (f Factory) CreateMetricsProcessor(
+	logger *zap.Logger,
+	nextConsumer consumer.MetricsConsumerOld,
+	cfg configmodels.Processor,
+) (component.MetricsProcessorOld, error) {
+	return f.Wrapped.CreateMetricsProcessor(logger, nextConsumer, cfg)
+}
+
+// AddFlags adds flags for Options.
+func AddFlags(flags *flag.FlagSet) {
+	flags.String(resourceTagsLegacy, "", "(deprecated, use --resource.tags) One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
+	flags.String(resourceTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
+}

--- a/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor.go
+++ b/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor.go
@@ -24,12 +24,12 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/cmd/flags"
 )
 
 const (
-	resourceTags       = "resource.tags"
-	resourceTagsLegacy = "jaeger.tags"
+	resourceTags = "resource.labels"
 )
 
 // Factory wraps resourceprocessor.Factory and makes the default config configurable via viper.
@@ -50,14 +50,14 @@ func (f Factory) Type() configmodels.Type {
 // This function implements OTEL component.ProcessorFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Processor {
 	cfg := f.Wrapped.CreateDefaultConfig().(*resourceprocessor.Config)
-	for k, v := range getTags(f.Viper) {
+	for k, v := range GetTags(f.Viper) {
 		cfg.Labels[k] = v
 	}
 	return cfg
 }
 
-func getTags(v *viper.Viper) map[string]string {
-	tagsLegacy := flags.ParseJaegerTags(v.GetString(resourceTagsLegacy))
+func GetTags(v *viper.Viper) map[string]string {
+	tagsLegacy := flags.ParseJaegerTags(v.GetString(reporter.AgentTagsDeprecated))
 	tags := flags.ParseJaegerTags(v.GetString(resourceTags))
 	for k, v := range tagsLegacy {
 		if _, ok := tags[k]; !ok {
@@ -89,6 +89,6 @@ func (f Factory) CreateMetricsProcessor(
 
 // AddFlags adds flags for Options.
 func AddFlags(flags *flag.FlagSet) {
-	flags.String(resourceTagsLegacy, "", "(deprecated, use --resource.tags) One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
+	flags.String(reporter.AgentTagsDeprecated, "", "(deprecated, use --resource.tags) One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
 	flags.String(resourceTags, "", "One or more tags to be added to the Process tags of all spans passing through this agent. Ex: key1=value1,key2=${envVar:defaultValue}")
 }

--- a/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor_test.go
+++ b/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor_test.go
@@ -76,6 +76,9 @@ func TestLoadConfigAndFlags(t *testing.T) {
 
 	cfg := colConfig.Processors[string(f.Type())].(*resourceprocessor.Config)
 	assert.Equal(t, map[string]string{"zone": "zone1", "foo": "bar"}, cfg.Labels)
+	p, err := f.CreateTraceProcessor(zap.NewNop(), nil, cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, p)
 }
 
 func TestType(t *testing.T) {

--- a/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor_test.go
+++ b/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"path"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/processor/resourceprocessor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/flags"
+	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+)
+
+func TestDefaultValues(t *testing.T) {
+	v, c := jConfig.Viperize(AddFlags)
+	err := c.ParseFlags([]string{})
+	require.NoError(t, err)
+
+	f := &Factory{Viper: v, Wrapped: &resourceprocessor.Factory{}}
+	cfg := f.CreateDefaultConfig().(*resourceprocessor.Config)
+	assert.Empty(t, cfg.Labels)
+}
+
+func TestDefaultValueFromViper(t *testing.T) {
+	v, c := jConfig.Viperize(AddFlags)
+	err := c.ParseFlags([]string{"--resource.tags=foo=bar,orig=fake", "--jaeger.tags=foo=legacy,leg=head"})
+	require.NoError(t, err)
+
+	f := &Factory{
+		Wrapped: &resourceprocessor.Factory{},
+		Viper:   v,
+	}
+
+	cfg := f.CreateDefaultConfig().(*resourceprocessor.Config)
+	assert.Equal(t, map[string]string{"foo": "bar", "leg": "head", "orig": "fake"}, cfg.Labels)
+}
+
+func TestLoadConfigAndFlags(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	require.NoError(t, err)
+
+	v, c := jConfig.Viperize(AddFlags, flags.AddConfigFileFlag)
+	err = c.ParseFlags([]string{"--resource.tags=foo=bar,zone=zone2"})
+	require.NoError(t, err)
+
+	err = flags.TryLoadConfigFile(v)
+	require.NoError(t, err)
+
+	f := &Factory{
+		Viper:   v,
+		Wrapped: &resourceprocessor.Factory{},
+	}
+
+	factories.Processors[f.Type()] = f
+	colConfig, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, colConfig)
+
+	cfg := colConfig.Processors[string(f.Type())].(*resourceprocessor.Config)
+	assert.Equal(t, map[string]string{"zone": "zone1", "foo": "bar"}, cfg.Labels)
+}
+
+func TestType(t *testing.T) {
+	f := &Factory{
+		Wrapped: &resourceprocessor.Factory{},
+	}
+	assert.Equal(t, configmodels.Type("resource"), f.Type())
+}
+
+func TestCreateMetricsExporter(t *testing.T) {
+	f := &Factory{
+		Wrapped: &resourceprocessor.Factory{},
+	}
+	mReceiver, err := f.CreateMetricsProcessor(zap.NewNop(), nil, &resourceprocessor.Config{})
+	require.Nil(t, err)
+	assert.NotNil(t, mReceiver)
+}

--- a/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor_test.go
+++ b/cmd/opentelemetry-collector/app/processor/resourceprocessor/resource_processor_test.go
@@ -41,7 +41,7 @@ func TestDefaultValues(t *testing.T) {
 
 func TestDefaultValueFromViper(t *testing.T) {
 	v, c := jConfig.Viperize(AddFlags)
-	err := c.ParseFlags([]string{"--resource.tags=foo=bar,orig=fake", "--jaeger.tags=foo=legacy,leg=head"})
+	err := c.ParseFlags([]string{"--resource.labels=foo=bar,orig=fake", "--jaeger.tags=foo=legacy,leg=head"})
 	require.NoError(t, err)
 
 	f := &Factory{
@@ -58,7 +58,7 @@ func TestLoadConfigAndFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	v, c := jConfig.Viperize(AddFlags, flags.AddConfigFileFlag)
-	err = c.ParseFlags([]string{"--resource.tags=foo=bar,zone=zone2"})
+	err = c.ParseFlags([]string{"--resource.labels=foo=bar,zone=zone2"})
 	require.NoError(t, err)
 
 	err = flags.TryLoadConfigFile(v)

--- a/cmd/opentelemetry-collector/app/processor/resourceprocessor/testdata/config.yaml
+++ b/cmd/opentelemetry-collector/app/processor/resourceprocessor/testdata/config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  examplereceiver:
+
+processors:
+  resource:
+    labels: {
+      "zone": "zone1",
+    }
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [resource]
+      exporters: [exampleexporter]

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/jaeger_receiver_test.go
@@ -45,10 +45,9 @@ func TestDefaultValues(t *testing.T) {
 func TestDefaultValueFromViper(t *testing.T) {
 	v := viper.New()
 	v.Set(static.SamplingStrategiesFile, "config.json")
-	jr := &jaegerreceiver.Factory{}
 
 	f := &Factory{
-		Wrapped: jr,
+		Wrapped: &jaegerreceiver.Factory{},
 		Viper:   v,
 	}
 
@@ -88,6 +87,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 		Wrapped: &jaegerreceiver.Factory{},
 	}
 	mReceiver, err := f.CreateMetricsReceiver(context.Background(), component.ReceiverCreateParams{}, nil, nil)
-	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
+	assert.Equal(t, configerror.ErrDataTypeIsNotSupported, err)
 	assert.Nil(t, mReceiver)
 }

--- a/cmd/opentelemetry-collector/cmd/agent/main.go
+++ b/cmd/opentelemetry-collector/cmd/agent/main.go
@@ -28,6 +28,7 @@ import (
 	jflags "github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/defaults"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/processor/resourceprocessor"
 	jconfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
 )
@@ -78,6 +79,7 @@ func main() {
 		jflags.AddConfigFileFlag,
 		grpc.AddFlags,
 		static.AddFlags,
+		resourceprocessor.AddFlags,
 	)
 
 	// parse flags to propagate Jaeger config file flag value to viper

--- a/cmd/opentelemetry-collector/cmd/collector/main.go
+++ b/cmd/opentelemetry-collector/cmd/collector/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/processor/resourceprocessor"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
 	"github.com/jaegertracing/jaeger/plugin/storage"
@@ -103,6 +104,7 @@ func main() {
 		storageFlags,
 		static.AddFlags,
 		grpc.AddFlags,
+		resourceprocessor.AddFlags,
 	)
 
 	// parse flags to propagate Jaeger config file flag value to viper

--- a/cmd/opentelemetry-collector/go.mod
+++ b/cmd/opentelemetry-collector/go.mod
@@ -10,8 +10,7 @@ require (
 	github.com/Shopify/sarama v1.22.2-0.20190604114437-cd910a683f9f
 	github.com/imdario/mergo v0.3.9
 	github.com/jaegertracing/jaeger v1.17.0
-	github.com/magiconair/properties v1.8.1
-	github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200505021754-29913a616b1f
+	github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200505202444-021607d68586
 	github.com/open-telemetry/opentelemetry-proto v0.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2

--- a/cmd/opentelemetry-collector/go.sum
+++ b/cmd/opentelemetry-collector/go.sum
@@ -951,12 +951,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200501033637-a0f4cf0384e4 h1:0f9PyGC02aC0gekfpPwV/NvXRuYpQZDDv0FtDPq8amE=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200501033637-a0f4cf0384e4/go.mod h1:hIfP5/uuFbC++oHT4BzzFVcMWj7uH35EGwNJ03wyjJU=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200503151053-5d1aacc0e168 h1:gmEYpU/2Nkqs7efKs89HcozlJQE8aDTVxqvC55GRDhE=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200503151053-5d1aacc0e168/go.mod h1:hIfP5/uuFbC++oHT4BzzFVcMWj7uH35EGwNJ03wyjJU=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200505021754-29913a616b1f h1:+j7LxxbgFeefZ/bcOq7J1Ji3eqgVhiMacx5+Wyl+uZU=
-github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200505021754-29913a616b1f/go.mod h1:ht/uOm+HLoXWjhq6seX/BoTwlR0dtCKFe2Y23YRk2a4=
+github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200505202444-021607d68586 h1:HD0/Opa/WiWaG+B6LP+5XT9lYqpErWd6DjH3ah9mQrU=
+github.com/open-telemetry/opentelemetry-collector v0.3.1-0.20200505202444-021607d68586/go.mod h1:ht/uOm+HLoXWjhq6seX/BoTwlR0dtCKFe2Y23YRk2a4=
 github.com/open-telemetry/opentelemetry-proto v0.3.0 h1:+ASAtcayvoELyCF40+rdCMlBOhZIn5TPDez85zSYc30=
 github.com/open-telemetry/opentelemetry-proto v0.3.0/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
Resolves #2161

This PR makes configurable collector/agent tags via env variables(or any viper manged config).

Changes:
* process tags are injected via resource processor https://github.com/open-telemetry/opentelemetry-collector/tree/master/processor#resource-processor
* Agent and collector use the same flag name to configure the tags. At the moment it is `resource.tags`. This name aligns with OTEL naming conventions. 

#### Why haven't I used the current flags `jaeger.tags/collector.tags/agent.tags`?

This PR https://github.com/jaegertracing/jaeger/pull/1854#issuecomment-541753066 added `collector.tags`, `agent.tags` and deprecated `jaeger.tags`. It does not seem right to offer the same functionality via 2 different configuration properties. It creates confusion and additional (dedup) handling  in all-in-one.
