### PR TITLE
Fix file descriptor leaks in tlscfg unit tests

### DIFF
--- a/pkg/config/tlscfg/cert_watcher.go
+++ b/pkg/config/tlscfg/cert_watcher.go
@@ -55,6 +55,7 @@ func newCertWatcher(opts Options, logger *zap.Logger) (*certWatcher, error) {
 		return nil, err
 	}
 	if err := addCertsToWatch(watcher, opts); err != nil {
+		watcher.Close()
 		return nil, err
 	}
 	return &certWatcher{

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -227,6 +227,7 @@ func TestReload_err_watch(t *testing.T) {
 func TestAddCertsToWatch_err(t *testing.T) {
 	watcher, err := fsnotify.NewWatcher()
 	require.NoError(t, err)
+	defer watcher.Close()
 
 	tests := []struct {
 		opts Options
@@ -323,6 +324,7 @@ func syncWrite(filename string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	if _, err = f.Write(data); err != nil {
 		return err
 	}


### PR DESCRIPTION
There are a few file descriptor leaks in the unit tests, and on an error
condition in certwatcher.

This is an issue when checking for flaky tests with
`go test -test.count ..`. One leak is in an error condition in
certwatcher but it is unlikely to be a runtime issue because it happens
on initialization.

Related #2586