### PR TITLE
Use goleak to capture goroutine leak

### DIFF
--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -21,7 +21,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestParseJaegerTags(t *testing.T) {
 

--- a/cmd/opentelemetry/app/defaultconfig/default_config_test.go
+++ b/cmd/opentelemetry/app/defaultconfig/default_config_test.go
@@ -37,7 +37,12 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/exporter/memoryexporter"
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/receiver/kafkareceiver"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
+
+func TestMain(m *testing.M) {
+	testutils.TolerantVerifyLeakMain(m)
+}
 
 func TestService(t *testing.T) {
 	tests := []struct {

--- a/cmd/opentelemetry/app/exporter/badgerexporter/badgerexporter_test.go
+++ b/cmd/opentelemetry/app/exporter/badgerexporter/badgerexporter_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package badgerexporter
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.TolerantVerifyLeakMain(m)
+}

--- a/cmd/opentelemetry/app/exporter/jaegerexporter/jaeger_exporter_test.go
+++ b/cmd/opentelemetry/app/exporter/jaegerexporter/jaeger_exporter_test.go
@@ -33,7 +33,12 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/receiver/jaegerreceiver"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
+
+func TestMain(m *testing.M) {
+	testutils.TolerantVerifyLeakMain(m)
+}
 
 func TestDefaultValues(t *testing.T) {
 	v, c := jConfig.Viperize(jaegerreceiver.AddFlags)

--- a/cmd/opentelemetry/app/internal/esclient/esclient_test.go
+++ b/cmd/opentelemetry/app/internal/esclient/esclient_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esclient
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/cmd/opentelemetry/app/internal/esutil/index_name_test.go
+++ b/cmd/opentelemetry/app/internal/esutil/index_name_test.go
@@ -19,7 +19,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestIndexNames(t *testing.T) {
 	tests := []struct {

--- a/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store_test.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esdependencyreader/dependency_store_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/opentelemetry/app/internal/esclient"
@@ -34,6 +35,10 @@ import (
 )
 
 const defaultMaxDocCount = 10_000
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestCreateTemplates(t *testing.T) {
 	client := &mockClient{}

--- a/cmd/opentelemetry/app/internal/reader/es/esspanreader/esspanreader_test.go
+++ b/cmd/opentelemetry/app/internal/reader/es/esspanreader/esspanreader_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esspanreader
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/cmd/opentelemetry/app/processor/resourceprocessor/resource_processor_test.go
+++ b/cmd/opentelemetry/app/processor/resourceprocessor/resource_processor_test.go
@@ -33,7 +33,12 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
+
+func TestMain(m *testing.M) {
+	testutils.TolerantVerifyLeakMain(m)
+}
 
 func TestDefaultValues(t *testing.T) {
 	v, c := jConfig.Viperize(AddFlags)

--- a/cmd/opentelemetry/app/receiver/jaegerreceiver/jaeger_receiver_test.go
+++ b/cmd/opentelemetry/app/receiver/jaegerreceiver/jaeger_receiver_test.go
@@ -35,8 +35,13 @@ import (
 
 	collectorApp "github.com/jaegertracing/jaeger/cmd/collector/app"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore/static"
 )
+
+func TestMain(m *testing.M) {
+	testutils.TolerantVerifyLeakMain(m)
+}
 
 func TestDefaultValues(t *testing.T) {
 	v, c := jConfig.Viperize(AddFlags)

--- a/cmd/opentelemetry/app/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/cmd/opentelemetry/app/receiver/kafkareceiver/kafka_receiver_test.go
@@ -27,8 +27,13 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/kafka"
 )
+
+func TestMain(m *testing.M) {
+	testutils.TolerantVerifyLeakMain(m)
+}
 
 func TestDefaultConfig(t *testing.T) {
 	v, c := jConfig.Viperize(AddFlags)

--- a/cmd/opentelemetry/app/receiver/zipkinreceiver/zipkin_receiver_test.go
+++ b/cmd/opentelemetry/app/receiver/zipkinreceiver/zipkin_receiver_test.go
@@ -29,7 +29,12 @@ import (
 	"go.opentelemetry.io/collector/receiver/zipkinreceiver"
 
 	jConfig "github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
+
+func TestMain(m *testing.M) {
+	testutils.TolerantVerifyLeakMain(m)
+}
 
 func TestDefaultValues(t *testing.T) {
 	v, c := jConfig.Viperize(AddFlags)

--- a/cmd/opentelemetry/go.mod
+++ b/cmd/opentelemetry/go.mod
@@ -18,5 +18,6 @@ require (
 	github.com/uber/jaeger-lib v2.4.0+incompatible
 	go.opencensus.io v0.22.4
 	go.opentelemetry.io/collector v0.12.0
+	go.uber.org/goleak v1.1.10
 	go.uber.org/zap v1.16.0
 )

--- a/crossdock/services/services_test.go
+++ b/crossdock/services/services_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	go.mongodb.org/mongo-driver v1.3.2 // indirect
 	go.uber.org/atomic v1.6.0
 	go.uber.org/automaxprocs v1.3.0
+	go.uber.org/goleak v1.1.10
 	go.uber.org/zap v1.16.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,8 @@ go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/automaxprocs v1.3.0 h1:II28aZoGdaglS5vVNnspf28lnZpXScxtIozx1lAjdb0=
 go.uber.org/automaxprocs v1.3.0/go.mod h1:9CWT6lKIep8U41DDaPiH6eFscnTyjfTANNQNx6LrIcA=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
@@ -729,6 +731,7 @@ golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TolerantVerifyLeakMain verifies go leaks but excludes the go routines that are
+// launched as side effects of some of our dependencies.
+func TolerantVerifyLeakMain(m *testing.M) {
+	goleak.VerifyTestMain(m,
+		// https://github.com/census-instrumentation/opencensus-go/blob/d7677d6af5953e0506ac4c08f349c62b917a443a/stats/view/worker.go#L34
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		// https://github.com/kubernetes/klog/blob/c85d02d1c76a9ebafa81eb6d35c980734f2c4727/klog.go#L417
+		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		// https://github.com/dgraph-io/badger/blob/v1.5.3/y/watermark.go#L54
+		goleak.IgnoreTopFunction("github.com/dgraph-io/badger/y.(*WaterMark).process"),
+		// https://github.com/dgraph-io/badger/blob/v1.5.3/db.go#L264
+		goleak.IgnoreTopFunction("github.com/dgraph-io/badger.(*DB).updateSize"),
+		// https://github.com/dgraph-io/badger/blob/v1.5.3/levels.go#L177
+		goleak.IgnoreTopFunction("time.Sleep"),
+		// https://github.com/dgraph-io/badger/blob/v1.5.3/levels.go#L177
+		goleak.IgnoreTopFunction("github.com/dgraph-io/badger.(*levelsController).runWorker"),
+		goleak.IgnoreTopFunction("github.com/dgraph-io/badger.(*DB).flushMemtable"),
+		goleak.IgnoreTopFunction("github.com/dgraph-io/badger.(*DB).doWrites"),
+		goleak.IgnoreTopFunction("github.com/dgraph-io/badger.(*valueLog).waitOnGC"),
+		goleak.IgnoreTopFunction("github.com/jaegertracing/jaeger/plugin/storage/badger.(*Factory).maintenance"),
+		goleak.IgnoreTopFunction("github.com/jaegertracing/jaeger/plugin/storage/badger.(*Factory).metricsCopier"),
+	)
+}


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
This PR uses goleak (https://github.com/uber-go/goleak) to identify goroutine leak as part of unit tests.

## Short description of the changes
We are adding a `TestMain` function for each test package. Goleak provides a way to exclude top functions, hence we are adding `TolerantVerifyLeakMain` with those exceptions. If this is accepted change, I'll add changes for rest of the test packages too.
