### PR TITLE
Fix sarama consumer deadlock

### DIFF
--- a/cmd/ingester/app/consumer/consumer.go
+++ b/cmd/ingester/app/consumer/consumer.go
@@ -50,10 +50,13 @@ type Consumer struct {
 	partitionMapLock    sync.Mutex
 	partitionsHeld      int64
 	partitionsHeldGauge metrics.Gauge
+
+	messagesDoneChan chan string
+	errorsDoneChan   chan string
+	doneWg           sync.WaitGroup
 }
 
 type consumerState struct {
-	wg                sync.WaitGroup
 	partitionConsumer sc.PartitionConsumer
 }
 
@@ -68,6 +71,8 @@ func New(params Params) (*Consumer, error) {
 		deadlockDetector:    deadlockDetector,
 		partitionIDToState:  make(map[int32]*consumerState),
 		partitionsHeldGauge: partitionsHeldGauge(params.MetricsFactory),
+		messagesDoneChan:    make(chan string),
+		errorsDoneChan:      make(chan string),
 	}, nil
 }
 
@@ -78,50 +83,65 @@ func (c *Consumer) Start() {
 		c.logger.Info("Starting main loop")
 		for pc := range c.internalConsumer.Partitions() {
 			c.partitionMapLock.Lock()
-			if p, ok := c.partitionIDToState[pc.Partition()]; ok {
-				// This is a guard against simultaneously draining messages
-				// from the last time the partition was assigned and
-				// processing new messages for the same partition, which may lead
-				// to the cleanup process not completing
-				p.wg.Wait()
-			}
 			c.partitionIDToState[pc.Partition()] = &consumerState{partitionConsumer: pc}
-			c.partitionIDToState[pc.Partition()].wg.Add(2)
 			c.partitionMapLock.Unlock()
 			c.partitionMetrics(pc.Partition()).startCounter.Inc(1)
+
+			c.doneWg.Add(2)
 			go c.handleMessages(pc)
 			go c.handleErrors(pc.Partition(), pc.Errors())
 		}
 	}()
+
+	// Expect to receive message and error handler "done" signals from each partition.
+	go waitForDoneSignals(c.messagesDoneChan, &c.doneWg, c.logger)
+	go waitForDoneSignals(c.errorsDoneChan, &c.doneWg, c.logger)
+}
+
+// waitForDoneSignals watches the doneChan for incoming "done" messages. If a message is received,
+// the doneWg WaitGroup is decremented via a call to Done().
+func waitForDoneSignals(doneChan <-chan string, doneWg *sync.WaitGroup, logger *zap.Logger) {
+	logger.Debug("Waiting for done signals")
+	for v := range doneChan {
+		logger.Debug("Received done signal", zap.String("msg", v))
+		doneWg.Done()
+	}
 }
 
 // Close closes the Consumer and underlying sarama consumer
 func (c *Consumer) Close() error {
-	c.partitionMapLock.Lock()
-	for _, p := range c.partitionIDToState {
-		c.closePartition(p.partitionConsumer)
-		p.wg.Wait()
-	}
-	c.partitionMapLock.Unlock()
-	c.deadlockDetector.close()
+	// Close the internal consumer, which will close each partition consumers' message and error channels.
 	c.logger.Info("Closing parent consumer")
-	return c.internalConsumer.Close()
+	err := c.internalConsumer.Close()
+
+	c.logger.Debug("Closing deadlock detector")
+	c.deadlockDetector.close()
+
+	c.logger.Debug("Waiting for messages and errors to be handled")
+	c.doneWg.Wait()
+
+	c.logger.Debug("Closing message and error done channels")
+	close(c.messagesDoneChan)
+	close(c.errorsDoneChan)
+
+	return err
 }
 
+// handleMessages handles incoming Kafka messages on a channel. Upon the closure of the message channel,
+// handleMessages will signal the messagesDoneChan to indicate the graceful shutdown of message handling is done.
 func (c *Consumer) handleMessages(pc sc.PartitionConsumer) {
 	c.logger.Info("Starting message handler", zap.Int32("partition", pc.Partition()))
 	c.partitionMapLock.Lock()
 	c.partitionsHeld++
 	c.partitionsHeldGauge.Update(c.partitionsHeld)
-	wg := &c.partitionIDToState[pc.Partition()].wg
 	c.partitionMapLock.Unlock()
 	defer func() {
 		c.closePartition(pc)
-		wg.Done()
 		c.partitionMapLock.Lock()
 		c.partitionsHeld--
 		c.partitionsHeldGauge.Update(c.partitionsHeld)
 		c.partitionMapLock.Unlock()
+		c.messagesDoneChan <- "HandleMessages done"
 	}()
 
 	msgMetrics := c.newMsgMetrics(pc.Partition())
@@ -165,12 +185,13 @@ func (c *Consumer) closePartition(partitionConsumer sc.PartitionConsumer) {
 	c.logger.Info("Closed partition consumer", zap.Int32("partition", partitionConsumer.Partition()))
 }
 
+// handleErrors handles incoming Kafka consumer errors on a channel. Upon the closure of the error channel,
+// handleErrors will signal the errorsDoneChan to indicate the graceful shutdown of error handling is done.
 func (c *Consumer) handleErrors(partition int32, errChan <-chan *sarama.ConsumerError) {
 	c.logger.Info("Starting error handler", zap.Int32("partition", partition))
-	c.partitionMapLock.Lock()
-	wg := &c.partitionIDToState[partition].wg
-	c.partitionMapLock.Unlock()
-	defer wg.Done()
+	defer func() {
+		c.errorsDoneChan <- "HandleErrors done"
+	}()
 
 	errMetrics := c.newErrMetrics(partition)
 	for err := range errChan {


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Closes #1314

## Short description of the changes
Prevent deadlock between the `handleErrors()` and `Close()` functions trying to acquire the `partitionLock` and access the partition WaitGroup by:
- Removing per-partition WaitGroups
- Removing the need for acquiring the `partitionLock` within `Close()`

Additional improvements:
- More correct ordering of `close` calls: Ensure underlying sarama consumer is closed first to prevent repartitioning, causing potentially new partition consumers to be created that attempt to write to already closed channels.
- Instead, `Close()` will rely on `Consumer`-scoped WaitGroups to determine graceful closure of message and error handlers. These WaitGroups will be managed through goroutines monitoring `messagesDone` and `errorsDone` channels, which will be produced to by the respective handler functions.
- Remove the redundant loop to close partition consumers which is already performed by closing the aforementioned underlying sarama consumer.
- Additional diagnostic logging, mostly at debug, to help pickup race-related errors.
- Sarama tests use the `New` Consumer constructor to DRY up duplicated construction logic.

### Testing
- Local unit tests have not failed any Sarama tests.
- Confirm this failure no longer occurs on Travis branch builds (in fork) on Sarama tests.
- Local integration tests with Kafka, Cassandra, collector, agent, query and mock trace generator running:
  - Start ingester binary `./cmd/ingester/ingester-darwin-amd64 --log-level debug`:
    - Confirm successful startup.
    - Confirm span data consumed and showing correctly in Jaeger UI.
    - Confirm metrics look fine: `rate(jaeger_kafka_spans_written_total[5m])` and `rate(jaeger_ingester_sarama_consumer_messages_total[5m])` more or less line up.
  - Manually send SIGINT with Ctrl+C to trigger shutdown:
    - Confirm shutdown completes without hanging.
    - Confirm no Kafka consumer _related_ error messages or panics present.
    - Test under two conditions: when there is 0 lag, and when the consumer is lagging behind; terminating while busy consuming messages to catch potential race conditions.
  - Force a race condition between Consumer start and shutdown to test potential race conditions:
    - Command: `./cmd/ingester/ingester-darwin-amd64 --log-level debug & pid1="$\!"; sleep 0.1; kill $pid1`
    - Confirm shutdown attempted before consumer starts.
    - Confirm graceful shutdown completes successfully without error.
    - Output:
```
{"level":"debug","ts":1603594054.544082,"caller":"consumer/deadlock_detector.go:149","msg":"Global deadlock detector disabled"}
{"level":"info","ts":1603594054.5441122,"caller":"healthcheck/handler.go:128","msg":"Health Check state change","status":"ready"}
{"level":"info","ts":1603594054.544123,"caller":"flags/service.go:154","msg":"Shutting down"}
{"level":"info","ts":1603594054.544128,"caller":"healthcheck/handler.go:128","msg":"Health Check state change","status":"unavailable"}
{"level":"info","ts":1603594054.544121,"caller":"consumer/consumer.go:85","msg":"Starting main loop"}
{"level":"debug","ts":1603594054.544126,"caller":"consumer/consumer.go:107","msg":"Waiting for done signals"}
{"level":"info","ts":1603594054.5441332,"caller":"consumer/consumer.go:118","msg":"Closing parent consumer"}
{"level":"debug","ts":1603594054.544141,"caller":"consumer/consumer.go:107","msg":"Waiting for done signals"}
{"level":"info","ts":1603594054.55716,"caller":"consumer/consumer.go:196","msg":"Starting error handler","partition":0}
{"level":"info","ts":1603594054.557175,"caller":"consumer/consumer.go:138","msg":"Starting message handler","partition":0}
{"level":"debug","ts":1603594054.561001,"caller":"consumer/consumer.go:121","msg":"Closing deadlock detector"}
{"level":"info","ts":1603594054.7042592,"caller":"consumer/consumer.go:206","msg":"Finished handling errors","partition":0}
{"level":"debug","ts":1603594054.704276,"caller":"consumer/consumer.go:124","msg":"Waiting for messages and errors to be handled"}
{"level":"debug","ts":1603594054.704284,"caller":"consumer/consumer.go:109","msg":"Received done signal","msg":"HandleErrors done"}
{"level":"debug","ts":1603594054.704291,"caller":"consumer/deadlock_detector.go:100","msg":"Partition deadlock detector disabled"}
{"level":"info","ts":1603594054.704301,"caller":"consumer/consumer.go:163","msg":"Message channel closed. ","partition":0}
{"level":"info","ts":1603594054.704475,"caller":"consumer/consumer.go:187","msg":"Closing partition consumer","partition":0}
{"level":"info","ts":1603594054.704489,"caller":"consumer/consumer.go:190","msg":"Closed partition consumer","partition":0}
{"level":"debug","ts":1603594054.704499,"caller":"consumer/consumer.go:109","msg":"Received done signal","msg":"HandleMessages done"}
{"level":"debug","ts":1603594054.704504,"caller":"consumer/consumer.go:128","msg":"Closing message and error done channels"}
{"level":"info","ts":1603594055.207753,"caller":"flags/service.go:162","msg":"Shutdown complete"}
```