### PR TITLE
Add --force to docker commands

### DIFF
--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -71,6 +71,6 @@ docker buildx build --output "${PUSHTAG}" \
 echo "Finished building${upload_flag} ${component_name} =============="
 
 df -h /
-docker buildx prune --all --verbose
-docker system prune
+docker buildx prune --all --verbose --force
+docker system prune --force
 df -h /


### PR DESCRIPTION
## Description of the changes
- `docker prune` commands will, by default, prompt the caller whether if they want to proceed, while defaulting to `N`, which resulted in a no-op in this [recent CI run](https://github.com/jaegertracing/jaeger/actions/runs/6442084773/job/17492537692#step:19:735).
- Adding a `--force` flag defaults to `y` without a prompt.

## How was this change tested?
- Tested locally in terminal.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
