### PR TITLE
Fix: skipping merge based on PR label

### DIFF
--- a/.github/workflows/donotmerge.yml
+++ b/.github/workflows/donotmerge.yml
@@ -1,0 +1,19 @@
+name: Do Not Merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  fail-for-skip-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'Do Not Merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is a draft
+        run: |
+          echo "This PR has marked as Do Not Merge."
+          exit 1


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4799 

## Description of the changes
-  Added github action to skip based on PR label. 

## How was this change tested?
-  tested it on my repository in main branch. which skipped this test.
I have deleted that repo.

## Checklist
- [ x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
