### PR TITLE
Fix for WithTenant() lost orig context

### DIFF
--- a/storage/tenant.go
+++ b/storage/tenant.go
@@ -26,7 +26,7 @@ const (
 
 // WithTenant creates a Context with a tenant association
 func WithTenant(ctx context.Context, tenant string) context.Context {
-	return context.WithValue(context.Background(), tenantKey, tenant)
+	return context.WithValue(ctx, tenantKey, tenant)
 }
 
 // GetTenant retrieves a tenant associated with a Context

--- a/storage/tenant_test.go
+++ b/storage/tenant_test.go
@@ -21,9 +21,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testContextKey string
+
 func TestContextTenantHandling(t *testing.T) {
 	ctxWithTenant := WithTenant(context.Background(), "tenant1")
 	assert.Equal(t, "tenant1", GetTenant(ctxWithTenant))
+}
+
+func TestContextPreserved(t *testing.T) {
+	key := testContextKey("expected-key")
+	val := "expected-value"
+	ctxWithValue := context.WithValue(context.Background(), key, val)
+	ctxWithTenant := WithTenant(ctxWithValue, "tenant1")
+	assert.Equal(t, "tenant1", GetTenant(ctxWithTenant))
+	assert.Equal(t, val, ctxWithTenant.Value(key))
 }
 
 func TestNoTenant(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

We missed a cut-and-paste error on the review of the previous PR https://github.com/jaegertracing/jaeger/pull/3661

Fixed the bug and added a test for it.