### PR TITLE
Fix flaky TestAddCertsToWatch_remove_ca test

### DIFF
--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -302,7 +302,7 @@ func TestAddCertsToWatch_remove_ca(t *testing.T) {
 	require.NoError(t, os.Remove(caFile.Name()))
 	require.NoError(t, os.Remove(clientCaFile.Name()))
 	waitUntil(func() bool {
-		return logObserver.FilterMessage("Certificate has been removed, using the last known version").Len() > 0
+		return logObserver.FilterMessage("Certificate has been removed, using the last known version").Len() >= 2
 	}, 100, time.Millisecond*100)
 	assert.True(t, logObserver.FilterMessage("Certificate has been removed, using the last known version").FilterField(zap.String("certificate", caFile.Name())).Len() > 0)
 	assert.True(t, logObserver.FilterMessage("Certificate has been removed, using the last known version").FilterField(zap.String("certificate", clientCaFile.Name())).Len() > 0)


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #2586 

## Short description of the changes
- Explicitly wait for at least two matching log events, since the test asserts on the existence of these two log entries.
