### PR TITLE
Fix flaky TestReload

### DIFF
--- a/pkg/config/tlscfg/cert_watcher.go
+++ b/pkg/config/tlscfg/cert_watcher.go
@@ -112,7 +112,12 @@ func (w *certWatcher) watchChangesLoop(rootCAs, clientCAs *x509.CertPool) {
 				w.mu.Unlock()
 				err = e
 			}
-			if err != nil {
+			if err == nil {
+				w.logger.Info("Loaded modified certificate",
+					zap.String("certificate", event.Name),
+					zap.String("event", event.Op.String()))
+
+			} else {
 				w.logger.Error("Failed to load certificate",
 					zap.String("certificate", event.Name),
 					zap.String("event", event.Op.String()),


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #2622

## Short description of the changes
Fixes the flaky `TestReload` test by:
- Firstly logging _after_ the modified certificate has finished reloading, as suggested by @chlunde; and use this log entry as our signal for cert file mod completion.
- Adds assertion on `keyFile` log entry, and make both assertions more specific along with diagnostic data on failure to help with debugging if the race condition presents itself again in future.

## Testing
Repeated the following test 3x with no errors.:
```
go test -test.count=5000 -test.run=TestReload$ ./pkg/config/tlscfg/
```