### PR TITLE
Add integration test for ErrTraceNotFound

### DIFF
--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -306,7 +306,7 @@ func TestFindNothing(t *testing.T) {
 		assert.Equal(t, 0, len(trs))
 
 		tr, err := sr.GetTrace(context.Background(), model.TraceID{High: 0, Low: 0})
-		assert.NoError(t, err)
+		assert.Equal(t, spanstore.ErrTraceNotFound, err)
 		assert.Nil(t, tr)
 	})
 }

--- a/plugin/storage/badger/spanstore/reader.go
+++ b/plugin/storage/badger/spanstore/reader.go
@@ -164,7 +164,7 @@ func (r *TraceReader) GetTrace(ctx context.Context, traceID model.TraceID) (*mod
 		return traces[0], nil
 	}
 
-	return nil, nil
+	return nil, spanstore.ErrTraceNotFound
 }
 
 // scanTimeRange returns all the Traces found between startTs and endTs

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -190,7 +190,7 @@ func (s *StorageIntegration) testGetTrace(t *testing.T) {
 	}
 
 	t.Run("NotFound error", func(t *testing.T) {
-		fakeTraceID := model.TraceID{High: 42, Low: 42}
+		fakeTraceID := model.TraceID{High: 0, Low: 0}
 		trace, err := s.SpanReader.GetTrace(context.Background(), fakeTraceID)
 		assert.Equal(t, spanstore.ErrTraceNotFound, err)
 		assert.Nil(t, trace)

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -191,8 +191,9 @@ func (s *StorageIntegration) testGetTrace(t *testing.T) {
 
 	t.Run("NotFound error", func(t *testing.T) {
 		fakeTraceID := model.TraceID{High: 42, Low: 42}
-		_, err := s.SpanReader.GetTrace(context.Background(), fakeTraceID)
+		trace, err := s.SpanReader.GetTrace(context.Background(), fakeTraceID)
 		assert.Equal(t, spanstore.ErrTraceNotFound, err)
+		assert.Nil(t, trace)
 	})
 }
 

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -188,6 +188,12 @@ func (s *StorageIntegration) testGetTrace(t *testing.T) {
 	if !assert.True(t, found) {
 		CompareTraces(t, expected, actual)
 	}
+
+	t.Run("NotFound error", func(t *testing.T) {
+		fakeTraceID := model.TraceID{High: 42, Low: 42}
+		_, err := s.SpanReader.GetTrace(context.Background(), fakeTraceID)
+		assert.Equal(t, spanstore.ErrTraceNotFound, err)
+	})
 }
 
 func (s *StorageIntegration) testFindTraces(t *testing.T) {

--- a/storage/spanstore/interface.go
+++ b/storage/spanstore/interface.go
@@ -35,10 +35,31 @@ type Writer interface {
 
 // Reader finds and loads traces and other data from storage.
 type Reader interface {
+	// GetTrace retrieves the trace with a given id.
+	//
+	// If no spans are stored for this trace, it returns ErrTraceNotFound.
 	GetTrace(ctx context.Context, traceID model.TraceID) (*model.Trace, error)
+
+	// GetServices returns all service names known to the backend from spans
+	// within its retention period.
 	GetServices(ctx context.Context) ([]string, error)
+
+	// GetOperations returns all operation names for a given service
+	// known to the backend from spans within its retention period.
 	GetOperations(ctx context.Context, query OperationQueryParameters) ([]Operation, error)
+
+	// FindTraces returns all traces matching query parameters. There's currently
+	// an implementation-dependent abiguity whether all query filters (such as
+	// multiple tags) must apply to the same span within a trace, or can be satisfied
+	// by different spans.
+	//
+	// If no matching traces are found, the function returns (nil, nil).
 	FindTraces(ctx context.Context, query *TraceQueryParameters) ([]*model.Trace, error)
+
+	// FindTraceIDs does the same search as FindTraces, but returns only the list
+	// of matching trace IDs.
+	//
+	// If no matching traces are found, the function returns (nil, nil).
 	FindTraceIDs(ctx context.Context, query *TraceQueryParameters) ([]model.TraceID, error)
 }
 


### PR DESCRIPTION
This is especially interesting when using go-plugin based storage, where the error has to be correctly passed through gRPC client.

The test revealed that Badger did not return NotFound when expected, so it's fixed here as well.

I added documentation to the span Reader API with expectations about not-found.