### PR TITLE
Fix flaky tls test

### DIFF
--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -316,6 +316,8 @@ func waitUntil(f func() bool, iterations int, sleepInterval time.Duration) {
 	}
 }
 
+// syncWrite ensures data is written to the given filename and flushed to disk.
+// This ensures that any watchers looking for file system changes can be reliably alerted.
 func syncWrite(filename string, data []byte, perm os.FileMode) error {
 	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_SYNC, perm)
 	if err != nil {

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -84,11 +84,11 @@ func TestReload(t *testing.T) {
 	// update the content with client certs
 	certData, err = ioutil.ReadFile(clientCert)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(certFile.Name(), certData, 0644)
+	err = syncWrite(certFile.Name(), certData, 0644)
 	require.NoError(t, err)
 	keyData, err = ioutil.ReadFile(clientKey)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(keyFile.Name(), keyData, 0644)
+	err = syncWrite(keyFile.Name(), keyData, 0644)
 	require.NoError(t, err)
 
 	waitUntil(func() bool {
@@ -138,11 +138,11 @@ func TestReload_ca_certs(t *testing.T) {
 	// update the content with client certs
 	caData, err = ioutil.ReadFile(caCert)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(caFile.Name(), caData, 0644)
+	err = syncWrite(caFile.Name(), caData, 0644)
 	require.NoError(t, err)
 	clientCaData, err = ioutil.ReadFile(caCert)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(clientCaFile.Name(), clientCaData, 0644)
+	err = syncWrite(clientCaFile.Name(), clientCaData, 0644)
 	require.NoError(t, err)
 
 	waitUntil(func() bool {
@@ -200,11 +200,11 @@ func TestReload_err_cert_update(t *testing.T) {
 	// update the content with client certs
 	certData, err = ioutil.ReadFile(badCaCert)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(certFile.Name(), certData, 0644)
+	err = syncWrite(certFile.Name(), certData, 0644)
 	require.NoError(t, err)
 	keyData, err = ioutil.ReadFile(clientKey)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(keyFile.Name(), keyData, 0644)
+	err = syncWrite(keyFile.Name(), keyData, 0644)
 	require.NoError(t, err)
 
 	waitUntil(func() bool {
@@ -314,4 +314,15 @@ func waitUntil(f func() bool, iterations int, sleepInterval time.Duration) {
 		}
 		time.Sleep(sleepInterval)
 	}
+}
+
+func syncWrite(filename string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_SYNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err = f.Write(data); err != nil {
+		return err
+	}
+	return f.Sync()
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #2428 

## Short description of the changes
- The hypothesis on the cause of these flaky tests is that the `certWatcher` isn't detecting file changes and, hence, isn't logging these events causing the assertions to fail occasionally.
- Ensures calls to `ioutil.WriteFile` are replaced with a synchronous write to disk.
- The reason for doing this is because `ioutil.WriteFile` does not call `Sync()` nor opens the file with the `os.O_SYNC` flag and hence, potentially fails to flush write buffers to disk.
