### PR TITLE
Clean-up "tcollector" references

### DIFF
--- a/cmd/agent/README.md
+++ b/cmd/agent/README.md
@@ -10,17 +10,17 @@ libraries.
     * processor as ThriftProcessor
         * server as TBufferedServer
             * Thrift UDP Transport
-        * reporter as TCollectorReporter
+        * reporter as CollectorReporter
     * sampling server
-        * sampling manager as sampling.TCollectorProxy
+        * sampling manager as sampling.CollectorProxy
 
 ### UDP Server
 
 Listens on UDP transport, reads data as `[]byte` and forwards to
 `processor` over channel. Processor has N workers that read from
 the channel, convert to thrift-generated object model, and pass on
-to the Reporter. `TCollectorReporter` submits the spans to remote
-`tcollector` service.
+to the Reporter. `CollectorReporter` submits the spans to remote
+`collector` service.
 
 ### Sampling Server
 
@@ -29,7 +29,7 @@ An HTTP server handling request in the form
     http://localhost:port/sampling?service=xxxx`
 
 Delegates to `sampling.Manager` to get the sampling strategy.
-`sampling.TCollectorProxy` implements `sampling.Manager` by querying
-remote `tcollector` service. Then the server converts
+`sampling.CollectorProxy` implements `sampling.Manager` by querying
+remote `collector` service. Then the server converts
 thrift response from sampling manager into JSON and responds to clients.
 

--- a/pkg/clientcfg/clientcfghttp/handler_test.go
+++ b/pkg/clientcfg/clientcfghttp/handler_test.go
@@ -175,7 +175,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			},
 		},
 		{
-			description: "baggage tcollector error",
+			description: "baggage collector error",
 			url:         "/baggageRestrictions?service=Y",
 			statusCode:  http.StatusInternalServerError,
 			body:        "collector error: no mock response provided\n",


### PR DESCRIPTION
Signed-off-by: Chen Zhengwei <chenzhengwei@inspur.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/285

## Short description of the changes
- Clean-up the outdated "tcollector".
