### PR TITLE
Configurable ES doc count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Changes by Version
 ### Backend Changes
 
 #### Breaking Changes
+* Configurable ES doc count ([#2453](https://github.com/jaegertracing/jaeger/pull/2453), [@albertteoh](https://github.com/albertteoh))
+
+    The `--es.max-num-spans` flag has been deprecated in favour of `--es.max-doc-count`.
+    `--es.max-num-spans` is marked for removal in v1.21.0 as indicated in the flag description.
+
+    If both `--es.max-num-spans` and `--es.max-doc-count` are set, the lesser of the two will be used.
+
+    The use of `--es.max-doc-count` (which defaults to 10,000) will limit the results from all Elasticsearch
+    queries by the configured value, limiting counts for Jaeger UI:
+
+    * Services
+    * Operations
+    * Dependencies (edges in a dependency graph)
+    * Span fetch size for a trace
 
 #### New Features
 

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/plugin/storage/integration"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 const (

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
@@ -120,7 +120,6 @@ func (s *IntegrationTest) initSpanstore(allTagsAsFields bool) error {
 		IndexPrefix:       indexPrefix,
 		TagDotReplacement: tagKeyDeDotChar,
 		MaxSpanAge:        maxSpanAge,
-		MaxNumSpans:       10_000,
 		MaxDocCount:       defaultMaxDocCount,
 	})
 	s.SpanReader = reader

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
@@ -40,15 +40,16 @@ import (
 )
 
 const (
-	host            = "0.0.0.0"
-	esPort          = "9200"
-	esHostPort      = host + ":" + esPort
-	esURL           = "http://" + esHostPort
-	indexPrefix     = "integration-test"
-	tagKeyDeDotChar = "@"
-	maxSpanAge      = time.Hour * 72
-	numShards       = 5
-	numReplicas     = 0
+	host               = "0.0.0.0"
+	esPort             = "9200"
+	esHostPort         = host + ":" + esPort
+	esURL              = "http://" + esHostPort
+	indexPrefix        = "integration-test"
+	tagKeyDeDotChar    = "@"
+	maxSpanAge         = time.Hour * 72
+	numShards          = 5
+	numReplicas        = 0
+	defaultMaxDocCount = 10_000
 )
 
 type IntegrationTest struct {
@@ -120,11 +121,12 @@ func (s *IntegrationTest) initSpanstore(allTagsAsFields bool) error {
 		TagDotReplacement: tagKeyDeDotChar,
 		MaxSpanAge:        maxSpanAge,
 		MaxNumSpans:       10_000,
+		MaxDocCount:       defaultMaxDocCount,
 	})
 	s.SpanReader = reader
 
 	depMapping := es.GetDependenciesMappings(numShards, numReplicas, esVersion)
-	depStore := esdependencyreader.NewDependencyStore(elasticsearchClient, s.logger, indexPrefix)
+	depStore := esdependencyreader.NewDependencyStore(elasticsearchClient, s.logger, indexPrefix, defaultMaxDocCount)
 	if err := depStore.CreateTemplates(depMapping); err != nil {
 		return nil
 	}

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/integration_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/plugin/storage/integration"
-	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 const (

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
@@ -88,7 +88,7 @@ func (s *StorageFactory) CreateSpanReader() (spanstore.Reader, error) {
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 		IndexPrefix:         cfg.GetIndexPrefix(),
 		MaxSpanAge:          cfg.GetMaxSpanAge(),
-		MaxNumSpans:         cfg.GetMaxNumSpans(),
+		MaxDocCount:         cfg.GetMaxDocCount(),
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 	}), nil
 }
@@ -100,7 +100,7 @@ func (s *StorageFactory) CreateDependencyReader() (dependencystore.Reader, error
 	if err != nil {
 		return nil, err
 	}
-	return esdependencyreader.NewDependencyStore(client, s.logger, cfg.GetIndexPrefix()), nil
+	return esdependencyreader.NewDependencyStore(client, s.logger, cfg.GetIndexPrefix(), cfg.GetMaxDocCount()), nil
 }
 
 // CreateArchiveSpanReader creates archive spanstore.Reader
@@ -115,7 +115,7 @@ func (s *StorageFactory) CreateArchiveSpanReader() (spanstore.Reader, error) {
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 		IndexPrefix:         cfg.GetIndexPrefix(),
 		MaxSpanAge:          cfg.GetMaxSpanAge(),
-		MaxNumSpans:         cfg.GetMaxNumSpans(),
+		MaxDocCount:         cfg.GetMaxDocCount(),
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 	}), nil
 }

--- a/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store.go
@@ -36,7 +36,7 @@ const (
 
 	timestampField = "timestamp"
 
-	// default number of documents to fetch in a query
+	// default number of documents to return from a query (elasticsearch allowed limit)
 	// see search.max_buckets and index.max_result_window
 	defaultMaxDocCount = 10_000
 	indexDateFormat    = "2006-01-02" // date format for index e.g. 2020-01-20

--- a/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store.go
@@ -38,8 +38,8 @@ const (
 
 	// default number of documents to fetch in a query
 	// see search.max_buckets and index.max_result_window
-	defaultDocCount = 10_000
-	indexDateFormat = "2006-01-02" // date format for index e.g. 2020-01-20
+	defaultMaxDocCount = 10_000
+	indexDateFormat    = "2006-01-02" // date format for index e.g. 2020-01-20
 )
 
 // DependencyStore defines Elasticsearch dependency store.
@@ -87,7 +87,7 @@ func (r *DependencyStore) GetDependencies(ctx context.Context, endTs time.Time, 
 	searchBody := getSearchBody(endTs, lookback)
 
 	indices := dailyIndices(r.indexPrefix, endTs, lookback)
-	response, err := r.client.Search(ctx, searchBody, defaultDocCount, indices...)
+	response, err := r.client.Search(ctx, searchBody,defaultMaxDocCount, indices...)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func getSearchBody(endTs time.Time, lookback time.Duration) esclient.SearchBody 
 		Query: &esclient.Query{
 			RangeQueries: map[string]esclient.RangeQuery{timestampField: {GTE: endTs.Add(-lookback), LTE: endTs}},
 		},
-		Size: defaultDocCount,
+		Size: defaultMaxDocCount,
 	}
 }
 

--- a/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store_test.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store_test.go
@@ -33,9 +33,11 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/es/dependencystore/dbmodel"
 )
 
+const defaultMaxDocCount = 10_000
+
 func TestCreateTemplates(t *testing.T) {
 	client := &mockClient{}
-	store := NewDependencyStore(client, zap.NewNop(), "foo")
+	store := NewDependencyStore(client, zap.NewNop(), "foo", defaultMaxDocCount)
 	template := "template"
 	err := store.CreateTemplates(template)
 	require.NoError(t, err)
@@ -46,7 +48,7 @@ func TestCreateTemplates(t *testing.T) {
 
 func TestWriteDependencies(t *testing.T) {
 	client := &mockClient{}
-	store := NewDependencyStore(client, zap.NewNop(), "foo")
+	store := NewDependencyStore(client, zap.NewNop(), "foo", defaultMaxDocCount)
 	dependencies := []model.DependencyLink{{Parent: "foo", Child: "bar", CallCount: 1}}
 	tsNow := time.Now()
 	err := store.WriteDependencies(tsNow, dependencies)
@@ -85,7 +87,7 @@ func TestGetDependencies(t *testing.T) {
 			},
 		},
 	}
-	store := NewDependencyStore(client, zap.NewNop(), "foo")
+	store := NewDependencyStore(client, zap.NewNop(), "foo", defaultMaxDocCount)
 	dependencies, err := store.GetDependencies(context.Background(), tsNow, time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, timeDependencies, dbmodel.TimeDependencies{
@@ -107,7 +109,7 @@ func TestGetDependencies_err_unmarshall(t *testing.T) {
 			},
 		},
 	}
-	store := NewDependencyStore(client, zap.NewNop(), "foo")
+	store := NewDependencyStore(client, zap.NewNop(), "foo", defaultMaxDocCount)
 	dependencies, err := store.GetDependencies(context.Background(), tsNow, time.Hour)
 	require.Contains(t, err.Error(), "invalid character")
 	assert.Nil(t, dependencies)
@@ -118,7 +120,7 @@ func TestGetDependencies_err_client(t *testing.T) {
 	client := &mockClient{
 		searchErr: searchErr,
 	}
-	store := NewDependencyStore(client, zap.NewNop(), "foo")
+	store := NewDependencyStore(client, zap.NewNop(), "foo", defaultMaxDocCount)
 	tsNow := time.Now()
 	dependencies, err := store.GetDependencies(context.Background(), tsNow, time.Hour)
 	require.Error(t, err)
@@ -141,7 +143,7 @@ const query = `{
 
 func TestSearchBody(t *testing.T) {
 	date := time.Date(2020, 8, 30, 15, 0, 0, 0, time.UTC)
-	sb := getSearchBody(date, time.Hour)
+	sb := getSearchBody(date, time.Hour, defaultMaxDocCount)
 	jsonQuery, err := json.MarshalIndent(sb, "", "  ")
 	require.NoError(t, err)
 	assert.Equal(t, query, string(jsonQuery))

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/query.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/query.go
@@ -187,15 +187,15 @@ func findTraceIDsSearchBody(converter dbmodel.ToDomain, query *spanstore.TraceQu
 	}
 }
 
-func getServicesSearchBody() esclient.SearchBody {
-	aggs := fmt.Sprintf(getServicesAggregation, defaultDocCount)
+func getServicesSearchBody(aggregationSize int) esclient.SearchBody {
+	aggs := fmt.Sprintf(getServicesAggregation, aggregationSize)
 	return esclient.SearchBody{
 		Aggregations: json.RawMessage(aggs),
 	}
 }
 
-func getOperationsSearchBody(serviceName string) esclient.SearchBody {
-	aggs := fmt.Sprintf(getOperationsAggregation, defaultDocCount)
+func getOperationsSearchBody(serviceName string, aggregationSize int) esclient.SearchBody {
+	aggs := fmt.Sprintf(getOperationsAggregation, aggregationSize)
 	return esclient.SearchBody{
 		Aggregations: json.RawMessage(aggs),
 		Query: &esclient.Query{

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/query.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/query.go
@@ -187,15 +187,15 @@ func findTraceIDsSearchBody(converter dbmodel.ToDomain, query *spanstore.TraceQu
 	}
 }
 
-func getServicesSearchBody(aggregationSize int) esclient.SearchBody {
-	aggs := fmt.Sprintf(getServicesAggregation, aggregationSize)
+func getServicesSearchBody(maxDocCount int) esclient.SearchBody {
+	aggs := fmt.Sprintf(getServicesAggregation, maxDocCount)
 	return esclient.SearchBody{
 		Aggregations: json.RawMessage(aggs),
 	}
 }
 
-func getOperationsSearchBody(serviceName string, aggregationSize int) esclient.SearchBody {
-	aggs := fmt.Sprintf(getOperationsAggregation, aggregationSize)
+func getOperationsSearchBody(serviceName string, maxDocCount int) esclient.SearchBody {
+	aggs := fmt.Sprintf(getOperationsAggregation, maxDocCount)
 	return esclient.SearchBody{
 		Aggregations: json.RawMessage(aggs),
 		Query: &esclient.Query{

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultMaxDocCount        = 10000
+	defaultMaxDocCount        = 10_000
 	servicesSearchBodyFixture = `{
   "aggs": {
     "serviceName": {

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
@@ -231,14 +231,14 @@ const (
 )
 
 func TestGetServicesSearchBody(t *testing.T) {
-	sb := getServicesSearchBody(defaultAggregationSize)
+	sb := getServicesSearchBody(defaultMaxDocCount)
 	jsonQuery, err := json.MarshalIndent(sb, "", "  ")
 	require.NoError(t, err)
 	assert.Equal(t, servicesSearchBodyFixture, string(jsonQuery))
 }
 
 func TestGetOperationsSearchBody(t *testing.T) {
-	sb := getOperationsSearchBody("foo", defaultAggregationSize)
+	sb := getOperationsSearchBody("foo", defaultMaxDocCount)
 	jsonQuery, err := json.MarshalIndent(sb, "", "  ")
 	require.NoError(t, err)
 	assert.Equal(t, operationsSearchBodyFixture, string(jsonQuery))

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
@@ -231,14 +231,14 @@ const (
 )
 
 func TestGetServicesSearchBody(t *testing.T) {
-	sb := getServicesSearchBody()
+	sb := getServicesSearchBody(defaultAggregationSize)
 	jsonQuery, err := json.MarshalIndent(sb, "", "  ")
 	require.NoError(t, err)
 	assert.Equal(t, servicesSearchBodyFixture, string(jsonQuery))
 }
 
 func TestGetOperationsSearchBody(t *testing.T) {
-	sb := getOperationsSearchBody("foo")
+	sb := getOperationsSearchBody("foo", defaultAggregationSize)
 	jsonQuery, err := json.MarshalIndent(sb, "", "  ")
 	require.NoError(t, err)
 	assert.Equal(t, operationsSearchBodyFixture, string(jsonQuery))

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/query_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	defaultMaxDocCount        = 10000
 	servicesSearchBodyFixture = `{
   "aggs": {
     "serviceName": {

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/span_reader.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/span_reader.go
@@ -59,10 +59,8 @@ type Reader struct {
 	serviceIndexName indexNameProvider
 	spanIndexName    indexNameProvider
 	maxSpanAge       time.Duration
-	// maximum number of spans to fetch per query in multi search
-	maxNumberOfSpans int
-	archive          bool
 	maxDocCount      int
+	archive          bool
 }
 
 var _ spanstore.Reader = (*Reader)(nil)
@@ -73,9 +71,8 @@ type Config struct {
 	UseReadWriteAliases bool
 	IndexPrefix         string
 	MaxSpanAge          time.Duration
-	MaxNumSpans         int
-	TagDotReplacement   string
 	MaxDocCount         int
+	TagDotReplacement   string
 }
 
 // NewEsSpanReader creates Elasticseach span reader.
@@ -85,11 +82,10 @@ func NewEsSpanReader(client esclient.ElasticsearchClient, logger *zap.Logger, co
 		logger:           logger,
 		archive:          config.Archive,
 		maxSpanAge:       config.MaxSpanAge,
-		maxNumberOfSpans: config.MaxNumSpans,
+		maxDocCount:      config.MaxDocCount,
 		converter:        dbmodel.NewToDomain(config.TagDotReplacement),
 		spanIndexName:    newIndexNameProvider(spanIndexBaseName, config.IndexPrefix, config.UseReadWriteAliases, config.Archive),
 		serviceIndexName: newIndexNameProvider(serviceIndexBaseName, config.IndexPrefix, config.UseReadWriteAliases, config.Archive),
-		maxDocCount:      config.MaxDocCount,
 	}
 }
 
@@ -291,7 +287,7 @@ func (r *Reader) multiSearchRequests(indices []string, traceIDs []model.TraceID,
 			Indices:        indices,
 			Query:          traceIDQuery(traceID),
 			Size:           r.maxDocCount,
-			TerminateAfter: r.maxNumberOfSpans,
+			TerminateAfter: r.maxDocCount,
 		}
 		if !r.archive {
 			s.SearchAfter = []interface{}{nextTime}

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -65,7 +65,7 @@ type Configuration struct {
 	UseReadWriteAliases   bool           `mapstructure:"use_aliases"`
 	CreateIndexTemplates  bool           `mapstructure:"create_mappings"`
 	Version               uint           `mapstructure:"version"`
-	AggregationSize       int            `mapstructure:"-"`
+	MaxDocCount           int            `mapstructure:"-"`
 }
 
 // TagsAsFields holds configuration for tag schema.
@@ -99,7 +99,7 @@ type ClientBuilder interface {
 	IsCreateIndexTemplates() bool
 	GetVersion() uint
 	TagKeysAsFields() ([]string, error)
-	GetAggregationSize() int
+	GetMaxDocCount() int
 }
 
 // NewClient creates a new ElasticSearch client
@@ -235,8 +235,8 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.Tags.File == "" {
 		c.Tags.File = source.Tags.File
 	}
-	if c.AggregationSize == 0 {
-		c.AggregationSize = source.AggregationSize
+	if c.MaxDocCount == 0 {
+		c.MaxDocCount = source.MaxDocCount
 	}
 }
 
@@ -296,9 +296,9 @@ func (c *Configuration) GetTokenFilePath() string {
 	return c.TokenFilePath
 }
 
-// GetAggregationSize returns the number of results (buckets) to return from a query
-func (c *Configuration) GetAggregationSize() int {
-	return c.AggregationSize
+// GetMaxDocCount returns the number of results (buckets) to return from a query
+func (c *Configuration) GetMaxDocCount() int {
+	return c.MaxDocCount
 }
 
 // IsStorageEnabled determines whether storage is enabled

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -65,6 +65,7 @@ type Configuration struct {
 	UseReadWriteAliases   bool           `mapstructure:"use_aliases"`
 	CreateIndexTemplates  bool           `mapstructure:"create_mappings"`
 	Version               uint           `mapstructure:"version"`
+	AggregationSize       int            `mapstructure:"-"`
 }
 
 // TagsAsFields holds configuration for tag schema.
@@ -98,6 +99,7 @@ type ClientBuilder interface {
 	IsCreateIndexTemplates() bool
 	GetVersion() uint
 	TagKeysAsFields() ([]string, error)
+	GetAggregationSize() int
 }
 
 // NewClient creates a new ElasticSearch client
@@ -233,6 +235,9 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.Tags.File == "" {
 		c.Tags.File = source.Tags.File
 	}
+	if c.AggregationSize == 0 {
+		c.AggregationSize = source.AggregationSize
+	}
 }
 
 // GetNumShards returns number of shards from Configuration
@@ -289,6 +294,11 @@ func (c *Configuration) GetUseReadWriteAliases() bool {
 // GetTokenFilePath returns file path containing the bearer token
 func (c *Configuration) GetTokenFilePath() string {
 	return c.TokenFilePath
+}
+
+// GetAggregationSize returns the number of results (buckets) to return from a query
+func (c *Configuration) GetAggregationSize() int {
+	return c.AggregationSize
 }
 
 // IsStorageEnabled determines whether storage is enabled

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -296,7 +296,7 @@ func (c *Configuration) GetTokenFilePath() string {
 	return c.TokenFilePath
 }
 
-// GetMaxDocCount returns the number of results (buckets) to return from a query
+// GetMaxDocCount returns the maximum number of documents that a query should return
 func (c *Configuration) GetMaxDocCount() int {
 	return c.MaxDocCount
 }

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -49,7 +49,7 @@ type Configuration struct {
 	AllowTokenFromContext bool           `mapstructure:"-"`
 	Sniffer               bool           `mapstructure:"sniffer"` // https://github.com/olivere/elastic/wiki/Sniffing
 	SnifferTLSEnabled     bool           `mapstructure:"sniffer_tls_enabled"`
-	MaxNumSpans           int            `mapstructure:"-"`                     // deprecated: use MaxDocCount instead. Defines maximum number of spans to fetch from storage per query
+	MaxDocCount           int            `mapstructure:"-"`                     // Defines maximum number of results to fetch from storage per query
 	MaxSpanAge            time.Duration  `yaml:"max_span_age" mapstructure:"-"` // configures the maximum lookback on span reads
 	NumShards             int64          `yaml:"shards" mapstructure:"num_shards"`
 	NumReplicas           int64          `yaml:"replicas" mapstructure:"num_replicas"`
@@ -65,7 +65,6 @@ type Configuration struct {
 	UseReadWriteAliases   bool           `mapstructure:"use_aliases"`
 	CreateIndexTemplates  bool           `mapstructure:"create_mappings"`
 	Version               uint           `mapstructure:"version"`
-	MaxDocCount           int            `mapstructure:"-"`
 }
 
 // TagsAsFields holds configuration for tag schema.
@@ -88,7 +87,7 @@ type ClientBuilder interface {
 	GetNumShards() int64
 	GetNumReplicas() int64
 	GetMaxSpanAge() time.Duration
-	GetMaxNumSpans() int
+	GetMaxDocCount() int
 	GetIndexPrefix() string
 	GetTagsFilePath() string
 	GetAllTagsAsFields() bool
@@ -99,7 +98,6 @@ type ClientBuilder interface {
 	IsCreateIndexTemplates() bool
 	GetVersion() uint
 	TagKeysAsFields() ([]string, error)
-	GetMaxDocCount() int
 }
 
 // NewClient creates a new ElasticSearch client
@@ -199,9 +197,6 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.MaxSpanAge == 0 {
 		c.MaxSpanAge = source.MaxSpanAge
 	}
-	if c.MaxNumSpans == 0 {
-		c.MaxNumSpans = source.MaxNumSpans
-	}
 	if c.NumShards == 0 {
 		c.NumShards = source.NumShards
 	}
@@ -255,9 +250,9 @@ func (c *Configuration) GetMaxSpanAge() time.Duration {
 	return c.MaxSpanAge
 }
 
-// GetMaxNumSpans returns max spans allowed per query from Configuration
-func (c *Configuration) GetMaxNumSpans() int {
-	return c.MaxNumSpans
+// GetMaxDocCount returns the maximum number of documents that a query should return
+func (c *Configuration) GetMaxDocCount() int {
+	return c.MaxDocCount
 }
 
 // GetIndexPrefix returns index prefix
@@ -294,11 +289,6 @@ func (c *Configuration) GetUseReadWriteAliases() bool {
 // GetTokenFilePath returns file path containing the bearer token
 func (c *Configuration) GetTokenFilePath() string {
 	return c.TokenFilePath
-}
-
-// GetMaxDocCount returns the maximum number of documents that a query should return
-func (c *Configuration) GetMaxDocCount() int {
-	return c.MaxDocCount
 }
 
 // IsStorageEnabled determines whether storage is enabled

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -49,7 +49,7 @@ type Configuration struct {
 	AllowTokenFromContext bool           `mapstructure:"-"`
 	Sniffer               bool           `mapstructure:"sniffer"` // https://github.com/olivere/elastic/wiki/Sniffing
 	SnifferTLSEnabled     bool           `mapstructure:"sniffer_tls_enabled"`
-	MaxNumSpans           int            `mapstructure:"-"`                     // defines maximum number of spans to fetch from storage per query
+	MaxNumSpans           int            `mapstructure:"-"`                     // deprecated: use MaxDocCount instead. Defines maximum number of spans to fetch from storage per query
 	MaxSpanAge            time.Duration  `yaml:"max_span_age" mapstructure:"-"` // configures the maximum lookback on span reads
 	NumShards             int64          `yaml:"shards" mapstructure:"num_shards"`
 	NumReplicas           int64          `yaml:"replicas" mapstructure:"num_replicas"`

--- a/plugin/storage/es/dependencystore/storage_test.go
+++ b/plugin/storage/es/dependencystore/storage_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 )
 
+const defaultMaxDocCount = 10_000
+
 type depStorageTest struct {
 	client    *mocks.Client
 	logger    *zap.Logger
@@ -67,7 +69,7 @@ func TestNewSpanReaderIndexPrefix(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		client := &mocks.Client{}
-		r := NewDependencyStore(client, zap.NewNop(), testCase.prefix, 0)
+		r := NewDependencyStore(client, zap.NewNop(), testCase.prefix, defaultMaxDocCount)
 		assert.Equal(t, testCase.expected+dependencyIndex, r.indexPrefix)
 	}
 }
@@ -88,7 +90,7 @@ func TestWriteDependencies(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		withDepStorage("", 0, func(r *depStorageTest) {
+		withDepStorage("", defaultMaxDocCount, func(r *depStorageTest) {
 			fixedTime := time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC)
 			indexName := indexWithDate("", fixedTime)
 			writeService := &mocks.IndexService{}
@@ -143,7 +145,7 @@ func TestGetDependencies(t *testing.T) {
 				},
 			},
 			indices:     []interface{}{"jaeger-dependencies-1995-04-21", "jaeger-dependencies-1995-04-20"},
-			maxDocCount: 1000,
+			maxDocCount: 1000, // can be anything, assertion will check this value is used in search query.
 		},
 		{
 			searchResult:  createSearchResult(badDependencies),

--- a/plugin/storage/es/dependencystore/storage_test.go
+++ b/plugin/storage/es/dependencystore/storage_test.go
@@ -41,14 +41,14 @@ type depStorageTest struct {
 	storage   *DependencyStore
 }
 
-func withDepStorage(indexPrefix string, fn func(r *depStorageTest)) {
+func withDepStorage(indexPrefix string, maxDocCount int, fn func(r *depStorageTest)) {
 	client := &mocks.Client{}
 	logger, logBuffer := testutils.NewLogger()
 	r := &depStorageTest{
 		client:    client,
 		logger:    logger,
 		logBuffer: logBuffer,
-		storage:   NewDependencyStore(client, logger, indexPrefix),
+		storage:   NewDependencyStore(client, logger, indexPrefix, maxDocCount),
 	}
 	fn(r)
 }
@@ -67,7 +67,7 @@ func TestNewSpanReaderIndexPrefix(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		client := &mocks.Client{}
-		r := NewDependencyStore(client, zap.NewNop(), testCase.prefix)
+		r := NewDependencyStore(client, zap.NewNop(), testCase.prefix, 0)
 		assert.Equal(t, testCase.expected+dependencyIndex, r.indexPrefix)
 	}
 }
@@ -88,7 +88,7 @@ func TestWriteDependencies(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		withDepStorage("", func(r *depStorageTest) {
+		withDepStorage("", 0, func(r *depStorageTest) {
 			fixedTime := time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC)
 			indexName := indexWithDate("", fixedTime)
 			writeService := &mocks.IndexService{}
@@ -130,6 +130,7 @@ func TestGetDependencies(t *testing.T) {
 		expectedError  string
 		expectedOutput []model.DependencyLink
 		indexPrefix    string
+		maxDocCount    int
 		indices        []interface{}
 	}{
 		{
@@ -141,7 +142,8 @@ func TestGetDependencies(t *testing.T) {
 					CallCount: 12,
 				},
 			},
-			indices: []interface{}{"jaeger-dependencies-1995-04-21", "jaeger-dependencies-1995-04-20"},
+			indices:     []interface{}{"jaeger-dependencies-1995-04-21", "jaeger-dependencies-1995-04-20"},
+			maxDocCount: 1000,
 		},
 		{
 			searchResult:  createSearchResult(badDependencies),
@@ -161,13 +163,15 @@ func TestGetDependencies(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		withDepStorage(testCase.indexPrefix, func(r *depStorageTest) {
+		withDepStorage(testCase.indexPrefix, testCase.maxDocCount, func(r *depStorageTest) {
 			fixedTime := time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC)
 
 			searchService := &mocks.SearchService{}
 			r.client.On("Search", testCase.indices...).Return(searchService)
 
-			searchService.On("Size", mock.Anything).Return(searchService)
+			searchService.On("Size", mock.MatchedBy(func(size int) bool {
+				return size == testCase.maxDocCount
+			})).Return(searchService)
 			searchService.On("Query", mock.Anything).Return(searchService)
 			searchService.On("IgnoreUnavailable", mock.AnythingOfType("bool")).Return(searchService)
 			searchService.On("Do", mock.Anything).Return(testCase.searchResult, testCase.searchError)

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -187,7 +187,7 @@ func createSpanWriter(
 }
 
 func createDependencyReader(client es.Client, logger *zap.Logger, cfg config.ClientBuilder) (dependencystore.Reader, error) {
-	reader := esDepStore.NewDependencyStore(client, logger, cfg.GetIndexPrefix())
+	reader := esDepStore.NewDependencyStore(client, logger, cfg.GetIndexPrefix(), cfg.GetMaxDocCount())
 	return reader, nil
 }
 

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -148,6 +148,7 @@ func createSpanReader(
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 		Archive:             archive,
+		AggregationSize:     cfg.GetAggregationSize(),
 	}), nil
 }
 

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -111,8 +111,7 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 
 // CreateDependencyReader implements storage.Factory
 func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
-	reader := esDepStore.NewDependencyStore(f.primaryClient, f.logger, f.primaryConfig.GetIndexPrefix())
-	return reader, nil
+	return createDependencyReader(f.primaryClient, f.logger, f.primaryConfig)
 }
 
 // CreateArchiveSpanReader implements storage.ArchiveFactory
@@ -185,6 +184,11 @@ func createSpanWriter(
 		}
 	}
 	return writer, nil
+}
+
+func createDependencyReader(client es.Client, logger *zap.Logger, cfg config.ClientBuilder) (dependencystore.Reader, error) {
+	reader := esDepStore.NewDependencyStore(client, logger, cfg.GetIndexPrefix())
+	return reader, nil
 }
 
 // GetSpanServiceMappings returns span and service mappings

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -142,13 +142,12 @@ func createSpanReader(
 		Client:              client,
 		Logger:              logger,
 		MetricsFactory:      mFactory,
-		MaxNumSpans:         cfg.GetMaxNumSpans(),
+		MaxDocCount:         cfg.GetMaxDocCount(),
 		MaxSpanAge:          cfg.GetMaxSpanAge(),
 		IndexPrefix:         cfg.GetIndexPrefix(),
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 		Archive:             archive,
-		MaxDocCount:         cfg.GetMaxDocCount(),
 	}), nil
 }
 

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -111,7 +111,8 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 
 // CreateDependencyReader implements storage.Factory
 func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
-	return createDependencyReader(f.primaryClient, f.logger, f.primaryConfig)
+	reader := esDepStore.NewDependencyStore(f.primaryClient, f.logger, f.primaryConfig.GetIndexPrefix(), f.primaryConfig.GetMaxDocCount())
+	return reader, nil
 }
 
 // CreateArchiveSpanReader implements storage.ArchiveFactory
@@ -184,11 +185,6 @@ func createSpanWriter(
 		}
 	}
 	return writer, nil
-}
-
-func createDependencyReader(client es.Client, logger *zap.Logger, cfg config.ClientBuilder) (dependencystore.Reader, error) {
-	reader := esDepStore.NewDependencyStore(client, logger, cfg.GetIndexPrefix(), cfg.GetMaxDocCount())
-	return reader, nil
 }
 
 // GetSpanServiceMappings returns span and service mappings

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -148,7 +148,7 @@ func createSpanReader(
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 		Archive:             archive,
-		AggregationSize:     cfg.GetAggregationSize(),
+		MaxDocCount:         cfg.GetMaxDocCount(),
 	}), nil
 }
 

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -179,7 +179,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Int(
 		nsConfig.namespace+suffixMaxNumSpans,
 		nsConfig.MaxNumSpans,
-		"(deprecated, will be removed in release v1.21.0. Please use es.max-doc-count.). The maximum number of spans to fetch at a time per query in Elasticsearch")
+		"(deprecated, will be removed in release v1.21.0. Please use es.max-doc-count). The maximum number of spans to fetch at a time per query in Elasticsearch")
 	flagSet.Int64(
 		nsConfig.namespace+suffixNumShards,
 		nsConfig.NumShards,

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -179,7 +179,9 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Int(
 		nsConfig.namespace+suffixMaxNumSpans,
 		nsConfig.MaxDocCount,
-		"(deprecated, will be removed in release v1.21.0. Please use es.max-doc-count). The maximum number of spans to fetch at a time per query in Elasticsearch")
+		"(deprecated, will be removed in release v1.21.0. Please use es.max-doc-count). "+
+			"The maximum number of spans to fetch at a time per query in Elasticsearch. "+
+			"The lesser of es.max-num-spans and es.max-doc-count will be used if both are set.")
 	flagSet.Int64(
 		nsConfig.namespace+suffixNumShards,
 		nsConfig.NumShards,
@@ -288,15 +290,11 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.CreateIndexTemplates = v.GetBool(cfg.namespace + suffixCreateIndexTemplate)
 	cfg.Version = uint(v.GetInt(cfg.namespace + suffixVersion))
 
-	maxNumSpans := v.GetInt(cfg.namespace + suffixMaxNumSpans)
 	cfg.MaxDocCount = v.GetInt(cfg.namespace + suffixMaxDocCount)
 
-	if maxNumSpans != 0 {
-		if cfg.MaxDocCount != 0 {
-			cfg.MaxDocCount = int(math.Min(float64(maxNumSpans), float64(cfg.MaxDocCount)))
-		} else {
-			cfg.MaxDocCount = maxNumSpans
-		}
+	if v.IsSet(cfg.namespace + suffixMaxNumSpans) {
+		maxNumSpans := v.GetInt(cfg.namespace + suffixMaxNumSpans)
+		cfg.MaxDocCount = int(math.Min(float64(maxNumSpans), float64(cfg.MaxDocCount)))
 	}
 
 	// TODO: Need to figure out a better way for do this.

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -53,10 +53,12 @@ const (
 	suffixCreateIndexTemplate = ".create-index-templates"
 	suffixEnabled             = ".enabled"
 	suffixVersion             = ".version"
-	suffixAggregationSize     = ".aggregation.size"
+	suffixMaxDocCount         = ".max-doc-count"
 
-	defaultServerURL       = "http://127.0.0.1:9200"
-	defaultAggregationSize = 10000 // the default elasticsearch allowed limit
+	// default number of documents to fetch in a query (elasticsearch allowed limit)
+	// see search.max_buckets and index.max_result_window
+	defaultMaxDocCount = 10_000
+	defaultServerURL   = "http://127.0.0.1:9200"
 )
 
 // TODO this should be moved next to config.Configuration struct (maybe ./flags package)
@@ -99,7 +101,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				CreateIndexTemplates: true,
 				Version:              0,
 				Servers:              []string{defaultServerURL},
-				AggregationSize:      defaultAggregationSize,
+				MaxDocCount:          defaultMaxDocCount,
 			},
 			namespace: primaryNamespace,
 		},
@@ -241,8 +243,8 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.SnifferTLSEnabled,
 		"Option to enable TLS when sniffing an Elasticsearch Cluster ; client uses sniffing process to find all nodes automatically, disabled by default")
 	flagSet.Int(
-		nsConfig.namespace+suffixAggregationSize,
-		nsConfig.AggregationSize,
+		nsConfig.namespace+suffixMaxDocCount,
+		nsConfig.MaxDocCount,
 		"The aggregation size to set in Elasticsearch queries to limit the number of results returned; used primarily for querying for distinct services and operations.")
 	if nsConfig.namespace == archiveNamespace {
 		flagSet.Bool(
@@ -286,7 +288,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Enabled = v.GetBool(cfg.namespace + suffixEnabled)
 	cfg.CreateIndexTemplates = v.GetBool(cfg.namespace + suffixCreateIndexTemplate)
 	cfg.Version = uint(v.GetInt(cfg.namespace + suffixVersion))
-	cfg.AggregationSize = v.GetInt(cfg.namespace + suffixAggregationSize)
+	cfg.MaxDocCount = v.GetInt(cfg.namespace + suffixMaxDocCount)
 	// TODO: Need to figure out a better way for do this.
 	cfg.AllowTokenFromContext = v.GetBool(spanstore.StoragePropagationKey)
 	cfg.TLS = cfg.getTLSFlagsConfig().InitFromViper(v)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -55,7 +55,7 @@ const (
 	suffixVersion             = ".version"
 	suffixMaxDocCount         = ".max-doc-count"
 
-	// default number of documents to fetch in a query (elasticsearch allowed limit)
+	// default number of documents to return from a query (elasticsearch allowed limit)
 	// see search.max_buckets and index.max_result_window
 	defaultMaxDocCount = 10_000
 	defaultServerURL   = "http://127.0.0.1:9200"
@@ -245,7 +245,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Int(
 		nsConfig.namespace+suffixMaxDocCount,
 		nsConfig.MaxDocCount,
-		"The aggregation size to set in Elasticsearch queries to limit the number of results returned; used primarily for querying for distinct services and operations.")
+		"The maximum document count to return from an Elasticsearch query. This will also apply to aggregations.")
 	if nsConfig.namespace == archiveNamespace {
 		flagSet.Bool(
 			nsConfig.namespace+suffixEnabled,

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -53,8 +53,10 @@ const (
 	suffixCreateIndexTemplate = ".create-index-templates"
 	suffixEnabled             = ".enabled"
 	suffixVersion             = ".version"
+	suffixAggregationSize     = ".aggregation.size"
 
-	defaultServerURL = "http://127.0.0.1:9200"
+	defaultServerURL       = "http://127.0.0.1:9200"
+	defaultAggregationSize = 10000 // the default elasticsearch allowed limit
 )
 
 // TODO this should be moved next to config.Configuration struct (maybe ./flags package)
@@ -97,6 +99,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				CreateIndexTemplates: true,
 				Version:              0,
 				Servers:              []string{defaultServerURL},
+				AggregationSize:      defaultAggregationSize,
 			},
 			namespace: primaryNamespace,
 		},
@@ -237,6 +240,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixSnifferTLSEnabled,
 		nsConfig.SnifferTLSEnabled,
 		"Option to enable TLS when sniffing an Elasticsearch Cluster ; client uses sniffing process to find all nodes automatically, disabled by default")
+	flagSet.Int(
+		nsConfig.namespace+suffixAggregationSize,
+		nsConfig.AggregationSize,
+		"The aggregation size to set in Elasticsearch queries to limit the number of results returned; used primarily for querying for distinct services and operations.")
 	if nsConfig.namespace == archiveNamespace {
 		flagSet.Bool(
 			nsConfig.namespace+suffixEnabled,
@@ -279,6 +286,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Enabled = v.GetBool(cfg.namespace + suffixEnabled)
 	cfg.CreateIndexTemplates = v.GetBool(cfg.namespace + suffixCreateIndexTemplate)
 	cfg.Version = uint(v.GetInt(cfg.namespace + suffixVersion))
+	cfg.AggregationSize = v.GetInt(cfg.namespace + suffixAggregationSize)
 	// TODO: Need to figure out a better way for do this.
 	cfg.AllowTokenFromContext = v.GetBool(spanstore.StoragePropagationKey)
 	cfg.TLS = cfg.getTLSFlagsConfig().InitFromViper(v)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -35,7 +35,7 @@ const (
 	suffixTokenPath           = ".token-file"
 	suffixServerURLs          = ".server-urls"
 	suffixMaxSpanAge          = ".max-span-age"
-	suffixMaxNumSpans         = ".max-num-spans"
+	suffixMaxNumSpans         = ".max-num-spans" // deprecated
 	suffixNumShards           = ".num-shards"
 	suffixNumReplicas         = ".num-replicas"
 	suffixBulkSize            = ".bulk.size"
@@ -179,7 +179,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Int(
 		nsConfig.namespace+suffixMaxNumSpans,
 		nsConfig.MaxNumSpans,
-		"The maximum number of spans to fetch at a time per query in Elasticsearch")
+		"(deprecated, will be removed in release v1.21.0. Please use es.max-doc-count.). The maximum number of spans to fetch at a time per query in Elasticsearch")
 	flagSet.Int64(
 		nsConfig.namespace+suffixNumShards,
 		nsConfig.NumShards,

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -96,7 +96,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "test,tags", aux.Tags.Include)
 }
 
-func TestMaxNumSpans(t *testing.T) {
+func TestMaxDocCount(t *testing.T) {
 	testCases := []struct {
 		name            string
 		flags           []string

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
-const defaultMaxDocCount = 10000
+const defaultMaxDocCount = 10_000
 
 var exampleESSpan = []byte(
 	`{
@@ -863,7 +863,7 @@ func mockSearchService(r *spanReaderTest) *mock.Call {
 	searchService.On("Size", mock.MatchedBy(func(size int) bool {
 		return size == 0
 	})).Return(searchService)
-	searchService.On("Aggregation", servicesAggregation, mock.MatchedBy(matchTermsAggregation)).Return(searchService)
+	searchService.On("Aggregation", stringMatcher(servicesAggregation), mock.MatchedBy(matchTermsAggregation)).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.MatchedBy(matchTermsAggregation)).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(traceIDAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)
 	r.client.On("Search", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(searchService)

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -84,11 +84,10 @@ var exampleESSpan = []byte(
 	}`)
 
 type spanReaderTest struct {
-	client      *mocks.Client
-	logger      *zap.Logger
-	logBuffer   *testutils.Buffer
-	reader      *SpanReader
-	maxDocCount int
+	client    *mocks.Client
+	logger    *zap.Logger
+	logBuffer *testutils.Buffer
+	reader    *SpanReader
 }
 
 func withSpanReader(fn func(r *spanReaderTest)) {

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -101,7 +101,7 @@ func withSpanReader(fn func(r *spanReaderTest)) {
 			MaxSpanAge:        0,
 			IndexPrefix:       "",
 			TagDotReplacement: "@",
-			AggregationSize:   999,
+			MaxDocCount:       999,
 		}),
 	}
 	fn(r)

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -101,6 +101,7 @@ func withSpanReader(fn func(r *spanReaderTest)) {
 			MaxSpanAge:        0,
 			IndexPrefix:       "",
 			TagDotReplacement: "@",
+			AggregationSize:   999,
 		}),
 	}
 	fn(r)
@@ -840,7 +841,7 @@ func mockSearchService(r *spanReaderTest) *mock.Call {
 	searchService.On("Query", mock.Anything).Return(searchService)
 	searchService.On("IgnoreUnavailable", mock.AnythingOfType("bool")).Return(searchService)
 	searchService.On("Size", mock.MatchedBy(func(i int) bool {
-		return i == 0 || i == defaultDocCount
+		return i == 0
 	})).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(servicesAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)

--- a/plugin/storage/es/spanstore/service_operation.go
+++ b/plugin/storage/es/spanstore/service_operation.go
@@ -77,8 +77,8 @@ func (s *ServiceOperationStorage) Write(indexName string, jsonSpan *dbmodel.Span
 	}
 }
 
-func (s *ServiceOperationStorage) getServices(context context.Context, indices []string, aggregationSize int) ([]string, error) {
-	serviceAggregation := getServicesAggregation(aggregationSize)
+func (s *ServiceOperationStorage) getServices(context context.Context, indices []string, maxDocCount int) ([]string, error) {
+	serviceAggregation := getServicesAggregation(maxDocCount)
 
 	searchService := s.client.Search(indices...).
 		Size(0). // set to 0 because we don't want actual documents.
@@ -100,15 +100,15 @@ func (s *ServiceOperationStorage) getServices(context context.Context, indices [
 	return bucketToStringArray(serviceNamesBucket)
 }
 
-func getServicesAggregation(aggregationSize int) elastic.Query {
+func getServicesAggregation(maxDocCount int) elastic.Query {
 	return elastic.NewTermsAggregation().
 		Field(serviceName).
-		Size(aggregationSize) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
+		Size(maxDocCount) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
 }
 
-func (s *ServiceOperationStorage) getOperations(context context.Context, indices []string, service string, aggregationSize int) ([]string, error) {
+func (s *ServiceOperationStorage) getOperations(context context.Context, indices []string, service string, maxDocCount int) ([]string, error) {
 	serviceQuery := elastic.NewTermQuery(serviceName, service)
-	serviceFilter := getOperationsAggregation(aggregationSize)
+	serviceFilter := getOperationsAggregation(maxDocCount)
 
 	searchService := s.client.Search(indices...).
 		Size(0).
@@ -131,10 +131,10 @@ func (s *ServiceOperationStorage) getOperations(context context.Context, indices
 	return bucketToStringArray(operationNamesBucket)
 }
 
-func getOperationsAggregation(aggregationSize int) elastic.Query {
+func getOperationsAggregation(maxDocCount int) elastic.Query {
 	return elastic.NewTermsAggregation().
 		Field(operationNameField).
-		Size(aggregationSize) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
+		Size(maxDocCount) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
 }
 
 func hashCode(s dbmodel.Service) string {

--- a/plugin/storage/es/spanstore/service_operation.go
+++ b/plugin/storage/es/spanstore/service_operation.go
@@ -77,8 +77,8 @@ func (s *ServiceOperationStorage) Write(indexName string, jsonSpan *dbmodel.Span
 	}
 }
 
-func (s *ServiceOperationStorage) getServices(context context.Context, indices []string) ([]string, error) {
-	serviceAggregation := getServicesAggregation()
+func (s *ServiceOperationStorage) getServices(context context.Context, indices []string, aggregationSize int) ([]string, error) {
+	serviceAggregation := getServicesAggregation(aggregationSize)
 
 	searchService := s.client.Search(indices...).
 		Size(0). // set to 0 because we don't want actual documents.
@@ -100,15 +100,15 @@ func (s *ServiceOperationStorage) getServices(context context.Context, indices [
 	return bucketToStringArray(serviceNamesBucket)
 }
 
-func getServicesAggregation() elastic.Query {
+func getServicesAggregation(aggregationSize int) elastic.Query {
 	return elastic.NewTermsAggregation().
 		Field(serviceName).
-		Size(defaultDocCount) // Must set to some large number. ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
+		Size(aggregationSize) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
 }
 
-func (s *ServiceOperationStorage) getOperations(context context.Context, indices []string, service string) ([]string, error) {
+func (s *ServiceOperationStorage) getOperations(context context.Context, indices []string, service string, aggregationSize int) ([]string, error) {
 	serviceQuery := elastic.NewTermQuery(serviceName, service)
-	serviceFilter := getOperationsAggregation()
+	serviceFilter := getOperationsAggregation(aggregationSize)
 
 	searchService := s.client.Search(indices...).
 		Size(0).
@@ -131,10 +131,10 @@ func (s *ServiceOperationStorage) getOperations(context context.Context, indices
 	return bucketToStringArray(operationNamesBucket)
 }
 
-func getOperationsAggregation() elastic.Query {
+func getOperationsAggregation(aggregationSize int) elastic.Query {
 	return elastic.NewTermsAggregation().
 		Field(operationNameField).
-		Size(defaultDocCount) // Must set to some large number. ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
+		Size(aggregationSize) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
 }
 
 func hashCode(s dbmodel.Service) string {

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -39,13 +39,13 @@ import (
 )
 
 const (
-	host            = "0.0.0.0"
-	queryPort       = "9200"
-	queryHostPort   = host + ":" + queryPort
-	queryURL        = "http://" + queryHostPort
-	indexPrefix     = "integration-test"
-	tagKeyDeDotChar = "@"
-	maxSpanAge      = time.Hour * 72
+	host               = "0.0.0.0"
+	queryPort          = "9200"
+	queryHostPort      = host + ":" + queryPort
+	queryURL           = "http://" + queryHostPort
+	indexPrefix        = "integration-test"
+	tagKeyDeDotChar    = "@"
+	maxSpanAge         = time.Hour * 72
 	defaultMaxDocCount = 10_000
 )
 
@@ -130,6 +130,7 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		MaxSpanAge:        maxSpanAge,
 		TagDotReplacement: tagKeyDeDotChar,
 		Archive:           archive,
+		MaxDocCount:       defaultMaxDocCount,
 	})
 	dependencyStore := dependencystore.NewDependencyStore(client, s.logger, indexPrefix, defaultMaxDocCount)
 	depMapping := es.GetDependenciesMappings(5, 1, client.GetVersion())

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -46,6 +46,7 @@ const (
 	indexPrefix     = "integration-test"
 	tagKeyDeDotChar = "@"
 	maxSpanAge      = time.Hour * 72
+	defaultMaxDocCount = 10_000
 )
 
 type ESStorageIntegration struct {
@@ -130,7 +131,7 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		TagDotReplacement: tagKeyDeDotChar,
 		Archive:           archive,
 	})
-	dependencyStore := dependencystore.NewDependencyStore(client, s.logger, indexPrefix, 0)
+	dependencyStore := dependencystore.NewDependencyStore(client, s.logger, indexPrefix, defaultMaxDocCount)
 	depMapping := es.GetDependenciesMappings(5, 1, client.GetVersion())
 	err = dependencyStore.CreateTemplates(depMapping)
 	if err != nil {

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -130,7 +130,7 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		TagDotReplacement: tagKeyDeDotChar,
 		Archive:           archive,
 	})
-	dependencyStore := dependencystore.NewDependencyStore(client, s.logger, indexPrefix)
+	dependencyStore := dependencystore.NewDependencyStore(client, s.logger, indexPrefix, 0)
 	depMapping := es.GetDependenciesMappings(5, 1, client.GetVersion())
 	err = dependencyStore.CreateTemplates(depMapping)
 	if err != nil {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Closes #2437

## Short description of the changes
- Add deprecation note for `--es.max-num-spans`. (Will create another issue to decommission this flag for a future release).
- Add new flag `--es.max-doc-count`, that configures query (and aggregation) doc sizes, defaulting to `10_000`. Name based on existing `defaultDocCount` variable for consistency.
- Fix tests which were incorrectly checking for the document size at the query level. 
- Add test to assert on aggregation sizes applied.
