### PR TITLE
Normalize multi-tenancy flags prefix

### DIFF
--- a/cmd/collector/app/flags/flags_test.go
+++ b/cmd/collector/app/flags/flags_test.go
@@ -120,7 +120,7 @@ func TestCollectorOptionsWithFlags_CheckSimpleTenancy(t *testing.T) {
 	c := &CollectorOptions{}
 	v, command := config.Viperize(AddFlags)
 	command.ParseFlags([]string{
-		"--multi_tenancy.enabled=true",
+		"--multi-tenancy.enabled=true",
 	})
 	c.InitFromViper(v, zap.NewNop())
 
@@ -132,9 +132,9 @@ func TestCollectorOptionsWithFlags_CheckFullTenancy(t *testing.T) {
 	c := &CollectorOptions{}
 	v, command := config.Viperize(AddFlags)
 	command.ParseFlags([]string{
-		"--multi_tenancy.enabled=true",
-		"--multi_tenancy.header=custom-tenant-header",
-		"--multi_tenancy.tenants=acme,hardware-store",
+		"--multi-tenancy.enabled=true",
+		"--multi-tenancy.header=custom-tenant-header",
+		"--multi-tenancy.tenants=acme,hardware-store",
 	})
 	c.InitFromViper(v, zap.NewNop())
 

--- a/pkg/tenancy/flags.go
+++ b/pkg/tenancy/flags.go
@@ -23,26 +23,27 @@ import (
 )
 
 const (
-	tenancyEnabled = "multi_tenancy.enabled"
-	tenancyHeader  = "multi_tenancy.header"
-	validTenants   = "multi_tenancy.tenants"
+	flagPrefix         = "multi-tenancy"
+	flagTenancyEnabled = flagPrefix + ".enabled"
+	flagTenancyHeader  = flagPrefix + ".header"
+	flagValidTenants   = flagPrefix + ".tenants"
 )
 
 // AddFlags adds flags for tenancy to the FlagSet.
 func AddFlags(flags *flag.FlagSet) {
-	flags.Bool(tenancyEnabled, false, "Enable tenancy header when receiving or querying")
-	flags.String(tenancyHeader, "x-tenant", "HTTP header carrying tenant")
-	flags.String(validTenants, "",
+	flags.Bool(flagTenancyEnabled, false, "Enable tenancy header when receiving or querying")
+	flags.String(flagTenancyHeader, "x-tenant", "HTTP header carrying tenant")
+	flags.String(flagValidTenants, "",
 		fmt.Sprintf("comma-separated list of allowed values for --%s header.  (If not supplied, tenants are not restricted)",
-			tenancyHeader))
+			flagTenancyHeader))
 }
 
 // InitFromViper creates tenancy.Options populated with values retrieved from Viper.
 func InitFromViper(v *viper.Viper) (Options, error) {
 	var p Options
-	p.Enabled = v.GetBool(tenancyEnabled)
-	p.Header = v.GetString(tenancyHeader)
-	tenants := v.GetString(validTenants)
+	p.Enabled = v.GetBool(flagTenancyEnabled)
+	p.Header = v.GetString(flagTenancyHeader)
+	tenants := v.GetString(flagValidTenants)
 	if len(tenants) != 0 {
 		p.Tenants = strings.Split(tenants, ",")
 	} else {

--- a/pkg/tenancy/flags_test.go
+++ b/pkg/tenancy/flags_test.go
@@ -33,8 +33,8 @@ func TestTenancyFlags(t *testing.T) {
 		{
 			name: "one tenant",
 			cmd: []string{
-				"--multi_tenancy.enabled=true",
-				"--multi_tenancy.tenants=acme",
+				"--multi-tenancy.enabled=true",
+				"--multi-tenancy.tenants=acme",
 			},
 			expected: Options{
 				Enabled: true,
@@ -45,8 +45,8 @@ func TestTenancyFlags(t *testing.T) {
 		{
 			name: "two tenants",
 			cmd: []string{
-				"--multi_tenancy.enabled=true",
-				"--multi_tenancy.tenants=acme,country-store",
+				"--multi-tenancy.enabled=true",
+				"--multi-tenancy.tenants=acme,country-store",
 			},
 			expected: Options{
 				Enabled: true,
@@ -57,9 +57,9 @@ func TestTenancyFlags(t *testing.T) {
 		{
 			name: "custom header",
 			cmd: []string{
-				"--multi_tenancy.enabled=true",
-				"--multi_tenancy.header=jaeger-tenant",
-				"--multi_tenancy.tenants=acme",
+				"--multi-tenancy.enabled=true",
+				"--multi-tenancy.header=jaeger-tenant",
+				"--multi-tenancy.tenants=acme",
 			},
 			expected: Options{
 				Enabled: true,
@@ -72,7 +72,7 @@ func TestTenancyFlags(t *testing.T) {
 			// "tenant header required, but any value will pass"
 			name: "no_tenants",
 			cmd: []string{
-				"--multi_tenancy.enabled=true",
+				"--multi-tenancy.enabled=true",
 			},
 			expected: Options{
 				Enabled: true,


### PR DESCRIPTION
Changing `--multi_tenancy...` to `multi-tenancy...` CLI flag prefix.
The usual pattern for CLI flags in Jaeger is to use `-` between words, so that they can be typed without using the SHIFT key.