### PR TITLE
Skip linting on Go tip

### DIFF
--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -35,3 +35,6 @@ jobs:
 
     - name: Run unit tests
       run: make test-ci
+
+    - name: Lint
+      run: echo skip linting on Go tip

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -46,3 +46,6 @@ jobs:
         flags: unittests
         fail_ci_if_error: true
         token: ${{ env.CODECOV_TOKEN }}
+
+    - name: Lint
+      run: make lint

--- a/Makefile
+++ b/Makefile
@@ -394,14 +394,14 @@ draft-release:
 .PHONY: install-tools
 install-tools:
 	$(GO) install github.com/vektra/mockery/v2@v2.14.0
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
 	$(GO) install mvdan.cc/gofumpt@latest
 
 .PHONY: install-ci
 install-ci: install-tools
 
 .PHONY: test-ci
-test-ci: build-examples cover lint
+test-ci: build-examples cover
 
 .PHONY: thrift
 thrift: idl/thrift/jaeger.thrift thrift-image


### PR DESCRIPTION
golangci-lint doesn't seem to like running against Go tip: https://github.com/jaegertracing/jaeger/actions/runs/4517523436/jobs/7956780871#step:7:5416

The errors are actually invalid, since `typecheck` is not a linter, it flags compile errors, but unit tests run fine.