### PR TITLE
Replaced devbots with issue-labeler

### DIFF
--- a/.devbots/needs-triage.yml
+++ b/.devbots/needs-triage.yml
@@ -1,2 +1,0 @@
-enabled: true
-label: "needs-triage"

--- a/.github/labeler-needs-triage.yaml
+++ b/.github/labeler-needs-triage.yaml
@@ -1,0 +1,3 @@
+# Add 'needs-triage' label to all new issues
+needs-triage:
+    - '.*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Add needs-triage to new issues"
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler-needs-triage.yaml
+        enable-versioned-regex: 0


### PR DESCRIPTION
The bot that used to add the 'needs-triage' label to new issues stopped working and I can't figure out why. Looks like GitHub has a more official action that does something similar, so, this PR is replacing the 'devbots' with the issue-labeler.

See https://github.com/jaegertracing/jaeger-operator/pull/1251

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
