### PR TITLE
Change build info date to commit timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ IMPORT_LOG=.import.log
 
 GIT_SHA=$(shell git rev-parse HEAD)
 GIT_CLOSEST_TAG=$(shell git describe --abbrev=0 --tags)
-DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+DATE=$(shell date -u -d @$(shell git show -s --format=%ct) +'%Y-%m-%dT%H:%M:%SZ')
 BUILD_INFO_IMPORT_PATH=$(JAEGER_IMPORT_PATH)/pkg/version
 BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).commitSHA=$(GIT_SHA) -X $(BUILD_INFO_IMPORT_PATH).latestVersion=$(GIT_CLOSEST_TAG) -X $(BUILD_INFO_IMPORT_PATH).date=$(DATE)"
 
@@ -170,15 +170,15 @@ build-tracegen:
 
 .PHONY: build-anonymizer
 build-anonymizer:
-	$(GOBUILD) -o ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) ./cmd/anonymizer/main.go
+	$(GOBUILD) -o ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/anonymizer/main.go
 
 .PHONY: build-esmapping-generator
 build-esmapping-generator:
-	$(GOBUILD) -o ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH) ./cmd/esmapping-generator/main.go
+	$(GOBUILD) -o ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/esmapping-generator/main.go
 
 .PHONY: build-esmapping-generator-linux
 build-esmapping-generator-linux:
-	 GOOS=linux GOARCH=amd64 $(GOBUILD) -o ./plugin/storage/es/esmapping-generator ./cmd/esmapping-generator/main.go
+	 GOOS=linux GOARCH=amd64 $(GOBUILD) -o ./plugin/storage/es/esmapping-generator $(BUILD_INFO) ./cmd/esmapping-generator/main.go
 
 .PHONY: build-es-index-cleaner
 build-es-index-cleaner:


### PR DESCRIPTION
## Which problem is this PR solving?
Binary Reproducibility
See https://reproducible-builds.org for more info on why this is important.

## Short description of the changes
This change fixes binary reproducibility of builds. Injecting a
timestamp of the time-of-build produces unique binaries for every build
which is undesirable for security and provenance tracking. If timestamps
for builds are desired, it is recommended to inject the timestamp of the
commit. This gives a timestamp that is consistent for a build based on
that commit and allows checking for binary consistenty across build systems.

This change updates BuildDate to use the commit timestamp from git.
This change also fixes some builds which include the version package but
were not injecting BUILD_INFO. 

## Manual testing on main
```
(main) $ make build-all-in-one-linux 
GOOS=linux make build-all-in-one
make[1]: Entering directory '/home/cjb/repos/misc/jaeger'
CGO_ENABLED=0 installsuffix=cgo go build -trimpath  -tags ui -o ./cmd/all-in-one/all-in-one-linux-amd64 -ldflags "-X github.com/jaegertracing/jaeger/pkg/version.commitSHA=711a2b8f0aabca256a8b4e7d61d5395f74e6d848 -X github.com/jaegertracing/jaeger/pkg/version.latestVersion=v1.37.0 -X github.com/jaegertracing/jaeger/pkg/version.date=2022-08-16T22:07:29Z" ./cmd/all-in-one/main.go
make[1]: Leaving directory '/home/cjb/repos/misc/jaeger'
(main) $ sha256sum ./cmd/all-in-one/all-in-one-linux-amd64 
3e8e4038c8dc745b6d1753ef2b3232e8b0e452c9c33326972a4fd3fee2c1aef8  ./cmd/all-in-one/all-in-one-linux-amd64
(main) $ make build-all-in-one-linux 
GOOS=linux make build-all-in-one
make[1]: Entering directory '/home/cjb/repos/misc/jaeger'
CGO_ENABLED=0 installsuffix=cgo go build -trimpath  -tags ui -o ./cmd/all-in-one/all-in-one-linux-amd64 -ldflags "-X github.com/jaegertracing/jaeger/pkg/version.commitSHA=711a2b8f0aabca256a8b4e7d61d5395f74e6d848 -X github.com/jaegertracing/jaeger/pkg/version.latestVersion=v1.37.0 -X github.com/jaegertracing/jaeger/pkg/version.date=2022-08-16T22:07:47Z" ./cmd/all-in-one/main.go
make[1]: Leaving directory '/home/cjb/repos/misc/jaeger'
(main) $ sha256sum ./cmd/all-in-one/all-in-one-linux-amd64 
8444711d8c7deebf0af620086745c2a7f102b63945a03ee82c69caadc6aba931  ./cmd/all-in-one/all-in-one-linux-amd64
```
## Manual testing on branch
```
(reproducible-date) $ make build-all-in-one-linux 
GOOS=linux make build-all-in-one
make[1]: Entering directory '/home/cjb/repos/misc/jaeger'
CGO_ENABLED=0 installsuffix=cgo go build -trimpath  -tags ui -o ./cmd/all-in-one/all-in-one-linux-amd64 -ldflags "-X github.com/jaegertracing/jaeger/pkg/version.commitSHA=a28c13cac4cf0202e3255ae47d577981f475e8a7 -X github.com/jaegertracing/jaeger/pkg/version.latestVersion=v1.37.0 -X github.com/jaegertracing/jaeger/pkg/version.date=2022-08-16T22:05:45Z" ./cmd/all-in-one/main.go
make[1]: Leaving directory '/home/cjb/repos/misc/jaeger'
(reproducible-date) $ sha256sum ./cmd/all-in-one/all-in-one-linux-amd64 | tee sha256.check
c68b48e2ec5e61e3c7674271c7b3a80cce6833e6a55b9daeedcde85fbcc810e7  ./cmd/all-in-one/all-in-one-linux-amd64
(reproducible-date) $ rm ./cmd/all-in-one/all-in-one-linux-amd64 
(reproducible-date) $ sha256sum -c sha256.check 
sha256sum: ./cmd/all-in-one/all-in-one-linux-amd64: No such file or directory
./cmd/all-in-one/all-in-one-linux-amd64: FAILED open or read
sha256sum: WARNING: 1 listed file could not be read
(reproducible-date) 1 $ make build-all-in-one-linux 
GOOS=linux make build-all-in-one
make[1]: Entering directory '/home/cjb/repos/misc/jaeger'
CGO_ENABLED=0 installsuffix=cgo go build -trimpath  -tags ui -o ./cmd/all-in-one/all-in-one-linux-amd64 -ldflags "-X github.com/jaegertracing/jaeger/pkg/version.commitSHA=a28c13cac4cf0202e3255ae47d577981f475e8a7 -X github.com/jaegertracing/jaeger/pkg/version.latestVersion=v1.37.0 -X github.com/jaegertracing/jaeger/pkg/version.date=2022-08-16T22:05:45Z" ./cmd/all-in-one/main.go
make[1]: Leaving directory '/home/cjb/repos/misc/jaeger'
(reproducible-date) $ sha256sum -c sha256.check 
./cmd/all-in-one/all-in-one-linux-amd64: OK
```