### PR TITLE
2814 - Throw an error when --es.use-ilm is set without --es.use-aliases

### DIFF
--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -138,6 +138,9 @@ func createSpanReader(
 	cfg config.ClientBuilder,
 	archive bool,
 ) (spanstore.Reader, error) {
+	if cfg.GetUseILM() && !cfg.GetUseReadWriteAliases() {
+		return nil, fmt.Errorf("--es.use-ilm must always be used in conjunction with --es.use-aliases to ensure ES writers and readers refer to the single index mapping")
+	}
 	return esSpanStore.NewSpanReader(esSpanStore.SpanReaderParams{
 		Client:              client,
 		Logger:              logger,
@@ -161,6 +164,9 @@ func createSpanWriter(
 ) (spanstore.Writer, error) {
 	var tags []string
 	var err error
+	if cfg.GetUseILM() && !cfg.GetUseReadWriteAliases() {
+		return nil, fmt.Errorf("--es.use-ilm must always be used in conjunction with --es.use-aliases to ensure ES writers and readers refer to the single index mapping")
+	}
 	if tags, err = cfg.TagKeysAsFields(); err != nil {
 		logger.Error("failed to get tag keys", zap.Error(err))
 		return nil, err

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -105,6 +105,22 @@ func TestElasticsearchTagsFileDoNotExist(t *testing.T) {
 	assert.Nil(t, r)
 }
 
+func TestElasticsearchILMUsedWithoutReadWriteAliases(t *testing.T) {
+	f := NewFactory()
+	mockConf := &mockClientBuilder{}
+	mockConf.UseILM = true
+	f.primaryConfig = mockConf
+	f.archiveConfig = mockConf
+	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	w, err := f.CreateSpanWriter()
+	require.EqualError(t, err, "--es.use-ilm must always be used in conjunction with --es.use-aliases to ensure ES writers and readers refer to the single index mapping")
+	assert.Nil(t, w)
+
+	r, err := f.CreateSpanReader()
+	require.EqualError(t, err, "--es.use-ilm must always be used in conjunction with --es.use-aliases to ensure ES writers and readers refer to the single index mapping")
+	assert.Nil(t, r)
+}
+
 func TestTagKeysAsFields(t *testing.T) {
 	tests := []struct {
 		path          string


### PR DESCRIPTION
Signed-off-by: santosh <bsantosh@thoughtworks.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
--> Resolves #2814 

## Which problem is this PR solving?
- Adds a check to make sure that --es.use-ilm is always used in conjunction with--es.use-aliases

## Short description of the changes
 Add validation at the top of each ES reader and writer constructor with the following logic:

if cfg.GetUseILM() && !cfg.GetUseReadWriteAliases() {
	return nil, fmt.Errorf("the error message")
}