### PR TITLE
Add flag to enable/disable dependencies on rollover

### DIFF
--- a/cmd/es-rollover/app/flags.go
+++ b/cmd/es-rollover/app/flags.go
@@ -21,25 +21,27 @@ import (
 )
 
 const (
-	indexPrefix   = "index-prefix"
-	archive       = "archive"
-	username      = "es.username"
-	password      = "es.password"
-	useILM        = "es.use-ilm"
-	ilmPolicyName = "es.ilm-policy-name"
-	timeout       = "timeout"
+	indexPrefix      = "index-prefix"
+	archive          = "archive"
+	username         = "es.username"
+	password         = "es.password"
+	useILM           = "es.use-ilm"
+	ilmPolicyName    = "es.ilm-policy-name"
+	timeout          = "timeout"
+	skipDependencies = "skip-dependencies"
 )
 
 // Config holds the global configurations for the es rollover, common to all actions
 type Config struct {
-	IndexPrefix   string
-	Archive       bool
-	Username      string
-	Password      string
-	TLSEnabled    bool
-	ILMPolicyName string
-	UseILM        bool
-	Timeout       int
+	IndexPrefix      string
+	Archive          bool
+	Username         string
+	Password         string
+	TLSEnabled       bool
+	ILMPolicyName    string
+	UseILM           bool
+	Timeout          int
+	SkipDependencies bool
 }
 
 // AddFlags adds flags
@@ -51,6 +53,8 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.Bool(useILM, false, "Use ILM to manage jaeger indices")
 	flags.String(ilmPolicyName, "jaeger-ilm-policy", "The name of the ILM policy to use if ILM is active")
 	flags.Int(timeout, 120, "Number of seconds to wait for master node response")
+	flags.Bool(skipDependencies, false, "Disable rollover for dependencies index")
+
 }
 
 // InitFromViper initializes config from viper.Viper.

--- a/cmd/es-rollover/app/index_options.go
+++ b/cmd/es-rollover/app/index_options.go
@@ -31,7 +31,7 @@ type IndexOption struct {
 }
 
 // RolloverIndices return an array of indices to rollover
-func RolloverIndices(archive bool, prefix string) []IndexOption {
+func RolloverIndices(archive bool, skipDependencies bool, prefix string) []IndexOption {
 	if archive {
 		return []IndexOption{
 			{
@@ -41,7 +41,8 @@ func RolloverIndices(archive bool, prefix string) []IndexOption {
 			},
 		}
 	}
-	return []IndexOption{
+
+	indexOptions := []IndexOption{
 		{
 			prefix:    prefix,
 			Mapping:   "jaeger-span",
@@ -52,12 +53,17 @@ func RolloverIndices(archive bool, prefix string) []IndexOption {
 			Mapping:   "jaeger-service",
 			indexType: "jaeger-service",
 		},
-		{
+	}
+
+	if !skipDependencies {
+		indexOptions = append(indexOptions, IndexOption{
 			prefix:    prefix,
 			Mapping:   "jaeger-dependencies",
 			indexType: "jaeger-dependencies",
-		},
+		})
 	}
+
+	return indexOptions
 }
 
 func (i *IndexOption) IndexName() string {

--- a/cmd/es-rollover/app/index_options_test.go
+++ b/cmd/es-rollover/app/index_options_test.go
@@ -30,10 +30,11 @@ func TestRolloverIndices(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		archive  bool
-		prefix   string
-		expected []expectedValues
+		name             string
+		archive          bool
+		prefix           string
+		skipDependencies bool
+		expected         []expectedValues
 	}{
 		{
 			name: "Empty prefix",
@@ -72,6 +73,13 @@ func TestRolloverIndices(t *testing.T) {
 					readAliasName:        "mytenant-jaeger-span-archive-read",
 					writeAliasName:       "mytenant-jaeger-span-archive-write",
 					initialRolloverIndex: "mytenant-jaeger-span-archive-000001",
+				},
+				{
+					mapping:              "jaeger-dependencies",
+					templateName:         "mytenant-jaeger-dependencies",
+					readAliasName:        "mytenant-jaeger-dependencies-read",
+					writeAliasName:       "mytenant-jaeger-dependencies-write",
+					initialRolloverIndex: "mytenant-jaeger-dependencies-000001",
 				},
 			},
 		},
@@ -115,6 +123,27 @@ func TestRolloverIndices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:             "dependency enable",
+			prefix:           "mytenant",
+			skipDependencies: true,
+			expected: []expectedValues{
+				{
+					mapping:              "jaeger-span",
+					templateName:         "mytenant-jaeger-span",
+					readAliasName:        "mytenant-jaeger-span-read",
+					writeAliasName:       "mytenant-jaeger-span-write",
+					initialRolloverIndex: "mytenant-jaeger-span-000001",
+				},
+				{
+					mapping:              "jaeger-service",
+					templateName:         "mytenant-jaeger-service",
+					readAliasName:        "mytenant-jaeger-service-read",
+					writeAliasName:       "mytenant-jaeger-service-write",
+					initialRolloverIndex: "mytenant-jaeger-service-000001",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -122,7 +151,7 @@ func TestRolloverIndices(t *testing.T) {
 			if test.prefix != "" {
 				test.prefix += "-"
 			}
-			result := RolloverIndices(test.archive, test.prefix)
+			result := RolloverIndices(test.archive, test.skipDependencies, test.prefix)
 			for i, r := range result {
 				assert.Equal(t, test.expected[i].templateName, r.TemplateName())
 				assert.Equal(t, test.expected[i].mapping, r.Mapping)

--- a/cmd/es-rollover/app/init/action.go
+++ b/cmd/es-rollover/app/init/action.go
@@ -69,7 +69,7 @@ func (c Action) Do() error {
 			return fmt.Errorf("ILM is supported only for ES version 7+")
 		}
 	}
-	rolloverIndices := app.RolloverIndices(c.Config.Archive, c.Config.IndexPrefix)
+	rolloverIndices := app.RolloverIndices(c.Config.Archive, c.Config.SkipDependencies, c.Config.IndexPrefix)
 	for _, indexName := range rolloverIndices {
 		if err := c.init(version, indexName); err != nil {
 			return err

--- a/cmd/es-rollover/app/lookback/action.go
+++ b/cmd/es-rollover/app/lookback/action.go
@@ -35,7 +35,7 @@ type Action struct {
 
 // Do the lookback action
 func (a *Action) Do() error {
-	rolloverIndices := app.RolloverIndices(a.Config.Archive, a.Config.IndexPrefix)
+	rolloverIndices := app.RolloverIndices(a.Config.Archive, a.Config.SkipDependencies, a.Config.IndexPrefix)
 	for _, indexName := range rolloverIndices {
 		if err := a.lookback(indexName); err != nil {
 			return err

--- a/cmd/es-rollover/app/rollover/action.go
+++ b/cmd/es-rollover/app/rollover/action.go
@@ -30,7 +30,7 @@ type Action struct {
 
 // Do the rollover action
 func (a *Action) Do() error {
-	rolloverIndices := app.RolloverIndices(a.Config.Archive, a.Config.IndexPrefix)
+	rolloverIndices := app.RolloverIndices(a.Config.Archive, a.Config.SkipDependencies, a.Config.IndexPrefix)
 	for _, indexName := range rolloverIndices {
 		if err := a.rollover(indexName); err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

## Which problem is this PR solving?
-  Solves https://github.com/jaegertracing/jaeger/issues/3706

## Short description of the changes
- This PR adds a flag to enable/disable the dependencies on roll-over, if the dependencies is disabled it won't rollover dependencies index.
