### PR TITLE
Build architecture for linux/amd64 only for pull requests

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -34,11 +34,18 @@ run_integration_test() {
 
 make create-baseimg-debugimg
 
-make build-all-in-one GOOS=linux GOARCH=amd64
-make build-all-in-one GOOS=linux GOARCH=s390x
-make build-all-in-one GOOS=linux GOARCH=ppc64le
-make build-all-in-one GOOS=linux GOARCH=arm64
-platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+if [ "$mode" = "pr-only" ]; then
+  # build architecture for linux/amd64 only for pull requests
+  platforms="linux/amd64"
+  make build-all-in-one GOOS=linux GOARCH=amd64
+else
+  platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+  make build-all-in-one GOOS=linux GOARCH=amd64
+  make build-all-in-one GOOS=linux GOARCH=s390x
+  make build-all-in-one GOOS=linux GOARCH=ppc64le
+  make build-all-in-one GOOS=linux GOARCH=arm64
+fi
+
 repo=jaegertracing/all-in-one
 #build all-in-one image locally for integration test
 bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one -d cmd/all-in-one -p "${platforms}" -t release


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/4664

## Description of the changes
- To make building CI for PRs faster, we can skip building for other architectures aside from linux/amd64. This PR makes the change to stop building CI for other architectures aside from linux/amd64

## How was this change tested?
- 

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
