### PR TITLE
Add option to configure max received message size for jaeger-query

### DIFF
--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -46,6 +46,7 @@ type Configuration struct {
 	RemoteTLS               tlscfg.Options
 	RemoteConnectTimeout    time.Duration `yaml:"connection-timeout" mapstructure:"connection-timeout"`
 	TenancyOpts             tenancy.Options
+	MaxRecvMsgSize          int `yaml:"max-receive-message-size" mapstructure:"max-receive-message-size"`
 
 	pluginHealthCheck     *time.Ticker
 	pluginHealthCheckDone chan bool
@@ -84,6 +85,7 @@ func (c *Configuration) Close() error {
 
 func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, error) {
 	opts := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(c.MaxRecvMsgSize)),
 		grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer())),
 		grpc.WithStreamInterceptor(otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer())),
 		grpc.WithBlock(),

--- a/plugin/storage/grpc/options.go
+++ b/plugin/storage/grpc/options.go
@@ -33,6 +33,7 @@ const (
 	remotePrefix             = "grpc-storage"
 	remoteServer             = remotePrefix + ".server"
 	remoteConnectionTimeout  = remotePrefix + ".connection-timeout"
+	grpcMaxRecvMsgSize       = remotePrefix + ".max-recv-msg-size"
 	defaultPluginLogLevel    = "warn"
 	defaultConnectionTimeout = time.Duration(5 * time.Second)
 )
@@ -58,6 +59,7 @@ func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(pluginLogLevel, defaultPluginLogLevel, "Set the log level of the plugin's logger")
 	flagSet.String(remoteServer, "", "The remote storage gRPC server address as host:port")
 	flagSet.Duration(remoteConnectionTimeout, defaultConnectionTimeout, "The remote storage gRPC server connection timeout")
+	flagSet.Int(grpcMaxRecvMsgSize, 4<<20, "The maximum receivable message size to receive from the remote storage gRPC server")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -73,5 +75,6 @@ func (opt *Options) InitFromViper(v *viper.Viper) error {
 	}
 	opt.Configuration.RemoteConnectTimeout = v.GetDuration(remoteConnectionTimeout)
 	opt.Configuration.TenancyOpts = tenancy.InitFromViper(v)
+	opt.Configuration.MaxRecvMsgSize = v.GetInt(grpcMaxRecvMsgSize)
 	return nil
 }


### PR DESCRIPTION
Currently this option only exists for collector but not for query.

This option is required when a storage returns a very large grpc message (>4MiB).

## Which problem is this PR solving?
- Resolves #4350

## Short description of the changes
- Add a `--grpc-storage.max-recv-msg-size` option.