### PR TITLE
Fix flaky TestReload

### DIFF
--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -95,7 +95,8 @@ func TestReload(t *testing.T) {
 	waitUntil(func() bool {
 		// Logged when both matching public and private keys are modified in the cert.
 		// If mismatched keys are present in the cert, the "Failed to load certificate" error will be logged instead.
-		return logObserver.FilterMessage("Loaded modified certificate").Len() > 0
+		return logObserver.FilterMessage("Loaded modified certificate").
+			FilterField(zap.String("certificate", keyFile.Name())).Len() > 0
 	}, 100, time.Millisecond*200)
 
 	// Logged when the cert is modified with the client's public key due to


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #2644 .

## Short description of the changes
- The logs from #2644 indicate a race condition where the `cert.crt` file was loaded before the `key.crt` file, which was not observed in local testing in #2624. That is `"Loaded modified certificate"` was logged for `certFile.Name()` before `keyFile.Name()`.
- This PR fixes the race condition by being more explicit on the wait condition to include the `keyFile.Name()` in the log entry.

## Testing
The following test run passes locally:
```
go test -test.count=5000 -test.run=TestReload$ ./pkg/config/tlscfg/
```
