### PR TITLE
Replace cassandra-spanstore tracing instrumentation with`OTEL`

### DIFF
--- a/plugin/storage/cassandra/savetracetest/main.go
+++ b/plugin/storage/cassandra/savetracetest/main.go
@@ -45,7 +45,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Cannot create Cassandra session", zap.Error(err))
 	}
-	tracer, err := jtracer.New("cassandra")
+	tracer, err := jtracer.New("savetracetest")
 	if err != nil {
 		logger.Fatal("Failed to initialize tracer", zap.Error(err))
 	}

--- a/plugin/storage/cassandra/savetracetest/main.go
+++ b/plugin/storage/cassandra/savetracetest/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -44,8 +45,9 @@ func main() {
 	if err != nil {
 		logger.Fatal("Cannot create Cassandra session", zap.Error(err))
 	}
+	tracer := otel.GetTracerProvider()
 	spanStore := cSpanStore.NewSpanWriter(cqlSession, time.Hour*12, noScope, logger)
-	spanReader := cSpanStore.NewSpanReader(cqlSession, noScope, logger)
+	spanReader := cSpanStore.NewSpanReader(cqlSession, noScope, logger, tracer.Tracer("cSpanStore.SpanReader"))
 	ctx := context.Background()
 	if err = spanStore.WriteSpan(ctx, getSomeSpan()); err != nil {
 		logger.Fatal("Failed to save", zap.Error(err))

--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -24,6 +24,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	ottag "github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -110,6 +111,7 @@ type SpanReader struct {
 	operationNamesReader operationNamesReader
 	metrics              spanReaderMetrics
 	logger               *zap.Logger
+	tracer               trace.Tracer
 }
 
 // NewSpanReader returns a new SpanReader.
@@ -117,6 +119,7 @@ func NewSpanReader(
 	session cassandra.Session,
 	metricsFactory metrics.Factory,
 	logger *zap.Logger,
+	tracer trace.Tracer,
 ) *SpanReader {
 	readFactory := metricsFactory.Namespace(metrics.NSOptions{Name: "read", Tags: nil})
 	serviceNamesStorage := NewServiceNamesStorage(session, 0, metricsFactory, logger)
@@ -134,6 +137,7 @@ func NewSpanReader(
 			queryServiceNameIndex:      casMetrics.NewTable(readFactory, "service_name_index"),
 		},
 		logger: logger,
+		tracer: tracer,
 	}
 }
 

--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -157,9 +157,7 @@ func (s *SpanReader) GetOperations(
 func (s *SpanReader) readTrace(ctx context.Context, traceID dbmodel.TraceID) (*model.Trace, error) {
 	ctx, span := s.startSpanForQuery(ctx, "readTrace", querySpanByTraceID)
 	defer span.End()
-	span.SetAttributes(
-		attribute.Key("trace_id").String(traceID.String()),
-	)
+	span.SetAttributes(attribute.Key("trace_id").String(traceID.String()))
 
 	trace, err := s.readTraceInSpan(ctx, traceID)
 	logErrorToSpan(span, err)
@@ -423,7 +421,6 @@ func (s *SpanReader) executeQuery(span trace.Span, query cassandra.Query, tableM
 	tableMetrics.Emit(err, time.Since(start))
 	if err != nil {
 		logErrorToSpan(span, err)
-		span.SetAttributes(attribute.Key("query").String(query.String()))
 		s.logger.Error("Failed to exec query", zap.Error(err), zap.String("query", query.String()))
 		return nil, err
 	}

--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -24,6 +24,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	ottag "github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -121,6 +122,9 @@ func NewSpanReader(
 	logger *zap.Logger,
 	tracer trace.Tracer,
 ) *SpanReader {
+	if tracer == nil {
+		tracer = otel.GetTracerProvider().Tracer("cSpanStore.SpanReader")
+	}
 	readFactory := metricsFactory.Namespace(metrics.NSOptions{Name: "read", Tags: nil})
 	serviceNamesStorage := NewServiceNamesStorage(session, 0, metricsFactory, logger)
 	operationNamesStorage := NewOperationNamesStorage(session, 0, metricsFactory, logger)

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -25,26 +25,41 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
-	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 type spanReaderTest struct {
-	session   *mocks.Session
-	logger    *zap.Logger
-	logBuffer *testutils.Buffer
-	reader    *SpanReader
+	session     *mocks.Session
+	logger      *zap.Logger
+	logBuffer   *testutils.Buffer
+	traceBuffer *tracetest.InMemoryExporter
+	reader      *SpanReader
 }
 
-func withSpanReader(fn func(r *spanReaderTest)) {
+func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExporter, func()) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSyncer(exporter),
+	)
+	closer := func() {
+		assert.NoError(t, tp.Shutdown(context.Background()))
+	}
+	return tp, exporter, closer
+}
+
+func withSpanReader(t *testing.T, fn func(r *spanReaderTest)) {
 	session := &mocks.Session{}
 	query := &mocks.Query{}
 	session.On("Query",
@@ -53,12 +68,14 @@ func withSpanReader(fn func(r *spanReaderTest)) {
 	query.On("Exec").Return(nil)
 	logger, logBuffer := testutils.NewLogger()
 	metricsFactory := metricstest.NewFactory(0)
-	tracer := jtracer.NoOp().OTEL
+	tracer, exp, closer := tracerProvider(t)
+	defer closer()
 	r := &spanReaderTest{
-		session:   session,
-		logger:    logger,
-		logBuffer: logBuffer,
-		reader:    NewSpanReader(session, metricsFactory, logger, tracer.Tracer("test")),
+		session:     session,
+		logger:      logger,
+		logBuffer:   logBuffer,
+		traceBuffer: exp,
+		reader:      NewSpanReader(session, metricsFactory, logger, tracer.Tracer("test")),
 	}
 	fn(r)
 }
@@ -66,7 +83,7 @@ func withSpanReader(fn func(r *spanReaderTest)) {
 var _ spanstore.Reader = &SpanReader{} // check API conformance
 
 func TestSpanReaderGetServices(t *testing.T) {
-	withSpanReader(func(r *spanReaderTest) {
+	withSpanReader(t, func(r *spanReaderTest) {
 		r.reader.serviceNamesReader = func() ([]string, error) { return []string{"service-a"}, nil }
 		s, err := r.reader.GetServices(context.Background())
 		assert.NoError(t, err)
@@ -75,7 +92,7 @@ func TestSpanReaderGetServices(t *testing.T) {
 }
 
 func TestSpanReaderGetOperations(t *testing.T) {
-	withSpanReader(func(r *spanReaderTest) {
+	withSpanReader(t, func(r *spanReaderTest) {
 		expectedOperations := []spanstore.Operation{
 			{
 				Name:     "operation-a",
@@ -123,7 +140,7 @@ func TestSpanReaderGetTrace(t *testing.T) {
 	for _, tc := range testCases {
 		testCase := tc // capture loop var
 		t.Run("expected err="+testCase.expectedErr, func(t *testing.T) {
-			withSpanReader(func(r *spanReaderTest) {
+			withSpanReader(t, func(r *spanReaderTest) {
 				iter := &mocks.Iterator{}
 				iter.On("Scan", testCase.scanner).Return(true)
 				iter.On("Scan", matchEverything()).Return(false)
@@ -137,6 +154,7 @@ func TestSpanReaderGetTrace(t *testing.T) {
 
 				trace, err := r.reader.GetTrace(context.Background(), model.TraceID{})
 				if testCase.expectedErr == "" {
+					require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 					assert.NoError(t, err)
 					assert.NotNil(t, trace)
 				} else {
@@ -150,7 +168,7 @@ func TestSpanReaderGetTrace(t *testing.T) {
 }
 
 func TestSpanReaderGetTrace_TraceNotFound(t *testing.T) {
-	withSpanReader(func(r *spanReaderTest) {
+	withSpanReader(t, func(r *spanReaderTest) {
 		iter := &mocks.Iterator{}
 		iter.On("Scan", matchEverything()).Return(false)
 		iter.On("Close").Return(nil)
@@ -162,14 +180,16 @@ func TestSpanReaderGetTrace_TraceNotFound(t *testing.T) {
 		r.session.On("Query", mock.AnythingOfType("string"), matchEverything()).Return(query)
 
 		trace, err := r.reader.GetTrace(context.Background(), model.TraceID{})
+		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 		assert.Nil(t, trace)
 		assert.EqualError(t, err, "trace not found")
 	})
 }
 
 func TestSpanReaderFindTracesBadRequest(t *testing.T) {
-	withSpanReader(func(r *spanReaderTest) {
+	withSpanReader(t, func(r *spanReaderTest) {
 		_, err := r.reader.FindTraces(context.Background(), nil)
+		require.Empty(t, r.traceBuffer.GetSpans(), "Spans Not recorded")
 		assert.Error(t, err)
 	})
 }
@@ -288,7 +308,7 @@ func TestSpanReaderFindTraces(t *testing.T) {
 	for _, tc := range testCases {
 		testCase := tc // capture loop var
 		t.Run(testCase.caption, func(t *testing.T) {
-			withSpanReader(func(r *spanReaderTest) {
+			withSpanReader(t, func(r *spanReaderTest) {
 				// scanMatcher can match Iter.Scan() parameters and set trace ID fields
 				scanMatcher := func(name string) interface{} {
 					traceIDs := []dbmodel.TraceID{
@@ -386,6 +406,7 @@ func TestSpanReaderFindTraces(t *testing.T) {
 				}
 				res, err := r.reader.FindTraces(context.Background(), queryParams)
 				if testCase.expectedError == "" {
+					require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 					assert.NoError(t, err)
 					assert.Len(t, res, testCase.expectedCount, "expecting certain number of traces")
 				} else {

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
+	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -52,11 +53,12 @@ func withSpanReader(fn func(r *spanReaderTest)) {
 	query.On("Exec").Return(nil)
 	logger, logBuffer := testutils.NewLogger()
 	metricsFactory := metricstest.NewFactory(0)
+	tracer := jtracer.NoOp().OTEL
 	r := &spanReaderTest{
 		session:   session,
 		logger:    logger,
 		logBuffer: logBuffer,
-		reader:    NewSpanReader(session, metricsFactory, logger),
+		reader:    NewSpanReader(session, metricsFactory, logger, tracer.Tracer("test")),
 	}
 	fn(r)
 }


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
* Part of #3381 
* This PR adds OTEL Provider to cassandra spanstore component

## Short description of the changes
- Replaces OT tracer with OTEL tracer to support jtracer pkg
