### PR TITLE
Ignore chmod events on UI config watcher.

### DIFF
--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -130,28 +130,21 @@ func (sH *StaticAssetsHandler) configListener(watcher *fsnotify.Watcher) {
 	for {
 		select {
 		case event := <-watcher.Events:
+			// Ignore if the event filename is not the UI configuration or if it is a chmod event.
+			if filepath.Base(event.Name) != filepath.Base(sH.options.UIConfigPath) || event.Op&fsnotify.Chmod == fsnotify.Chmod {
+				continue
+			}
 			if event.Op&fsnotify.Remove == fsnotify.Remove {
-				// this might be related to a file inside the dir, so, just log a warn if this is about the file we care about
-				// otherwise, just ignore the event
-				if event.Name == sH.options.UIConfigPath {
-					sH.options.Logger.Warn("the UI config file has been removed, using the last known version")
-				}
+				sH.options.Logger.Warn("the UI config file has been removed, using the last known version")
 				continue
 			}
-			if event.Op&fsnotify.Write != fsnotify.Write && event.Op&fsnotify.Create != fsnotify.Create {
-				continue
+			// this will catch events for all files inside the same directory, which is OK if we don't have many changes
+			sH.options.Logger.Info("reloading UI config", zap.String("filename", sH.options.UIConfigPath))
+			content, err := loadIndexBytes(sH.assetsFS.Open, sH.options)
+			if err != nil {
+				sH.options.Logger.Error("error while reloading the UI config", zap.Error(err))
 			}
-			if event.Name == sH.options.UIConfigPath {
-				// this will catch events for all files inside the same directory, which is OK if we don't have many changes
-				sH.options.Logger.Info("reloading UI config", zap.String("filename", sH.options.UIConfigPath))
-
-				content, err := loadIndexBytes(sH.assetsFS.Open, sH.options)
-				if err != nil {
-					sH.options.Logger.Error("error while reloading the UI config", zap.Error(err))
-				}
-
-				sH.indexHTML.Store(content)
-			}
+			sH.indexHTML.Store(content)
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -130,8 +130,12 @@ func (sH *StaticAssetsHandler) configListener(watcher *fsnotify.Watcher) {
 	for {
 		select {
 		case event := <-watcher.Events:
-			// Ignore if the event filename is not the UI configuration or if it is a chmod event.
-			if filepath.Base(event.Name) != filepath.Base(sH.options.UIConfigPath) || event.Op&fsnotify.Chmod == fsnotify.Chmod {
+			// ignore if the event filename is not the UI configuration
+			if filepath.Base(event.Name) != filepath.Base(sH.options.UIConfigPath) {
+				continue
+			}
+			// ignore if the event is a chmod event (permission or owner changes)
+			if event.Op&fsnotify.Chmod == fsnotify.Chmod {
 				continue
 			}
 			if event.Op&fsnotify.Remove == fsnotify.Remove {


### PR DESCRIPTION
Signed-off-by: Ruben <ruben.vargas@aluxoft.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  Fixes https://github.com/jaegertracing/jaeger-operator/issues/934 (The issue was filed on jaeger-operator but I think the issue should be transferred to main jaeger project).

## Short description of the changes
- The config file watcher now reacts to `CHMOD` and other events, and should only react when `CREATE` or `WRITE` events occurs. This prevents a lot of log noisy. Specially on kubernetes/openshift environments.
 

