### PR TITLE
Fix the unbound variable error on all-in-one image build

### DIFF
--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -7,6 +7,7 @@ BRANCH=${BRANCH:?'missing BRANCH env var'}
 # be overrided by passing architecture value to the script:
 # `GOARCH=<target arch> ./scripts/travis/build-all-in-one-image.sh`.
 GOARCH=${GOARCH:-$(go env GOARCH)}
+DOCKERHUB_LOGIN=${DOCKERHUB_LOGIN:-false}
 
 expected_version="v10"
 version=$(node --version)
@@ -35,8 +36,8 @@ run_integration_test() {
 }
 
 upload_to_docker() {
-  # Only push the docker container to Docker Hub for master branch
-  if [[ ("$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$) && "${DOCKERHUB_LOGIN:-false}" == "true" ]]; then
+  # Only push the docker container to Docker Hub for master/release branch and when dockerhub login is done
+  if [[ ("$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$) && "$DOCKERHUB_LOGIN" == "true" ]]; then
     echo "upload $1 to Docker Hub"
     export REPO=$1
     bash ./scripts/travis/upload-to-docker.sh

--- a/scripts/travis/build-all-in-one-image.sh
+++ b/scripts/travis/build-all-in-one-image.sh
@@ -36,7 +36,7 @@ run_integration_test() {
 
 upload_to_docker() {
   # Only push the docker container to Docker Hub for master branch
-  if [[ ("$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$) && "$DOCKERHUB_LOGIN" == "true" ]]; then
+  if [[ ("$BRANCH" == "master" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$) && "${DOCKERHUB_LOGIN:-false}" == "true" ]]; then
     echo "upload $1 to Docker Hub"
     export REPO=$1
     bash ./scripts/travis/upload-to-docker.sh


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
When someone creates a PR from fork's master branch, first part of the if condition succeeds and then it looks for DOCKERHUB_LOGIN variable which is only set when we push to master (ie. not for pr) here: https://github.com/jaegertracing/jaeger/blob/master/.github/workflows/ci-all-in-one-build.yml#L38-L41
This is causing unbound variable error. Setting it default to `false` will help in solving the error.

This is currently happening for this PR: https://github.com/jaegertracing/jaeger/pull/2657
