### PR TITLE
Adding missing build instruction #1887

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Then install dependencies and run the tests:
 git submodule update --init --recursive
 make install-tools
 make test
+#if you wish to build platform binaries locally - the step below is needed.
+make build-ui
 ```
 
 ### Running local build with the UI


### PR DESCRIPTION
Adding missing build instruction that allows jaeger binaries to be built.