### PR TITLE
Expose drop span hook as an option in Collector SpanProcessor

### DIFF
--- a/cmd/collector/app/options.go
+++ b/cmd/collector/app/options.go
@@ -42,6 +42,7 @@ type options struct {
 	extraFormatTypes       []processor.SpanFormat
 	collectorTags          map[string]string
 	spanSizeMetricsEnabled bool
+	onDroppedSpan          func(span *model.Span)
 }
 
 // Option is a function that sets some option on StorageBuilder.
@@ -161,6 +162,13 @@ func (options) CollectorTags(extraTags map[string]string) Option {
 func (options) SpanSizeMetricsEnabled(spanSizeMetrics bool) Option {
 	return func(b *options) {
 		b.spanSizeMetricsEnabled = spanSizeMetrics
+	}
+}
+
+// OnDroppedSpan creates an Option that initializes the onDroppedSpan function
+func (options) OnDroppedSpan(onDroppedSpan func(span *model.Span)) Option {
+	return func(b *options) {
+		b.onDroppedSpan = onDroppedSpan
 	}
 }
 

--- a/cmd/collector/app/options_test.go
+++ b/cmd/collector/app/options_test.go
@@ -46,6 +46,7 @@ func TestAllOptionSet(t *testing.T) {
 		Options.PreSave(func(span *model.Span, tenant string) {}),
 		Options.CollectorTags(map[string]string{"extra": "tags"}),
 		Options.SpanSizeMetricsEnabled(true),
+		Options.OnDroppedSpan(func(span *model.Span) {}),
 	)
 	assert.EqualValues(t, 5, opts.numWorkers)
 	assert.EqualValues(t, 10, opts.queueSize)
@@ -53,6 +54,7 @@ func TestAllOptionSet(t *testing.T) {
 	assert.EqualValues(t, 1000, opts.dynQueueSizeWarmup)
 	assert.EqualValues(t, 1024, opts.dynQueueSizeMemory)
 	assert.True(t, opts.spanSizeMetricsEnabled)
+	assert.NotNil(t, opts.onDroppedSpan)
 }
 
 func TestNoOptionsSet(t *testing.T) {
@@ -69,4 +71,5 @@ func TestNoOptionsSet(t *testing.T) {
 	assert.EqualValues(t, &span, opts.sanitizer(&span))
 	assert.EqualValues(t, 0, opts.dynQueueSizeWarmup)
 	assert.False(t, opts.spanSizeMetricsEnabled)
+	assert.Nil(t, opts.onDroppedSpan)
 }

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -95,6 +95,9 @@ func newSpanProcessor(spanWriter spanstore.Writer, additional []ProcessSpan, opt
 		options.extraFormatTypes)
 	droppedItemHandler := func(item interface{}) {
 		handlerMetrics.SpansDropped.Inc(1)
+		if options.onDroppedSpan != nil {
+			options.onDroppedSpan(item.(*queueItem).span)
+		}
 	}
 	boundedQueue := queue.NewBoundedQueue(options.queueSize, droppedItemHandler)
 


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4375

## Short description of the changes
Expose drop span hook as an option when creating SpanProcessor in collector so that users have the flexibility to get more insights on dropped spans in addition to the dropped count.