### PR TITLE
Build binaries for darwin/arm64

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -19,6 +19,8 @@ jobs:
           task: build-binaries-windows
         - name: osx
           task: build-binaries-darwin
+        - name: osx-m1
+          task: build-binaries-darwin-arm64
         - name: system/390
           task: build-binaries-s390x
         - name: arm

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,10 @@ build-binaries-windows:
 build-binaries-darwin:
 	GOOS=darwin GOARCH=amd64 $(MAKE) build-platform-binaries
 
+.PHONY: build-binaries-darwin-arm64
+build-binaries-darwin-arm64:
+	GOOS=darwin GOARCH=arm64 $(MAKE) build-platform-binaries
+
 .PHONY: build-binaries-s390x
 build-binaries-s390x:
 	GOOS=linux GOARCH=s390x $(MAKE) build-platform-binaries
@@ -277,7 +281,7 @@ build-platform-binaries: build-agent \
 	build-es-rollover
 
 .PHONY: build-all-platforms
-build-all-platforms: build-binaries-linux build-binaries-windows build-binaries-darwin build-binaries-s390x build-binaries-arm64 build-binaries-ppc64le
+build-all-platforms: build-binaries-linux build-binaries-windows build-binaries-darwin build-binaries-darwin-arm64 build-binaries-s390x build-binaries-arm64 build-binaries-ppc64le
 
 .PHONY: docker-images-cassandra
 docker-images-cassandra:

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -59,6 +59,7 @@ mkdir $DEPLOY_STAGING_DIR
 
 package linux-amd64
 package darwin-amd64
+package darwin-arm64
 package windows-amd64 .exe
 package linux-s390x
 package linux-arm64


### PR DESCRIPTION
Signed-off-by: Jean-Hadrien Chabran <jh@chabran.fr>

Hello 👋 (reopening this with a proper feature branch)  

## Which problem is this PR solving?

I noticed that the release binaries do not include darwin/arm64, which is just about adding it to the build scripts. 

## Short description of the changes

I added a target in the Makefile and patched a few other scripts. You can see a successful binary build here https://github.com/jhchabran/jaeger/runs/4216116176?check_suite_focus=true and the release workflow uploads here: https://github.com/jhchabran/jaeger/releases/tag/v1.28.1 

Please tell me if I have missed anything!