### PR TITLE
Add TLS support for Prometheus Reader

### DIFF
--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -22,7 +22,7 @@ import (
 
 // Configuration describes the options to customize the storage behavior.
 type Configuration struct {
-	ServerURL      string         `validate:"nonzero" mapstructure:"server"`
-	ConnectTimeout time.Duration  `validate:"nonzero" mapstructure:"timeout"`
-	TLS            tlscfg.Options `mapstructure:"tls"`
+	ServerURL      string
+	ConnectTimeout time.Duration
+	TLS            tlscfg.Options
 }

--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -14,10 +14,15 @@
 
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
+)
 
 // Configuration describes the options to customize the storage behavior.
 type Configuration struct {
-	HostPort       string        `validate:"nonzero" mapstructure:"server"`
-	ConnectTimeout time.Duration `validate:"nonzero" mapstructure:"timeout"`
+	ServerURL      string         `validate:"nonzero" mapstructure:"server"`
+	ConnectTimeout time.Duration  `validate:"nonzero" mapstructure:"timeout"`
+	TLS            tlscfg.Options `mapstructure:"tls"`
 }

--- a/plugin/metrics/prometheus/factory.go
+++ b/plugin/metrics/prometheus/factory.go
@@ -55,5 +55,5 @@ func (f *Factory) Initialize(logger *zap.Logger) error {
 
 // CreateMetricsReader implements storage.MetricsFactory.
 func (f *Factory) CreateMetricsReader() (metricsstore.Reader, error) {
-	return prometheusstore.NewMetricsReader(f.logger, f.options.Primary.HostPort, f.options.Primary.ConnectTimeout)
+	return prometheusstore.NewMetricsReader(f.logger, f.options.Primary.Configuration)
 }

--- a/plugin/metrics/prometheus/factory_test.go
+++ b/plugin/metrics/prometheus/factory_test.go
@@ -40,7 +40,7 @@ func TestPrometheusFactory(t *testing.T) {
 	assert.NotNil(t, listener)
 	defer listener.Close()
 
-	f.options.Primary.HostPort = listener.Addr().String()
+	f.options.Primary.ServerURL = "http://" + listener.Addr().String()
 	reader, err := f.CreateMetricsReader()
 
 	assert.NoError(t, err)
@@ -49,20 +49,20 @@ func TestPrometheusFactory(t *testing.T) {
 
 func TestWithDefaultConfiguration(t *testing.T) {
 	f := NewFactory()
-	assert.Equal(t, f.options.Primary.HostPort, defaultServerHostPort)
-	assert.Equal(t, f.options.Primary.ConnectTimeout, defaultConnectTimeout)
+	assert.Equal(t, f.options.Primary.ServerURL, "http://localhost:9090")
+	assert.Equal(t, f.options.Primary.ConnectTimeout, 30*time.Second)
 }
 
 func TestWithConfiguration(t *testing.T) {
 	f := NewFactory()
 	v, command := config.Viperize(f.AddFlags)
 	err := command.ParseFlags([]string{
-		"--prometheus.host-port=localhost:1234",
+		"--prometheus.server-url=http://localhost:1234",
 		"--prometheus.connect-timeout=5s",
 	})
 	require.NoError(t, err)
 
 	f.InitFromViper(v)
-	assert.Equal(t, f.options.Primary.HostPort, "localhost:1234")
+	assert.Equal(t, f.options.Primary.ServerURL, "http://localhost:1234")
 	assert.Equal(t, f.options.Primary.ConnectTimeout, 5*time.Second)
 }

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -16,6 +16,7 @@ package metricsstore
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -242,13 +243,12 @@ func logErrorToSpan(span opentracing.Span, err error) {
 	span.LogFields(otlog.Error(err))
 }
 
-func getHTTPRoundTripper(c *config.Configuration, logger *zap.Logger) (http.RoundTripper, error) {
-	if !c.TLS.Enabled {
-		return nil, nil
-	}
-	ctlsConfig, err := c.TLS.Config(logger)
-	if err != nil {
-		return nil, err
+func getHTTPRoundTripper(c *config.Configuration, logger *zap.Logger) (rt http.RoundTripper, err error) {
+	var ctlsConfig *tls.Config
+	if c.TLS.Enabled {
+		if ctlsConfig, err = c.TLS.Config(logger); err != nil {
+			return nil, err
+		}
 	}
 
 	// KeepAlive and TLSHandshake timeouts are kept to existing Prometheus client's

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -30,6 +30,7 @@ import (
 	promapi "github.com/prometheus/client_golang/api/prometheus/v1"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/pkg/prometheus/config"
 	"github.com/jaegertracing/jaeger/plugin/metrics/prometheus/metricsstore/dbmodel"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
@@ -72,20 +73,13 @@ type (
 )
 
 // NewMetricsReader returns a new MetricsReader.
-func NewMetricsReader(logger *zap.Logger, hostPort string, connectTimeout time.Duration) (*MetricsReader, error) {
-	// KeepAlive and TLSHandshake timeouts are kept to existing Prometheus client's
-	// DefaultRoundTripper to simplify user configuration and may be made configurable when required.
-	roundTripper := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   connectTimeout,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout: 10 * time.Second,
+func NewMetricsReader(logger *zap.Logger, cfg config.Configuration) (*MetricsReader, error) {
+	roundTripper, err := getHTTPRoundTripper(&cfg, logger)
+	if err != nil {
+		return nil, err
 	}
-
 	client, err := api.NewClient(api.Config{
-		Address:      "http://" + hostPort,
+		Address:      cfg.ServerURL,
 		RoundTripper: roundTripper,
 	})
 	if err != nil {
@@ -95,7 +89,7 @@ func NewMetricsReader(logger *zap.Logger, hostPort string, connectTimeout time.D
 		client: promapi.NewAPI(client),
 		logger: logger,
 	}
-	logger.Info("Prometheus reader initialized", zap.String("addr", hostPort))
+	logger.Info("Prometheus reader initialized", zap.String("addr", cfg.ServerURL))
 	return mr, nil
 }
 
@@ -246,4 +240,26 @@ func startSpanForQuery(ctx context.Context, metricName, query string) (opentraci
 func logErrorToSpan(span opentracing.Span, err error) {
 	ottag.Error.Set(span, true)
 	span.LogFields(otlog.Error(err))
+}
+
+func getHTTPRoundTripper(c *config.Configuration, logger *zap.Logger) (http.RoundTripper, error) {
+	if !c.TLS.Enabled {
+		return nil, nil
+	}
+	ctlsConfig, err := c.TLS.Config(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// KeepAlive and TLSHandshake timeouts are kept to existing Prometheus client's
+	// DefaultRoundTripper to simplify user configuration and may be made configurable when required.
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   c.ConnectTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     ctlsConfig,
+	}, nil
 }

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
+	"github.com/jaegertracing/jaeger/pkg/prometheus/config"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
 )
@@ -52,14 +54,20 @@ const defaultTimeout = 30 * time.Second
 
 func TestNewMetricsReaderValidAddress(t *testing.T) {
 	logger := zap.NewNop()
-	reader, err := NewMetricsReader(logger, "localhost:1234", defaultTimeout)
+	reader, err := NewMetricsReader(logger, config.Configuration{
+		ServerURL:      "http://localhost:1234",
+		ConnectTimeout: defaultTimeout,
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, reader)
 }
 
 func TestNewMetricsReaderInvalidAddress(t *testing.T) {
 	logger := zap.NewNop()
-	reader, err := NewMetricsReader(logger, "\n", defaultTimeout)
+	reader, err := NewMetricsReader(logger, config.Configuration{
+		ServerURL:      "\n",
+		ConnectTimeout: defaultTimeout,
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to initialize prometheus client")
 	assert.Nil(t, reader)
@@ -72,7 +80,10 @@ func TestGetMinStepDuration(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, listener)
 
-	reader, err := NewMetricsReader(logger, listener.Addr().String(), defaultTimeout)
+	reader, err := NewMetricsReader(logger, config.Configuration{
+		ServerURL:      "http://" + listener.Addr().String(),
+		ConnectTimeout: defaultTimeout,
+	})
 	require.NoError(t, err)
 
 	minStep, err := reader.GetMinStepDuration(context.Background(), &params)
@@ -102,7 +113,10 @@ func TestMetricsServerError(t *testing.T) {
 
 	logger := zap.NewNop()
 	address := mockPrometheus.Listener.Addr().String()
-	reader, err := NewMetricsReader(logger, address, defaultTimeout)
+	reader, err := NewMetricsReader(logger, config.Configuration{
+		ServerURL:      "http://" + address,
+		ConnectTimeout: defaultTimeout,
+	})
 	require.NoError(t, err)
 
 	m, err := reader.GetCallRates(context.Background(), &params)
@@ -299,6 +313,33 @@ func TestWarningResponse(t *testing.T) {
 	assert.NotNil(t, m)
 }
 
+func TestTLSEnabledMetricsReader(t *testing.T) {
+	logger := zap.NewNop()
+	reader, err := NewMetricsReader(logger, config.Configuration{
+		ServerURL:      "https://localhost:1234",
+		ConnectTimeout: defaultTimeout,
+		TLS: tlscfg.Options{
+			Enabled: true,
+		},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, reader)
+}
+
+func TestInvalidCertFile(t *testing.T) {
+	logger := zap.NewNop()
+	reader, err := NewMetricsReader(logger, config.Configuration{
+		ServerURL:      "https://localhost:1234",
+		ConnectTimeout: defaultTimeout,
+		TLS: tlscfg.Options{
+			Enabled: true,
+			CAPath:  "foo",
+		},
+	})
+	require.Error(t, err)
+	assert.Nil(t, reader)
+}
+
 func startMockPrometheusServer(t *testing.T, wantPromQlQuery string, wantWarnings []string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(wantWarnings) > 0 {
@@ -356,7 +397,10 @@ func prepareMetricsReaderAndServer(t *testing.T, wantPromQlQuery string, wantWar
 
 	logger := zap.NewNop()
 	address := mockPrometheus.Listener.Addr().String()
-	reader, err := NewMetricsReader(logger, address, defaultTimeout)
+	reader, err := NewMetricsReader(logger, config.Configuration{
+		ServerURL:      "http://" + address,
+		ConnectTimeout: defaultTimeout,
+	})
 	require.NoError(t, err)
 	return reader, mockPrometheus
 }


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Relates to #2954.

## Short description of the changes
- Adds TLS encryption to Prometheus server.

## Testing
- As [documented](https://prometheus.io/docs/guides/tls-encryption/), Prometheus does not natively support TLS encryption for connections to its HTTP API, however, it does suggest an alternative means of enforcing TLS encryption at the proxy layer with something like nginx.
- This PR was tested using nginx as a reverse proxy to Prometheus, as suggested above.

```
# Queries succeed: Directly connect to Prometheus, bypassing nginx
$ METRICS_STORAGE_TYPE=prometheus ./cmd/query/query-darwin-amd64 \
  --prometheus.server-url http://localhost:9090

# Queries succeed: Enable TLS and provide public key
$ METRICS_STORAGE_TYPE=prometheus ./cmd/query/query-darwin-amd64 \
  --prometheus.server-url https://example.com/prometheus \
  --prometheus.tls.ca=example.com.crt \
  --prometheus.tls.enabled

# Queries fail: TLS not enabled
$ METRICS_STORAGE_TYPE=prometheus ./cmd/query/query-darwin-amd64 \
  --prometheus.server-url https://example.com/prometheus  \
  --prometheus.tls.ca=example.com.crt 
...failed executing metrics query: Post "https://example.com/prometheus/api/v1/query_range": x509: certificate signed by unknown authority...

# Queries fail: Missing public key
$ METRICS_STORAGE_TYPE=prometheus ./cmd/query/query-darwin-amd64 \
  --prometheus.server-url https://example.com/prometheus  \
  --prometheus.tls.enabled
...failed executing metrics query: Post "https://example.com/prometheus/api/v1/query_range": x509: certificate signed by unknown authority...
```