### PR TITLE
Add Keep-Alive flag for Zipkin HTTP server

### DIFF
--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -150,6 +150,7 @@ func (c *Collector) Start(options *flags.CollectorOptions) error {
 		AllowedOrigins: options.Zipkin.AllowedOrigins,
 		Logger:         c.logger,
 		MetricsFactory: c.metricsFactory,
+		KeepAlive:      options.Zipkin.KeepAlive,
 	})
 	if err != nil {
 		return fmt.Errorf("could not start Zipkin server: %w", err)

--- a/cmd/collector/app/flags/flags.go
+++ b/cmd/collector/app/flags/flags.go
@@ -48,9 +48,10 @@ const (
 
 	flagCollectorOTLPEnabled = "collector.otlp.enabled"
 
-	flagZipkinHTTPHostPort   = "collector.zipkin.host-port"
-	flagZipkinAllowedHeaders = "collector.zipkin.allowed-headers"
-	flagZipkinAllowedOrigins = "collector.zipkin.allowed-origins"
+	flagZipkinHTTPHostPort     = "collector.zipkin.host-port"
+	flagZipkinAllowedHeaders   = "collector.zipkin.allowed-headers"
+	flagZipkinAllowedOrigins   = "collector.zipkin.allowed-origins"
+	flagZipkinKeepAliveEnabled = "collector.zipkin.keep-alive"
 
 	// DefaultNumWorkers is the default number of workers consuming from the processor queue
 	DefaultNumWorkers = 50
@@ -126,6 +127,8 @@ type CollectorOptions struct {
 		AllowedHeaders string
 		// TLS configures secure transport for Zipkin endpoint to collect spans
 		TLS tlscfg.Options
+		// KeepAlive configures allow Keep-Alive for Zipkin HTTP server
+		KeepAlive bool
 	}
 	// CollectorTags is the string representing collector tags to append to each and every span
 	CollectorTags map[string]string
@@ -188,6 +191,7 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.String(flagZipkinAllowedHeaders, "content-type", "Comma separated list of allowed headers for the Zipkin collector service, default content-type")
 	flags.String(flagZipkinAllowedOrigins, "*", "Comma separated list of allowed origins for the Zipkin collector service, default accepts all")
 	flags.String(flagZipkinHTTPHostPort, "", "The host:port (e.g. 127.0.0.1:9411 or :9411) of the collector's Zipkin server (disabled by default)")
+	flags.Bool(flagZipkinKeepAliveEnabled, true, "KeepAlive configures allow Keep-Alive for Zipkin HTTP server (enabled by default)")
 	tlsZipkinFlagsConfig.AddFlags(flags)
 
 	tenancy.AddFlags(flags)
@@ -275,6 +279,7 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper, logger *zap.Logger)
 
 	cOpts.Zipkin.AllowedHeaders = v.GetString(flagZipkinAllowedHeaders)
 	cOpts.Zipkin.AllowedOrigins = v.GetString(flagZipkinAllowedOrigins)
+	cOpts.Zipkin.KeepAlive = v.GetBool(flagZipkinKeepAliveEnabled)
 	cOpts.Zipkin.HTTPHostPort = ports.FormatHostPort(v.GetString(flagZipkinHTTPHostPort))
 	if tlsZipkin, err := tlsZipkinFlagsConfig.InitFromViper(v); err == nil {
 		cOpts.Zipkin.TLS = tlsZipkin

--- a/cmd/collector/app/flags/flags_test.go
+++ b/cmd/collector/app/flags/flags_test.go
@@ -148,3 +148,14 @@ func TestCollectorOptionsWithFlags_CheckFullTenancy(t *testing.T) {
 	assert.Equal(t, "custom-tenant-header", c.GRPC.Tenancy.Header)
 	assert.Equal(t, []string{"acme", "hardware-store"}, c.GRPC.Tenancy.Tenants)
 }
+
+func TestCollectorOptionsWithFlags_CheckZipkinKeepAlive(t *testing.T) {
+	c := &CollectorOptions{}
+	v, command := config.Viperize(AddFlags)
+	command.ParseFlags([]string{
+		"--collector.zipkin.keep-alive=false",
+	})
+	c.InitFromViper(v, zap.NewNop())
+
+	assert.Equal(t, false, c.Zipkin.KeepAlive)
+}

--- a/cmd/collector/app/server/zipkin.go
+++ b/cmd/collector/app/server/zipkin.go
@@ -44,6 +44,7 @@ type ZipkinServerParams struct {
 	HealthCheck    *healthcheck.HealthCheck
 	Logger         *zap.Logger
 	MetricsFactory metrics.Factory
+	KeepAlive      bool
 }
 
 // StartZipkinServer based on the given parameters
@@ -73,6 +74,8 @@ func StartZipkinServer(params *ZipkinServerParams) (*http.Server, error) {
 		}
 		server.TLSConfig = tlsCfg
 	}
+
+	server.SetKeepAlivesEnabled(params.KeepAlive)
 	serveZipkin(server, listener, params)
 
 	return server, nil


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4365 

## Short description of the changes
- Add cli flag for change jaeger-collector's Zipkin HTTP server KeepAlive configuration.
