### PR TITLE
Fix HotROD docker-compose with OTLP enabled bug

### DIFF
--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "16686:16686"
       - "4318:4318"
     environment:
+      - COLLECTOR_OTLP_ENABLED=true
       - LOG_LEVEL=debug
     networks:
       - jaeger-example


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4768

## Description of the changes
- Bring back COLLECTOR_OTLP_ENABLED env in HotROD docker-compose so jaeger-all-in-one's collector will accept traces at 4318 port.

## How was this change tested?
- Manually tested in local
```
...
hotrod-hotrod-1  | 2023-10-05T16:47:14.858Z	INFO	cobra@v1.6.1/command.go:946	Using expvar as metrics backend
hotrod-hotrod-1  | 2023-10-05T16:47:14.858Z	INFO	cobra@v1.6.1/command.go:916	Starting all services
hotrod-hotrod-1  | 2023-10-05T16:47:14.859Z	INFO	customer/server.go:55	Starting	{"service": "customer", "address": "http://0.0.0.0:8081"}
hotrod-hotrod-1  | 2023-10-05T16:47:14.859Z	INFO	frontend/server.go:74	Starting	{"service": "frontend", "address": "http://0.0.0.0:8080"}
hotrod-hotrod-1  | 2023-10-05T16:47:14.861Z	INFO	route/server.go:57	Starting	{"service": "route", "address": "http://0.0.0.0:8083"}
hotrod-hotrod-1  | 2023-10-05T16:47:20.727Z	INFO	frontend/server.go:96	HTTP request received	{"service": "frontend", "trace_id": "d71a053b9d0224327179db741aaa56a1", "span_id": "9849b9bab50c2551", "method": "GET", "url": "/dispatch?customer=123&nonse=0.31036564339272577"}
hotrod-hotrod-1  | 2023-10-05T16:47:20.727Z	INFO	customer/client.go:54	Getting customer	{"service": "frontend", "component": "customer_client", "trace_id": "d71a053b9d0224327179db741aaa56a1", "span_id": "9849b9bab50c2551", "customer_id": "123"}
hotrod-hotrod-1  | 2023-10-05T16:47:20.730Z	INFO	customer/server.go:67	HTTP request received	{"service": "customer", "trace_id": "d71a053b9d0224327179db741aaa56a1", "span_id": "c658e3c11e5c4f4a", "method": "GET", "url": "/customer?customer=123"}
...
hotrod-jaeger-1  | {"level":"debug","ts":1696524444.8720562,"caller":"app/span_processor.go:164","msg":"Span written to the storage by the collector","trace-id":"d71a053b9d0224327179db741aaa56a1","span-id":"026926b7650a2c82"}
hotrod-jaeger-1  | {"level":"debug","ts":1696524444.8724928,"caller":"app/span_processor.go:164","msg":"Span written to the storage by the collector","trace-id":"d71a053b9d0224327179db741aaa56a1","span-id":"e85195ecfa25e490"}
hotrod-jaeger-1  | {"level":"debug","ts":1696524444.8726494,"caller":"app/span_processor.go:164","msg":"Span written to the storage by the collector","trace-id":"d71a053b9d0224327179db741aaa56a1","span-id":"aa0aa94389c0357a"}
...
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
