### PR TITLE
[es] Add remote read clusters option for cross-cluster querying

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -45,6 +45,7 @@ import (
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
 	Servers               []string       `mapstructure:"server_urls"`
+	RemoteReadClusters    []string       `mapstructure:"remote_read_clusters"`
 	Username              string         `mapstructure:"username"`
 	Password              string         `mapstructure:"password" json:"-"`
 	TokenFilePath         string         `mapstructure:"token_file"`
@@ -89,6 +90,7 @@ type TagsAsFields struct {
 // ClientBuilder creates new es.Client
 type ClientBuilder interface {
 	NewClient(logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error)
+	GetRemoteReadClusters() []string
 	GetNumShards() int64
 	GetNumReplicas() int64
 	GetMaxSpanAge() time.Duration
@@ -193,6 +195,9 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 
 // ApplyDefaults copies settings from source unless its own value is non-zero.
 func (c *Configuration) ApplyDefaults(source *Configuration) {
+	if len(c.RemoteReadClusters) == 0 {
+		c.RemoteReadClusters = source.RemoteReadClusters
+	}
 	if c.Username == "" {
 		c.Username = source.Username
 	}
@@ -244,6 +249,11 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.LogLevel == "" {
 		c.LogLevel = source.LogLevel
 	}
+}
+
+// GetRemoteReadClusters returns list of remote read clusters
+func (c *Configuration) GetRemoteReadClusters() []string {
+	return c.RemoteReadClusters
 }
 
 // GetNumShards returns number of shards from Configuration

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -151,6 +151,7 @@ func createSpanReader(
 		TagDotReplacement:   cfg.GetTagDotReplacement(),
 		UseReadWriteAliases: cfg.GetUseReadWriteAliases(),
 		Archive:             archive,
+		RemoteReadClusters:  cfg.GetRemoteReadClusters(),
 	}), nil
 }
 

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -35,6 +35,7 @@ const (
 	suffixSnifferTLSEnabled   = ".sniffer-tls-enabled"
 	suffixTokenPath           = ".token-file"
 	suffixServerURLs          = ".server-urls"
+	suffixRemoteReadClusters  = ".remote-read-clusters"
 	suffixMaxSpanAge          = ".max-span-age"
 	suffixNumShards           = ".num-shards"
 	suffixNumReplicas         = ".num-replicas"
@@ -59,8 +60,9 @@ const (
 	suffixLogLevel            = ".log-level"
 	// default number of documents to return from a query (elasticsearch allowed limit)
 	// see search.max_buckets and index.max_result_window
-	defaultMaxDocCount = 10_000
-	defaultServerURL   = "http://127.0.0.1:9200"
+	defaultMaxDocCount        = 10_000
+	defaultServerURL          = "http://127.0.0.1:9200"
+	defaultRemoteReadClusters = ""
 	// default separator for Elasticsearch index date layout.
 	defaultIndexDateSeparator = "-"
 )
@@ -102,6 +104,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 		CreateIndexTemplates: true,
 		Version:              0,
 		Servers:              []string{defaultServerURL},
+		RemoteReadClusters:   []string{},
 		MaxDocCount:          defaultMaxDocCount,
 		LogLevel:             "error",
 	}
@@ -162,6 +165,11 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixServerURLs,
 		defaultServerURL,
 		"The comma-separated list of Elasticsearch servers, must be full url i.e. http://localhost:9200")
+	flagSet.String(
+		nsConfig.namespace+suffixRemoteReadClusters,
+		defaultRemoteReadClusters,
+		"Comma-separated list of Elasticsearch remote cluster names for cross-cluster querying."+
+			"See Elasticsearch remote clusters and cross-cluster query api.")
 	flagSet.Duration(
 		nsConfig.namespace+suffixTimeout,
 		nsConfig.Timeout,
@@ -278,6 +286,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
 	cfg.SnifferTLSEnabled = v.GetBool(cfg.namespace + suffixSnifferTLSEnabled)
 	cfg.Servers = strings.Split(stripWhiteSpace(v.GetString(cfg.namespace+suffixServerURLs)), ",")
+	cfg.RemoteReadClusters = strings.Split(stripWhiteSpace(v.GetString(cfg.namespace+suffixRemoteReadClusters)), ",")
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)
 	cfg.NumShards = v.GetInt64(cfg.namespace + suffixNumShards)
 	cfg.NumReplicas = v.GetInt64(cfg.namespace + suffixNumReplicas)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -286,7 +286,6 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Sniffer = v.GetBool(cfg.namespace + suffixSniffer)
 	cfg.SnifferTLSEnabled = v.GetBool(cfg.namespace + suffixSnifferTLSEnabled)
 	cfg.Servers = strings.Split(stripWhiteSpace(v.GetString(cfg.namespace+suffixServerURLs)), ",")
-	cfg.RemoteReadClusters = strings.Split(stripWhiteSpace(v.GetString(cfg.namespace+suffixRemoteReadClusters)), ",")
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)
 	cfg.NumShards = v.GetInt64(cfg.namespace + suffixNumShards)
 	cfg.NumReplicas = v.GetInt64(cfg.namespace + suffixNumReplicas)
@@ -313,6 +312,11 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	// TODO: Need to figure out a better way for do this.
 	cfg.AllowTokenFromContext = v.GetBool(spanstore.StoragePropagationKey)
 	cfg.TLS = cfg.getTLSFlagsConfig().InitFromViper(v)
+
+	remoteReadClusters := stripWhiteSpace(v.GetString(cfg.namespace + suffixRemoteReadClusters))
+	if len(remoteReadClusters) > 0 {
+		cfg.RemoteReadClusters = strings.Split(remoteReadClusters, ",")
+	}
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -154,7 +154,7 @@ func getTimeRangeIndexFn(archive, useReadWriteAliases bool, remoteReadClusters [
 	}
 	if useReadWriteAliases {
 		return addRemoteReadClusters(func(indexPrefix string, indexDateLayout string, startTime time.Time, endTime time.Time) []string {
-			return []string{indices + "read"}
+			return []string{indexPrefix + "read"}
 		}, remoteReadClusters)
 	}
 	return addRemoteReadClusters(timeRangeIndices, remoteReadClusters)

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -153,7 +153,7 @@ func getTimeRangeIndexFn(archive, useReadWriteAliases bool, remoteReadClusters [
 		}, remoteReadClusters)
 	}
 	if useReadWriteAliases {
-		return addRemoteReadClusters(func(indices string, indexDateLayout string, startTime time.Time, endTime time.Time) []string {
+		return addRemoteReadClusters(func(indexPrefix string, indexDateLayout string, startTime time.Time, endTime time.Time) []string {
 			return []string{indices + "read"}
 		}, remoteReadClusters)
 	}

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -149,35 +149,40 @@ func TestSpanReaderIndices(t *testing.T) {
 	date := time.Date(2019, 10, 10, 5, 0, 0, 0, time.UTC)
 	dateFormat := date.UTC().Format("2006-01-02")
 	testCases := []struct {
-		index  string
-		params SpanReaderParams
+		indices []string
+		params  SpanReaderParams
 	}{
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", Archive: false},
-			index: spanIndex + dateFormat},
+			indices: []string{spanIndex + dateFormat}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", UseReadWriteAliases: true},
-			index: spanIndex + "read"},
+			indices: []string{spanIndex + "read"}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: false},
-			index: "foo:" + indexPrefixSeparator + spanIndex + dateFormat},
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + dateFormat}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", UseReadWriteAliases: true},
-			index: "foo:-" + spanIndex + "read"},
+			indices: []string{"foo:-" + spanIndex + "read"}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", Archive: true},
-			index: spanIndex + archiveIndexSuffix},
+			indices: []string{spanIndex + archiveIndexSuffix}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: true},
-			index: "foo:" + indexPrefixSeparator + spanIndex + archiveIndexSuffix},
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveIndexSuffix}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "foo:", Archive: true, UseReadWriteAliases: true},
-			index: "foo:" + indexPrefixSeparator + spanIndex + archiveReadIndexSuffix},
+			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveReadIndexSuffix}},
+		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			IndexPrefix: "", Archive: false, RemoteReadClusters: []string{"cluster_one", "cluster_two"}},
+			indices: []string{spanIndex + dateFormat,
+				"cluster_one:" + spanIndex + dateFormat,
+				"cluster_two:" + spanIndex + dateFormat}},
 	}
 	for _, testCase := range testCases {
 		r := NewSpanReader(testCase.params)
 		actual := r.timeRangeIndices(r.spanIndexPrefix, "2006-01-02", date, date)
-		assert.Equal(t, []string{testCase.index}, actual)
+		assert.Equal(t, testCase.indices, actual)
 	}
 }
 

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -175,9 +175,28 @@ func TestSpanReaderIndices(t *testing.T) {
 			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveReadIndexSuffix}},
 		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
 			IndexPrefix: "", Archive: false, RemoteReadClusters: []string{"cluster_one", "cluster_two"}},
-			indices: []string{spanIndex + dateFormat,
+			indices: []string{
+				spanIndex + dateFormat,
 				"cluster_one:" + spanIndex + dateFormat,
 				"cluster_two:" + spanIndex + dateFormat}},
+		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			IndexPrefix: "", Archive: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"}},
+			indices: []string{
+				spanIndex + archiveIndexSuffix,
+				"cluster_one:" + spanIndex + archiveIndexSuffix,
+				"cluster_two:" + spanIndex + archiveIndexSuffix}},
+		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			IndexPrefix: "", Archive: false, UseReadWriteAliases: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"}},
+			indices: []string{
+				spanIndex + "read",
+				"cluster_one:" + spanIndex + "read",
+				"cluster_two:" + spanIndex + "read"}},
+		{params: SpanReaderParams{Client: client, Logger: logger, MetricsFactory: metricsFactory,
+			IndexPrefix: "", Archive: true, UseReadWriteAliases: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"}},
+			indices: []string{
+				spanIndex + archiveReadIndexSuffix,
+				"cluster_one:" + spanIndex + archiveReadIndexSuffix,
+				"cluster_two:" + spanIndex + archiveReadIndexSuffix}},
 	}
 	for _, testCase := range testCases {
 		r := NewSpanReader(testCase.params)

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	iterations = 30
+	iterations = 100
 )
 
 // StorageIntegration holds components for storage integration test
@@ -90,7 +90,7 @@ func (s *StorageIntegration) waitForCondition(t *testing.T, predicate func(t *te
 		if predicate(t) {
 			return true
 		}
-		time.Sleep(100 * time.Millisecond) // Will wait up to 3 seconds at worst.
+		time.Sleep(100 * time.Millisecond) // Will wait up to 10 seconds at worst.
 	}
 	return predicate(t)
 }

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	iterations = 100
+	iterations = 30
 )
 
 // StorageIntegration holds components for storage integration test
@@ -90,7 +90,7 @@ func (s *StorageIntegration) waitForCondition(t *testing.T, predicate func(t *te
 		if predicate(t) {
 			return true
 		}
-		time.Sleep(100 * time.Millisecond) // Will wait up to 10 seconds at worst.
+		time.Sleep(100 * time.Millisecond) // Will wait up to 3 seconds at worst.
 	}
 	return predicate(t)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Enables elasticsearch [cross-cluster querying](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cross-cluster-search.html)

Resolves #1883
Updates to PR #1892

## Short description of the changes
The cross cluster query api functions by appending a pre-configured remote cluster to an index e.g. cluster_one:index_name. This change simply applies a prefix for each remote cluster and for each index. You will end up with `total_indicies = indicies * remote_clusters`. Also added a special case local which will not append a prefix and query the local cluster.

This works with both standard and rollover indices since it mostly comes down to a simple string manipulation.