### PR TITLE
Prepare release 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ next release
 * Fixing otel configuration in docker compose ([#3286](https://github.com/jaegertracing/jaeger/pull/3286), [@Ashmita152](https://github.com/Ashmita152))
 * Added ability to pass config file to grpc plugin in integration tests ([#3253](https://github.com/jaegertracing/jaeger/pull/3253), [@EinKrebs](https://github.com/EinKrebs))
 
+### UI Changes
+
+* UI pinned to version 1.17.0. The changelog is available here [v1.17.0](https://github.com/jaegertracing/jaeger-ui/blob/master/CHANGELOG.md#v1170-oct-6-2021)
+
+
 1.26.0 (2021-09-06)
 -------------------
 ### Backend Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ next release
 * Add 'opensearch' as a supported value for SPAN_STORAGE_TYPE ([#3255](https://github.com/jaegertracing/jaeger/pull/3255), [@yurishkuro](https://github.com/yurishkuro))
 
 #### New Features
-* Add support for adaptive sampling with a Cassandra backend. ([#2966](https://github.com/jaegertracing/jaeger/pull/2966), [@joe-elliott](https://github.com/joe-elliott))
+* Add support for adaptive sampling with a Cassandra backend. ([#2966](https://github.com/jaegertracing/jaeger/pull/2966), [@joe-elliott](https://github.com/joe-elliott), [@Ashmita152](https://github.com/Ashmita152))
 
 #### Bug fixes, Minor Improvements
 * Support graceful shutdown in grpc plugin ([#3249](https://github.com/jaegertracing/jaeger/pull/3249), [@slon](https://github.com/slon))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,26 @@ next release
 -------------------
 ### Backend Changes
 #### New Features
+
+1.27.0 (2021-10-06)
+-------------------
+### Backend Changes
+* Migrate elasticsearch rollover to go ([#3242](https://github.com/jaegertracing/jaeger/pull/3242), [@rubenvp8510](https://github.com/rubenvp8510))
+* Add 'opensearch' as a supported value for SPAN_STORAGE_TYPE ([#3255](https://github.com/jaegertracing/jaeger/pull/3255), [@yurishkuro](https://github.com/yurishkuro))
+
+#### New Features
 * Add support for adaptive sampling with a Cassandra backend. ([#2966](https://github.com/jaegertracing/jaeger/pull/2966), [@joe-elliott](https://github.com/joe-elliott))
 
+#### Bug fixes, Minor Improvements
+* Support graceful shutdown in grpc plugin ([#3249](https://github.com/jaegertracing/jaeger/pull/3249), [@slon](https://github.com/slon))
+* Enable gzip compression for collector grpc endpoint. ([#3236](https://github.com/jaegertracing/jaeger/pull/3236), [@slon](https://github.com/slon))
+* Use UTC in es-index-cleaner ([#3261](https://github.com/jaegertracing/jaeger/pull/3261), [@pavolloffay](https://github.com/pavolloffay))
+* Upgrade to alpine-3.14 ([#3304](https://github.com/jaegertracing/jaeger/pull/3304), [@nontw](https://github.com/nontw))
+* refactor: move from io/ioutil to io and os package ([#3294](https://github.com/jaegertracing/jaeger/pull/3294), [@Juneezee](https://github.com/Juneezee))
+* Changed sampling type env var and updated collector help text ([#3302](https://github.com/jaegertracing/jaeger/pull/3302), [@joe-elliott](https://github.com/joe-elliott))
+* Close #3270: Prevent rollover lookback from passing the Unix epoch ([#3299](https://github.com/jaegertracing/jaeger/pull/3299), [@ctreatma](https://github.com/ctreatma))
+* Fixing otel configuration in docker compose ([#3286](https://github.com/jaegertracing/jaeger/pull/3286), [@Ashmita152](https://github.com/Ashmita152))
+* Added ability to pass config file to grpc plugin in integration tests ([#3253](https://github.com/jaegertracing/jaeger/pull/3253), [@EinKrebs](https://github.com/EinKrebs))
 
 1.26.0 (2021-09-06)
 -------------------

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ build-crossdock-fresh: build-crossdock-linux
 
 .PHONY: changelog
 changelog:
-	@echo "Set env variable OAUTH_TOKEN before invoking, https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token"
+	@echo "Set env variable OAUTH_TOKEN before invoking, https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token. The token only needs default permissions."
 	docker run --rm  -v "${PWD}:/app" pavolloffay/gch:latest --oauth-token ${OAUTH_TOKEN} --owner jaegertracing --repo jaeger
 
 .PHONY: install-tools

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
         git fetch
         git checkout {new_version} //e.g. v1.5.0
         ```
+      * Even if a submodule does not have a new release, it should be checked to see if there were any changes warranting cutting a new release and then including it.
     * Rotate the below release managers table placing yourself at the bottom. The date should be the first Wednesday of the month.
 2. Add all merged pull requests to the milestone for the release and create a new milestone for a next release e.g. `Release 1.16`.
 3. After the PR is merged, create a release on Github:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
         git fetch
         git checkout {new_version} //e.g. v1.5.0
         ```
+    * Rotate the below release managers table placing yourself at the bottom. The date should be the first Wednesday of the month.
 2. Add all merged pull requests to the milestone for the release and create a new milestone for a next release e.g. `Release 1.16`.
 3. After the PR is merged, create a release on Github:
     * Title "Release X.Y.Z"
@@ -36,9 +37,9 @@ Here are the release managers for future versions with the tentative release dat
 
 | Version   | Release Manager  | Tentative release date |
 |-----------|------------------|------------------------|
-| 1.26.0    | @yurishkuro      |  1 September 2021      |
-| 1.27.0    | @joe-elliott     |  6 October   2021      |
 | 1.28.0    | @albertteoh      |  3 November  2021      |
 | 1.29.0    | @jpkrohling      |  1 December  2021      |
 | 1.30.0    | @pavolloffay     |  5 January   2022      |
 | 1.31.0    | @vprithvi        |  2 February  2022      |
+| 1.32.0    | @yurishkuro      |  2 March     2022      |
+| 1.33.0    | @joe-elliott     |  6 April     2022      |


### PR DESCRIPTION
## Short description of the changes
- Added 1.27.0 release notes
- Added note for `make changelog` that only default token permissions are needed
