### PR TITLE
Add draft-release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,10 @@ build-crossdock-fresh: build-crossdock-linux
 changelog:
 	python3 ./scripts/release-notes.py
 
+.PHONY: draft-release
+draft-release:
+	python3 ./scripts/draft-release.py
+
 .PHONY: install-tools
 install-tools:
 	go install github.com/vektra/mockery/v2@v2.10.4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,16 +15,19 @@
     * Rotate the below release managers table placing yourself at the bottom. The date should be the first Wednesday of the month.
 2. Add all merged pull requests to the milestone for the release and create a new milestone for a next release e.g. `Release 1.16`.
 3. After the PR is merged, create a release on Github:
-    * Title "Release X.Y.Z"
-    * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch
-    * Copy the new CHANGELOG.md section into the release notes
-4. The release tag will trigger a build of the docker images. Since forks don't have jaegertracingbot dockerhub token, they can never publish images to jaegertracing organisation.
+    * Automated:
+       * `make draft-release`
+    * Manual:
+       * Title "Release X.Y.Z"
+       * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch
+       * Copy the new CHANGELOG.md section into the release notes
+5. The release tag will trigger a build of the docker images. Since forks don't have jaegertracingbot dockerhub token, they can never publish images to jaegertracing organisation.
    1. Check the images are available on [Docker Hub](https://hub.docker.com/r/jaegertracing/).
    2. For monitoring and troubleshooting, refer to the [jaegertracing/jaeger GithubActions tab](https://github.com/jaegertracing/jaeger/actions).
-5. [Publish documentation](https://github.com/jaegertracing/documentation/blob/main/RELEASE.md) for the new version in [jaegertracing.io](https://www.jaegertracing.io/docs/latest).
+6. [Publish documentation](https://github.com/jaegertracing/documentation/blob/main/RELEASE.md) for the new version in [jaegertracing.io](https://www.jaegertracing.io/docs/latest).
    1. Check [jaegertracing.io](https://www.jaegertracing.io/docs/latest) redirects to the new documentation release version URL.
    2. For monitoring and troubleshooting, refer to the [jaegertracing/documentation GithubActions tab](https://github.com/jaegertracing/documentation/actions).
-6. Announce the release on the [mailing list](https://groups.google.com/g/jaeger-tracing), [slack](https://cloud-native.slack.com/archives/CGG7NFUJ3), and [twitter](https://twitter.com/JaegerTracing?lang=en).
+7. Announce the release on the [mailing list](https://groups.google.com/g/jaeger-tracing), [slack](https://cloud-native.slack.com/archives/CGG7NFUJ3), and [twitter](https://twitter.com/JaegerTracing?lang=en).
 
 Maintenance branches should follow naming convention: `release-major.minor` (e.g.`release-1.8`).
 

--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -1,0 +1,52 @@
+import re
+import subprocess
+
+
+release_header_pattern = re.compile(r"([\d]+\.[\d]+\.[\d]+) \([\d]{4}-[\d]{2}-[\d]{2}\)", flags=0)
+underline_pattern = re.compile(r"^[-]+$", flags=0)
+
+
+def main():
+    changelog_text, version = get_changelog()
+    print(changelog_text)
+    output_string = subprocess.check_output(
+        ["gh", "release", "create", f"v{version}",
+         "--draft",
+         "--title", f"Release v{version}",
+         "--repo", "jaegertracing/jaeger",
+         "-F", "-"],
+        input=changelog_text,
+        text=True,
+    )
+    print(f"Draft created at: {output_string}")
+    print("Please review, then edit it and click 'Publish release'.")
+
+
+def get_changelog():
+    changelog_text = ""
+    in_changelog_text = False
+    version = ""
+    with open("CHANGELOG.md") as f:
+        for line in f:
+            release_header_match = release_header_pattern.match(line)
+
+            if release_header_match is not None:
+                # Found the first release.
+                if not in_changelog_text:
+                    in_changelog_text = True
+                    version = release_header_match.group(1)
+                else:
+                    # Found the next release.
+                    break
+            else:
+                underline_match = underline_pattern.match(line)
+                if underline_match is not None:
+                    continue
+                elif in_changelog_text:
+                    changelog_text += line
+
+    return changelog_text, version
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

Similar PR to: https://github.com/jaegertracing/jaeger-ui/pull/968

## Which problem is this PR solving?
- Tag and release creation are manual steps which are prone to human error.

## Short description of the changes
- Proposal to automate this process given there seems to be little value with manual human interaction since all the inputs can be derived from the CHANGELOG (assuming it's correctly formatted in the first place).
- For cases where there are errors in CHANGELOG preventing this script from working correctly, the release is created as a draft to provide the release engineer the opportunity to make fixes prior to publishing the release.

## Testing
Used to create the [v1.36.0 release](https://github.com/jaegertracing/jaeger/releases/tag/v1.36.0) of jaeger.

