### PR TITLE
[test] Replace OT const with OTEL

### DIFF
--- a/cmd/query/app/handler_options.go
+++ b/cmd/query/app/handler_options.go
@@ -61,7 +61,7 @@ func (handlerOptions) QueryLookbackDuration(queryLookbackDuration time.Duration)
 	}
 }
 
-// Tracer creates a HandlerOption that initializes OpenTracing tracer
+// Tracer creates a HandlerOption that passes the tracer to the handler
 func (handlerOptions) Tracer(tracer *jtracer.JTracer) HandlerOption {
 	return func(apiHandler *APIHandler) {
 		apiHandler.tracer = tracer

--- a/model/adjuster/span_id_deduper_test.go
+++ b/model/adjuster/span_id_deduper_test.go
@@ -18,8 +18,8 @@ package adjuster
 import (
 	"testing"
 
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -27,6 +27,7 @@ import (
 var (
 	clientSpanID  = model.NewSpanID(1)
 	anotherSpanID = model.NewSpanID(11)
+	keySpanKind   = "span.kind"
 )
 
 func newTrace() *model.Trace {
@@ -39,7 +40,7 @@ func newTrace() *model.Trace {
 				SpanID:  clientSpanID,
 				Tags: model.KeyValues{
 					// span.kind = client
-					model.String(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum)),
+					model.String(keySpanKind, trace.SpanKindClient.String()),
 				},
 			},
 			{
@@ -48,7 +49,7 @@ func newTrace() *model.Trace {
 				SpanID:  clientSpanID, // shared span ID
 				Tags: model.KeyValues{
 					// span.kind = server
-					model.String(string(ext.SpanKind), string(ext.SpanKindRPCServerEnum)),
+					model.String(keySpanKind, trace.SpanKindServer.String()),
 				},
 			},
 			{


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
* Part of #3381 
* This PR adds `otel trace` spans type to span model

## Short description of the changes
- Replace OT const with `otel trace` spans const i.e. `ext.SpanKind..` with `trace.SpanKind..`
