### PR TITLE
Refactor: build linux artifacts only for PR

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -44,7 +44,12 @@ jobs:
 
     - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
 
+    - name: Build only linux/amd64 docker image for Pull Request
+      if: github.ref_name != 'main'
+      run: bash scripts/build-upload-docker-images.sh pr-only
+
     - name: Build and upload all docker images
+      if: github.ref_name == 'main'
       run: bash scripts/build-upload-docker-images.sh
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -2,16 +2,22 @@
 
 set -euxf -o pipefail
 
+mode=${1-main}
+
 make create-baseimg-debugimg
 
-# build multi-arch binaries
 make build-binaries-linux
-make build-binaries-s390x
-make build-binaries-ppc64le
-make build-binaries-arm64
 
-# build multi-arch docker images
-platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+if [ "$mode" = "pr-only" ]; then
+  # build artifacts for linux/amd64 only for pull requests
+  platforms="linux/amd64"
+else
+  platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+  # build multi-arch binaries
+  make build-binaries-s390x
+  make build-binaries-ppc64le
+  make build-binaries-arm64
+fi
 
 # build/upload raw and debug images of Jaeger backend components
 for component in agent collector query ingester remote-storage


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/4172

## Short description of the changes
- scripts/build-upload-docker-images.sh: Set platforms variable dynamically based on ~~env `PLATFORMS`~~ the first argument
- .github/workflows/ci-docker-build.yml: Add a new job for PR only and pass `pr-only` as the first argument
