### PR TITLE
Bump alpine 3.12 -> 3.13 in base image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,6 @@
 VERSION := 1.0.0
-ROOT_IMAGE ?= alpine:3.12
-CERT_IMAGE := alpine:3.12
+ROOT_IMAGE ?= alpine:3.13
+CERT_IMAGE := alpine:3.13
 GOLANG_IMAGE := golang:1.15-alpine
 
 BASE_IMAGE := localhost/baseimg:$(VERSION)-$(shell echo $(ROOT_IMAGE) | tr : -)


### PR DESCRIPTION
Signed-off-by: Ashmita Bohara <ashmita.bohara152@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Part of https://github.com/jaegertracing/jaeger/issues/3031

## Short description of the changes

All those CVEs are due to alpine:3.12.3. Hence bumping it to latest release of 3.13.

```
❯ trivy image alpine:3.13
2021-05-27T02:14:21.045+0800    INFO    Detected OS: alpine
2021-05-27T02:14:21.045+0800    INFO    Detecting Alpine vulnerabilities...
2021-05-27T02:14:21.051+0800    INFO    Number of PL dependency files: 0

alpine:3.13 (alpine 3.13.5)
===========================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
