### PR TITLE
Fix error equals

### DIFF
--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -16,7 +16,9 @@
 package app
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,8 +43,8 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&start=string", errParseInt, nil},
 		{"x?service=service&end=string", errParseInt, nil},
 		{"x?service=service&limit=string", errParseInt, nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", "cannot not parse minDuration: time: missing unit in duration 20", nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", "cannot not parse maxDuration: time: missing unit in duration 30", nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", "cannot not parse minDuration: time: missing unit in duration", nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", "cannot not parse maxDuration: time: missing unit in duration", nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `malformed 'tag' parameter, expecting key:value, received: k`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=25s&maxDuration=1s", `'maxDuration' should be greater than 'minDuration'`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
@@ -161,7 +163,7 @@ func TestParseTraceQuery(t *testing.T) {
 					}
 				}
 			} else {
-				assert.EqualError(t, err, test.errMsg)
+				assert.True(t, strings.HasPrefix(err.Error(), test.errMsg), fmt.Sprintf("Error \"%s\" should start with \"%s\"", err.Error(), test.errMsg))
 			}
 		})
 	}

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -18,12 +18,13 @@ package app
 import (
 	"fmt"
 	"net/http"
-	"strings"
+	"regexp"
 	"testing"
 	"time"
 
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -43,8 +44,8 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&start=string", errParseInt, nil},
 		{"x?service=service&end=string", errParseInt, nil},
 		{"x?service=service&limit=string", errParseInt, nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", "cannot not parse minDuration: time: missing unit in duration", nil},
-		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", "cannot not parse maxDuration: time: missing unit in duration", nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", `cannot not parse minDuration: time: missing unit in duration "?20"?$`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", `cannot not parse maxDuration: time: missing unit in duration "?30"?$`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `malformed 'tag' parameter, expecting key:value, received: k`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=25s&maxDuration=1s", `'maxDuration' should be greater than 'minDuration'`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
@@ -163,7 +164,9 @@ func TestParseTraceQuery(t *testing.T) {
 					}
 				}
 			} else {
-				assert.True(t, strings.HasPrefix(err.Error(), test.errMsg), fmt.Sprintf("Error \"%s\" should start with \"%s\"", err.Error(), test.errMsg))
+				matched, matcherr := regexp.MatchString(test.errMsg, err.Error())
+				require.NoError(t, matcherr)
+				assert.True(t, matched, fmt.Sprintf("Error \"%s\" should match \"%s\"", err.Error(), test.errMsg))
 			}
 		})
 	}


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Fixes a broken test introduced by an upgrade of go version to 1.15, caused by a [change in the time package](https://github.com/golang/go/commit/201cb046b745f8bb00e3d382290190c74ba7b7e1), specifically in [format.go:1437](https://github.com/golang/go/blob/18ea6f597c031d5f3c5160217db72d80cb62f689/src/time/format.go#L1437).

## Short description of the changes
- Although the practice of asserting on error messages is debatable, the spirit of this PR is to respect the original intention of this test in making a strong assertion on the specific input value which causes the error. Further, the error message should be consistent between OSes, just not between go versions of course.
- Fixes the broken test, which does not expect a quoted value in the error message. Go 1.15 introduces a sensible change of quoting the values to more clearly identify what is being parsed.
- The fix involves modifying the test to accept either quoted (1.15) or unquoted values (1.14 or below) in a regex of the error message and hence, ensures compatibility between both versions.
- Alternatives considered:
  - Using `strings.HasPrefix` which is slightly simpler but slightly reduces the fidelity of the test, losing a comparison on the actual value.
  - Just `assert.Error(t, err)`, which is the simplest yet loses the most fidelity from the original test assertion.

Tested with the following to ensure they pass:
```
# Using go 1.14
$ go clean -testcache
$ go test github.com/jaegertracing/jaeger/cmd/query/app

# Switch to go 1.15
$ go clean -testcache
$ go test github.com/jaegertracing/jaeger/cmd/query/app
```