### PR TITLE
Expose option to enable TLS when sniffing an Elasticsearch Cluster

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -46,7 +46,7 @@ type Configuration struct {
 	TokenFilePath         string         `mapstructure:"token_file"`
 	AllowTokenFromContext bool           `mapstructure:"-"`
 	Sniffer               bool           `mapstructure:"sniffer"` // https://github.com/olivere/elastic/wiki/Sniffing
-	SnifferTlsEnabled     bool           `mapstructure:"sniffer_tls_enabled"`
+	SnifferTLSEnabled     bool           `mapstructure:"sniffer_tls_enabled"`
 	MaxNumSpans           int            `mapstructure:"-"`                     // defines maximum number of spans to fetch from storage per query
 	MaxSpanAge            time.Duration  `yaml:"max_span_age" mapstructure:"-"` // configures the maximum lookback on span reads
 	NumShards             int64          `yaml:"shards" mapstructure:"num_shards"`
@@ -213,8 +213,8 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.BulkFlushInterval == 0 {
 		c.BulkFlushInterval = source.BulkFlushInterval
 	}
-	if !c.SnifferTlsEnabled {
-		c.SnifferTlsEnabled = source.SnifferTlsEnabled
+	if !c.SnifferTLSEnabled {
+		c.SnifferTLSEnabled = source.SnifferTLSEnabled
 	}
 }
 
@@ -292,10 +292,8 @@ func (c *Configuration) getConfigOptions(logger *zap.Logger) ([]elastic.ClientOp
 		// we don' have a valid token to do the check ad if we don't disable the check the service that
 		// uses this won't start.
 		elastic.SetHealthcheck(!c.AllowTokenFromContext)}
-	if c.SnifferTlsEnabled {
+	if c.SnifferTLSEnabled {
 		options = append(options, elastic.SetScheme("https"))
-	} else {
-		options = append(options, elastic.SetScheme("http"))
 	}
 	httpClient := &http.Client{
 		Timeout: c.Timeout,

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -45,7 +45,8 @@ type Configuration struct {
 	Password              string         `mapstructure:"password"`
 	TokenFilePath         string         `mapstructure:"token_file"`
 	AllowTokenFromContext bool           `mapstructure:"-"`
-	Sniffer               bool           `mapstructure:"sniffer"`               // https://github.com/olivere/elastic/wiki/Sniffing
+	Sniffer               bool           `mapstructure:"sniffer"` // https://github.com/olivere/elastic/wiki/Sniffing
+	SnifferTlsEnabled     bool           `mapstructure:"sniffer_tls_enabled"`
 	MaxNumSpans           int            `mapstructure:"-"`                     // defines maximum number of spans to fetch from storage per query
 	MaxSpanAge            time.Duration  `yaml:"max_span_age" mapstructure:"-"` // configures the maximum lookback on span reads
 	NumShards             int64          `yaml:"shards" mapstructure:"num_shards"`
@@ -212,6 +213,9 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.BulkFlushInterval == 0 {
 		c.BulkFlushInterval = source.BulkFlushInterval
 	}
+	if !c.SnifferTlsEnabled {
+		c.SnifferTlsEnabled = source.SnifferTlsEnabled
+	}
 }
 
 // GetNumShards returns number of shards from Configuration
@@ -288,6 +292,11 @@ func (c *Configuration) getConfigOptions(logger *zap.Logger) ([]elastic.ClientOp
 		// we don' have a valid token to do the check ad if we don't disable the check the service that
 		// uses this won't start.
 		elastic.SetHealthcheck(!c.AllowTokenFromContext)}
+	if c.SnifferTlsEnabled {
+		options = append(options, elastic.SetScheme("https"))
+	} else {
+		options = append(options, elastic.SetScheme("http"))
+	}
 	httpClient := &http.Client{
 		Timeout: c.Timeout,
 	}

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -31,6 +31,7 @@ const (
 	suffixUsername            = ".username"
 	suffixPassword            = ".password"
 	suffixSniffer             = ".sniffer"
+	suffixSnifferTlsEnabled   = ".sniffer-tls-enabled"
 	suffixTokenPath           = ".token-file"
 	suffixServerURLs          = ".server-urls"
 	suffixMaxSpanAge          = ".max-span-age"
@@ -95,6 +96,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				CreateIndexTemplates: true,
 				Version:              0,
 				Servers:              []string{defaultServerURL},
+				SnifferTlsEnabled:    false,
 			},
 			namespace: primaryNamespace,
 		},
@@ -211,6 +213,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixVersion,
 		0,
 		"The major Elasticsearch version. If not specified, the value will be auto-detected from Elasticsearch.")
+	flagSet.Bool(
+		nsConfig.namespace+suffixSnifferTlsEnabled,
+		nsConfig.SnifferTlsEnabled,
+		"Option to enable TLS when sniffing an Elasticsearch Cluster ; client uses sniffing process to find all nodes automatically, disabled by default")
 	if nsConfig.namespace == archiveNamespace {
 		flagSet.Bool(
 			nsConfig.namespace+suffixEnabled,
@@ -233,6 +239,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Password = v.GetString(cfg.namespace + suffixPassword)
 	cfg.TokenFilePath = v.GetString(cfg.namespace + suffixTokenPath)
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
+	cfg.SnifferTlsEnabled = v.GetBool(cfg.namespace + suffixSnifferTlsEnabled)
 	cfg.Servers = strings.Split(stripWhiteSpace(v.GetString(cfg.namespace+suffixServerURLs)), ",")
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)
 	cfg.MaxNumSpans = v.GetInt(cfg.namespace + suffixMaxNumSpans)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -31,7 +31,7 @@ const (
 	suffixUsername            = ".username"
 	suffixPassword            = ".password"
 	suffixSniffer             = ".sniffer"
-	suffixSnifferTlsEnabled   = ".sniffer-tls-enabled"
+	suffixSnifferTLSEnabled   = ".sniffer-tls-enabled"
 	suffixTokenPath           = ".token-file"
 	suffixServerURLs          = ".server-urls"
 	suffixMaxSpanAge          = ".max-span-age"
@@ -96,7 +96,6 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				CreateIndexTemplates: true,
 				Version:              0,
 				Servers:              []string{defaultServerURL},
-				SnifferTlsEnabled:    false,
 			},
 			namespace: primaryNamespace,
 		},
@@ -214,8 +213,8 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		0,
 		"The major Elasticsearch version. If not specified, the value will be auto-detected from Elasticsearch.")
 	flagSet.Bool(
-		nsConfig.namespace+suffixSnifferTlsEnabled,
-		nsConfig.SnifferTlsEnabled,
+		nsConfig.namespace+suffixSnifferTLSEnabled,
+		nsConfig.SnifferTLSEnabled,
 		"Option to enable TLS when sniffing an Elasticsearch Cluster ; client uses sniffing process to find all nodes automatically, disabled by default")
 	if nsConfig.namespace == archiveNamespace {
 		flagSet.Bool(
@@ -239,7 +238,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Password = v.GetString(cfg.namespace + suffixPassword)
 	cfg.TokenFilePath = v.GetString(cfg.namespace + suffixTokenPath)
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
-	cfg.SnifferTlsEnabled = v.GetBool(cfg.namespace + suffixSnifferTlsEnabled)
+	cfg.SnifferTLSEnabled = v.GetBool(cfg.namespace + suffixSnifferTLSEnabled)
 	cfg.Servers = strings.Split(stripWhiteSpace(v.GetString(cfg.namespace+suffixServerURLs)), ",")
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)
 	cfg.MaxNumSpans = v.GetInt(cfg.namespace + suffixMaxNumSpans)

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -34,6 +34,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, int64(1), primary.NumReplicas)
 	assert.Equal(t, 72*time.Hour, primary.MaxSpanAge)
 	assert.False(t, primary.Sniffer)
+	assert.False(t, primary.SnifferTlsEnabled)
 
 	aux := opts.Get("archive")
 	assert.Equal(t, primary.Username, aux.Username)
@@ -50,6 +51,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.password=world",
 		"--es.token-file=/foo/bar",
 		"--es.sniffer=true",
+		"--es.sniffer-tls-enabled=true",
 		"--es.max-span-age=48h",
 		"--es.num-shards=20",
 		"--es.num-replicas=10",
@@ -68,6 +70,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, primary.Servers)
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
 	assert.True(t, primary.Sniffer)
+	assert.True(t, primary.SnifferTlsEnabled)
 	assert.Equal(t, true, primary.TLS.Enabled)
 	assert.Equal(t, true, primary.TLS.SkipHostVerify)
 

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -34,7 +34,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, int64(1), primary.NumReplicas)
 	assert.Equal(t, 72*time.Hour, primary.MaxSpanAge)
 	assert.False(t, primary.Sniffer)
-	assert.False(t, primary.SnifferTlsEnabled)
+	assert.False(t, primary.SnifferTLSEnabled)
 
 	aux := opts.Get("archive")
 	assert.Equal(t, primary.Username, aux.Username)
@@ -70,7 +70,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, primary.Servers)
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
 	assert.True(t, primary.Sniffer)
-	assert.True(t, primary.SnifferTlsEnabled)
+	assert.True(t, primary.SnifferTLSEnabled)
 	assert.Equal(t, true, primary.TLS.Enabled)
 	assert.Equal(t, true, primary.TLS.SkipHostVerify)
 


### PR DESCRIPTION
Jaeger uses the default scheme set by the olivere client (which is http) when sniffing an Elasticsearch cluster without the option to change it.  This makes it impossible to use sniffing with a TLS Elasticsearch cluster.

The scheme can be set using the SetScheme client option
https://pkg.go.dev/github.com/olivere/elatic/v7\?tab\=doc\#SetScheme

This change exposes that client option as a boolean command line option: --es.sniffer-tls-enabled

Signed-off-by: nilsenj <jennynilsen@rentalcars.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
In our use case, jaeger-collector needs to connect to Elasticsearch running in Kubernetes from outside the cluster.  By using sniffing, we can use the ingress for the initial node discovery and then send traffic directly to the elasticsearch nodes without it needing to go through the ingress.
In our case, when using ingress only (without sniffing) jaeger represents a substantial proportion of the ingress traffic.  When we switched to using sniffing we were able to reduce the load on our ingress 10x.
If Elasticsearch is running with TLS enabled, then we need a way to tell jaeger-collector to use https when connecting to the discovered nodes.

## Short description of the changes
- 
