### PR TITLE
Optionally supply tenancy when reporting spans

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -244,7 +244,6 @@ func CreateCollectorProxy(
 	opts ProxyBuilderOptions,
 	builders map[reporter.Type]CollectorProxyBuilder,
 ) (CollectorProxy, error) {
-	fmt.Printf("@@@ ecs REACHED CreateCollectorProxy, opts=%#v\n", opts)
 	builder, ok := builders[opts.ReporterType]
 	if !ok {
 		return nil, fmt.Errorf("unknown reporter type %s", string(opts.ReporterType))

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -244,6 +244,7 @@ func CreateCollectorProxy(
 	opts ProxyBuilderOptions,
 	builders map[reporter.Type]CollectorProxyBuilder,
 ) (CollectorProxy, error) {
+	fmt.Printf("@@@ ecs REACHED CreateCollectorProxy, opts=%#v\n", opts)
 	builder, ok := builders[opts.ReporterType]
 	if !ok {
 		return nil, fmt.Errorf("unknown reporter type %s", string(opts.ReporterType))

--- a/cmd/agent/app/proxy_builders.go
+++ b/cmd/agent/app/proxy_builders.go
@@ -15,8 +15,6 @@
 package app
 
 import (
-	"fmt"
-
 	"google.golang.org/grpc/metadata"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
@@ -25,7 +23,6 @@ import (
 // GRPCCollectorProxyBuilder creates CollectorProxyBuilder for GRPC reporter
 func GRPCCollectorProxyBuilder(builder *grpc.ConnBuilder) CollectorProxyBuilder {
 	return func(opts ProxyBuilderOptions) (proxy CollectorProxy, err error) {
-		fmt.Printf("@@@ ecs REACHED GRPCCollectorProxyBuilder, builder=%#v, opts=%#v\n", builder, opts)
 		md := metadata.New(map[string]string{})
 		if builder.CollectorTenancyHeader != "" {
 			md = metadata.New(map[string]string{builder.CollectorTenancyHeader: builder.CollectorTenant})

--- a/cmd/agent/app/proxy_builders.go
+++ b/cmd/agent/app/proxy_builders.go
@@ -15,12 +15,21 @@
 package app
 
 import (
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/grpc"
 )
 
 // GRPCCollectorProxyBuilder creates CollectorProxyBuilder for GRPC reporter
 func GRPCCollectorProxyBuilder(builder *grpc.ConnBuilder) CollectorProxyBuilder {
 	return func(opts ProxyBuilderOptions) (proxy CollectorProxy, err error) {
-		return grpc.NewCollectorProxy(builder, opts.AgentTags, opts.Metrics, opts.Logger)
+		fmt.Printf("@@@ ecs REACHED GRPCCollectorProxyBuilder, builder=%#v, opts=%#v\n", builder, opts)
+		md := metadata.New(map[string]string{})
+		if builder.CollectorTenancyHeader != "" {
+			md = metadata.New(map[string]string{builder.CollectorTenancyHeader: builder.CollectorTenant})
+		}
+		return grpc.NewCollectorProxy(builder, opts.AgentTags, opts.Metrics, md, opts.Logger)
 	}
 }

--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -47,6 +47,11 @@ type ConnBuilder struct {
 	DiscoveryMinPeers int
 	Notifier          discovery.Notifier
 	Discoverer        discovery.Discoverer
+
+	// CollectorTenancyHeader is the header used for reporting to a multi-tenant Jaeger, typically x-tenant
+	CollectorTenancyHeader string
+	// CollectorTenant is the tenant reported, typically 'jaeger'
+	CollectorTenant string
 }
 
 // NewConnBuilder creates a new grpc connection builder.

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
@@ -43,6 +44,8 @@ collectorHostPorts:
 `
 
 var testCertKeyLocation = "../../../../../pkg/config/tlscfg/testdata/"
+
+var emptyMetadata = metadata.New(map[string]string{})
 
 type noopNotifier struct{}
 
@@ -210,7 +213,7 @@ func TestProxyBuilder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			proxy, err := NewCollectorProxy(test.grpcBuilder, nil, metrics.NullFactory, zap.NewNop())
+			proxy, err := NewCollectorProxy(test.grpcBuilder, nil, metrics.NullFactory, emptyMetadata, zap.NewNop())
 			if test.expectError {
 				require.Error(t, err)
 			} else {
@@ -359,6 +362,7 @@ func TestProxyClientTLS(t *testing.T) {
 				grpcBuilder,
 				nil,
 				mFactory,
+				emptyMetadata,
 				zap.NewNop())
 
 			require.NoError(t, err)

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -15,11 +15,13 @@
 package grpc
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/configmanager"
 	grpcManager "github.com/jaegertracing/jaeger/cmd/agent/app/configmanager/grpc"
@@ -36,13 +38,14 @@ type ProxyBuilder struct {
 }
 
 // NewCollectorProxy creates ProxyBuilder
-func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFactory metrics.Factory, logger *zap.Logger) (*ProxyBuilder, error) {
+func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFactory metrics.Factory, md metadata.MD, logger *zap.Logger) (*ProxyBuilder, error) {
+	fmt.Printf("@@@ ecs REACHED NewCollectorProxy, builder=%#v\n", builder)
 	conn, err := builder.CreateConnection(logger, mFactory)
 	if err != nil {
 		return nil, err
 	}
 	grpcMetrics := mFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"protocol": "grpc"}})
-	r1 := NewReporter(conn, agentTags, logger)
+	r1 := NewReporterWithMetadata(conn, agentTags, md, logger)
 	r2 := reporter.WrapWithMetrics(r1, grpcMetrics)
 	r3 := reporter.WrapWithClientMetrics(reporter.ClientMetricsReporterParams{
 		Reporter:       r2,

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -15,7 +15,6 @@
 package grpc
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/uber/jaeger-lib/metrics"
@@ -39,7 +38,6 @@ type ProxyBuilder struct {
 
 // NewCollectorProxy creates ProxyBuilder
 func NewCollectorProxy(builder *ConnBuilder, agentTags map[string]string, mFactory metrics.Factory, md metadata.MD, logger *zap.Logger) (*ProxyBuilder, error) {
-	fmt.Printf("@@@ ecs REACHED NewCollectorProxy, builder=%#v\n", builder)
 	conn, err := builder.CreateConnection(logger, mFactory)
 	if err != nil {
 		return nil, err

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -46,7 +46,7 @@ func TestMultipleCollectors(t *testing.T) {
 	defer s2.Stop()
 
 	mFactory := metricstest.NewFactory(time.Microsecond)
-	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, mFactory, zap.NewNop())
+	proxy, err := NewCollectorProxy(&ConnBuilder{CollectorHostPorts: []string{addr1.String(), addr2.String()}}, nil, mFactory, emptyMetadata, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetReporter())

--- a/cmd/agent/app/reporter/grpc/flags.go
+++ b/cmd/agent/app/reporter/grpc/flags.go
@@ -25,11 +25,13 @@ import (
 )
 
 const (
-	gRPCPrefix        = "reporter.grpc"
-	collectorHostPort = gRPCPrefix + ".host-port"
-	retry             = gRPCPrefix + ".retry.max"
-	defaultMaxRetry   = 3
-	discoveryMinPeers = gRPCPrefix + ".discovery.min-peers"
+	gRPCPrefix             = "reporter.grpc"
+	collectorHostPort      = gRPCPrefix + ".host-port"
+	retry                  = gRPCPrefix + ".retry.max"
+	defaultMaxRetry        = 3
+	discoveryMinPeers      = gRPCPrefix + ".discovery.min-peers"
+	collectorTenancyHeader = gRPCPrefix + ".tenancy-header"
+	collectorTenant        = gRPCPrefix + ".tenant"
 )
 
 var tlsFlagsConfig = tlscfg.ClientFlagsConfig{
@@ -42,6 +44,8 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.Int(discoveryMinPeers, 3, "Max number of collectors to which the agent will try to connect at any given time")
 	flags.String(collectorHostPort, "", "Comma-separated string representing host:port of a static list of collectors to connect to directly")
 	tlsFlagsConfig.AddFlags(flags)
+	flags.String(collectorTenancyHeader, "", "HTTP header carrying reporter tenant")
+	flags.String(collectorTenant, "jaeger", "Reporter tenant")
 }
 
 // InitFromViper initializes Options with properties retrieved from Viper.
@@ -57,5 +61,7 @@ func (b *ConnBuilder) InitFromViper(v *viper.Viper) (*ConnBuilder, error) {
 		return b, fmt.Errorf("failed to process TLS options: %w", err)
 	}
 	b.DiscoveryMinPeers = v.GetInt(discoveryMinPeers)
+	b.CollectorTenancyHeader = v.GetString(collectorTenancyHeader)
+	b.CollectorTenant = v.GetString(collectorTenant)
 	return b, nil
 }

--- a/cmd/agent/app/reporter/grpc/flags_test.go
+++ b/cmd/agent/app/reporter/grpc/flags_test.go
@@ -33,15 +33,23 @@ func TestBindFlags(t *testing.T) {
 	}{
 		{
 			cOpts:    []string{"--reporter.grpc.host-port=localhost:1111", "--reporter.grpc.retry.max=15"},
-			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111"}, MaxRetry: 15, DiscoveryMinPeers: 3},
+			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111"}, MaxRetry: 15, DiscoveryMinPeers: 3, CollectorTenant: "jaeger"},
 		},
 		{
 			cOpts:    []string{"--reporter.grpc.host-port=localhost:1111,localhost:2222"},
-			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111", "localhost:2222"}, MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 3},
+			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111", "localhost:2222"}, MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 3, CollectorTenant: "jaeger"},
 		},
 		{
 			cOpts:    []string{"--reporter.grpc.host-port=localhost:1111,localhost:2222", "--reporter.grpc.discovery.min-peers=5"},
-			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111", "localhost:2222"}, MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 5},
+			expected: &ConnBuilder{CollectorHostPorts: []string{"localhost:1111", "localhost:2222"}, MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 5, CollectorTenant: "jaeger"},
+		},
+		{
+			cOpts:    []string{"--reporter.grpc.tenancy-header=jaeger-tenant"},
+			expected: &ConnBuilder{MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 3, CollectorTenancyHeader: "jaeger-tenant", CollectorTenant: "jaeger"},
+		},
+		{
+			cOpts:    []string{"--reporter.grpc.tenancy-header=jaeger-tenant", "--reporter.grpc.tenant=acme"},
+			expected: &ConnBuilder{MaxRetry: defaultMaxRetry, DiscoveryMinPeers: 3, CollectorTenancyHeader: "jaeger-tenant", CollectorTenant: "acme"},
 		},
 	}
 	for _, test := range tests {

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -17,7 +17,6 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -78,7 +77,6 @@ func (r *Reporter) send(ctx context.Context, spans []*model.Span, process *model
 	spans, process = addProcessTags(spans, process, r.agentTags)
 	batch := model.Batch{Spans: spans, Process: process}
 	req := &api_v2.PostSpansRequest{Batch: batch}
-	fmt.Printf("@@@ ecs in Reporter.send, r.metadata=%#v\n", r.metadata)
 	if len(r.metadata) > 0 {
 		ctx = metadata.NewOutgoingContext(ctx, r.metadata)
 	}

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -16,7 +16,6 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -30,7 +29,6 @@ import (
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/storage"
 	jThrift "github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
@@ -64,8 +62,6 @@ func (h *mockSpanHandler) PostSpans(c context.Context, r *api_v2.PostSpansReques
 	}
 	if h.tenantHeader != "" {
 		md, ok := metadata.FromIncomingContext(c)
-		fmt.Printf("@@@ ecs in mockSpanHandler, c metadata is %#v\n", md)
-		fmt.Printf("@@@ ecs in mockSpanHandler, storage.GetTenant() is %q\n", storage.GetTenant(c))
 		if ok {
 			tenants := md.Get(h.tenantHeader)
 			if len(tenants) > 0 {


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

With https://github.com/jaegertracing/jaeger/pull/3688 we introduced `--multi_tenancy.enabled=true` which enables the collector to reject spans with missing or invalid tenant header.

This PR restores correct span reporting when tenancy is enabled.  Without this change, when a multi-tenant Jaeger gets a (currently untenanted) query, it reports spans related to handling the query without a tenant.  Those (usually) self spans are rejected.

Some of the work in this PR was previously done in the draft PR for query tenancy, https://github.com/jaegertracing/jaeger/pull/3735 .  That PR was getting big so the reporting stuff will be removed and handled in this PR.