### PR TITLE
[fix panic] fix runtime error: invalid memory address or nil pointer …

### DIFF
--- a/cmd/ingester/app/consumer/consumer.go
+++ b/cmd/ingester/app/consumer/consumer.go
@@ -135,6 +135,10 @@ func (c *Consumer) handleMessages(pc sc.PartitionConsumer) {
 				c.logger.Info("Message channel closed. ", zap.Int32("partition", pc.Partition()))
 				return
 			}
+			if msg == nil || msg.Value == nil {
+				c.logger.Info("Message or Message value is nil")
+				continue
+			}
 			c.logger.Debug("Got msg", zap.Any("msg", msg))
 			msgMetrics.counter.Inc(1)
 			msgMetrics.offsetGauge.Update(msg.Offset)


### PR DESCRIPTION
fix panic, i think this panic is caused by sarama, so i add the nil check

The details:
```
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1068c65]
goroutine 96 [running]:
github.com/jaegertracing/jaeger/cmd/ingester/app/consumer.confluentMessageWrapper.Value(0x0, 0xc075950780, 0x0, 0x0)
	github.com/jaegertracing/jaeger@/cmd/ingester/app/consumer/message.go:40 +0x5
github.com/jaegertracing/jaeger/cmd/ingester/app/processor.KafkaSpanProcessor.Process(0x1857220, 0x24da0f8, 0x1856fa0, 0xc000242180, 0x0, 0x0, 0x1857740, 0xc0002b29b0, 0x1858e00, 0x0, ...)
	github.com/jaegertracing/jaeger@/cmd/ingester/app/processor/span_processor.go:69 +0x3b
github.com/jaegertracing/jaeger/cmd/ingester/app/processor/decorator.(*retryDecorator).Process(0xc00016c2a0, 0x1858e00, 0x0, 0x7fabf2b411a8, 0x0)
	github.com/jaegertracing/jaeger@/cmd/ingester/app/processor/decorator/retry.go:110 +0x4b
github.com/jaegertracing/jaeger/cmd/ingester/app/consumer.(*comittingProcessor).Process(0xc0001fad20, 0x1858e00, 0x0, 0x3215, 0x0)
	github.com/jaegertracing/jaeger@/cmd/ingester/app/consumer/committing_processor.go:44 +0x8e
github.com/jaegertracing/jaeger/cmd/ingester/app/processor.(*metricsDecorator).Process(0xc000256a80, 0x1858e00, 0x0, 0x0, 0x1)
	github.com/jaegertracing/jaeger@/cmd/ingester/app/processor/metrics_decorator.go:44 +0x6e
github.com/jaegertracing/jaeger/cmd/ingester/app/processor.(*ParallelProcessor).Start.func1(0xc000256b40)
	github.com/jaegertracing/jaeger@/cmd/ingester/app/processor/parallel_processor.go:57 +0x5f
created by github.com/jaegertracing/jaeger/cmd/ingester/app/processor.(*ParallelProcessor).Start
	github.com/jaegertracing/jaeger@/cmd/ingester/app/processor/parallel_processor.go:53 +0x19b
```
