### PR TITLE
Add GO param to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 JAEGER_IMPORT_PATH = github.com/jaegertracing/jaeger
 STORAGE_PKGS = ./plugin/storage/integration/...
+GO = go
 
 include docker/Makefile
 
@@ -31,11 +32,11 @@ ifeq ($(UNAME), s390x)
 else
 	RACE=-race
 endif
-GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
+GOOS ?= $(shell $(GO) env GOOS)
+GOARCH ?= $(shell $(GO) env GOARCH)
 GOCACHE=$(abspath .gocache)
-GOBUILD=GOCACHE=$(GOCACHE) CGO_ENABLED=0 installsuffix=cgo go build -trimpath
-GOTEST=GOCACHE=$(GOCACHE) go test -v $(RACE)
+GOBUILD=GOCACHE=$(GOCACHE) CGO_ENABLED=0 installsuffix=cgo $(GO) build -trimpath
+GOTEST=GOCACHE=$(GOCACHE) $(GO) test -v $(RACE)
 GOFMT=gofmt
 GOFUMPT=gofumpt
 FMT_LOG=.fmt.log
@@ -392,9 +393,9 @@ draft-release:
 
 .PHONY: install-tools
 install-tools:
-	go install github.com/vektra/mockery/v2@v2.14.0
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
-	go install mvdan.cc/gofumpt@latest
+	$(GO) install github.com/vektra/mockery/v2@v2.14.0
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	$(GO) install mvdan.cc/gofumpt@latest
 
 .PHONY: install-ci
 install-ci: install-tools


### PR DESCRIPTION
`go` command was hardcoded, making it difficult to run with `gotip`. Now can do `make test GO=gotip`