### PR TITLE
Fix errors in build-binaries task

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -14,6 +14,10 @@ jobs:
       with:
         submodules: true
 
+    - name: Fetch git tags
+      run: |
+        git fetch --prune --unshallow --tags
+
     - uses: actions/setup-go@v2
       with:
         go-version: ^1.15


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
As described https://github.com/jaegertracing/jaeger/pull/2740#issuecomment-770567346

```
GOOS=linux GOARCH=amd64 make build-platform-binaries
make[1]: Entering directory '/home/runner/work/jaeger/jaeger'
fatal: No names found, cannot describe anything.
```

## Short description of the changes

Each build job of jaeger component's binary adds BUILD_INFO (part of which is extracted from git tag i.e. GIT_CLOSEST_TAG) in Makefile. Hence we need to pull the git tags before building binaries.
