### PR TITLE
Remove needs-triage labeler

### DIFF
--- a/.github/labeler-needs-triage.yaml
+++ b/.github/labeler-needs-triage.yaml
@@ -1,3 +1,0 @@
-# Add 'needs-triage' label to all new issues
-needs-triage:
-    - '.*'


### PR DESCRIPTION
## Which problem is this PR solving?
- The `needs-triage` label was added, hoping that it would help us better triage the new issues. Unfortunately, it's not helping much, and I'm afraid it's actually making the situation worse, as it's causing unnecessary noise.

## Short description of the changes
- Remove the action that adds a new label to all new issues.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>