### PR TITLE
test: use `t.Setenv` to set env vars in tests

### DIFF
--- a/cmd/agent/app/reporter/flags_test.go
+++ b/cmd/agent/app/reporter/flags_test.go
@@ -17,7 +17,6 @@ package reporter
 import (
 	"flag"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -72,11 +71,8 @@ func TestBindFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	b := &Options{}
-	os.Setenv("envKey1", "envVal1")
-	defer os.Unsetenv("envKey1")
-
-	os.Setenv("envKey4", "envVal4")
-	defer os.Unsetenv("envKey4")
+	t.Setenv("envKey1", "envVal1")
+	t.Setenv("envKey4", "envVal4")
 
 	b.InitFromViper(v, zap.NewNop())
 

--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -17,7 +17,6 @@ package flags
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,11 +34,8 @@ func TestParseJaegerTags(t *testing.T) {
 		"envVar5=${envVar5:}",
 	)
 
-	os.Setenv("envKey1", "envVal1")
-	defer os.Unsetenv("envKey1")
-
-	os.Setenv("envKey4", "envVal4")
-	defer os.Unsetenv("envKey4")
+	t.Setenv("envKey1", "envVal1")
+	t.Setenv("envKey4", "envVal4")
 
 	expectedTags := map[string]string{
 		"key":     "value",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,6 @@ package config
 import (
 	"flag"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -56,14 +55,11 @@ func TestEnv(t *testing.T) {
 	envFlag := "jaeger.test-flag"
 	actualEnvFlag := "JAEGER_TEST_FLAG"
 
-	tempEnv := os.Getenv(actualEnvFlag)
-	defer os.Setenv(actualEnvFlag, tempEnv)
-
 	addFlags := func(flagSet *flag.FlagSet) {
 		flagSet.String(envFlag, "", "")
 	}
 	expectedString := "string"
-	os.Setenv(actualEnvFlag, expectedString)
+	t.Setenv(actualEnvFlag, expectedString)
 
 	v, _ := Viperize(addFlags)
 	assert.Equal(t, expectedString, v.GetString(envFlag))

--- a/plugin/metrics/factory_config_test.go
+++ b/plugin/metrics/factory_config_test.go
@@ -15,27 +15,16 @@
 package metrics
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func clearEnv(t *testing.T) {
-	err := os.Setenv(StorageTypeEnvVar, "")
-	require.NoError(t, err)
-}
-
 func TestFactoryConfigFromEnv(t *testing.T) {
-	clearEnv(t)
-	defer clearEnv(t)
-
 	fc := FactoryConfigFromEnv()
 	assert.Empty(t, fc.MetricsStorageType)
 
-	err := os.Setenv(StorageTypeEnvVar, prometheusStorageType)
-	require.NoError(t, err)
+	t.Setenv(StorageTypeEnvVar, prometheusStorageType)
 
 	fc = FactoryConfigFromEnv()
 	assert.Equal(t, prometheusStorageType, fc.MetricsStorageType)

--- a/plugin/metrics/factory_test.go
+++ b/plugin/metrics/factory_test.go
@@ -97,9 +97,6 @@ func (f *configurable) InitFromViper(v *viper.Viper, logger *zap.Logger) {
 }
 
 func TestConfigurable(t *testing.T) {
-	clearEnv(t)
-	defer clearEnv(t)
-
 	f, err := NewFactory(withConfig(prometheusStorageType))
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)

--- a/plugin/sampling/strategystore/factory_test.go
+++ b/plugin/sampling/strategystore/factory_test.go
@@ -18,7 +18,6 @@ package strategystore
 import (
 	"errors"
 	"flag"
-	"os"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -33,10 +32,6 @@ import (
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/samplingstore"
 )
-
-func clearEnv() {
-	os.Setenv(SamplingTypeEnvVar, "static")
-}
 
 var (
 	_ ss.Factory          = new(Factory)
@@ -99,8 +94,7 @@ func TestNewFactory(t *testing.T) {
 }
 
 func TestConfigurable(t *testing.T) {
-	clearEnv()
-	defer clearEnv()
+	t.Setenv(SamplingTypeEnvVar, "static")
 
 	f, err := NewFactory(FactoryConfig{StrategyStoreType: "file"})
 	require.NoError(t, err)

--- a/plugin/storage/factory_config_test.go
+++ b/plugin/storage/factory_config_test.go
@@ -17,22 +17,12 @@ package storage
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func clearEnv() {
-	os.Setenv(SpanStorageTypeEnvVar, "")
-	os.Setenv(DependencyStorageTypeEnvVar, "")
-	os.Setenv(SamplingStorageTypeEnvVar, "")
-}
-
 func TestFactoryConfigFromEnv(t *testing.T) {
-	clearEnv()
-	defer clearEnv()
-
 	f := FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Equal(t, 1, len(f.SpanWriterTypes))
 	assert.Equal(t, cassandraStorageType, f.SpanWriterTypes[0])
@@ -40,9 +30,9 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	assert.Equal(t, cassandraStorageType, f.DependenciesStorageType)
 	assert.Empty(t, f.SamplingStorageType)
 
-	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType)
-	os.Setenv(DependencyStorageTypeEnvVar, memoryStorageType)
-	os.Setenv(SamplingStorageTypeEnvVar, cassandraStorageType)
+	t.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType)
+	t.Setenv(DependencyStorageTypeEnvVar, memoryStorageType)
+	t.Setenv(SamplingStorageTypeEnvVar, cassandraStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Equal(t, 1, len(f.SpanWriterTypes))
@@ -51,14 +41,14 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	assert.Equal(t, memoryStorageType, f.DependenciesStorageType)
 	assert.Equal(t, cassandraStorageType, f.SamplingStorageType)
 
-	os.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType+","+kafkaStorageType)
+	t.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType+","+kafkaStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Equal(t, 2, len(f.SpanWriterTypes))
 	assert.Equal(t, []string{elasticsearchStorageType, kafkaStorageType}, f.SpanWriterTypes)
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
 
-	os.Setenv(SpanStorageTypeEnvVar, badgerStorageType)
+	t.Setenv(SpanStorageTypeEnvVar, badgerStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, nil)
 	assert.Equal(t, 1, len(f.SpanWriterTypes))
@@ -67,8 +57,6 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 }
 
 func TestFactoryConfigFromEnvDeprecated(t *testing.T) {
-	clearEnv()
-
 	testCases := []struct {
 		args  []string
 		log   bool

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -356,9 +356,6 @@ func (f *configurable) InitFromViper(v *viper.Viper, logger *zap.Logger) {
 }
 
 func TestConfigurable(t *testing.T) {
-	clearEnv()
-	defer clearEnv()
-
 	f, err := NewFactory(defaultCfg())
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories)


### PR DESCRIPTION
## Which problem is this PR solving?

## Short description of the changes

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```

