### PR TITLE
Replace es-spanstore tracing instrumentation with OpenTelemetry

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel"
 	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 
@@ -104,6 +105,7 @@ by default uses only in-memory database.`,
 			if err != nil {
 				logger.Fatal("Failed to initialize tracer", zap.Error(err))
 			}
+			otel.SetTracerProvider(tracer.OTEL)
 
 			storageFactory.InitFromViper(v, logger)
 			if err := storageFactory.Initialize(metricsFactory, logger); err != nil {

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel"
 	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 
@@ -76,6 +77,7 @@ func main() {
 			if err != nil {
 				logger.Fatal("Failed to create tracer:", zap.Error(err))
 			}
+			otel.SetTracerProvider(jtracer.OTEL)
 			queryOpts, err := new(app.QueryOptions).InitFromViper(v, logger)
 			if err != nil {
 				logger.Fatal("Failed to configure query service", zap.Error(err))

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/es"
@@ -51,6 +52,7 @@ type Factory struct {
 
 	metricsFactory metrics.Factory
 	logger         *zap.Logger
+	tracer         trace.TracerProvider
 
 	newClientFn func(c *config.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error)
 
@@ -65,6 +67,7 @@ func NewFactory() *Factory {
 	return &Factory{
 		Options:     NewOptions(primaryNamespace, archiveNamespace),
 		newClientFn: config.NewClient,
+		tracer:      otel.GetTracerProvider(),
 	}
 }
 
@@ -109,17 +112,17 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 
 // CreateSpanReader implements storage.Factory
 func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
-	return createSpanReader(f.metricsFactory, f.logger, f.primaryClient, f.primaryConfig, false)
+	return createSpanReader(f.primaryClient, f.primaryConfig, false, f.metricsFactory, f.logger, f.tracer)
 }
 
 // CreateSpanWriter implements storage.Factory
 func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
-	return createSpanWriter(f.metricsFactory, f.logger, f.primaryClient, f.primaryConfig, false)
+	return createSpanWriter(f.primaryClient, f.primaryConfig, false, f.metricsFactory, f.logger)
 }
 
 // CreateDependencyReader implements storage.Factory
 func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
-	return createDependencyReader(f.logger, f.primaryClient, f.primaryConfig)
+	return createDependencyReader(f.primaryClient, f.primaryConfig, f.logger)
 }
 
 // CreateArchiveSpanReader implements storage.ArchiveFactory
@@ -127,7 +130,7 @@ func (f *Factory) CreateArchiveSpanReader() (spanstore.Reader, error) {
 	if !f.archiveConfig.Enabled {
 		return nil, nil
 	}
-	return createSpanReader(f.metricsFactory, f.logger, f.archiveClient, f.archiveConfig, true)
+	return createSpanReader(f.archiveClient, f.archiveConfig, true, f.metricsFactory, f.logger, f.tracer)
 }
 
 // CreateArchiveSpanWriter implements storage.ArchiveFactory
@@ -135,23 +138,22 @@ func (f *Factory) CreateArchiveSpanWriter() (spanstore.Writer, error) {
 	if !f.archiveConfig.Enabled {
 		return nil, nil
 	}
-	return createSpanWriter(f.metricsFactory, f.logger, f.archiveClient, f.archiveConfig, true)
+	return createSpanWriter(f.archiveClient, f.archiveConfig, true, f.metricsFactory, f.logger)
 }
 
 func createSpanReader(
-	mFactory metrics.Factory,
-	logger *zap.Logger,
 	client es.Client,
 	cfg *config.Configuration,
 	archive bool,
+	mFactory metrics.Factory,
+	logger *zap.Logger,
+	tp trace.TracerProvider,
 ) (spanstore.Reader, error) {
 	if cfg.UseILM && !cfg.UseReadWriteAliases {
 		return nil, fmt.Errorf("--es.use-ilm must always be used in conjunction with --es.use-aliases to ensure ES writers and readers refer to the single index mapping")
 	}
 	return esSpanStore.NewSpanReader(esSpanStore.SpanReaderParams{
 		Client:                        client,
-		Logger:                        logger,
-		MetricsFactory:                mFactory,
 		MaxDocCount:                   cfg.MaxDocCount,
 		MaxSpanAge:                    cfg.MaxSpanAge,
 		IndexPrefix:                   cfg.IndexPrefix,
@@ -163,16 +165,18 @@ func createSpanReader(
 		UseReadWriteAliases:           cfg.UseReadWriteAliases,
 		Archive:                       archive,
 		RemoteReadClusters:            cfg.RemoteReadClusters,
-		Tracer:                        otel.GetTracerProvider().Tracer("span-reader"),
+		Logger:                        logger,
+		MetricsFactory:                mFactory,
+		Tracer:                        tp.Tracer("esSpanStore.SpanReader"),
 	}), nil
 }
 
 func createSpanWriter(
-	mFactory metrics.Factory,
-	logger *zap.Logger,
 	client es.Client,
 	cfg *config.Configuration,
 	archive bool,
+	mFactory metrics.Factory,
+	logger *zap.Logger,
 ) (spanstore.Writer, error) {
 	var tags []string
 	var err error
@@ -199,8 +203,6 @@ func createSpanWriter(
 	}
 	writer := esSpanStore.NewSpanWriter(esSpanStore.SpanWriterParams{
 		Client:                 client,
-		Logger:                 logger,
-		MetricsFactory:         mFactory,
 		IndexPrefix:            cfg.IndexPrefix,
 		SpanIndexDateLayout:    cfg.IndexDateLayoutSpans,
 		ServiceIndexDateLayout: cfg.IndexDateLayoutServices,
@@ -209,6 +211,8 @@ func createSpanWriter(
 		TagDotReplacement:      cfg.Tags.DotReplacement,
 		Archive:                archive,
 		UseReadWriteAliases:    cfg.UseReadWriteAliases,
+		Logger:                 logger,
+		MetricsFactory:         mFactory,
 	})
 
 	// Creating a template here would conflict with the one created for ILM resulting to no index rollover
@@ -222,9 +226,9 @@ func createSpanWriter(
 }
 
 func createDependencyReader(
-	logger *zap.Logger,
 	client es.Client,
 	cfg *config.Configuration,
+	logger *zap.Logger,
 ) (dependencystore.Reader, error) {
 	reader := esDepStore.NewDependencyStore(esDepStore.DependencyStoreParams{
 		Client:              client,

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/es"
@@ -162,6 +163,7 @@ func createSpanReader(
 		UseReadWriteAliases:           cfg.UseReadWriteAliases,
 		Archive:                       archive,
 		RemoteReadClusters:            cfg.RemoteReadClusters,
+		Tracer:                        otel.GetTracerProvider().Tracer("span-reader"),
 	}), nil
 }
 

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -144,7 +144,9 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 	if err != nil {
 		log.Fatal("Failed to initialise tracer", zap.Error(err))
 	}
-	defer jt.Close(context.Background())
+	if err := jt.Close(context.Background()); err != nil {
+		log.Fatal("Error shutting down tracer provider", zap.Error(err))
+	}
 	return &SpanReader{
 		client:                        p.Client,
 		logger:                        p.Logger,

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/olivere/elastic"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -697,4 +698,5 @@ func (s *SpanReader) buildObjectQuery(field string, k string, v string) elastic.
 
 func logErrorToSpan(span trace.Span, err error) {
 	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
 }

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -331,7 +331,7 @@ func bucketToStringArray(buckets []*elastic.AggregationBucketKeyItem) ([]string,
 
 // FindTraces retrieves traces that match the traceQuery
 func (s *SpanReader) FindTraces(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) ([]*model.Trace, error) {
-	ctx, span := s.tracer.Start(ctx, "GetOperations")
+	ctx, span := s.tracer.Start(ctx, "FindTraces")
 	defer span.End()
 
 	uniqueTraceIDs, err := s.FindTraceIDs(ctx, traceQuery)

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/olivere/elastic"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -138,9 +137,6 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 	// When read/write aliases are enabled, which are required for index rollovers, only the "read" alias is queried and therefore should not affect performance.
 	if p.UseReadWriteAliases {
 		maxSpanAge = rolloverMaxSpanAge
-	}
-	if p.Tracer == nil {
-		p.Tracer = otel.Tracer("eSpanstore.SpanReader")
 	}
 	return &SpanReader{
 		client:                        p.Client,

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/olivere/elastic"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -137,6 +138,9 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 	// When read/write aliases are enabled, which are required for index rollovers, only the "read" alias is queried and therefore should not affect performance.
 	if p.UseReadWriteAliases {
 		maxSpanAge = rolloverMaxSpanAge
+	}
+	if p.Tracer == nil {
+		p.Tracer = otel.Tracer("eSpanstore.SpanReader")
 	}
 	return &SpanReader{
 		client:                        p.Client,

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -108,6 +108,7 @@ func tracerProvider() (trace.TracerProvider, *tracetest.InMemoryExporter, func()
 func withSpanReader(fn func(r *spanReaderTest)) {
 	client := &mocks.Client{}
 	tracer, exp, closer := tracerProvider()
+	defer closer()
 	logger, logBuffer := testutils.NewLogger()
 	r := &spanReaderTest{
 		client:      client,
@@ -124,13 +125,13 @@ func withSpanReader(fn func(r *spanReaderTest)) {
 			MaxDocCount:       defaultMaxDocCount,
 		}),
 	}
-	defer closer()
 	fn(r)
 }
 
 func withArchiveSpanReader(readAlias bool, fn func(r *spanReaderTest)) {
 	client := &mocks.Client{}
 	tracer, exp, closer := tracerProvider()
+	defer closer()
 	logger, logBuffer := testutils.NewLogger()
 	r := &spanReaderTest{
 		client:      client,
@@ -148,7 +149,6 @@ func withArchiveSpanReader(readAlias bool, fn func(r *spanReaderTest)) {
 			UseReadWriteAliases: readAlias,
 		}),
 	}
-	defer closer()
 	fn(r)
 }
 
@@ -195,6 +195,7 @@ func TestSpanReaderIndices(t *testing.T) {
 	metricsFactory := metricstest.NewFactory(0)
 	logger, _ := testutils.NewLogger()
 	tracer, _, closer := tracerProvider()
+	defer closer()
 
 	testCases := []struct {
 		indices []string
@@ -306,7 +307,6 @@ func TestSpanReaderIndices(t *testing.T) {
 		actualService := r.timeRangeIndices(r.serviceIndexPrefix, r.serviceIndexDateLayout, date, date, -24*time.Hour)
 		assert.Equal(t, testCase.indices, append(actualSpan, actualService...))
 	}
-	require.NoError(t, closer())
 }
 
 func TestSpanReader_GetTrace(t *testing.T) {

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -179,56 +179,48 @@ func TestSpanReaderIndices(t *testing.T) {
 	}{
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: false, SpanIndexDateLayout: spanDataLayout, ServiceIndexDateLayout: serviceDataLayout,
 			},
 			indices: []string{spanIndex + spanDataLayoutFormat, serviceIndex + serviceDataLayoutFormat},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", UseReadWriteAliases: true,
 			},
 			indices: []string{spanIndex + "read", serviceIndex + "read"},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", Archive: false, SpanIndexDateLayout: spanDataLayout, ServiceIndexDateLayout: serviceDataLayout,
 			},
 			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + spanDataLayoutFormat, "foo:" + indexPrefixSeparator + serviceIndex + serviceDataLayoutFormat},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", UseReadWriteAliases: true,
 			},
 			indices: []string{"foo:-" + spanIndex + "read", "foo:-" + serviceIndex + "read"},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: true,
 			},
 			indices: []string{spanIndex + archiveIndexSuffix, serviceIndex + archiveIndexSuffix},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", Archive: true,
 			},
 			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveIndexSuffix, "foo:" + indexPrefixSeparator + serviceIndex + archiveIndexSuffix},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", Archive: true, UseReadWriteAliases: true,
 			},
 			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveReadIndexSuffix, "foo:" + indexPrefixSeparator + serviceIndex + archiveReadIndexSuffix},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: false, RemoteReadClusters: []string{"cluster_one", "cluster_two"}, SpanIndexDateLayout: spanDataLayout, ServiceIndexDateLayout: serviceDataLayout,
 			},
 			indices: []string{
@@ -242,7 +234,6 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"},
 			},
 			indices: []string{
@@ -256,7 +247,6 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: false, UseReadWriteAliases: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"},
 			},
 			indices: []string{
@@ -270,7 +260,6 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: true, UseReadWriteAliases: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"},
 			},
 			indices: []string{
@@ -284,6 +273,13 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
+		testCase.params = SpanReaderParams{
+			Client: client,
+			Logger: logger,
+			MetricsFactory: metricsFactory,
+			Tracer: tracer,
+
+		}
 		r := NewSpanReader(testCase.params)
 
 		actualSpan := r.timeRangeIndices(r.spanIndexPrefix, r.spanIndexDateLayout, date, date, -1*time.Hour)

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/mocks"
+	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -170,6 +171,7 @@ func TestSpanReaderIndices(t *testing.T) {
 	serviceDataLayout := "2006-01-02"
 	spanDataLayoutFormat := date.UTC().Format(spanDataLayout)
 	serviceDataLayoutFormat := date.UTC().Format(serviceDataLayout)
+	tracer := jtracer.NoOp()
 
 	testCases := []struct {
 		indices []string
@@ -177,56 +179,56 @@ func TestSpanReaderIndices(t *testing.T) {
 	}{
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: false, SpanIndexDateLayout: spanDataLayout, ServiceIndexDateLayout: serviceDataLayout,
 			},
 			indices: []string{spanIndex + spanDataLayoutFormat, serviceIndex + serviceDataLayoutFormat},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", UseReadWriteAliases: true,
 			},
 			indices: []string{spanIndex + "read", serviceIndex + "read"},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", Archive: false, SpanIndexDateLayout: spanDataLayout, ServiceIndexDateLayout: serviceDataLayout,
 			},
 			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + spanDataLayoutFormat, "foo:" + indexPrefixSeparator + serviceIndex + serviceDataLayoutFormat},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", UseReadWriteAliases: true,
 			},
 			indices: []string{"foo:-" + spanIndex + "read", "foo:-" + serviceIndex + "read"},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: true,
 			},
 			indices: []string{spanIndex + archiveIndexSuffix, serviceIndex + archiveIndexSuffix},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", Archive: true,
 			},
 			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveIndexSuffix, "foo:" + indexPrefixSeparator + serviceIndex + archiveIndexSuffix},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "foo:", Archive: true, UseReadWriteAliases: true,
 			},
 			indices: []string{"foo:" + indexPrefixSeparator + spanIndex + archiveReadIndexSuffix, "foo:" + indexPrefixSeparator + serviceIndex + archiveReadIndexSuffix},
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: false, RemoteReadClusters: []string{"cluster_one", "cluster_two"}, SpanIndexDateLayout: spanDataLayout, ServiceIndexDateLayout: serviceDataLayout,
 			},
 			indices: []string{
@@ -240,7 +242,7 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"},
 			},
 			indices: []string{
@@ -254,7 +256,7 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: false, UseReadWriteAliases: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"},
 			},
 			indices: []string{
@@ -268,7 +270,7 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 		{
 			params: SpanReaderParams{
-				Client: client, Logger: logger, MetricsFactory: metricsFactory,
+				Client: client, Logger: logger, MetricsFactory: metricsFactory, Tracer: tracer,
 				IndexPrefix: "", Archive: true, UseReadWriteAliases: true, RemoteReadClusters: []string{"cluster_one", "cluster_two"},
 			},
 			indices: []string{

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -100,6 +100,7 @@ func withSpanReader(fn func(r *spanReaderTest)) {
 		reader: NewSpanReader(SpanReaderParams{
 			Client:            client,
 			Logger:            zap.NewNop(),
+			Tracer:            jtracer.NoOp().OTEL.Tracer("test"),
 			MaxSpanAge:        0,
 			IndexPrefix:       "",
 			TagDotReplacement: "@",
@@ -119,6 +120,7 @@ func withArchiveSpanReader(readAlias bool, fn func(r *spanReaderTest)) {
 		reader: NewSpanReader(SpanReaderParams{
 			Client:              client,
 			Logger:              zap.NewNop(),
+			Tracer:              jtracer.NoOp().OTEL.Tracer("test"),
 			MaxSpanAge:          0,
 			IndexPrefix:         "",
 			TagDotReplacement:   "@",

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -171,7 +171,7 @@ func TestSpanReaderIndices(t *testing.T) {
 	serviceDataLayout := "2006-01-02"
 	spanDataLayoutFormat := date.UTC().Format(spanDataLayout)
 	serviceDataLayoutFormat := date.UTC().Format(serviceDataLayout)
-	tracer := jtracer.NoOp()
+	tracer := jtracer.NoOp().OTEL.Tracer("")
 
 	testCases := []struct {
 		indices []string

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -164,14 +164,14 @@ func TestNewSpanReader(t *testing.T) {
 
 func TestSpanReaderIndices(t *testing.T) {
 	client := &mocks.Client{}
-	logger, _ := testutils.NewLogger()
-	metricsFactory := metricstest.NewFactory(0)
 	date := time.Date(2019, 10, 10, 5, 0, 0, 0, time.UTC)
 	spanDataLayout := "2006-01-02-15"
 	serviceDataLayout := "2006-01-02"
 	spanDataLayoutFormat := date.UTC().Format(spanDataLayout)
 	serviceDataLayoutFormat := date.UTC().Format(serviceDataLayout)
-	tracer := jtracer.NoOp().OTEL.Tracer("")
+	metricsFactory := metricstest.NewFactory(0)
+	logger, _ := testutils.NewLogger()
+	tracer := jtracer.NoOp().OTEL
 
 	testCases := []struct {
 		indices []string
@@ -273,13 +273,10 @@ func TestSpanReaderIndices(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase.params = SpanReaderParams{
-			Client: client,
-			Logger: logger,
-			MetricsFactory: metricsFactory,
-			Tracer: tracer,
-
-		}
+		testCase.params.Client = client
+		testCase.params.Logger = logger
+		testCase.params.MetricsFactory = metricsFactory
+		testCase.params.Tracer = tracer.Tracer("test")
 		r := NewSpanReader(testCase.params)
 
 		actualSpan := r.timeRangeIndices(r.spanIndexPrefix, r.spanIndexDateLayout, date, date, -1*time.Hour)

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -328,7 +328,7 @@ func TestSpanReader_GetTrace(t *testing.T) {
 			}, nil)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.NewTraceID(0, 1))
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.NoError(t, err)
 		require.NotNil(t, trace)
@@ -406,7 +406,7 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 			}, nil)
 
 		traces, err := r.reader.multiRead(context.Background(), []model.TraceID{{High: 0, Low: 1}, {High: 0, Low: 2}}, date, date)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.NoError(t, err)
 		require.NotNil(t, traces)
@@ -445,7 +445,7 @@ func TestSpanReader_SearchAfter(t *testing.T) {
 			}, nil).Times(2)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.NewTraceID(0, 1))
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.NoError(t, err)
 		require.NotNil(t, trace)
@@ -466,7 +466,7 @@ func TestSpanReader_GetTraceQueryError(t *testing.T) {
 				Responses: []*elastic.SearchResult{},
 			}, nil)
 		trace, err := r.reader.GetTrace(context.Background(), model.NewTraceID(0, 1))
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.EqualError(t, err, "trace not found")
 		require.Nil(t, trace)
@@ -487,7 +487,7 @@ func TestSpanReader_GetTraceNilHits(t *testing.T) {
 			}, nil)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.NewTraceID(0, 1))
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.EqualError(t, err, "trace not found")
 		require.Nil(t, trace)
@@ -512,7 +512,7 @@ func TestSpanReader_GetTraceInvalidSpanError(t *testing.T) {
 			}, nil)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.NewTraceID(0, 1))
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.Error(t, err, "invalid span")
 		require.Nil(t, trace)
@@ -538,7 +538,7 @@ func TestSpanReader_GetTraceSpanConversionError(t *testing.T) {
 			}, nil)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.NewTraceID(0, 1))
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.Error(t, err, "span conversion error, because lacks elements")
 		require.Nil(t, trace)
@@ -769,7 +769,7 @@ func TestSpanReader_FindTraces(t *testing.T) {
 		}
 
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.NoError(t, err)
 		assert.Len(t, traces, 1)
@@ -815,7 +815,7 @@ func TestSpanReader_FindTracesInvalidQuery(t *testing.T) {
 		}
 
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.Error(t, err)
 		assert.Nil(t, traces)
@@ -849,7 +849,7 @@ func TestSpanReader_FindTracesAggregationFailure(t *testing.T) {
 		}
 
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.Error(t, err)
 		assert.Nil(t, traces)
@@ -885,7 +885,7 @@ func TestSpanReader_FindTracesNoTraceIDs(t *testing.T) {
 		}
 
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.NoError(t, err)
 		assert.Len(t, traces, 0)
@@ -920,7 +920,7 @@ func TestSpanReader_FindTracesReadTraceFailure(t *testing.T) {
 		}
 
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.EqualError(t, err, "read error")
 		assert.Len(t, traces, 0)
@@ -960,7 +960,7 @@ func TestSpanReader_FindTracesSpanCollectionFailure(t *testing.T) {
 		}
 
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.Error(t, err)
 		assert.Len(t, traces, 0)
@@ -1267,7 +1267,7 @@ func TestSpanReader_GetEmptyIndex(t *testing.T) {
 		}
 
 		services, err := r.reader.FindTraces(context.Background(), traceQuery)
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.NoError(t, err)
 		assert.Empty(t, services)
@@ -1284,7 +1284,7 @@ func TestSpanReader_ArchiveTraces(t *testing.T) {
 			}, nil)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.TraceID{})
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 		require.Nil(t, trace)
 		assert.EqualError(t, err, "trace not found")
@@ -1300,7 +1300,7 @@ func TestSpanReader_ArchiveTraces_ReadAlias(t *testing.T) {
 				Responses: []*elastic.SearchResult{},
 			}, nil)
 
-		assert.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
+		require.NotEmpty(t, r.exporter.GetSpans(), "Spans recorded")
 		require.NoError(t, r.err)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.TraceID{})

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -152,7 +152,7 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		TagDotReplacement: tagKeyDeDotChar,
 		Archive:           archive,
 		MaxDocCount:       defaultMaxDocCount,
-		Tracer:            jtracer.NoOp().OTEL.Tracer(""),
+		Tracer:            jtracer.NoOp().OTEL.Tracer("test"),
 	})
 	dependencyStore := dependencystore.NewDependencyStore(dependencystore.DependencyStoreParams{
 		Client:          client,

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -157,6 +157,7 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		return err
 	}
 	tracer, _, closer := tracerProvider()
+	defer closer()
 	s.SpanWriter = w
 	s.SpanReader = spanstore.NewSpanReader(spanstore.SpanReaderParams{
 		Client:            client,
@@ -176,10 +177,6 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		IndexDateLayout: indexDateLayout,
 		MaxDocCount:     defaultMaxDocCount,
 	})
-
-	if closer != nil {
-		return err
-	}
 
 	depMapping, err := mappingBuilder.GetDependenciesMappings()
 	if err != nil {

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 	estemplate "github.com/jaegertracing/jaeger/pkg/es"
 	eswrapper "github.com/jaegertracing/jaeger/pkg/es/wrapper"
+	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/dependencystore"
@@ -151,6 +152,7 @@ func (s *ESStorageIntegration) initSpanstore(allTagsAsFields, archive bool) erro
 		TagDotReplacement: tagKeyDeDotChar,
 		Archive:           archive,
 		MaxDocCount:       defaultMaxDocCount,
+		Tracer:            jtracer.NoOp().OTEL.Tracer(""),
 	})
 	dependencyStore := dependencystore.NewDependencyStore(dependencystore.DependencyStoreParams{
 		Client:          client,


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
* Part of #3381 
* This PR adds OTEL Provider to es-spanstore component

## Short description of the changes
- Replaces OT tracer with OTEL tracer to support jtracer pkg
