### PR TITLE
Preparing release v1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Changes by Version
 #### Bug fixes, Minor Improvements
 
 * Use workaround for windows x509.SystemCertPool() ([#2756](https://github.com/jaegertracing/jaeger/pull/2756), [@Ashmita152](https://github.com/Ashmita152))
-* Guard against large string/binary allocations due to malformed sizes that lead to high memory utilization in jaeger-agent ([#2780](https://github.com/jaegertracing/jaeger/pull/2780), [@jpkrohling](https://github.com/jpkrohling))
+* Guard against mal-formed payloads received by the agent, potentially causing high memory utilization ([#2780](https://github.com/jaegertracing/jaeger/pull/2780), [@jpkrohling](https://github.com/jpkrohling))
 * Expose cache TTL for ES span writer index+service ([#2737](https://github.com/jaegertracing/jaeger/pull/2737), [@necrolyte2](https://github.com/necrolyte2))
 * Copy spans from memory store ([#2720](https://github.com/jaegertracing/jaeger/pull/2720), [@bobrik](https://github.com/bobrik))
 * [pkg/queue] Add `StartConsumersWithFactory` function ([#2714](https://github.com/jaegertracing/jaeger/pull/2714), [@mx-psi](https://github.com/mx-psi))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,15 @@ Changes by Version
     
 #### New Features
 
-* Add TLS Support for gRPC and HTTP endpoints of the Query server ([#2337](https://github.com/jaegertracing/jaeger/pull/2337), [#2772](https://github.com/jaegertracing/jaeger/pull/2772), [@rjs211](https://github.com/rjs211))
+* Add TLS Support for gRPC and HTTP endpoints of the Query and Collector servers ([#2337](https://github.com/jaegertracing/jaeger/pull/2337), [#2772](https://github.com/jaegertracing/jaeger/pull/2772), [#2798](https://github.com/jaegertracing/jaeger/pull/2798), [@rjs211](https://github.com/rjs211))
 
-    *  If TLS in enabled on either or both of gRPC or HTTP endpoints, the gRPC host-port and the HTTP hostport have to be different
-    *  If TLS is disabled on both endpoints, common HTTP and gRPC host-port can be explicitly set using the `--query.http-server.host-port` and  `--query.grpc-server.host-port` host-port flags
+    *  If TLS in enabled on either or both of gRPC or HTTP endpoints, the gRPC host-port and the HTTP host-port have to be different
+    *  If TLS is disabled on both endpoints, common HTTP and gRPC host-port can be explicitly set using the following host-port flags respectively:
+        * Query: `--query.http-server.host-port` and  `--query.grpc-server.host-port`
+        * Collector: `--collector.http-server.host-port` and `--collector.grpc-server.host-port`
+* Add support for Kafka SASL/PLAIN authentication via SCRAM-SHA-256 or SCRAM-SHA-512 mechanism ([#2724](https://github.com/jaegertracing/jaeger/pull/2724), [@WalkerWang731](https://github.com/WalkerWang731))
+* [agent] Add metrics to show connections status between agent and collectors ([#2657](https://github.com/jaegertracing/jaeger/pull/2657), [@WalkerWang731](https://github.com/WalkerWang731))
+* Add plaintext as a supported kafka auth option ([#2721](https://github.com/jaegertracing/jaeger/pull/2721), [@pdepaepe](https://github.com/pdepaepe))
 * Add ability to use JS file for UI configuration (#123 from jaeger-ui) ([#2707](https://github.com/jaegertracing/jaeger/pull/2707), [@th3M1ke](https://github.com/th3M1ke))
 * Support Elasticsearch ILM for managing jaeger indices ([#2796](https://github.com/jaegertracing/jaeger/pull/2796), [@bhiravabhatla](https://github.com/bhiravabhatla))
 * Push official images to quay.io, in addition to Docker Hub ([#2783](https://github.com/jaegertracing/jaeger/pull/2783), [@Ashmita152](https://github.com/Ashmita152))
@@ -59,27 +64,21 @@ Changes by Version
       $ ./cmd/collector/collector-darwin-amd64 status
       {"status":"Server available","upSince":"2021-02-19T17:57:12.671902+11:00","uptime":"25.241233383s"}
       ```
+* Support configurable date separator for Elasticsearch index names ([#2637](https://github.com/jaegertracing/jaeger/pull/2637), [@sniperking1234](https://github.com/sniperking1234))
 
 #### Bug fixes, Minor Improvements
 
 * Use workaround for windows x509.SystemCertPool() ([#2756](https://github.com/jaegertracing/jaeger/pull/2756), [@Ashmita152](https://github.com/Ashmita152))
-* Use fork of Apache Thrift ([#2780](https://github.com/jaegertracing/jaeger/pull/2780), [@jpkrohling](https://github.com/jpkrohling))
+* Guard against large string/binary allocations due to malformed sizes that lead to high memory utilization in jaeger-agent ([#2780](https://github.com/jaegertracing/jaeger/pull/2780), [@jpkrohling](https://github.com/jpkrohling))
 * Expose cache TTL for ES span writer index+service ([#2737](https://github.com/jaegertracing/jaeger/pull/2737), [@necrolyte2](https://github.com/necrolyte2))
-* TLS support for HTTP Endpoint of Collector server ([#2798](https://github.com/jaegertracing/jaeger/pull/2798), [@rjs211](https://github.com/rjs211))
-* TLS support for HTTP API of Query server ([#2337](https://github.com/jaegertracing/jaeger/pull/2337), [@rjs211](https://github.com/rjs211))
-* Add support for Kafka SASL/PLAIN authentication via SCRAM-SHA-256 or SCRAM-SHA-512 mechanism ([#2724](https://github.com/jaegertracing/jaeger/pull/2724), [@WalkerWang731](https://github.com/WalkerWang731))
-* [agent] Add metrics to show connections status between agent and collectors ([#2657](https://github.com/jaegertracing/jaeger/pull/2657), [@WalkerWang731](https://github.com/WalkerWang731))
-* Add plaintext as a supported kafka auth option ([#2721](https://github.com/jaegertracing/jaeger/pull/2721), [@pdepaepe](https://github.com/pdepaepe))
 * Copy spans from memory store ([#2720](https://github.com/jaegertracing/jaeger/pull/2720), [@bobrik](https://github.com/bobrik))
 * [pkg/queue] Add `StartConsumersWithFactory` function ([#2714](https://github.com/jaegertracing/jaeger/pull/2714), [@mx-psi](https://github.com/mx-psi))
 * Fix potential cross-site scripting issue ([#2697](https://github.com/jaegertracing/jaeger/pull/2697), [@yurishkuro](https://github.com/yurishkuro))
 * Updated gRPC Storage Plugin README with example ([#2687](https://github.com/jaegertracing/jaeger/pull/2687), [@js8080](https://github.com/js8080))
-* Dedup collector tags ([#2658](https://github.com/jaegertracing/jaeger/pull/2658), [@Betula-L](https://github.com/Betula-L))
-* Support configurable date separator for Elasticsearch index names ([#2637](https://github.com/jaegertracing/jaeger/pull/2637), [@sniperking1234](https://github.com/sniperking1234))
+* Deduplicate collector tags ([#2658](https://github.com/jaegertracing/jaeger/pull/2658), [@Betula-L](https://github.com/Betula-L))
 * Add latency metrics on collector HTTP endpoints ([#2664](https://github.com/jaegertracing/jaeger/pull/2664), [@dimitarvdimitrov](https://github.com/dimitarvdimitrov))
 * Fix collector panic due to sarama sdk ([#2654](https://github.com/jaegertracing/jaeger/pull/2654), [@Betula-L](https://github.com/Betula-L))
 * Handle collector Start error ([#2647](https://github.com/jaegertracing/jaeger/pull/2647), [@albertteoh](https://github.com/albertteoh))
-* Use fossa-contrib/fossa-action instead of fossa CLI ([#2571](https://github.com/jaegertracing/jaeger/pull/2571), [@smorimoto](https://github.com/smorimoto))
 * [anonymizer] Save trace in UI format ([#2629](https://github.com/jaegertracing/jaeger/pull/2629), [@yurishkuro](https://github.com/yurishkuro))
 
 ### UI Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 Changes by Version
 ==================
 
-1.22.0 (unreleased)
+1.23.0 (unreleased)
+-------------------
+
+1.22.0 (2021-02-23)
 -------------------
 
 ### Backend Changes
@@ -37,14 +40,51 @@ Changes by Version
     * `--cassandra.enable-dependencies-v2` - Jaeger will automatically detect the version of the dependencies table
     * `--cassandra.tls.verify-host` - please use `--cassandra.tls.skip-host-verify` instead
 
+* Remove incorrectly scoped downsample flags from the query service ([#2782](https://github.com/jaegertracing/jaeger/pull/2782), [@joe-elliott](https://github.com/joe-elliott))
+    * `--downsampling.hashsalt` removed from jaeger-query
+    * `--downsampling.ratio` removed from jaeger-query
+    
 #### New Features
 
 * Add TLS Support for gRPC and HTTP endpoints of the Query server ([#2337](https://github.com/jaegertracing/jaeger/pull/2337), [#2772](https://github.com/jaegertracing/jaeger/pull/2772), [@rjs211](https://github.com/rjs211))
 
     *  If TLS in enabled on either or both of gRPC or HTTP endpoints, the gRPC host-port and the HTTP hostport have to be different
     *  If TLS is disabled on both endpoints, common HTTP and gRPC host-port can be explicitly set using the `--query.http-server.host-port` and  `--query.grpc-server.host-port` host-port flags
+* Add ability to use JS file for UI configuration (#123 from jaeger-ui) ([#2707](https://github.com/jaegertracing/jaeger/pull/2707), [@th3M1ke](https://github.com/th3M1ke))
+* Support Elasticsearch ILM for managing jaeger indices ([#2796](https://github.com/jaegertracing/jaeger/pull/2796), [@bhiravabhatla](https://github.com/bhiravabhatla))
+* Push official images to quay.io, in addition to Docker Hub ([#2783](https://github.com/jaegertracing/jaeger/pull/2783), [@Ashmita152](https://github.com/Ashmita152))
+* Add status command ([#2684](https://github.com/jaegertracing/jaeger/pull/2684), [@sniperking1234](https://github.com/sniperking1234))
+    * Usage:
+      ```bash
+      $ ./cmd/collector/collector-darwin-amd64 status
+      {"status":"Server available","upSince":"2021-02-19T17:57:12.671902+11:00","uptime":"25.241233383s"}
+      ```
+
+#### Bug fixes, Minor Improvements
+
+* Use workaround for windows x509.SystemCertPool() ([#2756](https://github.com/jaegertracing/jaeger/pull/2756), [@Ashmita152](https://github.com/Ashmita152))
+* Use fork of Apache Thrift ([#2780](https://github.com/jaegertracing/jaeger/pull/2780), [@jpkrohling](https://github.com/jpkrohling))
+* Expose cache TTL for ES span writer index+service ([#2737](https://github.com/jaegertracing/jaeger/pull/2737), [@necrolyte2](https://github.com/necrolyte2))
+* TLS support for HTTP Endpoint of Collector server ([#2798](https://github.com/jaegertracing/jaeger/pull/2798), [@rjs211](https://github.com/rjs211))
+* TLS support for HTTP API of Query server ([#2337](https://github.com/jaegertracing/jaeger/pull/2337), [@rjs211](https://github.com/rjs211))
+* Add support for Kafka SASL/PLAIN authentication via SCRAM-SHA-256 or SCRAM-SHA-512 mechanism ([#2724](https://github.com/jaegertracing/jaeger/pull/2724), [@WalkerWang731](https://github.com/WalkerWang731))
+* [agent] Add metrics to show connections status between agent and collectors ([#2657](https://github.com/jaegertracing/jaeger/pull/2657), [@WalkerWang731](https://github.com/WalkerWang731))
+* Add plaintext as a supported kafka auth option ([#2721](https://github.com/jaegertracing/jaeger/pull/2721), [@pdepaepe](https://github.com/pdepaepe))
+* Copy spans from memory store ([#2720](https://github.com/jaegertracing/jaeger/pull/2720), [@bobrik](https://github.com/bobrik))
+* [pkg/queue] Add `StartConsumersWithFactory` function ([#2714](https://github.com/jaegertracing/jaeger/pull/2714), [@mx-psi](https://github.com/mx-psi))
+* Fix potential cross-site scripting issue ([#2697](https://github.com/jaegertracing/jaeger/pull/2697), [@yurishkuro](https://github.com/yurishkuro))
+* Updated gRPC Storage Plugin README with example ([#2687](https://github.com/jaegertracing/jaeger/pull/2687), [@js8080](https://github.com/js8080))
+* Dedup collector tags ([#2658](https://github.com/jaegertracing/jaeger/pull/2658), [@Betula-L](https://github.com/Betula-L))
+* Support configurable date separator for Elasticsearch index names ([#2637](https://github.com/jaegertracing/jaeger/pull/2637), [@sniperking1234](https://github.com/sniperking1234))
+* Add latency metrics on collector HTTP endpoints ([#2664](https://github.com/jaegertracing/jaeger/pull/2664), [@dimitarvdimitrov](https://github.com/dimitarvdimitrov))
+* Fix collector panic due to sarama sdk ([#2654](https://github.com/jaegertracing/jaeger/pull/2654), [@Betula-L](https://github.com/Betula-L))
+* Handle collector Start error ([#2647](https://github.com/jaegertracing/jaeger/pull/2647), [@albertteoh](https://github.com/albertteoh))
+* Use fossa-contrib/fossa-action instead of fossa CLI ([#2571](https://github.com/jaegertracing/jaeger/pull/2571), [@smorimoto](https://github.com/smorimoto))
+* [anonymizer] Save trace in UI format ([#2629](https://github.com/jaegertracing/jaeger/pull/2629), [@yurishkuro](https://github.com/yurishkuro))
 
 ### UI Changes
+
+* UI pinned to version 1.13.0. The changelog is available here [v1.13.0](https://github.com/jaegertracing/jaeger-ui/blob/master/CHANGELOG.md#v1130-february-20-2021)
 
 
 1.21.0 (2020-11-13)


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Prepares master for 1.22.0 release
- Fixes #2734

## Short description of the changes
- Update changelog following instructions from [RELEASE.md](https://github.com/jaegertracing/jaeger/blob/master/RELEASE.md)
- The excluded PRs (not including dependabot PRs) generated from `make changelog` are as follows:
```
* Pass context to goroutine ([#2823](https://github.com/jaegertracing/jaeger/pull/2823), [@albertteoh](https://github.com/albertteoh))	
* 2814 - Throw an error when --es.use-ilm is set without --es.use-aliases ([#2820](https://github.com/jaegertracing/jaeger/pull/2820), [@bhiravabhatla](https://github.com/bhiravabhatla))	
* Add hotrod in release and push all tags ([#2812](https://github.com/jaegertracing/jaeger/pull/2812), [@Ashmita152](https://github.com/Ashmita152))	
* Fix default username when pushing container images to Quay.io ([#2809](https://github.com/jaegertracing/jaeger/pull/2809), [@jpkrohling](https://github.com/jpkrohling))	
* Clean up go.sum to support building with Go 1.16 ([#2773](https://github.com/jaegertracing/jaeger/pull/2773), [@gsagula](https://github.com/gsagula))	
* Remove the labeler workflow ([#2770](https://github.com/jaegertracing/jaeger/pull/2770), [@jpkrohling](https://github.com/jpkrohling))	
* Add dependabot to the repository ([#2759](https://github.com/jaegertracing/jaeger/pull/2759), [@jpkrohling](https://github.com/jpkrohling))	
* Update gogo/protobuf to 1.3.2 ([#2758](https://github.com/jaegertracing/jaeger/pull/2758), [@jpkrohling](https://github.com/jpkrohling))	
* Remove needs-triage labeler ([#2761](https://github.com/jaegertracing/jaeger/pull/2761), [@jpkrohling](https://github.com/jpkrohling))	
* Divide build-binaries job to multiple jobs per platform ([#2757](https://github.com/jaegertracing/jaeger/pull/2757), [@Ashmita152](https://github.com/Ashmita152))	
* Fix errors in build-binaries task ([#2754](https://github.com/jaegertracing/jaeger/pull/2754), [@Ashmita152](https://github.com/Ashmita152))	
* Github action for jaeger packages and docker image ([#2740](https://github.com/jaegertracing/jaeger/pull/2740), [@Ashmita152](https://github.com/Ashmita152))	
* Fix Grafana example ([#2750](https://github.com/jaegertracing/jaeger/pull/2750), [@Daverkex](https://github.com/Daverkex))	
* Add changelog entry for Query server TLS support ([#2746](https://github.com/jaegertracing/jaeger/pull/2746), [@rjs211](https://github.com/rjs211))	
* Enable stale bot for PRs and questions ([#2731](https://github.com/jaegertracing/jaeger/pull/2731), [@yurishkuro](https://github.com/yurishkuro))	
* Transition black-adder and tiffon to Emeritus Maintainers ([#2735](https://github.com/jaegertracing/jaeger/pull/2735), [@yurishkuro](https://github.com/yurishkuro))	
* Add ability to remove inactive maintainers; introduce Emeritus status ([#2733](https://github.com/jaegertracing/jaeger/pull/2733), [@yurishkuro](https://github.com/yurishkuro))	
* Update UI for js config ([#2732](https://github.com/jaegertracing/jaeger/pull/2732), [@th3M1ke](https://github.com/th3M1ke))
* [tests] Increase timeout for TestGRPCResolverRoundRobin ([#2729](https://github.com/jaegertracing/jaeger/pull/2729), [@yurishkuro](https://github.com/yurishkuro))	
* [refactor] Minor clean-up of #2657 ([#2728](https://github.com/jaegertracing/jaeger/pull/2728), [@yurishkuro](https://github.com/yurishkuro))
* Fix flaky TestHotReloadUIConfigTempFile ([#2713](https://github.com/jaegertracing/jaeger/pull/2713), [@albertteoh](https://github.com/albertteoh))	
* Clean-up "tcollector" references ([#2704](https://github.com/jaegertracing/jaeger/pull/2704), [@sniperking1234](https://github.com/sniperking1234))	
* Add github actions for hotrod ci job ([#2702](https://github.com/jaegertracing/jaeger/pull/2702), [@Ashmita152](https://github.com/Ashmita152))
* Fix misleading use-alias help doc ([#2692](https://github.com/jaegertracing/jaeger/pull/2692), [@albertteoh](https://github.com/albertteoh))	
* Replace deprecated function in command_test.go ([#2690](https://github.com/jaegertracing/jaeger/pull/2690), [@sniperking1234](https://github.com/sniperking1234))	
* Remove Question issue type and add Discussions ([#2689](https://github.com/jaegertracing/jaeger/pull/2689), [@yurishkuro](https://github.com/yurishkuro))
* Fix typo in hotrod README.md ([#2683](https://github.com/jaegertracing/jaeger/pull/2683), [@sniperking1234](https://github.com/sniperking1234))
* Add gh action for crossdock and crossdock otel ci jobs ([#2681](https://github.com/jaegertracing/jaeger/pull/2681), [@Ashmita152](https://github.com/Ashmita152))	
* Add logz.io to adopters list ([#2680](https://github.com/jaegertracing/jaeger/pull/2680), [@albertteoh](https://github.com/albertteoh))	
* Fix issue for Elasticsearch CI failures ([#2678](https://github.com/jaegertracing/jaeger/pull/2678), [@Ashmita152](https://github.com/Ashmita152))	
* Fix the unbound variable error on all-in-one image build ([#2675](https://github.com/jaegertracing/jaeger/pull/2675), [@Ashmita152](https://github.com/Ashmita152))	
* Add github action for elasticsearch otel integration tests ([#2671](https://github.com/jaegertracing/jaeger/pull/2671), [@Ashmita152](https://github.com/Ashmita152))	
* Address review comments from #2655 ([#2673](https://github.com/jaegertracing/jaeger/pull/2673), [@albertteoh](https://github.com/albertteoh))	
* Rename GH Action workflows ([#2672](https://github.com/jaegertracing/jaeger/pull/2672), [@yurishkuro](https://github.com/yurishkuro))	
* Move cert loading failure assertion on client public key write ([#2655](https://github.com/jaegertracing/jaeger/pull/2655), [@albertteoh](https://github.com/albertteoh))	
* Fix issue with all-in-one build ([#2670](https://github.com/jaegertracing/jaeger/pull/2670), [@Ashmita152](https://github.com/Ashmita152))	
* Fix issue with all-in-one build ([#2669](https://github.com/jaegertracing/jaeger/pull/2669), [@Ashmita152](https://github.com/Ashmita152))	
* Fix docker login issue with all-in-one build ([#2668](https://github.com/jaegertracing/jaeger/pull/2668), [@Ashmita152](https://github.com/Ashmita152))	
* Fix and minor improvements to all-in-one github action ([#2667](https://github.com/jaegertracing/jaeger/pull/2667), [@Ashmita152](https://github.com/Ashmita152))	
* Add github action for jaeger all-in-one image ([#2663](https://github.com/jaegertracing/jaeger/pull/2663), [@Ashmita152](https://github.com/Ashmita152))	
* Add protogen validation test github actions workflow ([#2662](https://github.com/jaegertracing/jaeger/pull/2662), [@Ashmita152](https://github.com/Ashmita152))	
* Fix for failures in badger integration tests ([#2660](https://github.com/jaegertracing/jaeger/pull/2660), [@Ashmita152](https://github.com/Ashmita152))	
* Clean-up GH action names ([#2661](https://github.com/jaegertracing/jaeger/pull/2661), [@yurishkuro](https://github.com/yurishkuro))	
* Add github action for jaeger integration tests ([#2649](https://github.com/jaegertracing/jaeger/pull/2649), [@Ashmita152](https://github.com/Ashmita152))	
* Fix flaky tbuffered server test ([#2635](https://github.com/jaegertracing/jaeger/pull/2635), [@pkositsyn](https://github.com/pkositsyn))	
* [tests]: call Close() to cleanup temporary directory ([#2651](https://github.com/jaegertracing/jaeger/pull/2651), [@zhijianli88](https://github.com/zhijianli88))	
* Clean-up Badger factory Close() behavior ([#2643](https://github.com/jaegertracing/jaeger/pull/2643), [@yurishkuro](https://github.com/yurishkuro))
* Add github action for unit test and coverage ([#2648](https://github.com/jaegertracing/jaeger/pull/2648), [@Ashmita152](https://github.com/Ashmita152))	
* Fix flaky TestReload ([#2646](https://github.com/jaegertracing/jaeger/pull/2646), [@albertteoh](https://github.com/albertteoh))	
* Add PalFish to ADOPTERS ([#2641](https://github.com/jaegertracing/jaeger/pull/2641), [@ZhengHe-MD](https://github.com/ZhengHe-MD))	
* Fix unit test fail ([#2636](https://github.com/jaegertracing/jaeger/pull/2636), [@Hellcatlk](https://github.com/Hellcatlk))	
* [anonymizer] Update Makefile and Dockerfile ([#2632](https://github.com/jaegertracing/jaeger/pull/2632), [@Ashmita152](https://github.com/Ashmita152))	
```
