### PR TITLE
Sort exporters in default config test

### DIFF
--- a/cmd/opentelemetry-collector/app/defaults/default_config_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/default_config_test.go
@@ -156,6 +156,7 @@ func TestDefaultCollectorConfig(t *testing.T) {
 			sort.Strings(types)
 			assert.Equal(t, test.exporterTypes, types)
 			sort.Strings(cfg.Service.Pipelines["traces"].Receivers)
+			sort.Strings(cfg.Service.Pipelines["traces"].Exporters)
 			assert.EqualValues(t, test.pipeline, cfg.Service.Pipelines)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

Fix for test failure during local build:
```
 --- FAIL: TestDefaultCollectorConfig/cassandra,elasticsearch,grpc-plugin (0.10s)
        default_config_test.go:159: 
            	Error Trace:	default_config_test.go:159
            	Error:      	Not equal: 
            	            	expected: configmodels.Pipelines{"traces":(*configmodels.Pipeline)(0xc0003312c0)}
            	            	actual  : configmodels.Pipelines{"traces":(*configmodels.Pipeline)(0xc0000c1f80)}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -9,5 +9,5 @@
            	            	   Exporters: ([]string) (len=3) {
            	            	+   (string) (len=18) "jaeger_grpc_plugin",
            	            	    (string) (len=16) "jaeger_cassandra",
            	            	-   (string) (len=20) "jaeger_elasticsearch",
            	            	-   (string) (len=18) "jaeger_grpc_plugin"
            	            	+   (string) (len=20) "jaeger_elasticsearch"
            	            	   }
            	Test:       	TestDefaultCollectorConfig/cassandra,elasticsearch,grpc-plugin
```