### PR TITLE
change variable name replacing golang's keyword "error"

### DIFF
--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -145,8 +145,8 @@ func main() {
 		app.AddFlags,
 	)
 
-	if error := command.Execute(); error != nil {
-		fmt.Println(error.Error())
+	if err := command.Execute(); err != nil {
+		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Code specification：change variable name replacing golang's keyword "error"

## Short description of the changes
- "error" is golang's keyword. It's better not to make it as a variable.
