### PR TITLE
Adding anchore for SBOM signing during release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -69,3 +69,8 @@ jobs:
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: SBOM Generation
+      uses: anchore/sbom-action@v0
+      with:
+        artifact-name: jaeger-SBOM.spdx.json


### PR DESCRIPTION
Signed-off-by: jkowall <jkowall@kowall.net>

## Which problem is this PR solving?
https://github.com/jaegertracing/jaeger/issues/3943

This creates a new SBOM file on releases to comply with CLOMonitor requirements. 

## Short description of the changes
Added new Githiub action in the ci-release.yml action. I tested this on my own fork to verify it generates the proper files. 
