### PR TITLE
Fix default username when pushing container images to Quay.io

### DIFF
--- a/scripts/travis/upload-to-registry.sh
+++ b/scripts/travis/upload-to-registry.sh
@@ -4,7 +4,7 @@ set -euxf -o pipefail
 
 DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-"jaegertracingbot"}
 DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:-}
-QUAY_USERNAME=${QUAY_USERNAME:-"jaegertracingbot+github_workflows"}
+QUAY_USERNAME=${QUAY_USERNAME:-"jaegertracing+github_workflows"}
 QUAY_TOKEN=${QUAY_TOKEN:-}
 
 usage() {


### PR DESCRIPTION
The PR #2783 introduced a change where container images are also pushed to Quay, but unfortunately, the username was incorrectly set. In order to use the same account that the jaeger-operator uses, I'm changing this here instead of creating a new robot account.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
