### PR TITLE
Modify badger storage reader to check for ErrTraceNotFound error

### DIFF
--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -292,7 +292,7 @@ func TestIndexSeeks(t *testing.T) {
 	})
 }
 
-func TestFindNothing(t *testing.T) {
+func TestFindNothingWithTraceNotFoundErr(t *testing.T) {
 	runFactoryTest(t, func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader) {
 		startT := time.Now()
 		params := &spanstore.TraceQueryParameters{
@@ -302,11 +302,11 @@ func TestFindNothing(t *testing.T) {
 		}
 
 		trs, err := sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		assert.EqualError(t, err, "trace not found")
 		assert.Equal(t, 0, len(trs))
 
 		tr, err := sr.GetTrace(context.Background(), model.TraceID{High: 0, Low: 0})
-		assert.NoError(t, err)
+		assert.EqualError(t, err, "trace not found")
 		assert.Nil(t, tr)
 	})
 }

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -160,6 +160,9 @@ func (r *TraceReader) GetTrace(ctx context.Context, traceID model.TraceID) (*mod
 	if err != nil {
 		return nil, err
 	}
+	if len(traces) == 0 {
+		return nil, spanstore.ErrTraceNotFound
+	}
 	if len(traces) == 1 {
 		return traces[0], nil
 	}


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #1848

## Short description of the changes
- The fix is intended to fix Jaeger crashing with with nil pointer on **span_id_deduper.go:57**.
