### PR TITLE
Check for invalid --agent.tags

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -58,6 +58,9 @@ func ParseJaegerTags(jaegerTags string) map[string]string {
 	tags := make(map[string]string)
 	for _, p := range tagPairs {
 		kv := strings.SplitN(p, "=", 2)
+		if len(kv) != 2 {
+			panic(fmt.Sprintf("invalid Jaeger tag pair %q, expected key=value", p))
+		}
 		k, v := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
 
 		if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") {

--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -50,3 +50,12 @@ func TestParseJaegerTags(t *testing.T) {
 
 	assert.Equal(t, expectedTags, ParseJaegerTags(jaegerTags))
 }
+
+func TestParseJaegerTagsPanic(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"invalid Jaeger tag pair \"no-equals-sign\", expected key=value",
+		func() {
+			ParseJaegerTags("no-equals-sign")
+		},
+	)
+}


### PR DESCRIPTION
If `--agent.tags` (or other tags) are malformed, display the invalid value as part of the panic.

No related Github issue.  Found this while testing the operator.  Improves an error message that will appear in the pod log if a misconfiguration keeps the Jaeger Query deployment from starting.

Old message:

```
panic: runtime error: index out of range [1] with length 1
```

New Message

```
panic: invalid Jaeger tag pair "dummy", expected key=value
```

Reproduce by building locally and running `~/go/src/github.com/jaegertracing/jaeger/cmd/query/query-darwin-amd64 --agent.tags=dummy`