### PR TITLE
Replace Thrift-gen with Proto-gen types for sampling strategies

### DIFF
--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -37,9 +37,9 @@ import (
 	"github.com/jaegertracing/jaeger/internal/metrics/fork"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
 
@@ -203,7 +203,7 @@ func (fakeCollectorProxy) Close() error {
 	return nil
 }
 
-func (f fakeCollectorProxy) GetSamplingStrategy(_ context.Context, _ string) (*sampling.SamplingStrategyResponse, error) {
+func (f fakeCollectorProxy) GetSamplingStrategy(_ context.Context, _ string) (*api_v2.SamplingStrategyResponse, error) {
 	return nil, errors.New("no peers available")
 }
 

--- a/cmd/agent/app/configmanager/grpc/manager.go
+++ b/cmd/agent/app/configmanager/grpc/manager.go
@@ -20,34 +20,28 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
-// SamplingManager returns sampling decisions from collector over gRPC.
-type SamplingManager struct {
+// ConfigManagerProxy returns sampling decisions from collector over gRPC.
+type ConfigManagerProxy struct {
 	client api_v2.SamplingManagerClient
 }
 
 // NewConfigManager creates gRPC sampling manager.
-func NewConfigManager(conn *grpc.ClientConn) *SamplingManager {
-	return &SamplingManager{
+func NewConfigManager(conn *grpc.ClientConn) *ConfigManagerProxy {
+	return &ConfigManagerProxy{
 		client: api_v2.NewSamplingManagerClient(conn),
 	}
 }
 
 // GetSamplingStrategy returns sampling strategies from collector.
-func (s *SamplingManager) GetSamplingStrategy(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
-	r, err := s.client.GetSamplingStrategy(ctx, &api_v2.SamplingStrategyParameters{ServiceName: serviceName})
-	if err != nil {
-		return nil, err
-	}
-	return jaeger.ConvertSamplingResponseFromDomain(r)
+func (s *ConfigManagerProxy) GetSamplingStrategy(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
+	return s.client.GetSamplingStrategy(ctx, &api_v2.SamplingStrategyParameters{ServiceName: serviceName})
 }
 
 // GetBaggageRestrictions returns baggage restrictions from collector.
-func (s *SamplingManager) GetBaggageRestrictions(_ context.Context, _ string) ([]*baggage.BaggageRestriction, error) {
+func (s *ConfigManagerProxy) GetBaggageRestrictions(_ context.Context, _ string) ([]*baggage.BaggageRestriction, error) {
 	return nil, errors.New("baggage not implemented")
 }

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 func close(t *testing.T, c io.Closer) {
@@ -44,7 +43,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 	manager := NewConfigManager(conn)
 	resp, err := manager.GetSamplingStrategy(context.Background(), "any")
 	require.NoError(t, err)
-	assert.Equal(t, &sampling.SamplingStrategyResponse{StrategyType: sampling.SamplingStrategyType_PROBABILISTIC}, resp)
+	assert.Equal(t, &api_v2.SamplingStrategyResponse{StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC}, resp)
 }
 
 func TestSamplingManager_GetSamplingStrategy_error(t *testing.T) {

--- a/cmd/agent/app/configmanager/manager.go
+++ b/cmd/agent/app/configmanager/manager.go
@@ -18,14 +18,17 @@ package configmanager
 import (
 	"context"
 
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
+
+// TODO this interface could be moved to pkg/clientcfg, along with grpc proxy,
+// but not the metrics wrapper (because its metric names are specific to agent).
 
 // ClientConfigManager decides:
 // 1) which sampling strategy a given service should be using
 // 2) which baggage restrictions a given service should be using.
 type ClientConfigManager interface {
-	GetSamplingStrategy(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error)
+	GetSamplingStrategy(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error)
 	GetBaggageRestrictions(ctx context.Context, serviceName string) ([]*baggage.BaggageRestriction, error)
 }

--- a/cmd/agent/app/configmanager/metrics.go
+++ b/cmd/agent/app/configmanager/metrics.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 // configManagerMetrics holds metrics related to ClientConfigManager
@@ -51,7 +51,7 @@ func WrapWithMetrics(manager ClientConfigManager, mFactory metrics.Factory) *Man
 }
 
 // GetSamplingStrategy returns sampling strategy from server.
-func (m *ManagerWithMetrics) GetSamplingStrategy(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
+func (m *ManagerWithMetrics) GetSamplingStrategy(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
 	r, err := m.wrapped.GetSamplingStrategy(ctx, serviceName)
 	if err != nil {
 		m.metrics.SamplingFailures.Inc(1)

--- a/cmd/agent/app/configmanager/metrics_test.go
+++ b/cmd/agent/app/configmanager/metrics_test.go
@@ -24,17 +24,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 type noopManager struct{}
 
-func (noopManager) GetSamplingStrategy(_ context.Context, s string) (*sampling.SamplingStrategyResponse, error) {
+func (noopManager) GetSamplingStrategy(_ context.Context, s string) (*api_v2.SamplingStrategyResponse, error) {
 	if s == "failed" {
 		return nil, errors.New("failed")
 	}
-	return &sampling.SamplingStrategyResponse{StrategyType: sampling.SamplingStrategyType_PROBABILISTIC}, nil
+	return &api_v2.SamplingStrategyResponse{StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC}, nil
 }
 
 func (noopManager) GetBaggageRestrictions(_ context.Context, s string) ([]*baggage.BaggageRestriction, error) {

--- a/cmd/collector/app/collector_test.go
+++ b/cmd/collector/app/collector_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
 var _ (io.Closer) = (*Collector)(nil)
@@ -122,8 +122,8 @@ func TestCollector_StartErrors(t *testing.T) {
 
 type mockStrategyStore struct{}
 
-func (m *mockStrategyStore) GetSamplingStrategy(_ context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
-	return &sampling.SamplingStrategyResponse{}, nil
+func (m *mockStrategyStore) GetSamplingStrategy(_ context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
+	return &api_v2.SamplingStrategyResponse{}, nil
 }
 
 func TestCollector_PublishOpts(t *testing.T) {

--- a/cmd/collector/app/sampling/grpc_handler.go
+++ b/cmd/collector/app/sampling/grpc_handler.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
-	"github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
@@ -36,9 +35,5 @@ func NewGRPCHandler(store strategystore.StrategyStore) GRPCHandler {
 
 // GetSamplingStrategy returns sampling decision from store.
 func (s GRPCHandler) GetSamplingStrategy(ctx context.Context, param *api_v2.SamplingStrategyParameters) (*api_v2.SamplingStrategyResponse, error) {
-	r, err := s.store.GetSamplingStrategy(ctx, param.GetServiceName())
-	if err != nil {
-		return nil, err
-	}
-	return jaeger.ConvertSamplingResponseToDomain(r)
+	return s.store.GetSamplingStrategy(ctx, param.GetServiceName())
 }

--- a/cmd/collector/app/sampling/grpc_handler_test.go
+++ b/cmd/collector/app/sampling/grpc_handler_test.go
@@ -23,18 +23,17 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 type mockSamplingStore struct{}
 
-func (s mockSamplingStore) GetSamplingStrategy(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
+func (s mockSamplingStore) GetSamplingStrategy(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
 	if serviceName == "error" {
 		return nil, errors.New("some error")
 	} else if serviceName == "nil" {
 		return nil, nil
 	}
-	return &sampling.SamplingStrategyResponse{StrategyType: sampling.SamplingStrategyType_PROBABILISTIC}, nil
+	return &api_v2.SamplingStrategyResponse{StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC}, nil
 }
 
 func TestNewGRPCHandler(t *testing.T) {

--- a/cmd/collector/app/sampling/strategystore/interface.go
+++ b/cmd/collector/app/sampling/strategystore/interface.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"io"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
 // StrategyStore keeps track of service specific sampling strategies.
 type StrategyStore interface {
 	// GetSamplingStrategy retrieves the sampling strategy for the specified service.
-	GetSamplingStrategy(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error)
+	GetSamplingStrategy(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error)
 }
 
 // Aggregator defines an interface used to aggregate operation throughput.

--- a/cmd/collector/app/server/test.go
+++ b/cmd/collector/app/server/test.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
 type mockSamplingStore struct{}
 
-func (s mockSamplingStore) GetSamplingStrategy(_ context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
+func (s mockSamplingStore) GetSamplingStrategy(_ context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
 	return nil, nil
 }
 

--- a/crossdock/services/agent.go
+++ b/crossdock/services/agent.go
@@ -16,7 +16,6 @@
 package services
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
+	p2json "github.com/jaegertracing/jaeger/model/converter/json"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
@@ -65,11 +65,11 @@ func (s *agentService) GetSamplingRate(service, operation string) (float64, erro
 	}
 	s.logger.Info("Retrieved sampling rates from agent", zap.String("body", string(body)))
 
-	var response api_v2.SamplingStrategyResponse
-	if err = json.Unmarshal(body, &response); err != nil {
+	response, err := p2json.SamplingStrategyResponseFromJSON(body)
+	if err != nil {
 		return 0, err
 	}
-	return getSamplingRate(operation, &response)
+	return getSamplingRate(operation, response)
 }
 
 func getSamplingRate(operation string, response *api_v2.SamplingStrategyResponse) (float64, error) {

--- a/crossdock/services/agent.go
+++ b/crossdock/services/agent.go
@@ -24,7 +24,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
 var errSamplingRateMissing = errors.New("sampling rate is missing")
@@ -65,14 +65,14 @@ func (s *agentService) GetSamplingRate(service, operation string) (float64, erro
 	}
 	s.logger.Info("Retrieved sampling rates from agent", zap.String("body", string(body)))
 
-	var response sampling.SamplingStrategyResponse
+	var response api_v2.SamplingStrategyResponse
 	if err = json.Unmarshal(body, &response); err != nil {
 		return 0, err
 	}
 	return getSamplingRate(operation, &response)
 }
 
-func getSamplingRate(operation string, response *sampling.SamplingStrategyResponse) (float64, error) {
+func getSamplingRate(operation string, response *api_v2.SamplingStrategyResponse) (float64, error) {
 	if response.OperationSampling == nil {
 		return 0, errSamplingRateMissing
 	}

--- a/crossdock/services/agent_test.go
+++ b/crossdock/services/agent_test.go
@@ -24,15 +24,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
-var testResponse = &sampling.SamplingStrategyResponse{
-	OperationSampling: &sampling.PerOperationSamplingStrategies{
-		PerOperationStrategies: []*sampling.OperationSamplingStrategy{
+var testResponse = &api_v2.SamplingStrategyResponse{
+	OperationSampling: &api_v2.PerOperationSamplingStrategies{
+		PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
 			{
 				Operation: "op",
-				ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+				ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 					SamplingRate: 0.01,
 				},
 			},
@@ -43,12 +43,12 @@ var testResponse = &sampling.SamplingStrategyResponse{
 func TestGetSamplingRateInternal(t *testing.T) {
 	tests := []struct {
 		operation string
-		response  *sampling.SamplingStrategyResponse
+		response  *api_v2.SamplingStrategyResponse
 		shouldErr bool
 		rate      float64
 	}{
-		{"op", &sampling.SamplingStrategyResponse{}, true, 0},
-		{"op", &sampling.SamplingStrategyResponse{OperationSampling: &sampling.PerOperationSamplingStrategies{}}, true, 0},
+		{"op", &api_v2.SamplingStrategyResponse{}, true, 0},
+		{"op", &api_v2.SamplingStrategyResponse{OperationSampling: &api_v2.PerOperationSamplingStrategies{}}, true, 0},
 		{"op", testResponse, false, 0.01},
 		{"nop", testResponse, true, 0},
 	}
@@ -58,7 +58,7 @@ func TestGetSamplingRateInternal(t *testing.T) {
 		if test.shouldErr {
 			assert.EqualError(t, err, errSamplingRateMissing.Error())
 		}
-		assert.Equal(t, test.rate, rate)
+		assert.EqualValues(t, test.rate, rate)
 	}
 }
 
@@ -68,12 +68,12 @@ func (h *testAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	svc := r.FormValue("service")
 	body := []byte("bad json")
 	if svc == "crossdock-svc" {
-		response := sampling.SamplingStrategyResponse{
-			OperationSampling: &sampling.PerOperationSamplingStrategies{
-				PerOperationStrategies: []*sampling.OperationSamplingStrategy{
+		response := api_v2.SamplingStrategyResponse{
+			OperationSampling: &api_v2.PerOperationSamplingStrategies{
+				PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
 					{
 						Operation: "op",
-						ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+						ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 							SamplingRate: 1,
 						},
 					},

--- a/crossdock/services/agent_test.go
+++ b/crossdock/services/agent_test.go
@@ -16,7 +16,6 @@
 package services
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	p2json "github.com/jaegertracing/jaeger/model/converter/json"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
@@ -80,7 +80,8 @@ func (h *testAgentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				},
 			},
 		}
-		body, _ = json.Marshal(response)
+		bodyStr, _ := p2json.SamplingStrategyResponseToJSON(&response)
+		body = []byte(bodyStr)
 	}
 	w.Write(body)
 }

--- a/model/converter/json/sampling.go
+++ b/model/converter/json/sampling.go
@@ -15,6 +15,7 @@
 package json
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -45,4 +46,13 @@ func SamplingStrategyResponseToJSON(protoObj *api_v2.SamplingStrategyResponse) (
 	str = strings.ReplaceAll(str, `,"operationSampling":null`, "")
 
 	return str, nil
+}
+
+// SamplingStrategyResponseFromJSON is the official way to parse strategy in JSON.
+func SamplingStrategyResponseFromJSON(json []byte) (*api_v2.SamplingStrategyResponse, error) {
+	var obj api_v2.SamplingStrategyResponse
+	if err := jsonpb.Unmarshal(bytes.NewReader(json), &obj); err != nil {
+		return nil, err
+	}
+	return &obj, nil
 }

--- a/model/converter/json/sampling_test.go
+++ b/model/converter/json/sampling_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	thriftconv "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	api_v1 "github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
@@ -89,4 +90,23 @@ func compareProtoAndThriftJSON(t *testing.T, thriftObj *api_v1.SamplingStrategyR
 	require.NoError(t, err)
 
 	assert.Equal(t, string(s1), s2)
+}
+
+func TestSamplingStrategyResponseFromJSON(t *testing.T) {
+	_, err := SamplingStrategyResponseFromJSON([]byte("broken"))
+	assert.Error(t, err)
+
+	s1 := &api_v2.SamplingStrategyResponse{
+		StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
+			SamplingRate: 0.42,
+		},
+	}
+	json, err := SamplingStrategyResponseToJSON(s1)
+	require.NoError(t, err)
+
+	s2, err := SamplingStrategyResponseFromJSON([]byte(json))
+	require.NoError(t, err)
+	assert.Equal(t, s1.GetStrategyType(), s2.GetStrategyType())
+	assert.EqualValues(t, s1.GetProbabilisticSampling(), s2.GetProbabilisticSampling())
 }

--- a/pkg/clientcfg/clientcfghttp/cfgmgr.go
+++ b/pkg/clientcfg/clientcfghttp/cfgmgr.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 // ConfigManager implements ClientConfigManager.
@@ -30,7 +30,7 @@ type ConfigManager struct {
 }
 
 // GetSamplingStrategy implements ClientConfigManager.GetSamplingStrategy.
-func (c *ConfigManager) GetSamplingStrategy(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
+func (c *ConfigManager) GetSamplingStrategy(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
 	return c.SamplingStrategyStore.GetSamplingStrategy(ctx, serviceName)
 }
 

--- a/pkg/clientcfg/clientcfghttp/cfgmgr_test.go
+++ b/pkg/clientcfg/clientcfghttp/cfgmgr_test.go
@@ -22,15 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 type mockSamplingStore struct {
-	samplingResponse *sampling.SamplingStrategyResponse
+	samplingResponse *api_v2.SamplingStrategyResponse
 }
 
-func (m *mockSamplingStore) GetSamplingStrategy(_ context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
+func (m *mockSamplingStore) GetSamplingStrategy(_ context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
 	if m.samplingResponse == nil {
 		return nil, errors.New("no mock response provided")
 	}
@@ -52,14 +52,14 @@ func TestConfigManager(t *testing.T) {
 	bgm := &mockBaggageMgr{}
 	mgr := &ConfigManager{
 		SamplingStrategyStore: &mockSamplingStore{
-			samplingResponse: &sampling.SamplingStrategyResponse{},
+			samplingResponse: &api_v2.SamplingStrategyResponse{},
 		},
 		BaggageManager: bgm,
 	}
 	t.Run("GetSamplingStrategy", func(t *testing.T) {
 		r, err := mgr.GetSamplingStrategy(context.Background(), "foo")
 		require.NoError(t, err)
-		assert.Equal(t, sampling.SamplingStrategyResponse{}, *r)
+		assert.Equal(t, api_v2.SamplingStrategyResponse{}, *r)
 	})
 	t.Run("GetBaggageRestrictions", func(t *testing.T) {
 		expResp := []*baggage.BaggageRestriction{}

--- a/pkg/clientcfg/clientcfghttp/handler_test.go
+++ b/pkg/clientcfg/clientcfghttp/handler_test.go
@@ -16,7 +16,6 @@
 package clientcfghttp
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -25,12 +24,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
+	p2json "github.com/jaegertracing/jaeger/model/converter/json"
 	tSampling092 "github.com/jaegertracing/jaeger/pkg/clientcfg/clientcfghttp/thrift-0.9.2"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/thrift-gen/baggage"
@@ -119,8 +118,8 @@ func testHTTPHandler(t *testing.T, basePath string) {
 						ts.samplingStore.samplingResponse.GetRateLimitingSampling().GetMaxTracesPerSecond(),
 						objResp.GetRateLimitingSampling().GetMaxTracesPerSecond())
 				} else {
-					objResp := &api_v2.SamplingStrategyResponse{}
-					require.NoError(t, jsonpb.Unmarshal(bytes.NewReader(body), objResp))
+					objResp, err := p2json.SamplingStrategyResponseFromJSON(body)
+					require.NoError(t, err)
 					assert.EqualValues(t, ts.samplingStore.samplingResponse, objResp)
 				}
 			})

--- a/plugin/sampling/strategystore/adaptive/processor_test.go
+++ b/plugin/sampling/strategystore/adaptive/processor_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/sampling/calculationstrategy"
 	epmocks "github.com/jaegertracing/jaeger/plugin/sampling/leaderelection/mocks"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	smocks "github.com/jaegertracing/jaeger/storage/samplingstore/mocks"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 func testThroughputs() []*model.Throughput {
@@ -565,16 +565,16 @@ func TestGenerateStrategyResponses(t *testing.T) {
 	}
 	p.generateStrategyResponses()
 
-	expectedResponse := map[string]*sampling.SamplingStrategyResponse{
+	expectedResponse := map[string]*api_v2.SamplingStrategyResponse{
 		"svcA": {
-			StrategyType: sampling.SamplingStrategyType_PROBABILISTIC,
-			OperationSampling: &sampling.PerOperationSamplingStrategies{
+			StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
+			OperationSampling: &api_v2.PerOperationSamplingStrategies{
 				DefaultSamplingProbability:       0.001,
 				DefaultLowerBoundTracesPerSecond: 0.0001,
-				PerOperationStrategies: []*sampling.OperationSamplingStrategy{
+				PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
 					{
 						Operation: "GET",
-						ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+						ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 							SamplingRate: 0.5,
 						},
 					},

--- a/plugin/sampling/strategystore/static/constants.go
+++ b/plugin/sampling/strategystore/static/constants.go
@@ -15,7 +15,7 @@
 package static
 
 import (
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
 const (
@@ -34,10 +34,10 @@ const (
 
 // defaultStrategy is the default sampling strategy the Strategy Store will return
 // if none is provided.
-func defaultStrategyResponse() *sampling.SamplingStrategyResponse {
-	return &sampling.SamplingStrategyResponse{
-		StrategyType: sampling.SamplingStrategyType_PROBABILISTIC,
-		ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+func defaultStrategyResponse() *api_v2.SamplingStrategyResponse {
+	return &api_v2.SamplingStrategyResponse{
+		StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 			SamplingRate: defaultSamplingProbability,
 		},
 	}
@@ -45,7 +45,7 @@ func defaultStrategyResponse() *sampling.SamplingStrategyResponse {
 
 func defaultStrategies() *storedStrategies {
 	s := &storedStrategies{
-		serviceStrategies: make(map[string]*sampling.SamplingStrategyResponse),
+		serviceStrategies: make(map[string]*api_v2.SamplingStrategyResponse),
 	}
 	s.defaultStrategy = defaultStrategyResponse()
 	return s

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/jaegertracing/jaeger/pkg/testutils"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
 // strategiesJSON returns the strategy with
@@ -104,22 +104,22 @@ func TestStrategyStoreWithFile(t *testing.T) {
 	assert.Contains(t, buf.String(), "No sampling strategies provided or URL is unavailable, using defaults")
 	s, err := store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.001), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.001), *s)
 
 	// Test reading strategies from a file
 	store, err = NewStrategyStore(Options{StrategiesFile: "fixtures/strategies.json"}, logger)
 	require.NoError(t, err)
 	s, err = store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
 
 	s, err = store.GetSamplingStrategy(context.Background(), "bar")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_RATE_LIMITING, 5), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_RATE_LIMITING, 5), *s)
 
 	s, err = store.GetSamplingStrategy(context.Background(), "default")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.5), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.5), *s)
 }
 
 func TestStrategyStoreWithURL(t *testing.T) {
@@ -131,7 +131,7 @@ func TestStrategyStoreWithURL(t *testing.T) {
 	assert.Contains(t, buf.String(), "No sampling strategies provided or URL is unavailable, using defaults")
 	s, err := store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.001), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.001), *s)
 
 	// Test downloading strategies from a URL.
 	store, err = NewStrategyStore(Options{StrategiesFile: mockServer.URL}, logger)
@@ -139,11 +139,11 @@ func TestStrategyStoreWithURL(t *testing.T) {
 
 	s, err = store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
 
 	s, err = store.GetSamplingStrategy(context.Background(), "bar")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_RATE_LIMITING, 5), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_RATE_LIMITING, 5), *s)
 }
 
 func TestPerOperationSamplingStrategies(t *testing.T) {
@@ -155,11 +155,11 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 		"'op4' defaulting to probabilistic sampling with probability 0.001")
 	require.NoError(t, err)
 
-	expected := makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.8)
+	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.8)
 
 	s, err := store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.Equal(t, sampling.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
+	assert.Equal(t, api_v2.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
 	assert.Equal(t, *expected.ProbabilisticSampling, *s.ProbabilisticSampling)
 
 	require.NotNil(t, s.OperationSampling)
@@ -176,11 +176,11 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 	assert.Equal(t, "op7", os.PerOperationStrategies[3].Operation)
 	assert.EqualValues(t, 1, os.PerOperationStrategies[3].ProbabilisticSampling.SamplingRate)
 
-	expected = makeResponse(sampling.SamplingStrategyType_RATE_LIMITING, 5)
+	expected = makeResponse(api_v2.SamplingStrategyType_RATE_LIMITING, 5)
 
 	s, err = store.GetSamplingStrategy(context.Background(), "bar")
 	require.NoError(t, err)
-	assert.Equal(t, sampling.SamplingStrategyType_RATE_LIMITING, s.StrategyType)
+	assert.Equal(t, api_v2.SamplingStrategyType_RATE_LIMITING, s.StrategyType)
 	assert.Equal(t, *expected.RateLimitingSampling, *s.RateLimitingSampling)
 
 	require.NotNil(t, s.OperationSampling)
@@ -200,25 +200,25 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 
 	s, err = store.GetSamplingStrategy(context.Background(), "default")
 	require.NoError(t, err)
-	expectedRsp := makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.5)
-	expectedRsp.OperationSampling = &sampling.PerOperationSamplingStrategies{
+	expectedRsp := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.5)
+	expectedRsp.OperationSampling = &api_v2.PerOperationSamplingStrategies{
 		DefaultSamplingProbability: 0.5,
-		PerOperationStrategies: []*sampling.OperationSamplingStrategy{
+		PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
 			{
 				Operation: "op0",
-				ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+				ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 					SamplingRate: 0.2,
 				},
 			},
 			{
 				Operation: "op6",
-				ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+				ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 					SamplingRate: 0,
 				},
 			},
 			{
 				Operation: "op7",
-				ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+				ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 					SamplingRate: 1,
 				},
 			},
@@ -233,11 +233,11 @@ func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 	assert.Contains(t, buf.String(), "Failed to parse sampling strategy")
 	require.NoError(t, err)
 
-	expected := makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
 
 	s, err := store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.Equal(t, sampling.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
+	assert.Equal(t, api_v2.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
 	assert.Equal(t, *expected.ProbabilisticSampling, *s.ProbabilisticSampling)
 
 	require.NotNil(t, s.OperationSampling)
@@ -247,11 +247,11 @@ func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 	assert.Equal(t, "op1", os.PerOperationStrategies[0].Operation)
 	assert.EqualValues(t, 0.2, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)
 
-	expected = makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+	expected = makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
 
 	s, err = store.GetSamplingStrategy(context.Background(), "bar")
 	require.NoError(t, err)
-	assert.Equal(t, sampling.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
+	assert.Equal(t, api_v2.SamplingStrategyType_PROBABILISTIC, s.StrategyType)
 	assert.Equal(t, *expected.ProbabilisticSampling, *s.ProbabilisticSampling)
 
 	require.NotNil(t, s.OperationSampling)
@@ -265,27 +265,27 @@ func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 
 	s, err = store.GetSamplingStrategy(context.Background(), "default")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.5), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.5), *s)
 }
 
 func TestParseStrategy(t *testing.T) {
 	tests := []struct {
 		strategy serviceStrategy
-		expected sampling.SamplingStrategyResponse
+		expected api_v2.SamplingStrategyResponse
 	}{
 		{
 			strategy: serviceStrategy{
 				Service:  "svc",
 				strategy: strategy{Type: "probabilistic", Param: 0.2},
 			},
-			expected: makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.2),
+			expected: makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.2),
 		},
 		{
 			strategy: serviceStrategy{
 				Service:  "svc",
 				strategy: strategy{Type: "ratelimiting", Param: 3.5},
 			},
-			expected: makeResponse(sampling.SamplingStrategyType_RATE_LIMITING, 3),
+			expected: makeResponse(api_v2.SamplingStrategyType_RATE_LIMITING, 3),
 		},
 	}
 	logger, buf := testutils.NewLogger()
@@ -300,29 +300,29 @@ func TestParseStrategy(t *testing.T) {
 
 	// Test nonexistent strategy type
 	actual := *store.parseStrategy(&strategy{Type: "blah", Param: 3.5})
-	expected := makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
 	assert.EqualValues(t, expected, actual)
 	assert.Contains(t, buf.String(), "Failed to parse sampling strategy")
 }
 
-func makeResponse(samplerType sampling.SamplingStrategyType, param float64) (resp sampling.SamplingStrategyResponse) {
+func makeResponse(samplerType api_v2.SamplingStrategyType, param float64) (resp api_v2.SamplingStrategyResponse) {
 	resp.StrategyType = samplerType
-	if samplerType == sampling.SamplingStrategyType_PROBABILISTIC {
-		resp.ProbabilisticSampling = &sampling.ProbabilisticSamplingStrategy{
+	if samplerType == api_v2.SamplingStrategyType_PROBABILISTIC {
+		resp.ProbabilisticSampling = &api_v2.ProbabilisticSamplingStrategy{
 			SamplingRate: param,
 		}
-	} else if samplerType == sampling.SamplingStrategyType_RATE_LIMITING {
-		resp.RateLimitingSampling = &sampling.RateLimitingSamplingStrategy{
-			MaxTracesPerSecond: int16(param),
+	} else if samplerType == api_v2.SamplingStrategyType_RATE_LIMITING {
+		resp.RateLimitingSampling = &api_v2.RateLimitingSamplingStrategy{
+			MaxTracesPerSecond: int32(param),
 		}
 	}
 	return resp
 }
 
 func TestDeepCopy(t *testing.T) {
-	s := &sampling.SamplingStrategyResponse{
-		StrategyType: sampling.SamplingStrategyType_PROBABILISTIC,
-		ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+	s := &api_v2.SamplingStrategyResponse{
+		StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 			SamplingRate: 0.5,
 		},
 	}
@@ -355,7 +355,7 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 	// confirm baseline value
 	s, err := store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
 
 	// verify that reloading is a no-op
 	value := store.reloadSamplingStrategy(store.samplingStrategyLoader(dstFile), string(srcBytes))
@@ -374,7 +374,7 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 		}
 		time.Sleep(1 * time.Millisecond)
 	}
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.9), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.9), *s)
 }
 
 func TestAutoUpdateStrategyWithURL(t *testing.T) {
@@ -390,7 +390,7 @@ func TestAutoUpdateStrategyWithURL(t *testing.T) {
 	// confirm baseline value
 	s, err := store.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
 
 	// verify that reloading in no-op
 	value := store.reloadSamplingStrategy(store.samplingStrategyLoader(mockServer.URL), mockStrategy.Load())
@@ -408,7 +408,7 @@ func TestAutoUpdateStrategyWithURL(t *testing.T) {
 		}
 		time.Sleep(1 * time.Millisecond)
 	}
-	assert.EqualValues(t, makeResponse(sampling.SamplingStrategyType_PROBABILISTIC, 0.9), *s)
+	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.9), *s)
 }
 
 func TestAutoUpdateStrategyErrors(t *testing.T) {
@@ -463,7 +463,7 @@ func TestServiceNoPerOperationStrategies(t *testing.T) {
 	s, err = store.GetSamplingStrategy(context.Background(), "ServiceB")
 	require.NoError(t, err)
 
-	expected := makeResponse(sampling.SamplingStrategyType_RATE_LIMITING, 3)
+	expected := makeResponse(api_v2.SamplingStrategyType_RATE_LIMITING, 3)
 	assert.Equal(t, *expected.RateLimitingSampling, *s.RateLimitingSampling)
 }
 


### PR DESCRIPTION
As the official API is now Protobuf, this change avoids unnecessary conversions to/from Thrift types.