### PR TITLE
[tests]: Use `t.TempDir` to create temporary test directory

### DIFF
--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -148,9 +148,7 @@ func TestNewStaticAssetsHandlerErrors(t *testing.T) {
 }
 
 func TestHotReloadUIConfig(t *testing.T) {
-	dir, err := os.MkdirTemp("", "ui-config-hotreload-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cfgFile, err := os.CreateTemp(dir, "*.json")
 	require.NoError(t, err)

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -180,9 +180,7 @@ func TestReload_err_cert_update(t *testing.T) {
 }
 
 func TestReload_kubernetes_secret_update(t *testing.T) {
-	mountDir, err := os.MkdirTemp("", "secret-mountpoint_")
-	require.NoError(t, err)
-	defer os.RemoveAll(mountDir)
+	mountDir := t.TempDir()
 
 	// Create directory layout before update:
 	//
@@ -195,7 +193,7 @@ func TestReload_kubernetes_secret_update(t *testing.T) {
 	// /secret-mountpoint/..timestamp-1/tls.crt # initial version of tls.crt
 	// /secret-mountpoint/..timestamp-1/tls.key # initial version of tls.key
 
-	err = os.Symlink("..timestamp-1", filepath.Join(mountDir, "..data"))
+	err := os.Symlink("..timestamp-1", filepath.Join(mountDir, "..data"))
 	require.NoError(t, err)
 	err = os.Symlink(filepath.Join("..data", "ca.crt"), filepath.Join(mountDir, "ca.crt"))
 	require.NoError(t, err)

--- a/pkg/fswatcher/fswatcher_test.go
+++ b/pkg/fswatcher/fswatcher_test.go
@@ -28,35 +28,28 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func createTestFiles(t *testing.T) (file1 string, file2 string, file3 string, close func()) {
-	testDir1, err := os.MkdirTemp("", "test1_")
-	require.NoError(t, err)
+func createTestFiles(t *testing.T) (file1 string, file2 string, file3 string) {
+	testDir1 := t.TempDir()
 
 	file1 = filepath.Join(testDir1, "test1.doc")
-	err = os.WriteFile(file1, []byte("test data"), 0o600)
+	err := os.WriteFile(file1, []byte("test data"), 0o600)
 	require.NoError(t, err)
 
 	file2 = filepath.Join(testDir1, "test2.doc")
 	err = os.WriteFile(file2, []byte("test data"), 0o600)
 	require.NoError(t, err)
 
-	testDir2, err := os.MkdirTemp("", "test2_")
-	require.NoError(t, err)
+	testDir2 := t.TempDir()
 
 	file3 = filepath.Join(testDir2, "test3.doc")
 	err = os.WriteFile(file3, []byte("test data"), 0o600)
 	require.NoError(t, err)
 
-	close = func() {
-		assert.NoError(t, os.RemoveAll(testDir1))
-		assert.NoError(t, os.RemoveAll(testDir2))
-	}
 	return
 }
 
 func TestFSWatcherAddFiles(t *testing.T) {
-	file1, file2, file3, close := createTestFiles(t)
-	defer close()
+	file1, file2, file3 := createTestFiles(t)
 
 	// Add one unreadable file
 	_, err := New([]string{"invalid-file-name"}, nil, nil)
@@ -161,11 +154,9 @@ func TestFSWatcherWithMultipleFiles(t *testing.T) {
 }
 
 func TestFSWatcherWithSymlinkAndRepoChanges(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
-	err = os.Symlink("..timestamp-1", filepath.Join(testDir, "..data"))
+	err := os.Symlink("..timestamp-1", filepath.Join(testDir, "..data"))
 	require.NoError(t, err)
 	err = os.Symlink(filepath.Join("..data", "test.doc"), filepath.Join(testDir, "test.doc"))
 	require.NoError(t, err)

--- a/plugin/storage/badger/spanstore/cache_test.go
+++ b/plugin/storage/badger/spanstore/cache_test.go
@@ -14,7 +14,6 @@
 package spanstore
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -109,14 +108,13 @@ func runWithBadger(t *testing.T, test func(store *badger.DB, t *testing.T)) {
 	opts := badger.DefaultOptions("")
 
 	opts.SyncWrites = false
-	dir, _ := os.MkdirTemp("", "badger")
+	dir := t.TempDir()
 	opts.Dir = dir
 	opts.ValueDir = dir
 
 	store, err := badger.Open(opts)
 	defer func() {
 		store.Close()
-		os.RemoveAll(dir)
 	}()
 
 	assert.NoError(t, err)

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -376,9 +376,7 @@ func TestMenuSeeks(t *testing.T) {
 }
 
 func TestPersist(t *testing.T) {
-	dir, err := os.MkdirTemp("", "badgerTest")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	p := func(t *testing.T, dir string, test func(t *testing.T, sw spanstore.Writer, sr spanstore.Reader)) {
 		f := badger.NewFactory()
@@ -400,7 +398,7 @@ func TestPersist(t *testing.T) {
 		})
 		f.InitFromViper(v, zap.NewNop())
 
-		err = f.Initialize(metrics.NullFactory, zap.NewNop())
+		err := f.Initialize(metrics.NullFactory, zap.NewNop())
 		assert.NoError(t, err)
 
 		sw, err := f.CreateSpanWriter()


### PR DESCRIPTION
## Which problem is this PR solving?

## Short description of the changes

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	dir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(dir)

	// now
	dir := t.TempDir()
}
```

