### PR TITLE
[tracegen] Enable BlockOnQueueFull in OTel SDK to avoid dropped spans

### DIFF
--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -81,8 +81,7 @@ func createTracers(cfg *tracegen.Config, logger *zap.Logger) ([]trace.Tracer, fu
 		logger.Sugar().Infof("using %s trace exporter for service %s", cfg.TraceExporter, svc)
 
 		tp := sdktrace.NewTracerProvider(
-			sdktrace.WithBatcher(exp),
-			sdktrace.WithBlocking(),
+			sdktrace.WithBatcher(exp, sdktrace.WithBlocking()),
 			sdktrace.WithResource(resource.NewWithAttributes(
 				semconv.SchemaURL,
 				semconv.ServiceNameKey.String(svc),

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -82,6 +82,7 @@ func createTracers(cfg *tracegen.Config, logger *zap.Logger) ([]trace.Tracer, fu
 
 		tp := sdktrace.NewTracerProvider(
 			sdktrace.WithBatcher(exp),
+			sdktrace.WithBlocking(),
 			sdktrace.WithResource(resource.NewWithAttributes(
 				semconv.SchemaURL,
 				semconv.ServiceNameKey.String(svc),


### PR DESCRIPTION
## Which problem is this PR solving?
[tracegen] Enable BlockOnQueueFull in OTel SDK to make spans not dropped in spikes

## Short description of the changes
Call `WithBlocking()` from OTel SDK to enable `BlockOnQueueFull=true` to make spans not dropped when the queue is full.

Tested locally:
- Before the change: Spans in tracegen were dropped when generated to jaeger-collector, even with just 1m duration and 1 worker.
- With the change: Spans in tracegen were not dropped even with 1h duration and 10 workers.

![Screenshot 2023-07-12 005149](https://github.com/jaegertracing/jaeger/assets/75315486/cff1e8c7-7a5a-451f-97f2-186ca4f06251)
