### PR TITLE
Move cert loading failure assertion on client public key write

### DIFF
--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -97,7 +97,7 @@ func TestReload(t *testing.T) {
 	assert.True(t, logObserver.
 		FilterMessage("Failed to load certificate").
 		FilterField(zap.String("certificate", certFile.Name())).Len() > 0,
-		"Unable to locate 'Failed to load certificate' error in log. All logs: "+fmt.Sprint(logObserver.All()))
+		"Unable to locate 'Failed to load certificate' in log. All logs: "+fmt.Sprint(logObserver.All()))
 
 	// Write the client's private key.
 	keyData, err = ioutil.ReadFile(clientKey)
@@ -115,7 +115,7 @@ func TestReload(t *testing.T) {
 	assert.True(t, logObserver.
 		FilterMessage("Loaded modified certificate").
 		FilterField(zap.String("certificate", keyFile.Name())).Len() > 0,
-		"Unable to locate 'Loaded modified certificate' error in log. All logs: "+fmt.Sprint(logObserver.All()))
+		"Unable to locate 'Loaded modified certificate' in log. All logs: "+fmt.Sprint(logObserver.All()))
 
 	cert, err = tls.LoadX509KeyPair(filepath.Clean(clientCert), clientKey)
 	require.NoError(t, err)

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -99,15 +99,7 @@ func TestReload(t *testing.T) {
 			FilterField(zap.String("certificate", keyFile.Name())).Len() > 0
 	}, 100, time.Millisecond*200)
 
-	// Logged when the cert is modified with the client's public key due to
-	// a mismatch with the existing server private key.
-	assert.True(t, logObserver.
-		FilterMessage("Failed to load certificate").
-		FilterField(zap.String("certificate", certFile.Name())).Len() > 0,
-		"Failed to find wanted logs. All logs: "+fmt.Sprint(logObserver.All()))
-
-	// Logged when the cert is modified with the client's private key,
-	// resulting in both public and private keys matching (from the client).
+	// Logged when the cert is modified with the client's private key.
 	assert.True(t, logObserver.
 		FilterMessage("Loaded modified certificate").
 		FilterField(zap.String("certificate", keyFile.Name())).Len() > 0,

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -97,7 +97,7 @@ func TestReload(t *testing.T) {
 	assert.True(t, logObserver.
 		FilterMessage("Failed to load certificate").
 		FilterField(zap.String("certificate", certFile.Name())).Len() > 0,
-		"Failed to find wanted logs. All logs: "+fmt.Sprint(logObserver.All()))
+		"Unable to locate 'Failed to load certificate' error in log. All logs: "+fmt.Sprint(logObserver.All()))
 
 	// Write the client's private key.
 	keyData, err = ioutil.ReadFile(clientKey)
@@ -115,7 +115,7 @@ func TestReload(t *testing.T) {
 	assert.True(t, logObserver.
 		FilterMessage("Loaded modified certificate").
 		FilterField(zap.String("certificate", keyFile.Name())).Len() > 0,
-		"Failed to find wanted logs. All logs: "+fmt.Sprint(logObserver.All()))
+		"Unable to locate 'Loaded modified certificate' error in log. All logs: "+fmt.Sprint(logObserver.All()))
 
 	cert, err = tls.LoadX509KeyPair(filepath.Clean(clientCert), clientKey)
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #2654 

## Short description of the changes
- Local testing revealed that `"Failed to load certificate"` is logged every time; however some tests in CI are not logging this failure state, perhaps due to disk I/O variability.
- Given the failure signal is unreliable, this PR removes the failure assertion and only performs an assertion identical to the `waitUntil` condition which should make this test more reliable.