### PR TITLE
Update README.md - fixing docker compose command

### DIFF
--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -29,8 +29,8 @@ The following diagram illustrates the relationship between these components:
 ## Bring up/down the dev environment
 
 ```bash
-docker-compose up
-docker-compose down
+docker compose up
+docker compose down
 ```
 
 **Tips:**


### PR DESCRIPTION
The correct command is "docker compose up" and not "docker-compose up"
Reference: https://docs.docker.com/engine/reference/commandline/compose/