### PR TITLE
Simplify ES config and factory

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -92,36 +92,8 @@ type TagsAsFields struct {
 	Include string `mapstructure:"include"`
 }
 
-// ClientBuilder creates new es.Client
-type ClientBuilder interface {
-	NewClient(logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error)
-	GetRemoteReadClusters() []string
-	GetNumShards() int64
-	GetNumReplicas() int64
-	GetMaxSpanAge() time.Duration
-	GetMaxDocCount() int
-	GetIndexPrefix() string
-	GetIndexDateLayoutSpans() string
-	GetIndexDateLayoutServices() string
-	GetIndexDateLayoutDependencies() string
-	GetIndexRolloverFrequencySpansDuration() time.Duration
-	GetIndexRolloverFrequencyServicesDuration() time.Duration
-	GetTagsFilePath() string
-	GetAllTagsAsFields() bool
-	GetTagDotReplacement() string
-	GetUseReadWriteAliases() bool
-	GetTokenFilePath() string
-	IsStorageEnabled() bool
-	IsCreateIndexTemplates() bool
-	GetVersion() uint
-	TagKeysAsFields() ([]string, error)
-	GetUseILM() bool
-	GetLogLevel() string
-	GetSendGetBodyAs() string
-}
-
 // NewClient creates a new ElasticSearch client
-func (c *Configuration) NewClient(logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
+func NewClient(c *Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
 	if len(c.Servers) < 1 {
 		return nil, errors.New("no servers specified")
 	}
@@ -275,51 +247,6 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	}
 }
 
-// GetRemoteReadClusters returns list of remote read clusters
-func (c *Configuration) GetRemoteReadClusters() []string {
-	return c.RemoteReadClusters
-}
-
-// GetNumShards returns number of shards from Configuration
-func (c *Configuration) GetNumShards() int64 {
-	return c.NumShards
-}
-
-// GetNumReplicas returns number of replicas from Configuration
-func (c *Configuration) GetNumReplicas() int64 {
-	return c.NumReplicas
-}
-
-// GetMaxSpanAge returns max span age from Configuration
-func (c *Configuration) GetMaxSpanAge() time.Duration {
-	return c.MaxSpanAge
-}
-
-// GetMaxDocCount returns the maximum number of documents that a query should return
-func (c *Configuration) GetMaxDocCount() int {
-	return c.MaxDocCount
-}
-
-// GetIndexPrefix returns index prefix
-func (c *Configuration) GetIndexPrefix() string {
-	return c.IndexPrefix
-}
-
-// GetIndexDateLayoutSpans returns jaeger-span index date layout
-func (c *Configuration) GetIndexDateLayoutSpans() string {
-	return c.IndexDateLayoutSpans
-}
-
-// GetIndexDateLayoutServices returns jaeger-service index date layout
-func (c *Configuration) GetIndexDateLayoutServices() string {
-	return c.IndexDateLayoutServices
-}
-
-// GetIndexDateLayoutDependencies returns jaeger-dependencies index date layout
-func (c *Configuration) GetIndexDateLayoutDependencies() string {
-	return c.IndexDateLayoutDependencies
-}
-
 // GetIndexRolloverFrequencySpansDuration returns jaeger-span index rollover frequency duration
 func (c *Configuration) GetIndexRolloverFrequencySpansDuration() time.Duration {
 	if c.IndexRolloverFrequencySpans == "hour" {
@@ -334,62 +261,6 @@ func (c *Configuration) GetIndexRolloverFrequencyServicesDuration() time.Duratio
 		return -1 * time.Hour
 	}
 	return -24 * time.Hour
-}
-
-// GetTagsFilePath returns a path to file containing tag keys
-func (c *Configuration) GetTagsFilePath() string {
-	return c.Tags.File
-}
-
-// GetAllTagsAsFields returns true if all tags should be stored as object fields
-func (c *Configuration) GetAllTagsAsFields() bool {
-	return c.Tags.AllAsFields
-}
-
-// GetVersion returns Elasticsearch version
-func (c *Configuration) GetVersion() uint {
-	return c.Version
-}
-
-// GetTagDotReplacement returns character is used to replace dots in tag keys, when
-// the tag is stored as object field.
-func (c *Configuration) GetTagDotReplacement() string {
-	return c.Tags.DotReplacement
-}
-
-// GetUseReadWriteAliases indicates whether read alias should be used
-func (c *Configuration) GetUseReadWriteAliases() bool {
-	return c.UseReadWriteAliases
-}
-
-// GetUseILM indicates whether ILM should be used
-func (c *Configuration) GetUseILM() bool {
-	return c.UseILM
-}
-
-// GetLogLevel returns the log-level the ES client should log at.
-func (c *Configuration) GetLogLevel() string {
-	return c.LogLevel
-}
-
-// GetSendGetBodyAs returns the SendGetBodyAs the ES client should use.
-func (c *Configuration) GetSendGetBodyAs() string {
-	return c.SendGetBodyAs
-}
-
-// GetTokenFilePath returns file path containing the bearer token
-func (c *Configuration) GetTokenFilePath() string {
-	return c.TokenFilePath
-}
-
-// IsStorageEnabled determines whether storage is enabled
-func (c *Configuration) IsStorageEnabled() bool {
-	return c.Enabled
-}
-
-// IsCreateIndexTemplates determines whether index templates should be created or not
-func (c *Configuration) IsCreateIndexTemplates() bool {
-	return c.CreateIndexTemplates
 }
 
 // TagKeysAsFields returns tags from the file and command line merged

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -40,7 +40,7 @@ type mockClientBuilder struct {
 	createTemplateError error
 }
 
-func (m *mockClientBuilder) NewClient(c *escfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
+func (m *mockClientBuilder) NewClient(_ *escfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
 	if m.err == nil {
 		c := &mocks.Client{}
 		tService := &mocks.TemplateCreateService{}

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -36,12 +36,12 @@ import (
 var _ storage.Factory = new(Factory)
 
 type mockClientBuilder struct {
-	escfg.Configuration
+	// escfg.Configuration
 	err                 error
 	createTemplateError error
 }
 
-func (m *mockClientBuilder) NewClient(logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
+func (m *mockClientBuilder) NewClient(c *escfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
 	if m.err == nil {
 		c := &mocks.Client{}
 		tService := &mocks.TemplateCreateService{}
@@ -60,16 +60,18 @@ func TestElasticsearchFactory(t *testing.T) {
 	command.ParseFlags([]string{})
 	f.InitFromViper(v, zap.NewNop())
 
-	// after InitFromViper, f.primaryConfig points to a real session builder that will fail in unit tests,
-	// so we override it with a mock.
-	f.primaryConfig = &mockClientBuilder{err: errors.New("made-up error")}
+	f.newClientFn = (&mockClientBuilder{err: errors.New("made-up error")}).NewClient
 	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "failed to create primary Elasticsearch client: made-up error")
 
-	f.primaryConfig = &mockClientBuilder{}
-	f.archiveConfig = &mockClientBuilder{err: errors.New("made-up error2"), Configuration: escfg.Configuration{Enabled: true}}
+	f.archiveConfig.Enabled = true
+	f.newClientFn = func(c *escfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
+		// to test archive storage error, pretend that primary client creation is successful
+		f.newClientFn = (&mockClientBuilder{err: errors.New("made-up error2")}).NewClient
+		return (&mockClientBuilder{}).NewClient(c, logger, metricsFactory)
+	}
 	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "failed to create archive Elasticsearch client: made-up error2")
 
-	f.archiveConfig = &mockClientBuilder{}
+	f.newClientFn = (&mockClientBuilder{}).NewClient
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	_, err := f.CreateSpanReader()
@@ -91,10 +93,13 @@ func TestElasticsearchFactory(t *testing.T) {
 
 func TestElasticsearchTagsFileDoNotExist(t *testing.T) {
 	f := NewFactory()
-	mockConf := &mockClientBuilder{}
-	mockConf.Tags.File = "fixtures/tags_foo.txt"
-	f.primaryConfig = mockConf
-	f.archiveConfig = mockConf
+	f.primaryConfig = &escfg.Configuration{
+		Tags: escfg.TagsAsFields{
+			File: "fixtures/file-does-not-exist.txt",
+		},
+	}
+	f.archiveConfig = &escfg.Configuration{}
+	f.newClientFn = (&mockClientBuilder{}).NewClient
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	r, err := f.CreateSpanWriter()
 	require.Error(t, err)
@@ -103,10 +108,11 @@ func TestElasticsearchTagsFileDoNotExist(t *testing.T) {
 
 func TestElasticsearchILMUsedWithoutReadWriteAliases(t *testing.T) {
 	f := NewFactory()
-	mockConf := &mockClientBuilder{}
-	mockConf.UseILM = true
-	f.primaryConfig = mockConf
-	f.archiveConfig = mockConf
+	f.primaryConfig = &escfg.Configuration{
+		UseILM: true,
+	}
+	f.archiveConfig = &escfg.Configuration{}
+	f.newClientFn = (&mockClientBuilder{}).NewClient
 	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	w, err := f.CreateSpanWriter()
 	require.EqualError(t, err, "--es.use-ilm must always be used in conjunction with --es.use-aliases to ensure ES writers and readers refer to the single index mapping")
@@ -176,8 +182,9 @@ func TestTagKeysAsFields(t *testing.T) {
 
 func TestCreateTemplateError(t *testing.T) {
 	f := NewFactory()
-	f.primaryConfig = &mockClientBuilder{createTemplateError: errors.New("template-error"), Configuration: escfg.Configuration{Enabled: true, CreateIndexTemplates: true}}
-	f.archiveConfig = &mockClientBuilder{}
+	f.primaryConfig = &escfg.Configuration{Enabled: true, CreateIndexTemplates: true}
+	f.archiveConfig = &escfg.Configuration{}
+	f.newClientFn = (&mockClientBuilder{createTemplateError: errors.New("template-error")}).NewClient
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
 	w, err := f.CreateSpanWriter()
@@ -187,8 +194,9 @@ func TestCreateTemplateError(t *testing.T) {
 
 func TestILMDisableTemplateCreation(t *testing.T) {
 	f := NewFactory()
-	f.primaryConfig = &mockClientBuilder{createTemplateError: errors.New("template-error"), Configuration: escfg.Configuration{Enabled: true, UseILM: true, UseReadWriteAliases: true, CreateIndexTemplates: true}}
-	f.archiveConfig = &mockClientBuilder{}
+	f.primaryConfig = &escfg.Configuration{Enabled: true, UseILM: true, UseReadWriteAliases: true, CreateIndexTemplates: true}
+	f.archiveConfig = &escfg.Configuration{}
+	f.newClientFn = (&mockClientBuilder{createTemplateError: errors.New("template-error")}).NewClient
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
 	_, err = f.CreateSpanWriter()
@@ -197,7 +205,8 @@ func TestILMDisableTemplateCreation(t *testing.T) {
 
 func TestArchiveDisabled(t *testing.T) {
 	f := NewFactory()
-	f.archiveConfig = &mockClientBuilder{Configuration: escfg.Configuration{Enabled: false}}
+	f.archiveConfig = &escfg.Configuration{Enabled: false}
+	f.newClientFn = (&mockClientBuilder{}).NewClient
 	w, err := f.CreateArchiveSpanWriter()
 	assert.Nil(t, w)
 	assert.Nil(t, err)
@@ -208,8 +217,8 @@ func TestArchiveDisabled(t *testing.T) {
 
 func TestArchiveEnabled(t *testing.T) {
 	f := NewFactory()
-	f.primaryConfig = &mockClientBuilder{}
-	f.archiveConfig = &mockClientBuilder{Configuration: escfg.Configuration{Enabled: true}}
+	f.archiveConfig = &escfg.Configuration{Enabled: true}
+	f.newClientFn = (&mockClientBuilder{}).NewClient
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
 	w, err := f.CreateArchiveSpanWriter()


### PR DESCRIPTION
The `ClientBuilder` interface was unnecessary, use Configuration struct directly
