### PR TITLE
Prepare release 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ next release
 
 ### UI Changes
 
+1.33.0 (2022-04-11)
+-------------------
+### Backend Changes
+
+* Elasticsearch: Only create ILM template if configured. ([@rbizos](https://github.com/rbizos) in [#3610](https://github.com/jaegertracing/jaeger/pull/3610))
+
+#### Breaking Changes
+
+#### New Features
+
+* Add SAMPLING_STORAGE_TYPE environment variable ([@joe-elliott](https://github.com/joe-elliott) in [#3573](https://github.com/jaegertracing/jaeger/pull/3573))
+* Support min/max TLS version in TLS config ([@Ashmita152](https://github.com/Ashmita152) in [#3567](https://github.com/jaegertracing/jaeger/pull/3567))
+* Add support for ciphersuites in tls config ([@Ashmita152](https://github.com/Ashmita152) in [#3564](https://github.com/jaegertracing/jaeger/pull/3564))
+
+#### Bug fixes, Minor Improvements
+
+* Fix: exit on grpc plugin crash ([@johanneswuerbach](https://github.com/johanneswuerbach) in [#3604](https://github.com/jaegertracing/jaeger/pull/3604))
+* Bump go.opentelemetry.io/collector/model from 0.47.0 to 0.48.0 ([@dependabot[bot]](https://github.com/apps/dependabot) in [#3608](https://github.com/jaegertracing/jaeger/pull/3608))
+* Fix format string for go1.18 ([@bobrik](https://github.com/bobrik) in [#3596](https://github.com/jaegertracing/jaeger/pull/3596))
+* Fix favicon returning 500 inside container ([@Ashmita152](https://github.com/Ashmita152) in [#3569](https://github.com/jaegertracing/jaeger/pull/3569))
+
+### UI Changes
+
+* UI pinned to version 1.22.0. The changelog is available here [v1.22.0](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#v1220-2022-04-11).
 
 1.32.0 (2022-03-06)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,6 @@ next release
 
 1.33.0 (2022-04-11)
 -------------------
-### Backend Changes
-
-* Elasticsearch: Only create ILM template if configured. ([@rbizos](https://github.com/rbizos) in [#3610](https://github.com/jaegertracing/jaeger/pull/3610))
-
 #### New Features
 
 * Add SAMPLING_STORAGE_TYPE environment variable ([@joe-elliott](https://github.com/joe-elliott) in [#3573](https://github.com/jaegertracing/jaeger/pull/3573))
@@ -31,6 +27,8 @@ next release
 * Bump go.opentelemetry.io/collector/model from 0.47.0 to 0.48.0 ([@dependabot[bot]](https://github.com/apps/dependabot) in [#3608](https://github.com/jaegertracing/jaeger/pull/3608))
 * Fix format string for go1.18 ([@bobrik](https://github.com/bobrik) in [#3596](https://github.com/jaegertracing/jaeger/pull/3596))
 * Fix favicon returning 500 inside container ([@Ashmita152](https://github.com/Ashmita152) in [#3569](https://github.com/jaegertracing/jaeger/pull/3569))
+* Elasticsearch: Do not create index templates if ILM is enabled. ([@rbizos](https://github.com/rbizos) in [#3610](https://github.com/jaegertracing/jaeger/pull/3610))
+
 
 ### UI Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ next release
 
 * Elasticsearch: Only create ILM template if configured. ([@rbizos](https://github.com/rbizos) in [#3610](https://github.com/jaegertracing/jaeger/pull/3610))
 
-#### Breaking Changes
-
 #### New Features
 
 * Add SAMPLING_STORAGE_TYPE environment variable ([@joe-elliott](https://github.com/joe-elliott) in [#3573](https://github.com/jaegertracing/jaeger/pull/3573))

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,7 +38,7 @@ Here are the release managers for future versions with the tentative release dat
 
 | Version | Release Manager  | Tentative release date |
 |---------|------------------|------------------------|
-| 1.33.0  | @joe-elliott     | 6 April     2022       |
 | 1.34.0  | @pavolloffay     | 4 May       2022       |
 | 1.35.0  | @yurishkuro      | 3 June      2022       |
 | 1.36.0  | @albertteoh      | 6 July      2022       |
+| 1.37.0  | @joe-elliott     | 3 August    2022       |


### PR DESCRIPTION
Updates changelog, release.md and jaeger ui for the 1.33.0 release.