### PR TITLE
Use patched version of github.com/opentracing-contrib/go-grpc in HotROD

### DIFF
--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     image: jaegertracing/all-in-one:latest
     ports:
       - "16686:16686"
+      - "14268:14268"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug
     networks:
       - jaeger-example
   hotrod:

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/olivere/elastic v6.2.37+incompatible
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.70.0
-	github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df
+	github.com/opentracing-contrib/go-grpc v0.0.0-20230205024533-5ced129e5996
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger 
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.70.0/go.mod h1:gXcINYk0VZMM69aWFcPerewtCg6HNuBjaajrwt0/9B0=
 github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df h1:vdYtBU6zvL7v+Tr+0xFM/qhahw/EvY8DMMunZHKH6eE=
 github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
+github.com/opentracing-contrib/go-grpc v0.0.0-20230205024533-5ced129e5996 h1:cNKquGUykT1G88PgdGC8yEB7eU3H3GyuySp/jfJS49w=
+github.com/opentracing-contrib/go-grpc v0.0.0-20230205024533-5ced129e5996/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
 github.com/opentracing-contrib/go-stdlib v1.0.0 h1:TBS7YuVotp8myLon4Pv7BtCBzOTo1DeZCld0Z63mW2w=
 github.com/opentracing-contrib/go-stdlib v1.0.0/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #4209

## Short description of the changes
- I created a temporary patch branch https://github.com/opentracing-contrib/go-grpc/tree/patch-for-opentelemetry-go-issue-3678 as a workaround for OTEL issue https://github.com/open-telemetry/opentelemetry-go/issues/3678
- Only HotROD code is using this library, our production code is using `grpc-ecosystem/grpc-opentracing` (which seems to be an identical copy, I am not sure why there are two libs, but it came in handy right now)
