### PR TITLE
Add Jaeger OTEL to docker image upload

### DIFF
--- a/scripts/travis/upload-all-docker-images.sh
+++ b/scripts/travis/upload-all-docker-images.sh
@@ -20,7 +20,7 @@ else
 fi
 
 export DOCKER_NAMESPACE=jaegertracing
-for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester tracegen opentelemetry-collector
+for component in agent cassandra-schema es-index-cleaner es-rollover collector query ingester tracegen opentelemetry-collector opentelemetry-agent
 do
   export REPO="jaegertracing/jaeger-${component}"
   bash ./scripts/travis/upload-to-docker.sh


### PR DESCRIPTION
* Add Jaeger OTEL to docker image upload

Signed-off-by: Ning Zhang <ning2008wisc@gmail.com>

## Which problem is this PR solving?
- As Jaeger OTEL agent was recently introduced, its docker image is currently not uploaded to the `jaegertracing` docker hub, which may block the deployment of Jaeger OTEL agent.

## Short description of the changes
- Given the `Dockerfile` of Jaeger OTEL has been made as well (https://github.com/jaegertracing/jaeger/blob/master/cmd/opentelemetry-collector/cmd/agent/Dockerfile), appending `opentelemetry-agent` to the exiting list of image upload should make `jaeger-opentelemetry-agent` available on docker hub. 