### PR TITLE
Use queue retry per exporter

### DIFF
--- a/cmd/opentelemetry/app/defaultconfig/default_config.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
-	"go.opentelemetry.io/collector/processor/queuedprocessor"
 	"go.opentelemetry.io/collector/processor/resourceprocessor"
 	"go.opentelemetry.io/collector/receiver/jaegerreceiver"
 	"go.opentelemetry.io/collector/receiver/zipkinreceiver"
@@ -107,9 +106,6 @@ func createProcessors(factories component.Factories) (configmodels.Processors, [
 	batch := factories.Processors["batch"].CreateDefaultConfig().(*batchprocessor.Config)
 	processors[batch.Name()] = batch
 	names = append(names, batch.Name())
-	queuedRetry := factories.Processors["queued_retry"].CreateDefaultConfig().(*queuedprocessor.Config)
-	processors[queuedRetry.Name()] = queuedRetry
-	names = append(names, queuedRetry.Name())
 	return processors, names
 }
 

--- a/cmd/opentelemetry/app/defaultconfig/default_config_test.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config_test.go
@@ -53,7 +53,7 @@ func TestService(t *testing.T) {
 					"traces": &configmodels.Pipeline{
 						InputType:  configmodels.TracesDataType,
 						Receivers:  []string{"otlp", "jaeger"},
-						Processors: []string{"batch", "queued_retry"},
+						Processors: []string{"batch"},
 						Exporters:  []string{"jaeger"},
 					},
 				},
@@ -71,7 +71,7 @@ func TestService(t *testing.T) {
 					"traces": &configmodels.Pipeline{
 						InputType:  configmodels.TracesDataType,
 						Receivers:  []string{"otlp", "jaeger"},
-						Processors: []string{"resource", "batch", "queued_retry"},
+						Processors: []string{"resource", "batch"},
 						Exporters:  []string{elasticsearchexporter.TypeStr, kafkaexporter.TypeStr, memoryexporter.TypeStr},
 					},
 				},
@@ -88,7 +88,7 @@ func TestService(t *testing.T) {
 					"traces": &configmodels.Pipeline{
 						InputType:  configmodels.TracesDataType,
 						Receivers:  []string{kafkareceiver.TypeStr},
-						Processors: []string{"batch", "queued_retry"},
+						Processors: []string{"batch"},
 						Exporters:  []string{elasticsearchexporter.TypeStr},
 					},
 				},
@@ -105,7 +105,7 @@ func TestService(t *testing.T) {
 					"traces": &configmodels.Pipeline{
 						InputType:  configmodels.TracesDataType,
 						Receivers:  []string{kafkareceiver.TypeStr},
-						Processors: []string{"batch", "queued_retry"},
+						Processors: []string{"batch"},
 						Exporters:  []string{cassandraexporter.TypeStr, elasticsearchexporter.TypeStr, grpcpluginexporter.TypeStr},
 					},
 				},
@@ -123,7 +123,7 @@ func TestService(t *testing.T) {
 					"traces": &configmodels.Pipeline{
 						InputType:  configmodels.TracesDataType,
 						Receivers:  []string{"otlp", "jaeger", "zipkin"},
-						Processors: []string{"batch", "queued_retry"},
+						Processors: []string{"batch"},
 						Exporters:  []string{elasticsearchexporter.TypeStr},
 					},
 				},

--- a/cmd/opentelemetry/app/exporter/badgerexporter/config.go
+++ b/cmd/opentelemetry/app/exporter/badgerexporter/config.go
@@ -16,12 +16,17 @@ package badgerexporter
 
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 )
 
 // Config holds configuration of Jaeger Badger exporter/storage.
 type Config struct {
-	badger.Options                `mapstructure:",squash"`
-	configmodels.ExporterSettings `mapstructure:",squash"`
+	configmodels.ExporterSettings  `mapstructure:",squash"`
+	exporterhelper.TimeoutSettings `mapstructure:",squash"`
+	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
+	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
+
+	badger.Options `mapstructure:",squash"`
 }

--- a/cmd/opentelemetry/app/exporter/badgerexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/badgerexporter/factory.go
@@ -76,9 +76,6 @@ func (f Factory) Type() configmodels.Type {
 // CreateDefaultConfig returns default configuration of Factory.
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
-	// TODO: Enable the queued settings by default.
-	qs := exporterhelper.CreateDefaultQueueSettings()
-	qs.Enabled = false
 	opts := f.optionsFactory()
 	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
@@ -87,7 +84,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 		},
 		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
 		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
-		QueueSettings:   qs,
+		QueueSettings:   exporterhelper.CreateDefaultQueueSettings(),
 		Options:         *opts,
 	}
 }

--- a/cmd/opentelemetry/app/exporter/badgerexporter/factory_test.go
+++ b/cmd/opentelemetry/app/exporter/badgerexporter/factory_test.go
@@ -42,13 +42,6 @@ func TestCreateTraceExporter(t *testing.T) {
 	assert.NotNil(t, exporter)
 }
 
-func TestCreateTraceExporter_NilConfig(t *testing.T) {
-	factory := Factory{}
-	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, nil)
-	require.Nil(t, exporter)
-	assert.Contains(t, err.Error(), "could not cast configuration to jaeger_badger")
-}
-
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory(DefaultOptions)
 	cfg := factory.CreateDefaultConfig()

--- a/cmd/opentelemetry/app/exporter/cassandraexporter/config.go
+++ b/cmd/opentelemetry/app/exporter/cassandraexporter/config.go
@@ -16,12 +16,17 @@ package cassandraexporter
 
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 )
 
 // Config holds configuration of Jaeger Cassandra exporter/storage.
 type Config struct {
-	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	cassandra.Options             `mapstructure:",squash"`
+	configmodels.ExporterSettings  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.TimeoutSettings `mapstructure:",squash"`
+	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
+	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
+
+	cassandra.Options `mapstructure:",squash"`
 }

--- a/cmd/opentelemetry/app/exporter/cassandraexporter/exporter.go
+++ b/cmd/opentelemetry/app/exporter/cassandraexporter/exporter.go
@@ -17,6 +17,7 @@ package cassandraexporter
 import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
@@ -31,5 +32,8 @@ func new(config *Config, params component.ExporterCreateParams) (component.Trace
 	if err != nil {
 		return nil, err
 	}
-	return exporter.NewSpanWriterExporter(config, f)
+	return exporter.NewSpanWriterExporter(config, f,
+		exporterhelper.WithTimeout(config.TimeoutSettings),
+		exporterhelper.WithQueue(config.QueueSettings),
+		exporterhelper.WithRetry(config.RetrySettings))
 }

--- a/cmd/opentelemetry/app/exporter/cassandraexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/cassandraexporter/factory.go
@@ -53,10 +53,6 @@ func (Factory) Type() configmodels.Type {
 // CreateDefaultConfig returns default configuration of Factory.
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
-	// TODO: Enable the queued settings by default.
-	qs := exporterhelper.CreateDefaultQueueSettings()
-	qs.Enabled = false
-
 	opts := f.OptionsFactory()
 	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
@@ -65,7 +61,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 		},
 		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
 		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
-		QueueSettings:   qs,
+		QueueSettings:   exporterhelper.CreateDefaultQueueSettings(),
 		Options:         *opts,
 	}
 }

--- a/cmd/opentelemetry/app/exporter/cassandraexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/cassandraexporter/factory.go
@@ -16,11 +16,11 @@ package cassandraexporter
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 )
@@ -53,13 +53,20 @@ func (Factory) Type() configmodels.Type {
 // CreateDefaultConfig returns default configuration of Factory.
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
+	// TODO: Enable the queued settings by default.
+	qs := exporterhelper.CreateDefaultQueueSettings()
+	qs.Enabled = false
+
 	opts := f.OptionsFactory()
 	return &Config{
-		Options: *opts,
 		ExporterSettings: configmodels.ExporterSettings{
 			TypeVal: TypeStr,
 			NameVal: TypeStr,
 		},
+		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
+		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
+		QueueSettings:   qs,
+		Options:         *opts,
 	}
 }
 
@@ -70,10 +77,7 @@ func (f Factory) CreateTraceExporter(
 	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.TraceExporter, error) {
-	config, ok := cfg.(*Config)
-	if !ok {
-		return nil, fmt.Errorf("could not cast configuration to %s", TypeStr)
-	}
+	config := cfg.(*Config)
 	return new(config, params)
 }
 

--- a/cmd/opentelemetry/app/exporter/cassandraexporter/factory_test.go
+++ b/cmd/opentelemetry/app/exporter/cassandraexporter/factory_test.go
@@ -41,13 +41,6 @@ func TestCreateTraceExporter(t *testing.T) {
 	assert.Contains(t, err.Error(), "gocql: unable to create session")
 }
 
-func TestCreateTraceExporter_NilConfig(t *testing.T) {
-	factory := Factory{}
-	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, nil)
-	require.Nil(t, exporter)
-	assert.Contains(t, err.Error(), "could not cast configuration to jaeger_cassandra")
-}
-
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{OptionsFactory: DefaultOptions}
 	cfg := factory.CreateDefaultConfig()

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/config.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/config.go
@@ -16,12 +16,17 @@ package elasticsearchexporter
 
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 )
 
 // Config holds configuration of Jaeger Elasticsearch exporter/storage.
 type Config struct {
-	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	es.Options                    `mapstructure:",squash"`
+	configmodels.ExporterSettings  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.TimeoutSettings `mapstructure:",squash"`
+	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
+	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
+
+	es.Options `mapstructure:",squash"`
 }

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/exporter.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/exporter.go
@@ -39,6 +39,9 @@ func new(ctx context.Context, config *Config, params component.ExporterCreatePar
 	return exporterhelper.NewTraceExporter(
 		config,
 		w.WriteTraces,
+		exporterhelper.WithTimeout(config.TimeoutSettings),
+		exporterhelper.WithQueue(config.QueueSettings),
+		exporterhelper.WithRetry(config.RetrySettings),
 		exporterhelper.WithShutdown(func(ctx context.Context) error {
 			return esCfg.TLS.Close()
 		}))

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
@@ -54,9 +54,6 @@ var _ component.ExporterFactory = (*Factory)(nil)
 // CreateDefaultConfig returns default configuration of Factory.
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
-	// TODO: Enable the queued settings by default.
-	qs := exporterhelper.CreateDefaultQueueSettings()
-	qs.Enabled = false
 	opts := f.OptionsFactory()
 	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
@@ -65,7 +62,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 		},
 		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
 		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
-		QueueSettings:   qs,
+		QueueSettings:   exporterhelper.CreateDefaultQueueSettings(),
 		Options:         *opts,
 	}
 }

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 )
@@ -53,13 +54,19 @@ var _ component.ExporterFactory = (*Factory)(nil)
 // CreateDefaultConfig returns default configuration of Factory.
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
+	// TODO: Enable the queued settings by default.
+	qs := exporterhelper.CreateDefaultQueueSettings()
+	qs.Enabled = false
 	opts := f.OptionsFactory()
 	return &Config{
-		Options: *opts,
 		ExporterSettings: configmodels.ExporterSettings{
 			TypeVal: TypeStr,
 			NameVal: TypeStr,
 		},
+		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
+		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
+		QueueSettings:   qs,
+		Options:         *opts,
 	}
 }
 

--- a/cmd/opentelemetry/app/exporter/grpcpluginexporter/config.go
+++ b/cmd/opentelemetry/app/exporter/grpcpluginexporter/config.go
@@ -16,12 +16,17 @@ package grpcpluginexporter
 
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	grpcStorage "github.com/jaegertracing/jaeger/plugin/storage/grpc"
 )
 
 // Config holds configuration of Jaeger gRPC exporter/storage.
 type Config struct {
-	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	grpcStorage.Options           `mapstructure:",squash"`
+	configmodels.ExporterSettings  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.TimeoutSettings `mapstructure:",squash"`
+	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
+	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
+
+	grpcStorage.Options `mapstructure:",squash"`
 }

--- a/cmd/opentelemetry/app/exporter/grpcpluginexporter/exporter.go
+++ b/cmd/opentelemetry/app/exporter/grpcpluginexporter/exporter.go
@@ -17,6 +17,7 @@ package grpcpluginexporter
 import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	storageOtelExporter "github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter"
 	storageGrpc "github.com/jaegertracing/jaeger/plugin/storage/grpc"
@@ -30,5 +31,8 @@ func new(config *Config, params component.ExporterCreateParams) (component.Trace
 	if err != nil {
 		return nil, err
 	}
-	return storageOtelExporter.NewSpanWriterExporter(&config.ExporterSettings, factory)
+	return storageOtelExporter.NewSpanWriterExporter(&config.ExporterSettings, factory,
+		exporterhelper.WithTimeout(config.TimeoutSettings),
+		exporterhelper.WithQueue(config.QueueSettings),
+		exporterhelper.WithRetry(config.RetrySettings))
 }

--- a/cmd/opentelemetry/app/exporter/grpcpluginexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/grpcpluginexporter/factory.go
@@ -51,9 +51,6 @@ func (f Factory) Type() configmodels.Type {
 // CreateDefaultConfig returns default configuration of Factory.
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
-	// TODO: Enable the queued settings by default.
-	qs := exporterhelper.CreateDefaultQueueSettings()
-	qs.Enabled = false
 	opts := f.OptionsFactory()
 	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
@@ -62,7 +59,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 		},
 		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
 		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
-		QueueSettings:   qs,
+		QueueSettings:   exporterhelper.CreateDefaultQueueSettings(),
 
 		Options: *opts,
 	}

--- a/cmd/opentelemetry/app/exporter/grpcpluginexporter/factory_test.go
+++ b/cmd/opentelemetry/app/exporter/grpcpluginexporter/factory_test.go
@@ -41,13 +41,6 @@ func TestCreateTraceExporter(t *testing.T) {
 	assert.Contains(t, err.Error(), "error attempting to connect to plugin rpc client: fork/exec : no such file or directory")
 }
 
-func TestCreateTraceExporter_nilConfig(t *testing.T) {
-	factory := &Factory{}
-	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, nil)
-	require.Nil(t, exporter)
-	assert.Contains(t, err.Error(), "could not cast configuration to jaeger_grpc_plugin")
-}
-
 func TestCreateMetricsExporter(t *testing.T) {
 	f := Factory{OptionsFactory: DefaultOptions}
 	mReceiver, err := f.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, f.CreateDefaultConfig())


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

This PR configures queue retry per exporter and removes the qretry form the default configuration. This is a prefered configuration since the global qretry would retry all exporters in the pipeline. See example ocnfig from OTEL https://github.com/open-telemetry/opentelemetry-collector/blob/master/exporter/otlpexporter/config.go#L26. 

Other notable changes:
* qretry is not defined for in-memory and kafka (we will swith to OTEL kafka impl soon)