### PR TITLE
Bring up cmd/flags test coverage to 100%

### DIFF
--- a/cmd/flags/admin.go
+++ b/cmd/flags/admin.go
@@ -86,7 +86,6 @@ func (s *AdminServer) initFromViper(v *viper.Viper, logger *zap.Logger) error {
 
 	s.adminHostPort = v.GetString(adminHTTPHostPort)
 	var tlsAdminHTTP tlscfg.Options
-	s.tlsCertWatcherCloser = &tlsAdminHTTP
 	tlsAdminHTTP, err := tlsAdminHTTPFlagsConfig.InitFromViper(v)
 	if err != nil {
 		return fmt.Errorf("failed to parse admin server TLS options: %w", err)
@@ -97,6 +96,9 @@ func (s *AdminServer) initFromViper(v *viper.Viper, logger *zap.Logger) error {
 			return err
 		}
 		s.tlsCfg = tlsCfg
+		s.tlsCertWatcherCloser = &tlsAdminHTTP
+	} else {
+		s.tlsCertWatcherCloser = io.NopCloser(nil)
 	}
 	return nil
 }

--- a/cmd/flags/admin_test.go
+++ b/cmd/flags/admin_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
+	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -58,7 +59,44 @@ func TestAdminServerHandlesPortZero(t *testing.T) {
 	assert.Greater(t, port, 0)
 }
 
-func TestCollectorAdminWithFailedFlags(t *testing.T) {
+func TestAdminHealthCheck(t *testing.T) {
+	adminServer := NewAdminServer(":0")
+	status := adminServer.HC().Get()
+	assert.Equal(t, healthcheck.Unavailable, status)
+}
+
+func TestAdminFailToServe(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	l.Close() // forcing Serve on a closed connection
+
+	adminServer := NewAdminServer(":0")
+	v, command := config.Viperize(adminServer.AddFlags)
+	command.ParseFlags([]string{})
+	zapCore, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(zapCore)
+
+	require.NoError(t, adminServer.initFromViper(v, logger))
+
+	adminServer.serveWithListener(l)
+	defer adminServer.Close()
+	for i := 0; i < 1000; i++ {
+		if adminServer.HC().Get() == healthcheck.Broken {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Equal(t, healthcheck.Broken, adminServer.HC().Get())
+	logEntries := logs.TakeAll()
+	for _, log := range logEntries {
+		if strings.Contains(log.Message, "failed to serve") {
+			return
+		}
+	}
+	assert.Fail(t, "logs do not contain 'failed to serve': %+v", logEntries)
+}
+
+func TestAdminWithFailedFlags(t *testing.T) {
 	adminServer := NewAdminServer(fmt.Sprintf(":%d", ports.CollectorAdminHTTP))
 	zapCore, _ := observer.New(zap.InfoLevel)
 	logger := zap.New(zapCore)
@@ -75,44 +113,10 @@ func TestCollectorAdminWithFailedFlags(t *testing.T) {
 
 func TestAdminServerTLS(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		serverTLSFlags       []string
-		clientTLS            tlscfg.Options
-		expectTLSClientErr   bool
-		expectAdminClientErr bool
-		expectServerFail     bool
+		name           string
+		serverTLSFlags []string
+		clientTLS      tlscfg.Options
 	}{
-		{
-			name: "should fail with TLS client to untrusted TLS server",
-			serverTLSFlags: []string{
-				"--admin.http.tls.enabled=true",
-				"--admin.http.tls.cert=" + testCertKeyLocation + "/example-server-cert.pem",
-				"--admin.http.tls.key=" + testCertKeyLocation + "/example-server-key.pem",
-			},
-			clientTLS: tlscfg.Options{
-				Enabled:    true,
-				ServerName: "example.com",
-			},
-			expectTLSClientErr:   true,
-			expectAdminClientErr: true,
-			expectServerFail:     false,
-		},
-		{
-			name: "should fail with TLS client to trusted TLS server with incorrect hostname",
-			serverTLSFlags: []string{
-				"--admin.http.tls.enabled=true",
-				"--admin.http.tls.cert=" + testCertKeyLocation + "/example-server-cert.pem",
-				"--admin.http.tls.key=" + testCertKeyLocation + "/example-server-key.pem",
-			},
-			clientTLS: tlscfg.Options{
-				Enabled:    true,
-				CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
-				ServerName: "nonEmpty",
-			},
-			expectTLSClientErr:   true,
-			expectAdminClientErr: true,
-			expectServerFail:     false,
-		},
 		{
 			name: "should pass with TLS client to trusted TLS server with correct hostname",
 			serverTLSFlags: []string{
@@ -125,84 +129,6 @@ func TestAdminServerTLS(t *testing.T) {
 				CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
 				ServerName: "example.com",
 			},
-			expectTLSClientErr:   false,
-			expectAdminClientErr: false,
-			expectServerFail:     false,
-		},
-		{
-			name: "should fail with TLS client without cert to trusted TLS server requiring cert",
-			serverTLSFlags: []string{
-				"--admin.http.tls.enabled=true",
-				"--admin.http.tls.cert=" + testCertKeyLocation + "/example-server-cert.pem",
-				"--admin.http.tls.key=" + testCertKeyLocation + "/example-server-key.pem",
-				"--admin.http.tls.client-ca=" + testCertKeyLocation + "/example-CA-cert.pem",
-			},
-			clientTLS: tlscfg.Options{
-				Enabled:    true,
-				CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
-				ServerName: "example.com",
-			},
-			expectTLSClientErr:   false,
-			expectServerFail:     false,
-			expectAdminClientErr: true,
-		},
-		{
-			name: "should pass with TLS client with cert to trusted TLS server requiring cert",
-			serverTLSFlags: []string{
-				"--admin.http.tls.enabled=true",
-				"--admin.http.tls.cert=" + testCertKeyLocation + "/example-server-cert.pem",
-				"--admin.http.tls.key=" + testCertKeyLocation + "/example-server-key.pem",
-				"--admin.http.tls.client-ca=" + testCertKeyLocation + "/example-CA-cert.pem",
-			},
-			clientTLS: tlscfg.Options{
-				Enabled:    true,
-				CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
-				ServerName: "example.com",
-				CertPath:   testCertKeyLocation + "/example-client-cert.pem",
-				KeyPath:    testCertKeyLocation + "/example-client-key.pem",
-			},
-			expectTLSClientErr:   false,
-			expectServerFail:     false,
-			expectAdminClientErr: false,
-		},
-		{
-			name: "should fail with TLS client without cert to trusted TLS server requiring cert from a different CA",
-			serverTLSFlags: []string{
-				"--admin.http.tls.enabled=true",
-				"--admin.http.tls.cert=" + testCertKeyLocation + "/example-server-cert.pem",
-				"--admin.http.tls.key=" + testCertKeyLocation + "/example-server-key.pem",
-				"--admin.http.tls.client-ca=" + testCertKeyLocation + "/wrong-CA-cert.pem", // NB: wrong CA
-			},
-			clientTLS: tlscfg.Options{
-				Enabled:    true,
-				CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
-				ServerName: "example.com",
-				CertPath:   testCertKeyLocation + "/example-client-cert.pem",
-				KeyPath:    testCertKeyLocation + "/example-client-key.pem",
-			},
-			expectTLSClientErr:   false,
-			expectServerFail:     false,
-			expectAdminClientErr: true,
-		},
-		{
-			name: "should fail with TLS client with cert to trusted TLS server with incorrect TLS min",
-			serverTLSFlags: []string{
-				"--admin.http.tls.enabled=true",
-				"--admin.http.tls.cert=" + testCertKeyLocation + "/example-server-cert.pem",
-				"--admin.http.tls.key=" + testCertKeyLocation + "/example-server-key.pem",
-				"--admin.http.tls.client-ca=" + testCertKeyLocation + "/example-CA-cert.pem",
-				"--admin.http.tls.min-version=1.5",
-			},
-			clientTLS: tlscfg.Options{
-				Enabled:    true,
-				CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
-				ServerName: "example.com",
-				CertPath:   testCertKeyLocation + "/example-client-cert.pem",
-				KeyPath:    testCertKeyLocation + "/example-client-key.pem",
-			},
-			expectTLSClientErr:   true,
-			expectServerFail:     true,
-			expectAdminClientErr: false,
 		},
 	}
 
@@ -217,11 +143,6 @@ func TestAdminServerTLS(t *testing.T) {
 			logger := zap.New(zapCore)
 
 			err = adminServer.initFromViper(v, logger)
-
-			if test.expectServerFail {
-				require.Error(t, err)
-				return
-			}
 			require.NoError(t, err)
 
 			adminServer.Serve()
@@ -231,13 +152,8 @@ func TestAdminServerTLS(t *testing.T) {
 			require.NoError(t, err0)
 			dialer := &net.Dialer{Timeout: 2 * time.Second}
 			conn, clientError := tls.DialWithDialer(dialer, "tcp", fmt.Sprintf("localhost:%d", ports.CollectorAdminHTTP), clientTLSCfg)
-
-			if test.expectTLSClientErr {
-				require.Error(t, clientError)
-			} else {
-				require.NoError(t, clientError)
-				require.Nil(t, conn.Close())
-			}
+			require.NoError(t, clientError)
+			require.Nil(t, conn.Close())
 
 			client := &http.Client{
 				Transport: &http.Transport{
@@ -246,13 +162,8 @@ func TestAdminServerTLS(t *testing.T) {
 			}
 
 			response, requestError := client.Get(fmt.Sprintf("https://localhost:%d", ports.CollectorAdminHTTP))
-
-			if test.expectAdminClientErr {
-				require.Error(t, requestError)
-			} else {
-				require.NoError(t, requestError)
-				require.NotNil(t, response)
-			}
+			require.NoError(t, requestError)
+			require.NotNil(t, response)
 		})
 	}
 }

--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestParseJaegerTags(t *testing.T) {
+	assert.Nil(t, ParseJaegerTags(""))
 
 	jaegerTags := fmt.Sprintf("%s,%s,%s,%s,%s,%s",
 		"key=value",

--- a/cmd/flags/service.go
+++ b/cmd/flags/service.go
@@ -37,7 +37,7 @@ type Service struct {
 	// AdminPort is the HTTP port number for admin server.
 	AdminPort int
 
-	// NoStorage indicates that storage type CLI flag is not applicable
+	// NoStorage indicates that storage-type CLI flag is not applicable
 	NoStorage bool
 
 	// Admin is the admin server that hosts the health check and metrics endpoints.
@@ -112,7 +112,7 @@ func (s *Service) Start(v *viper.Viper) error {
 	s.MetricsFactory = metricsFactory
 
 	if err = s.Admin.initFromViper(v, s.Logger); err != nil {
-		s.Logger.Fatal("Failed to initialize admin server", zap.Error(err))
+		return fmt.Errorf("cannot initialize admin server: %w", err)
 	}
 	if h := metricsBuilder.Handler(); h != nil {
 		route := metricsBuilder.HTTPRoute

--- a/cmd/flags/service_test.go
+++ b/cmd/flags/service_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package flags
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/crossdock/crossdock-go/assert"
+	"github.com/crossdock/crossdock-go/require"
+	"github.com/jaegertracing/jaeger/pkg/config"
+)
+
+func TestAddFlags(t *testing.T) {
+	s := NewService(0)
+	s.AddFlags(new(flag.FlagSet))
+
+	s.NoStorage = true
+	s.AddFlags(new(flag.FlagSet))
+}
+
+func TestStartErrors(t *testing.T) {
+	scenarios := []struct {
+		name   string
+		flags  []string
+		expErr string
+	}{
+		{
+			name:   "bad config",
+			flags:  []string{"--config-file=invalid-file-name"},
+			expErr: "cannot load config file",
+		},
+		{
+			name:   "bad log level",
+			flags:  []string{"--log-level=invalid-log-level"},
+			expErr: "cannot create logger",
+		},
+		{
+			name:   "bad metrics backend",
+			flags:  []string{"--metrics-backend=invalid-metrics-backend"},
+			expErr: "cannot create metrics factory",
+		},
+		{
+			name:   "bad admin TLS",
+			flags:  []string{"--admin.http.tls.enabled=true", "--admin.http.tls.cert=invalid-cert"},
+			expErr: "cannot initialize admin server",
+		},
+		{
+			name:   "bad host:port",
+			flags:  []string{"--admin.http.host-port=invalid"},
+			expErr: "cannot start the admin server",
+		},
+	}
+	for _, test := range scenarios {
+		t.Run(test.name, func(t *testing.T) {
+			s := NewService( /*default port=*/ 0)
+			v, cmd := config.Viperize(s.AddFlags)
+			err := cmd.ParseFlags(test.flags)
+			assert.NoError(t, err)
+			err = s.Start(v)
+			if test.expErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.expErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
@mmorel-35 I deleted some of the tests you added, because they were testing general TLS functionality that is already tested in our tls package. I only left the tests that are exercising the different initialization paths.