### PR TITLE
remove global platform arg in cassandra schema dockerfile

### DIFF
--- a/plugin/storage/cassandra/Dockerfile
+++ b/plugin/storage/cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} cassandra:4.0
+FROM cassandra:4.0
 
 COPY schema/* /cassandra-schema/
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Multi arch cassandra-schema container support is introduced in https://github.com/jaegertracing/jaeger/pull/4122
- for some reason `BUILDPLATFORM` argument is not loaded, hence `linux/amd64` base image taken to all platforms containers, which leads the following error on non `linux/amd64` systems.
```
standard_init_linux.go:228: exec user process caused: exec format error
```
- To fix this issue, I removed the strict `platform` in base image of `Dockerfile`. Now the docker engine decide the base image architecture. 
## Short description of the changes
- Removed `--platform=${BUILDPLATFORM:-linux/amd64}` from the base image.

## Tested
- Verified this change locally by running the following command under the directory `plugin/storage/cassandra`, result of the execution, I see actual platform images.
```
platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"

docker buildx build --push \
  --progress=plain \
  --platform ${platforms} \
  --file ./Dockerfile \
  --tag quay.io/redhat-distributed-tracing-qe/jaeger-cassandra-schema:1.40.0 .
```
- images are available in: quay.io/redhat-distributed-tracing-qe/jaeger-cassandra-schema:1.40.0

### Document about platform argument on a base image
- https://docs.docker.com/engine/reference/builder/#from
![image](https://user-images.githubusercontent.com/1004403/209175106-d77b603e-d6be-47fd-96b8-37633d227c1c.png)
