### PR TITLE
[es] Add index rollover mode that can choose day and hour

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -44,33 +44,34 @@ import (
 
 // Configuration describes the configuration properties needed to connect to an ElasticSearch cluster
 type Configuration struct {
-	Servers               []string       `mapstructure:"server_urls"`
-	RemoteReadClusters    []string       `mapstructure:"remote_read_clusters"`
-	Username              string         `mapstructure:"username"`
-	Password              string         `mapstructure:"password" json:"-"`
-	TokenFilePath         string         `mapstructure:"token_file"`
-	AllowTokenFromContext bool           `mapstructure:"-"`
-	Sniffer               bool           `mapstructure:"sniffer"` // https://github.com/olivere/elastic/wiki/Sniffing
-	SnifferTLSEnabled     bool           `mapstructure:"sniffer_tls_enabled"`
-	MaxDocCount           int            `mapstructure:"-"`                     // Defines maximum number of results to fetch from storage per query
-	MaxSpanAge            time.Duration  `yaml:"max_span_age" mapstructure:"-"` // configures the maximum lookback on span reads
-	NumShards             int64          `yaml:"shards" mapstructure:"num_shards"`
-	NumReplicas           int64          `yaml:"replicas" mapstructure:"num_replicas"`
-	Timeout               time.Duration  `validate:"min=500" mapstructure:"-"`
-	BulkSize              int            `mapstructure:"-"`
-	BulkWorkers           int            `mapstructure:"-"`
-	BulkActions           int            `mapstructure:"-"`
-	BulkFlushInterval     time.Duration  `mapstructure:"-"`
-	IndexPrefix           string         `mapstructure:"index_prefix"`
-	IndexDateLayout       string         `mapstructure:"index_date_layout"`
-	Tags                  TagsAsFields   `mapstructure:"tags_as_fields"`
-	Enabled               bool           `mapstructure:"-"`
-	TLS                   tlscfg.Options `mapstructure:"tls"`
-	UseReadWriteAliases   bool           `mapstructure:"use_aliases"`
-	CreateIndexTemplates  bool           `mapstructure:"create_mappings"`
-	UseILM                bool           `mapstructure:"use_ilm"`
-	Version               uint           `mapstructure:"version"`
-	LogLevel              string         `mapstructure:"log_level"`
+	Servers                []string       `mapstructure:"server_urls"`
+	RemoteReadClusters     []string       `mapstructure:"remote_read_clusters"`
+	Username               string         `mapstructure:"username"`
+	Password               string         `mapstructure:"password" json:"-"`
+	TokenFilePath          string         `mapstructure:"token_file"`
+	AllowTokenFromContext  bool           `mapstructure:"-"`
+	Sniffer                bool           `mapstructure:"sniffer"` // https://github.com/olivere/elastic/wiki/Sniffing
+	SnifferTLSEnabled      bool           `mapstructure:"sniffer_tls_enabled"`
+	MaxDocCount            int            `mapstructure:"-"`                     // Defines maximum number of results to fetch from storage per query
+	MaxSpanAge             time.Duration  `yaml:"max_span_age" mapstructure:"-"` // configures the maximum lookback on span reads
+	NumShards              int64          `yaml:"shards" mapstructure:"num_shards"`
+	NumReplicas            int64          `yaml:"replicas" mapstructure:"num_replicas"`
+	Timeout                time.Duration  `validate:"min=500" mapstructure:"-"`
+	BulkSize               int            `mapstructure:"-"`
+	BulkWorkers            int            `mapstructure:"-"`
+	BulkActions            int            `mapstructure:"-"`
+	BulkFlushInterval      time.Duration  `mapstructure:"-"`
+	IndexPrefix            string         `mapstructure:"index_prefix"`
+	IndexDateLayout        string         `mapstructure:"index_date_layout"`
+	IndexRolloverFrequency string         `mapstructure:"-"`
+	Tags                   TagsAsFields   `mapstructure:"tags_as_fields"`
+	Enabled                bool           `mapstructure:"-"`
+	TLS                    tlscfg.Options `mapstructure:"tls"`
+	UseReadWriteAliases    bool           `mapstructure:"use_aliases"`
+	CreateIndexTemplates   bool           `mapstructure:"create_mappings"`
+	UseILM                 bool           `mapstructure:"use_ilm"`
+	Version                uint           `mapstructure:"version"`
+	LogLevel               string         `mapstructure:"log_level"`
 }
 
 // TagsAsFields holds configuration for tag schema.

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -174,3 +174,27 @@ func TestIndexDateSeparator(t *testing.T) {
 		})
 	}
 }
+
+func TestIndexRollover(t *testing.T) {
+	testCases := []struct {
+		name           string
+		flags          []string
+		wantDateLayout string
+	}{
+		{"not defined (default)", []string{}, "2006-01-02"},
+		{"day rotation", []string{"--es.index-rollover-frequency=day"}, "2006-01-02"},
+		{"hour rotation", []string{"--es.index-rollover-frequency=hour"}, "2006-01-02-15"},
+		{"error rotation change default", []string{"--es.index-rollover=hours"}, "2006-01-02"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := NewOptions("es")
+			v, command := config.Viperize(opts.AddFlags)
+			command.ParseFlags(tc.flags)
+			opts.InitFromViper(v)
+			primary := opts.GetPrimary()
+			assert.Equal(t, tc.wantDateLayout, primary.IndexDateLayout)
+
+		})
+	}
+}

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/olivere/elastic"
@@ -199,9 +200,16 @@ func timeRangeIndices(indexName, indexDateLayout string, startTime time.Time, en
 	var indices []string
 	firstIndex := indexWithDate(indexName, indexDateLayout, startTime)
 	currentIndex := indexWithDate(indexName, indexDateLayout, endTime)
+
+	reduce := -24 * time.Hour
+	if strings.HasSuffix(indexDateLayout, "15") {
+		reduce = -1 * time.Hour
+	}
 	for currentIndex != firstIndex {
-		indices = append(indices, currentIndex)
-		endTime = endTime.Add(-24 * time.Hour)
+		if len(indices) == 0 || indices[len(indices)-1] != currentIndex {
+			indices = append(indices, currentIndex)
+		}
+		endTime = endTime.Add(reduce)
 		currentIndex = indexWithDate(indexName, indexDateLayout, endTime)
 	}
 	indices = append(indices, firstIndex)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2933
- Replace https://github.com/jaegertracing/jaeger/pull/2935

## Short description of the changes
- Add a parameter `index-rollover-frequency`, default is day mode, will not affect existing usage
- Minimize changes to ensure compatibility with previous code 

### Parameter config of `collector` `ingester` `query`  (SPAN_STORAGE_TYPE=elasticsearch)
```
--es-archive.index-rollover-frequency string                     Rotates Jaeger indices over the given period. For example "day" creates "jaeger-span-yyyy-HH-dd" every day after UTC 12AM. Valid options: [hour, day]. Jaeger also support Elasticsearch ILM to manage indices, reference(https://www.jaegertracing.io/docs/deployment/#elasticsearch-ilm-support) (default "day")
--es.index-rollover-frequency string                             Rotates Jaeger indices over the given period. For example "day" creates "jaeger-span-yyyy-HH-dd" every day after UTC 12AM. Valid options: [hour, day]. Jaeger also support Elasticsearch ILM to manage indices, reference(https://www.jaegertracing.io/docs/deployment/#elasticsearch-ilm-support) (default "day")
```
