### PR TITLE
Enable batch and queued retry processors by default

### DIFF
--- a/cmd/opentelemetry/app/defaultconfig/default_config.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config.go
@@ -199,6 +199,7 @@ func receiverNames(receivers configmodels.Receivers) []string {
 	return names
 }
 
+// processorNames returns processor names that are present in both input parameters
 func processorNames(processorNames []string, processors configmodels.Processors) []string {
 	var names []string
 	for _, name := range processorNames {

--- a/cmd/opentelemetry/app/defaultconfig/default_config_test.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config_test.go
@@ -51,9 +51,10 @@ func TestService(t *testing.T) {
 				Extensions: []string{"health_check"},
 				Pipelines: configmodels.Pipelines{
 					"traces": &configmodels.Pipeline{
-						InputType: configmodels.TracesDataType,
-						Receivers: []string{"otlp", "jaeger"},
-						Exporters: []string{"jaeger"},
+						InputType:  configmodels.TracesDataType,
+						Receivers:  []string{"otlp", "jaeger"},
+						Processors: []string{"batch", "queued_retry"},
+						Exporters:  []string{"jaeger"},
 					},
 				},
 			},
@@ -70,7 +71,7 @@ func TestService(t *testing.T) {
 					"traces": &configmodels.Pipeline{
 						InputType:  configmodels.TracesDataType,
 						Receivers:  []string{"otlp", "jaeger"},
-						Processors: []string{"resource"},
+						Processors: []string{"resource", "batch", "queued_retry"},
 						Exporters:  []string{elasticsearchexporter.TypeStr, kafkaexporter.TypeStr, memoryexporter.TypeStr},
 					},
 				},
@@ -85,9 +86,10 @@ func TestService(t *testing.T) {
 				Extensions: []string{"health_check"},
 				Pipelines: configmodels.Pipelines{
 					"traces": &configmodels.Pipeline{
-						InputType: configmodels.TracesDataType,
-						Receivers: []string{kafkareceiver.TypeStr},
-						Exporters: []string{elasticsearchexporter.TypeStr},
+						InputType:  configmodels.TracesDataType,
+						Receivers:  []string{kafkareceiver.TypeStr},
+						Processors: []string{"batch", "queued_retry"},
+						Exporters:  []string{elasticsearchexporter.TypeStr},
 					},
 				},
 			},
@@ -101,9 +103,10 @@ func TestService(t *testing.T) {
 				Extensions: []string{"health_check"},
 				Pipelines: configmodels.Pipelines{
 					"traces": &configmodels.Pipeline{
-						InputType: configmodels.TracesDataType,
-						Receivers: []string{kafkareceiver.TypeStr},
-						Exporters: []string{cassandraexporter.TypeStr, elasticsearchexporter.TypeStr, grpcpluginexporter.TypeStr},
+						InputType:  configmodels.TracesDataType,
+						Receivers:  []string{kafkareceiver.TypeStr},
+						Processors: []string{"batch", "queued_retry"},
+						Exporters:  []string{cassandraexporter.TypeStr, elasticsearchexporter.TypeStr, grpcpluginexporter.TypeStr},
 					},
 				},
 			},
@@ -118,9 +121,10 @@ func TestService(t *testing.T) {
 				Extensions: []string{"health_check"},
 				Pipelines: configmodels.Pipelines{
 					"traces": &configmodels.Pipeline{
-						InputType: configmodels.TracesDataType,
-						Receivers: []string{"otlp", "jaeger", "zipkin"},
-						Exporters: []string{elasticsearchexporter.TypeStr},
+						InputType:  configmodels.TracesDataType,
+						Receivers:  []string{"otlp", "jaeger", "zipkin"},
+						Processors: []string{"batch", "queued_retry"},
+						Exporters:  []string{elasticsearchexporter.TypeStr},
 					},
 				},
 			},


### PR DESCRIPTION
Related to https://github.com/jaegertracing/jaeger/issues/2152 and https://github.com/open-telemetry/opentelemetry-collector/issues/886

This PR enables by default `batch` and `queued_retry` OTEL processors. 

By default should be also enabled memory limiter, however it requires absolute settings which is not ideal solution for a single binary that is deployed in various environments. the memory limiter will support percentage settings in the future https://github.com/open-telemetry/opentelemetry-collector/issues/1078. 