### PR TITLE
Add github action for jaeger all-in-one image

### DIFF
--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -1,0 +1,50 @@
+name: Docker
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  all-in-one:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: ${{ github.head_ref }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15
+
+    - uses: actions/setup-node@v2-beta
+      with:
+        node-version: '10'
+
+    - uses: docker/login-action@v1
+      id: dockerhub-login
+      with:
+        username: jaegertracingbot
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      env:
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      if: env.DOCKERHUB_TOKEN != null
+
+    - name: Set DOCKERHUB_LOGIN
+      run: |
+        echo "DOCKERHUB_LOGIN=true" >> $GITHUB_ENV
+      if: steps.dockerhub-login.outcome == "success"
+
+    - name: Export BRANCH variable if undefined
+      run: |
+        echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      if: env.BRANCH == null
+
+    - name: Install tools
+      run: make install-ci
+
+    - name: Build, test, and publish all-in-one image
+      run: bash scripts/travis/build-all-in-one-image.sh

--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -14,6 +14,10 @@ jobs:
       with:
         submodules: true
 
+    - name: Fetch git tags
+      run: |
+        git fetch --prune --unshallow --tags
+
     - uses: actions/setup-go@v2
       with:
         go-version: ^1.15

--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   all-in-one:
     runs-on: ubuntu-latest
-    env:
-      BRANCH: ${{ github.head_ref }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -38,10 +36,15 @@ jobs:
         echo "DOCKERHUB_LOGIN=true" >> $GITHUB_ENV
       if: steps.dockerhub-login.outcome == 'success'
 
-    - name: Export BRANCH variable if undefined
+    - name: Export BRANCH variable for pull_request event
+      run: |
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+      if: github.event_name == 'pull_request'
+
+    - name: Export BRANCH variable for push event
       run: |
         echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      if: env.BRANCH == null
+      if: github.event_name == 'push'
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -25,7 +25,6 @@ jobs:
         node-version: '10'
 
     - uses: docker/login-action@v1
-      id: dockerhub-login
       with:
         username: jaegertracingbot
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -36,7 +35,7 @@ jobs:
     - name: Set DOCKERHUB_LOGIN
       run: |
         echo "DOCKERHUB_LOGIN=true" >> $GITHUB_ENV
-      if: steps.dockerhub-login.outcome == "success"
+      if: env.DOCKERHUB_TOKEN != null
 
     - name: Export BRANCH variable if undefined
       run: |

--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Build all-in-one
 
 on:
   push:

--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Export DOCKERHUB_LOGIN variable
       run: |
         echo "DOCKERHUB_LOGIN=true" >> $GITHUB_ENV
-      if: env.DOCKERHUB_TOKEN != null
+      if: success()
 
     - name: Export BRANCH variable if undefined
       run: |

--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -25,6 +25,7 @@ jobs:
         node-version: '10'
 
     - uses: docker/login-action@v1
+      id: dockerhub-login
       with:
         username: jaegertracingbot
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -35,7 +36,7 @@ jobs:
     - name: Export DOCKERHUB_LOGIN variable
       run: |
         echo "DOCKERHUB_LOGIN=true" >> $GITHUB_ENV
-      if: success()
+      if: steps.dockerhub-login.outcome == 'success'
 
     - name: Export BRANCH variable if undefined
       run: |

--- a/.github/workflows/all-in-one-build.yml
+++ b/.github/workflows/all-in-one-build.yml
@@ -32,7 +32,7 @@ jobs:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       if: env.DOCKERHUB_TOKEN != null
 
-    - name: Set DOCKERHUB_LOGIN
+    - name: Export DOCKERHUB_LOGIN variable
       run: |
         echo "DOCKERHUB_LOGIN=true" >> $GITHUB_ENV
       if: env.DOCKERHUB_TOKEN != null

--- a/.github/workflows/es-integration-tests.yml
+++ b/.github/workflows/es-integration-tests.yml
@@ -16,5 +16,8 @@ jobs:
       with:
         go-version: ^1.15
 
+    - name: Install tools
+      run: make install-ci
+
     - name: Run elasticsearch integration tests
       run: bash scripts/travis/es-integration-test.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@
     * Title "Release X.Y.Z" 
     * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch
     * Copy the new CHANGELOG.md section into the release notes
-4. The release tag will trigger a build of the docker images
+4. The release tag will trigger a build of the docker images. Since forks don't have jaegertracingbot dockerhub token, they can never publish images to jaegertracing organisation.
 5. Once the images are available on [Docker Hub](https://hub.docker.com/r/jaegertracing/), announce the release on the mailing list, gitter, and twitter.
 6. Publish documentation for the new version in [jaegertracing.io](https://github.com/jaegertracing/documentation).
 

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -12,9 +12,9 @@ expected_version="v10"
 version=$(node --version)
 major_version=${version%.*.*}
 if [ "$major_version" = "$expected_version" ] ; then
-  echo "node version is as expected"
+  echo "Node version is as expected: $version"
 else
-  echo "installed version $major_version doesn't match $expected_version"
+  echo "ERROR: installed Node version $version doesn't match expected version $expected_version"
   exit 1
 fi
 

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -8,8 +8,16 @@ BRANCH=${BRANCH:?'missing BRANCH env var'}
 # `GOARCH=<target arch> ./scripts/travis/build-all-in-one-image.sh`.
 GOARCH=${GOARCH:-$(go env GOARCH)}
 
-source ~/.nvm/nvm.sh
-nvm use 10
+expected_version="v10"
+version=$(node --version)
+major_version=${version%.*.*}
+if [ "$major_version" = "$expected_version" ] ; then
+  echo "node version is as expected"
+else
+  echo "installed version $major_version doesn't match $expected_version"
+  exit 1
+fi
+
 make build-ui
 
 set +e
@@ -28,7 +36,7 @@ run_integration_test() {
 
 upload_to_docker() {
   # Only push the docker container to Docker Hub for master branch
-  if [[ ("$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$) && "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
+  if [[ ("$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$) && "DOCKERHUB_LOGIN" == "true" ]]; then
     echo "upload $1 to Docker Hub"
     export REPO=$1
     bash ./scripts/travis/upload-to-docker.sh
@@ -38,6 +46,7 @@ upload_to_docker() {
 }
 
 make build-all-in-one GOOS=linux GOARCH=$GOARCH
+make create-baseimg-debugimg
 repo=jaegertracing/all-in-one
 docker build -f cmd/all-in-one/Dockerfile \
         --target release \

--- a/scripts/travis/es-integration-test.sh
+++ b/scripts/travis/es-integration-test.sh
@@ -26,7 +26,7 @@ if [ "$ES_OTEL_INTEGRATION_TEST" == true ]; then
   exit 0
 fi
 
-echo "Executing token propatagion test"
+echo "Executing token propagation test"
 
 # Mock UI, needed only for build query service.
 make build-crossdock-ui-placeholder


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
This PR adds the build job of all-in-one image to github actions. 

Part of https://github.com/jaegertracing/jaeger/issues/2645

## Short description of the changes
1. To make the docker login action work we need to add two environment variables like this 

<img width="2270" alt="jaeger" src="https://user-images.githubusercontent.com/16268376/100495175-ae51b800-3183-11eb-9189-c5027066603e.png">

2. To get the branch name we are using github action https://github.com/nelonoel/branch-name which populates env var `BRANCH_NAME`

3. I tried using nodejs official github action (https://github.com/actions/setup-node) instead of calling `scripts/travis/install-ui-deps.sh` but it didn't work and I wasn't able to make it work after several retries. So thought do it in the same way how we do in travis for now.
