### PR TITLE
Fix JaegerQueryReqsFailing alert rule missing 'operation' in query

### DIFF
--- a/monitoring/jaeger-mixin/prometheus_alerts.yml
+++ b/monitoring/jaeger-mixin/prometheus_alerts.yml
@@ -61,7 +61,7 @@
     "annotations":
       "message": |
         {{ $labels.job }} {{ $labels.instance }} is seeing {{ printf "%.2f" $value }}% query errors on {{ $labels.operation }}.
-    "expr": "100 * sum(rate(jaeger_query_requests_total{result=\"err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_query_requests_total[1m])) by (instance, job, namespace)> 1"
+    "expr": "100 * sum(rate(jaeger_query_requests_total{result=\"err\"}[1m])) by (instance, job, namespace, operation) / sum(rate(jaeger_query_requests_total[1m])) by (instance, job, namespace, operation)> 1"
     "for": "15m"
     "labels":
       "severity": "warning"


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4771

## Description of the changes
- Add group by `operation` to JaegerQueryReqsFailing rule
- Here's the difference between before and after the changes. With `operation` group by, the alert will be distinguished by `operation`
<img width="1433" alt="image" src="https://github.com/jaegertracing/jaeger/assets/46216691/aaef0a58-bf65-4769-8445-71e679a549f0">
- Tested manually because PR at #1745 says creating the automated tests are not easy.


## How was this change tested?
- Manually tested in local
- Ran `curl -s http://localhost:9090/api/v1/alerts | jq` and returns
```
{
  "status": "success",
  "data": {
    "alerts": [
      {
        ...
        "annotations": {
          "message": "prometheus localhost:14269 is seeing 100.00% query errors on get_trace.\n"
        },
        ...
      }
    ]
  }
}
```
Before it was
```
{
  "status": "success",
  "data": {
    "alerts": [
      {
        ...
        "annotations": {
          "message": "prometheus localhost:14269 is seeing 100.00% query errors on .\n"
        },
        ...
      }
    ]
  }
}
```
- Ran `pint lint prometheus_alerts.yml`
```
james_ryans@james-ryans ~/g/s/g/j/jaeger (spm_alert_operation)> pint lint monitoring/jaeger-mixin/prometheus_alerts.yml 
level=info msg="Problems found" Information=8
level=info msg="1 problem(s) not visible because of --min-severity=warning flag"
```
Before changes it was
```
pint lint monitoring/jaeger-mixin/prometheus_alerts.yml
monitoring/jaeger-mixin/prometheus_alerts.yml:62-64 Bug: template is using "operation" label but the query removes it (alerts/template)
 62 |       "message": |
 63 |         {{ $labels.job }} {{ $labels.instance }} is seeing {{ printf "%.2f" $value }}% query errors on {{ $labels.operation }}.
 64 |     "expr": "100 * sum(rate(jaeger_query_requests_total{result=\"err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_query_requests_total[1m])) by (instance, job, namespace)> 1"

level=info msg="Problems found" Bug=1 Information=8
level=info msg="1 problem(s) not visible because of --min-severity=warning flag"
level=fatal msg="Execution completed with error(s)" error="found 1 problem(s) with severity Bug or higher"
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
