### PR TITLE
Add ability to stop and drain the bounded queue

### DIFF
--- a/pkg/queue/bounded_queue.go
+++ b/pkg/queue/bounded_queue.go
@@ -128,6 +128,16 @@ func (q *BoundedQueue) Stop() {
 	close(*q.items)
 }
 
+// StopWithDrain disable producer, drains the queue then stops all consumers,
+// as well as the length reporter if started, and releases the items channel.
+// It blocks until all items are consumed and all consumers have stopped.
+func (q *BoundedQueue) StopWithDrain() {
+	q.stopped.Store(1) // disable producer
+	close(*q.items)
+	q.stopWG.Wait()
+	close(q.stopCh)
+}
+
 // Size returns the current size of the queue
 func (q *BoundedQueue) Size() int {
 	return int(q.size.Load())


### PR DESCRIPTION
## Which problem is this PR solving?
- Draining the queue when stop is called. This is to ensure that items are not dropped while shutting down.

## Short description of the changes
- Close the items channel first to ensure consumers consume all the items from the queue. then call stop which has no effect on the consumers but will stop the length reporting