### PR TITLE
Refactor tenancy checking from gRPC to gRPC batch consumer

### DIFF
--- a/cmd/collector/app/handler/grpc_handler.go
+++ b/cmd/collector/app/handler/grpc_handler.go
@@ -33,7 +33,6 @@ import (
 type GRPCHandler struct {
 	logger        *zap.Logger
 	batchConsumer batchConsumer
-	tenancyConfig *tenancy.TenancyConfig
 }
 
 // NewGRPCHandler registers routes for this handler on the given router.
@@ -47,21 +46,15 @@ func NewGRPCHandler(logger *zap.Logger, spanProcessor processor.SpanProcessor, t
 				InboundTransport: processor.GRPCTransport,
 				SpanFormat:       processor.ProtoSpanFormat,
 			},
+			tenancyConfig: *tenancyConfig,
 		},
-		tenancyConfig: tenancyConfig,
 	}
 }
 
 // PostSpans implements gRPC CollectorService.
 func (g *GRPCHandler) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) (*api_v2.PostSpansResponse, error) {
-	tenant, err := g.validateTenant(ctx)
-	if err != nil {
-		g.logger.Error("rejecting spans (tenancy)", zap.Error(err))
-		return nil, err
-	}
-
 	batch := &r.Batch
-	err = g.batchConsumer.consume(batch, tenant)
+	err := g.batchConsumer.consume(ctx, batch)
 	return &api_v2.PostSpansResponse{}, err
 }
 
@@ -69,15 +62,22 @@ type batchConsumer struct {
 	logger        *zap.Logger
 	spanProcessor processor.SpanProcessor
 	spanOptions   processor.SpansOptions
+	tenancyConfig tenancy.TenancyConfig
 }
 
-func (c *batchConsumer) consume(batch *model.Batch, tenant string) error {
+func (c *batchConsumer) consume(ctx context.Context, batch *model.Batch) error {
+	tenant, err := c.validateTenant(ctx)
+	if err != nil {
+		c.logger.Error("rejecting spans (tenancy)", zap.Error(err))
+		return err
+	}
+
 	for _, span := range batch.Spans {
 		if span.GetProcess() == nil {
 			span.Process = batch.Process
 		}
 	}
-	_, err := c.spanProcessor.ProcessSpans(batch.Spans, processor.SpansOptions{
+	_, err = c.spanProcessor.ProcessSpans(batch.Spans, processor.SpansOptions{
 		InboundTransport: processor.GRPCTransport,
 		SpanFormat:       processor.ProtoSpanFormat,
 		Tenant:           tenant,
@@ -92,8 +92,8 @@ func (c *batchConsumer) consume(batch *model.Batch, tenant string) error {
 	return nil
 }
 
-func (g *GRPCHandler) validateTenant(ctx context.Context) (string, error) {
-	if !g.tenancyConfig.Enabled {
+func (c *batchConsumer) validateTenant(ctx context.Context) (string, error) {
+	if !c.tenancyConfig.Enabled {
 		return "", nil
 	}
 
@@ -102,14 +102,14 @@ func (g *GRPCHandler) validateTenant(ctx context.Context) (string, error) {
 		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
 	}
 
-	tenants := md[g.tenancyConfig.Header]
+	tenants := md[c.tenancyConfig.Header]
 	if len(tenants) < 1 {
 		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
 	} else if len(tenants) > 1 {
 		return "", status.Errorf(codes.PermissionDenied, "extra tenant header")
 	}
 
-	if !g.tenancyConfig.Valid(tenants[0]) {
+	if !c.tenancyConfig.Valid(tenants[0]) {
 		return "", status.Errorf(codes.PermissionDenied, "unknown tenant")
 	}
 

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -350,7 +350,7 @@ func TestGetTenant(t *testing.T) {
 		}))
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tenant, err := handler.validateTenant(test.ctx)
+			tenant, err := handler.batchConsumer.validateTenant(test.ctx)
 			if test.mustFail {
 				require.Error(t, err)
 			} else {

--- a/cmd/collector/app/handler/otlp_receiver.go
+++ b/cmd/collector/app/handler/otlp_receiver.go
@@ -139,14 +139,11 @@ func applyTLSSettings(opts *tlscfg.Options) *configtls.TLSServerSetting {
 
 func newConsumerDelegate(logger *zap.Logger, spanProcessor processor.SpanProcessor) *consumerDelegate {
 	return &consumerDelegate{
-		batchConsumer: batchConsumer{
-			logger:        logger,
-			spanProcessor: spanProcessor,
-			spanOptions: processor.SpansOptions{
-				SpanFormat:       processor.OTLPSpanFormat,
-				InboundTransport: processor.UnknownTransport, // could be gRPC or HTTP
-			},
-		},
+		batchConsumer: newBatchConsumer(logger,
+			spanProcessor,
+			processor.UnknownTransport, // could be gRPC or HTTP
+			processor.OTLPSpanFormat,
+			nil),
 		protoFromTraces: otlp2jaeger.ProtoFromTraces,
 	}
 }

--- a/cmd/collector/app/handler/otlp_receiver.go
+++ b/cmd/collector/app/handler/otlp_receiver.go
@@ -156,13 +156,13 @@ type consumerDelegate struct {
 	protoFromTraces func(td ptrace.Traces) ([]*model.Batch, error)
 }
 
-func (c *consumerDelegate) consume(_ context.Context, td ptrace.Traces) error {
+func (c *consumerDelegate) consume(ctx context.Context, td ptrace.Traces) error {
 	batches, err := c.protoFromTraces(td)
 	if err != nil {
 		return err
 	}
 	for _, batch := range batches {
-		err := c.batchConsumer.consume(batch, "")
+		err := c.batchConsumer.consume(ctx, batch)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

The addresses https://github.com/jaegertracing/jaeger/pull/3688#discussion_r885717997 by moving tenancy checking so that the OTLP consumer can reuse it.