### PR TITLE
Increase coverage on otel/app/defaultconfig and otel/app/defaultcomponents

### DIFF
--- a/cmd/opentelemetry/app/defaultcomponents/defaults_test.go
+++ b/cmd/opentelemetry/app/defaultcomponents/defaults_test.go
@@ -52,7 +52,16 @@ func TestComponents(t *testing.T) {
 	cassandraFactory := factories.Exporters[cassandraexporter.TypeStr]
 	cc := cassandraFactory.CreateDefaultConfig().(*cassandraexporter.Config)
 	assert.Equal(t, []string{"127.0.0.1"}, cc.Options.GetPrimary().Servers)
+
 	esFactory := factories.Exporters[elasticsearchexporter.TypeStr]
 	ec := esFactory.CreateDefaultConfig().(*elasticsearchexporter.Config)
 	assert.Equal(t, []string{"http://127.0.0.1:9200"}, ec.GetPrimary().Servers)
+
+	grpcFactory := factories.Exporters[grpcpluginexporter.TypeStr]
+	gc := grpcFactory.CreateDefaultConfig().(*grpcpluginexporter.Config)
+	assert.Equal(t, "", gc.Configuration.PluginBinary)
+
+	badgerFactory := factories.Exporters[badgerexporter.TypeStr]
+	bc := badgerFactory.CreateDefaultConfig().(*badgerexporter.Config)
+	assert.Equal(t, "", bc.GetPrimary().ValueDirectory)
 }

--- a/cmd/opentelemetry/app/defaultconfig/default_config_test.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config_test.go
@@ -15,14 +15,17 @@
 package defaultconfig
 
 import (
+	"flag"
 	"fmt"
 	"sort"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/service/builder"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app"
@@ -42,6 +45,7 @@ func TestService(t *testing.T) {
 		cfg         ComponentSettings
 		err         string
 		viperConfig map[string]interface{}
+		otelConfig  string
 	}{
 		{
 			cfg: ComponentSettings{
@@ -75,6 +79,24 @@ func TestService(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			cfg: ComponentSettings{
+				ComponentType: Agent,
+			},
+			service: configmodels.Service{
+				Extensions: []string{"health_check"},
+				Pipelines: configmodels.Pipelines{
+					"traces": &configmodels.Pipeline{
+						Name:       "traces",
+						InputType:  configmodels.TracesDataType,
+						Receivers:  []string{"otlp", "jaeger"},
+						Processors: []string{"batch", "queued_retry"},
+						Exporters:  []string{"jaeger"},
+					},
+				},
+			},
+			otelConfig: "testdata/addqueuedprocessor.yaml",
 		},
 		{
 			viperConfig: map[string]interface{}{"resource.attributes": "foo=bar"},
@@ -153,6 +175,13 @@ func TestService(t *testing.T) {
 			},
 			err: "unknown storage type: floppy",
 		},
+		{
+			cfg: ComponentSettings{
+				ComponentType: Agent,
+			},
+			otelConfig: "testdata/doesntexist.yaml",
+			err:        `error loading config file "testdata/doesntexist.yaml": open testdata/doesntexist.yaml: no such file or directory`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v:%v", test.cfg.ComponentType, test.cfg.StorageType), func(t *testing.T) {
@@ -160,9 +189,18 @@ func TestService(t *testing.T) {
 			for key, val := range test.viperConfig {
 				v.Set(key, val)
 			}
+
+			otelFlags := &flag.FlagSet{}
+			builder.Flags(otelFlags)
+			if test.otelConfig != "" {
+				otelFlags.Parse([]string{"-config=" + test.otelConfig})
+			}
+
 			factories := defaultcomponents.Components(v)
 			test.cfg.Factories = factories
-			cfg, err := test.cfg.createDefaultConfig()
+			createDefaultConfig := test.cfg.DefaultConfigFactory(v)
+
+			cfg, err := createDefaultConfig(viper.New(), factories)
 			if test.err != "" {
 				require.Nil(t, cfg)
 				assert.Contains(t, err.Error(), test.err)

--- a/cmd/opentelemetry/app/defaultconfig/default_config_test.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config_test.go
@@ -193,7 +193,7 @@ func TestService(t *testing.T) {
 			otelFlags := &flag.FlagSet{}
 			builder.Flags(otelFlags)
 			if test.otelConfig != "" {
-				otelFlags.Parse([]string{"-config=" + test.otelConfig})
+				otelFlags.Parse([]string{"--config=" + test.otelConfig})
 			}
 
 			factories := defaultcomponents.Components(v)

--- a/cmd/opentelemetry/app/defaultconfig/default_config_test.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config_test.go
@@ -60,6 +60,23 @@ func TestService(t *testing.T) {
 			},
 		},
 		{
+			cfg: ComponentSettings{
+				ComponentType: Collector,
+				StorageType:   "badger",
+			},
+			service: configmodels.Service{
+				Extensions: []string{"health_check"},
+				Pipelines: configmodels.Pipelines{
+					"traces": &configmodels.Pipeline{
+						InputType:  configmodels.TracesDataType,
+						Receivers:  []string{"otlp", "jaeger"},
+						Processors: []string{"batch"},
+						Exporters:  []string{"jaeger_badger"},
+					},
+				},
+			},
+		},
+		{
 			viperConfig: map[string]interface{}{"resource.attributes": "foo=bar"},
 			cfg: ComponentSettings{
 				ComponentType: Collector,

--- a/cmd/opentelemetry/app/defaultconfig/merge.go
+++ b/cmd/opentelemetry/app/defaultconfig/merge.go
@@ -25,10 +25,5 @@ func MergeConfigs(dst, src *configmodels.Config) error {
 	if src == nil {
 		return nil
 	}
-	err := mergo.Merge(dst, src,
-		mergo.WithOverride)
-	if err != nil {
-		return err
-	}
-	return nil
+	return mergo.Merge(dst, src, mergo.WithOverride)
 }

--- a/cmd/opentelemetry/app/defaultconfig/testdata/addqueuedprocessor.yaml
+++ b/cmd/opentelemetry/app/defaultconfig/testdata/addqueuedprocessor.yaml
@@ -1,0 +1,7 @@
+processors:
+  queued_retry:
+
+service:
+  pipelines:
+    traces:
+      processors: [batch, queued_retry]


### PR DESCRIPTION
## Which problem is this PR solving?
- Increasing coverage for #2514 

## Short description of the changes
- Added the ability to test the factory returned by CreateDefaultConfig()
- Added the ability to test otelconfigs
- Refactored Merge() to remove an untested line
- Increased coverage on defaultscomponents/defaults

```
jaeger/cmd/opentelemetry/app/defaultconfig (master)$ go test -cover
PASS
coverage: 81.9% of statements
ok  	github.com/jaegertracing/jaeger/cmd/opentelemetry/app/defaultconfig	0.153s

jaeger/cmd/opentelemetry/app/defaultconfig (otel-coverage)$ go test -cover
PASS
coverage: 98.8% of statements
```

```
jaeger/cmd/opentelemetry/app/defaultcomponents (master)$ go test -cover
PASS
coverage: 84.6% of statements

jaeger/cmd/opentelemetry/app/defaultcomponents (otel-coverage)$ go test -cover
PASS
coverage: 100.0% of statements
```
