### PR TITLE
Add Cassandra schema compaction window configuration

### DIFF
--- a/plugin/storage/cassandra/schema/v004.cql.tmpl
+++ b/plugin/storage/cassandra/schema/v004.cql.tmpl
@@ -67,8 +67,8 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.traces (
     PRIMARY KEY (trace_id, span_id, span_hash)
 )
     WITH compaction = {
-        'compaction_window_size': '1',
-        'compaction_window_unit': 'HOURS',
+        'compaction_window_size': '${compaction_window_size}',
+        'compaction_window_unit': '${compaction_window_unit}',
         'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'
     }
     AND default_time_to_live = ${trace_ttl}


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4561

## Description of the changes
- Include compaction window settings based on the 'COMPACTION_WINDOW' environment variable
- The value of the compaction window is either provided by the user or by calculating `ceil(ttl / 30)`

## How was this change tested?
Locally tested change by generating the CSQL code from the template.
Can reproduce by running:
```bash
$ MODE=test ./create.sh v004.cql.tmpl

$ TRACE_TTL=2592000 MODE=test ./create.sh v004.cql.tmpl

$ COMPACTION_WINDOW=12h MODE=test ./create.sh v004.cql.tmpl
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
