### PR TITLE
Draft release support jaeger UI

### DIFF
--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     parser.add_argument('--title', type=str, default='Release',
                         help='The title of the release. (default: Release)')
     parser.add_argument('--repo', type=str, default='jaeger',
-                        help='The repository name to fetch commit logs from. (default: jaeger)')
+                        help='The repository name where the draft release will be created. (default: jaeger)')
 
     args = parser.parse_args()
 

--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python3
 
+import argparse
 import re
 import subprocess
 
 
-release_header_pattern = re.compile(r"([\d]+\.[\d]+\.[\d]+) \([\d]{4}-[\d]{2}-[\d]{2}\)", flags=0)
+release_header_pattern = re.compile(r"(\d+\.\d+\.\d) \(\d{4}-\d{2}-\d{2}\)", flags=0)
 underline_pattern = re.compile(r"^[-]+$", flags=0)
 
 
-def main():
+def main(repo):
     changelog_text, version = get_changelog()
     print(changelog_text)
     output_string = subprocess.check_output(
         ["gh", "release", "create", f"v{version}",
          "--draft",
          "--title", f"Release v{version}",
-         "--repo", "jaegertracing/jaeger",
+         "--repo", f"jaegertracing/{repo}",
          "-F", "-"],
         input=changelog_text,
         text=True,
@@ -51,4 +52,11 @@ def get_changelog():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description='List changes based on git log for release notes.')
+
+    parser.add_argument('--repo', type=str, default='jaeger',
+                        help='The repository name to fetch commit logs from. (default: jaeger)')
+
+    args = parser.parse_args()
+
+    main(args.repo)

--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -34,7 +34,6 @@ def get_changelog():
             release_header_match = release_header_pattern.match(line)
 
             if release_header_match is not None:
-                print(f"found header {line}")
                 # Found the first release.
                 if not in_changelog_text:
                     in_changelog_text = True
@@ -45,10 +44,8 @@ def get_changelog():
             else:
                 underline_match = underline_pattern.match(line)
                 if underline_match is not None:
-                    print(f"found underline {line}")
                     continue
                 elif in_changelog_text:
-                    print(f"in changelog {line}")
                     changelog_text += line
 
     return changelog_text, version


### PR DESCRIPTION
## Description of the changes
- Makes the title and repo configurable to support drafting jaeger-ui releases.

## How was this change tested?
- Run `make draft-release` using this script in both jaeger and jaeger-ui repos.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
