### PR TITLE
Tenant handling for queries using interceptor

### DIFF
--- a/cmd/agent/app/proxy_builders.go
+++ b/cmd/agent/app/proxy_builders.go
@@ -16,11 +16,16 @@ package app
 
 import (
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // GRPCCollectorProxyBuilder creates CollectorProxyBuilder for GRPC reporter
 func GRPCCollectorProxyBuilder(builder *grpc.ConnBuilder) CollectorProxyBuilder {
 	return func(opts ProxyBuilderOptions) (proxy CollectorProxy, err error) {
-		return grpc.NewCollectorProxy(builder, opts.AgentTags, opts.Metrics, opts.Logger)
+		md := metadata.New(map[string]string{})
+		if opts.TenancyHeader != "" {
+			md = metadata.New(map[string]string{opts.TenancyHeader: opts.Tenant})
+		}
+		return grpc.NewCollectorProxy(builder, opts.AgentTags, opts.Metrics, md, opts.Logger)
 	}
 }

--- a/cmd/agent/app/proxy_builders.go
+++ b/cmd/agent/app/proxy_builders.go
@@ -15,8 +15,9 @@
 package app
 
 import (
-	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 )
 
 // GRPCCollectorProxyBuilder creates CollectorProxyBuilder for GRPC reporter

--- a/cmd/agent/app/reporter/flags.go
+++ b/cmd/agent/app/reporter/flags.go
@@ -39,8 +39,10 @@ type Type string
 
 // Options holds generic reporter configuration.
 type Options struct {
-	ReporterType Type
-	AgentTags    map[string]string
+	ReporterType  Type
+	AgentTags     map[string]string
+	TenancyHeader string
+	Tenant        string
 }
 
 // AddFlags adds flags for Options.
@@ -59,5 +61,8 @@ func (b *Options) InitFromViper(v *viper.Viper, logger *zap.Logger) *Options {
 			b.AgentTags = flags.ParseJaegerTags(v.GetString(agentTags))
 		}
 	}
+	// @@@ ecs TODO These MUST be defined as flags, not constants
+	b.TenancyHeader = "x-tenant"
+	b.Tenant = "_self"
 	return b
 }

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
@@ -43,6 +44,8 @@ collectorHostPorts:
 `
 
 var testCertKeyLocation = "../../../../../pkg/config/tlscfg/testdata/"
+
+var emptyMetadata = metadata.New(map[string]string{})
 
 type noopNotifier struct{}
 
@@ -210,7 +213,7 @@ func TestProxyBuilder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			proxy, err := NewCollectorProxy(test.grpcBuilder, nil, metrics.NullFactory, zap.NewNop())
+			proxy, err := NewCollectorProxy(test.grpcBuilder, nil, metrics.NullFactory, emptyMetadata, zap.NewNop())
 			if test.expectError {
 				require.Error(t, err)
 			} else {
@@ -359,6 +362,7 @@ func TestProxyClientTLS(t *testing.T) {
 				grpcBuilder,
 				nil,
 				mFactory,
+				emptyMetadata,
 				zap.NewNop())
 
 			require.NoError(t, err)

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -43,7 +43,7 @@ func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFacto
 		return nil, err
 	}
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
-	r1 := NewReporter(conn, agentTags, metadata, logger)
+	r1 := NewReporterWithMetadata(conn, agentTags, metadata, logger)
 	r2 := reporter.WrapWithMetrics(r1, grpcMetrics)
 	r3 := reporter.WrapWithClientMetrics(reporter.ClientMetricsReporterParams{
 		Reporter:       r2,

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/configmanager"
 	grpcManager "github.com/jaegertracing/jaeger/cmd/agent/app/configmanager/grpc"
@@ -36,13 +37,13 @@ type ProxyBuilder struct {
 }
 
 // NewCollectorProxy creates ProxyBuilder
-func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
+func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFactory metrics.Factory, metadata metadata.MD, logger *zap.Logger) (*ProxyBuilder, error) {
 	conn, err := builder.CreateConnection(logger, mFactory)
 	if err != nil {
 		return nil, err
 	}
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
-	r1 := NewReporter(conn, agentTags, logger)
+	r1 := NewReporter(conn, agentTags, metadata, logger)
 	r2 := reporter.WrapWithMetrics(r1, grpcMetrics)
 	r3 := reporter.WrapWithClientMetrics(reporter.ClientMetricsReporterParams{
 		Reporter:       r2,

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -46,7 +46,7 @@ func TestMultipleCollectors(t *testing.T) {
 	defer s2.Stop()
 
 	mFactory := metricstest.NewFactory(time.Microsecond)
-	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, mFactory, zap.NewNop())
+	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, mFactory, emptyMetadata, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -41,13 +41,18 @@ type Reporter struct {
 }
 
 // NewReporter creates gRPC reporter.
-func NewReporter(conn *grpc.ClientConn, agentTags map[string]string, metadata metadata.MD, logger *zap.Logger) *Reporter {
+func NewReporter(conn *grpc.ClientConn, agentTags map[string]string, logger *zap.Logger) *Reporter {
+	return NewReporterWithMetadata(conn, agentTags, metadata.New(map[string]string{}), logger)
+}
+
+// NewReporter creates gRPC reporter that supplies metadata (e.g. for tenancy).
+func NewReporterWithMetadata(conn *grpc.ClientConn, agentTags map[string]string, md metadata.MD, logger *zap.Logger) *Reporter {
 	return &Reporter{
 		collector: api_v2.NewCollectorServiceClient(conn),
 		agentTags: makeModelKeyValue(agentTags),
 		logger:    logger,
 		sanitizer: zipkin2.NewChainedSanitizer(zipkin2.NewStandardSanitizers()...),
-		metadata:  metadata,
+		metadata:  md,
 	}
 }
 

--- a/cmd/collector/app/handler/grpc_handler.go
+++ b/cmd/collector/app/handler/grpc_handler.go
@@ -113,7 +113,7 @@ func (c *batchConsumer) validateTenant(ctx context.Context) (string, error) {
 		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
 	}
 
-	tenants := md[c.tenancyConfig.Header]
+	tenants := md.Get(c.tenancyConfig.Header)
 	if len(tenants) < 1 {
 		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
 	} else if len(tenants) > 1 {

--- a/cmd/query/app/apiv3/grpc_gateway.go
+++ b/cmd/query/app/apiv3/grpc_gateway.go
@@ -25,16 +25,22 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v3"
 )
 
 // RegisterGRPCGateway registers api_v3 endpoints into provided mux.
-func RegisterGRPCGateway(ctx context.Context, logger *zap.Logger, r *mux.Router, basePath string, grpcEndpoint string, grpcTLS tlscfg.Options) error {
+func RegisterGRPCGateway(ctx context.Context, logger *zap.Logger, r *mux.Router, basePath string, grpcEndpoint string, grpcTLS tlscfg.Options, tenancyOptions tenancy.Options) error {
 	jsonpb := &runtime.JSONPb{}
-	grpcGatewayMux := runtime.NewServeMux(
+	muxOpts := []runtime.ServeMuxOption{
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, jsonpb),
-	)
+	}
+	tc := tenancy.NewTenancyConfig(&tenancyOptions)
+	if tenancyOptions.Enabled {
+		muxOpts = append(muxOpts, runtime.WithMetadata(tc.MetadataAnnotator()))
+	}
+	grpcGatewayMux := runtime.NewServeMux(muxOpts...)
 	var handler http.Handler = grpcGatewayMux
 	if basePath != "/" {
 		handler = http.StripPrefix(basePath, grpcGatewayMux)

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model/adjuster"
 	"github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/ports"
 	"github.com/jaegertracing/jaeger/storage"
@@ -79,6 +80,8 @@ type QueryOptions struct {
 	AdditionalHeaders http.Header
 	// MaxClockSkewAdjust is the maximum duration by which jaeger-query will adjust a span
 	MaxClockSkewAdjust time.Duration
+	// Tenancy configures tenancy for endpoints that query spans
+	Tenancy tenancy.Options
 }
 
 // AddFlags adds flags for QueryOptions
@@ -93,6 +96,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Duration(queryMaxClockSkewAdjust, 0, "The maximum delta by which span timestamps may be adjusted in the UI due to clock skew; set to 0s to disable clock skew adjustments")
 	tlsGRPCFlagsConfig.AddFlags(flagSet)
 	tlsHTTPFlagsConfig.AddFlags(flagSet)
+	tenancy.AddFlags(flagSet)
 }
 
 // InitFromViper initializes QueryOptions with properties from viper
@@ -121,6 +125,11 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper, logger *zap.Logger) (*Q
 		logger.Error("Failed to parse headers", zap.Strings("slice", stringSlice), zap.Error(err))
 	} else {
 		qOpts.AdditionalHeaders = headers
+	}
+	if tenancy, err := tenancy.InitFromViper(v); err == nil {
+		qOpts.Tenancy = tenancy
+	} else {
+		return qOpts, fmt.Errorf("failed to parse Tenancy options: %w", err)
 	}
 	return qOpts, nil
 }

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -31,10 +31,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/plugin/metrics/disabled"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
@@ -143,9 +145,17 @@ type grpcClient struct {
 	conn *grpc.ClientConn
 }
 
-func newGRPCServer(t *testing.T, q *querysvc.QueryService, mq querysvc.MetricsQueryService, logger *zap.Logger, tracer opentracing.Tracer) (*grpc.Server, net.Addr) {
+func newGRPCServer(t *testing.T, q *querysvc.QueryService, mq querysvc.MetricsQueryService, logger *zap.Logger, tracer opentracing.Tracer, tenancyConfig *tenancy.TenancyConfig) (*grpc.Server, net.Addr) {
 	lis, _ := net.Listen("tcp", ":0")
-	grpcServer := grpc.NewServer()
+
+	var grpcOpts []grpc.ServerOption
+	if tenancyConfig.Enabled {
+		grpcOpts = append(grpcOpts, grpc.StreamInterceptor(
+			tenancy.NewGuardingStreamInterceptor(tenancyConfig)),
+		)
+	}
+	grpcServer := grpc.NewServer(grpcOpts...)
+
 	grpcHandler := &GRPCHandler{
 		queryService:        q,
 		metricsQueryService: mq,
@@ -219,7 +229,7 @@ func initializeTestServerGRPCWithOptions(t *testing.T, options ...testOption) *g
 	logger := zap.NewNop()
 	tracer := opentracing.NoopTracer{}
 
-	server, addr := newGRPCServer(t, q, tqs.metricsQueryService, logger, tracer)
+	server, addr := newGRPCServer(t, q, tqs.metricsQueryService, logger, tracer, &tenancy.TenancyConfig{})
 
 	return &grpcServer{
 		server:              server,
@@ -929,4 +939,180 @@ func TestMetricsQueryNilRequestGRPC(t *testing.T) {
 	bqp, err := grpcHandler.newBaseQueryParameters(nil)
 	assert.Empty(t, bqp)
 	assert.EqualError(t, err, errNilRequest.Error())
+}
+
+func initializeTenantedTestServerGRPCWithOptions(t *testing.T, tc *tenancy.TenancyConfig, options ...testOption) *grpcServer {
+	archiveSpanReader := &spanstoremocks.Reader{}
+	archiveSpanWriter := &spanstoremocks.Writer{}
+
+	spanReader := &spanstoremocks.Reader{}
+	dependencyReader := &depsmocks.Reader{}
+	disabledReader, err := disabled.NewMetricsReader()
+	require.NoError(t, err)
+
+	q := querysvc.NewQueryService(
+		spanReader,
+		dependencyReader,
+		querysvc.QueryServiceOptions{
+			ArchiveSpanReader: archiveSpanReader,
+			ArchiveSpanWriter: archiveSpanWriter,
+		})
+
+	tqs := &testQueryService{
+		// Disable metrics query by default.
+		metricsQueryService: disabledReader,
+	}
+	for _, opt := range options {
+		opt(tqs)
+	}
+
+	logger := zap.NewNop()
+	tracer := opentracing.NoopTracer{}
+
+	server, addr := newGRPCServer(t, q, tqs.metricsQueryService, logger, tracer, tc)
+
+	return &grpcServer{
+		server:              server,
+		lisAddr:             addr,
+		spanReader:          spanReader,
+		depReader:           dependencyReader,
+		metricsQueryService: tqs.metricsQueryService,
+		archiveSpanReader:   archiveSpanReader,
+		archiveSpanWriter:   archiveSpanWriter,
+	}
+}
+
+func withTenantedServerAndClient(t *testing.T, tc *tenancy.TenancyConfig, actualTest func(server *grpcServer, client *grpcClient), options ...testOption) {
+	server := initializeTenantedTestServerGRPCWithOptions(t, tc, options...)
+	client := newGRPCClient(t, server.lisAddr.String())
+	defer server.server.Stop()
+	defer client.conn.Close()
+
+	actualTest(server, client)
+}
+
+// withOutgoingMetadata returns a Context with metadata for a server to receive
+func withOutgoingMetadata(t *testing.T, ctx context.Context, headerName, headerValue string) context.Context {
+	t.Helper()
+
+	md := metadata.New(map[string]string{headerName: headerValue})
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func TestSearchTenancyGRPC(t *testing.T) {
+	tc := tenancy.NewTenancyConfig(&tenancy.Options{
+		Enabled: true,
+	})
+	withTenantedServerAndClient(t, tc, func(server *grpcServer, client *grpcClient) {
+		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
+			Return(mockTrace, nil).Once()
+
+		// First try without tenancy header
+		res, err := client.GetTrace(context.Background(), &api_v2.GetTraceRequest{
+			TraceID: mockTraceID,
+		})
+
+		require.NoError(t, err, "could not initiate GetTraceRequest")
+
+		spanResChunk, err := res.Recv()
+		assertGRPCError(t, err, codes.PermissionDenied, "missing tenant header")
+		assert.Nil(t, spanResChunk)
+
+		// Next try with tenancy
+		res, err = client.GetTrace(
+			withOutgoingMetadata(t, context.Background(), tc.Header, "acme"),
+			&api_v2.GetTraceRequest{
+				TraceID: mockTraceID,
+			})
+
+		spanResChunk, _ = res.Recv()
+
+		require.NoError(t, err, "expecting gRPC to succeed with any tenancy header")
+		require.NotNil(t, spanResChunk)
+		require.NotNil(t, spanResChunk.Spans)
+		require.Equal(t, len(mockTrace.Spans), len(spanResChunk.Spans))
+		assert.Equal(t, mockTraceID, spanResChunk.Spans[0].TraceID)
+	})
+}
+
+func TestSearchTenancyGRPCExplicitList(t *testing.T) {
+	tc := tenancy.NewTenancyConfig(&tenancy.Options{
+		Enabled: true,
+		Header:  "non-standard-tenant-header",
+		Tenants: []string{"mercury", "venus", "mars"},
+	})
+	withTenantedServerAndClient(t, tc, func(server *grpcServer, client *grpcClient) {
+		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
+			Return(mockTrace, nil).Once()
+
+		for _, tc := range []struct {
+			name           string
+			tenancyHeader  string
+			tenant         string
+			wantErr        bool
+			failureCode    codes.Code
+			failureMessage string
+		}{
+			{
+				name:           "no header",
+				wantErr:        true,
+				failureCode:    codes.PermissionDenied,
+				failureMessage: "missing tenant header",
+			},
+			{
+				name:           "invalid header",
+				tenancyHeader:  "not-the-correct-header",
+				tenant:         "mercury",
+				wantErr:        true,
+				failureCode:    codes.PermissionDenied,
+				failureMessage: "missing tenant header",
+			},
+			{
+				name:           "missing tenant",
+				tenancyHeader:  tc.Header,
+				tenant:         "",
+				wantErr:        true,
+				failureCode:    codes.PermissionDenied,
+				failureMessage: "unknown tenant",
+			},
+			{
+				name:           "invalid tenant",
+				tenancyHeader:  tc.Header,
+				tenant:         "some-other-tenant-not-in-the-list",
+				wantErr:        true,
+				failureCode:    codes.PermissionDenied,
+				failureMessage: "unknown tenant",
+			},
+			{
+				name:          "valid tenant",
+				tenancyHeader: tc.Header,
+				tenant:        "venus",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx := context.Background()
+				if tc.tenancyHeader != "" {
+					ctx = withOutgoingMetadata(t, context.Background(), tc.tenancyHeader, tc.tenant)
+				}
+				res, err := client.GetTrace(ctx, &api_v2.GetTraceRequest{
+					TraceID: mockTraceID,
+				})
+
+				require.NoError(t, err, "could not initiate GetTraceRequest")
+
+				spanResChunk, err := res.Recv()
+
+				if tc.wantErr {
+					assertGRPCError(t, err, tc.failureCode, tc.failureMessage)
+					assert.Nil(t, spanResChunk)
+				} else {
+					require.NoError(t, err, "expecting gRPC to succeed")
+					require.NotNil(t, spanResChunk)
+					require.NotNil(t, spanResChunk.Spans)
+					require.Equal(t, len(mockTrace.Spans), len(spanResChunk.Spans))
+					assert.Equal(t, mockTraceID, spanResChunk.Spans[0].TraceID)
+				}
+			})
+		}
+	})
 }

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/adjuster"
 	ui "github.com/jaegertracing/jaeger/model/json"
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 	"github.com/jaegertracing/jaeger/plugin/metrics/disabled"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 	depsmocks "github.com/jaegertracing/jaeger/storage/dependencystore/mocks"
@@ -90,7 +91,7 @@ type structuredTraceResponse struct {
 }
 
 func initializeTestServerWithHandler(queryOptions querysvc.QueryServiceOptions, options ...HandlerOption) *testServer {
-	return initializeTestServerWithOptions(
+	return initializeTestServerWithOptions(tenancy.TenancyConfig{},
 		queryOptions,
 		append(
 			[]HandlerOption{
@@ -105,15 +106,19 @@ func initializeTestServerWithHandler(queryOptions querysvc.QueryServiceOptions, 
 	)
 }
 
-func initializeTestServerWithOptions(queryOptions querysvc.QueryServiceOptions, options ...HandlerOption) *testServer {
+func initializeTestServerWithOptions(tenancyConfig tenancy.TenancyConfig, queryOptions querysvc.QueryServiceOptions, options ...HandlerOption) *testServer {
 	readStorage := &spanstoremocks.Reader{}
 	dependencyStorage := &depsmocks.Reader{}
-	qs := querysvc.NewQueryService(readStorage, dependencyStorage, queryOptions)
+	qs := querysvc.NewQueryService(
+		readStorage,
+		dependencyStorage,
+		queryOptions)
 	r := NewRouter()
 	handler := NewAPIHandler(qs, options...)
 	handler.RegisterRoutes(r)
 	return &testServer{
-		server:           httptest.NewServer(r),
+		server: httptest.NewServer(
+			tenancyConfig.PropagationHandler(zap.NewNop(), r)),
 		spanReader:       readStorage,
 		dependencyReader: dependencyStorage,
 		handler:          handler,
@@ -132,7 +137,7 @@ type testServer struct {
 }
 
 func withTestServer(doTest func(s *testServer), queryOptions querysvc.QueryServiceOptions, options ...HandlerOption) {
-	ts := initializeTestServerWithOptions(queryOptions, options...)
+	ts := initializeTestServerWithOptions(tenancy.TenancyConfig{}, queryOptions, options...)
 	defer ts.server.Close()
 	doTest(ts)
 }
@@ -401,7 +406,7 @@ func TestSearchByTraceIDSuccess(t *testing.T) {
 
 func TestSearchByTraceIDSuccessWithArchive(t *testing.T) {
 	archiveReadMock := &spanstoremocks.Reader{}
-	ts := initializeTestServerWithOptions(querysvc.QueryServiceOptions{
+	ts := initializeTestServerWithOptions(tenancy.TenancyConfig{}, querysvc.QueryServiceOptions{
 		ArchiveSpanReader: archiveReadMock,
 	})
 	defer ts.server.Close()
@@ -443,7 +448,7 @@ func TestSearchByTraceIDFailure(t *testing.T) {
 }
 
 func TestSearchModelConversionFailure(t *testing.T) {
-	ts := initializeTestServerWithOptions(
+	ts := initializeTestServerWithOptions(tenancy.TenancyConfig{},
 		querysvc.QueryServiceOptions{
 			Adjuster: adjuster.Func(func(trace *model.Trace) (*model.Trace, error) {
 				return trace, errAdjustment
@@ -812,11 +817,15 @@ func TestGetMinStep(t *testing.T) {
 
 // getJSON fetches a JSON document from a server via HTTP GET
 func getJSON(url string, out interface{}) error {
+	return getJSONCustomHeaders(url, make(map[string]string), out)
+}
+
+func getJSONCustomHeaders(url string, additionalHeaders map[string]string, out interface{}) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
 	}
-	return execJSON(req, out)
+	return execJSON(req, additionalHeaders, out)
 }
 
 // postJSON submits a JSON document to a server via HTTP POST and parses response as JSON.
@@ -830,12 +839,15 @@ func postJSON(url string, req interface{}, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	return execJSON(r, out)
+	return execJSON(r, make(map[string]string), out)
 }
 
 // execJSON executes an http request against a server and parses response as JSON
-func execJSON(req *http.Request, out interface{}) error {
+func execJSON(req *http.Request, additionalHeaders map[string]string, out interface{}) error {
 	req.Header.Add("Accept", "application/json")
+	for k, v := range additionalHeaders {
+		req.Header.Add(k, v)
+	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -868,4 +880,30 @@ func execJSON(req *http.Request, out interface{}) error {
 // Generates a JSON response that the server should produce given a certain error code and error.
 func parsedError(code int, err string) string {
 	return fmt.Sprintf(`%d error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":%d,"msg":"%s"}]}`+"\n", code, code, err)
+}
+
+func TestSearchTenancyHTTP(t *testing.T) {
+	tenancyOptions := tenancy.Options{
+		Enabled: true,
+	}
+	ts := initializeTestServerWithOptions(
+		*tenancy.NewTenancyConfig(&tenancyOptions),
+		querysvc.QueryServiceOptions{})
+	defer ts.server.Close()
+	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
+		Return(mockTrace, nil).Twice()
+
+	var response structuredResponse
+	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2`, &response)
+	assert.Error(t, err)
+	assert.Len(t, response.Errors, 0)
+	assert.Nil(t, response.Data)
+
+	err = getJSONCustomHeaders(
+		ts.server.URL+`/api/traces?traceID=1&traceID=2`,
+		map[string]string{"x-tenant": "acme"},
+		&response)
+	assert.NoError(t, err)
+	assert.Len(t, response.Errors, 0)
+	assert.Len(t, response.Data, 2)
 }

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -168,7 +168,7 @@ func createHTTPServer(querySvc *querysvc.QueryService, metricsQuerySvc querysvc.
 	}
 
 	ctx, closeGRPCGateway := context.WithCancel(context.Background())
-	if err := apiv3.RegisterGRPCGateway(ctx, logger, r, queryOpts.BasePath, queryOpts.GRPCHostPort, queryOpts.TLSGRPC); err != nil {
+	if err := apiv3.RegisterGRPCGateway(ctx, logger, r, queryOpts.BasePath, queryOpts.GRPCHostPort, queryOpts.TLSGRPC, queryOpts.Tenancy); err != nil {
 		closeGRPCGateway()
 		return nil, nil, err
 	}

--- a/pkg/config/tenancy/context.go
+++ b/pkg/config/tenancy/context.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenancy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/jaegertracing/jaeger/storage"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func tenantFromMetadata(md metadata.MD, tenancyHeader string) (string, error) {
+	tenants := md.Get(tenancyHeader)
+	if len(tenants) < 1 {
+		return "", status.Errorf(codes.PermissionDenied, "missing tenant header")
+	} else if len(tenants) > 1 {
+		return "", status.Errorf(codes.PermissionDenied, "extra tenant header")
+	}
+
+	return tenants[0], nil
+}
+
+// @@@ TODO WRITE TESTS
+func (tc *TenancyConfig) GetValidTenantContext(ctx context.Context) (context.Context, error) {
+	tenant := storage.GetTenant(ctx)
+	// Is the tenant directly in the context?
+	if tenant != "" {
+		fmt.Printf("@@@ ecs GetValidTenantContext found %q directly in context\n", tenant)
+		if !tc.Valid(tenant) {
+			fmt.Printf("@@@ ecs GetValidTenantContext: tenant %q not valid\n", tenant)
+			return ctx, status.Errorf(codes.PermissionDenied, "missing tenant header")
+		}
+		return ctx, nil
+	}
+
+	// The tenant might be in the metadata
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx, status.Errorf(codes.PermissionDenied, "missing tenant header")
+	}
+
+	var err error
+	tenant, err = tenantFromMetadata(md, tc.Header)
+	if err != nil {
+		return ctx, err
+	}
+	if !tc.Valid(tenant) {
+		return ctx, status.Errorf(codes.PermissionDenied, "unknown tenant")
+	}
+
+	// Apply the tenant directly the context (in addition to metadata)
+	return storage.WithTenant(ctx, tenant), nil
+}
+
+// PropagationHandler returns a http.Handler containing the logic to extract
+// the tenancy header of the http.Request and insert the tenant into request.Context
+// for propagation. The token can be accessed via storage.GetTenant().
+func (tc *TenancyConfig) PropagationHandler(logger *zap.Logger, h http.Handler) http.Handler {
+	if !tc.Enabled {
+		return h
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tenant := r.Header.Get(tc.Header)
+		if tenant == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("missing tenant header"))
+			return
+		}
+
+		if !tc.Valid(tenant) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("unknown tenant"))
+			return
+		}
+
+		h.ServeHTTP(w, r.WithContext(storage.WithTenant(r.Context(), tenant)))
+	})
+}

--- a/pkg/config/tenancy/flags.go
+++ b/pkg/config/tenancy/flags.go
@@ -30,11 +30,15 @@ const (
 
 // AddFlags adds flags for tenancy to the FlagSet.
 func AddFlags(flags *flag.FlagSet) {
-	flags.Bool(tenancyEnabled, false, "Enable tenancy header when receiving or querying")
-	flags.String(tenancyHeader, "x-tenant", "HTTP header carrying tenant")
-	flags.String(validTenants, "",
-		fmt.Sprintf("comma-separated list of allowed values for --%s header.  (If not supplied, tenants are not restricted)",
-			tenancyHeader))
+	// These flags are used by both query and collector,
+	// but may only be defined once.
+	if flags.Lookup(tenancyEnabled) == nil {
+		flags.Bool(tenancyEnabled, false, "Enable tenancy header when receiving or querying")
+		flags.String(tenancyHeader, "x-tenant", "HTTP header carrying tenant")
+		flags.String(validTenants, "",
+			fmt.Sprintf("comma-separated list of allowed values for --%s header.  (If not supplied, tenants are not restricted)",
+				tenancyHeader))
+	}
 }
 
 // InitFromViper creates tenancy.Options populated with values retrieved from Viper.

--- a/pkg/config/tenancy/interceptor.go
+++ b/pkg/config/tenancy/interceptor.go
@@ -16,6 +16,7 @@ package tenancy
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc"
 )
@@ -35,9 +36,11 @@ func NewGuardingStreamInterceptor(tc *TenancyConfig) grpc.StreamServerIntercepto
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		tenantedCtx, err := tc.GetValidTenantContext(ss.Context())
 		if err != nil {
+			fmt.Printf("@@@ ecs failed to get GetValidTenantContext for %v\n", tc)
 			return err
 		}
 
+		fmt.Printf("@@@ ecs got GetValidTenantContext for %v\n", tc)
 		wrappedSS := &tenantedServerStream{
 			ServerStream: ss,
 			context:      tenantedCtx,

--- a/pkg/config/tenancy/interceptor.go
+++ b/pkg/config/tenancy/interceptor.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenancy
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// tenantedServerStream is a wrapper for ServerStream providing settable context
+type tenantedServerStream struct {
+	grpc.ServerStream
+	context context.Context
+}
+
+func (tss *tenantedServerStream) Context() context.Context {
+	return tss.context
+}
+
+// NewGuardingStreamInterceptor blocks handling of streams whose tenancy header isn't doesn't meet tenancy requirements
+func NewGuardingStreamInterceptor(tc *TenancyConfig) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		tenantedCtx, err := tc.GetValidTenantContext(ss.Context())
+		if err != nil {
+			return err
+		}
+
+		wrappedSS := &tenantedServerStream{
+			ServerStream: ss,
+			context:      tenantedCtx,
+		}
+		return handler(srv, wrappedSS)
+	}
+}

--- a/pkg/config/tenancy/tenancy.go
+++ b/pkg/config/tenancy/tenancy.go
@@ -35,9 +35,14 @@ type Options struct {
 
 // NewTenancyConfig creates a tenancy configuration for tenancy Options
 func NewTenancyConfig(options *Options) *TenancyConfig {
+	// Default header value (although set by CLI flags, this helps tests and API users)
+	header := options.Header
+	if header == "" && options.Enabled {
+		header = "x-tenant"
+	}
 	return &TenancyConfig{
 		Enabled: options.Enabled,
-		Header:  options.Header,
+		Header:  header,
 		guard:   tenancyGuardFactory(options),
 	}
 }

--- a/plugin/storage/factory_config.go
+++ b/plugin/storage/factory_config.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/jaegertracing/jaeger/pkg/config/tenancy"
 )
 
 const (
@@ -43,6 +45,7 @@ type FactoryConfig struct {
 	DependenciesStorageType string
 	DownsamplingRatio       float64
 	DownsamplingHashSalt    string
+	TenancyConfig           tenancy.TenancyConfig
 }
 
 // FactoryConfigFromEnvAndCLI reads the desired types of storage backends from SPAN_STORAGE_TYPE and


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

This replaces the draft https://github.com/jaegertracing/jaeger/pull/3700

This PR flows the tenant header through the query APIs.
This PR blocks requests with invalid tenant or missing tenant header from reaching the query APIs.

@pavolloffay @yurishkuro I had planned to only deliver tenant header checking in this PR.  In interactive testing I discovered that enabling tenancy was causing self-spans to be rejected.  I added a simple implementation for that.  It is possible we should break that implementation out (and deliver it separately first.)

I was uncertain how to handle the CLI options for self-span reporting.  I only test with Jaeger reporting against itself.  Probably I should introduce new CLI options `-reporter.tenant_header` and `-reporter.tenant` so that Jaeger can send spans to a different Jaeger.  Do you concur?  Or should we use the `--multi_tenancy.header` and a special value like `_self` for the tenant?