### PR TITLE
Fix issue for Elasticsearch CI failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ es-otel-exporter-integration-test: go-gen
 
 .PHONY: test-compile-es-scripts
 test-compile-es-scripts:
-	docker run --rm -v ${PWD}:/tmp/jaeger python:3-alpine /usr/local/bin/python -m py_compile /tmp/jaeger/plugin/storage/es/esRollover.py
-	docker run --rm -v ${PWD}:/tmp/jaeger python:3-alpine /usr/local/bin/python -m py_compile /tmp/jaeger/plugin/storage/es/esCleaner.py
+	docker run --rm -v ${PWD}:/tmp/jaeger python:3-alpine3.11 /usr/local/bin/python -m py_compile /tmp/jaeger/plugin/storage/es/esRollover.py
+	docker run --rm -v ${PWD}:/tmp/jaeger python:3-alpine3.11 /usr/local/bin/python -m py_compile /tmp/jaeger/plugin/storage/es/esCleaner.py
 
 .PHONY: index-cleaner-integration-test
 index-cleaner-integration-test: docker-images-elastic

--- a/plugin/storage/es/Dockerfile
+++ b/plugin/storage/es/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.11
 
 # Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494
 RUN pip install urllib3==1.24.3

--- a/plugin/storage/es/Dockerfile
+++ b/plugin/storage/es/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3-alpine3.11
 
-# Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494
-RUN pip install urllib3==1.24.3
-
-RUN pip install elasticsearch elasticsearch-curator
 COPY esCleaner.py /es-index-cleaner/
+COPY requirements.txt /es-index-cleaner/
+
+RUN pip install -r /es-index-cleaner/requirements.txt
 
 ENTRYPOINT ["python3", "/es-index-cleaner/esCleaner.py"]

--- a/plugin/storage/es/Dockerfile
+++ b/plugin/storage/es/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3-alpine3.11
 
-COPY esCleaner.py /es-index-cleaner/
-COPY requirements.txt /es-index-cleaner/
+# Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494
+RUN pip install urllib3==1.24.3
 
-RUN pip install -r /es-index-cleaner/requirements.txt
+RUN pip install elasticsearch elasticsearch-curator
+COPY esCleaner.py /es-index-cleaner/
 
 ENTRYPOINT ["python3", "/es-index-cleaner/esCleaner.py"]

--- a/plugin/storage/es/Dockerfile.rollover
+++ b/plugin/storage/es/Dockerfile.rollover
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.11
 
 # Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494
 RUN pip install urllib3==1.24.3

--- a/plugin/storage/es/Dockerfile.rollover
+++ b/plugin/storage/es/Dockerfile.rollover
@@ -1,10 +1,9 @@
 FROM python:3-alpine3.11
 
-# Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494
-RUN pip install urllib3==1.24.3
-
-RUN pip install elasticsearch elasticsearch-curator pathlib2
 COPY ./mappings/* /mappings/
 COPY esRollover.py /es-rollover/
+COPY requirements.txt /es-rollover/
+
+RUN pip install -r /es-rollover/requirements.txt
 
 ENTRYPOINT ["python3", "/es-rollover/esRollover.py"]

--- a/plugin/storage/es/Dockerfile.rollover
+++ b/plugin/storage/es/Dockerfile.rollover
@@ -1,9 +1,10 @@
 FROM python:3-alpine3.11
 
+# Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494
+RUN pip install urllib3==1.24.3
+
+RUN pip install elasticsearch elasticsearch-curator pathlib2
 COPY ./mappings/* /mappings/
 COPY esRollover.py /es-rollover/
-COPY requirements.txt /es-rollover/
-
-RUN pip install -r /es-rollover/requirements.txt
 
 ENTRYPOINT ["python3", "/es-rollover/esRollover.py"]

--- a/plugin/storage/es/requirements.txt
+++ b/plugin/storage/es/requirements.txt
@@ -1,0 +1,3 @@
+elasticsearch==7.10.0
+elasticsearch-curator==5.8.3
+urllib3==1.24.3 # Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494

--- a/plugin/storage/es/requirements.txt
+++ b/plugin/storage/es/requirements.txt
@@ -1,3 +1,0 @@
-elasticsearch==7.10.0
-elasticsearch-curator==5.8.3
-urllib3==1.24.3 # Temporary fix for https://github.com/jaegertracing/jaeger/issues/1494


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Around 10 hours back, python:3-alpine image was upgraded which bumped the pip version from 20.2 to 20.3. 

<img width="314" alt="docker" src="https://user-images.githubusercontent.com/16268376/100870310-614e4880-34d9-11eb-8810-eaf518ca0caf.png">


elasticsearch-curator library has hard requirement of elasticsearch lib v7.1.0 (https://github.com/elastic/curator/blob/master/setup.cfg#L26) which isn't compatible with our escleanup.py.

You can see the failure build where elasticsearch-py is being downgraded to v7.1.0.

```
Collecting elasticsearch
Downloading elasticsearch-7.10.0-py2.py3-none-any.whl (321 kB)
Requirement already satisfied: urllib3<2,>=1.21.1 in /usr/local/lib/python3.9/site-packages (from elasticsearch) (1.24.3)
Collecting elasticsearch-curator
Downloading elasticsearch_curator-5.8.3-py2.py3-none-any.whl (106 kB)
Requirement already satisfied: urllib3<2,>=1.21.1 in /usr/local/lib/python3.9/site-packages (from elasticsearch) (1.24.3)
Collecting elasticsearch
Downloading elasticsearch-7.1.0-py2.py3-none-any.whl (83 kB)
```

Picking it from previous successful run, there is no downgrade.

```
Collecting elasticsearch
Downloading elasticsearch-7.10.0-py2.py3-none-any.whl (321 kB)
Collecting elasticsearch-curator
Downloading elasticsearch_curator-5.8.3-py2.py3-none-any.whl (106 kB)
```

Making image to use a python image with pip 20.2 should fix this issue.
