### PR TITLE
Use commit hash as image label when building & integration-testing

### DIFF
--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -7,7 +7,7 @@ docker_file_arg="Dockerfile"
 target_arg=""
 local_test_only='N'
 platforms="linux/amd64"
-name_space="jaegertracing"
+namespace="jaegertracing"
 
 while getopts "lbc:d:f:p:t:" opt; do
 	# shellcheck disable=SC2220 # we don't need a *) case
@@ -42,11 +42,11 @@ fi
 
 docker_file_arg="${dir_arg}/${docker_file_arg}"
 
-IMAGE_TAGS=$(bash scripts/compute-tags.sh "${name_space}/${component_name}")
+IMAGE_TAGS=$(bash scripts/compute-tags.sh "${namespace}/${component_name}")
 upload_flag=""
 
 if [[ "${local_test_only}" = "Y" ]]; then
-    IMAGE_TAGS="--tag localhost:5000/${name_space}/${component_name}:latest"
+    IMAGE_TAGS="--tag localhost:5000/${namespace}/${component_name}:${GITHUB_SHA}"
     PUSHTAG="type=image, push=true"
 else
     # Only push multi-arch images to dockerhub/quay.io for main branch or for release tags vM.N.P
@@ -56,7 +56,7 @@ else
 	    PUSHTAG="type=image, push=true"
 	    upload_flag=" and uploading"
     else
-	    echo 'skip docker images upload, only allowed for tagged releases or main (latest tag)'
+	    echo 'skipping docker images upload, because not on tagged release or main branch'
 	    PUSHTAG="type=image, push=false"
     fi
 fi
@@ -71,6 +71,6 @@ docker buildx build --output "${PUSHTAG}" \
 echo "Finished building${upload_flag} ${component_name} =============="
 
 df -h /
-docker buildx prune --all --verbose --force
+docker buildx prune --all --force
 docker system prune --force
 df -h /

--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -13,7 +13,7 @@ make prepare-docker-buildx
 #build image locally for integration test
 bash scripts/build-upload-a-docker-image.sh -l -c example-hotrod -d examples/hotrod -p "${platforms}"
 
-export CID=$(docker run -d -p 8080:8080 localhost:5000/$REPO:latest)
+export CID=$(docker run -d -p 8080:8080 localhost:5000/$REPO:${GITHUB_SHA})
 i=0
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080)" != "200" && ${i} -lt 30 ]]; do
   sleep 1


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4821

## Description of the changes
- Just to validate that the correct image is being tested, use the exact commit sha instead of `latest` as image tag when building & running for local testing

## How was this change tested?
- CI
