### PR TITLE
[chore]: Use http.MethodGet instead of "GET"

### DIFF
--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -68,7 +68,7 @@ func TestAllInOne(t *testing.T) {
 }
 
 func createTrace(t *testing.T) {
-	req, err := http.NewRequest("GET", getServicesURL, nil)
+	req, err := http.NewRequest(http.MethodGet, getServicesURL, nil)
 	require.NoError(t, err)
 	req.Header.Add("jaeger-debug-id", "debug")
 
@@ -82,7 +82,7 @@ type response struct {
 }
 
 func getAPITrace(t *testing.T) {
-	req, err := http.NewRequest("GET", getTraceURL, nil)
+	req, err := http.NewRequest(http.MethodGet, getTraceURL, nil)
 	require.NoError(t, err)
 
 	var queryResponse response
@@ -107,7 +107,7 @@ func getAPITrace(t *testing.T) {
 }
 
 func getSamplingStrategy(t *testing.T) {
-	req, err := http.NewRequest("GET", getSamplingStrategyURL, nil)
+	req, err := http.NewRequest(http.MethodGet, getSamplingStrategyURL, nil)
 	require.NoError(t, err)
 
 	resp, err := httpClient.Do(req)
@@ -147,7 +147,7 @@ func faviconCheck(t *testing.T) {
 }
 
 func getServicesAPIV3(t *testing.T) {
-	req, err := http.NewRequest("GET", getServicesAPIV3URL, nil)
+	req, err := http.NewRequest(http.MethodGet, getServicesAPIV3URL, nil)
 	require.NoError(t, err)
 	resp, err := httpClient.Do(req)
 	require.NoError(t, err)

--- a/cmd/query/app/additional_headers_test.go
+++ b/cmd/query/app/additional_headers_test.go
@@ -37,7 +37,7 @@ func TestAdditionalHeadersHandler(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	req, err := http.NewRequest("GET", server.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 	assert.NoError(t, err)
 
 	resp, err := server.Client().Do(req)

--- a/cmd/query/app/apiv3/grpc_gateway_test.go
+++ b/cmd/query/app/apiv3/grpc_gateway_test.go
@@ -125,7 +125,7 @@ func testGRPCGatewayWithTenancy(t *testing.T, basePath string, serverTLS tlscfg.
 			},
 		}, nil).Once()
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost%s%s/api/v3/traces/123", strings.Replace(httpLis.Addr().String(), "[::]", "", 1), basePath), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost%s%s/api/v3/traces/123", strings.Replace(httpLis.Addr().String(), "[::]", "", 1), basePath), nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	setupRequest(req)
@@ -208,7 +208,7 @@ func TestTenancyGRPCRejection(t *testing.T) {
 			},
 		}, nil).Once()
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost%s%s/api/v3/traces/123", strings.Replace(httpLis.Addr().String(), "[::]", "", 1), basePath), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost%s%s/api/v3/traces/123", strings.Replace(httpLis.Addr().String(), "[::]", "", 1), basePath), nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	// We don't set tenant header

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -820,7 +820,7 @@ func getJSON(url string, out interface{}) error {
 }
 
 func getJSONCustomHeaders(url string, additionalHeaders map[string]string, out interface{}) error {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
@@ -834,7 +834,7 @@ func postJSON(url string, req interface{}, out interface{}) error {
 	if err := encoder.Encode(req); err != nil {
 		return err
 	}
-	r, err := http.NewRequest("POST", url, buf)
+	r, err := http.NewRequest(http.MethodPost, url, buf)
 	if err != nil {
 		return err
 	}
@@ -919,7 +919,7 @@ func TestSearchTenancyRejectionHTTP(t *testing.T) {
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Twice()
 
-	req, err := http.NewRequest("GET", ts.server.URL+`/api/traces?traceID=1&traceID=2`, nil)
+	req, err := http.NewRequest(http.MethodGet, ts.server.URL+`/api/traces?traceID=1&traceID=2`, nil)
 	assert.NoError(t, err)
 	req.Header.Add("Accept", "application/json")
 	// We don't set tenant header

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -405,7 +405,7 @@ func TestServerHTTPTLS(t *testing.T) {
 				readMock := spanReader
 				readMock.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).Return([]*model.Trace{mockTrace}, nil).Once()
 				queryString := "/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms"
-				req, err := http.NewRequest("GET", "https://localhost:"+fmt.Sprintf("%d", ports.QueryHTTP)+queryString, nil)
+				req, err := http.NewRequest(http.MethodGet, "https://localhost:"+fmt.Sprintf("%d", ports.QueryHTTP)+queryString, nil)
 				assert.Nil(t, err)
 				req.Header.Add("Accept", "application/json")
 
@@ -769,7 +769,7 @@ func TestServerHTTPTenancy(t *testing.T) {
 			require.NoError(t, clientError)
 
 			queryString := "/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms"
-			req, err := http.NewRequest("GET", "http://localhost:8080"+queryString, nil)
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080"+queryString, nil)
 			if test.tenant != "" {
 				req.Header.Add(tenancyMgr.Header, test.tenant)
 			}

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -123,7 +123,7 @@ func TestBearerTokenPropagation(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", url, nil)
+			req, err := http.NewRequest(http.MethodGet, url, nil)
 			require.NoError(t, err)
 			req.Header.Add(testCase.headerName, testCase.headerValue)
 

--- a/examples/hotrod/pkg/tracing/http.go
+++ b/examples/hotrod/pkg/tracing/http.go
@@ -35,7 +35,7 @@ type HTTPClient struct {
 // GetJSON executes HTTP GET against specified url and tried to parse
 // the response into out object.
 func (c *HTTPClient) GetJSON(ctx context.Context, endpoint string, url string, out interface{}) error {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/bearertoken/http_test.go
+++ b/pkg/bearertoken/http_test.go
@@ -74,7 +74,7 @@ func Test_PropagationHandler(t *testing.T) {
 			r := PropagationHandler(logger, testCase.handler(&stop))
 			server := httptest.NewServer(r)
 			defer server.Close()
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			assert.Nil(t, err)
 			if testCase.sendHeader {
 				req.Header.Add(testCase.headerName, testCase.headerValue)

--- a/pkg/recoveryhandler/zap_test.go
+++ b/pkg/recoveryhandler/zap_test.go
@@ -33,7 +33,7 @@ func TestNewRecoveryHandler(t *testing.T) {
 	})
 
 	recovery := NewRecoveryHandler(logger, false)(handlerFunc)
-	req, err := http.NewRequest("GET", "/subdir/asdf", nil)
+	req, err := http.NewRequest(http.MethodGet, "/subdir/asdf", nil)
 	assert.NoError(t, err)
 
 	res := httptest.NewRecorder()

--- a/pkg/tenancy/http_test.go
+++ b/pkg/tenancy/http_test.go
@@ -70,7 +70,7 @@ func TestProgationHandler(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			handler := &testHttpHandler{}
 			propH := ExtractTenantHTTPHandler(test.tenancyMgr, handler)
-			req, err := http.NewRequest("GET", "/", strings.NewReader(""))
+			req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader(""))
 			for k, vs := range test.requestHeaders {
 				for _, v := range vs {
 					req.Header.Add(k, v)
@@ -104,7 +104,7 @@ func TestMetadataAnnotator(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/", strings.NewReader(""))
+			req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader(""))
 			for k, vs := range test.requestHeaders {
 				for _, v := range vs {
 					req.Header.Add(k, v)


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- <!-- e.g. Resolves #123 -->

## Short description of the changes
-  Use http constants to replace numbers
