### PR TITLE
Flow tenant from query

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -268,7 +268,6 @@ func startQuery(
 	metricsQueryService querysvc.MetricsQueryService,
 	baseFactory metrics.Factory,
 ) *queryApp.Server {
-	fmt.Printf("@@@ ecs REACHED startQuery, tenancy is %v\n", qOpts.Tenancy.Enabled)
 	if qOpts.Tenancy.Enabled {
 		spanReader = tenancy.NewGuardedSpanReader(spanReader, &qOpts.Tenancy)
 		depReader = tenancy.NewGuardedDependencyReader(depReader, &qOpts.Tenancy)

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/jaegertracing/jaeger/cmd/flags"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/ports"
 )
@@ -53,6 +54,8 @@ var tlsHTTPFlagsConfig = tlscfg.ServerFlagsConfig{
 var tlsZipkinFlagsConfig = tlscfg.ServerFlagsConfig{
 	Prefix: "collector.zipkin",
 }
+
+var tenancyFlagsConfig = tenancy.TenancyFlagsConfig{}
 
 // CollectorOptions holds configuration for collector
 type CollectorOptions struct {
@@ -88,6 +91,8 @@ type CollectorOptions struct {
 	// CollectorGRPCMaxConnectionAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
 	// See gRPC's keepalive.ServerParameters#MaxConnectionAgeGrace.
 	CollectorGRPCMaxConnectionAgeGrace time.Duration
+	// TenancyGRPC configures tenancy for gRPC endpoint to collect spans
+	TenancyGRPC tenancy.Options
 }
 
 // AddFlags adds flags for CollectorOptions
@@ -108,6 +113,8 @@ func AddFlags(flags *flag.FlagSet) {
 	tlsGRPCFlagsConfig.AddFlags(flags)
 	tlsHTTPFlagsConfig.AddFlags(flags)
 	tlsZipkinFlagsConfig.AddFlags(flags)
+
+	tenancyFlagsConfig.AddFlags(flags)
 }
 
 // InitFromViper initializes CollectorOptions with properties from viper

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -55,8 +55,6 @@ var tlsZipkinFlagsConfig = tlscfg.ServerFlagsConfig{
 	Prefix: "collector.zipkin",
 }
 
-var tenancyFlagsConfig = tenancy.TenancyFlagsConfig{}
-
 // CollectorOptions holds configuration for collector
 type CollectorOptions struct {
 	// DynQueueSizeMemory determines how much memory to use for the queue
@@ -91,8 +89,8 @@ type CollectorOptions struct {
 	// CollectorGRPCMaxConnectionAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
 	// See gRPC's keepalive.ServerParameters#MaxConnectionAgeGrace.
 	CollectorGRPCMaxConnectionAgeGrace time.Duration
-	// TenancyGRPC configures tenancy for gRPC endpoint to collect spans
-	TenancyGRPC tenancy.Options
+	// Tenancy configures tenancy for endpoints that collect spans
+	Tenancy tenancy.Options
 }
 
 // AddFlags adds flags for CollectorOptions
@@ -114,7 +112,7 @@ func AddFlags(flags *flag.FlagSet) {
 	tlsHTTPFlagsConfig.AddFlags(flags)
 	tlsZipkinFlagsConfig.AddFlags(flags)
 
-	tenancyFlagsConfig.AddFlags(flags)
+	tenancy.AddFlags(flags)
 }
 
 // InitFromViper initializes CollectorOptions with properties from viper

--- a/cmd/collector/app/builder_flags.go
+++ b/cmd/collector/app/builder_flags.go
@@ -145,5 +145,11 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) (*CollectorOptions,
 		return cOpts, fmt.Errorf("failed to parse Zipkin TLS options: %w", err)
 	}
 
+	if tenancy, err := tenancy.InitFromViper(v); err == nil {
+		cOpts.Tenancy = tenancy
+	} else {
+		return cOpts, fmt.Errorf("failed to parse Tenancy options: %w", err)
+	}
+
 	return cOpts, nil
 }

--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -93,7 +93,7 @@ func (c *Collector) Start(builderOpts *CollectorOptions) error {
 	}
 
 	c.spanProcessor = handlerBuilder.BuildSpanProcessor(additionalProcessors...)
-	c.spanHandlers = handlerBuilder.BuildHandlers(c.spanProcessor)
+	c.spanHandlers = handlerBuilder.BuildHandlers(c.spanProcessor, builderOpts)
 
 	grpcServer, err := server.StartGRPCServer(&server.GRPCServerParams{
 		HostPort:                builderOpts.CollectorGRPCHostPort,

--- a/cmd/collector/app/handler/grpc_handler.go
+++ b/cmd/collector/app/handler/grpc_handler.go
@@ -82,16 +82,5 @@ func (g *GRPCHandler) validateTenant(ctx context.Context) (string, error) {
 		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
 	}
 
-	tenants := md[g.tenancyConfig.Header]
-	if len(tenants) < 1 {
-		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
-	} else if len(tenants) > 1 {
-		return "", status.Errorf(codes.PermissionDenied, "extra tenant header")
-	}
-
-	if !g.tenancyConfig.Valid(tenants[0]) {
-		return "", status.Errorf(codes.PermissionDenied, "unknown tenant")
-	}
-
-	return tenants[0], nil
+	return tenancy.TenantFromMetadata(md, g.tenancyConfig.Header)
 }

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -177,10 +177,8 @@ func withMetadata(ctx context.Context, headerName, headerValue string, t *testin
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
-// @@@ ecs TODO also add something similar to queries and v3 queries
 func TestPostTenantedSpans(t *testing.T) {
 	tenantHeader := "x-tenant"
-	// @@@ ecs TODO test with bogus tenant
 	dummyTenant := "grpc-test-tenant"
 
 	processor := &mockSpanProcessor{}
@@ -278,7 +276,6 @@ func withIncomingMetadata(ctx context.Context, headerName, headerValue string, t
 	return metadata.NewIncomingContext(ctx, md)
 }
 
-// @@@ ecs TODO also add this to v3 version
 func TestGetTenant(t *testing.T) {
 	tenantHeader := "some-tenant-header"
 	validTenants := []string{"acme", "another-example"}

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -26,9 +26,11 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
@@ -36,6 +38,7 @@ type mockSpanProcessor struct {
 	expectedError error
 	mux           sync.Mutex
 	spans         []*model.Span
+	tenants       map[string]bool
 }
 
 func (p *mockSpanProcessor) ProcessSpans(spans []*model.Span, opts processor.SpansOptions) ([]bool, error) {
@@ -43,6 +46,12 @@ func (p *mockSpanProcessor) ProcessSpans(spans []*model.Span, opts processor.Spa
 	defer p.mux.Unlock()
 	p.spans = append(p.spans, spans...)
 	oks := make([]bool, len(spans))
+
+	if p.tenants == nil {
+		p.tenants = make(map[string]bool)
+	}
+	p.tenants[opts.Tenant] = true
+
 	return oks, p.expectedError
 }
 
@@ -52,10 +61,17 @@ func (p *mockSpanProcessor) getSpans() []*model.Span {
 	return p.spans
 }
 
+func (p *mockSpanProcessor) getTenants() map[string]bool {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	return p.tenants
+}
+
 func (p *mockSpanProcessor) reset() {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	p.spans = nil
+	p.tenants = nil
 }
 
 func (p *mockSpanProcessor) Close() error {
@@ -83,7 +99,7 @@ func newClient(t *testing.T, addr net.Addr) (api_v2.CollectorServiceClient, *grp
 func TestPostSpans(t *testing.T) {
 	processor := &mockSpanProcessor{}
 	server, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
-		handler := NewGRPCHandler(zap.NewNop(), processor)
+		handler := NewGRPCHandler(zap.NewNop(), processor, &tenancy.TenancyConfig{})
 		api_v2.RegisterCollectorServiceServer(s, handler)
 	})
 	defer server.Stop()
@@ -114,7 +130,7 @@ func TestPostSpans(t *testing.T) {
 func TestGRPCCompressionEnabled(t *testing.T) {
 	processor := &mockSpanProcessor{}
 	server, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
-		handler := NewGRPCHandler(zap.NewNop(), processor)
+		handler := NewGRPCHandler(zap.NewNop(), processor, &tenancy.TenancyConfig{})
 		api_v2.RegisterCollectorServiceServer(s, handler)
 	})
 	defer server.Stop()
@@ -132,7 +148,7 @@ func TestPostSpansWithError(t *testing.T) {
 	expectedError := errors.New("test-error")
 	processor := &mockSpanProcessor{expectedError: expectedError}
 	server, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
-		handler := NewGRPCHandler(zap.NewNop(), processor)
+		handler := NewGRPCHandler(zap.NewNop(), processor, &tenancy.TenancyConfig{})
 		api_v2.RegisterCollectorServiceServer(s, handler)
 	})
 	defer server.Stop()
@@ -151,4 +167,171 @@ func TestPostSpansWithError(t *testing.T) {
 	require.Nil(t, r)
 	require.Contains(t, err.Error(), expectedError.Error())
 	require.Len(t, processor.getSpans(), 1)
+}
+
+// withMetadata returns a Context with metadata for outbound (client) calls
+func withMetadata(ctx context.Context, headerName, headerValue string, t *testing.T) context.Context {
+	t.Helper()
+
+	md := metadata.New(map[string]string{headerName: headerValue})
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// @@@ ecs TODO also add something similar to queries and v3 queries
+func TestPostTenantedSpans(t *testing.T) {
+	tenantHeader := "x-tenant"
+	// @@@ ecs TODO test with bogus tenant
+	dummyTenant := "grpc-test-tenant"
+
+	processor := &mockSpanProcessor{}
+	server, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
+		handler := NewGRPCHandler(zap.NewNop(), processor,
+			tenancy.NewTenancyConfig(&tenancy.Options{
+				Enabled: true,
+				Header:  tenantHeader,
+				Tenants: []string{dummyTenant},
+			}))
+		api_v2.RegisterCollectorServiceServer(s, handler)
+	})
+	defer server.Stop()
+	client, conn := newClient(t, addr)
+	defer conn.Close()
+
+	ctxWithTenant := withMetadata(context.Background(), tenantHeader, dummyTenant, t)
+	ctxNoTenant := context.Background()
+	mdTwoTenants := metadata.Pairs()
+	mdTwoTenants.Set(tenantHeader, "a", "b")
+	ctxTwoTenants := metadata.NewOutgoingContext(context.Background(), mdTwoTenants)
+	ctxBadTenant := withMetadata(context.Background(), tenantHeader, "invalid-tenant", t)
+
+	withMetadata(context.Background(),
+		tenantHeader, dummyTenant, t)
+
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		batch           model.Batch
+		mustFail        bool
+		expected        []*model.Span
+		expectedTenants map[string]bool
+	}{
+		{
+			name:  "valid tenant",
+			ctx:   ctxWithTenant,
+			batch: model.Batch{Process: &model.Process{ServiceName: "batch-process"}, Spans: []*model.Span{{OperationName: "test-op", Process: &model.Process{ServiceName: "bar"}}}},
+
+			mustFail:        false,
+			expected:        []*model.Span{{OperationName: "test-op", Process: &model.Process{ServiceName: "bar"}}},
+			expectedTenants: map[string]bool{dummyTenant: true},
+		},
+		{
+			name:  "no tenant",
+			ctx:   ctxNoTenant,
+			batch: model.Batch{Process: &model.Process{ServiceName: "batch-process"}, Spans: []*model.Span{{OperationName: "test-op", Process: &model.Process{ServiceName: "bar"}}}},
+
+			// Because NewGRPCHandler expects a tenant header, it will reject spans without one
+			mustFail:        true,
+			expected:        nil,
+			expectedTenants: nil,
+		},
+		{
+			name:  "two tenants",
+			ctx:   ctxTwoTenants,
+			batch: model.Batch{Process: &model.Process{ServiceName: "batch-process"}, Spans: []*model.Span{{OperationName: "test-op", Process: &model.Process{ServiceName: "bar"}}}},
+
+			// NewGRPCHandler rejects spans with multiple values for tenant header
+			mustFail:        true,
+			expected:        nil,
+			expectedTenants: nil,
+		},
+		{
+			name:  "invalid tenant",
+			ctx:   ctxBadTenant,
+			batch: model.Batch{Process: &model.Process{ServiceName: "batch-process"}, Spans: []*model.Span{{OperationName: "test-op", Process: &model.Process{ServiceName: "bar"}}}},
+
+			// NewGRPCHandler rejects spans with multiple values for tenant header
+			mustFail:        true,
+			expected:        nil,
+			expectedTenants: nil,
+		},
+	}
+	for _, test := range tests {
+		_, err := client.PostSpans(test.ctx, &api_v2.PostSpansRequest{
+			Batch: test.batch,
+		})
+		if test.mustFail {
+			require.Error(t, err, "test: %s", test.name)
+		} else {
+			require.NoError(t, err, "test: %s", test.name)
+		}
+		assert.Equal(t, test.expected, processor.getSpans(), "test: %s", test.name)
+		assert.Equal(t, test.expectedTenants, processor.getTenants(), "test: %s", test.name)
+		processor.reset()
+	}
+}
+
+// withIncomingMetadata returns a Context with metadata for a server to receive
+func withIncomingMetadata(ctx context.Context, headerName, headerValue string, t *testing.T) context.Context {
+	t.Helper()
+
+	md := metadata.New(map[string]string{headerName: headerValue})
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+// @@@ ecs TODO also add this to v3 version
+func TestGetTenant(t *testing.T) {
+	tenantHeader := "some-tenant-header"
+	validTenants := []string{"acme", "another-example"}
+
+	mdTwoTenants := metadata.Pairs()
+	mdTwoTenants.Set(tenantHeader, "a", "b")
+	ctxTwoTenants := metadata.NewOutgoingContext(context.Background(), mdTwoTenants)
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		tenant   string
+		mustFail bool
+	}{
+		{
+			name:     "valid tenant",
+			ctx:      withIncomingMetadata(context.TODO(), tenantHeader, "acme", t),
+			mustFail: false,
+			tenant:   "acme",
+		},
+		{
+			name:     "no tenant",
+			ctx:      context.TODO(),
+			mustFail: true,
+			tenant:   "",
+		},
+		{
+			name:     "two tenants",
+			ctx:      ctxTwoTenants,
+			mustFail: true,
+			tenant:   "",
+		},
+		{
+			name:     "invalid tenant",
+			ctx:      withIncomingMetadata(context.TODO(), tenantHeader, "an-invalid-tenant", t),
+			mustFail: true,
+			tenant:   "",
+		},
+	}
+
+	processor := &mockSpanProcessor{}
+	handler := NewGRPCHandler(zap.NewNop(), processor, tenancy.NewTenancyConfig(&tenancy.Options{
+		Enabled: true,
+		Header:  tenantHeader,
+		Tenants: validTenants,
+	}))
+	for _, test := range tests {
+		tenant, err := handler.validateTenant(test.ctx)
+		if test.mustFail {
+			require.Error(t, err, "test: %s", test.name)
+		} else {
+			require.NoError(t, err, "test: %s", test.name)
+		}
+		assert.Equal(t, test.tenant, tenant, "test: %s", test.name)
+	}
 }

--- a/cmd/collector/app/server/grpc_test.go
+++ b/cmd/collector/app/server/grpc_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
 	"github.com/jaegertracing/jaeger/internal/grpctest"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
@@ -39,7 +40,7 @@ func TestFailToListen(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	server, err := StartGRPCServer(&GRPCServerParams{
 		HostPort:      ":-1",
-		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}),
+		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}, &tenancy.TenancyConfig{}),
 		SamplingStore: &mockSamplingStore{},
 		Logger:        logger,
 	})
@@ -56,7 +57,7 @@ func TestFailServe(t *testing.T) {
 
 	logger := zap.New(core)
 	serveGRPC(grpc.NewServer(), lis, &GRPCServerParams{
-		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}),
+		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}, &tenancy.TenancyConfig{}),
 		SamplingStore: &mockSamplingStore{},
 		Logger:        logger,
 		OnError: func(e error) {
@@ -71,7 +72,7 @@ func TestFailServe(t *testing.T) {
 func TestSpanCollector(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	params := &GRPCServerParams{
-		Handler:                 handler.NewGRPCHandler(logger, &mockSpanProcessor{}),
+		Handler:                 handler.NewGRPCHandler(logger, &mockSpanProcessor{}, &tenancy.TenancyConfig{}),
 		SamplingStore:           &mockSamplingStore{},
 		Logger:                  logger,
 		MaxReceiveMessageLength: 1024 * 1024,
@@ -96,7 +97,7 @@ func TestSpanCollector(t *testing.T) {
 func TestCollectorStartWithTLS(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	params := &GRPCServerParams{
-		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}),
+		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}, &tenancy.TenancyConfig{}),
 		SamplingStore: &mockSamplingStore{},
 		Logger:        logger,
 		TLSConfig: tlscfg.Options{
@@ -115,7 +116,7 @@ func TestCollectorStartWithTLS(t *testing.T) {
 func TestCollectorReflection(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	params := &GRPCServerParams{
-		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}),
+		Handler:       handler.NewGRPCHandler(logger, &mockSpanProcessor{}, &tenancy.TenancyConfig{}),
 		SamplingStore: &mockSamplingStore{},
 		Logger:        logger,
 	}

--- a/cmd/collector/app/span_handler_builder.go
+++ b/cmd/collector/app/span_handler_builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	zs "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
@@ -65,7 +66,7 @@ func (b *SpanHandlerBuilder) BuildSpanProcessor(additional ...ProcessSpan) proce
 }
 
 // BuildHandlers builds span handlers (Zipkin, Jaeger)
-func (b *SpanHandlerBuilder) BuildHandlers(spanProcessor processor.SpanProcessor) *SpanHandlers {
+func (b *SpanHandlerBuilder) BuildHandlers(spanProcessor processor.SpanProcessor, colectorOpts *CollectorOptions) *SpanHandlers {
 	return &SpanHandlers{
 		handler.NewZipkinSpanHandler(
 			b.Logger,
@@ -73,7 +74,7 @@ func (b *SpanHandlerBuilder) BuildHandlers(spanProcessor processor.SpanProcessor
 			zs.NewChainedSanitizer(zs.NewStandardSanitizers()...),
 		),
 		handler.NewJaegerSpanHandler(b.Logger, spanProcessor),
-		handler.NewGRPCHandler(b.Logger, spanProcessor),
+		handler.NewGRPCHandler(b.Logger, spanProcessor, tenancy.NewTenancyConfig(&b.CollectorOpts.TenancyGRPC)),
 	}
 }
 

--- a/cmd/collector/app/span_handler_builder.go
+++ b/cmd/collector/app/span_handler_builder.go
@@ -74,7 +74,7 @@ func (b *SpanHandlerBuilder) BuildHandlers(spanProcessor processor.SpanProcessor
 			zs.NewChainedSanitizer(zs.NewStandardSanitizers()...),
 		),
 		handler.NewJaegerSpanHandler(b.Logger, spanProcessor),
-		handler.NewGRPCHandler(b.Logger, spanProcessor, tenancy.NewTenancyConfig(&b.CollectorOpts.TenancyGRPC)),
+		handler.NewGRPCHandler(b.Logger, spanProcessor, tenancy.NewTenancyConfig(&b.CollectorOpts.Tenancy)),
 	}
 }
 

--- a/cmd/collector/app/span_handler_builder_test.go
+++ b/cmd/collector/app/span_handler_builder_test.go
@@ -52,7 +52,7 @@ func TestNewSpanHandlerBuilder(t *testing.T) {
 	}
 
 	spanProcessor := builder.BuildSpanProcessor()
-	spanHandlers := builder.BuildHandlers(spanProcessor)
+	spanHandlers := builder.BuildHandlers(spanProcessor, &CollectorOptions{})
 	assert.NotNil(t, spanHandlers.ZipkinSpansHandler)
 	assert.NotNil(t, spanHandlers.JaegerBatchesHandler)
 	assert.NotNil(t, spanHandlers.GRPCHandler)

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -79,6 +79,7 @@ type QueryOptions struct {
 	AdditionalHeaders http.Header
 	// MaxClockSkewAdjust is the maximum duration by which jaeger-query will adjust a span
 	MaxClockSkewAdjust time.Duration
+	// @@@ ecs TODO tenancy.Options
 }
 
 // AddFlags adds flags for QueryOptions

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -79,7 +79,6 @@ type QueryOptions struct {
 	AdditionalHeaders http.Header
 	// MaxClockSkewAdjust is the maximum duration by which jaeger-query will adjust a span
 	MaxClockSkewAdjust time.Duration
-	// @@@ ecs TODO tenancy.Options
 }
 
 // AddFlags adds flags for QueryOptions

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -866,3 +866,38 @@ func execJSON(req *http.Request, out interface{}) error {
 func parsedError(code int, err string) string {
 	return fmt.Sprintf(`%d error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":%d,"msg":"%s"}]}`+"\n", code, code, err)
 }
+
+/** @@@ ecs TODO uncomment
+func initializeTestServerWithTenancy(tenancyOptions *tenancy.Options, queryOptions querysvc.QueryServiceOptions, options ...HandlerOption) *testServer {
+	readStorage := tenancy.NewGuardedSpanReader(&spanstoremocks.Reader{}, tenancyOptions)
+	dependencyStorage := tenancy.NewGuardedDependencyReader(&depsmocks.Reader{}, tenancyOptions)
+	qs := querysvc.NewQueryService(readStorage, dependencyStorage, queryOptions)
+	r := NewRouter()
+	handler := NewAPIHandler(qs, options...)
+	handler.RegisterRoutes(r)
+	return &testServer{
+		server:           httptest.NewServer(r),
+		spanReader:       readStorage,
+		dependencyReader: dependencyStorage,
+		handler:          handler,
+	}
+}
+
+func TestSearchTenancy(t *testing.T) {
+	tenancyOptions := tenancy.Options{
+		Enabled: true,
+	}
+	ts := initializeTestServerWithTenancy(&tenancyOptions, querysvc.QueryServiceOptions{})
+	defer ts.server.Close()
+	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
+		Return(nil, spanstore.ErrTraceNotFound).Twice()
+
+	var response structuredResponse
+	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2`, &response)
+	assert.Error(t, err)
+	assert.Len(t, response.Errors, 1)
+	assert.Len(t, response.Data, 0)
+
+	// @@@ TODO a second GET with X-Tenant header
+}
+*/

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/status"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	metricsPlugin "github.com/jaegertracing/jaeger/plugin/metrics"
 	"github.com/jaegertracing/jaeger/plugin/storage"
@@ -112,6 +113,11 @@ func main() {
 			dependencyReader, err := storageFactory.CreateDependencyReader()
 			if err != nil {
 				logger.Fatal("Failed to create dependency reader", zap.Error(err))
+			}
+
+			if queryOpts.Tenancy.Enabled {
+				spanReader = tenancy.NewGuardedSpanReader(spanReader, &queryOpts.Tenancy)
+				dependencyReader = tenancy.NewGuardedDependencyReader(dependencyReader, &queryOpts.Tenancy)
 			}
 
 			metricsQueryService, err := createMetricsQueryService(metricsReaderFactory, v, logger, metricsFactory)

--- a/pkg/config/tenancy/flags.go
+++ b/pkg/config/tenancy/flags.go
@@ -16,7 +16,6 @@ package tenancy
 
 import (
 	"flag"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -28,27 +27,19 @@ const (
 	validTenants   = "multi_tenancy.tenants"
 )
 
-// TenancyFlagsConfig describes which CLI flags for TLS client should be generated.
-type TenancyFlagsConfig struct {
-}
-
 // AddFlags adds flags for tenancy to the FlagSet.
-func (c TenancyFlagsConfig) AddFlags(flags *flag.FlagSet) {
+func AddFlags(flags *flag.FlagSet) {
 	flags.Bool(tenancyEnabled, false, "Enable tenancy header when receiving or querying")
 	flags.String(tenancyHeader, "x-tenant", "HTTP header carrying tenant")
 	flags.String(validTenants, "", "Acceptable tenants")
 }
 
-// InitFromViper creates tls.Config populated with values retrieved from Viper.
-func (c TenancyFlagsConfig) InitFromViper(v *viper.Viper) (Options, error) {
+// InitFromViper creates tenancy.Options populated with values retrieved from Viper.
+func InitFromViper(v *viper.Viper) (Options, error) {
 	var p Options
 	p.Enabled = v.GetBool(tenancyEnabled)
 	p.Header = v.GetString(tenancyHeader)
 	p.Tenants = strings.Split(v.GetString(validTenants), ",")
-
-	if p.Enabled && len(p.Tenants) == 0 {
-		return p, fmt.Errorf("%s must have at least one tenant when tenancy is enabled", validTenants)
-	}
 
 	return p, nil
 }

--- a/pkg/config/tenancy/flags.go
+++ b/pkg/config/tenancy/flags.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenancy
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	tenancyEnabled = "multi_tenancy.enabled"
+	tenancyHeader  = "multi_tenancy.header"
+	validTenants   = "multi_tenancy.tenants"
+)
+
+// TenancyFlagsConfig describes which CLI flags for TLS client should be generated.
+type TenancyFlagsConfig struct {
+}
+
+// AddFlags adds flags for tenancy to the FlagSet.
+func (c TenancyFlagsConfig) AddFlags(flags *flag.FlagSet) {
+	flags.Bool(tenancyEnabled, false, "Enable tenancy header when receiving or querying")
+	flags.String(tenancyHeader, "x-tenant", "HTTP header carrying tenant")
+	flags.String(validTenants, "", "Acceptable tenants")
+}
+
+// InitFromViper creates tls.Config populated with values retrieved from Viper.
+func (c TenancyFlagsConfig) InitFromViper(v *viper.Viper) (Options, error) {
+	var p Options
+	p.Enabled = v.GetBool(tenancyEnabled)
+	p.Header = v.GetString(tenancyHeader)
+	p.Tenants = strings.Split(v.GetString(validTenants), ",")
+
+	if p.Enabled && len(p.Tenants) == 0 {
+		return p, fmt.Errorf("%s must have at least one tenant when tenancy is enabled", validTenants)
+	}
+
+	return p, nil
+}

--- a/pkg/config/tenancy/flags.go
+++ b/pkg/config/tenancy/flags.go
@@ -39,7 +39,12 @@ func InitFromViper(v *viper.Viper) (Options, error) {
 	var p Options
 	p.Enabled = v.GetBool(tenancyEnabled)
 	p.Header = v.GetString(tenancyHeader)
-	p.Tenants = strings.Split(v.GetString(validTenants), ",")
+	tenants := v.GetString(validTenants)
+	if len(tenants) != 0 {
+		p.Tenants = strings.Split(tenants, ",")
+	} else {
+		p.Tenants = []string{}
+	}
 
 	return p, nil
 }

--- a/pkg/config/tenancy/flags.go
+++ b/pkg/config/tenancy/flags.go
@@ -29,9 +29,13 @@ const (
 
 // AddFlags adds flags for tenancy to the FlagSet.
 func AddFlags(flags *flag.FlagSet) {
-	flags.Bool(tenancyEnabled, false, "Enable tenancy header when receiving or querying")
-	flags.String(tenancyHeader, "x-tenant", "HTTP header carrying tenant")
-	flags.String(validTenants, "", "Acceptable tenants")
+	// These flags are used by both query and collector,
+	// but may only be defined once.
+	if flags.Lookup(tenancyEnabled) == nil {
+		flags.Bool(tenancyEnabled, false, "Enable tenancy header when receiving or querying")
+		flags.String(tenancyHeader, "x-tenant", "HTTP header carrying tenant")
+		flags.String(validTenants, "", "Acceptable tenants")
+	}
 }
 
 // InitFromViper creates tenancy.Options populated with values retrieved from Viper.

--- a/pkg/config/tenancy/flags_test.go
+++ b/pkg/config/tenancy/flags_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenancy
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenancyFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      []string
+		expected Options
+	}{
+		{
+			name: "one tenant",
+			cmd: []string{
+				"--multi_tenancy.enabled=true",
+				"--multi_tenancy.tenants=acme",
+			},
+			expected: Options{
+				Enabled: true,
+				Header:  "x-tenant",
+				Tenants: []string{"acme"},
+			},
+		},
+		{
+			name: "two tenants",
+			cmd: []string{
+				"--multi_tenancy.enabled=true",
+				"--multi_tenancy.tenants=acme,country-store",
+			},
+			expected: Options{
+				Enabled: true,
+				Header:  "x-tenant",
+				Tenants: []string{"acme", "country-store"},
+			},
+		},
+		{
+			name: "custom header",
+			cmd: []string{
+				"--multi_tenancy.enabled=true",
+				"--multi_tenancy.header=jaeger-tenant",
+				"--multi_tenancy.tenants=acme",
+			},
+			expected: Options{
+				Enabled: true,
+				Header:  "jaeger-tenant",
+				Tenants: []string{"acme"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v := viper.New()
+			command := cobra.Command{}
+			flagSet := &flag.FlagSet{}
+			flagCfg := TenancyFlagsConfig{}
+			flagCfg.AddFlags(flagSet)
+			command.PersistentFlags().AddGoFlagSet(flagSet)
+			v.BindPFlags(command.PersistentFlags())
+
+			err := command.ParseFlags(test.cmd)
+			require.NoError(t, err)
+			tenancyCfg, err := flagCfg.InitFromViper(v)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, tenancyCfg)
+		})
+	}
+}
+
+// TestFailedTLSFlags verifies that TLS options cannot be used when tls.enabled=false
+func TestInvalidTenancyFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  []string
+	}{
+		{
+			name: "no tenants",
+			cmd: []string{
+				"--multi_tenancy.enabled=true",
+				"--multi_tenancy.tenants=",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v := viper.New()
+			command := cobra.Command{}
+			flagSet := &flag.FlagSet{}
+			flagCfg := TenancyFlagsConfig{}
+			flagCfg.AddFlags(flagSet)
+			command.PersistentFlags().AddGoFlagSet(flagSet)
+			v.BindPFlags(command.PersistentFlags())
+
+			err := command.ParseFlags(test.cmd)
+			require.NoError(t, err)
+			_, err = flagCfg.InitFromViper(v)
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/config/tenancy/flags_test.go
+++ b/pkg/config/tenancy/flags_test.go
@@ -77,7 +77,7 @@ func TestTenancyFlags(t *testing.T) {
 			expected: Options{
 				Enabled: true,
 				Header:  "x-tenant",
-				Tenants: []string{""},
+				Tenants: []string{},
 			},
 		},
 	}

--- a/pkg/config/tenancy/flags_test.go
+++ b/pkg/config/tenancy/flags_test.go
@@ -67,38 +67,17 @@ func TestTenancyFlags(t *testing.T) {
 				Tenants: []string{"acme"},
 			},
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			v := viper.New()
-			command := cobra.Command{}
-			flagSet := &flag.FlagSet{}
-			flagCfg := TenancyFlagsConfig{}
-			flagCfg.AddFlags(flagSet)
-			command.PersistentFlags().AddGoFlagSet(flagSet)
-			v.BindPFlags(command.PersistentFlags())
-
-			err := command.ParseFlags(test.cmd)
-			require.NoError(t, err)
-			tenancyCfg, err := flagCfg.InitFromViper(v)
-			require.NoError(t, err)
-			assert.Equal(t, test.expected, tenancyCfg)
-		})
-	}
-}
-
-// TestFailedTLSFlags verifies that TLS options cannot be used when tls.enabled=false
-func TestInvalidTenancyFlags(t *testing.T) {
-	tests := []struct {
-		name string
-		cmd  []string
-	}{
 		{
-			name: "no tenants",
+			// Not supplying a list of tenants will mean
+			// "tenant header required, but any value will pass"
+			name: "no_tenants",
 			cmd: []string{
 				"--multi_tenancy.enabled=true",
-				"--multi_tenancy.tenants=",
+			},
+			expected: Options{
+				Enabled: true,
+				Header:  "x-tenant",
+				Tenants: []string{""},
 			},
 		},
 	}
@@ -108,15 +87,15 @@ func TestInvalidTenancyFlags(t *testing.T) {
 			v := viper.New()
 			command := cobra.Command{}
 			flagSet := &flag.FlagSet{}
-			flagCfg := TenancyFlagsConfig{}
-			flagCfg.AddFlags(flagSet)
+			AddFlags(flagSet)
 			command.PersistentFlags().AddGoFlagSet(flagSet)
 			v.BindPFlags(command.PersistentFlags())
 
 			err := command.ParseFlags(test.cmd)
 			require.NoError(t, err)
-			_, err = flagCfg.InitFromViper(v)
-			require.Error(t, err)
+			tenancyCfg, err := InitFromViper(v)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, tenancyCfg)
 		})
 	}
 }

--- a/pkg/config/tenancy/tenancy.go
+++ b/pkg/config/tenancy/tenancy.go
@@ -28,9 +28,9 @@ type guard interface {
 
 // Options describes the configuration properties for multitenancy
 type Options struct {
-	Enabled bool     `mapstructure:"enabled"`
-	Header  string   `mapstructure:"header"`
-	Tenants []string `mapstructure:"tenants"`
+	Enabled bool
+	Header  string
+	Tenants []string
 }
 
 // NewTenancyConfig creates a tenancy configuration for tenancy Options

--- a/pkg/config/tenancy/tenancy.go
+++ b/pkg/config/tenancy/tenancy.go
@@ -38,11 +38,9 @@ func NewTenancyConfig(options *Options) *TenancyConfig {
 	return &TenancyConfig{
 		Enabled: options.Enabled,
 		Header:  options.Header,
-		Valid:   TenancyGuardFactory(options),
+		Valid:   tenancyGuardFactory(options),
 	}
 }
-
-// @@@ ecs TODO a function that validates Options; and call it
 
 type tenantUnaware bool
 
@@ -70,8 +68,7 @@ func newTenantList(tenants []string) tenantList {
 	}
 }
 
-// @@@ ecs
-func TenancyGuardFactory(options *Options) Guard {
+func tenancyGuardFactory(options *Options) Guard {
 	if !options.Enabled {
 		return tenantUnaware(true)
 	}

--- a/pkg/config/tenancy/tenancy.go
+++ b/pkg/config/tenancy/tenancy.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenancy
+
+// TenancyConfig holds the settings for multi-tenant Jaeger
+type TenancyConfig struct {
+	Enabled bool
+	Header  string
+	Valid   Guard
+}
+
+// Guard verifies a valid tenant when tenancy is enabled
+type Guard interface {
+	Valid(candidate string) bool
+}
+
+// Options describes the configuration properties for multitenancy
+type Options struct {
+	Enabled bool     `mapstructure:"enabled"`
+	Header  string   `mapstructure:"header"`
+	Tenants []string `mapstructure:"tenants"`
+}
+
+// NewTenancyConfig creates a tenancy configuration for tenancy Options
+func NewTenancyConfig(options *Options) *TenancyConfig {
+	return &TenancyConfig{
+		Enabled: options.Enabled,
+		Header:  options.Header,
+		Valid:   TenancyGuardFactory(options),
+	}
+}
+
+// @@@ ecs TODO a function that validates Options; and call it
+
+type tenantUnaware bool
+
+func (tenantUnaware) Valid(candidate string) bool {
+	return true
+}
+
+type tenantList struct {
+	tenants map[string]bool
+}
+
+func (tl tenantList) Valid(candidate string) bool {
+	_, ok := tl.tenants[candidate]
+	return ok
+}
+
+func newTenantList(tenants []string) tenantList {
+	tenantMap := make(map[string]bool)
+	for _, tenant := range tenants {
+		tenantMap[tenant] = true
+	}
+
+	return tenantList{
+		tenants: tenantMap,
+	}
+}
+
+// @@@ ecs
+func TenancyGuardFactory(options *Options) Guard {
+	if !options.Enabled {
+		return tenantUnaware(true)
+	}
+
+	return newTenantList(options.Tenants)
+}

--- a/pkg/config/tenancy/tenancy.go
+++ b/pkg/config/tenancy/tenancy.go
@@ -14,6 +14,22 @@
 
 package tenancy
 
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/storage"
+	"github.com/jaegertracing/jaeger/storage/dependencystore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
 // TenancyConfig holds the settings for multi-tenant Jaeger
 type TenancyConfig struct {
 	Enabled bool
@@ -24,6 +40,18 @@ type TenancyConfig struct {
 // Guard verifies a valid tenant when tenancy is enabled
 type guard interface {
 	Valid(candidate string) bool
+}
+
+type guardedSpanstoreReader struct {
+	tenancyHeader string
+	reader        spanstore.Reader
+	guard         guard
+}
+
+type guardedDependencystoreReader struct {
+	tenancyHeader string
+	reader        dependencystore.Reader
+	guard         guard
 }
 
 // Options describes the configuration properties for multitenancy
@@ -46,12 +74,21 @@ func (tc *TenancyConfig) Valid(tenant string) bool {
 	return tc.guard.Valid(tenant)
 }
 
+// Anything will pass: no header, empty tenant, etc
 type tenantDontCare bool
 
 func (tenantDontCare) Valid(candidate string) bool {
 	return true
 }
 
+// Header is required, tenant must have any non-empty value
+type tenantAny bool
+
+func (tenantAny) Valid(candidate string) bool {
+	return candidate != ""
+}
+
+// Header is required, tenant must be predefined
 type tenantList struct {
 	tenants map[string]bool
 }
@@ -78,9 +115,133 @@ func tenancyGuardFactory(options *Options) guard {
 	// - tenancy, but no guarding by tenant
 	// - tenancy, with guarding by a list
 
-	if !options.Enabled || len(options.Tenants) == 0 {
+	if !options.Enabled {
 		return tenantDontCare(true)
 	}
 
+	if len(options.Tenants) == 0 {
+		return tenantAny(true)
+	}
+
 	return newTenantList(options.Tenants)
+}
+
+func NewGuardedSpanReader(reader spanstore.Reader, options *Options) spanstore.Reader {
+	return &guardedSpanstoreReader{
+		tenancyHeader: options.Header,
+		guard:         tenancyGuardFactory(options),
+		reader:        reader,
+	}
+}
+
+// @@@ ecs TODO refactor validateTenant
+func TenantFromMetadata(md metadata.MD, tenancyHeader string) (string, error) {
+	tenants := md.Get(tenancyHeader)
+	if len(tenants) < 1 {
+		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
+	} else if len(tenants) > 1 {
+		return "", status.Errorf(codes.PermissionDenied, "extra tenant header")
+	}
+
+	return tenants[0], nil
+}
+
+func ensureTenant(ctx context.Context, tenancyHeader string) (string, context.Context, error) {
+	tenant := storage.GetTenant(ctx)
+	// The tenant might be in either directly in the context or through the metadata
+	if tenant == "" {
+		fmt.Printf("@@@ ecs ensureTenant found no context tenant, checking metadata\n")
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			fmt.Printf("@@@ ecs ensureTenant NO METADATA\n")
+			return "", ctx, status.Errorf(codes.PermissionDenied, "missing tenant header")
+		}
+		fmt.Printf("@@@ ecs ensureTenant found metadata\n")
+
+		var err error
+		tenant, err = TenantFromMetadata(md, tenancyHeader)
+		fmt.Printf("@@@ ecs ensureTenant value of header %s is %q\n", tenancyHeader, tenant)
+		if err != nil {
+			return "", ctx, err
+		}
+
+		ctx = storage.WithTenant(ctx, tenant)
+	}
+
+	return tenant, ctx, nil
+}
+
+func (gsr *guardedSpanstoreReader) GetTrace(ctx context.Context, traceID model.TraceID) (*model.Trace, error) {
+	tenant, tenantedCtx, err := ensureTenant(ctx, gsr.tenancyHeader)
+	if !gsr.guard.Valid(tenant) {
+		return nil, err
+	}
+
+	return gsr.reader.GetTrace(tenantedCtx, traceID)
+}
+
+func (gsr *guardedSpanstoreReader) GetServices(ctx context.Context) ([]string, error) {
+	tenant, tenantedCtx, err := ensureTenant(ctx, gsr.tenancyHeader)
+	if !gsr.guard.Valid(tenant) {
+		return nil, err
+	}
+
+	return gsr.reader.GetServices(tenantedCtx)
+}
+
+func (gsr *guardedSpanstoreReader) GetOperations(ctx context.Context, query spanstore.OperationQueryParameters) ([]spanstore.Operation, error) {
+	tenant, tenantedCtx, err := ensureTenant(ctx, gsr.tenancyHeader)
+	if !gsr.guard.Valid(tenant) {
+		return nil, err
+	}
+
+	return gsr.reader.GetOperations(tenantedCtx, query)
+}
+
+func (gsr *guardedSpanstoreReader) FindTraces(ctx context.Context, query *spanstore.TraceQueryParameters) ([]*model.Trace, error) {
+	fmt.Printf("@@@ ecs REACHED gsr.FindTraces, ctx is %#v, a %T\n", ctx, ctx)
+	if _, ok := metadata.FromIncomingContext(ctx); ok {
+		fmt.Printf("@@@ ecs REACHED gsr.FindTraces, ctx has incoming metadata\n")
+	}
+	if _, ok := metadata.FromOutgoingContext(ctx); ok {
+		fmt.Printf("@@@ ecs REACHED gsr.FindTraces, ctx has outgoing metadata\n")
+	}
+	debug.PrintStack()
+
+	tenant, tenantedCtx, err := ensureTenant(ctx, gsr.tenancyHeader)
+	if !gsr.guard.Valid(tenant) {
+		fmt.Printf("@@@ ecs REACHED gsr.FindTraces(): tenant %q is NOT VALID\n", tenant)
+		return nil, err
+	}
+
+	fmt.Printf("@@@ ecs REACHED gsr.FindTraces(): tenant %q is VALID\n", tenant)
+	return gsr.reader.FindTraces(tenantedCtx, query)
+
+}
+
+func (gsr *guardedSpanstoreReader) FindTraceIDs(ctx context.Context, query *spanstore.TraceQueryParameters) ([]model.TraceID, error) {
+	tenant, tenantedCtx, err := ensureTenant(ctx, gsr.tenancyHeader)
+	if !gsr.guard.Valid(tenant) {
+		return nil, err
+	}
+
+	return gsr.reader.FindTraceIDs(tenantedCtx, query)
+
+}
+
+func (gsr *guardedDependencystoreReader) GetDependencies(ctx context.Context, endTs time.Time, lookback time.Duration) ([]model.DependencyLink, error) {
+	tenant, tenantedCtx, err := ensureTenant(ctx, gsr.tenancyHeader)
+	if !gsr.guard.Valid(tenant) {
+		return nil, err
+	}
+
+	return gsr.reader.GetDependencies(tenantedCtx, endTs, lookback)
+}
+
+func NewGuardedDependencyReader(reader dependencystore.Reader, options *Options) dependencystore.Reader {
+	return &guardedDependencystoreReader{
+		tenancyHeader: options.Header,
+		guard:         tenancyGuardFactory(options),
+		reader:        reader,
+	}
 }

--- a/pkg/config/tenancy/tenancy_test.go
+++ b/pkg/config/tenancy/tenancy_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenancy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTenancyValidity(t *testing.T) {
+	tests := []struct {
+		name    string
+		options Options
+		tenant  string
+		valid   bool
+	}{
+		{
+			name: "valid single tenant",
+			options: Options{
+				Enabled: true,
+				Header:  "x-tenant",
+				Tenants: []string{"acme"},
+			},
+			tenant: "acme",
+			valid:  true,
+		},
+		{
+			name: "valid tenant in multi-tenant setup",
+			options: Options{
+				Enabled: true,
+				Header:  "x-tenant",
+				Tenants: []string{"acme", "country-store"},
+			},
+			tenant: "acme",
+			valid:  true,
+		},
+		{
+			name: "invalid tenant",
+			options: Options{
+				Enabled: true,
+				Header:  "x-tenant",
+				Tenants: []string{"acme", "country-store"},
+			},
+			tenant: "auto-repair",
+			valid:  false,
+		},
+		{
+			// Not supplying a list of tenants will mean
+			// "tenant header required, but any value will pass"
+			name: "any tenant",
+			options: Options{
+				Enabled: true,
+				Header:  "x-tenant",
+				Tenants: []string{},
+			},
+			tenant: "convenience-store",
+			valid:  true,
+		},
+		{
+			name: "ignore tenant",
+			options: Options{
+				Enabled: false,
+				Header:  "",
+				Tenants: []string{"acme"},
+			},
+			tenant: "country-store",
+			// If tenancy not enabled, any tenant is valid
+			valid: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tc := NewTenancyConfig(&test.options)
+			assert.Equal(t, test.valid, tc.Valid(test.tenant))
+		})
+	}
+}


### PR DESCRIPTION
This PR ensures the client-supplied tenant is validated by the HTTP/gRPC layer, and passed through the Context to the storage layer.

This builds upon https://github.com/jaegertracing/jaeger/pull/3688 and should will be rebased after that PR merges

Please review this for direction only until after 3688 is merged.  Some stuff in the current PR duplicates 3688.

The basic idea is to merely guard the spanstore.Reader and the dependencystore.Reader.

cc @pavolloffay 