### PR TITLE
[tracegen] Add build info during compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,11 +174,11 @@ build-examples:
 
 .PHONY: build-tracegen
 build-tracegen:
-	$(GOBUILD) -o ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH) ./cmd/tracegen/main.go
+	$(GOBUILD) $(BUILD_INFO) -o ./cmd/tracegen/tracegen-$(GOOS)-$(GOARCH) ./cmd/tracegen/main.go
 
 .PHONY: build-anonymizer
 build-anonymizer:
-	$(GOBUILD) -o ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/anonymizer/main.go
+	$(GOBUILD) $(BUILD_INFO) -o ./cmd/anonymizer/anonymizer-$(GOOS)-$(GOARCH) $(BUILD_INFO) ./cmd/anonymizer/main.go
 
 .PHONY: build-esmapping-generator
 build-esmapping-generator:


### PR DESCRIPTION
## Which problem is this PR solving?
- PR #4723 added logging, but tracegen was not built with build-info embedded

## Description of the changes
-  add build info to tracegen and anonymizer binaries

## How was this change tested?
```
$ make build-tracegen
CGO_ENABLED=0 installsuffix=cgo go build -trimpath -ldflags "-X github.com/jaegertracing/jaeger/pkg/version.commitSHA=f8c1523f64159bf05eedf6aa6ffb09c9402a9932 -X github.com/jaegertracing/jaeger/pkg/version.latestVersion=v1.48.0 -X github.com/jaegertracing/jaeger/pkg/version.date=2023-09-05T00:05:46Z" -o ./cmd/tracegen/tracegen-darwin-amd64 ./cmd/tracegen/main.go

$ ./cmd/tracegen/tracegen-darwin-amd64
2023-09-05T21:55:58.923-0400	INFO	./main.go:56	application version: git-commit=f8c1523f64159bf05eedf6aa6ffb09c9402a9932, git-version=v1.48.0, build-date=2023-09-05T00:05:46Z
```
