### PR TITLE
[Bug]: "jaeger_collector_spans_serviceNames" metrics names should be written in snake_case not camelCase #4128

### DIFF
--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -133,7 +133,7 @@ func NewSpanProcessorMetrics(serviceMetrics metrics.Factory, hostMetrics metrics
 		SavedOkBySvc:   newMetricsBySvc(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"result": "ok"}}), "saved-by-svc"),
 		SavedErrBySvc:  newMetricsBySvc(serviceMetrics.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"result": "err"}}), "saved-by-svc"),
 		spanCounts:     spanCounts,
-		serviceNames:   hostMetrics.Gauge(metrics.Options{Name: "spans.serviceNames", Tags: nil}),
+		serviceNames:   hostMetrics.Gauge(metrics.Options{Name: "spans.service-names", Tags: nil}),
 	}
 
 	return m


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4128