### PR TITLE
Upgrade to alpine-3.14

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,8 @@
 VERSION := 1.0.0
-ROOT_IMAGE ?= alpine:3.13
+ROOT_IMAGE ?= alpine:3.14
 CERT_IMAGE := $(ROOT_IMAGE)
 # TODO: Change back to golang:1.17-alpine once https://github.com/docker-library/golang/issues/383 is resolved.
-GOLANG_IMAGE := golang:1.17-alpine3.13
+GOLANG_IMAGE := golang:1.17-alpine3.14
 
 BASE_IMAGE := localhost:5000/baseimg_alpine:latest
 DEBUG_IMAGE := localhost:5000/debugimg_alpine:latest


### PR DESCRIPTION
Signed-off-by: Nont <nontkrub@gmail.com>

## Short description of the changes
This is update of [my previous PR](https://github.com/jaegertracing/jaeger/pull/3303), Bumping the version of the image from alpine-3.13 to alpine-3.14 for both the root and the go images.