### PR TITLE
Remove error from tenancy.InitFromViper

### DIFF
--- a/cmd/collector/app/flags/flags.go
+++ b/cmd/collector/app/flags/flags.go
@@ -228,11 +228,7 @@ func (opts *GRPCOptions) initFromViper(v *viper.Viper, logger *zap.Logger, cfg s
 	} else {
 		return fmt.Errorf("failed to parse gRPC TLS options: %w", err)
 	}
-	if tenancy, err := tenancy.InitFromViper(v); err == nil {
-		opts.Tenancy = tenancy
-	} else {
-		return fmt.Errorf("failed to parse Tenancy options: %w", err)
-	}
+	opts.Tenancy = tenancy.InitFromViper(v)
 
 	return nil
 }

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -125,11 +125,7 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper, logger *zap.Logger) (*Q
 	} else {
 		qOpts.AdditionalHeaders = headers
 	}
-	if tenancy, err := tenancy.InitFromViper(v); err == nil {
-		qOpts.Tenancy = tenancy
-	} else {
-		return qOpts, fmt.Errorf("failed to parse Tenancy options: %w", err)
-	}
+	qOpts.Tenancy = tenancy.InitFromViper(v)
 	return qOpts, nil
 }
 

--- a/pkg/tenancy/flags.go
+++ b/pkg/tenancy/flags.go
@@ -39,7 +39,7 @@ func AddFlags(flags *flag.FlagSet) {
 }
 
 // InitFromViper creates tenancy.Options populated with values retrieved from Viper.
-func InitFromViper(v *viper.Viper) (Options, error) {
+func InitFromViper(v *viper.Viper) Options {
 	var p Options
 	p.Enabled = v.GetBool(flagTenancyEnabled)
 	p.Header = v.GetString(flagTenancyHeader)
@@ -50,5 +50,5 @@ func InitFromViper(v *viper.Viper) (Options, error) {
 		p.Tenants = []string{}
 	}
 
-	return p, nil
+	return p
 }

--- a/pkg/tenancy/flags_test.go
+++ b/pkg/tenancy/flags_test.go
@@ -93,8 +93,7 @@ func TestTenancyFlags(t *testing.T) {
 
 			err := command.ParseFlags(test.cmd)
 			require.NoError(t, err)
-			tenancyCfg, err := InitFromViper(v)
-			require.NoError(t, err)
+			tenancyCfg := InitFromViper(v)
 			assert.Equal(t, test.expected, tenancyCfg)
 		})
 	}


### PR DESCRIPTION
The function never returns an error, which makes it impossible to test for.