### PR TITLE
Add support for ciphersuites in tls config

### DIFF
--- a/pkg/config/tlscfg/ciphersuites.go
+++ b/pkg/config/tlscfg/ciphersuites.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlscfg
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+)
+
+var (
+	// https://golang.org/pkg/crypto/tls/#pkg-constants
+	ciphers         = map[string]uint16{}
+	insecureCiphers = map[string]uint16{}
+)
+
+func init() {
+	for _, suite := range tls.CipherSuites() {
+		ciphers[suite.Name] = suite.ID
+	}
+	for _, suite := range tls.InsecureCipherSuites() {
+		insecureCiphers[suite.Name] = suite.ID
+	}
+}
+
+func allCiphers() map[string]uint16 {
+	acceptedCiphers := make(map[string]uint16, len(ciphers))
+	for k, v := range ciphers {
+		acceptedCiphers[k] = v
+	}
+	for k, v := range insecureCiphers {
+		acceptedCiphers[k] = v
+	}
+	return acceptedCiphers
+}
+
+// TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed.
+func TLSCipherSuites(cipherNames string) ([]uint16, error) {
+	if cipherNames == "" {
+		return nil, nil
+	}
+	ciphersIntSlice := make([]uint16, 0)
+	possibleCiphers := allCiphers()
+	for _, cipher := range strings.Split(cipherNames, ",") {
+		intValue, ok := possibleCiphers[cipher]
+		if !ok {
+			return nil, fmt.Errorf("cipher suite %s not supported or doesn't exist", cipher)
+		}
+		ciphersIntSlice = append(ciphersIntSlice, intValue)
+	}
+	return ciphersIntSlice, nil
+}

--- a/pkg/config/tlscfg/ciphersuites.go
+++ b/pkg/config/tlscfg/ciphersuites.go
@@ -17,48 +17,29 @@ package tlscfg
 import (
 	"crypto/tls"
 	"fmt"
-	"strings"
 )
-
-var (
-	// https://golang.org/pkg/crypto/tls/#pkg-constants
-	ciphers         = map[string]uint16{}
-	insecureCiphers = map[string]uint16{}
-)
-
-func init() {
-	for _, suite := range tls.CipherSuites() {
-		ciphers[suite.Name] = suite.ID
-	}
-	for _, suite := range tls.InsecureCipherSuites() {
-		insecureCiphers[suite.Name] = suite.ID
-	}
-}
 
 func allCiphers() map[string]uint16 {
-	acceptedCiphers := make(map[string]uint16, len(ciphers))
-	for k, v := range ciphers {
-		acceptedCiphers[k] = v
-	}
-	for k, v := range insecureCiphers {
-		acceptedCiphers[k] = v
+	acceptedCiphers := make(map[string]uint16)
+	for _, suite := range tls.CipherSuites() {
+		acceptedCiphers[suite.Name] = suite.ID
 	}
 	return acceptedCiphers
 }
 
-// TLSCipherSuites returns a list of cipher suite IDs from the cipher suite names passed.
-func TLSCipherSuites(cipherNames string) ([]uint16, error) {
-	if cipherNames == "" {
+// CipherSuiteNamesToIDs returns a list of cipher suite IDs from the cipher suite names passed.
+func CipherSuiteNamesToIDs(cipherNames []string) ([]uint16, error) {
+	if len(cipherNames) == 0 {
 		return nil, nil
 	}
-	ciphersIntSlice := make([]uint16, 0)
+	var ciphersIDs []uint16
 	possibleCiphers := allCiphers()
-	for _, cipher := range strings.Split(cipherNames, ",") {
+	for _, cipher := range cipherNames {
 		intValue, ok := possibleCiphers[cipher]
 		if !ok {
 			return nil, fmt.Errorf("cipher suite %s not supported or doesn't exist", cipher)
 		}
-		ciphersIntSlice = append(ciphersIntSlice, intValue)
+		ciphersIDs = append(ciphersIDs, intValue)
 	}
-	return ciphersIntSlice, nil
+	return ciphersIDs, nil
 }

--- a/pkg/config/tlscfg/ciphersuites.go
+++ b/pkg/config/tlscfg/ciphersuites.go
@@ -29,9 +29,6 @@ func allCiphers() map[string]uint16 {
 
 // CipherSuiteNamesToIDs returns a list of cipher suite IDs from the cipher suite names passed.
 func CipherSuiteNamesToIDs(cipherNames []string) ([]uint16, error) {
-	if len(cipherNames) == 0 {
-		return nil, nil
-	}
 	var ciphersIDs []uint16
 	possibleCiphers := allCiphers()
 	for _, cipher := range cipherNames {

--- a/pkg/config/tlscfg/ciphersuites_test.go
+++ b/pkg/config/tlscfg/ciphersuites_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlscfg
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+)
+
+func TestTLSCipherSuites(t *testing.T) {
+	tests := []struct {
+		flag          string
+		expected      []uint16
+		expectedError bool
+	}{
+		{
+			// Happy case
+			flag:          "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			expected:      []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384},
+			expectedError: false,
+		},
+		{
+			// One flag only
+			flag:          "TLS_AES_128_GCM_SHA256",
+			expected:      []uint16{tls.TLS_AES_128_GCM_SHA256},
+			expectedError: false,
+		},
+		{
+			// Empty flag
+			flag:          "",
+			expected:      nil,
+			expectedError: false,
+		},
+		{
+			// Duplicated flag
+			flag:          "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256",
+			expected:      []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_AES_128_GCM_SHA256},
+			expectedError: false,
+		},
+		{
+			// Invalid flag
+			flag:          "TLS_INVALID_CIPHER_SUITE",
+			expected:      nil,
+			expectedError: true,
+		},
+	}
+
+	for i, test := range tests {
+		uIntFlags, err := TLSCipherSuites(test.flag)
+		if !reflect.DeepEqual(uIntFlags, test.expected) {
+			t.Errorf("%d: expected %+v, got %+v", i, test.expected, uIntFlags)
+		}
+		if test.expectedError && err == nil {
+			t.Errorf("%d: expecting error, got %+v", i, err)
+		}
+	}
+}

--- a/pkg/config/tlscfg/ciphersuites_test.go
+++ b/pkg/config/tlscfg/ciphersuites_test.go
@@ -22,44 +22,44 @@ import (
 
 func TestTLSCipherSuites(t *testing.T) {
 	tests := []struct {
-		flag          string
+		flag          []string
 		expected      []uint16
 		expectedError bool
 	}{
 		{
 			// Happy case
-			flag:          "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			flag:          []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"},
 			expected:      []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384},
 			expectedError: false,
 		},
 		{
 			// One flag only
-			flag:          "TLS_AES_128_GCM_SHA256",
+			flag:          []string{"TLS_AES_128_GCM_SHA256"},
 			expected:      []uint16{tls.TLS_AES_128_GCM_SHA256},
 			expectedError: false,
 		},
 		{
 			// Empty flag
-			flag:          "",
+			flag:          []string{},
 			expected:      nil,
 			expectedError: false,
 		},
 		{
 			// Duplicated flag
-			flag:          "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256",
+			flag:          []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"},
 			expected:      []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_AES_128_GCM_SHA256},
 			expectedError: false,
 		},
 		{
 			// Invalid flag
-			flag:          "TLS_INVALID_CIPHER_SUITE",
+			flag:          []string{"TLS_INVALID_CIPHER_SUITE"},
 			expected:      nil,
 			expectedError: true,
 		},
 	}
 
 	for i, test := range tests {
-		uIntFlags, err := TLSCipherSuites(test.flag)
+		uIntFlags, err := CipherSuiteNamesToIDs(test.flag)
 		if !reflect.DeepEqual(uIntFlags, test.expected) {
 			t.Errorf("%d: expected %+v, got %+v", i, test.expected, uIntFlags)
 		}

--- a/pkg/config/tlscfg/flags.go
+++ b/pkg/config/tlscfg/flags.go
@@ -16,6 +16,7 @@ package tlscfg
 
 import (
 	"flag"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -80,6 +81,11 @@ func (c ServerFlagsConfig) InitFromViper(v *viper.Viper) Options {
 	p.CertPath = v.GetString(c.Prefix + tlsCert)
 	p.KeyPath = v.GetString(c.Prefix + tlsKey)
 	p.ClientCAPath = v.GetString(c.Prefix + tlsClientCA)
-	p.CipherSuites = v.GetStringSlice(c.Prefix + tlsCipherSuites)
+	p.CipherSuites = strings.Split(stripWhiteSpace(v.GetString(c.Prefix+tlsCipherSuites)), ",")
 	return p
+}
+
+// stripWhiteSpace removes all whitespace characters from a string
+func stripWhiteSpace(str string) string {
+	return strings.Replace(str, " ", "", -1)
 }

--- a/pkg/config/tlscfg/flags.go
+++ b/pkg/config/tlscfg/flags.go
@@ -58,7 +58,7 @@ func (c ServerFlagsConfig) AddFlags(flags *flag.FlagSet) {
 	flags.String(c.Prefix+tlsCert, "", "Path to a TLS Certificate file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsKey, "", "Path to a TLS Private Key file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsClientCA, "", "Path to a TLS CA (Certification Authority) file used to verify certificates presented by clients (if unset, all clients are permitted)")
-	flags.String(c.Prefix+tlsCipherSuites, "", "Comma-separated list of cipher suites for the server, values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).")
+	flags.String(c.Prefix+tlsCipherSuites, "", "Space-separated list of cipher suites for the server, values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).")
 }
 
 // InitFromViper creates tls.Config populated with values retrieved from Viper.
@@ -80,6 +80,6 @@ func (c ServerFlagsConfig) InitFromViper(v *viper.Viper) Options {
 	p.CertPath = v.GetString(c.Prefix + tlsCert)
 	p.KeyPath = v.GetString(c.Prefix + tlsKey)
 	p.ClientCAPath = v.GetString(c.Prefix + tlsClientCA)
-	p.CipherSuites = v.GetString(c.Prefix + tlsCipherSuites)
+	p.CipherSuites = v.GetStringSlice(c.Prefix + tlsCipherSuites)
 	return p
 }

--- a/pkg/config/tlscfg/flags.go
+++ b/pkg/config/tlscfg/flags.go
@@ -29,6 +29,7 @@ const (
 	tlsServerName     = tlsPrefix + ".server-name"
 	tlsClientCA       = tlsPrefix + ".client-ca"
 	tlsSkipHostVerify = tlsPrefix + ".skip-host-verify"
+	tlsCipherSuites   = tlsPrefix + ".cipher-suites"
 )
 
 // ClientFlagsConfig describes which CLI flags for TLS client should be generated.
@@ -57,6 +58,7 @@ func (c ServerFlagsConfig) AddFlags(flags *flag.FlagSet) {
 	flags.String(c.Prefix+tlsCert, "", "Path to a TLS Certificate file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsKey, "", "Path to a TLS Private Key file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsClientCA, "", "Path to a TLS CA (Certification Authority) file used to verify certificates presented by clients (if unset, all clients are permitted)")
+	flags.String(c.Prefix+tlsCipherSuites, "", "Comma-separated list of cipher suites for the server, values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).")
 }
 
 // InitFromViper creates tls.Config populated with values retrieved from Viper.
@@ -78,5 +80,6 @@ func (c ServerFlagsConfig) InitFromViper(v *viper.Viper) Options {
 	p.CertPath = v.GetString(c.Prefix + tlsCert)
 	p.KeyPath = v.GetString(c.Prefix + tlsKey)
 	p.ClientCAPath = v.GetString(c.Prefix + tlsClientCA)
+	p.CipherSuites = v.GetString(c.Prefix + tlsCipherSuites)
 	return p
 }

--- a/pkg/config/tlscfg/flags.go
+++ b/pkg/config/tlscfg/flags.go
@@ -59,7 +59,7 @@ func (c ServerFlagsConfig) AddFlags(flags *flag.FlagSet) {
 	flags.String(c.Prefix+tlsCert, "", "Path to a TLS Certificate file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsKey, "", "Path to a TLS Private Key file, used to identify this server to clients")
 	flags.String(c.Prefix+tlsClientCA, "", "Path to a TLS CA (Certification Authority) file used to verify certificates presented by clients (if unset, all clients are permitted)")
-	flags.String(c.Prefix+tlsCipherSuites, "", "Space-separated list of cipher suites for the server, values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).")
+	flags.String(c.Prefix+tlsCipherSuites, "", "Comma-separated list of cipher suites for the server, values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).")
 }
 
 // InitFromViper creates tls.Config populated with values retrieved from Viper.

--- a/pkg/config/tlscfg/flags_test.go
+++ b/pkg/config/tlscfg/flags_test.go
@@ -74,7 +74,7 @@ func TestServerFlags(t *testing.T) {
 		"--prefix.tls.enabled=true",
 		"--prefix.tls.cert=cert-file",
 		"--prefix.tls.key=key-file",
-		"--prefix.tls.cipher-suites=TLS_RSA_WITH_RC4_128_SHA",
+		"--prefix.tls.cipher-suites=TLS_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
 	}
 
 	tests := []struct {
@@ -108,7 +108,7 @@ func TestServerFlags(t *testing.T) {
 				CertPath:     "cert-file",
 				KeyPath:      "key-file",
 				ClientCAPath: test.file,
-				CipherSuites: "TLS_RSA_WITH_RC4_128_SHA",
+				CipherSuites: []string{"TLS_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"},
 			}, tlsOpts)
 		})
 	}

--- a/pkg/config/tlscfg/flags_test.go
+++ b/pkg/config/tlscfg/flags_test.go
@@ -74,6 +74,7 @@ func TestServerFlags(t *testing.T) {
 		"--prefix.tls.enabled=true",
 		"--prefix.tls.cert=cert-file",
 		"--prefix.tls.key=key-file",
+		"--prefix.tls.cipher-suites=TLS_RSA_WITH_RC4_128_SHA",
 	}
 
 	tests := []struct {
@@ -107,6 +108,7 @@ func TestServerFlags(t *testing.T) {
 				CertPath:     "cert-file",
 				KeyPath:      "key-file",
 				ClientCAPath: test.file,
+				CipherSuites: "TLS_RSA_WITH_RC4_128_SHA",
 			}, tlsOpts)
 		})
 	}

--- a/pkg/config/tlscfg/flags_test.go
+++ b/pkg/config/tlscfg/flags_test.go
@@ -74,7 +74,7 @@ func TestServerFlags(t *testing.T) {
 		"--prefix.tls.enabled=true",
 		"--prefix.tls.cert=cert-file",
 		"--prefix.tls.key=key-file",
-		"--prefix.tls.cipher-suites=TLS_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+		"--prefix.tls.cipher-suites=TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
 	}
 
 	tests := []struct {

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -33,7 +33,7 @@ type Options struct {
 	KeyPath        string       `mapstructure:"key"`
 	ServerName     string       `mapstructure:"server_name"` // only for client-side TLS config
 	ClientCAPath   string       `mapstructure:"client_ca"`   // only for server-side TLS config for client auth
-	CipherSuites   string       `mapstructure:"cipher_suites"`
+	CipherSuites   []string     `mapstructure:"cipher_suites"`
 	SkipHostVerify bool         `mapstructure:"skip_host_verify"`
 	certWatcher    *certWatcher `mapstructure:"-"`
 }
@@ -47,7 +47,7 @@ func (p *Options) Config(logger *zap.Logger) (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to load CA CertPool: %w", err)
 	}
 
-	cipherSuiteIds, err := TLSCipherSuites(p.CipherSuites)
+	cipherSuiteIds, err := CipherSuiteNamesToIDs(p.CipherSuites)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cipher suite ids from cipher suite names: %w", err)
 	}

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	KeyPath        string       `mapstructure:"key"`
 	ServerName     string       `mapstructure:"server_name"` // only for client-side TLS config
 	ClientCAPath   string       `mapstructure:"client_ca"`   // only for server-side TLS config for client auth
+	CipherSuites   string       `mapstructure:"cipher_suites"`
 	SkipHostVerify bool         `mapstructure:"skip_host_verify"`
 	certWatcher    *certWatcher `mapstructure:"-"`
 }
@@ -41,17 +42,24 @@ var systemCertPool = x509.SystemCertPool // to allow overriding in unit test
 
 // Config loads TLS certificates and returns a TLS Config.
 func (p *Options) Config(logger *zap.Logger) (*tls.Config, error) {
-
 	certPool, err := p.loadCertPool()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load CA CertPool: %w", err)
 	}
+
+	cipherSuiteIds, err := TLSCipherSuites(p.CipherSuites)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cipher suite ids from cipher suite names: %w", err)
+	}
+
 	// #nosec G402
 	tlsCfg := &tls.Config{
 		RootCAs:            certPool,
 		ServerName:         p.ServerName,
 		InsecureSkipVerify: p.SkipHostVerify,
+		CipherSuites:       cipherSuiteIds,
 	}
+
 	if p.ClientCAPath != "" {
 		certPool := x509.NewCertPool()
 		if err := addCertToPool(p.ClientCAPath, certPool); err != nil {

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -121,6 +121,13 @@ func TestOptionsToConfig(t *testing.T) {
 				ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
 			},
 		},
+		{
+			name: "should fail with invalid Cipher Suite",
+			options: Options{
+				CipherSuites: []string{"TLS_INVALID_CIPHER_SUITE"},
+			},
+			expectError: "failed to get cipher suite ids from cipher suite names: cipher suite TLS_INVALID_CIPHER_SUITE not supported or doesn't exist",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Signed-off-by: Ashmita <ashmita.bohara@logz.io>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Part of  https://github.com/jaegertracing/jaeger/issues/3019

## Short description of the changes
In golang's tls package, there are two kinds of ciphers: secure and insecure, we need to support both hence we are creating a map of all ciphers (mapping cipherName to cipherID) 

I will raise min tls version support as separate pr.
