### PR TITLE
Fix debug image builds by installing `build-base` to enable GCC

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,7 @@
 VERSION := 1.0.0
 ROOT_IMAGE ?= alpine:3.14
 CERT_IMAGE := $(ROOT_IMAGE)
-# TODO: Change back to golang:1.17-alpine once https://github.com/docker-library/golang/issues/383 is resolved.
-GOLANG_IMAGE := golang:1.17-alpine3.14
+GOLANG_IMAGE := golang:1.17-alpine
 
 BASE_IMAGE := localhost:5000/baseimg_alpine:latest
 DEBUG_IMAGE := localhost:5000/debugimg_alpine:latest

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -3,7 +3,7 @@ ARG golang_image
 FROM $golang_image AS build
 ARG TARGETARCH
 ENV GOPATH /go
-RUN apk add --update --no-cache ca-certificates make git
+RUN apk add --update --no-cache ca-certificates make git build-base
 #Once go-delve adds support for s390x (see PR #2948), remove this entire conditional.
 #Once go-delve adds support for ppc64le (see PR go-delve/delve#1564), remove this entire conditional.
 RUN if [[ "$TARGETARCH" == "s390x"  ||  "$TARGETARCH" == "ppc64le" ]] ; then \

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -20,8 +20,6 @@ fi
 
 make build-ui
 
-set +e
-
 run_integration_test() {
   CID=$(docker run -d -p 16686:16686 -p 5778:5778 $1:latest)
   make all-in-one-integration-test


### PR DESCRIPTION
* Install `build-base` in debug image to provide GCC required by delve
* Resolves #3401
* Clean up after https://github.com/docker-library/golang/issues/383 has been resolved.