### PR TITLE
OTel Cassandra/Elasticsearch Exporter queue defaults

### DIFF
--- a/cmd/opentelemetry/app/exporter/cassandraexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/cassandraexporter/factory.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
+	collector_app "github.com/jaegertracing/jaeger/cmd/collector/app"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 )
 
@@ -54,6 +55,10 @@ func (Factory) Type() configmodels.Type {
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 	opts := f.OptionsFactory()
+	queueSettings := exporterhelper.CreateDefaultQueueSettings()
+	queueSettings.NumConsumers = collector_app.DefaultNumWorkers
+	queueSettings.QueueSize = collector_app.DefaultQueueSize
+
 	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
 			TypeVal: TypeStr,
@@ -61,7 +66,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 		},
 		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
 		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
-		QueueSettings:   exporterhelper.CreateDefaultQueueSettings(),
+		QueueSettings:   queueSettings,
 		Options:         *opts,
 	}
 }

--- a/cmd/opentelemetry/app/exporter/cassandraexporter/factory_test.go
+++ b/cmd/opentelemetry/app/exporter/cassandraexporter/factory_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
 
+	collector_app "github.com/jaegertracing/jaeger/cmd/collector/app"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 )
@@ -44,6 +45,9 @@ func TestCreateTraceExporter(t *testing.T) {
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{OptionsFactory: DefaultOptions}
 	cfg := factory.CreateDefaultConfig()
+
+	assert.Equal(t, collector_app.DefaultNumWorkers, cfg.(*Config).NumConsumers)
+	assert.Equal(t, collector_app.DefaultQueueSize, cfg.(*Config).QueueSize)
 	assert.NotNil(t, cfg, "failed to create default config")
 	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
+	collector_app "github.com/jaegertracing/jaeger/cmd/collector/app"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 )
 
@@ -54,6 +55,10 @@ var _ component.ExporterFactory = (*Factory)(nil)
 // CreateDefaultConfig returns default configuration of Factory.
 // This function implements OTEL component.ExporterFactoryBase interface.
 func (f Factory) CreateDefaultConfig() configmodels.Exporter {
+	queueSettings := exporterhelper.CreateDefaultQueueSettings()
+	queueSettings.NumConsumers = collector_app.DefaultNumWorkers
+	queueSettings.QueueSize = collector_app.DefaultQueueSize
+
 	opts := f.OptionsFactory()
 	return &Config{
 		ExporterSettings: configmodels.ExporterSettings{
@@ -62,7 +67,7 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 		},
 		TimeoutSettings: exporterhelper.CreateDefaultTimeoutSettings(),
 		RetrySettings:   exporterhelper.CreateDefaultRetrySettings(),
-		QueueSettings:   exporterhelper.CreateDefaultQueueSettings(),
+		QueueSettings:   queueSettings,
 		Options:         *opts,
 	}
 }

--- a/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory_test.go
+++ b/cmd/opentelemetry/app/exporter/elasticsearchexporter/factory_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.uber.org/zap"
 
+	collector_app "github.com/jaegertracing/jaeger/cmd/collector/app"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 )
@@ -61,6 +62,9 @@ func TestCreateMetricsExporter(t *testing.T) {
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{OptionsFactory: DefaultOptions}
 	cfg := factory.CreateDefaultConfig()
+	assert.Equal(t, collector_app.DefaultNumWorkers, cfg.(*Config).NumConsumers)
+	assert.Equal(t, collector_app.DefaultQueueSize, cfg.(*Config).QueueSize)
+
 	assert.NotNil(t, cfg, "failed to create default config")
 	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }


### PR DESCRIPTION
## Which problem is this PR solving?
While working on #2494 I discovered that the default otel config was pushing far less spans/second to my Scylla backend.  After some research it was discovered that it's b/c the default otel collector config only has 10 workers while the default jaeger collector config has 50.

## Short description of the changes
This PR uses the default collector queue settings for both the cassandra and elasticsearch exporters' queue settings.  These are the two "production" exporters supported

This does bring up another concern that might make sense to discuss as part of this issue.  By default the ingester pulls from the Kafka queue and immediately pushes its spans into the configured backend, but a no-queue configuration of the otel collector does not seem possible at the moment.  The queue can technically be disabled but performance is abysmal.  This requires more research.

There are certainly other ways to approach "fixing" this.  Including leaving it alone and making the user change the configuration.