### PR TITLE
[kafka-consumer] Consumer metrics should have a tag with topic name

### DIFF
--- a/cmd/ingester/app/consumer/consumer_metrics.go
+++ b/cmd/ingester/app/consumer/consumer_metrics.go
@@ -37,12 +37,17 @@ type partitionMetrics struct {
 	closeCounter metrics.Counter
 }
 
-func (c *Consumer) namespace(partition int32) metrics.Factory {
-	return c.metricsFactory.Namespace(metrics.NSOptions{Name: consumerNamespace, Tags: map[string]string{"partition": strconv.Itoa(int(partition))}})
+func (c *Consumer) namespace(topic string, partition int32) metrics.Factory {
+	return c.metricsFactory.Namespace(
+		metrics.NSOptions{
+			Name: consumerNamespace,
+			Tags: map[string]string{
+				"topic":     topic,
+				"partition": strconv.Itoa(int(partition))}})
 }
 
-func (c *Consumer) newMsgMetrics(partition int32) msgMetrics {
-	f := c.namespace(partition)
+func (c *Consumer) newMsgMetrics(topic string, partition int32) msgMetrics {
+	f := c.namespace(topic, partition)
 	return msgMetrics{
 		counter:     f.Counter(metrics.Options{Name: "messages", Tags: nil}),
 		offsetGauge: f.Gauge(metrics.Options{Name: "current-offset", Tags: nil}),
@@ -50,12 +55,12 @@ func (c *Consumer) newMsgMetrics(partition int32) msgMetrics {
 	}
 }
 
-func (c *Consumer) newErrMetrics(partition int32) errMetrics {
-	return errMetrics{errCounter: c.namespace(partition).Counter(metrics.Options{Name: "errors", Tags: nil})}
+func (c *Consumer) newErrMetrics(topic string, partition int32) errMetrics {
+	return errMetrics{errCounter: c.namespace(topic, partition).Counter(metrics.Options{Name: "errors", Tags: nil})}
 }
 
-func (c *Consumer) partitionMetrics(partition int32) partitionMetrics {
-	f := c.namespace(partition)
+func (c *Consumer) partitionMetrics(topic string, partition int32) partitionMetrics {
+	f := c.namespace(topic, partition)
 	return partitionMetrics{
 		closeCounter: f.Counter(metrics.Options{Name: "partition-close", Tags: nil}),
 		startCounter: f.Counter(metrics.Options{Name: "partition-start", Tags: nil}),

--- a/cmd/ingester/app/consumer/consumer_metrics.go
+++ b/cmd/ingester/app/consumer/consumer_metrics.go
@@ -43,7 +43,9 @@ func (c *Consumer) namespace(topic string, partition int32) metrics.Factory {
 			Name: consumerNamespace,
 			Tags: map[string]string{
 				"topic":     topic,
-				"partition": strconv.Itoa(int(partition))}})
+				"partition": strconv.Itoa(int(partition)),
+			},
+		})
 }
 
 func (c *Consumer) newMsgMetrics(topic string, partition int32) msgMetrics {

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -172,20 +172,23 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 		Value: 0,
 	})
 
-	partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
+	tags := map[string]string{
+		"topic":     topic,
+		"partition": fmt.Sprint(partition),
+	}
 	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.messages",
-		Tags:  partitionTag,
+		Tags:  tags,
 		Value: 1,
 	})
 	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.current-offset",
-		Tags:  partitionTag,
+		Tags:  tags,
 		Value: int(msgOffset),
 	})
 	localFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name: "sarama-consumer.offset-lag",
-		Tags: partitionTag,
+		Tags: tags,
 		// Prior to sarama v1.31.0 this would be 0, it's unclear why this changed.
 		// v=1 seems to be correct because high watermark in mock is incremented upon
 		// consuming the message, and func HighWaterMarkOffset() returns internal value
@@ -195,7 +198,7 @@ func TestSaramaConsumerWrapper_start_Messages(t *testing.T) {
 	})
 	localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "sarama-consumer.partition-start",
-		Tags:  partitionTag,
+		Tags:  tags,
 		Value: 1,
 	})
 }
@@ -223,10 +226,13 @@ func TestSaramaConsumerWrapper_start_Errors(t *testing.T) {
 			continue
 		}
 
-		partitionTag := map[string]string{"partition": fmt.Sprint(partition)}
+		tags := map[string]string{
+			"topic":     topic,
+			"partition": fmt.Sprint(partition),
+		}
 		localFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 			Name:  "sarama-consumer.errors",
-			Tags:  partitionTag,
+			Tags:  tags,
 			Value: 1,
 		})
 		undertest.Close()
@@ -255,7 +261,7 @@ func TestHandleClosePartition(t *testing.T) {
 		undertest.deadlockDetector.allPartitionsDeadlockDetector.incrementMsgCount() // Don't trigger panic on all partitions detector
 		time.Sleep(100 * time.Millisecond)
 		c, _ := metricsFactory.Snapshot()
-		if c["sarama-consumer.partition-close|partition=316"] == 1 {
+		if c["sarama-consumer.partition-close|partition=316|topic=morekuzambu"] == 1 {
 			return
 		}
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4777 

## Description of the changes
Add tag with topic name to Kafka consumer metrics.

## How was this change tested?
Unit tests

Signed-off-by: Alex Bublichenko <alexbub@uber.com>