### PR TITLE
Add Zipkin OTEL receiver

### DIFF
--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -35,8 +35,9 @@ const (
 	// CollectorHTTPHostPort is the flag for collector HTTP port
 	CollectorHTTPHostPort = "collector.http-server.host-port"
 	// CollectorGRPCHostPort is the flag for collector gRPC port
-	CollectorGRPCHostPort         = "collector.grpc-server.host-port"
-	collectorZipkinHTTPPort       = "collector.zipkin.http-port"
+	CollectorGRPCHostPort   = "collector.grpc-server.host-port"
+	collectorZipkinHTTPPort = "collector.zipkin.http-port"
+	// CollectorZipkinHTTPHostPort is the flag for Zipkin HTTP port
 	CollectorZipkinHTTPHostPort   = "collector.zipkin.host-port"
 	collectorTags                 = "collector.tags"
 	collectorZipkinAllowedOrigins = "collector.zipkin.allowed-origins"

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -95,8 +95,8 @@ func AddFlags(flags *flag.FlagSet) {
 
 // AddOTELJaegerFlags adds flags that are exposed by OTEL Jaeger receier
 func AddOTELJaegerFlags(flags *flag.FlagSet) {
-	flags.String(CollectorHTTPHostPort, ports.PortToHostPort(ports.CollectorHTTP), "The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's HTTP server")
-	flags.String(CollectorGRPCHostPort, ports.PortToHostPort(ports.CollectorGRPC), "The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's GRPC server")
+	flags.String(CollectorHTTPHostPort, ports.PortToHostPort(ports.CollectorHTTP), "The host:port (e.g. 127.0.0.1:9411 or :9411) of the collector's HTTP server")
+	flags.String(CollectorGRPCHostPort, ports.PortToHostPort(ports.CollectorGRPC), "The host:port (e.g. 127.0.0.1:14250 or :14250) of the collector's GRPC server")
 	tlsFlagsConfig.AddFlags(flags)
 }
 

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -37,7 +37,7 @@ const (
 	// CollectorGRPCHostPort is the flag for collector gRPC port
 	CollectorGRPCHostPort         = "collector.grpc-server.host-port"
 	collectorZipkinHTTPPort       = "collector.zipkin.http-port"
-	collectorZipkinHTTPHostPort   = "collector.zipkin.host-port"
+	CollectorZipkinHTTPHostPort   = "collector.zipkin.host-port"
 	collectorTags                 = "collector.tags"
 	collectorZipkinAllowedOrigins = "collector.zipkin.allowed-origins"
 	collectorZipkinAllowedHeaders = "collector.zipkin.allowed-headers"
@@ -83,20 +83,25 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.Int(collectorNumWorkers, DefaultNumWorkers, "The number of workers pulling items from the queue")
 	flags.Int(collectorHTTPPort, 0, collectorHTTPPortWarning+" see --"+CollectorHTTPHostPort)
 	flags.Int(collectorGRPCPort, 0, collectorGRPCPortWarning+" see --"+CollectorGRPCHostPort)
-	flags.Int(collectorZipkinHTTPPort, 0, collectorZipkinHTTPPortWarning+" see --"+collectorZipkinHTTPHostPort)
+	flags.Int(collectorZipkinHTTPPort, 0, collectorZipkinHTTPPortWarning+" see --"+CollectorZipkinHTTPHostPort)
 	flags.Uint(collectorDynQueueSizeMemory, 0, "(experimental) The max memory size in MiB to use for the dynamic queue.")
 	flags.String(collectorTags, "", "One or more tags to be added to the Process tags of all spans passing through this collector. Ex: key1=value1,key2=${envVar:defaultValue}")
 	flags.String(collectorZipkinAllowedOrigins, "*", "Comma separated list of allowed origins for the Zipkin collector service, default accepts all")
 	flags.String(collectorZipkinAllowedHeaders, "content-type", "Comma separated list of allowed headers for the Zipkin collector service, default content-type")
-	AddOTELFlags(flags)
+	AddOTELJaegerFlags(flags)
+	AddOTELZipkinFlags(flags)
 }
 
-// AddOTELFlags adds flags that are exposed by OTEL collector
-func AddOTELFlags(flags *flag.FlagSet) {
-	flags.String(collectorZipkinHTTPHostPort, ports.PortToHostPort(0), "The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's Zipkin server")
+// AddOTELJaegerFlags adds flags that are exposed by OTEL Jaeger receier
+func AddOTELJaegerFlags(flags *flag.FlagSet) {
 	flags.String(CollectorHTTPHostPort, ports.PortToHostPort(ports.CollectorHTTP), "The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's HTTP server")
 	flags.String(CollectorGRPCHostPort, ports.PortToHostPort(ports.CollectorGRPC), "The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's GRPC server")
 	tlsFlagsConfig.AddFlags(flags)
+}
+
+// AddOTELZipkinFlags adds flag that are exposed by OTEL Zipkin receiver
+func AddOTELZipkinFlags(flags *flag.FlagSet) {
+	flags.String(CollectorZipkinHTTPHostPort, ports.PortToHostPort(0), "The host:port (e.g. 127.0.0.1:5555 or :5555) of the collector's Zipkin server")
 }
 
 // InitFromViper initializes CollectorOptions with properties from viper
@@ -106,7 +111,7 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
 	cOpts.NumWorkers = v.GetInt(collectorNumWorkers)
 	cOpts.CollectorHTTPHostPort = getAddressFromCLIOptions(v.GetInt(collectorHTTPPort), v.GetString(CollectorHTTPHostPort))
 	cOpts.CollectorGRPCHostPort = getAddressFromCLIOptions(v.GetInt(collectorGRPCPort), v.GetString(CollectorGRPCHostPort))
-	cOpts.CollectorZipkinHTTPHostPort = getAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(collectorZipkinHTTPHostPort))
+	cOpts.CollectorZipkinHTTPHostPort = getAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(CollectorZipkinHTTPHostPort))
 	cOpts.CollectorTags = flags.ParseJaegerTags(v.GetString(collectorTags))
 	cOpts.CollectorZipkinAllowedOrigins = v.GetString(collectorZipkinAllowedOrigins)
 	cOpts.CollectorZipkinAllowedHeaders = v.GetString(collectorZipkinAllowedHeaders)

--- a/cmd/opentelemetry-collector/app/defaults/defaults.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults.go
@@ -21,6 +21,7 @@ import (
 	otelJaegerExporter "github.com/open-telemetry/opentelemetry-collector/exporter/jaegerexporter"
 	otelResourceProcessor "github.com/open-telemetry/opentelemetry-collector/processor/resourceprocessor"
 	otelJaegerReceiver "github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+	otelZipkinReceiver "github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/service/defaultcomponents"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -34,6 +35,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/processor/resourceprocessor"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/jaegerreceiver"
 	kafkaRec "github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/kafka"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/zipkinreceiver"
 	storageCassandra "github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	storageEs "github.com/jaegertracing/jaeger/plugin/storage/es"
 	storageGrpc "github.com/jaegertracing/jaeger/plugin/storage/grpc"
@@ -87,6 +89,11 @@ func Components(v *viper.Viper) config.Factories {
 	jaegerExp := factories.Exporters["jaeger"].(*otelJaegerExporter.Factory)
 	factories.Exporters["jaeger"] = &jaegerexporter.Factory{
 		Wrapped: jaegerExp,
+		Viper:   v,
+	}
+	zipkinRec := factories.Receivers["zipkin"].(*otelZipkinReceiver.Factory)
+	factories.Receivers["zipkin"] = &zipkinreceiver.Factory{
+		Wrapped: zipkinRec,
 		Viper:   v,
 	}
 

--- a/cmd/opentelemetry-collector/app/defaults/defaults_test.go
+++ b/cmd/opentelemetry-collector/app/defaults/defaults_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/jaegerreceiver"
 	kafkaRec "github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/kafka"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/zipkinreceiver"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 )
 
@@ -43,6 +44,7 @@ func TestComponents(t *testing.T) {
 	assert.IsType(t, &jaegerreceiver.Factory{}, factories.Receivers["jaeger"])
 	assert.IsType(t, &jaegerexporter.Factory{}, factories.Exporters["jaeger"])
 	assert.IsType(t, &kafkaRec.Factory{}, factories.Receivers[kafkaRec.TypeStr])
+	assert.IsType(t, &zipkinreceiver.Factory{}, factories.Receivers["zipkin"])
 
 	kafkaFactory := factories.Exporters[kafka.TypeStr]
 	kc := kafkaFactory.CreateDefaultConfig().(*kafka.Config)

--- a/cmd/opentelemetry-collector/app/flags.go
+++ b/cmd/opentelemetry-collector/app/flags.go
@@ -26,12 +26,14 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/exporter/kafka"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/processor/resourceprocessor"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/jaegerreceiver"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry-collector/app/receiver/zipkinreceiver"
 )
 
 // AddComponentFlags adds all flags exposed by components
 func AddComponentFlags(flags *flag.FlagSet) {
 	// Jaeger receiver (via sampling strategies receiver) exposes the same flags as exporter.
 	jaegerreceiver.AddFlags(flags)
+	zipkinreceiver.AddFlags(flags)
 	resourceprocessor.AddFlags(flags)
 	jConfigFile.AddConfigFileFlag(flags)
 }

--- a/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/flags.go
+++ b/cmd/opentelemetry-collector/app/receiver/jaegerreceiver/flags.go
@@ -34,7 +34,7 @@ const (
 func AddFlags(flags *flag.FlagSet) {
 	flags.String(thriftBinaryHostPort, ":"+strconv.Itoa(ports.AgentJaegerThriftBinaryUDP), "host:port for the UDP server")
 	flags.String(thriftCompactHostPort, ":"+strconv.Itoa(ports.AgentJaegerThriftCompactUDP), "host:port for the UDP server")
-	collectorApp.AddOTELFlags(flags)
+	collectorApp.AddOTELJaegerFlags(flags)
 	agentApp.AddOTELFlags(flags)
 	grpcRep.AddOTELFlags(flags)
 	static.AddOTELFlags(flags)

--- a/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/flags.go
+++ b/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/flags.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkinreceiver
+
+import (
+	"flag"
+
+	"github.com/jaegertracing/jaeger/cmd/collector/app"
+)
+
+// AddFlags adds flags to flag set.
+func AddFlags(flags *flag.FlagSet) {
+	app.AddOTELZipkinFlags(flags)
+}

--- a/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/testdata/config.yaml
+++ b/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/testdata/config.yaml
@@ -1,0 +1,16 @@
+receivers:
+  zipkin:
+    endpoint: foo:9411
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [zipkin]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/zipkin_receiver_test.go
+++ b/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/zipkin_receiver_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkinreceiver
+
+import (
+	"path"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+)
+
+func TestDefaultValues(t *testing.T) {
+	v, c := jConfig.Viperize(AddFlags)
+	err := c.ParseFlags([]string{})
+	require.NoError(t, err)
+
+	factory := &Factory{Viper: v, Wrapped: &zipkinreceiver.Factory{}}
+	cfg := factory.CreateDefaultConfig().(*zipkinreceiver.Config)
+	assert.Equal(t, "localhost:9411", cfg.Endpoint)
+}
+
+func TestLoadConfigAndFlags(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	require.NoError(t, err)
+
+	v, c := jConfig.Viperize(AddFlags)
+	err = c.ParseFlags([]string{"--collector.zipkin.host-port=bar:111"})
+	require.NoError(t, err)
+
+	factory := &Factory{Viper: v, Wrapped: &zipkinreceiver.Factory{}}
+	assert.Equal(t, "bar:111", factory.CreateDefaultConfig().(*zipkinreceiver.Config).Endpoint)
+
+	factories.Receivers["zipkin"] = factory
+	colConfig, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, colConfig)
+
+	cfg := colConfig.Receivers["zipkin"].(*zipkinreceiver.Config)
+	assert.Equal(t, "foo:9411", cfg.Endpoint)
+}
+
+func TestType(t *testing.T) {
+	f := &Factory{
+		Wrapped: &zipkinreceiver.Factory{},
+	}
+	assert.Equal(t, configmodels.Type("zipkin"), f.Type())
+}
+
+func TestCreateMetricsExporter(t *testing.T) {
+	f := &Factory{
+		Wrapped: &zipkinreceiver.Factory{},
+	}
+	mReceiver, err := f.CreateMetricsReceiver(zap.NewNop(), nil, nil)
+	assert.Equal(t, configerror.ErrDataTypeIsNotSupported, err)
+	assert.Nil(t, mReceiver)
+}

--- a/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/zipkin_recevier.go
+++ b/cmd/opentelemetry-collector/app/receiver/zipkinreceiver/zipkin_recevier.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkinreceiver
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	collectorApp "github.com/jaegertracing/jaeger/cmd/collector/app"
+)
+
+// Factory wraps zipkinreceiver.Factory and makes the default config configurable via viper.
+// For instance this enables using flags as default values in the config object.
+type Factory struct {
+	Wrapped *zipkinreceiver.Factory
+	// Viper is used to get configuration values for default configuration
+	Viper *viper.Viper
+}
+
+var _ component.ReceiverFactoryOld = (*Factory)(nil)
+
+// Type returns the type of the receiver.
+func (f Factory) Type() configmodels.Type {
+	return f.Wrapped.Type()
+}
+
+// CreateDefaultConfig returns default configuration of Factory.
+// This function implements OTEL component.ReceiverFactoryBase interface.
+func (f Factory) CreateDefaultConfig() configmodels.Receiver {
+	cfg := f.Wrapped.CreateDefaultConfig().(*zipkinreceiver.Config)
+	if f.Viper.IsSet(collectorApp.CollectorZipkinHTTPHostPort) {
+		cfg.Endpoint = f.Viper.GetString(collectorApp.CollectorZipkinHTTPHostPort)
+	}
+	return cfg
+}
+
+// CustomUnmarshaler creates custom unmarshaller for Zipkin receiver config.
+// This function implements component.ReceiverFactoryBase interface.
+func (f Factory) CustomUnmarshaler() component.CustomUnmarshaler {
+	return f.Wrapped.CustomUnmarshaler()
+}
+
+// CreateTraceReceiver creates Zipkin receiver trace receiver.
+// This function implements OTEL component.ReceiverFactoryOld interface.
+func (f Factory) CreateTraceReceiver(
+	ctx context.Context,
+	logger *zap.Logger,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.TraceConsumerOld,
+) (component.TraceReceiver, error) {
+	return f.Wrapped.CreateTraceReceiver(ctx, logger, cfg, nextConsumer)
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on provided config.
+// This function implements component.ReceiverFactoryOld.
+func (f Factory) CreateMetricsReceiver(
+	logger *zap.Logger,
+	cfg configmodels.Receiver,
+	consumer consumer.MetricsConsumerOld,
+) (component.MetricsReceiver, error) {
+	return f.Wrapped.CreateMetricsReceiver(logger, cfg, consumer)
+}


### PR DESCRIPTION
Related to https://github.com/jaegertracing/jaeger/pull/2241#discussion_r425272173

Zipkin receiver is configurable via Jaeger flag `collector.zipkin.host-port`, hence to follow the same approach as for Jaeger receiver we should provide a wrapper that configures the endpoint every time the receiver is used.
