### PR TITLE
Remove Show* TLS configs

### DIFF
--- a/cmd/agent/app/reporter/grpc/flags.go
+++ b/cmd/agent/app/reporter/grpc/flags.go
@@ -32,9 +32,7 @@ const (
 )
 
 var tlsFlagsConfig = tlscfg.ClientFlagsConfig{
-	Prefix:         gRPCPrefix,
-	ShowEnabled:    true,
-	ShowServerName: true,
+	Prefix: gRPCPrefix,
 }
 
 // AddFlags adds flags for Options.

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -38,15 +38,11 @@ const (
 )
 
 var tlsGRPCFlagsConfig = tlscfg.ServerFlagsConfig{
-	Prefix:       "collector.grpc",
-	ShowEnabled:  true,
-	ShowClientCA: true,
+	Prefix: "collector.grpc",
 }
 
 var tlsHTTPFlagsConfig = tlscfg.ServerFlagsConfig{
-	Prefix:       "collector.http",
-	ShowEnabled:  true,
-	ShowClientCA: true,
+	Prefix: "collector.http",
 }
 
 // CollectorOptions holds configuration for collector

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -48,15 +48,11 @@ const (
 )
 
 var tlsGRPCFlagsConfig = tlscfg.ServerFlagsConfig{
-	Prefix:       "query.grpc",
-	ShowEnabled:  true,
-	ShowClientCA: true,
+	Prefix: "query.grpc",
 }
 
 var tlsHTTPFlagsConfig = tlscfg.ServerFlagsConfig{
-	Prefix:       "query.http",
-	ShowEnabled:  true,
-	ShowClientCA: true,
+	Prefix: "query.http",
 }
 
 // QueryOptions holds configuration for query service

--- a/pkg/config/tlscfg/flags.go
+++ b/pkg/config/tlscfg/flags.go
@@ -33,37 +33,27 @@ const (
 
 // ClientFlagsConfig describes which CLI flags for TLS client should be generated.
 type ClientFlagsConfig struct {
-	Prefix         string
-	ShowEnabled    bool
-	ShowServerName bool
+	Prefix string
 }
 
 // ServerFlagsConfig describes which CLI flags for TLS server should be generated.
 type ServerFlagsConfig struct {
-	Prefix       string
-	ShowEnabled  bool
-	ShowClientCA bool
+	Prefix string
 }
 
 // AddFlags adds flags for TLS to the FlagSet.
 func (c ClientFlagsConfig) AddFlags(flags *flag.FlagSet) {
-	if c.ShowEnabled {
-		flags.Bool(c.Prefix+tlsEnabled, false, "Enable TLS when talking to the remote server(s)")
-	}
+	flags.Bool(c.Prefix+tlsEnabled, false, "Enable TLS when talking to the remote server(s)")
 	flags.String(c.Prefix+tlsCA, "", "Path to a TLS CA (Certification Authority) file used to verify the remote server(s) (by default will use the system truststore)")
 	flags.String(c.Prefix+tlsCert, "", "Path to a TLS Certificate file, used to identify this process to the remote server(s)")
 	flags.String(c.Prefix+tlsKey, "", "Path to a TLS Private Key file, used to identify this process to the remote server(s)")
-	if c.ShowServerName {
-		flags.String(c.Prefix+tlsServerName, "", "Override the TLS server name we expect in the certificate of the remote server(s)")
-	}
+	flags.String(c.Prefix+tlsServerName, "", "Override the TLS server name we expect in the certificate of the remote server(s)")
 	flags.Bool(c.Prefix+tlsSkipHostVerify, false, "(insecure) Skip server's certificate chain and host name verification")
 }
 
 // AddFlags adds flags for TLS to the FlagSet.
 func (c ServerFlagsConfig) AddFlags(flags *flag.FlagSet) {
-	if c.ShowEnabled {
-		flags.Bool(c.Prefix+tlsEnabled, false, "Enable TLS on the server")
-	}
+	flags.Bool(c.Prefix+tlsEnabled, false, "Enable TLS on the server")
 	flags.String(c.Prefix+tlsCert, "", "Path to a TLS Certificate file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsKey, "", "Path to a TLS Private Key file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsClientCA, "", "Path to a TLS CA (Certification Authority) file used to verify certificates presented by clients (if unset, all clients are permitted)")
@@ -72,15 +62,11 @@ func (c ServerFlagsConfig) AddFlags(flags *flag.FlagSet) {
 // InitFromViper creates tls.Config populated with values retrieved from Viper.
 func (c ClientFlagsConfig) InitFromViper(v *viper.Viper) Options {
 	var p Options
-	if c.ShowEnabled {
-		p.Enabled = v.GetBool(c.Prefix + tlsEnabled)
-	}
+	p.Enabled = v.GetBool(c.Prefix + tlsEnabled)
 	p.CAPath = v.GetString(c.Prefix + tlsCA)
 	p.CertPath = v.GetString(c.Prefix + tlsCert)
 	p.KeyPath = v.GetString(c.Prefix + tlsKey)
-	if c.ShowServerName {
-		p.ServerName = v.GetString(c.Prefix + tlsServerName)
-	}
+	p.ServerName = v.GetString(c.Prefix + tlsServerName)
 	p.SkipHostVerify = v.GetBool(c.Prefix + tlsSkipHostVerify)
 	return p
 }
@@ -88,13 +74,9 @@ func (c ClientFlagsConfig) InitFromViper(v *viper.Viper) Options {
 // InitFromViper creates tls.Config populated with values retrieved from Viper.
 func (c ServerFlagsConfig) InitFromViper(v *viper.Viper) Options {
 	var p Options
-	if c.ShowEnabled {
-		p.Enabled = v.GetBool(c.Prefix + tlsEnabled)
-	}
+	p.Enabled = v.GetBool(c.Prefix + tlsEnabled)
 	p.CertPath = v.GetString(c.Prefix + tlsCert)
 	p.KeyPath = v.GetString(c.Prefix + tlsKey)
-	if c.ShowClientCA {
-		p.ClientCAPath = v.GetString(c.Prefix + tlsClientCA)
-	}
+	p.ClientCAPath = v.GetString(c.Prefix + tlsClientCA)
 	return p
 }

--- a/pkg/config/tlscfg/flags_test.go
+++ b/pkg/config/tlscfg/flags_test.go
@@ -47,9 +47,7 @@ func TestClientFlags(t *testing.T) {
 			command := cobra.Command{}
 			flagSet := &flag.FlagSet{}
 			flagCfg := ClientFlagsConfig{
-				Prefix:         "prefix",
-				ShowEnabled:    true,
-				ShowServerName: true,
+				Prefix: "prefix",
 			}
 			flagCfg.AddFlags(flagSet)
 			command.PersistentFlags().AddGoFlagSet(flagSet)
@@ -94,9 +92,7 @@ func TestServerFlags(t *testing.T) {
 			command := cobra.Command{}
 			flagSet := &flag.FlagSet{}
 			flagCfg := ServerFlagsConfig{
-				Prefix:       "prefix",
-				ShowEnabled:  true,
-				ShowClientCA: true,
+				Prefix: "prefix",
 			}
 			flagCfg.AddFlags(flagSet)
 			command.PersistentFlags().AddGoFlagSet(flagSet)

--- a/pkg/kafka/auth/config.go
+++ b/pkg/kafka/auth/config.go
@@ -90,9 +90,7 @@ func (config *AuthenticationConfig) InitFromViper(configPrefix string, v *viper.
 	config.Kerberos.KeyTabPath = v.GetString(configPrefix + kerberosPrefix + suffixKerberosKeyTab)
 
 	var tlsClientConfig = tlscfg.ClientFlagsConfig{
-		Prefix:         configPrefix,
-		ShowEnabled:    true,
-		ShowServerName: true,
+		Prefix: configPrefix,
 	}
 
 	config.TLS = tlsClientConfig.InitFromViper(v)

--- a/pkg/kafka/auth/options.go
+++ b/pkg/kafka/auth/options.go
@@ -109,9 +109,7 @@ func AddFlags(configPrefix string, flagSet *flag.FlagSet) {
 	addKerberosFlags(configPrefix, flagSet)
 
 	tlsClientConfig := tlscfg.ClientFlagsConfig{
-		Prefix:         configPrefix,
-		ShowEnabled:    true,
-		ShowServerName: true,
+		Prefix: configPrefix,
 	}
 	tlsClientConfig.AddFlags(flagSet)
 

--- a/plugin/metrics/prometheus/options.go
+++ b/plugin/metrics/prometheus/options.go
@@ -77,9 +77,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 
 func (config *namespaceConfig) getTLSFlagsConfig() tlscfg.ClientFlagsConfig {
 	return tlscfg.ClientFlagsConfig{
-		Prefix:         config.namespace,
-		ShowEnabled:    true,
-		ShowServerName: true,
+		Prefix: config.namespace,
 	}
 }
 

--- a/plugin/storage/cassandra/options.go
+++ b/plugin/storage/cassandra/options.go
@@ -230,9 +230,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) {
 
 func tlsFlagsConfig(namespace string) tlscfg.ClientFlagsConfig {
 	return tlscfg.ClientFlagsConfig{
-		Prefix:         namespace,
-		ShowEnabled:    true,
-		ShowServerName: true,
+		Prefix: namespace,
 	}
 }
 

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -133,9 +133,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 
 func (config *namespaceConfig) getTLSFlagsConfig() tlscfg.ClientFlagsConfig {
 	return tlscfg.ClientFlagsConfig{
-		Prefix:         config.namespace,
-		ShowEnabled:    true,
-		ShowServerName: true,
+		Prefix: config.namespace,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Resolves #3104.

## Short description of the changes
- Removes the redundant `Show*` TLS config flags, which appear to all be `true` and don't seem to have changed for months (in some cases, years) since its [introduction](https://github.com/jaegertracing/jaeger/commit/d553583ce1716285cf71e894f45bc980b67b7012), and cannot see evidence where this could be changed by users via config parameters; i.e. it can only be changed in code.
- If there is still a use case for keeping these flags, please advise and I suggest we document these reasons in a sensible place somewhere in code.