### PR TITLE
Fix empty operationNames used in storage integration tests

### DIFF
--- a/plugin/storage/integration/fixtures/traces/default.json
+++ b/plugin/storage/integration/fixtures/traces/default.json
@@ -3,7 +3,7 @@
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
       "spanId": "AAAAAAAAAAM=",
-      "operationName": "",
+      "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": "100000ns",

--- a/plugin/storage/integration/fixtures/traces/multiple1_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple1_trace.json
@@ -3,7 +3,7 @@
     {
       "traceId": "AAAAAAAAAAAAAAAAAAACIQ==",
       "spanId": "AAAAAAAAAAM=",
-      "operationName": "",
+      "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": "100000ns",

--- a/plugin/storage/integration/fixtures/traces/multiple2_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple2_trace.json
@@ -3,7 +3,7 @@
     {
       "traceId": "AAAAAAAAAAAAAAAAAAACIg==",
       "spanId": "AAAAAAAAAAM=",
-      "operationName": "",
+      "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": "100000ns",

--- a/plugin/storage/integration/fixtures/traces/multiple3_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple3_trace.json
@@ -3,7 +3,7 @@
     {
       "traceId": "AAAAAAAAAAAAAAAAAAACIw==",
       "spanId": "AAAAAAAAAAM=",
-      "operationName": "",
+      "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": "100000ns",

--- a/plugin/storage/integration/fixtures/traces/tags_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_maxdur_trace.json
@@ -3,7 +3,7 @@
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAFg==",
       "spanId": "AAAAAAAAAAU=",
-      "operationName": "",
+      "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",
       "duration": "1000ns",

--- a/plugin/storage/integration/fixtures/traces/tags_wildcard_regex_1.json
+++ b/plugin/storage/integration/fixtures/traces/tags_wildcard_regex_1.json
@@ -3,7 +3,7 @@
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAKEg==",
       "spanId": "AAAAAAAAAAQ=",
-      "operationName": "",
+      "operationName": "placeholder",
       "references": [
       ],
       "tags": [

--- a/plugin/storage/integration/fixtures/traces/tags_wildcard_regex_2.json
+++ b/plugin/storage/integration/fixtures/traces/tags_wildcard_regex_2.json
@@ -3,7 +3,7 @@
     {
       "traceId": "AAAAAAAAAAAAAAAAAAASEg==",
       "spanId": "AAAAAAAAAAQ=",
-      "operationName": "",
+      "operationName": "placeholder",
       "references": [
       ],
       "tags": [


### PR DESCRIPTION
Few fixtures in storage integration tests has empty operationName which doesn't soundcorrect.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->