### PR TITLE
Set Content-Type in healthcheck's http response

### DIFF
--- a/pkg/healthcheck/handler.go
+++ b/pkg/healthcheck/handler.go
@@ -98,9 +98,10 @@ func (hc *HealthCheck) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		state := hc.getState()
 		template := hc.responses[state.status]
-		w.WriteHeader(template.statusCode)
 
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(template.statusCode)
+
 		w.Write(hc.createRespBody(state, template))
 	})
 }

--- a/pkg/healthcheck/handler_test.go
+++ b/pkg/healthcheck/handler_test.go
@@ -16,6 +16,8 @@
 package healthcheck_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +50,12 @@ func TestStatusSetGet(t *testing.T) {
 	hc.Ready()
 	assert.Equal(t, Ready, hc.Get())
 	assert.Equal(t, map[string]string{"level": "info", "msg": "Health Check state change", "status": "ready"}, logBuf.JSONLine(0))
+}
+
+func TestHealthCheck_Handler_ContentType(t *testing.T) {
+	rec := httptest.NewRecorder()
+	New().Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	resp := rec.Result()
+
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }


### PR DESCRIPTION
Signed-off-by: logeable <logeable@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolve #2924 

## Short description of the changes
- set header before call WriteHeader
