### PR TITLE
Add entries to env command for new storage types

### DIFF
--- a/cmd/env/command.go
+++ b/cmd/env/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	metrics "github.com/jaegertracing/jaeger/plugin/metrics"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore"
 	"github.com/jaegertracing/jaeger/plugin/storage"
 )
@@ -49,6 +50,14 @@ when Jaeger is deployed in the collector+ingester configuration.
 to clients configured with remote sampling enabled. "file" uses a periodically reloaded file and
 "adaptive" dynamically adjusts sampling rates based on current traffic.
 `
+
+	samplingStorageTypeDescription = `The type of backend [%s] used for adaptive sampling storage
+when adaptive sampling is enabled via %s.
+`
+
+	metricsStorageTypeDescription = `The type of backend [%s] used as a metrics store with
+Service Performance Monitoring (https://www.jaegertracing.io/docs/latest/spm/).
+`
 )
 
 // Command creates `env` command
@@ -73,6 +82,23 @@ func Command() *cobra.Command {
 		fmt.Sprintf(
 			strings.ReplaceAll(samplingTypeDescription, "\n", " "),
 			strings.Join(strategystore.AllSamplingTypes, ", "),
+		),
+	)
+	fs.String(
+		storage.SamplingStorageTypeEnvVar,
+		"",
+		fmt.Sprintf(
+			strings.ReplaceAll(samplingStorageTypeDescription, "\n", " "),
+			strings.Join(storage.AllSamplingStorageTypes(), ", "),
+			strategystore.SamplingTypeEnvVar,
+		),
+	)
+	fs.String(
+		metrics.StorageTypeEnvVar,
+		"",
+		fmt.Sprintf(
+			strings.ReplaceAll(metricsStorageTypeDescription, "\n", " "),
+			strings.Join(metrics.AllStorageTypes, ", "),
 		),
 	)
 	long := fmt.Sprintf(longTemplate, strings.Replace(fs.FlagUsagesWrapped(0), "      --", "\n", -1))

--- a/cmd/env/command.go
+++ b/cmd/env/command.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	metrics "github.com/jaegertracing/jaeger/plugin/metrics"
+	"github.com/jaegertracing/jaeger/plugin/metrics"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategystore"
 	"github.com/jaegertracing/jaeger/plugin/storage"
 )

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -57,16 +57,23 @@ const (
 )
 
 // AllStorageTypes defines all available storage backends
-var AllStorageTypes = []string{cassandraStorageType, opensearchStorageType, elasticsearchStorageType, memoryStorageType, kafkaStorageType, badgerStorageType, grpcPluginStorageType}
+var AllStorageTypes = []string{
+	cassandraStorageType,
+	opensearchStorageType,
+	elasticsearchStorageType,
+	memoryStorageType,
+	kafkaStorageType,
+	badgerStorageType,
+	grpcPluginStorageType,
+}
 
 // AllSamplingStorageTypes returns all storage backends that implement adaptive sampling
 func AllSamplingStorageTypes() []string {
 	f := &Factory{}
 	var backends []string
 	for _, st := range AllStorageTypes {
-		f, _ := f.getFactoryOfType(st)
-		_, ok := f.(storage.SamplingStoreFactory)
-		if ok {
+		f, _ := f.getFactoryOfType(st) // no errors since we're looping through supported types
+		if _, ok := f.(storage.SamplingStoreFactory); ok {
 			backends = append(backends, st)
 		}
 	}

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -64,10 +64,7 @@ func AllSamplingStorageTypes() []string {
 	f := &Factory{}
 	var backends []string
 	for _, st := range AllStorageTypes {
-		f, err := f.getFactoryOfType(st)
-		if err != nil {
-			panic(err.Error())
-		}
+		f, _ := f.getFactoryOfType(st)
 		_, ok := f.(storage.SamplingStoreFactory)
 		if ok {
 			backends = append(backends, st)

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -59,6 +59,23 @@ const (
 // AllStorageTypes defines all available storage backends
 var AllStorageTypes = []string{cassandraStorageType, opensearchStorageType, elasticsearchStorageType, memoryStorageType, kafkaStorageType, badgerStorageType, grpcPluginStorageType}
 
+// AllSamplingStorageTypes returns all storage backends that implement adaptive sampling
+func AllSamplingStorageTypes() []string {
+	f := &Factory{}
+	var backends []string
+	for _, st := range AllStorageTypes {
+		f, err := f.getFactoryOfType(st)
+		if err != nil {
+			panic(err.Error())
+		}
+		_, ok := f.(storage.SamplingStoreFactory)
+		if ok {
+			backends = append(backends, st)
+		}
+	}
+	return backends
+}
+
 // Factory implements storage.Factory interface as a meta-factory for storage components.
 type Factory struct {
 	FactoryConfig

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -296,6 +296,10 @@ func TestCreateError(t *testing.T) {
 	}
 }
 
+func TestAllSamplingStorageTypes(t *testing.T) {
+	assert.Equal(t, AllSamplingStorageTypes(), []string{"cassandra", "memory"})
+}
+
 func TestCreateSamplingStoreFactory(t *testing.T) {
 	f, err := NewFactory(defaultCfg())
 	require.NoError(t, err)


### PR DESCRIPTION
We did not update this command when adding the adaptive sampling storage and metrics storage env vars.