### PR TITLE
Add dependabot to the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
dependabot will open a PR with new versions that it detects. Once we trust it enough in this repository, we might consider auto-merging PRs if they pass the CI, which is what we are currently doing for the otel-operator, for instance.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

