### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/docker-compose/monitor/requirements.txt
+++ b/docker-compose/monitor/requirements.txt
@@ -1,5 +1,5 @@
 backoff==2.2.1
-certifi==2022.12.7
+certifi==2022.12.07
 charset-normalizer==2.1.1
 Deprecated==1.2.13
 googleapis-common-protos==1.56.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS