### PR TITLE
fix: jaeger-agent sampling endpoint returns backwards incompatible JSON

### DIFF
--- a/model/converter/thrift/jaeger/sampling_from_domain.go
+++ b/model/converter/thrift/jaeger/sampling_from_domain.go
@@ -67,14 +67,12 @@ func convertPerOperationFromDomain(s *api_v2.PerOperationSamplingStrategies) *sa
 		DefaultLowerBoundTracesPerSecond: s.GetDefaultLowerBoundTracesPerSecond(),
 		DefaultUpperBoundTracesPerSecond: &s.DefaultUpperBoundTracesPerSecond,
 	}
-	if s.GetPerOperationStrategies() != nil {
-		r.PerOperationStrategies = make([]*sampling.OperationSamplingStrategy, len(s.GetPerOperationStrategies()))
-		for i, k := range s.PerOperationStrategies {
-			r.PerOperationStrategies[i] = convertOperationFromDomain(k)
-		}
-	} else {
-		// Initialize to an empty array so that using json.Marshal results in [] instead of null.
-		r.PerOperationStrategies = make([]*sampling.OperationSamplingStrategy, 0)
+
+	perOp := s.GetPerOperationStrategies()
+	// Default to empty array so that json.Marshal returns [] instead of null (Issue #3891).
+	r.PerOperationStrategies = make([]*sampling.OperationSamplingStrategy, len(perOp))
+	for i, k := range perOp {
+		r.PerOperationStrategies[i] = convertOperationFromDomain(k)
 	}
 	return r
 }

--- a/model/converter/thrift/jaeger/sampling_from_domain.go
+++ b/model/converter/thrift/jaeger/sampling_from_domain.go
@@ -72,6 +72,9 @@ func convertPerOperationFromDomain(s *api_v2.PerOperationSamplingStrategies) *sa
 		for i, k := range s.PerOperationStrategies {
 			r.PerOperationStrategies[i] = convertOperationFromDomain(k)
 		}
+	} else {
+		// Initialize to an empty array so that using json.Marshal results in [] instead of null.
+		r.PerOperationStrategies = make([]*sampling.OperationSamplingStrategy, 0)
 	}
 	return r
 }

--- a/model/converter/thrift/jaeger/sampling_from_domain_test.go
+++ b/model/converter/thrift/jaeger/sampling_from_domain_test.go
@@ -116,7 +116,9 @@ func TestConvertPerOperationStrategyFromDomain(t *testing.T) {
 				PerOperationStrategies: []*sampling.OperationSamplingStrategy{{Operation: "fao"}},
 			},
 		},
-		{},
+		{in: &api_v2.PerOperationSamplingStrategies{DefaultSamplingProbability: 15.2, DefaultUpperBoundTracesPerSecond: a, DefaultLowerBoundTracesPerSecond: 2},
+			expected: &sampling.PerOperationSamplingStrategies{DefaultSamplingProbability: 15.2, DefaultUpperBoundTracesPerSecond: &a, DefaultLowerBoundTracesPerSecond: 2,
+				PerOperationStrategies: []*sampling.OperationSamplingStrategy{}}},
 	}
 	for _, test := range tests {
 		o := convertPerOperationFromDomain(test.in)

--- a/model/converter/thrift/jaeger/sampling_from_domain_test.go
+++ b/model/converter/thrift/jaeger/sampling_from_domain_test.go
@@ -116,9 +116,13 @@ func TestConvertPerOperationStrategyFromDomain(t *testing.T) {
 				PerOperationStrategies: []*sampling.OperationSamplingStrategy{{Operation: "fao"}},
 			},
 		},
-		{in: &api_v2.PerOperationSamplingStrategies{DefaultSamplingProbability: 15.2, DefaultUpperBoundTracesPerSecond: a, DefaultLowerBoundTracesPerSecond: 2},
-			expected: &sampling.PerOperationSamplingStrategies{DefaultSamplingProbability: 15.2, DefaultUpperBoundTracesPerSecond: &a, DefaultLowerBoundTracesPerSecond: 2,
-				PerOperationStrategies: []*sampling.OperationSamplingStrategy{}}},
+		{
+			in: &api_v2.PerOperationSamplingStrategies{DefaultSamplingProbability: 15.2, DefaultUpperBoundTracesPerSecond: a, DefaultLowerBoundTracesPerSecond: 2},
+			expected: &sampling.PerOperationSamplingStrategies{
+				DefaultSamplingProbability: 15.2, DefaultUpperBoundTracesPerSecond: &a, DefaultLowerBoundTracesPerSecond: 2,
+				PerOperationStrategies: []*sampling.OperationSamplingStrategy{},
+			},
+		},
 	}
 	for _, test := range tests {
 		o := convertPerOperationFromDomain(test.in)


### PR DESCRIPTION
- Sampling endpoint's `perOperationStrategies` field contains `[]` as a default value instead of nil. This was the behavior as of jaeger-agent v1.17 when using tchannel/thrift to communicate with collector.
- Returning an empty slice for `perOperationStrategies` instead of the default nil slice allows
  json.Marshal to marshal it to `[]` instead of `null`
- Resolves #3891

Signed-off-by: Prithvi Raj <p.r@uber.com>
