### PR TITLE
plaintext as supported kafka auth option

### DIFF
--- a/pkg/kafka/auth/config.go
+++ b/pkg/kafka/auth/config.go
@@ -36,6 +36,7 @@ var authTypes = []string{
 	none,
 	kerberos,
 	tls,
+	plaintext,
 }
 
 // AuthenticationConfig describes the configuration properties needed authenticate with kafka cluster


### PR DESCRIPTION
Hello Jaeger Team,

This tiny patch will simply add "plaintext" as one of the supported Kafka authentication in the CLI options. 

Thanks for your awesome work on this project.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@ovhcloud.com>