### PR TITLE
Yarn as pre-requisite for run-all-in-one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ We gratefully welcome improvements to documentation as well as to code.
 
 ### Pre-requisites
 * Install [Go](https://golang.org/doc/install) and setup GOPATH and add $GOPATH/bin in PATH
+* Install [Yarn](https://yarnpkg.com/) for running local build with the UI
 
 This library uses Go modules to manage dependencies.
 


### PR DESCRIPTION
Yarn as pre-requisite for run-all-in-one

Otherwise one gets following error:
```
$ make run-all-in-one
cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build
/bin/sh: yarn: command not found
make: *** [jaeger-ui/packages/jaeger-ui/build/index.html] Error 127
```

Signed-off-by: Rostislav Svoboda <rsvoboda@redhat.com>

