### PR TITLE
Make all python scripts python3 compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,11 +386,11 @@ build-crossdock-fresh: build-crossdock-linux
 
 .PHONY: changelog
 changelog:
-	python3 ./scripts/release-notes.py --exclude-dependabot
+	./scripts/release-notes.py --exclude-dependabot
 
 .PHONY: draft-release
 draft-release:
-	python3 ./scripts/draft-release.py
+	./scripts/draft-release.py
 
 .PHONY: install-tools
 install-tools:

--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -90,7 +90,7 @@ this SPM Development Environment.
 
 Run the following commands to setup the Python virtual environment and install the Opentelemetry SDK:
 ```shell
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```

--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import subprocess
 

--- a/scripts/import-order-cleanup.py
+++ b/scripts/import-order-cleanup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 
 def cleanup_imports_and_return(imports):

--- a/scripts/import-order-cleanup.sh
+++ b/scripts/import-order-cleanup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-python scripts/import-order-cleanup.py -o $1 -t $(git ls-files "*\.go" | \
+./scripts/import-order-cleanup.py -o $1 -t $(git ls-files "*\.go" | \
     grep -v \
         -e thrift-gen \
         -e swagger-gen \

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -7,7 +7,7 @@
 # Requires personal GitHub token with default permissions:
 #   https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 #
-# Usage: python release-notes.py --help
+# Usage: ./release-notes.py --help
 #
 
 import argparse

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This script can read N latest commits from one of Jaeger repos
 # and output them in the release notes format:
 # * {title} ({author} in {pull_request})

--- a/scripts/updateLicense.py
+++ b/scripts/updateLicense.py
@@ -1,6 +1,4 @@
-from __future__ import (
-    absolute_import, print_function, division, unicode_literals
-)
+#!/usr/bin/env python3
 
 import logging
 import re

--- a/scripts/updateLicenses.sh
+++ b/scripts/updateLicenses.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-python scripts/updateLicense.py $(git ls-files "*\.go" | \
+./scripts/updateLicense.py $(git ls-files "*\.go" | \
     grep -v \
         -e thrift-gen \
         -e swagger-gen \

--- a/scripts/utils/ids-to-base64.py
+++ b/scripts/utils/ids-to-base64.py
@@ -1,7 +1,10 @@
+#!/usr/bin/env python3
+
 import base64
 import os
 import re
 import sys
+
 
 def trace_id_base64(match):
     id = int(match.group(1), 16)
@@ -9,22 +12,23 @@ def trace_id_base64(match):
     b64 = base64.b64encode(hex.decode('hex'))
     return '"traceId": "%s"' % b64
 
+
 def span_id_base64(match):
     id = int(match.group(1), 16)
     hex = '%016x' % id
     b64 = base64.b64encode(hex.decode('hex'))
-    return '"spanId": "%s"' % b64
+    return f'"spanId": "{b64}"'
+
 
 for file in sys.argv[1:]:
-    print file
-    backup = '%s.bak' % file
+    print(file)
+    backup = f'{file}.bak'
     with open(file, 'r') as fin:
         with open(backup, 'w') as fout:
             for line in fin:
                 # line = line[:-1] # remove \n
                 line = re.sub(r'"traceId": "(.+)"', trace_id_base64, line)
                 line = re.sub(r'"spanId": "(.+)"', span_id_base64, line)
-                # print(line)
                 fout.write(line)
     os.remove(file)
     os.rename(backup, file)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4673

## Description of the changes
- Adds python 3 shebang to each python script.
- The same can be done in a follow up PR to jaeger-ui if this PR is accepted.

## How was this change tested?

- Checked all python scripts within the jaeger project begin with a python3 shebang:
```shell
$ find . -name "*.py" | grep -v site-packages | grep -v venv | grep -v jaeger-ui | xargs head -1
```

<details>

    ```
    ==> ./scripts/utils/ids-to-base64.py <==
    #!/usr/bin/env python3

    ==> ./scripts/draft-release.py <==
    #!/usr/bin/env python3

    ==> ./scripts/release-notes.py <==
    #!/usr/bin/env python3

    ==> ./scripts/import-order-cleanup.py <==
    #!/usr/bin/env python3

    ==> ./scripts/updateLicense.py <==
    #!/usr/bin/env python3

    ==> ./docker-compose/monitor/otlp_exporter_example.py <==
    #!/usr/bin/env python3
    ```

</details>


- Checked all python scripts within the jaeger project are executable:

```
$  find . -name "*.py" | grep -v site-packages | grep -v venv | grep -v jaeger-ui | xargs ls -al
-rwxr-xr-x  1 albertteoh  staff   949 Apr 24 00:35 ./docker-compose/monitor/otlp_exporter_example.py
-rwxr-xr-x  1 albertteoh  staff  1561 Aug 27 06:41 ./scripts/draft-release.py
-rwxr-xr-x  1 albertteoh  staff  2874 Aug 26 20:44 ./scripts/import-order-cleanup.py
-rwxr-xr-x  1 albertteoh  staff  5095 Aug 27 06:32 ./scripts/release-notes.py
-rwxr-xr-x  1 albertteoh  staff  2787 Aug 26 20:44 ./scripts/updateLicense.py
-rwxr-xr-x  1 albertteoh  staff   848 Aug 27 06:37 ./scripts/utils/ids-to-base64.py
```

- Checked `make fmt` runs successfully.
- Checked `make changelog` runs successfully.
- Checked `make draft-release` runs successfully.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
~- [ ] I have added unit tests for the new functionality~
~- [ ] I have run lint and test steps successfully~
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
