### PR TITLE
Add cmux.ErrServerClosed

### DIFF
--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -235,7 +235,7 @@ func (s *Server) Start() error {
 			err = s.httpServer.Serve(s.httpConn)
 		}
 		switch err {
-		case nil, http.ErrServerClosed, cmux.ErrListenerClosed:
+		case nil, http.ErrServerClosed, cmux.ErrListenerClosed, cmux.ErrServerClosed:
 			// normal exit, nothing to do
 		default:
 			s.logger.Error("Could not start HTTP server", zap.Error(err))


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Fixes #3025 

## Short description of the changes
- Add expected `cmux.ErrServerClosed` error when connection is closed when waiting to `Accept`.