### PR TITLE
Fix ci-release.yml perms

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,7 +9,7 @@ on:
 # and https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 permissions:
   deployments: write
-  contents: read
+  contents: read,write
 
 jobs:
   publish-release:


### PR DESCRIPTION
Release CI is currently failing with:

![image](https://user-images.githubusercontent.com/2272392/206558115-b7b9f51d-66b8-482b-b66b-9decd5c231ee.png)

Currently testing this change in my fork