### PR TITLE
proof of concept of tenancy

### DIFF
--- a/cmd/collector/app/model_consumer.go
+++ b/cmd/collector/app/model_consumer.go
@@ -16,23 +16,25 @@
 package app
 
 import (
+	"context"
+
 	"github.com/jaegertracing/jaeger/model"
 )
 
 // ProcessSpan processes a Domain Model Span
-type ProcessSpan func(span *model.Span)
+type ProcessSpan func(span *model.Span, ctx context.Context) // @@@ ecs modified public method
 
 // ProcessSpans processes a batch of Domain Model Spans
-type ProcessSpans func(spans []*model.Span)
+type ProcessSpans func(spans []*model.Span, ctx context.Context) // @@@ ecs modified public method
 
 // FilterSpan decides whether to allow or disallow a span
 type FilterSpan func(span *model.Span) bool
 
 // ChainedProcessSpan chains spanProcessors as a single ProcessSpan call
 func ChainedProcessSpan(spanProcessors ...ProcessSpan) ProcessSpan {
-	return func(span *model.Span) {
+	return func(span *model.Span, ctx context.Context) {
 		for _, processor := range spanProcessors {
-			processor(span)
+			processor(span, ctx)
 		}
 	}
 }

--- a/cmd/collector/app/model_consumer.go
+++ b/cmd/collector/app/model_consumer.go
@@ -30,6 +30,9 @@ type ProcessSpans func(spans []*model.Span, ctx context.Context) // @@@ ecs modi
 // FilterSpan decides whether to allow or disallow a span
 type FilterSpan func(span *model.Span) bool
 
+// ValidTenant decides whether to allow or disallow a slice of spans based on tenancy
+type ValidTenant func(tenant string) bool
+
 // ChainedProcessSpan chains spanProcessors as a single ProcessSpan call
 func ChainedProcessSpan(spanProcessors ...ProcessSpan) ProcessSpan {
 	return func(span *model.Span, ctx context.Context) {

--- a/cmd/collector/app/model_consumer_test.go
+++ b/cmd/collector/app/model_consumer_test.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,10 +27,10 @@ import (
 func TestChainedProcessSpan(t *testing.T) {
 	happened1 := false
 	happened2 := false
-	func1 := func(span *model.Span) { happened1 = true }
-	func2 := func(span *model.Span) { happened2 = true }
+	func1 := func(span *model.Span, _ context.Context) { happened1 = true }
+	func2 := func(span *model.Span, _ context.Context) { happened2 = true }
 	chained := ChainedProcessSpan(func1, func2)
-	chained(&model.Span{})
+	chained(&model.Span{}, nil)
 	assert.True(t, happened1)
 	assert.True(t, happened2)
 }

--- a/cmd/collector/app/options.go
+++ b/cmd/collector/app/options.go
@@ -42,6 +42,7 @@ type options struct {
 	preProcessSpans    ProcessSpans
 	sanitizer          sanitizer.SanitizeSpan
 	preSave            ProcessSpan
+	validTenant        ValidTenant
 	spanFilter         FilterSpan
 	numWorkers         int
 	blockingSubmit     bool
@@ -77,6 +78,13 @@ func (options) ServiceMetrics(serviceMetrics metrics.Factory) Option {
 func (options) HostMetrics(hostMetrics metrics.Factory) Option {
 	return func(b *options) {
 		b.hostMetrics = hostMetrics
+	}
+}
+
+// ValidTenant creates an Option that initializes the validTenant function
+func (options) ValidTenant(tenantValiator ValidTenant) Option {
+	return func(b *options) {
+		b.validTenant = tenantValiator
 	}
 }
 
@@ -186,6 +194,9 @@ func (o options) apply(opts ...Option) options {
 	}
 	if ret.preSave == nil {
 		ret.preSave = func(span *model.Span, _ context.Context) {}
+	}
+	if ret.validTenant == nil {
+		ret.validTenant = func(tenant string) bool { return true }
 	}
 	if ret.spanFilter == nil {
 		ret.spanFilter = func(span *model.Span) bool { return true }

--- a/cmd/collector/app/options.go
+++ b/cmd/collector/app/options.go
@@ -16,6 +16,8 @@
 package app
 
 import (
+	"context"
+
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
@@ -177,13 +179,13 @@ func (o options) apply(opts ...Option) options {
 		ret.hostMetrics = metrics.NullFactory
 	}
 	if ret.preProcessSpans == nil {
-		ret.preProcessSpans = func(spans []*model.Span) {}
+		ret.preProcessSpans = func(spans []*model.Span, _ context.Context) {}
 	}
 	if ret.sanitizer == nil {
 		ret.sanitizer = func(span *model.Span) *model.Span { return span }
 	}
 	if ret.preSave == nil {
-		ret.preSave = func(span *model.Span) {}
+		ret.preSave = func(span *model.Span, _ context.Context) {}
 	}
 	if ret.spanFilter == nil {
 		ret.spanFilter = func(span *model.Span) bool { return true }

--- a/cmd/collector/app/options_test.go
+++ b/cmd/collector/app/options_test.go
@@ -44,6 +44,7 @@ func TestAllOptionSet(t *testing.T) {
 		Options.DynQueueSizeWarmup(1000),
 		Options.DynQueueSizeMemory(1024),
 		Options.PreSave(func(span *model.Span, _ context.Context) {}),
+		Options.ValidTenant(func(tenant string) bool { return true }),
 		Options.CollectorTags(map[string]string{"extra": "tags"}),
 	)
 	assert.EqualValues(t, 5, opts.numWorkers)

--- a/cmd/collector/app/options_test.go
+++ b/cmd/collector/app/options_test.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,12 +38,12 @@ func TestAllOptionSet(t *testing.T) {
 		Options.ServiceMetrics(metrics.NullFactory),
 		Options.Logger(zap.NewNop()),
 		Options.NumWorkers(5),
-		Options.PreProcessSpans(func(spans []*model.Span) {}),
+		Options.PreProcessSpans(func(spans []*model.Span, _ context.Context) {}),
 		Options.Sanitizer(func(span *model.Span) *model.Span { return span }),
 		Options.QueueSize(10),
 		Options.DynQueueSizeWarmup(1000),
 		Options.DynQueueSizeMemory(1024),
-		Options.PreSave(func(span *model.Span) {}),
+		Options.PreSave(func(span *model.Span, _ context.Context) {}),
 		Options.CollectorTags(map[string]string{"extra": "tags"}),
 	)
 	assert.EqualValues(t, 5, opts.numWorkers)
@@ -59,8 +60,8 @@ func TestNoOptionsSet(t *testing.T) {
 	assert.Nil(t, opts.collectorTags)
 	assert.False(t, opts.reportBusy)
 	assert.False(t, opts.blockingSubmit)
-	assert.NotPanics(t, func() { opts.preProcessSpans(nil) })
-	assert.NotPanics(t, func() { opts.preSave(nil) })
+	assert.NotPanics(t, func() { opts.preProcessSpans(nil, nil) })
+	assert.NotPanics(t, func() { opts.preSave(nil, nil) })
 	assert.True(t, opts.spanFilter(nil))
 	span := model.Span{}
 	assert.EqualValues(t, &span, opts.sanitizer(&span))

--- a/cmd/collector/app/processor/interface.go
+++ b/cmd/collector/app/processor/interface.go
@@ -24,6 +24,9 @@ import (
 // ErrBusy signalizes that processor cannot process incoming data
 var ErrBusy = errors.New("server busy")
 
+// ErrTenant signalizes that processor wont accept incoming data for tenant
+var ErrTenant = errors.New("invalid tenant")
+
 // SpansOptions additional options passed to processor along with the spans.
 type SpansOptions struct {
 	SpanFormat       SpanFormat

--- a/cmd/collector/app/processor/interface.go
+++ b/cmd/collector/app/processor/interface.go
@@ -28,6 +28,7 @@ var ErrBusy = errors.New("server busy")
 type SpansOptions struct {
 	SpanFormat       SpanFormat
 	InboundTransport InboundTransport
+	SpanTenant       string
 }
 
 // SpanProcessor handles model spans

--- a/cmd/collector/app/root_span_handler.go
+++ b/cmd/collector/app/root_span_handler.go
@@ -15,6 +15,8 @@
 package app
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
@@ -23,7 +25,7 @@ import (
 
 // handleRootSpan returns a function that records throughput for root spans
 func handleRootSpan(aggregator strategystore.Aggregator, logger *zap.Logger) ProcessSpan {
-	return func(span *model.Span) {
+	return func(span *model.Span, _ context.Context) {
 		// TODO simply checking parentId to determine if a span is a root span is not sufficient. However,
 		// we can be sure that only a root span will have sampler tags.
 		if span.ParentSpanID() != model.NewSpanID(0) {

--- a/cmd/collector/app/root_span_handler_test.go
+++ b/cmd/collector/app/root_span_handler_test.go
@@ -43,7 +43,7 @@ func TestHandleRootSpan(t *testing.T) {
 
 	// Testing non-root span
 	span := &model.Span{References: []model.SpanRef{{SpanID: model.NewSpanID(1), RefType: model.ChildOf}}}
-	processor(span)
+	processor(span, nil)
 	assert.Equal(t, 0, aggregator.callCount)
 
 	// Testing span with service name but no operation
@@ -51,12 +51,12 @@ func TestHandleRootSpan(t *testing.T) {
 	span.Process = &model.Process{
 		ServiceName: "service",
 	}
-	processor(span)
+	processor(span, nil)
 	assert.Equal(t, 0, aggregator.callCount)
 
 	// Testing span with service name and operation but no probabilistic sampling tags
 	span.OperationName = "GET"
-	processor(span)
+	processor(span, nil)
 	assert.Equal(t, 0, aggregator.callCount)
 
 	// Testing span with service name, operation, and probabilistic sampling tags
@@ -64,6 +64,6 @@ func TestHandleRootSpan(t *testing.T) {
 		model.String("sampler.type", "probabilistic"),
 		model.String("sampler.param", "0.001"),
 	}
-	processor(span)
+	processor(span, nil)
 	assert.Equal(t, 1, aggregator.callCount)
 }

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -30,17 +30,12 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
-type TenantKeyType string
-
 const (
 	// if this proves to be too low, we can increase it
 	maxQueueSize = 1_000_000
 
 	// if the new queue size isn't 20% bigger than the previous one, don't change
 	minRequiredChange = 1.2
-
-	// Tenancy for spans
-	TenantKey = TenantKeyType("tenant")
 )
 
 type spanProcessor struct {
@@ -183,7 +178,7 @@ func (sp *spanProcessor) ProcessSpans(mSpans []*model.Span, options processor.Sp
 
 func (sp *spanProcessor) processItemFromQueue(item *queueItem) {
 	sp.processSpan(sp.sanitizer(item.span),
-		context.WithValue(context.TODO(), TenantKey, item.tenant))
+		context.WithValue(context.TODO(), spanstore.TenantKey, item.tenant))
 	sp.metrics.InQueueLatency.Record(time.Since(item.queuedTime))
 }
 

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -327,7 +327,7 @@ func TestSpanProcessorWithNilProcess(t *testing.T) {
 	p := NewSpanProcessor(w, nil, Options.ServiceMetrics(serviceMetrics)).(*spanProcessor)
 	defer assert.NoError(t, p.Close())
 
-	p.saveSpan(&model.Span{})
+	p.saveSpan(&model.Span{}, context.TODO())
 
 	expected := []metricstest.ExpectedMetric{{
 		Name: "service.spans.saved-by-svc|debug=false|result=err|svc=__unknown", Value: 1,

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -391,7 +391,7 @@ func TestSpanProcessorCountSpan(t *testing.T) {
 	p := NewSpanProcessor(w, nil, Options.HostMetrics(m), Options.DynQueueSizeMemory(1000)).(*spanProcessor)
 	p.background(10*time.Millisecond, p.updateGauges)
 
-	p.processSpan(&model.Span{})
+	p.processSpan(&model.Span{}, nil)
 	assert.NotEqual(t, uint64(0), p.bytesProcessed)
 
 	for i := 0; i < 15; i++ {
@@ -546,7 +546,7 @@ func TestAdditionalProcessors(t *testing.T) {
 
 	// additional processor is called
 	count := 0
-	f := func(s *model.Span) {
+	f := func(s *model.Span, _ context.Context) {
 		count++
 	}
 	p = NewSpanProcessor(w, []ProcessSpan{f}, Options.QueueSize(1))

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/collector/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
 	uiconv "github.com/jaegertracing/jaeger/model/converter/json"
@@ -421,7 +422,10 @@ func (aH *APIHandler) getTrace(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	trace, err := aH.queryService.GetTrace(r.Context(), traceID)
+	tenant := r.Header.Get("x-tenant")
+	trace, err := aH.queryService.GetTrace(
+		context.WithValue(r.Context(), app.TenantKey, tenant),
+		traceID)
 	if err == spanstore.ErrTraceNotFound {
 		aH.handleError(w, err, http.StatusNotFound)
 		return

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/cmd/collector/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
 	uiconv "github.com/jaegertracing/jaeger/model/converter/json"
@@ -424,7 +423,7 @@ func (aH *APIHandler) getTrace(w http.ResponseWriter, r *http.Request) {
 	}
 	tenant := r.Header.Get("x-tenant")
 	trace, err := aH.queryService.GetTrace(
-		context.WithValue(r.Context(), app.TenantKey, tenant),
+		context.WithValue(r.Context(), spanstore.TenantKey, tenant),
 		traceID)
 	if err == spanstore.ErrTraceNotFound {
 		aH.handleError(w, err, http.StatusNotFound)

--- a/docs/proposals/05022022-storage-tenancy.md
+++ b/docs/proposals/05022022-storage-tenancy.md
@@ -1,0 +1,61 @@
+# Storage tenancy
+
+* **Owners:**:
+  * `@esnible`
+
+## TL;DR
+
+This proposal supports a new optional `x-tenant` header to Jaeger's HTTP and GRPC interfaces.
+
+This proposal adds a `"tenant"` key to the Jaeger `Context` that accompanies spans through their processing pipeline down to the `spanstore.Writer`.
+The `"tenant"` key also accompanies queries to their `spanstore.Reader`.
+
+## Why
+
+To allow a single Jaeger deployment to store and query traces for multiple entities.
+
+## Goals
+
+* Allow Jaeger to service multiple tenants/customers
+* Let SpanWriter implementations make their own decision to offer tenancy, and implementation strategies.
+* Let deployers enumerate accepted tenants
+
+## Non-Goals
+
+* A security mechanism for tenants
+* Conventions/APIs/libraries to help storage writers implement tenancy.
+
+## How
+
+The how is split into the following sections:
+* Jaeger implementation - describes how users access data stored in Jaeger.
+* Jaeger configuration - describes how Jaeger components are deployed.
+
+### Jaeger implementation
+
+Storage implementations that wish to support tenancy have may use whatever strategy they choose.
+
+For example, 
+
+- create one NoSQL connection per-tenant, to isolated database hosts
+- pass the tenant to a NoSQL service through a header
+- Incorporate the tenant into a NoSQL index name
+- Incoporate the tenant into a NoSQL value
+
+Jaeger does not prescribe an implementation.
+
+The memory storage example uses a `Map[tenant]Tenant`, with each `Tenant` being an independent memory span store.
+
+If a `spanstore.Writer` also implements the new `spanstore.TenantValidator`
+interface, and spans will be passed through the validator before they are
+queued and processed.
+
+### Jaeger configuration
+
+The tenant configuration is part of the storage configuration.
+
+For example, the memory storage offers `--memory.max-tenants=12` and `--memory.valid-tenants=acme,wonka,stark-industries`.
+
+For memory storage, `--memory.valid-tenants` has precedence and will reject any batches or queries that do not include a header with a value in the list.
+
+`--memory.max-tenants` defaults to 10, and can be set to 0 to allow all tenants.  When non-zero, it rejects any new tenants seen after the first N.  It is intended as a demonstration, but also so that a Jaeger deploy can be configured to reject an unbounded number of traces (when combined with `--memory.max-traces`.)

--- a/pkg/memory/config/config.go
+++ b/pkg/memory/config/config.go
@@ -16,5 +16,8 @@ package config
 
 // Configuration describes the options to customize the storage behavior
 type Configuration struct {
-	MaxTraces int `yaml:"max-traces" mapstructure:"max_traces"`
+	// MaxTraces is now a per-tenant limit, not an over-all limit
+	MaxTraces    int      `yaml:"max-traces" mapstructure:"max_traces"`
+	ValidTenants []string `yaml:"valid-tenants" mapstructure:"valid_tenants"`
+	MaxTenants   int      `yaml:"max-tenants" mapstructure:"max_tenants"`
 }

--- a/plugin/storage/memory/factory_test.go
+++ b/plugin/storage/memory/factory_test.go
@@ -57,7 +57,23 @@ func TestWithConfiguration(t *testing.T) {
 	v, command := config.Viperize(f.AddFlags)
 	command.ParseFlags([]string{"--memory.max-traces=100"})
 	f.InitFromViper(v, zap.NewNop())
-	assert.Equal(t, f.options.Configuration.MaxTraces, 100)
+	assert.Equal(t, 100, f.options.Configuration.MaxTraces)
+}
+
+func TestWithValidTenantConfiguration(t *testing.T) {
+	f := NewFactory()
+	v, command := config.Viperize(f.AddFlags)
+	command.ParseFlags([]string{"--memory.valid-tenants=acme,stark-industries"})
+	f.InitFromViper(v, zap.NewNop())
+	assert.Equal(t, []string{"acme", "stark-industries"}, f.options.Configuration.ValidTenants, f.options.Configuration.ValidTenants)
+}
+
+func TestWithMaxTenantConfiguration(t *testing.T) {
+	f := NewFactory()
+	v, command := config.Viperize(f.AddFlags)
+	command.ParseFlags([]string{"--memory.max-tenants=12"})
+	f.InitFromViper(v, zap.NewNop())
+	assert.Equal(t, 12, f.options.Configuration.MaxTenants)
 }
 
 func TestInitFromOptions(t *testing.T) {

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	"github.com/jaegertracing/jaeger/cmd/collector/app"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/adjuster"
 	"github.com/jaegertracing/jaeger/pkg/memory/config"
@@ -323,7 +322,7 @@ func (m *Store) flattenTags(span *model.Span) model.KeyValues {
 }
 
 func GetTenantID(ctx context.Context) string {
-	tenant := ctx.Value(app.TenantKey)
+	tenant := ctx.Value(spanstore.TenantKey)
 	if tenant != nil {
 		return fmt.Sprintf("%v", tenant)
 	}
@@ -338,7 +337,7 @@ func (s *Store) GetTenant(tenantID string) *Tenant {
 	if !ok {
 		tenant = NewTenant(s.config)
 		s.tenants[tenantID] = tenant
-		log.Printf("Memory storage reated tenant %q\n", tenantID)
+		log.Printf("Memory storage created tenant %q\n", tenantID)
 	}
 	return tenant
 }

--- a/plugin/storage/memory/memory_test.go
+++ b/plugin/storage/memory/memory_test.go
@@ -205,8 +205,8 @@ func TestStoreWithLimit(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.Equal(t, maxTraces, len(store.traces))
-	assert.Equal(t, maxTraces, len(store.ids))
+	assert.Equal(t, maxTraces, len(store.GetTenant("").traces))
+	assert.Equal(t, maxTraces, len(store.GetTenant("").ids))
 }
 
 func TestStoreGetTraceSuccess(t *testing.T) {
@@ -238,7 +238,7 @@ func TestStoreGetAndMutateTrace(t *testing.T) {
 
 func TestStoreGetTraceError(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
-		store.traces[testingSpan.TraceID] = &model.Trace{
+		store.GetTenant("").traces[testingSpan.TraceID] = &model.Trace{
 			Spans: []*model.Span{nonSerializableSpan},
 		}
 		_, err := store.GetTrace(context.Background(), testingSpan.TraceID)

--- a/plugin/storage/memory/options.go
+++ b/plugin/storage/memory/options.go
@@ -16,6 +16,7 @@ package memory
 
 import (
 	"flag"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -23,6 +24,8 @@ import (
 )
 
 const limit = "memory.max-traces"
+const limitTenants = "memory.max-tenants"
+const validTenants = "memory.valid-tenants"
 
 // Options stores the configuration entries for this storage
 type Options struct {
@@ -32,9 +35,13 @@ type Options struct {
 // AddFlags from this storage to the CLI
 func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Int(limit, 0, "The maximum amount of traces to store in memory. The default number of traces is unbounded.")
+	flagSet.Int(limitTenants, 10, "limit on the number of tenants that may send and query (use 0 for no limit)")
+	flagSet.String(validTenants, "", "If defined; only tenants in this list may send and query")
 }
 
 // InitFromViper initializes the options struct with values from Viper
 func (opt *Options) InitFromViper(v *viper.Viper) {
 	opt.Configuration.MaxTraces = v.GetInt(limit)
+	opt.Configuration.MaxTenants = v.GetInt(limitTenants)
+	opt.Configuration.ValidTenants = strings.Split(v.GetString(validTenants), ",")
 }

--- a/storage/spanstore/interface.go
+++ b/storage/spanstore/interface.go
@@ -23,6 +23,14 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 )
 
+// TenantKeyType is the type of key used to store a tenant in a Context.
+type TenantKeyType string
+
+const (
+	// TenantKey holds tenancy for spans
+	TenantKey = TenantKeyType("tenant")
+)
+
 var (
 	// ErrTraceNotFound is returned by Reader's GetTrace if no data is found for given trace ID.
 	ErrTraceNotFound = errors.New("trace not found")

--- a/storage/spanstore/interface.go
+++ b/storage/spanstore/interface.go
@@ -71,6 +71,11 @@ type Reader interface {
 	FindTraceIDs(ctx context.Context, query *TraceQueryParameters) ([]model.TraceID, error)
 }
 
+// An optional interface that a Writer may also choose to implement
+type TenantValidator interface {
+	IsValid(tenant string) bool
+}
+
 // TraceQueryParameters contains parameters of a trace query.
 type TraceQueryParameters struct {
 	ServiceName   string


### PR DESCRIPTION
Updates: #3427 

Demo of tenancy implementation

I have Jaeger running behind a proxy that adds `x-tenant` header depending on an Authorization header token or on a cookie.  Each tenant sees only the traces posted with the same header value.

Only HTTP `GET /api/traces/*` and gRPC `jaeger.api_v2.CollectorService/PostSpans` are implemented.
Only the memory storage is implemented.  No limits on the number of tenants allowed.

Is this the right approach?  This PR offered as a proof-of-concept.

cc @pavolloffay 