### PR TITLE
Allow nil closer in multicloser

### DIFF
--- a/pkg/multicloser/multicloser.go
+++ b/pkg/multicloser/multicloser.go
@@ -31,6 +31,9 @@ var _ io.Closer = (*MultiCloser)(nil)
 func (m MultiCloser) Close() error {
 	var errs []error
 	for _, c := range m.closers {
+		if c == nil {
+			continue
+		}
 		err := c.Close()
 		if err != nil {
 			errs = append(errs, err)

--- a/pkg/multicloser/multicloser_test.go
+++ b/pkg/multicloser/multicloser_test.go
@@ -39,6 +39,9 @@ func TestCloser(t *testing.T) {
 			closer:      Wrap(testCloser{fmt.Errorf(expectedErr)}, testCloser{fmt.Errorf(expectedErr)}),
 			expectedErr: fmt.Sprintf("[%v, %v]", expectedErr, expectedErr),
 		},
+		{
+			closer: Wrap(nil),
+		},
 	}
 	for _, test := range tests {
 		err := test.closer.Close()


### PR DESCRIPTION
This was causing nil dereference as we are passing nil closer to the multicloser. 

E.g. some storage writers implement closer and sometimes not.


```
2020-08-25T16:32:03.079+0200	INFO	healthcheck/handler.go:128	Health Check state change	{"component_kind": "extension", "status": "unavailable"}
2020-08-25T16:32:03.079+0200	INFO	service/service.go:381	Stopping receivers...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x168e5df]

goroutine 1 [running]:
github.com/jaegertracing/jaeger/pkg/multicloser.MultiCloser.Close(0xc000be1320, 0x3, 0x3, 0x394ab01, 0xc000100101)
	/home/ploffay/projects/jaegertracing/jaeger/pkg/multicloser/multicloser.go:34 +0x7f
main.main()
	/home/ploffay/projects/jaegertracing/jaeger/cmd/opentelemetry/cmd/all-in-one/main.go:155 +0xa80
exit status 2

```