### PR TITLE
[WIP] feat: implement adjuster moving tags from span to process

### DIFF
--- a/cmd/query/app/querysvc/adjusters.go
+++ b/cmd/query/app/querysvc/adjusters.go
@@ -31,5 +31,6 @@ func StandardAdjusters(maxClockSkewAdjust time.Duration) []adjuster.Adjuster {
 		adjuster.SortLogFields(),
 		adjuster.SpanReferences(),
 		adjuster.ParentReference(),
+		adjuster.SpanTagsToProcessAdjuster(),
 	}
 }

--- a/model/adjuster/span_tag_to_process.go
+++ b/model/adjuster/span_tag_to_process.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adjuster
+
+import (
+	"github.com/jaegertracing/jaeger/model"
+)
+
+var spanTagsToMove = map[string]struct{}{
+	"otel.library.name": {},
+}
+
+// SpanTagsToProcessAdjuster moves certain tags from span.tags to
+// span.process.tags that should be there. This should ideally be
+// fixed in upstream OTEL.
+func SpanTagsToProcessAdjuster() Adjuster {
+	return Func(func(trace *model.Trace) (*model.Trace, error) {
+		for _, span := range trace.Spans {
+			processTagsMap := make(map[string]struct{})
+			for _, check := range span.Process.Tags {
+				processTagsMap[check.Key] = struct{}{}
+			}
+
+			index := 0
+			for _, tag := range span.Tags {
+				if _, ok := spanTagsToMove[tag.Key]; ok {
+					if _, exists := processTagsMap[tag.Key]; !exists {
+						span.Process.Tags = append(span.Process.Tags, tag)
+						continue
+					}
+				}
+				span.Tags[index] = tag
+				index++
+			}
+			span.Tags = span.Tags[:index]
+		}
+		return trace, nil
+	})
+}

--- a/model/adjuster/span_tag_to_process.go
+++ b/model/adjuster/span_tag_to_process.go
@@ -1,5 +1,4 @@
-// Copyright (c) 2019 The Jaeger Authors.
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +20,7 @@ import (
 
 var spanTagsToMove = map[string]struct{}{
 	"otel.library.name": {},
+	"otel.library.version": {},
 }
 
 // SpanTagsToProcessAdjuster moves certain tags from span.tags to
@@ -35,14 +35,16 @@ func SpanTagsToProcessAdjuster() Adjuster {
 			}
 
 			index := 0
-			for _, tag := range span.Tags {
+			for i, tag := range span.Tags {
 				if _, ok := spanTagsToMove[tag.Key]; ok {
 					if _, exists := processTagsMap[tag.Key]; !exists {
 						span.Process.Tags = append(span.Process.Tags, tag)
 						continue
 					}
 				}
-				span.Tags[index] = tag
+				if i != index {
+					span.Tags[index] = tag
+				}
 				index++
 			}
 			span.Tags = span.Tags[:index]

--- a/model/adjuster/span_tag_to_process_test.go
+++ b/model/adjuster/span_tag_to_process_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adjuster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+func TestSpanTagsToProcessAdjuster(t *testing.T) {
+	trace := &model.Trace{
+		Spans: []*model.Span{
+			{
+				Tags: model.KeyValues{
+					model.Int64("a", 42),
+					model.String("b", "val"),
+					model.Float64("c", 6.9),
+				},
+				Process: &model.Process{
+					Tags: model.KeyValues{
+						model.Int64("a", 42),
+						model.String("b", "val"),
+						model.Float64("c", 6.9),
+					},
+				},
+			},
+		},
+	}
+	out, _ := SpanTagsToProcessAdjuster().Adjust(trace)
+	assert.Equal(t, trace, out)
+
+	otelLibNameTrace := &model.Trace{
+		Spans: []*model.Span{
+			{
+				Tags: model.KeyValues{
+					model.Int64("a", 42),
+					model.String("otel.library.name", "val"),
+					model.Float64("c", 6.9),
+				},
+				Process: &model.Process{
+					Tags: model.KeyValues{
+						model.Int64("a", 42),
+						model.Float64("c", 6.9),
+					},
+				},
+			},
+		},
+	}
+	outAdjusted, _ := SpanTagsToProcessAdjuster().Adjust(otelLibNameTrace)
+
+	assert.Equal(t, "otel.library.name", outAdjusted.Spans[0].Process.Tags[2].Key)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
One possible solution for  #4534 

## Description of the changes
- added adjuster that moves set of tags from span to process

## How was this change tested?
- added unit test for new adjuster
- tested by launching all-in-one and producing traces from test app with otel-go

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
