### PR TITLE
Rename ARCH to TARGETARCH for multi platform build by docker buildx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ build-tracegen:
 .PHONY: docker-hotrod
 docker-hotrod:
 	GOOS=linux $(MAKE) build-examples
-	docker build -t $(DOCKER_NAMESPACE)/example-hotrod:${DOCKER_TAG} ./examples/hotrod --build-arg ARCH=$(GOARCH)
+	docker build -t $(DOCKER_NAMESPACE)/example-hotrod:${DOCKER_TAG} ./examples/hotrod --build-arg TARGETARCH=$(GOARCH)
 
 .PHONY: run-all-in-one
 run-all-in-one:
@@ -305,16 +305,16 @@ docker-images-elastic:
 .PHONY: docker-images-jaeger-backend
 docker-images-jaeger-backend:
 	for component in agent collector query ingester ; do \
-		docker build -t $(DOCKER_NAMESPACE)/jaeger-$$component:${DOCKER_TAG} cmd/$$component --build-arg ARCH=$(GOARCH) ; \
+		docker build -t $(DOCKER_NAMESPACE)/jaeger-$$component:${DOCKER_TAG} cmd/$$component --build-arg TARGETARCH=$(GOARCH) ; \
 		echo "Finished building $$component ==============" ; \
 	done
-	docker build -t $(DOCKER_NAMESPACE)/jaeger-opentelemetry-collector:${DOCKER_TAG} -f ${OTEL_COLLECTOR_DIR}/cmd/collector/Dockerfile cmd/opentelemetry/cmd/collector --build-arg ARCH=$(GOARCH)
-	docker build -t $(DOCKER_NAMESPACE)/jaeger-opentelemetry-agent:${DOCKER_TAG} -f ${OTEL_COLLECTOR_DIR}/cmd/agent/Dockerfile cmd/opentelemetry/cmd/agent --build-arg ARCH=$(GOARCH)
-	docker build -t $(DOCKER_NAMESPACE)/jaeger-opentelemetry-ingester:${DOCKER_TAG} -f ${OTEL_COLLECTOR_DIR}/cmd/ingester/Dockerfile cmd/opentelemetry/cmd/ingester --build-arg ARCH=$(GOARCH)
+	docker build -t $(DOCKER_NAMESPACE)/jaeger-opentelemetry-collector:${DOCKER_TAG} -f ${OTEL_COLLECTOR_DIR}/cmd/collector/Dockerfile cmd/opentelemetry/cmd/collector --build-arg TARGETARCH=$(GOARCH)
+	docker build -t $(DOCKER_NAMESPACE)/jaeger-opentelemetry-agent:${DOCKER_TAG} -f ${OTEL_COLLECTOR_DIR}/cmd/agent/Dockerfile cmd/opentelemetry/cmd/agent --build-arg TARGETARCH=$(GOARCH)
+	docker build -t $(DOCKER_NAMESPACE)/jaeger-opentelemetry-ingester:${DOCKER_TAG} -f ${OTEL_COLLECTOR_DIR}/cmd/ingester/Dockerfile cmd/opentelemetry/cmd/ingester --build-arg TARGETARCH=$(GOARCH)
 
 .PHONY: docker-images-tracegen
 docker-images-tracegen:
-	docker build -t $(DOCKER_NAMESPACE)/jaeger-tracegen:${DOCKER_TAG} cmd/tracegen/ --build-arg ARCH=$(GOARCH)
+	docker build -t $(DOCKER_NAMESPACE)/jaeger-tracegen:${DOCKER_TAG} cmd/tracegen/ --build-arg TARGETARCH=$(GOARCH)
 	@echo "Finished building jaeger-tracegen =============="
 
 .PHONY: docker-images-only

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 5775/udp 6831/udp 6832/udp 5778
-COPY agent-linux-$ARCH /go/bin/agent-linux
+COPY agent-linux-$TARGETARCH /go/bin/agent-linux
 ENTRYPOINT ["/go/bin/agent-linux"]

--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
@@ -27,7 +27,7 @@ EXPOSE 14250
 # Web HTTP
 EXPOSE 16686
 
-COPY all-in-one-linux-$ARCH /go/bin/all-in-one-linux
+COPY all-in-one-linux-$TARGETARCH /go/bin/all-in-one-linux
 COPY sampling_strategies.json /etc/jaeger/
 
 VOLUME ["/tmp"]

--- a/cmd/collector/Dockerfile
+++ b/cmd/collector/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 14250
-COPY collector-linux-$ARCH /go/bin/collector-linux
+COPY collector-linux-$TARGETARCH /go/bin/collector-linux
 ENTRYPOINT ["/go/bin/collector-linux"]

--- a/cmd/ingester/Dockerfile
+++ b/cmd/ingester/Dockerfile
@@ -2,10 +2,10 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 14270
 EXPOSE 14271
-COPY ingester-linux-$ARCH /go/bin/ingester-linux
+COPY ingester-linux-$TARGETARCH /go/bin/ingester-linux
 ENTRYPOINT ["/go/bin/ingester-linux"]

--- a/cmd/opentelemetry/cmd/agent/Dockerfile
+++ b/cmd/opentelemetry/cmd/agent/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY opentelemetry-agent-linux-$ARCH /go/bin/opentelemetry-agent-linux
+COPY opentelemetry-agent-linux-$TARGETARCH /go/bin/opentelemetry-agent-linux
 ENTRYPOINT ["/go/bin/opentelemetry-agent-linux"]

--- a/cmd/opentelemetry/cmd/all-in-one/Dockerfile
+++ b/cmd/opentelemetry/cmd/all-in-one/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY opentelemetry-all-in-one-linux-$ARCH /go/bin/opentelemetry-all-in-one-linux
+COPY opentelemetry-all-in-one-linux-$TARGETARCH /go/bin/opentelemetry-all-in-one-linux
 ENTRYPOINT ["/go/bin/opentelemetry-all-in-one-linux"]

--- a/cmd/opentelemetry/cmd/collector/Dockerfile
+++ b/cmd/opentelemetry/cmd/collector/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY opentelemetry-collector-linux-$ARCH /go/bin/opentelemetry-collector-linux
+COPY opentelemetry-collector-linux-$TARGETARCH /go/bin/opentelemetry-collector-linux
 ENTRYPOINT ["/go/bin/opentelemetry-collector-linux"]

--- a/cmd/opentelemetry/cmd/ingester/Dockerfile
+++ b/cmd/opentelemetry/cmd/ingester/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY opentelemetry-ingester-linux-$ARCH /go/bin/opentelemetry-ingester-linux
+COPY opentelemetry-ingester-linux-$TARGETARCH /go/bin/opentelemetry-ingester-linux
 ENTRYPOINT ["/go/bin/opentelemetry-ingester-linux"]

--- a/cmd/query/Dockerfile
+++ b/cmd/query/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine:latest as certs
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 16686
-COPY query-linux-$ARCH /go/bin/query-linux
+COPY query-linux-$TARGETARCH /go/bin/query-linux
 
 ENTRYPOINT ["/go/bin/query-linux"]

--- a/cmd/tracegen/Dockerfile
+++ b/cmd/tracegen/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 
-COPY tracegen-linux-$ARCH /go/bin/tracegen-linux
+COPY tracegen-linux-$TARGETARCH /go/bin/tracegen-linux
 ENTRYPOINT ["/go/bin/tracegen-linux"]

--- a/examples/hotrod/Dockerfile
+++ b/examples/hotrod/Dockerfile
@@ -1,6 +1,6 @@
 FROM scratch
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 EXPOSE 8080 8081 8082 8083
-COPY hotrod-linux-$ARCH /go/bin/hotrod-linux
+COPY hotrod-linux-$TARGETARCH /go/bin/hotrod-linux
 ENTRYPOINT ["/go/bin/hotrod-linux"]
 CMD ["all"]

--- a/plugin/storage/es/mappings/gen_assets.go
+++ b/plugin/storage/es/mappings/gen_assets.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    ".nocover",
 		local:   "plugin/storage/es/mappings/.nocover",
 		size:    43,
-		modtime: 1585551291,
+		modtime: 1593482248,
 		compressed: `
 H4sIAAAAAAAC/youSSzJzFYoSEzOTkxPVcjILy4pVkgsLcnXTU/NSy1KLElNUUjLzEkt1uMCBAAA//8y
 IKK1KwAAAA==
@@ -224,7 +224,7 @@ IKK1KwAAAA==
 		name:    "jaeger-dependencies-7.json",
 		local:   "plugin/storage/es/mappings/jaeger-dependencies-7.json",
 		size:    283,
-		modtime: 1587046073,
+		modtime: 1593482248,
 		compressed: `
 H4sIAAAAAAAC/2zPz0vDQBDF8Xv+imXxVNrFi5fcqlYU/EWK52GbfU1HknHdmYBQ8r9LRA/S3t/nC+9Y
 OedZEr4oRzMUUV87v3iP6FBWCRmSIC1DVwu/nNcKM5ZOfT3jPx5kHHYo9LEnPcSS5szFkej57el609DL
@@ -237,7 +237,7 @@ rYyonPvp+t/efGyqpuo7AAD//66cHf8bAQAA
 		name:    "jaeger-dependencies.json",
 		local:   "plugin/storage/es/mappings/jaeger-dependencies.json",
 		size:    277,
-		modtime: 1587046206,
+		modtime: 1593482248,
 		compressed: `
 H4sIAAAAAAAC/2zPzUoDMRTF8f08Rbi4Km1w4ya7qhUFv5ji+pJOTqeRTIy5d0Ao8+4y4kbG/fn94Zwb
 Y0gxlOQV5Ayt3j161E1AQQ7IXYRsVrSedwLVmHshNzNjKOaAL5vH4YDKH0eWk69ByJmLM/Pz29P1ruWX
@@ -250,7 +250,7 @@ tI5ojPnp0m9vPjY1U/MdAAD//5ZQx/QVAQAA
 		name:    "jaeger-service-7.json",
 		local:   "plugin/storage/es/mappings/jaeger-service-7.json",
 		size:    878,
-		modtime: 1585551291,
+		modtime: 1593482248,
 		compressed: `
 H4sIAAAAAAAC/8ySwW7aQBCG736K1agnBFZViR72RluqVmppBcopikaDPdibeNeb3YEEIb97ZGTAhHDL
 IReP5H++35/t3SVKgXE5P6MnEQ4uglYwuCcuOIwih43JeDSAYbsYWcS4IoJuuQOZurVdcsB6hbGkkLcN
@@ -265,7 +265,7 @@ FMjWM2h44O1THXIYnqemcHVgpGW9YdBfxl97cdPfBU9SoiXJStAgVKQDOMZN8oroOftQZxzjh9DuXNJr
 		name:    "jaeger-service.json",
 		local:   "plugin/storage/es/mappings/jaeger-service.json",
 		size:    1060,
-		modtime: 1585551291,
+		modtime: 1593482248,
 		compressed: `
 H4sIAAAAAAAC/8yTT2/UMBDF7/kU1ojTamshpHLwrUARSFDQVpwQGs3Gs1mD7RjbKayqfHfk4pKkW+2J
 Q3PIn/F78/xz7NtGCMjsgqXMoASsvhN3HM8SxxvT8tkK1kWSOGfjuwSqOIQA4zX/ln5wW47Y7zDtKeoE
@@ -281,7 +281,7 @@ TmGdQJrhQAmkbHr//7o382e5j83Y/AkAAP//qd2MzCQEAAA=
 		name:    "jaeger-span-7.json",
 		local:   "plugin/storage/es/mappings/jaeger-span-7.json",
 		size:    3420,
-		modtime: 1585551291,
+		modtime: 1593482248,
 		compressed: `
 H4sIAAAAAAAC/+xWXW+UQBR951eQG5+aLTEm9YG3amtsYqtp65Mxk7twYaedL2fuVjcN/93A0hYKbE2k
 xhhflix3zuHcmXsO3EZxDNLk9EM4ZCZvAqQx7F0hleT3g0OzvweLuF4WiFmaMkBao+5wiVnrJXlhCxFW
@@ -300,7 +300,7 @@ s/IPX+q/S7/jOB55dNyfveXPdm4jPpxtT0d9N2fQzT1xE5+s9W8VVdHPAAAA//+SuQbQXA0AAA==
 		name:    "jaeger-span.json",
 		local:   "plugin/storage/es/mappings/jaeger-span.json",
 		size:    3830,
-		modtime: 1585551291,
+		modtime: 1593482248,
 		compressed: `
 H4sIAAAAAAAC/+xW0W/TPhB+z18RnX5PUxf9hDQe8jbYEJPYQNt4Qsi6JpfUm2Mb+zqopv7vKE1Lm9ZJ
 QGoQEvShbWx/391n333xcxTHwFRZhUyQxnDygFSSO/UW9ekJTOp5T8xSlx7Senkcg9Q5fUv0vJqSE6YQ

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -40,12 +40,12 @@ upload_to_docker() {
 
 make build-all-in-one GOOS=linux GOARCH=$GOARCH
 repo=jaegertracing/all-in-one
-docker build -f cmd/all-in-one/Dockerfile -t $repo:latest cmd/all-in-one --build-arg ARCH=$GOARCH
+docker build -f cmd/all-in-one/Dockerfile -t $repo:latest cmd/all-in-one --build-arg TARGETARCH=$GOARCH
 run_integration_test $repo
 upload_to_docker $repo
 
 make build-otel-all-in-one GOOS=linux GOARCH=$GOARCH
 repo=jaegertracing/opentelemetry-all-in-one
-docker build -f cmd/opentelemetry/cmd/all-in-one/Dockerfile -t $repo:latest cmd/opentelemetry/cmd/all-in-one --build-arg ARCH=$GOARCH
+docker build -f cmd/opentelemetry/cmd/all-in-one/Dockerfile -t $repo:latest cmd/opentelemetry/cmd/all-in-one --build-arg TARGETARCH=$GOARCH
 run_integration_test $repo
 upload_to_docker $repo


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- first step to support #1091 

## Short description of the changes
- `TARGETARCH` is the `ARG` need for `buildx` https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope

now could build local by

```bash
make build-ui
make build-query GOOS=linux GOARCH=arm64
make build-all-in-one GOOS=linux GOARCH=arm64
make build-query GOOS=linux GOARCH=amd64
make build-all-in-one GOOS=linux GOARCH=amd64
repo=jaegertracing/all-in-one # all change to custom repo
docker buildx build --platform=linux/amd64,linux/arm64 --push -f cmd/all-in-one/Dockerfile -t $repo:latest cmd/all-in-one
```

demo <https://hub.docker.com/r/querycap/jaegertracing-all-in-one/tags>

In travis, need to setup buildx with qemu <https://github.com/crazy-max/ghaction-docker-buildx>
