### PR TITLE
Do not skip service/operation indexing for firehose spans

### DIFF
--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -37,10 +37,6 @@ const (
 		INTO traces(trace_id, span_id, span_hash, parent_id, operation_name, flags,
 				    start_time, duration, tags, logs, refs, process)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	insertTag = `
-		INSERT
-		INTO tag_index(trace_id, span_id, service_name, start_time, tag_key, tag_value)
-		VALUES (?, ?, ?, ?, ?, ?)`
 
 	serviceNameIndex = `
 		INSERT
@@ -52,6 +48,11 @@ const (
 		INTO
 		service_operation_index(service_name, operation_name, start_time, trace_id)
 		VALUES (?, ?, ?, ?)`
+
+	tagIndex = `
+		INSERT
+		INTO tag_index(trace_id, span_id, service_name, start_time, tag_key, tag_value)
+		VALUES (?, ?, ?, ?, ?, ?)`
 
 	durationIndex = `
 		INSERT
@@ -215,7 +216,7 @@ func (s *SpanWriter) indexByTags(span *model.Span, ds *dbmodel.Span) error {
 		// we should introduce retries or just ignore failures imo, retrying each individual tag insertion might be better
 		// we should consider bucketing.
 		if s.shouldIndexTag(v) {
-			insertTagQuery := s.session.Query(insertTag, ds.TraceID, ds.SpanID, v.ServiceName, ds.StartTime, v.TagKey, v.TagValue)
+			insertTagQuery := s.session.Query(tagIndex, ds.TraceID, ds.SpanID, v.ServiceName, ds.StartTime, v.TagKey, v.TagValue)
 			if err := s.writerMetrics.tagIndex.Exec(insertTagQuery, s.logger); err != nil {
 				withTagInfo := s.logger.
 					With(zap.String("tag_key", v.TagKey)).

--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -182,14 +182,6 @@ func (s *SpanWriter) writeIndexes(span *model.Span, ds *dbmodel.Span) error {
 		return s.logError(ds, err, "Failed to insert service name and operation name", s.logger)
 	}
 
-	if span.Flags.IsFirehoseEnabled() {
-		return nil // skipping expensive indexing
-	}
-
-	if err := s.indexByTags(span, ds); err != nil {
-		return s.logError(ds, err, "Failed to index tags", s.logger)
-	}
-
 	if s.indexFilter(ds, dbmodel.ServiceIndex) {
 		if err := s.indexByService(ds); err != nil {
 			return s.logError(ds, err, "Failed to index service name", s.logger)
@@ -200,6 +192,14 @@ func (s *SpanWriter) writeIndexes(span *model.Span, ds *dbmodel.Span) error {
 		if err := s.indexByOperation(ds); err != nil {
 			return s.logError(ds, err, "Failed to index operation name", s.logger)
 		}
+	}
+
+	if span.Flags.IsFirehoseEnabled() {
+		return nil // skipping expensive indexing
+	}
+
+	if err := s.indexByTags(span, ds); err != nil {
+		return s.logError(ds, err, "Failed to index tags", s.logger)
 	}
 
 	if s.indexFilter(ds, dbmodel.DurationIndex) {

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -74,6 +74,7 @@ func TestClientClose(t *testing.T) {
 func TestSpanWriter(t *testing.T) {
 	testCases := []struct {
 		caption                        string
+		firehose                       bool
 		mainQueryError                 error
 		tagsQueryError                 error
 		serviceNameQueryError          error
@@ -85,6 +86,10 @@ func TestSpanWriter(t *testing.T) {
 	}{
 		{
 			caption: "main query",
+		},
+		{
+			caption:  "main firehose query",
+			firehose: true,
 		},
 		{
 			caption:        "main query error",
@@ -166,15 +171,14 @@ func TestSpanWriter(t *testing.T) {
 						ServiceName: "service-a",
 					},
 				}
+				if testCase.firehose {
+					span.Flags = model.FirehoseFlag
+				}
 
 				spanQuery := &mocks.Query{}
 				spanQuery.On("Bind", matchEverything()).Return(spanQuery)
 				spanQuery.On("Exec").Return(testCase.mainQueryError)
 				spanQuery.On("String").Return("select from traces")
-
-				tagsQuery := &mocks.Query{}
-				tagsQuery.On("Exec").Return(testCase.tagsQueryError)
-				tagsQuery.On("String").Return("select from tags")
 
 				serviceNameQuery := &mocks.Query{}
 				serviceNameQuery.On("Bind", matchEverything()).Return(serviceNameQuery)
@@ -186,19 +190,21 @@ func TestSpanWriter(t *testing.T) {
 				serviceOperationNameQuery.On("Exec").Return(testCase.serviceOperationNameQueryError)
 				serviceOperationNameQuery.On("String").Return("select from service_operation_index")
 
+				tagsQuery := &mocks.Query{}
+				tagsQuery.On("Exec").Return(testCase.tagsQueryError)
+				tagsQuery.On("String").Return("select from tags")
+
 				durationNoOperationQuery := &mocks.Query{}
 				durationNoOperationQuery.On("Bind", matchEverything()).Return(durationNoOperationQuery)
 				durationNoOperationQuery.On("Exec").Return(testCase.durationNoOperationQueryError)
 				durationNoOperationQuery.On("String").Return("select from duration_index")
 
+				// Define expected order of queries
 				w.session.On("Query", stringMatcher(insertSpan), matchEverything()).Return(spanQuery)
-
 				w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
 				w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
-
 				// note: using matchOnce below because we only want one tag to be inserted
-				w.session.On("Query", stringMatcher(insertTag), matchOnce()).Return(tagsQuery)
-
+				w.session.On("Query", stringMatcher(tagIndex), matchOnce()).Return(tagsQuery)
 				w.session.On("Query", stringMatcher(durationIndex), matchOnce()).Return(durationNoOperationQuery)
 
 				w.writer.serviceNamesWriter = func(serviceName string) error { return testCase.serviceNameError }
@@ -324,7 +330,7 @@ func TestStorageMode_IndexOnly(t *testing.T) {
 		serviceOperationNameQuery.AssertExpectations(t)
 		durationNoOperationQuery.AssertExpectations(t)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(insertSpan))
+		w.session.AssertNotCalled(t, "Query", stringMatcher(insertSpan), matchEverything())
 	}, StoreIndexesOnly())
 }
 
@@ -346,9 +352,9 @@ func TestStorageMode_IndexOnly_WithFilter(t *testing.T) {
 		err := w.writer.WriteSpan(span)
 		assert.NoError(t, err)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceOperationIndex))
-		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex))
-		w.session.AssertNotCalled(t, "Query", stringMatcher(durationIndex))
+		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceOperationIndex), matchEverything())
+		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex), matchEverything())
+		w.session.AssertNotCalled(t, "Query", stringMatcher(durationIndex), matchEverything())
 	}, StoreIndexesOnly())
 }
 
@@ -373,11 +379,25 @@ func TestStorageMode_IndexOnly_FirehoseSpan(t *testing.T) {
 			Flags: model.Flags(8),
 		}
 
+		serviceNameQuery := &mocks.Query{}
+		serviceNameQuery.On("Bind", matchEverything()).Return(serviceNameQuery)
+		serviceNameQuery.On("Exec").Return(nil)
+		serviceNameQuery.On("String").Return("select from service_name_index")
+
+		serviceOperationNameQuery := &mocks.Query{}
+		serviceOperationNameQuery.On("Bind", matchEverything()).Return(serviceOperationNameQuery)
+		serviceOperationNameQuery.On("Exec").Return(nil)
+		serviceOperationNameQuery.On("String").Return("select from service_operation_index")
+
+		// Define expected order of queries
+		w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
+		w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
+
 		err := w.writer.WriteSpan(span)
 		assert.NoError(t, err)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex))
-		w.session.AssertNotCalled(t, "Query", stringMatcher(durationIndex))
+		w.session.AssertNotCalled(t, "Query", stringMatcher(tagIndex), matchEverything())
+		w.session.AssertNotCalled(t, "Query", stringMatcher(durationIndex), matchEverything())
 		assert.Equal(t, "planet-express", serviceWritten.Load())
 		assert.Equal(t, dbmodel.Operation{
 			ServiceName:   "planet-express",
@@ -410,6 +430,6 @@ func TestStorageMode_StoreWithoutIndexing(t *testing.T) {
 		assert.NoError(t, err)
 		spanQuery.AssertExpectations(t)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex))
+		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex), matchEverything())
 	}, StoreWithoutIndexing())
 }

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -192,11 +192,12 @@ func TestSpanWriter(t *testing.T) {
 				durationNoOperationQuery.On("String").Return("select from duration_index")
 
 				w.session.On("Query", stringMatcher(insertSpan), matchEverything()).Return(spanQuery)
-				// note: using matchOnce below because we only want one tag to be inserted
-				w.session.On("Query", stringMatcher(insertTag), matchOnce()).Return(tagsQuery)
 
 				w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
 				w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
+
+				// note: using matchOnce below because we only want one tag to be inserted
+				w.session.On("Query", stringMatcher(insertTag), matchOnce()).Return(tagsQuery)
 
 				w.session.On("Query", stringMatcher(durationIndex), matchOnce()).Return(durationNoOperationQuery)
 

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -199,7 +199,7 @@ func TestSpanWriter(t *testing.T) {
 				durationNoOperationQuery.On("Exec").Return(testCase.durationNoOperationQueryError)
 				durationNoOperationQuery.On("String").Return("select from duration_index")
 
-				// Define expected order of queries
+				// Define expected queries
 				w.session.On("Query", stringMatcher(insertSpan), matchEverything()).Return(spanQuery)
 				w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
 				w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
@@ -389,7 +389,7 @@ func TestStorageMode_IndexOnly_FirehoseSpan(t *testing.T) {
 		serviceOperationNameQuery.On("Exec").Return(nil)
 		serviceOperationNameQuery.On("String").Return("select from service_operation_index")
 
-		// Define expected order of queries
+		// Define expected queries
 		w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
 		w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
 


### PR DESCRIPTION
PR #2090 allowed recording of service and operations in the services/operations tables, but did not index traces by service & operation. This actually made UI even more confusing since the Operations dropdown shows a lot more operations, yet no traces can be found for them.

This change re-enables indexing of firehose traces by service and operation for real. It's a compromise, which brings 3x write amplification for each span (writes from PR #2090 are cached so don't happen often).  However, it significantly improves usability and is still much cheaper than indexing all of the span tags.