### PR TITLE
Rebuild jaeger-ui if the tree does not match any tag exactly

### DIFF
--- a/scripts/rebuild-ui.sh
+++ b/scripts/rebuild-ui.sh
@@ -4,13 +4,13 @@ set -euxf -o pipefail
 
 cd jaeger-ui
 
-LAST_TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
-BRANCH_HASH=$(git rev-parse HEAD)
-LAST_TAG_HASH=$(git rev-parse $LAST_TAG)
+LAST_TAG=$(git describe --tags --dirty 2>/dev/null)
 
-if [[ "$BRANCH_HASH" == "$LAST_TAG_HASH" ]]; then
-    
-    if [[ "$LAST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]];  then
+if [[ "$LAST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]];  then
+    BRANCH_HASH=$(git rev-parse HEAD)
+    LAST_TAG_HASH=$(git rev-parse $LAST_TAG)
+
+    if [[ "$BRANCH_HASH" == "$LAST_TAG_HASH" ]]; then
         temp_file=$(mktemp)
         trap "rm -f ${temp_file}" EXIT
         release_url="https://github.com/jaegertracing/jaeger-ui/releases/download/${LAST_TAG}/assets.tar.gz"
@@ -20,16 +20,9 @@ if [[ "$BRANCH_HASH" == "$LAST_TAG_HASH" ]]; then
             rm -r -f packages/jaeger-ui/build/
             tar -zxvf "$temp_file" packages/jaeger-ui/build/
             exit 0
-            
         fi
     fi
-
 fi
 
 # do a regular full build
 yarn install --frozen-lockfile && cd packages/jaeger-ui && yarn build
-
-
-
-
-


### PR DESCRIPTION
The previous behavior resulted in the prebuild upstream package being downloaded, even if the local tree has any changes, whether they are commited or not. This broke our internal build that has some patches applied. See:

* https://github.com/jaegertracing/jaeger/pull/4251#issuecomment-1608393236

Let's use a more strict approach and only use the prebuild package if the tag is exact and does not contain any extra changes.