### PR TITLE
Update Jaeger community support URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question via Jaeger Community Support (online chat)
-    url: https://gitter.im/jaegertracing/Lobby
+    url: https://cloud-native.slack.com/archives/CGG7NFUJ3
     about: Please ask and answer questions here for faster response.
   - name: Question via GitHub Discussions (similar to Stack Overflow)
     url: https://github.com/jaegertracing/jaeger/discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,7 @@ Welcome to the Jaeger project! 👋🎉
 - Please be respectful and considerate of others when commenting on issues.
 - Please provide as much information as possible so we all understand the issue.
 - If you only have a question, you may get a faster response by asking in
-    - our chat room https://gitter.im/jaegertracing/Lobby, or
+    - our chat room https://cloud-native.slack.com/archives/CGG7NFUJ3, or
     - the forum https://groups.google.com/d/forum/jaeger-tracing
     (but please don't double post)
 -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img align="right" width="290" height="290" src="https://www.jaegertracing.io/img/jaeger-vector.svg">
 
 
-[![Gitter chat][gitter-img]][gitter]
+[![Slack chat][slack-img]][slack]
 [![Project+Community stats][community-badge]][community-stats]
 [![OpenTracing-1.0][ot-badge]](https://opentracing.io)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go#performance)
@@ -163,7 +163,7 @@ See https://www.jaegertracing.io/docs/roadmap/
 Reach project contributors via these channels:
 
  * [jaeger-tracing mail group](https://groups.google.com/forum/#!forum/jaeger-tracing)
- * [Gitter chat room](https://gitter.im/jaegertracing/Lobby)
+ * [Slack chat room](https://cloud-native.slack.com/archives/CGG7NFUJ3)
  * [Github issues](https://github.com/jaegertracing/jaeger/issues)
 
 ## Adopters
@@ -194,5 +194,5 @@ If you would like to add your organization to the list, please comment on our
 [community-badge]: https://img.shields.io/badge/Project+Community-stats-blue.svg
 [community-stats]: https://all.devstats.cncf.io/d/54/project-health?orgId=1&var-repogroup_name=Jaeger
 [hotrod-tutorial]: https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941
-[gitter]: https://gitter.im/jaegertracing/Lobby
-[gitter-img]: https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-brightgreen?logo=slack
+[slack]: https://cloud-native.slack.com/archives/CGG7NFUJ3
+[slack-img]: https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-brightgreen?logo=slack

--- a/README.md
+++ b/README.md
@@ -195,4 +195,4 @@ If you would like to add your organization to the list, please comment on our
 [community-stats]: https://all.devstats.cncf.io/d/54/project-health?orgId=1&var-repogroup_name=Jaeger
 [hotrod-tutorial]: https://medium.com/@YuriShkuro/take-opentracing-for-a-hotrod-ride-f6e3141f7941
 [gitter]: https://gitter.im/jaegertracing/Lobby
-[gitter-img]: https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg
+[gitter-img]: https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-brightgreen?logo=slack

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,6 @@
 5. [Publish documentation](https://github.com/jaegertracing/documentation/blob/master/RELEASE.md) for the new version in [jaegertracing.io](https://www.jaegertracing.io/docs/latest).
    1. Check [jaegertracing.io](https://www.jaegertracing.io/docs/latest) redirects to the new documentation release version URL.
    2. For monitoring and troubleshooting, refer to the [jaegertracing/documentation GithubActions tab](https://github.com/jaegertracing/documentation/actions).
-6. Announce the release on the [mailing list](https://groups.google.com/g/jaeger-tracing), [gitter](https://gitter.im/jaegertracing/Lobby), and [twitter](https://twitter.com/JaegerTracing?lang=en).
+6. Announce the release on the [mailing list](https://groups.google.com/g/jaeger-tracing), [slack](https://cloud-native.slack.com/archives/CGG7NFUJ3), and [twitter](https://twitter.com/JaegerTracing?lang=en).
 
 Maintenance branches should follow naming convention: `release-major.minor` (e.g.`release-1.8`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,9 +15,9 @@ If you find something suspicious and want to report it, we'd really appreciate!
 ### Ways to report
 
 * It is preferable to always encrypt your message, no matter the channel you choose to report the issue
-* Contact us on our open chat room on [Gitter][gitter-room]
-* If you can't use Gitter, send a message to [jaeger-tracing@googlegroups.com][mailing-list]
-* If you can't use Gitter nor send an email, open a merge request on GitHub: fork the affected repository and send us a pull request. We really prefer if you'd talk to us before, though, as our repositories are public and we would like to give a heads up to our users before disclosing it publicly
+* Contact us on our open chat room on [Slack][slack-room]
+* If you can't use Slack, send a message to [jaeger-tracing@googlegroups.com][mailing-list]
+* If you can't use Slack nor send an email, open a merge request on GitHub: fork the affected repository and send us a pull request. We really prefer if you'd talk to us before, though, as our repositories are public and we would like to give a heads up to our users before disclosing it publicly
 
 ### Our PGP key
 
@@ -91,7 +91,7 @@ oF+qZY4uEvqFvYo8
 
 [published-key]: http://pool.sks-keyservers.net/pks/lookup?op=get&search=0xC043A4D2B3F2AC31
 [mailing-list]: https://groups.google.com/forum/#!forum/jaeger-tracing
-[gitter-room]: https://gitter.im/jaegertracing/Lobby
+[slack-room]: https://cloud-native.slack.com/archives/CGG7NFUJ3
 
 ## Securing a Jaeger installation
 


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
From Gitter -> Slack.

URL obtained by right-clicking #jaeger channel -> "Copy link".