### PR TITLE
Watch directories for certificate hot-reload

### DIFF
--- a/pkg/config/tlscfg/cert_watcher.go
+++ b/pkg/config/tlscfg/cert_watcher.go
@@ -15,10 +15,13 @@
 package tlscfg
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
+	"os"
+	"path"
 	"path/filepath"
 	"sync"
 
@@ -31,11 +34,15 @@ import (
 // The certificate and key can be obtained via certWatcher.certificate.
 // The consumers of this API should use GetCertificate or GetClientCertificate from tls.Config to supply the certificate to the config.
 type certWatcher struct {
-	opts    Options
-	watcher *fsnotify.Watcher
-	cert    *tls.Certificate
-	logger  *zap.Logger
-	mu      *sync.RWMutex
+	opts         Options
+	watcher      *fsnotify.Watcher
+	cert         *tls.Certificate
+	logger       *zap.Logger
+	mu           *sync.RWMutex
+	caHash       string
+	clientCAHash string
+	certHash     string
+	keyHash      string
 }
 
 var _ io.Closer = (*certWatcher)(nil)
@@ -54,17 +61,19 @@ func newCertWatcher(opts Options, logger *zap.Logger) (*certWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := addCertsToWatch(watcher, opts); err != nil {
-		watcher.Close()
-		return nil, err
-	}
-	return &certWatcher{
+
+	w := &certWatcher{
 		cert:    cert,
 		opts:    opts,
 		watcher: watcher,
 		logger:  logger,
 		mu:      &sync.RWMutex{},
-	}, nil
+	}
+	if err := w.addWatches(watcher, opts); err != nil {
+		watcher.Close()
+		return nil, err
+	}
+	return w, nil
 }
 
 func (w *certWatcher) Close() error {
@@ -81,77 +90,158 @@ func (w *certWatcher) watchChangesLoop(rootCAs, clientCAs *x509.CertPool) {
 	for {
 		select {
 		case event, ok := <-w.watcher.Events:
+			w.logger.Debug("Received event", zap.String("event", event.String()))
 			if !ok {
 				return
 			}
-			// ignore if the event is a chmod event (permission or owner changes)
-			if event.Op&fsnotify.Chmod == fsnotify.Chmod {
-				continue
-			}
-			if event.Op&fsnotify.Remove == fsnotify.Remove {
-				w.logger.Warn("Certificate has been removed, using the last known version",
-					zap.String("certificate", event.Name))
-				continue
-			}
 
-			w.logger.Info("Loading modified certificate",
-				zap.String("certificate", event.Name),
-				zap.String("event", event.Op.String()))
-			var err error
-			switch event.Name {
-			case w.opts.CAPath:
-				err = addCertToPool(w.opts.CAPath, rootCAs)
-			case w.opts.ClientCAPath:
-				err = addCertToPool(w.opts.ClientCAPath, clientCAs)
-			case w.opts.CertPath, w.opts.KeyPath:
-				w.mu.Lock()
-				c, e := tls.LoadX509KeyPair(filepath.Clean(w.opts.CertPath), filepath.Clean(w.opts.KeyPath))
-				if e == nil {
-					w.cert = &c
-				}
-				w.mu.Unlock()
-				err = e
+			// Write and Rename events indicate that some files might have changed and reload might be necessary.
+			// Remove event indicates that the file was deleted and we should write an error to log.
+			//
+			// Reasoning:
+			//
+			// Write event is sent if the file content is rewritten.
+			//
+			// Usually files are not rewritten, but they are updated by swapping them with new
+			// ones by calling Rename. That avoids files being read while they are not yet
+			// completely written but it also means that inotify on file level will not work:
+			// watch is invalidated when the old file is deleted.
+			//
+			// If reading from Kubernetes Secret volumes the target files are symbolic links
+			// to files in a different directory. That directory is swapped with a new one,
+			// while the symbolic links remain the same. This guarantees atomic swap for all
+			// files at once, but it also means any Rename event in the directory might
+			// indicate that the files were replaced, even if event.Name is not any of the
+			// files we are monitoring. We check the hashes of the files to detect if they
+			// were really changed.
+			if event.Op&fsnotify.Write == fsnotify.Write ||
+				event.Op&fsnotify.Rename == fsnotify.Rename ||
+				event.Op&fsnotify.Remove == fsnotify.Remove {
+				w.attemptReload(rootCAs, clientCAs)
 			}
-			if err == nil {
-				w.logger.Info("Loaded modified certificate",
-					zap.String("certificate", event.Name),
-					zap.String("event", event.Op.String()))
-			} else {
-				w.logger.Error("Failed to load certificate",
-					zap.String("certificate", event.Name),
-					zap.String("event", event.Op.String()),
-					zap.Error(err))
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
 			}
-		case err := <-w.watcher.Errors:
 			w.logger.Error("Watcher got error", zap.Error(err))
 		}
 	}
 }
 
-func addCertsToWatch(watcher *fsnotify.Watcher, opts Options) error {
-	if len(opts.CAPath) != 0 {
-		err := watcher.Add(opts.CAPath)
+func (w *certWatcher) addWatches(watcher *fsnotify.Watcher, opts Options) error {
+	// Get initial hashes of the files so that we can detect changes.
+	// Build a list of parent directories.
+	var dirs []string
+	var err error
+	if opts.CAPath != "" {
+		w.caHash, err = hashFile(opts.CAPath)
 		if err != nil {
 			return err
 		}
+		dirs = append(dirs, path.Dir(opts.CAPath))
 	}
-	if len(opts.ClientCAPath) != 0 {
-		err := watcher.Add(opts.ClientCAPath)
+	if opts.ClientCAPath != "" {
+		w.clientCAHash, err = hashFile(opts.ClientCAPath)
 		if err != nil {
 			return err
 		}
+		dirs = append(dirs, path.Dir(opts.ClientCAPath))
 	}
-	if len(opts.CertPath) != 0 {
-		err := watcher.Add(opts.CertPath)
+	if opts.CertPath != "" {
+		w.certHash, err = hashFile(opts.CertPath)
 		if err != nil {
 			return err
 		}
+		dirs = append(dirs, path.Dir(opts.CertPath))
 	}
-	if len(opts.KeyPath) != 0 {
-		err := watcher.Add(opts.KeyPath)
+	if opts.KeyPath != "" {
+		w.keyHash, err = hashFile(opts.KeyPath)
 		if err != nil {
 			return err
 		}
+		dirs = append(dirs, path.Dir(opts.KeyPath))
+	}
+
+	// Find unique directories and add watches.
+	uniqueDirs := make(map[string]bool)
+	for _, p := range dirs {
+		if _, ok := uniqueDirs[p]; !ok {
+			err := watcher.Add(p)
+			if err != nil {
+				return err
+			}
+		}
+		uniqueDirs[p] = true
 	}
 	return nil
+}
+
+// attemptReload checks if the watched files have been modified and reloads them if necessary.
+func (w *certWatcher) attemptReload(rootCAs, clientCAs *x509.CertPool) {
+	if isModified, newHash := w.isModified(w.opts.CAPath, w.caHash); isModified {
+		err := addCertToPool(w.opts.CAPath, rootCAs)
+		if err != nil {
+			w.logger.Error("Failed to load certificate", zap.String("certificate", w.opts.CAPath), zap.Error(err))
+		} else {
+			w.caHash = newHash
+			w.logger.Info("Loaded modified certificate", zap.String("certificate", w.opts.CAPath))
+		}
+	}
+
+	if isModified, newHash := w.isModified(w.opts.ClientCAPath, w.clientCAHash); isModified {
+		err := addCertToPool(w.opts.ClientCAPath, clientCAs)
+		if err != nil {
+			w.logger.Error("Failed to load certificate", zap.String("certificate", w.opts.ClientCAPath), zap.Error(err))
+		} else {
+			w.clientCAHash = newHash
+			w.logger.Info("Loaded modified certificate", zap.String("certificate", w.opts.ClientCAPath))
+		}
+	}
+
+	isCertModified, newCertHash := w.isModified(w.opts.CertPath, w.certHash)
+	isKeyModified, newKeyHash := w.isModified(w.opts.KeyPath, w.keyHash)
+	if isCertModified || isKeyModified {
+		c, err := tls.LoadX509KeyPair(filepath.Clean(w.opts.CertPath), filepath.Clean(w.opts.KeyPath))
+		if err != nil {
+			w.logger.Error("Failed to load certificate",
+				zap.String("certificate", w.opts.CertPath), zap.String("key", w.opts.KeyPath), zap.Error(err))
+		} else {
+			w.mu.Lock()
+			w.cert = &c
+			w.certHash = newCertHash
+			w.keyHash = newKeyHash
+			w.mu.Unlock()
+			w.logger.Info("Loaded modified certificate", zap.String("certificate", w.opts.CertPath))
+			w.logger.Info("Loaded modified certificate", zap.String("certificate", w.opts.KeyPath))
+		}
+	}
+}
+
+// isModified returns true if the file has been modified since the last check.
+func (w *certWatcher) isModified(file string, previousHash string) (bool, string) {
+	if file == "" {
+		return false, ""
+	}
+	hash, err := hashFile(file)
+	if err != nil {
+		w.logger.Warn("Certificate has been removed, using the last known version", zap.String("certificate", file))
+		return false, ""
+	}
+	return previousHash != hash, hash
+}
+
+// hashFile returns the SHA256 hash of the file.
+func hashFile(file string) (string, error) {
+	f, err := os.Open(filepath.Clean(file))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
This PR fixes the certificate hot-reload on Kubernetes.

Resolves #3968

## Short description of the changes
This PR moves the inotify watch from certificate files to monitoring the parent directory instead, as also recommended [here](https://github.com/fsnotify/fsnotify/blob/c6f5cfa163edb0f1bb78be3a77053ee14c48a3ce/backend_inotify.go#L246-L254) by the [fsnotify](https://github.com/fsnotify/fsnotify) library.

Without this change, certificate hot-reload only works if the content of certificate or key files is overwritten. That approach is rarely used for update since it is not atomic and it risks files being read in the middle of the update. Therefore more often the files are replaced by a rename operation, by swapping the old file with a new one. It allows the file to be completely written and closed before exposing it to the application. However, in this update scheme, the old file gets deleted and the current inotify watch on file level is automatically terminated. No reload happens and warning message like following was printed into log

```json
{"msg":"Certificate has been removed, using the last known version","certificate":"/certs/server-ca.pem"}
```

Example use case:

When Kubelet writes certificate and key files on Kubernetes Secret volume, the target files are symbolic links to files in a different directory - a hidden subdirectory in a same level as the files themselves. During update, that directory is swapped with a new one, while the symbolic links remains the same. This guarantees atomic swap for both certificate and key files at once.  It also means that any rename event received at the parent directory level might indicate that the files were replaced, even if name of the renamed file was not any of the files being monitored. Therefore this PR proposes checking the hashes of the files to detect changes.

With this change, following update schemes will work:
* Replace file content in-place (old behaviour: e.g. `cat newfile > cert.pem`)
* Update the files by making any rename operation in the parent directory (Kubernetes secret volume update scheme: `mv ..data_tmp ..data`)
* Update the files by renaming the target files (e.g. `mv cert.pem.tmp cert.pem`)

Signed-off-by: Tero Saarni <tero.saarni@est.tech>

