### PR TITLE
Add HTTP post port mapping to docker command

### DIFF
--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -54,6 +54,7 @@ docker run \
   --name jaeger \
   -p6831:6831/udp \
   -p16686:16686 \
+  -p14268:14268 \
   jaegertracing/all-in-one:latest
 ```
 

--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -70,7 +70,7 @@ func Init(serviceName string, exporterType string, metricsFactory metrics.Factor
 		)),
 	)
 	otTracer, _ := otbridge.NewTracerPair(tp.Tracer(""))
-	logger.Bg().Debug("created OTEL->OT brige", zap.String("service-name", serviceName))
+	logger.Bg().Debug("created OTEL->OT bridge", zap.String("service-name", serviceName))
 	return otTracer
 }
 
@@ -78,7 +78,6 @@ func Init(serviceName string, exporterType string, metricsFactory metrics.Factor
 func withSecure() bool {
 	return strings.HasPrefix(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"), "https://") ||
 		strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")) == "false"
-
 }
 
 func createOtelExporter(exporterType string) (sdktrace.SpanExporter, error) {


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/discussions/4356

## Short description of the changes
- The HotRod example emits spans on jaeger-collector's HTTP endpoint.
- This exposes the port being listened to for spans over the HTTP endpoint to fix an error in the HotRod example.
- A minor typo is also fixed.
