### PR TITLE
Fix host-port flag in docker-compose

### DIFF
--- a/docker-compose/jaeger-docker-compose.yml
+++ b/docker-compose/jaeger-docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
     jaeger-collector:
       image: jaegertracing/jaeger-collector
-      command: ["--cassandra.keyspace=jaeger_v1_dc1", "--cassandra.servers=cassandra", "--collector.zipkin.http-port=9411"]
+      command: ["--cassandra.keyspace=jaeger_v1_dc1", "--cassandra.servers=cassandra", "--collector.zipkin.host-port=9411"]
       ports:
         - "14269"
         - "14268:14268"


### PR DESCRIPTION
…llector because http-port no exists

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- 
2021/03/23 07:18:54 maxprocs: Leaving GOMAXPROCS=2: CPU quota undefined
Error: unknown flag: --collector.zipkin.http-port
Usage:
  jaeger-collector [flags]
  jaeger-collector [command]

Available Commands:
  docs        Generates documentation
  env         Help about environment variables.
  help        Help about any command
  status      Print the status.
  version     Print the version.

Flags:
      --admin.http.host-port string                     The host:port (e.g. 127.0.0.1:14269 or :14269) for the admin server, including health check, /metrics, etc. (default ":14269")
      --cassandra-archive.connect-timeout duration      Timeout used for connections to Cassandra Servers (default 0s)
      --cassandra-archive.connections-per-host int      The number of Cassandra connections from a single backend instance
      --cassandra-archive.consistency string            The Cassandra consistency level, e.g. ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, LOCAL_ONE (default LOCAL_ONE)
      --cassandra-archive.disable-compression           Disables the use of the default Snappy Compression while connecting to the Cassandra Cluster if set to true. This is useful for connecting to Cassandra Clusters(like Azure Cosmos Db with Cassandra API) that do not support SnappyCompression
      --cassandra-archive.enabled                       Enable extra storage
      --cassandra-archive.keyspace string               The Cassandra keyspace for Jaeger data
      --cassandra-archive.local-dc string               The name of the Cassandra local data center for DC Aware host selection
      --cassandra-archive.max-retry-attempts int        The number of attempts when reading from Cassandra
      --cassandra-archive.password string               Password for password authentication for Cassandra
      --cassandra-archive.port int                      The port for cassandra
      --cassandra-archive.proto-version int             The Cassandra protocol version
      --cassandra-archive.reconnect-interval duration   Reconnect interval to retry connecting to downed hosts (default 0s)
      --cassandra-archive.servers string                The comma-separated list of Cassandra servers
      --cassandra-archive.socket-keep-alive duration    Cassandra's keepalive period to use, enabled if > 0 (default 0s)
      --cassandra-archive.timeout duration              Timeout used for queries. A Timeout of zero means no timeout (default 0s)
      --cassandra-archive.tls.ca string                 Path to a TLS CA (Certification Authority) file used to verify the remote server(s) (by default will use the system truststore)
      --cassandra-archive.tls.cert string               Path to a TLS Certificate file, used to identify this process to the remote server(s)
      --cassandra-archive.tls.enabled                   Enable TLS when talking to the remote server(s)
      --cassandra-archive.tls.key string                Path to a TLS Private Key file, used to identify this process to the remote server(s)
      --cassandra-archive.tls.server-name string        Override the TLS server name we expect in the certificate of the remote server(s)
      --cassandra-archive.tls.skip-host-verify          (insecure) Skip server's certificate chain and host name verification
      --cassandra-archive.username string               Username for password authentication for Cassandra
      --cassandra.connect-timeout duration              Timeout used for connections to Cassandra Servers (default 0s)
      --cassandra.connections-per-host int              The number of Cassandra connections from a single backend instance (default 2)
      --cassandra.consistency string                    The Cassandra consistency level, e.g. ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, LOCAL_ONE (default LOCAL_ONE)
      --cassandra.disable-compression                   Disables the use of the default Snappy Compression while connecting to the Cassandra Cluster if set to true. This is useful for connecting to Cassandra Clusters(like Azure Cosmos Db with Cassandra API) that do not support SnappyCompression
      --cassandra.index.logs                            Controls log field indexing. Set to false to disable. (default true)
      --cassandra.index.process-tags                    Controls process tag indexing. Set to false to disable. (default true)
      --cassandra.index.tag-blacklist string            The comma-separated list of span tags to blacklist from being indexed. All other tags will be indexed. Mutually exclusive with the whitelist option.
      --cassandra.index.tag-whitelist string            The comma-separated list of span tags to whitelist for being indexed. All other tags will not be indexed. Mutually exclusive with the blacklist option.
      --cassandra.index.tags                            Controls tag indexing. Set to false to disable. (default true)
      --cassandra.keyspace string                       The Cassandra keyspace for Jaeger data (default "jaeger_v1_test")
      --cassandra.local-dc string                       The name of the Cassandra local data center for DC Aware host selection
      --cassandra.max-retry-attempts int                The number of attempts when reading from Cassandra (default 3)
      --cassandra.password string                       Password for password authentication for Cassandra
      --cassandra.port int                              The port for cassandra
      --cassandra.proto-version int                     The Cassandra protocol version (default 4)
      --cassandra.reconnect-interval duration           Reconnect interval to retry connecting to downed hosts (default 1m0s)
      --cassandra.servers string                        The comma-separated list of Cassandra servers (default "127.0.0.1")
      --cassandra.socket-keep-alive duration            Cassandra's keepalive period to use, enabled if > 0 (default 0s)
      --cassandra.span-store-write-cache-ttl duration   The duration to wait before rewriting an existing service or operation name (default 12h0m0s)
      --cassandra.timeout duration                      Timeout used for queries. A Timeout of zero means no timeout (default 0s)
      --cassandra.tls.ca string                         Path to a TLS CA (Certification Authority) file used to verify the remote server(s) (by default will use the system truststore)
      --cassandra.tls.cert string                       Path to a TLS Certificate file, used to identify this process to the remote server(s)
      --cassandra.tls.enabled                           Enable TLS when talking to the remote server(s)
      --cassandra.tls.key string                        Path to a TLS Private Key file, used to identify this process to the remote server(s)
      --cassandra.tls.server-name string                Override the TLS server name we expect in the certificate of the remote server(s)
      --cassandra.tls.skip-host-verify                  (insecure) Skip server's certificate chain and host name verification
      --cassandra.username string                       Username for password authentication for Cassandra
      --collector.grpc-server.host-port string          The host:port (e.g. 127.0.0.1:14250 or :14250) of the collector's GRPC server (default ":14250")
      --collector.grpc.tls.cert string                  Path to a TLS Certificate file, used to identify this server to clients
      --collector.grpc.tls.client-ca string             Path to a TLS CA (Certification Authority) file used to verify certificates presented by clients (if unset, all clients are permitted)
      --collector.grpc.tls.enabled                      Enable TLS on the server
      --collector.grpc.tls.key string                   Path to a TLS Private Key file, used to identify this server to clients
      --collector.http-server.host-port string          The host:port (e.g. 127.0.0.1:14268 or :14268) of the collector's HTTP server (default ":14268")
      --collector.http.tls.cert string                  Path to a TLS Certificate file, used to identify this server to clients
      --collector.http.tls.client-ca string             Path to a TLS CA (Certification Authority) file used to verify certificates presented by clients (if unset, all clients are permitted)
      --collector.http.tls.enabled                      Enable TLS on the server
      --collector.http.tls.key string                   Path to a TLS Private Key file, used to identify this server to clients
      --collector.num-workers int                       The number of workers pulling items from the queue (default 50)
      --collector.queue-size int                        The queue size of the collector (default 2000)
      --collector.queue-size-memory uint                (experimental) The max memory size in MiB to use for the dynamic queue.
      --collector.tags string                           One or more tags to be added to the Process tags of all spans passing through this collector. Ex: key1=value1,key2=${envVar:defaultValue}
      --collector.zipkin.allowed-headers string         Comma separated list of allowed headers for the Zipkin collector service, default content-type (default "content-type")
      --collector.zipkin.allowed-origins string         Comma separated list of allowed origins for the Zipkin collector service, default accepts all (default "*")
      --collector.zipkin.host-port string               The host:port (e.g. 127.0.0.1:9411 or :9411) of the collector's Zipkin server (disabled by default)
      --config-file string                              Configuration file in JSON, TOML, YAML, HCL, or Java properties formats (default none). See spf13/viper for precedence.
      --downsampling.hashsalt string                    Salt used when hashing trace id for downsampling.
      --downsampling.ratio float                        Ratio of spans passed to storage after downsampling (between 0 and 1), e.g ratio = 0.3 means we are keeping 30% of spans and dropping 70% of spans; ratio = 1.0 disables downsampling. (default 1)
  -h, --help                                            help for jaeger-collector
      --log-level string                                Minimal allowed log Level. For more levels see https://github.com/uber-go/zap (default "info")
      --metrics-backend string                          Defines which metrics backend to use for metrics reporting: expvar, prometheus, none (default "prometheus")
      --metrics-http-route string                       Defines the route of HTTP endpoint for metrics backends that support scraping (default "/metrics")
      --sampling.strategies-file string                 The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file
      --sampling.strategies-reload-interval duration    Reload interval to check and reload sampling strategies file. Zero value means no reloading (default 0s)
      --span-storage.type string                        (deprecated) please use SPAN_STORAGE_TYPE environment variable. Run this binary with the 'env' command for help.

Use "jaeger-collector [command] --help" for more information about a command.

unknown flag: --collector.zipkin.http-port

## Short description of the changes
- 
"--collector.zipkin.http-port=9411" 

"--collector.zipkin.host-port=9411"