### PR TITLE
Enable gzip compression for collector grpc endpoint.

### DIFF
--- a/cmd/collector/app/handler/grpc_handler.go
+++ b/cmd/collector/app/handler/grpc_handler.go
@@ -19,6 +19,7 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #3235

## Short description of the changes

Import gzip compressor in cmd/collector/app/handler. That way gzip compressor is linked into every binary that exposes collector GRPC endpoint.