### PR TITLE
Correct deploy permissions

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -6,7 +6,9 @@ on:
       - published
 
 # See https://github.com/jaegertracing/jaeger/issues/4017
-permissions: read-all|write-all
+# and https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
+permissions:
+  deployments: write
 
 jobs:
   publish-release:


### PR DESCRIPTION
Turns out `read-all|write-all` is invalid syntax. Narrowing this further to just deploy perms.

#4017