### PR TITLE
Add URL option for sampling strategies file

### DIFF
--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -207,7 +207,7 @@ func loadUIConfig(uiConfig string) (map[string]interface{}, error) {
 		return nil, nil
 	}
 	ext := filepath.Ext(uiConfig)
-	bytes, err := ioutil.ReadFile(uiConfig) /* nolint #nosec , this comes from an admin, not user */
+	bytes, err := ioutil.ReadFile(filepath.Clean(uiConfig))
 	if err != nil {
 		return nil, fmt.Errorf("cannot read UI config file %v: %w", uiConfig, err)
 	}

--- a/plugin/sampling/strategystore/static/options.go
+++ b/plugin/sampling/strategystore/static/options.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// SamplingStrategiesFile contains the name of CLI opions for config file.
+	// SamplingStrategiesFile contains the name of CLI option for config file.
 	SamplingStrategiesFile           = "sampling.strategies-file"
 	samplingStrategiesReloadInterval = "sampling.strategies-reload-interval"
 )

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -21,7 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
+	"net/http"
+	"net/url"
 	"sync/atomic"
 	"time"
 
@@ -30,6 +31,9 @@ import (
 	ss "github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
 	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
+
+// null represents "null" JSON value.
+const null = "null"
 
 type strategyStore struct {
 	logger *zap.Logger
@@ -45,6 +49,8 @@ type storedStrategies struct {
 	serviceStrategies map[string]*sampling.SamplingStrategyResponse
 }
 
+type strategyLoader func() ([]byte, error)
+
 // NewStrategyStore creates a strategy store that holds static sampling strategies.
 func NewStrategyStore(options Options, logger *zap.Logger) (ss.StrategyStore, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -55,14 +61,15 @@ func NewStrategyStore(options Options, logger *zap.Logger) (ss.StrategyStore, er
 	}
 	h.storedStrategies.Store(defaultStrategies())
 
-	strategies, err := loadStrategies(options.StrategiesFile)
+	loadFn := samplingStrategyLoader(options.StrategiesFile)
+	strategies, err := loadStrategies(loadFn)
 	if err != nil {
 		return nil, err
 	}
 	h.parseStrategies(strategies)
 
 	if options.ReloadInterval > 0 {
-		go h.autoUpdateStrategies(options.ReloadInterval, options.StrategiesFile)
+		go h.autoUpdateStrategies(options.ReloadInterval, loadFn)
 	}
 	return h, nil
 }
@@ -83,35 +90,86 @@ func (h *strategyStore) Close() {
 	h.cancelFunc()
 }
 
-func (h *strategyStore) autoUpdateStrategies(interval time.Duration, filePath string) {
-	lastValue := ""
+func downloadSamplingStrategies(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download sampling strategies: %w", err)
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			return []byte("null"), nil
+		}
+		return nil, fmt.Errorf(
+			"receiving %s while downloading strategies file",
+			resp.Status,
+		)
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err = buf.ReadFrom(resp.Body); err != nil {
+		return nil, fmt.Errorf("failed to read sampling strategies from downloaded JSON: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func isURL(str string) bool {
+	u, err := url.Parse(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+func samplingStrategyLoader(strategiesFile string) strategyLoader {
+	if strategiesFile == "" {
+		return func() ([]byte, error) {
+			// Using null so that it un-marshals to nil pointer.
+			return []byte(null), nil
+		}
+	}
+
+	if isURL(strategiesFile) {
+		return func() ([]byte, error) {
+			return downloadSamplingStrategies(strategiesFile)
+		}
+	}
+
+	return func() ([]byte, error) {
+		currBytes, err := ioutil.ReadFile(strategiesFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open strategies file: %w", err)
+		}
+		return currBytes, nil
+	}
+}
+
+func (h *strategyStore) autoUpdateStrategies(interval time.Duration, loader strategyLoader) {
+	lastValue := null
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			lastValue = h.reloadSamplingStrategyFile(filePath, lastValue)
+			lastValue = h.reloadSamplingStrategy(loader, lastValue)
 		case <-h.ctx.Done():
 			return
 		}
 	}
 }
 
-func (h *strategyStore) reloadSamplingStrategyFile(filePath string, lastValue string) string {
-	currBytes, err := ioutil.ReadFile(filepath.Clean(filePath))
+func (h *strategyStore) reloadSamplingStrategy(loadFn strategyLoader, lastValue string) string {
+	newValue, err := loadFn()
 	if err != nil {
-		h.logger.Error("failed to load sampling strategies", zap.String("file", filePath), zap.Error(err))
+		h.logger.Error("failed to re-load sampling strategies", zap.Error(err))
 		return lastValue
 	}
-	newValue := string(currBytes)
-	if lastValue == newValue {
+	if lastValue == string(newValue) {
 		return lastValue
 	}
-	if err = h.updateSamplingStrategy(currBytes); err != nil {
-		h.logger.Error("failed to update sampling strategies from file", zap.Error(err))
+	if err := h.updateSamplingStrategy(newValue); err != nil {
+		h.logger.Error("failed to update sampling strategies", zap.Error(err))
 		return lastValue
 	}
-	return newValue
+	return string(newValue)
 }
 
 func (h *strategyStore) updateSamplingStrategy(bytes []byte) error {
@@ -125,24 +183,22 @@ func (h *strategyStore) updateSamplingStrategy(bytes []byte) error {
 }
 
 // TODO good candidate for a global util function
-func loadStrategies(strategiesFile string) (*strategies, error) {
-	if strategiesFile == "" {
-		return nil, nil
-	}
-	data, err := ioutil.ReadFile(strategiesFile) /* nolint #nosec , this comes from an admin, not user */
+func loadStrategies(loadFn strategyLoader) (*strategies, error) {
+	strategyBytes, err := loadFn()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open strategies file: %w", err)
+		return nil, err
 	}
-	var strategies strategies
-	if err := json.Unmarshal(data, &strategies); err != nil {
+
+	var strategies *strategies
+	if err := json.Unmarshal(strategyBytes, &strategies); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal strategies: %w", err)
 	}
-	return &strategies, nil
+	return strategies, nil
 }
 
 func (h *strategyStore) parseStrategies(strategies *strategies) {
 	if strategies == nil {
-		h.logger.Info("No sampling strategies provided, using defaults")
+		h.logger.Info("No sampling strategies provided or URL is unavailable, using defaults")
 		return
 	}
 	newStore := defaultStrategies()

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -128,6 +128,7 @@ func TestStrategyStoreWithURL(t *testing.T) {
 	logger, buf := testutils.NewLogger()
 	mockServer, _ := mockStrategyServer()
 	store, err := NewStrategyStore(Options{StrategiesFile: mockServer.URL + "/service-unavailable"}, logger)
+	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No sampling strategies provided or URL is unavailable, using defaults")
 	s, err := store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
@@ -482,5 +483,6 @@ func TestSamplingStrategyLoader(t *testing.T) {
 	// should download content from URL
 	loader = samplingStrategyLoader(mockServer.URL + "/bad-content")
 	content, err := loader()
+	require.NoError(t, err)
 	assert.Equal(t, "bad-content", string(content))
 }

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -66,7 +66,7 @@ func mockStrategyServer() *httptest.Server {
 
 func TestStrategyStore(t *testing.T) {
 	_, err := NewStrategyStore(Options{StrategiesFile: "fileNotFound.json"}, zap.NewNop())
-	assert.EqualError(t, err, "failed to open strategies file: open fileNotFound.json: no such file or directory")
+	assert.EqualError(t, err, "failed to read strategies file fileNotFound.json: open fileNotFound.json: no such file or directory")
 
 	_, err = NewStrategyStore(Options{StrategiesFile: "fixtures/bad_strategies.json"}, zap.NewNop())
 	assert.EqualError(t, err,
@@ -450,7 +450,7 @@ func TestSamplingStrategyLoader(t *testing.T) {
 	// invalid file path
 	loader := samplingStrategyLoader("not-exists")
 	_, err := loader()
-	assert.Contains(t, err.Error(), "failed to open strategies file")
+	assert.Contains(t, err.Error(), "failed to read strategies file not-exists")
 
 	// status code other than 200
 	mockServer := mockStrategyServer()

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -387,26 +387,8 @@ func TestAutoUpdateStrategyWithURL(t *testing.T) {
 	assert.Equal(t, string(strategiesJSON), value)
 
 	// update original strategies with new probability of 0.9
-	strategiesJSON = []byte(`
-	{
-		"default_strategy": {
-		  "type": "probabilistic",
-		  "param": 0.5
-		},
-		"service_strategies": [
-		  {
-			"service": "foo",
-			"type": "probabilistic",
-			"param": 0.9
-		  },
-		  {
-			"service": "bar",
-			"type": "ratelimiting",
-			"param": 5
-		  }
-		]
-	  }  
-	`)
+	newStrategies := strings.Replace(string(strategiesJSON), "0.8", "0.9", 1)
+	strategiesJSON = []byte(newStrategies)
 
 	// wait for reload timer
 	for i := 0; i < 1000; i++ { // wait up to 1sec


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolve #2015 

## Short description of the changes
- Added a URL option to support downloading a sampling strategies file from a url.
