### PR TITLE
plugin/storage/badger/spanstore: use (TB).TempDir not hardcoded non-portable /mnt/*

### DIFF
--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"runtime/pprof"
 	"testing"
 	"time"
@@ -614,7 +615,7 @@ func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Wr
 	opts := badger.NewOptions("badger")
 	v, command := config.Viperize(opts.AddFlags)
 
-	dir := "/mnt/ssd/badger/testRun"
+	dir := filepath.Join(tb.TempDir(), "badger-testRun")
 	err := os.MkdirAll(dir, 0700)
 	assert.NoError(err)
 	keyParam := fmt.Sprintf("--badger.directory-key=%s", dir)


### PR DESCRIPTION
Previously the Benchmark code ALWAYS assumed that "/mnt/ssd/" would
exist, yet when there is no permission or on read only systems,
using it would fail. This change instead uses the benchmarks'
temporary directory as the base for operations.

Fixes #3301

Signed-off-by: Emmanuel T Odeke <emmanuel@orijtech.com>

Closes #3320
Rebased #3320 - the original PR wasn't passing DCO

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- <!-- e.g. Resolves #123 -->

## Short description of the changes
- 
