### PR TITLE
[hotrod] Move metrics endpoints from route to frontend service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ next release (yyyy-mm-dd)
 * [SPM] Support spanmetrics connector by default ([@albertteoh](https://github.com/albertteoh) in [#4704](https://github.com/jaegertracing/jaeger/pull/4704))
 * [tracegen] Stop supporting -trace-exporter=jaeger ([@yurishkuro](https://github.com/yurishkuro) in [#4717](https://github.com/jaegertracing/jaeger/pull/4717))
 * [hotrod] Stop supporting -otel-exporter=jaeger ([@yurishkuro](https://github.com/yurishkuro) in [#4719](https://github.com/jaegertracing/jaeger/pull/4719))
+* [hotrod] Metrics endpoints moved from route service (:8083) to frontend service (:8080) ([@yurishkuro](https://github.com/yurishkuro) in [#4720](https://github.com/jaegertracing/jaeger/pull/4720))
 
 #### New Features
 

--- a/examples/hotrod/services/frontend/server.go
+++ b/examples/hotrod/services/frontend/server.go
@@ -18,10 +18,12 @@ package frontend
 import (
 	"embed"
 	"encoding/json"
+	"expvar"
 	"net/http"
 	"path"
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -82,6 +84,8 @@ func (s *Server) createServeMux() http.Handler {
 	mux.Handle(p, http.StripPrefix(p, http.FileServer(s.assetFS)))
 	mux.Handle(path.Join(p, "/dispatch"), http.HandlerFunc(s.dispatch))
 	mux.Handle(path.Join(p, "/config"), http.HandlerFunc(s.config))
+	mux.Handle(path.Join(p, "/debug/vars"), expvar.Handler()) // expvar
+	mux.Handle(path.Join(p, "/metrics"), promhttp.Handler())  // Prometheus
 	return mux
 }
 

--- a/examples/hotrod/services/route/server.go
+++ b/examples/hotrod/services/route/server.go
@@ -18,13 +18,11 @@ package route
 import (
 	"context"
 	"encoding/json"
-	"expvar"
 	"math"
 	"math/rand"
 	"net/http"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -61,8 +59,6 @@ func (s *Server) Run() error {
 func (s *Server) createServeMux() http.Handler {
 	mux := tracing.NewServeMux(false, s.tracer, s.logger)
 	mux.Handle("/route", http.HandlerFunc(s.route))
-	mux.Handle("/debug/vars", expvar.Handler()) // expvar
-	mux.Handle("/metrics", promhttp.Handler())  // Prometheus
 	return mux
 }
 

--- a/examples/hotrod/services/route/server.go
+++ b/examples/hotrod/services/route/server.go
@@ -59,7 +59,13 @@ func (s *Server) Run() error {
 func (s *Server) createServeMux() http.Handler {
 	mux := tracing.NewServeMux(false, s.tracer, s.logger)
 	mux.Handle("/route", http.HandlerFunc(s.route))
+	mux.Handle("/debug/vars", http.HandlerFunc(movedToFrontend))
+	mux.Handle("/metrics", http.HandlerFunc(movedToFrontend))
 	return mux
+}
+
+func movedToFrontend(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "endpoint moved to the frontend service", http.StatusNotFound)
 }
 
 func (s *Server) route(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Previously, for unexplained reasons, the metrics endpoints (/metrics and /debug/expvar) in HotROD were served from the route service. That means 8083 port was also required to be exposed.

## Description of the changes
- Move metrics handlers to the frontend service
- Return error from root service

## How was this change tested?
```
$ curl http://0.0.0.0:8083/metrics
endpoint moved to the frontend service
```
