### PR TITLE
Add capability to build docker all-in-one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,21 +308,19 @@ docker-images-jaeger-backend-debug: SUFFIX = -debug
 .PHONY: docker-images-jaeger-backend docker-images-jaeger-backend-debug
 docker-images-jaeger-backend docker-images-jaeger-backend-debug: create-baseimg create-debugimg
 	for component in "jaeger-agent" "jaeger-collector" "jaeger-query" "jaeger-ingester" "all-in-one" ; do \
-		regex="(jaeger-)(.*)"; \
-		component_prefix=""; \
+		regex="jaeger-(.*)"; \
 		component_suffix=$$component; \
 		if [[ $$component =~ $$regex ]]; then \
-			component_prefix="$${BASH_REMATCH[1]}"; \
-			component_suffix="$${BASH_REMATCH[2]}"; \
+			component_suffix="$${BASH_REMATCH[1]}"; \
 		fi; \
 		docker buildx build --target $(TARGET) \
-			--tag $(DOCKER_NAMESPACE)/$$component_prefix$$component_suffix$(SUFFIX):${DOCKER_TAG} \
+			--tag $(DOCKER_NAMESPACE)/$$component$(SUFFIX):${DOCKER_TAG} \
 			--build-arg base_image=$(BASE_IMAGE) \
 			--build-arg debug_image=$(DEBUG_IMAGE) \
 			--build-arg TARGETARCH=$(GOARCH) \
 			--load \
-			cmd/$$component_suffix ; \
-		echo "Finished building $$component_suffix ==============" ; \
+			cmd/$$component_suffix; \
+		echo "Finished building $$component ==============" ; \
 	done; \
 
 .PHONY: docker-images-tracegen

--- a/Makefile
+++ b/Makefile
@@ -306,15 +306,26 @@ docker-images-jaeger-backend-debug: SUFFIX = -debug
 
 .PHONY: docker-images-jaeger-backend docker-images-jaeger-backend-debug
 docker-images-jaeger-backend docker-images-jaeger-backend-debug: create-baseimg create-debugimg
-	for component in agent collector query ingester ; do \
-		docker build --target $(TARGET) \
-			--tag $(DOCKER_NAMESPACE)/jaeger-$$component$(SUFFIX):${DOCKER_TAG} \
+	# Save the current Internal Field Separator (IFS) for later recovery, then set it to a comma-separator.
+	# The reason for using a comma-separator is to support the empty prefix required for all-in-one.
+	OLDIFS=$IFS; \
+	IFS=","; \
+	for pair in "jaeger,agent" "jaeger,collector" "jaeger,query" "jaeger,ingester" ",all-in-one" ; do \
+		set -- $$pair; \
+		prefix=$$1; \
+		component=$$2; \
+		docker buildx build --target $(TARGET) \
+			--tag $(DOCKER_NAMESPACE)/$$prefix$$component$(SUFFIX):${DOCKER_TAG} \
 			--build-arg base_image=$(BASE_IMAGE) \
 			--build-arg debug_image=$(DEBUG_IMAGE) \
 			--build-arg TARGETARCH=$(GOARCH) \
+			--load \
 			cmd/$$component ; \
 		echo "Finished building $$component ==============" ; \
-	done
+	done; \
+
+	# Restore the old IFS.
+	IFS=$OLDIFS;
 
 .PHONY: docker-images-tracegen
 docker-images-tracegen:

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ docker-images-jaeger-backend docker-images-jaeger-backend-debug: create-baseimg 
 			--load \
 			cmd/$$component_suffix; \
 		echo "Finished building $$component ==============" ; \
-	done; \
+	done;
 
 .PHONY: docker-images-tracegen
 docker-images-tracegen:


### PR DESCRIPTION
## Which problem is this PR solving?
- As a developer, I want to quickly test changes to SPM locally, which depends on the `jaegertracing/all-in-one:latest` image.
- Building this image is currently not supported in the current Makefile.

## Short description of the changes
- Add `all-in-one` component to the list of components to build docker images for.
- Note: I don't believe this impacts existing CI builds, which utilise the `scripts/build-all-in-one-image.sh` for all-in-one, and `scripts/build-upload-docker-images.sh` for other components. These scripts, in turn, execute their own docker commands (not sure why, instead of using Makefile targets).

## Testing

- Used to locally test changes from https://github.com/jaegertracing/jaeger-ui/pull/971.