### PR TITLE
[kafka-consumer] Use wait group to ensure goroutine is finished before returning from Close

### DIFF
--- a/cmd/ingester/app/consumer/consumer.go
+++ b/cmd/ingester/app/consumer/consumer.go
@@ -15,6 +15,7 @@
 package consumer
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -77,8 +78,8 @@ func (c *Consumer) Start() {
 	c.deadlockDetector.start()
 	c.doneWg.Add(1)
 	go func() {
+		defer c.doneWg.Done()
 		c.logger.Info("Starting main loop")
-		c.doneWg.Done()
 		for pc := range c.internalConsumer.Partitions() {
 			c.partitionMapLock.Lock()
 			c.partitionIDToState[pc.Partition()] = &consumerState{partitionConsumer: pc}
@@ -96,7 +97,9 @@ func (c *Consumer) Start() {
 func (c *Consumer) Close() error {
 	// Close the internal consumer, which will close each partition consumers' message and error channels.
 	c.logger.Info("Closing parent consumer")
+	// close(c.internalConsumer.Partitions())
 	err := c.internalConsumer.Close()
+	fmt.Println(err)
 
 	c.logger.Debug("Closing deadlock detector")
 	c.deadlockDetector.close()

--- a/cmd/ingester/app/consumer/consumer.go
+++ b/cmd/ingester/app/consumer/consumer.go
@@ -15,7 +15,6 @@
 package consumer
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -97,9 +96,7 @@ func (c *Consumer) Start() {
 func (c *Consumer) Close() error {
 	// Close the internal consumer, which will close each partition consumers' message and error channels.
 	c.logger.Info("Closing parent consumer")
-	// close(c.internalConsumer.Partitions())
 	err := c.internalConsumer.Close()
-	fmt.Println(err)
 
 	c.logger.Debug("Closing deadlock detector")
 	c.deadlockDetector.close()

--- a/cmd/ingester/app/consumer/consumer.go
+++ b/cmd/ingester/app/consumer/consumer.go
@@ -75,8 +75,10 @@ func New(params Params) (*Consumer, error) {
 // Start begins consuming messages in a go routine
 func (c *Consumer) Start() {
 	c.deadlockDetector.start()
+	c.doneWg.Add(1)
 	go func() {
 		c.logger.Info("Starting main loop")
+		c.doneWg.Done()
 		for pc := range c.internalConsumer.Partitions() {
 			c.partitionMapLock.Lock()
 			c.partitionIDToState[pc.Partition()] = &consumerState{partitionConsumer: pc}

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -79,6 +79,7 @@ func newSaramaClusterConsumer(saramaPartitionConsumer sarama.PartitionConsumer, 
 	saramaClusterConsumer.On("Partitions").Return((<-chan cluster.PartitionConsumer)(pcha))
 	saramaClusterConsumer.On("Close").Return(nil).Run(func(args mock.Arguments) {
 		mc.Close()
+		close(pcha)
 	})
 	saramaClusterConsumer.On("MarkPartitionOffset", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	return saramaClusterConsumer

--- a/pkg/kafka/consumer/config.go
+++ b/pkg/kafka/consumer/config.go
@@ -71,5 +71,6 @@ func (c *Configuration) NewConsumer(logger *zap.Logger) (Consumer, error) {
 	// that does not set saramaConfig.Consumer.Offsets.CommitInterval to its default value 1s.
 	// then the samara-cluster fails if the default interval is not 1s.
 	saramaConfig.Consumer.Offsets.CommitInterval = time.Second
+
 	return cluster.NewConsumer(c.Brokers, c.GroupID, []string{c.Topic}, saramaConfig)
 }

--- a/pkg/kafka/consumer/config.go
+++ b/pkg/kafka/consumer/config.go
@@ -71,6 +71,5 @@ func (c *Configuration) NewConsumer(logger *zap.Logger) (Consumer, error) {
 	// that does not set saramaConfig.Consumer.Offsets.CommitInterval to its default value 1s.
 	// then the samara-cluster fails if the default interval is not 1s.
 	saramaConfig.Consumer.Offsets.CommitInterval = time.Second
-
 	return cluster.NewConsumer(c.Brokers, c.GroupID, []string{c.Topic}, saramaConfig)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves # [4576](https://github.com/jaegertracing/jaeger/issues/4576)

## Short description of the changes
Once we call [start](https://github.com/jaegertracing/jaeger/blob/main/cmd/ingester/app/consumer/consumer.go#L76) and call [close](https://github.com/jaegertracing/jaeger/blob/main/cmd/ingester/app/consumer/consumer.go#L76) again with fxtest module, there is a chance that the application will close the goroutine before the l[ogline](https://github.com/jaegertracing/jaeger/blob/main/cmd/ingester/app/consumer/consumer.go#L79) is executed causing **panic Log in routine after .. has completed**. 

Fix:
Add a wait group that will wait for the goroutine to finish before closing the channel.