### PR TITLE
Fix a typo in `collector/main.go`

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -119,7 +119,7 @@ func main() {
 			if err := collector.Start(collectorOpts); err != nil {
 				logger.Fatal("Failed to start collector", zap.Error(err))
 			}
-			// Wait for shutfown
+			// Wait for shutdown
 			svc.RunAndThen(func() {
 				if err := collector.Close(); err != nil {
 					logger.Error("failed to cleanly close the collector", zap.Error(err))


### PR DESCRIPTION
## Short description of the changes
- Fixes a typo in `collector/main.go`
