### PR TITLE
jpkrohling as emeritus maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ Please use `@jaegertracing/jaeger-maintainers` to tag them on issues / PRs.
 
 * [@albertteoh](https://github.com/albertteoh)
 * [@joe-elliott](https://github.com/joe-elliott)
-* [@jpkrohling](https://github.com/jpkrohling)
 * [@pavolloffay](https://github.com/pavolloffay)
 * [@vprithvi](https://github.com/vprithvi)
 * [@yurishkuro](https://github.com/yurishkuro)
@@ -161,6 +160,7 @@ Some repositories under [jaegertracing](https://github.com/jaegertracing) org ha
 We are grateful to our former maintainers for their contributions to the Jaeger project.
 
 * [@black-adder](https://github.com/black-adder)
+* [@jpkrohling](https://github.com/jpkrohling)
 * [@objectiser](https://github.com/objectiser)
 * [@tiffon](https://github.com/tiffon)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,7 +40,6 @@ Here are the release managers for future versions with the tentative release dat
 |---------|------------------|------------------------|
 | 1.31.0  | @vprithvi        | 2 February  2022       |
 | 1.32.0  | @yurishkuro      | 2 March     2022       |
-| 1.33.0  | @jpkrohling      | 6 April     2022       |
-| 1.34.0  | @albertteoh      | 4 May       2022       |
-| 1.35.0  | @joe-elliott     | 1 June      2022       |
-| 1.36.0  | @pavolloffay     | 6 July      2022       |
+| 1.33.0  | @albertteoh      | 6 April     2022       |
+| 1.34.0  | @joe-elliott     | 4 May       2022       |
+| 1.35.0  | @pavolloffay     | 1 June      2022       |


### PR DESCRIPTION
Dear Jaeger Community, dear fellow Jaeger maintainers (@jaegertracing/jaeger-maintainers),

After [almost four years](https://github.com/jaegertracing/jaeger/issues/849) as a Jaeger maintainer, I'm resigning today. It's a tough decision, but one that I think is in the best interest of the project. As Jaeger moves toward v2, it needs people who can actually provide engineering work to the project, and I cannot realistically provide it.

My contributions to the OpenTelemetry community, especially the OpenTelemetry Collector, started as a way to build the features there that I thought would be useful to Jaeger v2, such as the auth and multitenancy capabilities. My involvement there kept growing, to the point where I was way more active there than here. Even before moving to Grafana Labs, I already had minimal engineering work being done as part of the Jaeger project. As I don't see this changing anytime soon, I don't think it's fair to keep having a maintainer status here.

I wanted to make it clear that I have the official backing of Grafana Labs to work on Jaeger and that this decision is a personal one.

I could learn a lot while contributing to this project, and I'm thankful for that. I'm sure I'll see you all around in a way or another :-)

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
