### PR TITLE
fix: dependency flag not recognized

### DIFF
--- a/cmd/es-rollover/app/flags.go
+++ b/cmd/es-rollover/app/flags.go
@@ -69,4 +69,5 @@ func (c *Config) InitFromViper(v *viper.Viper) {
 	c.ILMPolicyName = v.GetString(ilmPolicyName)
 	c.UseILM = v.GetBool(useILM)
 	c.Timeout = v.GetInt(timeout)
+	c.SkipDependencies = v.GetBool(skipDependencies)
 }

--- a/cmd/es-rollover/app/flags_test.go
+++ b/cmd/es-rollover/app/flags_test.go
@@ -41,6 +41,7 @@ func TestBindFlags(t *testing.T) {
 		"--es.password=qwerty123",
 		"--es.use-ilm=true",
 		"--es.ilm-policy-name=jaeger-ilm",
+		"--skip-dependencies=true",
 	})
 	require.NoError(t, err)
 
@@ -51,4 +52,5 @@ func TestBindFlags(t *testing.T) {
 	assert.Equal(t, "admin", c.Username)
 	assert.Equal(t, "qwerty123", c.Password)
 	assert.Equal(t, "jaeger-ilm", c.ILMPolicyName)
+	assert.Equal(t, true, c.SkipDependencies)
 }


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Closes https://github.com/jaegertracing/jaeger/issues/3723

## Short description of the changes
- init `skip-dependencies` flag.
