### PR TITLE
Use all span kinds as default for metrics

### DIFF
--- a/cmd/query/app/default_params.go
+++ b/cmd/query/app/default_params.go
@@ -28,5 +28,12 @@ var (
 	defaultMetricsQueryLookbackDuration = time.Hour
 	defaultMetricsQueryStepDuration     = 5 * time.Second
 	defaultMetricsQueryRateDuration     = 10 * time.Minute
-	defaultMetricsSpanKinds             = []string{metrics.SpanKind_SPAN_KIND_SERVER.String()}
+	defaultMetricsSpanKinds             = []string{
+		metrics.SpanKind_SPAN_KIND_UNSPECIFIED.String(),
+		metrics.SpanKind_SPAN_KIND_INTERNAL.String(),
+		metrics.SpanKind_SPAN_KIND_SERVER.String(),
+		metrics.SpanKind_SPAN_KIND_CLIENT.String(),
+		metrics.SpanKind_SPAN_KIND_PRODUCER.String(),
+		metrics.SpanKind_SPAN_KIND_CONSUMER.String(),
+	}
 )


### PR DESCRIPTION
Hi everyone, if this change doesn't make sense or if I missed something to configure the span kind feel free to close the PR.

## Which problem is this PR solving?

Background: The span kind for some services could have another value then "SPAN_KIND_SERVER", e.g. the spans from Istio are using "SPAN_KIND_CLIENT". Because of the default span kind and the fact that the span kind is not configureable in the frontend (the query parameter is never set in the API calls) it was not possible to use the service performance monitoring with some services.

## Short description of the changes

Instead of just using "SPAN_KIND_SERVER" as the default span kind for the metrics, the default value now includes all span kinds.