### PR TITLE
Split opensearch tests from elasticsearch

### DIFF
--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -1,4 +1,4 @@
-name: CIT Elasticsearch
+name: CIT OpenSearch
 
 on:
   push:
@@ -8,20 +8,14 @@ on:
     branches: [main]
 
 jobs:
-  elasticsearch:
+  opensearch:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         version:
-        - major: 5.x
-          image: 5.6.16
-          distribution: elasticsearch
-        - major: 6.x
-          image: 6.8.18
-          distribution: elasticsearch
-        - major: 7.x
-          image: 7.14.0
-          distribution: elasticsearch
+        - major: 1.x
+          image: 1.0.0
+          distribution: opensearch
     name: ${{ matrix.version.distribution }} ${{ matrix.version.major }}
     steps:
     - uses: actions/checkout@v2.4.0
@@ -41,5 +35,5 @@ jobs:
 
     - uses: docker/setup-qemu-action@v1
 
-    - name: Run elasticsearch integration tests
+    - name: Run opensearch integration tests
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}


### PR DESCRIPTION
The integration tests don't seem to be as stable on opensearch as they are for elasticsearch, and restarting it would restart the entire matrix. This PR splits the opensearch test execution from those of elasticsearch, making it easier to re-run only that portion of the matrix. It would also help us determine whether opensearch is the only stable variant for this integration test.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
