### PR TITLE
Fix misleading use-alias help doc

### DIFF
--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -239,7 +239,7 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.UseReadWriteAliases,
 		"Use read and write aliases for indices. Use this option with Elasticsearch rollover "+
 			"API. It requires an external component to create aliases before startup and then performing its management. "+
-			"Note that "+nsConfig.namespace+suffixMaxSpanAge+" is not taken into the account and has to be substituted by external component managing read alias.")
+			"Note that "+nsConfig.namespace+suffixMaxSpanAge+" will influence trace search window start times.")
 	flagSet.Bool(
 		nsConfig.namespace+suffixCreateIndexTemplate,
 		nsConfig.CreateIndexTemplates,


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #2138

## Short description of the changes
- The documentation states that `es.max-span-age` is not taken into account when `use-alias` is enabled, which causes users to think that all indices under the `jaeger-...-read` alias are searchable. However, `es.max-span-age` is used to define the starting window of ES queries like [in this example](https://github.com/jaegertracing/jaeger/blob/6c2be456ca41cdb98ac4b81cb8d9a9a9044463cd/cmd/opentelemetry/app/internal/reader/es/esspanreader/span_reader.go#L101).
- We address this by explicitly documenting that `es.max-span-age` _does_ influence search window start times, without being too specific to implementation.