### PR TITLE
[hotrod] Reduce span exporter's batch timeout to let the spans be exported sooner

### DIFF
--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"go.opentelemetry.io/otel"
@@ -62,7 +63,7 @@ func Init(serviceName string, exporterType string, metricsFactory metrics.Factor
 	rpcmetricsObserver := rpcmetrics.NewObserver(metricsFactory, rpcmetrics.DefaultNameNormalizer)
 
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exp),
+		sdktrace.WithBatcher(exp, sdktrace.WithBatchTimeout(1000*time.Millisecond)),
 		sdktrace.WithSpanProcessor(rpcmetricsObserver),
 		sdktrace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,


### PR DESCRIPTION
In HotROD appbatching is not required it should export traces asap so BatchTimeOut value can be lowered from 5sec solves the issue
Resolves jaegertracing/jaeger-ui#1180