### PR TITLE
Disable OTLP and gRPC for OTEL-based agent

### DIFF
--- a/cmd/opentelemetry/app/defaultconfig/default_config_test.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config_test.go
@@ -56,7 +56,7 @@ func TestService(t *testing.T) {
 				Pipelines: configmodels.Pipelines{
 					"traces": &configmodels.Pipeline{
 						InputType:  configmodels.TracesDataType,
-						Receivers:  []string{"otlp", "jaeger"},
+						Receivers:  []string{"jaeger"},
 						Processors: []string{"batch"},
 						Exporters:  []string{"jaeger"},
 					},
@@ -90,7 +90,7 @@ func TestService(t *testing.T) {
 					"traces": &configmodels.Pipeline{
 						Name:       "traces",
 						InputType:  configmodels.TracesDataType,
-						Receivers:  []string{"otlp", "jaeger"},
+						Receivers:  []string{"jaeger"},
 						Processors: []string{"batch", "queued_retry"},
 						Exporters:  []string{"jaeger"},
 					},


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #2568

## Short description of the changes
- Changes the builder to not create a gRPC configuration when the component type is "Agent".
- Do not add OTLP as receiver when the component type is "Agent".

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>


