### PR TITLE
Prepare release 1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Changes by Version
 
 ### UI Changes
 
+1.19.2 (2020-08-26)
+-------------------
+
+Upgrade to a working UI version before React refactoring.
+
+
 1.19.1 (2020-08-26)
 -------------------
 


### PR DESCRIPTION
UI is bumped to commit `8279218` which includes the fixes we needed to release, but excludes all the new React refactoring, which seems to have broken the trace view (reported in https://github.com/jaegertracing/jaeger-ui/issues/628).

```
5b4ca26 - (HEAD -> master, tag: v1.10.0, upstream/master) Preparing release v1.10.0 (#627) (2 days ago) <Gary Brown>
6513b53 - Additional Test Coverage around TimelineViewingLayer (#617) (5 days ago) <Tim Klever>
60ee1fd - Add rubenvp8510 to code owners (8 days ago) <Yuri Shkuro>
0507ac8 - Add ArchiveNotifier tests (#619) (8 days ago) <Tim Klever>
6843b03 - Refactor SpanGraph.UNSAFE_componentWillReceiveProps  (#613) (9 days ago) <Tim Klever>
122a59e - Remove UNSAFE_componentWillMount lifecycle methods (#611) (12 days ago) <Tim Klever>
dac8c4a - Migrate ArchiveNotifier from UNSAFE_componentWillReceiveProps (#614) (12 days ago) <Tim Klever>
9cc67df - Refactor UNSAFE_componentWillReceiveProps to use componentDidUpdate (#612) (13 days ago) <Tim Klever>
fe67712 - Clear console errors (proptype violations) from CLI output (#615) (2 weeks ago) <Tim Klever>
aa096b0 - Add unit coverage for component TraceIDSearchInput (#616) (2 weeks ago) <Tim Klever>
6340b9a - Update legacy React lifecycle methods to indicate unsafe status (#610) (2 weeks ago) <Tim Klever>

-- cut here --

8279218 - Added view for showing detailed trace statistics (#506) (4 weeks ago) <Philip Dengler>
89f0050 - Render seconds in dark color, millis in light (#605) (5 weeks ago) <Yuri Shkuro>
ade1d34 - Tweak css definition for span tree offset color (#604) (5 weeks ago) <Everett>
f3f7c90 - span bar row size fix. resolves #589 (#599) (5 weeks ago) <Ivan Kopeykin>
7ac8df2 - Fixed missing 'types/node' dependency (#603) (5 weeks ago) <Gary Brown>
da8591a - Update lodash from 4.17.15 to 4.17.19 (#598) (6 weeks ago) <Gary Brown>
e4bf749 - Bump lodash from 4.17.15 to 4.17.19 (#597) (6 weeks ago) <dependabot[bot]>
```