### PR TITLE
Flow context to SpanWriter

### DIFF
--- a/cmd/collector/app/processor/interface.go
+++ b/cmd/collector/app/processor/interface.go
@@ -15,6 +15,7 @@
 package processor
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -28,6 +29,7 @@ var ErrBusy = errors.New("server busy")
 type SpansOptions struct {
 	SpanFormat       SpanFormat
 	InboundTransport InboundTransport
+	Context          context.Context
 }
 
 // SpanProcessor handles model spans


### PR DESCRIPTION
This PR replaces https://github.com/jaegertracing/jaeger/pull/3605 and is an alternative to https://github.com/jaegertracing/jaeger/pull/3659

This PR allows key/value pairs to reach the SpanWriter, but doesn't make them available to the processors.

I hope to build on this when I introduce tenancy.

I have chosen to implement sending the tenant through the processors this way because
- This PR is very small
- Contexts are traditionally used when data needs to flow through to an inner API; that is what we are doing.

cc @pavolloffay 