### PR TITLE
Map old env vars from Jaeger SDK to OTel SDK vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ next release
 
 #### ⛔ Breaking Changes
 
+* HotROD application is switched from Jaeger SDK to OpenTelemetry SDK in [#4187](https://github.com/jaegertracing/jaeger/pull/4187). Some environment variables previously accepted are no longer recognized. See PR for details.
+* `tracegen` utility is switched from Jaeger SDK to OpenTelemetry SDK in [#4189](https://github.com/jaegertracing/jaeger/pull/4189). Some environment variables previously accepted are no longer recognized. See PR for details.
+
 #### New Features
 
 #### Bug fixes, Minor Improvements
@@ -40,7 +43,7 @@ next release
 * Catch panic from Prometheus client on invalid label strings ([@yurishkuro](https://github.com/yurishkuro) in [#4051](https://github.com/jaegertracing/jaeger/pull/4051))
 * Span tags of type int64 may lose precision ([@shubbham1215](https://github.com/shubbham1215) in [#4034](https://github.com/jaegertracing/jaeger/pull/4034))
 
-### UI 
+### UI
 
 * UI pinned to version [1.27.3](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#v1273-2022-12-07).
 
@@ -67,7 +70,7 @@ next release
 * Add grafana container to monitor docker-compose ([@albertteoh](https://github.com/albertteoh) in [#3955](https://github.com/jaegertracing/jaeger/pull/3955))
 * Expose storage integration helpers as go pkg ([@arajkumar](https://github.com/arajkumar) in [#3944](https://github.com/jaegertracing/jaeger/pull/3944))
 
-### UI 
+### UI
 
 * UI pinned to version [1.27.2](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#v1272-2022-11-01).
 

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -30,6 +30,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/jaegerclientenv2otel"
 	"github.com/jaegertracing/jaeger/internal/tracegen"
 )
 
@@ -42,6 +43,7 @@ func main() {
 	flag.Parse()
 
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	jaegerclientenv2otel.MapJaegerToOtelEnvVars(logger)
 
 	exp, err := createOtelExporter(cfg.TraceExporter)
 	if err != nil {

--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -6,6 +6,8 @@ to view the traces. A tutorial / walkthrough is available:
   * as a blog post [Take OpenTracing for a HotROD ride][hotrod-tutorial],
   * as a video [OpenShift Commons Briefing: Distributed Tracing with Jaeger & Prometheus on Kubernetes][hotrod-openshift].
 
+As of Jaeger v1.42.0 this application was upgraded to use OpenTelemetry SDK for traces.
+
 ## Features
 
 * Discover architecture of the whole system via data-driven dependency diagram
@@ -70,8 +72,7 @@ go run ./examples/hotrod/main.go all
 docker run \
   --rm \
   --link jaeger \
-  --env JAEGER_AGENT_HOST=jaeger \
-  --env JAEGER_AGENT_PORT=6831 \
+  --env OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger:14268/api/traces
   -p8080-8083:8080-8083 \
   jaegertracing/example-hotrod:latest \
   all

--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/jaegertracing/jaeger/examples/hotrod/services/config"
+	"github.com/jaegertracing/jaeger/internal/jaegerclientenv2otel"
 	"github.com/jaegertracing/jaeger/internal/metrics/expvar"
 	"github.com/jaegertracing/jaeger/internal/metrics/prometheus"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -88,6 +89,7 @@ func init() {
 		zap.AddStacktrace(zapcore.FatalLevel),
 		zap.AddCallerSkip(1),
 	)
+	jaegerclientenv2otel.MapJaegerToOtelEnvVars(logger)
 	cobra.OnInitialize(onInitialize)
 }
 

--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -3,20 +3,19 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
-      - "6831:6831/udp"
       - "16686:16686"
     networks:
       - jaeger-example
   hotrod:
     image: jaegertracing/example-hotrod:latest
-    ports: 
+    # To run the latest trunk build, find the tag at Docker Hub and use the line below
+    # https://hub.docker.com/r/jaegertracing/example-hotrod-snapshot/tags
+    #image: jaegertracing/example-hotrod-snapshot:0ab8f2fcb12ff0d10830c1ee3bb52b745522db6c
+    ports:
       - "8080:8080"
     command: ["all"]
     environment:
-      - JAEGER_AGENT_HOST=jaeger
-      # Note: if your application is using Node.js Jaeger Client, you need port 6832,
-      #       unless issue https://github.com/jaegertracing/jaeger/issues/1596 is resolved.
-      - JAEGER_AGENT_PORT=6831
+      - OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger:14268/api/traces
     networks:
       - jaeger-example
     depends_on:

--- a/internal/jaegerclientenv2otel/envvars.go
+++ b/internal/jaegerclientenv2otel/envvars.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaegerclientenv2otel
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+)
+
+var envVars = map[string]string{
+	"JAEGER_SERVICE_NAME":                           "",
+	"JAEGER_AGENT_HOST":                             "OTEL_EXPORTER_JAEGER_AGENT_HOST",
+	"JAEGER_AGENT_PORT":                             "OTEL_EXPORTER_JAEGER_AGENT_PORT",
+	"JAEGER_ENDPOINT":                               "OTEL_EXPORTER_JAEGER_ENDPOINT",
+	"JAEGER_USER":                                   "OTEL_EXPORTER_JAEGER_USER",
+	"JAEGER_PASSWORD":                               "OTEL_EXPORTER_JAEGER_PASSWORD",
+	"JAEGER_REPORTER_LOG_SPANS":                     "",
+	"JAEGER_REPORTER_MAX_QUEUE_SIZE":                "",
+	"JAEGER_REPORTER_FLUSH_INTERVAL":                "",
+	"JAEGER_REPORTER_ATTEMPT_RECONNECTING_DISABLED": "",
+	"JAEGER_REPORTER_ATTEMPT_RECONNECT_INTERVAL":    "",
+	"JAEGER_SAMPLER_TYPE":                           "",
+	"JAEGER_SAMPLER_PARAM":                          "",
+	"JAEGER_SAMPLER_MANAGER_HOST_PORT":              "",
+	"JAEGER_SAMPLING_ENDPOINT":                      "",
+	"JAEGER_SAMPLER_MAX_OPERATIONS":                 "",
+	"JAEGER_SAMPLER_REFRESH_INTERVAL":               "",
+	"JAEGER_TAGS":                                   "",
+	"JAEGER_TRACEID_128BIT":                         "",
+	"JAEGER_DISABLED":                               "",
+	"JAEGER_RPC_METRICS":                            "",
+}
+
+func MapJaegerToOtelEnvVars(logger *zap.Logger) {
+	for jname, otelname := range envVars {
+		val := os.Getenv(jname)
+		if val == "" {
+			continue
+		}
+		if otelname == "" {
+			logger.Sugar().Infof("Ignoring deprecated Jaeger SDK env var %s, as there is no equivalent in OpenTelemetry", jname)
+		} else {
+			os.Setenv(otelname, val)
+			logger.Sugar().Infof("Replacing deprecated Jaeger SDK env var %s with OpenTelemetry env var %s", jname, otelname)
+		}
+	}
+}

--- a/internal/jaegerclientenv2otel/envvars_test.go
+++ b/internal/jaegerclientenv2otel/envvars_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaegerclientenv2otel
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMapJaegerToOtelEnvVars(t *testing.T) {
+	os.Setenv("JAEGER_TAGS", "tags")
+	os.Setenv("JAEGER_USER", "user")
+	os.Unsetenv("OTEL_EXPORTER_JAEGER_USER")
+
+	logger, buffer := testutils.NewLogger()
+	MapJaegerToOtelEnvVars(logger)
+
+	assert.Equal(t, "user", os.Getenv("OTEL_EXPORTER_JAEGER_USER"))
+	assert.Contains(t, buffer.String(), "Replacing deprecated Jaeger SDK env var JAEGER_USER with OpenTelemetry env var OTEL_EXPORTER_JAEGER_USER")
+	assert.Contains(t, buffer.String(), "Ignoring deprecated Jaeger SDK env var JAEGER_TAGS")
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/discussions/4199

## Short description of the changes
- Map some of old env vars to OTel vars
- Document breaking changes in the CHANGELOG
