### PR TITLE
Clean up CI scripts and prune Docker images between builds

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -15,9 +15,13 @@ permissions:
 
 jobs:
   publish-release:
+    if: github.repository == 'jaegertracing/jaeger'
     runs-on: ubuntu-latest
 
     steps:
+    - name: How much disk space do we have at the start?
+      run: df -h /
+
     - name: Harden Runner
       uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
@@ -76,7 +80,12 @@ jobs:
         overwrite: true
         tag: ${{ github.ref }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-      if: steps.package-binaries.outcome == 'success'
+      if: ${{ steps.package-binaries.outcome == 'success' && env.BRANCH != 'main' }}
+
+    - name: Clean up deployed archives
+      run: |
+        bash rm -rf deploy
+        df -h /
 
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
 

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -2,7 +2,6 @@
 
 set -exu
 
-BRANCH=${BRANCH:?'missing BRANCH env var'}
 # Set default GOARCH variable to the host GOARCH, the target architecture can
 # be overrided by passing architecture value to the script:
 # `GOARCH=<target arch> ./scripts/build-all-in-one-image.sh`.
@@ -55,7 +54,7 @@ bash scripts/build-upload-a-docker-image.sh -b -c all-in-one -d cmd/all-in-one -
 
 
 #do not run debug image build when it is pr-only
-if ["$mode" != "pr-only"]; then 
+if ["$mode" != "pr-only"]; then
   make build-all-in-one-debug GOOS=linux GOARCH=$GOARCH
   repo=${repo}-debug
   #build all-in-one-debug image locally for integration test

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -71,3 +71,6 @@ docker buildx build --output "${PUSHTAG}" \
 echo "Finished building${upload_flag} ${component_name} =============="
 
 df -h /
+docker buildx prune --all --verbose
+docker system prune
+df -h /

--- a/scripts/compute-tags.sh
+++ b/scripts/compute-tags.sh
@@ -2,34 +2,35 @@
 
 # Compute major/minor/etc image tags based on the current branch
 
-set -eux
+set -exu
 
 BASE_BUILD_IMAGE=$1
-GITHUB_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
-VERSION=${VERSION:-$(make echo-version)}
+BRANCH=${BRANCH:?'expecting BRANCH env var'}
 
-if [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    VERSION="${VERSION#[vV]}"
-    VERSION_MAJOR="${VERSION%%\.*}"
-    VERSION_MINOR="${VERSION#*.}"
-    VERSION_MINOR="${VERSION_MINOR%.*}"
-    VERSION_PATCH="${VERSION##*.}"
+## if we are on a release tag, let's extract the version number
+## the other possible value, currently, is 'main' (or another branch name)
+if [[ $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    MAJOR_MINOR_PATCH=$(echo ${BRANCH} | grep -Po "([\d\.]+)")
+    MAJOR_MINOR=$(echo ${MAJOR_MINOR_PATCH} | awk -F. '{print $1"."$2}')
+    MAJOR=$(echo ${MAJOR_MINOR_PATCH} | awk -F. '{print $1}')  
 else
-    VERSION="latest"
+    MAJOR_MINOR_PATCH="latest"
+    MAJOR_MINOR=""
+    MAJOR=""
 fi
 
 # for docker.io and quay.io
-BUILD_IMAGE=${BUILD_IMAGE:-"${BASE_BUILD_IMAGE}:${VERSION}"}
+BUILD_IMAGE=${BUILD_IMAGE:-"${BASE_BUILD_IMAGE}:${MAJOR_MINOR_PATCH}"}
 IMAGE_TAGS="--tag docker.io/${BASE_BUILD_IMAGE} --tag docker.io/${BUILD_IMAGE} --tag quay.io/${BASE_BUILD_IMAGE} --tag quay.io/${BUILD_IMAGE}"
 SNAPSHOT_TAG="${BASE_BUILD_IMAGE}-snapshot:${GITHUB_SHA}"
 
-
-if [ "${VERSION}" != "latest" ]; then
-    MAJOR_MINOR_IMAGE="${BASE_BUILD_IMAGE}:${VERSION_MAJOR}.${VERSION_MINOR}"
+if [ "${MAJOR_MINOR}x" != "x" ]; then
+    MAJOR_MINOR_IMAGE="${BASE_BUILD_IMAGE}:${MAJOR_MINOR}"
     IMAGE_TAGS="${IMAGE_TAGS} --tag docker.io/${MAJOR_MINOR_IMAGE} --tag quay.io/${MAJOR_MINOR_IMAGE}"
+fi
 
-    # TODO we should stop publishing these, as everything ends up with tag "1" but not backwards compatible
-    MAJOR_IMAGE="${BASE_BUILD_IMAGE}:${VERSION_MAJOR}"
+if [ "${MAJOR}x" != "x" ]; then
+    MAJOR_IMAGE="${BASE_BUILD_IMAGE}:${MAJOR}"
     IMAGE_TAGS="${IMAGE_TAGS} --tag docker.io/${MAJOR_IMAGE} --tag quay.io/${MAJOR_IMAGE}"
 fi
 

--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -26,5 +26,4 @@ if [[ $body != *"Rides On Demand"* ]]; then
 fi
 docker rm -f $CID
 
-BRANCH=${BRANCH:?'missing BRANCH env var'}
 bash scripts/build-upload-a-docker-image.sh -c example-hotrod -d examples/hotrod -p "${platforms}"

--- a/scripts/rebuild-ui.sh
+++ b/scripts/rebuild-ui.sh
@@ -7,16 +7,16 @@ cd jaeger-ui
 git fetch --all --tags
 git log --oneline --decorate=full -n 10 | cat
 
-LAST_TAG=$(git describe --tags --dirty 2>/dev/null)
+last_tag=$(git describe --tags --dirty 2>/dev/null)
 
-if [[ "$LAST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]];  then
-    BRANCH_HASH=$(git rev-parse HEAD)
-    LAST_TAG_HASH=$(git rev-parse $LAST_TAG)
+if [[ "$last_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]];  then
+    branch_hash=$(git rev-parse HEAD)
+    last_tag_hash=$(git rev-parse $last_tag)
 
-    if [[ "$BRANCH_HASH" == "$LAST_TAG_HASH" ]]; then
+    if [[ "$branch_hash" == "$last_tag_hash" ]]; then
         temp_file=$(mktemp)
         trap "rm -f ${temp_file}" EXIT
-        release_url="https://github.com/jaegertracing/jaeger-ui/releases/download/${LAST_TAG}/assets.tar.gz"
+        release_url="https://github.com/jaegertracing/jaeger-ui/releases/download/${last_tag}/assets.tar.gz"
         if curl --silent --fail --location --output "$temp_file" "$release_url"; then
 
             mkdir -p packages/jaeger-ui/build/


### PR DESCRIPTION
## Which problem is this PR solving?
- Current ci-release workflow is running out of disk space

## Description of the changes
- 

## How was this change tested?
- Cannot test until merged
