### PR TITLE
Temporarily remove UI from OTEL all-in-one build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ build-otel-ingester:
 
 .PHONY: build-otel-all-in-one
 build-otel-all-in-one:
-	# TODO add -tags ui once OTEL module depends overrides Jaeger version
+	# TODO add -tags ui once Jaeger OTEL module depends on master Jaeger version https://github.com/jaegertracing/jaeger/issues/2319
 	cd ${OTEL_COLLECTOR_DIR}/cmd/all-in-one && $(GOBUILD) -o ./opentelemetry-all-in-one-$(GOOS)-$(GOARCH) $(BUILD_INFO) main.go
 
 .PHONY: build-ingester

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,8 @@ build-otel-ingester:
 
 .PHONY: build-otel-all-in-one
 build-otel-all-in-one:
-	cd ${OTEL_COLLECTOR_DIR}/cmd/all-in-one && $(GOBUILD) -tags ui -o ./opentelemetry-all-in-one-$(GOOS)-$(GOARCH) $(BUILD_INFO) main.go
+	# TODO add -tags ui once OTEL module depends overrides Jaeger version
+	cd ${OTEL_COLLECTOR_DIR}/cmd/all-in-one && $(GOBUILD) -o ./opentelemetry-all-in-one-$(GOOS)-$(GOARCH) $(BUILD_INFO) main.go
 
 .PHONY: build-ingester
 build-ingester:


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Temporarily reverts https://github.com/jaegertracing/jaeger/pull/2312

PR https://github.com/jaegertracing/jaeger/pull/2311/files#diff-816674aac023894f13d8ee1ed31467a1R13 pinned Jaeger in OTEL module to 1.18.1. The pinned version (all versions) does not contain `assets.FS` for the UI, hence it's causing the build to fail. 

```
/home/travis/gopath/pkg/mod/github.com/jaegertracing/jaeger@v1.18.1/cmd/query/app/ui/actual.go:24:19: undefined: assets.FS
```