### PR TITLE
Changed sampling type env var and updated collector help text

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -68,7 +68,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}
-	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv()
+	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv(os.Stderr)
 	if err != nil {
 		log.Fatalf("Cannot initialize sampling strategy store factory config: %v", err)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -50,7 +50,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}
-	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv()
+	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv(os.Stderr)
 	if err != nil {
 		log.Fatalf("Cannot initialize sampling strategy store factory config: %v", err)
 	}

--- a/cmd/env/command.go
+++ b/cmd/env/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore"
 	"github.com/jaegertracing/jaeger/plugin/storage"
 )
 
@@ -43,6 +44,11 @@ Multiple backends can be specified as comma-separated list, e.g. "cassandra,elas
 it is not a replacement for a proper storage backend, and only used as a buffer for spans
 when Jaeger is deployed in the collector+ingester configuration.
 `
+
+	samplingTypeDescription = `The method [%s] used for determining the sampling rates served
+to clients configured with remote sampling enabled. "file" uses a periodically reloaded file and
+"adaptive" dynamically adjusts sampling rates based on current traffic.
+`
 )
 
 // Command creates `env` command
@@ -60,6 +66,14 @@ func Command() *cobra.Command {
 		storage.DependencyStorageTypeEnvVar,
 		"${SPAN_STORAGE_TYPE}",
 		"The type of backend used for service dependencies storage.",
+	)
+	fs.String(
+		strategystore.SamplingTypeEnvVar,
+		"file",
+		fmt.Sprintf(
+			strings.ReplaceAll(samplingTypeDescription, "\n", " "),
+			strings.Join(strategystore.AllSamplingTypes, ", "),
+		),
 	)
 	long := fmt.Sprintf(longTemplate, strings.Replace(fs.FlagUsagesWrapped(0), "      --", "\n", -1))
 	return &cobra.Command{

--- a/docker-compose/jaeger-docker-compose.yml
+++ b/docker-compose/jaeger-docker-compose.yml
@@ -24,7 +24,7 @@ services:
         - "--sampling.initial-sampling-probability=.5"
         - "--sampling.target-samples-per-second=.01"
       environment: 
-        - SAMPLING_TYPE=adaptive
+        - SAMPLING_CONFIG_TYPE=adaptive
       ports:
         - "14269:14269"
         - "14268:14268"

--- a/plugin/sampling/strategystore/factory.go
+++ b/plugin/sampling/strategystore/factory.go
@@ -34,10 +34,10 @@ type Kind string
 
 const (
 	samplingTypeAdaptive = "adaptive"
-	samplingTypeStatic   = "file"
+	samplingTypeFile     = "file"
 )
 
-var AllSamplingTypes = []string{samplingTypeStatic, samplingTypeAdaptive}
+var AllSamplingTypes = []string{samplingTypeFile, samplingTypeAdaptive}
 
 // Factory implements strategystore.Factory interface as a meta-factory for strategy storage components.
 type Factory struct {
@@ -65,7 +65,7 @@ func NewFactory(config FactoryConfig) (*Factory, error) {
 
 func (f *Factory) getFactoryOfType(factoryType Kind) (strategystore.Factory, error) {
 	switch factoryType {
-	case samplingTypeStatic:
+	case samplingTypeFile:
 		return static.NewFactory(), nil
 	case samplingTypeAdaptive:
 		return adaptive.NewFactory(), nil

--- a/plugin/sampling/strategystore/factory.go
+++ b/plugin/sampling/strategystore/factory.go
@@ -34,10 +34,10 @@ type Kind string
 
 const (
 	samplingTypeAdaptive = "adaptive"
-	samplingTypeStatic   = "static"
+	samplingTypeStatic   = "file"
 )
 
-var allSamplingTypes = []Kind{samplingTypeStatic, samplingTypeAdaptive}
+var AllSamplingTypes = []string{samplingTypeStatic, samplingTypeAdaptive}
 
 // Factory implements strategystore.Factory interface as a meta-factory for strategy storage components.
 type Factory struct {
@@ -70,7 +70,7 @@ func (f *Factory) getFactoryOfType(factoryType Kind) (strategystore.Factory, err
 	case samplingTypeAdaptive:
 		return adaptive.NewFactory(), nil
 	default:
-		return nil, fmt.Errorf("unknown sampling strategy store type %s. Valid types are %v", factoryType, allSamplingTypes)
+		return nil, fmt.Errorf("unknown sampling strategy store type %s. Valid types are %v", factoryType, AllSamplingTypes)
 	}
 }
 

--- a/plugin/sampling/strategystore/factory_config.go
+++ b/plugin/sampling/strategystore/factory_config.go
@@ -41,14 +41,8 @@ type FactoryConfig struct {
 func FactoryConfigFromEnv(log io.Writer) (*FactoryConfig, error) {
 	strategyStoreType := getStrategyStoreTypeFromEnv(log)
 	if strategyStoreType != samplingTypeAdaptive &&
-		strategyStoreType != samplingTypeFile &&
-		strategyStoreType != deprecatedSamplingTypeStatic {
+		strategyStoreType != samplingTypeFile {
 		return nil, fmt.Errorf("invalid sampling type: %s. Valid types are %v", strategyStoreType, AllSamplingTypes)
-	}
-
-	if strategyStoreType == deprecatedSamplingTypeStatic {
-		fmt.Fprintf(log, "WARNING: Using deprecated '%s' value for %s. Please switch to '%s'.\n", strategyStoreType, SamplingTypeEnvVar, samplingTypeFile)
-		strategyStoreType = samplingTypeFile
 	}
 
 	return &FactoryConfig{
@@ -63,10 +57,14 @@ func getStrategyStoreTypeFromEnv(log io.Writer) string {
 		return strategyStoreType
 	}
 
-	// accept the old env var but warn
+	// accept the old env var and value but warn
 	strategyStoreType = os.Getenv(deprecatedSamplingTypeEnvVar)
 	if strategyStoreType != "" {
 		fmt.Fprintf(log, "WARNING: Using deprecated '%s' env var. Please switch to '%s'.\n", deprecatedSamplingTypeEnvVar, SamplingTypeEnvVar)
+		if strategyStoreType == deprecatedSamplingTypeStatic {
+			fmt.Fprintf(log, "WARNING: Using deprecated '%s' value for %s. Please switch to '%s'.\n", strategyStoreType, SamplingTypeEnvVar, samplingTypeFile)
+			strategyStoreType = samplingTypeFile
+		}
 		return strategyStoreType
 	}
 

--- a/plugin/sampling/strategystore/factory_config.go
+++ b/plugin/sampling/strategystore/factory_config.go
@@ -16,12 +16,18 @@ package strategystore
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
 const (
 	// SamplingTypeEnvVar is the name of the env var that defines the type of sampling strategy store used.
 	SamplingTypeEnvVar = "SAMPLING_CONFIG_TYPE"
+
+	// previously the SAMPLING_TYPE env var was used for configuration, continue to support this old env var with warnings
+	deprecatedSamplingTypeEnvVar = "SAMPLING_TYPE"
+	// static is the old name for "file". we will translate from the deprecated to current name here. all other code will expect "file"
+	deprecatedSamplingTypeStatic = "static"
 )
 
 // FactoryConfig tells the Factory what sampling type it needs to create.
@@ -32,16 +38,38 @@ type FactoryConfig struct {
 // FactoryConfigFromEnv reads the desired sampling type from the SAMPLING_CONFIG_TYPE environment variable. Allowed values:
 //   * `file` - built-in
 //   * `adaptive` - built-in
-func FactoryConfigFromEnv() (*FactoryConfig, error) {
-	strategyStoreType := os.Getenv(SamplingTypeEnvVar)
-	if strategyStoreType == "" {
-		strategyStoreType = samplingTypeStatic
+func FactoryConfigFromEnv(log io.Writer) (*FactoryConfig, error) {
+	strategyStoreType := getStrategyStoreTypeFromEnv(log)
+	if strategyStoreType != samplingTypeAdaptive &&
+		strategyStoreType != samplingTypeFile &&
+		strategyStoreType != deprecatedSamplingTypeStatic {
+		return nil, fmt.Errorf("invalid sampling type: %s. Valid types are %v", strategyStoreType, AllSamplingTypes)
 	}
 
-	if strategyStoreType != samplingTypeAdaptive && strategyStoreType != samplingTypeStatic {
-		return nil, fmt.Errorf("invalid sampling type: %s. . Valid types are %v", strategyStoreType, AllSamplingTypes)
+	if strategyStoreType == deprecatedSamplingTypeStatic {
+		fmt.Fprintf(log, "WARNING: Using deprecated '%s' value for %s. Please switch to '%s'.\n", strategyStoreType, SamplingTypeEnvVar, samplingTypeFile)
+		strategyStoreType = samplingTypeFile
 	}
+
 	return &FactoryConfig{
 		StrategyStoreType: Kind(strategyStoreType),
 	}, nil
+}
+
+func getStrategyStoreTypeFromEnv(log io.Writer) string {
+	// check the new env var
+	strategyStoreType := os.Getenv(SamplingTypeEnvVar)
+	if strategyStoreType != "" {
+		return strategyStoreType
+	}
+
+	// accept the old env var but warn
+	strategyStoreType = os.Getenv(deprecatedSamplingTypeEnvVar)
+	if strategyStoreType != "" {
+		fmt.Fprintf(log, "WARNING: Using deprecated '%s' env var. Please switch to '%s'.\n", deprecatedSamplingTypeEnvVar, SamplingTypeEnvVar)
+		return strategyStoreType
+	}
+
+	// default
+	return samplingTypeFile
 }

--- a/plugin/sampling/strategystore/factory_config.go
+++ b/plugin/sampling/strategystore/factory_config.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// SamplingTypeEnvVar is the name of the env var that defines the type of sampling strategy store used.
-	SamplingTypeEnvVar = "SAMPLING_TYPE"
+	SamplingTypeEnvVar = "SAMPLING_CONFIG_TYPE"
 )
 
 // FactoryConfig tells the Factory what sampling type it needs to create.
@@ -29,8 +29,8 @@ type FactoryConfig struct {
 	StrategyStoreType Kind
 }
 
-// FactoryConfigFromEnv reads the desired sampling type from the SAMPLING_TYPE environment variable. Allowed values:
-//   * `static` - built-in
+// FactoryConfigFromEnv reads the desired sampling type from the SAMPLING_CONFIG_TYPE environment variable. Allowed values:
+//   * `file` - built-in
 //   * `adaptive` - built-in
 func FactoryConfigFromEnv() (*FactoryConfig, error) {
 	strategyStoreType := os.Getenv(SamplingTypeEnvVar)
@@ -39,7 +39,7 @@ func FactoryConfigFromEnv() (*FactoryConfig, error) {
 	}
 
 	if strategyStoreType != samplingTypeAdaptive && strategyStoreType != samplingTypeStatic {
-		return nil, fmt.Errorf("invalid sampling type: %s. . Valid types are %v", strategyStoreType, allSamplingTypes)
+		return nil, fmt.Errorf("invalid sampling type: %s. . Valid types are %v", strategyStoreType, AllSamplingTypes)
 	}
 	return &FactoryConfig{
 		StrategyStoreType: Kind(strategyStoreType),

--- a/plugin/sampling/strategystore/factory_config_test.go
+++ b/plugin/sampling/strategystore/factory_config_test.go
@@ -53,17 +53,24 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		err := os.Setenv(SamplingTypeEnvVar, tc.env)
-		require.NoError(t, err)
+		// for each test case test both the old and new env vars
+		for _, envVar := range []string{SamplingTypeEnvVar, deprecatedSamplingTypeEnvVar} {
+			// clear env
+			os.Setenv(SamplingTypeEnvVar, "")
+			os.Setenv(deprecatedSamplingTypeEnvVar, "")
 
-		f, err := FactoryConfigFromEnv(io.Discard)
-		if tc.expectsError {
-			assert.Error(t, err)
-			continue
+			err := os.Setenv(envVar, tc.env)
+			require.NoError(t, err)
+
+			f, err := FactoryConfigFromEnv(io.Discard)
+			if tc.expectsError {
+				assert.Error(t, err)
+				continue
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedType, f.StrategyStoreType)
 		}
-
-		require.NoError(t, err)
-		assert.Equal(t, tc.expectedType, f.StrategyStoreType)
 	}
 }
 

--- a/plugin/sampling/strategystore/factory_config_test.go
+++ b/plugin/sampling/strategystore/factory_config_test.go
@@ -30,11 +30,11 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 		expectsError bool
 	}{
 		{
-			expectedType: Kind("static"),
+			expectedType: Kind("file"),
 		},
 		{
-			env:          "static",
-			expectedType: Kind("static"),
+			env:          "file",
+			expectedType: Kind("file"),
 		},
 		{
 			env:          "adaptive",

--- a/plugin/sampling/strategystore/factory_test.go
+++ b/plugin/sampling/strategystore/factory_test.go
@@ -47,7 +47,7 @@ func TestNewFactory(t *testing.T) {
 		expectError       bool
 	}{
 		{
-			strategyStoreType: "static",
+			strategyStoreType: "file",
 		},
 		{
 			strategyStoreType: "adaptive",
@@ -94,13 +94,13 @@ func TestConfigurable(t *testing.T) {
 	clearEnv()
 	defer clearEnv()
 
-	f, err := NewFactory(FactoryConfig{StrategyStoreType: "static"})
+	f, err := NewFactory(FactoryConfig{StrategyStoreType: "file"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)
-	assert.NotEmpty(t, f.factories["static"])
+	assert.NotEmpty(t, f.factories["file"])
 
 	mock := new(mockFactory)
-	f.factories["static"] = mock
+	f.factories["file"] = mock
 
 	fs := new(flag.FlagSet)
 	v := viper.New()

--- a/plugin/sampling/strategystore/factory_test.go
+++ b/plugin/sampling/strategystore/factory_test.go
@@ -53,6 +53,12 @@ func TestNewFactory(t *testing.T) {
 			strategyStoreType: "adaptive",
 		},
 		{
+			// expliclitly test that the deprecated value is refused in NewFactory(). it should be translated correctly in factory_config.go
+			// and no other code should need to be aware of the old name.
+			strategyStoreType: "static",
+			expectError:       true,
+		},
+		{
 			strategyStoreType: "nonsense",
 			expectError:       true,
 		},


### PR DESCRIPTION
## Which problem is this PR solving?

## Short description of the changes
As suggested here: https://github.com/jaegertracing/documentation/pull/526

This PR renamed `SAMPLING_TYPE` env var to `SAMPLING_CONFIG_TYPE`. Additionally it extends the collector help text to include information about this new env var.

New text:
```
$ go run ./cmd/collector env
2021/10/04 10:00:45 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined

All command line options can be provided via environment variables by converting
their names to upper case and replacing punctuation with underscores. For example:

command line option                 environment variable
------------------------------------------------------------------
--cassandra.connections-per-host    CASSANDRA_CONNECTIONS_PER_HOST
--metrics-backend                   METRICS_BACKEND

The following configuration options are only available via environment variables:

SPAN_STORAGE_TYPE string         The type of backend [cassandra, opensearch, elasticsearch, memory, kafka, badger, grpc-plugin] used for trace storage. Multiple backends can be specified as comma-separated list, e.g. "cassandra,elasticsearch" (currently only for writing spans). Note that "kafka" is only valid in jaeger-collector; it is not a replacement for a proper storage backend, and only used as a buffer for spans when Jaeger is deployed in the collector+ingester configuration.  (default "cassandra")

DEPENDENCY_STORAGE_TYPE string   The type of backend used for service dependencies storage. (default "${SPAN_STORAGE_TYPE}")

SAMPLING_CONFIG_TYPE string      The method [file, adaptive] used for determining the sampling rates served to clients configured with remote sampling enabled. "file" uses a periodically reloaded file and "adaptive" dynamically adjusts sampling rates based on current traffic.  (default "file")
```