### PR TITLE
Fix failing ServerInUseHostPort test on MacOS

### DIFF
--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -74,7 +74,7 @@ func NewServer(logger *zap.Logger, querySvc *querysvc.QueryService, options *Que
 		tracer:             tracer,
 		grpcServer:         grpcServer,
 		httpServer:         createHTTPServer(querySvc, options, tracer, logger),
-		separatePorts:      (grpcPort != httpPort),
+		separatePorts:      grpcPort != httpPort,
 		unavailableChannel: make(chan healthcheck.Status),
 	}, nil
 }

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -24,6 +24,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -83,18 +83,18 @@ func TestServerInUseHostPort(t *testing.T) {
 		httpHostPort string
 		grpcHostPort string
 	}{
-		{"HTTP host port clash on " + conn.Addr().String(), conn.Addr().String(), availableHostPort},
-		{"GRPC host port clash on " + conn.Addr().String(), availableHostPort, conn.Addr().String()},
+		{"HTTP host port clash", conn.Addr().String(), availableHostPort},
+		{"GRPC host port clash", availableHostPort, conn.Addr().String()},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server, err := NewServer(
-			        zap.NewNop(), 
-			        &querysvc.QueryService{},
+				zap.NewNop(),
+				&querysvc.QueryService{},
 				&QueryOptions{
-				    HTTPHostPort: tc.httpHostPort, 
-				    GRPCHostPort: tc.grpcHostPort, 
-				    BearerTokenPropagation: true,
+					HTTPHostPort:           tc.httpHostPort,
+					GRPCHostPort:           tc.grpcHostPort,
+					BearerTokenPropagation: true,
 				},
 				opentracing.NoopTracer{},
 			)

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -75,8 +75,8 @@ func TestServerBadHostPort(t *testing.T) {
 func TestServerInUseHostPort(t *testing.T) {
 	const availableHostPort = "127.0.0.1:0"
 	conn, err := net.Listen("tcp", availableHostPort)
-	defer func() { conn.Close() }()
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
 
 	testCases := []struct {
 		name         string


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Master branch unit tests are failing on `TestServerInUseHostPort`, seemingly only for MacOS (okay for Linux builds).
- IIUC, the reason for the test is to have test coverage of error handling code when listening on GRPC and HTTP ports. To achieve this, the test first listens on those same ports, then attempts to bind to those same ports again via the QueryService `Start()`; and expecting an error to be returned.
- When running this test, no error is returned when binding to `127.0.0.1:8080` while `:8080` is bound, causing the assertion to fail. Interestingly, this behaviour differs between MacOS and Linux (at least on my Centos 8 VM).
- From this, it appears that the Linux OS libraries are stricter than MacOS; the former considering the `0.0.0.0` address to be bindable to the loopback network interface.
- Confirmed with the following simple program which I ran on both OSes:

```
package main

import (
     "fmt"
     "net"
 )

 const (
     hostname0 = ":8080"
     hostname1 = "127.0.0.1:8080"
 )

 func listen(hostname string) {
     fmt.Println("Listening to", hostname)
     if _, err := net.Listen("tcp", hostname); err != nil {
         fmt.Println(err.Error())
     }
 }

 func main() {
     listen(hostname0)
     listen(hostname1)
 }
```

...and here are the results:

**MacOS**
```
$ go run main.go
Listening to :8080
Listening to 127.0.0.1:8080
```

**Centos 8**
```
$ go run main.go
Listening to :8080
Listening to 127.0.0.1:8080
listen tcp 127.0.0.1:8080: bind: address already in use
```

## Short description of the changes

- The fix involves explicitly providing the host IP (loopback in this case) in the host port string.
- Add a stronger assertion on the error.
- Have tried adding a MacOS job in Travis checks to prevent this from happening in future (there've been 2 MacOS specific unit test breakages in the last few weeks already), however, had some difficulties getting the Sarama unit tests to pass, and not sure why they're failing.