### PR TITLE
Update static UI assets path in contrib doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ $ go run -tags ui ./cmd/all-in-one/main.go
 Alternatively, the path to the built UI assets can be provided via `--query.static-files` flag:
 
 ```
-$ go run ./cmd/all-in-one/main.go --query.static-files jaeger-ui/build
+$ go run ./cmd/all-in-one/main.go --query.static-files jaeger-ui/packages/jaeger-ui/build
 ```
 
 ## Project Structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,22 +30,14 @@ Then install dependencies and run the tests:
 git submodule update --init --recursive
 make install-tools
 make test
-#if you wish to build platform binaries locally - the step below is needed.
+# if you wish to build platform binaries locally - the step below is needed.
 make build-ui
 ```
 
 ### Running local build with the UI
 
-The `jaeger-ui` submodule contains the source code for the UI assets (requires Node.js 6+). The assets must be compiled first with `make build-ui`, which runs Node.js build and then packages the assets into a Go file that is `.gitignore`-ed. The packaged assets can be enabled by providing a build tag `ui`, e.g.:
-
 ```
-$ go run -tags ui ./cmd/all-in-one/main.go
-```
-
-Alternatively, the path to the built UI assets can be provided via `--query.static-files` flag:
-
-```
-$ go run ./cmd/all-in-one/main.go --query.static-files jaeger-ui/packages/jaeger-ui/build
+$ make run-all-in-one
 ```
 
 ## Project Structure


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Following the instruction from the CONTRIBUTING.md file results in a "no such file or directory" error when trying to fetch static UI assets:

```
$ go run ./cmd/all-in-one/main.go --query.static-files jaeger-ui/packages

"Could not create static assets handler","error":"cannot load index.html: cannot open index.html: open jaeger-ui/build/index.html: no such file or directory"
```

## Short description of the changes
The `Makefile` appears to copy the static UI assets into `jaeger-ui/packages/jaeger-ui/build` instead. See: https://github.com/jaegertracing/jaeger/blob/master/Makefile#L234

Changing the command to the correct path as specified in the `build-ui` `Makefile` target results in the all-in-one running successfully:
```
$ go run ./cmd/all-in-one/main.go --query.static-files jaeger-ui/packages/jaeger-ui/build 
```