### PR TITLE
Pass context to goroutine

### DIFF
--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -358,7 +358,7 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
 
-	// verify that reloading in no-op
+	// verify that reloading is a no-op
 	value := store.reloadSamplingStrategy(samplingStrategyLoader(dstFile), string(srcBytes))
 	assert.Equal(t, string(srcBytes), value)
 


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Follow up to this discussion: https://github.com/jaegertracing/jaeger/pull/2818#discussion_r579978925
- From the [golang docs on context](https://golang.org/pkg/context/):
> Do not store Contexts inside a struct type; instead, pass a Context explicitly to each function that needs it. The Context should be the first parameter, typically named ctx

## Short description of the changes
- Fixes an anti-pattern where ctx is stored in a struct rather than passed as a first parameter to the goroutine using the struct.
