### PR TITLE
Allow the ILM policy name to be configurable

### DIFF
--- a/cmd/esmapping-generator/app/flags.go
+++ b/cmd/esmapping-generator/app/flags.go
@@ -20,21 +20,23 @@ import (
 
 // Options represent configurable parameters for jaeger-esmapping-generator
 type Options struct {
-	Mapping     string
-	EsVersion   uint
-	Shards      int64
-	Replicas    int64
-	IndexPrefix string
-	UseILM      string // using string as util is being used in python and using bool leads to type issues.
+	Mapping       string
+	EsVersion     uint
+	Shards        int64
+	Replicas      int64
+	IndexPrefix   string
+	UseILM        string // using string as util is being used in python and using bool leads to type issues.
+	ILMPolicyName string
 }
 
 const (
-	mappingFlag     = "mapping"
-	esVersionFlag   = "es-version"
-	shardsFlag      = "shards"
-	replicasFlag    = "replicas"
-	indexPrefixFlag = "index-prefix"
-	useILMFlag      = "use-ilm"
+	mappingFlag       = "mapping"
+	esVersionFlag     = "es-version"
+	shardsFlag        = "shards"
+	replicasFlag      = "replicas"
+	indexPrefixFlag   = "index-prefix"
+	useILMFlag        = "use-ilm"
+	ilmPolicyNameFlag = "ilm-policy-name"
 )
 
 // AddFlags adds flags for esmapping-generator main program
@@ -69,6 +71,11 @@ func (o *Options) AddFlags(command *cobra.Command) {
 		useILMFlag,
 		"false",
 		"Set to true to use ILM for managing lifecycle of jaeger indices")
+	command.Flags().StringVar(
+		&o.ILMPolicyName,
+		ilmPolicyNameFlag,
+		"jaeger-ilm-policy",
+		"The name of the ILM policy to use if ILM is active")
 
 	// mark mapping flag as mandatory
 	command.MarkFlagRequired(mappingFlag)

--- a/cmd/esmapping-generator/app/flags_test.go
+++ b/cmd/esmapping-generator/app/flags_test.go
@@ -33,6 +33,7 @@ func TestOptionsWithDefaultFlags(t *testing.T) {
 	assert.Equal(t, int64(1), o.Replicas)
 	assert.Equal(t, "", o.IndexPrefix)
 	assert.Equal(t, "false", o.UseILM)
+	assert.Equal(t, "jaeger-ilm-policy", o.ILMPolicyName)
 }
 
 func TestOptionsWithFlags(t *testing.T) {
@@ -47,6 +48,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--replicas=1",
 		"--index-prefix=test",
 		"--use-ilm=true",
+		"--ilm-policy-name=jaeger-test-policy",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "jaeger-span", o.Mapping)
@@ -55,4 +57,5 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, int64(1), o.Replicas)
 	assert.Equal(t, "test", o.IndexPrefix)
 	assert.Equal(t, "true", o.UseILM)
+	assert.Equal(t, "jaeger-test-policy", o.ILMPolicyName)
 }

--- a/cmd/esmapping-generator/app/renderer/render.go
+++ b/cmd/esmapping-generator/app/renderer/render.go
@@ -42,6 +42,7 @@ func GetMappingAsString(builder es.TemplateBuilder, opt *app.Options) (string, e
 		EsVersion:       opt.EsVersion,
 		IndexPrefix:     opt.IndexPrefix,
 		UseILM:          enableILM,
+		ILMPolicyName:   opt.ILMPolicyName,
 	}
 	return mappingBuilder.GetMapping(opt.Mapping)
 }

--- a/cmd/esmapping-generator/app/renderer/render_test.go
+++ b/cmd/esmapping-generator/app/renderer/render_test.go
@@ -50,23 +50,23 @@ func Test_getMappingAsString(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "ES version 7", args: app.Options{Mapping: "jaeger-span", EsVersion: 7, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "true"},
+			name: "ES version 7", args: app.Options{Mapping: "jaeger-span", EsVersion: 7, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "true", ILMPolicyName: "jaeger-test-policy"},
 			want: "ES version 7",
 		},
 		{
-			name: "ES version 6", args: app.Options{Mapping: "jaeger-span", EsVersion: 6, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "false"},
+			name: "ES version 6", args: app.Options{Mapping: "jaeger-span", EsVersion: 6, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "false", ILMPolicyName: "jaeger-test-policy"},
 			want: "ES version 6",
 		},
 		{
-			name: "Parse Error version 6", args: app.Options{Mapping: "jaeger-span", EsVersion: 6, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "false"},
+			name: "Parse Error version 6", args: app.Options{Mapping: "jaeger-span", EsVersion: 6, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "false", ILMPolicyName: "jaeger-test-policy"},
 			wantErr: errors.New("parse error"),
 		},
 		{
-			name: "Parse Error version 7", args: app.Options{Mapping: "jaeger-span", EsVersion: 7, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "true"},
+			name: "Parse Error version 7", args: app.Options{Mapping: "jaeger-span", EsVersion: 7, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "true", ILMPolicyName: "jaeger-test-policy"},
 			wantErr: errors.New("parse error"),
 		},
 		{
-			name: "Parse bool error", args: app.Options{Mapping: "jaeger-span", EsVersion: 7, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "foo"},
+			name: "Parse bool error", args: app.Options{Mapping: "jaeger-span", EsVersion: 7, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "foo", ILMPolicyName: "jaeger-test-policy"},
 			wantErr: errors.New("strconv.ParseBool: parsing \"foo\": invalid syntax"),
 		},
 	}

--- a/plugin/storage/es/mappings/fixtures/jaeger-service-7.json
+++ b/plugin/storage/es/mappings/fixtures/jaeger-service-7.json
@@ -9,7 +9,7 @@
     "index.mapping.nested_fields.limit":50,
     "index.requests.cache.enable":true
     ,"lifecycle": {
-        "name": "jaeger-ilm-policy",
+        "name": "jaeger-test-policy",
         "rollover_alias": "test-jaeger-service-write"
     }
   },

--- a/plugin/storage/es/mappings/fixtures/jaeger-span-7.json
+++ b/plugin/storage/es/mappings/fixtures/jaeger-span-7.json
@@ -9,7 +9,7 @@
     "index.mapping.nested_fields.limit":50,
     "index.requests.cache.enable":true
     ,"lifecycle": {
-      "name": "jaeger-ilm-policy",
+      "name": "jaeger-test-policy",
       "rollover_alias": "test-jaeger-span-write"
     }
   },

--- a/plugin/storage/es/mappings/jaeger-service-7.json
+++ b/plugin/storage/es/mappings/jaeger-service-7.json
@@ -12,7 +12,7 @@
     "index.requests.cache.enable":true
   {{- if .UseILM }}
     ,"lifecycle": {
-        "name": "jaeger-ilm-policy",
+        "name": "{{ .ILMPolicyName }}",
         "rollover_alias": "{{ .IndexPrefix }}jaeger-service-write"
     }
   {{- end }}

--- a/plugin/storage/es/mappings/jaeger-span-7.json
+++ b/plugin/storage/es/mappings/jaeger-span-7.json
@@ -12,7 +12,7 @@
     "index.requests.cache.enable":true
     {{- if .UseILM }}
     ,"lifecycle": {
-      "name": "jaeger-ilm-policy",
+      "name": "{{ .ILMPolicyName }}",
       "rollover_alias": "{{ .IndexPrefix }}jaeger-span-write"
     }
     {{- end }}

--- a/plugin/storage/es/mappings/mapping.go
+++ b/plugin/storage/es/mappings/mapping.go
@@ -34,6 +34,7 @@ type MappingBuilder struct {
 	EsVersion       uint
 	IndexPrefix     string
 	UseILM          bool
+	ILMPolicyName   string
 }
 
 // GetMapping returns the rendered mapping based on elasticsearch version

--- a/plugin/storage/es/mappings/mapping_test.go
+++ b/plugin/storage/es/mappings/mapping_test.go
@@ -54,6 +54,7 @@ func TestMappingBuilder_GetMapping(t *testing.T) {
 				EsVersion:       tt.esVersion,
 				IndexPrefix:     "test-",
 				UseILM:          true,
+				ILMPolicyName:   "jaeger-test-policy",
 			}
 			got, err := mb.GetMapping(tt.mapping)
 			require.NoError(t, err)
@@ -142,6 +143,7 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 				EsVersion:       7,
 				IndexPrefix:     "test",
 				UseILM:          true,
+				ILMPolicyName:   "jaeger-test-policy",
 			}
 			_, err := mappingBuilder.fixMapping("test")
 			if test.err != "" {
@@ -156,11 +158,12 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 
 func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 	type args struct {
-		shards      int64
-		replicas    int64
-		esVersion   uint
-		indexPrefix string
-		useILM      bool
+		shards        int64
+		replicas      int64
+		esVersion     uint
+		indexPrefix   string
+		useILM        bool
+		ilmPolicyName string
 	}
 	tests := []struct {
 		name                       string
@@ -171,11 +174,12 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 		{
 			name: "ES Version 7",
 			args: args{
-				shards:      3,
-				replicas:    3,
-				esVersion:   7,
-				indexPrefix: "test",
-				useILM:      true,
+				shards:        3,
+				replicas:      3,
+				esVersion:     7,
+				indexPrefix:   "test",
+				useILM:        true,
+				ilmPolicyName: "jaeger-test-policy",
 			},
 			mockNewTextTemplateBuilder: func() es.TemplateBuilder {
 				tb := mocks.TemplateBuilder{}
@@ -189,11 +193,12 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 		{
 			name: "ES Version 7 Service Error",
 			args: args{
-				shards:      3,
-				replicas:    3,
-				esVersion:   7,
-				indexPrefix: "test",
-				useILM:      true,
+				shards:        3,
+				replicas:      3,
+				esVersion:     7,
+				indexPrefix:   "test",
+				useILM:        true,
+				ilmPolicyName: "jaeger-test-policy",
 			},
 			mockNewTextTemplateBuilder: func() es.TemplateBuilder {
 				tb := mocks.TemplateBuilder{}
@@ -209,11 +214,12 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 		{
 			name: "ES Version < 7",
 			args: args{
-				shards:      3,
-				replicas:    3,
-				esVersion:   6,
-				indexPrefix: "test",
-				useILM:      true,
+				shards:        3,
+				replicas:      3,
+				esVersion:     6,
+				indexPrefix:   "test",
+				useILM:        true,
+				ilmPolicyName: "jaeger-test-policy",
 			},
 			mockNewTextTemplateBuilder: func() es.TemplateBuilder {
 				tb := mocks.TemplateBuilder{}
@@ -227,11 +233,12 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 		{
 			name: "ES Version < 7 Service Error",
 			args: args{
-				shards:      3,
-				replicas:    3,
-				esVersion:   6,
-				indexPrefix: "test",
-				useILM:      true,
+				shards:        3,
+				replicas:      3,
+				esVersion:     6,
+				indexPrefix:   "test",
+				useILM:        true,
+				ilmPolicyName: "jaeger-test-policy",
 			},
 			mockNewTextTemplateBuilder: func() es.TemplateBuilder {
 				tb := mocks.TemplateBuilder{}
@@ -246,11 +253,12 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 		{
 			name: "ES Version < 7 Span Error",
 			args: args{
-				shards:      3,
-				replicas:    3,
-				esVersion:   6,
-				indexPrefix: "test",
-				useILM:      true,
+				shards:        3,
+				replicas:      3,
+				esVersion:     6,
+				indexPrefix:   "test",
+				useILM:        true,
+				ilmPolicyName: "jaeger-test-policy",
 			},
 			mockNewTextTemplateBuilder: func() es.TemplateBuilder {
 				tb := mocks.TemplateBuilder{}
@@ -264,11 +272,12 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 		{
 			name: "ES Version  7 Span Error",
 			args: args{
-				shards:      3,
-				replicas:    3,
-				esVersion:   7,
-				indexPrefix: "test",
-				useILM:      true,
+				shards:        3,
+				replicas:      3,
+				esVersion:     7,
+				indexPrefix:   "test",
+				useILM:        true,
+				ilmPolicyName: "jaeger-test-policy",
 			},
 			mockNewTextTemplateBuilder: func() es.TemplateBuilder {
 				tb := mocks.TemplateBuilder{}
@@ -289,6 +298,7 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 				EsVersion:       test.args.esVersion,
 				IndexPrefix:     test.args.indexPrefix,
 				UseILM:          test.args.useILM,
+				ILMPolicyName:   test.args.ilmPolicyName,
 			}
 			_, _, err := mappingBuilder.GetSpanServiceMappings()
 			if test.err != "" {


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves https://github.com/jaegertracing/jaeger/issues/2967

## Short description of the changes

- Add an option `--ilm-policy-name` to `esmapping-generator`, to set the policy name in the mappings file;
- Set the mapping's option in the rollover script (using an env var - `ES_ILM_POLICY_NAME`).
- The policy name defaults to `jaeger-ilm-policy` (both in the mapping generator and in the `init` action of the rollover script), so no breaking changes are added.