### PR TITLE
Avoid deadlock if Stop is called before Serve

### DIFF
--- a/cmd/agent/app/servers/tbuffered_server.go
+++ b/cmd/agent/app/servers/tbuffered_server.go
@@ -59,6 +59,16 @@ type TBufferedServer struct {
 	}
 }
 
+// state values for TBufferedServer.serving
+//
+// init -> serving -> stopped
+// init -> stopped (might happen in unit tests)
+const (
+	stateStopped = iota
+	stateServing
+	stateInit
+)
+
 // NewTBufferedServer creates a TBufferedServer
 func NewTBufferedServer(
 	transport ThriftTransport,
@@ -79,14 +89,20 @@ func NewTBufferedServer(
 		maxQueueSize:  maxQueueSize,
 		maxPacketSize: maxPacketSize,
 		readBufPool:   readBufPool,
+		serving:       stateInit,
 	}
+
 	metrics.MustInit(&res.metrics, mFactory, nil)
 	return res, nil
 }
 
 // Serve initiates the readers and starts serving traffic
 func (s *TBufferedServer) Serve() {
-	atomic.StoreUint32(&s.serving, 1)
+	defer close(s.dataChan)
+	if !atomic.CompareAndSwapUint32(&s.serving, stateInit, stateServing) {
+		return // Stop already called
+	}
+
 	for s.IsServing() {
 		readBuf := s.readBufPool.Get().(*ReadBuf)
 		n, err := s.transport.Read(readBuf.bytes)
@@ -104,7 +120,6 @@ func (s *TBufferedServer) Serve() {
 			s.metrics.ReadError.Inc(1)
 		}
 	}
-	close(s.dataChan)
 }
 
 func (s *TBufferedServer) updateQueueSize(delta int64) {
@@ -114,13 +129,13 @@ func (s *TBufferedServer) updateQueueSize(delta int64) {
 
 // IsServing indicates whether the server is currently serving traffic
 func (s *TBufferedServer) IsServing() bool {
-	return atomic.LoadUint32(&s.serving) == 1
+	return atomic.LoadUint32(&s.serving) == stateServing
 }
 
 // Stop stops the serving of traffic and waits until the queue is
 // emptied by the readers
 func (s *TBufferedServer) Stop() {
-	atomic.StoreUint32(&s.serving, 0)
+	atomic.StoreUint32(&s.serving, stateStopped)
 	_ = s.transport.Close()
 }
 


### PR DESCRIPTION
Make a tiny state machine to detect the transition init -> stopped (not via serving)

Not 100% sure about this, I don't now this code and the origin issue mentions an issue `thrift_processor` too, but that might have been fixed already?

Fixes #2601
Related #103
