### PR TITLE
Add lint checking for bidi characters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - gosec
     - govet
     - misspell
+    - bidichk
   disable:
     - errcheck
 


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

Jaeger doesn't currently have bidi characters; this will ensure it doesn't gain any.

For an explanation of why this is important see https://github.com/nickboucher/trojan-source/blob/main/Go/commenting-out.go .

In theory this shouldn't be a problem for Jaeger, as all code is reviewed, as Github's UI should complain during code reviews.  This makes it explicit so the build itself fails if someone tries to sneak in bidi characters.