### PR TITLE
Ignore the problem of self-reported spans when multi-tenant enabled

### DIFF
--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -20,6 +20,8 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	zipkin2 "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
 	"github.com/jaegertracing/jaeger/model"
@@ -71,7 +73,12 @@ func (r *Reporter) send(ctx context.Context, spans []*model.Span, process *model
 	req := &api_v2.PostSpansRequest{Batch: batch}
 	_, err := r.collector.PostSpans(ctx, req)
 	if err != nil {
-		r.logger.Error("Could not send spans over gRPC", zap.Error(err))
+		stat, ok := status.FromError(err)
+		if ok && stat.Code() == codes.PermissionDenied && stat.Message() == "missing tenant header" {
+			r.logger.Debug("Could not send spans over gRPC", zap.Error(err))
+		} else {
+			r.logger.Error("Could not send spans over gRPC", zap.Error(err))
+		}
 	}
 	return err
 }

--- a/cmd/agent/app/reporter/grpc/reporter.go
+++ b/cmd/agent/app/reporter/grpc/reporter.go
@@ -75,7 +75,7 @@ func (r *Reporter) send(ctx context.Context, spans []*model.Span, process *model
 	if err != nil {
 		stat, ok := status.FromError(err)
 		if ok && stat.Code() == codes.PermissionDenied && stat.Message() == "missing tenant header" {
-			r.logger.Debug("Could not send spans over gRPC", zap.Error(err))
+			r.logger.Debug("Could not report untenanted spans over gRPC", zap.Error(err))
 		} else {
 			r.logger.Error("Could not send spans over gRPC", zap.Error(err))
 		}

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -207,12 +207,11 @@ func TestReporter_MultitenantEmitBatch(t *testing.T) {
 	})
 	defer s.Stop()
 	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	//nolint:staticcheck // don't care about errors
-	defer conn.Close()
 	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
 	rep := NewReporter(conn, nil, zap.NewNop())
 
-	tm := time.Unix(158, 0)
+	tm := time.Now()
 	tests := []struct {
 		in  *jThrift.Batch
 		err string

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -24,7 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
@@ -177,4 +180,50 @@ func TestReporter_MakeModelKeyValue(t *testing.T) {
 	actualTags := makeModelKeyValue(stringTags)
 
 	assert.Equal(t, expectedTags, actualTags)
+}
+
+type mockMultitenantSpanHandler struct{}
+
+func (h *mockMultitenantSpanHandler) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) (*api_v2.PostSpansResponse, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return &api_v2.PostSpansResponse{}, status.Errorf(codes.PermissionDenied, "missing tenant header")
+	}
+
+	tenants := md["x-tenant"]
+	if len(tenants) < 1 {
+		return &api_v2.PostSpansResponse{}, status.Errorf(codes.PermissionDenied, "missing tenant header")
+	} else if len(tenants) > 1 {
+		return &api_v2.PostSpansResponse{}, status.Errorf(codes.PermissionDenied, "extra tenant header")
+	}
+
+	return &api_v2.PostSpansResponse{}, nil
+}
+
+func TestReporter_MultitenantEmitBatch(t *testing.T) {
+	handler := &mockMultitenantSpanHandler{}
+	s, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
+		api_v2.RegisterCollectorServiceServer(s, handler)
+	})
+	defer s.Stop()
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	//nolint:staticcheck // don't care about errors
+	defer conn.Close()
+	require.NoError(t, err)
+	rep := NewReporter(conn, nil, zap.NewNop())
+
+	tm := time.Unix(158, 0)
+	tests := []struct {
+		in  *jThrift.Batch
+		err string
+	}{
+		{
+			in:  &jThrift.Batch{Process: &jThrift.Process{ServiceName: "node"}, Spans: []*jThrift.Span{{OperationName: "foo", StartTime: int64(model.TimeAsEpochMicroseconds(tm))}}},
+			err: "rpc error: code = PermissionDenied desc = missing tenant header",
+		},
+	}
+	for _, test := range tests {
+		err = rep.EmitBatch(context.Background(), test.in)
+		assert.EqualError(t, err, test.err)
+	}
 }

--- a/cmd/collector/app/handler/grpc_handler.go
+++ b/cmd/collector/app/handler/grpc_handler.go
@@ -79,7 +79,7 @@ func newBatchConsumer(logger *zap.Logger, spanProcessor processor.SpanProcessor,
 func (c *batchConsumer) consume(ctx context.Context, batch *model.Batch) error {
 	tenant, err := c.validateTenant(ctx)
 	if err != nil {
-		c.logger.Error("rejecting spans (tenancy)", zap.Error(err))
+		c.logger.Debug("rejecting spans (tenancy)", zap.Error(err))
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

If the experimental tenancy feature is enabled, every self-reported span generates two **error** level log entries with full stack traces.

This PR causes Jaeger to log missing tenancy at **debug** level.

The goal is to mitigate the problem of self-reports while we focus on adding tenancy to the query APIs.

See https://github.com/jaegertracing/jaeger/pull/3750#issuecomment-1151819300