### PR TITLE
Fix prefixed index rollover

### DIFF
--- a/cmd/es-rollover/app/flags.go
+++ b/cmd/es-rollover/app/flags.go
@@ -56,6 +56,9 @@ func AddFlags(flags *flag.FlagSet) {
 // InitFromViper initializes config from viper.Viper.
 func (c *Config) InitFromViper(v *viper.Viper) {
 	c.IndexPrefix = v.GetString(indexPrefix)
+	if c.IndexPrefix != "" {
+		c.IndexPrefix += "-"
+	}
 	c.Archive = v.GetBool(archive)
 	c.Username = v.GetString(username)
 	c.Password = v.GetString(password)

--- a/cmd/es-rollover/app/flags_test.go
+++ b/cmd/es-rollover/app/flags_test.go
@@ -45,7 +45,7 @@ func TestBindFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	c.InitFromViper(v)
-	assert.Equal(t, "tenant1", c.IndexPrefix)
+	assert.Equal(t, "tenant1-", c.IndexPrefix)
 	assert.Equal(t, true, c.Archive)
 	assert.Equal(t, 150, c.Timeout)
 	assert.Equal(t, "admin", c.Username)

--- a/cmd/es-rollover/app/index_options.go
+++ b/cmd/es-rollover/app/index_options.go
@@ -56,7 +56,7 @@ func RolloverIndices(archive bool, prefix string) []IndexOption {
 }
 
 func (i *IndexOption) IndexName() string {
-	return strings.TrimLeft(fmt.Sprintf("%s-%s", i.prefix, i.indexType), "-")
+	return strings.TrimLeft(fmt.Sprintf("%s%s", i.prefix, i.indexType), "-")
 }
 
 // ReadAliasName returns read alias name of the index
@@ -76,5 +76,5 @@ func (i *IndexOption) InitialRolloverIndex() string {
 
 // TemplateName returns the prefixed template name
 func (i *IndexOption) TemplateName() string {
-	return strings.TrimLeft(fmt.Sprintf("%s-%s", i.prefix, i.Mapping), "-")
+	return strings.TrimLeft(fmt.Sprintf("%s%s", i.prefix, i.Mapping), "-")
 }

--- a/cmd/es-rollover/app/index_options_test.go
+++ b/cmd/es-rollover/app/index_options_test.go
@@ -105,6 +105,9 @@ func TestRolloverIndices(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.prefix != "" {
+				test.prefix += "-"
+			}
 			result := RolloverIndices(test.archive, test.prefix)
 			for i, r := range result {
 				assert.Equal(t, test.expected[i].templateName, r.TemplateName())

--- a/pkg/es/client/index_client.go
+++ b/pkg/es/client/index_client.go
@@ -61,10 +61,13 @@ type IndicesClient struct {
 //     aliases: jaeger-span-archive-read, jaeger-span-archive-write
 //         indices: jaeger-span-archive-000001
 func (i *IndicesClient) GetJaegerIndices(prefix string) ([]Index, error) {
-	prefix += "jaeger-*"
+	indexPattern := "jaeger-*"
+	if prefix != "" {
+		indexPattern = strings.Join([]string{prefix, indexPattern}, "-")
+	}
 
 	body, err := i.request(elasticRequest{
-		endpoint: fmt.Sprintf("%s?flat_settings=true&filter_path=*.aliases,*.settings", prefix),
+		endpoint: fmt.Sprintf("%s?flat_settings=true&filter_path=*.aliases,*.settings", indexPattern),
 		method:   http.MethodGet,
 	})
 

--- a/pkg/es/client/index_client.go
+++ b/pkg/es/client/index_client.go
@@ -61,13 +61,10 @@ type IndicesClient struct {
 //     aliases: jaeger-span-archive-read, jaeger-span-archive-write
 //         indices: jaeger-span-archive-000001
 func (i *IndicesClient) GetJaegerIndices(prefix string) ([]Index, error) {
-	indexPattern := "jaeger-*"
-	if prefix != "" {
-		indexPattern = strings.Join([]string{prefix, indexPattern}, "-")
-	}
+	prefix += "jaeger-*"
 
 	body, err := i.request(elasticRequest{
-		endpoint: fmt.Sprintf("%s?flat_settings=true&filter_path=*.aliases,*.settings", indexPattern),
+		endpoint: fmt.Sprintf("%s?flat_settings=true&filter_path=*.aliases,*.settings", prefix),
 		method:   http.MethodGet,
 	})
 

--- a/pkg/es/client/index_client_test.go
+++ b/pkg/es/client/index_client_test.go
@@ -104,7 +104,7 @@ func TestClientGetIndices(t *testing.T) {
 		},
 		{
 			name:         "no error with prefix",
-			prefix:       "foo",
+			prefix:       "foo-",
 			responseCode: http.StatusOK,
 			response:     esIndexResponse,
 			indices: []Index{
@@ -144,13 +144,9 @@ func TestClientGetIndices(t *testing.T) {
 				res.WriteHeader(test.responseCode)
 
 				response := test.response
-				// Formatted string only applies to "success" response bodies.
 				if test.errContains == "" {
-					var prefix string
-					if test.prefix != "" {
-						prefix = test.prefix + "-"
-					}
-					response = fmt.Sprintf(test.response, prefix, prefix, prefix)
+					// Formatted string only applies to "success" response bodies.
+					response = fmt.Sprintf(test.response, test.prefix, test.prefix, test.prefix)
 				}
 				res.Write([]byte(response))
 			}))

--- a/pkg/es/client/index_client_test.go
+++ b/pkg/es/client/index_client_test.go
@@ -30,7 +30,7 @@ import (
 
 const esIndexResponse = `
 {
-  "jaeger-service-2021-08-06" : {
+  "%sjaeger-service-2021-08-06" : {
     "aliases" : { },
     "settings" : {
       "index.creation_date" : "1628259381266",
@@ -44,7 +44,7 @@ const esIndexResponse = `
       "index.version.created" : "5061099"
     }
   },
-  "jaeger-span-2021-08-06" : {
+  "%sjaeger-span-2021-08-06" : {
     "aliases" : { },
     "settings" : {
       "index.creation_date" : "1628259381326",
@@ -58,7 +58,7 @@ const esIndexResponse = `
       "index.version.created" : "5061099"
     }
   },
- "jaeger-span-000001" : {
+ "%sjaeger-span-000001" : {
     "aliases" : {
       "jaeger-span-read" : { },
       "jaeger-span-write" : { }
@@ -74,6 +74,7 @@ const esErrResponse = `{"error":{"root_cause":[{"type":"illegal_argument_excepti
 func TestClientGetIndices(t *testing.T) {
 	tests := []struct {
 		name         string
+		prefix       string
 		responseCode int
 		response     string
 		errContains  string
@@ -102,6 +103,29 @@ func TestClientGetIndices(t *testing.T) {
 			},
 		},
 		{
+			name:         "no error with prefix",
+			prefix:       "foo",
+			responseCode: http.StatusOK,
+			response:     esIndexResponse,
+			indices: []Index{
+				{
+					Index:        "foo-jaeger-service-2021-08-06",
+					CreationTime: time.Unix(0, int64(time.Millisecond)*1628259381266),
+					Aliases:      map[string]bool{},
+				},
+				{
+					Index:        "foo-jaeger-span-000001",
+					CreationTime: time.Unix(0, int64(time.Millisecond)*1628259381326),
+					Aliases:      map[string]bool{"jaeger-span-read": true, "jaeger-span-write": true},
+				},
+				{
+					Index:        "foo-jaeger-span-2021-08-06",
+					CreationTime: time.Unix(0, int64(time.Millisecond)*1628259381326),
+					Aliases:      map[string]bool{},
+				},
+			},
+		},
+		{
 			name:         "client error",
 			responseCode: http.StatusBadRequest,
 			response:     esErrResponse,
@@ -118,7 +142,17 @@ func TestClientGetIndices(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 				res.WriteHeader(test.responseCode)
-				res.Write([]byte(test.response))
+
+				response := test.response
+				// Formatted string only applies to "success" response bodies.
+				if test.errContains == "" {
+					var prefix string
+					if test.prefix != "" {
+						prefix = test.prefix + "-"
+					}
+					response = fmt.Sprintf(test.response, prefix, prefix, prefix)
+				}
+				res.Write([]byte(response))
 			}))
 			defer testServer.Close()
 
@@ -129,7 +163,7 @@ func TestClientGetIndices(t *testing.T) {
 				},
 			}
 
-			indices, err := c.GetJaegerIndices("")
+			indices, err := c.GetJaegerIndices(test.prefix)
 			if test.errContains != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.errContains)


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Which problem is this PR solving?
- Resolves #3441 

## Short description of the changes
- Fixes the bug where read aliases are not rolled over, and remain on the first index.

## Testing
- Update unit tests.

- Reproduced the bug locally; output of aliases after 3 rollovers with prefixes (note write aliases successfully rollover, but read aliases remain pointing to first index):
```
foo-jaeger-service-write foo-jaeger-service-000003 - - - -
foo-jaeger-span-read     foo-jaeger-span-000001    - - - -
foo-jaeger-service-read  foo-jaeger-service-000001 - - - -
foo-jaeger-span-write    foo-jaeger-span-000003    - - - -
```

- After the fix, the aliases look like the following after 3 rollovers (note each rolled over index is tracked by the read alias):
```
foo-jaeger-service-read  foo-jaeger-service-000001 - - - -
foo-jaeger-span-read     foo-jaeger-span-000001    - - - -
foo-jaeger-span-read     foo-jaeger-span-000003    - - - -
foo-jaeger-span-write    foo-jaeger-span-000003    - - - -
foo-jaeger-service-read  foo-jaeger-service-000002 - - - -
foo-jaeger-service-read  foo-jaeger-service-000003 - - - -
foo-jaeger-service-write foo-jaeger-service-000003 - - - -
foo-jaeger-span-read     foo-jaeger-span-000002    - - - -
```

- Checked counts of prefixed indices against prefixed alias:
```
GET /foo-jaeger-span-read/_search # 53
GET /foo-jaeger-span-000001/_search # 28
GET /foo-jaeger-span-000002/_search # 20
GET /foo-jaeger-span-000003/_search # 5
```

- Checked aliases when no prefix is defined to ensure no regression introduced:
```
jaeger-span-read     jaeger-span-000002    - - - -
jaeger-service-read  jaeger-service-000003 - - - -
jaeger-service-write jaeger-service-000003 - - - -
jaeger-service-read  jaeger-service-000002 - - - -
jaeger-span-read     jaeger-span-000003    - - - -
jaeger-span-write    jaeger-span-000003    - - - -
jaeger-service-read  jaeger-service-000001 - - - -
jaeger-span-read     jaeger-span-000001    - - - -
```