### PR TITLE
plugin/storage/badger/spanstore: use (TB).TempDir not hardcoded non-portable /mnt/*

### DIFF
--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"runtime/pprof"
 	"testing"
 	"time"
@@ -614,7 +615,7 @@ func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Wr
 	opts := badger.NewOptions("badger")
 	v, command := config.Viperize(opts.AddFlags)
 
-	dir := "/mnt/ssd/badger/testRun"
+	dir := filepath.Join(tb.TempDir(), "badger-testRun")
 	err := os.MkdirAll(dir, 0700)
 	assert.NoError(err)
 	keyParam := fmt.Sprintf("--badger.directory-key=%s", dir)


### PR DESCRIPTION
Previously the Benchmark code ALWAYS assumed that "/mnt/ssd/" would
exist, yet when there is no permission or on read only systems,
using it would fail. This change instead uses the benchmarks'
temporary directory as the base for operations.

Fixes #3301

Signed-off-by: Emmanuel T Odeke <emmanuel@orijtech.com>