### PR TITLE
Permit overriding COLORIZE in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ JAEGER_DOCKER_PROTOBUF=jaegertracing/protobuf:0.2.0
 
 COLOR_PASS=$(shell printf "\033[32mPASS\033[0m")
 COLOR_FAIL=$(shell printf "\033[31mFAIL\033[0m")
-COLORIZE=$(SED) ''/PASS/s//$(COLOR_PASS)/'' | $(SED) ''/FAIL/s//$(COLOR_FAIL)/''
+COLORIZE ?=$(SED) ''/PASS/s//$(COLOR_PASS)/'' | $(SED) ''/FAIL/s//$(COLOR_FAIL)/''
 DOCKER_NAMESPACE?=jaegertracing
 DOCKER_TAG?=latest
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Currently if you redirect the output of make test to a file (which can be useful for analyzing test failures) that file gets control characters added, which can make grepping for things such as "PASS:" not work correctly

## Short description of the changes
- Allow overriding the COLORIZE value externally.
