### PR TITLE
[tests] Fix failing e2e test  for Cassandra storage

### DIFF
--- a/plugin/storage/cassandra/factory.go
+++ b/plugin/storage/cassandra/factory.go
@@ -218,6 +218,7 @@ func (f *Factory) Close() error {
 	return f.Options.GetPrimary().TLS.Close()
 }
 
-func (f *Factory) CassendraSession() cassandra.Session {
+// PrimarySession is used from integration tests to clean database between tests
+func (f *Factory) PrimarySession() cassandra.Session {
 	return f.primarySession
 }

--- a/plugin/storage/cassandra/factory.go
+++ b/plugin/storage/cassandra/factory.go
@@ -62,7 +62,7 @@ type Factory struct {
 	tracer                trace.TracerProvider
 
 	primaryConfig  config.SessionBuilder
-	primarySession cassandra.Session
+	PrimarySession cassandra.Session
 	archiveConfig  config.SessionBuilder
 	archiveSession cassandra.Session
 }
@@ -104,11 +104,11 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 	f.archiveMetricsFactory = metricsFactory.Namespace(metrics.NSOptions{Name: "cassandra-archive", Tags: nil})
 	f.logger = logger
 
-	primarySession, err := f.primaryConfig.NewSession(logger)
+	PrimarySession, err := f.primaryConfig.NewSession(logger)
 	if err != nil {
 		return err
 	}
-	f.primarySession = primarySession
+	f.PrimarySession = PrimarySession
 
 	if f.archiveConfig != nil {
 		if archiveSession, err := f.archiveConfig.NewSession(logger); err == nil {
@@ -124,7 +124,7 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 
 // CreateSpanReader implements storage.Factory
 func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
-	return cSpanStore.NewSpanReader(f.primarySession, f.primaryMetricsFactory, f.logger, f.tracer.Tracer("cSpanStore.SpanReader")), nil
+	return cSpanStore.NewSpanReader(f.PrimarySession, f.primaryMetricsFactory, f.logger, f.tracer.Tracer("cSpanStore.SpanReader")), nil
 }
 
 // CreateSpanWriter implements storage.Factory
@@ -133,13 +133,13 @@ func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cSpanStore.NewSpanWriter(f.primarySession, f.Options.SpanStoreWriteCacheTTL, f.primaryMetricsFactory, f.logger, options...), nil
+	return cSpanStore.NewSpanWriter(f.PrimarySession, f.Options.SpanStoreWriteCacheTTL, f.primaryMetricsFactory, f.logger, options...), nil
 }
 
 // CreateDependencyReader implements storage.Factory
 func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
-	version := cDepStore.GetDependencyVersion(f.primarySession)
-	return cDepStore.NewDependencyStore(f.primarySession, f.primaryMetricsFactory, f.logger, version)
+	version := cDepStore.GetDependencyVersion(f.PrimarySession)
+	return cDepStore.NewDependencyStore(f.PrimarySession, f.primaryMetricsFactory, f.logger, version)
 }
 
 // CreateArchiveSpanReader implements storage.ArchiveFactory
@@ -170,12 +170,12 @@ func (f *Factory) CreateLock() (distributedlock.Lock, error) {
 	}
 	f.logger.Info("Using unique participantName in the distributed lock", zap.String("participantName", hostname))
 
-	return cLock.NewLock(f.primarySession, hostname), nil
+	return cLock.NewLock(f.PrimarySession, hostname), nil
 }
 
 // CreateSamplingStore implements storage.SamplingStoreFactory
 func (f *Factory) CreateSamplingStore(maxBuckets int) (samplingstore.Store, error) {
-	return cSamplingStore.New(f.primarySession, f.primaryMetricsFactory, f.logger), nil
+	return cSamplingStore.New(f.PrimarySession, f.primaryMetricsFactory, f.logger), nil
 }
 
 func writerOptions(opts *Options) ([]cSpanStore.Option, error) {

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -87,7 +87,7 @@ func (s *CassandraStorageIntegration) initializeCassandra() error {
 	if s.SpanReader, err = f.CreateSpanReader(); err != nil {
 		return err
 	}
-	if s.CleanUp, err = s.cleanUp(f.PrimarySession); err != nil {
+	if s.CleanUp, err = s.cleanUp(f.CassendraSession()); err != nil {
 		return err
 	}
 	if err = s.initializeDependencyReaderAndWriter(f); err != nil {

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -47,7 +47,7 @@ func newCassandraStorageIntegration() *CassandraStorageIntegration {
 
 			Refresh:  func() error { return nil },
 			CleanUp:  func() error { return nil },
-			SkipList: []string{"Tags_+_Operation_name_+_Duration_range", "Tags_+_Duration_range", "Tags_+_Operation_name_+_max_Duration", "Tags_+_max_Duration"},
+			SkipList: []string{"Tags_+_Operation_name_+_Duration_range", "Tags_+_Duration_range", "Tags_+_Operation_name_+_max_Duration", "Tags_+_max_Duration", "Operation_name_+_Duration_range", "Duration_range", "max_Duration"},
 		},
 	}
 }

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -88,7 +88,7 @@ func (s *CassandraStorageIntegration) initializeCassandra() error {
 	if s.SpanReader, err = f.CreateSpanReader(); err != nil {
 		return err
 	}
-	if s.CleanUp, err = s.cleanUp(f.CassendraSession()); err != nil {
+	if s.CleanUp, err = s.cleanUp(f.PrimarySession()); err != nil {
 		return err
 	}
 	if err = s.initializeDependencyReaderAndWriter(f); err != nil {

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -45,8 +45,9 @@ func newCassandraStorageIntegration() *CassandraStorageIntegration {
 		StorageIntegration: StorageIntegration{
 			GetDependenciesReturnsSource: true,
 
-			Refresh: func() error { return nil },
-			CleanUp: func() error { return nil },
+			Refresh:  func() error { return nil },
+			CleanUp:  func() error { return nil },
+			SkipList: []string{"Tags_+_Operation_name_+_Duration_range", "Tags_+_Duration_range", "Tags_+_Operation_name_+_max_Duration", "Tags_+_max_Duration"},
 		},
 	}
 }

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -96,7 +96,8 @@ func (s *StorageIntegration) refresh(t *testing.T) {
 
 func (s *StorageIntegration) skipIfNeeded(t *testing.T) {
 	for _, pat := range s.SkipList {
-		ok, err := regexp.MatchString(pat, t.Name())
+		escapedPat := regexp.QuoteMeta(pat)
+		ok, err := regexp.MatchString(escapedPat, t.Name())
 		assert.NoError(t, err)
 		if ok {
 			t.Skip()

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -55,7 +55,7 @@ run_integration_test() {
   apply_schema "$2"
   STORAGE=cassandra make storage-integration-test
   exit_status=$?
-  trap 'teardown_cassandra ${cid}' EXIT
+  trap "teardown_cassandra ${cid}" EXIT
 }
 
 main() {

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -51,7 +51,7 @@ apply_schema() {
 run_integration_test() {
   local version=$1
   local schema_version=$2
-  local cid=$(setup_cassandra ${version})
+  cid=$(setup_cassandra ${version})
   apply_schema "$2"
   STORAGE=cassandra make storage-integration-test
   exit_status=$?

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -51,7 +51,7 @@ apply_schema() {
 run_integration_test() {
   local version=$1
   local schema_version=$2
-  cid=$(setup_cassandra ${version})
+  local cid=$(setup_cassandra ${version})
   apply_schema "$2"
   STORAGE=cassandra make storage-integration-test
   exit_status=$?


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?

Resolves #4782
## Description of the changes
-  Recently a [PR](https://github.com/jaegertracing/jaeger/pull/4773) was raised to run all integration tests against Cassandra while checking it's [CI for cassandra](https://github.com/jaegertracing/jaeger/actions/runs/6287799686/job/17072619668) I found that the some test where failing but CI passed. 
-  Fixed the script so that if the test fail we get exit code as non-zero.
-  Fixed  `TestCassandraStorage/GetLargeSpans` test which was failing due to older traces not getting cleanup from db.

## How was this change tested?
- run the cassandra script to test it.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
