### PR TITLE
Fix httpmetrics deadlock cause by panic

### DIFF
--- a/cmd/collector/app/server/http.go
+++ b/cmd/collector/app/server/http.go
@@ -89,7 +89,7 @@ func serveHTTP(server *http.Server, listener net.Listener, params *HTTPServerPar
 	cfgHandler.RegisterRoutes(r)
 
 	recoveryHandler := recoveryhandler.NewRecoveryHandler(params.Logger, true)
-	server.Handler = httpmetrics.Wrap(recoveryHandler(r), params.MetricsFactory)
+	server.Handler = recoveryHandler(httpmetrics.Wrap(r, params.MetricsFactory))
 	go func() {
 		var err error
 		if params.TLSConfig.Enabled {


### PR DESCRIPTION
## Which problem is this PR solving?
- fix #2944 
- `buildTimer` would panic, cause lock not being release.

## Short description of the changes
- put unlock in `defer` statement. so lock can release after panic.
- put `httpmetrics.Wrap` inside `recoveryHandler`. just seems to be right.
