### PR TITLE
Document evolution of Cassandra schema files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,7 +426,8 @@ next release
 -------------------
 ### Backend Changes
 #### New Features
-* Add cassandra v4 support ([@Ashmita152](https://github.com/Ashmita152) in [#3225](https://github.com/jaegertracing/jaeger/pull/3225))
+* Add cassandra v4 support ([@Ashmita152](https://github.com/Ashmita152) in [#3225](https://github.com/jaegertracing/jaeger/pull/3225)).
+  * **Note**: Users running on existing schema version [v3](https://github.com/jaegertracing/jaeger/blob/1d563f964da4b472a6f7e4cfdb85fe1167c30129/plugin/storage/cassandra/schema/v003.cql.tmpl) without issues, need not run an upgrade to [v4](https://github.com/jaegertracing/jaeger/blob/1d563f964da4b472a6f7e4cfdb85fe1167c30129/plugin/storage/cassandra/schema/v004.cql.tmpl). The new schema simply updates the table metadata, primarily removing `dclocal_read_repair_chance` deprecated table option, [which automatically gets ignored/removed when upgrading to Cassandra 4.0](https://issues.apache.org/jira/browse/CASSANDRA-13910).
 * Add es-index-cleaner golang implementation ([@pavolloffay](https://github.com/pavolloffay) in [#3204](https://github.com/jaegertracing/jaeger/pull/3204))
 * Add CLI Option for gRPC Max Receive Message Size ([@js8080](https://github.com/js8080) in [#3214](https://github.com/jaegertracing/jaeger/pull/3214) and [#3192](https://github.com/jaegertracing/jaeger/pull/3192))
 * Automatically detect OpenSearch version ([@pavolloffay](https://github.com/pavolloffay) in [#3198](https://github.com/jaegertracing/jaeger/pull/3198))

--- a/plugin/storage/cassandra/schema/README.md
+++ b/plugin/storage/cassandra/schema/README.md
@@ -1,0 +1,10 @@
+# Cassandra Schema Management
+
+The table below lists Jaeger releases in which new cassandra schema were introduced.
+
+| Jaeger Version                                                         | Cassandra Schema File | Notes                                                                                                                                 |
+|------------------------------------------------------------------------|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| [0.5.0](https://github.com/jaegertracing/jaeger/releases/tag/v0.5.0)   | `v001.cql.tmpl`       |                                                                                                                                       |
+| [1.10.0](https://github.com/jaegertracing/jaeger/releases/tag/v1.10.0) | `v002.cql.tmpl`       | See [CHANGELOG.md](https://github.com/jaegertracing/jaeger/blob/main/CHANGELOG.md#1100-2019-02-15) for more details on the migration. |
+| [1.16.0](https://github.com/jaegertracing/jaeger/releases/tag/v1.16.0) | `v003.cql.tmpl`       | See [CHANGELOG.md](https://github.com/jaegertracing/jaeger/blob/main/CHANGELOG.md#1160-2019-12-17) for more details on the migration. |
+| [1.26.0](https://github.com/jaegertracing/jaeger/releases/tag/v1.26.0) | `v004.cql.tmpl`       | See [CHANGELOG.md](https://github.com/jaegertracing/jaeger/blob/main/CHANGELOG.md#1260-2021-09-06) for more details on the migration. |


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4284 

## Short description of the changes
- Map versions of Cassandra schema files to Jaeger releases.
- Update `CHANGELOG.md` for Jaeger v1.26.0 to include a note on migration.
