### PR TITLE
fix: streaming span writer is not working in grpc based remote storage plugin

### DIFF
--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -107,8 +107,9 @@ func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, 
 	grpcClient := shared.NewGRPCClient(conn)
 	return &ClientPluginServices{
 		PluginServices: shared.PluginServices{
-			Store:        grpcClient,
-			ArchiveStore: grpcClient,
+			Store:               grpcClient,
+			ArchiveStore:        grpcClient,
+			StreamingSpanWriter: grpcClient,
 		},
 		Capabilities: grpcClient,
 	}, nil

--- a/plugin/storage/grpc/shared/grpc_handler.go
+++ b/plugin/storage/grpc/shared/grpc_handler.go
@@ -115,6 +115,9 @@ func (s *GRPCHandler) WriteSpanStream(stream storage_v1.StreamingSpanWriterPlugi
 		if err == io.EOF {
 			break
 		}
+		if err != nil {
+			return err
+		}
 		err = writer.WriteSpan(stream.Context(), in.Span)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Which problem is this PR solving?
- streaming span writer is not working in grpc remote storage plugin
- errors other than io.EOF from grpc framework causes crash with streaming span writer

