### PR TITLE
Add warning if esc not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,15 +230,14 @@ jaeger-ui/packages/jaeger-ui/build/index.html:
 	cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build
 
 cmd/query/app/ui/actual/gen_assets.go: jaeger-ui/packages/jaeger-ui/build/index.html
-	@if ! command -v esc &> /dev/null; then \
+	@if ! command -v esc > /dev/null 2>&1 ; then \
 		echo "esc: Command not found" ; \
 		echo "Check:" ; \
 		echo "- esc is installed: 'make install-tools'" ; \
 		echo "- add \$$GOPATH into \$$PATH: 'export PATH=\$$PATH:\$$(go env GOPATH)/bin'" ; \
-		false \
-	else \
-		esc -pkg assets -o cmd/query/app/ui/actual/gen_assets.go -prefix jaeger-ui/packages/jaeger-ui/build jaeger-ui/packages/jaeger-ui/build ; \
+		false ; \
 	fi
+	esc -pkg assets -o cmd/query/app/ui/actual/gen_assets.go -prefix jaeger-ui/packages/jaeger-ui/build jaeger-ui/packages/jaeger-ui/build ; \
 
 .PHONY: build-all-in-one-linux
 build-all-in-one-linux:

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ cmd/query/app/ui/actual/gen_assets.go: jaeger-ui/packages/jaeger-ui/build/index.
 		echo "Check:" ; \
 		echo "- esc is installed: 'make install-tools'" ; \
 		echo "- add \$$GOPATH into \$$PATH: 'export PATH=\$$PATH:\$$(go env GOPATH)/bin'" ; \
+		false \
 	else \
 		esc -pkg assets -o cmd/query/app/ui/actual/gen_assets.go -prefix jaeger-ui/packages/jaeger-ui/build jaeger-ui/packages/jaeger-ui/build ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,14 @@ jaeger-ui/packages/jaeger-ui/build/index.html:
 	cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build
 
 cmd/query/app/ui/actual/gen_assets.go: jaeger-ui/packages/jaeger-ui/build/index.html
-	esc -pkg assets -o cmd/query/app/ui/actual/gen_assets.go -prefix jaeger-ui/packages/jaeger-ui/build jaeger-ui/packages/jaeger-ui/build
+	@if ! command -v esc &> /dev/null; then \
+		echo "esc: Command not found" ; \
+		echo "Check:" ; \
+		echo "- esc is installed: 'make install-tools'" ; \
+		echo "- add \$$GOPATH into \$$PATH: 'export PATH=\$$PATH:\$$(go env GOPATH)/bin'" ; \
+	else \
+		esc -pkg assets -o cmd/query/app/ui/actual/gen_assets.go -prefix jaeger-ui/packages/jaeger-ui/build jaeger-ui/packages/jaeger-ui/build ; \
+	fi
 
 .PHONY: build-all-in-one-linux
 build-all-in-one-linux:


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Addresses comment from https://github.com/jaegertracing/documentation/pull/500.

## Short description of the changes
Outputs the following if `esc` is not installed:
```
esc: Command not found.
Check:
- esc is installed: 'make install-tools'
- add $GOPATH into $PATH: 'export PATH=$PATH:$(go env GOPATH)/bin'
```