### PR TITLE
[tracegen] Switch from Jaeger Client to OTEL SDK

### DIFF
--- a/cmd/tracegen/README.md
+++ b/cmd/tracegen/README.md
@@ -9,12 +9,12 @@ The binary is available from the Releases page, as well as a Docker image:
 $ docker run jaegertracing/jaeger-tracegen -service abcd -traces 10
 ```
 
-Notice, however, that by default the generator uses the UDP exporter of `jaeger-client-go`,
-which sends data to `localhost`, i.e. inside the networking namespace of the container itself,
-which obviously doesn't go anywhere. You can use the environment variables supported by
-[jaeger-client-go][env] to instruct the SDK where to send the data, for example to switch
-to HTTP by setting `JAEGER_ENDPOINT`.
+The generator can be configured to export traces in different formats, via `-exporter` flag.
+By default, the exporters send data to `localhost`. If running in a container, this refers
+to the networking namespace of the container itself, so to export to another container
+(like Jaeger Collector), the exporters need to be provided with appropriate location.
+Exporters accept configuration via environment variables:
+  * Jaeger exporter: see https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/jaeger/README.md
+  * OTLP exporter: see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
 
 See example in the included [docker-compose](./docker-compose.yml) file.
-
-[env]: https://github.com/jaegertracing/jaeger-client-go#environment-variables

--- a/cmd/tracegen/docker-compose.yml
+++ b/cmd/tracegen/docker-compose.yml
@@ -3,14 +3,17 @@ version: '2'
 services:
     jaeger:
       image: jaegertracing/all-in-one:latest
+      environment:
+        - COLLECTOR_OTLP_ENABLED=true
       ports:
         - '16686:16686'
+        - '4318:4318'
 
     tracegen:
       image: jaegertracing/jaeger-tracegen:latest
       environment:
-        - JAEGER_AGENT_HOST=jaeger
-        - JAEGER_AGENT_PORT=6831
+        - OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger:14268/api/traces
+        - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=jaeger:4318
       command: ["-duration", "10s", "-workers", "3", "-pause", "250ms"]
       depends_on:
         - jaeger


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of migrating away from deprecated Jaeger Go SDK

## Short description of the changes
- switch tracegen from Jaeger Client to OTEL SDK
- a breaking change in some respect:
  - default exporter changed to Jaeger HTTP
  - different environment variables are used to configure exporters
  - debug and firehose flags are no longer set in the trace context, but as span attributes 
  - no more metrics from tracegen
