### PR TITLE
BUG: Remove TerminateAfter from Elasticsearch/Opensearch query resulting in incomplete span count/list

### DIFF
--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -204,8 +204,7 @@ func getSourceFn(archive bool, maxDocCount int) sourceFn {
 	return func(query elastic.Query, nextTime uint64) *elastic.SearchSource {
 		s := elastic.NewSearchSource().
 			Query(query).
-			Size(maxDocCount).
-			TerminateAfter(maxDocCount)
+			Size(maxDocCount)
 		if !archive {
 			s.Sort("startTime", true).
 				SearchAfter(nextTime)

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -1296,3 +1296,29 @@ func TestBuildTraceByIDQuery(t *testing.T) {
 		assert.Equal(t, test.query, q)
 	}
 }
+
+func TestTerminateAfterNotSet(t *testing.T) {
+	srcFn := getSourceFn(false, 99)
+	searchSource := srcFn(elastic.NewMatchAllQuery(), 1)
+	sp, err := searchSource.Source()
+	require.NoError(t, err)
+
+	searchParams, ok := sp.(map[string]interface{})
+	require.True(t, ok)
+
+	termAfter, ok := searchParams["terminate_after"]
+	require.False(t, ok)
+	assert.Nil(t, termAfter)
+
+	query, ok := searchParams["query"]
+	require.True(t, ok)
+
+	queryMap, ok := query.(map[string]interface{})
+	require.True(t, ok)
+	_, ok = queryMap["match_all"]
+	require.True(t, ok)
+
+	size, ok := searchParams["size"]
+	require.True(t, ok)
+	assert.Equal(t, 99, size)
+}


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Closes #4330 

## Short description of the changes
- Remove TerminateAfter from Elasticsearch/Opensearch query resulting in incomplete span count/list.  
