### PR TITLE
Propagate TraceNotFound error from grpc storage plugins

### DIFF
--- a/plugin/storage/grpc/shared/grpc_client.go
+++ b/plugin/storage/grpc/shared/grpc_client.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
@@ -77,7 +77,8 @@ func (c *grpcClient) GetTrace(ctx context.Context, traceID model.TraceID) (*mode
 	trace := model.Trace{}
 	for received, err := stream.Recv(); err != io.EOF; received, err = stream.Recv() {
 		if err != nil {
-			if strings.Contains(err.Error(), spanstore.ErrTraceNotFound.Error()) {
+			traceNotFoundStatus, _ := status.FromError(spanstore.ErrTraceNotFound)
+			if err.Error() == traceNotFoundStatus.Err().Error() {
 				return nil, spanstore.ErrTraceNotFound
 			}
 			return nil, fmt.Errorf("grpc stream error: %w", err)

--- a/plugin/storage/grpc/shared/grpc_client.go
+++ b/plugin/storage/grpc/shared/grpc_client.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
@@ -77,10 +77,8 @@ func (c *grpcClient) GetTrace(ctx context.Context, traceID model.TraceID) (*mode
 	trace := model.Trace{}
 	for received, err := stream.Recv(); err != io.EOF; received, err = stream.Recv() {
 		if err != nil {
-			if e, ok := status.FromError(err); !ok {
-				if e.Message() == spanstore.ErrTraceNotFound.Error() {
-					return nil, spanstore.ErrTraceNotFound
-				}
+			if strings.Contains(err.Error(), spanstore.ErrTraceNotFound.Error()) {
+				return nil, spanstore.ErrTraceNotFound
 			}
 			return nil, fmt.Errorf("grpc stream error: %w", err)
 		}

--- a/plugin/storage/grpc/shared/grpc_client.go
+++ b/plugin/storage/grpc/shared/grpc_client.go
@@ -77,9 +77,10 @@ func (c *grpcClient) GetTrace(ctx context.Context, traceID model.TraceID) (*mode
 	trace := model.Trace{}
 	for received, err := stream.Recv(); err != io.EOF; received, err = stream.Recv() {
 		if err != nil {
-			s, _ := status.FromError(err)
-			if s.Message() == spanstore.ErrTraceNotFound.Error() {
-				return nil, spanstore.ErrTraceNotFound
+			if s, _ := status.FromError(err); s != nil {
+				if s.Message() == spanstore.ErrTraceNotFound.Error() {
+					return nil, spanstore.ErrTraceNotFound
+				}
 			}
 			return nil, fmt.Errorf("grpc stream error: %w", err)
 		}

--- a/plugin/storage/grpc/shared/grpc_client.go
+++ b/plugin/storage/grpc/shared/grpc_client.go
@@ -77,8 +77,8 @@ func (c *grpcClient) GetTrace(ctx context.Context, traceID model.TraceID) (*mode
 	trace := model.Trace{}
 	for received, err := stream.Recv(); err != io.EOF; received, err = stream.Recv() {
 		if err != nil {
-			traceNotFoundStatus, _ := status.FromError(spanstore.ErrTraceNotFound)
-			if err.Error() == traceNotFoundStatus.Err().Error() {
+			s, _ := status.FromError(err)
+			if s.Message() == spanstore.ErrTraceNotFound.Error() {
 				return nil, spanstore.ErrTraceNotFound
 			}
 			return nil, fmt.Errorf("grpc stream error: %w", err)

--- a/plugin/storage/grpc/shared/grpc_client_test.go
+++ b/plugin/storage/grpc/shared/grpc_client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
@@ -200,9 +201,11 @@ func TestGRPCClientGetTrace_NoTrace(t *testing.T) {
 }
 
 func TestGRPCClientGetTrace_StreamErrorTraceNotFound(t *testing.T) {
+	s, _ := status.FromError(spanstore.ErrTraceNotFound)
+
 	withGRPCClient(func(r *grpcClientTest) {
 		traceClient := new(grpcMocks.SpanReaderPlugin_GetTraceClient)
-		traceClient.On("Recv").Return(nil, spanstore.ErrTraceNotFound)
+		traceClient.On("Recv").Return(nil, s.Err())
 		r.spanReader.On("GetTrace", mock.Anything, &storage_v1.GetTraceRequest{
 			TraceID: mockTraceID,
 		}).Return(traceClient, nil)


### PR DESCRIPTION
A previous attempt to fix this was made here:  https://github.com/jaegertracing/jaeger/pull/1814
Original issue: https://github.com/jaegertracing/jaeger/issues/1741

However, this is currently not working b/c on this line `ok` is set to true which skips the code that checks to see if the string equals "trace not found".
https://github.com/jaegertracing/jaeger/blob/412022065959c6a45e6250a733b081c387e9fdea/plugin/storage/grpc/shared/grpc_client.go#L80

Tracking it down:
**RecvMsg**
https://github.com/grpc/grpc-go/blob/8630cac324bf02ea0edfba758c2b2f3344af7bf7/stream.go#L749
**recvMsg**
https://github.com/grpc/grpc-go/blob/master/stream.go#L886
**toRPCErr**
https://github.com/grpc/grpc-go/blob/8630cac324bf02ea0edfba758c2b2f3344af7bf7/rpc_util.go#L775

`toRPCErr` calls `status.FromError` which wraps the error in a `GRPCStatus`.  This causes the `FromError` in `grpc_client.go` to recognize the error as `GRPCStatus` and return `true`.

Fix:
- Remove the `status.FromError` check and test the error directly.
- Compare the error message to a `GRPCStatus` wrapped `spanstore.ErrTraceNotFound`

I have confirmed this works manually by building jaeger-query with a custom GRPC plugin.