### PR TITLE
Add ppc64le support on multiarch docker images

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,7 +5,7 @@ GOLANG_IMAGE := golang:1.15-alpine
 
 BASE_IMAGE := localhost:5000/baseimg_alpine:latest
 DEBUG_IMAGE := localhost:5000/debugimg_alpine:latest
-PLATFORMS := linux/amd64,linux/s390x,linux/arm64
+PLATFORMS := linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
 
 create-baseimg-debugimg: create-baseimg create-debugimg
 

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 ENV GOPATH /go
 RUN apk add --update --no-cache ca-certificates make git
 #Once go-delve adds support for s390x (see PR #2948), remove this entire conditional.
-RUN if [[ "$TARGETARCH" != "s390x" ]] ; then \
+RUN if [[ "$TARGETARCH" != "s390x" ] || [ "$TARGETARCH" != "ppc64le" ]] ; then \
         go get github.com/go-delve/delve/cmd/dlv && \
         cd /go/src/github.com/go-delve/delve && \
         make install; \

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -5,12 +5,13 @@ ARG TARGETARCH
 ENV GOPATH /go
 RUN apk add --update --no-cache ca-certificates make git
 #Once go-delve adds support for s390x (see PR #2948), remove this entire conditional.
-RUN if [[ "$TARGETARCH" != "s390x" ] || [ "$TARGETARCH" != "ppc64le" ]] ; then \
+#Once go-delve adds support for ppc64le (see PR go-delve/delve#1564), remove this entire conditional.
+RUN if [[ "$TARGETARCH" == "s390x"  ||  "$TARGETARCH" == "ppc64le" ]] ; then \
+	touch /go/bin/dlv; \
+    else \
         go get github.com/go-delve/delve/cmd/dlv && \
         cd /go/src/github.com/go-delve/delve && \
         make install; \
-    else \
-        touch /go/bin/dlv; \
     fi
 
 FROM $golang_image

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -38,8 +38,9 @@ make create-baseimg-debugimg
 
 make build-all-in-one GOOS=linux GOARCH=amd64
 make build-all-in-one GOOS=linux GOARCH=s390x
+make build-all-in-one GOOS=linux GOARCH=ppc64le
 make build-all-in-one GOOS=linux GOARCH=arm64
-platforms="linux/amd64,linux/s390x,linux/arm64"
+platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 repo=jaegertracing/all-in-one
 #build all-in-one image locally for integration test
 bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one -d cmd/all-in-one -p "${platforms}" -t release

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -7,10 +7,11 @@ make create-baseimg-debugimg
 # build multi-arch binaries
 make build-binaries-linux
 make build-binaries-s390x
+make build-binaries-ppc64le
 make build-binaries-arm64
 
 # build multi-arch docker images
-platforms="linux/amd64,linux/s390x,linux/arm64"
+platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 
 # build/upload images for release version of Jaeger backend components
 for component in agent collector query ingester

--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -4,10 +4,11 @@ set -euxf -o pipefail
 
 make build-examples GOOS=linux GOARCH=amd64
 make build-examples GOOS=linux GOARCH=s390x
+make build-examples GOOS=linux GOARCH=ppc64le
 make build-examples GOOS=linux GOARCH=arm64
 
 REPO=jaegertracing/example-hotrod
-platforms="linux/amd64,linux/s390x,linux/arm64"
+platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 #build image locally for integration test
 bash scripts/build-upload-a-docker-image.sh -l -c example-hotrod -d examples/hotrod -p "${platforms}"
 


### PR DESCRIPTION
Signed-off-by: Krishna Harsha Voora <krishvoor@in.ibm.com>

## Which problem is this PR solving?
Re-adding the support for ppc64le arch, as it was missing in the following files.

## Short description of the changes
* updates `docker/Makefile`, `scripts/build-all-in-one-image.sh`, `scripts/build-upload-docker-images.sh`, `scripts/hotrod-intergration-test.sh` & `docker/debug/Dockerfile`