### PR TITLE
Preparing release 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,16 @@ Changes by Version
 
 ### Backend Changes
 
-#### Breaking Changes
-
-* Remove deprecated es.max-num-spans ([#2482](https://github.com/jaegertracing/jaeger/pull/2482), [@BernardTolosajr](https://github.com/BernardTolosajr))
-
 #### New Features
 
-* Implement anonymizer's main program ([#2621](https://github.com/jaegertracing/jaeger/pull/2621), [@Ashmita152](https://github.com/Ashmita152))
-* Extend anonymizer with additional parameters ([#2585](https://github.com/jaegertracing/jaeger/pull/2585), [@Ashmita152](https://github.com/Ashmita152))
+* Add trace anonymizer utility ([#2621](https://github.com/jaegertracing/jaeger/pull/2621), [#2585](https://github.com/jaegertracing/jaeger/pull/2585), [@Ashmita152](https://github.com/Ashmita152))
 * Add URL option for sampling strategies file ([#2519](https://github.com/jaegertracing/jaeger/pull/2519), [@goku321](https://github.com/goku321))
-* Update static UI assets path in contrib doc ([#2548](https://github.com/jaegertracing/jaeger/pull/2548), [@albertteoh](https://github.com/albertteoh))
 * Expose tunning options via expvar ([#2496](https://github.com/jaegertracing/jaeger/pull/2496), [@dstdfx](https://github.com/dstdfx))
+* Support more encodings for Kafka in OTel Ingester ([#2580](https://github.com/jaegertracing/jaeger/pull/2580), [@XSAM](https://github.com/XSAM))
+* Create debug docker images for jaeger backends ([#2545](https://github.com/jaegertracing/jaeger/pull/2545), [@Ashmita152](https://github.com/Ashmita152))
+* Display backend & UI versions in Jaeger UI
+  * Inject version info into index.html ([#2547](https://github.com/jaegertracing/jaeger/pull/2547), [@yurishkuro](https://github.com/yurishkuro))
+  * Added jaeger ui version to about menu ([#606](https://github.com/jaegertracing/jaeger-ui/pull/606), [@alanisaac](https://github.com/alanisaac))
 
 #### Bug fixes, Minor Improvements
 
@@ -33,15 +32,13 @@ Changes by Version
 * Clarify deadlock panic message ([#2605](https://github.com/jaegertracing/jaeger/pull/2605), [@yurishkuro](https://github.com/yurishkuro))
 * fix: don't create tags w/ empty name for internal zipkin spans ([#2596](https://github.com/jaegertracing/jaeger/pull/2596), [@mzahor](https://github.com/mzahor))
 * TBufferedServer: Avoid channel close/send race on Stop ([#2583](https://github.com/jaegertracing/jaeger/pull/2583), [@chlunde](https://github.com/chlunde))
-* Support more encodings for Kafka in OTel Ingester ([#2580](https://github.com/jaegertracing/jaeger/pull/2580), [@XSAM](https://github.com/XSAM))
-* Create debug docker images for jaeger backends ([#2545](https://github.com/jaegertracing/jaeger/pull/2545), [@Ashmita152](https://github.com/Ashmita152))
 * Bumped OpenTelemetry Collector to v0.12.0 ([#2562](https://github.com/jaegertracing/jaeger/pull/2562), [@jpkrohling](https://github.com/jpkrohling))
 * Disable Zipkin server if port/address is not configured ([#2554](https://github.com/jaegertracing/jaeger/pull/2554), [@yurishkuro](https://github.com/yurishkuro))
-* Inject version info into index.html ([#2547](https://github.com/jaegertracing/jaeger/pull/2547), [@yurishkuro](https://github.com/yurishkuro))
 * [hotrod] Add links to traces ([#2536](https://github.com/jaegertracing/jaeger/pull/2536), [@yurishkuro](https://github.com/yurishkuro))
 * OTel Cassandra/Elasticsearch Exporter queue defaults ([#2533](https://github.com/jaegertracing/jaeger/pull/2533), [@joe-elliott](https://github.com/joe-elliott))
 * [otel] Update jaeger-lib to v2.4.0 ([#2538](https://github.com/jaegertracing/jaeger/pull/2538), [@dstdfx](https://github.com/dstdfx))
 * Remove unnecessary ServiceName index seek if tags query is available ([#2535](https://github.com/jaegertracing/jaeger/pull/2535), [@burmanm](https://github.com/burmanm))
+* Update static UI assets path in contrib doc ([#2548](https://github.com/jaegertracing/jaeger/pull/2548), [@albertteoh](https://github.com/albertteoh))
 
 ### UI Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,53 @@
 Changes by Version
 ==================
 
-1.21.0 (unreleased)
+1.22.0 (unreleased)
 -------------------
+
+1.21.0 (2020-11-13)
+-------------------
+
+### Backend Changes
+
+#### Breaking Changes
+
+* Remove deprecated es.max-num-spans ([#2482](https://github.com/jaegertracing/jaeger/pull/2482), [@BernardTolosajr](https://github.com/BernardTolosajr))
+
+#### New Features
+
+* Implement anonymizer's main program ([#2621](https://github.com/jaegertracing/jaeger/pull/2621), [@Ashmita152](https://github.com/Ashmita152))
+* Extend anonymizer with additional parameters ([#2585](https://github.com/jaegertracing/jaeger/pull/2585), [@Ashmita152](https://github.com/Ashmita152))
+* Add URL option for sampling strategies file ([#2519](https://github.com/jaegertracing/jaeger/pull/2519), [@goku321](https://github.com/goku321))
+* Update static UI assets path in contrib doc ([#2548](https://github.com/jaegertracing/jaeger/pull/2548), [@albertteoh](https://github.com/albertteoh))
+* Expose tunning options via expvar ([#2496](https://github.com/jaegertracing/jaeger/pull/2496), [@dstdfx](https://github.com/dstdfx))
+
+#### Bug fixes, Minor Improvements
+
+* Update x/text to v0.3.4 ([#2625](https://github.com/jaegertracing/jaeger/pull/2625), [@objectiser](https://github.com/objectiser))
+* Update CodeQL to latest best practices ([#2615](https://github.com/jaegertracing/jaeger/pull/2615), [@jhutchings1](https://github.com/jhutchings1))
+* Bump opentelemetry-collector to v0.14.0 ([#2617](https://github.com/jaegertracing/jaeger/pull/2617), [@Vemmy124](https://github.com/Vemmy124))
+* Bump Badger to v1.6.2 ([#2613](https://github.com/jaegertracing/jaeger/pull/2613), [@Ackar](https://github.com/Ackar))
+* Fix sarama consumer deadlock ([#2587](https://github.com/jaegertracing/jaeger/pull/2587), [@albertteoh](https://github.com/albertteoh))
+* Avoid deadlock if Stop is called before Serve ([#2608](https://github.com/jaegertracing/jaeger/pull/2608), [@chlunde](https://github.com/chlunde))
+* Return buffers to pool on network errors or queue overflow ([#2609](https://github.com/jaegertracing/jaeger/pull/2609), [@chlunde](https://github.com/chlunde))
+* Clarify deadlock panic message ([#2605](https://github.com/jaegertracing/jaeger/pull/2605), [@yurishkuro](https://github.com/yurishkuro))
+* fix: don't create tags w/ empty name for internal zipkin spans ([#2596](https://github.com/jaegertracing/jaeger/pull/2596), [@mzahor](https://github.com/mzahor))
+* TBufferedServer: Avoid channel close/send race on Stop ([#2583](https://github.com/jaegertracing/jaeger/pull/2583), [@chlunde](https://github.com/chlunde))
+* Support more encodings for Kafka in OTel Ingester ([#2580](https://github.com/jaegertracing/jaeger/pull/2580), [@XSAM](https://github.com/XSAM))
+* Create debug docker images for jaeger backends ([#2545](https://github.com/jaegertracing/jaeger/pull/2545), [@Ashmita152](https://github.com/Ashmita152))
+* Bumped OpenTelemetry Collector to v0.12.0 ([#2562](https://github.com/jaegertracing/jaeger/pull/2562), [@jpkrohling](https://github.com/jpkrohling))
+* Disable Zipkin server if port/address is not configured ([#2554](https://github.com/jaegertracing/jaeger/pull/2554), [@yurishkuro](https://github.com/yurishkuro))
+* Inject version info into index.html ([#2547](https://github.com/jaegertracing/jaeger/pull/2547), [@yurishkuro](https://github.com/yurishkuro))
+* [hotrod] Add links to traces ([#2536](https://github.com/jaegertracing/jaeger/pull/2536), [@yurishkuro](https://github.com/yurishkuro))
+* OTel Cassandra/Elasticsearch Exporter queue defaults ([#2533](https://github.com/jaegertracing/jaeger/pull/2533), [@joe-elliott](https://github.com/joe-elliott))
+* [otel] Update jaeger-lib to v2.4.0 ([#2538](https://github.com/jaegertracing/jaeger/pull/2538), [@dstdfx](https://github.com/dstdfx))
+* Remove unnecessary ServiceName index seek if tags query is available ([#2535](https://github.com/jaegertracing/jaeger/pull/2535), [@burmanm](https://github.com/burmanm))
+
+### UI Changes
+
+* Bump to latest UI for snapshop builds ([#2626](https://github.com/jaegertracing/jaeger/pull/2626), [@yurishkuro](https://github.com/yurishkuro))
+  * Pinned UI to [this commit](https://github.com/jaegertracing/jaeger-ui/commit/df17e8d80e6f630ed3ed744a80dbf27c0418718c)
+
 
 1.20.0 (2020-09-29)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,20 +45,7 @@ Changes by Version
 
 ### UI Changes
 
-* Pinned UI to [this commit](https://github.com/jaegertracing/jaeger-ui/commit/df17e8d80e6f630ed3ed744a80dbf27c0418718c)
-
-#### New Features
-
-* Identify uninstrumented services ([#659](https://github.com/jaegertracing/jaeger-ui/pull/659), [@rubenvp8510](https://github.com/rubenvp8510))
-* Added jaeger ui version to about menu ([#606](https://github.com/jaegertracing/jaeger-ui/pull/606), [@alanisaac](https://github.com/alanisaac))
-
-#### Bug fixes, Minor Improvements
-
-* Pass a function that doesn't return anything to FileUpload component ([#658](https://github.com/jaegertracing/jaeger-ui/pull/658), [@rubenvp8510](https://github.com/rubenvp8510))
-* Prevent DAG crashes because of empty service name string ([#656](https://github.com/jaegertracing/jaeger-ui/pull/656), [@rubenvp8510](https://github.com/rubenvp8510))
-* Explain "self time" in graph view ([#655](https://github.com/jaegertracing/jaeger-ui/pull/655), [@yurishkuro](https://github.com/yurishkuro))
-* Improve duration formatting ([#647](https://github.com/jaegertracing/jaeger-ui/pull/647), [@jamesfer](https://github.com/jamesfer))
-* Upgrade build to Node 10 ([#649](https://github.com/jaegertracing/jaeger-ui/pull/649), [@yurishkuro](https://github.com/yurishkuro))
+* UI pinned to version 1.12.0. The changelog is available here [v1.12.0](https://github.com/jaegertracing/jaeger-ui/blob/master/CHANGELOG.md#v1120-november-14-2020)
 
 
 1.20.0 (2020-09-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,20 @@ Changes by Version
 
 ### UI Changes
 
-* Bump to latest UI for snapshop builds ([#2626](https://github.com/jaegertracing/jaeger/pull/2626), [@yurishkuro](https://github.com/yurishkuro))
-  * Pinned UI to [this commit](https://github.com/jaegertracing/jaeger-ui/commit/df17e8d80e6f630ed3ed744a80dbf27c0418718c)
+* Pinned UI to [this commit](https://github.com/jaegertracing/jaeger-ui/commit/df17e8d80e6f630ed3ed744a80dbf27c0418718c)
+
+#### New Features
+
+* Identify uninstrumented services ([#659](https://github.com/jaegertracing/jaeger-ui/pull/659), [@rubenvp8510](https://github.com/rubenvp8510))
+* Added jaeger ui version to about menu ([#606](https://github.com/jaegertracing/jaeger-ui/pull/606), [@alanisaac](https://github.com/alanisaac))
+
+#### Bug fixes, Minor Improvements
+
+* Pass a function that doesn't return anything to FileUpload component ([#658](https://github.com/jaegertracing/jaeger-ui/pull/658), [@rubenvp8510](https://github.com/rubenvp8510))
+* Prevent DAG crashes because of empty service name string ([#656](https://github.com/jaegertracing/jaeger-ui/pull/656), [@rubenvp8510](https://github.com/rubenvp8510))
+* Explain "self time" in graph view ([#655](https://github.com/jaegertracing/jaeger-ui/pull/655), [@yurishkuro](https://github.com/yurishkuro))
+* Improve duration formatting ([#647](https://github.com/jaegertracing/jaeger-ui/pull/647), [@jamesfer](https://github.com/jamesfer))
+* Upgrade build to Node 10 ([#649](https://github.com/jaegertracing/jaeger-ui/pull/649), [@yurishkuro](https://github.com/yurishkuro))
 
 
 1.20.0 (2020-09-29)


### PR DESCRIPTION
## Which problem is this PR solving?
- Prepares master for 1.21.0 release
- Fixes #2627 

## Short description of the changes
Updated the changelog in preparation for release.  Per discussions in the bi-weekly we will not actually merge this PR and build images until early next week, but I wanted this up in case we needed to discuss the changelog.

## TODO
- ~[ ] Merge #2482 before this PR so it's in 1.21.0~

## Notes
- ~Since we are pinning jaeger-ui at a commit that is not a release I went ahead and included a jaeger-ui changelog as well.  It appears that normally we just refer to the UI changelog, but that was not an option here~
- I did not include the following lines in the changelog.  Since this is my first time, I'm including them here in case we wanted to keep any of these:

```
* Fix flaky TestReload ([#2624](https://github.com/jaegertracing/jaeger/pull/2624), [@albertteoh](https://github.com/albertteoh))
* Fix flaky TestAddCertsToWatch_remove_ca test ([#2610](https://github.com/jaegertracing/jaeger/pull/2610), [@albertteoh](https://github.com/albertteoh))
* Remove md-to-godoc ([#2598](https://github.com/jaegertracing/jaeger/pull/2598), [@yurishkuro](https://github.com/yurishkuro))
* Clean-up error handling and logging ([#2590](https://github.com/jaegertracing/jaeger/pull/2590), [@tzzed](https://github.com/tzzed))
* Fix file descriptor leaks in tlscfg unit tests ([#2592](https://github.com/jaegertracing/jaeger/pull/2592), [@chlunde](https://github.com/chlunde))
* Exit properly after displayed help ([#2589](https://github.com/jaegertracing/jaeger/pull/2589), [@tzzed](https://github.com/tzzed))
* Improve `build-ui` Makefile target and fix dependencies ([#2573](https://github.com/jaegertracing/jaeger/pull/2573), [@albertteoh](https://github.com/albertteoh))
* Simplify test coverage collection ([#2560](https://github.com/jaegertracing/jaeger/pull/2560), [@PankhudiB](https://github.com/PankhudiB))
* Add mergify ([#2559](https://github.com/jaegertracing/jaeger/pull/2559), [@jpkrohling](https://github.com/jpkrohling))
* Replaced devbots with issue-labeler ([#2558](https://github.com/jaegertracing/jaeger/pull/2558), [@jpkrohling](https://github.com/jpkrohling))
* Align help message with default values ([#2553](https://github.com/jaegertracing/jaeger/pull/2553), [@tobiaskohlbau](https://github.com/tobiaskohlbau))
* Added .nocover to otel mains ([#2524](https://github.com/jaegertracing/jaeger/pull/2524), [@joe-elliott](https://github.com/joe-elliott))
* Adding missing build instruction #1887 ([#2542](https://github.com/jaegertracing/jaeger/pull/2542), [@listaction](https://github.com/listaction))
* README.md: Point to operator under deployment section ([#2539](https://github.com/jaegertracing/jaeger/pull/2539), [@lilic](https://github.com/lilic))
* Remove Go report card ([#2529](https://github.com/jaegertracing/jaeger/pull/2529), [@yurishkuro](https://github.com/yurishkuro))
* Fix max-num-spans flag's usage message ([#2528](https://github.com/jaegertracing/jaeger/pull/2528), [@albertteoh](https://github.com/albertteoh))
```
