### PR TITLE
README.md: Point to operator under deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ of routing the traffic from Zipkin libraries to the Jaeger backend.
 
 ### Deployment
 
-  * [Kubernetes templates](https://github.com/jaegertracing/jaeger-kubernetes)
-  * [OpenShift templates](https://github.com/jaegertracing/jaeger-openshift)
+  * [Jaeger Operator for Kubernetes](https://github.com/jaegertracing/jaeger-operator#getting-started)
 
 ### Components
 


### PR DESCRIPTION
## Which problem is this PR solving?

Right now the README points to a deprecated repo which then redirects you the
operator project.


