### PR TITLE
Re-add `// +build` style build flags for building with Go 1.16

### DIFF
--- a/cmd/agent/app/servers/thriftudp/socket_buffer.go
+++ b/cmd/agent/app/servers/thriftudp/socket_buffer.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build !windows
+// +build !windows
 
 package thriftudp
 

--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 //go:build integration
+// +build integration
 
 package main
 

--- a/cmd/query/app/ui/actual.go
+++ b/cmd/query/app/ui/actual.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build ui
+// +build ui
 
 package ui
 

--- a/cmd/query/app/ui/placeholder.go
+++ b/cmd/query/app/ui/placeholder.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build !ui
+// +build !ui
 
 package ui
 

--- a/pkg/config/tlscfg/certpool_unix.go
+++ b/pkg/config/tlscfg/certpool_unix.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build !windows
+// +build !windows
 
 package tlscfg
 

--- a/pkg/config/tlscfg/certpool_windows.go
+++ b/pkg/config/tlscfg/certpool_windows.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build windows
+// +build windows
 
 package tlscfg
 

--- a/plugin/storage/badger/stats.go
+++ b/plugin/storage/badger/stats.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build !linux
+// +build !linux
 
 package badger
 

--- a/plugin/storage/badger/stats_test.go
+++ b/plugin/storage/badger/stats_test.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build !linux
+// +build !linux
 
 package badger
 

--- a/plugin/storage/integration/es_index_cleaner_test.go
+++ b/plugin/storage/integration/es_index_cleaner_test.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build index_cleaner
+// +build index_cleaner
 
 package integration
 

--- a/plugin/storage/integration/es_index_rollover_test.go
+++ b/plugin/storage/integration/es_index_rollover_test.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build index_rollover
+// +build index_rollover
 
 package integration
 

--- a/plugin/storage/integration/token_propagation_test.go
+++ b/plugin/storage/integration/token_propagation_test.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build token_propagation
+// +build token_propagation
 
 package integration
 

--- a/tools.go
+++ b/tools.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //go:build tools
+// +build tools
 
 package jaeger
 


### PR DESCRIPTION
Fixes #3268.

Signed-off-by: Pablo Baeyens <pablo.baeyens@datadoghq.com>
