### PR TITLE
Remove Go report card

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1273/badge)](https://bestpractices.coreinfrastructure.org/projects/1273)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jaegertracing/jaeger?style=flat-square)](https://goreportcard.com/report/github.com/jaegertracing/jaeger)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go#performance)
 [![OpenTracing-1.0][ot-badge]](https://opentracing.io)
 


### PR DESCRIPTION
The way this service works does not allow for investigation of the issues that it raises. Since most of those are just linters anyway, we'd be better off running the actual linters, e.g. #2503, #538.

