### PR TITLE
Make sure tag map is always initialized

### DIFF
--- a/cmd/opentelemetry/app/processor/resourceprocessor/resource_processor.go
+++ b/cmd/opentelemetry/app/processor/resourceprocessor/resource_processor.go
@@ -57,7 +57,7 @@ func (f Factory) GetTags() map[string]string {
 	tagsLegacy := flags.ParseJaegerTags(f.Viper.GetString(reporter.AgentTagsDeprecated))
 	tags := flags.ParseJaegerTags(f.Viper.GetString(resourceLabels))
 	if tags == nil {
-		tags = map[string]string{}
+		return tagsLegacy
 	}
 	for k, v := range tagsLegacy {
 		if _, ok := tags[k]; !ok {

--- a/cmd/opentelemetry/app/processor/resourceprocessor/resource_processor.go
+++ b/cmd/opentelemetry/app/processor/resourceprocessor/resource_processor.go
@@ -56,6 +56,9 @@ func (f Factory) CreateDefaultConfig() configmodels.Processor {
 func (f Factory) GetTags() map[string]string {
 	tagsLegacy := flags.ParseJaegerTags(f.Viper.GetString(reporter.AgentTagsDeprecated))
 	tags := flags.ParseJaegerTags(f.Viper.GetString(resourceLabels))
+	if tags == nil {
+		tags = map[string]string{}
+	}
 	for k, v := range tagsLegacy {
 		if _, ok := tags[k]; !ok {
 			tags[k] = v


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Fixes:

```
go run ./cmd/all-in-one/main.go --jaeger.tags=foo.val=kok                         1:22 
2020-08-25T13:22:43.651+0200	INFO	service/service.go:412	Starting Jaeger OpenTelemetry all-in-one...	{"Version": "", "GitHash": "", "NumCPU": 8}
2020-08-25T13:22:43.651+0200	INFO	service/service.go:256	Setting up own telemetry...
2020-08-25T13:22:43.651+0200	INFO	service/telemetry.go:102	Serving Prometheus metrics	{"address": "localhost:8888", "legacy_metrics": false, "new_metrics": true, "level": 3, "service.instance.id": "6fe8d94a-c107-4e26-8197-c9a2e605e694"}
2020-08-25T13:22:43.705+0200	INFO	service/service.go:293	Loading configuration...
panic: assignment to entry in nil map

goroutine 110 [running]:
github.com/jaegertracing/jaeger/cmd/opentelemetry/app/processor/resourceprocessor.Factory.GetTags(0x39aa540, 0xc0006bfa40, 0xc000152ea0, 0x8)
	/home/ploffay/projects/jaegertracing/jaeger/cmd/opentelemetry/app/processor/resourceprocessor/resource_processor.go:61 +0x1a0
github.com/jaegertracing/jaeger/cmd/opentelemetry/app/defaultconfig.createProcessors(0xc000198c60, 0xc000198cc0, 0xc000198c90, 0xc000198c30, 0xc000198cc0, 0xc000198c90, 0xc000198c30, 0xc0003afa40)
	/home/ploffay/projects/jaegertracing/jaeger/cmd/opentelemetry/app/defaultconfig/default_config.go:102 +0xac
github.com/jaegertracing/jaeger/cmd/opentelemetry/app/defaultconfig.ComponentSettings.CreateDefaultConfig(0x3, 0xc000198c60, 0xc000198cc0, 0xc000198c90, 0xc000198c30, 0x3360c92, 0x6, 0xc00068c3b2, 0x2, 0x0, ...)
	/home/ploffay/projects/jaegertracing/jaeger/cmd/opentelemetry/app/defaultconfig/default_config.go:77 +0x152
main.main.func2(0xc0000d2d80, 0xc000198c60, 0xc000198cc0, 0xc000198c90, 0xc000198c30, 0x0, 0xc0004cf920, 0x0)
	/home/ploffay/projects/jaegertracing/jaeger/cmd/opentelemetry/cmd/all-in-one/main.go:88 +0x1ab
go.opentelemetry.io/collector/service.(*Application).setupConfigurationComponents(0xc00054e840, 0x39a9140, 0xc00005a108, 0xc0006bfa80, 0x0, 0x3)
	/home/ploffay/projects/golang/pkg/mod/go.opentelemetry.io/collector@v0.8.1-0.20200820012544-1e65674799c8/service/service.go:294 +0xec
go.opentelemetry.io/collector/service.(*Application).execute(0xc00054e840, 0x39a9140, 0xc00005a108, 0xc0006bfa80, 0x0, 0x0)
	/home/ploffay/projects/golang/pkg/mod/go.opentelemetry.io/collector@v0.8.1-0.20200820012544-1e65674799c8/service/service.go:430 +0x4d7
go.opentelemetry.io/collector/service.New.func1(0xc0004918c0, 0xc0006915e0, 0x0, 0x1, 0x0, 0x0)
	/home/ploffay/projects/golang/pkg/mod/go.opentelemetry.io/collector@v0.8.1-0.20200820012544-1e65674799c8/service/service.go:170 +0x9f
github.com/spf13/cobra.(*Command).execute(0xc0004918c0, 0xc00000e090, 0x1, 0x1, 0xc0004918c0, 0xc00000e090)
	/home/ploffay/projects/golang/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x453
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004918c0, 0xc0c919, 0xc0004cf620, 0xc0004cf620)
	/home/ploffay/projects/golang/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/home/ploffay/projects/golang/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
go.opentelemetry.io/collector/service.(*Application).Start(...)
	/home/ploffay/projects/golang/pkg/mod/go.opentelemetry.io/collector@v0.8.1-0.20200820012544-1e65674799c8/service/service.go:483
main.main.func3(0xc00054e840, 0xc000691360, 0x3481228)
	/home/ploffay/projects/jaegertracing/jaeger/cmd/opentelemetry/cmd/all-in-one/main.go:135 +0x3a
created by main.main
	/home/ploffay/projects/jaegertracing/jaeger/cmd/opentelemetry/cmd/all-in-one/main.go:134 +0x8ab
exit status 2

```