### PR TITLE
Changes for testing my storage backend.

### DIFF
--- a/plugin/storage/integration/fixtures/traces/default.json
+++ b/plugin/storage/integration/fixtures/traces/default.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA116AAAM=",
       "operationName": "",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/dur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAACQ==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA114AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/log_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/log_tags_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAAg==",
-      "spanId": "AAAAAAAAAAE=",
+      "spanId": "AAAA123AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/max_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/max_dur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAEA==",
-      "spanId": "AAAAAAAAAAI=",
+      "spanId": "AAAA115AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multi_spot_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multi_spot_tags_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAABA==",
-      "spanId": "AAAAAAAAAAE=",
+      "spanId": "AAAA125AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multiple1_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple1_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAACIQ==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA117AAAM=",
       "operationName": "",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multiple2_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple2_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAACIg==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA118AAAM=",
       "operationName": "",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multiple3_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multiple3_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAACIw==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA119AAAM=",
       "operationName": "",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multispottag_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_dur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAIA==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA135AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multispottag_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_maxdur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAIQ==",
-      "spanId": "AAAAAAAAAAU=",
+      "spanId": "AAAA136AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multispottag_opname_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_opname_dur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAGQ==",
-      "spanId": "AAAAAAAAAAU=",
+      "spanId": "AAAA134AAAM=",
       "operationName": "query19-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multispottag_opname_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_opname_maxdur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAGA==",
-      "spanId": "AAAAAAAAAAQ=",
+      "spanId": "AAAA133AAAM=",
       "operationName": "query18-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/multispottag_opname_trace.json
+++ b/plugin/storage/integration/fixtures/traces/multispottag_opname_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAFw==",
-      "spanId": "AAAAAAAAAAQ=",
+      "spanId": "AAAA132AAAM=",
       "operationName": "query17-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/opname_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/opname_dur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAACA==",
-      "spanId": "AAAAAAAAAAI=",
+      "spanId": "AAAA113AAAM=",
       "operationName": "query08-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/opname_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/opname_maxdur_trace.json
@@ -2,14 +2,14 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAABw==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA112AAAM=",
       "operationName": "query07-operation",
       "tags": [],
       "references": [
         {
           "refType": "CHILD_OF",
           "traceId": "AAAAAAAAAAAAAAAAAAAABw==",
-          "spanId": "AAAAAAAAAAI="
+          "spanId": "AAAA121AAAM="
         }
       ],
       "startTime": "2017-01-26T16:46:31.639875Z",
@@ -22,7 +22,7 @@
     },
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAABw==",
-      "spanId": "AAAAAAAAAAI=",
+      "spanId": "AAAA121AAAM=",
       "operationName": "query07-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/opname_trace.json
+++ b/plugin/storage/integration/fixtures/traces/opname_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAABg==",
-      "spanId": "AAAAAAAAAAE=",
+      "spanId": "AAAA111AAAM=",
       "operationName": "query06-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/process_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/process_tags_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAAw==",
-      "spanId": "AAAAAAAAAAE=",
+      "spanId": "AAAA124AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/span_tags_trace.json
+++ b/plugin/storage/integration/fixtures/traces/span_tags_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAAQ==",
-      "spanId": "AAAAAAAAAAI=",
+      "spanId": "AAAA122AAAM=",
       "operationName": "some-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/tags_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_dur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAFQ==",
-      "spanId": "AAAAAAAAAAQ=",
+      "spanId": "AAAA129AAAM=",
       "operationName": "placeholder",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/tags_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_maxdur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAFg==",
-      "spanId": "AAAAAAAAAAU=",
+      "spanId": "AAAA131AAAM=",
       "operationName": "",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/tags_opname_dur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_opname_dur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAFA==",
-      "spanId": "AAAAAAAAAAM=",
+      "spanId": "AAAA128AAAM=",
       "operationName": "query14-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/tags_opname_maxdur_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_opname_maxdur_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAEw==",
-      "spanId": "AAAAAAAAAAc=",
+      "spanId": "AAAA127AAAM=",
       "operationName": "query13-operation",
       "references": [],
       "startTime": "2017-01-26T16:46:31.639875Z",

--- a/plugin/storage/integration/fixtures/traces/tags_opname_trace.json
+++ b/plugin/storage/integration/fixtures/traces/tags_opname_trace.json
@@ -2,7 +2,7 @@
   "spans": [
     {
       "traceId": "AAAAAAAAAAAAAAAAAAAAEg==",
-      "spanId": "AAAAAAAAAAQ=",
+      "spanId": "AAAA126AAAM=",
       "operationName": "query12-operation",
       "references": [
         {
@@ -13,12 +13,12 @@
         {
           "refType": "CHILD_OF",
           "traceId": "AAAAAAAAAAAAAAAAAAAAAQ==",
-          "spanId": "AAAAAAAAAAI="
+          "spanId": "AAAA122AAAM="
         },
         {
           "refType": "FOLLOWS_FROM",
           "traceId": "AAAAAAAAAAAAAAAAAAAAAQ==",
-          "spanId": "AAAAAAAAAAI="
+          "spanId": "AAAA122AAAM="
         }
       ],
       "tags": [

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -288,6 +288,7 @@ func (s *StorageIntegration) loadParseAndWriteExampleTrace(t *testing.T) *model.
 func (s *StorageIntegration) loadParseAndWriteLargeTrace(t *testing.T) *model.Trace {
 	trace := s.getTraceFixture(t, "example_trace")
 	span := trace.Spans[0]
+	span.SpanID = model.SpanID(20008)
 	spns := make([]*model.Span, 1, 10008)
 	trace.Spans = spns
 	trace.Spans[0] = span


### PR DESCRIPTION
My backend is running the gRPC server locally on `localhost:10500`.

On top of supporting running only the tests needed to test the gRPC storage backend, this PR fixes duplicate span ids for https://github.com/jaegertracing/jaeger/issues/4466.