### PR TITLE
[tracegen] Allow to control cardinality of attribute keys

### DIFF
--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Traces        int
 	ChildSpans    int
 	Attributes    int
+	AttrKeys      int
 	AttrValues    int
 	Marshal       bool
 	Debug         bool
@@ -47,8 +48,9 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.IntVar(&c.Workers, "workers", 1, "Number of workers (goroutines) to run")
 	fs.IntVar(&c.Traces, "traces", 1, "Number of traces to generate in each worker (ignored if duration is provided)")
 	fs.IntVar(&c.ChildSpans, "spans", 1, "Number of child spans to generate for each trace")
-	fs.IntVar(&c.Attributes, "attrs", 1, "Number of attributes to generate for each child span")
-	fs.IntVar(&c.AttrValues, "attr-values", 5, "Number of distinct values to allow for each attribute")
+	fs.IntVar(&c.Attributes, "attrs", 11, "Number of attributes to generate for each child span")
+	fs.IntVar(&c.AttrKeys, "attr-keys", 97, "Number of distinct attributes keys to use")
+	fs.IntVar(&c.AttrValues, "attr-values", 1000, "Number of distinct values to allow for each attribute")
 	fs.BoolVar(&c.Debug, "debug", false, "Whether to set DEBUG flag on the spans to force sampling")
 	fs.BoolVar(&c.Firehose, "firehose", false, "Whether to set FIREHOSE flag on the spans to skip indexing")
 	fs.DurationVar(&c.Pause, "pause", time.Microsecond, "How long to sleep before finishing each span. If set to 0s then a fake 123µs duration is used.")

--- a/internal/tracegen/worker.go
+++ b/internal/tracegen/worker.go
@@ -36,6 +36,7 @@ type worker struct {
 
 	// internal counters
 	traceNo   int
+	attrKeyNo int
 	attrValNo int
 }
 
@@ -94,10 +95,11 @@ func (w *worker) simulateChildSpans(ctx context.Context, start time.Time, tracer
 	for c := 0; c < w.ChildSpans; c++ {
 		var attrs []attribute.KeyValue
 		for a := 0; a < w.Attributes; a++ {
-			key := fmt.Sprintf("attr_%02d", a)
+			key := fmt.Sprintf("attr_%02d", w.attrKeyNo)
 			val := fmt.Sprintf("val_%02d", w.attrValNo)
-			w.attrValNo = (w.attrValNo + 1) % w.AttrValues
 			attrs = append(attrs, attribute.String(key, val))
+			w.attrKeyNo = (w.attrKeyNo + 1) % w.AttrKeys
+			w.attrValNo = (w.attrValNo + 1) % w.AttrValues
 		}
 		opts := []trace.SpanStartOption{
 			trace.WithSpanKind(trace.SpanKindClient),


### PR DESCRIPTION
## Description of the changes
- Add flag to control cardinality of attribute keys
- Use prime numbers for  default number of attributes and keys
