### PR TITLE
cmd/es-rollover/app/init: fix args order in strings.Contains

### DIFF
--- a/cmd/es-rollover/app/init/action.go
+++ b/cmd/es-rollover/app/init/action.go
@@ -94,7 +94,7 @@ func createIndexIfNotExist(c client.IndexAPI, index string) error {
 			}
 			errorMap := jsonError["error"].(map[string]interface{})
 			// check for reason, ignore already exist error
-			if strings.Contains("resource_already_exists_exception", errorMap["type"].(string)) {
+			if strings.Contains(errorMap["type"].(string), "resource_already_exists_exception") {
 				return nil
 			}
 		}


### PR DESCRIPTION
If we do `strings.Contains("resource_already_exists_exception", errorMap["type"].(string))`,
we're basically doing `"resource_already_exists_exception" == errorMap["type"].(string)`.
I would assume that we intended to test whether `errorMap["type"]` contains
`"resource_already_exists_exception"` as a substring, so the reverse `strings.Contains` order
is more applicable here.

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- <!-- e.g. Resolves #123 -->

## Short description of the changes
- 
