### PR TITLE
Add a Context that flows through span processors to SpanWriters

### DIFF
--- a/cmd/collector/app/model_consumer.go
+++ b/cmd/collector/app/model_consumer.go
@@ -16,23 +16,25 @@
 package app
 
 import (
+	"context"
+
 	"github.com/jaegertracing/jaeger/model"
 )
 
 // ProcessSpan processes a Domain Model Span
-type ProcessSpan func(span *model.Span)
+type ProcessSpan func(span *model.Span, ctx context.Context)
 
 // ProcessSpans processes a batch of Domain Model Spans
-type ProcessSpans func(spans []*model.Span)
+type ProcessSpans func(spans []*model.Span, ctx context.Context)
 
 // FilterSpan decides whether to allow or disallow a span
 type FilterSpan func(span *model.Span) bool
 
 // ChainedProcessSpan chains spanProcessors as a single ProcessSpan call
 func ChainedProcessSpan(spanProcessors ...ProcessSpan) ProcessSpan {
-	return func(span *model.Span) {
+	return func(span *model.Span, ctx context.Context) {
 		for _, processor := range spanProcessors {
-			processor(span)
+			processor(span, ctx)
 		}
 	}
 }

--- a/cmd/collector/app/model_consumer_test.go
+++ b/cmd/collector/app/model_consumer_test.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,10 +27,10 @@ import (
 func TestChainedProcessSpan(t *testing.T) {
 	happened1 := false
 	happened2 := false
-	func1 := func(span *model.Span) { happened1 = true }
-	func2 := func(span *model.Span) { happened2 = true }
+	func1 := func(span *model.Span, _ context.Context) { happened1 = true }
+	func2 := func(span *model.Span, _ context.Context) { happened2 = true }
 	chained := ChainedProcessSpan(func1, func2)
-	chained(&model.Span{})
+	chained(&model.Span{}, context.TODO())
 	assert.True(t, happened1)
 	assert.True(t, happened2)
 }

--- a/cmd/collector/app/options.go
+++ b/cmd/collector/app/options.go
@@ -16,6 +16,8 @@
 package app
 
 import (
+	"context"
+
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
@@ -177,13 +179,13 @@ func (o options) apply(opts ...Option) options {
 		ret.hostMetrics = metrics.NullFactory
 	}
 	if ret.preProcessSpans == nil {
-		ret.preProcessSpans = func(spans []*model.Span) {}
+		ret.preProcessSpans = func(spans []*model.Span, ctx context.Context) {}
 	}
 	if ret.sanitizer == nil {
 		ret.sanitizer = func(span *model.Span) *model.Span { return span }
 	}
 	if ret.preSave == nil {
-		ret.preSave = func(span *model.Span) {}
+		ret.preSave = func(span *model.Span, ctx context.Context) {}
 	}
 	if ret.spanFilter == nil {
 		ret.spanFilter = func(span *model.Span) bool { return true }

--- a/cmd/collector/app/options_test.go
+++ b/cmd/collector/app/options_test.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,12 +38,12 @@ func TestAllOptionSet(t *testing.T) {
 		Options.ServiceMetrics(metrics.NullFactory),
 		Options.Logger(zap.NewNop()),
 		Options.NumWorkers(5),
-		Options.PreProcessSpans(func(spans []*model.Span) {}),
+		Options.PreProcessSpans(func([]*model.Span, context.Context) {}),
 		Options.Sanitizer(func(span *model.Span) *model.Span { return span }),
 		Options.QueueSize(10),
 		Options.DynQueueSizeWarmup(1000),
 		Options.DynQueueSizeMemory(1024),
-		Options.PreSave(func(span *model.Span) {}),
+		Options.PreSave(func(*model.Span, context.Context) {}),
 		Options.CollectorTags(map[string]string{"extra": "tags"}),
 	)
 	assert.EqualValues(t, 5, opts.numWorkers)
@@ -59,8 +60,8 @@ func TestNoOptionsSet(t *testing.T) {
 	assert.Nil(t, opts.collectorTags)
 	assert.False(t, opts.reportBusy)
 	assert.False(t, opts.blockingSubmit)
-	assert.NotPanics(t, func() { opts.preProcessSpans(nil) })
-	assert.NotPanics(t, func() { opts.preSave(nil) })
+	assert.NotPanics(t, func() { opts.preProcessSpans(nil, nil) })
+	assert.NotPanics(t, func() { opts.preSave(nil, nil) })
 	assert.True(t, opts.spanFilter(nil))
 	span := model.Span{}
 	assert.EqualValues(t, &span, opts.sanitizer(&span))

--- a/cmd/collector/app/processor/interface.go
+++ b/cmd/collector/app/processor/interface.go
@@ -15,6 +15,7 @@
 package processor
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -28,6 +29,7 @@ var ErrBusy = errors.New("server busy")
 type SpansOptions struct {
 	SpanFormat       SpanFormat
 	InboundTransport InboundTransport
+	Context          context.Context
 }
 
 // SpanProcessor handles model spans

--- a/cmd/collector/app/root_span_handler.go
+++ b/cmd/collector/app/root_span_handler.go
@@ -15,6 +15,8 @@
 package app
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
@@ -23,7 +25,7 @@ import (
 
 // handleRootSpan returns a function that records throughput for root spans
 func handleRootSpan(aggregator strategystore.Aggregator, logger *zap.Logger) ProcessSpan {
-	return func(span *model.Span) {
+	return func(span *model.Span, ctx context.Context) {
 		// TODO simply checking parentId to determine if a span is a root span is not sufficient. However,
 		// we can be sure that only a root span will have sampler tags.
 		if span.ParentSpanID() != model.NewSpanID(0) {

--- a/cmd/collector/app/root_span_handler_test.go
+++ b/cmd/collector/app/root_span_handler_test.go
@@ -15,6 +15,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func TestHandleRootSpan(t *testing.T) {
 
 	// Testing non-root span
 	span := &model.Span{References: []model.SpanRef{{SpanID: model.NewSpanID(1), RefType: model.ChildOf}}}
-	processor(span)
+	processor(span, context.TODO())
 	assert.Equal(t, 0, aggregator.callCount)
 
 	// Testing span with service name but no operation
@@ -51,12 +52,12 @@ func TestHandleRootSpan(t *testing.T) {
 	span.Process = &model.Process{
 		ServiceName: "service",
 	}
-	processor(span)
+	processor(span, context.TODO())
 	assert.Equal(t, 0, aggregator.callCount)
 
 	// Testing span with service name and operation but no probabilistic sampling tags
 	span.OperationName = "GET"
-	processor(span)
+	processor(span, context.TODO())
 	assert.Equal(t, 0, aggregator.callCount)
 
 	// Testing span with service name, operation, and probabilistic sampling tags
@@ -64,6 +65,6 @@ func TestHandleRootSpan(t *testing.T) {
 		model.String("sampler.type", "probabilistic"),
 		model.String("sampler.param", "0.001"),
 	}
-	processor(span)
+	processor(span, context.TODO())
 	assert.Equal(t, 1, aggregator.callCount)
 }

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -61,6 +61,7 @@ type spanProcessor struct {
 type queueItem struct {
 	queuedTime time.Time
 	span       *model.Span
+	context    context.Context
 }
 
 // NewSpanProcessor returns a SpanProcessor that preProcesses, filters, queues, sanitizes, and processes spans
@@ -136,7 +137,7 @@ func (sp *spanProcessor) Close() error {
 	return nil
 }
 
-func (sp *spanProcessor) saveSpan(span *model.Span) {
+func (sp *spanProcessor) saveSpan(span *model.Span, ctx context.Context) {
 	if nil == span.Process {
 		sp.logger.Error("process is empty for the span")
 		sp.metrics.SavedErrBySvc.ReportServiceNameForSpan(span)
@@ -145,7 +146,7 @@ func (sp *spanProcessor) saveSpan(span *model.Span) {
 
 	startTime := time.Now()
 	// TODO context should be propagated from upstream components
-	if err := sp.spanWriter.WriteSpan(context.TODO(), span); err != nil {
+	if err := sp.spanWriter.WriteSpan(ctx, span); err != nil {
 		sp.logger.Error("Failed to save span", zap.Error(err))
 		sp.metrics.SavedErrBySvc.ReportServiceNameForSpan(span)
 	} else {
@@ -156,17 +157,21 @@ func (sp *spanProcessor) saveSpan(span *model.Span) {
 	sp.metrics.SaveLatency.Record(time.Since(startTime))
 }
 
-func (sp *spanProcessor) countSpan(span *model.Span) {
+func (sp *spanProcessor) countSpan(span *model.Span, ctx context.Context) {
 	sp.bytesProcessed.Add(uint64(span.Size()))
 	sp.spansProcessed.Inc()
 }
 
 func (sp *spanProcessor) ProcessSpans(mSpans []*model.Span, options processor.SpansOptions) ([]bool, error) {
-	sp.preProcessSpans(mSpans)
+	ctx := options.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sp.preProcessSpans(mSpans, ctx)
 	sp.metrics.BatchSize.Update(int64(len(mSpans)))
 	retMe := make([]bool, len(mSpans))
 	for i, mSpan := range mSpans {
-		ok := sp.enqueueSpan(mSpan, options.SpanFormat, options.InboundTransport)
+		ok := sp.enqueueSpan(mSpan, options.SpanFormat, options.InboundTransport, ctx)
 		if !ok && sp.reportBusy {
 			return nil, processor.ErrBusy
 		}
@@ -176,7 +181,8 @@ func (sp *spanProcessor) ProcessSpans(mSpans []*model.Span, options processor.Sp
 }
 
 func (sp *spanProcessor) processItemFromQueue(item *queueItem) {
-	sp.processSpan(sp.sanitizer(item.span))
+	sp.processSpan(sp.sanitizer(item.span), item.context)
+
 	sp.metrics.InQueueLatency.Record(time.Since(item.queuedTime))
 }
 
@@ -201,7 +207,7 @@ func (sp *spanProcessor) addCollectorTags(span *model.Span) {
 	typedTags.Sort()
 }
 
-func (sp *spanProcessor) enqueueSpan(span *model.Span, originalFormat processor.SpanFormat, transport processor.InboundTransport) bool {
+func (sp *spanProcessor) enqueueSpan(span *model.Span, originalFormat processor.SpanFormat, transport processor.InboundTransport, cxt context.Context) bool {
 	spanCounts := sp.metrics.GetCountsForFormat(originalFormat, transport)
 	spanCounts.ReceivedBySvc.ReportServiceNameForSpan(span)
 
@@ -219,6 +225,7 @@ func (sp *spanProcessor) enqueueSpan(span *model.Span, originalFormat processor.
 	item := &queueItem{
 		queuedTime: time.Now(),
 		span:       span,
+		context:    cxt,
 	}
 	return sp.queue.Produce(item)
 }

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -36,6 +37,14 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	zc "github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+)
+
+// tenantKeyType is a custom type for the key "tenant", following context.Context convention
+type tenantKeyType string
+
+const (
+	// TenantKey holds tenancy for spans
+	tenantKey = tenantKeyType("tenant")
 )
 
 var (
@@ -165,10 +174,20 @@ func isSpanAllowed(span *model.Span) bool {
 }
 
 type fakeSpanWriter struct {
-	err error
+	tenants map[string]bool
+	err     error
 }
 
 func (n *fakeSpanWriter) WriteSpan(ctx context.Context, span *model.Span) error {
+	// Record all unique tenants arriving in span Contexts
+	tenant := ctx.Value(tenantKey)
+	if tenant != nil {
+		if n.tenants == nil {
+			n.tenants = make(map[string]bool)
+		}
+		n.tenants[tenant.(string)] = true
+	}
+
 	return n.err
 }
 
@@ -327,7 +346,7 @@ func TestSpanProcessorWithNilProcess(t *testing.T) {
 	p := NewSpanProcessor(w, nil, Options.ServiceMetrics(serviceMetrics)).(*spanProcessor)
 	defer assert.NoError(t, p.Close())
 
-	p.saveSpan(&model.Span{})
+	p.saveSpan(&model.Span{}, context.TODO())
 
 	expected := []metricstest.ExpectedMetric{{
 		Name: "service.spans.saved-by-svc|debug=false|result=err|svc=__unknown", Value: 1,
@@ -391,7 +410,7 @@ func TestSpanProcessorCountSpan(t *testing.T) {
 	p := NewSpanProcessor(w, nil, Options.HostMetrics(m), Options.DynQueueSizeMemory(1000)).(*spanProcessor)
 	p.background(10*time.Millisecond, p.updateGauges)
 
-	p.processSpan(&model.Span{})
+	p.processSpan(&model.Span{}, context.TODO())
 	assert.NotEqual(t, uint64(0), p.bytesProcessed)
 
 	for i := 0; i < 15; i++ {
@@ -546,7 +565,7 @@ func TestAdditionalProcessors(t *testing.T) {
 
 	// additional processor is called
 	count := 0
-	f := func(s *model.Span) {
+	f := func(*model.Span, context.Context) {
 		count++
 	}
 	p = NewSpanProcessor(w, []ProcessSpan{f}, Options.QueueSize(1))
@@ -561,4 +580,29 @@ func TestAdditionalProcessors(t *testing.T) {
 	assert.Equal(t, []bool{true}, res)
 	assert.NoError(t, p.Close())
 	assert.Equal(t, 1, count)
+}
+
+func TestSpanProcessorContextPropagation(t *testing.T) {
+	w := &fakeSpanWriter{}
+	p := NewSpanProcessor(w, nil, Options.QueueSize(1))
+
+	dummyTenant := "context-prop-test-tenant"
+
+	res, err := p.ProcessSpans([]*model.Span{
+		{
+			Process: &model.Process{
+				ServiceName: "x",
+			},
+		},
+	}, processor.SpansOptions{
+		Context: context.WithValue(context.Background(), tenantKey, dummyTenant),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []bool{true}, res)
+	assert.NoError(t, p.Close())
+
+	// Verify that the dummy tenant from SpansOptions context made it to writer
+	assert.Equal(t, true, w.tenants[dummyTenant])
+	// Verify no other tenantKey context values made it to writer
+	assert.True(t, reflect.DeepEqual(w.tenants, map[string]bool{dummyTenant: true}))
 }


### PR DESCRIPTION
This PR replaces https://github.com/jaegertracing/jaeger/pull/3605 and is an alternative to https://github.com/jaegertracing/jaeger/pull/3660

This PR adds a Context to `ProcessSpans()`.  This allows key/value pairs to flow through the processor down to the SpanWriter.

I hope to build on this when I introduce tenancy.

I have chosen to implement sending the tenant through the processors this way because
- We already use a context on the read path, e.g. _/proto-gen/storage_v1/storage.pb.go_ which has `GetTrace(ctx context.Context, in *GetTraceRequest, opts ...grpc.CallOption) (SpanReaderPlugin_GetTraceClient, error)`; it is symmetric to add a context to the write path.
- Contexts are traditionally used when data needs to flow through to an inner API; that is what we are doing.
- This is very flexible; only processors and writers that care need to look for the keys they honor
- Currently only the saveSpan() processor uses the context, and it only uses it to call the spanWriter.  However, in the future, other processors might take advantage of the context settings.
 
cc @pavolloffay 