### PR TITLE
Fix build-all-in-one-image script

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -54,7 +54,7 @@ bash scripts/build-upload-a-docker-image.sh -b -c all-in-one -d cmd/all-in-one -
 
 
 #do not run debug image build when it is pr-only
-if ["$mode" != "pr-only"]; then
+if [ "$mode" != "pr-only" ]; then
   make build-all-in-one-debug GOOS=linux GOARCH=$GOARCH
   repo=${repo}-debug
   #build all-in-one-debug image locally for integration test


### PR DESCRIPTION
## Description of the changes
- Fixes [this error in CI builds](https://github.com/jaegertracing/jaeger/actions/runs/6442084773/job/17492537692#step:19:744) and may explain why the jaeger all-in-one v1.50 image is [missing in docker hub](https://hub.docker.com/r/jaegertracing/all-in-one/tags?page=1&name=1.50):

```
+ '[main' '!=' 'pr-only]'
scripts/build-all-in-one-image.sh: line 57: [main: command not found
```

## How was this change tested?
- Tested using a simple bash script to reproduce the problem.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
