### PR TITLE
[memstore-plugin]Replace ot with otel sdk

### DIFF
--- a/examples/memstore-plugin/main.go
+++ b/examples/memstore-plugin/main.go
@@ -18,11 +18,11 @@ import (
 	"flag"
 	"strings"
 
-	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/hashicorp/go-plugin"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/viper"
 	jaegerClientConfig "github.com/uber/jaeger-client-go/config"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	googleGRPC "google.golang.org/grpc"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc"
@@ -81,8 +81,8 @@ func main() {
 	}
 	grpc.ServeWithGRPCServer(service, func(options []googleGRPC.ServerOption) *googleGRPC.Server {
 		return plugin.DefaultGRPCServer([]googleGRPC.ServerOption{
-			googleGRPC.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),
-			googleGRPC.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)),
+			googleGRPC.UnaryInterceptor(otelgrpc.UnaryServerInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
+			googleGRPC.StreamInterceptor(otelgrpc.StreamServerInterceptor(otelgrpc.WithTracerProvider(tracerProvider))),
 		})
 	})
 }

--- a/examples/memstore-plugin/main.go
+++ b/examples/memstore-plugin/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"strings"
@@ -30,6 +31,10 @@ import (
 	grpcMemory "github.com/jaegertracing/jaeger/plugin/storage/grpc/memory"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
 	"github.com/jaegertracing/jaeger/plugin/storage/memory"
+)
+
+const (
+	serviceName = "mem-store"
 )
 
 var configPath string
@@ -52,10 +57,11 @@ func main() {
 	opts := memory.Options{}
 	opts.InitFromViper(v)
 
-	tracer, err := jtracer.New("mem-store")
+	tracer, err := jtracer.New(serviceName)
 	if err != nil {
 		panic(fmt.Errorf("failed to initialize tracer: %w", err))
 	}
+	defer tracer.Close(context.Background())
 	otel.SetTracerProvider(tracer.OTEL)
 
 	memStorePlugin := grpcMemory.NewStoragePlugin(memory.NewStore(), memory.NewStore())

--- a/examples/memstore-plugin/main.go
+++ b/examples/memstore-plugin/main.go
@@ -16,14 +16,13 @@ package main
 
 import (
 	"flag"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
-	"go.uber.org/zap"
 	googleGRPC "google.golang.org/grpc"
 
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
@@ -55,7 +54,7 @@ func main() {
 
 	tracer, err := jtracer.New("mem-store")
 	if err != nil {
-		log.Fatal("Failed to initialize tracer", zap.Error(err))
+		panic(fmt.Errorf("failed to initialize tracer: %w", err))
 	}
 	otel.SetTracerProvider(tracer.OTEL)
 


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
* Part of #3381 
* This PR adds `otel` traces and removes deprecated `jaeger-client-go` api

## Short description of the changes
- Replace OT tracer with OTEL
