### PR TITLE
TBufferedServer: Avoid channel close/send race on Stop

### DIFF
--- a/cmd/agent/app/servers/tbuffered_server.go
+++ b/cmd/agent/app/servers/tbuffered_server.go
@@ -104,6 +104,7 @@ func (s *TBufferedServer) Serve() {
 			s.metrics.ReadError.Inc(1)
 		}
 	}
+	close(s.dataChan)
 }
 
 func (s *TBufferedServer) updateQueueSize(delta int64) {
@@ -121,7 +122,6 @@ func (s *TBufferedServer) IsServing() bool {
 func (s *TBufferedServer) Stop() {
 	atomic.StoreUint32(&s.serving, 0)
 	_ = s.transport.Close()
-	close(s.dataChan)
 }
 
 // DataChan returns the data chan of the buffered server


### PR DESCRIPTION
TBufferedServer.Close() may close the data channel before
Serve detects it. Move chan close() to Serve to prevent
a panic caused by sending on a closed channel.

See also https://github.com/golang/go/issues/27769#issuecomment-423045727

	=== RUN   TestTBufferedServer_SendReceive
	==================
	WARNING: DATA RACE
	Write at 0x00c000074850 by goroutine 9:
	  runtime.closechan()
	      /home/travis/.gimme/versions/go1.15.2.linux.amd64/src/runtime/chan.go:352 +0x0
	  github.com/jaegertracing/jaeger/cmd/agent/app/servers.(*TBufferedServer).Stop()
	...
	Previous read at 0x00c000074850 by goroutine 10:
	  runtime.chansend()
	      /home/travis/.gimme/versions/go1.15.2.linux.amd64/src/runtime/chan.go:158 +0x0
	  github.com/jaegertracing/jaeger/cmd/agent/app/servers.(*TBufferedServer).Serve()
	      /home/travis/gopath/src/github.com/jaegertracing/jaeger/cmd/agent/app/servers/tbuffered_server.go:97 +0x264
	...
	==================
	    testing.go:1042: race detected during execution of test
	--- FAIL: TestTBufferedServer_SendReceive (0.01s)

Closes #2577

Signed-off-by: Carl Henrik Lunde <chlunde@ifi.uio.no>