### PR TITLE
Fix Release Perms

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,7 +9,7 @@ on:
 # and https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 permissions:
   deployments: write
-  contents: read,write
+  contents: write
 
 jobs:
   publish-release:


### PR DESCRIPTION
This correctly sets the `contents` permission to `write`. This allowed CI on my fork to move past the "Upload Binaries" step. This fixes the change here: https://github.com/jaegertracing/jaeger/pull/4097