### PR TITLE
fix(integration): no spans in the future

### DIFF
--- a/plugin/storage/integration/integration_test.go
+++ b/plugin/storage/integration/integration_test.go
@@ -327,10 +327,10 @@ func loadAndParseJSON(t *testing.T, path string, object interface{}) {
 func correctTime(json []byte) []byte {
 	jsonString := string(json)
 	now := time.Now().UTC()
-	today := now.Format("2006-01-02")
 	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
-	retString := strings.Replace(jsonString, "2017-01-26", today, -1)
-	retString = strings.Replace(retString, "2017-01-25", yesterday, -1)
+	twoDaysAgo := now.AddDate(0, 0, -2).Format("2006-01-02")
+	retString := strings.Replace(jsonString, "2017-01-26", yesterday, -1)
+	retString = strings.Replace(retString, "2017-01-25", twoDaysAgo, -1)
 	return []byte(retString)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

I'm using the integration test framework to test my custom [grpc plugin](https://github.com/johanneswuerbach/jaeger-s3), which is working great, except that it can't really deal with traces hours in the future.

Traces in the future are happening if you run the tests before 16:00 UTC as on fixture loading only the date is replaced with the current day, but not the time.

If I run my tests after 17:00 UTC all tests pass as all spans are now in the past.

## Short description of the changes
- Adjusted the timeframe to be yesterday and the day before to ensure no spans are generated in the future.
