### PR TITLE
Restore baggage support in HotROD 🚗

### DIFF
--- a/examples/hotrod/cmd/customer.go
+++ b/examples/hotrod/cmd/customer.go
@@ -46,5 +46,4 @@ var customerCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(customerCmd)
-
 }

--- a/examples/hotrod/cmd/driver.go
+++ b/examples/hotrod/cmd/driver.go
@@ -46,5 +46,4 @@ var driverCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(driverCmd)
-
 }

--- a/examples/hotrod/cmd/frontend.go
+++ b/examples/hotrod/cmd/frontend.go
@@ -56,5 +56,4 @@ var options frontend.ConfigOptions
 
 func init() {
 	RootCmd.AddCommand(frontendCmd)
-
 }

--- a/examples/hotrod/cmd/route.go
+++ b/examples/hotrod/cmd/route.go
@@ -46,5 +46,4 @@ var routeCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(routeCmd)
-
 }

--- a/examples/hotrod/pkg/log/factory.go
+++ b/examples/hotrod/pkg/log/factory.go
@@ -37,7 +37,7 @@ func NewFactory(logger *zap.Logger) Factory {
 
 // Bg creates a context-unaware logger.
 func (b Factory) Bg() Logger {
-	return logger(b)
+	return wrapper(b)
 }
 
 // For returns a context-aware Logger. If the context

--- a/examples/hotrod/pkg/log/logger.go
+++ b/examples/hotrod/pkg/log/logger.go
@@ -22,33 +22,39 @@ import (
 
 // Logger is a simplified abstraction of the zap.Logger
 type Logger interface {
+	Debug(msg string, fields ...zapcore.Field)
 	Info(msg string, fields ...zapcore.Field)
 	Error(msg string, fields ...zapcore.Field)
 	Fatal(msg string, fields ...zapcore.Field)
 	With(fields ...zapcore.Field) Logger
 }
 
-// logger delegates all calls to the underlying zap.Logger
-type logger struct {
+// wrapper delegates all calls to the underlying zap.Logger
+type wrapper struct {
 	logger *zap.Logger
 }
 
+// Debug logs an debug msg with fields
+func (l wrapper) Debug(msg string, fields ...zapcore.Field) {
+	l.logger.Debug(msg, fields...)
+}
+
 // Info logs an info msg with fields
-func (l logger) Info(msg string, fields ...zapcore.Field) {
+func (l wrapper) Info(msg string, fields ...zapcore.Field) {
 	l.logger.Info(msg, fields...)
 }
 
 // Error logs an error msg with fields
-func (l logger) Error(msg string, fields ...zapcore.Field) {
+func (l wrapper) Error(msg string, fields ...zapcore.Field) {
 	l.logger.Error(msg, fields...)
 }
 
 // Fatal logs a fatal error msg with fields
-func (l logger) Fatal(msg string, fields ...zapcore.Field) {
+func (l wrapper) Fatal(msg string, fields ...zapcore.Field) {
 	l.logger.Fatal(msg, fields...)
 }
 
 // With creates a child logger, and optionally adds some context fields to that logger.
-func (l logger) With(fields ...zapcore.Field) Logger {
-	return logger{logger: l.logger.With(fields...)}
+func (l wrapper) With(fields ...zapcore.Field) Logger {
+	return wrapper{logger: l.logger.With(fields...)}
 }

--- a/examples/hotrod/pkg/log/spanlogger.go
+++ b/examples/hotrod/pkg/log/spanlogger.go
@@ -31,6 +31,11 @@ type spanLogger struct {
 	spanFields []zapcore.Field
 }
 
+func (sl spanLogger) Debug(msg string, fields ...zapcore.Field) {
+	sl.logToSpan("Debug", msg, fields...)
+	sl.logger.Debug(msg, append(sl.spanFields, fields...)...)
+}
+
 func (sl spanLogger) Info(msg string, fields ...zapcore.Field) {
 	sl.logToSpan("info", msg, fields...)
 	sl.logger.Info(msg, append(sl.spanFields, fields...)...)

--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -55,7 +55,7 @@ func Init(serviceName string, exporterType string, metricsFactory metrics.Factor
 	if err != nil {
 		logger.Bg().Fatal("cannot create exporter", zap.String("exporterType", exporterType), zap.Error(err))
 	}
-	logger.Bg().Info("using " + exporterType + " trace exporter")
+	logger.Bg().Debug("using " + exporterType + " trace exporter")
 
 	rpcmetricsObserver := rpcmetrics.NewObserver(metricsFactory, rpcmetrics.DefaultNameNormalizer)
 
@@ -68,7 +68,7 @@ func Init(serviceName string, exporterType string, metricsFactory metrics.Factor
 		)),
 	)
 	otTracer, _ := otbridge.NewTracerPair(tp.Tracer(""))
-	logger.Bg().Info("created OTEL->OT brige", zap.String("service-name", serviceName))
+	logger.Bg().Debug("created OTEL->OT brige", zap.String("service-name", serviceName))
 	return otTracer
 }
 

--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -44,7 +44,11 @@ var once sync.Once
 // to return an OpenTracing-compatible tracer.
 func Init(serviceName string, exporterType string, metricsFactory metrics.Factory, logger log.Factory) opentracing.Tracer {
 	once.Do(func() {
-		otel.SetTextMapPropagator(propagation.TraceContext{})
+		otel.SetTextMapPropagator(
+			propagation.NewCompositeTextMapPropagator(
+				propagation.TraceContext{},
+				propagation.Baggage{},
+			))
 	})
 
 	exp, err := createOtelExporter(exporterType)

--- a/examples/hotrod/services/customer/client.go
+++ b/examples/hotrod/services/customer/client.go
@@ -54,7 +54,6 @@ func (c *Client) Get(ctx context.Context, customerID string) (*Customer, error) 
 	c.logger.For(ctx).Info("Getting customer", zap.String("customer_id", customerID))
 
 	url := fmt.Sprintf("http://"+c.hostPort+"/customer?customer=%s", customerID)
-	fmt.Println(url)
 	var customer Customer
 	if err := c.client.GetJSON(ctx, "/customer", url, &customer); err != nil {
 		return nil, err

--- a/examples/hotrod/services/customer/server.go
+++ b/examples/hotrod/services/customer/server.go
@@ -57,7 +57,7 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) createServeMux() http.Handler {
-	mux := tracing.NewServeMux(s.tracer)
+	mux := tracing.NewServeMux(s.tracer, s.logger)
 	mux.Handle("/customer", http.HandlerFunc(s.customer))
 	return mux
 }

--- a/examples/hotrod/services/customer/server.go
+++ b/examples/hotrod/services/customer/server.go
@@ -57,7 +57,7 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) createServeMux() http.Handler {
-	mux := tracing.NewServeMux(s.tracer, s.logger)
+	mux := tracing.NewServeMux(false, s.tracer, s.logger)
 	mux.Handle("/customer", http.HandlerFunc(s.customer))
 	return mux
 }

--- a/examples/hotrod/services/driver/server.go
+++ b/examples/hotrod/services/driver/server.go
@@ -43,10 +43,10 @@ var _ DriverServiceServer = (*Server)(nil)
 // NewServer creates a new driver.Server
 func NewServer(hostPort string, otelExporter string, metricsFactory metrics.Factory, logger log.Factory) *Server {
 	tracer := tracing.Init("driver", otelExporter, metricsFactory, logger)
-	server := grpc.NewServer(grpc.UnaryInterceptor(
-		otgrpc.OpenTracingServerInterceptor(tracer)),
-		grpc.StreamInterceptor(
-			otgrpc.OpenTracingStreamServerInterceptor(tracer)))
+	server := grpc.NewServer(
+		grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),
+		grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)),
+	)
 	return &Server{
 		hostPort: hostPort,
 		tracer:   tracer,

--- a/examples/hotrod/services/frontend/best_eta.go
+++ b/examples/hotrod/services/frontend/best_eta.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"net/url"
 	"sync"
 	"time"
 
@@ -77,7 +78,8 @@ func (eta *bestETA) Get(ctx context.Context, customerID string) (*Response, erro
 	eta.logger.For(ctx).Info("Found customer", zap.Any("customer", customer))
 
 	if span := opentracing.SpanFromContext(ctx); span != nil {
-		span.SetBaggageItem("customer", customer.Name)
+		escaped := url.QueryEscape(customer.Name)
+		span.SetBaggageItem("customer", escaped)
 	}
 
 	drivers, err := eta.driver.FindNearest(ctx, customer.Location)

--- a/examples/hotrod/services/frontend/best_eta.go
+++ b/examples/hotrod/services/frontend/best_eta.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"math"
-	"net/url"
 	"sync"
 	"time"
 
@@ -78,8 +77,7 @@ func (eta *bestETA) Get(ctx context.Context, customerID string) (*Response, erro
 	eta.logger.For(ctx).Info("Found customer", zap.Any("customer", customer))
 
 	if span := opentracing.SpanFromContext(ctx); span != nil {
-		escaped := url.QueryEscape(customer.Name)
-		span.SetBaggageItem("customer", escaped)
+		span.SetBaggageItem("customer", customer.Name)
 	}
 
 	drivers, err := eta.driver.FindNearest(ctx, customer.Location)

--- a/examples/hotrod/services/frontend/server.go
+++ b/examples/hotrod/services/frontend/server.go
@@ -76,7 +76,7 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) createServeMux() http.Handler {
-	mux := tracing.NewServeMux(s.tracer)
+	mux := tracing.NewServeMux(s.tracer, s.logger)
 	p := path.Join("/", s.basepath)
 	mux.Handle(p, http.StripPrefix(p, http.FileServer(s.assetFS)))
 	mux.Handle(path.Join(p, "/dispatch"), http.HandlerFunc(s.dispatch))

--- a/examples/hotrod/services/frontend/server.go
+++ b/examples/hotrod/services/frontend/server.go
@@ -76,7 +76,7 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) createServeMux() http.Handler {
-	mux := tracing.NewServeMux(s.tracer, s.logger)
+	mux := tracing.NewServeMux(true, s.tracer, s.logger)
 	p := path.Join("/", s.basepath)
 	mux.Handle(p, http.StripPrefix(p, http.FileServer(s.assetFS)))
 	mux.Handle(path.Join(p, "/dispatch"), http.HandlerFunc(s.dispatch))

--- a/examples/hotrod/services/frontend/web_assets/index.html
+++ b/examples/hotrod/services/frontend/web_assets/index.html
@@ -69,7 +69,7 @@ $(".hotrod-button").click(function(evt) {
   var freshCar = $($("#hotrod-log").prepend('<div class="fresh-car"><em>Dispatching a car...[req: '+requestID+']</em></div>').children()[0]);
   var customer = evt.target.dataset.customer;
   var headers = {
-      'jaeger-baggage': 'session=' + clientUUID + ', request=' + requestID
+      'baggage': 'session=' + clientUUID + ', request=' + requestID
   };
   console.log(headers);
   var before = Date.now();

--- a/examples/hotrod/services/route/server.go
+++ b/examples/hotrod/services/route/server.go
@@ -59,7 +59,7 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) createServeMux() http.Handler {
-	mux := tracing.NewServeMux(s.tracer)
+	mux := tracing.NewServeMux(s.tracer, s.logger)
 	mux.Handle("/route", http.HandlerFunc(s.route))
 	mux.Handle("/debug/vars", expvar.Handler()) // expvar
 	mux.Handle("/metrics", promhttp.Handler())  // Prometheus

--- a/examples/hotrod/services/route/server.go
+++ b/examples/hotrod/services/route/server.go
@@ -59,7 +59,7 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) createServeMux() http.Handler {
-	mux := tracing.NewServeMux(s.tracer, s.logger)
+	mux := tracing.NewServeMux(false, s.tracer, s.logger)
 	mux.Handle("/route", http.HandlerFunc(s.route))
 	mux.Handle("/debug/vars", expvar.Handler()) // expvar
 	mux.Handle("/metrics", promhttp.Handler())  // Prometheus


### PR DESCRIPTION
## Which problem is this PR solving?
- The baggage propagation was broken in HotROD after #4187
- This restores the baggage support by providing a few integration points with OTEL
- [ ] This change will not work until OTEL Baggage & Bridge bugs are fixed: https://github.com/open-telemetry/opentelemetry-go/issues/3685

## Short description of the changes
- [`index.html`] The webapp used to send baggage via `jaeger-baggage` header, this is now changed to W3C `baggage` header
- [`mux.go`] The Jaeger SDK was able to accept `jaeger-baggage` header even for requests without am active trace. OTEL Bridge does not support that, so we use OTEL's Baggage propagator to manually extract the baggage into Context, and once the Bridge creates a Span, we copy OTEL baggage from Context into the Span.
- All other changes are cosmetic / logging related