### PR TITLE
Enable depguard linter on io/ioutil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,13 @@ run:
     - cmd/ingester/app/consumer/mocks
 
 linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      - io/ioutil
+    packages-with-error-message:
+      - io/ioutil: "Use os or io instead of io/ioutil"
   goimports:
     local-prefixes: github.com/jaegertracing/jaeger
   gosec:
@@ -22,6 +29,7 @@ linters-settings:
 
 linters:
   enable:
+    - depguard
     - gofmt
     - goimports
     - gosec

--- a/pkg/gzipfs/gzip_test.go
+++ b/pkg/gzipfs/gzip_test.go
@@ -17,8 +17,8 @@ package gzipfs
 
 import (
 	"embed"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -38,9 +38,11 @@ type mockFile struct {
 func (f *mockFile) Stat() (fs.FileInfo, error) {
 	return nil, f.err
 }
+
 func (f *mockFile) Read([]byte) (int, error) {
 	return 0, f.err
 }
+
 func (f *mockFile) Close() error {
 	return f.err
 }
@@ -59,7 +61,7 @@ func TestFS(t *testing.T) {
 		{
 			name:            "uncompressed file",
 			path:            "testdata/foobar",
-			expectedMode:    0444,
+			expectedMode:    0o444,
 			expectedName:    "foobar",
 			expectedSize:    11,
 			expectedContent: "hello world",
@@ -68,7 +70,7 @@ func TestFS(t *testing.T) {
 		{
 			name:            "compressed file",
 			path:            "testdata/foobar.gz",
-			expectedMode:    0444,
+			expectedMode:    0o444,
 			expectedName:    "foobar.gz",
 			expectedSize:    38,
 			expectedContent: "", // actual gzipped payload is returned
@@ -77,7 +79,7 @@ func TestFS(t *testing.T) {
 		{
 			name:            "compressed file accessed without gz extension",
 			path:            "testdata/foobaz",
-			expectedMode:    0444,
+			expectedMode:    0o444,
 			expectedName:    "foobaz",
 			expectedSize:    11,
 			expectedContent: "hello world",
@@ -126,7 +128,7 @@ func TestFS(t *testing.T) {
 			assert.Equal(t, c.expectedModTime, stat.ModTime())
 			assert.False(t, stat.IsDir())
 			assert.Nil(t, stat.Sys())
-			content, err := ioutil.ReadAll(f)
+			content, err := io.ReadAll(f)
 			require.NoError(t, err)
 			if c.expectedContent != "" {
 				assert.Equal(t, c.expectedContent, string(content))


### PR DESCRIPTION
## Short description of the changes
Enable depguard on io/ioutil : It ensures that no io/ioutil package is used in the project and advise the developer to use the right packages.

Signed-off-by: Matthieu MOREL <mmorel-35@users.noreply.github.com>