### PR TITLE
Fix upload of zip file in release github action

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Upload binaries
       uses: svenstaro/upload-release-action@2.3.0
       with:
-        file: deploy/*.tar.gz
+        file: '{deploy/*.tar.gz,deploy/*.zip}'
         file_glob: true
         tag: ${{ github.ref }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -28,19 +28,17 @@ function stage-platform-files {
     stage-file ./examples/hotrod/hotrod-$PLATFORM $PACKAGE_STAGING_DIR/example-hotrod$FILE_EXTENSION
 }
 
-# package pulls built files for the platform ($1). If you pass in a file
-# extension ($2) it will be used on the binaries
+# package pulls built files for the platform ($2) and compresses it using the compression ($1).
+# If you pass in a file extension ($3) it will be look for binaries with that extension.
 function package {
-    
     local COMPRESSION=$1
     local PLATFORM=$2
     local FILE_EXTENSION=$3
-    # script start
     local PACKAGE_STAGING_DIR=jaeger-$VERSION-$PLATFORM
 
     mkdir $PACKAGE_STAGING_DIR
-
     stage-platform-files $PLATFORM $PACKAGE_STAGING_DIR $FILE_EXTENSION
+
     if [ "$COMPRESSION" == "zip" ]
     then
         local ARCHIVE_NAME="$PACKAGE_STAGING_DIR.zip"
@@ -68,7 +66,8 @@ mkdir $DEPLOY_STAGING_DIR
 package tar linux-amd64
 package tar darwin-amd64
 package tar darwin-arm64
-package zip windows-amd64 .exe 
+package tar windows-amd64 .exe
+package zip windows-amd64 .exe
 package tar linux-s390x
 package tar linux-arm64
 package tar linux-ppc64le


### PR DESCRIPTION


<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/jaeger/issues/3851

## Short description of the changes
Earlier we used to have tar.gz for windows release. https://github.com/jaegertracing/jaeger/pull/3817 changed the windows release from tar.gz to zip format. It broke jaeger windows users hence we need to restore earlier format too. This PR also restores the backward compatibility i.e. now we have both tar.gz and zip for windows release.

I tested the file_glob in a test repo with test release:
- https://github.com/Ashmita152/test-upload/blob/master/.github/workflows/ci-release.yml
- https://github.com/Ashmita152/test-upload/releases/tag/v0.4

