### PR TITLE
ci(lint): bump golangci-lint to v1.50.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ draft-release:
 .PHONY: install-tools
 install-tools:
 	go install github.com/vektra/mockery/v2@v2.14.0
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 	go install mvdan.cc/gofumpt@latest
 
 .PHONY: install-ci

--- a/cmd/collector/app/zipkin/http_handler.go
+++ b/cmd/collector/app/zipkin/http_handler.go
@@ -92,7 +92,7 @@ func (aH *APIHandler) saveSpans(w http.ResponseWriter, r *http.Request) {
 	var tSpans []*zipkincore.Span
 	switch contentType {
 	case "application/x-thrift":
-		tSpans, err = zipkin.DeserializeThrift(bodyBytes)
+		tSpans, err = zipkin.DeserializeThrift(r.Context(), bodyBytes)
 	case "application/json":
 		tSpans, err = zipkindeser.DeserializeJSON(bodyBytes)
 	default:

--- a/cmd/collector/app/zipkin/http_handler_test.go
+++ b/cmd/collector/app/zipkin/http_handler_test.go
@@ -18,6 +18,7 @@ package zipkin
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -109,7 +110,7 @@ func waitForSpans(t *testing.T, handler *mockZipkinHandler, expecting int) {
 func TestThriftFormat(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
-	bodyBytes := zipkinTrift.SerializeThrift([]*zipkincore.Span{{}})
+	bodyBytes := zipkinTrift.SerializeThrift(context.Background(), []*zipkincore.Span{{}})
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, bodyBytes, createHeader("application/x-thrift"))
 	assert.NoError(t, err)
 	assert.EqualValues(t, http.StatusAccepted, statusCode)
@@ -202,7 +203,7 @@ func TestZipkinJsonV1Format(t *testing.T) {
 func TestGzipEncoding(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
-	bodyBytes := zipkinTrift.SerializeThrift([]*zipkincore.Span{{}})
+	bodyBytes := zipkinTrift.SerializeThrift(context.Background(), []*zipkincore.Span{{}})
 	header := createHeader("application/x-thrift")
 	header.Add("Content-Encoding", "gzip")
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, gzipEncode(bodyBytes), header)

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -73,6 +73,7 @@ func main() {
 		}
 		handler.xHandler.ServeHTTP(w, r)
 	})
+	//nolint:gosec
 	http.ListenAndServe(":8080", nil)
 }
 

--- a/model/converter/thrift/zipkin/deserialize.go
+++ b/model/converter/thrift/zipkin/deserialize.go
@@ -24,8 +24,7 @@ import (
 )
 
 // SerializeThrift is only used in tests.
-func SerializeThrift(spans []*zipkincore.Span) []byte {
-	ctx := context.Background()
+func SerializeThrift(ctx context.Context, spans []*zipkincore.Span) []byte {
 	t := thrift.NewTMemoryBuffer()
 	p := thrift.NewTBinaryProtocolConf(t, &thrift.TConfiguration{})
 	p.WriteListBegin(ctx, thrift.STRUCT, len(spans))
@@ -37,8 +36,7 @@ func SerializeThrift(spans []*zipkincore.Span) []byte {
 }
 
 // DeserializeThrift decodes Thrift bytes to a list of spans.
-func DeserializeThrift(b []byte) ([]*zipkincore.Span, error) {
-	ctx := context.Background()
+func DeserializeThrift(ctx context.Context, b []byte) ([]*zipkincore.Span, error) {
 	buffer := thrift.NewTMemoryBuffer()
 	buffer.Write(b)
 

--- a/model/converter/thrift/zipkin/deserialize_test.go
+++ b/model/converter/thrift/zipkin/deserialize_test.go
@@ -16,6 +16,7 @@
 package zipkin
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,20 +25,23 @@ import (
 )
 
 func TestDeserializeWithBadListStart(t *testing.T) {
-	spanBytes := SerializeThrift([]*zipkincore.Span{{}})
-	_, err := DeserializeThrift(append([]byte{0, 255, 255}, spanBytes...))
+	ctx := context.Background()
+	spanBytes := SerializeThrift(ctx, []*zipkincore.Span{{}})
+	_, err := DeserializeThrift(ctx, append([]byte{0, 255, 255}, spanBytes...))
 	assert.Error(t, err)
 }
 
 func TestDeserializeWithCorruptedList(t *testing.T) {
-	spanBytes := SerializeThrift([]*zipkincore.Span{{}})
+	ctx := context.Background()
+	spanBytes := SerializeThrift(ctx, []*zipkincore.Span{{}})
 	spanBytes[2] = 255
-	_, err := DeserializeThrift(spanBytes)
+	_, err := DeserializeThrift(ctx, spanBytes)
 	assert.Error(t, err)
 }
 
 func TestDeserialize(t *testing.T) {
-	spanBytes := SerializeThrift([]*zipkincore.Span{{}})
-	_, err := DeserializeThrift(spanBytes)
+	ctx := context.Background()
+	spanBytes := SerializeThrift(ctx, []*zipkincore.Span{{}})
+	_, err := DeserializeThrift(ctx, spanBytes)
 	assert.NoError(t, err)
 }

--- a/plugin/storage/kafka/marshalling_test.go
+++ b/plugin/storage/kafka/marshalling_test.go
@@ -15,6 +15,7 @@
 package kafka
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +46,7 @@ func testMarshallerAndUnmarshaller(t *testing.T, marshaller Marshaller, unmarsha
 
 func TestZipkinThriftUnmarshaller(t *testing.T) {
 	operationName := "foo"
-	bytes := zipkin.SerializeThrift([]*zipkincore.Span{
+	bytes := zipkin.SerializeThrift(context.Background(), []*zipkincore.Span{
 		{
 			ID:   12345,
 			Name: operationName,
@@ -62,7 +63,7 @@ func TestZipkinThriftUnmarshaller(t *testing.T) {
 }
 
 func TestZipkinThriftUnmarshallerErrorNoService(t *testing.T) {
-	bytes := zipkin.SerializeThrift([]*zipkincore.Span{
+	bytes := zipkin.SerializeThrift(context.Background(), []*zipkincore.Span{
 		{
 			ID:   12345,
 			Name: "foo",

--- a/plugin/storage/kafka/unmarshaller.go
+++ b/plugin/storage/kafka/unmarshaller.go
@@ -16,6 +16,7 @@ package kafka
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -69,7 +70,7 @@ func NewZipkinThriftUnmarshaller() *ZipkinThriftUnmarshaller {
 
 // Unmarshal decodes a json byte array to a span
 func (h *ZipkinThriftUnmarshaller) Unmarshal(msg []byte) (*model.Span, error) {
-	tSpans, err := zipkin.DeserializeThrift(msg)
+	tSpans, err := zipkin.DeserializeThrift(context.Background(), msg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- bump golangci-lint to v1.50.1

## Short description of the changes
- fixes contextlint
- disable gosec g114

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>