### PR TITLE
Fix Prometheus factory signature

### DIFF
--- a/pkg/testutils/logger.go
+++ b/pkg/testutils/logger.go
@@ -30,7 +30,7 @@ import (
 // NewLogger creates a new zap.Logger backed by a zaptest.Buffer, which is also returned.
 func NewLogger() (*zap.Logger, *Buffer) {
 	core, buf := newRecordingCore()
-	logger := zap.New(core)
+	logger := zap.New(core, zap.OnFatal(zapcore.WriteThenPanic))
 	return logger, buf
 }
 

--- a/plugin/metrics/disabled/factory.go
+++ b/plugin/metrics/disabled/factory.go
@@ -20,8 +20,11 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
 )
+
+var _ plugin.Configurable = (*Factory)(nil)
 
 // Factory implements storage.Factory that returns a Disabled metrics reader.
 type Factory struct{}

--- a/plugin/metrics/factory.go
+++ b/plugin/metrics/factory.go
@@ -38,6 +38,8 @@ const (
 // AllStorageTypes defines all available storage backends.
 var AllStorageTypes = []string{prometheusStorageType}
 
+var _ plugin.Configurable = (*Factory)(nil)
+
 // Factory implements storage.Factory interface as a meta-factory for storage components.
 type Factory struct {
 	FactoryConfig

--- a/plugin/metrics/prometheus/factory.go
+++ b/plugin/metrics/prometheus/factory.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
 )
 
-var _ plugin.Configurable = new(Factory)
+var _ plugin.Configurable = (*Factory)(nil)
 
 // Factory implements storage.Factory and creates storage components backed by memory store.
 type Factory struct {

--- a/plugin/metrics/prometheus/factory.go
+++ b/plugin/metrics/prometheus/factory.go
@@ -20,9 +20,12 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/plugin"
 	prometheusstore "github.com/jaegertracing/jaeger/plugin/metrics/prometheus/metricsstore"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
 )
+
+var _ plugin.Configurable = new(Factory)
 
 // Factory implements storage.Factory and creates storage components backed by memory store.
 type Factory struct {
@@ -43,8 +46,10 @@ func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
 }
 
 // InitFromViper implements plugin.Configurable.
-func (f *Factory) InitFromViper(v *viper.Viper, logger *zap.Logger) error {
-	return f.options.InitFromViper(v)
+func (f *Factory) InitFromViper(v *viper.Viper, logger *zap.Logger) {
+	if err := f.options.InitFromViper(v); err != nil {
+		logger.Fatal("Failed to initialize metrics storage factory", zap.Error(err))
+	}
 }
 
 // Initialize implements storage.MetricsFactory.

--- a/plugin/sampling/strategystore/adaptive/factory.go
+++ b/plugin/sampling/strategystore/adaptive/factory.go
@@ -24,9 +24,12 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
+	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/samplingstore"
 )
+
+var _ plugin.Configurable = (*Factory)(nil)
 
 // Factory implements strategystore.Factory for an adaptive strategy store.
 type Factory struct {

--- a/plugin/sampling/strategystore/factory.go
+++ b/plugin/sampling/strategystore/factory.go
@@ -37,7 +37,10 @@ const (
 	samplingTypeFile     = "file"
 )
 
+// AllSamplingTypes lists all types of sampling factories.
 var AllSamplingTypes = []string{samplingTypeFile, samplingTypeAdaptive}
+
+var _ plugin.Configurable = (*Factory)(nil)
 
 // Factory implements strategystore.Factory interface as a meta-factory for strategy storage components.
 type Factory struct {

--- a/plugin/sampling/strategystore/static/factory.go
+++ b/plugin/sampling/strategystore/static/factory.go
@@ -22,8 +22,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
+	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/storage"
 )
+
+var _ plugin.Configurable = (*Factory)(nil)
 
 // Factory implements strategystore.Factory for a static strategy store.
 type Factory struct {

--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -17,6 +17,7 @@ package badger
 import (
 	"expvar"
 	"flag"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/plugin"
 	depStore "github.com/jaegertracing/jaeger/plugin/storage/badger/dependencystore"
 	badgerStore "github.com/jaegertracing/jaeger/plugin/storage/badger/spanstore"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
@@ -37,6 +39,11 @@ const (
 	keyLogSpaceAvailableName   = "badger_key_log_bytes_available"
 	lastMaintenanceRunName     = "badger_storage_maintenance_last_run"
 	lastValueLogCleanedName    = "badger_storage_valueloggc_last_run"
+)
+
+var (
+	_ io.Closer           = (*Factory)(nil)
+	_ plugin.Configurable = (*Factory)(nil)
 )
 
 // Factory implements storage.Factory for Badger backend.

--- a/plugin/storage/cassandra/factory.go
+++ b/plugin/storage/cassandra/factory.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/cassandra/config"
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
 	"github.com/jaegertracing/jaeger/pkg/hostname"
+	"github.com/jaegertracing/jaeger/plugin"
 	cLock "github.com/jaegertracing/jaeger/plugin/pkg/distributedlock/cassandra"
 	cDepStore "github.com/jaegertracing/jaeger/plugin/storage/cassandra/dependencystore"
 	cSamplingStore "github.com/jaegertracing/jaeger/plugin/storage/cassandra/samplingstore"
@@ -42,6 +43,11 @@ import (
 const (
 	primaryStorageConfig = "cassandra"
 	archiveStorageConfig = "cassandra-archive"
+)
+
+var (
+	_ io.Closer           = (*Factory)(nil)
+	_ plugin.Configurable = (*Factory)(nil)
 )
 
 // Factory implements storage.Factory for Cassandra backend.

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/es"
 	"github.com/jaegertracing/jaeger/pkg/es/config"
+	"github.com/jaegertracing/jaeger/plugin"
 	esDepStore "github.com/jaegertracing/jaeger/plugin/storage/es/dependencystore"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/mappings"
 	esSpanStore "github.com/jaegertracing/jaeger/plugin/storage/es/spanstore"
@@ -36,6 +37,11 @@ import (
 const (
 	primaryNamespace = "es"
 	archiveNamespace = "es-archive"
+)
+
+var (
+	_ io.Closer           = (*Factory)(nil)
+	_ plugin.Configurable = (*Factory)(nil)
 )
 
 // Factory implements storage.Factory for Elasticsearch backend.

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -80,6 +80,11 @@ func AllSamplingStorageTypes() []string {
 	return backends
 }
 
+var (
+	_ io.Closer           = (*Factory)(nil)
+	_ plugin.Configurable = (*Factory)(nil)
+)
+
 // Factory implements storage.Factory interface as a meta-factory for storage components.
 type Factory struct {
 	FactoryConfig

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -23,11 +23,17 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+var (
+	_ io.Closer           = (*Factory)(nil)
+	_ plugin.Configurable = (*Factory)(nil)
 )
 
 // Factory implements storage.Factory and creates storage components backed by a storage plugin.
@@ -43,8 +49,6 @@ type Factory struct {
 	streamingSpanWriter shared.StreamingSpanWriterPlugin
 	capabilities        shared.PluginCapabilities
 }
-
-var _ io.Closer = (*Factory)(nil)
 
 // NewFactory creates a new Factory.
 func NewFactory() *Factory {

--- a/plugin/storage/kafka/factory.go
+++ b/plugin/storage/kafka/factory.go
@@ -25,8 +25,14 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/kafka/producer"
+	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+var (
+	_ io.Closer           = (*Factory)(nil)
+	_ plugin.Configurable = (*Factory)(nil)
 )
 
 // Factory implements storage.Factory and creates write-only storage components backed by kafka.

--- a/plugin/storage/memory/factory.go
+++ b/plugin/storage/memory/factory.go
@@ -23,10 +23,13 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
+	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/samplingstore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
+
+var _ plugin.Configurable = (*Factory)(nil)
 
 // Factory implements storage.Factory and creates storage components backed by memory store.
 type Factory struct {


### PR DESCRIPTION
Resolves #3677 
  * adds `plugin.Configurable' validation to all factories to avoid re-introducing the bug
  * remove error return value from Prometheus factory and log it as fatal inside the function, similar to all other factories

cc @albertteoh 