### PR TITLE
Mask passwords when written as json

### DIFF
--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -57,7 +57,7 @@ type Authenticator struct {
 // BasicAuthenticator holds the username and password for a password authenticator for a Cassandra cluster
 type BasicAuthenticator struct {
 	Username string `yaml:"username" mapstructure:"username"`
-	Password string `yaml:"password" mapstructure:"password"`
+	Password string `yaml:"password" mapstructure:"password" json:"-"`
 }
 
 // ApplyDefaults copies settings from source unless its own value is non-zero.

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -42,7 +42,7 @@ import (
 type Configuration struct {
 	Servers               []string       `mapstructure:"server_urls"`
 	Username              string         `mapstructure:"username"`
-	Password              string         `mapstructure:"password"`
+	Password              string         `mapstructure:"password" json:"-"`
 	TokenFilePath         string         `mapstructure:"token_file"`
 	AllowTokenFromContext bool           `mapstructure:"-"`
 	Sniffer               bool           `mapstructure:"sniffer"` // https://github.com/olivere/elastic/wiki/Sniffing


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Ensure that passwords are not accidentally written out as json.

## Short description of the changes
Don't serialize the password fields as json.
