### PR TITLE
Support HTTP proxy env variables

### DIFF
--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -101,7 +101,6 @@ func (b *ConnBuilder) CreateConnection(logger *zap.Logger, mFactory metrics.Fact
 			dialTarget = r.Scheme() + ":///round_robin"
 			logger.Info("Agent is connecting to a static list of collectors", zap.String("dialTarget", dialTarget), zap.String("collector hosts", strings.Join(b.CollectorHostPorts, ",")))
 		} else {
-			// if strings.
 			dialTarget = hostPorts[0]
 		}
 	}

--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -82,26 +82,26 @@ func (b *ConnBuilder) CreateConnection(logger *zap.Logger, mFactory metrics.Fact
 		if b.CollectorHostPorts == nil {
 			return nil, errors.New("at least one collector hostPort address is required when resolver is not available")
 		}
-		var hostPorts []string
+		var collectorEndpoints []string
 		// use explicitly localhost as bind address if :port is specified. The :port is not recognized by NO_PROXY
 		for _, endpoint := range b.CollectorHostPorts {
 			if strings.HasPrefix(endpoint, ":") {
 				endpoint = "localhost" + endpoint
 			}
-			hostPorts = append(hostPorts, endpoint)
+			collectorEndpoints = append(collectorEndpoints, endpoint)
 		}
-		if len(hostPorts) > 1 {
+		if len(collectorEndpoints) > 1 {
 			r := manual.NewBuilderWithScheme("jaeger-manual")
 			dialOptions = append(dialOptions, grpc.WithResolvers(r))
 			var resolvedAddrs []resolver.Address
-			for _, addr := range b.CollectorHostPorts {
+			for _, addr := range collectorEndpoints {
 				resolvedAddrs = append(resolvedAddrs, resolver.Address{Addr: addr})
 			}
 			r.InitialState(resolver.State{Addresses: resolvedAddrs})
 			dialTarget = r.Scheme() + ":///round_robin"
-			logger.Info("Agent is connecting to a static list of collectors", zap.String("dialTarget", dialTarget), zap.String("collector hosts", strings.Join(b.CollectorHostPorts, ",")))
+			logger.Info("Agent is connecting to a static list of collectors", zap.String("dialTarget", dialTarget), zap.String("collector hosts", strings.Join(collectorEndpoints, ",")))
 		} else {
-			dialTarget = hostPorts[0]
+			dialTarget = collectorEndpoints[0]
 		}
 	}
 	dialOptions = append(dialOptions, grpc.WithDefaultServiceConfig(grpcresolver.GRPCServiceConfig))

--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -85,7 +85,7 @@ func (b *ConnBuilder) CreateConnection(logger *zap.Logger, mFactory metrics.Fact
 		var hostPorts []string
 		// use explicitly localhost as bind address if :port is specified. The :port is not recognized by NO_PROXY
 		for _, endpoint := range b.CollectorHostPorts {
-			if strings.HasPrefix(":", endpoint) {
+			if strings.HasPrefix(endpoint, ":") {
 				endpoint = "localhost" + endpoint
 			}
 			hostPorts = append(hostPorts, endpoint)

--- a/cmd/agent/app/reporter/grpc/builder.go
+++ b/cmd/agent/app/reporter/grpc/builder.go
@@ -101,9 +101,8 @@ func (b *ConnBuilder) CreateConnection(logger *zap.Logger, mFactory metrics.Fact
 			dialTarget = r.Scheme() + ":///round_robin"
 			logger.Info("Agent is connecting to a static list of collectors", zap.String("dialTarget", dialTarget), zap.String("collector hosts", strings.Join(b.CollectorHostPorts, ",")))
 		} else {
-			hostPort := hostPorts[0]
 			// if strings.
-			dialTarget = hostPort
+			dialTarget = hostPorts[0]
 		}
 	}
 	dialOptions = append(dialOptions, grpc.WithDefaultServiceConfig(grpcresolver.GRPCServiceConfig))

--- a/cmd/query/app/apiv3/grpc_gateway.go
+++ b/cmd/query/app/apiv3/grpc_gateway.go
@@ -17,6 +17,7 @@ package apiv3
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -32,6 +33,10 @@ import (
 
 // RegisterGRPCGateway registers api_v3 endpoints into provided mux.
 func RegisterGRPCGateway(ctx context.Context, logger *zap.Logger, r *mux.Router, basePath string, grpcEndpoint string, grpcTLS tlscfg.Options, tm *tenancy.Manager) error {
+	// use explicitly localhost as bind address if :port is specified. The :port is not recognized by NO_PROXY
+	if strings.HasPrefix(":", grpcEndpoint) {
+		grpcEndpoint = "localhost" + grpcEndpoint
+	}
 	jsonpb := &runtime.JSONPb{}
 
 	muxOpts := []runtime.ServeMuxOption{

--- a/cmd/query/app/apiv3/grpc_gateway.go
+++ b/cmd/query/app/apiv3/grpc_gateway.go
@@ -34,7 +34,7 @@ import (
 // RegisterGRPCGateway registers api_v3 endpoints into provided mux.
 func RegisterGRPCGateway(ctx context.Context, logger *zap.Logger, r *mux.Router, basePath string, grpcEndpoint string, grpcTLS tlscfg.Options, tm *tenancy.Manager) error {
 	// use explicitly localhost as bind address if :port is specified. The :port is not recognized by NO_PROXY
-	if strings.HasPrefix(":", grpcEndpoint) {
+	if strings.HasPrefix(grpcEndpoint, ":") {
 		grpcEndpoint = "localhost" + grpcEndpoint
 	}
 	jsonpb := &runtime.JSONPb{}

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -373,6 +373,7 @@ func GetHTTPRoundTripper(c *Configuration, logger *zap.Logger) (http.RoundTrippe
 			return nil, err
 		}
 		return &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: ctlsConfig,
 		}, nil
 	}


### PR DESCRIPTION
Support HTTP proxy variables (some docs https://superuser.com/questions/944958/are-http-proxy-https-proxy-and-no-proxy-environment-variables-standard).

The codebase already supports it, but some places were missed. There were also two problems:
1. query  grpc gateway was connecting to :16686 which is not recognized by NO_PROXY
2. grpc reporter in agent when used with all-in-one was connecting to `:14250` also not recognized by NO_PROXY


Example of proxy vars set on OpenShift
```
 - name: HTTP_PROXY
              value: >-
                http://proxy-user1:foo@ec2-32-138-32-212.us-east-2.compute.amazonaws.com:3128
            - name: http_proxy
              value: >-
                http://proxy-user1:foo@ec2-32-138-32-212.us-east-2.compute.amazonaws.com:3128
            - name: HTTPS_PROXY
              value: >-
                http://proxy-user1:foo@ec2-32-138-32-221.us-east-2.compute.amazonaws.com:3128
            - name: https_proxy
              value: >-
                http://proxy-user1:foo@ec2-32-138-32-212.us-east-2.compute.amazonaws.com:3128
            - name: NO_PROXY
              value: >-
                .cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16,api-int.rererer.qe.devcluster.openshift.com,localhost,test.no-proxy.com
            - name: no_proxy
              value: >-
                .cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16,api-int.rerererer.qe.devcluster.openshift.com,localhost,test.no-proxy.com
```

PR is related to https://github.com/jaegertracing/jaeger-operator/pull/2330
```
make build-binaries-linux
DOCKER_NAMESPACE=pavolloffay DOCKER_TAG=proxy-3 make docker-images-jaeger-backend
```