### PR TITLE
Allow configuration of ES tag keys directly through config/cli

### DIFF
--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore.go
@@ -60,7 +60,7 @@ func newEsSpanWriter(params config.Configuration, logger *zap.Logger) (*esSpanWr
 	if err != nil {
 		return nil, err
 	}
-	tagsKeysAsFields, err := config.LoadTagsFromFile(params.Tags.File)
+	tagsKeysAsFields, err := params.TagKeysAsFields()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -221,7 +221,7 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if !c.SnifferTLSEnabled {
 		c.SnifferTLSEnabled = source.SnifferTLSEnabled
 	}
-	if c.Tags.AllAsFields == false {
+	if !c.Tags.AllAsFields {
 		c.Tags.AllAsFields = source.Tags.AllAsFields
 	}
 	if c.Tags.DotReplacement == "" {

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -77,7 +77,7 @@ type TagsAsFields struct {
 	DotReplacement string `mapstructure:"dot_replacement"`
 	// File path to tag keys which should be stored as object fields
 	File string `mapstructure:"config_file"`
-	// Comma Delimited list of tags to store as object fields
+	// Comma delimited list of tags to store as object fields
 	Include string `mapstructure:"include"`
 }
 

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -77,6 +77,8 @@ type TagsAsFields struct {
 	DotReplacement string `mapstructure:"dot_replacement"`
 	// File path to tag keys which should be stored as object fields
 	File string `mapstructure:"config_file"`
+	// Comma Delimited list of tags to store as object fields
+	Include string `mapstructure:"include"`
 }
 
 // ClientBuilder creates new es.Client
@@ -217,6 +219,18 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	}
 	if !c.SnifferTLSEnabled {
 		c.SnifferTLSEnabled = source.SnifferTLSEnabled
+	}
+	if c.Tags.AllAsFields == false {
+		c.Tags.AllAsFields = source.Tags.AllAsFields
+	}
+	if c.Tags.DotReplacement == "" {
+		c.Tags.DotReplacement = source.Tags.DotReplacement
+	}
+	if c.Tags.Include == "" {
+		c.Tags.Include = source.Tags.Include
+	}
+	if c.Tags.File == "" {
+		c.Tags.File = source.Tags.File
 	}
 }
 

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -159,12 +159,10 @@ func createSpanWriter(
 	archive bool,
 ) (spanstore.Writer, error) {
 	var tags []string
-	if cfg.GetTagsFilePath() != "" {
-		var err error
-		if tags, err = config.LoadTagsFromFile(cfg.GetTagsFilePath()); err != nil {
-			logger.Error("Could not open file with tags", zap.Error(err))
-			return nil, err
-		}
+	var err error
+	if tags, err = cfg.TagKeysAsFields(); err != nil {
+		logger.Error("failed to get tag keys", zap.Error(err))
+		return nil, err
 	}
 
 	spanMapping, serviceMapping := GetSpanServiceMappings(cfg.GetNumShards(), cfg.GetNumReplicas(), client.GetVersion())

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -106,33 +106,59 @@ func TestElasticsearchTagsFileDoNotExist(t *testing.T) {
 	assert.Nil(t, r)
 }
 
-func TestLoadTagsFromFile(t *testing.T) {
+func TestTagKeysAsFields(t *testing.T) {
 	tests := []struct {
-		path  string
-		tags  []string
-		error bool
+		path          string
+		include       string
+		expected      []string
+		errorExpected bool
 	}{
 		{
-			path:  "fixtures/do_not_exists.txt",
-			error: true,
+			path:          "fixtures/do_not_exists.txt",
+			errorExpected: true,
 		},
 		{
-			path: "fixtures/tags_01.txt",
-			tags: []string{"foo", "bar", "space"},
+			path:     "fixtures/tags_01.txt",
+			expected: []string{"foo", "bar", "space"},
 		},
 		{
-			path: "fixtures/tags_02.txt",
-			tags: nil,
+			path:     "fixtures/tags_02.txt",
+			expected: nil,
+		},
+		{
+			include:  "televators,eriatarka,thewidow",
+			expected: []string{"televators", "eriatarka", "thewidow"},
+		},
+		{
+			expected: nil,
+		},
+		{
+			path:     "fixtures/tags_01.txt",
+			include:  "televators,eriatarka,thewidow",
+			expected: []string{"foo", "bar", "space", "televators", "eriatarka", "thewidow"},
+		},
+		{
+			path:     "fixtures/tags_02.txt",
+			include:  "televators,eriatarka,thewidow",
+			expected: []string{"televators", "eriatarka", "thewidow"},
 		},
 	}
 
 	for _, test := range tests {
-		tags, err := escfg.LoadTagsFromFile(test.path)
-		if test.error {
+		cfg := escfg.Configuration{
+			Tags: escfg.TagsAsFields{
+				File:    test.path,
+				Include: test.include,
+			},
+		}
+
+		tags, err := cfg.TagKeysAsFields()
+		if test.errorExpected {
 			require.Error(t, err)
 			assert.Nil(t, tags)
 		} else {
-			assert.Equal(t, test.tags, tags)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, tags)
 		}
 	}
 }

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -46,6 +46,7 @@ const (
 	suffixIndexPrefix         = ".index-prefix"
 	suffixTagsAsFields        = ".tags-as-fields"
 	suffixTagsAsFieldsAll     = suffixTagsAsFields + ".all"
+	suffixTagsAsFieldsInclude = suffixTagsAsFields + ".include"
 	suffixTagsFile            = suffixTagsAsFields + ".config-file"
 	suffixTagDeDotChar        = suffixTagsAsFields + ".dot-replacement"
 	suffixReadAlias           = ".use-aliases"
@@ -205,7 +206,11 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Bool(
 		nsConfig.namespace+suffixTagsAsFieldsAll,
 		nsConfig.Tags.AllAsFields,
-		"(experimental) Store all span and process tags as object fields. If true "+suffixTagsFile+" is ignored. Binary tags are always stored as nested objects.")
+		"(experimental) Store all span and process tags as object fields. If true "+suffixTagsFile+" and "+suffixTagsAsFieldsInclude+" is ignored. Binary tags are always stored as nested objects.")
+	flagSet.String(
+		nsConfig.namespace+suffixTagsAsFieldsInclude,
+		nsConfig.Tags.Include,
+		"(experimental) Comma delimited list of tag keys which will be stored as object fields.")
 	flagSet.String(
 		nsConfig.namespace+suffixTagsFile,
 		nsConfig.Tags.File,
@@ -267,6 +272,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Timeout = v.GetDuration(cfg.namespace + suffixTimeout)
 	cfg.IndexPrefix = v.GetString(cfg.namespace + suffixIndexPrefix)
 	cfg.Tags.AllAsFields = v.GetBool(cfg.namespace + suffixTagsAsFieldsAll)
+	cfg.Tags.Include = v.GetString(cfg.namespace + suffixTagsAsFieldsInclude)
 	cfg.Tags.File = v.GetString(cfg.namespace + suffixTagsFile)
 	cfg.Tags.DotReplacement = v.GetString(cfg.namespace + suffixTagDeDotChar)
 	cfg.UseReadWriteAliases = v.GetBool(cfg.namespace + suffixReadAlias)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -210,7 +210,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.String(
 		nsConfig.namespace+suffixTagsAsFieldsInclude,
 		nsConfig.Tags.Include,
-		"(experimental) Comma delimited list of tag keys which will be stored as object fields. Merged with "+suffixTagsFile)
+		"(experimental) Comma delimited list of tag keys which will be stored as object fields. Merged with the contents of "+suffixTagsFile)
 	flagSet.String(
 		nsConfig.namespace+suffixTagsFile,
 		nsConfig.Tags.File,

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -210,11 +210,11 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.String(
 		nsConfig.namespace+suffixTagsAsFieldsInclude,
 		nsConfig.Tags.Include,
-		"(experimental) Comma delimited list of tag keys which will be stored as object fields.")
+		"(experimental) Comma delimited list of tag keys which will be stored as object fields. Merged with "+suffixTagsFile)
 	flagSet.String(
 		nsConfig.namespace+suffixTagsFile,
 		nsConfig.Tags.File,
-		"(experimental) Optional path to a file containing tag keys which will be stored as object fields. Each key should be on a separate line.")
+		"(experimental) Optional path to a file containing tag keys which will be stored as object fields. Each key should be on a separate line.  Merged with "+suffixTagsAsFieldsInclude)
 	flagSet.String(
 		nsConfig.namespace+suffixTagDeDotChar,
 		nsConfig.Tags.DotReplacement,

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -61,6 +61,10 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.aux.num-replicas=10",
 		"--es.tls.enabled=true",
 		"--es.tls.skip-host-verify=true",
+		"--es.tags-as-fields.all=true",
+		"--es.tags-as-fields.include=test,tags",
+		"--es.tags-as-fields.config-file=./file.txt",
+		"--es.tags-as-fields.dot-replacement=!",
 	})
 	opts.InitFromViper(v)
 
@@ -73,6 +77,10 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.True(t, primary.SnifferTLSEnabled)
 	assert.Equal(t, true, primary.TLS.Enabled)
 	assert.Equal(t, true, primary.TLS.SkipHostVerify)
+	assert.True(t, primary.Tags.AllAsFields)
+	assert.Equal(t, "!", primary.Tags.DotReplacement)
+	assert.Equal(t, "./file.txt", primary.Tags.File)
+	assert.Equal(t, "test,tags", primary.Tags.Include)
 
 	aux := opts.Get("es.aux")
 	assert.Equal(t, []string{"3.3.3.3", "4.4.4.4"}, aux.Servers)
@@ -82,5 +90,8 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, int64(10), aux.NumReplicas)
 	assert.Equal(t, 24*time.Hour, aux.MaxSpanAge)
 	assert.True(t, aux.Sniffer)
-
+	assert.True(t, aux.Tags.AllAsFields)
+	assert.Equal(t, "!", aux.Tags.DotReplacement)
+	assert.Equal(t, "./file.txt", aux.Tags.File)
+	assert.Equal(t, "test,tags", aux.Tags.Include)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #2295 by providing a way to specify ES tag keys directly through the CLI/config file

## Short description of the changes
- Added a new parameter `es.tags-as-fields.include`.  "include" was chosen to leave space later for "exclude", but I'd be willing to change it to whatever.
- Dropped `LoadTagsFromFile` in favor of `TagKeysAsFields`.  `TagKeysAsFields` returns a slice of tags keys that combines both the new cli option and the file.
- Added appropriate tests
- Added missing `.Tags` fields to `ApplyDefaults`.  Unsure if these were left out for a reason.