### PR TITLE
feat: implement gRPC storage plugin for metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ proto: init-submodules proto-prepare-otel
 	$(PROTOC) \
 		$(PROTO_INCLUDES) \
 		-Iplugin/storage/grpc/proto \
-		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS):$(PWD)/proto-gen/storage_v1 \
+		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS),Mopenmetrics.proto=github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics:$(PWD)/proto-gen/storage_v1 \
 		plugin/storage/grpc/proto/storage.proto
 
 	$(PROTOC) \

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -55,8 +55,7 @@ func main() {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}
 
-	fc := metricsPlugin.FactoryConfigFromEnv()
-	metricsReaderFactory, err := metricsPlugin.NewFactory(fc)
+	metricsReaderFactory, err := metricsPlugin.NewFactory(metricsPlugin.FactoryConfigFromEnv())
 	if err != nil {
 		log.Fatalf("Cannot initialize metrics factory: %v", err)
 	}
@@ -179,12 +178,13 @@ func createMetricsQueryService(
 	logger *zap.Logger,
 	metricsReaderMetricsFactory metrics.Factory,
 ) (querysvc.MetricsQueryService, error) {
+	// Ensure default parameter values are loaded correctly.
+	metricsReaderFactory.InitFromViper(v, logger)
+
 	if err := metricsReaderFactory.Initialize(logger); err != nil {
 		return nil, fmt.Errorf("failed to init metrics reader factory: %w", err)
 	}
 
-	// Ensure default parameter values are loaded correctly.
-	metricsReaderFactory.InitFromViper(v, logger)
 	reader, err := metricsReaderFactory.CreateMetricsReader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metrics reader: %w", err)

--- a/plugin/metrics/factory.go
+++ b/plugin/metrics/factory.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/plugin/metrics/disabled"
+	"github.com/jaegertracing/jaeger/plugin/metrics/grpc"
 	"github.com/jaegertracing/jaeger/plugin/metrics/prometheus"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
@@ -33,6 +34,7 @@ const (
 	disabledStorageType = ""
 
 	prometheusStorageType = "prometheus"
+	grpcStorageType       = "grpc-plugin"
 )
 
 // AllStorageTypes defines all available storage backends.
@@ -67,6 +69,8 @@ func (f *Factory) getFactoryOfType(factoryType string) (storage.MetricsFactory, 
 	switch factoryType {
 	case prometheusStorageType:
 		return prometheus.NewFactory(), nil
+	case grpcStorageType:
+		return grpc.NewFactory(), nil
 	case disabledStorageType:
 		return disabled.NewFactory(), nil
 	}
@@ -76,7 +80,9 @@ func (f *Factory) getFactoryOfType(factoryType string) (storage.MetricsFactory, 
 // Initialize implements storage.MetricsFactory.
 func (f *Factory) Initialize(logger *zap.Logger) error {
 	for _, factory := range f.factories {
-		factory.Initialize(logger)
+		if err := factory.Initialize(logger); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/plugin/metrics/grpc/factory.go
+++ b/plugin/metrics/grpc/factory.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/plugin"
+	"github.com/jaegertracing/jaeger/plugin/storage/grpc/config"
+	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
+	"github.com/jaegertracing/jaeger/storage"
+	"github.com/jaegertracing/jaeger/storage/metricsstore"
+)
+
+var (
+	_ plugin.Configurable = (*Factory)(nil)
+	_ io.Closer           = (*Factory)(nil)
+)
+
+// Factory implements storage.MetricsFactory
+type Factory struct {
+	options Options
+	logger  *zap.Logger
+
+	builder config.PluginBuilder
+
+	metricsReader shared.MetricsReaderPlugin
+	capabilities  shared.PluginCapabilities
+}
+
+// NewFactory creates a new Factory
+func NewFactory() *Factory {
+	return &Factory{}
+}
+
+// AddFlags implements plugin.Configurable
+func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
+	f.options.AddFlags(flagSet)
+}
+
+// InitFromViper implements plugin.Configurable
+func (f *Factory) InitFromViper(v *viper.Viper, logger *zap.Logger) {
+	if err := f.options.InitFromViper(v); err != nil {
+		logger.Fatal("unable to initialize gRPC metrics factory", zap.Error(err))
+	}
+	f.builder = &f.options.Configuration
+}
+
+// Initialize implements storage.MetricsFactory
+func (f *Factory) Initialize(logger *zap.Logger) error {
+	f.logger = logger
+
+	services, err := f.builder.Build(logger)
+	if err != nil {
+		return fmt.Errorf("grpc-plugin builder failed to create a store: %w", err)
+	}
+
+	f.metricsReader = services.MetricsReader
+	f.capabilities = services.Capabilities
+	logger.Info("External plugin storage configuration", zap.Any("configuration", f.options.Configuration))
+	return nil
+}
+
+// CreateMetricsReader implements storage.MetricsFactory
+func (f *Factory) CreateMetricsReader() (metricsstore.Reader, error) {
+	if f.capabilities == nil {
+		return nil, storage.ErrMetricsStorageNotSupported
+	}
+	capabilities, err := f.capabilities.Capabilities()
+	if err != nil {
+		return nil, err
+	}
+	if capabilities == nil || !capabilities.MetricsReader {
+		return nil, storage.ErrMetricsStorageNotSupported
+	}
+	return f.metricsReader.MetricsReader(), nil
+}
+
+// Close closes the resources held by the factory
+func (f *Factory) Close() error {
+	return f.builder.Close()
+}

--- a/plugin/metrics/grpc/factory_test.go
+++ b/plugin/metrics/grpc/factory_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+// TODO write tests

--- a/plugin/metrics/grpc/options.go
+++ b/plugin/metrics/grpc/options.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
+	"github.com/jaegertracing/jaeger/pkg/tenancy"
+	"github.com/jaegertracing/jaeger/plugin/storage/grpc/config"
+)
+
+const (
+	remotePrefix             = "grpc-metrics"
+	remoteServer             = remotePrefix + ".server"
+	remoteConnectionTimeout  = remotePrefix + ".connection-timeout"
+	defaultConnectionTimeout = time.Duration(5 * time.Second)
+)
+
+type Options struct {
+	Configuration config.Configuration `mapstructure:",squash"`
+}
+
+func NewOptions() *Options {
+	return &Options{}
+}
+
+func tlsFlagsConfig() tlscfg.ClientFlagsConfig {
+	return tlscfg.ClientFlagsConfig{
+		Prefix: remotePrefix,
+	}
+}
+
+// AddFlags adds flags for Options
+func (opt *Options) AddFlags(flagSet *flag.FlagSet) {
+	tlsFlagsConfig().AddFlags(flagSet)
+
+	flagSet.String(remoteServer, "", "The remote metrics gRPC server address as host:port")
+	flagSet.Duration(remoteConnectionTimeout, defaultConnectionTimeout, "The remote metrics gRPC server connection timeout")
+}
+
+// InitFromViper initializes Options with properties from viper
+func (opt *Options) InitFromViper(v *viper.Viper) error {
+	opt.Configuration.RemoteServerAddr = v.GetString(remoteServer)
+	var err error
+	opt.Configuration.RemoteTLS, err = tlsFlagsConfig().InitFromViper(v)
+	if err != nil {
+		return fmt.Errorf("failed to parse gRPC storage TLS options: %w", err)
+	}
+	opt.Configuration.RemoteConnectTimeout = v.GetDuration(remoteConnectionTimeout)
+	opt.Configuration.TenancyOpts = tenancy.InitFromViper(v)
+	return nil
+}

--- a/plugin/metrics/grpc/options_test.go
+++ b/plugin/metrics/grpc/options_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+// TODO write tests

--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -118,6 +118,7 @@ func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, 
 			Store:               grpcClient,
 			ArchiveStore:        grpcClient,
 			StreamingSpanWriter: grpcClient,
+			MetricsReader:       grpcClient,
 		},
 		Capabilities: grpcClient,
 	}, nil

--- a/plugin/storage/grpc/grpc.go
+++ b/plugin/storage/grpc/grpc.go
@@ -38,6 +38,7 @@ func ServeWithGRPCServer(services *shared.PluginServices, grpcServer func([]grpc
 					Impl:        services.Store,
 					ArchiveImpl: services.ArchiveStore,
 					StreamImpl:  services.StreamingSpanWriter,
+					MetricsImpl: services.MetricsReader,
 				},
 			},
 		},

--- a/plugin/storage/grpc/proto/storage.proto
+++ b/plugin/storage/grpc/proto/storage.proto
@@ -23,6 +23,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 
 import "model.proto";
+import "openmetrics.proto";
 
 // Enable gogoprotobuf extensions (https://github.com/gogo/protobuf/blob/master/extensions.md).
 // Enable custom Marshal method.
@@ -174,6 +175,56 @@ service DependenciesReaderPlugin {
     rpc GetDependencies(GetDependenciesRequest) returns (GetDependenciesResponse);
 }
 
+service MetricsReaderPlugin {
+    // metricsstore/Reader
+    rpc GetLatencies(GetLatenciesRequest) returns (GetLatenciesResponse);
+    rpc GetCallRates(GetCallRatesRequest) returns (GetCallRatesResponse);
+    rpc GetErrorRates(GetErrorRatesRequest) returns (GetErrorRatesResponse);
+    rpc GetMinStepDuration(GetMinStepDurationRequest) returns (GetMinStepDurationResponse);
+}
+
+message MetricsBaseQueryParameters {
+    repeated string service_names = 1;
+    bool group_by_operation = 2;
+    google.protobuf.Timestamp end_time = 3;
+    google.protobuf.Duration lookback = 4;
+    google.protobuf.Duration step = 5;
+    google.protobuf.Duration rate_per = 6;
+    repeated string span_kinds = 7;
+}
+
+message GetLatenciesRequest {
+    MetricsBaseQueryParameters base_query_parameters = 1;
+    float quantile = 2;
+}
+
+message GetLatenciesResponse {
+    jaeger.api_v2.metrics.MetricFamily metric_family = 1;
+}
+
+message GetCallRatesRequest {
+    MetricsBaseQueryParameters base_query_parameters = 1;
+}
+
+message GetCallRatesResponse {
+    jaeger.api_v2.metrics.MetricFamily metric_family = 1;
+}
+
+message GetErrorRatesRequest {
+    MetricsBaseQueryParameters base_query_parameters = 1;
+}
+
+message GetErrorRatesResponse {
+    jaeger.api_v2.metrics.MetricFamily metric_family = 1;
+}
+
+message GetMinStepDurationRequest {
+}
+
+message GetMinStepDurationResponse {
+    google.protobuf.Duration min_step = 1;
+}
+
 // empty; extensible in the future
 message CapabilitiesRequest {
 
@@ -183,6 +234,7 @@ message CapabilitiesResponse {
     bool archiveSpanReader = 1;
     bool archiveSpanWriter = 2;
     bool streamingSpanWriter = 3;
+    bool metricsReader = 4;
 }
 
 service PluginCapabilities {

--- a/plugin/storage/grpc/shared/interface.go
+++ b/plugin/storage/grpc/shared/interface.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
+	"github.com/jaegertracing/jaeger/storage/metricsstore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
@@ -53,6 +54,10 @@ type StreamingSpanWriterPlugin interface {
 	StreamingSpanWriter() spanstore.Writer
 }
 
+type MetricsReaderPlugin interface {
+	MetricsReader() metricsstore.Reader
+}
+
 // PluginCapabilities allow expose plugin its capabilities.
 type PluginCapabilities interface {
 	Capabilities() (*Capabilities, error)
@@ -63,6 +68,7 @@ type Capabilities struct {
 	ArchiveSpanReader   bool
 	ArchiveSpanWriter   bool
 	StreamingSpanWriter bool
+	MetricsReader       bool
 }
 
 // PluginServices defines services plugin can expose
@@ -70,4 +76,5 @@ type PluginServices struct {
 	Store               StoragePlugin
 	ArchiveStore        ArchiveStoragePlugin
 	StreamingSpanWriter StreamingSpanWriterPlugin
+	MetricsReader       MetricsReaderPlugin
 }

--- a/plugin/storage/grpc/shared/metrics.go
+++ b/plugin/storage/grpc/shared/metrics.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
+	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
+	"github.com/jaegertracing/jaeger/storage/metricsstore"
+)
+
+var _ metricsstore.Reader = (*metricsReader)(nil)
+
+type metricsReader struct {
+	client storage_v1.MetricsReaderPluginClient
+}
+
+func (m *metricsReader) GetLatencies(ctx context.Context, params *metricsstore.LatenciesQueryParameters) (*metrics.MetricFamily, error) {
+	request := &storage_v1.GetLatenciesRequest{
+		BaseQueryParameters: baseQueryParametersFromPogo(params.BaseQueryParameters),
+		Quantile:            float32(params.Quantile),
+	}
+
+	response, err := m.client.GetLatencies(upgradeContext(ctx), request)
+	if err != nil {
+		return nil, err
+	}
+	return response.MetricFamily, nil
+}
+
+func (m *metricsReader) GetCallRates(ctx context.Context, params *metricsstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
+	request := &storage_v1.GetCallRatesRequest{
+		BaseQueryParameters: baseQueryParametersFromPogo(params.BaseQueryParameters),
+	}
+
+	response, err := m.client.GetCallRates(upgradeContext(ctx), request)
+	if err != nil {
+		return nil, err
+	}
+	return response.MetricFamily, nil
+}
+
+func (m *metricsReader) GetErrorRates(ctx context.Context, params *metricsstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
+	request := &storage_v1.GetErrorRatesRequest{
+		BaseQueryParameters: baseQueryParametersFromPogo(params.BaseQueryParameters),
+	}
+
+	response, err := m.client.GetErrorRates(upgradeContext(ctx), request)
+	if err != nil {
+		return nil, err
+	}
+	return response.MetricFamily, nil
+}
+
+func (m *metricsReader) GetMinStepDuration(ctx context.Context, params *metricsstore.MinStepDurationQueryParameters) (time.Duration, error) {
+	response, err := m.client.GetMinStepDuration(upgradeContext(ctx), &storage_v1.GetMinStepDurationRequest{})
+	if err != nil {
+		return 0, err
+	}
+
+	minStep := time.Second
+	if response.MinStep != nil {
+		minStep = time.Duration(response.MinStep.Seconds)*time.Second + time.Duration(response.MinStep.Nanos)
+	}
+
+	return minStep, nil
+}
+
+func baseQueryParametersFromPogo(pogo metricsstore.BaseQueryParameters) *storage_v1.MetricsBaseQueryParameters {
+	proto := &storage_v1.MetricsBaseQueryParameters{
+		ServiceNames:     pogo.ServiceNames,
+		GroupByOperation: pogo.GroupByOperation,
+		SpanKinds:        pogo.SpanKinds,
+	}
+
+	if pogo.EndTime != nil {
+		proto.EndTime = &types.Timestamp{Seconds: pogo.EndTime.Unix(), Nanos: int32(pogo.EndTime.Nanosecond())}
+	}
+	if pogo.Lookback != nil {
+		proto.Lookback = &types.Duration{Seconds: int64(*pogo.Lookback / time.Second), Nanos: int32(*pogo.Lookback % time.Second)}
+	}
+	if pogo.Step != nil {
+		proto.Step = &types.Duration{Seconds: int64(*pogo.Step / time.Second), Nanos: int32(*pogo.Step % time.Second)}
+	}
+	if pogo.RatePer != nil {
+		proto.RatePer = &types.Duration{Seconds: int64(*pogo.RatePer / time.Second), Nanos: int32(*pogo.RatePer % time.Second)}
+	}
+
+	return proto
+}

--- a/plugin/storage/grpc/shared/metrics_test.go
+++ b/plugin/storage/grpc/shared/metrics_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+// TODO write tests

--- a/plugin/storage/grpc/shared/plugin.go
+++ b/plugin/storage/grpc/shared/plugin.go
@@ -34,11 +34,12 @@ type StorageGRPCPlugin struct {
 	Impl        StoragePlugin
 	ArchiveImpl ArchiveStoragePlugin
 	StreamImpl  StreamingSpanWriterPlugin
+	MetricsImpl MetricsReaderPlugin
 }
 
 // RegisterHandlers registers the plugin with the server
 func (p *StorageGRPCPlugin) RegisterHandlers(s *grpc.Server) error {
-	handler := NewGRPCHandlerWithPlugins(p.Impl, p.ArchiveImpl, p.StreamImpl)
+	handler := NewGRPCHandlerWithPlugins(p.Impl, p.ArchiveImpl, p.StreamImpl, p.MetricsImpl)
 	return handler.Register(s)
 }
 

--- a/proto-gen/storage_v1/storage.pb.go
+++ b/proto-gen/storage_v1/storage.pb.go
@@ -5,13 +5,15 @@ package storage_v1
 
 import (
 	context "context"
+	encoding_binary "encoding/binary"
 	fmt "fmt"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
-	_ "github.com/gogo/protobuf/types"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
+	types "github.com/gogo/protobuf/types"
 	github_com_jaegertracing_jaeger_model "github.com/jaegertracing/jaeger/model"
 	model "github.com/jaegertracing/jaeger/model"
+	metrics "github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -877,6 +879,477 @@ func (m *FindTraceIDsResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FindTraceIDsResponse proto.InternalMessageInfo
 
+type MetricsBaseQueryParameters struct {
+	ServiceNames         []string         `protobuf:"bytes,1,rep,name=service_names,json=serviceNames,proto3" json:"service_names,omitempty"`
+	GroupByOperation     bool             `protobuf:"varint,2,opt,name=group_by_operation,json=groupByOperation,proto3" json:"group_by_operation,omitempty"`
+	EndTime              *types.Timestamp `protobuf:"bytes,3,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
+	Lookback             *types.Duration  `protobuf:"bytes,4,opt,name=lookback,proto3" json:"lookback,omitempty"`
+	Step                 *types.Duration  `protobuf:"bytes,5,opt,name=step,proto3" json:"step,omitempty"`
+	RatePer              *types.Duration  `protobuf:"bytes,6,opt,name=rate_per,json=ratePer,proto3" json:"rate_per,omitempty"`
+	SpanKinds            []string         `protobuf:"bytes,7,rep,name=span_kinds,json=spanKinds,proto3" json:"span_kinds,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
+	XXX_unrecognized     []byte           `json:"-"`
+	XXX_sizecache        int32            `json:"-"`
+}
+
+func (m *MetricsBaseQueryParameters) Reset()         { *m = MetricsBaseQueryParameters{} }
+func (m *MetricsBaseQueryParameters) String() string { return proto.CompactTextString(m) }
+func (*MetricsBaseQueryParameters) ProtoMessage()    {}
+func (*MetricsBaseQueryParameters) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{17}
+}
+func (m *MetricsBaseQueryParameters) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MetricsBaseQueryParameters) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MetricsBaseQueryParameters.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MetricsBaseQueryParameters) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MetricsBaseQueryParameters.Merge(m, src)
+}
+func (m *MetricsBaseQueryParameters) XXX_Size() int {
+	return m.Size()
+}
+func (m *MetricsBaseQueryParameters) XXX_DiscardUnknown() {
+	xxx_messageInfo_MetricsBaseQueryParameters.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MetricsBaseQueryParameters proto.InternalMessageInfo
+
+func (m *MetricsBaseQueryParameters) GetServiceNames() []string {
+	if m != nil {
+		return m.ServiceNames
+	}
+	return nil
+}
+
+func (m *MetricsBaseQueryParameters) GetGroupByOperation() bool {
+	if m != nil {
+		return m.GroupByOperation
+	}
+	return false
+}
+
+func (m *MetricsBaseQueryParameters) GetEndTime() *types.Timestamp {
+	if m != nil {
+		return m.EndTime
+	}
+	return nil
+}
+
+func (m *MetricsBaseQueryParameters) GetLookback() *types.Duration {
+	if m != nil {
+		return m.Lookback
+	}
+	return nil
+}
+
+func (m *MetricsBaseQueryParameters) GetStep() *types.Duration {
+	if m != nil {
+		return m.Step
+	}
+	return nil
+}
+
+func (m *MetricsBaseQueryParameters) GetRatePer() *types.Duration {
+	if m != nil {
+		return m.RatePer
+	}
+	return nil
+}
+
+func (m *MetricsBaseQueryParameters) GetSpanKinds() []string {
+	if m != nil {
+		return m.SpanKinds
+	}
+	return nil
+}
+
+type GetLatenciesRequest struct {
+	BaseQueryParameters  *MetricsBaseQueryParameters `protobuf:"bytes,1,opt,name=base_query_parameters,json=baseQueryParameters,proto3" json:"base_query_parameters,omitempty"`
+	Quantile             float32                     `protobuf:"fixed32,2,opt,name=quantile,proto3" json:"quantile,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
+	XXX_unrecognized     []byte                      `json:"-"`
+	XXX_sizecache        int32                       `json:"-"`
+}
+
+func (m *GetLatenciesRequest) Reset()         { *m = GetLatenciesRequest{} }
+func (m *GetLatenciesRequest) String() string { return proto.CompactTextString(m) }
+func (*GetLatenciesRequest) ProtoMessage()    {}
+func (*GetLatenciesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{18}
+}
+func (m *GetLatenciesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetLatenciesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetLatenciesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetLatenciesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetLatenciesRequest.Merge(m, src)
+}
+func (m *GetLatenciesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetLatenciesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetLatenciesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetLatenciesRequest proto.InternalMessageInfo
+
+func (m *GetLatenciesRequest) GetBaseQueryParameters() *MetricsBaseQueryParameters {
+	if m != nil {
+		return m.BaseQueryParameters
+	}
+	return nil
+}
+
+func (m *GetLatenciesRequest) GetQuantile() float32 {
+	if m != nil {
+		return m.Quantile
+	}
+	return 0
+}
+
+type GetLatenciesResponse struct {
+	MetricFamily         *metrics.MetricFamily `protobuf:"bytes,1,opt,name=metric_family,json=metricFamily,proto3" json:"metric_family,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
+	XXX_unrecognized     []byte                `json:"-"`
+	XXX_sizecache        int32                 `json:"-"`
+}
+
+func (m *GetLatenciesResponse) Reset()         { *m = GetLatenciesResponse{} }
+func (m *GetLatenciesResponse) String() string { return proto.CompactTextString(m) }
+func (*GetLatenciesResponse) ProtoMessage()    {}
+func (*GetLatenciesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{19}
+}
+func (m *GetLatenciesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetLatenciesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetLatenciesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetLatenciesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetLatenciesResponse.Merge(m, src)
+}
+func (m *GetLatenciesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetLatenciesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetLatenciesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetLatenciesResponse proto.InternalMessageInfo
+
+func (m *GetLatenciesResponse) GetMetricFamily() *metrics.MetricFamily {
+	if m != nil {
+		return m.MetricFamily
+	}
+	return nil
+}
+
+type GetCallRatesRequest struct {
+	BaseQueryParameters  *MetricsBaseQueryParameters `protobuf:"bytes,1,opt,name=base_query_parameters,json=baseQueryParameters,proto3" json:"base_query_parameters,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
+	XXX_unrecognized     []byte                      `json:"-"`
+	XXX_sizecache        int32                       `json:"-"`
+}
+
+func (m *GetCallRatesRequest) Reset()         { *m = GetCallRatesRequest{} }
+func (m *GetCallRatesRequest) String() string { return proto.CompactTextString(m) }
+func (*GetCallRatesRequest) ProtoMessage()    {}
+func (*GetCallRatesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{20}
+}
+func (m *GetCallRatesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetCallRatesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetCallRatesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetCallRatesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetCallRatesRequest.Merge(m, src)
+}
+func (m *GetCallRatesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetCallRatesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetCallRatesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetCallRatesRequest proto.InternalMessageInfo
+
+func (m *GetCallRatesRequest) GetBaseQueryParameters() *MetricsBaseQueryParameters {
+	if m != nil {
+		return m.BaseQueryParameters
+	}
+	return nil
+}
+
+type GetCallRatesResponse struct {
+	MetricFamily         *metrics.MetricFamily `protobuf:"bytes,1,opt,name=metric_family,json=metricFamily,proto3" json:"metric_family,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
+	XXX_unrecognized     []byte                `json:"-"`
+	XXX_sizecache        int32                 `json:"-"`
+}
+
+func (m *GetCallRatesResponse) Reset()         { *m = GetCallRatesResponse{} }
+func (m *GetCallRatesResponse) String() string { return proto.CompactTextString(m) }
+func (*GetCallRatesResponse) ProtoMessage()    {}
+func (*GetCallRatesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{21}
+}
+func (m *GetCallRatesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetCallRatesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetCallRatesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetCallRatesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetCallRatesResponse.Merge(m, src)
+}
+func (m *GetCallRatesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetCallRatesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetCallRatesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetCallRatesResponse proto.InternalMessageInfo
+
+func (m *GetCallRatesResponse) GetMetricFamily() *metrics.MetricFamily {
+	if m != nil {
+		return m.MetricFamily
+	}
+	return nil
+}
+
+type GetErrorRatesRequest struct {
+	BaseQueryParameters  *MetricsBaseQueryParameters `protobuf:"bytes,1,opt,name=base_query_parameters,json=baseQueryParameters,proto3" json:"base_query_parameters,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
+	XXX_unrecognized     []byte                      `json:"-"`
+	XXX_sizecache        int32                       `json:"-"`
+}
+
+func (m *GetErrorRatesRequest) Reset()         { *m = GetErrorRatesRequest{} }
+func (m *GetErrorRatesRequest) String() string { return proto.CompactTextString(m) }
+func (*GetErrorRatesRequest) ProtoMessage()    {}
+func (*GetErrorRatesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{22}
+}
+func (m *GetErrorRatesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetErrorRatesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetErrorRatesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetErrorRatesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetErrorRatesRequest.Merge(m, src)
+}
+func (m *GetErrorRatesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetErrorRatesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetErrorRatesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetErrorRatesRequest proto.InternalMessageInfo
+
+func (m *GetErrorRatesRequest) GetBaseQueryParameters() *MetricsBaseQueryParameters {
+	if m != nil {
+		return m.BaseQueryParameters
+	}
+	return nil
+}
+
+type GetErrorRatesResponse struct {
+	MetricFamily         *metrics.MetricFamily `protobuf:"bytes,1,opt,name=metric_family,json=metricFamily,proto3" json:"metric_family,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
+	XXX_unrecognized     []byte                `json:"-"`
+	XXX_sizecache        int32                 `json:"-"`
+}
+
+func (m *GetErrorRatesResponse) Reset()         { *m = GetErrorRatesResponse{} }
+func (m *GetErrorRatesResponse) String() string { return proto.CompactTextString(m) }
+func (*GetErrorRatesResponse) ProtoMessage()    {}
+func (*GetErrorRatesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{23}
+}
+func (m *GetErrorRatesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetErrorRatesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetErrorRatesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetErrorRatesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetErrorRatesResponse.Merge(m, src)
+}
+func (m *GetErrorRatesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetErrorRatesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetErrorRatesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetErrorRatesResponse proto.InternalMessageInfo
+
+func (m *GetErrorRatesResponse) GetMetricFamily() *metrics.MetricFamily {
+	if m != nil {
+		return m.MetricFamily
+	}
+	return nil
+}
+
+type GetMinStepDurationRequest struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetMinStepDurationRequest) Reset()         { *m = GetMinStepDurationRequest{} }
+func (m *GetMinStepDurationRequest) String() string { return proto.CompactTextString(m) }
+func (*GetMinStepDurationRequest) ProtoMessage()    {}
+func (*GetMinStepDurationRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{24}
+}
+func (m *GetMinStepDurationRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetMinStepDurationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetMinStepDurationRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetMinStepDurationRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetMinStepDurationRequest.Merge(m, src)
+}
+func (m *GetMinStepDurationRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetMinStepDurationRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetMinStepDurationRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetMinStepDurationRequest proto.InternalMessageInfo
+
+type GetMinStepDurationResponse struct {
+	MinStep              *types.Duration `protobuf:"bytes,1,opt,name=min_step,json=minStep,proto3" json:"min_step,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
+	XXX_sizecache        int32           `json:"-"`
+}
+
+func (m *GetMinStepDurationResponse) Reset()         { *m = GetMinStepDurationResponse{} }
+func (m *GetMinStepDurationResponse) String() string { return proto.CompactTextString(m) }
+func (*GetMinStepDurationResponse) ProtoMessage()    {}
+func (*GetMinStepDurationResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{25}
+}
+func (m *GetMinStepDurationResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetMinStepDurationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetMinStepDurationResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetMinStepDurationResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetMinStepDurationResponse.Merge(m, src)
+}
+func (m *GetMinStepDurationResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetMinStepDurationResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetMinStepDurationResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetMinStepDurationResponse proto.InternalMessageInfo
+
+func (m *GetMinStepDurationResponse) GetMinStep() *types.Duration {
+	if m != nil {
+		return m.MinStep
+	}
+	return nil
+}
+
 // empty; extensible in the future
 type CapabilitiesRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -888,7 +1361,7 @@ func (m *CapabilitiesRequest) Reset()         { *m = CapabilitiesRequest{} }
 func (m *CapabilitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*CapabilitiesRequest) ProtoMessage()    {}
 func (*CapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_0d2c4ccf1453ffdb, []int{17}
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{26}
 }
 func (m *CapabilitiesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -921,6 +1394,7 @@ type CapabilitiesResponse struct {
 	ArchiveSpanReader    bool     `protobuf:"varint,1,opt,name=archiveSpanReader,proto3" json:"archiveSpanReader,omitempty"`
 	ArchiveSpanWriter    bool     `protobuf:"varint,2,opt,name=archiveSpanWriter,proto3" json:"archiveSpanWriter,omitempty"`
 	StreamingSpanWriter  bool     `protobuf:"varint,3,opt,name=streamingSpanWriter,proto3" json:"streamingSpanWriter,omitempty"`
+	MetricsReader        bool     `protobuf:"varint,4,opt,name=metricsReader,proto3" json:"metricsReader,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -930,7 +1404,7 @@ func (m *CapabilitiesResponse) Reset()         { *m = CapabilitiesResponse{} }
 func (m *CapabilitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*CapabilitiesResponse) ProtoMessage()    {}
 func (*CapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_0d2c4ccf1453ffdb, []int{18}
+	return fileDescriptor_0d2c4ccf1453ffdb, []int{27}
 }
 func (m *CapabilitiesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -980,6 +1454,13 @@ func (m *CapabilitiesResponse) GetStreamingSpanWriter() bool {
 	return false
 }
 
+func (m *CapabilitiesResponse) GetMetricsReader() bool {
+	if m != nil {
+		return m.MetricsReader
+	}
+	return false
+}
+
 func init() {
 	proto.RegisterType((*GetDependenciesRequest)(nil), "jaeger.storage.v1.GetDependenciesRequest")
 	proto.RegisterType((*GetDependenciesResponse)(nil), "jaeger.storage.v1.GetDependenciesResponse")
@@ -999,6 +1480,15 @@ func init() {
 	proto.RegisterType((*SpansResponseChunk)(nil), "jaeger.storage.v1.SpansResponseChunk")
 	proto.RegisterType((*FindTraceIDsRequest)(nil), "jaeger.storage.v1.FindTraceIDsRequest")
 	proto.RegisterType((*FindTraceIDsResponse)(nil), "jaeger.storage.v1.FindTraceIDsResponse")
+	proto.RegisterType((*MetricsBaseQueryParameters)(nil), "jaeger.storage.v1.MetricsBaseQueryParameters")
+	proto.RegisterType((*GetLatenciesRequest)(nil), "jaeger.storage.v1.GetLatenciesRequest")
+	proto.RegisterType((*GetLatenciesResponse)(nil), "jaeger.storage.v1.GetLatenciesResponse")
+	proto.RegisterType((*GetCallRatesRequest)(nil), "jaeger.storage.v1.GetCallRatesRequest")
+	proto.RegisterType((*GetCallRatesResponse)(nil), "jaeger.storage.v1.GetCallRatesResponse")
+	proto.RegisterType((*GetErrorRatesRequest)(nil), "jaeger.storage.v1.GetErrorRatesRequest")
+	proto.RegisterType((*GetErrorRatesResponse)(nil), "jaeger.storage.v1.GetErrorRatesResponse")
+	proto.RegisterType((*GetMinStepDurationRequest)(nil), "jaeger.storage.v1.GetMinStepDurationRequest")
+	proto.RegisterType((*GetMinStepDurationResponse)(nil), "jaeger.storage.v1.GetMinStepDurationResponse")
 	proto.RegisterType((*CapabilitiesRequest)(nil), "jaeger.storage.v1.CapabilitiesRequest")
 	proto.RegisterType((*CapabilitiesResponse)(nil), "jaeger.storage.v1.CapabilitiesResponse")
 }
@@ -1006,77 +1496,101 @@ func init() {
 func init() { proto.RegisterFile("storage.proto", fileDescriptor_0d2c4ccf1453ffdb) }
 
 var fileDescriptor_0d2c4ccf1453ffdb = []byte{
-	// 1117 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0x4f, 0x6f, 0xdc, 0xc4,
-	0x1b, 0xfe, 0x39, 0xd9, 0x6d, 0x76, 0xdf, 0xdd, 0xb4, 0xc9, 0xec, 0xf6, 0x57, 0xd7, 0xd0, 0x24,
-	0x18, 0x9a, 0x04, 0x04, 0xde, 0x66, 0x39, 0x80, 0xa0, 0x08, 0x9a, 0x3f, 0x8d, 0x02, 0x14, 0x8a,
-	0x13, 0xb5, 0x12, 0x85, 0xac, 0x66, 0xe3, 0xc1, 0x19, 0xb2, 0x1e, 0x6f, 0xed, 0xf1, 0x2a, 0x11,
-	0xe2, 0xc6, 0x07, 0xe0, 0xc8, 0x89, 0x13, 0x12, 0xdf, 0x83, 0x53, 0x8f, 0x9c, 0x39, 0x04, 0x94,
-	0x2b, 0x5f, 0x02, 0x79, 0x66, 0xec, 0xd8, 0x6b, 0x2b, 0x49, 0xa3, 0xdc, 0x3c, 0xef, 0x3c, 0xf3,
-	0xbc, 0xff, 0x66, 0x9e, 0xd7, 0x30, 0x1d, 0x72, 0x3f, 0xc0, 0x2e, 0xb1, 0x86, 0x81, 0xcf, 0x7d,
-	0x34, 0xfb, 0x3d, 0x26, 0x2e, 0x09, 0xac, 0xc4, 0x3a, 0x5a, 0x31, 0xda, 0xae, 0xef, 0xfa, 0x62,
-	0xb7, 0x13, 0x7f, 0x49, 0xa0, 0x31, 0xef, 0xfa, 0xbe, 0x3b, 0x20, 0x1d, 0xb1, 0xea, 0x47, 0xdf,
-	0x75, 0x38, 0xf5, 0x48, 0xc8, 0xb1, 0x37, 0x54, 0x80, 0xb9, 0x71, 0x80, 0x13, 0x05, 0x98, 0x53,
-	0x9f, 0xa9, 0xfd, 0x86, 0xe7, 0x3b, 0x64, 0x20, 0x17, 0xe6, 0xaf, 0x1a, 0xfc, 0x7f, 0x93, 0xf0,
-	0x75, 0x32, 0x24, 0xcc, 0x21, 0x6c, 0x8f, 0x92, 0xd0, 0x26, 0xcf, 0x23, 0x12, 0x72, 0xb4, 0x06,
-	0x10, 0x72, 0x1c, 0xf0, 0x5e, 0xec, 0x40, 0xd7, 0x16, 0xb4, 0xe5, 0x46, 0xd7, 0xb0, 0x24, 0xb9,
-	0x95, 0x90, 0x5b, 0x3b, 0x89, 0xf7, 0xd5, 0xda, 0x8b, 0xe3, 0xf9, 0xff, 0xfd, 0xfc, 0xf7, 0xbc,
-	0x66, 0xd7, 0xc5, 0xb9, 0x78, 0x07, 0x7d, 0x0c, 0x35, 0xc2, 0x1c, 0x49, 0x31, 0xf1, 0x12, 0x14,
-	0x53, 0x84, 0x39, 0xb1, 0xdd, 0xec, 0xc3, 0xad, 0x42, 0x7c, 0xe1, 0xd0, 0x67, 0x21, 0x41, 0x9b,
-	0xd0, 0x74, 0x32, 0x76, 0x5d, 0x5b, 0x98, 0x5c, 0x6e, 0x74, 0xef, 0x58, 0xaa, 0x92, 0x78, 0x48,
-	0x7b, 0xa3, 0xae, 0x95, 0x1e, 0x3d, 0xfa, 0x9c, 0xb2, 0x83, 0xd5, 0x4a, 0xec, 0xc2, 0xce, 0x1d,
-	0x34, 0x3f, 0x84, 0x99, 0xa7, 0x01, 0xe5, 0x64, 0x7b, 0x88, 0x59, 0x92, 0xfd, 0x12, 0x54, 0xc2,
-	0x21, 0x66, 0x2a, 0xef, 0xd6, 0x18, 0xa9, 0x40, 0x0a, 0x80, 0xd9, 0x82, 0xd9, 0xcc, 0x61, 0x19,
-	0x9a, 0xd9, 0x06, 0xb4, 0x36, 0xf0, 0x43, 0x22, 0x76, 0x02, 0xc5, 0x69, 0xde, 0x84, 0x56, 0xce,
-	0xaa, 0xc0, 0x0c, 0x6e, 0x6c, 0x12, 0xbe, 0x13, 0xe0, 0x3d, 0x92, 0x78, 0x7f, 0x06, 0x35, 0x1e,
-	0xaf, 0x7b, 0xd4, 0x11, 0x11, 0x34, 0x57, 0x3f, 0x89, 0xe3, 0xfe, 0xeb, 0x78, 0xfe, 0x1d, 0x97,
-	0xf2, 0xfd, 0xa8, 0x6f, 0xed, 0xf9, 0x5e, 0x47, 0xc6, 0x14, 0x03, 0x29, 0x73, 0xd5, 0xaa, 0x23,
-	0xbb, 0x2b, 0xd8, 0xb6, 0xd6, 0x4f, 0x8e, 0xe7, 0xa7, 0xd4, 0xa7, 0x3d, 0x25, 0x18, 0xb7, 0x9c,
-	0x38, 0xb8, 0x4d, 0xc2, 0xb7, 0x49, 0x30, 0xa2, 0x7b, 0x69, 0xbb, 0xcd, 0x15, 0x68, 0xe5, 0xac,
-	0xaa, 0xc8, 0x06, 0xd4, 0x42, 0x65, 0x13, 0x05, 0xae, 0xdb, 0xe9, 0xda, 0x7c, 0x04, 0xed, 0x4d,
-	0xc2, 0xbf, 0x1c, 0x12, 0x79, 0xbf, 0xd2, 0x9b, 0xa3, 0xc3, 0x94, 0xc2, 0x88, 0xe0, 0xeb, 0x76,
-	0xb2, 0x44, 0xaf, 0x40, 0x3d, 0x2e, 0x5a, 0xef, 0x80, 0x32, 0x47, 0xdc, 0x87, 0x98, 0x6e, 0x88,
-	0xd9, 0x67, 0x94, 0x39, 0xe6, 0x7d, 0xa8, 0xa7, 0x5c, 0x08, 0x41, 0x85, 0x61, 0x2f, 0x21, 0x10,
-	0xdf, 0x67, 0x9f, 0xfe, 0x11, 0x6e, 0x8e, 0x05, 0xa3, 0x32, 0x58, 0x84, 0xeb, 0x7e, 0x62, 0xfd,
-	0x02, 0x7b, 0x69, 0x1e, 0x63, 0x56, 0x74, 0x1f, 0x20, 0xb5, 0x84, 0xfa, 0x84, 0xb8, 0x4c, 0xaf,
-	0x5a, 0x85, 0x67, 0x69, 0xa5, 0x2e, 0xec, 0x0c, 0xde, 0xfc, 0xbd, 0x02, 0x6d, 0x51, 0xe9, 0xaf,
-	0x22, 0x12, 0x1c, 0x3d, 0xc6, 0x01, 0xf6, 0x08, 0x27, 0x41, 0x88, 0x5e, 0x83, 0xa6, 0xca, 0xbe,
-	0x97, 0x49, 0xa8, 0xa1, 0x6c, 0xb1, 0x6b, 0x74, 0x37, 0x13, 0xa1, 0x04, 0xc9, 0xe4, 0xa6, 0x73,
-	0x11, 0xa2, 0x0d, 0xa8, 0x70, 0xec, 0x86, 0xfa, 0xa4, 0x08, 0x6d, 0xa5, 0x24, 0xb4, 0xb2, 0x00,
-	0xac, 0x1d, 0xec, 0x86, 0x1b, 0x8c, 0x07, 0x47, 0xb6, 0x38, 0x8e, 0x3e, 0x85, 0xeb, 0xa7, 0xef,
-	0xba, 0xe7, 0x51, 0xa6, 0x57, 0x5e, 0xe2, 0x61, 0x36, 0xd3, 0xb7, 0xfd, 0x88, 0xb2, 0x71, 0x2e,
-	0x7c, 0xa8, 0x57, 0x2f, 0xc7, 0x85, 0x0f, 0xd1, 0x43, 0x68, 0x26, 0x4a, 0x25, 0xa2, 0xba, 0x26,
-	0x98, 0x6e, 0x17, 0x98, 0xd6, 0x15, 0x48, 0x12, 0xfd, 0x12, 0x13, 0x35, 0x92, 0x83, 0x71, 0x4c,
-	0x39, 0x1e, 0x7c, 0xa8, 0x4f, 0x5d, 0x86, 0x07, 0x1f, 0xa2, 0x3b, 0x00, 0x2c, 0xf2, 0x7a, 0xe2,
-	0xd5, 0x84, 0x7a, 0x6d, 0x41, 0x5b, 0xae, 0xda, 0x75, 0x16, 0x79, 0xa2, 0xc8, 0xa1, 0xf1, 0x1e,
-	0xd4, 0xd3, 0xca, 0xa2, 0x19, 0x98, 0x3c, 0x20, 0x47, 0xaa, 0xb7, 0xf1, 0x27, 0x6a, 0x43, 0x75,
-	0x84, 0x07, 0x51, 0xd2, 0x4a, 0xb9, 0xf8, 0x60, 0xe2, 0x7d, 0xcd, 0xb4, 0x61, 0xf6, 0x21, 0x65,
-	0x8e, 0xa4, 0x49, 0x9e, 0xcc, 0x47, 0x50, 0x7d, 0x1e, 0xf7, 0x4d, 0xe9, 0xcd, 0xd2, 0x05, 0x9b,
-	0x6b, 0xcb, 0x53, 0xe6, 0x06, 0xa0, 0x58, 0x7f, 0xd2, 0x4b, 0xbf, 0xb6, 0x1f, 0xb1, 0x03, 0xd4,
-	0x81, 0x6a, 0xfc, 0x3c, 0x12, 0x65, 0x2c, 0x13, 0x31, 0xa5, 0x87, 0x12, 0x67, 0xee, 0x40, 0x2b,
-	0x0d, 0x6d, 0x6b, 0xfd, 0xaa, 0x82, 0x1b, 0x41, 0x3b, 0xcf, 0xaa, 0x1e, 0xe6, 0x2e, 0xd4, 0x13,
-	0x91, 0x93, 0x21, 0x36, 0x57, 0x1f, 0x5c, 0x56, 0xe5, 0x6a, 0x29, 0x7b, 0x4d, 0xc9, 0x5c, 0x28,
-	0xe4, 0x16, 0x0f, 0x71, 0x9f, 0x0e, 0x28, 0x3f, 0x9d, 0x6b, 0xe6, 0x6f, 0x1a, 0xb4, 0xf3, 0x76,
-	0x15, 0xcf, 0xdb, 0x30, 0x8b, 0x83, 0xbd, 0x7d, 0x3a, 0x52, 0x5a, 0x8e, 0x1d, 0x12, 0x88, 0x94,
-	0x6b, 0x76, 0x71, 0x63, 0x0c, 0x2d, 0x25, 0x5d, 0x34, 0x3b, 0x8f, 0x96, 0x1b, 0xe8, 0x1e, 0xb4,
-	0x42, 0x1e, 0x10, 0xec, 0x51, 0xe6, 0x66, 0xf0, 0x93, 0x02, 0x5f, 0xb6, 0xd5, 0xfd, 0x43, 0x83,
-	0x99, 0xd3, 0xe5, 0xe3, 0x41, 0xe4, 0x52, 0x86, 0x9e, 0x40, 0x3d, 0x1d, 0x36, 0xe8, 0xf5, 0x92,
-	0x3e, 0x8c, 0xcf, 0x31, 0xe3, 0x8d, 0xb3, 0x41, 0x2a, 0xf5, 0x27, 0x50, 0x15, 0x93, 0x09, 0xdd,
-	0x2d, 0x81, 0x17, 0x27, 0x99, 0xb1, 0x78, 0x1e, 0x4c, 0xf2, 0x76, 0x7f, 0x80, 0xdb, 0xdb, 0xc5,
-	0xdc, 0x54, 0x32, 0xbb, 0x70, 0x23, 0x8d, 0x44, 0xa2, 0xae, 0x30, 0xa5, 0x65, 0xad, 0xfb, 0xef,
-	0xa4, 0xac, 0xa0, 0x6c, 0x98, 0x72, 0xfa, 0x14, 0x6a, 0xc9, 0xb0, 0x45, 0x66, 0x09, 0xd1, 0xd8,
-	0x24, 0x36, 0xca, 0x0a, 0x52, 0x7c, 0x6a, 0xf7, 0x34, 0xf4, 0x0d, 0x34, 0x32, 0xf3, 0xb3, 0xb4,
-	0x90, 0xc5, 0xa9, 0x5b, 0x5a, 0xc8, 0xb2, 0x31, 0xdc, 0x87, 0xe9, 0xdc, 0x74, 0x43, 0x4b, 0xe5,
-	0x07, 0x0b, 0xc3, 0xd8, 0x58, 0x3e, 0x1f, 0xa8, 0x7c, 0x3c, 0x03, 0x38, 0x15, 0x26, 0x54, 0x56,
-	0xe5, 0x82, 0x6e, 0x5d, 0xbc, 0x3c, 0x3d, 0x68, 0x66, 0x45, 0x00, 0x2d, 0x9e, 0x45, 0x7f, 0xaa,
-	0x3d, 0xc6, 0xd2, 0xb9, 0x38, 0x75, 0xd5, 0x0e, 0xe1, 0xd6, 0x83, 0xf1, 0x67, 0xa7, 0x7a, 0xfe,
-	0xad, 0xfa, 0xbf, 0xcb, 0xec, 0x5f, 0xe1, 0x4d, 0xeb, 0x1e, 0xe5, 0x3c, 0xe7, 0x6e, 0xdb, 0xae,
-	0xf8, 0xb5, 0x53, 0xbb, 0x57, 0x7f, 0xe9, 0xba, 0x3f, 0x69, 0xa0, 0xe7, 0xff, 0x8d, 0x33, 0xce,
-	0xf7, 0x85, 0xf3, 0xec, 0x36, 0x7a, 0xb3, 0xdc, 0x79, 0xc9, 0xef, 0xbf, 0xf1, 0xd6, 0x45, 0xa0,
-	0xaa, 0x02, 0x11, 0x20, 0xe9, 0x33, 0xab, 0xab, 0x71, 0xcb, 0x73, 0xeb, 0x52, 0xd1, 0x28, 0x0a,
-	0x74, 0x69, 0xcb, 0xcb, 0x04, 0x7b, 0x55, 0x7f, 0x71, 0x32, 0xa7, 0xfd, 0x79, 0x32, 0xa7, 0xfd,
-	0x73, 0x32, 0xa7, 0x7d, 0x0d, 0x0a, 0xde, 0x1b, 0xad, 0xf4, 0xaf, 0x89, 0x29, 0xff, 0xee, 0x7f,
-	0x01, 0x00, 0x00, 0xff, 0xff, 0x6c, 0xa3, 0xc0, 0x72, 0x65, 0x0d, 0x00, 0x00,
+	// 1490 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x58, 0x4b, 0x73, 0xdb, 0x44,
+	0x1c, 0x47, 0x89, 0x53, 0xdb, 0xff, 0x38, 0x6d, 0xb2, 0x76, 0xa9, 0xab, 0xd2, 0xa4, 0xa8, 0x8f,
+	0x04, 0xa6, 0x71, 0x1a, 0x53, 0x06, 0x06, 0xca, 0x40, 0x9d, 0xa4, 0xa1, 0xd0, 0x40, 0x51, 0x32,
+	0xed, 0x0c, 0x85, 0x8a, 0xb5, 0xbd, 0x75, 0x44, 0xac, 0x95, 0x22, 0xad, 0x3d, 0xf1, 0x30, 0xdc,
+	0xf8, 0x00, 0x1c, 0x38, 0x70, 0xe2, 0xca, 0x8d, 0x0f, 0xc1, 0xa9, 0xc3, 0x89, 0x33, 0x87, 0x02,
+	0xb9, 0xf2, 0x25, 0x18, 0xed, 0xae, 0x64, 0xbd, 0x1c, 0xa7, 0x9d, 0x4c, 0x6f, 0xda, 0xdd, 0xdf,
+	0xff, 0xb9, 0xff, 0xd7, 0x0a, 0x66, 0x3c, 0x66, 0xbb, 0xb8, 0x43, 0x6a, 0x8e, 0x6b, 0x33, 0x1b,
+	0xcd, 0x7d, 0x8b, 0x49, 0x87, 0xb8, 0xb5, 0x60, 0xb7, 0xbf, 0xaa, 0x56, 0x3a, 0x76, 0xc7, 0xe6,
+	0xa7, 0x2b, 0xfe, 0x97, 0x00, 0xaa, 0x0b, 0x1d, 0xdb, 0xee, 0x74, 0xc9, 0x0a, 0x5f, 0x35, 0x7b,
+	0x4f, 0x56, 0x98, 0x69, 0x11, 0x8f, 0x61, 0xcb, 0x91, 0x80, 0xf9, 0x24, 0xa0, 0xdd, 0x73, 0x31,
+	0x33, 0x6d, 0x2a, 0xcf, 0xa7, 0x2d, 0xbb, 0x4d, 0xba, 0x72, 0x31, 0x67, 0x3b, 0x84, 0x5a, 0x84,
+	0xb9, 0x66, 0xcb, 0x13, 0x5b, 0xda, 0x2f, 0x0a, 0xbc, 0xba, 0x49, 0xd8, 0x3a, 0x71, 0x08, 0x6d,
+	0x13, 0xda, 0x32, 0x89, 0xa7, 0x93, 0xfd, 0x1e, 0xf1, 0x18, 0x5a, 0x03, 0xf0, 0x18, 0x76, 0x99,
+	0xe1, 0xcb, 0xac, 0x2a, 0x97, 0x94, 0xa5, 0xe9, 0xba, 0x5a, 0x13, 0xf2, 0x6a, 0x81, 0xbc, 0xda,
+	0x4e, 0xa0, 0x50, 0xa3, 0xf0, 0xf4, 0xd9, 0xc2, 0x2b, 0x3f, 0xfe, 0xbd, 0xa0, 0xe8, 0x45, 0x4e,
+	0xe7, 0x9f, 0xa0, 0x0f, 0xa1, 0x40, 0x68, 0x5b, 0xb0, 0x98, 0x78, 0x0e, 0x16, 0x79, 0x42, 0xdb,
+	0xfe, 0xbe, 0xd6, 0x84, 0x73, 0x29, 0xfd, 0x3c, 0xc7, 0xa6, 0x1e, 0x41, 0x9b, 0x50, 0x6a, 0x47,
+	0xf6, 0xab, 0xca, 0xa5, 0xc9, 0xa5, 0xe9, 0xfa, 0xc5, 0x9a, 0x74, 0x2e, 0x76, 0x4c, 0xa3, 0x5f,
+	0xaf, 0x85, 0xa4, 0x83, 0x7b, 0x26, 0xdd, 0x6b, 0xe4, 0x7c, 0x11, 0x7a, 0x8c, 0x50, 0x7b, 0x1f,
+	0x66, 0x1f, 0xba, 0x26, 0x23, 0xdb, 0x0e, 0xa6, 0x81, 0xf5, 0x8b, 0x90, 0xf3, 0x1c, 0x4c, 0xa5,
+	0xdd, 0xe5, 0x04, 0x53, 0x8e, 0xe4, 0x00, 0xad, 0x0c, 0x73, 0x11, 0x62, 0xa1, 0x9a, 0x56, 0x01,
+	0xb4, 0xd6, 0xb5, 0x3d, 0xc2, 0x4f, 0x5c, 0xc9, 0x53, 0x3b, 0x0b, 0xe5, 0xd8, 0xae, 0x04, 0x53,
+	0x38, 0xb3, 0x49, 0xd8, 0x8e, 0x8b, 0x5b, 0x24, 0x90, 0xfe, 0x08, 0x0a, 0xcc, 0x5f, 0x1b, 0x66,
+	0x9b, 0x6b, 0x50, 0x6a, 0x7c, 0xe4, 0xeb, 0xfd, 0xd7, 0xb3, 0x85, 0xe5, 0x8e, 0xc9, 0x76, 0x7b,
+	0xcd, 0x5a, 0xcb, 0xb6, 0x56, 0x84, 0x4e, 0x3e, 0xd0, 0xa4, 0x1d, 0xb9, 0x5a, 0x11, 0x17, 0xce,
+	0xb9, 0xdd, 0x5d, 0x3f, 0x7c, 0xb6, 0x90, 0x97, 0x9f, 0x7a, 0x9e, 0x73, 0xbc, 0xdb, 0xf6, 0x95,
+	0xdb, 0x24, 0x6c, 0x9b, 0xb8, 0x7d, 0xb3, 0x15, 0x5e, 0xb7, 0xb6, 0x0a, 0xe5, 0xd8, 0xae, 0x74,
+	0xb2, 0x0a, 0x05, 0x4f, 0xee, 0x71, 0x07, 0x17, 0xf5, 0x70, 0xad, 0x6d, 0x41, 0x65, 0x93, 0xb0,
+	0xcf, 0x1d, 0x22, 0x42, 0x2e, 0x8c, 0x9c, 0x2a, 0xe4, 0x25, 0x86, 0x2b, 0x5f, 0xd4, 0x83, 0x25,
+	0xba, 0x00, 0x45, 0xdf, 0x69, 0xc6, 0x9e, 0x49, 0xdb, 0x3c, 0x1e, 0x7c, 0x76, 0x0e, 0xa6, 0x9f,
+	0x9a, 0xb4, 0xad, 0xdd, 0x82, 0x62, 0xc8, 0x0b, 0x21, 0xc8, 0x51, 0x6c, 0x05, 0x0c, 0xf8, 0xf7,
+	0xd1, 0xd4, 0xdf, 0xc3, 0xd9, 0x84, 0x32, 0xd2, 0x82, 0x6b, 0x70, 0xda, 0x0e, 0x76, 0x3f, 0xc3,
+	0x56, 0x68, 0x47, 0x62, 0x17, 0xdd, 0x02, 0x08, 0x77, 0xbc, 0xea, 0x04, 0x0f, 0xa6, 0xd7, 0x6a,
+	0xa9, 0x4c, 0xad, 0x85, 0x22, 0xf4, 0x08, 0x5e, 0xfb, 0x35, 0x07, 0x15, 0xee, 0xe9, 0x2f, 0x7a,
+	0xc4, 0x1d, 0xdc, 0xc7, 0x2e, 0xb6, 0x08, 0x23, 0xae, 0x87, 0x5e, 0x87, 0x92, 0xb4, 0xde, 0x88,
+	0x18, 0x34, 0x2d, 0xf7, 0x7c, 0xd1, 0xe8, 0x6a, 0x44, 0x43, 0x01, 0x12, 0xc6, 0xcd, 0xc4, 0x34,
+	0x44, 0x1b, 0x90, 0x63, 0xb8, 0xe3, 0x55, 0x27, 0xb9, 0x6a, 0xab, 0x19, 0xaa, 0x65, 0x29, 0x50,
+	0xdb, 0xc1, 0x1d, 0x6f, 0x83, 0x32, 0x77, 0xa0, 0x73, 0x72, 0xf4, 0x09, 0x9c, 0x1e, 0xe6, 0xb5,
+	0x61, 0x99, 0xb4, 0x9a, 0x7b, 0x8e, 0xc4, 0x2c, 0x85, 0xb9, 0xbd, 0x65, 0xd2, 0x24, 0x2f, 0x7c,
+	0x50, 0x9d, 0x7a, 0x31, 0x5e, 0xf8, 0x00, 0xdd, 0x81, 0x52, 0x50, 0xbc, 0xb8, 0x56, 0xa7, 0x38,
+	0xa7, 0xf3, 0x29, 0x4e, 0xeb, 0x12, 0x24, 0x18, 0xfd, 0xec, 0x33, 0x9a, 0x0e, 0x08, 0x7d, 0x9d,
+	0x62, 0x7c, 0xf0, 0x41, 0x35, 0xff, 0x22, 0x7c, 0xf0, 0x01, 0xba, 0x08, 0x40, 0x7b, 0x96, 0xc1,
+	0xb3, 0xc6, 0xab, 0x16, 0x2e, 0x29, 0x4b, 0x53, 0x7a, 0x91, 0xf6, 0x2c, 0xee, 0x64, 0x4f, 0x7d,
+	0x07, 0x8a, 0xa1, 0x67, 0xd1, 0x2c, 0x4c, 0xee, 0x91, 0x81, 0xbc, 0x5b, 0xff, 0x13, 0x55, 0x60,
+	0xaa, 0x8f, 0xbb, 0xbd, 0xe0, 0x2a, 0xc5, 0xe2, 0xbd, 0x89, 0x77, 0x15, 0x4d, 0x87, 0xb9, 0x3b,
+	0x26, 0x6d, 0x0b, 0x36, 0x41, 0xca, 0x7c, 0x00, 0x53, 0xfb, 0xfe, 0xbd, 0xc9, 0x7a, 0xb3, 0x78,
+	0xcc, 0xcb, 0xd5, 0x05, 0x95, 0xb6, 0x01, 0xc8, 0xaf, 0x3f, 0x61, 0xd0, 0xaf, 0xed, 0xf6, 0xe8,
+	0x1e, 0x5a, 0x81, 0x29, 0x3f, 0x3d, 0x82, 0xca, 0x98, 0x55, 0xc4, 0x64, 0x3d, 0x14, 0x38, 0x6d,
+	0x07, 0xca, 0xa1, 0x6a, 0x77, 0xd7, 0x4f, 0x4a, 0xb9, 0x3e, 0x54, 0xe2, 0x5c, 0x65, 0x62, 0x3e,
+	0x86, 0x62, 0x50, 0xe4, 0x84, 0x8a, 0xa5, 0xc6, 0xed, 0x17, 0xad, 0x72, 0x85, 0x90, 0x7b, 0x41,
+	0x96, 0x39, 0x4f, 0xfb, 0x77, 0x02, 0xd4, 0x2d, 0xd1, 0xed, 0x1a, 0xd8, 0x4b, 0x25, 0xe6, 0x65,
+	0x98, 0x89, 0x26, 0x66, 0x50, 0x16, 0x4a, 0x91, 0xcc, 0xf4, 0xd0, 0x75, 0x40, 0x1d, 0xd7, 0xee,
+	0x39, 0x46, 0x73, 0x60, 0x84, 0xd9, 0xc8, 0xef, 0xb4, 0xa0, 0xcf, 0xf2, 0x93, 0xc6, 0x60, 0x58,
+	0xb4, 0xde, 0x8e, 0x74, 0xbb, 0xc9, 0x71, 0x89, 0x10, 0xf6, 0x38, 0x9f, 0xac, 0x6b, 0xdb, 0x7b,
+	0x4d, 0xdc, 0xda, 0x93, 0xb9, 0x38, 0x3a, 0x5a, 0xf5, 0x10, 0x8a, 0x96, 0x21, 0xe7, 0x31, 0xe2,
+	0xc8, 0x94, 0x3b, 0x82, 0x84, 0xc3, 0xd0, 0x4d, 0x28, 0xb8, 0x98, 0x11, 0xc3, 0x21, 0xee, 0xd8,
+	0xdc, 0xd2, 0xf3, 0x3e, 0xf4, 0x3e, 0x71, 0xfd, 0x2c, 0x08, 0x6b, 0xae, 0x57, 0xcd, 0x73, 0x17,
+	0x15, 0x83, 0xa2, 0xeb, 0x69, 0x3f, 0x29, 0xbc, 0x6d, 0xdc, 0xc3, 0x2c, 0x3e, 0x3c, 0x60, 0x38,
+	0xdb, 0xc4, 0x1e, 0x31, 0x78, 0x04, 0x18, 0x4e, 0xe8, 0x75, 0x19, 0x42, 0xcb, 0x19, 0x21, 0x34,
+	0xfa, 0xaa, 0xf4, 0x72, 0x33, 0xe3, 0xfe, 0x54, 0x28, 0xec, 0xf7, 0x30, 0x65, 0x66, 0x57, 0x24,
+	0xd9, 0x84, 0x1e, 0xae, 0xb5, 0x6f, 0x78, 0x67, 0x8a, 0x68, 0x25, 0x43, 0xee, 0x63, 0x98, 0x11,
+	0xf3, 0x8f, 0xf1, 0x04, 0x5b, 0x66, 0x37, 0x88, 0xe8, 0xcb, 0x89, 0xcc, 0x08, 0x66, 0x24, 0xa1,
+	0xd2, 0x1d, 0x0e, 0xd5, 0x4b, 0x56, 0x64, 0xa5, 0x1d, 0x70, 0xbb, 0xd7, 0x70, 0xb7, 0xab, 0x63,
+	0xf6, 0x32, 0xed, 0x96, 0xb6, 0x45, 0x24, 0x9f, 0xb8, 0x6d, 0x03, 0x2e, 0x61, 0xc3, 0x75, 0x6d,
+	0xf7, 0x65, 0x1b, 0x87, 0x79, 0x17, 0x8f, 0x8a, 0x3e, 0x71, 0xeb, 0x2e, 0xc0, 0xf9, 0x4d, 0xc2,
+	0xb6, 0x4c, 0xba, 0xcd, 0x88, 0x13, 0x06, 0xbc, 0x9c, 0x82, 0x74, 0x50, 0xb3, 0x0e, 0xa5, 0x12,
+	0x37, 0xa1, 0x60, 0x99, 0xd4, 0xe0, 0x59, 0xa7, 0x8c, 0x4d, 0x21, 0x4b, 0x70, 0xe1, 0x63, 0x1f,
+	0x76, 0x70, 0xd3, 0xec, 0x9a, 0x6c, 0x98, 0x22, 0xda, 0x1f, 0x0a, 0x54, 0xe2, 0xfb, 0x52, 0xca,
+	0x75, 0x98, 0xc3, 0x6e, 0x6b, 0xd7, 0xec, 0xcb, 0x99, 0x12, 0xb7, 0x89, 0xcb, 0xc5, 0x15, 0xf4,
+	0xf4, 0x41, 0x02, 0x2d, 0x46, 0x4b, 0x59, 0xa0, 0xd2, 0x07, 0xe8, 0x06, 0x94, 0x3d, 0xe6, 0x12,
+	0x6c, 0x99, 0xb4, 0x13, 0xc1, 0x4f, 0x72, 0x7c, 0xd6, 0x11, 0xba, 0x12, 0x38, 0xde, 0x93, 0x9a,
+	0xe4, 0x38, 0x36, 0xbe, 0x59, 0xff, 0x5d, 0x81, 0xd9, 0x21, 0xd1, 0xfd, 0x6e, 0xaf, 0x63, 0x52,
+	0xf4, 0x00, 0x8a, 0xe1, 0x68, 0x8c, 0x2e, 0x67, 0x44, 0x47, 0x72, 0xea, 0x56, 0xaf, 0x1c, 0x0d,
+	0x92, 0x0e, 0x7a, 0x00, 0x53, 0x7c, 0x8e, 0x46, 0x57, 0x33, 0xe0, 0xe9, 0xb9, 0x5b, 0xbd, 0x36,
+	0x0e, 0x26, 0xf8, 0xd6, 0xbf, 0x83, 0xf3, 0xdb, 0x69, 0x0f, 0x48, 0x63, 0x1e, 0xc3, 0x99, 0x50,
+	0x13, 0x81, 0x3a, 0x41, 0x93, 0x96, 0x94, 0xfa, 0x7f, 0x93, 0xc2, 0x83, 0xc2, 0xa1, 0x52, 0xe8,
+	0x43, 0x28, 0x04, 0x4f, 0x03, 0xa4, 0x65, 0x30, 0x4a, 0xbc, 0x1b, 0xd4, 0x2c, 0x87, 0xa4, 0x07,
+	0x83, 0x1b, 0x0a, 0xfa, 0x0a, 0xa6, 0x23, 0xd3, 0x7e, 0xa6, 0x23, 0xd3, 0x6f, 0x84, 0x4c, 0x47,
+	0x66, 0x3d, 0x1a, 0x9a, 0x30, 0x13, 0x9b, 0xc5, 0xd1, 0x62, 0x36, 0x61, 0xea, 0xe9, 0xa0, 0x2e,
+	0x8d, 0x07, 0x4a, 0x19, 0x8f, 0x00, 0x86, 0x63, 0x14, 0xca, 0xf2, 0x72, 0x6a, 0xca, 0x3a, 0xbe,
+	0x7b, 0x0c, 0x28, 0x45, 0x47, 0x16, 0x74, 0xed, 0x28, 0xf6, 0xc3, 0x49, 0x49, 0x5d, 0x1c, 0x8b,
+	0x93, 0xa1, 0x76, 0x00, 0xe7, 0x6e, 0x27, 0x93, 0x53, 0xde, 0xf9, 0xd7, 0xf2, 0x35, 0x1a, 0x39,
+	0x3f, 0xc1, 0x48, 0xab, 0x0f, 0x62, 0x92, 0x63, 0xd1, 0xf6, 0x98, 0x3f, 0x44, 0xe5, 0xe9, 0xc9,
+	0x07, 0x5d, 0xfd, 0x07, 0x05, 0xaa, 0xf1, 0x97, 0x7c, 0x44, 0xf8, 0x2e, 0x17, 0x1e, 0x3d, 0x46,
+	0x6f, 0x64, 0x0b, 0xcf, 0xf8, 0x59, 0xa1, 0xbe, 0x79, 0x1c, 0xa8, 0xf4, 0xc0, 0x6f, 0x93, 0x50,
+	0xde, 0x8a, 0x56, 0x2f, 0xa9, 0x81, 0x01, 0xa5, 0xe8, 0xd0, 0x80, 0x46, 0x44, 0x7b, 0x72, 0xd6,
+	0x51, 0x17, 0xc7, 0xe2, 0x64, 0xc8, 0x0a, 0x01, 0x61, 0xe7, 0x1e, 0x25, 0x20, 0x39, 0x54, 0x8c,
+	0x12, 0x90, 0x1e, 0x01, 0x44, 0xde, 0x0d, 0xbb, 0xe7, 0xa8, 0xbc, 0x4b, 0xb5, 0xf6, 0x51, 0x79,
+	0x97, 0xd1, 0x88, 0xf7, 0xf9, 0xdf, 0x83, 0x44, 0x87, 0x44, 0xd7, 0xb3, 0xe9, 0xb3, 0xbb, 0xac,
+	0xba, 0x7c, 0x4c, 0xb4, 0xbc, 0xb0, 0x1e, 0x20, 0x71, 0x45, 0xd1, 0x76, 0xe9, 0x7b, 0x33, 0xb6,
+	0xce, 0xac, 0xf2, 0xe9, 0xbe, 0x9b, 0xe9, 0xcd, 0xac, 0x3e, 0xdc, 0xa8, 0x3e, 0x3d, 0x9c, 0x57,
+	0xfe, 0x3c, 0x9c, 0x57, 0xfe, 0x39, 0x9c, 0x57, 0xbe, 0x04, 0x09, 0x37, 0xfa, 0xab, 0xcd, 0x53,
+	0xbc, 0xdb, 0xbf, 0xf5, 0x7f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x22, 0x38, 0x88, 0x3b, 0xd7, 0x13,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1819,6 +2333,188 @@ var _DependenciesReaderPlugin_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDependencies",
 			Handler:    _DependenciesReaderPlugin_GetDependencies_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "storage.proto",
+}
+
+// MetricsReaderPluginClient is the client API for MetricsReaderPlugin service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type MetricsReaderPluginClient interface {
+	// metricsstore/Reader
+	GetLatencies(ctx context.Context, in *GetLatenciesRequest, opts ...grpc.CallOption) (*GetLatenciesResponse, error)
+	GetCallRates(ctx context.Context, in *GetCallRatesRequest, opts ...grpc.CallOption) (*GetCallRatesResponse, error)
+	GetErrorRates(ctx context.Context, in *GetErrorRatesRequest, opts ...grpc.CallOption) (*GetErrorRatesResponse, error)
+	GetMinStepDuration(ctx context.Context, in *GetMinStepDurationRequest, opts ...grpc.CallOption) (*GetMinStepDurationResponse, error)
+}
+
+type metricsReaderPluginClient struct {
+	cc *grpc.ClientConn
+}
+
+func NewMetricsReaderPluginClient(cc *grpc.ClientConn) MetricsReaderPluginClient {
+	return &metricsReaderPluginClient{cc}
+}
+
+func (c *metricsReaderPluginClient) GetLatencies(ctx context.Context, in *GetLatenciesRequest, opts ...grpc.CallOption) (*GetLatenciesResponse, error) {
+	out := new(GetLatenciesResponse)
+	err := c.cc.Invoke(ctx, "/jaeger.storage.v1.MetricsReaderPlugin/GetLatencies", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *metricsReaderPluginClient) GetCallRates(ctx context.Context, in *GetCallRatesRequest, opts ...grpc.CallOption) (*GetCallRatesResponse, error) {
+	out := new(GetCallRatesResponse)
+	err := c.cc.Invoke(ctx, "/jaeger.storage.v1.MetricsReaderPlugin/GetCallRates", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *metricsReaderPluginClient) GetErrorRates(ctx context.Context, in *GetErrorRatesRequest, opts ...grpc.CallOption) (*GetErrorRatesResponse, error) {
+	out := new(GetErrorRatesResponse)
+	err := c.cc.Invoke(ctx, "/jaeger.storage.v1.MetricsReaderPlugin/GetErrorRates", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *metricsReaderPluginClient) GetMinStepDuration(ctx context.Context, in *GetMinStepDurationRequest, opts ...grpc.CallOption) (*GetMinStepDurationResponse, error) {
+	out := new(GetMinStepDurationResponse)
+	err := c.cc.Invoke(ctx, "/jaeger.storage.v1.MetricsReaderPlugin/GetMinStepDuration", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MetricsReaderPluginServer is the server API for MetricsReaderPlugin service.
+type MetricsReaderPluginServer interface {
+	// metricsstore/Reader
+	GetLatencies(context.Context, *GetLatenciesRequest) (*GetLatenciesResponse, error)
+	GetCallRates(context.Context, *GetCallRatesRequest) (*GetCallRatesResponse, error)
+	GetErrorRates(context.Context, *GetErrorRatesRequest) (*GetErrorRatesResponse, error)
+	GetMinStepDuration(context.Context, *GetMinStepDurationRequest) (*GetMinStepDurationResponse, error)
+}
+
+// UnimplementedMetricsReaderPluginServer can be embedded to have forward compatible implementations.
+type UnimplementedMetricsReaderPluginServer struct {
+}
+
+func (*UnimplementedMetricsReaderPluginServer) GetLatencies(ctx context.Context, req *GetLatenciesRequest) (*GetLatenciesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetLatencies not implemented")
+}
+func (*UnimplementedMetricsReaderPluginServer) GetCallRates(ctx context.Context, req *GetCallRatesRequest) (*GetCallRatesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetCallRates not implemented")
+}
+func (*UnimplementedMetricsReaderPluginServer) GetErrorRates(ctx context.Context, req *GetErrorRatesRequest) (*GetErrorRatesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetErrorRates not implemented")
+}
+func (*UnimplementedMetricsReaderPluginServer) GetMinStepDuration(ctx context.Context, req *GetMinStepDurationRequest) (*GetMinStepDurationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMinStepDuration not implemented")
+}
+
+func RegisterMetricsReaderPluginServer(s *grpc.Server, srv MetricsReaderPluginServer) {
+	s.RegisterService(&_MetricsReaderPlugin_serviceDesc, srv)
+}
+
+func _MetricsReaderPlugin_GetLatencies_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetLatenciesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetricsReaderPluginServer).GetLatencies(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/jaeger.storage.v1.MetricsReaderPlugin/GetLatencies",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetricsReaderPluginServer).GetLatencies(ctx, req.(*GetLatenciesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MetricsReaderPlugin_GetCallRates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetCallRatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetricsReaderPluginServer).GetCallRates(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/jaeger.storage.v1.MetricsReaderPlugin/GetCallRates",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetricsReaderPluginServer).GetCallRates(ctx, req.(*GetCallRatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MetricsReaderPlugin_GetErrorRates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetErrorRatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetricsReaderPluginServer).GetErrorRates(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/jaeger.storage.v1.MetricsReaderPlugin/GetErrorRates",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetricsReaderPluginServer).GetErrorRates(ctx, req.(*GetErrorRatesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MetricsReaderPlugin_GetMinStepDuration_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMinStepDurationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MetricsReaderPluginServer).GetMinStepDuration(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/jaeger.storage.v1.MetricsReaderPlugin/GetMinStepDuration",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MetricsReaderPluginServer).GetMinStepDuration(ctx, req.(*GetMinStepDurationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _MetricsReaderPlugin_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "jaeger.storage.v1.MetricsReaderPlugin",
+	HandlerType: (*MetricsReaderPluginServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "GetLatencies",
+			Handler:    _MetricsReaderPlugin_GetLatencies_Handler,
+		},
+		{
+			MethodName: "GetCallRates",
+			Handler:    _MetricsReaderPlugin_GetCallRates_Handler,
+		},
+		{
+			MethodName: "GetErrorRates",
+			Handler:    _MetricsReaderPlugin_GetErrorRates_Handler,
+		},
+		{
+			MethodName: "GetMinStepDuration",
+			Handler:    _MetricsReaderPlugin_GetMinStepDuration_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -2590,6 +3286,415 @@ func (m *FindTraceIDsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MetricsBaseQueryParameters) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MetricsBaseQueryParameters) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MetricsBaseQueryParameters) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.SpanKinds) > 0 {
+		for iNdEx := len(m.SpanKinds) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SpanKinds[iNdEx])
+			copy(dAtA[i:], m.SpanKinds[iNdEx])
+			i = encodeVarintStorage(dAtA, i, uint64(len(m.SpanKinds[iNdEx])))
+			i--
+			dAtA[i] = 0x3a
+		}
+	}
+	if m.RatePer != nil {
+		{
+			size, err := m.RatePer.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.Step != nil {
+		{
+			size, err := m.Step.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.Lookback != nil {
+		{
+			size, err := m.Lookback.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.EndTime != nil {
+		{
+			size, err := m.EndTime.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.GroupByOperation {
+		i--
+		if m.GroupByOperation {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.ServiceNames) > 0 {
+		for iNdEx := len(m.ServiceNames) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ServiceNames[iNdEx])
+			copy(dAtA[i:], m.ServiceNames[iNdEx])
+			i = encodeVarintStorage(dAtA, i, uint64(len(m.ServiceNames[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetLatenciesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetLatenciesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetLatenciesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.Quantile != 0 {
+		i -= 4
+		encoding_binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.Quantile))))
+		i--
+		dAtA[i] = 0x15
+	}
+	if m.BaseQueryParameters != nil {
+		{
+			size, err := m.BaseQueryParameters.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetLatenciesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetLatenciesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetLatenciesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.MetricFamily != nil {
+		{
+			size, err := m.MetricFamily.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetCallRatesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetCallRatesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetCallRatesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.BaseQueryParameters != nil {
+		{
+			size, err := m.BaseQueryParameters.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetCallRatesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetCallRatesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetCallRatesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.MetricFamily != nil {
+		{
+			size, err := m.MetricFamily.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetErrorRatesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetErrorRatesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetErrorRatesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.BaseQueryParameters != nil {
+		{
+			size, err := m.BaseQueryParameters.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetErrorRatesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetErrorRatesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetErrorRatesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.MetricFamily != nil {
+		{
+			size, err := m.MetricFamily.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetMinStepDurationRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetMinStepDurationRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetMinStepDurationRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetMinStepDurationResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetMinStepDurationResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetMinStepDurationResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.MinStep != nil {
+		{
+			size, err := m.MinStep.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStorage(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *CapabilitiesRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -2640,6 +3745,16 @@ func (m *CapabilitiesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	if m.XXX_unrecognized != nil {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.MetricsReader {
+		i--
+		if m.MetricsReader {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
 	}
 	if m.StreamingSpanWriter {
 		i--
@@ -2986,6 +4101,176 @@ func (m *FindTraceIDsResponse) Size() (n int) {
 	return n
 }
 
+func (m *MetricsBaseQueryParameters) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.ServiceNames) > 0 {
+		for _, s := range m.ServiceNames {
+			l = len(s)
+			n += 1 + l + sovStorage(uint64(l))
+		}
+	}
+	if m.GroupByOperation {
+		n += 2
+	}
+	if m.EndTime != nil {
+		l = m.EndTime.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.Lookback != nil {
+		l = m.Lookback.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.Step != nil {
+		l = m.Step.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.RatePer != nil {
+		l = m.RatePer.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if len(m.SpanKinds) > 0 {
+		for _, s := range m.SpanKinds {
+			l = len(s)
+			n += 1 + l + sovStorage(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetLatenciesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BaseQueryParameters != nil {
+		l = m.BaseQueryParameters.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.Quantile != 0 {
+		n += 5
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetLatenciesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MetricFamily != nil {
+		l = m.MetricFamily.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetCallRatesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BaseQueryParameters != nil {
+		l = m.BaseQueryParameters.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetCallRatesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MetricFamily != nil {
+		l = m.MetricFamily.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetErrorRatesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BaseQueryParameters != nil {
+		l = m.BaseQueryParameters.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetErrorRatesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MetricFamily != nil {
+		l = m.MetricFamily.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetMinStepDurationRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *GetMinStepDurationResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MinStep != nil {
+		l = m.MinStep.Size()
+		n += 1 + l + sovStorage(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *CapabilitiesRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -3011,6 +4296,9 @@ func (m *CapabilitiesResponse) Size() (n int) {
 		n += 2
 	}
 	if m.StreamingSpanWriter {
+		n += 2
+	}
+	if m.MetricsReader {
 		n += 2
 	}
 	if m.XXX_unrecognized != nil {
@@ -4770,6 +6058,956 @@ func (m *FindTraceIDsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *MetricsBaseQueryParameters) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MetricsBaseQueryParameters: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MetricsBaseQueryParameters: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceNames", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ServiceNames = append(m.ServiceNames, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GroupByOperation", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.GroupByOperation = bool(v != 0)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EndTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.EndTime == nil {
+				m.EndTime = &types.Timestamp{}
+			}
+			if err := m.EndTime.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Lookback", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Lookback == nil {
+				m.Lookback = &types.Duration{}
+			}
+			if err := m.Lookback.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Step", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Step == nil {
+				m.Step = &types.Duration{}
+			}
+			if err := m.Step.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RatePer", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RatePer == nil {
+				m.RatePer = &types.Duration{}
+			}
+			if err := m.RatePer.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpanKinds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SpanKinds = append(m.SpanKinds, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetLatenciesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetLatenciesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetLatenciesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BaseQueryParameters", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.BaseQueryParameters == nil {
+				m.BaseQueryParameters = &MetricsBaseQueryParameters{}
+			}
+			if err := m.BaseQueryParameters.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 5 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Quantile", wireType)
+			}
+			var v uint32
+			if (iNdEx + 4) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint32(encoding_binary.LittleEndian.Uint32(dAtA[iNdEx:]))
+			iNdEx += 4
+			m.Quantile = float32(math.Float32frombits(v))
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetLatenciesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetLatenciesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetLatenciesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MetricFamily", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MetricFamily == nil {
+				m.MetricFamily = &metrics.MetricFamily{}
+			}
+			if err := m.MetricFamily.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetCallRatesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetCallRatesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetCallRatesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BaseQueryParameters", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.BaseQueryParameters == nil {
+				m.BaseQueryParameters = &MetricsBaseQueryParameters{}
+			}
+			if err := m.BaseQueryParameters.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetCallRatesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetCallRatesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetCallRatesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MetricFamily", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MetricFamily == nil {
+				m.MetricFamily = &metrics.MetricFamily{}
+			}
+			if err := m.MetricFamily.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetErrorRatesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetErrorRatesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetErrorRatesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BaseQueryParameters", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.BaseQueryParameters == nil {
+				m.BaseQueryParameters = &MetricsBaseQueryParameters{}
+			}
+			if err := m.BaseQueryParameters.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetErrorRatesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetErrorRatesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetErrorRatesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MetricFamily", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MetricFamily == nil {
+				m.MetricFamily = &metrics.MetricFamily{}
+			}
+			if err := m.MetricFamily.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetMinStepDurationRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetMinStepDurationRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetMinStepDurationRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetMinStepDurationResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStorage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetMinStepDurationResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetMinStepDurationResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MinStep", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStorage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MinStep == nil {
+				m.MinStep = &types.Duration{}
+			}
+			if err := m.MinStep.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStorage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthStorage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *CapabilitiesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4910,6 +7148,26 @@ func (m *CapabilitiesResponse) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.StreamingSpanWriter = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MetricsReader", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStorage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.MetricsReader = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipStorage(dAtA[iNdEx:])

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -75,6 +75,9 @@ type ArchiveFactory interface {
 	CreateArchiveSpanWriter() (spanstore.Writer, error)
 }
 
+// ErrMetricsStorageNotSupported can be returned by the MetricsFactory when the metrics storage is not supported by the backend.
+var ErrMetricsStorageNotSupported = errors.New("metrics storage not supported")
+
 // MetricsFactory defines an interface for a factory that can create implementations of different metrics storage components.
 // Implementations are also encouraged to implement plugin.Configurable interface.
 //


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4413

## Short description of the changes
- define the metrics gRPC API in protos
- refactor: move two subpackages of plugin/storage/grpc to pkg/grpc
- implement the gRPC metrics plugin

A POC is implemented here: https://github.com/influxdata/influxdb-observability/pull/239

## TODO
- [ ] initial review by maintainers
- [ ] add unit tests (new _test.go files with TODO comments)