### PR TITLE
Make OTLP receiver enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ next release
 
 #### ⛔ Breaking Changes
 
+* Make OTLP receiver enabled by default ([@yurishkuro](https://github.com/yurishkuro) in [#4494](https://github.com/jaegertracing/jaeger/pull/4494))
 
 #### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ next release
 ### UI Changes
 
 
+1.46.0
+-------------------
+### Backend Changes
+
+#### ⛔ Breaking Changes
+
+
+#### New Features
+
+#### Bug fixes, Minor Improvements
+
+### UI Changes
+
+
 1.45.0 (2023-05-03)
 -------------------
 ### Backend Changes

--- a/cmd/collector/app/flags/flags.go
+++ b/cmd/collector/app/flags/flags.go
@@ -184,7 +184,7 @@ func AddFlags(flags *flag.FlagSet) {
 	addHTTPFlags(flags, httpServerFlagsCfg, ports.PortToHostPort(ports.CollectorHTTP))
 	addGRPCFlags(flags, grpcServerFlagsCfg, ports.PortToHostPort(ports.CollectorGRPC))
 
-	flags.Bool(flagCollectorOTLPEnabled, false, "Enables OpenTelemetry OTLP receiver on dedicated HTTP and gRPC ports")
+	flags.Bool(flagCollectorOTLPEnabled, true, "Enables OpenTelemetry OTLP receiver on dedicated HTTP and gRPC ports")
 	addHTTPFlags(flags, otlpServerFlagsCfg.HTTP, "")
 	addGRPCFlags(flags, otlpServerFlagsCfg.GRPC, "")
 


### PR DESCRIPTION
This simplifies compatibility with OTEL/OTLP by not requiring to set the option to enable OTLP receiver. The option is still supported and allows OTLP receiver to be disabled when needed.