### PR TITLE
[tests] Give each span a unique ID in large span test

### DIFF
--- a/plugin/storage/integration/integration_test.go
+++ b/plugin/storage/integration/integration_test.go
@@ -277,6 +277,7 @@ func (s *StorageIntegration) loadParseAndWriteLargeTrace(t *testing.T) *model.Tr
 	for i := 1; i < 10008; i++ {
 		s := new(model.Span)
 		*s = *span
+		s.SpanID = model.SpanID(i)
 		s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
 		trace.Spans = append(trace.Spans, s)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
-  Resolves #3912

## Short description of the changes
- To make the test simulate a more realistic scenario, each span in the `loadParseAndWriteLargeTrace` test will have a unique spanID instead of having all the spans be the same.

