### PR TITLE
[/docker-compose/monitor] Group all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      otel:
+      all:
         patterns:
-          - "opentelemetry-*"
+          - "*"


### PR DESCRIPTION
This is not a critical example file, and its dependencies do not change often, so to minimize PR churn upgrade them all together