### PR TITLE
Fix package naming

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -32,7 +32,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
 	"github.com/jaegertracing/jaeger/ports"
-	zipkinThrift "github.com/jaegertracing/jaeger/thrift-gen/agent"
+	agentThrift "github.com/jaegertracing/jaeger/thrift-gen/agent"
 )
 
 const (
@@ -152,7 +152,7 @@ func (b *Builder) getProcessors(rep reporter.Reporter, mFactory metrics.Factory,
 		var handler processors.AgentProcessor
 		switch cfg.Model {
 		case jaegerModel, zipkinModel:
-			handler = zipkinThrift.NewAgentProcessor(rep)
+			handler = agentThrift.NewAgentProcessor(rep)
 		default:
 			return nil, fmt.Errorf("cannot find agent processor for data model %v", cfg.Model)
 		}


### PR DESCRIPTION
Fix incorrect naming
```diff
-       zipkinThrift "github.com/jaegertracing/jaeger/thrift-gen/agent"
+       agentThrift "github.com/jaegertracing/jaeger/thrift-gen/agent"
```