### PR TITLE
Removes Auth requirement on monitor demo

### DIFF
--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -49,6 +49,10 @@ services:
     volumes:
       - ./grafana.ini:/etc/grafana/grafana.ini
       - ./datasource.yml:/etc/grafana/provisioning/datasources/datasource.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
     ports:
       - 3000:3000
 


### PR DESCRIPTION
## Which problem is this PR solving?
Currently when using the monitor demo and visiting the Grafana UI you are greeted with a login page like this:
![image](https://user-images.githubusercontent.com/2272392/197837984-fa7aa332-260d-4b50-9dbe-fff984825a25.png)

This PR adds env vars to skip the login page and immediately be using Grafana.

## Short description of the changes
- Add 3 env vars to grafana 
