### PR TITLE
Replace OpenTracing instrumentation with OpenTelemetry in grpc storage plugin 

### DIFF
--- a/plugin/storage/grpc/README.md
+++ b/plugin/storage/grpc/README.md
@@ -200,13 +200,13 @@ grpc.ServeWithGRPCServer(&shared.PluginServices{
     ArchiveStore: memStorePlugin,
 }, func(options []googleGRPC.ServerOption) *googleGRPC.Server {
     return plugin.DefaultGRPCServer([]googleGRPC.ServerOption{
-        googleGRPC.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),
-        googleGRPC.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)),
+        grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
+		grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
     })
 })
 ```
 
-Refer to `example/memstore-plugin` for more details.
+Refer to `example/hotrod` for more details.
 
 Bearer token propagation from the UI
 ------------------------------------

--- a/plugin/storage/grpc/README.md
+++ b/plugin/storage/grpc/README.md
@@ -206,7 +206,7 @@ grpc.ServeWithGRPCServer(&shared.PluginServices{
 })
 ```
 
-Refer to `example/hotrod` for more details.
+Refer to `example/memstore-plugin` for more details.
 
 Bearer token propagation from the UI
 ------------------------------------

--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -21,10 +21,10 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
-	"github.com/opentracing/opentracing-go"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -84,8 +84,10 @@ func (c *Configuration) Close() error {
 
 func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, error) {
 	opts := []grpc.DialOption{
-		grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer())),
-		grpc.WithStreamInterceptor(otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer())),
+		grpc.WithUnaryInterceptor(
+			otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
+		grpc.WithStreamInterceptor(
+			otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
 		grpc.WithBlock(),
 	}
 	if c.RemoteTLS.Enabled {
@@ -125,8 +127,10 @@ func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, 
 
 func (c *Configuration) buildPlugin(logger *zap.Logger) (*ClientPluginServices, error) {
 	opts := []grpc.DialOption{
-		grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer())),
-		grpc.WithStreamInterceptor(otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer())),
+		grpc.WithUnaryInterceptor(
+			otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
+		grpc.WithStreamInterceptor(
+			otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
 	}
 
 	tenancyMgr := tenancy.NewManager(&c.TenancyOpts)

--- a/plugin/storage/grpc/config/config.go
+++ b/plugin/storage/grpc/config/config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -60,16 +60,16 @@ type ClientPluginServices struct {
 
 // PluginBuilder is used to create storage plugins. Implemented by Configuration.
 type PluginBuilder interface {
-	Build(logger *zap.Logger) (*ClientPluginServices, error)
+	Build(logger *zap.Logger, tracerProvider trace.TracerProvider) (*ClientPluginServices, error)
 	Close() error
 }
 
 // Build instantiates a PluginServices
-func (c *Configuration) Build(logger *zap.Logger) (*ClientPluginServices, error) {
+func (c *Configuration) Build(logger *zap.Logger, tracerProvider trace.TracerProvider) (*ClientPluginServices, error) {
 	if c.PluginBinary != "" {
-		return c.buildPlugin(logger)
+		return c.buildPlugin(logger, tracerProvider)
 	} else {
-		return c.buildRemote(logger)
+		return c.buildRemote(logger, tracerProvider)
 	}
 }
 
@@ -82,12 +82,12 @@ func (c *Configuration) Close() error {
 	return c.RemoteTLS.Close()
 }
 
-func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, error) {
+func (c *Configuration) buildRemote(logger *zap.Logger, tracerProvider trace.TracerProvider) (*ClientPluginServices, error) {
 	opts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(
-			otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
+			otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
 		grpc.WithStreamInterceptor(
-			otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
+			otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
 		grpc.WithBlock(),
 	}
 	if c.RemoteTLS.Enabled {
@@ -125,12 +125,12 @@ func (c *Configuration) buildRemote(logger *zap.Logger) (*ClientPluginServices, 
 	}, nil
 }
 
-func (c *Configuration) buildPlugin(logger *zap.Logger) (*ClientPluginServices, error) {
+func (c *Configuration) buildPlugin(logger *zap.Logger, tracerProvider trace.TracerProvider) (*ClientPluginServices, error) {
 	opts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(
-			otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
+			otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
 		grpc.WithStreamInterceptor(
-			otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
+			otelgrpc.StreamClientInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
 	}
 
 	tenancyMgr := tenancy.NewManager(&c.TenancyOpts)

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -20,6 +20,8 @@ import (
 	"io"
 
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -41,6 +43,7 @@ type Factory struct {
 	options        Options
 	metricsFactory metrics.Factory
 	logger         *zap.Logger
+	tracerProvider         trace.TracerProvider
 
 	builder config.PluginBuilder
 
@@ -77,8 +80,9 @@ func (f *Factory) InitFromOptions(opts Options) {
 // Initialize implements storage.Factory
 func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
 	f.metricsFactory, f.logger = metricsFactory, logger
+	f.tracerProvider = otel.GetTracerProvider()
 
-	services, err := f.builder.Build(logger)
+	services, err := f.builder.Build(logger, f.tracerProvider)
 	if err != nil {
 		return fmt.Errorf("grpc-plugin builder failed to create a store: %w", err)
 	}

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -43,7 +43,7 @@ type Factory struct {
 	options        Options
 	metricsFactory metrics.Factory
 	logger         *zap.Logger
-	tracerProvider         trace.TracerProvider
+	tracerProvider trace.TracerProvider
 
 	builder config.PluginBuilder
 

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/config"
@@ -43,7 +44,7 @@ type mockPluginBuilder struct {
 	err        error
 }
 
-func (b *mockPluginBuilder) Build(logger *zap.Logger) (*grpcConfig.ClientPluginServices, error) {
+func (b *mockPluginBuilder) Build(logger *zap.Logger, tracer trace.TracerProvider) (*grpcConfig.ClientPluginServices, error) {
 	if b.err != nil {
 		return nil, b.err
 	}


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
* Part of #3381 
* This PR adds `otelgrpc` plugin to storage

## Short description of the changes
- Replaces `otgrpc` plugin storage with otel grpc interceptors
