### PR TITLE
useILM will prevent index template creation

### DIFF
--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -199,7 +199,7 @@ func createSpanWriter(
 		Archive:                archive,
 		UseReadWriteAliases:    cfg.GetUseReadWriteAliases(),
 	})
-	if cfg.IsCreateIndexTemplates() {
+	if cfg.IsCreateIndexTemplates() && !cfg.GetUseILM() {
 		err := writer.CreateTemplates(spanMapping, serviceMapping, cfg.GetIndexPrefix())
 		if err != nil {
 			return nil, err

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -199,6 +199,8 @@ func createSpanWriter(
 		Archive:                archive,
 		UseReadWriteAliases:    cfg.GetUseReadWriteAliases(),
 	})
+
+	// Creating a template here would conflict with the one created for ILM resulting to no index rollover
 	if cfg.IsCreateIndexTemplates() && !cfg.GetUseILM() {
 		err := writer.CreateTemplates(spanMapping, serviceMapping, cfg.GetIndexPrefix())
 		if err != nil {

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -185,6 +185,17 @@ func TestCreateTemplateError(t *testing.T) {
 	assert.Error(t, err, "template-error")
 }
 
+func TestILMDisableTemplateCreation(t *testing.T) {
+	f := NewFactory()
+	f.primaryConfig = &mockClientBuilder{createTemplateError: errors.New("template-error"), Configuration: escfg.Configuration{Enabled: true, UseILM: false, UseReadWriteAliases: true, CreateIndexTemplates: true}}
+	f.archiveConfig = &mockClientBuilder{}
+	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	require.NoError(t, err)
+	w, err := f.CreateSpanWriter()
+	assert.Nil(t, w)
+	assert.Nil(t, err) // as the createTemplate is not called, CreateSpanWriter should not return an error
+}
+
 func TestArchiveDisabled(t *testing.T) {
 	f := NewFactory()
 	f.archiveConfig = &mockClientBuilder{Configuration: escfg.Configuration{Enabled: false}}

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -187,12 +187,11 @@ func TestCreateTemplateError(t *testing.T) {
 
 func TestILMDisableTemplateCreation(t *testing.T) {
 	f := NewFactory()
-	f.primaryConfig = &mockClientBuilder{createTemplateError: errors.New("template-error"), Configuration: escfg.Configuration{Enabled: true, UseILM: false, UseReadWriteAliases: true, CreateIndexTemplates: true}}
+	f.primaryConfig = &mockClientBuilder{createTemplateError: errors.New("template-error"), Configuration: escfg.Configuration{Enabled: true, UseILM: true, UseReadWriteAliases: true, CreateIndexTemplates: true}}
 	f.archiveConfig = &mockClientBuilder{}
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
-	w, err := f.CreateSpanWriter()
-	assert.Nil(t, w)
+	_, err = f.CreateSpanWriter()
 	assert.Nil(t, err) // as the createTemplate is not called, CreateSpanWriter should not return an error
 }
 


### PR DESCRIPTION
## Problem

With ILM, index patter overridden without lifecycle policy set by collector if not explicitly disabled with --es.create-index-templates=false

## Proposal

Making useILM disable index creation to prevent this issue to happen

## Alternative
Make the actual cmd flags mutually exclusive. This is more explicit but is breaking 
https://github.com/rbizos/jaeger/commit/12bff254b32c83971c2bea27aa60cce7ecfa35cb 
