### PR TITLE
Fixes reproducibility for binaries

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -49,15 +49,3 @@ jobs:
 
     - name: Build binaries
       run: make ${{ matrix.platform.task }}
-
-    - name: Collect checksums
-      run: make collect-sums
-
-    - name: Clean
-      run: make clean
-
-    - name: Build binaries
-      run: make ${{ matrix.platform.task }}
-
-    - name: Validate reproducibility
-      run: make test-checksums

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -49,3 +49,15 @@ jobs:
 
     - name: Build binaries
       run: make ${{ matrix.platform.task }}
+
+    - name: Collect checksums
+      run: make collect-sums
+
+    - name: Clean
+      run: make clean
+
+    - name: Build binaries
+      run: make ${{ matrix.platform.task }}
+
+    - name: Validate reproducibility
+      run: make test-checksums

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Upload binaries
       uses: svenstaro/upload-release-action@2.3.0
       with:
-        file: '{deploy/*.tar.gz,deploy/*.zip}'
+        file: '{deploy/*.tar.gz,deploy/*.zip,deploy/*.sha256sum.txt}'
         file_glob: true
         tag: ${{ github.ref }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ crossdock/crossdock-*
 run-crossdock.log
 proto-gen/.patched-otel-proto/
 __pycache__
+.asset-manifest.json
+deploy/
+deploy-staging/
+sha256sum.combined.txt

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ build-collector build-collector-debug:
 
 .PHONY: build-ingester build-ingester-debug
 build-ingester build-ingester-debug:
-	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH) ./cmd/ingester/main.go
+	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/ingester/main.go
 
 .PHONY: build-remote-storage build-remote-storage-debug
 build-remote-storage build-remote-storage-debug:
@@ -603,19 +603,13 @@ certs:
 certs-dryrun:
 	cd pkg/config/tlscfg/testdata && ./gen-certs.sh -d
 
-.PHONY: collect-sums
-collect-sums:
-	find cmd -type f -executable -exec sha256sum {} \; | sort -k2 > sha256sum.combined.txt
-
-.PHONY: test-checksums
-test-checksums:
-	sha256sum --strict --check ./sha256sum.combined.txt
-
 .PHONY: repro-check
 repro-check:
+	# Check local reproducibility of generated executables.
 	$(MAKE) clean
 	$(MAKE) build-all-platforms
-	$(MAKE) collect-sums
+	# Generate checksum for all executables under ./cmd
+	find cmd -type f -executable -exec sha256sum {} \; | sort -k2 > sha256sum.combined.txt
 	$(MAKE) clean
 	$(MAKE) build-all-platforms
-	$(MAKE) test-checksums
+	sha256sum --strict --check ./sha256sum.combined.txt

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ else
 endif
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-GOBUILD=CGO_ENABLED=0 installsuffix=cgo go build -trimpath
-GOTEST=go test -v $(RACE)
+GOCACHE=$(abspath .gocache)
+GOBUILD=GOCACHE=$(GOCACHE) CGO_ENABLED=0 installsuffix=cgo go build -trimpath
+GOTEST=GOCACHE=$(GOCACHE) go test -v $(RACE)
 GOFMT=gofmt
 GOFUMPT=gofumpt
 FMT_LOG=.fmt.log
@@ -43,7 +44,6 @@ IMPORT_LOG=.import.log
 GIT_SHA=$(shell git rev-parse HEAD)
 GIT_CLOSEST_TAG=$(shell git describe --abbrev=0 --tags)
 DATE=$(shell date -u -d @$(shell git show -s --format=%ct) +'%Y-%m-%dT%H:%M:%SZ')
-UIDATE=$(shell cd ./jaeger-ui; date -u -d @$(shell git show -s --format=%ct) +'%Y-%m-%dT%H:%M:%SZ')
 BUILD_INFO_IMPORT_PATH=$(JAEGER_IMPORT_PATH)/pkg/version
 BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).commitSHA=$(GIT_SHA) -X $(BUILD_INFO_IMPORT_PATH).latestVersion=$(GIT_CLOSEST_TAG) -X $(BUILD_INFO_IMPORT_PATH).date=$(DATE)"
 
@@ -84,6 +84,8 @@ clean:
 	rm -rf cover.out .cover/ cover.html $(FMT_LOG) $(IMPORT_LOG) \
 		jaeger-ui/packages/jaeger-ui/build
 	find ./cmd/query/app/ui/actual -type f -name '*.gz' -delete
+	GOCACHE=$(GOCACHE) go clean -cache -testcache
+	find cmd -type f -executable | xargs -I{} sh -c '(git ls-files --error-unmatch {} 2>/dev/null || rm -v {})'
 
 .PHONY: test
 test: go-gen
@@ -165,37 +167,30 @@ lint:
 .PHONY: build-examples
 build-examples:
 	$(GOBUILD) -o ./examples/hotrod/hotrod-$(GOOS)-$(GOARCH) ./examples/hotrod/main.go
-	sha256sum ./examples/hotrod/hotrod-$(GOOS)-$(GOARCH) > ./examples/hotrod/hotrod-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-tracegen
 build-tracegen:
 	$(GOBUILD) -o ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH) ./cmd/tracegen/main.go
-	sha256sum ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH) > ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-anonymizer
 build-anonymizer:
 	$(GOBUILD) -o ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/anonymizer/main.go
-	sha256sum ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) > ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-esmapping-generator
 build-esmapping-generator:
 	$(GOBUILD) -o ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/esmapping-generator/main.go
-	sha256sum ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH) > ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-esmapping-generator-linux
 build-esmapping-generator-linux:
 	 GOOS=linux GOARCH=amd64 $(GOBUILD) -o ./plugin/storage/es/esmapping-generator $(BUILD_INFO) ./cmd/esmapping-generator/main.go
-	sha256sum ./plugin/storage/es/esmapping-generator > ./plugin/storage/es/esmapping-generator.sha256sum.txt
 
 .PHONY: build-es-index-cleaner
 build-es-index-cleaner:
 	$(GOBUILD) -o ./cmd/es-index-cleaner/es-index-cleaner-$(GOOS)-$(GOARCH) ./cmd/es-index-cleaner/main.go
-	sha256sum ./cmd/es-index-cleaner/es-index-cleaner-$(GOOS)-$(GOARCH) > ./cmd/es-index-cleaner/es-index-cleaner-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-es-rollover
 build-es-rollover:
 	$(GOBUILD) -o ./cmd/es-rollover/es-rollover-$(GOOS)-$(GOARCH) ./cmd/es-rollover/main.go
-	sha256sum ./cmd/es-rollover/es-rollover-$(GOOS)-$(GOARCH) > ./cmd/es-rollover/es-rollover-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: docker-hotrod
 docker-hotrod:
@@ -212,12 +207,7 @@ cmd/query/app/ui/actual/index.html.gz: jaeger-ui/packages/jaeger-ui/build/index.
 	# do not delete dot-files
 	rm -rf cmd/query/app/ui/actual/*
 	cp -r jaeger-ui/packages/jaeger-ui/build/* cmd/query/app/ui/actual/
-	@echo "Set UI file dates to UI repository commit timestamp: $(UIDATE)"
-	# gzip stores file timestamps and therefore breaks reproducibility by default, setting the timestamps fixes this.
-	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs touch --date=$(UIDATE)
-	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs gzip
-	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs sha256sum | tee ui.sha256sum.txt
-
+	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs gzip --no-name
 
 jaeger-ui/packages/jaeger-ui/build/index.html:
 	$(MAKE) rebuild-ui
@@ -225,8 +215,6 @@ jaeger-ui/packages/jaeger-ui/build/index.html:
 .PHONY: rebuild-ui
 rebuild-ui:
 	cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build
-	mv jaeger-ui/packages/jaeger-ui/build/asset-manifest.json .asset-manifest.json
-	cat .asset-manifest.json | python -c 'import json, sys; o = json.loads(sys.stdin.read()); print(json.dumps(o, indent=2, sort_keys=True))' > jaeger-ui/packages/jaeger-ui/build/asset-manifest.json
 
 .PHONY: build-all-in-one-linux
 build-all-in-one-linux:
@@ -238,32 +226,26 @@ build-all-in-one-debug build-agent-debug build-query-debug build-collector-debug
 .PHONY: build-all-in-one build-all-in-one-debug
 build-all-in-one build-all-in-one-debug: build-ui
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -tags ui -o ./cmd/all-in-one/all-in-one$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/all-in-one/main.go
-	sha256sum ./cmd/all-in-one/all-in-one$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/all-in-one/all-in-one$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-agent build-agent-debug
 build-agent build-agent-debug:
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/agent/agent$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/agent/main.go
-	sha256sum './cmd/agent/agent$(SUFFIX)-$(GOOS)-$(GOARCH)' > './cmd/agent/agent$(SUFFIX)-$(GOOS)-$(GOARCH)'.sha256sum.txt
 
 .PHONY: build-query build-query-debug
 build-query build-query-debug: build-ui
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -tags ui -o ./cmd/query/query$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/query/main.go
-	sha256sum ./cmd/query/query$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/query/query$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-collector build-collector-debug
 build-collector build-collector-debug:
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/collector/collector$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/collector/main.go
-	sha256sum ./cmd/collector/collector$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/collector/collector$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-ingester build-ingester-debug
 build-ingester build-ingester-debug:
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH) ./cmd/ingester/main.go
-	sha256sum ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-remote-storage build-remote-storage-debug
 build-remote-storage build-remote-storage-debug:
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/remote-storage/remote-storage$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/remote-storage/main.go
-	sha256sum ./cmd/remote-storage/remote-storage$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/remote-storage/remote-storage$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-binaries-linux
 build-binaries-linux:
@@ -373,7 +355,6 @@ docker-images-only: docker-images-cassandra \
 .PHONY: build-crossdock-binary
 build-crossdock-binary:
 	$(GOBUILD) -o ./crossdock/crossdock-$(GOOS)-$(GOARCH) ./crossdock/main.go
-	sha256sum ./crossdock/crossdock-$(GOOS)-$(GOARCH) > ./crossdock/crossdock-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-crossdock-linux
 build-crossdock-linux:
@@ -624,22 +605,17 @@ certs-dryrun:
 
 .PHONY: collect-sums
 collect-sums:
-	find . -name '*sha256sum.txt' -exec cat {} \; > sha256sum.combined.txt
+	find cmd -type f -executable -exec sha256sum {} \; | sort -k2 > sha256sum.combined.txt
 
 .PHONY: test-checksums
 test-checksums:
-	sha256sum --check --strict ./sha256sum.combined.txt
-
-.PHONY: clean-bin
-clean-bin: collect-sums
-	cut -d\  -f3 ./sha256sum.combined.txt | xargs rm
+	sha256sum --strict --check ./sha256sum.combined.txt
 
 .PHONY: repro-check
 repro-check:
 	$(MAKE) clean
 	$(MAKE) build-all-platforms
 	$(MAKE) collect-sums
-	$(MAKE) clean-bin
 	$(MAKE) clean
 	$(MAKE) build-all-platforms
 	$(MAKE) test-checksums

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ IMPORT_LOG=.import.log
 GIT_SHA=$(shell git rev-parse HEAD)
 GIT_CLOSEST_TAG=$(shell git describe --abbrev=0 --tags)
 DATE=$(shell date -u -d @$(shell git show -s --format=%ct) +'%Y-%m-%dT%H:%M:%SZ')
+UIDATE=$(shell cd ./jaeger-ui; date -u -d @$(shell git show -s --format=%ct) +'%Y-%m-%dT%H:%M:%SZ')
 BUILD_INFO_IMPORT_PATH=$(JAEGER_IMPORT_PATH)/pkg/version
 BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).commitSHA=$(GIT_SHA) -X $(BUILD_INFO_IMPORT_PATH).latestVersion=$(GIT_CLOSEST_TAG) -X $(BUILD_INFO_IMPORT_PATH).date=$(DATE)"
 
@@ -82,6 +83,7 @@ go-gen:
 clean:
 	rm -rf cover.out .cover/ cover.html $(FMT_LOG) $(IMPORT_LOG) \
 		jaeger-ui/packages/jaeger-ui/build
+	find ./cmd/query/app/ui/actual -type f -name '*.gz' -delete
 
 .PHONY: test
 test: go-gen
@@ -163,30 +165,37 @@ lint:
 .PHONY: build-examples
 build-examples:
 	$(GOBUILD) -o ./examples/hotrod/hotrod-$(GOOS)-$(GOARCH) ./examples/hotrod/main.go
+	sha256sum ./examples/hotrod/hotrod-$(GOOS)-$(GOARCH) > ./examples/hotrod/hotrod-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-tracegen
 build-tracegen:
 	$(GOBUILD) -o ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH) ./cmd/tracegen/main.go
+	sha256sum ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH) > ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-anonymizer
 build-anonymizer:
 	$(GOBUILD) -o ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/anonymizer/main.go
+	sha256sum ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) > ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-esmapping-generator
 build-esmapping-generator:
 	$(GOBUILD) -o ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/esmapping-generator/main.go
+	sha256sum ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH) > ./plugin/storage/es/esmapping-generator-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-esmapping-generator-linux
 build-esmapping-generator-linux:
 	 GOOS=linux GOARCH=amd64 $(GOBUILD) -o ./plugin/storage/es/esmapping-generator $(BUILD_INFO) ./cmd/esmapping-generator/main.go
+	sha256sum ./plugin/storage/es/esmapping-generator > ./plugin/storage/es/esmapping-generator.sha256sum.txt
 
 .PHONY: build-es-index-cleaner
 build-es-index-cleaner:
 	$(GOBUILD) -o ./cmd/es-index-cleaner/es-index-cleaner-$(GOOS)-$(GOARCH) ./cmd/es-index-cleaner/main.go
+	sha256sum ./cmd/es-index-cleaner/es-index-cleaner-$(GOOS)-$(GOARCH) > ./cmd/es-index-cleaner/es-index-cleaner-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-es-rollover
 build-es-rollover:
 	$(GOBUILD) -o ./cmd/es-rollover/es-rollover-$(GOOS)-$(GOARCH) ./cmd/es-rollover/main.go
+	sha256sum ./cmd/es-rollover/es-rollover-$(GOOS)-$(GOARCH) > ./cmd/es-rollover/es-rollover-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: docker-hotrod
 docker-hotrod:
@@ -203,7 +212,12 @@ cmd/query/app/ui/actual/index.html.gz: jaeger-ui/packages/jaeger-ui/build/index.
 	# do not delete dot-files
 	rm -rf cmd/query/app/ui/actual/*
 	cp -r jaeger-ui/packages/jaeger-ui/build/* cmd/query/app/ui/actual/
+	@echo "Set UI file dates to UI repository commit timestamp: $(UIDATE)"
+	# gzip stores file timestamps and therefore breaks reproducibility by default, setting the timestamps fixes this.
+	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs touch --date=$(UIDATE)
 	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs gzip
+	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs sha256sum | tee ui.sha256sum.txt
+
 
 jaeger-ui/packages/jaeger-ui/build/index.html:
 	$(MAKE) rebuild-ui
@@ -211,6 +225,8 @@ jaeger-ui/packages/jaeger-ui/build/index.html:
 .PHONY: rebuild-ui
 rebuild-ui:
 	cd jaeger-ui && yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build
+	mv jaeger-ui/packages/jaeger-ui/build/asset-manifest.json .asset-manifest.json
+	cat .asset-manifest.json | python -c 'import json, sys; o = json.loads(sys.stdin.read()); print(json.dumps(o, indent=2, sort_keys=True))' > jaeger-ui/packages/jaeger-ui/build/asset-manifest.json
 
 .PHONY: build-all-in-one-linux
 build-all-in-one-linux:
@@ -222,26 +238,32 @@ build-all-in-one-debug build-agent-debug build-query-debug build-collector-debug
 .PHONY: build-all-in-one build-all-in-one-debug
 build-all-in-one build-all-in-one-debug: build-ui
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -tags ui -o ./cmd/all-in-one/all-in-one$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/all-in-one/main.go
+	sha256sum ./cmd/all-in-one/all-in-one$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/all-in-one/all-in-one$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-agent build-agent-debug
 build-agent build-agent-debug:
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/agent/agent$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/agent/main.go
+	sha256sum './cmd/agent/agent$(SUFFIX)-$(GOOS)-$(GOARCH)' > './cmd/agent/agent$(SUFFIX)-$(GOOS)-$(GOARCH)'.sha256sum.txt
 
 .PHONY: build-query build-query-debug
 build-query build-query-debug: build-ui
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -tags ui -o ./cmd/query/query$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/query/main.go
+	sha256sum ./cmd/query/query$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/query/query$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-collector build-collector-debug
 build-collector build-collector-debug:
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/collector/collector$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/collector/main.go
+	sha256sum ./cmd/collector/collector$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/collector/collector$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-ingester build-ingester-debug
 build-ingester build-ingester-debug:
-	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/ingester/main.go
+	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH) ./cmd/ingester/main.go
+	sha256sum ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/ingester/ingester$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-remote-storage build-remote-storage-debug
 build-remote-storage build-remote-storage-debug:
 	$(GOBUILD) $(DISABLE_OPTIMIZATIONS) -o ./cmd/remote-storage/remote-storage$(SUFFIX)-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/remote-storage/main.go
+	sha256sum ./cmd/remote-storage/remote-storage$(SUFFIX)-$(GOOS)-$(GOARCH) > ./cmd/remote-storage/remote-storage$(SUFFIX)-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-binaries-linux
 build-binaries-linux:
@@ -351,6 +373,7 @@ docker-images-only: docker-images-cassandra \
 .PHONY: build-crossdock-binary
 build-crossdock-binary:
 	$(GOBUILD) -o ./crossdock/crossdock-$(GOOS)-$(GOARCH) ./crossdock/main.go
+	sha256sum ./crossdock/crossdock-$(GOOS)-$(GOARCH) > ./crossdock/crossdock-$(GOOS)-$(GOARCH).sha256sum.txt
 
 .PHONY: build-crossdock-linux
 build-crossdock-linux:
@@ -598,3 +621,25 @@ certs:
 .PHONY: certs-dryrun
 certs-dryrun:
 	cd pkg/config/tlscfg/testdata && ./gen-certs.sh -d
+
+.PHONY: collect-sums
+collect-sums:
+	find . -name '*sha256sum.txt' -exec cat {} \; > sha256sum.combined.txt
+
+.PHONY: test-checksums
+test-checksums:
+	sha256sum --check --strict ./sha256sum.combined.txt
+
+.PHONY: clean-bin
+clean-bin: collect-sums
+	cut -d\  -f3 ./sha256sum.combined.txt | xargs rm
+
+.PHONY: repro-check
+repro-check:
+	$(MAKE) clean
+	$(MAKE) build-all-platforms
+	$(MAKE) collect-sums
+	$(MAKE) clean-bin
+	$(MAKE) clean
+	$(MAKE) build-all-platforms
+	$(MAKE) test-checksums

--- a/Makefile
+++ b/Makefile
@@ -609,7 +609,7 @@ repro-check:
 	$(MAKE) clean
 	$(MAKE) build-all-platforms
 	# Generate checksum for all executables under ./cmd
-	find cmd -type f -executable -exec sha256sum {} \; | sort -k2 > sha256sum.combined.txt
+	find cmd -type f -executable -exec shasum -b -a 256 {} \; | sort -k2 | tee sha256sum.combined.txt
 	$(MAKE) clean
 	$(MAKE) build-all-platforms
-	sha256sum --strict --check ./sha256sum.combined.txt
+	shasum -b -a 256 --strict --check ./sha256sum.combined.txt

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -1,40 +1,30 @@
 #!/bin/bash
-# stage-file copies the file $1 with the specified path $2
-# if no file exists it will abort
-function stage-file {
-    if [ ! -f $1 ]
-    then
-        echo "$1 does not exist. Aborting."
-        exit 1
-    fi
-    echo "Copying $1 to $2"
-    cp $1 $2
-}
+set -euxf -o pipefail
 
 # stage-platform-files stages the different the platform ($1) into the package
 # staging dir ($2). If you pass in a file extension ($3) it will be used when
 # copying on the source
 function stage-platform-files {
-    local PLATFORM=$1
-    local PACKAGE_STAGING_DIR=$2
-    local FILE_EXTENSION=$3
+    local -r PLATFORM=$1
+    local -r PACKAGE_STAGING_DIR=$2
+    local -r FILE_EXTENSION=${3:-}
 
-    stage-file ./cmd/all-in-one/all-in-one-$PLATFORM  $PACKAGE_STAGING_DIR/jaeger-all-in-one$FILE_EXTENSION
-    stage-file ./cmd/agent/agent-$PLATFORM            $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
-    stage-file ./cmd/query/query-$PLATFORM            $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
-    stage-file ./cmd/collector/collector-$PLATFORM    $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
-    stage-file ./cmd/ingester/ingester-$PLATFORM      $PACKAGE_STAGING_DIR/jaeger-ingester$FILE_EXTENSION
-    stage-file ./examples/hotrod/hotrod-$PLATFORM     $PACKAGE_STAGING_DIR/example-hotrod$FILE_EXTENSION
+    cp ./cmd/all-in-one/all-in-one-$PLATFORM  $PACKAGE_STAGING_DIR/jaeger-all-in-one$FILE_EXTENSION
+    cp ./cmd/agent/agent-$PLATFORM            $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
+    cp ./cmd/query/query-$PLATFORM            $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
+    cp ./cmd/collector/collector-$PLATFORM    $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
+    cp ./cmd/ingester/ingester-$PLATFORM      $PACKAGE_STAGING_DIR/jaeger-ingester$FILE_EXTENSION
+    cp ./examples/hotrod/hotrod-$PLATFORM     $PACKAGE_STAGING_DIR/example-hotrod$FILE_EXTENSION
 }
 
 # package pulls built files for the platform ($2) and compresses it using the compression ($1).
 # If you pass in a file extension ($3) it will be look for binaries with that extension.
 function package {
-    local COMPRESSION=$1
-    local PLATFORM=$2
-    local FILE_EXTENSION=$3
-    local PACKAGE_NAME=jaeger-$VERSION-$PLATFORM
-    local PACKAGE_STAGING_DIR=$PACKAGE_NAME
+    local -r COMPRESSION=$1
+    local -r PLATFORM=$2
+    local -r FILE_EXTENSION=${3:-}
+    local -r PACKAGE_NAME=jaeger-$VERSION-$PLATFORM
+    local -r PACKAGE_STAGING_DIR=$PACKAGE_NAME
 
     if [ -d $PACKAGE_STAGING_DIR ]
     then
@@ -42,15 +32,16 @@ function package {
     fi
     mkdir $PACKAGE_STAGING_DIR
     stage-platform-files $PLATFORM $PACKAGE_STAGING_DIR $FILE_EXTENSION
+    # Create a checksum file for all the files being packaged in the archive. Sorted by filename.
     find $PACKAGE_STAGING_DIR -type f -exec sha256sum {} \; | sort -k2 | tee ./deploy/$PACKAGE_NAME.sha256sum.txt
 
     if [ "$COMPRESSION" == "zip" ]
     then
-        local ARCHIVE_NAME="$PACKAGE_NAME.zip"
+        local -r ARCHIVE_NAME="$PACKAGE_NAME.zip"
         echo "Packaging into $ARCHIVE_NAME:"
         zip -r ./deploy/$ARCHIVE_NAME $PACKAGE_STAGING_DIR
     else
-        local ARCHIVE_NAME="$PACKAGE_NAME.tar.gz"
+        local -r ARCHIVE_NAME="$PACKAGE_NAME.tar.gz"
         echo "Packaging into $ARCHIVE_NAME:"
         tar --sort=name -czvf ./deploy/$ARCHIVE_NAME $PACKAGE_STAGING_DIR
     fi
@@ -75,4 +66,5 @@ package zip windows-amd64 .exe
 package tar linux-s390x
 package tar linux-arm64
 package tar linux-ppc64le
-find deploy \( ! -name '*sha256sum.txt' \) -type f -exec sha256sum {} \; | sed -r 's/(\w+\s+).*(jaeger)/\1\2/' | sort -k2 | tee ./deploy/jaeger-$VERSION.sha256sum.txt
+# Create a checksum file for all non-checksum files in the deploy directory. Strips the leading 'deploy/' directory from filepaths. Sort by filename.
+find deploy \( ! -name '*sha256sum.txt' \) -type f -exec sha256sum {} \; | sed -r 's#(\w+\s+)deploy/(.*)#\1\2#' | sort -k2 | tee ./deploy/jaeger-$VERSION.sha256sum.txt

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
-
 # stage-file copies the file $1 with the specified path $2
-# if no file exists it will silently continue
+# if no file exists it will abort
 function stage-file {
-    if [ -f $1 ]; then
-        echo "Copying $1 to $2"
-        cp $1 $2
-    else
+    if [ ! -f $1 ]
+    then
         echo "$1 does not exist. Aborting."
         exit 1
     fi
+    echo "Copying $1 to $2"
+    cp $1 $2
 }
 
 # stage-platform-files stages the different the platform ($1) into the package
@@ -20,12 +19,12 @@ function stage-platform-files {
     local PACKAGE_STAGING_DIR=$2
     local FILE_EXTENSION=$3
 
-    stage-file ./cmd/all-in-one/all-in-one-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-all-in-one$FILE_EXTENSION
-    stage-file ./cmd/agent/agent-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
-    stage-file ./cmd/query/query-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
-    stage-file ./cmd/collector/collector-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
-    stage-file ./cmd/ingester/ingester-$PLATFORM $PACKAGE_STAGING_DIR/jaeger-ingester$FILE_EXTENSION
-    stage-file ./examples/hotrod/hotrod-$PLATFORM $PACKAGE_STAGING_DIR/example-hotrod$FILE_EXTENSION
+    stage-file ./cmd/all-in-one/all-in-one-$PLATFORM  $PACKAGE_STAGING_DIR/jaeger-all-in-one$FILE_EXTENSION
+    stage-file ./cmd/agent/agent-$PLATFORM            $PACKAGE_STAGING_DIR/jaeger-agent$FILE_EXTENSION
+    stage-file ./cmd/query/query-$PLATFORM            $PACKAGE_STAGING_DIR/jaeger-query$FILE_EXTENSION
+    stage-file ./cmd/collector/collector-$PLATFORM    $PACKAGE_STAGING_DIR/jaeger-collector$FILE_EXTENSION
+    stage-file ./cmd/ingester/ingester-$PLATFORM      $PACKAGE_STAGING_DIR/jaeger-ingester$FILE_EXTENSION
+    stage-file ./examples/hotrod/hotrod-$PLATFORM     $PACKAGE_STAGING_DIR/example-hotrod$FILE_EXTENSION
 }
 
 # package pulls built files for the platform ($2) and compresses it using the compression ($1).
@@ -34,34 +33,39 @@ function package {
     local COMPRESSION=$1
     local PLATFORM=$2
     local FILE_EXTENSION=$3
-    local PACKAGE_STAGING_DIR=jaeger-$VERSION-$PLATFORM
+    local PACKAGE_NAME=jaeger-$VERSION-$PLATFORM
+    local PACKAGE_STAGING_DIR=$PACKAGE_NAME
 
+    if [ -d $PACKAGE_STAGING_DIR ]
+    then
+        rm -vrf "$PACKAGE_STAGING_DIR"
+    fi
     mkdir $PACKAGE_STAGING_DIR
     stage-platform-files $PLATFORM $PACKAGE_STAGING_DIR $FILE_EXTENSION
+    find $PACKAGE_STAGING_DIR -type f -exec sha256sum {} \; | sort -k2 | tee ./deploy/$PACKAGE_NAME.sha256sum.txt
 
     if [ "$COMPRESSION" == "zip" ]
     then
-        local ARCHIVE_NAME="$PACKAGE_STAGING_DIR.zip"
+        local ARCHIVE_NAME="$PACKAGE_NAME.zip"
         echo "Packaging into $ARCHIVE_NAME:"
         zip -r ./deploy/$ARCHIVE_NAME $PACKAGE_STAGING_DIR
     else
-        local ARCHIVE_NAME="$PACKAGE_STAGING_DIR.tar.gz"
+        local ARCHIVE_NAME="$PACKAGE_NAME.tar.gz"
         echo "Packaging into $ARCHIVE_NAME:"
-        tar -czvf ./deploy/$ARCHIVE_NAME $PACKAGE_STAGING_DIR
+        tar --sort=name -czvf ./deploy/$ARCHIVE_NAME $PACKAGE_STAGING_DIR
     fi
+
     rm -rf $PACKAGE_STAGING_DIR
 }
 
 set -e
 
-DEPLOY_STAGING_DIR=./deploy-staging
-VERSION="$(make echo-version | awk 'match($0, /([0-9]*\.[0-9]*\.[0-9]*)$/) { print substr($0, RSTART, RLENGTH) }')"
+readonly VERSION="$(make echo-version | awk 'match($0, /([0-9]*\.[0-9]*\.[0-9]*)$/) { print substr($0, RSTART, RLENGTH) }')"
 echo "Working on version: $VERSION"
 
 # make needed directories
-rm -rf deploy $DEPLOY_STAGING_DIR
+rm -rf deploy
 mkdir deploy
-mkdir $DEPLOY_STAGING_DIR
 
 package tar linux-amd64
 package tar darwin-amd64
@@ -71,3 +75,4 @@ package zip windows-amd64 .exe
 package tar linux-s390x
 package tar linux-arm64
 package tar linux-ppc64le
+find deploy \( ! -name '*sha256sum.txt' \) -type f -exec sha256sum {} \; | sed -r 's/(\w+\s+).*(jaeger)/\1\2/' | sort -k2 | tee ./deploy/jaeger-$VERSION.sha256sum.txt


### PR DESCRIPTION
This does not help with reproducibility checks across build systems. But
should help ensure that multiple builds on the same build system are
reproducible.

## Which problem is this PR solving?
Resolves Issue: #3877

## Short description of the changes

Adds reproducibility checks to the make file and CI.
Fixes timestamps embedded in gzipped UI files.
Fixes reproducibility for asset-manifest.json before compression/embedding.

