### PR TITLE
Adding Multi-DC Cassandra Support to Bootstrap Configuration Script(s)

### DIFF
--- a/plugin/storage/cassandra/schema/docker.sh
+++ b/plugin/storage/cassandra/schema/docker.sh
@@ -36,7 +36,7 @@ do
   fi
 done
 
-echo "Generating the schema for the keyspace ${KEYSPACE} and datacenter ${DATACENTER}"
+echo "Generating the schema for the keyspace ${KEYSPACE} and datacenter(s) ${DATACENTER}"
 
 
 if [ -z "$PASSWORD" ]; then


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Solves: https://github.com/jaegertracing/jaeger/issues/2618

TL;DR from the issue:
- Multi-DC Cassandra setups are not supported by the jaeger-cassandra bootstrap scripts (i.e., can only provide a single Datacenter value, versus `N` Datacenter values, where `N > 1`)
- Even numbered quorum value is being used for `prod` setups, versus using an odd number

## Short description of the changes
Adding the capability to provide a comma-delimited list of data-centers from the jaeger-operator, through `docker.sh`, and into `create.sh` to allow for multi-DC Cassandra setups.
- Added internal field separator to `create.sh`
- Set default replication factor for prod setups to be 3, and provide minimum odd-number quorum
- Create replication factor string for 1+ Datacenter values when in prod mode
- Updated `echo` statements accordingly
