### PR TITLE
Passing default sampling strategies file as environment variable

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -25,12 +25,14 @@ EXPOSE 14250
 # Web HTTP
 EXPOSE 16686
 
+# Default configuration file for setting sampling strategies
+ENV SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json
+
 COPY all-in-one-linux-$TARGETARCH /go/bin/all-in-one-linux
 COPY sampling_strategies.json /etc/jaeger/
 
 VOLUME ["/tmp"]
 ENTRYPOINT ["/go/bin/all-in-one-linux"]
-CMD ["--sampling.strategies-file=/etc/jaeger/sampling_strategies.json"]
 
 FROM $debug_image AS debug
 ARG TARGETARCH=amd64
@@ -59,9 +61,11 @@ EXPOSE 16686
 # Delve
 EXPOSE 12345
 
+# Default configuration file for setting sampling strategies
+ENV SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json
+
 COPY all-in-one-debug-linux-$TARGETARCH /go/bin/all-in-one-linux
 COPY sampling_strategies.json /etc/jaeger/
 
 VOLUME ["/tmp"]
 ENTRYPOINT ["/go/bin/dlv", "exec", "/go/bin/all-in-one-linux", "--headless", "--listen=:12345", "--api-version=2", "--accept-multiclient", "--log", "--"]
-CMD ["--sampling.strategies-file=/etc/jaeger/sampling_strategies.json"]


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Closes https://github.com/jaegertracing/jaeger/issues/3022

## Short description of the changes
Setting env var SAMPLING_STRATEGIES_FILE with default value and removing default argument in all-in-one's Dockerfile.
