### PR TITLE
Return buffers to pool on network errors or queue overflow

### DIFF
--- a/cmd/agent/app/servers/tbuffered_server.go
+++ b/cmd/agent/app/servers/tbuffered_server.go
@@ -98,9 +98,11 @@ func (s *TBufferedServer) Serve() {
 				s.metrics.PacketsProcessed.Inc(1)
 				s.updateQueueSize(1)
 			default:
+				s.readBufPool.Put(readBuf)
 				s.metrics.PacketsDropped.Inc(1)
 			}
 		} else {
+			s.readBufPool.Put(readBuf)
 			s.metrics.ReadError.Inc(1)
 		}
 	}


### PR DESCRIPTION
Use of `sync.Pool` requires a `.Put` for every `.Get`.
On success, the downstream `ThriftProcessor` invoked `.Put` via `.DataRecd`
but in error cases there seems to be a leak.

## Which problem is this PR solving?
I think I found a leak when reviewing this code for deadlock-related issues. 

## Short description of the changes
Free memory in error cases.
