### PR TITLE
Attempt to fix flaky TestGetRoundTripper* tests

### DIFF
--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -305,8 +305,9 @@ func TestPublishOpts(t *testing.T) {
 	forkFactory := metricstest.NewFactory(time.Second)
 	metricsFactory := fork.New("internal", forkFactory, baseMetrics)
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metricsFactory)
-	assert.NoError(t, err)
-	assert.NotNil(t, agent)
+	require.NoError(t, err)
+	require.NotNil(t, agent)
+	defer agent.Stop()
 
 	forkFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "internal.processor.jaeger-binary.server-max-packet-size",

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -305,8 +305,8 @@ func TestPublishOpts(t *testing.T) {
 	forkFactory := metricstest.NewFactory(time.Second)
 	metricsFactory := fork.New("internal", forkFactory, baseMetrics)
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metricsFactory)
-	require.NoError(t, err)
-	require.NotNil(t, agent)
+	assert.NoError(t, err)
+	assert.NotNil(t, agent)
 
 	forkFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "internal.processor.jaeger-binary.server-max-packet-size",

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -307,7 +307,6 @@ func TestPublishOpts(t *testing.T) {
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metricsFactory)
 	require.NoError(t, err)
 	require.NotNil(t, agent)
-	defer agent.Stop()
 
 	forkFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "internal.processor.jaeger-binary.server-max-packet-size",

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -561,8 +561,8 @@ func TestGetRoundTripperTLSConfig(t *testing.T) {
 
 			resp, err := rt.RoundTrip(req)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			assert.True(t, authReceived.Load())
 		})
 	}
@@ -606,10 +606,11 @@ func TestGetRoundTripperTokenFile(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
+
 	resp, err := rt.RoundTrip(req)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, authReceived.Load())
 }
 
@@ -648,10 +649,11 @@ func TestGetRoundTripperTokenFromContext(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
+
 	resp, err := rt.RoundTrip(req)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, authReceived.Load())
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4732

## Description of the changes
- Introduces an atomic boolean outside of the HTTP test handler and only set to `true` if the expected request is received.
- This should prevent cases where unrelated processes are hitting the same test URL.

## How was this change tested?
- Ran `make test` to pass.
- Ran `go test -tags=memory_storage_integration -count 10 ./...` and confirmed `metricsstore` tests are passing.
- Note that a number of unrelated tests were failing with the `-count 10` flag set, **not as a result of the changes from this PR**, namely:
```
--- FAIL: TestFactory (0.00s)
    --- FAIL: TestFactory/#00 (0.00s)
panic: Reuse of exported var name: test_1694287567920905000_counter_x
 [recovered]
	panic: Reuse of exported var name: test_1694287567920905000_counter_x
```
and
```
--- FAIL: TestPublishOpts (0.00s)
    builder_test.go:308:
        	Error Trace:	/Users/albertteoh/go/src/github.com/albertteoh/jaeger/cmd/agent/app/builder_test.go:308
        	Error:      	Received unexpected error:
        	            	cannot create processors: cannot create Thrift Processor: cannot create UDP Server: cannot create UDPServerTransport: listen udp :5775: bind: address already in use
        	Test:       	TestPublishOpts
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
