### PR TITLE
Close #3270: Prevent rollover lookback from passing the Unix epoch

### DIFF
--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -61,7 +61,7 @@ const (
 
 	defaultNumTraces = 100
 
-	rolloverMaxSpanAge = time.Hour * 24 * 365 * 100
+	rolloverMaxSpanAge = time.Hour * 24 * 365 * 50
 )
 
 var (

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -149,7 +149,7 @@ func TestNewSpanReader(t *testing.T) {
 				MaxSpanAge:          time.Hour * 72,
 				UseReadWriteAliases: true,
 			},
-			maxSpanAge: time.Hour * 24 * 365 * 100,
+			maxSpanAge: time.Hour * 24 * 365 * 50,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #3270

## Short description of the changes

Version 1.26 introduced an automatic configuration for the query lookback
when using ElasticSearch with aliases enabled.  When aliases are enabled,
the ES plugin will look back 100 years.  This pre-dates the Unix epoch, and
while such dates can be modeled as negative timestamps, the model defined
in `jaeger/model/time.go` only supports unsigned timestamps.  As a result,
the 100-year lookback ends up overflowing the time model, resulting in a
distant-future lookback date, rather than a distant-past lookback date.

While the time model could be updated to support negative timestamps, it
seems unlikely that any Jaeger users would reasonably need to search for
spans from the 1920s.  This reduces the automatic lookback to 50 years to
remove the overflow issue while still providing an extremely long search
window that should serve even the most ambitious searches of historical
trace data.
