### PR TITLE
Fix go vet warnings on Go 1.15

### DIFF
--- a/crossdock/services/tracehandler_test.go
+++ b/crossdock/services/tracehandler_test.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	testTrace = ui.Trace{
-		TraceID: ui.TraceID(0),
+		TraceID: ui.TraceID("0"),
 		Spans:   []ui.Span{{Tags: []ui.KeyValue{{Key: "k", Value: "v", Type: ui.StringType}}}},
 	}
 )
@@ -249,7 +249,7 @@ func TestTraceHandlerGetTraces(t *testing.T) {
 	traces := handler.getTraces("go", "op", nil)
 	assert.Nil(t, traces)
 
-	query.On("GetTraces", "crossdock-go", "op", mock.Anything).Return([]*ui.Trace{{TraceID: ui.TraceID(0)}}, nil)
+	query.On("GetTraces", "crossdock-go", "op", mock.Anything).Return([]*ui.Trace{{TraceID: ui.TraceID("0")}}, nil)
 	traces = handler.getTraces("go", "op", nil)
 	assert.Len(t, traces, 1)
 }

--- a/pkg/normalizer/service_name.go
+++ b/pkg/normalizer/service_name.go
@@ -54,7 +54,7 @@ func newServiceNameReplacer() *strings.Replacer {
 	oldnew := make([]string, 0, 2*(256-2-10-int('z'-'a'+1)))
 	for i := range mapping {
 		if mapping[i] != byte(i) {
-			oldnew = append(oldnew, string(i), string(mapping[i]))
+			oldnew = append(oldnew, string(rune(i)), string(rune(mapping[i])))
 		}
 	}
 


### PR DESCRIPTION
go vet reports 3 issues when using Go 1.15:

```
go vet ./...
crossdock/services/tracehandler_test.go:40:12: conversion from untyped int to TraceID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
crossdock/services/tracehandler_test.go:252:90: conversion from untyped int to TraceID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/normalizer/service_name.go:57:28: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```
Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

