### PR TITLE
Generate and publish sbom on release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -41,10 +41,16 @@ jobs:
       run: bash scripts/package-deploy.sh
       if: steps.build-binaries.outcome == 'success'
 
+    - name: Generate SBOM
+      uses: CycloneDX/gh-gomod-generate-sbom@v1
+      with:
+        version: v1
+        args: mod -licenses -json -output bom.json
+
     - name: Upload binaries
       uses: svenstaro/upload-release-action@2.3.0
       with:
-        file: '{deploy/*.tar.gz,deploy/*.zip,deploy/*.sha256sum.txt}'
+        file: '{bom.json,deploy/*.tar.gz,deploy/*.zip,deploy/*.sha256sum.txt}'
         file_glob: true
         tag: ${{ github.ref }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>

## Which problem is this PR solving?
- Fixes #3943

## Short description of the changes
- Generate a sbom as a bom.json file and publish it on release
