### PR TITLE
Enable service default sampling param

### DIFF
--- a/plugin/sampling/strategystore/static/fixtures/service_no_per_operation.json
+++ b/plugin/sampling/strategystore/static/fixtures/service_no_per_operation.json
@@ -4,7 +4,12 @@
            "service": "ServiceA",
            "type": "probabilistic",
            "param": 1.0
-         }
+         },
+         {
+          "service": "ServiceB",
+          "type": "ratelimiting",
+          "param": 3
+        }
        ],
        "default_strategy": {
          "type": "probabilistic",

--- a/plugin/sampling/strategystore/static/fixtures/service_no_per_operation.json
+++ b/plugin/sampling/strategystore/static/fixtures/service_no_per_operation.json
@@ -1,0 +1,20 @@
+  {
+       "service_strategies": [
+         {
+           "service": "ServiceA",
+           "type": "probabilistic",
+           "param": 1.0
+         }
+       ],
+       "default_strategy": {
+         "type": "probabilistic",
+         "param": 0.2,
+         "operation_strategies": [
+           {
+             "operation": "/health",
+             "type": "probabilistic",
+             "param": 0.0
+           }
+         ]
+       }
+     }

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -164,7 +164,8 @@ func (h *strategyStore) parseStrategies(strategies *strategies) {
 		// is not merged with and only used as a fallback).
 		opS := newStore.serviceStrategies[s.Service].OperationSampling
 		if opS == nil {
-			if newStore.defaultStrategy.OperationSampling == nil {
+			if newStore.defaultStrategy.OperationSampling == nil ||
+				newStore.serviceStrategies[s.Service].ProbabilisticSampling == nil {
 				continue
 			}
 			// Service has no per-operation strategies, so just reference the default settings and change default samplingRate.

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -164,11 +164,15 @@ func (h *strategyStore) parseStrategies(strategies *strategies) {
 		// is not merged with and only used as a fallback).
 		opS := newStore.serviceStrategies[s.Service].OperationSampling
 		if opS == nil {
-			// Service has no per-operation strategies, so just reference the default settings.
-			newStore.serviceStrategies[s.Service].OperationSampling = newStore.defaultStrategy.OperationSampling
+			if newStore.defaultStrategy.OperationSampling == nil {
+				continue
+			}
+			// Service has no per-operation strategies, so just reference the default settings and change default samplingRate.
+			newOpS := *newStore.defaultStrategy.OperationSampling
+			newOpS.DefaultSamplingProbability = newStore.serviceStrategies[s.Service].ProbabilisticSampling.SamplingRate
+			newStore.serviceStrategies[s.Service].OperationSampling = &newOpS
 			continue
 		}
-
 		if merge {
 			opS.PerOperationStrategies = mergePerOperationSamplingStrategies(
 				opS.PerOperationStrategies,

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -321,3 +321,16 @@ func TestAutoUpdateStrategyErrors(t *testing.T) {
 	assert.Equal(t, "blah", store.reloadSamplingStrategyFile(tempFile.Name(), "blah"))
 	assert.Len(t, logs.FilterMessage("failed to update sampling strategies from file").All(), 1)
 }
+
+func TestServiceNoPerOperationStrategies(t *testing.T) {
+	store, err := NewStrategyStore(Options{StrategiesFile: "fixtures/service_no_per_operation.json"}, zap.NewNop())
+	require.NoError(t, err)
+
+	s, err := store.GetSamplingStrategy("ServiceA")
+	require.NoError(t, err)
+	assert.Equal(t, s.OperationSampling.DefaultSamplingProbability, 1.0)
+
+	s, err = store.GetSamplingStrategy("ServiceB")
+	require.NoError(t, err)
+	assert.Equal(t, s.OperationSampling.DefaultSamplingProbability, 0.2)
+}

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -328,9 +328,11 @@ func TestServiceNoPerOperationStrategies(t *testing.T) {
 
 	s, err := store.GetSamplingStrategy("ServiceA")
 	require.NoError(t, err)
-	assert.Equal(t, s.OperationSampling.DefaultSamplingProbability, 1.0)
+	assert.Equal(t, 1.0, s.OperationSampling.DefaultSamplingProbability)
 
 	s, err = store.GetSamplingStrategy("ServiceB")
 	require.NoError(t, err)
-	assert.Equal(t, s.OperationSampling.DefaultSamplingProbability, 0.2)
+
+	expected := makeResponse(sampling.SamplingStrategyType_RATE_LIMITING, 3)
+	assert.Equal(t, *expected.RateLimitingSampling, *s.RateLimitingSampling)
 }


### PR DESCRIPTION
Signed-off-by: defool <defool@foxmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  Fix #2171

## Short description of the changes
- Use `service`'s sampling param event though it has no per-operation strategies. 
