### PR TITLE
Prepare release 1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ next release
 
 ### UI
 
-* UI pinned to version [1.27.3](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#v1273-2022-12-07).
+* No changes.
 
 1.40.0 (2022-12-07)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,22 @@ next release
 
 ### UI Changes
 
+1.41.0 (2023-01-04)
+-------------------
+### Backend Changes
+
+#### Bug fixes, Minor Improvements
+
+* Remove global platform arg in cassandra schema dockerfile ([@jkandasa](https://github.com/jkandasa) in [#4123](https://github.com/jaegertracing/jaeger/pull/4123))
+* Add multi arch support to cassandra-schema container ([@jkandasa](https://github.com/jkandasa) in [#4122](https://github.com/jaegertracing/jaeger/pull/4122))
+
+### UI
+
+* UI pinned to version [1.27.3](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#v1273-2022-12-07).
+
 1.40.0 (2022-12-07)
 -------------------
+### Backend Changes
 
 #### New Features
 

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ build-crossdock-fresh: build-crossdock-linux
 
 .PHONY: changelog
 changelog:
-	python3 ./scripts/release-notes.py
+	python3 ./scripts/release-notes.py --exclude-dependabot
 
 .PHONY: draft-release
 draft-release:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
         git checkout {new_version} //e.g. v1.5.0
         ```
       * Even if a submodule does not have a new release, it should be checked to see if there were any changes warranting cutting a new release and then including it.
+      * If there are no changes, indicate this with "No changes" ([example](https://github.com/jaegertracing/jaeger/pull/4131/files)).
     * Rotate the below release managers table placing yourself at the bottom. The date should be the first Wednesday of the month.
 2. After the PR is merged, create a release on Github:
     * Automated:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,8 @@
 
 1. Create a PR "Prepare release X.Y.Z" against main or maintenance branch ([example](https://github.com/jaegertracing/jaeger/pull/543/files)) by updating CHANGELOG.md to include:
     * A new section with the header `<X.Y.Z> (YYYY-MM-DD)`
-    * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users. To obtain the list of all changes run `make changelog` or use `scripts/release-notes.py`.
+    * A curated list of notable changes and links to PRs. Do not simply dump git log, select the changes that affect the users.
+      To obtain the list of all changes run `make changelog` or use `scripts/release-notes.py`.
     * The section can be split into sub-section if necessary, e.g. UI Changes, Backend Changes, Bug Fixes, etc.
     * If the submodules have new releases, please also upgrade the submodule versions then commit, for example:
         ```
@@ -38,8 +39,8 @@ Sometimes we need to do a patch release, e.g. to fix a newly introduced bug. If 
 2. `git checkout ${commit}; git checkout -b ${branch-name}`. The branch name should be in the form `release-major.minor`, e.g., `release-1.34`. Push the branch to the upstream repository.
 3. Apply fixes to the branch. The recommended way is to merge the fixes into `main` first and then cherry-pick them into the version branch (e.g., `git cherry-pick c733708c` for the fix going into `v1.34.1`).
 4. Follow the regular process for creating a release (except for the Documentation step).
-  * When creating a release on GitHub, pick the version branch when applying the new tag.
-  * Once the release tag is created, the `ci-release` workflow will kick in and deploy the artifacts for the patch release.
+   * When creating a release on GitHub, pick the version branch when applying the new tag.
+   * Once the release tag is created, the `ci-release` workflow will kick in and deploy the artifacts for the patch release.
 5. Do not perform a new release of the documentation since the major.minor is not changing. The one change that may be useful is bumping the `binariesLatest` variable in the `config.toml` file ([example](https://github.com/jaegertracing/documentation/commit/eacb52f332a7e069c254e652a6b4a58ea5a07b32)).
 
 ## Release managers
@@ -52,7 +53,7 @@ Here are the release managers for future versions with the tentative release dat
 
 | Version | Release Manager | Tentative release date |
 |---------|-----------------|------------------------|
-| 1.41.0  | @albertteoh     | 4 January   2023       |
 | 1.42.0  | @yurishkuro     | 1 February  2023       |
 | 1.43.0  | @pavolloffay    | 8 March  2023          |
 | 1.44.0  | @joe-elliott    | 5 April  2023          |
+| 1.45.0  | @albertteoh     | 3 May 2023             |


### PR DESCRIPTION
## Short description of the changes
- Update changelog.md with changes since v1.40.0.
- Update `changelog` make target to exclude dependabot updates by default.
- Rotate release managers in release.md.
