### PR TITLE
Clean-up & fortify ci-release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -42,6 +42,11 @@ jobs:
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch
 
+    - name: Fail early if the latest tag is not in semver format
+      id: validate-semver
+      run: |
+        make echo-version | grep -E '^v\d+.\d+.\d+$'
+
     - name: Install tools
       run: make install-ci
 
@@ -55,6 +60,7 @@ jobs:
     - name: Build binaries
       id: build-binaries
       run: make build-all-platforms
+      if: steps.validate-semver.outcome == 'success'
 
     - name: Package binaries
       id: package-binaries
@@ -78,20 +84,24 @@ jobs:
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+      if: steps.package-binaries.outcome == 'success'
 
     - name: Build, test, and publish all-in-one image
       run: bash scripts/build-all-in-one-image.sh
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+      if: steps.package-binaries.outcome == 'success'
 
     - name: Build, test, and publish hotrod image
       run: bash scripts/hotrod-integration-test.sh
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+      if: steps.package-binaries.outcome == 'success'
 
     - name: SBOM Generation
       uses: anchore/sbom-action@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1
       with:
         artifact-name: jaeger-SBOM.spdx.json
+      if: steps.package-binaries.outcome == 'success'

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -51,10 +51,9 @@ function package {
 
 set -e
 
-readonly VERSION="$(make echo-version | awk 'match($0, /([0-9]*\.[0-9]*\.[0-9]*)$/) { print substr($0, RSTART, RLENGTH) }')"
+readonly VERSION="$(make echo-version | perl -lne 'print $1 if /^v(\d+.\d+.\d+)$/' )"
 echo "Working on version: $VERSION"
-if [ -z "$VERSION" ]
-then
+if [ -z "$VERSION" ]; then
     # We want to halt if for some reason the version string is empty as this is an obvious error case
     >&2 echo 'Failed to detect a version string'
     exit 1
@@ -81,4 +80,3 @@ find deploy \( ! -name '*sha256sum.txt' \) -type f -exec gpg --armor --detach-si
 
 # show your work
 ls -lF deploy/
-


### PR DESCRIPTION
## Which problem is this PR solving?
- One of the previous runs of ci-release mistaken `main` tag as release version and pushed a release with this tag

## Description of the changes
- Add checks to the workflow to fail early of the latest git tag is not a semver
- Speed-up Makefile by making ALL_SRCS and ALL_PKGS vars lazy-evaluated
- Make semver check in scripts/package-deploy.sh more redable (perl instead of awk)

## How was this change tested?
- CI
