### PR TITLE
Add internal action to setup Node.js version appropriate for Jaeger UI

### DIFF
--- a/.github/actions/setup-node.js/action.yml
+++ b/.github/actions/setup-node.js/action.yml
@@ -1,0 +1,14 @@
+name: 'Setup Node.js'
+description: 'Setup Node.js version as required by jaeger-ui repo. Must be called after checkout with submodules.'
+runs:
+  using: "composite"
+  steps:
+    - name: Get Node.js version from jaeger-ui
+      shell: bash
+      run: |
+        echo "JAEGER_UI_NODE_JS_VERSION=$(cat jaeger-ui/.nvmrc)" >> ${GITHUB_ENV}
+
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+      with:
+        node-version: ${{ JAEGER_UI_NODE_JS_VERSION }}
+        cache: 'npm'

--- a/.github/actions/setup-node.js/action.yml
+++ b/.github/actions/setup-node.js/action.yml
@@ -10,5 +10,5 @@ runs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
       with:
-        node-version: ${{ JAEGER_UI_NODE_JS_VERSION }}
+        node-version: ${{ env.JAEGER_UI_NODE_JS_VERSION }}
         cache: 'npm'

--- a/.github/actions/setup-node.js/action.yml
+++ b/.github/actions/setup-node.js/action.yml
@@ -11,4 +11,5 @@ runs:
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
       with:
         node-version: ${{ env.JAEGER_UI_NODE_JS_VERSION }}
-        cache: 'npm'
+        cache: 'yarn'
+        cache-dependency-path: jaeger-ui/yarn.lock

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -33,7 +33,7 @@ jobs:
         go-version: 1.19.x
 
     - name: Setup Node.js version
-      uses: ./.github/actions/setup-nodejs
+      uses: ./.github/actions/setup-node.js
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -32,9 +32,8 @@ jobs:
       with:
         go-version: 1.19.x
 
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-      with:
-        node-version: '16'
+    - name: Setup Node.js version
+      uses: ./.github/actions/setup-nodejs
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -51,7 +51,7 @@ jobs:
         go-version: 1.19.x
 
     - name: Setup Node.js version
-      uses: ./.github/actions/setup-nodejs
+      uses: ./.github/actions/setup-node.js
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -50,6 +50,9 @@ jobs:
       with:
         go-version: 1.19.x
 
+    - name: Setup Node.js version
+      uses: ./.github/actions/setup-nodejs
+
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch
 

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -33,9 +33,8 @@ jobs:
       with:
         go-version: 1.19.x
 
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-      with:
-        node-version: '16'
+    - name: Setup Node.js version
+      uses: ./.github/actions/setup-nodejs
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -34,7 +34,7 @@ jobs:
         go-version: 1.19.x
 
     - name: Setup Node.js version
-      uses: ./.github/actions/setup-nodejs
+      uses: ./.github/actions/setup-node.js
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch


### PR DESCRIPTION
Builds started failing, probably because GH moved containers to Node 18 and Jaeger-UI is not ready for it.

https://github.com/jaegertracing/jaeger/actions/runs/4217171446/jobs/7320758782

This change adds a new internal action that reads the Node version from jaeger-ui/.npmrc instead of hardcoding or not specifying it at all (as was the case in build-binaries workflow).