### PR TITLE
Remove milestone instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,10 +185,7 @@ requires connection to Cassandra
 ```
 
 ## Merging PRs
-For maintainers: before merging a PR make sure:
-* the title is descriptive and follows [a good commit message](./CONTRIBUTING_GUIDELINES.md)
-* pull request is assigned to the current release milestone
-* add `changelog:*` and other labels
+**For maintainers:** before merging a PR make sure the title is descriptive and follows [a good commit message](./CONTRIBUTING_GUIDELINES.md)
 
 Merge the PR by using "Squash and merge" option on Github. Avoid creating merge commits.
 After the merge make sure referenced issues were closed.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,21 +13,20 @@
         ```
       * Even if a submodule does not have a new release, it should be checked to see if there were any changes warranting cutting a new release and then including it.
     * Rotate the below release managers table placing yourself at the bottom. The date should be the first Wednesday of the month.
-2. Add all merged pull requests to the milestone for the release and create a new milestone for a next release e.g. `Release 1.16`.
-3. After the PR is merged, create a release on Github:
+2. After the PR is merged, create a release on Github:
     * Automated:
        * `make draft-release`
     * Manual:
        * Title "Release X.Y.Z"
        * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch
        * Copy the new CHANGELOG.md section into the release notes
-5. The release tag will trigger a build of the docker images. Since forks don't have jaegertracingbot dockerhub token, they can never publish images to jaegertracing organisation.
+3. The release tag will trigger a build of the docker images. Since forks don't have jaegertracingbot dockerhub token, they can never publish images to jaegertracing organisation.
    1. Check the images are available on [Docker Hub](https://hub.docker.com/r/jaegertracing/).
    2. For monitoring and troubleshooting, refer to the [jaegertracing/jaeger GithubActions tab](https://github.com/jaegertracing/jaeger/actions).
-6. [Publish documentation](https://github.com/jaegertracing/documentation/blob/main/RELEASE.md) for the new version in [jaegertracing.io](https://www.jaegertracing.io/docs/latest).
+4. [Publish documentation](https://github.com/jaegertracing/documentation/blob/main/RELEASE.md) for the new version in [jaegertracing.io](https://www.jaegertracing.io/docs/latest).
    1. Check [jaegertracing.io](https://www.jaegertracing.io/docs/latest) redirects to the new documentation release version URL.
    2. For monitoring and troubleshooting, refer to the [jaegertracing/documentation GithubActions tab](https://github.com/jaegertracing/documentation/actions).
-7. Announce the release on the [mailing list](https://groups.google.com/g/jaeger-tracing), [slack](https://cloud-native.slack.com/archives/CGG7NFUJ3), and [twitter](https://twitter.com/JaegerTracing?lang=en).
+5. Announce the release on the [mailing list](https://groups.google.com/g/jaeger-tracing), [slack](https://cloud-native.slack.com/archives/CGG7NFUJ3), and [twitter](https://twitter.com/JaegerTracing?lang=en).
 
 Maintenance branches should follow naming convention: `release-major.minor` (e.g.`release-1.8`).
 


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Short description of the changes

Supersedes #3795.

Proposal to remove instructions around milestones. The current milestones are 4 years old and I don't think we have any plans on defining a milestone per release.