### PR TITLE
Add shell script to ensure consistent version of OTEL semconv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ lint:
 	./scripts/updateLicenses.sh > $(FMT_LOG)
 	./scripts/import-order-cleanup.sh stdout > $(IMPORT_LOG)
 	@[ ! -s "$(FMT_LOG)" -a ! -s "$(IMPORT_LOG)" ] || (echo "License check or import ordering failures, run 'make fmt'" | cat - $(FMT_LOG) $(IMPORT_LOG) && false)
+	./scripts/check-semconv-version.sh
 
 .PHONY: build-examples
 build-examples:

--- a/scripts/check-semconv-version.sh
+++ b/scripts/check-semconv-version.sh
@@ -2,20 +2,22 @@
 
 declare -A semconv_map
 
+package_name="go.opentelemetry.io/otel/semconv"
+version_regex="v[0-9]\.[0-9]\+\.[0-9]\+"
+
 while IFS=: read -r file_name package_string; do
-    version_number=$(echo "$package_string" | grep -o -E "v1\.[0-9]+\.[0-9]+")
-    semconv_map["$file_name"]=$version_number
-done < <(find . -type f -name "*.go" -exec grep -o -H "go.opentelemetry.io/otel/semconv/v1\.[0-9]\+\.[0-9]\+" {} +)
+    semconv_map["$file_name"]="${package_string##*/}"
+done < <(find . -type f -name "*.go" -exec grep -o -H "$package_name/$version_regex" {} +)
 
 semconv_versions=($(printf "%s\n" "${semconv_map[@]}" | sort -u))
 
 if [ ${#semconv_versions[@]} -gt 1 ]; then
-    echo "Error: semconv version mismatch detected. Run ./scripts/update-semconv-version.sh to update semconv to latest version."
+    echo "Error: semconv version mismatch detected."
     {
         for key in "${!semconv_map[@]}"; do
-            printf "Source File: %-30s | Semconv Version: %s\n" "$key" "${semconv_map[$key]}"
+            printf "Source File: %-50s | Semconv Version: %s\n" "$key" "${semconv_map[$key]}"
         done
     } | column -t -s '|'
-
+    echo "Run ./scripts/update-semconv-version.sh to update semconv to latest version."
     exit 1
 fi

--- a/scripts/check-semconv-version.sh
+++ b/scripts/check-semconv-version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+declare -A semconv_map
+
+while IFS=: read -r file_name package_string; do
+    version_number=$(echo "$package_string" | grep -o -E "v1\.[0-9]+\.[0-9]+")
+    semconv_map["$file_name"]=$version_number
+done < <(find . -type f -name "*.go" -exec grep -o -H "go.opentelemetry.io/otel/semconv/v1\.[0-9]\+\.[0-9]\+" {} +)
+
+semconv_versions=($(printf "%s\n" "${semconv_map[@]}" | sort -u))
+
+if [ ${#semconv_versions[@]} -gt 1 ]; then
+    echo "Error: semconv version mismatch detected"
+    {
+        for key in "${!semconv_map[@]}"; do
+            printf "Source File: %-30s | Semconv Version: %s\n" "$key" "${semconv_map[$key]}"
+        done
+    } | column -t -s '|'
+
+    exit 1
+fi

--- a/scripts/check-semconv-version.sh
+++ b/scripts/check-semconv-version.sh
@@ -10,7 +10,7 @@ done < <(find . -type f -name "*.go" -exec grep -o -H "go.opentelemetry.io/otel/
 semconv_versions=($(printf "%s\n" "${semconv_map[@]}" | sort -u))
 
 if [ ${#semconv_versions[@]} -gt 1 ]; then
-    echo "Error: semconv version mismatch detected"
+    echo "Error: semconv version mismatch detected. Run ./scripts/update-semconv-version.sh to update semconv to latest version."
     {
         for key in "${!semconv_map[@]}"; do
             printf "Source File: %-30s | Semconv Version: %s\n" "$key" "${semconv_map[$key]}"

--- a/scripts/update-semconv-version.sh
+++ b/scripts/update-semconv-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+latest_semconv_version=$(
+    curl -s https://pkg.go.dev/go.opentelemetry.io/otel/semconv \
+    | grep -oP 'data-id="v\d+\.\d+\.\d+"' \
+    | sed -E 's/data-id="v([0-9]+\.[0-9]+\.[0-9]+)"/v\1/' \
+    | sort -Vr \
+    | head -n 1
+)
+
+latest_package_string="go.opentelemetry.io/otel/semconv/$latest_semconv_version"
+
+while IFS=: read -r file_name package_string; do
+    version_number=$(echo "$package_string" | grep -o -E "v1\.[0-9]+\.[0-9]+")
+
+    if [ "$version_number" != "$latest_semconv_version" ]; then
+	sed -i "s#go\.opentelemetry\.io\/otel\/semconv\/v[0-9]\+\.[0-9]\+\.[0-9]\+#$latest_package_string#g" "$file_name"
+	{
+            printf "Source File: %-60s | Previous Semconv Version: %s | Updated Semconv Version: %s\n" "$file_name" "$version_number" "$latest_semconv_version"
+        } | column -t -s '|'
+    fi
+done < <(find . -type f -name "*.go" -exec grep -o -H "go.opentelemetry.io/otel/semconv/v1\.[0-9]\+\.[0-9]\+" {} +)

--- a/scripts/update-semconv-version.sh
+++ b/scripts/update-semconv-version.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 
+package_name="go.opentelemetry.io/otel/semconv"
+version_regex="v[0-9]\.[0-9]\+\.[0-9]\+"
+
 latest_semconv_version=$(
-    curl -s https://pkg.go.dev/go.opentelemetry.io/otel/semconv \
+    curl -s https://pkg.go.dev/$package_name \
     | grep -oP 'data-id="v\d+\.\d+\.\d+"' \
-    | sed -E 's/data-id="v([0-9]+\.[0-9]+\.[0-9]+)"/v\1/' \
+    | sed -E 's/\"($version_regex)\"/v\1/' \
     | sort -Vr \
-    | head -n 1
+    | head -n 1 \
+    | awk -F'"' '{print $2}'
 )
 
-latest_package_string="go.opentelemetry.io/otel/semconv/$latest_semconv_version"
+latest_package_string="$package_name/$latest_semconv_version"
 
 while IFS=: read -r file_name package_string; do
-    version_number=$(echo "$package_string" | grep -o -E "v1\.[0-9]+\.[0-9]+")
+    version_number=${package_string##*/}
 
     if [ "$version_number" != "$latest_semconv_version" ]; then
-	sed -i "s#go\.opentelemetry\.io\/otel\/semconv\/v[0-9]\+\.[0-9]\+\.[0-9]\+#$latest_package_string#g" "$file_name"
+	sed -i "s#$package_name/$version_regex#$latest_package_string#g" "$file_name"
 	{
             printf "Source File: %-60s | Previous Semconv Version: %s | Updated Semconv Version: %s\n" "$file_name" "$version_number" "$latest_semconv_version"
         } | column -t -s '|'
     fi
-done < <(find . -type f -name "*.go" -exec grep -o -H "go.opentelemetry.io/otel/semconv/v1\.[0-9]\+\.[0-9]\+" {} +)
+done < <(find . -type f -name "*.go" -exec grep -o -H "$package_name/$version_regex" {} +)


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4646 

## Description of the changes
- Added scripts/check-semconv-version.sh to search the code for all usages of "go.opentelemetry.io/otel/semconv/v1.xx.x" and fail if they are not identical, with an error message and the source files along with their respective versions.
- Added scripts/update-semconv-version.sh to fetch the latest version of semconv with curl and replace all references of 
"go.opentelemetry.io/otel/semconv/v1.xx.x" with the latest version.

## How was this change tested?
I have tested the changes locally by modifying import statements
![Mismatch_Version_Test](https://github.com/jaegertracing/jaeger/assets/140232061/769ae5cd-0d3e-4f45-b5a1-e5cadb6b248e)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
