### PR TITLE
Add partial retry capability to OTEL ES exporter.

### DIFF
--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/esmodeltranslator/modeltranslator_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/esmodeltranslator/modeltranslator_test.go
@@ -129,34 +129,40 @@ func TestConvertSpan(t *testing.T) {
 	c := &Translator{
 		tagKeysAsFields: map[string]bool{"toTagMap": true},
 	}
-	spans, err := c.ConvertSpans(traces)
+	spanDataContainers, err := c.ConvertSpans(traces)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(spans))
-	assert.Equal(t, &dbmodel.Span{
-		TraceID:         "30313233343536373839616263646566",
-		SpanID:          "3031323334353637",
-		StartTime:       1000,
-		Duration:        1000,
-		OperationName:   "root",
-		StartTimeMillis: 1,
-		Tags: []dbmodel.KeyValue{
-			{Key: "span.kind", Type: dbmodel.StringType, Value: "client"},
-			{Key: "status.code", Type: dbmodel.StringType, Value: "Cancelled"},
-			{Key: "error", Type: dbmodel.BoolType, Value: "true"},
-			{Key: "status.message", Type: dbmodel.StringType, Value: "messagetext"},
-			{Key: "foo", Type: dbmodel.BoolType, Value: "true"}},
-		Tag: map[string]interface{}{"toTagMap": "val"},
-		Logs: []dbmodel.Log{{Fields: []dbmodel.KeyValue{
-			{Key: "event", Value: "eventName", Type: dbmodel.StringType},
-			{Key: "foo", Value: "bar", Type: dbmodel.StringType}}, Timestamp: 500}},
-		References: []dbmodel.Reference{
-			{SpanID: "3031323334353637", TraceID: "30313233343536373839616263646566", RefType: dbmodel.ChildOf},
-			{SpanID: "3031323334353637", TraceID: "30313233343536373839616263646566", RefType: dbmodel.FollowsFrom}},
-		Process: dbmodel.Process{
-			ServiceName: "myservice",
-			Tags:        []dbmodel.KeyValue{{Key: "num", Value: "16.66", Type: dbmodel.Float64Type}},
-		},
-	}, spans[0])
+	assert.Equal(t, 1, len(spanDataContainers))
+	assert.Equal(t,
+		ConvertedData{
+			Span:                   span,
+			Resource:               resource,
+			InstrumentationLibrary: traces.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).InstrumentationLibrary(),
+			DBSpan: &dbmodel.Span{
+				TraceID:         "30313233343536373839616263646566",
+				SpanID:          "3031323334353637",
+				StartTime:       1000,
+				Duration:        1000,
+				OperationName:   "root",
+				StartTimeMillis: 1,
+				Tags: []dbmodel.KeyValue{
+					{Key: "span.kind", Type: dbmodel.StringType, Value: "client"},
+					{Key: "status.code", Type: dbmodel.StringType, Value: "Cancelled"},
+					{Key: "error", Type: dbmodel.BoolType, Value: "true"},
+					{Key: "status.message", Type: dbmodel.StringType, Value: "messagetext"},
+					{Key: "foo", Type: dbmodel.BoolType, Value: "true"}},
+				Tag: map[string]interface{}{"toTagMap": "val"},
+				Logs: []dbmodel.Log{{Fields: []dbmodel.KeyValue{
+					{Key: "event", Value: "eventName", Type: dbmodel.StringType},
+					{Key: "foo", Value: "bar", Type: dbmodel.StringType}}, Timestamp: 500}},
+				References: []dbmodel.Reference{
+					{SpanID: "3031323334353637", TraceID: "30313233343536373839616263646566", RefType: dbmodel.ChildOf},
+					{SpanID: "3031323334353637", TraceID: "30313233343536373839616263646566", RefType: dbmodel.FollowsFrom}},
+				Process: dbmodel.Process{
+					ServiceName: "myservice",
+					Tags:        []dbmodel.KeyValue{{Key: "num", Value: "16.66", Type: dbmodel.Float64Type}},
+				},
+			},
+		}, spanDataContainers[0])
 }
 
 func TestSpanEmptyRef(t *testing.T) {
@@ -166,24 +172,30 @@ func TestSpanEmptyRef(t *testing.T) {
 	span.SetEndTime(pdata.TimestampUnixNano(2000000))
 
 	c := &Translator{}
-	spans, err := c.ConvertSpans(traces)
+	spanDataContainers, err := c.ConvertSpans(traces)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(spans))
-	assert.Equal(t, &dbmodel.Span{
-		TraceID:         "30313233343536373839616263646566",
-		SpanID:          "3031323334353637",
-		StartTime:       1000,
-		Duration:        1000,
-		OperationName:   "root",
-		StartTimeMillis: 1,
-		Tags:            []dbmodel.KeyValue{},  // should not be nil
-		Logs:            []dbmodel.Log{},       // should not be nil
-		References:      []dbmodel.Reference{}, // should not be nil
-		Process: dbmodel.Process{
-			ServiceName: "myservice",
-			Tags:        nil,
-		},
-	}, spans[0])
+	assert.Equal(t, 1, len(spanDataContainers))
+	assert.Equal(t,
+		ConvertedData{
+			Span:                   span,
+			Resource:               traces.ResourceSpans().At(0).Resource(),
+			InstrumentationLibrary: traces.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).InstrumentationLibrary(),
+			DBSpan: &dbmodel.Span{
+				TraceID:         "30313233343536373839616263646566",
+				SpanID:          "3031323334353637",
+				StartTime:       1000,
+				Duration:        1000,
+				OperationName:   "root",
+				StartTimeMillis: 1,
+				Tags:            []dbmodel.KeyValue{},  // should not be nil
+				Logs:            []dbmodel.Log{},       // should not be nil
+				References:      []dbmodel.Reference{}, // should not be nil
+				Process: dbmodel.Process{
+					ServiceName: "myservice",
+					Tags:        nil,
+				},
+			},
+		}, spanDataContainers[0])
 }
 
 func TestEmpty(t *testing.T) {

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/exporter.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/exporter.go
@@ -23,8 +23,8 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 )
 
-// new creates Elasticsearch exporter/storage.
-func new(ctx context.Context, config *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
+// newExporter creates Elasticsearch exporter/storage.
+func newExporter(ctx context.Context, config *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
 	esCfg := config.GetPrimary()
 	w, err := newEsSpanWriter(*esCfg, params.Logger, false, config.Name())
 	if err != nil {

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
@@ -78,7 +78,7 @@ func (Factory) CreateTraceExporter(
 	if !ok {
 		return nil, fmt.Errorf("could not cast configuration to %s", TypeStr)
 	}
-	return new(ctx, esCfg, params)
+	return newExporter(ctx, esCfg, params)
 }
 
 // CreateMetricsExporter is not implemented.

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/spanstore.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cache"
 	"github.com/jaegertracing/jaeger/pkg/es/config"
+	"github.com/jaegertracing/jaeger/pkg/multierror"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 )
 
@@ -114,69 +115,75 @@ func (w *esSpanWriter) WriteTraces(ctx context.Context, traces pdata.Traces) (in
 	return w.writeSpans(ctx, spans)
 }
 
-func (w *esSpanWriter) writeSpans(ctx context.Context, spans []*dbmodel.Span) (int, error) {
+func (w *esSpanWriter) writeSpans(ctx context.Context, spansData []esmodeltranslator.ConvertedData) (int, error) {
 	buffer := &bytes.Buffer{}
 	// mapping for bulk operation to span
-	var bulkOperations []bulkItem
+	var bulkItems []bulkItem
 	var errs []error
 	dropped := 0
-	for _, span := range spans {
-		data, err := json.Marshal(span)
+	for _, spanData := range spansData {
+		data, err := json.Marshal(spanData.DBSpan)
 		if err != nil {
 			errs = append(errs, err)
 			dropped++
 			continue
 		}
-		indexName := w.spanIndexName.IndexName(model.EpochMicrosecondsAsTime(span.StartTime))
-		bulkOperations = append(bulkOperations, bulkItem{span: span, isService: false})
+		indexName := w.spanIndexName.IndexName(model.EpochMicrosecondsAsTime(spanData.DBSpan.StartTime))
+		bulkItems = append(bulkItems, bulkItem{spanData: spanData, isService: false})
 		w.client.AddDataToBulkBuffer(buffer, data, indexName, spanTypeName)
-
 		if !w.isArchive {
-			storeService, err := w.writeService(span, buffer)
+			storeService, err := w.writeService(spanData.DBSpan, buffer)
 			if err != nil {
 				errs = append(errs, err)
 				// dropped is not increased since this is only service name, the span could be written well
 				continue
 			} else if storeService {
-				bulkOperations = append(bulkOperations, bulkItem{span: span, isService: true})
+				bulkItems = append(bulkItems, bulkItem{spanData: spanData, isService: true})
 			}
 		}
 	}
-	res, err := w.client.Bulk(ctx, bytes.NewReader(buffer.Bytes()))
+	res, err := w.client.Bulk(ctx, buffer)
 	if err != nil {
 		errs = append(errs, err)
-		return len(spans), componenterror.CombineErrors(errs)
+		return len(spansData), componenterror.CombineErrors(errs)
 	}
-	droppedFromResponse := w.handleResponse(ctx, res, bulkOperations)
-	dropped += droppedFromResponse
+	failedOperations, err := w.handleResponse(ctx, res, bulkItems)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	dropped += len(failedOperations)
+	if len(failedOperations) > 0 {
+		return dropped, consumererror.PartialTracesError(componenterror.CombineErrors(errs), bulkItemsToTraces(failedOperations))
+	}
 	return dropped, componenterror.CombineErrors(errs)
 }
 
-func (w *esSpanWriter) handleResponse(ctx context.Context, blk *esclient.BulkResponse, operationToSpan []bulkItem) int {
-	numErrors := 0
+// handleResponse processes blk response and returns spans that
+func (w *esSpanWriter) handleResponse(ctx context.Context, blk *esclient.BulkResponse, bulkItems []bulkItem) ([]bulkItem, error) {
 	storedSpans := map[string]int64{}
 	notStoredSpans := map[string]int64{}
+	var failed []bulkItem
+	var errs []error
 	for i, d := range blk.Items {
-		bulkOp := operationToSpan[i]
+		bulkItem := bulkItems[i]
 		if d.Index.Status > 201 {
-			numErrors++
 			w.logger.Error("Part of the bulk request failed",
 				zap.String("result", d.Index.Result),
 				zap.String("error.reason", d.Index.Error.Reason),
 				zap.String("error.type", d.Index.Error.Type),
 				zap.String("error.cause.type", d.Index.Error.Cause.Type),
 				zap.String("error.cause.reason", d.Index.Error.Cause.Reason))
-			// TODO return an error or a struct that indicates which spans should be retried
-			// https://github.com/open-telemetry/opentelemetry-collector/issues/990
-			if !bulkOp.isService {
-				notStoredSpans[bulkOp.span.Process.ServiceName] = notStoredSpans[bulkOp.span.Process.ServiceName] + 1
+			errs = append(errs, fmt.Errorf("bulk request failed, reason %v, result: %v", d.Index.Error.Reason, d.Index.Result))
+			if !bulkItem.isService {
+				failed = append(failed, bulkItem)
+				notStoredSpans[bulkItem.spanData.DBSpan.Process.ServiceName] = notStoredSpans[bulkItem.spanData.DBSpan.Process.ServiceName] + 1
 			}
 		} else {
 			// passed
-			if !bulkOp.isService {
-				storedSpans[bulkOp.span.Process.ServiceName] = storedSpans[bulkOp.span.Process.ServiceName] + 1
+			if !bulkItem.isService {
+				storedSpans[bulkItem.spanData.DBSpan.Process.ServiceName] = storedSpans[bulkItem.spanData.DBSpan.Process.ServiceName] + 1
 			} else {
-				cacheKey := hashCode(bulkOp.span.Process.ServiceName, bulkOp.span.OperationName)
+				cacheKey := hashCode(bulkItem.spanData.DBSpan.Process.ServiceName, bulkItem.spanData.DBSpan.OperationName)
 				w.serviceCache.Put(cacheKey, cacheKey)
 			}
 		}
@@ -191,7 +198,7 @@ func (w *esSpanWriter) handleResponse(ctx context.Context, blk *esclient.BulkRes
 			tag.Insert(storagemetrics.TagServiceName(), k), w.nameTag)
 		stats.Record(ctx, storagemetrics.StatSpansStoredCount().M(v))
 	}
-	return numErrors
+	return failed, multierror.Wrap(errs)
 }
 
 func (w *esSpanWriter) writeService(span *dbmodel.Span, buffer *bytes.Buffer) (bool, error) {
@@ -221,11 +228,32 @@ func hashCode(serviceName, operationName string) string {
 
 type bulkItem struct {
 	// span associated with the bulk operation
-	span *dbmodel.Span
+	spanData esmodeltranslator.ConvertedData
 	// isService indicates that this bulk operation is for service index
 	isService bool
 }
 
 func (w *esSpanWriter) esClientVersion() int {
 	return w.client.MajorVersion()
+}
+
+func bulkItemsToTraces(bulkItems []bulkItem) pdata.Traces {
+	traces := pdata.NewTraces()
+	traces.ResourceSpans().Resize(len(bulkItems))
+	for i, op := range bulkItems {
+		spanData := op.spanData
+		rss := traces.ResourceSpans().At(i)
+		if !spanData.Resource.IsNil() {
+			rss.Resource().InitEmpty()
+			rss.Resource().Attributes().InitFromAttributeMap(spanData.Resource.Attributes())
+		}
+		rss.InstrumentationLibrarySpans().Resize(1)
+		ispans := rss.InstrumentationLibrarySpans().At(0)
+		ispans.InitEmpty()
+		if !spanData.InstrumentationLibrary.IsNil() {
+			spanData.InstrumentationLibrary.CopyTo(ispans.InstrumentationLibrary())
+		}
+		ispans.Spans().Append(&spanData.Span)
+	}
+	return traces
 }

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory.go
@@ -21,6 +21,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/elasticsearchexporter/esmodeltranslator"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/esclient"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/reader/es/esdependencyreader"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/reader/es/esspanreader"
@@ -143,13 +144,13 @@ type singleSpanWriter struct {
 }
 
 type batchSpanWriter interface {
-	writeSpans(context.Context, []*dbmodel.Span) (int, error)
+	writeSpans(context.Context, []esmodeltranslator.ConvertedData) (int, error)
 }
 
 var _ spanstore.Writer = (*singleSpanWriter)(nil)
 
 func (s singleSpanWriter) WriteSpan(ctx context.Context, span *model.Span) error {
 	dbSpan := s.converter.FromDomainEmbedProcess(span)
-	_, err := s.writer.writeSpans(ctx, []*dbmodel.Span{dbSpan})
+	_, err := s.writer.writeSpans(ctx, []esmodeltranslator.ConvertedData{{DBSpan: dbSpan}})
 	return err
 }

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/storagefactory_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/elasticsearchexporter/esmodeltranslator"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
@@ -139,7 +140,9 @@ type mockWriter struct {
 
 var _ batchSpanWriter = (*mockWriter)(nil)
 
-func (m *mockWriter) writeSpans(_ context.Context, spans []*dbmodel.Span) (int, error) {
-	m.spans = append(spans)
+func (m *mockWriter) writeSpans(ctx context.Context, containers []esmodeltranslator.ConvertedData) (int, error) {
+	for _, c := range containers {
+		m.spans = append(m.spans, c.DBSpan)
+	}
 	return 0, nil
 }

--- a/cmd/opentelemetry/go.sum
+++ b/cmd/opentelemetry/go.sum
@@ -1471,7 +1471,6 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.28.0-pre/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=


### PR DESCRIPTION
The partial retry as the name suggests ensures that only spans that failed to be stored were retried. The returned error encapsulates `pdata.Traces` that is used by qretry on in the consecutive call to the exporter. The `pdata.Traces`  for retry is created from a struct that is created by ES model translator.