### PR TITLE
Update Jaeger community support URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question via Jaeger Community Support (online chat)
-    url: https://gitter.im/jaegertracing/Lobby
+    url: https://cloud-native.slack.com/archives/CGG7NFUJ3
     about: Please ask and answer questions here for faster response.
   - name: Question via GitHub Discussions (similar to Stack Overflow)
     url: https://github.com/jaegertracing/jaeger/discussions


### PR DESCRIPTION
## Which problem is this PR solving?

From Gitter -> Slack

URL obtained by right-clicking #jaeger channel -> "Copy link".