### PR TITLE
[hotrod] Return trace ID via traceresponse header

### DIFF
--- a/examples/hotrod/services/frontend/web_assets/index.html
+++ b/examples/hotrod/services/frontend/web_assets/index.html
@@ -85,7 +85,6 @@ $(".hotrod-button").click(function(evt) {
       'baggage': 'session=' + clientUUID + ', request=' + requestID
   };
   console.log('sending headers', headers);
-  const before = Date.now();
 
   // Use current URI as basepath for ajax requests
   var pathPrefix = window.location.pathname;
@@ -96,12 +95,12 @@ $(".hotrod-button").click(function(evt) {
   $.ajax(pathPrefix + '/config?nonse=' + Math.random(), {
     method: 'GET',
     success: function(data, textStatus) {
-      const after = Date.now();
       console.log('config', data);
       config = data;
     },
   });
 
+  const before = Date.now();
   $.ajax(pathPrefix + '/dispatch?customer=' + customer + '&nonse=' + Math.random(), {
     headers: headers,
     method: 'GET',

--- a/examples/hotrod/services/frontend/web_assets/index.html
+++ b/examples/hotrod/services/frontend/web_assets/index.html
@@ -53,37 +53,51 @@
   <script>
 
 function formatDuration(duration) {
-  var d = duration / (1000000 * 1000 * 60);
-  var units = 'min';
+  const d = duration / (1000000 * 1000 * 60);
+  const units = 'min';
   return Math.round(d) + units;
 }
 
-var clientUUID = Math.round(Math.random() * 10000);
+function parseTraceResponse(value) {
+  const VERSION = '00';
+  const VERSION_PART = '(?!ff)[\\da-f]{2}';
+  const TRACE_ID_PART = '(?![0]{32})[\\da-f]{32}';
+  const PARENT_ID_PART = '(?![0]{16})[\\da-f]{16}';
+  const FLAGS_PART = '[\\da-f]{2}';
+  const TRACE_PARENT_REGEX = new RegExp(
+    `^\\s?(${VERSION_PART})-(${TRACE_ID_PART})-(${PARENT_ID_PART})-(${FLAGS_PART})(-.*)?\\s?$`
+  );
+  const match = TRACE_PARENT_REGEX.exec(value);
+  return (match) ? match[2] : null;
+}
+
+const clientUUID = Math.round(Math.random() * 10000);
 var lastRequestID = 0;
 
 $(".uuid").html(`Your web client's id: <strong>${clientUUID}</strong>`);
 
 $(".hotrod-button").click(function(evt) {
   lastRequestID++;
-  var requestID = clientUUID + "-" + lastRequestID;
-  var freshCar = $($("#hotrod-log").prepend('<div class="fresh-car"><em>Dispatching a car...[req: '+requestID+']</em></div>').children()[0]);
-  var customer = evt.target.dataset.customer;
-  var headers = {
+  const requestID = clientUUID + "-" + lastRequestID;
+  const freshCar = $($("#hotrod-log").prepend('<div class="fresh-car"><em>Dispatching a car...[req: '+requestID+']</em></div>').children()[0]);
+  const customer = evt.target.dataset.customer;
+  const headers = {
       'baggage': 'session=' + clientUUID + ', request=' + requestID
   };
-  console.log(headers);
-  var before = Date.now();
+  console.log('sending headers', headers);
+  const before = Date.now();
 
   // Use current URI as basepath for ajax requests
   var pathPrefix = window.location.pathname;
   pathPrefix = pathPrefix != "/" ? pathPrefix : '';
 
+  // TODO this should be done on page load, not on every button click
   var config = {};
   $.ajax(pathPrefix + '/config?nonse=' + Math.random(), {
     method: 'GET',
     success: function(data, textStatus) {
-      var after = Date.now();
-      console.log(data);
+      const after = Date.now();
+      console.log('config', data);
       config = data;
     },
   });
@@ -91,15 +105,24 @@ $(".hotrod-button").click(function(evt) {
   $.ajax(pathPrefix + '/dispatch?customer=' + customer + '&nonse=' + Math.random(), {
     headers: headers,
     method: 'GET',
-    success: function(data, textStatus) {
-      var after = Date.now();
-      console.log(data);
-      var duration = formatDuration(data.ETA);
+    success: function(data, textStatus, xhr) {
+      const after = Date.now();
+      const traceResponse = xhr.getResponseHeader('traceresponse');
+      const traceID = parseTraceResponse(traceResponse);
+      console.log('response', data);
+      console.log('traceResponse', traceResponse, 'traceID', traceID);
+
+      const duration = formatDuration(data.ETA);
       var traceLink = '';
       if (config && config['jaeger']) {
-        var jaeger = config['jaeger'];
-        var trace = `${jaeger}/search?limit=20&lookback=1h&service=frontend&tags=%7B%22driver%22%3A%22${data.Driver}%22%7D`;
-        traceLink = ` [<a href="${trace}" target="_blank">find trace</a>]`;
+        const jaeger = config['jaeger'];
+        const traceURL = function() {
+          if (traceID) {
+            return `/trace/${traceID}`;
+          }
+          return `/search?limit=20&lookback=1h&service=frontend&tags=%7B%22driver%22%3A%22${data.Driver}%22%7D`;
+        }();
+        traceLink = ` [<a href="${jaeger}${traceURL}" target="_blank">find trace</a>]`;
       }
       freshCar.html(`HotROD <b>${data.Driver}</b> arriving in ${duration} [req: ${requestID}, latency: ${after-before}ms] ${traceLink}`);
     },

--- a/examples/hotrod/services/frontend/web_assets/index.html
+++ b/examples/hotrod/services/frontend/web_assets/index.html
@@ -116,13 +116,11 @@ $(".hotrod-button").click(function(evt) {
       var traceLink = '';
       if (config && config['jaeger']) {
         const jaeger = config['jaeger'];
-        const traceURL = function() {
-          if (traceID) {
-            return `/trace/${traceID}`;
-          }
-          return `/search?limit=20&lookback=1h&service=frontend&tags=%7B%22driver%22%3A%22${data.Driver}%22%7D`;
-        }();
-        traceLink = ` [<a href="${jaeger}${traceURL}" target="_blank">find trace</a>]`;
+        const findURL = `/search?limit=20&lookback=1h&service=frontend&tags=%7B%22driver%22%3A%22${data.Driver}%22%7D`;
+        traceLink = ` [<a href="${jaeger}${findURL}" target="_blank">find trace</a>]`;
+        if (traceID) {
+          traceLink += ` [<a href="${jaeger}/trace/${traceID}" target="_blank">open trace</a>]`;
+        }
       }
       freshCar.html(`HotROD <b>${data.Driver}</b> arriving in ${duration} [req: ${requestID}, latency: ${after-before}ms] ${traceLink}`);
     },


### PR DESCRIPTION
## Which problem is this PR solving?
Since the HotROD UI does not start traces, it can only search for a trace corresponding to a particular request by some span tags. This makes the experience of opening a trace a big clunky as we first see the search page with one trace, and then have to click on the trace again.

Related to https://github.com/jaegertracing/jaeger/issues/3380

## Short description of the changes
Change the HTTP instrumentation to always generate a `traceresponse` header per the [current W3C draft](https://github.com/w3c/trace-context/blob/main/spec/21-http_response_header_format.md). Then parse the trace ID from that header in the UI and generate a hyperlink to open the trace view directly, bypassing the search.
