### PR TITLE
Fix kustomization directory path

### DIFF
--- a/examples/hotrod/kubernetes/kustomization.yaml
+++ b/examples/hotrod/kubernetes/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 bases:
 # If you only want the hotrod application, uncomment this line and comment out jaeger-all-in-one
 #  - base/hotrod
-  - base/jaeger
+  - base/jaeger-all-in-one
 
 namespace: example-hotrod
 


### PR DESCRIPTION
The kustomization file used in the hotrod example specifies a wrong directory path.
This commit fixes the path.

Signed-off-by: banban9999 <"patariro1000@gmail.com">

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- This PR solves the misconfiguration of the kustomization file used in the hotrod example.

## Short description of the changes
- Fix kustomization  file used in the hotrod example.
