### PR TITLE
Add the signing of releases to build process

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -43,6 +43,12 @@ jobs:
     - name: Install tools
       run: make install-ci
 
+    - name: Configure GPG Key
+      uses: crazy-max/ghaction-import-gpg@v1
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+
     - name: Build binaries
       id: build-binaries
       run: make build-all-platforms
@@ -55,7 +61,7 @@ jobs:
     - name: Upload binaries
       uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575
       with:
-        file: '{deploy/*.tar.gz,deploy/*.zip,deploy/*.sha256sum.txt}'
+        file: '{deploy/*.tar.gz,deploy/*.zip,deploy/*.sha256sum.txt,deploy/*.asc}'
         file_glob: true
         tag: ${{ github.ref }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -47,7 +47,7 @@ jobs:
       uses: crazy-max/ghaction-import-gpg@v1
       env:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+        PASSPHRASE: ${{ secrets. GPG_PASSPHRASE }}
 
     - name: Build binaries
       id: build-binaries

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -74,3 +74,5 @@ package tar linux-arm64
 package tar linux-ppc64le
 # Create a checksum file for all non-checksum files in the deploy directory. Strips the leading 'deploy/' directory from filepaths. Sort by filename.
 find deploy \( ! -name '*sha256sum.txt' \) -type f -exec shasum -b -a 256 {} \; | sed -r 's#(\w+\s+\*?)deploy/(.*)#\1\2#' | sort -k2 | tee ./deploy/jaeger-$VERSION.sha256sum.txt
+# Setup gpg and sign the keys to include the files in the package. Exclude the checksum files created.
+find deploy \( ! -name '*sha256sum.txt' \) -type f -exec gpg --armor --detach-sign {} \; | sed -r 's#(\w+\s+\*?)deploy/(.*)#\1\2#' | sort -k2 | tee ./deploy/jaeger-$VERSION.asc


### PR DESCRIPTION
Signed-off-by: jkowall <jkowall@kowall.net>

## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/jaeger/issues/3960 

## Short description of the changes
This adds in signing to the build process, the following steps must be taken to configure 2 new secrets in the repo by another team member.

1. Generate a GPG key : gpg --gen-key
   Answer the prompts accordingly for the email specified (you can set a password as well)

2. pgp --list-keys
  Find the GUID for the key you want to use ex: 79FAF16A8C42B3593143DD7C8DE95E7E9BC9CA3C 

3. Get the contents of the key: gpg --export-secret-keys -a 8DE95E7E9BC9CA3C
4. Copy and paste (or pipe to a file and use that). This should be added as a secret called GPG_PRIVATE_KEY
 
5. The password you created should be added as a secret called GPG_PASSWORD

Please let me know if you have questions. We can either re-run the last build or wait for the next release to test it. 
