### PR TITLE
Pin CI to use Go 1.17

### DIFF
--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -39,7 +39,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Run cassandra integration tests
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.image }} ${{ matrix.version.schema }}

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/ci-grpc-badger.yml
+++ b/.github/workflows/ci-grpc-badger.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Run Badger storage integration tests
       run: make badger-storage-integration-test

--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Run kafka integration tests
       run: bash scripts/kafka-integration-test.sh

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/ci-protogen-tests.yml
+++ b/.github/workflows/ci-protogen-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Run protogen validation
       run: make proto && git diff --name-status --exit-code

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: ^1.17.6
+        go-version: 1.17.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: ^1.17.6
+          go-version: 1.17.x
 
       - name: Add GOPATH
         run: |


### PR DESCRIPTION
This PR pins our CI to use 1.17.x. This should resolve recent issues with golangci-lint:

![image](https://user-images.githubusercontent.com/2272392/162806817-2df7056e-72a3-480a-951e-8d14d7ab3833.png)
