### PR TITLE
Enable CI for badger and grpc-plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
     - CASSANDRA_INTEGRATION_TEST=true
   - go: "1.15.x"
     env:
+    - MEM_AND_BADGER_INTEGRATION_TEST=true
+  - go: "1.15.x"
+    env:
     - HOTROD=true
 
 services:
@@ -63,6 +66,7 @@ install:
 script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - if [ "$TESTS" == true ]; then make test-ci ; else echo 'skipping tests'; fi
+  - if [ "$PROTO_GEN_TEST" == true ]; then make proto && git diff --name-status --exit-code ; else echo 'skipping protoc validation'; fi
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/build-all-in-one-image.sh ; else echo 'skipping all_in_one'; fi
   - if [ "$CROSSDOCK" == true ]; then bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi
   - if [ "$CROSSDOCK_OTEL" == true ]; then make build-crossdock crossdock-otel ; else echo 'skipping OpenTelemetry crossdock'; fi
@@ -73,8 +77,8 @@ script:
   - if [ "$ES_OTEL_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$KAFKA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/kafka-integration-test.sh ; else echo 'skipping kafka integration test'; fi
   - if [ "$CASSANDRA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/cassandra-integration-test.sh ; else echo 'skipping cassandra integration test'; fi
+  - if [ "$MEM_AND_BADGER_INTEGRATION_TEST" == true ]; then make mem-and-badger-storage-integration-test ; ; else echo 'skipping mem and badger integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
-  - if [ "$PROTO_GEN_TEST" == true ]; then make proto && git diff --name-status --exit-code ; else echo 'skipping protoc validation'; fi
 
 after_success:
   - if [ "$COVERAGE" == true ]; then mv cover.out coverage.txt ; else echo 'skipping coverage'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
   - if [ "$ES_OTEL_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
   - if [ "$KAFKA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/kafka-integration-test.sh ; else echo 'skipping kafka integration test'; fi
   - if [ "$CASSANDRA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/cassandra-integration-test.sh ; else echo 'skipping cassandra integration test'; fi
-  - if [ "$MEM_AND_BADGER_INTEGRATION_TEST" == true ]; then make mem-and-badger-storage-integration-test ; ; else echo 'skipping mem and badger integration test'; fi
+  - if [ "$MEM_AND_BADGER_INTEGRATION_TEST" == true ]; then make mem-and-badger-storage-integration-test ; else echo 'skipping mem and badger integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,18 @@ storage-integration-test: go-gen
 	go clean -testcache
 	bash -c "set -e; set -o pipefail; $(GOTEST) $(STORAGE_PKGS) | $(COLORIZE)"
 
+.PHONY: mem-and-badger-storage-integration-test
+mem-and-badger-storage-integration-test: badger-storage-integration-test grpc-plugin-storage-integration-test
+
+.PHONY: badger-storage-integration-test
+badger-storage-integration-test:
+	STORAGE=badger $(MAKE) storage-integration-test
+
+.PHONY: grpc-plugin-storage-integration-test
+grpc-plugin-storage-integration-test:
+	(cd examples/memstore-plugin/ && go build .)
+	STORAGE=grpc-plugin $(MAKE) storage-integration-test
+
 .PHONY: es-otel-exporter-integration-test
 es-otel-exporter-integration-test: go-gen
 	go clean -testcache

--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -25,11 +25,16 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
 )
 
-// Configuration describes the options to customize the storage behavior
+// Configuration describes the options to customize the storage behavior.
 type Configuration struct {
 	PluginBinary            string `yaml:"binary" mapstructure:"binary"`
 	PluginConfigurationFile string `yaml:"configuration-file" mapstructure:"configuration_file"`
 	PluginLogLevel          string `yaml:"log-level" mapstructure:"log_level"`
+}
+
+// PluginBuilder is used to create storage plugins. Implemented by Configuration.
+type PluginBuilder interface {
+	Build() (shared.StoragePlugin, error)
 }
 
 // Build instantiates a StoragePlugin
@@ -69,9 +74,4 @@ func (c *Configuration) Build() (shared.StoragePlugin, error) {
 	}
 
 	return storagePlugin, nil
-}
-
-// PluginBuilder is used to create storage plugins
-type PluginBuilder interface {
-	Build() (shared.StoragePlugin, error)
 }

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -16,6 +16,7 @@ package grpc
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
@@ -66,7 +67,7 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 
 	store, err := f.builder.Build()
 	if err != nil {
-		return err
+		return fmt.Errorf("grpc-plugin builder failed to create a store: %w", err)
 	}
 
 	f.store = store

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
@@ -75,7 +76,9 @@ func TestGRPCStorageFactory(t *testing.T) {
 	f.builder = &mockPluginBuilder{
 		err: errors.New("made-up error"),
 	}
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "made-up error")
 
 	f.builder = &mockPluginBuilder{
 		plugin: &mockPlugin{

--- a/plugin/storage/grpc/shared/interface.go
+++ b/plugin/storage/grpc/shared/interface.go
@@ -15,12 +15,8 @@
 package shared
 
 import (
-	"context"
-
 	"github.com/hashicorp/go-plugin"
-	"google.golang.org/grpc"
 
-	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
@@ -44,30 +40,4 @@ type StoragePlugin interface {
 	SpanReader() spanstore.Reader
 	SpanWriter() spanstore.Writer
 	DependencyReader() dependencystore.Reader
-}
-
-// StorageGRPCPlugin is the implementation of plugin.GRPCPlugin so we can serve/consume this.
-type StorageGRPCPlugin struct {
-	plugin.Plugin
-	// Concrete implementation, written in Go. This is only used for plugins
-	// that are written in Go.
-	Impl StoragePlugin
-}
-
-// GRPCServer is used by go-plugin to create a grpc plugin server
-func (p *StorageGRPCPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
-	server := &grpcServer{Impl: p.Impl}
-	storage_v1.RegisterSpanReaderPluginServer(s, server)
-	storage_v1.RegisterSpanWriterPluginServer(s, server)
-	storage_v1.RegisterDependenciesReaderPluginServer(s, server)
-	return nil
-}
-
-// GRPCClient is used by go-plugin to create a grpc plugin client
-func (*StorageGRPCPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
-	return &grpcClient{
-		readerClient:     storage_v1.NewSpanReaderPluginClient(c),
-		writerClient:     storage_v1.NewSpanWriterPluginClient(c),
-		depsReaderClient: storage_v1.NewDependenciesReaderPluginClient(c),
-	}, nil
 }

--- a/plugin/storage/grpc/shared/plugin.go
+++ b/plugin/storage/grpc/shared/plugin.go
@@ -18,8 +18,9 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
 	"google.golang.org/grpc"
+
+	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
 )
 
 // Ensure plugin.GRPCPlugin API match.

--- a/plugin/storage/grpc/shared/plugin.go
+++ b/plugin/storage/grpc/shared/plugin.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
+	"google.golang.org/grpc"
+)
+
+// Ensure plugin.GRPCPlugin API match.
+var _ plugin.GRPCPlugin = (*StorageGRPCPlugin)(nil)
+
+// StorageGRPCPlugin is the implementation of plugin.GRPCPlugin.
+type StorageGRPCPlugin struct {
+	plugin.Plugin
+
+	// Concrete implementation, This is only used for plugins that are written in Go.
+	Impl StoragePlugin
+}
+
+// GRPCServer implements plugin.GRPCPlugin. It is used by go-plugin to create a grpc plugin server.
+func (p *StorageGRPCPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
+	server := &grpcServer{Impl: p.Impl}
+	storage_v1.RegisterSpanReaderPluginServer(s, server)
+	storage_v1.RegisterSpanWriterPluginServer(s, server)
+	storage_v1.RegisterDependenciesReaderPluginServer(s, server)
+	return nil
+}
+
+// GRPCClient implements plugin.GRPCPlugin. It is used by go-plugin to create a grpc plugin client.
+func (*StorageGRPCPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{
+		readerClient:     storage_v1.NewSpanReaderPluginClient(c),
+		writerClient:     storage_v1.NewSpanWriterPluginClient(c),
+		depsReaderClient: storage_v1.NewDependenciesReaderPluginClient(c),
+	}, nil
+}


### PR DESCRIPTION
Partially address #1516 since the badger and grpc-plugin storage integration tests are not running in CI at all today.

* adds a new CI step to run grpc-plugin and badger integration tests
* minor clean-up of the plugin framework code
* reorder logic in .travis.yml to match the actual order of the matrix steps