### PR TITLE
Introduce ParentReference adjuster

### DIFF
--- a/cmd/query/app/querysvc/adjusters.go
+++ b/cmd/query/app/querysvc/adjusters.go
@@ -30,5 +30,6 @@ func StandardAdjusters(maxClockSkewAdjust time.Duration) []adjuster.Adjuster {
 		adjuster.IPTagAdjuster(),
 		adjuster.SortLogFields(),
 		adjuster.SpanReferences(),
+		adjuster.ParentReference(),
 	}
 }

--- a/model/adjuster/parent_reference.go
+++ b/model/adjuster/parent_reference.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adjuster
+
+import (
+	"github.com/jaegertracing/jaeger/model"
+)
+
+// ParentReference returns an Adjuster that puts CHILD_OF references first.
+// This is necessary to match jaeger-ui expectations:
+// * https://github.com/jaegertracing/jaeger-ui/issues/966
+func ParentReference() Adjuster {
+	return Func(func(trace *model.Trace) (*model.Trace, error) {
+		for _, span := range trace.Spans {
+			if len(span.References) == 0 {
+				continue
+			}
+
+			for i := range span.References {
+				if i == 0 {
+					continue
+				}
+
+				if span.References[0].RefType == model.SpanRefType_CHILD_OF && span.References[0].TraceID == span.TraceID {
+					break
+				}
+
+				if span.References[0].TraceID != span.TraceID {
+					if span.References[i].TraceID == span.TraceID {
+						span.References[i], span.References[0] = span.References[0], span.References[i]
+					}
+				} else if span.References[0].RefType != model.ChildOf && span.References[i].RefType == model.ChildOf {
+					span.References[i], span.References[0] = span.References[0], span.References[i]
+				}
+			}
+		}
+
+		return trace, nil
+	})
+}

--- a/model/adjuster/parent_reference_test.go
+++ b/model/adjuster/parent_reference_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adjuster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+func TestParentReference(t *testing.T) {
+	selfTraceID := model.NewTraceID(0, 1)
+	otherTraceID := model.NewTraceID(0, 2)
+
+	testCases := []struct {
+		incoming []model.SpanRef
+		expected []model.SpanRef
+	}{
+		{
+			incoming: []model.SpanRef{},
+			expected: []model.SpanRef{},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}},
+			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}},
+			expected: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.ChildOf}},
+			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.FollowsFrom}, {TraceID: selfTraceID, RefType: model.ChildOf}},
+			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.FollowsFrom}},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}},
+			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.FollowsFrom}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}},
+			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.FollowsFrom}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+		},
+		{
+			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}, {TraceID: selfTraceID, RefType: model.ChildOf}},
+			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}},
+		},
+	}
+	for _, testCase := range testCases {
+		trace := &model.Trace{
+			Spans: []*model.Span{
+				{
+					TraceID:    selfTraceID,
+					References: testCase.incoming,
+				},
+			},
+		}
+		trace, err := ParentReference().Adjust(trace)
+		assert.NoError(t, err)
+		assert.Equal(t, testCase.expected, trace.Spans[0].References)
+	}
+}

--- a/model/adjuster/parent_reference_test.go
+++ b/model/adjuster/parent_reference_test.go
@@ -23,61 +23,87 @@ import (
 )
 
 func TestParentReference(t *testing.T) {
-	selfTraceID := model.NewTraceID(0, 1)
-	otherTraceID := model.NewTraceID(0, 2)
+	a := model.NewTraceID(0, 1)
+	b := model.NewTraceID(0, 2)
+	childOf := func(id model.TraceID) model.SpanRef {
+		return model.NewChildOfRef(id, 1)
+	}
+	followsFrom := func(id model.TraceID) model.SpanRef {
+		return model.NewFollowsFromRef(id, 1)
+	}
+	followsFrom2 := func(id model.TraceID) model.SpanRef {
+		return model.NewFollowsFromRef(id, 2)
+	}
 
 	testCases := []struct {
+		name     string
 		incoming []model.SpanRef
 		expected []model.SpanRef
 	}{
 		{
+			name:     "empty",
 			incoming: []model.SpanRef{},
 			expected: []model.SpanRef{},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}},
-			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}},
+			name:     "single child",
+			incoming: []model.SpanRef{childOf(a)},
+			expected: []model.SpanRef{childOf(a)},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}},
-			expected: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}},
+			name:     "single remote child",
+			incoming: []model.SpanRef{childOf(b)},
+			expected: []model.SpanRef{childOf(b)},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}},
-			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+			name:     "local and remote child in order",
+			incoming: []model.SpanRef{childOf(a), childOf(b)},
+			expected: []model.SpanRef{childOf(a), childOf(b)},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.ChildOf}},
-			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+			name:     "local and remote child out of order",
+			incoming: []model.SpanRef{childOf(b), childOf(a)},
+			expected: []model.SpanRef{childOf(a), childOf(b)},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.FollowsFrom}, {TraceID: selfTraceID, RefType: model.ChildOf}},
-			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.FollowsFrom}},
+			name:     "local child, remote follows",
+			incoming: []model.SpanRef{followsFrom(b), childOf(a)},
+			expected: []model.SpanRef{childOf(a), followsFrom(b)},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}},
-			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.FollowsFrom}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+			name:     "remote, local, local follows - keep order",
+			incoming: []model.SpanRef{followsFrom(b), followsFrom2(a), followsFrom(a)},
+			expected: []model.SpanRef{followsFrom2(a), followsFrom(b), followsFrom(a)},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}},
-			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.FollowsFrom}, {TraceID: otherTraceID, RefType: model.ChildOf}},
+			name:     "remote child, local follows",
+			incoming: []model.SpanRef{childOf(b), followsFrom(a)},
+			expected: []model.SpanRef{followsFrom(a), childOf(b)},
 		},
 		{
-			incoming: []model.SpanRef{{TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}, {TraceID: selfTraceID, RefType: model.ChildOf}},
-			expected: []model.SpanRef{{TraceID: selfTraceID, RefType: model.ChildOf}, {TraceID: otherTraceID, RefType: model.ChildOf}, {TraceID: selfTraceID, RefType: model.FollowsFrom}},
+			name:     "remote child, local follows, local child",
+			incoming: []model.SpanRef{childOf(b), followsFrom(a), childOf(a)},
+			expected: []model.SpanRef{childOf(a), followsFrom(a), childOf(b)},
+		},
+		{
+			name:     "remote follows, local follows, local child",
+			incoming: []model.SpanRef{followsFrom(b), followsFrom(a), childOf(a)},
+			expected: []model.SpanRef{childOf(a), followsFrom(a), followsFrom(b)},
 		},
 	}
 	for _, testCase := range testCases {
-		trace := &model.Trace{
-			Spans: []*model.Span{
-				{
-					TraceID:    selfTraceID,
-					References: testCase.incoming,
+		t.Run(testCase.name, func(t *testing.T) {
+			trace := &model.Trace{
+				Spans: []*model.Span{
+					{
+						TraceID:    a,
+						References: testCase.incoming,
+					},
 				},
-			},
-		}
-		trace, err := ParentReference().Adjust(trace)
-		assert.NoError(t, err)
-		assert.Equal(t, testCase.expected, trace.Spans[0].References)
+			}
+			trace, err := ParentReference().Adjust(trace)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, trace.Spans[0].References)
+		})
 	}
 }


### PR DESCRIPTION
As demonstrated in https://github.com/jaegertracing/jaeger-ui/issues/966, jaeger-ui expects the first reference to be of `CHILD_OF` type to properly render the tree. This new adjuster achieves exactly that.