### PR TITLE
[breaking] Remove support for SAMPLING_TYPE env var and 'static' value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ next release (yyyy-mm-dd)
 
 ### UI Changes
 
+1.50.0 (yyyy-mm-dd)
+-------------------
+
+### Backend Changes
+
+#### ⛔ Breaking Changes
+
+* [sampling] Remove support for SAMPLING_TYPE env var and 'static' value ([@yurishkuro](https://github.com/yurishkuro) in [#4735](https://github.com/jaegertracing/jaeger/pull/4735))
+
+
+#### New Features
+
+#### Bug fixes, Minor Improvements
+
+### UI Changes
+
 1.49.0 (2023-09-07)
 -------------------
 

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -69,7 +69,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}
-	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv(os.Stderr)
+	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv()
 	if err != nil {
 		log.Fatalf("Cannot initialize sampling strategy store factory config: %v", err)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -52,7 +52,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}
-	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv(os.Stderr)
+	strategyStoreFactoryConfig, err := ss.FactoryConfigFromEnv()
 	if err != nil {
 		log.Fatalf("Cannot initialize sampling strategy store factory config: %v", err)
 	}

--- a/plugin/sampling/strategystore/factory_config.go
+++ b/plugin/sampling/strategystore/factory_config.go
@@ -16,7 +16,6 @@ package strategystore
 
 import (
 	"fmt"
-	"io"
 	"os"
 )
 
@@ -33,8 +32,8 @@ type FactoryConfig struct {
 // FactoryConfigFromEnv reads the desired sampling type from the SAMPLING_CONFIG_TYPE environment variable. Allowed values:
 // * `file` - built-in
 // * `adaptive` - built-in
-func FactoryConfigFromEnv(log io.Writer) (*FactoryConfig, error) {
-	strategyStoreType := getStrategyStoreTypeFromEnv(log)
+func FactoryConfigFromEnv() (*FactoryConfig, error) {
+	strategyStoreType := getStrategyStoreTypeFromEnv()
 	if strategyStoreType != samplingTypeAdaptive &&
 		strategyStoreType != samplingTypeFile {
 		return nil, fmt.Errorf("invalid sampling type: %s. Valid types are %v", strategyStoreType, AllSamplingTypes)
@@ -45,7 +44,7 @@ func FactoryConfigFromEnv(log io.Writer) (*FactoryConfig, error) {
 	}, nil
 }
 
-func getStrategyStoreTypeFromEnv(log io.Writer) string {
+func getStrategyStoreTypeFromEnv() string {
 	// check the new env var
 	strategyStoreType := os.Getenv(SamplingTypeEnvVar)
 	if strategyStoreType != "" {

--- a/plugin/sampling/strategystore/factory_config.go
+++ b/plugin/sampling/strategystore/factory_config.go
@@ -23,11 +23,6 @@ import (
 const (
 	// SamplingTypeEnvVar is the name of the env var that defines the type of sampling strategy store used.
 	SamplingTypeEnvVar = "SAMPLING_CONFIG_TYPE"
-
-	// previously the SAMPLING_TYPE env var was used for configuration, continue to support this old env var with warnings
-	deprecatedSamplingTypeEnvVar = "SAMPLING_TYPE"
-	// static is the old name for "file". we will translate from the deprecated to current name here. all other code will expect "file"
-	deprecatedSamplingTypeStatic = "static"
 )
 
 // FactoryConfig tells the Factory what sampling type it needs to create.
@@ -54,17 +49,6 @@ func getStrategyStoreTypeFromEnv(log io.Writer) string {
 	// check the new env var
 	strategyStoreType := os.Getenv(SamplingTypeEnvVar)
 	if strategyStoreType != "" {
-		return strategyStoreType
-	}
-
-	// accept the old env var and value but warn
-	strategyStoreType = os.Getenv(deprecatedSamplingTypeEnvVar)
-	if strategyStoreType != "" {
-		fmt.Fprintf(log, "WARNING: Using deprecated '%s' env var. Please switch to '%s'.\n", deprecatedSamplingTypeEnvVar, SamplingTypeEnvVar)
-		if strategyStoreType == deprecatedSamplingTypeStatic {
-			fmt.Fprintf(log, "WARNING: Using deprecated '%s' value for %s. Please switch to '%s'.\n", strategyStoreType, SamplingTypeEnvVar, samplingTypeFile)
-			strategyStoreType = samplingTypeFile
-		}
 		return strategyStoreType
 	}
 

--- a/plugin/sampling/strategystore/factory_config_test.go
+++ b/plugin/sampling/strategystore/factory_config_test.go
@@ -36,21 +36,9 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 			expectedType: Kind("file"),
 		},
 		{
-			name:         "file on deprecatedSamplingTypeEnvVar",
-			env:          "file",
-			envVar:       deprecatedSamplingTypeEnvVar,
-			expectedType: Kind("file"),
-		},
-		{
 			name:         "file on SamplingTypeEnvVar",
 			env:          "file",
 			envVar:       SamplingTypeEnvVar,
-			expectedType: Kind("file"),
-		},
-		{
-			name:         "static works on the deprecatedSamplingTypeEnvVar",
-			env:          "static",
-			envVar:       deprecatedSamplingTypeEnvVar,
 			expectedType: Kind("file"),
 		},
 		{
@@ -60,22 +48,10 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 			expectsError: true,
 		},
 		{
-			name:         "adaptive on deprecatedSamplingTypeEnvVar",
-			env:          "adaptive",
-			envVar:       deprecatedSamplingTypeEnvVar,
-			expectedType: Kind("adaptive"),
-		},
-		{
 			name:         "adaptive on SamplingTypeEnvVar",
 			env:          "adaptive",
 			envVar:       SamplingTypeEnvVar,
 			expectedType: Kind("adaptive"),
-		},
-		{
-			name:         "unexpected string on deprecatedSamplingTypeEnvVar",
-			env:          "??",
-			envVar:       deprecatedSamplingTypeEnvVar,
-			expectsError: true,
 		},
 		{
 			name:         "unexpected string on SamplingTypeEnvVar",
@@ -140,8 +116,6 @@ func TestGetStrategyStoreTypeFromEnv(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(SamplingTypeEnvVar, tc.currentEnvValue)
-			t.Setenv(deprecatedSamplingTypeEnvVar, tc.deprecatedEnvValue)
-
 			actual := getStrategyStoreTypeFromEnv(io.Discard)
 			assert.Equal(t, actual, tc.expected)
 		})


### PR DESCRIPTION
These were deprecated in 2021 (#3302)