### PR TITLE
Fix archive signing step

### DIFF
--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -72,7 +72,13 @@ package zip windows-amd64 .exe
 package tar linux-s390x
 package tar linux-arm64
 package tar linux-ppc64le
+
 # Create a checksum file for all non-checksum files in the deploy directory. Strips the leading 'deploy/' directory from filepaths. Sort by filename.
 find deploy \( ! -name '*sha256sum.txt' \) -type f -exec shasum -b -a 256 {} \; | sed -r 's#(\w+\s+\*?)deploy/(.*)#\1\2#' | sort -k2 | tee ./deploy/jaeger-$VERSION.sha256sum.txt
-# Setup gpg and sign the keys to include the files in the package. Exclude the checksum files created.
-find deploy \( ! -name '*sha256sum.txt' \) -type f -exec gpg --armor --detach-sign {} \; | sed -r 's#(\w+\s+\*?)deploy/(.*)#\1\2#' | sort -k2 | tee ./deploy/jaeger-$VERSION.asc
+
+# Use gpg to sign the (g)zip files (excluding checksum files) into .asc files.
+find deploy \( ! -name '*sha256sum.txt' \) -type f -exec gpg --armor --detach-sign {} \;
+
+# show your work
+ls -lF deploy/
+


### PR DESCRIPTION
The release process fails because `./deploy/jaeger-$VERSION.asc` file is empty. But we don't need that file.
```
Error: Validation Failed: {"resource":"ReleaseAsset","code":"custom","field":"size","message":"size must be greater than or equal to 1"}
```
