### PR TITLE
Improve release notes script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,8 +362,7 @@ build-crossdock-fresh: build-crossdock-linux
 
 .PHONY: changelog
 changelog:
-	@echo "Set env variable OAUTH_TOKEN before invoking, https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token. The token only needs default permissions."
-	docker run --rm  -v "${PWD}:/app" pavolloffay/gch:latest --oauth-token ${OAUTH_TOKEN} --owner jaegertracing --repo jaeger
+	python ./scripts/release-notes.py
 
 .PHONY: install-tools
 install-tools:

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -95,13 +95,11 @@ def main(token, repo, num_commits, exclude_dependabot):
 
 
 if __name__ == "__main__":
-    if "OAUTH_TOKEN" not in os.environ:
-        eprint("Please set OAUTH_TOKEN environment variable: " +
-               "https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token")
-        sys.exit(1)
-
     parser = argparse.ArgumentParser(description='List changes based on git log for release notes.')
 
+    parser.add_argument('--token', type=str,
+                        help='The personal github token to access the github API. ' +
+                             '(default: uses OATH_TOKEN environment variable)')
     parser.add_argument('--repo', type=str, default='jaeger',
                         help='The repository name to fetch commit logs from. (default: jaeger)')
     parser.add_argument('--exclude-dependabot', action='store_true',
@@ -111,4 +109,13 @@ if __name__ == "__main__":
                              '(default: number of commits before the previous tag)')
 
     args = parser.parse_args()
-    main(os.environ["OAUTH_TOKEN"], args.repo, args.num_commits, args.exclude_dependabot)
+
+    token = args.token
+    if not token:
+        if "OAUTH_TOKEN" not in os.environ:
+            eprint("Please provide a --token or set OAUTH_TOKEN environment variable to a generated token: " +
+                   "https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token")
+            sys.exit(1)
+        token = os.environ["OAUTH_TOKEN"]
+
+    main(token, args.repo, args.num_commits, args.exclude_dependabot)

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -91,7 +91,7 @@ def main(token, repo, num_commits, exclude_dependabot):
         print(f'* {msg} ([@{author}]({author_url}) in [#{pull_id}]({pull_url}))')
 
     if skipped_dependabot:
-        print(f"\n(Skipped {skipped_dependabot} dependabot commits)")
+        print(f"\n(Skipped {skipped_dependabot} dependabot commit{'' if skipped_dependabot == 1 else 's'})")
 
 
 if __name__ == "__main__":

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,67 +1,114 @@
-
 # This script can read N latest commits from one of Jaeger repos
 # and output them in the release notes format:
-#   {title} ({author} in {pull_request})
+# * {title} ({author} in {pull_request})
 #
 # Requires personal GitHub token with default permissions:
-#   https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token
+#   https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 #
-# Usage: python release-notes.py <github_token> <jaeger-repo> <num-commits>
+# Usage: python release-notes.py --help
 #
 
+import argparse
 import json
+import urllib.parse
+import os
+import sys
 from urllib.request import (
     urlopen,
     Request
 )
-import urllib.parse
-import sys
+
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
-if len(sys.argv) < 4:
-    eprint("Usage: python release-notes.py <github_token> <jaeger-repo> <num-commits>")
-    sys.exit(1)
 
-token=sys.argv[1]
-repo=sys.argv[2]
-num_commits=sys.argv[3]
+def num_commits_before_prev_tag(token, base_url):
+    tags_url = f"{base_url}/tags"
 
-accept_header="application/vnd.github.groot-preview+json"
-commits_url='https://api.github.com/repos/jaegertracing/{repo}/commits'.format(repo=repo)
-pulls_url="{commits_url}/{commit_sha}/pulls"
+    req = Request(tags_url)
+    req.add_header("Authorization", f"token {token}")
+    tags = json.loads(urlopen(req).read())
+    prev_release_tag = tags[0]['name']
+    compare_url = f"{base_url}/compare/master...{prev_release_tag}"
+    req = Request(compare_url)
+    req.add_header("Authorization", f"token {token}")
+    compare_results = json.loads(urlopen(req).read())
+    num_commits = compare_results['behind_by']
 
-# load commits
-data = urllib.parse.urlencode({'per_page': num_commits})
-req=Request(commits_url + '?' + data)
-print(req.full_url)
-req.add_header('Authorization', 'token {token}'.format(token=token))
-commits=json.loads(urlopen(req).read())
-print('Retrieved', len(commits), 'commits')
+    print(f"master is behind {prev_release_tag} by {num_commits} commits")
+    return num_commits
 
-# load PR for each commit and print summary
-for commit in commits:
-    sha = commit['sha']
-    msg_lines = commit['commit']['message'].split('\n')
-    msg = msg_lines[0]
-    req = Request(pulls_url.format(commits_url=commits_url,commit_sha=sha))
-    req.add_header('accept', accept_header)
-    req.add_header('Authorization', 'token {token}'.format(token=token))
-    pulls = json.loads(urlopen(req).read())
-    if len(pulls) > 1:
-        print("More than one pull request for commit {commit}".format(commit=sha))
-    # TODO handle commits without pull requests
-    pull = pulls[0]
-    pull_no = pull['number']
-    pull_url = pull['html_url']
-    author = pull['user']['login']
-    author_url = pull['user']['html_url']
-    msg = msg.replace('(#{pull})'.format(pull=pull_no), '').strip()
-    print('* {msg} ([@{author}]({author_url}) in [#{pull}]({pull_url}))'.format(
-        msg=msg,
-        author=author,
-        author_url=author_url,
-        pull=pull_no,
-        pull_url=pull_url,
-    ))
+
+def main(token, repo, num_commits, exclude_dependabot):
+    accept_header = "application/vnd.github.groot-preview+json"
+    base_url = f"https://api.github.com/repos/jaegertracing/{repo}"
+    commits_url = f"{base_url}/commits"
+    skipped_dependabot = 0
+
+    # If num_commits isn't set, get the number of commits made since the previous release tag.
+    if not num_commits:
+        num_commits = num_commits_before_prev_tag(token, base_url)
+
+    # Load commits
+    data = urllib.parse.urlencode({'per_page': num_commits})
+    req = Request(commits_url + '?' + data)
+    print(req.full_url)
+    req.add_header('Authorization', f'token {token}')
+    commits = json.loads(urlopen(req).read())
+    print('Retrieved', len(commits), 'commits')
+
+    # Load PR for each commit and print summary
+    for commit in commits:
+        sha = commit['sha']
+        author = commit['author']['login']
+
+        if exclude_dependabot and author == "dependabot[bot]":
+            skipped_dependabot += 1
+            continue
+
+        author_url = commit['author']['html_url']
+        msg_lines = commit['commit']['message'].split('\n')
+        msg = msg_lines[0]
+        req = Request(f"{commits_url}/{sha}/pulls")
+        req.add_header('accept', accept_header)
+        req.add_header('Authorization', f'token {token}')
+        pulls = json.loads(urlopen(req).read())
+        if len(pulls) > 1:
+            print(f"WARNING: More than one pull request for commit {sha}")
+
+        # Handle commits without pull requests.
+        if not pulls:
+            short_sha = sha[:7]
+            commit_url = commit['html_url']
+            print(f'* {msg} ([@{author}]({author_url}) in [{short_sha}]({commit_url}))')
+            continue
+
+        pull = pulls[0]
+        pull_id = pull['number']
+        pull_url = pull['html_url']
+        msg = msg.replace(f'(#{pull_id})', '').strip()
+        print(f'* {msg} ([@{author}]({author_url}) in [#{pull_id}]({pull_url}))')
+
+    if skipped_dependabot:
+        print(f"\n(Skipped {skipped_dependabot} dependabot commits)")
+
+
+if __name__ == "__main__":
+    if "OAUTH_TOKEN" not in os.environ:
+        eprint("Please set OAUTH_TOKEN environment variable: " +
+               "https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description='List changes based on git log for release notes.')
+
+    parser.add_argument('--repo', type=str, default='jaeger',
+                        help='The repository name to fetch commit logs from. (default: jaeger)')
+    parser.add_argument('--exclude-dependabot', action='store_true',
+                        help='Excludes dependabot commits. (default: false)')
+    parser.add_argument('--num-commits', type=int,
+                        help='Print this number of commits from git log. ' +
+                             '(default: number of commits before the previous tag)')
+
+    args = parser.parse_args()
+    main(os.environ["OAUTH_TOKEN"], args.repo, args.num_commits, args.exclude_dependabot)

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -26,12 +26,13 @@ def eprint(*args, **kwargs):
 
 def num_commits_since_prev_tag(token, base_url):
     tags_url = f"{base_url}/tags"
+    trunk = "master"
 
     req = Request(tags_url)
     req.add_header("Authorization", f"token {token}")
     tags = json.loads(urlopen(req).read())
     prev_release_tag = tags[0]['name']
-    compare_url = f"{base_url}/compare/master...{prev_release_tag}"
+    compare_url = f"{base_url}/compare/{trunk}...{prev_release_tag}"
     req = Request(compare_url)
     req.add_header("Authorization", f"token {token}")
     compare_results = json.loads(urlopen(req).read())
@@ -115,7 +116,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     generate_token_url = "https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token"
     generate_err_msg = (f"Please generate a token from this URL: {generate_token_url} and "
-                        f"place it in the token-file. The token only needs default permissions.")
+                        f"place it in the token-file. Protect the file so only you can read it: chmod 0600 <file>.")
 
     token_file = expanduser(args.token_file)
 


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Which problem is this PR solving?

- When generating release notes, the most relevant commit messages for the release are those that are before the previous release tag.
- `make changelog` nicely outputs these relevant changes, however, the release manager either needs to scroll to the top where the relevant commits are then copy-paste them.
- `make changelog` depends on a personal docker image and would be a burden to the owning engineer to keep publishing improvements/updates.
- In most cases, `dependabot` version bumps are not relevant to a changelog.

## Short description of the changes

This PR proposes the following improvements:

- Uses argparse to manage arguments, providing sensible defaults, which has the following benefits:
  - More robust parameter handling.
  - Better help documentation.
- Given python3 is in mainstream use (and python 2 discontinued), I've switched to using f-strings for readability and reduced stutter.
- Add a convenience option to `--exclude-dependabot`.
- If `--commit-num` is not supplied, the script will find the number of commits from HEAD of `master` to the previous tag and list out those commits.

### Examples

Using the default parameters:
```
$ python ./scripts/release-notes.py
There are 29 new commits since v1.27.0
https://api.github.com/repos/jaegertracing/jaeger/commits?per_page=29
Retrieved 29 commits
* Prepare release 1.28.0 ([@albertteoh](https://github.com/albertteoh) in [#3378](https://github.com/jaegertracing/jaeger/pull/3378))
* Do not throw error on empty indices in Elasticsach rollover lookback ([@jkandasa](https://github.com/jkandasa) in [#3369](https://github.com/jaegertracing/jaeger/pull/3369))
...
* Bump github.com/dgraph-io/badger/v3 from 3.2103.1 to 3.2103.2 ([@dependabot[bot]](https://github.com/apps/dependabot) in [#3310](https://github.com/jaegertracing/jaeger/pull/3310))
* List Yarn as pre-requisite for run-all-in-one ([@rsvoboda](https://github.com/rsvoboda) in [#3307](https://github.com/jaegertracing/jaeger/pull/3307))
```

All optional params provided:
```
$ python ./scripts/release-notes.py --token-file my-github-token-file --num-commits 3 --exclude-dependabot --repo jaeger-ui    
https://api.github.com/repos/jaegertracing/jaeger-ui/commits?per_page=3
Retrieved 3 commits
* Prepare release v1.18.0 ([@albertteoh](https://github.com/albertteoh) in [#846](https://github.com/jaegertracing/jaeger-ui/pull/846))
* fix deep dependency graph not show in uiEmbed=v0 mode ([@leroy-chen](https://github.com/leroy-chen) in [#768](https://github.com/jaegertracing/jaeger-ui/pull/768))

(Skipped 1 dependabot commit)
```