### PR TITLE
Add back support for Go 1.19 when using Jaeger as a library

### DIFF
--- a/.github/workflows/ci-unit-tests-1.19.yml
+++ b/.github/workflows/ci-unit-tests-1.19.yml
@@ -1,0 +1,48 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [main]
+
+  pull_request:
+    branches: [main]
+
+# See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+env:
+  # Using upload token helps against rate limiting errors.
+  # Cannot define it as secret as we need it accessible from forks.
+  # See https://github.com/codecov/codecov-action/issues/837
+  CODECOV_TOKEN: f457b710-93af-4191-8678-bcf51281f98c
+
+jobs:
+  unit-tests-1.19:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
+      with:
+        go-version: 1.19.x
+
+    - name: Install tools
+      run: make install-ci
+
+    - name: Run unit tests
+      run: make test-ci
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+      with:
+        file: cover.out
+        verbose: true
+        flags: unittests
+        fail_ci_if_error: true
+        token: ${{ env.CODECOV_TOKEN }}

--- a/cmd/agent/app/reporter/grpc/collector_proxy.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy.go
@@ -15,7 +15,6 @@
 package grpc
 
 import (
-	"errors"
 	"io"
 
 	"go.uber.org/zap"
@@ -25,6 +24,7 @@ import (
 	grpcManager "github.com/jaegertracing/jaeger/cmd/agent/app/configmanager/grpc"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/pkg/multicloser"
 )
 
 // ProxyBuilder holds objects communicating with collector
@@ -74,9 +74,5 @@ func (b ProxyBuilder) GetManager() configmanager.ClientConfigManager {
 
 // Close closes connections used by proxy.
 func (b ProxyBuilder) Close() error {
-	return errors.Join(
-		b.reporter.Close(),
-		b.tlsCloser.Close(),
-		b.GetConn().Close(),
-	)
+	return multicloser.Wrap(b.reporter, b.tlsCloser, b.GetConn()).Close()
 }

--- a/cmd/agent/app/reporter/reporter.go
+++ b/cmd/agent/app/reporter/reporter.go
@@ -17,8 +17,8 @@ package reporter
 
 import (
 	"context"
-	"errors"
 
+	"github.com/jaegertracing/jaeger/pkg/multierror"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
@@ -43,22 +43,22 @@ func NewMultiReporter(reps ...Reporter) MultiReporter {
 
 // EmitZipkinBatch calls each EmitZipkinBatch, returning the first error.
 func (mr MultiReporter) EmitZipkinBatch(ctx context.Context, spans []*zipkincore.Span) error {
-	var errs []error
+	var errors []error
 	for _, rep := range mr {
 		if err := rep.EmitZipkinBatch(ctx, spans); err != nil {
-			errs = append(errs, err)
+			errors = append(errors, err)
 		}
 	}
-	return errors.Join(errs...)
+	return multierror.Wrap(errors)
 }
 
 // EmitBatch calls each EmitBatch, returning the first error.
 func (mr MultiReporter) EmitBatch(ctx context.Context, batch *jaeger.Batch) error {
-	var errs []error
+	var errors []error
 	for _, rep := range mr {
 		if err := rep.EmitBatch(ctx, batch); err != nil {
-			errs = append(errs, err)
+			errors = append(errors, err)
 		}
 	}
-	return errors.Join(errs...)
+	return multierror.Wrap(errors)
 }

--- a/cmd/agent/app/reporter/reporter_test.go
+++ b/cmd/agent/app/reporter/reporter_test.go
@@ -60,8 +60,8 @@ func TestMultiReporterErrors(t *testing.T) {
 			{},
 		},
 	})
-	assert.EqualError(t, e1, fmt.Sprintf("%s\n%s", errMsg, errMsg))
-	assert.EqualError(t, e2, fmt.Sprintf("%s\n%s", errMsg, errMsg))
+	assert.EqualError(t, e1, fmt.Sprintf("[%s, %s]", errMsg, errMsg))
+	assert.EqualError(t, e2, fmt.Sprintf("[%s, %s]", errMsg, errMsg))
 }
 
 type mockReporter struct {

--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -123,6 +123,6 @@ func TestArchiveTrace_WriteErrors(t *testing.T) {
 			Return(mockTrace, nil).Once()
 		var response structuredResponse
 		err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String(), []string{}, &response)
-		assert.EqualError(t, err, `500 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"cannot save\ncannot save"}]}`+"\n")
+		assert.EqualError(t, err, `500 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"[cannot save, cannot save]"}]}`+"\n")
 	}, querysvc.QueryServiceOptions{ArchiveSpanWriter: mockWriter})
 }

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/adjuster"
+	"github.com/jaegertracing/jaeger/pkg/multierror"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -109,7 +110,7 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, traceID model.TraceID) 
 			writeErrors = append(writeErrors, err)
 		}
 	}
-	return errors.Join(writeErrors...)
+	return multierror.Wrap(writeErrors)
 }
 
 // Adjust applies adjusters to the trace.

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -239,9 +239,10 @@ func TestArchiveTraceWithArchiveWriterError(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	joinErr := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), mockTraceID)
+	multiErr := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), mockTraceID)
+	assert.Len(t, multiErr, 2)
 	// There are two spans in the mockTrace, ArchiveTrace should return a wrapped error.
-	assert.EqualError(t, joinErr, "cannot save\ncannot save")
+	assert.EqualError(t, multiErr, "[cannot save, cannot save]")
 }
 
 // Test QueryService.ArchiveTrace() with correctly configured ArchiveSpanWriter.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaegertracing/jaeger
 
-go 1.20
+go 1.19
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2

--- a/model/adjuster/adjuster.go
+++ b/model/adjuster/adjuster.go
@@ -16,9 +16,8 @@
 package adjuster
 
 import (
-	"errors"
-
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/pkg/multierror"
 )
 
 // Adjuster applies certain modifications to a Trace object.
@@ -57,7 +56,7 @@ type sequence struct {
 }
 
 func (c sequence) Adjust(trace *model.Trace) (*model.Trace, error) {
-	var errs []error
+	var errors []error
 	for _, adjuster := range c.adjusters {
 		var err error
 		trace, err = adjuster.Adjust(trace)
@@ -65,8 +64,8 @@ func (c sequence) Adjust(trace *model.Trace) (*model.Trace, error) {
 			if c.failFast {
 				return trace, err
 			}
-			errs = append(errs, err)
+			errors = append(errors, err)
 		}
 	}
-	return trace, errors.Join(errs...)
+	return trace, multierror.Wrap(errors)
 }

--- a/model/adjuster/adjuster_test.go
+++ b/model/adjuster/adjuster_test.go
@@ -45,7 +45,7 @@ func TestSequences(t *testing.T) {
 	}{
 		{
 			adjuster:   adjuster.Sequence(adj, failingAdj, adj, failingAdj),
-			err:        fmt.Sprintf("%s\n%s", adjErr, adjErr),
+			err:        fmt.Sprintf("[%s, %s]", adjErr, adjErr),
 			lastSpanID: 2,
 		},
 		{

--- a/pkg/config/tlscfg/cert_watcher.go
+++ b/pkg/config/tlscfg/cert_watcher.go
@@ -17,7 +17,6 @@ package tlscfg
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -26,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/fswatcher"
+	"github.com/jaegertracing/jaeger/pkg/multierror"
 )
 
 const (
@@ -84,7 +84,7 @@ func (w *certWatcher) Close() error {
 	for _, w := range w.watchers {
 		errs = append(errs, w.Close())
 	}
-	return errors.Join(errs...)
+	return multierror.Wrap(errs)
 }
 
 func (w *certWatcher) certificate() *tls.Certificate {

--- a/pkg/multicloser/multicloser.go
+++ b/pkg/multicloser/multicloser.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicloser
+
+import (
+	"io"
+
+	"github.com/jaegertracing/jaeger/pkg/multierror"
+)
+
+// MultiCloser wraps multiple io.Closer interfaces
+type MultiCloser struct {
+	closers []io.Closer
+}
+
+var _ io.Closer = (*MultiCloser)(nil)
+
+// Close implements io.Closer
+func (m MultiCloser) Close() error {
+	var errs []error
+	for _, c := range m.closers {
+		if c == nil {
+			continue
+		}
+		err := c.Close()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return multierror.Wrap(errs)
+}
+
+// Wrap creates io.Closer that encapsulates multiple io.Closer interfaces
+func Wrap(closers ...io.Closer) *MultiCloser {
+	return &MultiCloser{
+		closers: closers,
+	}
+}

--- a/pkg/multicloser/multicloser_test.go
+++ b/pkg/multicloser/multicloser_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicloser
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloser(t *testing.T) {
+	expectedErr := "some error"
+	tests := []struct {
+		closer      io.Closer
+		expectedErr string
+	}{
+		{
+			closer: Wrap(testCloser{}, testCloser{}),
+		},
+		{
+			closer:      Wrap(testCloser{}, testCloser{fmt.Errorf(expectedErr)}),
+			expectedErr: expectedErr,
+		},
+		{
+			closer:      Wrap(testCloser{fmt.Errorf(expectedErr)}, testCloser{fmt.Errorf(expectedErr)}),
+			expectedErr: fmt.Sprintf("[%v, %v]", expectedErr, expectedErr),
+		},
+		{
+			closer: Wrap(nil),
+		},
+	}
+	for _, test := range tests {
+		err := test.closer.Close()
+		if test.expectedErr == "" {
+			assert.Nil(t, err)
+		} else {
+			assert.EqualError(t, err, test.expectedErr)
+		}
+	}
+}
+
+type testCloser struct {
+	err error
+}
+
+var _ io.Closer = (*testCloser)(nil)
+
+func (t testCloser) Close() error {
+	return t.err
+}

--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multierror
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Wrap takes a slice of errors and returns a single error that encapsulates
+// those underlying errors. If the slice is nil or empty it returns nil.
+// If the slice only contains a single element, that error is returned directly.
+// When more than one error is wrapped, the Error() string is a concatenation
+// of the Error() values of all underlying errors.
+func Wrap(errs []error) error {
+	return multiError(errs).flatten()
+}
+
+// multiError bundles several errors together into a single error.
+type multiError []error
+
+// flatten returns either: nil, the only error, or the multiError instance itself
+// if there are 0, 1, or more errors in the slice respectively.
+func (errors multiError) flatten() error {
+	switch len(errors) {
+	case 0:
+		return nil
+	case 1:
+		return errors[0]
+	default:
+		return errors
+	}
+}
+
+// Error returns a string like "[e1, e2, ...]" where each eN is the Error() of
+// each error in the slice.
+func (errors multiError) Error() string {
+	parts := make([]string, len(errors))
+	for i, err := range errors {
+		parts[i] = err.Error()
+	}
+	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
+}

--- a/pkg/multierror/multierror_test.go
+++ b/pkg/multierror/multierror_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multierror
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleWrap() {
+	someFunc := func() error {
+		return errors.New("doh")
+	}
+
+	var errs []error
+	for i := 0; i < 2; i++ {
+		if err := someFunc(); err != nil {
+			errs = append(errs, err)
+		}
+		fmt.Println(Wrap(errs).Error())
+	}
+	// Output: doh
+	// [doh, doh]
+}
+
+func TestWrapEmptySlice(t *testing.T) {
+	var errors []error
+	e1 := Wrap(errors)
+	assert.Nil(t, e1)
+	e2 := Wrap([]error{})
+	assert.Nil(t, e2)
+}
+
+func TestWrapSingleError(t *testing.T) {
+	err := errors.New("doh")
+	e1 := Wrap([]error{err})
+	assert.Error(t, e1)
+	assert.Equal(t, err, e1)
+	assert.Equal(t, "doh", e1.Error())
+}
+
+func TestWrapManyErrors(t *testing.T) {
+	err1 := errors.New("ay")
+	err2 := errors.New("caramba")
+	e1 := Wrap([]error{err1, err2})
+	assert.Error(t, e1)
+	assert.Equal(t, "[ay, caramba]", e1.Error())
+}

--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -16,7 +16,6 @@
 package storage
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -25,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/pkg/multierror"
 	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
@@ -327,7 +327,7 @@ func (f *Factory) Close() error {
 			}
 		}
 	}
-	return errors.Join(errs...)
+	return multierror.Wrap(errs)
 }
 
 func (f *Factory) publishOpts() {

--- a/storage/spanstore/composite.go
+++ b/storage/spanstore/composite.go
@@ -17,9 +17,9 @@ package spanstore
 
 import (
 	"context"
-	"errors"
 
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/pkg/multierror"
 )
 
 // CompositeWriter is a span Writer that tries to save spans into several underlying span Writers
@@ -36,11 +36,11 @@ func NewCompositeWriter(spanWriters ...Writer) *CompositeWriter {
 
 // WriteSpan calls WriteSpan on each span writer. It will sum up failures, it is not transactional
 func (c *CompositeWriter) WriteSpan(ctx context.Context, span *model.Span) error {
-	var errs []error
+	var errors []error
 	for _, writer := range c.spanWriters {
 		if err := writer.WriteSpan(ctx, span); err != nil {
-			errs = append(errs, err)
+			errors = append(errors, err)
 		}
 	}
-	return errors.Join(errs...)
+	return multierror.Wrap(errors)
 }

--- a/storage/spanstore/composite_test.go
+++ b/storage/spanstore/composite_test.go
@@ -48,10 +48,10 @@ func TestCompositeWriteSpanStoreSuccess(t *testing.T) {
 
 func TestCompositeWriteSpanStoreSecondFailure(t *testing.T) {
 	c := NewCompositeWriter(&errProneWriteSpanStore{}, &errProneWriteSpanStore{})
-	assert.EqualError(t, c.WriteSpan(context.Background(), nil), fmt.Sprintf("%s\n%s", errIWillAlwaysFail, errIWillAlwaysFail))
+	assert.EqualError(t, c.WriteSpan(context.Background(), nil), fmt.Sprintf("[%s, %s]", errIWillAlwaysFail, errIWillAlwaysFail))
 }
 
 func TestCompositeWriteSpanStoreFirstFailure(t *testing.T) {
 	c := NewCompositeWriter(&errProneWriteSpanStore{}, &noopWriteSpanStore{})
-	assert.EqualError(t, c.WriteSpan(context.Background(), nil), errIWillAlwaysFail.Error())
+	assert.Equal(t, errIWillAlwaysFail, c.WriteSpan(context.Background(), nil))
 }


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- Relates to #4202

## Short description of the changes

This partially reverts #4206 and fully reverts #4291 and #4293.

On the OpenTelemetry Collector project we aim to provide support for all officially supported Go versions. Per [Go's support policy][1], Go 1.19 will remain a supported Go version until Go 1.21 is released.

Since we take a dependency on Jaeger as a library, we would prefer Jaeger to remain compatible with Go 1.19 as a library to be able to keep it updated.

This patch does not revert some changes on #4206; Jaeger binaries would continue to be built with Go 1.20 and benefit from all performance and security improvements that the 1.20 release cycle offers. It does impose the requirement that new code is compatible with Go 1.19 (which sounds okay to me since there was no specific need for Go 1.20 mentioned on the related issues, the only obvious downside is delaying the removal of some helper code).

[1]: https://go.dev/doc/devel/release#policy

Signed-off-by: Pablo Baeyens <pablo.baeyens@datadoghq.com>
 
