### PR TITLE
Use golang:1.16-alpine and `go install` to install delve

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 VERSION := 1.0.0
 ROOT_IMAGE ?= alpine:3.13
 CERT_IMAGE := $(ROOT_IMAGE)
-GOLANG_IMAGE := golang:1.15-alpine
+GOLANG_IMAGE := golang:1.16-alpine
 
 BASE_IMAGE := localhost:5000/baseimg_alpine:latest
 DEBUG_IMAGE := localhost:5000/debugimg_alpine:latest

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -9,9 +9,7 @@ RUN apk add --update --no-cache ca-certificates make git
 RUN if [[ "$TARGETARCH" == "s390x"  ||  "$TARGETARCH" == "ppc64le" ]] ; then \
 	touch /go/bin/dlv; \
     else \
-        go get github.com/go-delve/delve/cmd/dlv && \
-        cd /go/src/github.com/go-delve/delve && \
-        make install; \
+        go install github.com/go-delve/delve/cmd/dlv@latest; \
     fi
 
 FROM $golang_image


### PR DESCRIPTION
Resolves #3188 

Per the [docs][1], delve can now be installed via `go install`

[1]: https://github.com/go-delve/delve/blob/master/Documentation/installation/README.md