### PR TITLE
fix: don't create tags w/ empty name for internal zipkin spans

### DIFF
--- a/cmd/collector/app/zipkin/jsonv2.go
+++ b/cmd/collector/app/zipkin/jsonv2.go
@@ -84,7 +84,9 @@ func spanV2ToThrift(s *models.Span) (*zipkincore.Span, error) {
 		if err != nil {
 			return nil, err
 		}
-		tSpan.BinaryAnnotations = append(tSpan.BinaryAnnotations, rAddrAnno)
+		if rAddrAnno != nil {
+			tSpan.BinaryAnnotations = append(tSpan.BinaryAnnotations, rAddrAnno)
+		}
 	}
 
 	// add local component to represent service name
@@ -112,6 +114,8 @@ func remoteEndpToThrift(e *models.Endpoint, kind string) (*zipkincore.BinaryAnno
 		key = zipkincore.CLIENT_ADDR
 	case models.SpanKindCONSUMER, models.SpanKindPRODUCER:
 		key = zipkincore.MESSAGE_ADDR
+	default:
+		return nil, nil
 	}
 
 	return &zipkincore.BinaryAnnotation{

--- a/cmd/collector/app/zipkin/jsonv2_test.go
+++ b/cmd/collector/app/zipkin/jsonv2_test.go
@@ -94,6 +94,7 @@ func TestRemoteEndpToThrift(t *testing.T) {
 		{kind: models.SpanKindSERVER, expected: &zipkincore.BinaryAnnotation{Key: zipkincore.CLIENT_ADDR, AnnotationType: zipkincore.AnnotationType_BOOL}},
 		{kind: models.SpanKindPRODUCER, expected: &zipkincore.BinaryAnnotation{Key: zipkincore.MESSAGE_ADDR, AnnotationType: zipkincore.AnnotationType_BOOL}},
 		{kind: models.SpanKindCONSUMER, expected: &zipkincore.BinaryAnnotation{Key: zipkincore.MESSAGE_ADDR, AnnotationType: zipkincore.AnnotationType_BOOL}},
+		{kind: "", expected: nil},
 	}
 	for _, test := range tests {
 		banns, err := remoteEndpToThrift(nil, test.kind)


### PR DESCRIPTION
Resolves #2595

For spans w/ span kind == "internal" and remoteEndpoint != nil, `spanV2ToThrift` would add a tag with empty name. This PR fixes the issue.