### PR TITLE
Specify branch in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "idl"]
 	path = idl
 	url = https://github.com/jaegertracing/jaeger-idl.git
+	branch = main
 [submodule "jaeger-ui"]
 	path = jaeger-ui
 	url = https://github.com/jaegertracing/jaeger-ui.git
+	branch = main


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

## Which problem is this PR solving?
- This PR set the git sub-module branches, some git libraries have problems with git sub-modules that doesn't provide information about their branch, it wrong assumes that the branch is master and fails to update the sub-modules when it doesn't exist. Because we removed our master branches it will fail:
 
See for example this : https://github.com/gitpython-developers/GitPython/issues/1058 

## Short description of the changes
- Set `branch=main` on `.gitmodules` file
