### PR TITLE
Add AdditionalDialOptions to ConnBuilder

### DIFF
--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -47,6 +47,8 @@ type ConnBuilder struct {
 	DiscoveryMinPeers int
 	Notifier          discovery.Notifier
 	Discoverer        discovery.Discoverer
+
+	AdditionalDialOptions []grpc.DialOption
 }
 
 // NewConnBuilder creates a new grpc connection builder.
@@ -96,6 +98,8 @@ func (b *ConnBuilder) CreateConnection(logger *zap.Logger, mFactory metrics.Fact
 	}
 	dialOptions = append(dialOptions, grpc.WithDefaultServiceConfig(grpcresolver.GRPCServiceConfig))
 	dialOptions = append(dialOptions, grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(grpc_retry.WithMax(b.MaxRetry))))
+	dialOptions = append(dialOptions, b.AdditionalDialOptions...)
+
 	conn, err := grpc.Dial(dialTarget, dialOptions...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Prithvi Raj <p.r@uber.com>

## Which problem is this PR solving?
- Resolves #3864

## Short description of the changes
- Add additional grpc DialOptions, which allow for specifying custom interceptors/etc.
