### PR TITLE
Add status command

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
@@ -95,6 +96,7 @@ func main() {
 
 	command.AddCommand(version.Command())
 	command.AddCommand(docs.Command(v))
+	command.AddCommand(status.Command(v, ports.AgentAdminHTTP))
 
 	config.AddFlags(
 		v,

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
@@ -33,6 +32,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 	"github.com/jaegertracing/jaeger/cmd/docs"
 	"github.com/jaegertracing/jaeger/cmd/flags"
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/ports"

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -182,6 +183,7 @@ by default uses only in-memory database.`,
 	command.AddCommand(version.Command())
 	command.AddCommand(env.Command())
 	command.AddCommand(docs.Command(v))
+	command.AddCommand(status.Command(v, ports.CollectorAdminHTTP))
 
 	config.AddFlags(
 		v,

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,6 +41,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	queryApp "github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	ss "github.com/jaegertracing/jaeger/plugin/sampling/strategystore"

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
@@ -122,6 +123,7 @@ func main() {
 	command.AddCommand(version.Command())
 	command.AddCommand(env.Command())
 	command.AddCommand(docs.Command(v))
+	command.AddCommand(status.Command(v, ports.CollectorAdminHTTP))
 
 	config.AddFlags(
 		v,

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
@@ -34,6 +33,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/docs"
 	"github.com/jaegertracing/jaeger/cmd/env"
 	"github.com/jaegertracing/jaeger/cmd/flags"
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	ss "github.com/jaegertracing/jaeger/plugin/sampling/strategystore"

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
@@ -32,6 +31,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/builder"
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/plugin/storage"

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics"
@@ -99,6 +100,7 @@ func main() {
 	command.AddCommand(version.Command())
 	command.AddCommand(env.Command())
 	command.AddCommand(docs.Command(v))
+	command.AddCommand(status.Command(v, ports.IngesterAdminHTTP))
 
 	config.AddFlags(
 		v,

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -134,6 +135,7 @@ func main() {
 	command.AddCommand(version.Command())
 	command.AddCommand(env.Command())
 	command.AddCommand(docs.Command(v))
+	command.AddCommand(status.Command(v, ports.QueryAdminHTTP))
 
 	config.AddFlags(
 		v,

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -35,6 +34,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/plugin/storage"

--- a/cmd/status/command.go
+++ b/cmd/status/command.go
@@ -21,9 +21,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/jaegertracing/jaeger/ports"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/jaegertracing/jaeger/ports"
 )
 
 const statusHTTPHostPort = "status.http.host-port"

--- a/cmd/status/command.go
+++ b/cmd/status/command.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/jaegertracing/jaeger/ports"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const statusHTTPHostPort = "status.http.host-port"
+
+// Command for check component status.
+func Command(v *viper.Viper, adminPort int) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "status",
+		Short: "Print the status.",
+		Long:  `Print Jaeger component status information, exit non-zero on any error.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			url := convert(v.GetString(statusHTTPHostPort))
+			resp, err := http.Get(url)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(body))
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("abnormal value of http status code: %v", resp.StatusCode)
+			}
+			return nil
+		},
+	}
+	c.Flags().AddGoFlagSet(flags(&flag.FlagSet{}, adminPort))
+	v.BindPFlags(c.Flags())
+	return c
+}
+
+func flags(flagSet *flag.FlagSet, adminPort int) *flag.FlagSet {
+	adminPortStr := ports.PortToHostPort(adminPort)
+	flagSet.String(statusHTTPHostPort, adminPortStr, fmt.Sprintf(
+		"The host:port (e.g. 127.0.0.1%s or %s) for the health check", adminPortStr, adminPortStr))
+	return flagSet
+}
+
+func convert(httpHostPort string) string {
+	if strings.HasPrefix(httpHostPort, ":") {
+		return fmt.Sprintf("http://127.0.0.1%s", httpHostPort)
+	}
+	return fmt.Sprintf("http://%s", httpHostPort)
+}

--- a/cmd/status/command.go
+++ b/cmd/status/command.go
@@ -42,10 +42,7 @@ func Command(v *viper.Viper, adminPort int) *cobra.Command {
 				return err
 			}
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return err
-			}
+			body, _ := ioutil.ReadAll(resp.Body)
 			fmt.Println(string(body))
 			if resp.StatusCode != http.StatusOK {
 				return fmt.Errorf("abnormal value of http status code: %v", resp.StatusCode)

--- a/cmd/status/command_test.go
+++ b/cmd/status/command_test.go
@@ -63,3 +63,10 @@ func TestUnready(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 }
+
+func TestNoService(t *testing.T) {
+	v := viper.New()
+	cmd := Command(v, 12345)
+	err := cmd.Execute()
+	assert.Error(t, err)
+}

--- a/cmd/status/command_test.go
+++ b/cmd/status/command_test.go
@@ -49,7 +49,7 @@ func TestOnlyPortConfig(t *testing.T) {
 	defer ts.Close()
 	v := viper.New()
 	cmd := Command(v, 80)
-	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://127.0.0.1")})
+	cmd.ParseFlags([]string{"--status.http.host-port=:" + strings.Split(ts.URL, ":")[len(strings.Split(ts.URL, ":"))-1]})
 	err := cmd.Execute()
 	assert.NoError(t, err)
 }

--- a/cmd/status/command_test.go
+++ b/cmd/status/command_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func readyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("{\"status\":\"Server available\"}"))
+}
+
+func unavailableHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusServiceUnavailable)
+	w.Write([]byte("{\"status\":\"Server not available\"}"))
+}
+
+func TestReady(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(readyHandler))
+	defer ts.Close()
+	v := viper.New()
+	cmd := Command(v, 80)
+	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://")})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestOnlyPortConfig(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(readyHandler))
+	defer ts.Close()
+	v := viper.New()
+	cmd := Command(v, 80)
+	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://127.0.0.1")})
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestUnready(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(unavailableHandler))
+	defer ts.Close()
+	v := viper.New()
+	cmd := Command(v, 80)
+	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://")})
+	err := cmd.Execute()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Chen Zhengwei <chenzhengwei@inspur.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/2361

## Short description of the changes
- Add status command. 
Usage: `<command> status` checks the localhost and the port of the corresponding component.
`<command> status --status.http.host-port` checks for a specific port or URL.
