### PR TITLE
Fix: Ensure Proper Handling of Password Changes

### DIFF
--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -312,8 +312,12 @@ func (f *Factory) onClientPasswordChange(cfg *config.Configuration, client *atom
 	if err != nil {
 		f.logger.Error("failed to recreate Elasticsearch client with new password", zap.Error(err))
 	} else {
-		client.Store(&primaryClient)
+		oldClient := client.Swap(&newClient)
+        if oldClient != nil {
+            oldClient.Close()
+        }
 	}
+    
 }
 
 func loadTokenFromFile(path string) (string, error) {


### PR DESCRIPTION
It was observed that the last logged request to the server used a Basic Auth string that resembled the old password, even after a new password was set. This could potentially happen if the es.Client object continued sending pings to the server without being properly closed.
This commit addresses the issue by ensuring that the es.Client object is correctly closed when needed, preventing any further requests with outdated passwords.
#4743 