### PR TITLE
Add SAMPLING_STORAGE_TYPE environment variable

### DIFF
--- a/plugin/sampling/strategystore/adaptive/factory.go
+++ b/plugin/sampling/strategystore/adaptive/factory.go
@@ -61,7 +61,7 @@ func (f *Factory) InitFromViper(v *viper.Viper, logger *zap.Logger) {
 // Initialize implements strategystore.Factory
 func (f *Factory) Initialize(metricsFactory metrics.Factory, ssFactory storage.SamplingStoreFactory, logger *zap.Logger) error {
 	if ssFactory == nil {
-		return errors.New("lock or SamplingStore nil. Please configure a backend that supports adaptive sampling")
+		return errors.New("sampling store factory is nil. Please configure a backend that supports adaptive sampling")
 	}
 
 	var err error

--- a/plugin/storage/factory_config.go
+++ b/plugin/storage/factory_config.go
@@ -29,6 +29,9 @@ const (
 	// DependencyStorageTypeEnvVar is the name of the env var that defines the type of backend used for dependencies storage.
 	DependencyStorageTypeEnvVar = "DEPENDENCY_STORAGE_TYPE"
 
+	// SamplingStorageTypeEnvVar is the name of the env var that defines the type of backend used for sampling data storage when using adaptive sampling.
+	SamplingStorageTypeEnvVar = "SAMPLING_STORAGE_TYPE"
+
 	spanStorageFlag = "--span-storage.type"
 )
 
@@ -36,6 +39,7 @@ const (
 type FactoryConfig struct {
 	SpanWriterTypes         []string
 	SpanReaderType          string
+	SamplingStorageType     string
 	DependenciesStorageType string
 	DownsamplingRatio       float64
 	DownsamplingHashSalt    string
@@ -73,11 +77,13 @@ func FactoryConfigFromEnvAndCLI(args []string, log io.Writer) FactoryConfig {
 	if depStorageType == "" {
 		depStorageType = spanWriterTypes[0]
 	}
+	samplingStorageType := os.Getenv(SamplingStorageTypeEnvVar)
 	// TODO support explicit configuration for readers
 	return FactoryConfig{
 		SpanWriterTypes:         spanWriterTypes,
 		SpanReaderType:          spanWriterTypes[0],
 		DependenciesStorageType: depStorageType,
+		SamplingStorageType:     samplingStorageType,
 	}
 }
 

--- a/plugin/storage/factory_config_test.go
+++ b/plugin/storage/factory_config_test.go
@@ -26,6 +26,7 @@ import (
 func clearEnv() {
 	os.Setenv(SpanStorageTypeEnvVar, "")
 	os.Setenv(DependencyStorageTypeEnvVar, "")
+	os.Setenv(SamplingStorageTypeEnvVar, "")
 }
 
 func TestFactoryConfigFromEnv(t *testing.T) {
@@ -37,15 +38,18 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	assert.Equal(t, cassandraStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, cassandraStorageType, f.SpanReaderType)
 	assert.Equal(t, cassandraStorageType, f.DependenciesStorageType)
+	assert.Equal(t, "", f.SamplingStorageType)
 
 	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType)
 	os.Setenv(DependencyStorageTypeEnvVar, memoryStorageType)
+	os.Setenv(SamplingStorageTypeEnvVar, cassandraStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Equal(t, 1, len(f.SpanWriterTypes))
 	assert.Equal(t, elasticsearchStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
 	assert.Equal(t, memoryStorageType, f.DependenciesStorageType)
+	assert.Equal(t, cassandraStorageType, f.SamplingStorageType)
 
 	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType+","+kafkaStorageType)
 

--- a/plugin/storage/factory_config_test.go
+++ b/plugin/storage/factory_config_test.go
@@ -38,7 +38,7 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	assert.Equal(t, cassandraStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, cassandraStorageType, f.SpanReaderType)
 	assert.Equal(t, cassandraStorageType, f.DependenciesStorageType)
-	assert.Equal(t, "", f.SamplingStorageType)
+	assert.Empty(t, f.SamplingStorageType)
 
 	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType)
 	os.Setenv(DependencyStorageTypeEnvVar, memoryStorageType)


### PR DESCRIPTION
## Which problem is this PR solving?
- Adds support for a new environment variable `SAMPLING_STORAGE_TYPE`. This allows the user to independently configure
their `SPAN_STORAGE_TYPE` and `SAMPLING_STORAGE_TYPE`. e.g. the user could choose to store their spans in elasticsearch while putting their adaptive sampling data in cassandra. This also paves the way for simpler to operate sampling storage types like redis or memcached.

## Short description of the changes
- Add support for `SAMPLING_STORAGE_TYPE` to plugin/storage/factory_config.go
- Add support to plugin/storage/factory.go to return the correct factory or fall back to previous behavior if unspecified.
- Add relevant testing.
