### PR TITLE
Add metrics query API spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,7 @@ echo-version:
 PROTOC := docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${JAEGER_DOCKER_PROTOBUF} --proto_path=${PWD}
 PROTO_INCLUDES := \
 	-Iidl/proto/api_v2 \
+	-Imodel/proto/metrics \
 	-I/usr/include/github.com/gogo/protobuf
 # Remapping of std types to gogo types (must not contain spaces)
 PROTO_GOGO_MAPPINGS := $(shell echo \
@@ -494,6 +495,21 @@ proto:
 		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS):$(PWD)/proto-gen/api_v2 \
 		idl/proto/api_v2/query.proto
 		### --swagger_out=allow_merge=true:$(PWD)/proto-gen/openapi/ \
+
+	$(PROTOC) \
+		$(PROTO_INCLUDES) \
+		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS):$(PWD)/proto-gen/api_v2 \
+		model/proto/metrics/otelspankind.proto
+
+	$(PROTOC) \
+		$(PROTO_INCLUDES) \
+		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS):$(PWD)/proto-gen/api_v2 \
+		model/proto/metrics/otelmetric.proto
+
+	$(PROTOC) \
+		$(PROTO_INCLUDES) \
+		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS):$(PWD)/proto-gen/api_v2 \
+		model/proto/metrics/service.proto
 
 	$(PROTOC) \
 		$(PROTO_INCLUDES) \

--- a/model/proto/metrics/README.md
+++ b/model/proto/metrics/README.md
@@ -42,8 +42,8 @@ The key trade-offs are:
 
 - Synchronizing with the original source proto definition.
   - It is anticipated that the maintenance effort to synchronize data models will be minimal considering
-    there is no direct dependency between Jaeger and OpenTelemetry in the context querying metrics,
-    with exception to SpanKind, and the existing data model more than satisfies existing metrics querying requirements.
+    there is no direct dependency between Jaeger and OpenTelemetry in the context of querying metrics,
+    with exception to `SpanKind`, and the existing data model more than satisfies existing metrics querying requirements.
 
     The OpenTelemetry metrics data model primarily serves as a carrier of metrics data, rather than a protocol
     of communication between Jaeger and OpenTelemetry components.

--- a/model/proto/metrics/README.md
+++ b/model/proto/metrics/README.md
@@ -1,0 +1,49 @@
+# Metrics Query Service
+
+Defines the MetricsQueryService's set of APIs along with required data models.
+
+## Overview
+
+Contained in this directory are a set of shared Protobuf data model definitions from
+https://github.com/open-telemetry/opentelemetry-proto; namely:
+
+- otelmetric.proto: OpenTelemetry's Metric data model.
+- otelspankind.proto: OpenTelemetry's SpanKind data model.
+
+The reasons for adopting OpenTelemetry's metrics data model are:
+
+- There is a basic requirement to "normalize" and un/marshal metrics queried from a backing store
+  for clients, that is agnostic to the backing store implementation.
+- The data being queried is sourced from an OpenTelemetry Collector.
+
+Importing data models directly from the open-telemetry/opentelemetry-proto github repo (via a submodule)
+was considered and explored; however, without custom marshaling enabled, which is required for sending
+imported message types over the wire, errors such as the following result:
+
+    `panic: invalid Go type v1.Metric for field jaeger.api_v2.GetMetricsResponse.Metrics`
+
+Enabling gogoproto's custom Marshal and Unmarshal methods to address the above issue result
+in compilation errors from the generated code as opentelemetry-proto's Metric type does not have
+gogoproto.marshaler_all, gogoproto.unmarshaler_all, etc. enabled.
+
+Moreover, if direct imports of other repositories were possible, it would mean importing and generating code for
+transitive dependencies not required by Jaeger leading to longer build times, and potentially larger docker
+image sizes.
+
+Given the aforementioned limitations, selectively copying necessary messages and enums allow for:
+
+- Marshaling and unmarshaling of externally defined custom data models such as those from OpenTelemetry.
+- Using Gogoproto's custom un/marshalers takes advantage of [reportedly faster marshaling and
+  unmarshaling](https://github.com/cockroachdb/gogoproto/blob/master/extensions.md).
+- Avoiding unwanted dependencies leading to simpler proto definitions,
+  faster build times and smaller image sizes.
+
+The key trade-offs are:
+
+- Synchronizing with the original source proto definition.
+  - It is anticipated that the maintenance effort to synchronize data models will be minimal considering
+    there is no direct dependency between Jaeger and OpenTelemetry in the context querying metrics,
+    with exception to SpanKind, and the existing data model more than satisfies existing metrics querying requirements.
+
+    The OpenTelemetry metrics data model primarily serves as a carrier of metrics data, rather than a protocol
+    of communication between Jaeger and OpenTelemetry components.

--- a/model/proto/metrics/otelmetric.proto
+++ b/model/proto/metrics/otelmetric.proto
@@ -1,0 +1,658 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based on: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto
+
+syntax="proto3";
+
+package jaeger.api_v2;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "api_v2";
+option java_package = "io.jaegertracing.api_v2";
+
+// Enable gogoprotobuf extensions (https://github.com/gogo/protobuf/blob/master/extensions.md).
+// Enable custom Marshal method.
+option (gogoproto.marshaler_all) = true;
+// Enable custom Unmarshal method.
+option (gogoproto.unmarshaler_all) = true;
+// Enable custom Size method (Required by Marshal and Unmarshal).
+option (gogoproto.sizer_all) = true;
+
+// StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
+// of KeyValue that only supports string values.
+message StringKeyValue {
+  string key = 1;
+  string value = 2;
+}
+
+// Defines a Metric which has one or more timeseries.
+//
+// The data model and relation between entities is shown in the
+// diagram below. Here, "DataPoint" is the term used to refer to any
+// one of the specific data point value types, and "points" is the term used
+// to refer to any one of the lists of points contained in the Metric.
+//
+// - Metric is composed of a metadata and data.
+// - Metadata part contains a name, description, unit.
+// - Data is one of the possible types (Gauge, Sum, Histogram, etc.).
+// - DataPoint contains timestamps, labels, and one of the possible value type
+//   fields.
+//
+//     Metric
+//  +------------+
+//  |name        |
+//  |description |
+//  |unit        |     +------------------------------------+
+//  |data        |---> |Gauge, Sum, Histogram, Summary, ... |
+//  +------------+     +------------------------------------+
+//
+//    Data [One of Gauge, Sum, Histogram, Summary, ...]
+//  +-----------+
+//  |...        |  // Metadata about the Data.
+//  |points     |--+
+//  +-----------+  |
+//                 |      +---------------------------+
+//                 |      |DataPoint 1                |
+//                 v      |+------+------+   +------+ |
+//              +-----+   ||label |label |...|label | |
+//              |  1  |-->||value1|value2|...|valueN| |
+//              +-----+   |+------+------+   +------+ |
+//              |  .  |   |+-----+                    |
+//              |  .  |   ||value|                    |
+//              |  .  |   |+-----+                    |
+//              |  .  |   +---------------------------+
+//              |  .  |                   .
+//              |  .  |                   .
+//              |  .  |                   .
+//              |  .  |   +---------------------------+
+//              |  .  |   |DataPoint M                |
+//              +-----+   |+------+------+   +------+ |
+//              |  M  |-->||label |label |...|label | |
+//              +-----+   ||value1|value2|...|valueN| |
+//                        |+------+------+   +------+ |
+//                        |+-----+                    |
+//                        ||value|                    |
+//                        |+-----+                    |
+//                        +---------------------------+
+//
+// All DataPoint types have three common fields:
+// - Labels zero or more key-value pairs associated with the data point.
+// - StartTimeUnixNano MUST be set to the start of the interval when the data's
+//   type includes an AggregationTemporality. This field is not set otherwise.
+// - TimeUnixNano MUST be set to:
+//   - the moment when an aggregation is reported (independent of the
+//     aggregation temporality).
+//   - the instantaneous time of the event.
+message Metric {
+  // name of the metric, including its DNS name prefix. It must be unique.
+  string name = 1;
+
+  // description of the metric, which can be used in documentation.
+  string description = 2;
+
+  // unit in which the metric value is reported. Follows the format
+  // described by http://unitsofmeasure.org/ucum.html.
+  string unit = 3;
+
+  // TODO: Decide if support for RawMeasurements (measurements recorded using
+  // the synchronous instruments) is necessary. It can be used to delegate the
+  // aggregation from the application to the agent/collector. See
+  // https://github.com/open-telemetry/opentelemetry-specification/issues/617
+
+  // Data determines the aggregation type (if any) of the metric, what is the
+  // reported value type for the data points, as well as the relatationship to
+  // the time interval over which they are reported.
+  oneof data {
+    // IntGauge and IntSum are deprecated and will be removed soon.
+    // 1. Old senders and receivers that are not aware of this change will
+    // continue using the `int_gauge` and `int_sum` fields.
+    // 2. New senders, which are aware of this change MUST send only `gauge`
+    // and `sum` fields.
+    // 3. New receivers, which are aware of this change MUST convert these into
+    // `gauge` and `sum` by using the provided as_int field in the oneof values.
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntGauge int_gauge = 4 [deprecated = true];
+    Gauge gauge = 5;
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntSum int_sum = 6 [deprecated = true];
+    Sum sum = 7;
+
+    // IntHistogram is deprecated and will be removed soon.
+    // 1. Old senders and receivers that are not aware of this change will
+    // continue using the `int_histogram` field.
+    // 2. New senders, which are aware of this change MUST send only `histogram`.
+    // 3. New receivers, which are aware of this change MUST convert this into
+    // `histogram` by simply converting all int64 values into float.
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntHistogram int_histogram = 8 [deprecated = true];
+    Histogram histogram = 9;
+    Summary summary = 11;
+  }
+}
+
+// IntGauge is deprecated.  Use Gauge with an integer value in NumberDataPoint.
+//
+// IntGauge represents the type of a int scalar metric that always exports the
+// "current value" for every data point. It should be used for an "unknown"
+// aggregation.
+//
+// A Gauge does not support different aggregation temporalities. Given the
+// aggregation is unknown, points cannot be combined using the same
+// aggregation, regardless of aggregation temporalities. Therefore,
+// AggregationTemporality is not included. Consequently, this also means
+// "StartTimeUnixNano" is ignored for all data points.
+message IntGauge {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+}
+
+// Gauge represents the type of a double scalar metric that always exports the
+// "current value" for every data point. It should be used for an "unknown"
+// aggregation.
+//
+// A Gauge does not support different aggregation temporalities. Given the
+// aggregation is unknown, points cannot be combined using the same
+// aggregation, regardless of aggregation temporalities. Therefore,
+// AggregationTemporality is not included. Consequently, this also means
+// "StartTimeUnixNano" is ignored for all data points.
+message Gauge {
+  repeated NumberDataPoint data_points = 1;
+}
+
+// IntSum is deprecated.  Use Sum with an integer value in NumberDataPoint.
+//
+// IntSum represents the type of a numeric int scalar metric that is calculated as
+// a sum of all reported measurements over a time interval.
+message IntSum {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+
+  // If "true" means that the sum is monotonic.
+  bool is_monotonic = 3;
+}
+
+// Sum represents the type of a numeric double scalar metric that is calculated
+// as a sum of all reported measurements over a time interval.
+message Sum {
+  repeated NumberDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+
+  // If "true" means that the sum is monotonic.
+  bool is_monotonic = 3;
+}
+
+// IntHistogram is deprecated, replaced by Histogram points using double-
+// valued exemplars.
+//
+// This represents the type of a metric that is calculated by aggregating as a
+// Histogram of all reported int measurements over a time interval.
+message IntHistogram {
+  option deprecated = true;
+
+  repeated IntHistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+}
+
+// Histogram represents the type of a metric that is calculated by aggregating as a
+// Histogram of all reported double measurements over a time interval.
+message Histogram {
+  repeated HistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+}
+
+// Summary metric data are used to convey quantile summaries,
+// a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary)
+// and OpenMetrics (see: https://github.com/OpenObservability/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45)
+// data type. These data points cannot always be merged in a meaningful way.
+// While they can be useful in some applications, histogram data points are
+// recommended for new applications.
+message Summary {
+  repeated SummaryDataPoint data_points = 1;
+}
+
+// AggregationTemporality defines how a metric aggregator reports aggregated
+// values. It describes how those values relate to the time interval over
+// which they are aggregated.
+enum AggregationTemporality {
+  // UNSPECIFIED is the default AggregationTemporality, it MUST not be used.
+  AGGREGATION_TEMPORALITY_UNSPECIFIED = 0;
+
+  // DELTA is an AggregationTemporality for a metric aggregator which reports
+  // changes since last report time. Successive metrics contain aggregation of
+  // values from continuous and non-overlapping intervals.
+  //
+  // The values for a DELTA metric are based only on the time interval
+  // associated with one measurement cycle. There is no dependency on
+  // previous measurements like is the case for CUMULATIVE metrics.
+  //
+  // For example, consider a system measuring the number of requests that
+  // it receives and reports the sum of these requests every second as a
+  // DELTA metric:
+  //
+  //   1. The system starts receiving at time=t_0.
+  //   2. A request is received, the system measures 1 request.
+  //   3. A request is received, the system measures 1 request.
+  //   4. A request is received, the system measures 1 request.
+  //   5. The 1 second collection cycle ends. A metric is exported for the
+  //      number of requests received over the interval of time t_0 to
+  //      t_0+1 with a value of 3.
+  //   6. A request is received, the system measures 1 request.
+  //   7. A request is received, the system measures 1 request.
+  //   8. The 1 second collection cycle ends. A metric is exported for the
+  //      number of requests received over the interval of time t_0+1 to
+  //      t_0+2 with a value of 2.
+  AGGREGATION_TEMPORALITY_DELTA = 1;
+
+  // CUMULATIVE is an AggregationTemporality for a metric aggregator which
+  // reports changes since a fixed start time. This means that current values
+  // of a CUMULATIVE metric depend on all previous measurements since the
+  // start time. Because of this, the sender is required to retain this state
+  // in some form. If this state is lost or invalidated, the CUMULATIVE metric
+  // values MUST be reset and a new fixed start time following the last
+  // reported measurement time sent MUST be used.
+  //
+  // For example, consider a system measuring the number of requests that
+  // it receives and reports the sum of these requests every second as a
+  // CUMULATIVE metric:
+  //
+  //   1. The system starts receiving at time=t_0.
+  //   2. A request is received, the system measures 1 request.
+  //   3. A request is received, the system measures 1 request.
+  //   4. A request is received, the system measures 1 request.
+  //   5. The 1 second collection cycle ends. A metric is exported for the
+  //      number of requests received over the interval of time t_0 to
+  //      t_0+1 with a value of 3.
+  //   6. A request is received, the system measures 1 request.
+  //   7. A request is received, the system measures 1 request.
+  //   8. The 1 second collection cycle ends. A metric is exported for the
+  //      number of requests received over the interval of time t_0 to
+  //      t_0+2 with a value of 5.
+  //   9. The system experiences a fault and loses state.
+  //   10. The system recovers and resumes receiving at time=t_1.
+  //   11. A request is received, the system measures 1 request.
+  //   12. The 1 second collection cycle ends. A metric is exported for the
+  //      number of requests received over the interval of time t_1 to
+  //      t_0+1 with a value of 1.
+  //
+  // Note: Even though, when reporting changes since last report time, using
+  // CUMULATIVE is valid, it is not recommended. This may cause problems for
+  // systems that do not use start_time to determine when the aggregation
+  // value was reset (e.g. Prometheus).
+  AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
+}
+
+// IntDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a int64 metric.
+message IntDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated StringKeyValue labels = 1;
+
+  // start_time_unix_nano is the last time when the aggregation value was reset
+  // to "zero". For some metric types this is ignored, see data types for more
+  // details.
+  //
+  // The aggregation value is over the time interval (start_time_unix_nano,
+  // time_unix_nano].
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the
+  // timestamp may be decided by the backend.
+  fixed64 start_time_unix_nano = 2;
+
+  // time_unix_nano is the moment when this aggregation value was reported.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // value itself.
+  sfixed64 value = 4;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 5;
+}
+
+// NumberDataPoint is a single data point in a timeseries that describes the
+// time-varying value of a double metric.
+message NumberDataPoint {
+  // The set of labels that uniquely identify this timeseries.
+  repeated StringKeyValue labels = 1;
+
+  // start_time_unix_nano is the last time when the aggregation value was reset
+  // to "zero". For some metric types this is ignored, see data types for more
+  // details.
+  //
+  // The aggregation value is over the time interval (start_time_unix_nano,
+  // time_unix_nano].
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the
+  // timestamp may be decided by the backend.
+  fixed64 start_time_unix_nano = 2;
+
+  // time_unix_nano is the moment when this aggregation value was reported.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // The value itself.  A point is considered invalid when one of the recognized
+  // value fields is not present inside this oneof.
+  oneof value {
+    double as_double = 4;
+    sfixed64 as_int = 6;
+  }
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated Exemplar exemplars = 5;
+}
+
+// IntHistogramDataPoint is deprecated; use HistogramDataPoint.
+//
+// This is a single data point in a timeseries that describes
+// the time-varying values of a Histogram of int values. A Histogram contains
+// summary statistics for a population of values, it may optionally contain
+// the distribution of those values across a set of buckets.
+//
+// If the histogram contains the distribution of values, then both
+// "explicit_bounds" and "bucket counts" fields must be defined.
+// If the histogram does not contain the distribution of values, then both
+// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
+// "sum" are known.
+message IntHistogramDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated StringKeyValue labels = 1;
+
+  // start_time_unix_nano is the last time when the aggregation value was reset
+  // to "zero". For some metric types this is ignored, see data types for more
+  // details.
+  //
+  // The aggregation value is over the time interval (start_time_unix_nano,
+  // time_unix_nano].
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the
+  // timestamp may be decided by the backend.
+  fixed64 start_time_unix_nano = 2;
+
+  // time_unix_nano is the moment when this aggregation value was reported.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  sfixed64 sum = 5;
+
+  // bucket_counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the bucket_counts must equal the value in the count field.
+  //
+  // The number of elements in bucket_counts array must be by one greater than
+  // the number of elements in explicit_bounds array.
+  repeated fixed64 bucket_counts = 6;
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  //
+  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
+  // bucket at index i are:
+  //
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
+  // (explicit_bounds[i], +infinity) for i == N-1
+  //
+  // The values in the explicit_bounds array must be strictly increasing.
+  //
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
+  repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 8;
+}
+
+// HistogramDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a Histogram of double values. A Histogram contains
+// summary statistics for a population of values, it may optionally contain the
+// distribution of those values across a set of buckets.
+//
+// If the histogram contains the distribution of values, then both
+// "explicit_bounds" and "bucket counts" fields must be defined.
+// If the histogram does not contain the distribution of values, then both
+// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
+// "sum" are known.
+message HistogramDataPoint {
+  // The set of labels that uniquely identify this timeseries.
+  repeated StringKeyValue labels = 1;
+
+  // start_time_unix_nano is the last time when the aggregation value was reset
+  // to "zero". For some metric types this is ignored, see data types for more
+  // details.
+  //
+  // The aggregation value is over the time interval (start_time_unix_nano,
+  // time_unix_nano].
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the
+  // timestamp may be decided by the backend.
+  fixed64 start_time_unix_nano = 2;
+
+  // time_unix_nano is the moment when this aggregation value was reported.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  double sum = 5;
+
+  // bucket_counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the bucket_counts must equal the value in the count field.
+  //
+  // The number of elements in bucket_counts array must be by one greater than
+  // the number of elements in explicit_bounds array.
+  repeated fixed64 bucket_counts = 6;
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  //
+  // This defines size(explicit_bounds) + 1 (= N) buckets. The boundaries for
+  // bucket at index i are:
+  //
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < N-1
+  // (explicit_bounds[i], +infinity) for i == N-1
+  //
+  // The values in the explicit_bounds array must be strictly increasing.
+  //
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
+  repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated Exemplar exemplars = 8;
+}
+
+// SummaryDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a Summary metric.
+message SummaryDataPoint {
+  // The set of labels that uniquely identify this timeseries.
+  repeated StringKeyValue labels = 1;
+
+  // start_time_unix_nano is the last time when the aggregation value was reset
+  // to "zero". For some metric types this is ignored, see data types for more
+  // details.
+  //
+  // The aggregation value is over the time interval (start_time_unix_nano,
+  // time_unix_nano].
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  //
+  // Value of 0 indicates that the timestamp is unspecified. In that case the
+  // timestamp may be decided by the backend.
+  fixed64 start_time_unix_nano = 2;
+
+  // time_unix_nano is the moment when this aggregation value was reported.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero.
+  double sum = 5;
+
+  // Represents the value at a given quantile of a distribution.
+  //
+  // To record Min and Max values following conventions are used:
+  // - The 1.0 quantile is equivalent to the maximum value observed.
+  // - The 0.0 quantile is equivalent to the minimum value observed.
+  //
+  // See the following issue for more context:
+  // https://github.com/open-telemetry/opentelemetry-proto/issues/125
+  message ValueAtQuantile {
+    // The quantile of a distribution. Must be in the interval
+    // [0.0, 1.0].
+    double quantile = 1;
+
+    // The value at the given quantile of a distribution.
+    double value = 2;
+  }
+
+  // (Optional) list of values at different quantiles of the distribution calculated
+  // from the current snapshot. The quantiles must be strictly increasing.
+  repeated ValueAtQuantile quantile_values = 6;
+}
+
+// A representation of an exemplar, which is a sample input int measurement.
+// Exemplars also hold information about the environment when the measurement
+// was recorded, for example the span and trace ID of the active span when the
+// exemplar was recorded.
+message IntExemplar {
+  option deprecated = true;
+
+  // The set of labels that were filtered out by the aggregator, but recorded
+  // alongside the original measurement. Only labels that were filtered out
+  // by the aggregator should be included
+  repeated StringKeyValue filtered_labels = 1;
+
+  // time_unix_nano is the exact time when this exemplar was recorded
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 2;
+
+  // Numerical int value of the measurement that was recorded.
+  sfixed64 value = 3;
+
+  // (Optional) Span ID of the exemplar trace.
+  // span_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes span_id = 4;
+
+  // (Optional) Trace ID of the exemplar trace.
+  // trace_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes trace_id = 5;
+}
+
+// A representation of an exemplar, which is a sample input measurement.
+// Exemplars also hold information about the environment when the measurement
+// was recorded, for example the span and trace ID of the active span when the
+// exemplar was recorded.
+message Exemplar {
+  // The set of labels that were filtered out by the aggregator, but recorded
+  // alongside the original measurement. Only labels that were filtered out
+  // by the aggregator should be included
+  repeated StringKeyValue filtered_labels = 1;
+
+  // time_unix_nano is the exact time when this exemplar was recorded
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 2;
+
+  // Numerical value of the measurement that was recorded. An exemplar is
+  // considered invalid when one of the recognized value fields is not present
+  // inside this oneof.
+  oneof value {
+    double as_double = 3;
+    sfixed64 as_int = 6;
+  }
+
+  // (Optional) Span ID of the exemplar trace.
+  // span_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes span_id = 4;
+
+  // (Optional) Trace ID of the exemplar trace.
+  // trace_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes trace_id = 5;
+}

--- a/model/proto/metrics/otelspankind.proto
+++ b/model/proto/metrics/otelspankind.proto
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based on: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+
+syntax="proto3";
+
+package jaeger.api_v2;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "api_v2";
+option java_package = "io.jaegertracing.api_v2";
+
+// Enable gogoprotobuf extensions (https://github.com/gogo/protobuf/blob/master/extensions.md).
+// Enable custom Marshal method.
+option (gogoproto.marshaler_all) = true;
+// Enable custom Unmarshal method.
+option (gogoproto.unmarshaler_all) = true;
+// Enable custom Size method (Required by Marshal and Unmarshal).
+option (gogoproto.sizer_all) = true;
+
+// SpanKind is the type of span. Can be used to specify additional relationships between spans
+// in addition to a parent/child relationship.
+enum SpanKind {
+  // Unspecified. Do NOT use as default.
+  // Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
+  SPAN_KIND_UNSPECIFIED = 0;
+
+  // Indicates that the span represents an internal operation within an application,
+  // as opposed to an operation happening at the boundaries. Default value.
+  SPAN_KIND_INTERNAL = 1;
+
+  // Indicates that the span covers server-side handling of an RPC or other
+  // remote network request.
+  SPAN_KIND_SERVER = 2;
+
+  // Indicates that the span describes a request to some remote service.
+  SPAN_KIND_CLIENT = 3;
+
+  // Indicates that the span describes a producer sending a message to a broker.
+  // Unlike CLIENT and SERVER, there is often no direct critical path latency relationship
+  // between producer and consumer spans. A PRODUCER span ends when the message was accepted
+  // by the broker while the logical processing of the message might span a much longer time.
+  SPAN_KIND_PRODUCER = 4;
+
+  // Indicates that the span describes consumer receiving a message from a broker.
+  // Like the PRODUCER kind, there is often no direct critical path latency relationship
+  // between producer and consumer spans.
+  SPAN_KIND_CONSUMER = 5;
+}

--- a/model/proto/metrics/service.proto
+++ b/model/proto/metrics/service.proto
@@ -35,9 +35,13 @@ option (gogoproto.sizer_all) = true;
 
 // MetricsQueryBaseRequest is the base request parameter accompanying a MetricsQueryService RPC call.
 message MetricsQueryBaseRequest {
+  // groupByOperation determines if the metrics returned should be grouped by operation.
+  // Optional. Default = false.
+  bool groupByOperation = 1;
+
   // end_time is the ending time of the time series query range.
   // Optional. Default = now.
-  google.protobuf.Timestamp end_time = 1 [
+  google.protobuf.Timestamp end_time = 2 [
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = true
   ];
@@ -45,7 +49,7 @@ message MetricsQueryBaseRequest {
   // lookback is the duration from the end_time to look back on for metrics data points.
   // For example, if set to 1h, the query would span from end_time-1h to end_time.
   // Optional. Default = 1h.
-  google.protobuf.Duration lookback = 2 [
+  google.protobuf.Duration lookback = 3 [
     (gogoproto.stdduration) = true,
     (gogoproto.nullable) = true
   ];
@@ -54,25 +58,25 @@ message MetricsQueryBaseRequest {
   // For example, if set to 5s, the results would produce a data point every 5 seconds
   // from the start_time to end_time.
   // Optional. Default = 5s.
-  google.protobuf.Duration step = 3 [
+  google.protobuf.Duration step = 4 [
     (gogoproto.stdduration) = true,
     (gogoproto.nullable) = true
   ];
 
   // ratePer is the duration in which the per-second rate of change is calculated for a cumulative counter metric.
   // Optional. Default = 10m.
-  google.protobuf.Duration ratePer = 4 [
+  google.protobuf.Duration ratePer = 5 [
     (gogoproto.stdduration) = true,
     (gogoproto.nullable) = true
   ];
 
   // spanKinds is the list of span kinds to include (logical OR) in the resulting metrics aggregation.
   // Optional. Default = [SPAN_KIND_SERVER].
-  repeated SpanKind spanKinds = 5;
+  repeated SpanKind spanKinds = 6;
 }
 
-// GetServiceLatenciesRequest contains parameters for the GetServiceLatencies RPC call.
-message GetServiceLatenciesRequest {
+// GetLatenciesRequest contains parameters for the GetLatencies RPC call.
+message GetLatenciesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
   // service_names are the service names to fetch operation metrics from.
   // Required.
@@ -82,16 +86,16 @@ message GetServiceLatenciesRequest {
   double quantile = 3;
 }
 
-// GetServiceCallRatesRequest contains parameters for the GetServiceCallRates RPC call.
-message GetServiceCallRatesRequest {
+// GetCallRatesRequest contains parameters for the GetCallRates RPC call.
+message GetCallRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
   // service_names are the service names to fetch operation metrics from.
   // Required.
   repeated string service_names = 2;
 }
 
-// GetServiceErrorRatesRequest contains parameters for the GetServiceErrorRates RPC call.
-message GetServiceErrorRatesRequest {
+// GetErrorRatesRequest contains parameters for the GetErrorRates RPC call.
+message GetErrorRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
   // service_names are the service names to fetch operation metrics from.
   // Required.
@@ -117,12 +121,12 @@ service MetricsQueryService {
   // GetMinStepDuration gets the min step duration supported by the backing metrics store.
   rpc GetMinStepDuration(GetMinStepDurationRequest) returns (GetMinStepDurationResponse);
 
-  // GetServiceLatencies gets the latency metrics grouped by operation for a given service.
-  rpc GetServiceLatencies(GetServiceLatenciesRequest) returns (GetMetricsResponse);
+  // GetLatencies gets the latency metrics grouped by operation for a given service.
+  rpc GetLatencies(GetLatenciesRequest) returns (GetMetricsResponse);
 
-  // GetServiceCallRates gets the call rate metrics grouped by operation for a given service.
-  rpc GetServiceCallRates(GetServiceCallRatesRequest) returns (GetMetricsResponse);
+  // GetCallRates gets the call rate metrics grouped by operation for a given service.
+  rpc GetCallRates(GetCallRatesRequest) returns (GetMetricsResponse);
 
-  // GetServiceErrorRates gets the error rate metrics grouped by operation for a given service.
-  rpc GetServiceErrorRates(GetServiceErrorRatesRequest) returns (GetMetricsResponse);
+  // GetErrorRates gets the error rate metrics grouped by operation for a given service.
+  rpc GetErrorRates(GetErrorRatesRequest) returns (GetMetricsResponse);
 }

--- a/model/proto/metrics/service.proto
+++ b/model/proto/metrics/service.proto
@@ -84,6 +84,11 @@ message MetricsQueryBaseRequest {
 message GetLatenciesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
   // quantile is the quantile to compute from latency histogram metrics.
+  // Valid range: 0 - 1 (inclusive).
+  //
+  // e.g. 0.99 will return the 99th percentile or P99 which is the worst latency
+  // observed from 99% of all spans for the given service (and operation).
+  //
   // Required.
   double quantile = 2;
 }
@@ -114,7 +119,8 @@ message GetMetricsResponse {
 }
 
 service MetricsQueryService {
-  // GetMinStepDuration gets the min step duration supported by the backing metrics store.
+  // GetMinStepDuration gets the min time resolution supported by the backing metrics store,
+  // e.g. 10s means the backend can only return data points that are at least 10s apart, not closer.
   rpc GetMinStepDuration(GetMinStepDurationRequest) returns (GetMinStepDurationResponse);
 
   // GetLatencies gets the latency metrics for a given list of services grouped by service

--- a/model/proto/metrics/service.proto
+++ b/model/proto/metrics/service.proto
@@ -74,9 +74,9 @@ message MetricsQueryBaseRequest {
 // GetServiceLatenciesRequest contains parameters for the GetServiceLatencies RPC call.
 message GetServiceLatenciesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
-  // service_name is the service name to fetch operation metrics from.
+  // service_names are the service names to fetch operation metrics from.
   // Required.
-  string service_name = 2;
+  repeated string service_names = 2;
   // quantile is the quantile to compute from latency histogram metrics.
   // Required.
   double quantile = 3;
@@ -85,17 +85,17 @@ message GetServiceLatenciesRequest {
 // GetServiceCallRatesRequest contains parameters for the GetServiceCallRates RPC call.
 message GetServiceCallRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
-  // service_name is the service name to fetch operation metrics from.
+  // service_names are the service names to fetch operation metrics from.
   // Required.
-  string service_name = 2;
+  repeated string service_names = 2;
 }
 
 // GetServiceErrorRatesRequest contains parameters for the GetServiceErrorRates RPC call.
 message GetServiceErrorRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
-  // service_name is the service name to fetch operation metrics from.
+  // service_names are the service names to fetch operation metrics from.
   // Required.
-  string service_name = 2;
+  repeated string service_names = 2;
 }
 
 message GetMinStepDurationRequest{};

--- a/model/proto/metrics/service.proto
+++ b/model/proto/metrics/service.proto
@@ -35,13 +35,18 @@ option (gogoproto.sizer_all) = true;
 
 // MetricsQueryBaseRequest is the base request parameter accompanying a MetricsQueryService RPC call.
 message MetricsQueryBaseRequest {
+  // service_names are the service names to fetch metrics from.
+  // The results will be grouped by service_name.
+  // Required. At least one service name must be provided.
+  repeated string service_names = 1;
+
   // groupByOperation determines if the metrics returned should be grouped by operation.
   // Optional. Default = false.
-  bool groupByOperation = 1;
+  bool groupByOperation = 2;
 
   // end_time is the ending time of the time series query range.
   // Optional. Default = now.
-  google.protobuf.Timestamp end_time = 2 [
+  google.protobuf.Timestamp end_time = 3 [
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = true
   ];
@@ -49,7 +54,7 @@ message MetricsQueryBaseRequest {
   // lookback is the duration from the end_time to look back on for metrics data points.
   // For example, if set to 1h, the query would span from end_time-1h to end_time.
   // Optional. Default = 1h.
-  google.protobuf.Duration lookback = 3 [
+  google.protobuf.Duration lookback = 4 [
     (gogoproto.stdduration) = true,
     (gogoproto.nullable) = true
   ];
@@ -58,48 +63,39 @@ message MetricsQueryBaseRequest {
   // For example, if set to 5s, the results would produce a data point every 5 seconds
   // from the start_time to end_time.
   // Optional. Default = 5s.
-  google.protobuf.Duration step = 4 [
+  google.protobuf.Duration step = 5 [
     (gogoproto.stdduration) = true,
     (gogoproto.nullable) = true
   ];
 
   // ratePer is the duration in which the per-second rate of change is calculated for a cumulative counter metric.
   // Optional. Default = 10m.
-  google.protobuf.Duration ratePer = 5 [
+  google.protobuf.Duration ratePer = 6 [
     (gogoproto.stdduration) = true,
     (gogoproto.nullable) = true
   ];
 
   // spanKinds is the list of span kinds to include (logical OR) in the resulting metrics aggregation.
   // Optional. Default = [SPAN_KIND_SERVER].
-  repeated SpanKind spanKinds = 6;
+  repeated SpanKind spanKinds = 7;
 }
 
 // GetLatenciesRequest contains parameters for the GetLatencies RPC call.
 message GetLatenciesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
-  // service_names are the service names to fetch operation metrics from.
-  // Required.
-  repeated string service_names = 2;
   // quantile is the quantile to compute from latency histogram metrics.
   // Required.
-  double quantile = 3;
+  double quantile = 2;
 }
 
 // GetCallRatesRequest contains parameters for the GetCallRates RPC call.
 message GetCallRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
-  // service_names are the service names to fetch operation metrics from.
-  // Required.
-  repeated string service_names = 2;
 }
 
 // GetErrorRatesRequest contains parameters for the GetErrorRates RPC call.
 message GetErrorRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
-  // service_names are the service names to fetch operation metrics from.
-  // Required.
-  repeated string service_names = 2;
 }
 
 message GetMinStepDurationRequest{};

--- a/model/proto/metrics/service.proto
+++ b/model/proto/metrics/service.proto
@@ -71,26 +71,8 @@ message MetricsQueryBaseRequest {
   repeated SpanKind spanKinds = 5;
 }
 
-// GetPerServiceLatenciesRequest contains parameters for the GetPerServiceLatencies RPC call.
-message GetPerServiceLatenciesRequest {
-  MetricsQueryBaseRequest baseRequest = 1;
-  // quantile is the quantile to compute from latency histogram metrics.
-  // Required.
-  double quantile = 2;
-}
-
-// GetPerServiceCallRatesRequest contains parameters for the GetPerServiceCallRates RPC call.
-message GetPerServiceCallRatesRequest {
-  MetricsQueryBaseRequest baseRequest = 1;
-}
-
-// GetPerServiceErrorRatesRequest contains parameters for the GetPerServiceErrorRates RPC call.
-message GetPerServiceErrorRatesRequest {
-  MetricsQueryBaseRequest baseRequest = 1;
-}
-
-// GetPerOperationLatenciesRequest contains parameters for the GetPerOperationLatencies RPC call.
-message GetPerOperationLatenciesRequest {
+// GetServiceLatenciesRequest contains parameters for the GetServiceLatencies RPC call.
+message GetServiceLatenciesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
   // service_name is the service name to fetch operation metrics from.
   // Required.
@@ -100,16 +82,16 @@ message GetPerOperationLatenciesRequest {
   double quantile = 3;
 }
 
-// GetPerOperationCallRatesRequest contains parameters for the GetPerOperationCallRates RPC call.
-message GetPerOperationCallRatesRequest {
+// GetServiceCallRatesRequest contains parameters for the GetServiceCallRates RPC call.
+message GetServiceCallRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
   // service_name is the service name to fetch operation metrics from.
   // Required.
   string service_name = 2;
 }
 
-// GetPerOperationErrorRatesRequest contains parameters for the GetPerOperationErrorRates RPC call.
-message GetPerOperationErrorRatesRequest {
+// GetServiceErrorRatesRequest contains parameters for the GetServiceErrorRates RPC call.
+message GetServiceErrorRatesRequest {
   MetricsQueryBaseRequest baseRequest = 1;
   // service_name is the service name to fetch operation metrics from.
   // Required.
@@ -135,21 +117,12 @@ service MetricsQueryService {
   // GetMinStepDuration gets the min step duration supported by the backing metrics store.
   rpc GetMinStepDuration(GetMinStepDurationRequest) returns (GetMinStepDurationResponse);
 
-  // GetPerServiceLatencies gets latency metrics grouped by service.
-  rpc GetPerServiceLatencies(GetPerServiceLatenciesRequest) returns (GetMetricsResponse);
+  // GetServiceLatencies gets the latency metrics grouped by operation for a given service.
+  rpc GetServiceLatencies(GetServiceLatenciesRequest) returns (GetMetricsResponse);
 
-  // GetPerServiceCallRates gets the call rate metrics grouped by service.
-  rpc GetPerServiceCallRates(GetPerServiceCallRatesRequest) returns (GetMetricsResponse);
+  // GetServiceCallRates gets the call rate metrics grouped by operation for a given service.
+  rpc GetServiceCallRates(GetServiceCallRatesRequest) returns (GetMetricsResponse);
 
-  // GetPerServiceErrorRates gets the error rate metrics grouped by service.
-  rpc GetPerServiceErrorRates(GetPerServiceErrorRatesRequest) returns (GetMetricsResponse);
-
-  // GetPerOperationLatencies gets the latency metrics grouped by operation for a given service.
-  rpc GetPerOperationLatencies(GetPerOperationLatenciesRequest) returns (GetMetricsResponse);
-
-  // GetPerOperationCallRates gets the call rate metrics grouped by operation for a given service.
-  rpc GetPerOperationCallRates(GetPerOperationCallRatesRequest) returns (GetMetricsResponse);
-
-  // GetPerOperationErrorRates gets the error rate metrics grouped by operation for a given service.
-  rpc GetPerOperationErrorRates(GetPerOperationErrorRatesRequest) returns (GetMetricsResponse);
+  // GetServiceErrorRates gets the error rate metrics grouped by operation for a given service.
+  rpc GetServiceErrorRates(GetServiceErrorRatesRequest) returns (GetMetricsResponse);
 }

--- a/model/proto/metrics/service.proto
+++ b/model/proto/metrics/service.proto
@@ -1,0 +1,155 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax="proto3";
+
+package jaeger.api_v2;
+
+import "otelmetric.proto";
+import "otelspankind.proto";
+import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+option go_package = "api_v2";
+option java_package = "io.jaegertracing.api_v2";
+
+// Enable gogoprotobuf extensions (https://github.com/gogo/protobuf/blob/master/extensions.md).
+// Enable custom Marshal method.
+option (gogoproto.marshaler_all) = true;
+// Enable custom Unmarshal method.
+option (gogoproto.unmarshaler_all) = true;
+// Enable custom Size method (Required by Marshal and Unmarshal).
+option (gogoproto.sizer_all) = true;
+
+// MetricsQueryBaseRequest is the base request parameter accompanying a MetricsQueryService RPC call.
+message MetricsQueryBaseRequest {
+  // end_time is the ending time of the time series query range.
+  // Optional. Default = now.
+  google.protobuf.Timestamp end_time = 1 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = true
+  ];
+
+  // lookback is the duration from the end_time to look back on for metrics data points.
+  // For example, if set to 1h, the query would span from end_time-1h to end_time.
+  // Optional. Default = 1h.
+  google.protobuf.Duration lookback = 2 [
+    (gogoproto.stdduration) = true,
+    (gogoproto.nullable) = true
+  ];
+
+  // step size is the duration between data points of the query results.
+  // For example, if set to 5s, the results would produce a data point every 5 seconds
+  // from the start_time to end_time.
+  // Optional. Default = 5s.
+  google.protobuf.Duration step = 3 [
+    (gogoproto.stdduration) = true,
+    (gogoproto.nullable) = true
+  ];
+
+  // ratePer is the duration in which the per-second rate of change is calculated for a cumulative counter metric.
+  // Optional. Default = 10m.
+  google.protobuf.Duration ratePer = 4 [
+    (gogoproto.stdduration) = true,
+    (gogoproto.nullable) = true
+  ];
+
+  // spanKinds is the list of span kinds to include (logical OR) in the resulting metrics aggregation.
+  // Optional. Default = [SPAN_KIND_SERVER].
+  repeated SpanKind spanKinds = 5;
+}
+
+// GetPerServiceLatenciesRequest contains parameters for the GetPerServiceLatencies RPC call.
+message GetPerServiceLatenciesRequest {
+  MetricsQueryBaseRequest baseRequest = 1;
+  // quantile is the quantile to compute from latency histogram metrics.
+  // Required.
+  double quantile = 2;
+}
+
+// GetPerServiceCallRatesRequest contains parameters for the GetPerServiceCallRates RPC call.
+message GetPerServiceCallRatesRequest {
+  MetricsQueryBaseRequest baseRequest = 1;
+}
+
+// GetPerServiceErrorRatesRequest contains parameters for the GetPerServiceErrorRates RPC call.
+message GetPerServiceErrorRatesRequest {
+  MetricsQueryBaseRequest baseRequest = 1;
+}
+
+// GetPerOperationLatenciesRequest contains parameters for the GetPerOperationLatencies RPC call.
+message GetPerOperationLatenciesRequest {
+  MetricsQueryBaseRequest baseRequest = 1;
+  // service_name is the service name to fetch operation metrics from.
+  // Required.
+  string service_name = 2;
+  // quantile is the quantile to compute from latency histogram metrics.
+  // Required.
+  double quantile = 3;
+}
+
+// GetPerOperationCallRatesRequest contains parameters for the GetPerOperationCallRates RPC call.
+message GetPerOperationCallRatesRequest {
+  MetricsQueryBaseRequest baseRequest = 1;
+  // service_name is the service name to fetch operation metrics from.
+  // Required.
+  string service_name = 2;
+}
+
+// GetPerOperationErrorRatesRequest contains parameters for the GetPerOperationErrorRates RPC call.
+message GetPerOperationErrorRatesRequest {
+  MetricsQueryBaseRequest baseRequest = 1;
+  // service_name is the service name to fetch operation metrics from.
+  // Required.
+  string service_name = 2;
+}
+
+message GetMinStepDurationRequest{};
+
+message GetMinStepDurationResponse {
+  google.protobuf.Duration minStep = 1 [
+    (gogoproto.stdduration) = true,
+    (gogoproto.nullable) = false
+  ];
+}
+
+message GetMetricsResponse {
+  repeated Metric metrics = 1 [
+    (gogoproto.nullable) = false
+  ];
+}
+
+service MetricsQueryService {
+  // GetMinStepDuration gets the min step duration supported by the backing metrics store.
+  rpc GetMinStepDuration(GetMinStepDurationRequest) returns (GetMinStepDurationResponse);
+
+  // GetPerServiceLatencies gets latency metrics grouped by service.
+  rpc GetPerServiceLatencies(GetPerServiceLatenciesRequest) returns (GetMetricsResponse);
+
+  // GetPerServiceCallRates gets the call rate metrics grouped by service.
+  rpc GetPerServiceCallRates(GetPerServiceCallRatesRequest) returns (GetMetricsResponse);
+
+  // GetPerServiceErrorRates gets the error rate metrics grouped by service.
+  rpc GetPerServiceErrorRates(GetPerServiceErrorRatesRequest) returns (GetMetricsResponse);
+
+  // GetPerOperationLatencies gets the latency metrics grouped by operation for a given service.
+  rpc GetPerOperationLatencies(GetPerOperationLatenciesRequest) returns (GetMetricsResponse);
+
+  // GetPerOperationCallRates gets the call rate metrics grouped by operation for a given service.
+  rpc GetPerOperationCallRates(GetPerOperationCallRatesRequest) returns (GetMetricsResponse);
+
+  // GetPerOperationErrorRates gets the error rate metrics grouped by operation for a given service.
+  rpc GetPerOperationErrorRates(GetPerOperationErrorRatesRequest) returns (GetMetricsResponse);
+}

--- a/model/proto/metrics/service.proto
+++ b/model/proto/metrics/service.proto
@@ -117,12 +117,15 @@ service MetricsQueryService {
   // GetMinStepDuration gets the min step duration supported by the backing metrics store.
   rpc GetMinStepDuration(GetMinStepDurationRequest) returns (GetMinStepDurationResponse);
 
-  // GetLatencies gets the latency metrics grouped by operation for a given service.
+  // GetLatencies gets the latency metrics for a given list of services grouped by service
+  // and optionally grouped by operation.
   rpc GetLatencies(GetLatenciesRequest) returns (GetMetricsResponse);
 
-  // GetCallRates gets the call rate metrics grouped by operation for a given service.
+  // GetCallRates gets the call rate metrics for a given list of services grouped by service
+  // and optionally grouped by operation.
   rpc GetCallRates(GetCallRatesRequest) returns (GetMetricsResponse);
 
-  // GetErrorRates gets the error rate metrics grouped by operation for a given service.
+  // GetErrorRates gets the error rate metrics for a given list of services grouped by service
+  // and optionally grouped by operation.
   rpc GetErrorRates(GetErrorRatesRequest) returns (GetMetricsResponse);
 }


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Please refer to https://github.com/jaegertracing/jaeger/issues/2954 for context on the use case.
- Addresses review comments from https://github.com/jaegertracing/jaeger-idl/pull/73, one of which is to place the API definition in the main jaeger repository during the prototype phase.

## Short description of the changes
- Defines a vendor-neutral API specification for querying from a metrics backing store.
- Add README to explain the motivation, approach taken and rationale for approach.
- Update Makefile to generate client/server code from new proto files.
- Tested on a working prototype with both gRPC and HTTP clients.
