### PR TITLE
feat: Add `OTEL tracer` to metricsstore reader component

### DIFF
--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -61,7 +61,7 @@ func New(serviceName string) (*JTracer, error) {
 }
 
 func NoOp() *JTracer {
-	return &JTracer{OT: opentracing.NoopTracer{}, OTEL: trace.NewNoopTracerProvider(), closer: func(ctx context.Context) error { return nil }}
+	return &JTracer{OT: opentracing.NoopTracer{}, OTEL: trace.NewNoopTracerProvider(), closer: nil}
 }
 
 // initOTEL initializes OTEL Tracer
@@ -107,5 +107,8 @@ func otelExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
 
 // Shutdown the tracerProvider to clean up resources
 func (jt *JTracer) Close(ctx context.Context) error {
-	return jt.closer(ctx)
+	if jt.closer != nil {
+		return jt.closer(ctx)
+	}
+	return nil
 }

--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -61,7 +61,7 @@ func New(serviceName string) (*JTracer, error) {
 }
 
 func NoOp() *JTracer {
-	return &JTracer{OT: opentracing.NoopTracer{}, OTEL: trace.NewNoopTracerProvider()}
+	return &JTracer{OT: opentracing.NoopTracer{}, OTEL: trace.NewNoopTracerProvider(), closer: func(ctx context.Context) error { return nil }}
 }
 
 // initOTEL initializes OTEL Tracer

--- a/plugin/metrics/prometheus/factory.go
+++ b/plugin/metrics/prometheus/factory.go
@@ -18,6 +18,8 @@ import (
 	"flag"
 
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/plugin"
@@ -31,11 +33,13 @@ var _ plugin.Configurable = (*Factory)(nil)
 type Factory struct {
 	options *Options
 	logger  *zap.Logger
+	tracer  trace.TracerProvider
 }
 
 // NewFactory creates a new Factory.
 func NewFactory() *Factory {
 	return &Factory{
+		tracer:  otel.GetTracerProvider(),
 		options: NewOptions("prometheus"),
 	}
 }
@@ -60,5 +64,5 @@ func (f *Factory) Initialize(logger *zap.Logger) error {
 
 // CreateMetricsReader implements storage.MetricsFactory.
 func (f *Factory) CreateMetricsReader() (metricsstore.Reader, error) {
-	return prometheusstore.NewMetricsReader(f.logger, f.options.Primary.Configuration)
+	return prometheusstore.NewMetricsReader(f.options.Primary.Configuration, f.logger, f.tracer)
 }

--- a/plugin/metrics/prometheus/factory.go
+++ b/plugin/metrics/prometheus/factory.go
@@ -16,12 +16,10 @@ package prometheus
 
 import (
 	"flag"
-	"log"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/plugin"
 	prometheusstore "github.com/jaegertracing/jaeger/plugin/metrics/prometheus/metricsstore"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
@@ -33,18 +31,12 @@ var _ plugin.Configurable = (*Factory)(nil)
 type Factory struct {
 	options *Options
 	logger  *zap.Logger
-	tracer  *jtracer.JTracer
 }
 
 // NewFactory creates a new Factory.
 func NewFactory() *Factory {
-	jt, err := jtracer.New("metricsreader")
-	if err != nil {
-		log.Fatal("Failed to initialize tracer: %w", err)
-	}
 	return &Factory{
 		options: NewOptions("prometheus"),
-		tracer:  jt,
 	}
 }
 
@@ -68,5 +60,5 @@ func (f *Factory) Initialize(logger *zap.Logger) error {
 
 // CreateMetricsReader implements storage.MetricsFactory.
 func (f *Factory) CreateMetricsReader() (metricsstore.Reader, error) {
-	return prometheusstore.NewMetricsReader(f.logger, f.options.Primary.Configuration, f.tracer)
+	return prometheusstore.NewMetricsReader(f.logger, f.options.Primary.Configuration)
 }

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -26,14 +26,15 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/opentracing/opentracing-go"
-	ottag "github.com/opentracing/opentracing-go/ext"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/api"
 	promapi "github.com/prometheus/client_golang/api/prometheus/v1"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
+	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/prometheus/config"
 	"github.com/jaegertracing/jaeger/plugin/metrics/prometheus/metricsstore/dbmodel"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
@@ -54,6 +55,7 @@ type (
 		latencyMetricName string
 		callsMetricName   string
 		operationLabel    string
+		tracer            *jtracer.JTracer
 	}
 
 	promQueryParams struct {
@@ -73,7 +75,7 @@ type (
 )
 
 // NewMetricsReader returns a new MetricsReader.
-func NewMetricsReader(logger *zap.Logger, cfg config.Configuration) (*MetricsReader, error) {
+func NewMetricsReader(logger *zap.Logger, cfg config.Configuration, jt *jtracer.JTracer) (*MetricsReader, error) {
 	logger.Info("Creating metrics reader", zap.Any("configuration", cfg))
 
 	roundTripper, err := getHTTPRoundTripper(&cfg, logger)
@@ -101,6 +103,7 @@ func NewMetricsReader(logger *zap.Logger, cfg config.Configuration) (*MetricsRea
 		callsMetricName:   buildFullCallsMetricName(cfg),
 		latencyMetricName: buildFullLatencyMetricName(cfg),
 		operationLabel:    operationLabel,
+		tracer:            jt,
 	}
 
 	logger.Info("Prometheus reader initialized", zap.String("addr", cfg.ServerURL))
@@ -224,8 +227,11 @@ func (m MetricsReader) executeQuery(ctx context.Context, p metricsQueryParams) (
 	}
 	promQuery := m.buildPromQuery(p)
 
-	span, ctx := startSpanForQuery(ctx, p.metricName, promQuery)
-	defer span.Finish()
+	ctx, span := startSpanForQuery(ctx, p.metricName, promQuery, m.tracer.OTEL)
+	defer span.End()
+	if err := m.tracer.Close(ctx); err != nil {
+		m.logger.Error("Error shutting down tracer provider", zap.Error(err))
+	}
 
 	queryRange := promapi.Range{
 		Start: p.EndTime.Add(-1 * *p.Lookback),
@@ -287,17 +293,18 @@ func promqlDurationString(d *time.Duration) string {
 	return string(b)
 }
 
-func startSpanForQuery(ctx context.Context, metricName, query string) (opentracing.Span, context.Context) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, metricName)
-	ottag.DBStatement.Set(span, query)
-	ottag.DBType.Set(span, "prometheus")
-	ottag.Component.Set(span, "promql")
-	return span, ctx
+func startSpanForQuery(ctx context.Context, metricName, query string, tp trace.TracerProvider) (context.Context, trace.Span) {
+	ctx, span := tp.Tracer("prom-metrics-reader").Start(ctx, metricName)
+	span.SetAttributes(
+		attribute.Key(semconv.DBStatementKey).String(query),
+		attribute.Key("db.type").String("prometheus"),
+		attribute.Key("component").String("promql"),
+	)
+	return ctx, span
 }
 
-func logErrorToSpan(span opentracing.Span, err error) {
-	ottag.Error.Set(span, true)
-	span.LogFields(otlog.Error(err))
+func logErrorToSpan(span trace.Span, err error) {
+	span.AddEvent(err.Error(), trace.WithAttributes(semconv.OTelStatusCodeError))
 }
 
 func getHTTPRoundTripper(c *config.Configuration, logger *zap.Logger) (rt http.RoundTripper, err error) {

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -237,8 +237,9 @@ func (m MetricsReader) executeQuery(ctx context.Context, p metricsQueryParams) (
 
 	mv, warnings, err := m.client.QueryRange(ctx, promQuery, queryRange)
 	if err != nil {
+		err = fmt.Errorf("failed executing metrics query: %w", err)
 		logErrorToSpan(span, err)
-		return &metrics.MetricFamily{}, fmt.Errorf("failed executing metrics query: %w", err)
+		return &metrics.MetricFamily{}, err
 	}
 	if len(warnings) > 0 {
 		m.logger.Warn("Warnings detected on Prometheus query", zap.Any("warnings", warnings), zap.String("query", promQuery), zap.Any("range", queryRange))

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	promapi "github.com/prometheus/client_golang/api/prometheus/v1"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -301,7 +302,8 @@ func startSpanForQuery(ctx context.Context, metricName, query string, tp trace.T
 }
 
 func logErrorToSpan(span trace.Span, err error) {
-	span.RecordError(err, trace.WithAttributes(semconv.OTelStatusCodeError))
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
 }
 
 func getHTTPRoundTripper(c *config.Configuration, logger *zap.Logger) (rt http.RoundTripper, err error) {

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -148,12 +148,12 @@ func TestMetricsServerError(t *testing.T) {
 		ServerURL:      "http://" + address,
 		ConnectTimeout: defaultTimeout,
 	}, logger, tracer)
-	assert.NotEmpty(t, exp.GetSpans(), "Expected spans are recorded")
-	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
-	defer closer()
 	require.NoError(t, err)
 
 	m, err := reader.GetCallRates(context.Background(), &params)
+	assert.NotEmpty(t, exp.GetSpans(), "Expected spans are recorded")
+	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
+	defer closer()
 	assert.NotNil(t, m)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed executing metrics query")

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -83,9 +83,9 @@ func TestNewMetricsReaderValidAddress(t *testing.T) {
 		ServerURL:      "http://localhost:1234",
 		ConnectTimeout: defaultTimeout,
 	}, logger, tracer)
+	defer closer()
 	require.NoError(t, err)
 	assert.NotNil(t, reader)
-	defer closer()
 }
 
 func TestNewMetricsReaderInvalidAddress(t *testing.T) {
@@ -95,10 +95,10 @@ func TestNewMetricsReaderInvalidAddress(t *testing.T) {
 		ServerURL:      "\n",
 		ConnectTimeout: defaultTimeout,
 	}, logger, tracer)
+	defer closer()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to initialize prometheus client")
 	assert.Nil(t, reader)
-	defer closer()
 }
 
 func TestGetMinStepDuration(t *testing.T) {
@@ -113,12 +113,12 @@ func TestGetMinStepDuration(t *testing.T) {
 		ServerURL:      "http://" + listener.Addr().String(),
 		ConnectTimeout: defaultTimeout,
 	}, logger, tracer)
+	defer closer()
 	require.NoError(t, err)
 
 	minStep, err := reader.GetMinStepDuration(context.Background(), &params)
 	require.NoError(t, err)
 	assert.Equal(t, time.Millisecond, minStep)
-	defer closer()
 }
 
 func TestMetricsServerError(t *testing.T) {
@@ -148,15 +148,15 @@ func TestMetricsServerError(t *testing.T) {
 		ServerURL:      "http://" + address,
 		ConnectTimeout: defaultTimeout,
 	}, logger, tracer)
+	assert.NotEmpty(t, exp.GetSpans(), "Expected spans are recorded")
+	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
+	defer closer()
 	require.NoError(t, err)
 
 	m, err := reader.GetCallRates(context.Background(), &params)
 	assert.NotNil(t, m)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed executing metrics query")
-	assert.NotEmpty(t, exp.GetSpans(), "Expected spans are recorded")
-	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
-	defer closer()
 }
 
 func TestGetLatencies(t *testing.T) {
@@ -254,11 +254,11 @@ func TestGetLatencies(t *testing.T) {
 			defer mockPrometheus.Close()
 
 			m, err := reader.GetLatencies(context.Background(), &params)
-			require.NoError(t, err)
 			assert.NotEmpty(t, exp.GetSpans(), "Spans recorded during the test.")
 			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
-			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
 			defer closer()
+			require.NoError(t, err)
+			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
 		})
 	}
 }
@@ -355,11 +355,11 @@ func TestGetCallRates(t *testing.T) {
 			defer mockPrometheus.Close()
 
 			m, err := reader.GetCallRates(context.Background(), &params)
-			require.NoError(t, err)
 			assert.NotEmpty(t, exp.GetSpans(), "Spans recorded during the test.")
 			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
-			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
 			defer closer()
+			require.NoError(t, err)
+			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
 		})
 	}
 }
@@ -481,11 +481,11 @@ func TestGetErrorRates(t *testing.T) {
 			defer mockPrometheus.Close()
 
 			m, err := reader.GetErrorRates(context.Background(), &params)
-			require.NoError(t, err)
 			assert.NotEmpty(t, exp.GetSpans(), "Spans recorded during the test.")
 			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
-			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
 			defer closer()
+			require.NoError(t, err)
+			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
 		})
 	}
 }
@@ -515,11 +515,11 @@ func TestWarningResponse(t *testing.T) {
 	defer mockPrometheus.Close()
 
 	m, err := reader.GetErrorRates(context.Background(), &params)
+	defer closer()
 	require.NoError(t, err)
 	assert.NotEmpty(t, exp.GetSpans(), "Spans recorded during the test.")
 	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 	assert.NotNil(t, m)
-	defer closer()
 }
 
 func TestGetRoundTripperTLSConfig(t *testing.T) {
@@ -622,9 +622,9 @@ func TestInvalidCertFile(t *testing.T) {
 			CAPath:  "foo",
 		},
 	}, logger, tracer)
+	defer closer()
 	require.Error(t, err)
 	assert.Nil(t, reader)
-	defer closer()
 }
 
 func startMockPrometheusServer(t *testing.T, wantPromQlQuery string, wantWarnings []string) *httptest.Server {

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -151,11 +151,11 @@ func TestMetricsServerError(t *testing.T) {
 	}, logger, tracer)
 	require.NoError(t, err)
 	m, err := reader.GetCallRates(context.Background(), &params)
-	assert.NotNil(t, exp.GetSpans()[0].Status)
-	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 	assert.NotNil(t, m)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed executing metrics query")
+	require.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
+	assert.Equal(t, "service_call_rate", exp.GetSpans()[0].Name)
 }
 
 func TestGetLatencies(t *testing.T) {
@@ -254,9 +254,9 @@ func TestGetLatencies(t *testing.T) {
 			defer mockPrometheus.Close()
 
 			m, err := reader.GetLatencies(context.Background(), &params)
-			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 			require.NoError(t, err)
 			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
+			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 		})
 	}
 }
@@ -354,9 +354,9 @@ func TestGetCallRates(t *testing.T) {
 			defer mockPrometheus.Close()
 
 			m, err := reader.GetCallRates(context.Background(), &params)
-			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 			require.NoError(t, err)
 			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
+			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 		})
 	}
 }
@@ -479,9 +479,9 @@ func TestGetErrorRates(t *testing.T) {
 			defer mockPrometheus.Close()
 
 			m, err := reader.GetErrorRates(context.Background(), &params)
-			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 			require.NoError(t, err)
 			assertMetrics(t, m, tc.wantLabels, tc.wantName, tc.wantDescription)
+			assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 		})
 	}
 }
@@ -512,9 +512,9 @@ func TestWarningResponse(t *testing.T) {
 	defer mockPrometheus.Close()
 
 	m, err := reader.GetErrorRates(context.Background(), &params)
-	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 	require.NoError(t, err)
 	assert.NotNil(t, m)
+	assert.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 }
 
 func TestGetRoundTripperTLSConfig(t *testing.T) {

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -155,7 +156,7 @@ func TestMetricsServerError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed executing metrics query")
 	require.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
-	assert.Equal(t, "service_call_rate", exp.GetSpans()[0].Name)
+	assert.Equal(t, codes.Error, exp.GetSpans()[0].Status.Code)
 }
 
 func TestGetLatencies(t *testing.T) {

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
-	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/prometheus/config"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
@@ -64,22 +63,20 @@ var defaultConfig = config.Configuration{
 
 func TestNewMetricsReaderValidAddress(t *testing.T) {
 	logger := zap.NewNop()
-	tracer := jtracer.NoOp()
 	reader, err := NewMetricsReader(logger, config.Configuration{
 		ServerURL:      "http://localhost:1234",
 		ConnectTimeout: defaultTimeout,
-	}, tracer)
+	})
 	require.NoError(t, err)
 	assert.NotNil(t, reader)
 }
 
 func TestNewMetricsReaderInvalidAddress(t *testing.T) {
 	logger := zap.NewNop()
-	tracer := jtracer.NoOp()
 	reader, err := NewMetricsReader(logger, config.Configuration{
 		ServerURL:      "\n",
 		ConnectTimeout: defaultTimeout,
-	}, tracer)
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to initialize prometheus client")
 	assert.Nil(t, reader)
@@ -88,7 +85,6 @@ func TestNewMetricsReaderInvalidAddress(t *testing.T) {
 func TestGetMinStepDuration(t *testing.T) {
 	params := metricsstore.MinStepDurationQueryParameters{}
 	logger := zap.NewNop()
-	tracer := jtracer.NoOp()
 	listener, err := net.Listen("tcp", "localhost:")
 	require.NoError(t, err)
 	assert.NotNil(t, listener)
@@ -96,7 +92,7 @@ func TestGetMinStepDuration(t *testing.T) {
 	reader, err := NewMetricsReader(logger, config.Configuration{
 		ServerURL:      "http://" + listener.Addr().String(),
 		ConnectTimeout: defaultTimeout,
-	}, tracer)
+	})
 	require.NoError(t, err)
 
 	minStep, err := reader.GetMinStepDuration(context.Background(), &params)
@@ -125,12 +121,11 @@ func TestMetricsServerError(t *testing.T) {
 	defer mockPrometheus.Close()
 
 	logger := zap.NewNop()
-	tracer := jtracer.NoOp()
 	address := mockPrometheus.Listener.Addr().String()
 	reader, err := NewMetricsReader(logger, config.Configuration{
 		ServerURL:      "http://" + address,
 		ConnectTimeout: defaultTimeout,
-	}, tracer)
+	})
 	require.NoError(t, err)
 
 	m, err := reader.GetCallRates(context.Background(), &params)
@@ -470,7 +465,7 @@ func TestInvalidLatencyUnit(t *testing.T) {
 		NormalizeDuration:           true,
 		LatencyUnit:                 "something invalid",
 	}
-	_, _ = NewMetricsReader(zap.NewNop(), cfg, jtracer.NoOp())
+	_, _ = NewMetricsReader(zap.NewNop(), cfg)
 }
 
 func TestWarningResponse(t *testing.T) {
@@ -576,7 +571,6 @@ func TestGetRoundTripperTokenError(t *testing.T) {
 
 func TestInvalidCertFile(t *testing.T) {
 	logger := zap.NewNop()
-	tracer := jtracer.NoOp()
 	reader, err := NewMetricsReader(logger, config.Configuration{
 		ServerURL:      "https://localhost:1234",
 		ConnectTimeout: defaultTimeout,
@@ -584,7 +578,7 @@ func TestInvalidCertFile(t *testing.T) {
 			Enabled: true,
 			CAPath:  "foo",
 		},
-	}, tracer)
+	})
 	require.Error(t, err)
 	assert.Nil(t, reader)
 }
@@ -645,13 +639,12 @@ func prepareMetricsReaderAndServer(t *testing.T, config config.Configuration, wa
 	mockPrometheus := startMockPrometheusServer(t, wantPromQlQuery, wantWarnings)
 
 	logger := zap.NewNop()
-	tracer := jtracer.NoOp()
 	address := mockPrometheus.Listener.Addr().String()
 
 	config.ServerURL = "http://" + address
 	config.ConnectTimeout = defaultTimeout
 
-	reader, err := NewMetricsReader(logger, config, tracer)
+	reader, err := NewMetricsReader(logger, config)
 	require.NoError(t, err)
 
 	return reader, mockPrometheus


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
* Part of #3381 
* This PR adds OTEL Provider to metrics reader component

## Short description of the changes
- Replaces OT tracer with OTEL tracer to support jtracer pkg
