### PR TITLE
Divide build-binaries job to multiple jobs per platform

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -9,6 +9,22 @@ on:
 jobs:
   build-binaries:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+        - name: linux
+          task: build-binaries-linux
+        - name: windows
+          task: build-binaries-windows
+        - name: osx
+          task: build-binaries-darwin
+        - name: system/390
+          task: build-binaries-s390x
+        - name: arm
+          task: build-binaries-arm64
+        - name: powerpc
+          task: build-binaries-ppc64le
+    name: binaries ${{ matrix.platform.name }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -29,4 +45,4 @@ jobs:
       run: make install-ci
 
     - name: Build binaries
-      run: make build-all-platforms
+      run: make ${{ matrix.platform.task }}

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -24,7 +24,7 @@ jobs:
           task: build-binaries-arm64
         - name: powerpc
           task: build-binaries-ppc64le
-    name: binaries ${{ matrix.platform.name }}
+    name: build binaries for ${{ matrix.platform.name }}
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Right now build-binaries is taking around 30 minutes to complete. This should do this in parallel.

## Short description of the changes
Moving each platform binaries build into separate job.
