### PR TITLE
Add support for OpenSearch 2.x

### DIFF
--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -16,6 +16,9 @@ jobs:
         - major: 1.x
           image: 1.0.0
           distribution: opensearch
+        - major: 2.x
+          image: 2.3.0
+          distribution: opensearch
     name: ${{ matrix.version.distribution }} ${{ matrix.version.major }}
     steps:
     - uses: actions/checkout@v3

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -202,6 +202,10 @@ func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Fac
 				logger.Info("OpenSearch 1.x detected, using ES 7.x index mappings")
 				esVersion = 7
 			}
+			if pingResult.Version.Number[0] == '2' {
+				logger.Info("OpenSearch 2.x detected, using ES 7.x index mappings")
+				esVersion = 7
+			}
 		}
 		logger.Info("Elasticsearch detected", zap.Int("version", esVersion))
 		c.Version = uint(esVersion)


### PR DESCRIPTION
Added support for OS 2.x

## Which problem is this PR solving?
https://github.com/jaegertracing/jaeger/issues/3808

## Short description of the changes
Added version check for OpenSearch 2.x and enable test run on OpenSearch 2.3.0
