### PR TITLE
Move build to Go 1.21

### DIFF
--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Setup Node.js version
       uses: ./.github/actions/setup-node.js

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -52,7 +52,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Setup Node.js version
       uses: ./.github/actions/setup-node.js

--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -40,7 +40,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Run cassandra integration tests
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.image }} ${{ matrix.version.schema }}

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Setup Node.js version
       uses: ./.github/actions/setup-node.js

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -47,7 +47,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/ci-grpc-badger.yml
+++ b/.github/workflows/ci-grpc-badger.yml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Run Badger storage integration tests
       run: make badger-storage-integration-test

--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Run kafka integration tests
       run: bash scripts/kafka-integration-test.sh

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -44,7 +44,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/ci-protogen-tests.yml
+++ b/.github/workflows/ci-protogen-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Run protogen validation
       run: make proto && git diff --name-status --exit-code

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -31,7 +31,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
       with:

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Add GOPATH
         run: |

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 VERSION := 1.0.0
 ROOT_IMAGE ?= alpine:3.16
 CERT_IMAGE := $(ROOT_IMAGE)
-GOLANG_IMAGE := golang:1.20-alpine
+GOLANG_IMAGE := golang:1.21-alpine
 
 DOCKER_REGISTRY ?= localhost:5000
 BASE_IMAGE ?= $(DOCKER_REGISTRY)/baseimg_alpine:latest


### PR DESCRIPTION
## Which problem is this PR solving?
- Move to next Go version per maintenance policy (see #4653)

## Description of the changes
Ran the script 
```shell
$ ./scripts/check-go-version.sh -u
go.mod                                             Go version: 1.20
docker/Makefile                                    Go version: 1.20 *** => 1.21 ***
.github/workflows/fossa.yml                        Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-release.yml                   Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-unit-tests.yml                Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-docker-build.yml              Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-build-binaries.yml            Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-crossdock.yml                 Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-elasticsearch.yml             Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-grpc-badger.yml               Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-hotrod.yml                    Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-protogen-tests.yml            Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-all-in-one-build.yml          Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-cassandra.yml                 Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-opensearch.yml                Go version: 1.20 *** => 1.21 ***
.github/workflows/ci-kafka.yml                     Go version: 1.20 *** => 1.21 ***
.golangci.yml                                      Go version: 1.20
15 file(s) updated.
```
