### PR TITLE
Change tags_opname_trace to have only one parent

### DIFF
--- a/plugin/storage/integration/fixtures/traces/tags_opname_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_opname_trace.json
@@ -7,13 +7,13 @@
       "references": [
         {
           "refType": "CHILD_OF",
-          "traceId": "AAAAAAAAAAAAAAAAAAAA/w==",
+          "traceId": "AAAAAAAAAAAAAAAAAAAAEg==",
           "spanId": "AAAAAAAAAP8="
         },
         {
-          "refType": "CHILD_OF",
-          "traceId": "AAAAAAAAAAAAAAAAAAAAAQ==",
-          "spanId": "AAAAAAAAAAI="
+          "refType": "FOLLOWS_FROM",
+          "traceId": "AAAAAAAAAAAAAAAAAAAAEg==",
+          "spanId": "AAAAAAAAAP8="
         },
         {
           "refType": "FOLLOWS_FROM",


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #3918

## Short description of the changes

Set the fixture `tags_opname_trace.json` used in the integration test

TestExternalGRPCStorage/FindTraces/Tags_+_Operation_name

To have the following references:

- A CHILD_OF to a different span that shares the same traceId.
- A FOLLOWS_FROM to the same span used in the `CHILD_OF` relationship.
- A FOLLOWS_FROM to a span belonging to a different trace.