### PR TITLE
Switch to user nobody for es cleaner and rollover

### DIFF
--- a/plugin/storage/es/Dockerfile
+++ b/plugin/storage/es/Dockerfile
@@ -6,4 +6,5 @@ RUN pip install urllib3==1.24.3
 RUN pip install elasticsearch elasticsearch-curator
 COPY esCleaner.py /es-index-cleaner/
 
+USER nobody
 ENTRYPOINT ["python3", "/es-index-cleaner/esCleaner.py"]

--- a/plugin/storage/es/Dockerfile.rollover
+++ b/plugin/storage/es/Dockerfile.rollover
@@ -8,4 +8,5 @@ COPY ./mappings/* /mappings/
 COPY esRollover.py /es-rollover/
 COPY esmapping-generator /usr/bin/
 
+USER nobody
 ENTRYPOINT ["python3", "/es-rollover/esRollover.py"]


### PR DESCRIPTION
`esCleaner.py` and `esRollover.py` run under user root which causes problem when setting pod/container security context (runAsNonRoot: true). Since base image is alpine and it already has user nobody, it would be good to switch the user to facilitate this.