### PR TITLE
Add docker buildx make target

### DIFF
--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -34,8 +34,6 @@ jobs:
     
     - uses: docker/setup-qemu-action@v1
 
-    - run: make prepare-docker-buildx
-
     - name: Build, test, and publish all-in-one image
       run: bash scripts/build-all-in-one-image.sh
       env:

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -9,11 +9,6 @@ on:
 jobs:
   all-in-one:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     steps:
     - uses: actions/checkout@v2.3.4
       with:
@@ -39,9 +34,7 @@ jobs:
     
     - uses: docker/setup-qemu-action@v1
 
-    - uses: docker/setup-buildx-action@v1
-      with:
-        driver-opts: network=host
+    - run: make prepare-docker-buildx
 
     - name: Build, test, and publish all-in-one image
       run: bash scripts/build-all-in-one-image.sh

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -9,11 +9,6 @@ on:
 jobs:
   crossdock:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     strategy:
       matrix:
         steps:
@@ -41,9 +36,7 @@ jobs:
     
     - uses: docker/setup-qemu-action@v1
 
-    - uses: docker/setup-buildx-action@v1
-      with:
-        driver-opts: network=host
+    - run: make prepare-docker-buildx
 
     - name: Build, test, and publish ${{ matrix.steps.name }} image
       run: ${{ matrix.steps.cmd }}

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -36,8 +36,6 @@ jobs:
     
     - uses: docker/setup-qemu-action@v1
 
-    - run: make prepare-docker-buildx
-
     - name: Build, test, and publish ${{ matrix.steps.name }} image
       run: ${{ matrix.steps.cmd }}
       env:

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -10,12 +10,6 @@ jobs:
   docker-images:
     runs-on: ubuntu-latest
 
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-
     steps:
     - uses: actions/checkout@v2.3.4
       with:
@@ -41,10 +35,8 @@ jobs:
 
     - uses: docker/setup-qemu-action@v1
 
-    - uses: docker/setup-buildx-action@v1
-      with:
-        driver-opts: network=host
-  
+    - run: make prepare-docker-buildx
+
     - name: Build and upload all docker images
       run: bash scripts/build-upload-docker-images.sh
       env:

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -35,8 +35,6 @@ jobs:
 
     - uses: docker/setup-qemu-action@v1
 
-    - run: make prepare-docker-buildx
-
     - name: Build and upload all docker images
       run: bash scripts/build-upload-docker-images.sh
       env:

--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -9,11 +9,6 @@ on:
 jobs:
   hotrod:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     steps:
     - uses: actions/checkout@v2.3.4
       with:
@@ -35,9 +30,7 @@ jobs:
     
     - uses: docker/setup-qemu-action@v1
 
-    - uses: docker/setup-buildx-action@v1
-      with:
-        driver-opts: network=host
+    - run: make prepare-docker-buildx
 
     - name: Build, test, and publish hotrod image
       run: bash scripts/hotrod-integration-test.sh

--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -30,8 +30,6 @@ jobs:
     
     - uses: docker/setup-qemu-action@v1
 
-    - run: make prepare-docker-buildx
-
     - name: Build, test, and publish hotrod image
       run: bash scripts/hotrod-integration-test.sh
       env:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: docker/setup-qemu-action@v1
 
     - run: make prepare-docker-buildx
-  
+
     - name: Build and upload all docker images
       run: bash scripts/build-upload-docker-images.sh
       env:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -52,8 +52,6 @@ jobs:
 
     - uses: docker/setup-qemu-action@v1
 
-    - run: make prepare-docker-buildx
-
     - name: Build and upload all docker images
       run: bash scripts/build-upload-docker-images.sh
       env:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -8,12 +8,7 @@ on:
 jobs:
   publish-release:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-          
+
     steps:
     - uses: actions/checkout@v2.3.4
       with:
@@ -57,9 +52,7 @@ jobs:
 
     - uses: docker/setup-qemu-action@v1
 
-    - uses: docker/setup-buildx-action@v1
-      with:
-        driver-opts: network=host
+    - run: make prepare-docker-buildx
   
     - name: Build and upload all docker images
       run: bash scripts/build-upload-docker-images.sh

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,3 +21,13 @@ create-debugimg:
 		--build-arg golang_image=$(GOLANG_IMAGE) \
 		--platform=$(PLATFORMS) \
 		docker/debug
+
+.PHONY: prepare-docker-buildx
+prepare-docker-buildx:
+	 docker buildx create --use --name=jaeger-build --buildkitd-flags="--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --driver-opt="network=host"
+	 docker run --rm -d -p 5000:5000 --name registry registry:2
+
+.PHONY: clean-docker-buildx
+clean-docker-buildx:
+	docker buildx rm jaeger-build
+	docker rm -f registry

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,14 +9,14 @@ PLATFORMS := linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
 
 create-baseimg-debugimg: create-baseimg create-debugimg
 
-create-baseimg:
+create-baseimg: prepare-docker-buildx
 	docker buildx build -t $(BASE_IMAGE) --push \
 		--build-arg root_image=$(ROOT_IMAGE) \
 		--build-arg cert_image=$(CERT_IMAGE) \
 		--platform=$(PLATFORMS) \
 		docker/base
 
-create-debugimg:
+create-debugimg: prepare-docker-buildx
 	docker buildx build -t $(DEBUG_IMAGE) --push \
 		--build-arg golang_image=$(GOLANG_IMAGE) \
 		--platform=$(PLATFORMS) \
@@ -24,8 +24,8 @@ create-debugimg:
 
 .PHONY: prepare-docker-buildx
 prepare-docker-buildx:
-	docker buildx create --use --name=jaeger-build --buildkitd-flags="--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --driver-opt="network=host"
-	docker run --rm -d -p 5000:5000 --name registry registry:2
+	docker buildx inspect jaeger-build > /dev/null || docker buildx create --use --name=jaeger-build --buildkitd-flags="--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --driver-opt="network=host"
+	docker inspect registry > /dev/null || docker run --rm -d -p 5000:5000 --name registry registry:2
 
 .PHONY: clean-docker-buildx
 clean-docker-buildx:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -24,8 +24,8 @@ create-debugimg:
 
 .PHONY: prepare-docker-buildx
 prepare-docker-buildx:
-	 docker buildx create --use --name=jaeger-build --buildkitd-flags="--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --driver-opt="network=host"
-	 docker run --rm -d -p 5000:5000 --name registry registry:2
+	docker buildx create --use --name=jaeger-build --buildkitd-flags="--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --driver-opt="network=host"
+	docker run --rm -d -p 5000:5000 --name registry registry:2
 
 .PHONY: clean-docker-buildx
 clean-docker-buildx:

--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -9,6 +9,7 @@ make build-examples GOOS=linux GOARCH=arm64
 
 REPO=jaegertracing/example-hotrod
 platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+make prepare-docker-buildx
 #build image locally for integration test
 bash scripts/build-upload-a-docker-image.sh -l -c example-hotrod -d examples/hotrod -p "${platforms}"
 


### PR DESCRIPTION
Updates #3209 

This PR adds make target to configure docker buildx command. The idea is to allow contributors to run the build locally the same way how it runs on CI.