### PR TITLE
Use codecov upload token

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -10,6 +10,12 @@ on:
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
+env:
+  # Using upload token helps against rate limiting errors.
+  # Cannot define it as secret as we need it accessible from forks.
+  # See https://github.com/codecov/codecov-action/issues/837
+  CODECOV_TOKEN: f457b710-93af-4191-8678-bcf51281f98c
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -35,5 +41,8 @@ jobs:
       uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       with:
         file: cover.out
-        fail_ci_if_error: true
         verbose: true
+        flags: unittests
+        fail_ci_if_error: true
+        token: ${{ env.CODECOV_TOKEN }}
+


### PR DESCRIPTION
To avoid sporadic CI failures like https://github.com/jaegertracing/jaeger/actions/runs/3316721197/jobs/5478836425

```
[2022-10-24T22:43:57.265Z] ['verbose'] https://codecov.io/upload/v4?package=github-action-3.1.1-uploader-0.3.2&branch=main&build=3316721197&build_url=https%3A%2F%2Fgithub.com%2Fjaegertracing%2Fjaeger%2Factions%2Fruns%2F3316721197&commit=b05a2d58acda713dab194e2feb750265fab96b64&job=Unit+Tests&pr=&service=github-actions&slug=jaegertracing%2Fjaeger&name=&tag=&flags=&parent=
        Content-Type: 'text/plain'
        Content-Encoding: 'gzip'
        X-Reduced-Redundancy: 'false'
[2022-10-24T22:43:57.613Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```
Cf. https://github.com/codecov/codecov-action/issues/837