### PR TITLE
Add storage metrics to OTEL, metrics by span service name

### DIFF
--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/exporter.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/exporter.go
@@ -26,7 +26,7 @@ import (
 // new creates Elasticsearch exporter/storage.
 func new(ctx context.Context, config *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
 	esCfg := config.GetPrimary()
-	w, err := newEsSpanWriter(*esCfg, params.Logger, false)
+	w, err := newEsSpanWriter(*esCfg, params.Logger, false, config.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
@@ -67,6 +67,7 @@ func (s storageWrapper) WriteSpan(ctx context.Context, span *model.Span) error {
 	// This fails because there is no binary tag type in OTEL and also OTEL span's status code is always created
 	//traces := jaegertranslator.ProtoBatchesToInternalTraces([]*model.Batch{{Process: span.Process, Spans: []*model.Span{span}}})
 	//_, err := s.writer.WriteTraces(context.Background(), traces)
+	// TODO set tags as keys
 	converter := dbmodel.FromDomain{}
 	dbSpan := converter.FromDomainEmbedProcess(span)
 	_, err := s.writer.writeSpans(ctx, []*dbmodel.Span{dbSpan})
@@ -108,7 +109,7 @@ func (s *IntegrationTest) initSpanstore(allTagsAsFields bool) error {
 			AllAsFields: allTagsAsFields,
 		},
 	}
-	w, err := newEsSpanWriter(cfg, s.logger, false, "elasticsearch")
+	w, err := newEsSpanWriter(cfg, s.logger, false, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
@@ -32,13 +32,11 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/esclient"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/reader/es/esdependencyreader"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/reader/es/esspanreader"
-	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/config"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/plugin/storage/integration"
-	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 const (
@@ -49,29 +47,14 @@ const (
 	indexPrefix     = "integration-test"
 	tagKeyDeDotChar = "@"
 	maxSpanAge      = time.Hour * 72
+	numShards = 5
+	numReplicas = 0
 )
 
 type IntegrationTest struct {
 	integration.StorageIntegration
 
 	logger *zap.Logger
-}
-
-type storageWrapper struct {
-	writer *esSpanWriter
-}
-
-var _ spanstore.Writer = (*storageWrapper)(nil)
-
-func (s storageWrapper) WriteSpan(ctx context.Context, span *model.Span) error {
-	// This fails because there is no binary tag type in OTEL and also OTEL span's status code is always created
-	//traces := jaegertranslator.ProtoBatchesToInternalTraces([]*model.Batch{{Process: span.Process, Spans: []*model.Span{span}}})
-	//_, err := s.writer.WriteTraces(context.Background(), traces)
-	// TODO set tags as keys
-	converter := dbmodel.FromDomain{}
-	dbSpan := converter.FromDomainEmbedProcess(span)
-	_, err := s.writer.writeSpans(ctx, []*dbmodel.Span{dbSpan})
-	return err
 }
 
 func (s *IntegrationTest) initializeES(allTagsAsFields bool) error {
@@ -97,7 +80,11 @@ func (s *IntegrationTest) esCleanUp(allTagsAsFields bool) error {
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	err = response.Body.Close()
+	if err != nil {
+		return err
+	}
+	// initialize writer, it caches service names
 	return s.initSpanstore(allTagsAsFields)
 }
 
@@ -114,13 +101,14 @@ func (s *IntegrationTest) initSpanstore(allTagsAsFields bool) error {
 		return err
 	}
 	esVersion := uint(w.esClientVersion())
-	spanMapping, serviceMapping := es.GetSpanServiceMappings(1, 0, esVersion)
+	spanMapping, serviceMapping := es.GetSpanServiceMappings(numShards, numReplicas, esVersion)
 	err = w.CreateTemplates(context.Background(), spanMapping, serviceMapping)
 	if err != nil {
 		return err
 	}
-	s.SpanWriter = storageWrapper{
+	s.SpanWriter = singleSpanWriter{
 		writer: w,
+		converter: dbmodel.NewFromDomain(allTagsAsFields, []string{}, tagKeyDeDotChar),
 	}
 
 	elasticsearchClient, err := esclient.NewElasticsearchClient(cfg, s.logger)
@@ -135,7 +123,7 @@ func (s *IntegrationTest) initSpanstore(allTagsAsFields bool) error {
 	})
 	s.SpanReader = reader
 
-	depMapping := es.GetDependenciesMappings(1, 0, esVersion)
+	depMapping := es.GetDependenciesMappings(numShards, numReplicas, esVersion)
 	depStore := esdependencyreader.NewDependencyStore(elasticsearchClient, s.logger, indexPrefix)
 	if err := depStore.CreateTemplates(depMapping); err != nil {
 		return nil

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
@@ -47,8 +47,8 @@ const (
 	indexPrefix     = "integration-test"
 	tagKeyDeDotChar = "@"
 	maxSpanAge      = time.Hour * 72
-	numShards = 5
-	numReplicas = 0
+	numShards       = 5
+	numReplicas     = 0
 )
 
 type IntegrationTest struct {
@@ -107,7 +107,7 @@ func (s *IntegrationTest) initSpanstore(allTagsAsFields bool) error {
 		return err
 	}
 	s.SpanWriter = singleSpanWriter{
-		writer: w,
+		writer:    w,
 		converter: dbmodel.NewFromDomain(allTagsAsFields, []string{}, tagKeyDeDotChar),
 	}
 

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore.go
@@ -23,12 +23,15 @@ import (
 	"strings"
 	"time"
 
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/elasticsearchexporter/esmodeltranslator"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/storagemetrics"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/esclient"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cache"
@@ -47,6 +50,7 @@ const (
 // esSpanWriter holds components required for ES span writer
 type esSpanWriter struct {
 	logger           *zap.Logger
+	nameTag          tag.Mutator
 	client           esclient.ElasticsearchClient
 	serviceCache     cache.Cache
 	spanIndexName    indexNameProvider
@@ -56,7 +60,7 @@ type esSpanWriter struct {
 }
 
 // newEsSpanWriter creates new instance of esSpanWriter
-func newEsSpanWriter(params config.Configuration, logger *zap.Logger, archive bool) (*esSpanWriter, error) {
+func newEsSpanWriter(params config.Configuration, logger *zap.Logger, archive bool, name string) (*esSpanWriter, error) {
 	client, err := esclient.NewElasticsearchClient(params, logger)
 	if err != nil {
 		return nil, err
@@ -66,6 +70,8 @@ func newEsSpanWriter(params config.Configuration, logger *zap.Logger, archive bo
 		return nil, err
 	}
 	return &esSpanWriter{
+		logger:           logger,
+		nameTag:          tag.Insert(storagemetrics.TagExporterName(), name),
 		client:           client,
 		spanIndexName:    newIndexNameProvider(spanIndexBaseName, params.IndexPrefix, params.UseReadWriteAliases, archive),
 		serviceIndexName: newIndexNameProvider(serviceIndexBaseName, params.IndexPrefix, params.UseReadWriteAliases, archive),
@@ -106,7 +112,7 @@ func (w *esSpanWriter) WriteTraces(ctx context.Context, traces pdata.Traces) (in
 func (w *esSpanWriter) writeSpans(ctx context.Context, spans []*dbmodel.Span) (int, error) {
 	buffer := &bytes.Buffer{}
 	// mapping for bulk operation to span
-	bulkOperations := make([]bulkItem, len(spans))
+	var bulkOperations []bulkItem
 	var errs []error
 	dropped := 0
 	for _, span := range spans {
@@ -136,14 +142,17 @@ func (w *esSpanWriter) writeSpans(ctx context.Context, spans []*dbmodel.Span) (i
 		errs = append(errs, err)
 		return len(spans), componenterror.CombineErrors(errs)
 	}
-	droppedFromResponse := w.handleResponse(res, bulkOperations)
+	droppedFromResponse := w.handleResponse(ctx, res, bulkOperations)
 	dropped += droppedFromResponse
 	return dropped, componenterror.CombineErrors(errs)
 }
 
-func (w *esSpanWriter) handleResponse(blk *esclient.BulkResponse, operationToSpan []bulkItem) int {
+func (w *esSpanWriter) handleResponse(ctx context.Context, blk *esclient.BulkResponse, operationToSpan []bulkItem) int {
 	numErrors := 0
+	storedSpans := map[string]int64{}
+	notStoredSpans := map[string]int64{}
 	for i, d := range blk.Items {
+		bulkOp := operationToSpan[i]
 		if d.Index.Status > 201 {
 			numErrors++
 			w.logger.Error("Part of the bulk request failed",
@@ -154,14 +163,28 @@ func (w *esSpanWriter) handleResponse(blk *esclient.BulkResponse, operationToSpa
 				zap.String("error.cause.reason", d.Index.Error.Cause.Reason))
 			// TODO return an error or a struct that indicates which spans should be retried
 			// https://github.com/open-telemetry/opentelemetry-collector/issues/990
+			if !bulkOp.isService {
+				notStoredSpans[bulkOp.span.Process.ServiceName] = notStoredSpans[bulkOp.span.Process.ServiceName] + 1
+			}
 		} else {
 			// passed
-			bulkOp := operationToSpan[i]
-			if bulkOp.isService {
+			if !bulkOp.isService {
+				storedSpans[bulkOp.span.Process.ServiceName] = storedSpans[bulkOp.span.Process.ServiceName] + 1
+			} else {
 				cacheKey := hashCode(bulkOp.span.Process.ServiceName, bulkOp.span.OperationName)
 				w.serviceCache.Put(cacheKey, cacheKey)
 			}
 		}
+	}
+	for k, v := range notStoredSpans {
+		ctx, _ := tag.New(ctx,
+			tag.Insert(storagemetrics.TagServiceName(), k), w.nameTag)
+		stats.Record(ctx, storagemetrics.StatSpansNotStoredCount().M(v))
+	}
+	for k, v := range storedSpans {
+		ctx, _ := tag.New(ctx,
+			tag.Insert(storagemetrics.TagServiceName(), k), w.nameTag)
+		stats.Record(ctx, storagemetrics.StatSpansStoredCount().M(v))
 	}
 	return numErrors
 }

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elasticsearchexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats/view"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/storagemetrics"
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/esclient"
+	"github.com/jaegertracing/jaeger/pkg/es/config"
+	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
+)
+
+func TestMetrics(t *testing.T) {
+	w, err := newEsSpanWriter(config.Configuration{Servers: []string{"localhost:9200"}, Version: 6}, zap.NewNop(), false, "elasticsearch")
+	require.NoError(t, err)
+	response := &esclient.BulkResponse{}
+	response.Items = []esclient.BulkResponseItem{
+		{Index: esclient.BulkIndexResponse{Status: 200}},
+		{Index: esclient.BulkIndexResponse{Status: 500}},
+		{Index: esclient.BulkIndexResponse{Status: 200}},
+		{Index: esclient.BulkIndexResponse{Status: 500}},
+	}
+	blkItms := []bulkItem{
+		{isService: true, span: &dbmodel.Span{}},
+		{isService: true, span: &dbmodel.Span{}},
+		{span: &dbmodel.Span{Process: dbmodel.Process{ServiceName: "foo"}}},
+		{span: &dbmodel.Span{Process: dbmodel.Process{ServiceName: "foo"}}},
+	}
+
+	views := storagemetrics.MetricViews()
+	require.NoError(t, view.Register(views...))
+	defer view.Unregister(views...)
+
+	errs := w.handleResponse(context.Background(), response, blkItms)
+	assert.Equal(t, 2, errs)
+
+	viewData, err := view.RetrieveData(storagemetrics.StatSpansStoredCount().Name())
+	require.NoError(t, err)
+	require.Equal(t, 1, len(viewData))
+	distData := viewData[0].Data.(*view.SumData)
+	assert.Equal(t, float64(1), distData.Value)
+
+	viewData, err = view.RetrieveData(storagemetrics.StatSpansNotStoredCount().Name())
+	require.NoError(t, err)
+	require.Equal(t, 1, len(viewData))
+	distData = viewData[0].Data.(*view.SumData)
+	assert.Equal(t, float64(1), distData.Value)
+}

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
@@ -49,7 +49,7 @@ func NewStorageFactory(opts *es.Options, logger *zap.Logger, name string) *Stora
 	return &StorageFactory{
 		options: opts,
 		logger:  logger,
-		name: name,
+		name:    name,
 	}
 }
 

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
@@ -16,6 +16,7 @@ package elasticsearchexporter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
@@ -35,7 +36,8 @@ const archiveNamespace = "es-archive"
 
 // StorageFactory implements storage.Factory and storage.ArchiveFactory
 type StorageFactory struct {
-	Options *es.Options
+	options *es.Options
+	name    string
 	logger  *zap.Logger
 }
 
@@ -43,9 +45,9 @@ var _ storage.Factory = (*StorageFactory)(nil)
 var _ storage.ArchiveFactory = (*StorageFactory)(nil)
 
 // NewStorageFactory creates StorageFactory
-func NewStorageFactory(opts *es.Options, logger *zap.Logger) *StorageFactory {
+func NewStorageFactory(opts *es.Options, logger *zap.Logger, name string) *StorageFactory {
 	return &StorageFactory{
-		Options: opts,
+		options: opts,
 		logger:  logger,
 	}
 }
@@ -58,8 +60,8 @@ func (s *StorageFactory) Initialize(_ metrics.Factory, logger *zap.Logger) error
 
 // CreateSpanWriter creates spanstore.Writer
 func (s *StorageFactory) CreateSpanWriter() (spanstore.Writer, error) {
-	cfg := s.Options.GetPrimary()
-	writer, err := newEsSpanWriter(*cfg, s.logger, false)
+	cfg := s.options.GetPrimary()
+	writer, err := newEsSpanWriter(*cfg, s.logger, false, s.name)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +77,7 @@ func (s *StorageFactory) CreateSpanWriter() (spanstore.Writer, error) {
 
 // CreateSpanReader creates spanstore.Reader
 func (s *StorageFactory) CreateSpanReader() (spanstore.Reader, error) {
-	cfg := s.Options.GetPrimary()
+	cfg := s.options.GetPrimary()
 	client, err := esclient.NewElasticsearchClient(*cfg, s.logger)
 	if err != nil {
 		return nil, err
@@ -92,7 +94,7 @@ func (s *StorageFactory) CreateSpanReader() (spanstore.Reader, error) {
 
 // CreateDependencyReader creates dependencystore.Reader
 func (s *StorageFactory) CreateDependencyReader() (dependencystore.Reader, error) {
-	cfg := s.Options.GetPrimary()
+	cfg := s.options.GetPrimary()
 	client, err := esclient.NewElasticsearchClient(*cfg, s.logger)
 	if err != nil {
 		return nil, err
@@ -102,7 +104,7 @@ func (s *StorageFactory) CreateDependencyReader() (dependencystore.Reader, error
 
 // CreateArchiveSpanReader creates archive spanstore.Reader
 func (s *StorageFactory) CreateArchiveSpanReader() (spanstore.Reader, error) {
-	cfg := s.Options.Get(archiveNamespace)
+	cfg := s.options.Get(archiveNamespace)
 	client, err := esclient.NewElasticsearchClient(*cfg, s.logger)
 	if err != nil {
 		return nil, err
@@ -119,8 +121,8 @@ func (s *StorageFactory) CreateArchiveSpanReader() (spanstore.Reader, error) {
 
 // CreateArchiveSpanWriter creates archive spanstore.Writer
 func (s *StorageFactory) CreateArchiveSpanWriter() (spanstore.Writer, error) {
-	cfg := s.Options.Get(archiveNamespace)
-	writer, err := newEsSpanWriter(*cfg, s.logger, true)
+	cfg := s.options.Get(archiveNamespace)
+	writer, err := newEsSpanWriter(*cfg, s.logger, true, fmt.Sprintf("%s/%s", s.name, archiveNamespace))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
@@ -49,6 +49,7 @@ func NewStorageFactory(opts *es.Options, logger *zap.Logger, name string) *Stora
 	return &StorageFactory{
 		options: opts,
 		logger:  logger,
+		name: name,
 	}
 }
 

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory_test.go
@@ -28,10 +28,12 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 )
 
+const testExporterName = "test"
+
 func TestFactoryCreateSpanWriter(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{Version: 6, Servers: []string{"foo:9200"}}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		assert.NoError(t, factory.Initialize(nil, nil))
 		writer, err := factory.CreateSpanWriter()
 		require.NoError(t, err)
@@ -39,7 +41,7 @@ func TestFactoryCreateSpanWriter(t *testing.T) {
 	})
 	t.Run("error_es_client", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		writer, err := factory.CreateSpanWriter()
 		require.Error(t, err)
 		assert.Nil(t, writer)
@@ -49,14 +51,14 @@ func TestFactoryCreateSpanWriter(t *testing.T) {
 func TestFactoryCreateSpanReader(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{Version: 6, Servers: []string{"foo:9200"}}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		reader, err := factory.CreateSpanReader()
 		require.NoError(t, err)
 		assert.NotNil(t, reader)
 	})
 	t.Run("error_es_client", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		reader, err := factory.CreateSpanReader()
 		require.Error(t, err)
 		assert.Nil(t, reader)
@@ -66,14 +68,14 @@ func TestFactoryCreateSpanReader(t *testing.T) {
 func TestFactoryCreateDependencyReader(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{Version: 6, Servers: []string{"foo:9200"}}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		reader, err := factory.CreateDependencyReader()
 		require.NoError(t, err)
 		assert.NotNil(t, reader)
 	})
 	t.Run("error_es_client", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		reader, err := factory.CreateDependencyReader()
 		require.Error(t, err)
 		assert.Nil(t, reader)
@@ -83,14 +85,14 @@ func TestFactoryCreateDependencyReader(t *testing.T) {
 func TestFactoryCreateArchiveSpanReader(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{}, config.Configuration{Version: 6, Servers: []string{"foo:9200"}})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		reader, err := factory.CreateArchiveSpanReader()
 		require.NoError(t, err)
 		assert.NotNil(t, reader)
 	})
 	t.Run("error_es_client", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		reader, err := factory.CreateArchiveSpanReader()
 		require.Error(t, err)
 		assert.Nil(t, reader)
@@ -100,14 +102,14 @@ func TestFactoryCreateArchiveSpanReader(t *testing.T) {
 func TestFactoryCreateArchiveSpanWriter(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{}, config.Configuration{Version: 6, Servers: []string{"foo:9200"}})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		writer, err := factory.CreateArchiveSpanWriter()
 		require.NoError(t, err)
 		assert.NotNil(t, writer)
 	})
 	t.Run("error_es_client", func(t *testing.T) {
 		opts := es.NewOptionsFromConfig(config.Configuration{}, config.Configuration{})
-		factory := NewStorageFactory(opts, zap.NewNop())
+		factory := NewStorageFactory(opts, zap.NewNop(), testExporterName)
 		writer, err := factory.CreateArchiveSpanWriter()
 		require.Error(t, err)
 		assert.Nil(t, writer)

--- a/cmd/opentelemetry/app/exporter/span_writer_exporter.go
+++ b/cmd/opentelemetry/app/exporter/span_writer_exporter.go
@@ -16,8 +16,9 @@ package exporter
 
 import (
 	"context"
-	"io"
 
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -26,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
 
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/storagemetrics"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
@@ -36,13 +38,7 @@ func NewSpanWriterExporter(config configmodels.Exporter, factory storage.Factory
 	if err != nil {
 		return nil, err
 	}
-	storage := store{Writer: spanWriter}
-	opts = append(opts, exporterhelper.WithShutdown(func(ctx context.Context) error {
-		if closer, ok := spanWriter.(io.Closer); ok {
-			return closer.Close()
-		}
-		return nil
-	}))
+	storage := store{Writer: spanWriter, storageNameTag: tag.Insert(storagemetrics.TagExporterName(), config.Name())}
 	return exporterhelper.NewTraceExporter(
 		config,
 		storage.traceDataPusher,
@@ -50,7 +46,8 @@ func NewSpanWriterExporter(config configmodels.Exporter, factory storage.Factory
 }
 
 type store struct {
-	Writer spanstore.Writer
+	Writer         spanstore.Writer
+	storageNameTag tag.Mutator
 }
 
 // traceDataPusher implements OTEL exporterhelper.traceDataPusher
@@ -61,6 +58,8 @@ func (s *store) traceDataPusher(ctx context.Context, td pdata.Traces) (droppedSp
 	}
 	dropped := 0
 	var errs []error
+	storedSpans := map[string]int64{}
+	notStoredSpans := map[string]int64{}
 	for _, batch := range batches {
 		for _, span := range batch.Spans {
 			span.Process = batch.Process
@@ -68,8 +67,21 @@ func (s *store) traceDataPusher(ctx context.Context, td pdata.Traces) (droppedSp
 			if err != nil {
 				errs = append(errs, err)
 				dropped++
+				notStoredSpans[span.Process.ServiceName] = notStoredSpans[span.Process.ServiceName] + 1
+			} else {
+				storedSpans[span.Process.ServiceName] = storedSpans[span.Process.ServiceName] + 1
 			}
 		}
+	}
+	for k, v := range notStoredSpans {
+		ctx, _ := tag.New(ctx,
+			tag.Insert(storagemetrics.TagServiceName(), k), s.storageNameTag)
+		stats.Record(ctx, storagemetrics.StatSpansNotStoredCount().M(v))
+	}
+	for k, v := range storedSpans {
+		ctx, _ := tag.New(ctx,
+			tag.Insert(storagemetrics.TagServiceName(), k), s.storageNameTag)
+		stats.Record(ctx, storagemetrics.StatSpansStoredCount().M(v))
 	}
 	return dropped, componenterror.CombineErrors(errs)
 }

--- a/cmd/opentelemetry/app/exporter/storagemetrics/metrics.go
+++ b/cmd/opentelemetry/app/exporter/storagemetrics/metrics.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagemetrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	tagServiceName = tag.MustNewKey("service")
+	tagExporter    = tag.MustNewKey("exporter")
+
+	statSpanStoredCount    = stats.Int64("storage_exporter_stored_spans", "Number of stored spans", stats.UnitDimensionless)
+	statSpanNotStoredCount = stats.Int64("storage_exporter_not_stored_spans", "Number of spans that failed to be stored", stats.UnitDimensionless)
+)
+
+// MetricViews returns the metrics views related to storage.
+func MetricViews() []*view.View {
+	tags := []tag.Key{tagServiceName, tagExporter}
+
+	countSpanStoredView := &view.View{
+		Name:        statSpanStoredCount.Name(),
+		Measure:     statSpanStoredCount,
+		Description: statSpanStoredCount.Description(),
+		TagKeys:     tags,
+		Aggregation: view.Sum(),
+	}
+	countSpanNotStoredView := &view.View{
+		Name:        statSpanNotStoredCount.Name(),
+		Measure:     statSpanNotStoredCount,
+		Description: statSpanNotStoredCount.Description(),
+		TagKeys:     tags,
+		Aggregation: view.Sum(),
+	}
+
+	return []*view.View{
+		countSpanStoredView,
+		countSpanNotStoredView,
+	}
+}
+
+// TagServiceName returns spans's service name tag.
+func TagServiceName() tag.Key {
+	return tagServiceName
+}
+
+// TagExporterName returns exporter name tag.
+func TagExporterName() tag.Key {
+	return tagExporter
+}
+
+// StatSpansStoredCount returns counter for spans that were successfully stored.
+func StatSpansStoredCount() *stats.Int64Measure {
+	return statSpanStoredCount
+}
+
+// StatSpansNotStoredCount returns counter for spans that failed to be stored.
+func StatSpansNotStoredCount() *stats.Int64Measure {
+	return statSpanNotStoredCount
+}

--- a/cmd/opentelemetry/app/exporter/storagemetrics/metrics_test.go
+++ b/cmd/opentelemetry/app/exporter/storagemetrics/metrics_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagemetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetrics(t *testing.T) {
+	metricViews := MetricViews()
+	require.Equal(t, 2, len(metricViews))
+	viewNames := []string{
+		"storage_exporter_stored_spans",
+		"storage_exporter_not_stored_spans",
+	}
+	for i, viewName := range viewNames {
+		assert.Equal(t, viewName, metricViews[i].Name)
+	}
+}

--- a/cmd/opentelemetry/app/internal/esclient/client.go
+++ b/cmd/opentelemetry/app/internal/esclient/client.go
@@ -53,22 +53,28 @@ type ElasticsearchClient interface {
 
 // BulkResponse is a response returned by Elasticsearch Bulk API
 type BulkResponse struct {
-	Errors bool `json:"errors"`
-	Items  []struct {
-		Index struct {
-			ID     string `json:"_id"`
-			Result string `json:"result"`
-			Status int    `json:"status"`
-			Error  struct {
-				Type   string `json:"type"`
-				Reason string `json:"reason"`
-				Cause  struct {
-					Type   string `json:"type"`
-					Reason string `json:"reason"`
-				} `json:"caused_by"`
-			} `json:"error"`
-		} `json:"index"`
-	} `json:"items"`
+	Errors bool               `json:"errors"`
+	Items  []BulkResponseItem `json:"items"`
+}
+
+// BulkResponseItem is a single response from BulkResponse
+type BulkResponseItem struct {
+	Index BulkIndexResponse `json:"index"`
+}
+
+// BulkIndexResponse is a bulk response for index action
+type BulkIndexResponse struct {
+	ID     string `json:"_id"`
+	Result string `json:"result"`
+	Status int    `json:"status"`
+	Error  struct {
+		Type   string `json:"type"`
+		Reason string `json:"reason"`
+		Cause  struct {
+			Type   string `json:"type"`
+			Reason string `json:"reason"`
+		} `json:"caused_by"`
+	} `json:"error"`
 }
 
 // SearchBody defines search request.

--- a/cmd/opentelemetry/app/telemetry.go
+++ b/cmd/opentelemetry/app/telemetry.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"go.opencensus.io/stats/view"
+
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/storagemetrics"
+)
+
+// RegisterMetricViews registers metric views.
+func RegisterMetricViews() error {
+	views := storagemetrics.MetricViews()
+	if err := view.Register(views...); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/opentelemetry/cmd/agent/main.go
+++ b/cmd/opentelemetry/cmd/agent/main.go
@@ -40,6 +40,10 @@ func main() {
 		}
 	}
 
+	if err := app.RegisterMetricViews(); err != nil {
+		handleErr(err)
+	}
+
 	ver := version.Get()
 	info := service.ApplicationStartInfo{
 		ExeName:  "jaeger-opentelemetry-agent",

--- a/cmd/opentelemetry/cmd/all-in-one/main.go
+++ b/cmd/opentelemetry/cmd/all-in-one/main.go
@@ -61,6 +61,10 @@ func main() {
 		}
 	}
 
+	if err := app.RegisterMetricViews(); err != nil {
+		handleErr(err)
+	}
+
 	ver := version.Get()
 	info := service.ApplicationStartInfo{
 		ExeName:  "jaeger-opentelemetry-all-in-one",
@@ -216,7 +220,7 @@ func getFactory(exporter configmodels.Exporter, v *viper.Viper, logger *zap.Logg
 		archiveOpts.InitFromViper(v)
 		primaryConfig := exporter.(*elasticsearchexporter.Config)
 		opts := esStorage.NewOptionsFromConfig(primaryConfig.Primary.Configuration, archiveOpts.Primary.Configuration)
-		return elasticsearchexporter.NewStorageFactory(opts, logger), nil
+		return elasticsearchexporter.NewStorageFactory(opts, logger, primaryConfig.Name()), nil
 	case "jaeger_cassandra":
 		archiveOpts := cassandraStorage.NewOptions("cassandra-archive")
 		archiveOpts.InitFromViper(v)

--- a/cmd/opentelemetry/cmd/collector/main.go
+++ b/cmd/opentelemetry/cmd/collector/main.go
@@ -42,6 +42,10 @@ func main() {
 		}
 	}
 
+	if err := app.RegisterMetricViews(); err != nil {
+		handleErr(err)
+	}
+
 	ver := version.Get()
 	info := service.ApplicationStartInfo{
 		ExeName:  "jaeger-opentelemetry-collector",

--- a/cmd/opentelemetry/cmd/ingester/main.go
+++ b/cmd/opentelemetry/cmd/ingester/main.go
@@ -42,6 +42,10 @@ func main() {
 		}
 	}
 
+	if err := app.RegisterMetricViews(); err != nil {
+		handleErr(err)
+	}
+
 	ver := version.Get()
 	info := service.ApplicationStartInfo{
 		ExeName:  "jaeger-opentelemetry-ingester",

--- a/cmd/opentelemetry/go.mod
+++ b/cmd/opentelemetry/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/uber/jaeger-client-go v2.23.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
+	go.opencensus.io v0.22.4
 	go.opentelemetry.io/collector v0.8.1-0.20200820012544-1e65674799c8
 	go.uber.org/zap v1.16.0
 )

--- a/plugin/storage/integration/trace_compare.go
+++ b/plugin/storage/integration/trace_compare.go
@@ -72,7 +72,7 @@ func CompareTraces(t *testing.T, expected *model.Trace, actual *model.Trace) {
 }
 
 func checkSize(t *testing.T, expected *model.Trace, actual *model.Trace) {
-	require.True(t, len(expected.Spans) == len(actual.Spans))
+	require.Equal(t, len(expected.Spans), len(actual.Spans))
 	for i := range expected.Spans {
 		expectedSpan := expected.Spans[i]
 		actualSpan := actual.Spans[i]


### PR DESCRIPTION
Resolves https://github.com/jaegertracing/jaeger/issues/2165#issuecomment-651179655

This PR adds storage metrics to OTEL distribution. The metrics show many spans were stored per service and exporter. There is a similar metric in the current jaeger distributions.

```
otelcol_spans_stored{service="jaeger-query",service_instance_id="23e9c69b-1383-4fbd-8614-638339329a8e",storage="in-memory"}
```

It is a similar metric to the core metric: 

```
otelcol_exporter_sent_spans{exporter="jaeger_memory",service_instance_id="23e9c69b-1383-4fbd-8614-638339329a8e"} 9
```

however it does not split the metric by reported service name.