### PR TITLE
Stop supporting -trace-exporter=jaeger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ next release (yyyy-mm-dd)
 
 #### ⛔ Breaking Changes
 
-* Make OTLP the default exporter in HotROD ([@yurishkuro](https://github.com/yurishkuro) in [#4698](https://github.com/jaegertracing/jaeger/pull/4698))
+* [hotrod] Make OTLP the default exporter in HotROD ([@yurishkuro](https://github.com/yurishkuro) in [#4698](https://github.com/jaegertracing/jaeger/pull/4698))
 * [SPM] Support spanmetrics connector by default ([@albertteoh](https://github.com/albertteoh) in [#4704](https://github.com/jaegertracing/jaeger/pull/4704))
+* [tracegen] Stop supporting -trace-exporter=jaeger
 
 #### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ next release (yyyy-mm-dd)
 
 * [hotrod] Make OTLP the default exporter in HotROD ([@yurishkuro](https://github.com/yurishkuro) in [#4698](https://github.com/jaegertracing/jaeger/pull/4698))
 * [SPM] Support spanmetrics connector by default ([@albertteoh](https://github.com/albertteoh) in [#4704](https://github.com/jaegertracing/jaeger/pull/4704))
-* [tracegen] Stop supporting -trace-exporter=jaeger
+* [tracegen] Stop supporting -trace-exporter=jaeger ([@yurishkuro](https://github.com/yurishkuro) in [#4717](https://github.com/jaegertracing/jaeger/pull/4717))
 
 #### New Features
 

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-logr/zapr"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -76,7 +75,7 @@ func createTracers(cfg *tracegen.Config, logger *zap.Logger) ([]trace.Tracer, fu
 
 		exp, err := createOtelExporter(cfg.TraceExporter)
 		if err != nil {
-			logger.Sugar().Fatalf("cannot create trace exporter %s: %w", cfg.TraceExporter, err)
+			logger.Sugar().Fatalf("cannot create trace exporter %s: %s", cfg.TraceExporter, err)
 		}
 		logger.Sugar().Infof("using %s trace exporter for service %s", cfg.TraceExporter, svc)
 
@@ -104,9 +103,7 @@ func createOtelExporter(exporterType string) (sdktrace.SpanExporter, error) {
 	var err error
 	switch exporterType {
 	case "jaeger":
-		exporter, err = jaeger.New(
-			jaeger.WithCollectorEndpoint(),
-		)
+		return nil, errors.New("jaeger exporter is no longer supported, please use otlp")
 	case "otlp", "otlp-http":
 		client := otlptracehttp.NewClient(
 			otlptracehttp.WithInsecure(),

--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -57,7 +57,7 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.Duration, "duration", 0, "For how long to run the test if greater than 0s (overrides -traces).")
 	fs.StringVar(&c.Service, "service", "tracegen", "Service name prefix to use")
 	fs.IntVar(&c.Services, "services", 1, "Number of unique suffixes to add to service name when generating traces, e.g. tracegen-01 (but only one service per trace)")
-	fs.StringVar(&c.TraceExporter, "trace-exporter", "jaeger", "Trace exporter (jaeger|otlp/otlp-http|otlp-grpc|stdout). Exporters can be additionally configured via environment variables, see https://github.com/jaegertracing/jaeger/blob/main/cmd/tracegen/README.md")
+	fs.StringVar(&c.TraceExporter, "trace-exporter", "otlp-http", "Trace exporter (otlp/otlp-http|otlp-grpc|stdout). Exporters can be additionally configured via environment variables, see https://github.com/jaegertracing/jaeger/blob/main/cmd/tracegen/README.md")
 }
 
 // Run executes the test scenario.


### PR DESCRIPTION
## Which problem is this PR solving?
- Upgrade of OTEL is failing in #4705 because `jaeger` exporter is deprecated

## Description of the changes
- Remove `jaeger` as supported trace exporter
