### PR TITLE
Fix max-num-spans flag's usage message

### DIFF
--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -179,9 +179,9 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 	flagSet.Int(
 		nsConfig.namespace+suffixMaxNumSpans,
 		nsConfig.MaxDocCount,
-		"(deprecated, will be removed in release v1.21.0. Please use es.max-doc-count). "+
+		"(deprecated, will be removed in release v1.21.0. Please use "+nsConfig.namespace+".max-doc-count). "+
 			"The maximum number of spans to fetch at a time per query in Elasticsearch. "+
-			"The lesser of es.max-num-spans and es.max-doc-count will be used if both are set.")
+			"The lesser of "+nsConfig.namespace+".max-num-spans and "+nsConfig.namespace+".max-doc-count will be used if both are set.")
 	flagSet.Int64(
 		nsConfig.namespace+suffixNumShards,
 		nsConfig.NumShards,

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -96,6 +96,33 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "test,tags", aux.Tags.Include)
 }
 
+func TestMaxNumSpansUsage(t *testing.T) {
+	testCases := []struct {
+		namespace string
+		wantUsage string
+	}{
+		{
+			namespace: "es",
+			wantUsage: "(deprecated, will be removed in release v1.21.0. Please use es.max-doc-count). " +
+				"The maximum number of spans to fetch at a time per query in Elasticsearch. " +
+				"The lesser of es.max-num-spans and es.max-doc-count will be used if both are set.",
+		},
+		{
+			namespace: "es-archive",
+			wantUsage: "(deprecated, will be removed in release v1.21.0. Please use es-archive.max-doc-count). " +
+				"The maximum number of spans to fetch at a time per query in Elasticsearch. " +
+				"The lesser of es-archive.max-num-spans and es-archive.max-doc-count will be used if both are set.",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.namespace, func(t *testing.T) {
+			opts := NewOptions(tc.namespace)
+			_, command := config.Viperize(opts.AddFlags)
+			assert.Equal(t, tc.wantUsage, command.Flag(tc.namespace+".max-num-spans").Usage)
+		})
+	}
+}
+
 func TestMaxDocCount(t *testing.T) {
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Closes #2526

## Short description of the changes
- Replaces the hard-coded namespace with the provided namespaceConfig's.
- Write test to fail usage message assertions and pass after applying fixes to `options.go`.
