### PR TITLE
Optimize ci builds

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -2,8 +2,6 @@
 
 set -exu
 
-mode=${1-main}
-
 BRANCH=${BRANCH:?'missing BRANCH env var'}
 # Set default GOARCH variable to the host GOARCH, the target architecture can
 # be overrided by passing architecture value to the script:

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -2,6 +2,8 @@
 
 set -exu
 
+mode=${1-main}
+
 BRANCH=${BRANCH:?'missing BRANCH env var'}
 # Set default GOARCH variable to the host GOARCH, the target architecture can
 # be overrided by passing architecture value to the script:
@@ -34,11 +36,18 @@ run_integration_test() {
 
 make create-baseimg-debugimg
 
-make build-all-in-one GOOS=linux GOARCH=amd64
-make build-all-in-one GOOS=linux GOARCH=s390x
-make build-all-in-one GOOS=linux GOARCH=ppc64le
-make build-all-in-one GOOS=linux GOARCH=arm64
 platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+
+if [ "$mode" = "pr-only" ]; then
+  make build-all-in-one GOOS=linux GOARCH=amd64
+  platforms="linux/amd64"
+else
+  make build-all-in-one GOOS=linux GOARCH=s390x
+  make build-all-in-one GOOS=linux GOARCH=ppc64le
+  make build-all-in-one GOOS=linux GOARCH=arm64
+  platforms="linux/s390x,linux/ppc64le,linux/arm64"
+fi
+
 repo=jaegertracing/all-in-one
 #build all-in-one image locally for integration test
 bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one -d cmd/all-in-one -p "${platforms}" -t release


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #4664

## Description of the changes
- Modified the build scripts to only build for linux/amd64 architecture for PRs.
- Updated the CI workflow to exclude non-Linux architectures when building PRs.

## How was this change tested?
- Not yet 

## Checklist
- [ Done ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ Done] I have signed all commits
- [ Not Done ] I have added unit tests for the new functionality
- [ Done ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
