### PR TITLE
Add auth support for collector

### DIFF
--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -40,6 +40,8 @@ type ConnBuilder struct {
 	MaxRetry uint
 	TLS      tlscfg.Options
 
+	BearerToken string
+
 	DiscoveryMinPeers int
 	Notifier          discovery.Notifier
 	Discoverer        discovery.Discoverer

--- a/cmd/agent/app/reporter/grpc/flags.go
+++ b/cmd/agent/app/reporter/grpc/flags.go
@@ -31,7 +31,7 @@ const (
 	discoveryMinPeers = gRPCPrefix + ".discovery.min-peers"
 
 	// auth options
-	authBearerToken = "auth.bearer.token"
+	authBearerToken = "auth.bearer.token" // #nosec , we are not really storing a token here ;)
 )
 
 var tlsFlagsConfig = tlscfg.ClientFlagsConfig{

--- a/cmd/agent/app/reporter/grpc/flags.go
+++ b/cmd/agent/app/reporter/grpc/flags.go
@@ -50,7 +50,7 @@ func AddFlags(flags *flag.FlagSet) {
 // AddOTELFlags adds flags that are exposed by OTEL collector
 func AddOTELFlags(flags *flag.FlagSet) {
 	flags.String(collectorHostPort, "", "Comma-separated string representing host:port of a static list of collectors to connect to directly")
-	flags.String(authBearerToken, "", "which bearer token to use for every call to the collector")
+	flags.String(authBearerToken, "", "Which bearer token to use for every call to the collector")
 	tlsFlagsConfig.AddFlags(flags)
 }
 

--- a/cmd/agent/app/reporter/grpc/flags.go
+++ b/cmd/agent/app/reporter/grpc/flags.go
@@ -29,6 +29,9 @@ const (
 	retry             = gRPCPrefix + ".retry.max"
 	defaultMaxRetry   = 3
 	discoveryMinPeers = gRPCPrefix + ".discovery.min-peers"
+
+	// auth options
+	authBearerToken = "auth.bearer.token"
 )
 
 var tlsFlagsConfig = tlscfg.ClientFlagsConfig{
@@ -47,6 +50,7 @@ func AddFlags(flags *flag.FlagSet) {
 // AddOTELFlags adds flags that are exposed by OTEL collector
 func AddOTELFlags(flags *flag.FlagSet) {
 	flags.String(collectorHostPort, "", "Comma-separated string representing host:port of a static list of collectors to connect to directly")
+	flags.String(authBearerToken, "", "which bearer token to use for every call to the collector")
 	tlsFlagsConfig.AddFlags(flags)
 }
 
@@ -59,5 +63,10 @@ func (b *ConnBuilder) InitFromViper(v *viper.Viper) *ConnBuilder {
 	b.MaxRetry = uint(v.GetInt(retry))
 	b.TLS = tlsFlagsConfig.InitFromViper(v)
 	b.DiscoveryMinPeers = v.GetInt(discoveryMinPeers)
+
+	if v.IsSet(authBearerToken) {
+		b.BearerToken = v.GetString(authBearerToken)
+	}
+
 	return b
 }

--- a/cmd/agent/app/reporter/grpc/flags_test.go
+++ b/cmd/agent/app/reporter/grpc/flags_test.go
@@ -35,6 +35,8 @@ func TestBindFlags(t *testing.T) {
 			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111", "localhost:2222"}, MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 3}},
 		{cOpts: []string{"--reporter.grpc.host-port=localhost:1111,localhost:2222", "--reporter.grpc.discovery.min-peers=5"},
 			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111", "localhost:2222"}, MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 5}},
+		{cOpts: []string{"--auth.bearer.token=some-token"},
+			expected: &ConnBuilder{BearerToken: "some-token", MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 3}},
 	}
 	for _, test := range tests {
 		v := viper.New()

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -115,7 +115,7 @@ func AddOTELJaegerFlags(flags *flag.FlagSet) {
 	flags.String(authOIDCIssuerURL, "", "the OpenID Connect server to validate the incoming auth tokens")
 	flags.String(authOIDCIssuerCAPath, "", "the path to the issuer's CA")
 	flags.String(authOIDCClientID, "", "this Jaeger's client ID")
-	flags.String(authOIDCUsernameClaim, "", "the username claim in the token, in case the 'sub' field shouldn't be used")
+	flags.String(authOIDCUsernameClaim, "", "the claim in the token that should be used for the username instead of the default 'sub' field")
 	flags.String(authOIDCGroupsClaim, "", "the claim containing the group membership, where each group is considered a tenant. When absent, multi-tenancy is disabled.")
 
 	tlsFlagsConfig.AddFlags(flags)

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -42,6 +42,13 @@ const (
 	collectorZipkinAllowedOrigins = "collector.zipkin.allowed-origins"
 	collectorZipkinAllowedHeaders = "collector.zipkin.allowed-headers"
 
+	// used in the receiver side (collector)
+	authOIDCIssuerURL     = "collector.auth.oidc.issuer-url"
+	authOIDCClientID      = "collector.auth.oidc.client-id"
+	authOIDCIssuerCAPath  = "collector.auth.oidc.issuer-ca-path"
+	authOIDCUsernameClaim = "collector.auth.oidc.username-claim"
+	authOIDCGroupsClaim   = "collector.auth.oidc.groups-claim"
+
 	collectorHTTPPortWarning       = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
 	collectorGRPCPortWarning       = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
 	collectorZipkinHTTPPortWarning = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
@@ -75,6 +82,13 @@ type CollectorOptions struct {
 	CollectorZipkinAllowedOrigins string
 	// CollectorZipkinAllowedHeaders is a list of headers that the Zipkin collector service allowes the client to use with cross-domain requests
 	CollectorZipkinAllowedHeaders string
+
+	// auth options
+	AuthOIDCIssuerURL     string
+	AuthOIDCIssuerCAPath  string
+	AuthOIDCClientID      string
+	AuthOIDCUsernameClaim string
+	AuthOIDCGroupsClaim   string
 }
 
 // AddFlags adds flags for CollectorOptions
@@ -96,6 +110,14 @@ func AddFlags(flags *flag.FlagSet) {
 func AddOTELJaegerFlags(flags *flag.FlagSet) {
 	flags.String(CollectorHTTPHostPort, ports.PortToHostPort(ports.CollectorHTTP), "The host:port (e.g. 127.0.0.1:14268 or :14268) of the collector's HTTP server")
 	flags.String(CollectorGRPCHostPort, ports.PortToHostPort(ports.CollectorGRPC), "The host:port (e.g. 127.0.0.1:14250 or :14250) of the collector's GRPC server")
+
+	// auth-related flags
+	flags.String(authOIDCIssuerURL, "", "the OpenID Connect server to validate the incoming auth tokens")
+	flags.String(authOIDCIssuerCAPath, "", "the path to the issuer's CA")
+	flags.String(authOIDCClientID, "", "this Jaeger's client ID")
+	flags.String(authOIDCUsernameClaim, "", "the username claim in the token, in case the 'sub' field shouldn't be used")
+	flags.String(authOIDCGroupsClaim, "", "the claim containing the group membership, where each group is considered a tenant. When absent, multi-tenancy is disabled.")
+
 	tlsFlagsConfig.AddFlags(flags)
 }
 
@@ -116,6 +138,13 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
 	cOpts.CollectorZipkinAllowedOrigins = v.GetString(collectorZipkinAllowedOrigins)
 	cOpts.CollectorZipkinAllowedHeaders = v.GetString(collectorZipkinAllowedHeaders)
 	cOpts.TLS = tlsFlagsConfig.InitFromViper(v)
+
+	// auth
+	cOpts.AuthOIDCIssuerURL = v.GetString(authOIDCIssuerURL)
+	cOpts.AuthOIDCIssuerCAPath = v.GetString(authOIDCIssuerCAPath)
+	cOpts.AuthOIDCClientID = v.GetString(authOIDCClientID)
+	cOpts.AuthOIDCUsernameClaim = v.GetString(authOIDCUsernameClaim)
+	cOpts.AuthOIDCGroupsClaim = v.GetString(authOIDCGroupsClaim)
 
 	return cOpts
 }

--- a/cmd/collector/app/builder_flags_test.go
+++ b/cmd/collector/app/builder_flags_test.go
@@ -51,3 +51,22 @@ func TestCollectorOptionsWithFlags_CheckFullHostPort(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:1234", c.CollectorGRPCHostPort)
 	assert.Equal(t, "0.0.0.0:3456", c.CollectorZipkinHTTPHostPort)
 }
+
+func TestCollectorAuthOptions(t *testing.T) {
+	c := &CollectorOptions{}
+	v, command := config.Viperize(AddFlags)
+	command.ParseFlags([]string{
+		"--collector.auth.oidc.issuer-url=https://example.com/",
+		"--collector.auth.oidc.client-id=http://jaeger.example.com",
+		"--collector.auth.oidc.issuer-ca-path=/path/to/ca.pem",
+		"--collector.auth.oidc.username-claim=username",
+		"--collector.auth.oidc.groups-claim=memberships",
+	})
+	c.InitFromViper(v)
+
+	assert.Equal(t, "https://example.com/", c.AuthOIDCIssuerURL)
+	assert.Equal(t, "http://jaeger.example.com", c.AuthOIDCClientID)
+	assert.Equal(t, "/path/to/ca.pem", c.AuthOIDCIssuerCAPath)
+	assert.Equal(t, "username", c.AuthOIDCUsernameClaim)
+	assert.Equal(t, "memberships", c.AuthOIDCGroupsClaim)
+}

--- a/cmd/opentelemetry/app/exporter/jaegerexporter/jaeger_exporter.go
+++ b/cmd/opentelemetry/app/exporter/jaegerexporter/jaeger_exporter.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/exporter/jaegerexporter"
 
@@ -55,6 +56,13 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 	cfg.GRPCClientSettings.TLSSetting.CertFile = repCfg.TLS.CertPath
 	cfg.GRPCClientSettings.TLSSetting.KeyFile = repCfg.TLS.KeyPath
 	cfg.GRPCClientSettings.TLSSetting.ServerName = repCfg.TLS.ServerName
+	if len(repCfg.BearerToken) > 0 {
+		cfg.GRPCClientSettings.PerRPCAuth = &configgrpc.PerRPCAuthConfig{
+			AuthType:    "bearer",
+			BearerToken: repCfg.BearerToken,
+		}
+	}
+
 	return cfg
 }
 

--- a/cmd/opentelemetry/app/receiver/jaegerreceiver/jaeger_receiver.go
+++ b/cmd/opentelemetry/app/receiver/jaegerreceiver/jaeger_receiver.go
@@ -113,7 +113,8 @@ func configureCollector(v *viper.Viper, cfg *jaegerreceiver.Config) {
 		}
 	}
 
-	// if at least one option is set, we assume they
+	// if at least one option is set, we assume they are all provided and let
+	// the underlying mechanism to handle missing values
 	if cfg.GRPC != nil && len(cOpts.AuthOIDCIssuerURL) > 0 {
 		// TODO: how can we log a warning if the user fails to specify a conditionally required flag?
 		// if authOIDCIssuerURL is set, authOIDCClientID has to be set as well (and vice-versa).

--- a/cmd/opentelemetry/go.mod
+++ b/cmd/opentelemetry/go.mod
@@ -5,6 +5,7 @@ go 1.14
 replace github.com/jaegertracing/jaeger => ./../../
 
 require (
+	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/Shopify/sarama v1.27.0
 	github.com/elastic/go-elasticsearch/v6 v6.8.10
 	github.com/elastic/go-elasticsearch/v7 v7.0.0

--- a/cmd/opentelemetry/go.sum
+++ b/cmd/opentelemetry/go.sum
@@ -219,6 +219,7 @@ github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70d
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -642,6 +643,7 @@ github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.3 h1:AVF6JDQQens6nMHT9OGERBvK0f8rPrAGILnsKLr6lzM=
 github.com/hashicorp/serf v0.9.3/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d h1:W+SIwDdl3+jXWeidYySAgzytE3piq6GumXeBjFBG67c=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
## Which problem is this PR solving?
- The first step towards the multi-tenancy solution: add auth support for both agent and collector.

## Short description of the changes
- This change uses the OpenTelemetry Collector support for OIDC authentication: on the client side (agent), we send a token with every RPC call. On the server side (collector), we verify this token against a OIDC server. On our side (Jaeger), all we have to do is configure the gRPC client/server settings.
- Because of a combination of issues (#2565 and #2566), this can only be tested with the Jaeger Agent from this PR against an OpenTelemetry Collector with a Jaeger Receiver, and with the OpenTelemetry Collector with Jaeger exporter sending data to the Jaeger Collector from this PR. For testing, #2568 will also be needed.

### Testing the Agent part from this PR

Start the OpenTelemetry Collector with this configuration:

```yaml
receivers:
  jaeger:
    protocols:
      grpc:
        tls_settings:
          cert_file: ./local/self-signed.pem
          key_file: ./local/self-signed-key.pem
        auth:
          oidc:
            issuer_url: https://dev-zkkhf874.eu.auth0.com/
            audience: http://auth.example.com

exporters:
  logging:

service:
  pipelines:
    traces:
      receivers:
        - jaeger
      processors: []
      exporters:
        - logging
```

And the agent from this PR with the following flags:

"--auth.bearer.token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImxiWmJrd2JHUXlrWGdub09mRXNRNCJ9.eyJpc3MiOiJodHRwczovL2Rldi16a2toZjg3NC5ldS5hdXRoMC5jb20vIiwic3ViIjoiMUpEUmZJMm43c0JhNnhvMkQ2VEJSVnpjbGs5M25uVUZAY2xpZW50cyIsImF1ZCI6Imh0dHA6Ly9hdXRoLmV4YW1wbGUuY29tIiwiaWF0IjoxNjAyNzU0NDU0LCJleHAiOjE2MDI4NDA4NTQsImF6cCI6IjFKRFJmSTJuN3NCYTZ4bzJENlRCUlZ6Y2xrOTNublVGIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.R128iWgn68uW_dPOifsYSRI2Yon4_CU-8E8gJeAvoIVQCka3u0S5RZ8C_I8zvLjdcuKePO9PjOp2vh9VcntXAZtc0II3D_K-fAXEsYE6aVM5taJFXnNwb7UAje0yfvMChXTVHfjcJkW8c-i3OrilJ9Ab-8ZSLDaR_a6cuT2c8BGj57tmDV2sWVJwe-dUCOzIPdwocQNK-pC9RsDTyq2uUMpqTRulyKlp51u2PtLd7tBjW1yZokoZcAlsVb4dJm4ZCutYZ4_tkeYSojZKw6JhhSDxcKvTAY4Y7nrMh2pGgjZbll1yzlsL1TyvD0PUWwM24wlDln5O0l4nU1Dzw6F8Wg", 
"--reporter.grpc.host-port=localhost:14250",
"--reporter.grpc.tls.enabled=true",
"--reporter.grpc.tls.ca=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/local/ca.pem",

Finally, send a trace with, for instance, Jaeger's tracegen: 

```console
$ go run ./cmd/tracegen/ -traces 1 
```

### Testing the Collector part of this PR

Start the Jaeger Collector with the following flags:

"--collector.auth.oidc.client-id=http://auth.example.com", 
"--collector.auth.oidc.issuer-url=https://dev-zkkhf874.eu.auth0.com/", 
"--collector.grpc.tls.cert=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/local/self-signed.pem", 
"--collector.grpc.tls.key=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/local/self-signed-key.pem", 
"--collector.grpc.tls.enabled=true",

And an OpenTelemetry Collector with this config:

```yaml
receivers:
  otlp/noauth:
    protocols:
      grpc:
        endpoint: localhost:56680

exporters:
  jaeger/auth:
    endpoint: localhost:14250
    ca_file: ./local/ca.pem
    per_rpc_auth:
      type: bearer
      bearer_token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImxiWmJrd2JHUXlrWGdub09mRXNRNCJ9.eyJpc3MiOiJodHRwczovL2Rldi16a2toZjg3NC5ldS5hdXRoMC5jb20vIiwic3ViIjoiMUpEUmZJMm43c0JhNnhvMkQ2VEJSVnpjbGs5M25uVUZAY2xpZW50cyIsImF1ZCI6Imh0dHA6Ly9hdXRoLmV4YW1wbGUuY29tIiwiaWF0IjoxNjAyNzU0NDU0LCJleHAiOjE2MDI4NDA4NTQsImF6cCI6IjFKRFJmSTJuN3NCYTZ4bzJENlRCUlZ6Y2xrOTNublVGIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.R128iWgn68uW_dPOifsYSRI2Yon4_CU-8E8gJeAvoIVQCka3u0S5RZ8C_I8zvLjdcuKePO9PjOp2vh9VcntXAZtc0II3D_K-fAXEsYE6aVM5taJFXnNwb7UAje0yfvMChXTVHfjcJkW8c-i3OrilJ9Ab-8ZSLDaR_a6cuT2c8BGj57tmDV2sWVJwe-dUCOzIPdwocQNK-pC9RsDTyq2uUMpqTRulyKlp51u2PtLd7tBjW1yZokoZcAlsVb4dJm4ZCutYZ4_tkeYSojZKw6JhhSDxcKvTAY4Y7nrMh2pGgjZbll1yzlsL1TyvD0PUWwM24wlDln5O0l4nU1Dzw6F8Wg

service:
  pipelines:
    traces:
      receivers:
        - otlp/noauth
      processors: []
      exporters:
        - jaeger/auth
```

And finally, send a trace with, for instance, OpenTelemetry's tracegen:

```console
$ go run . -otlp-endpoint localhost:56680 -otlp-insecure -traces 1 
```

### Negative tests

Just change the bearer token to something else in either of the cases.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
