### PR TITLE
Add CLI flags for controlling HTTP server timeouts

### DIFF
--- a/cmd/collector/app/flags/flags_test.go
+++ b/cmd/collector/app/flags/flags_test.go
@@ -99,12 +99,18 @@ func TestCollectorOptionsWithFlags_CheckMaxConnectionAge(t *testing.T) {
 	command.ParseFlags([]string{
 		"--collector.grpc-server.max-connection-age=5m",
 		"--collector.grpc-server.max-connection-age-grace=1m",
+		"--collector.http-server.idle-timeout=5m",
+		"--collector.http-server.read-timeout=6m",
+		"--collector.http-server.read-header-timeout=5s",
 	})
 	_, err := c.InitFromViper(v, zap.NewNop())
 	require.NoError(t, err)
 
 	assert.Equal(t, 5*time.Minute, c.GRPC.MaxConnectionAge)
 	assert.Equal(t, time.Minute, c.GRPC.MaxConnectionAgeGrace)
+	assert.Equal(t, 5*time.Minute, c.HTTP.IdleTimeout)
+	assert.Equal(t, 6*time.Minute, c.HTTP.ReadTimeout)
+	assert.Equal(t, 5*time.Second, c.HTTP.ReadHeaderTimeout)
 }
 
 func TestCollectorOptionsWithFlags_CheckNoTenancy(t *testing.T) {

--- a/cmd/collector/app/server/http.go
+++ b/cmd/collector/app/server/http.go
@@ -42,6 +42,13 @@ type HTTPServerParams struct {
 	MetricsFactory metrics.Factory
 	HealthCheck    *healthcheck.HealthCheck
 	Logger         *zap.Logger
+
+	// ReadTimeout sets the respective parameter of http.Server
+	ReadTimeout time.Duration
+	// ReadHeaderTimeout sets the respective parameter of http.Server
+	ReadHeaderTimeout time.Duration
+	// IdleTimeout sets the respective parameter of http.Server
+	IdleTimeout time.Duration
 }
 
 // StartHTTPServer based on the given parameters
@@ -51,8 +58,10 @@ func StartHTTPServer(params *HTTPServerParams) (*http.Server, error) {
 	errorLog, _ := zap.NewStdLogAt(params.Logger, zapcore.ErrorLevel)
 	server := &http.Server{
 		Addr:              params.HostPort,
+		ReadTimeout:       params.ReadTimeout,
+		ReadHeaderTimeout: params.ReadHeaderTimeout,
+		IdleTimeout:       params.IdleTimeout,
 		ErrorLog:          errorLog,
-		ReadHeaderTimeout: 2 * time.Second,
 	}
 	if params.TLSConfig.Enabled {
 		tlsCfg, err := params.TLSConfig.Config(params.Logger) // This checks if the certificates are correctly provided

--- a/cmd/collector/app/server/http_test.go
+++ b/cmd/collector/app/server/http_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -201,7 +202,7 @@ func TestSpanCollectorHTTPS(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			logger, _ := zap.NewDevelopment()
+			logger := zaptest.NewLogger(t)
 			params := &HTTPServerParams{
 				HostPort:       fmt.Sprintf(":%d", ports.CollectorHTTP),
 				Handler:        handler.NewJaegerSpanHandler(logger, &mockSpanProcessor{}),
@@ -256,4 +257,25 @@ func TestSpanCollectorHTTPS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartHTTPServerParams(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	params := &HTTPServerParams{
+		HostPort:          fmt.Sprintf(":%d", ports.CollectorHTTP),
+		Handler:           handler.NewJaegerSpanHandler(logger, &mockSpanProcessor{}),
+		SamplingStore:     &mockSamplingStore{},
+		MetricsFactory:    metricstest.NewFactory(time.Hour),
+		HealthCheck:       healthcheck.New(),
+		Logger:            logger,
+		IdleTimeout:       5 * time.Minute,
+		ReadTimeout:       6 * time.Minute,
+		ReadHeaderTimeout: 7 * time.Second,
+	}
+
+	server, err := StartHTTPServer(params)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, server.IdleTimeout)
+	assert.Equal(t, 6*time.Minute, server.ReadTimeout)
+	assert.Equal(t, 7*time.Second, server.ReadHeaderTimeout)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Allows to control collector's HTTP server timeout settings: idle, read, and read-header
- Resolves #4166

## Short description of the changes
- add 3 options to http-server CLI flags
