### PR TITLE
Let build be customized by env vars for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,6 @@ docker-images-jaeger-backend docker-images-jaeger-backend-debug: create-baseimg 
 			--build-arg base_image=$(BASE_IMAGE) \
 			--build-arg debug_image=$(DEBUG_IMAGE) \
 			--build-arg TARGETARCH=$(GOARCH) \
-			--load \
 			cmd/$$component ; \
 		echo "Finished building $$component ==============" ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,7 @@ docker-images-jaeger-backend docker-images-jaeger-backend-debug: create-baseimg 
 			--build-arg base_image=$(BASE_IMAGE) \
 			--build-arg debug_image=$(DEBUG_IMAGE) \
 			--build-arg TARGETARCH=$(GOARCH) \
+			--load \
 			cmd/$$component ; \
 		echo "Finished building $$component ==============" ; \
 	done

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,9 +3,10 @@ ROOT_IMAGE ?= alpine:3.14
 CERT_IMAGE := $(ROOT_IMAGE)
 GOLANG_IMAGE := golang:1.17-alpine
 
-BASE_IMAGE := localhost:5000/baseimg_alpine:latest
-DEBUG_IMAGE := localhost:5000/debugimg_alpine:latest
-PLATFORMS := linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+DOCKER_REPO ?= localhost:5000
+BASE_IMAGE ?= $(DOCKER_REPO)/baseimg_alpine:latest
+DEBUG_IMAGE ?= $(DOCKER_REPO)/debugimg_alpine:latest
+PLATFORMS ?= linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
 
 create-baseimg-debugimg: create-baseimg create-debugimg
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,9 +3,9 @@ ROOT_IMAGE ?= alpine:3.14
 CERT_IMAGE := $(ROOT_IMAGE)
 GOLANG_IMAGE := golang:1.17-alpine
 
-DOCKER_REPO ?= localhost:5000
-BASE_IMAGE ?= $(DOCKER_REPO)/baseimg_alpine:latest
-DEBUG_IMAGE ?= $(DOCKER_REPO)/debugimg_alpine:latest
+DOCKER_REGISTRY ?= localhost:5000
+BASE_IMAGE ?= $(DOCKER_REGISTRY)/baseimg_alpine:latest
+DEBUG_IMAGE ?= $(DOCKER_REGISTRY)/debugimg_alpine:latest
 PLATFORMS ?= linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
 
 create-baseimg-debugimg: create-baseimg create-debugimg


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

## Which problem is this PR solving?

Resolves #3445

## Short description of the changes

With this change, I can build on a Mac.  The biggest problem is that the Mac doesn't let the containers see the real _localhost_, but instead puts the Mac's localhost at _host.docker.internal_.

First, I must tell Docker to let host.docker.internal be insecure:

```bash
cat <<EOF | > /tmp/buildkitd.toml
[registry."host.docker.internal:5000"]
  http = true
EOF

docker buildx create --use --config /tmp/buildkitd.toml
```

I then build using

make build-binaries-linux
PLATFORMS=linux/amd64 DOCKER_REPO=host.docker.internal:5000 make docker-images-jaeger-backend

(Note that I am confident about every change except for the `--load`.  I am not sure what that is needed!  Without it, the build complained that "No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load ")