### PR TITLE
[ci] Avoid building debug image for PRs

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -32,13 +32,13 @@ run_integration_test() {
   docker kill $CID
 }
 
-make create-baseimg-debugimg
-
 if [ "$mode" = "pr-only" ]; then
+  make create-baseimg
   # build architecture for linux/amd64 only for pull requests
   platforms="linux/amd64"
   make build-all-in-one GOOS=linux GOARCH=amd64
 else
+  make create-baseimg-debugimg
   platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
   make build-all-in-one GOOS=linux GOARCH=amd64
   make build-all-in-one GOOS=linux GOARCH=s390x

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -4,14 +4,14 @@ set -euxf -o pipefail
 
 mode=${1-main}
 
-make create-baseimg-debugimg
-
 make build-binaries-linux
 
 if [ "$mode" = "pr-only" ]; then
+  make create-baseimg
   # build artifacts for linux/amd64 only for pull requests
   platforms="linux/amd64"
 else
+  make create-baseimg-debugimg
   platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
   # build multi-arch binaries
   make build-binaries-s390x


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/4663

## Description of the changes
- Update image build/upload scripts to create base image only when `mode=pr-only`

## How was this change tested?
- Works from my local by running `BRANCH=refactor/avoid-build-debug-img-in-pr ./scripts/build-all-in-one-image.sh pr-only`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
