### PR TITLE
Add travis_retry to some CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,16 +68,16 @@ script:
   - if [ "$TESTS" == true ]; then make test-ci ; else echo 'skipping tests'; fi
   - if [ "$PROTO_GEN_TEST" == true ]; then make proto && git diff --name-status --exit-code ; else echo 'skipping protoc validation'; fi
   - if [ "$ALL_IN_ONE" == true ]; then bash ./scripts/travis/build-all-in-one-image.sh ; else echo 'skipping all_in_one'; fi
-  - if [ "$CROSSDOCK" == true ]; then bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi
-  - if [ "$CROSSDOCK_OTEL" == true ]; then make build-crossdock crossdock-otel ; else echo 'skipping OpenTelemetry crossdock'; fi
+  - if [ "$CROSSDOCK" == true ]; then travis_retry bash ./scripts/travis/build-crossdock.sh ; else echo 'skipping crossdock'; fi
+  - if [ "$CROSSDOCK_OTEL" == true ]; then travis_retry make build-crossdock crossdock-otel ; else echo 'skipping OpenTelemetry crossdock'; fi
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/build-docker-images.sh ; else echo 'skipping build-docker-images'; fi
   - if [ "$DOCKER" == true ]; then bash ./scripts/travis/upload-all-docker-images.sh ; else echo 'skipping docker upload'; fi
   - if [ "$DEPLOY" == true ]; then make build-all-platforms ; else echo 'skipping build-all-platforms'; fi
-  - if [ "$ES_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
-  - if [ "$ES_OTEL_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
-  - if [ "$KAFKA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/kafka-integration-test.sh ; else echo 'skipping kafka integration test'; fi
-  - if [ "$CASSANDRA_INTEGRATION_TEST" == true ]; then bash ./scripts/travis/cassandra-integration-test.sh ; else echo 'skipping cassandra integration test'; fi
-  - if [ "$MEM_AND_BADGER_INTEGRATION_TEST" == true ]; then make mem-and-badger-storage-integration-test ; else echo 'skipping mem and badger integration test'; fi
+  - if [ "$ES_INTEGRATION_TEST" == true ]; then travis_retry bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
+  - if [ "$ES_OTEL_INTEGRATION_TEST" == true ]; then travis_retry bash ./scripts/travis/es-integration-test.sh ; else echo 'skipping elastic search integration test'; fi
+  - if [ "$KAFKA_INTEGRATION_TEST" == true ]; then travis_retry bash ./scripts/travis/kafka-integration-test.sh ; else echo 'skipping kafka integration test'; fi
+  - if [ "$CASSANDRA_INTEGRATION_TEST" == true ]; then travis_retry bash ./scripts/travis/cassandra-integration-test.sh ; else echo 'skipping cassandra integration test'; fi
+  - if [ "$MEM_AND_BADGER_INTEGRATION_TEST" == true ]; then travis_retry make mem-and-badger-storage-integration-test ; else echo 'skipping mem and badger integration test'; fi
   - if [ "$HOTROD" == true ]; then bash ./scripts/travis/hotrod-integration-test.sh ; else echo 'skipping hotrod example'; fi
 
 after_success:


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Some CI jobs are flaky, working on second/third attempt. This PR adds a "travis_retry" in front of the jobs that are more likely to suffer from it.

## Short description of the changes
- Added travis_retry in front of integration and crossdock tests
