### PR TITLE
Read expected Node version from ui dir

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -8,7 +8,7 @@ BRANCH=${BRANCH:?'missing BRANCH env var'}
 # `GOARCH=<target arch> ./scripts/build-all-in-one-image.sh`.
 GOARCH=${GOARCH:-$(go env GOARCH)}
 mode=${1-main}
-expected_version="v16"
+expected_version="v$(cat jaeger-ui/.nvmrc)"
 version=$(node --version)
 major_version=${version%.*.*}
 


### PR DESCRIPTION
## Which problem is this PR solving?
Build was failing
```
+ BRANCH=release-v1.50.0
++ go env GOARCH
+ GOARCH=amd64
+ mode=pr-only
+ expected_version=v16
++ node --version
+ version=v1[8](https://github.com/jaegertracing/jaeger/actions/runs/6426910109/job/17453121910?pr=4804#step:11:9).18.0
ERROR: installed Node version v18.18.0 doesn't match expected version v16
+ major_version=v18
+ '[' v18 = v[16](https://github.com/jaegertracing/jaeger/actions/runs/6426910109/job/17453121910?pr=4804#step:11:17) ']'
+ echo 'ERROR: installed Node version v18.18.0 doesn'\''t match expected version v16'
+ exit 1
```

## Description of the changes
- Remove hardcoded v16 version and read it from jaeger-ui/.nvmrc

## How was this change tested?
- CI
