### PR TITLE
Use ES7 index mapping files for ES8 and higher too

### DIFF
--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -22,6 +22,9 @@ jobs:
         - major: 7.x
           image: 7.14.0
           distribution: elasticsearch
+        - major: 8.x
+          image: 8.1.0
+          distribution: elasticsearch
     name: ${{ matrix.version.distribution }} ${{ matrix.version.major }}
     steps:
     - uses: actions/checkout@v3

--- a/plugin/storage/es/mappings/mapping.go
+++ b/plugin/storage/es/mappings/mapping.go
@@ -39,7 +39,7 @@ type MappingBuilder struct {
 
 // GetMapping returns the rendered mapping based on elasticsearch version
 func (mb *MappingBuilder) GetMapping(mapping string) (string, error) {
-	if mb.EsVersion == 7 {
+	if mb.EsVersion >= 7 {
 		return mb.fixMapping(mapping + "-7.json")
 	}
 	return mb.fixMapping(mapping + ".json")

--- a/plugin/storage/es/mappings/mapping_test.go
+++ b/plugin/storage/es/mappings/mapping_test.go
@@ -114,7 +114,7 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 				tb.On("Parse", mock.Anything).Return(&ta, nil)
 				return &tb
 			},
-			err: "",
+			err:       "",
 			esVersion: 7,
 		},
 		{
@@ -126,7 +126,7 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 				tb.On("Parse", mock.Anything).Return(&ta, nil)
 				return &tb
 			},
-			err: "template exec error",
+			err:       "template exec error",
 			esVersion: 7,
 		},
 		{
@@ -136,7 +136,7 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 				tb.On("Parse", mock.Anything).Return(nil, errors.New("template load error"))
 				return &tb
 			},
-			err: "template load error",
+			err:       "template load error",
 			esVersion: 7,
 		},
 		{
@@ -148,7 +148,7 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 				tb.On("Parse", mock.Anything).Return(&ta, nil)
 				return &tb
 			},
-			err: "",
+			err:       "",
 			esVersion: 8,
 		},
 		{
@@ -160,7 +160,7 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 				tb.On("Parse", mock.Anything).Return(&ta, nil)
 				return &tb
 			},
-			err: "template exec error",
+			err:       "template exec error",
 			esVersion: 8,
 		},
 		{
@@ -170,7 +170,7 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 				tb.On("Parse", mock.Anything).Return(nil, errors.New("template load error"))
 				return &tb
 			},
-			err: "template load error",
+			err:       "template load error",
 			esVersion: 8,
 		},
 	}

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -24,8 +24,12 @@ setup_es() {
     --env "http.host=0.0.0.0"
     --env "transport.host=127.0.0.1"
     --env "xpack.security.enabled=false"
-    --env "xpack.monitoring.enabled=false"
   )
+  if [ ${1:0:1} = "8" ]; then
+    params+=(--env "xpack.monitoring.templates.enabled=false")
+  else
+    params+=(--env "xpack.monitoring.enabled=false")
+  fi
   local cid=$(docker run ${params[@]} ${image}:${tag})
   echo ${cid}
 }


### PR DESCRIPTION
Signed-off-by: Stefan Seft <tornhoof+github@gmail.com>

## Which problem is this PR solving?
- Resolves  #3571

## Short description of the changes
- Modifies the index mapping to use the ES 7 mappings for higher versions too.
- Modifies the tests to include ES 8
- Modifies the github ci pipeline to add ES 8.1.0 
