### PR TITLE
Pin golandci-lint to hash pending v1.45.3 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,9 @@ changelog:
 .PHONY: install-tools
 install-tools:
 	go install github.com/vektra/mockery/v2@v2.10.4
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	# FIXME: pin to f5b92e1 until v1.45.3 is available to pick up fixes for staticheck
+	# go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@f5b92e1
 
 .PHONY: install-ci
 install-ci: install-tools

--- a/cmd/query/app/apiv3/otlp_translator.go
+++ b/cmd/query/app/apiv3/otlp_translator.go
@@ -25,6 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/model/pdata"
 	semconv "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger/model"
 	commonv1 "github.com/jaegertracing/jaeger/proto-gen/otel/common/v1"
@@ -376,7 +377,7 @@ func uint64ToTraceID(high, low uint64) []byte {
 // See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status
 func statusCodeFromHTTP(httpStatusCode int) pdata.StatusCode {
 	if httpStatusCode >= 100 && httpStatusCode < 399 {
-		return pdata.StatusCodeUnset
+		return ptrace.StatusCodeUnset
 	}
-	return pdata.StatusCodeError
+	return ptrace.StatusCodeError
 }


### PR DESCRIPTION
This re-enables 3 out of 4 default linters that were disabled due to incompatibility with Go 1.18.