### PR TITLE
Expose collector ports in docker images

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -17,11 +17,20 @@ EXPOSE 6832/udp
 # Agent config HTTP
 EXPOSE 5778
 
+# Collector OTLP gRPC
+EXPOSE 4317
+
+# Collector OTLP HTTP
+EXPOSE 4318
+
 # Collector HTTP
 EXPOSE 14268
 
 # Collector gRPC
 EXPOSE 14250
+
+# Collector Zipkin
+EXPOSE 9411
 
 # Web HTTP
 EXPOSE 16686
@@ -52,11 +61,20 @@ EXPOSE 6832/udp
 # Agent config HTTP
 EXPOSE 5778
 
+# Collector OTLP gRPC
+EXPOSE 4317
+
+# Collector OTLP HTTP
+EXPOSE 4318
+
 # Collector HTTP
 EXPOSE 14268
 
 # Collector gRPC
 EXPOSE 14250
+
+# Collector Zipkin
+EXPOSE 9411
 
 # Web HTTP
 EXPOSE 16686

--- a/cmd/collector/Dockerfile
+++ b/cmd/collector/Dockerfile
@@ -5,7 +5,22 @@ FROM $base_image AS release
 ARG TARGETARCH
 ARG USER_UID=10001
 COPY collector-linux-$TARGETARCH /go/bin/collector-linux
-EXPOSE 14250/tcp
+
+# Collector OTLP gRPC
+EXPOSE 4317
+
+# Collector OTLP HTTP
+EXPOSE 4318
+
+# Collector HTTP
+EXPOSE 14268
+
+# Collector gRPC
+EXPOSE 14250
+
+# Collector Zipkin
+EXPOSE 9411
+
 ENTRYPOINT ["/go/bin/collector-linux"]
 USER ${USER_UID}
 
@@ -13,6 +28,24 @@ FROM $debug_image AS debug
 ARG TARGETARCH=amd64
 ARG USER_UID=10001
 COPY collector-debug-linux-$TARGETARCH /go/bin/collector-linux
-EXPOSE 12345/tcp 14250/tcp
+
+# Collector OTLP gRPC
+EXPOSE 4317
+
+# Collector OTLP HTTP
+EXPOSE 4318
+
+# Collector HTTP
+EXPOSE 14268
+
+# Collector gRPC
+EXPOSE 14250
+
+# Collector Zipkin
+EXPOSE 9411
+
+# Delve
+EXPOSE 12345
+
 ENTRYPOINT ["/go/bin/dlv", "exec", "/go/bin/collector-linux", "--headless", "--listen=:12345", "--api-version=2", "--accept-multiclient", "--log", "--"]
 USER ${USER_UID}


### PR DESCRIPTION
## Which problem is this PR solving?
Resolved #4808 

## Description of the changes
- Expose OTLP gRPC and HTTP Collector ports in all-in-one Docker image.
- Expose all collector ports in collector Docker image

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
