### PR TITLE
Prepare grpc bump to v1.43 or higher

### DIFF
--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
@@ -36,7 +37,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 	s, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
 		api_v2.RegisterSamplingManagerServer(s, &mockSamplingHandler{})
 	})
-	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	defer close(t, conn)
 	require.NoError(t, err)
 	defer s.GracefulStop()
@@ -47,7 +48,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 }
 
 func TestSamplingManager_GetSamplingStrategy_error(t *testing.T) {
-	conn, err := grpc.Dial("foo", grpc.WithInsecure())
+	conn, err := grpc.Dial("foo", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	defer close(t, conn)
 	require.NoError(t, err)
 	manager := NewConfigManager(conn)

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	grpcrep "github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
@@ -80,7 +81,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 
 func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.GrpcCollector, reporter.Reporter, *grpc.ClientConn) {
 	grpcCollector := testutils.StartGRPCCollector(t)
-	conn, err := grpc.Dial(grpcCollector.Listener().Addr().String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(grpcCollector.Listener().Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	rep := grpcrep.NewReporter(conn, map[string]string{}, zap.NewNop())
 	metricsFactory := metricstest.NewFactory(0)

--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 
@@ -68,7 +69,7 @@ func (b *ConnBuilder) CreateConnection(logger *zap.Logger, mFactory metrics.Fact
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(creds))
 	} else { // insecure connection
 		logger.Info("Agent requested insecure grpc connection to collector(s)")
-		dialOptions = append(dialOptions, grpc.WithInsecure())
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	if b.Notifier != nil && b.Discoverer != nil {

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
@@ -55,7 +56,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 		api_v2.RegisterCollectorServiceServer(s, handler)
 	})
 	defer s.Stop()
-	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	//nolint:staticcheck // don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
@@ -93,7 +94,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 		api_v2.RegisterCollectorServiceServer(s, handler)
 	})
 	defer s.Stop()
-	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	//nolint:staticcheck // don't care about errors
 	defer conn.Close()
 	require.NoError(t, err)
@@ -120,7 +121,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 }
 
 func TestReporter_SendFailure(t *testing.T) {
-	conn, err := grpc.Dial("", grpc.WithInsecure())
+	conn, err := grpc.Dial("", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	rep := NewReporter(conn, nil, zap.NewNop())
 	err = rep.send(context.Background(), nil, nil)

--- a/cmd/anonymizer/app/query/query.go
+++ b/cmd/anonymizer/app/query/query.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -39,7 +40,7 @@ func New(addr string) (*Query, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure())
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect with the jaeger-query service: %w", err)
 	}

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	"github.com/jaegertracing/jaeger/model"
@@ -74,7 +75,7 @@ func initializeGRPCTestServer(t *testing.T, beforeServe func(s *grpc.Server)) (*
 }
 
 func newClient(t *testing.T, addr net.Addr) (api_v2.CollectorServiceClient, *grpc.ClientConn) {
-	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	return api_v2.NewCollectorServiceClient(conn), conn
 }

--- a/cmd/collector/app/server/grpc_test.go
+++ b/cmd/collector/app/server/grpc_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
@@ -84,7 +85,7 @@ func TestSpanCollector(t *testing.T) {
 
 	serveGRPC(server, listener, params)
 
-	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/cmd/query/app/apiv3/grpc_gateway.go
+++ b/cmd/query/app/apiv3/grpc_gateway.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v3"
@@ -49,7 +50,7 @@ func RegisterGRPCGateway(ctx context.Context, logger *zap.Logger, r *mux.Router,
 		creds := credentials.NewTLS(tlsCfg)
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
 	} else {
-		dialOpts = append(dialOpts, grpc.WithInsecure())
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 	return api_v3.RegisterQueryServiceHandlerFromEndpoint(ctx, grpcGatewayMux, grpcEndpoint, dialOpts)
 }

--- a/cmd/query/app/apiv3/grpc_handler_test.go
+++ b/cmd/query/app/apiv3/grpc_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
@@ -66,7 +67,7 @@ func TestGetTrace(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -92,7 +93,7 @@ func TestGetTrace_storage_error(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -120,7 +121,7 @@ func TestGetTrace_traceID_error(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -154,7 +155,7 @@ func TestFindTraces(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -181,7 +182,7 @@ func TestFindTraces_query_nil(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -217,7 +218,7 @@ func TestFindTraces_storage_error(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -248,7 +249,7 @@ func TestGetServices(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -269,7 +270,7 @@ func TestGetServices_storage_error(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -294,7 +295,7 @@ func TestGetOperations(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)
@@ -319,7 +320,7 @@ func TestGetOperations_storage_error(t *testing.T) {
 	server, addr := newGrpcServer(t, h)
 	defer server.Stop()
 
-	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()
 	client := api_v3.NewQueryServiceClient(conn)

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
@@ -168,7 +169,7 @@ func newGRPCServer(t *testing.T, q *querysvc.QueryService, mq querysvc.MetricsQu
 func newGRPCClient(t *testing.T, addr string) *grpcClient {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure())
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 
 	return &grpcClient{

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/cmd/flags"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
@@ -430,7 +431,7 @@ func newGRPCClientWithTLS(t *testing.T, addr string, creds credentials.Transport
 	if creds != nil {
 		conn, err = grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(creds))
 	} else {
-		conn, err = grpc.DialContext(ctx, addr, grpc.WithInsecure())
+		conn, err = grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	require.NoError(t, err)

--- a/examples/hotrod/services/driver/client.go
+++ b/examples/hotrod/services/driver/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/log"
 )
@@ -36,7 +37,7 @@ type Client struct {
 
 // NewClient creates a new driver.Client
 func NewClient(tracer opentracing.Tracer, logger log.Factory, hostPort string) *Client {
-	conn, err := grpc.Dial(hostPort, grpc.WithInsecure(),
+	conn, err := grpc.Dial(hostPort, grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithUnaryInterceptor(
 			otgrpc.OpenTracingClientInterceptor(tracer)),
 		grpc.WithStreamInterceptor(

--- a/pkg/discovery/grpcresolver/grpc_resolver_test.go
+++ b/pkg/discovery/grpcresolver/grpc_resolver_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
 	grpctest "google.golang.org/grpc/test/grpc_testing"
@@ -146,7 +147,7 @@ func TestGRPCResolverRoundRobin(t *testing.T) {
 			res := New(notifier, discoverer, zap.NewNop(), test.minPeers)
 			defer resolver.UnregisterForTesting(res.Scheme())
 
-			cc, err := grpc.Dial(res.Scheme()+":///round_robin", grpc.WithInsecure(), grpc.WithDefaultServiceConfig(GRPCServiceConfig))
+			cc, err := grpc.Dial(res.Scheme()+":///round_robin", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(GRPCServiceConfig))
 			assert.NoError(t, err, "could not dial using resolver's scheme")
 			defer cc.Close()
 

--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
@@ -82,7 +83,7 @@ func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, 
 		creds := credentials.NewTLS(tlsCfg)
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	} else {
-		opts = append(opts, grpc.WithInsecure())
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.RemoteConnectTimeout)


### PR DESCRIPTION
This change keeps staticcheck linter from failing when grpc is updated to v1.43 or higher.
Because after that version, grpc.WithInsecure is marked as deprecated.

See: https://github.com/grpc/grpc-go/pull/4718
Closes #3450

Signed-off-by: Benedikt Bongartz <benne@klimlive.de>
