### PR TITLE
Fix panic in collector when Zipkin server is shutdown 

### DIFF
--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -110,6 +110,7 @@ func (c *Collector) Start(builderOpts *CollectorOptions) error {
 	if zkServer, err := server.StartZipkinServer(&server.ZipkinServerParams{
 		HostPort:       builderOpts.CollectorZipkinHTTPHostPort,
 		Handler:        c.spanHandlers.ZipkinSpansHandler,
+		HealthCheck:    c.hCheck,
 		AllowedHeaders: builderOpts.CollectorZipkinAllowedHeaders,
 		AllowedOrigins: builderOpts.CollectorZipkinAllowedOrigins,
 		Logger:         c.logger,

--- a/cmd/collector/app/server/zipkin.go
+++ b/cmd/collector/app/server/zipkin.go
@@ -76,7 +76,9 @@ func serveZipkin(server *http.Server, listener net.Listener, params *ZipkinServe
 	server.Handler = cors.Handler(recoveryHandler(r))
 	go func(listener net.Listener, server *http.Server) {
 		if err := server.Serve(listener); err != nil {
-			params.Logger.Fatal("Could not launch Zipkin server", zap.Error(err))
+			if err != http.ErrServerClosed {
+				params.Logger.Fatal("Could not launch Zipkin server", zap.Error(err))
+			}
 		}
 		params.HealthCheck.Set(healthcheck.Unavailable)
 	}(listener, server)


### PR DESCRIPTION
…cit shutdown

Signed-off-by: Sreevani871 <sreevani@freshdesk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Solving https://github.com/jaegertracing/jaeger/issues/2395

## Short description of the changes
- Handling explicit shutdown case to avoid collector exiting abruptly after Zipkin server close to allow shutdown process to complete.
