### PR TITLE
Remove deprecated collector flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Changes by Version
 
 ### Backend Changes
 
+#### Breaking Changes
+* Remove deprecated CLI flags ([#2738](https://github.com/jaegertracing/jaeger/issues/2738), [@LostLaser](https://github.com/LostLaser))
+    * The `--collector.http-port` flag has been removed in favour of `--collector.http-server.host-port`.
+    * The `--collector.grpc-port` flag has been removed in favour of `--collector.grpc-server.host-port`.
+    * The `--collector.zipkin.http-port` flag has been removed in favour of `--collector.zipkin.host-port`.
+
 ### New Features
 
 * Add TLS Support for GRPC and HTTP endpoints of the Query server ([#2337](https://github.com/jaegertracing/jaeger/pull/2337), [@rjs211](https://github.com/rjs211))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changes by Version
 
 #### Breaking Changes
 
-* Remove deprecated CLI flags ([#2738](https://github.com/jaegertracing/jaeger/issues/2738), [@LostLaser](https://github.com/LostLaser)):
+* Remove deprecated CLI flags ([#2751](https://github.com/jaegertracing/jaeger/issues/2751), [@LostLaser](https://github.com/LostLaser)):
     * `--collector.http-port` is replaced by `--collector.http-server.host-port`
     * `--collector.grpc-port` is replaced by `--collector.grpc-server.host-port`
     * `--collector.zipkin.http-port` is replaced by `--collector.zipkin.host-port`

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -29,7 +29,6 @@ const (
 	collectorDynQueueSizeMemory = "collector.queue-size-memory"
 	collectorQueueSize          = "collector.queue-size"
 	collectorNumWorkers         = "collector.num-workers"
-	collectorHTTPPort           = "collector.http-port"
 	collectorGRPCPort           = "collector.grpc-port"
 	// CollectorHTTPHostPort is the flag for collector HTTP port
 	CollectorHTTPHostPort = "collector.http-server.host-port"
@@ -42,7 +41,6 @@ const (
 	collectorZipkinAllowedOrigins = "collector.zipkin.allowed-origins"
 	collectorZipkinAllowedHeaders = "collector.zipkin.allowed-headers"
 
-	collectorHTTPPortWarning       = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
 	collectorGRPCPortWarning       = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
 	collectorZipkinHTTPPortWarning = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
 )
@@ -81,7 +79,6 @@ type CollectorOptions struct {
 func AddFlags(flags *flag.FlagSet) {
 	flags.Int(collectorQueueSize, DefaultQueueSize, "The queue size of the collector")
 	flags.Int(collectorNumWorkers, DefaultNumWorkers, "The number of workers pulling items from the queue")
-	flags.Int(collectorHTTPPort, 0, collectorHTTPPortWarning+" see --"+CollectorHTTPHostPort)
 	flags.Int(collectorGRPCPort, 0, collectorGRPCPortWarning+" see --"+CollectorGRPCHostPort)
 	flags.Int(collectorZipkinHTTPPort, 0, collectorZipkinHTTPPortWarning+" see --"+CollectorZipkinHTTPHostPort)
 	flags.Uint(collectorDynQueueSizeMemory, 0, "(experimental) The max memory size in MiB to use for the dynamic queue.")
@@ -109,7 +106,7 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
 	cOpts.DynQueueSizeMemory = v.GetUint(collectorDynQueueSizeMemory) * 1024 * 1024 // we receive in MiB and store in bytes
 	cOpts.QueueSize = v.GetInt(collectorQueueSize)
 	cOpts.NumWorkers = v.GetInt(collectorNumWorkers)
-	cOpts.CollectorHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorHTTPPort), v.GetString(CollectorHTTPHostPort))
+	cOpts.CollectorHTTPHostPort = ports.FormatHostPort(v.GetString(CollectorHTTPHostPort))
 	cOpts.CollectorGRPCHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorGRPCPort), v.GetString(CollectorGRPCHostPort))
 	cOpts.CollectorZipkinHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(CollectorZipkinHTTPHostPort))
 	cOpts.CollectorTags = flags.ParseJaegerTags(v.GetString(collectorTags))

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -29,20 +29,15 @@ const (
 	collectorDynQueueSizeMemory = "collector.queue-size-memory"
 	collectorQueueSize          = "collector.queue-size"
 	collectorNumWorkers         = "collector.num-workers"
-	collectorGRPCPort           = "collector.grpc-port"
 	// CollectorHTTPHostPort is the flag for collector HTTP port
 	CollectorHTTPHostPort = "collector.http-server.host-port"
 	// CollectorGRPCHostPort is the flag for collector gRPC port
-	CollectorGRPCHostPort   = "collector.grpc-server.host-port"
-	collectorZipkinHTTPPort = "collector.zipkin.http-port"
+	CollectorGRPCHostPort = "collector.grpc-server.host-port"
 	// CollectorZipkinHTTPHostPort is the flag for Zipkin HTTP port
 	CollectorZipkinHTTPHostPort   = "collector.zipkin.host-port"
 	collectorTags                 = "collector.tags"
 	collectorZipkinAllowedOrigins = "collector.zipkin.allowed-origins"
 	collectorZipkinAllowedHeaders = "collector.zipkin.allowed-headers"
-
-	collectorGRPCPortWarning       = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
-	collectorZipkinHTTPPortWarning = "(deprecated, will be removed after 2020-06-30 or in release v1.20.0, whichever is later)"
 )
 
 var tlsFlagsConfig = tlscfg.ServerFlagsConfig{
@@ -79,8 +74,6 @@ type CollectorOptions struct {
 func AddFlags(flags *flag.FlagSet) {
 	flags.Int(collectorQueueSize, DefaultQueueSize, "The queue size of the collector")
 	flags.Int(collectorNumWorkers, DefaultNumWorkers, "The number of workers pulling items from the queue")
-	flags.Int(collectorGRPCPort, 0, collectorGRPCPortWarning+" see --"+CollectorGRPCHostPort)
-	flags.Int(collectorZipkinHTTPPort, 0, collectorZipkinHTTPPortWarning+" see --"+CollectorZipkinHTTPHostPort)
 	flags.Uint(collectorDynQueueSizeMemory, 0, "(experimental) The max memory size in MiB to use for the dynamic queue.")
 	flags.String(collectorTags, "", "One or more tags to be added to the Process tags of all spans passing through this collector. Ex: key1=value1,key2=${envVar:defaultValue}")
 	flags.String(collectorZipkinAllowedOrigins, "*", "Comma separated list of allowed origins for the Zipkin collector service, default accepts all")
@@ -107,8 +100,8 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
 	cOpts.QueueSize = v.GetInt(collectorQueueSize)
 	cOpts.NumWorkers = v.GetInt(collectorNumWorkers)
 	cOpts.CollectorHTTPHostPort = ports.FormatHostPort(v.GetString(CollectorHTTPHostPort))
-	cOpts.CollectorGRPCHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorGRPCPort), v.GetString(CollectorGRPCHostPort))
-	cOpts.CollectorZipkinHTTPHostPort = ports.GetAddressFromCLIOptions(v.GetInt(collectorZipkinHTTPPort), v.GetString(CollectorZipkinHTTPHostPort))
+	cOpts.CollectorGRPCHostPort = ports.FormatHostPort(v.GetString(CollectorGRPCHostPort))
+	cOpts.CollectorZipkinHTTPHostPort = ports.FormatHostPort(v.GetString(CollectorZipkinHTTPHostPort))
 	cOpts.CollectorTags = flags.ParseJaegerTags(v.GetString(collectorTags))
 	cOpts.CollectorZipkinAllowedOrigins = v.GetString(collectorZipkinAllowedOrigins)
 	cOpts.CollectorZipkinAllowedHeaders = v.GetString(collectorZipkinAllowedHeaders)

--- a/cmd/opentelemetry/go.sum
+++ b/cmd/opentelemetry/go.sum
@@ -1024,8 +1024,10 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/cmd/opentelemetry/go.sum
+++ b/cmd/opentelemetry/go.sum
@@ -1024,10 +1024,8 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
-github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
-github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/ports/ports.go
+++ b/ports/ports.go
@@ -60,6 +60,11 @@ func GetAddressFromCLIOptions(port int, hostPort string) string {
 		return PortToHostPort(port)
 	}
 
+	return FormatHostPort(hostPort)
+}
+
+// FormatHostPort returns hostPort in a usable format (host:port) if it wasn't already
+func FormatHostPort(hostPort string) string {
 	if hostPort == "" {
 		return ""
 	}

--- a/ports/ports_test.go
+++ b/ports/ports_test.go
@@ -44,3 +44,10 @@ func TestGetAddressFromCLIOptionsLegacy(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatHostPort(t *testing.T) {
+	assert.Equal(t, ":42", FormatHostPort("42"))
+	assert.Equal(t, ":831", FormatHostPort(":831"))
+	assert.Equal(t, "", FormatHostPort(""))
+	assert.Equal(t, "localhost:42", FormatHostPort("localhost:42"))
+}


### PR DESCRIPTION
Signed-off-by: Jacob Goldsworthy <jtgolds6@gmail.com>

## Which problem is this PR solving?
-  Resolves part of  #2738 

## Short description of the changes
- Removed the deprecated ```collectorHTTPPort``` flag and the associated warning flag ```collectorHTTPPortWarning```
- Separated the hostPort formatting from ```GetAddressFromCLIOptions``` into its' own function called ```FormatHostPort```
- Wrapped retrieval of the ```CollectorHTTPHostPort``` property with a call to ```FormatHostPort```
- Added tests for the ```FormatHostPort``` function
