### PR TITLE
Handle collector Start error

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -96,7 +96,9 @@ func main() {
 				HealthCheck:    svc.HC(),
 			})
 			collectorOpts := new(app.CollectorOptions).InitFromViper(v)
-			c.Start(collectorOpts)
+			if err := c.Start(collectorOpts); err != nil {
+				logger.Fatal("Failed to start collector", zap.Error(err))
+			}
 
 			svc.RunAndThen(func() {
 				if err := c.Close(); err != nil {


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #2640

## Short description of the changes
- Handle error from `Start` call in collector.
- Fixes symptom of collector not reporting error and exiting if port 14250 is taken.

## Testing
Tested happy path where no port conflicts exist as well as failure case:
- Start [jaeger all-in-one](https://www.jaegertracing.io/docs/latest/getting-started/#all-in-one)
- Logs error and returns non-0 exit status code:
```
$ SPAN_STORAGE_TYPE=memory go run ./cmd/collector/main.go
...
{"level":"fatal","ts":1606280888.116083,"caller":"collector/main.go:100","msg":"Failed to start collector","error":"could not start gRPC collector failed to listen on gRPC port: listen tcp :14250: bind: address already in use","stacktrace":"main.main.func1\n\t/Users/albertteoh/go/src/github.com/albertteoh/jaeger/cmd/collector/main.go:100\ngithub.com/spf13/cobra.(*Command).execute\n\t/Users/albertteoh/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/Users/albertteoh/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914\ngithub.com/spf13/cobra.(*Command).Execute\n\t/Users/albertteoh/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864\nmain.main\n\t/Users/albertteoh/go/src/github.com/albertteoh/jaeger/cmd/collector/main.go:135\nruntime.main\n\t/usr/local/Cellar/go/1.15.2/libexec/src/runtime/proc.go:204"}
exit status 1
```
