### PR TITLE
Use setup-node.js for Publish Release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -39,9 +39,8 @@ jobs:
       with:
         go-version: 1.21.x
 
-    - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
-      with:
-        node-version: '16'
+    - name: Setup Node.js version
+      uses: ./.github/actions/setup-node.js
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch


### PR DESCRIPTION
## Description of the changes
- Fix this [CI build error](https://github.com/jaegertracing/jaeger/actions/runs/6439689215/job/17487662586#step:19:16), using `ci-docker-build.yml` and `ci-build-binaries.yml` and `ci-all-in-one-build.yml` as examples:

```
ERROR: installed Node version v16.20.2 doesn't match expected version v18
```

## How was this change tested?
- Test in CI pipeline; maybe there's a better way to test?

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
