### PR TITLE
dependabot: group otel contrib instrumentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/docker-compose/monitor"
+    schedule:
+      interval: "weekly"
+    groups:
+      otel:
+        patterns:
+          - "opentelemetry-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
         patterns:
           - "go.opentelemetry.io/collector*"
           - "github.com/open-telemetry/o*-collector-contrib/*"
+      otel-instrumentation:
+        patterns:
+          - "go.opentelemetry.io/contrib/instrumentation/*"
       go-openapi:
         patterns:
           - "github.com/go-openapi/*"


### PR DESCRIPTION
## Short description of the changes
- group otel contrib instrumentation dependabot updates
- add pip package-ecosystem on docker-compose/monitor
