### PR TITLE
Align ES index-prefix parameter for jobs

### DIFF
--- a/cmd/es-index-cleaner/main.go
+++ b/cmd/es-index-cleaner/main.go
@@ -51,7 +51,7 @@ func main() {
 				return fmt.Errorf("could not parse NUM_OF_DAYS argument: %w", err)
 			}
 
-			cfg.InitFromViper(v)
+			cfg.InitFromViper(v, logger)
 			tlsOpts, err := tlsFlags.InitFromViper(v)
 			if err != nil {
 				return err

--- a/cmd/es-rollover/app/actions.go
+++ b/cmd/es-rollover/app/actions.go
@@ -60,7 +60,7 @@ type ActionCreatorFunction func(client.Client, Config) Action
 // ExecuteAction execute the action returned by the createAction function
 func ExecuteAction(opts ActionExecuteOptions, createAction ActionCreatorFunction) error {
 	cfg := Config{}
-	cfg.InitFromViper(opts.Viper)
+	cfg.InitFromViper(opts.Viper, opts.Logger)
 	tlsOpts, err := opts.TLSFlags.InitFromViper(opts.Viper)
 	if err != nil {
 		return err

--- a/cmd/esmapping-generator/app/flags.go
+++ b/cmd/esmapping-generator/app/flags.go
@@ -16,6 +16,7 @@ package app
 
 import (
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 // Options represent configurable parameters for jaeger-esmapping-generator
@@ -30,17 +31,19 @@ type Options struct {
 }
 
 const (
-	mappingFlag       = "mapping"
-	esVersionFlag     = "es-version"
-	shardsFlag        = "shards"
-	replicasFlag      = "replicas"
-	indexPrefixFlag   = "index-prefix"
-	useILMFlag        = "use-ilm"
-	ilmPolicyNameFlag = "ilm-policy-name"
+	mappingFlag                  = "mapping"
+	esVersionFlag                = "es-version"
+	shardsFlag                   = "shards"
+	replicasFlag                 = "replicas"
+	indexPrefixFlag              = "es.index-prefix"
+	useILMFlag                   = "use-ilm"
+	ilmPolicyNameFlag            = "ilm-policy-name"
+	deprecatedIndexPrefix        = "index-prefix"
+	deprecatedIndexPrefixWarning = "(deprecated, will be removed after 2023-06-05 or in release v1.44.0, whichever is later)"
 )
 
 // AddFlags adds flags for esmapping-generator main program
-func (o *Options) AddFlags(command *cobra.Command) {
+func (o *Options) AddFlags(command *cobra.Command, logger *zap.Logger) {
 	command.Flags().StringVar(
 		&o.Mapping,
 		mappingFlag,
@@ -61,6 +64,15 @@ func (o *Options) AddFlags(command *cobra.Command) {
 		replicasFlag,
 		1,
 		"The number of replicas per index in Elasticsearch")
+	command.Flags().StringVar(
+		&o.IndexPrefix,
+		deprecatedIndexPrefix,
+		"",
+		deprecatedIndexPrefixWarning+" see --"+indexPrefixFlag)
+
+	if o.IndexPrefix != "" {
+		logger.Warn(deprecatedIndexPrefix + " " + deprecatedIndexPrefixWarning + " see --" + indexPrefixFlag)
+	}
 	command.Flags().StringVar(
 		&o.IndexPrefix,
 		indexPrefixFlag,

--- a/cmd/esmapping-generator/app/flags_test.go
+++ b/cmd/esmapping-generator/app/flags_test.go
@@ -17,6 +17,7 @@ package app
 import (
 	"testing"
 
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,8 @@ import (
 func TestOptionsWithDefaultFlags(t *testing.T) {
 	o := Options{}
 	c := cobra.Command{}
-	o.AddFlags(&c)
+	logger, _ := testutils.NewLogger()
+	o.AddFlags(&c, logger)
 
 	assert.Equal(t, "", o.Mapping)
 	assert.Equal(t, uint(7), o.EsVersion)
@@ -39,8 +41,34 @@ func TestOptionsWithDefaultFlags(t *testing.T) {
 func TestOptionsWithFlags(t *testing.T) {
 	o := Options{}
 	c := cobra.Command{}
+	logger, _ := testutils.NewLogger()
 
-	o.AddFlags(&c)
+	o.AddFlags(&c, logger)
+	err := c.ParseFlags([]string{
+		"--mapping=jaeger-span",
+		"--es-version=6",
+		"--shards=5",
+		"--replicas=1",
+		"--es.index-prefix=test",
+		"--use-ilm=true",
+		"--ilm-policy-name=jaeger-test-policy",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "jaeger-span", o.Mapping)
+	assert.Equal(t, uint(6), o.EsVersion)
+	assert.Equal(t, int64(5), o.Shards)
+	assert.Equal(t, int64(1), o.Replicas)
+	assert.Equal(t, "test", o.IndexPrefix)
+	assert.Equal(t, "true", o.UseILM)
+	assert.Equal(t, "jaeger-test-policy", o.ILMPolicyName)
+}
+
+func TestOptionsWithFlagsAndDeprecatedIndex(t *testing.T) {
+	o := Options{}
+	c := cobra.Command{}
+	logger, _ := testutils.NewLogger()
+
+	o.AddFlags(&c, logger)
 	err := c.ParseFlags([]string{
 		"--mapping=jaeger-span",
 		"--es-version=6",

--- a/cmd/esmapping-generator/main.go
+++ b/cmd/esmapping-generator/main.go
@@ -47,7 +47,7 @@ func main() {
 		},
 	}
 
-	options.AddFlags(command)
+	options.AddFlags(command, logger)
 
 	command.AddCommand(version.Command())
 


### PR DESCRIPTION
## Which problem is this PR solving?
Proposal to fix https://github.com/jaegertracing/jaeger/issues/4268
As it's a non-backward compatible change, let me know how you want to handle this.
I'm open to changes.

## Short description of the changes
- Align ES index-prefix flag for jobs to what's defined for other jaeger components. This allows to have a single configuration for all items.
