### PR TITLE
Remove explicit parsing of OTEL config flag

### DIFF
--- a/cmd/opentelemetry-collector/app/util.go
+++ b/cmd/opentelemetry-collector/app/util.go
@@ -17,27 +17,13 @@ package app
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
-
-	"github.com/open-telemetry/opentelemetry-collector/service/builder"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/cassandra"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/elasticsearch"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/grpcplugin"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
 )
-
-// GetOTELConfigFile returns name of OTEL config file.
-func GetOTELConfigFile() string {
-	f := &flag.FlagSet{}
-	f.SetOutput(ioutil.Discard)
-	builder.Flags(f)
-	// parse flags to bind the value
-	f.Parse(os.Args[1:])
-	return builder.GetConfigFile()
-}
 
 // StorageFlags return a function that adds storage flags.
 // storage parameter can contain a comma separated list of supported Jaeger storage backends.

--- a/cmd/opentelemetry-collector/cmd/agent/main.go
+++ b/cmd/opentelemetry-collector/cmd/agent/main.go
@@ -22,11 +22,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/service"
+	"github.com/open-telemetry/opentelemetry-collector/service/builder"
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 	jflags "github.com/jaegertracing/jaeger/cmd/flags"
-	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/defaults"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/processor/resourceprocessor"
 	jconfig "github.com/jaegertracing/jaeger/pkg/config"
@@ -53,7 +53,7 @@ func main() {
 	cmpts := defaults.Components(v)
 	cfgFactory := func(otelViper *viper.Viper, f config.Factories) (*configmodels.Config, error) {
 		cfg := defaults.AgentConfig(cmpts)
-		if len(app.GetOTELConfigFile()) > 0 {
+		if len(builder.GetConfigFile()) > 0 {
 			otelCfg, err := service.FileLoaderConfigFactory(otelViper, f)
 			if err != nil {
 				return nil, err

--- a/cmd/opentelemetry-collector/cmd/collector/main.go
+++ b/cmd/opentelemetry-collector/cmd/collector/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/service"
+	"github.com/open-telemetry/opentelemetry-collector/service/builder"
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
@@ -65,7 +66,7 @@ func main() {
 			return nil, err
 		}
 
-		if len(app.GetOTELConfigFile()) > 0 {
+		if len(builder.GetConfigFile()) > 0 {
 			otelCfg, err := service.FileLoaderConfigFactory(otelViper, f)
 			if err != nil {
 				return nil, err

--- a/cmd/opentelemetry-collector/cmd/ingester/main.go
+++ b/cmd/opentelemetry-collector/cmd/ingester/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/service"
+	"github.com/open-telemetry/opentelemetry-collector/service/builder"
 	"github.com/spf13/viper"
 
 	jflags "github.com/jaegertracing/jaeger/cmd/flags"
@@ -60,7 +61,7 @@ func main() {
 		if err != nil {
 			return nil, err
 		}
-		if len(app.GetOTELConfigFile()) > 0 {
+		if len(builder.GetConfigFile()) > 0 {
 			otelCfg, err := service.FileLoaderConfigFactory(otelViper, f)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Explicit parsing of the flag is not needed. `GetConfigFile` is called after command run so it should be already intialized.