### PR TITLE
Fix grpc protobuf encoder/decoder

### DIFF
--- a/pkg/gogocodec/codec.go
+++ b/pkg/gogocodec/codec.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 
 	gogoproto "github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
-	"google.golang.org/protobuf/proto"
 )
 
 const jaegerProtoGenPkgPath = "github.com/jaegertracing/jaeger/proto-gen"


### PR DESCRIPTION
compatibility fix for older protobuf generated with `github.com/golang/protobuf` in grpc plugins

Resolves #3239