### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -17,7 +17,7 @@ package app
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -66,7 +66,7 @@ func TestAgentSamplingEndpoint(t *testing.T) {
 		}
 		resp, err := http.Get(url)
 		require.NoError(t, err)
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "collector error: no peers available\n", string(body))
 	})
@@ -77,7 +77,7 @@ func TestAgentMetricsEndpoint(t *testing.T) {
 		url := fmt.Sprintf("http://%s/metrics", httpAddr)
 		resp, err := http.Get(url)
 		require.NoError(t, err)
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Contains(t, string(body), "# HELP")
 	})

--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -21,7 +21,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -92,7 +92,7 @@ func getAPITrace(t *testing.T) {
 		resp, err := httpClient.Do(req)
 		require.NoError(t, err)
 
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 
 		err = json.Unmarshal(body, &queryResponse)
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func getSamplingStrategy(t *testing.T) {
 	resp, err := httpClient.Do(req)
 	require.NoError(t, err)
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	err = json.Unmarshal(body, &queryResponse)
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func getServicesAPIV3(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := httpClient.Do(req)
 	require.NoError(t, err)
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	var servicesResponse api_v3.GetServicesResponse
 	jsonpb := runtime.JSONPb{}

--- a/cmd/anonymizer/app/anonymizer/anonymizer.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -81,7 +80,7 @@ func New(mappingFile string, options Options, logger *zap.Logger) *Anonymizer {
 		options: options,
 	}
 	if _, err := os.Stat(filepath.Clean(mappingFile)); err == nil {
-		dat, err := ioutil.ReadFile(filepath.Clean(mappingFile))
+		dat, err := os.ReadFile(filepath.Clean(mappingFile))
 		if err != nil {
 			logger.Fatal("Cannot load previous mapping", zap.Error(err))
 		}
@@ -108,7 +107,7 @@ func (a *Anonymizer) SaveMapping() {
 		a.logger.Error("Failed to marshal mapping file", zap.Error(err))
 		return
 	}
-	if err := ioutil.WriteFile(filepath.Clean(a.mappingFile), dat, os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Clean(a.mappingFile), dat, os.ModePerm); err != nil {
 		a.logger.Error("Failed to write mapping file", zap.Error(err))
 		return
 	}

--- a/cmd/anonymizer/app/uiconv/extractor_test.go
+++ b/cmd/anonymizer/app/uiconv/extractor_test.go
@@ -15,7 +15,6 @@
 package uiconv
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -111,7 +110,7 @@ func TestExtractor_TraceScanError(t *testing.T) {
 }
 
 func loadJSON(t *testing.T, fileName string, i interface{}) {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	require.NoError(t, err)
 	err = swag.ReadJSON(b, i)
 	require.NoError(t, err, "Failed to parse json fixture file %s", fileName)

--- a/cmd/collector/app/handler/http_handler.go
+++ b/cmd/collector/app/handler/http_handler.go
@@ -18,7 +18,7 @@ package handler
 import (
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 
@@ -62,7 +62,7 @@ func (aH *APIHandler) RegisterRoutes(router *mux.Router) {
 
 // SaveSpan submits the span provided in the request body to the JaegerBatchesHandler
 func (aH *APIHandler) SaveSpan(w http.ResponseWriter, r *http.Request) {
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
 		http.Error(w, fmt.Sprintf(UnableToReadBodyErrFormat, err), http.StatusInternalServerError)

--- a/cmd/collector/app/handler/http_handler_test.go
+++ b/cmd/collector/app/handler/http_handler_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -204,7 +204,7 @@ func postBytes(contentType, urlStr string, bodyBytes []byte) (int, string, error
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 0, "", err
 	}

--- a/cmd/collector/app/zipkin/http_handler.go
+++ b/cmd/collector/app/zipkin/http_handler.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"strings"
@@ -77,7 +76,7 @@ func (aH *APIHandler) saveSpans(w http.ResponseWriter, r *http.Request) {
 		bRead = gz
 	}
 
-	bodyBytes, err := ioutil.ReadAll(bRead)
+	bodyBytes, err := io.ReadAll(bRead)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(handler.UnableToReadBodyErrFormat, err), http.StatusInternalServerError)
 		return
@@ -127,7 +126,7 @@ func (aH *APIHandler) saveSpansV2(w http.ResponseWriter, r *http.Request) {
 		bRead = gz
 	}
 
-	bodyBytes, err := ioutil.ReadAll(bRead)
+	bodyBytes, err := io.ReadAll(bRead)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(handler.UnableToReadBodyErrFormat, err), http.StatusInternalServerError)
 		return

--- a/cmd/collector/app/zipkin/http_handler_test.go
+++ b/cmd/collector/app/zipkin/http_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -392,7 +392,7 @@ func postBytes(urlStr string, bytesBody []byte, header *http.Header) (int, strin
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 0, "", err
 	}

--- a/cmd/collector/app/zipkin/jsonv2_test.go
+++ b/cmd/collector/app/zipkin/jsonv2_test.go
@@ -16,7 +16,7 @@ package zipkin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-openapi/swag"
@@ -147,7 +147,7 @@ func TestErrSpans(t *testing.T) {
 }
 
 func loadJSON(t *testing.T, fileName string, i interface{}) {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	require.NoError(t, err)
 	err = swag.ReadJSON(b, i)
 	require.NoError(t, err, "Failed to parse json fixture file %s", fileName)

--- a/cmd/collector/app/zipkin/protov2_test.go
+++ b/cmd/collector/app/zipkin/protov2_test.go
@@ -17,7 +17,7 @@ package zipkin
 import (
 	"crypto/rand"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,7 +67,7 @@ func TestLCFromProtoSpanLocalEndpoint(t *testing.T) {
 }
 
 func loadProto(t *testing.T, fname string, spans *zipkinProto.ListOfSpans) {
-	b, err := ioutil.ReadFile(fname)
+	b, err := os.ReadFile(fname)
 	require.NoError(t, err)
 	err = json.Unmarshal(b, spans)
 	require.NoError(t, err)

--- a/cmd/docs/command_test.go
+++ b/cmd/docs/command_test.go
@@ -15,7 +15,7 @@
 package docs
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestOutputFormats(t *testing.T) {
 		cmd.ParseFlags([]string{test.flag})
 		err := cmd.Execute()
 		if err == nil {
-			f, err := ioutil.ReadFile(test.file)
+			f, err := os.ReadFile(test.file)
 			require.NoError(t, err)
 			assert.True(t, strings.Contains(string(f), "documentation"))
 		} else {
@@ -62,7 +62,7 @@ func TestDocsForParent(t *testing.T) {
 	parent.AddCommand(docs)
 	err := docs.RunE(docs, []string{})
 	require.NoError(t, err)
-	f, err := ioutil.ReadFile("root_command.md")
+	f, err := os.ReadFile("root_command.md")
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(string(f), "some description"))
 }

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -239,7 +238,7 @@ func TestWriteJSON(t *testing.T) {
 	get := func(url string) string {
 		res, err := http.Get(url)
 		require.NoError(t, err)
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		return string(body)
 	}
@@ -843,7 +842,7 @@ func execJSON(req *http.Request, out interface{}) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode > 399 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -851,7 +850,7 @@ func execJSON(req *http.Request, out interface{}) error {
 	}
 
 	if out == nil {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -19,8 +19,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -212,7 +213,7 @@ func loadIndexHTML(open func(string) (http.File, error)) ([]byte, error) {
 		return nil, fmt.Errorf("cannot open index.html: %w", err)
 	}
 	defer indexFile.Close()
-	indexBytes, err := ioutil.ReadAll(indexFile)
+	indexBytes, err := io.ReadAll(indexFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read from index.html: %w", err)
 	}
@@ -223,7 +224,7 @@ func loadUIConfig(uiConfig string) (*loadedConfig, error) {
 	if uiConfig == "" {
 		return nil, nil
 	}
-	bytesConfig, err := ioutil.ReadFile(filepath.Clean(uiConfig))
+	bytesConfig, err := os.ReadFile(filepath.Clean(uiConfig))
 	if err != nil {
 		return nil, fmt.Errorf("cannot read UI config file %v: %w", uiConfig, err)
 	}

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -18,7 +18,7 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -115,7 +115,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 				require.NoError(t, err)
 				defer resp.Body.Close()
 
-				respByteArray, err := ioutil.ReadAll(resp.Body)
+				respByteArray, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				require.Equal(t, http.StatusOK, resp.StatusCode, "url: %s, response: %v", url, string(respByteArray))
 				return string(respByteArray)
@@ -241,15 +241,15 @@ func TestWatcherError(t *testing.T) {
 }
 
 func TestHotReloadUIConfigTempFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "ui-config-hotreload-*")
+	dir, err := os.MkdirTemp("", "ui-config-hotreload-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	tmpfile, err := ioutil.TempFile(dir, "*.json")
+	tmpfile, err := os.CreateTemp(dir, "*.json")
 	require.NoError(t, err)
 	tmpFileName := tmpfile.Name()
 
-	content, err := ioutil.ReadFile("fixture/ui-config-hotreload.json")
+	content, err := os.ReadFile("fixture/ui-config-hotreload.json")
 	require.NoError(t, err)
 
 	err = syncWrite(tmpFileName, content, 0644)

--- a/cmd/status/command.go
+++ b/cmd/status/command.go
@@ -17,7 +17,7 @@ package status
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -42,7 +42,7 @@ func Command(v *viper.Viper, adminPort int) *cobra.Command {
 				return err
 			}
 			defer resp.Body.Close()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			fmt.Println(string(body))
 			if resp.StatusCode != http.StatusOK {
 				return fmt.Errorf("abnormal value of http status code: %v", resp.StatusCode)

--- a/crossdock/services/agent.go
+++ b/crossdock/services/agent.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -61,7 +61,7 @@ func (s *agentService) GetSamplingRate(service, operation string) (float64, erro
 		return 0, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/crossdock/services/query.go
+++ b/crossdock/services/query.go
@@ -18,7 +18,7 @@ package services
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -71,7 +71,7 @@ func (s *queryService) GetTraces(serviceName, operation string, tags map[string]
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/crossdock/services/tracehandler_test.go
+++ b/crossdock/services/tracehandler_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -194,7 +194,7 @@ type testClientHandler struct {
 
 func (h *testClientHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	var request traceRequest
 	json.Unmarshal(body, &request)

--- a/examples/hotrod/pkg/tracing/http.go
+++ b/examples/hotrod/pkg/tracing/http.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -51,7 +51,7 @@ func (c *HTTPClient) GetJSON(ctx context.Context, endpoint string, url string, o
 	defer res.Body.Close()
 
 	if res.StatusCode >= 400 {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}

--- a/model/converter/json/from_domain_test.go
+++ b/model/converter/json/from_domain_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -112,7 +112,7 @@ func loadFixtures(t *testing.T, i int, processEmbedded bool) ([]byte, []byte) {
 	} else {
 		in = fmt.Sprintf("fixtures/domain_%02d.json", i)
 	}
-	inStr, err := ioutil.ReadFile(in)
+	inStr, err := os.ReadFile(in)
 	require.NoError(t, err)
 	var out string
 	if processEmbedded {
@@ -120,7 +120,7 @@ func loadFixtures(t *testing.T, i int, processEmbedded bool) ([]byte, []byte) {
 	} else {
 		out = fmt.Sprintf("fixtures/ui_%02d.json", i)
 	}
-	outStr, err := ioutil.ReadFile(out)
+	outStr, err := os.ReadFile(out)
 	require.NoError(t, err)
 	return inStr, outStr
 }
@@ -139,7 +139,7 @@ func testJSONEncoding(t *testing.T, i int, expectedStr []byte, object interface{
 	require.NoError(t, enc.Encode(object))
 
 	if !assert.Equal(t, string(expectedStr), buf.String()) {
-		err := ioutil.WriteFile(outFile+"-actual.json", buf.Bytes(), 0644)
+		err := os.WriteFile(outFile+"-actual.json", buf.Bytes(), 0644)
 		assert.NoError(t, err)
 	}
 }

--- a/pkg/clientcfg/clientcfghttp/handler_test.go
+++ b/pkg/clientcfg/clientcfghttp/handler_test.go
@@ -18,7 +18,7 @@ package clientcfghttp
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -86,7 +86,7 @@ func testHTTPHandler(t *testing.T, basePath string) {
 				resp, err := http.Get(ts.server.URL + basePath + endpoint + "?service=Y")
 				require.NoError(t, err)
 				assert.Equal(t, http.StatusOK, resp.StatusCode)
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				err = resp.Body.Close()
 				require.NoError(t, err)
@@ -111,7 +111,7 @@ func testHTTPHandler(t *testing.T, basePath string) {
 			resp, err := http.Get(ts.server.URL + basePath + "/baggageRestrictions?service=Y")
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			require.NoError(t, err)
 			var objResp []*baggage.BaggageRestriction
@@ -202,7 +202,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, testCase.statusCode, resp.StatusCode)
 				if testCase.body != "" {
-					body, err := ioutil.ReadAll(resp.Body)
+					body, err := io.ReadAll(resp.Body)
 					assert.NoError(t, err)
 					assert.Equal(t, testCase.body, string(body))
 				}

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -17,7 +17,6 @@ package tlscfg
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,19 +42,19 @@ const (
 
 func TestReload(t *testing.T) {
 	// copy certs to temp so we can modify them
-	certFile, err := ioutil.TempFile("", "cert.crt")
+	certFile, err := os.CreateTemp("", "cert.crt")
 	require.NoError(t, err)
 	defer os.Remove(certFile.Name())
-	certData, err := ioutil.ReadFile(serverCert)
+	certData, err := os.ReadFile(serverCert)
 	require.NoError(t, err)
 	_, err = certFile.Write(certData)
 	require.NoError(t, err)
 	certFile.Close()
 
-	keyFile, err := ioutil.TempFile("", "key.crt")
+	keyFile, err := os.CreateTemp("", "key.crt")
 	require.NoError(t, err)
 	defer os.Remove(keyFile.Name())
-	keyData, err := ioutil.ReadFile(serverKey)
+	keyData, err := os.ReadFile(serverKey)
 	require.NoError(t, err)
 	_, err = keyFile.Write(keyData)
 	require.NoError(t, err)
@@ -82,7 +81,7 @@ func TestReload(t *testing.T) {
 	assert.Equal(t, &cert, watcher.certificate())
 
 	// Write the client's public key.
-	certData, err = ioutil.ReadFile(clientCert)
+	certData, err = os.ReadFile(clientCert)
 	require.NoError(t, err)
 	err = syncWrite(certFile.Name(), certData, 0644)
 	require.NoError(t, err)
@@ -99,7 +98,7 @@ func TestReload(t *testing.T) {
 		"Unable to locate 'Failed to load certificate' in log. All logs: %v", logObserver.All())
 
 	// Write the client's private key.
-	keyData, err = ioutil.ReadFile(clientKey)
+	keyData, err = os.ReadFile(clientKey)
 	require.NoError(t, err)
 	err = syncWrite(keyFile.Name(), keyData, 0644)
 	require.NoError(t, err)
@@ -123,19 +122,19 @@ func TestReload(t *testing.T) {
 
 func TestReload_ca_certs(t *testing.T) {
 	// copy certs to temp so we can modify them
-	caFile, err := ioutil.TempFile("", "cert.crt")
+	caFile, err := os.CreateTemp("", "cert.crt")
 	require.NoError(t, err)
 	defer os.Remove(caFile.Name())
-	caData, err := ioutil.ReadFile(caCert)
+	caData, err := os.ReadFile(caCert)
 	require.NoError(t, err)
 	_, err = caFile.Write(caData)
 	require.NoError(t, err)
 	caFile.Close()
 
-	clientCaFile, err := ioutil.TempFile("", "key.crt")
+	clientCaFile, err := os.CreateTemp("", "key.crt")
 	require.NoError(t, err)
 	defer os.Remove(clientCaFile.Name())
-	clientCaData, err := ioutil.ReadFile(caCert)
+	clientCaData, err := os.ReadFile(caCert)
 	require.NoError(t, err)
 	_, err = clientCaFile.Write(clientCaData)
 	require.NoError(t, err)
@@ -156,11 +155,11 @@ func TestReload_ca_certs(t *testing.T) {
 	go watcher.watchChangesLoop(certPool, certPool)
 
 	// update the content with client certs
-	caData, err = ioutil.ReadFile(caCert)
+	caData, err = os.ReadFile(caCert)
 	require.NoError(t, err)
 	err = syncWrite(caFile.Name(), caData, 0644)
 	require.NoError(t, err)
-	clientCaData, err = ioutil.ReadFile(caCert)
+	clientCaData, err = os.ReadFile(caCert)
 	require.NoError(t, err)
 	err = syncWrite(clientCaFile.Name(), clientCaData, 0644)
 	require.NoError(t, err)
@@ -179,19 +178,19 @@ func TestReload_ca_certs(t *testing.T) {
 
 func TestReload_err_cert_update(t *testing.T) {
 	// copy certs to temp so we can modify them
-	certFile, err := ioutil.TempFile("", "cert.crt")
+	certFile, err := os.CreateTemp("", "cert.crt")
 	require.NoError(t, err)
 	defer os.Remove(certFile.Name())
-	certData, err := ioutil.ReadFile(serverCert)
+	certData, err := os.ReadFile(serverCert)
 	require.NoError(t, err)
 	_, err = certFile.Write(certData)
 	require.NoError(t, err)
 	certFile.Close()
 
-	keyFile, err := ioutil.TempFile("", "key.crt")
+	keyFile, err := os.CreateTemp("", "key.crt")
 	require.NoError(t, err)
 	defer os.Remove(keyFile.Name())
-	keyData, err := ioutil.ReadFile(serverKey)
+	keyData, err := os.ReadFile(serverKey)
 	require.NoError(t, err)
 	_, err = keyFile.Write(keyData)
 	require.NoError(t, err)
@@ -218,11 +217,11 @@ func TestReload_err_cert_update(t *testing.T) {
 	assert.Equal(t, &serverCert, watcher.certificate())
 
 	// update the content with client certs
-	certData, err = ioutil.ReadFile(badCaCert)
+	certData, err = os.ReadFile(badCaCert)
 	require.NoError(t, err)
 	err = syncWrite(certFile.Name(), certData, 0644)
 	require.NoError(t, err)
-	keyData, err = ioutil.ReadFile(clientKey)
+	keyData, err = os.ReadFile(clientKey)
 	require.NoError(t, err)
 	err = syncWrite(keyFile.Name(), keyData, 0644)
 	require.NoError(t, err)
@@ -287,19 +286,19 @@ func TestAddCertsToWatch_err(t *testing.T) {
 }
 
 func TestAddCertsToWatch_remove_ca(t *testing.T) {
-	caFile, err := ioutil.TempFile("", "ca.crt")
+	caFile, err := os.CreateTemp("", "ca.crt")
 	require.NoError(t, err)
 	defer os.Remove(caFile.Name())
-	caData, err := ioutil.ReadFile(caCert)
+	caData, err := os.ReadFile(caCert)
 	require.NoError(t, err)
 	_, err = caFile.Write(caData)
 	require.NoError(t, err)
 	caFile.Close()
 
-	clientCaFile, err := ioutil.TempFile("", "clientCa.crt")
+	clientCaFile, err := os.CreateTemp("", "clientCa.crt")
 	require.NoError(t, err)
 	defer os.Remove(clientCaFile.Name())
-	clientCaData, err := ioutil.ReadFile(caCert)
+	clientCaData, err := os.ReadFile(caCert)
 	require.NoError(t, err)
 	_, err = clientCaFile.Write(clientCaData)
 	require.NoError(t, err)

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"go.uber.org/zap"
@@ -101,7 +101,7 @@ func (p Options) loadCertPool() (*x509.CertPool, error) {
 }
 
 func addCertToPool(caPath string, certPool *x509.CertPool) error {
-	caPEM, err := ioutil.ReadFile(filepath.Clean(caPath))
+	caPEM, err := os.ReadFile(filepath.Clean(caPath))
 	if err != nil {
 		return fmt.Errorf("failed to load CA %s: %w", caPath, err)
 	}

--- a/pkg/es/client/client.go
+++ b/pkg/es/client/client.go
@@ -17,7 +17,7 @@ package client
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -92,7 +92,7 @@ func (c *Client) request(esRequest elasticRequest) ([]byte, error) {
 		return []byte{}, c.handleFailedRequest(res)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -107,7 +107,7 @@ func (c *Client) setAuthorization(r *http.Request) {
 
 func (c *Client) handleFailedRequest(res *http.Response) error {
 	if res.Body != nil {
-		bodyBytes, err := ioutil.ReadAll(res.Body)
+		bodyBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			return newResponseError(fmt.Errorf("request failed and failed to read response body, status code: %d, %w", res.StatusCode, err), res.StatusCode, nil)
 		}

--- a/pkg/es/client/index_client_test.go
+++ b/pkg/es/client/index_client_test.go
@@ -15,7 +15,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -305,7 +305,7 @@ func TestClientCreateAliases(t *testing.T) {
 				assert.True(t, strings.HasSuffix(req.URL.String(), "_aliases"))
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				require.NoError(t, err)
 				assert.Equal(t, expectedRequestBody, string(body))
 				res.WriteHeader(test.responseCode)
@@ -365,7 +365,7 @@ func TestClientDeleteAliases(t *testing.T) {
 				assert.True(t, strings.HasSuffix(req.URL.String(), "_aliases"))
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				require.NoError(t, err)
 				assert.Equal(t, expectedRequestBody, string(body))
 				res.WriteHeader(test.responseCode)
@@ -415,7 +415,7 @@ func TestClientCreateTemplate(t *testing.T) {
 				assert.True(t, strings.HasSuffix(req.URL.String(), "_template/jaeger-template"))
 				assert.Equal(t, http.MethodPut, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				require.NoError(t, err)
 				assert.Equal(t, templateContent, string(body))
 
@@ -469,7 +469,7 @@ func TestRollover(t *testing.T) {
 				assert.True(t, strings.HasSuffix(req.URL.String(), "jaeger-span/_rollover/"))
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				require.NoError(t, err)
 				assert.Equal(t, expectedRequestBody, string(body))
 

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -549,7 +548,7 @@ func (tr *tokenAuthTransport) RoundTrip(r *http.Request) (*http.Response, error)
 }
 
 func loadToken(path string) (string, error) {
-	b, err := ioutil.ReadFile(filepath.Clean(path))
+	b, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/healthcheck/internal_test.go
+++ b/pkg/healthcheck/internal_test.go
@@ -17,7 +17,7 @@ package healthcheck
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +63,7 @@ func TestHttpCall(t *testing.T) {
 }
 
 func parseHealthCheckResponse(t *testing.T, resp *http.Response) healthCheckResponse {
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	var hr healthCheckResponse
 	err = json.Unmarshal(body, &hr)

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -17,7 +17,7 @@ package metricsstore
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -362,7 +362,7 @@ func startMockPrometheusServer(t *testing.T, wantPromQlQuery string, wantWarning
 			return
 		}
 
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		defer r.Body.Close()
 
 		u, err := url.Parse("http://" + r.Host + r.RequestURI + "?" + string(body))

--- a/plugin/sampling/strategystore/static/strategy_store.go
+++ b/plugin/sampling/strategystore/static/strategy_store.go
@@ -20,9 +20,9 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"time"
@@ -136,7 +136,7 @@ func (h *strategyStore) samplingStrategyLoader(strategiesFile string) strategyLo
 
 	return func() ([]byte, error) {
 		h.logger.Info("Loading sampling strategies", zap.String("filename", strategiesFile))
-		currBytes, err := ioutil.ReadFile(filepath.Clean(strategiesFile))
+		currBytes, err := os.ReadFile(filepath.Clean(strategiesFile))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read strategies file %s: %w", strategiesFile, err)
 		}

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -17,7 +17,6 @@ package static
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -333,7 +332,7 @@ func TestDeepCopy(t *testing.T) {
 }
 
 func TestAutoUpdateStrategyWithFile(t *testing.T) {
-	tempFile, _ := ioutil.TempFile("", "for_go_test_*.json")
+	tempFile, _ := os.CreateTemp("", "for_go_test_*.json")
 	require.NoError(t, tempFile.Close())
 	defer func() {
 		require.NoError(t, os.Remove(tempFile.Name()))
@@ -341,9 +340,9 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 
 	// copy known fixture content into temp file which we can later overwrite
 	srcFile, dstFile := "fixtures/strategies.json", tempFile.Name()
-	srcBytes, err := ioutil.ReadFile(srcFile)
+	srcBytes, err := os.ReadFile(srcFile)
 	require.NoError(t, err)
-	require.NoError(t, ioutil.WriteFile(dstFile, srcBytes, 0644))
+	require.NoError(t, os.WriteFile(dstFile, srcBytes, 0644))
 
 	ss, err := NewStrategyStore(Options{
 		StrategiesFile: dstFile,
@@ -364,7 +363,7 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 
 	// update file with new probability of 0.9
 	newStr := strings.Replace(string(srcBytes), "0.8", "0.9", 1)
-	require.NoError(t, ioutil.WriteFile(dstFile, []byte(newStr), 0644))
+	require.NoError(t, os.WriteFile(dstFile, []byte(newStr), 0644))
 
 	// wait for reload timer
 	for i := 0; i < 1000; i++ { // wait up to 1sec
@@ -413,7 +412,7 @@ func TestAutoUpdateStrategyWithURL(t *testing.T) {
 }
 
 func TestAutoUpdateStrategyErrors(t *testing.T) {
-	tempFile, _ := ioutil.TempFile("", "for_go_test_*.json")
+	tempFile, _ := os.CreateTemp("", "for_go_test_*.json")
 	require.NoError(t, tempFile.Close())
 	defer func() {
 		_ = os.Remove(tempFile.Name())
@@ -435,7 +434,7 @@ func TestAutoUpdateStrategyErrors(t *testing.T) {
 	assert.Len(t, logs.FilterMessage("failed to re-load sampling strategies").All(), 1)
 
 	// check bad file content
-	require.NoError(t, ioutil.WriteFile(tempFile.Name(), []byte("bad value"), 0644))
+	require.NoError(t, os.WriteFile(tempFile.Name(), []byte("bad value"), 0644))
 	assert.Equal(t, "blah", store.reloadSamplingStrategy(store.samplingStrategyLoader(tempFile.Name()), "blah"))
 	assert.Len(t, logs.FilterMessage("failed to update sampling strategies").All(), 1)
 

--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -17,7 +17,6 @@ package badger
 import (
 	"expvar"
 	"flag"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -98,7 +97,7 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 	if f.Options.Primary.Ephemeral {
 		opts.SyncWrites = false
 		// Error from TempDir is ignored to satisfy Codecov
-		dir, _ := ioutil.TempDir("", "badger")
+		dir, _ := os.MkdirTemp("", "badger")
 		f.tmpDir = dir
 		opts.Dir = f.tmpDir
 		opts.ValueDir = f.tmpDir

--- a/plugin/storage/badger/spanstore/cache_test.go
+++ b/plugin/storage/badger/spanstore/cache_test.go
@@ -14,7 +14,6 @@
 package spanstore
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -110,7 +109,7 @@ func runWithBadger(t *testing.T, test func(store *badger.DB, t *testing.T)) {
 	opts := badger.DefaultOptions("")
 
 	opts.SyncWrites = false
-	dir, _ := ioutil.TempDir("", "badger")
+	dir, _ := os.MkdirTemp("", "badger")
 	opts.Dir = dir
 	opts.ValueDir = dir
 

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -17,7 +17,6 @@ package spanstore_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -376,7 +375,7 @@ func TestMenuSeeks(t *testing.T) {
 }
 
 func TestPersist(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badgerTest")
+	dir, err := os.MkdirTemp("", "badgerTest")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/plugin/storage/es/mappings/mapping_test.go
+++ b/plugin/storage/es/mappings/mapping_test.go
@@ -17,7 +17,7 @@ package mappings
 import (
 	"embed"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 	"text/template"
@@ -87,7 +87,7 @@ func TestMappingBuilder_loadMapping(t *testing.T) {
 		mapping := loadMapping(test.name)
 		f, err := os.Open("./" + test.name)
 		require.NoError(t, err)
-		b, err := ioutil.ReadAll(f)
+		b, err := io.ReadAll(f)
 		require.NoError(t, err)
 		assert.Equal(t, string(b), mapping)
 		_, err = template.New("mapping").Parse(mapping)

--- a/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -55,10 +55,10 @@ func TestFromDomainEmbedProcess(t *testing.T) {
 // Loads and returns domain model and JSON model fixtures with given number i.
 func loadFixtures(t *testing.T, i int) ([]byte, []byte) {
 	in := fmt.Sprintf("fixtures/domain_%02d.json", i)
-	inStr, err := ioutil.ReadFile(in)
+	inStr, err := os.ReadFile(in)
 	require.NoError(t, err)
 	out := fmt.Sprintf("fixtures/es_%02d.json", i)
-	outStr, err := ioutil.ReadFile(out)
+	outStr, err := os.ReadFile(out)
 	require.NoError(t, err)
 	return inStr, outStr
 }
@@ -72,7 +72,7 @@ func testJSONEncoding(t *testing.T, i int, expectedStr []byte, object interface{
 	require.NoError(t, enc.Encode(object))
 
 	if !assert.Equal(t, string(expectedStr), buf.String()) {
-		err := ioutil.WriteFile(outFile+"-actual.json", buf.Bytes(), 0644)
+		err := os.WriteFile(outFile+"-actual.json", buf.Bytes(), 0644)
 		assert.NoError(t, err)
 	}
 }

--- a/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
@@ -19,8 +19,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 
 	gogojsonpb "github.com/gogo/protobuf/jsonpb"
@@ -50,7 +50,7 @@ func testToDomain(t *testing.T, testParentSpanID bool) {
 		require.NoError(t, err)
 
 		out := fmt.Sprintf("fixtures/domain_%02d.json", i)
-		outStr, err := ioutil.ReadFile(out)
+		outStr, err := os.ReadFile(out)
 		require.NoError(t, err)
 		var expectedSpan model.Span
 		require.NoError(t, gogojsonpb.Unmarshal(bytes.NewReader(outStr), &expectedSpan))
@@ -61,7 +61,7 @@ func testToDomain(t *testing.T, testParentSpanID bool) {
 
 func loadESSpanFixture(i int) (Span, error) {
 	in := fmt.Sprintf("fixtures/es_%02d.json", i)
-	inStr, err := ioutil.ReadFile(in)
+	inStr, err := os.ReadFile(in)
 	if err != nil {
 		return Span{}, err
 	}

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -1111,7 +1111,7 @@ func TestSpanReader_buildOperationNameQuery(t *testing.T) {
 }
 
 func TestSpanReader_buildTagQuery(t *testing.T) {
-	inStr, err := ioutil.ReadFile("fixtures/query_01.json")
+	inStr, err := os.ReadFile("fixtures/query_01.json")
 	require.NoError(t, err)
 	withSpanReader(func(r *spanReaderTest) {
 		tagQuery := r.reader.buildTagQuery("bat.foo", "spook")
@@ -1126,7 +1126,7 @@ func TestSpanReader_buildTagQuery(t *testing.T) {
 }
 
 func TestSpanReader_buildTagRegexQuery(t *testing.T) {
-	inStr, err := ioutil.ReadFile("fixtures/query_02.json")
+	inStr, err := os.ReadFile("fixtures/query_02.json")
 	require.NoError(t, err)
 	withSpanReader(func(r *spanReaderTest) {
 		tagQuery := r.reader.buildTagQuery("bat.foo", "spo.*")
@@ -1141,7 +1141,7 @@ func TestSpanReader_buildTagRegexQuery(t *testing.T) {
 }
 
 func TestSpanReader_buildTagRegexEscapedQuery(t *testing.T) {
-	inStr, err := ioutil.ReadFile("fixtures/query_03.json")
+	inStr, err := os.ReadFile("fixtures/query_03.json")
 	require.NoError(t, err)
 	withSpanReader(func(r *spanReaderTest) {
 		tagQuery := r.reader.buildTagQuery("bat.foo", "spo\\*")

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -300,7 +300,7 @@ func getTraceFixtureExact(t *testing.T, fileName string) *model.Trace {
 
 func loadAndParseJSONPB(t *testing.T, path string, object proto.Message) {
 	// #nosec
-	inStr, err := ioutil.ReadFile(path)
+	inStr, err := os.ReadFile(path)
 	require.NoError(t, err, "Not expecting error when loading fixture %s", path)
 	err = jsonpb.Unmarshal(bytes.NewReader(correctTime(inStr)), object)
 	require.NoError(t, err, "Not expecting error when unmarshaling fixture %s", path)
@@ -315,7 +315,7 @@ func LoadAndParseQueryTestCases(t *testing.T, queriesFile string) []*QueryFixtur
 
 func loadAndParseJSON(t *testing.T, path string, object interface{}) {
 	// #nosec
-	inStr, err := ioutil.ReadFile(path)
+	inStr, err := os.ReadFile(path)
 	require.NoError(t, err, "Not expecting error when loading fixture %s", path)
 	err = json.Unmarshal(correctTime(inStr), object)
 	require.NoError(t, err, "Not expecting error when unmarshaling fixture %s", path)


### PR DESCRIPTION
## Which problem is this PR solving?
Remove all usage of `io/ioutil` functions

## Short description of the changes
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since Jaeger has upgraded to Go 1.17 (#3220), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.
