### PR TITLE
add multi arch support to cassandra-schema container

### DIFF
--- a/plugin/storage/cassandra/Dockerfile
+++ b/plugin/storage/cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM cassandra:4.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} cassandra:4.0
 
 COPY schema/* /cassandra-schema/
 

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -22,7 +22,7 @@ done
 
 bash scripts/build-upload-a-docker-image.sh -b -c jaeger-es-index-cleaner -d cmd/es-index-cleaner -p "${platforms}" -t release
 bash scripts/build-upload-a-docker-image.sh -b -c jaeger-es-rollover -d cmd/es-rollover  -p "${platforms}" -t release
-bash scripts/build-upload-a-docker-image.sh -c jaeger-cassandra-schema -d plugin/storage/cassandra/
+bash scripts/build-upload-a-docker-image.sh -c jaeger-cassandra-schema -d plugin/storage/cassandra/ -p "${platforms}"
 
 # build/upload images for jaeger-tracegen and jaeger-anonymizer
 for component in tracegen anonymizer


### PR DESCRIPTION
## Which problem is this PR solving?
- [jager-cassandra-schema](https://hub.docker.com/r/jaegertracing/jaeger-cassandra-schema/tags)  container does not have multi arch support.
- This PR adds support to generate multi arch container images

## Short description of the changes
- additionally passed platform arguments to the build script
