### PR TITLE
Returning formatted error on index duration error

### DIFF
--- a/plugin/storage/cassandra/spanstore/writer.go
+++ b/plugin/storage/cassandra/spanstore/writer.go
@@ -239,7 +239,7 @@ func (s *SpanWriter) indexByDuration(span *dbmodel.Span, startTime time.Time) er
 	indexByOperationName := func(operationName string) {
 		q1 := query.Bind(span.Process.ServiceName, operationName, timeBucket, span.Duration, span.StartTime, span.TraceID)
 		if err2 := s.writerMetrics.durationIndex.Exec(q1, s.logger); err2 != nil {
-			s.logError(span, err2, "Cannot index duration", s.logger)
+			_ = s.logError(span, err2, "Cannot index duration", s.logger)
 			err = err2
 		}
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3361

## Short description of the changes
Returning formatted error message during the index by duration
This was adding more context but especially solving a lint generated
by discarding the return value of `s.logError`