### PR TITLE
Fix typo in ci-release.yml

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,7 +9,7 @@ on:
 # and https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 permissions:
   deployments: write
-  content: read
+  contents: read
 
 jobs:
   publish-release:


### PR DESCRIPTION
Release of 1.40.0 is blocked b/c ci is failing with:

```
Invalid workflow file: .github/workflows/ci-release.yml#L12
The workflow is not valid. .github/workflows/ci-release.yml (Line: 12, Col: 3): Unexpected value 'content'
```

Reviewing docs it seems this node should be called `contents`.