### PR TITLE
Improve `build-ui` Makefile target and fix dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,6 @@ Then install dependencies and run the tests:
 git submodule update --init --recursive
 make install-tools
 make test
-# if you wish to build platform binaries locally - the step below is needed.
-make build-ui
 ```
 
 ### Running local build with the UI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,13 @@ cd jaeger
 Then install dependencies and run the tests:
 
 ```
+# Adds the jaeger-ui submodule
 git submodule update --init --recursive
+
+# Installs required tools
 make install-tools
+
+# Runs all unit tests
 make test
 ```
 
@@ -37,6 +42,23 @@ make test
 ```
 $ make run-all-in-one
 ```
+
+#### What does this command do?
+
+The `jaeger-ui` submodule, which was added from the Pre-requisites step above, contains
+the source code for the UI assets (requires Node.js 6+).
+
+The assets must be compiled first with `make build-ui`, which runs Node.js build and then
+packages the assets into a Go file that is `.gitignore`-ed.
+
+The packaged assets can be enabled by providing a build tag `ui`, for example:
+
+```
+$ go run -tags ui ./cmd/all-in-one/main.go
+```
+
+`make run-all-in-one` essentially runs Jaeger all-in-one by combining both of the above
+steps into a single `make` command.
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -229,13 +229,6 @@ run-all-in-one: build-ui
 .PHONY: build-ui
 build-ui: cmd/query/app/ui/actual/gen_assets.go cmd/query/app/ui/placeholder/gen_assets.go
 	# Do nothing. If you need to force a rebuild of UI assets, run `make clean`.
-	#
-	# The `jaeger-ui` submodule contains the source code for the UI assets (requires Node.js 6+).
-	# The assets must be compiled first with `make build-ui`, which runs Node.js build and then
-	# packages the assets into a Go file that is `.gitignore`-ed.
-	#
-	# The packaged assets can be enabled by providing a build tag `ui`; for example:
-	# $ go run -tags ui ./cmd/all-in-one/main.go
 
 jaeger-ui/packages/jaeger-ui/build/index.html:
 	cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ md-to-godoc-gen:
 .PHONY: clean
 clean:
 	rm -rf cover.out .cover/ cover.html lint.log fmt.log \
-		cmd/query/app/ui/actual/gen_assets.go
+		jaeger-ui/packages/jaeger-ui/build
 
 .PHONY: test
 test: go-gen test-otel
@@ -226,25 +226,16 @@ docker-hotrod:
 run-all-in-one: build-ui
 	go run -tags ui ./cmd/all-in-one --log-level debug
 
-# Be explicit about exactly what assets we want, as asset files could be partially deleted
-# after initial generation; which is the case in Travis CI builds (DOCKER + DEPLOY).
-EXPECT_ASSETS := cmd/query/app/ui/actual/gen_assets.go \
-                 cmd/query/app/ui/placeholder/gen_assets.go
-FOUND_ASSETS := $(wildcard $(EXPECT_ASSETS))
 .PHONY: build-ui
 build-ui: cmd/query/app/ui/actual/gen_assets.go cmd/query/app/ui/placeholder/gen_assets.go
+	# Do nothing. If you need to force a rebuild of UI assets, run `make clean`.
+	#
 	# The `jaeger-ui` submodule contains the source code for the UI assets (requires Node.js 6+).
 	# The assets must be compiled first with `make build-ui`, which runs Node.js build and then
 	# packages the assets into a Go file that is `.gitignore`-ed.
 	#
 	# The packaged assets can be enabled by providing a build tag `ui`; for example:
 	# $ go run -tags ui ./cmd/all-in-one/main.go
-	#
-	# To reduce `build-ui` execution times, no work will be done if the resulting UI assets exist.
-	# These expected assets are cmd/query/app/ui/(actual|placeholder)/gen_assets.go.
-	#
-	# To force a rebuild of UI assets, run `make clean` which deletes any files matching the
-	# above glob pattern.
 
 jaeger-ui/packages/jaeger-ui/build/index.html:
 	cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build

--- a/Makefile
+++ b/Makefile
@@ -369,6 +369,8 @@ include crossdock/rules.mk
 # Crossdock tests do not require fully functioning UI, so we skip it to speed up the build.
 .PHONY: build-crossdock-ui-placeholder
 build-crossdock-ui-placeholder:
+	mkdir -p jaeger-ui/packages/jaeger-ui/build/
+	cp cmd/query/app/ui/placeholder/public/index.html jaeger-ui/packages/jaeger-ui/build/index.html
 	mkdir -p cmd/query/app/ui/actual
 	[ -e cmd/query/app/ui/actual/gen_assets.go ] || cp cmd/query/app/ui/placeholder/gen_assets.go cmd/query/app/ui/actual/gen_assets.go
 

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ run-all-in-one:
 
 .PHONY: build-ui
 build-ui:
+	git submodule update --init --recursive
 	cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build
 	esc -pkg assets -o cmd/query/app/ui/actual/gen_assets.go -prefix jaeger-ui/packages/jaeger-ui/build jaeger-ui/packages/jaeger-ui/build
 	esc -pkg assets -o cmd/query/app/ui/placeholder/gen_assets.go -prefix cmd/query/app/ui/placeholder/public cmd/query/app/ui/placeholder/public
@@ -244,7 +245,7 @@ build-agent:
 	$(GOBUILD) -o ./cmd/agent/agent-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/agent/main.go
 
 .PHONY: build-query
-build-query:
+build-query: build-ui
 	$(GOBUILD) -tags ui -o ./cmd/query/query-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/query/main.go
 
 .PHONY: build-collector


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #2572

## Short description of the changes
- Remove `build-ui` step from CONTRIBUTING.md as it's automated by Makefile.
- Add UI asset files in `clean` target to enable rebuilding of UI assets.
- Reinstate the explanation of what `build-ui` does under the hood into the Makefile under its namesake, which was deleted in #2548.
- `build-ui` target dependency should _only_ be used for builds that use `-tags ui` (remove from `docker` and `build-all-in-one-linux` targets).
- Make `build-ui` target idempotent by explicitly checking for the UI assets files' existence. If all expected files exist, do nothing. Otherwise, regenerate UI asset files.
