### PR TITLE
[fix] Close Elasticsearch client properly

### DIFF
--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -325,7 +325,9 @@ func (f *Factory) onClientPasswordChange(cfg *config.Configuration, client *atom
 		f.logger.Error("failed to recreate Elasticsearch client with new password", zap.Error(err))
 	} else {
 		oldClient := *client.Swap(&newClient)
-		oldClient.Close()
+		if err := oldClient.Close(); err != nil {
+			f.logger.Error("failed to close Elasticsearch client", zap.Error(err))
+		}
 	}
 }
 

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -137,11 +137,17 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 }
 
 func (f *Factory) getPrimaryClient() es.Client {
-	return *(f.primaryClient.Load())
+	if c := f.primaryClient.Load(); c != nil {
+		return *c
+	}
+	return nil
 }
 
 func (f *Factory) getArchiveClient() es.Client {
-	return *f.archiveClient.Load()
+	if c := f.archiveClient.Load(); c != nil {
+		return *c
+	}
+	return nil
 }
 
 // CreateSpanReader implements storage.Factory

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -287,10 +287,11 @@ func (f *Factory) Close() error {
 	if cfg := f.Options.Get(archiveNamespace); cfg != nil {
 		errs = append(errs, cfg.TLS.Close())
 	}
-	errs = append(errs,
-		f.Options.GetPrimary().TLS.Close(),
-		f.getArchiveClient().Close(),
-		f.getPrimaryClient().Close())
+	errs = append(errs, f.Options.GetPrimary().TLS.Close())
+	errs = append(errs, f.getPrimaryClient().Close())
+	if client := f.getArchiveClient(); client != nil {
+		errs = append(errs, client.Close())
+	}
 
 	return errors.Join(errs...)
 }

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -324,8 +324,8 @@ func (f *Factory) onClientPasswordChange(cfg *config.Configuration, client *atom
 	if err != nil {
 		f.logger.Error("failed to recreate Elasticsearch client with new password", zap.Error(err))
 	} else {
-		oldclinet := *client.Swap(&newClient)
-		oldclinet.Close()
+		oldClient := *client.Swap(&newClient)
+		oldClient.Close()
 	}
 }
 

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -338,6 +338,12 @@ func testPasswordFromFile(t *testing.T, f *Factory, getClient func() es.Client, 
 	require.Equal(t, ":second password", *authReceived.Load())
 }
 
+func TestFactoryESClientsAreNil(t *testing.T) {
+	f := &Factory{}
+	assert.Nil(t, f.getPrimaryClient())
+	assert.Nil(t, f.getArchiveClient())
+}
+
 func TestPasswordFromFileErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(mockEsServerResponse)

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -361,14 +361,7 @@ func TestPasswordFromFileErrors(t *testing.T) {
 
 	logger, buf := testutils.NewEchoLogger(t)
 	require.NoError(t, f.Initialize(metrics.NullFactory, logger))
-
-	for _, w := range f.watchers {
-		w.Close()
-	}
-	if cfg := f.Options.Get(archiveNamespace); cfg != nil {
-		cfg.TLS.Close()
-	}
-	f.Options.GetPrimary().TLS.Close()
+	defer f.Close()
 
 	f.primaryConfig.Servers = []string{}
 	f.onPrimaryPasswordChange()


### PR DESCRIPTION
## Which problem is this PR solving?
- resolves #4743 

## Description of the changes
- Resolved an issue where the Elasticsearch client was not being closed correctly. 

## How was this change tested?
- manually on local env

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
