### PR TITLE
Add e2e test for sampling storage

### DIFF
--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -86,6 +86,10 @@ func (s *CassandraStorageIntegration) initializeCassandra() error {
 	if s.SpanReader, err = f.CreateSpanReader(); err != nil {
 		return err
 	}
+	if s.SamplingStore, err = f.CreateSamplingStore(0); err != nil {
+		return err
+	}
+
 	if err = s.initializeDependencyReaderAndWriter(f); err != nil {
 		return err
 	}

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -424,6 +424,10 @@ func (s *StorageIntegration) testGetDependencies(t *testing.T) {
 
 func (s *StorageIntegration) testGetThroughput(t *testing.T) {
 	s.skipIfNeeded(t)
+	if s.SamplingStore == nil {
+		t.Skip("Skipping GetThroughput test because sampling store is nil")
+		return
+	}
 	defer s.cleanUp(t)
 	start := time.Now()
 
@@ -442,6 +446,10 @@ func (s *StorageIntegration) testGetThroughput(t *testing.T) {
 
 func (s *StorageIntegration) testGetLatestProbability(t *testing.T) {
 	s.skipIfNeeded(t)
+	if s.SamplingStore == nil {
+		t.Skip("Skipping GetLatestProbability test because sampling store is nil")
+		return
+	}
 	defer s.cleanUp(t)
 
 	s.SamplingStore.InsertProbabilitiesAndQPS("dell11eg843d", samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}}, samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}})
@@ -478,9 +486,6 @@ func (s *StorageIntegration) IntegrationTestAll(t *testing.T) {
 	t.Run("GetLargeSpans", s.testGetLargeSpan)
 	t.Run("FindTraces", s.testFindTraces)
 	t.Run("GetDependencies", s.testGetDependencies)
-	if s.SamplingStore == nil {
-		t.Skip("Skipping GetThroughput and GetLatestProbability Intergration test for Sampling store as it is only implemented for cassendra and in-memory storage as of now.")
-	}
 	t.Run("GetThroughput", s.testGetThroughput)
 	t.Run("GetLatestProbability", s.testGetLatestProbability)
 }

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -21,7 +21,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -479,9 +478,8 @@ func (s *StorageIntegration) IntegrationTestAll(t *testing.T) {
 	t.Run("GetLargeSpans", s.testGetLargeSpan)
 	t.Run("FindTraces", s.testFindTraces)
 	t.Run("GetDependencies", s.testGetDependencies)
-	// Remove the below line check once we have sampling store implemented for all the backend
-	if os.Getenv("STORAGE") != "cassendra" || os.Getenv("STORAGE") != "in-memory" {
-		t.Skip("Intergration test for Sampling store is only implemented for cassendra and in-memory storage as of now")
+	if s.SamplingStore == nil {
+		t.Skip("Skipping GetThroughput and GetLatestProbability Intergration test for Sampling store as it is only implemented for cassendra and in-memory storage as of now.")
 	}
 	t.Run("GetThroughput", s.testGetThroughput)
 	t.Run("GetLatestProbability", s.testGetLatestProbability)

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -131,7 +131,8 @@ func (s *StorageIntegration) testGetServices(t *testing.T) {
 
 	var actual []string
 	found := s.waitForCondition(t, func(t *testing.T) bool {
-		actual, err := s.SpanReader.GetServices(context.Background())
+		var err error
+		actual, err = s.SpanReader.GetServices(context.Background())
 		require.NoError(t, err)
 		sort.Strings(actual)
 		return assert.ObjectsAreEqualValues(expected, actual)
@@ -429,18 +430,14 @@ func (s *StorageIntegration) testGetThroughput(t *testing.T) {
 	s.insertThroughput(t)
 
 	expected := 2
-	var actual []string
-	found := s.waitForCondition(t, func(t *testing.T) bool {
-		actual, err := s.SamplingStore.GetThroughput(start, start.Add(time.Second*time.Duration(10)))
+	var actual []*samplemodel.Throughput
+	_ = s.waitForCondition(t, func(t *testing.T) bool {
+		var err error
+		actual, err = s.SamplingStore.GetThroughput(start, start.Add(time.Second*time.Duration(10)))
 		require.NoError(t, err)
-		fmt.Printf("actual: %v\n", actual)
-		fmt.Printf("expected: %v\n", expected)
 		return assert.ObjectsAreEqualValues(expected, len(actual))
 	})
-	if !assert.True(t, found) {
-		t.Log("\t Expected:", expected)
-		t.Log("\t Actual  :", actual)
-	}
+	assert.Len(t, actual, expected)
 }
 
 func (s *StorageIntegration) testGetLatestProbability(t *testing.T) {
@@ -452,7 +449,8 @@ func (s *StorageIntegration) testGetLatestProbability(t *testing.T) {
 	expected := samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}}
 	var actual samplemodel.ServiceOperationProbabilities
 	found := s.waitForCondition(t, func(t *testing.T) bool {
-		actual, err := s.SamplingStore.GetLatestProbabilities()
+		var err error
+		actual, err = s.SamplingStore.GetLatestProbabilities()
 		require.NoError(t, err)
 		return assert.ObjectsAreEqualValues(expected, actual)
 	})

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -21,6 +21,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -478,6 +479,10 @@ func (s *StorageIntegration) IntegrationTestAll(t *testing.T) {
 	t.Run("GetLargeSpans", s.testGetLargeSpan)
 	t.Run("FindTraces", s.testFindTraces)
 	t.Run("GetDependencies", s.testGetDependencies)
+	// Remove the below line check once we have sampling store implemented for all the backend
+	if os.Getenv("STORAGE") != "cassendra" || os.Getenv("STORAGE") != "in-memory" {
+		t.Skip("Intergration test for Sampling store is only implemented for cassendra and in-memory storage as of now")
+	}
 	t.Run("GetThroughput", s.testGetThroughput)
 	t.Run("GetLatestProbability", s.testGetLatestProbability)
 }

--- a/plugin/storage/integration/memstore_test.go
+++ b/plugin/storage/integration/memstore_test.go
@@ -18,6 +18,7 @@
 package integration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,5 +60,10 @@ func (s *MemStorageIntegrationTestSuite) cleanUp() error {
 func TestMemoryStorage(t *testing.T) {
 	s := &MemStorageIntegrationTestSuite{}
 	require.NoError(t, s.initialize())
+	// Remove the below line check once we have sampling store implemented for all the storage backend
+	err := os.Setenv("STORAGE", "in-memory")
+	if err != nil {
+		t.Fatal(err)
+	}
 	s.IntegrationTestAll(t)
 }

--- a/plugin/storage/integration/memstore_test.go
+++ b/plugin/storage/integration/memstore_test.go
@@ -18,7 +18,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,10 +36,9 @@ func (s *MemStorageIntegrationTestSuite) initialize() error {
 	s.logger, _ = testutils.NewLogger()
 
 	store := memory.NewStore()
-	sampleStore := memory.NewSamplingStore(2)
+	s.SamplingStore = memory.NewSamplingStore(2)
 	s.SpanReader = store
 	s.SpanWriter = store
-	s.SamplingStore = sampleStore
 
 	// TODO DependencyWriter is not implemented in memory store
 
@@ -60,10 +58,5 @@ func (s *MemStorageIntegrationTestSuite) cleanUp() error {
 func TestMemoryStorage(t *testing.T) {
 	s := &MemStorageIntegrationTestSuite{}
 	require.NoError(t, s.initialize())
-	// Remove the below line check once we have sampling store implemented for all the storage backend
-	err := os.Setenv("STORAGE", "in-memory")
-	if err != nil {
-		t.Fatal(err)
-	}
 	s.IntegrationTestAll(t)
 }

--- a/plugin/storage/integration/memstore_test.go
+++ b/plugin/storage/integration/memstore_test.go
@@ -36,8 +36,10 @@ func (s *MemStorageIntegrationTestSuite) initialize() error {
 	s.logger, _ = testutils.NewLogger()
 
 	store := memory.NewStore()
+	sampleStore := memory.NewSamplingStore(2)
 	s.SpanReader = store
 	s.SpanWriter = store
+	s.SamplingStore = sampleStore
 
 	// TODO DependencyWriter is not implemented in memory store
 


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Related #3305

## Description of the changes
-  Adding e2e test for Implemented Storage backends for adaptive sampling i.e (cassendra, in-memory)

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
