### PR TITLE
Verify FindTraces() received a query

### DIFF
--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -84,6 +84,9 @@ func (g *GRPCHandler) ArchiveTrace(ctx context.Context, r *api_v2.ArchiveTraceRe
 // FindTraces is the gRPC handler to fetch traces based on TraceQueryParameters.
 func (g *GRPCHandler) FindTraces(r *api_v2.FindTracesRequest, stream api_v2.QueryService_FindTracesServer) error {
 	query := r.GetQuery()
+	if query == nil {
+		return status.Errorf(codes.InvalidArgument, "missing query")
+	}
 	queryParams := spanstore.TraceQueryParameters{
 		ServiceName:   query.ServiceName,
 		OperationName: query.OperationName,

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -370,6 +370,24 @@ func TestSearchFailure_GRPC(t *testing.T) {
 		server.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
 			Return(nil, mockErrorGRPC).Once()
 
+		res, err := client.FindTraces(context.Background(), &api_v2.FindTracesRequest{
+			Query: nil,
+		})
+		assert.NoError(t, err)
+
+		spanResChunk, err := res.Recv()
+		assert.Error(t, err)
+		assert.Nil(t, spanResChunk)
+	})
+}
+
+func TestSearchInvalid_GRPC(t *testing.T) {
+	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
+		mockErrorGRPC := fmt.Errorf("whatsamattayou")
+
+		server.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
+			Return(nil, mockErrorGRPC).Once()
+
 		// Trace query parameters.
 		queryParams := &api_v2.TraceQueryParameters{
 			ServiceName:   "service",

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -363,7 +363,7 @@ func TestSearchSuccess_SpanStreamingGRPC(t *testing.T) {
 	})
 }
 
-func TestSearchFailure_GRPC(t *testing.T) {
+func TestSearchInvalid_GRPC(t *testing.T) {
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		res, err := client.FindTraces(context.Background(), &api_v2.FindTracesRequest{
 			Query: nil,
@@ -376,7 +376,7 @@ func TestSearchFailure_GRPC(t *testing.T) {
 	})
 }
 
-func TestSearchInvalid_GRPC(t *testing.T) {
+func TestSearchFailure_GRPC(t *testing.T) {
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		mockErrorGRPC := fmt.Errorf("whatsamattayou")
 

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -365,11 +365,6 @@ func TestSearchSuccess_SpanStreamingGRPC(t *testing.T) {
 
 func TestSearchFailure_GRPC(t *testing.T) {
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
-		mockErrorGRPC := fmt.Errorf("whatsamattayou")
-
-		server.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
-			Return(nil, mockErrorGRPC).Once()
-
 		res, err := client.FindTraces(context.Background(), &api_v2.FindTracesRequest{
 			Query: nil,
 		})


### PR DESCRIPTION
Fixes a problem where FindTraces misbehaves if sent no query.