### PR TITLE
Store span warnings as tags in Cassandra

### DIFF
--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -128,14 +128,14 @@ func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 func (c converter) fromDBTags(tags []KeyValue) ([]model.KeyValue, error) {
 	retMe := make([]model.KeyValue, 0, len(tags))
 	for i := range tags {
+		if strings.HasPrefix(tags[i].Key, warningStringPrefix) {
+			continue
+		}
 		kv, err := c.fromDBTag(&tags[i])
 		if err != nil {
 			return nil, err
 		}
-		// Ignore the warnings that were saved as tags.
-		if !strings.HasPrefix(kv.Key, warningStringPrefix) {
-			retMe = append(retMe, kv)
-		}
+		retMe = append(retMe, kv)
 	}
 	return retMe, nil
 }
@@ -143,13 +143,14 @@ func (c converter) fromDBTags(tags []KeyValue) ([]model.KeyValue, error) {
 func (c converter) fromDBWarnings(tags []KeyValue) ([]string, error) {
 	var retMe []string
 	for _, tag := range tags {
+		if !strings.HasPrefix(tag.Key, warningStringPrefix) {
+			continue
+		}
 		kv, err := c.fromDBTag(&tag)
 		if err != nil {
 			return nil, err
 		}
-		if strings.HasPrefix(kv.Key, warningStringPrefix) && kv.VType == model.StringType {
-			retMe = append(retMe, kv.VStr)
-		}
+		retMe = append(retMe, kv.VStr)
 	}
 	return retMe, nil
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -126,9 +126,9 @@ func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 }
 
 func (c converter) fromDBTags(tags []KeyValue) ([]model.KeyValue, error) {
-	var retMe []model.KeyValue
-	for _, tag := range tags {
-		kv, err := c.fromDBTag(&tag)
+	retMe := make([]model.KeyValue, 0, len(tags))
+	for i := range tags {
+		kv, err := c.fromDBTag(&tags[i])
 		if err != nil {
 			return nil, err
 		}

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -234,13 +234,9 @@ func (c converter) toDBWarnings(warnings []string) []KeyValue {
 	for i, w := range warnings {
 		kv := model.String(fmt.Sprintf("%s%d", warningStringPrefix, i+1), w)
 		retMe[i] = KeyValue{
-			Key:          kv.Key,
-			ValueType:    domainToDBValueTypeMap[kv.VType],
-			ValueString:  kv.VStr,
-			ValueBool:    kv.Bool(),
-			ValueInt64:   kv.Int64(),
-			ValueFloat64: kv.Float64(),
-			ValueBinary:  kv.Binary(),
+			Key:         kv.Key,
+			ValueType:   domainToDBValueTypeMap[kv.VType],
+			ValueString: kv.VStr,
 		}
 	}
 	return retMe

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter.go
@@ -17,8 +17,14 @@ package dbmodel
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jaegertracing/jaeger/model"
+)
+
+const (
+	// warningStringPrefix is a magic string prefix for tag names to store span warnings.
+	warningStringPrefix = "$$span.warning."
 )
 
 var (
@@ -57,10 +63,13 @@ type converter struct{}
 
 func (c converter) fromDomain(span *model.Span) *Span {
 	tags := c.toDBTags(span.Tags)
+	warnings := c.toDBWarnings(span.Warnings)
 	logs := c.toDBLogs(span.Logs)
 	refs := c.toDBRefs(span.References)
 	udtProcess := c.toDBProcess(span.Process)
 	spanHash, _ := model.HashCode(span)
+
+	tags = append(tags, warnings...)
 
 	return &Span{
 		TraceID:       TraceIDFromDomain(span.TraceID),
@@ -80,6 +89,10 @@ func (c converter) fromDomain(span *model.Span) *Span {
 
 func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 	tags, err := c.fromDBTags(dbSpan.Tags)
+	if err != nil {
+		return nil, err
+	}
+	warnings, err := c.fromDBWarnings(dbSpan.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -105,6 +118,7 @@ func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 		StartTime:     model.EpochMicrosecondsAsTime(uint64(dbSpan.StartTime)),
 		Duration:      model.MicrosecondsAsDuration(uint64(dbSpan.Duration)),
 		Tags:          tags,
+		Warnings:      warnings,
 		Logs:          logs,
 		Process:       process,
 	}
@@ -112,13 +126,30 @@ func (c converter) toDomain(dbSpan *Span) (*model.Span, error) {
 }
 
 func (c converter) fromDBTags(tags []KeyValue) ([]model.KeyValue, error) {
-	retMe := make([]model.KeyValue, len(tags))
-	for i := range tags {
-		kv, err := c.fromDBTag(&tags[i])
+	var retMe []model.KeyValue
+	for _, tag := range tags {
+		kv, err := c.fromDBTag(&tag)
 		if err != nil {
 			return nil, err
 		}
-		retMe[i] = kv
+		// Ignore the warnings that were saved as tags.
+		if !strings.HasPrefix(kv.Key, warningStringPrefix) {
+			retMe = append(retMe, kv)
+		}
+	}
+	return retMe, nil
+}
+
+func (c converter) fromDBWarnings(tags []KeyValue) ([]string, error) {
+	var retMe []string
+	for _, tag := range tags {
+		kv, err := c.fromDBTag(&tag)
+		if err != nil {
+			return nil, err
+		}
+		if strings.HasPrefix(kv.Key, warningStringPrefix) && kv.VType == model.StringType {
+			retMe = append(retMe, kv.VStr)
+		}
 	}
 	return retMe, nil
 }
@@ -193,6 +224,23 @@ func (c converter) toDBTags(tags []model.KeyValue) []KeyValue {
 			ValueInt64:   t.Int64(),
 			ValueFloat64: t.Float64(),
 			ValueBinary:  t.Binary(),
+		}
+	}
+	return retMe
+}
+
+func (c converter) toDBWarnings(warnings []string) []KeyValue {
+	retMe := make([]KeyValue, len(warnings))
+	for i, w := range warnings {
+		kv := model.String(fmt.Sprintf("%s%d", warningStringPrefix, i+1), w)
+		retMe[i] = KeyValue{
+			Key:          kv.Key,
+			ValueType:    domainToDBValueTypeMap[kv.VType],
+			ValueString:  kv.VStr,
+			ValueBool:    kv.Bool(),
+			ValueInt64:   kv.Int64(),
+			ValueFloat64: kv.Float64(),
+			ValueBinary:  kv.Binary(),
 		}
 	}
 	return retMe

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -340,10 +340,7 @@ func TestFromDBWarnings(t *testing.T) {
 }
 
 func TestFailingFromDBWarnings(t *testing.T) {
-	span := getCustomSpan(badDBTags, someDBProcess, someDBLogs, someDBRefs)
-	warnings, err := converter{}.fromDBWarnings(span.Tags)
-
-	assert.Nil(t, warnings)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), notValidTagTypeErrStr)
+	badDBWarningTags := []KeyValue{{Key: warningStringPrefix + "1", ValueType: "invalidValueType"}}
+	span := getCustomSpan(badDBWarningTags, someDBProcess, someDBLogs, someDBRefs)
+	failingDBSpanTransform(t, span, notValidTagTypeErrStr)
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -338,3 +338,12 @@ func TestFromDBWarnings(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, warnings, span.Warnings)
 }
+
+func TestFailingFromDBWarnings(t *testing.T) {
+	span := getCustomSpan(badDBTags, someDBProcess, someDBLogs, someDBRefs)
+	warnings, err := converter{}.fromDBWarnings(span.Tags)
+
+	assert.Nil(t, warnings)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), notValidTagTypeErrStr)
+}

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -53,7 +53,8 @@ var (
 		model.Float64(someDoubleTagKey, someDoubleTagValue),
 		model.Binary(someBinaryTagKey, someBinaryTagValue),
 	}
-	someDBTags = []KeyValue{
+	someWarnings = []string{"warning text 1", "warning text 2"}
+	someDBTags   = []KeyValue{
 		{
 			Key:         someStringTagKey,
 			ValueType:   stringType,
@@ -287,4 +288,53 @@ func TestGenerateHashCode(t *testing.T) {
 	hc2, err2 = model.HashCode(span2)
 	assert.NotEqual(t, hc1, hc2)
 	assert.NoError(t, err2)
+}
+
+func TestFromDBTagsWithoutWarnings(t *testing.T) {
+	span := getTestJaegerSpan()
+	dbSpan := FromDomain(span)
+
+	tags, err := converter{}.fromDBTags(dbSpan.Tags)
+	assert.NoError(t, err)
+	assert.Equal(t, tags, span.Tags)
+}
+
+func TestFromDBTagsWithWarnings(t *testing.T) {
+	span := getTestJaegerSpan()
+	span.Warnings = someWarnings
+	dbSpan := FromDomain(span)
+
+	tags, err := converter{}.fromDBTags(dbSpan.Tags)
+	assert.NoError(t, err)
+	assert.Equal(t, tags, span.Tags)
+}
+
+func TestFromDBLogsWithWarnings(t *testing.T) {
+	span := getTestJaegerSpan()
+	span.Warnings = someWarnings
+	dbSpan := FromDomain(span)
+
+	logs, err := converter{}.fromDBLogs(dbSpan.Logs)
+	assert.NoError(t, err)
+	assert.Equal(t, logs, span.Logs)
+}
+
+func TestFromDBProcessWithWarnings(t *testing.T) {
+	span := getTestJaegerSpan()
+	span.Warnings = someWarnings
+	dbSpan := FromDomain(span)
+
+	process, err := converter{}.fromDBProcess(dbSpan.Process)
+	assert.NoError(t, err)
+	assert.Equal(t, process, span.Process)
+}
+
+func TestFromDBWarnings(t *testing.T) {
+	span := getTestJaegerSpan()
+	span.Warnings = someWarnings
+	dbSpan := FromDomain(span)
+
+	warnings, err := converter{}.fromDBWarnings(dbSpan.Tags)
+	assert.NoError(t, err)
+	assert.Equal(t, warnings, span.Warnings)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #705
- Resolves #704 

## Short description of the changes
- Instead of creating a separate column in the table, [we encode warnings as tags, with a magic string prefix](https://github.com/jaegertracing/jaeger/pull/4217#discussion_r1097637013) so that they can be parsed and converted back to warnings during reads.