### PR TITLE
Expose cache ttl for es span writer index+service

### DIFF
--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -65,29 +65,20 @@ type SpanWriterParams struct {
 	TagDotReplacement   string
 	Archive             bool
 	UseReadWriteAliases bool
-	ServiceCacheTTL     string
-	IndexCacheTTL       string
+	ServiceCacheTTL     time.Duration
+	IndexCacheTTL       time.Duration
 }
 
 // NewSpanWriter creates a new SpanWriter for use
 func NewSpanWriter(p SpanWriterParams) *SpanWriter {
-	var err error
-	serviceCacheTTL := serviceCacheTTLDefault
-	if p.ServiceCacheTTL != "" {
-		serviceCacheTTL, err = time.ParseDuration(p.ServiceCacheTTL)
-		if err != nil {
-			p.Logger.Warn("error parsing service cache duration. Using default", zap.Error(err), zap.Duration("default", serviceCacheTTLDefault))
-			serviceCacheTTL = serviceCacheTTLDefault
-		}
+	serviceCacheTTL := p.ServiceCacheTTL
+	if p.ServiceCacheTTL == 0 {
+		serviceCacheTTL = serviceCacheTTLDefault
 	}
 
-	indexCacheTTL := indexCacheTTLDefault
-	if p.ServiceCacheTTL != "" {
-		indexCacheTTL, err = time.ParseDuration(p.IndexCacheTTL)
-		if err != nil {
-			p.Logger.Warn("error parsing index cache duration. Using default", zap.Error(err), zap.Duration("default", indexCacheTTLDefault))
-			indexCacheTTL = indexCacheTTLDefault
-		}
+	indexCacheTTL := p.IndexCacheTTL
+	if p.ServiceCacheTTL == 0 {
+		indexCacheTTL = indexCacheTTLDefault
 	}
 
 	serviceOperationStorage := NewServiceOperationStorage(p.Client, p.Logger, serviceCacheTTL)

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -360,26 +360,20 @@ func TestSpanWriterParamsTTL(t *testing.T) {
 	logger, _ := testutils.NewLogger()
 	metricsFactory := metricstest.NewFactory(0)
 	testCases := []struct {
-		indexTTL         string
-		serviceTTL       string
+		indexTTL         time.Duration
+		serviceTTL       time.Duration
 		name             string
 		expectedAddCalls int
 	}{
 		{
-			indexTTL:         indexCacheTTLDefault.String(),
-			serviceTTL:       serviceCacheTTLDefault.String(),
+			indexTTL:         0,
+			serviceTTL:       0,
 			name:             "uses defaults",
 			expectedAddCalls: 1,
 		},
 		{
-			indexTTL:         "invalid",
-			serviceTTL:       "invalid2",
-			name:             "uses defaults if invalid input",
-			expectedAddCalls: 1,
-		},
-		{
-			indexTTL:         "1ns",
-			serviceTTL:       "1ns",
+			indexTTL:         1 * time.Nanosecond,
+			serviceTTL:       1 * time.Nanosecond,
 			name:             "uses provided values",
 			expectedAddCalls: 3,
 		},


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Unable to specify a cache duration for the service or index caches
- Our use case requires that we can set these

## Short description of the changes
- Added ability to pass ttl duration for both service and index caches for the elastic spanstore writer
- If not specified it will use the previous defaults of 12h and 48h
