### PR TITLE
[chore] Stop using constants from jaeger-client-go

### DIFF
--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -56,8 +56,8 @@ func TestProcessorMetrics(t *testing.T) {
 
 	assert.EqualValues(t, 1, counters["service.spans.received|debug=false|format=jaeger|svc=fry|transport=grpc"])
 	assert.EqualValues(t, 2, counters["service.spans.received|debug=true|format=jaeger|svc=fry|transport=grpc"])
-	assert.EqualValues(t, 1, counters["service.traces.received|debug=false|format=jaeger|sampler_type=unknown|svc=fry|transport=grpc"])
-	assert.EqualValues(t, 1, counters["service.traces.received|debug=true|format=jaeger|sampler_type=unknown|svc=fry|transport=grpc"])
+	assert.EqualValues(t, 1, counters["service.traces.received|debug=false|format=jaeger|sampler_type=unrecognized|svc=fry|transport=grpc"])
+	assert.EqualValues(t, 1, counters["service.traces.received|debug=true|format=jaeger|sampler_type=unrecognized|svc=fry|transport=grpc"])
 	assert.Empty(t, gauges)
 }
 
@@ -65,23 +65,23 @@ func TestNewTraceCountsBySvc(t *testing.T) {
 	baseMetrics := metricstest.NewFactory(time.Hour)
 	metrics := newTraceCountsBySvc(baseMetrics, "not_on_my_level", 3)
 
-	metrics.countByServiceName("fry", false, "unknown")
-	metrics.countByServiceName("leela", false, "unknown")
-	metrics.countByServiceName("bender", false, "unknown")
-	metrics.countByServiceName("zoidberg", false, "unknown")
+	metrics.countByServiceName("fry", false, model.SamplerTypeUnrecognized)
+	metrics.countByServiceName("leela", false, model.SamplerTypeUnrecognized)
+	metrics.countByServiceName("bender", false, model.SamplerTypeUnrecognized)
+	metrics.countByServiceName("zoidberg", false, model.SamplerTypeUnrecognized)
 
 	counters, _ := baseMetrics.Backend.Snapshot()
-	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|sampler_type=unknown|svc=fry"])
-	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|sampler_type=unknown|svc=leela"])
-	assert.EqualValues(t, 2, counters["not_on_my_level|debug=false|sampler_type=unknown|svc=other-services"])
+	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|sampler_type=unrecognized|svc=fry"])
+	assert.EqualValues(t, 1, counters["not_on_my_level|debug=false|sampler_type=unrecognized|svc=leela"])
+	assert.EqualValues(t, 2, counters["not_on_my_level|debug=false|sampler_type=unrecognized|svc=other-services"])
 
-	metrics.countByServiceName("bender", true, "const")
-	metrics.countByServiceName("bender", true, "probabilistic")
-	metrics.countByServiceName("leela", true, "probabilistic")
-	metrics.countByServiceName("fry", true, "ratelimiting")
-	metrics.countByServiceName("fry", true, "const")
-	metrics.countByServiceName("elzar", true, "lowerbound")
-	metrics.countByServiceName("url", true, "unknown")
+	metrics.countByServiceName("bender", true, model.SamplerTypeConst)
+	metrics.countByServiceName("bender", true, model.SamplerTypeProbabilistic)
+	metrics.countByServiceName("leela", true, model.SamplerTypeProbabilistic)
+	metrics.countByServiceName("fry", true, model.SamplerTypeRateLimiting)
+	metrics.countByServiceName("fry", true, model.SamplerTypeConst)
+	metrics.countByServiceName("elzar", true, model.SamplerTypeLowerBound)
+	metrics.countByServiceName("url", true, model.SamplerTypeUnrecognized)
 
 	counters, _ = baseMetrics.Backend.Snapshot()
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|sampler_type=const|svc=bender"])
@@ -90,7 +90,7 @@ func TestNewTraceCountsBySvc(t *testing.T) {
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|sampler_type=ratelimiting|svc=other-services"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|sampler_type=const|svc=other-services"])
 	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|sampler_type=lowerbound|svc=other-services"])
-	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|sampler_type=unknown|svc=other-services"])
+	assert.EqualValues(t, 1, counters["not_on_my_level|debug=true|sampler_type=unrecognized|svc=other-services"])
 }
 
 func TestNewSpanCountsBySvc(t *testing.T) {
@@ -120,8 +120,8 @@ func TestNewSpanCountsBySvc(t *testing.T) {
 func TestBuildKey(t *testing.T) {
 	// This test checks if stringBuilder is reset every time buildKey is called.
 	tc := newTraceCountsBySvc(jaegerM.NullFactory, "received", 100)
-	key := tc.buildKey("sample-service", "unknown")
-	assert.Equal(t, "sample-service$_$unknown", key)
-	key = tc.buildKey("sample-service2", "const")
+	key := tc.buildKey("sample-service", model.SamplerTypeUnrecognized.String())
+	assert.Equal(t, "sample-service$_$unrecognized", key)
+	key = tc.buildKey("sample-service2", model.SamplerTypeConst.String())
 	assert.Equal(t, "sample-service2$_$const", key)
 }

--- a/cmd/collector/app/root_span_handler.go
+++ b/cmd/collector/app/root_span_handler.go
@@ -34,7 +34,7 @@ func handleRootSpan(aggregator strategystore.Aggregator, logger *zap.Logger) Pro
 			return
 		}
 		samplerType, samplerParam := span.GetSamplerParams(logger)
-		if samplerType == "" {
+		if samplerType == 0 {
 			return
 		}
 		aggregator.RecordThroughput(service, span.OperationName, samplerType, samplerParam)

--- a/cmd/collector/app/root_span_handler.go
+++ b/cmd/collector/app/root_span_handler.go
@@ -34,7 +34,7 @@ func handleRootSpan(aggregator strategystore.Aggregator, logger *zap.Logger) Pro
 			return
 		}
 		samplerType, samplerParam := span.GetSamplerParams(logger)
-		if samplerType == 0 {
+		if samplerType == model.SamplerTypeUnrecognized {
 			return
 		}
 		aggregator.RecordThroughput(service, span.OperationName, samplerType, samplerParam)

--- a/cmd/collector/app/root_span_handler_test.go
+++ b/cmd/collector/app/root_span_handler_test.go
@@ -29,7 +29,7 @@ type mockAggregator struct {
 	closeCount atomic.Int32
 }
 
-func (t *mockAggregator) RecordThroughput(service, operation, samplerType string, probability float64) {
+func (t *mockAggregator) RecordThroughput(service, operation string, samplerType model.SamplerType, probability float64) {
 	t.callCount.Inc()
 }
 func (t *mockAggregator) Start() {}

--- a/cmd/collector/app/sampling/strategystore/interface.go
+++ b/cmd/collector/app/sampling/strategystore/interface.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
@@ -33,7 +34,7 @@ type Aggregator interface {
 	io.Closer
 
 	// RecordThroughput records throughput for an operation for aggregation.
-	RecordThroughput(service, operation, samplerType string, probability float64)
+	RecordThroughput(service, operation string, samplerType model.SamplerType, probability float64)
 
 	// Start starts aggregating operation throughput.
 	Start()

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -136,11 +136,11 @@ func TestBySvcMetrics(t *testing.T) {
 		if test.rootSpan {
 			if test.debug {
 				expected = append(expected, metricstest.ExpectedMetric{
-					Name: metricPrefix + ".traces.received|debug=true|format=" + format + "|sampler_type=unknown|svc=" + test.serviceName + "|transport=unknown", Value: 2,
+					Name: metricPrefix + ".traces.received|debug=true|format=" + format + "|sampler_type=unrecognized|svc=" + test.serviceName + "|transport=unknown", Value: 2,
 				})
 			} else {
 				expected = append(expected, metricstest.ExpectedMetric{
-					Name: metricPrefix + ".traces.received|debug=false|format=" + format + "|sampler_type=unknown|svc=" + test.serviceName + "|transport=unknown", Value: 2,
+					Name: metricPrefix + ".traces.received|debug=false|format=" + format + "|sampler_type=unrecognized|svc=" + test.serviceName + "|transport=unknown", Value: 2,
 				})
 			}
 		}

--- a/model/span.go
+++ b/model/span.go
@@ -62,6 +62,7 @@ var toSamplerType = map[string]SamplerType{
 	"probabilistic": SamplerTypeProbabilistic,
 	"lowerbound":    SamplerTypeLowerBound,
 	"ratelimiting":  SamplerTypeRateLimiting,
+	"const":         SamplerTypeConst,
 }
 
 func (s SamplerType) String() string {
@@ -74,6 +75,8 @@ func (s SamplerType) String() string {
 		return "lowerbound"
 	case SamplerTypeRateLimiting:
 		return "ratelimiting"
+	case SamplerTypeConst:
+		return "const"
 	default:
 		return ""
 	}
@@ -109,10 +112,9 @@ func (s *Span) GetSpanKind() (spanKind trace.SpanKind, found bool) {
 func (s *Span) GetSamplerType() SamplerType {
 	// There's no corresponding opentelemetry tag label corresponding to sampler.type
 	if tag, ok := KeyValues(s.Tags).FindByKey(keySamplerType); ok {
-		if tag.VStr == "" {
-			return toSamplerType[SamplerTypeUnrecognized.String()]
+		if s, ok := toSamplerType[tag.VStr]; ok {
+			return s
 		}
-		return toSamplerType[tag.VStr]
 	}
 	return SamplerTypeUnrecognized
 }

--- a/model/span.go
+++ b/model/span.go
@@ -32,6 +32,7 @@ const (
 	SamplerTypeLowerBound
 	SamplerTypeRateLimiting
 	SamplerTypeConst
+
 	// SampledFlag is the bit set in Flags in order to define a span as a sampled span
 	SampledFlag = Flags(1)
 	// DebugFlag is the bit set in Flags in order to define a span as a debug span
@@ -56,16 +57,21 @@ var toSpanKind = map[string]trace.SpanKind{
 	"internal": trace.SpanKindInternal,
 }
 
-var toSamplerType = map[SamplerType]string{
-	SamplerTypeUnrecognized:  "unrecognized",
-	SamplerTypeProbabilistic: "probabilistic",
-	SamplerTypeLowerBound:    "lowerbound",
-	SamplerTypeRateLimiting:  "ratelimiting",
-	SamplerTypeConst:         "const",
-}
-
 func (s SamplerType) String() string {
-	return toSamplerType[s]
+	switch s {
+	case SamplerTypeUnrecognized:
+		return "unrecognized"
+	case SamplerTypeProbabilistic:
+		return "probabilistic"
+	case SamplerTypeLowerBound:
+		return "lowerbound"
+	case SamplerTypeRateLimiting:
+		return "ratelimiting"
+	case SamplerTypeConst:
+		return "const"
+	default:
+		return ""
+	}
 }
 
 // Hash implements Hash from Hashable.
@@ -98,14 +104,17 @@ func (s *Span) GetSpanKind() (spanKind trace.SpanKind, found bool) {
 func (s *Span) GetSamplerType() SamplerType {
 	// There's no corresponding opentelemetry tag label corresponding to sampler.type
 	if tag, ok := KeyValues(s.Tags).FindByKey(keySamplerType); ok {
-		if tag.VStr == "" {
-			return SamplerTypeUnrecognized
-		} else if tag.VStr == toSamplerType[SamplerTypeProbabilistic] {
+		switch tag.VStr {
+		case SamplerTypeProbabilistic.String():
 			return SamplerTypeProbabilistic
-		} else if tag.VStr == toSamplerType[SamplerTypeRateLimiting] {
+		case SamplerTypeRateLimiting.String():
 			return SamplerTypeRateLimiting
-		} else {
+		case SamplerTypeLowerBound.String():
 			return SamplerTypeLowerBound
+		case SamplerTypeConst.String():
+			return SamplerTypeConst
+		default:
+			return SamplerTypeUnrecognized
 		}
 	}
 	return SamplerTypeUnrecognized

--- a/model/span.go
+++ b/model/span.go
@@ -33,9 +33,10 @@ const (
 	// FirehoseFlag is the bit in Flags in order to define a span as a firehose span
 	FirehoseFlag = Flags(8)
 
-	samplerType        = "sampler.type"
-	keySpanKind        = "span.kind"
-	samplerTypeUnknown = "unknown"
+	samplerType              = "sampler.type"
+	keySpanKind              = "span.kind"
+	samplerTypeUnknown       = "unknown"
+	samplerTypeProbabilistic = "probabilistic"
 )
 
 // Flags is a bit map of flags for a span
@@ -82,6 +83,8 @@ func (s *Span) GetSamplerType() string {
 	if tag, ok := KeyValues(s.Tags).FindByKey(samplerType); ok {
 		if tag.VStr == "" {
 			return samplerTypeUnknown
+		} else if tag.VStr == "probabilistic" {
+			return samplerTypeProbabilistic
 		}
 		return tag.VStr
 	}

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -408,7 +408,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.String("sampler.param", "1e-05"),
 			},
-			expectedType:  1,
+			expectedType:  model.SamplerTypeProbabilistic,
 			expectedParam: 0.00001,
 		},
 		{
@@ -416,7 +416,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.Float64("sampler.param", 0.10404450002098709),
 			},
-			expectedType:  1,
+			expectedType:  model.SamplerTypeProbabilistic,
 			expectedParam: 0.10404450002098709,
 		},
 		{
@@ -424,7 +424,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.String("sampler.param", "0.10404450002098709"),
 			},
-			expectedType:  1,
+			expectedType:  model.SamplerTypeProbabilistic,
 			expectedParam: 0.10404450002098709,
 		},
 		{
@@ -432,7 +432,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.Int64("sampler.param", 1),
 			},
-			expectedType:  1,
+			expectedType:  model.SamplerTypeProbabilistic,
 			expectedParam: 1.0,
 		},
 		{
@@ -440,26 +440,26 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "ratelimiting"),
 				model.String("sampler.param", "1"),
 			},
-			expectedType:  3,
+			expectedType:  model.SamplerTypeRateLimiting,
 			expectedParam: 1,
 		},
 		{
 			tags: model.KeyValues{
 				model.Float64("sampler.type", 1.5),
 			},
-			expectedType:  0,
+			expectedType:  model.SamplerTypeUnrecognized,
 			expectedParam: 0,
 		},
 		{
 			tags: model.KeyValues{
 				model.String("sampler.type", "probabilistic"),
 			},
-			expectedType:  0,
+			expectedType:  model.SamplerTypeUnrecognized,
 			expectedParam: 0,
 		},
 		{
 			tags:          model.KeyValues{},
-			expectedType:  0,
+			expectedType:  model.SamplerTypeUnrecognized,
 			expectedParam: 0,
 		},
 		{
@@ -467,7 +467,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.String("sampler.param", "1"),
 			},
-			expectedType:  2,
+			expectedType:  model.SamplerTypeLowerBound,
 			expectedParam: 1,
 		},
 		{
@@ -475,7 +475,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.Int64("sampler.param", 1),
 			},
-			expectedType:  2,
+			expectedType:  model.SamplerTypeLowerBound,
 			expectedParam: 1,
 		},
 		{
@@ -483,7 +483,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.Float64("sampler.param", 0.5),
 			},
-			expectedType:  2,
+			expectedType:  model.SamplerTypeLowerBound,
 			expectedParam: 0.5,
 		},
 		{
@@ -491,7 +491,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.String("sampler.param", "not_a_number"),
 			},
-			expectedType:  0,
+			expectedType:  model.SamplerTypeUnrecognized,
 			expectedParam: 0,
 		},
 		{
@@ -499,7 +499,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "not_a_type"),
 				model.String("sampler.param", "not_a_number"),
 			},
-			expectedType:  0,
+			expectedType:  model.SamplerTypeUnrecognized,
 			expectedParam: 0,
 		},
 	}

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -240,13 +240,13 @@ func TestGetSpanKind(t *testing.T) {
 
 func TestSamplerType(t *testing.T) {
 	span := makeSpan(model.String("sampler.type", "lowerbound"))
-	assert.Equal(t, "lowerbound", span.GetSamplerType())
+	assert.Equal(t, model.SamplerTypeLowerBound, span.GetSamplerType())
 	span = makeSpan(model.String("sampler.type", ""))
-	assert.Equal(t, "unknown", span.GetSamplerType())
+	assert.Equal(t, model.SamplerTypeUnrecognized, span.GetSamplerType())
 	span = makeSpan(model.String("sampler.type", "probabilistic"))
-	assert.Equal(t, "probabilistic", span.GetSamplerType())
+	assert.Equal(t, model.SamplerTypeProbabilistic, span.GetSamplerType())
 	span = makeSpan(model.KeyValue{})
-	assert.Equal(t, "unknown", span.GetSamplerType())
+	assert.Equal(t, model.SamplerTypeUnrecognized, span.GetSamplerType())
 }
 
 func TestIsSampled(t *testing.T) {
@@ -400,7 +400,7 @@ func TestGetSamplerParams(t *testing.T) {
 	logger := zap.NewNop()
 	tests := []struct {
 		tags          model.KeyValues
-		expectedType  string
+		expectedType  model.SamplerType
 		expectedParam float64
 	}{
 		{
@@ -408,7 +408,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.String("sampler.param", "1e-05"),
 			},
-			expectedType:  "probabilistic",
+			expectedType:  1,
 			expectedParam: 0.00001,
 		},
 		{
@@ -416,7 +416,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.Float64("sampler.param", 0.10404450002098709),
 			},
-			expectedType:  "probabilistic",
+			expectedType:  1,
 			expectedParam: 0.10404450002098709,
 		},
 		{
@@ -424,7 +424,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.String("sampler.param", "0.10404450002098709"),
 			},
-			expectedType:  "probabilistic",
+			expectedType:  1,
 			expectedParam: 0.10404450002098709,
 		},
 		{
@@ -432,7 +432,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "probabilistic"),
 				model.Int64("sampler.param", 1),
 			},
-			expectedType:  "probabilistic",
+			expectedType:  1,
 			expectedParam: 1.0,
 		},
 		{
@@ -440,26 +440,26 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "ratelimiting"),
 				model.String("sampler.param", "1"),
 			},
-			expectedType:  "ratelimiting",
+			expectedType:  3,
 			expectedParam: 1,
 		},
 		{
 			tags: model.KeyValues{
 				model.Float64("sampler.type", 1.5),
 			},
-			expectedType:  "",
+			expectedType:  0,
 			expectedParam: 0,
 		},
 		{
 			tags: model.KeyValues{
 				model.String("sampler.type", "probabilistic"),
 			},
-			expectedType:  "",
+			expectedType:  0,
 			expectedParam: 0,
 		},
 		{
 			tags:          model.KeyValues{},
-			expectedType:  "",
+			expectedType:  0,
 			expectedParam: 0,
 		},
 		{
@@ -467,7 +467,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.String("sampler.param", "1"),
 			},
-			expectedType:  "lowerbound",
+			expectedType:  2,
 			expectedParam: 1,
 		},
 		{
@@ -475,7 +475,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.Int64("sampler.param", 1),
 			},
-			expectedType:  "lowerbound",
+			expectedType:  2,
 			expectedParam: 1,
 		},
 		{
@@ -483,7 +483,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.Float64("sampler.param", 0.5),
 			},
-			expectedType:  "lowerbound",
+			expectedType:  2,
 			expectedParam: 0.5,
 		},
 		{
@@ -491,7 +491,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "lowerbound"),
 				model.String("sampler.param", "not_a_number"),
 			},
-			expectedType:  "",
+			expectedType:  0,
 			expectedParam: 0,
 		},
 		{
@@ -499,7 +499,7 @@ func TestGetSamplerParams(t *testing.T) {
 				model.String("sampler.type", "not_a_type"),
 				model.String("sampler.param", "not_a_number"),
 			},
-			expectedType:  "",
+			expectedType:  0,
 			expectedParam: 0,
 		},
 	}

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -243,6 +243,8 @@ func TestSamplerType(t *testing.T) {
 	assert.Equal(t, "lowerbound", span.GetSamplerType())
 	span = makeSpan(model.String("sampler.type", ""))
 	assert.Equal(t, "unknown", span.GetSamplerType())
+	span = makeSpan(model.String("sampler.type", "probabilistic"))
+	assert.Equal(t, "probabilistic", span.GetSamplerType())
 	span = makeSpan(model.KeyValue{})
 	assert.Equal(t, "unknown", span.GetSamplerType())
 }

--- a/plugin/sampling/strategystore/adaptive/aggregator.go
+++ b/plugin/sampling/strategystore/adaptive/aggregator.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
+	span_model "github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/storage/samplingstore"
 )
 
 const (
-	maxProbabilities         = 10
-	samplerTypeProbabilistic = "probabilistic"
+	maxProbabilities = 10
 )
 
 type aggregator struct {
@@ -83,7 +83,7 @@ func (a *aggregator) saveThroughput() {
 	a.storage.InsertThroughput(throughputSlice)
 }
 
-func (a *aggregator) RecordThroughput(service, operation, samplerType string, probability float64) {
+func (a *aggregator) RecordThroughput(service, operation string, samplerType span_model.SamplerType, probability float64) {
 	a.Lock()
 	defer a.Unlock()
 	if _, ok := a.currentThroughput[service]; !ok {
@@ -105,7 +105,7 @@ func (a *aggregator) RecordThroughput(service, operation, samplerType string, pr
 	// Only if we see probabilistically sampled root spans do we increment the throughput counter,
 	// for lowerbound sampled spans, we don't increment at all but we still save a count of 0 as
 	// the throughput so that the adaptive sampling processor is made aware of the endpoint.
-	if samplerType == samplerTypeProbabilistic {
+	if samplerType == span_model.SamplerTypeProbabilistic {
 		throughput.Count++
 	}
 }

--- a/plugin/sampling/strategystore/adaptive/aggregator.go
+++ b/plugin/sampling/strategystore/adaptive/aggregator.go
@@ -18,8 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/uber/jaeger-client-go"
-
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -27,7 +25,8 @@ import (
 )
 
 const (
-	maxProbabilities = 10
+	maxProbabilities         = 10
+	SamplerTypeProbabilistic = "probabilistic"
 )
 
 type aggregator struct {
@@ -106,7 +105,7 @@ func (a *aggregator) RecordThroughput(service, operation, samplerType string, pr
 	// Only if we see probabilistically sampled root spans do we increment the throughput counter,
 	// for lowerbound sampled spans, we don't increment at all but we still save a count of 0 as
 	// the throughput so that the adaptive sampling processor is made aware of the endpoint.
-	if samplerType == jaeger.SamplerTypeProbabilistic {
+	if samplerType == SamplerTypeProbabilistic {
 		throughput.Count++
 	}
 }

--- a/plugin/sampling/strategystore/adaptive/aggregator.go
+++ b/plugin/sampling/strategystore/adaptive/aggregator.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	maxProbabilities         = 10
-	SamplerTypeProbabilistic = "probabilistic"
+	samplerTypeProbabilistic = "probabilistic"
 )
 
 type aggregator struct {
@@ -105,7 +105,7 @@ func (a *aggregator) RecordThroughput(service, operation, samplerType string, pr
 	// Only if we see probabilistically sampled root spans do we increment the throughput counter,
 	// for lowerbound sampled spans, we don't increment at all but we still save a count of 0 as
 	// the throughput so that the adaptive sampling processor is made aware of the endpoint.
-	if samplerType == SamplerTypeProbabilistic {
+	if samplerType == samplerTypeProbabilistic {
 		throughput.Count++
 	}
 }

--- a/plugin/sampling/strategystore/adaptive/aggregator_test.go
+++ b/plugin/sampling/strategystore/adaptive/aggregator_test.go
@@ -26,11 +26,6 @@ import (
 	"github.com/jaegertracing/jaeger/storage/samplingstore/mocks"
 )
 
-const (
-	probabilistic = "probabilistic"
-	lowerbound    = "lowerbound"
-)
-
 func TestAggregator(t *testing.T) {
 	t.Skip("Skipping flaky unit test")
 	metricsFactory := metricstest.NewFactory(0)


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
* Part of #3381 
* This PR removes `jaeger-client` pkg constant and replaces it with const variable