### PR TITLE
Fix favicon returning 500 inside container

### DIFF
--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -62,6 +62,10 @@ func TestAllInOne(t *testing.T) {
 	if err := healthCheck(); err != nil {
 		t.Fatal(err)
 	}
+	// Check if the favicon icon is available
+	if err := faviconCheck(); err != nil {
+		t.Fatal(err)
+	}
 	createTrace(t)
 	getAPITrace(t)
 	getSamplingStrategy(t)
@@ -136,6 +140,18 @@ func healthCheck() error {
 		time.Sleep(time.Second)
 	}
 	return fmt.Errorf("query service is not ready")
+}
+
+func faviconCheck() error {
+	println("Checking favicon...")
+	resp, err := http.Get(queryURL + "/favicon.ico")
+	if err == nil && resp.StatusCode == http.StatusOK {
+		println("Favicon check successful")
+		return nil
+	} else {
+		println("Favicon check failed")
+		return fmt.Errorf("all-in-one failed to serve favicon icon")
+	}
 }
 
 func getServicesAPIV3(t *testing.T) {

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -2,7 +2,7 @@ ARG cert_image
 ARG root_image
 
 FROM $cert_image AS cert
-RUN apk add --update --no-cache ca-certificates
+RUN apk add --update --no-cache ca-certificates mailcap
 
 FROM $root_image
 COPY --from=cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -6,3 +6,4 @@ RUN apk add --update --no-cache ca-certificates mailcap
 
 FROM $root_image
 COPY --from=cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=cert /etc/mime.types /etc/mime.types

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -15,3 +15,4 @@ RUN if [[ "$TARGETARCH" == "s390x"  ||  "$TARGETARCH" == "ppc64le" ]] ; then \
 FROM $golang_image
 COPY --from=build /go/bin/dlv /go/bin/dlv
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /etc/mime.types /etc/mime.types

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -3,7 +3,7 @@ ARG golang_image
 FROM $golang_image AS build
 ARG TARGETARCH
 ENV GOPATH /go
-RUN apk add --update --no-cache ca-certificates make git build-base
+RUN apk add --update --no-cache ca-certificates make git build-base mailcap
 #Once go-delve adds support for s390x (see PR #2948), remove this entire conditional.
 #Once go-delve adds support for ppc64le (see PR go-delve/delve#1564), remove this entire conditional.
 RUN if [[ "$TARGETARCH" == "s390x"  ||  "$TARGETARCH" == "ppc64le" ]] ; then \


### PR DESCRIPTION
Signed-off-by: Ashmita152 <ashmita.bohara@logz.io>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/3563

## Short description of the changes
- net/http depends on mime-type to set the Content-Type for a http response (https://github.com/golang/go/blob/master/src/net/http/fs.go#L173-L176)
- mime-type is calculated using https://pkg.go.dev/mime#TypeByExtension (https://github.com/golang/go/blob/master/src/net/http/fs.go#L235)
- In alpine, there is no default installation of mime-type library hence net/http was setting application/text for favicon.ico which was leading to 500. Adding mailcap package will install /etc/mime.types (https://pkgs.alpinelinux.org/contents?branch=edge&name=mailcap&arch=x86_64&repo=main) and fix the issue by setting the right content-type.

cc @yurishkuro 
