### PR TITLE
feat: Add span adjuster that moves some OTel Resource attributes to Span.Process

### DIFF
--- a/cmd/query/app/querysvc/adjusters.go
+++ b/cmd/query/app/querysvc/adjusters.go
@@ -28,6 +28,7 @@ func StandardAdjusters(maxClockSkewAdjust time.Duration) []adjuster.Adjuster {
 		adjuster.SpanIDDeduper(),
 		adjuster.ClockSkew(maxClockSkewAdjust),
 		adjuster.IPTagAdjuster(),
+		adjuster.OTelTagAdjuster(),
 		adjuster.SortLogFields(),
 		adjuster.SpanReferences(),
 		adjuster.ParentReference(),

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -66,7 +66,6 @@ func InitOTEL(serviceName string, exporterType string, metricsFactory metrics.Fa
 		resource.WithAttributes(semconv.ServiceNameKey.String(serviceName)),
 		resource.WithTelemetrySDK(),
 		resource.WithHost(),
-		resource.WithHostID(),
 		resource.WithOSType(),
 	)
 	if err != nil {

--- a/examples/hotrod/pkg/tracing/rpcmetrics/observer.go
+++ b/examples/hotrod/pkg/tracing/rpcmetrics/observer.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"

--- a/examples/hotrod/pkg/tracing/rpcmetrics/observer_test.go
+++ b/examples/hotrod/pkg/tracing/rpcmetrics/observer_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	u "github.com/jaegertracing/jaeger/internal/metricstest"

--- a/examples/hotrod/services/customer/database.go
+++ b/examples/hotrod/services/customer/database.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 

--- a/model/adjuster/otel_tag.go
+++ b/model/adjuster/otel_tag.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package adjuster
 
 import (

--- a/model/adjuster/otel_tag.go
+++ b/model/adjuster/otel_tag.go
@@ -1,0 +1,30 @@
+package adjuster
+
+import (
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+var otelLibraryKeys = map[string]struct{}{
+	string(semconv.OTelLibraryNameKey):    {},
+	string(semconv.OTelLibraryVersionKey): {},
+}
+
+func OTelTagAdjuster() Adjuster {
+	return Func(func(trace *model.Trace) (*model.Trace, error) {
+		for _, span := range trace.Spans {
+			filteredTags := make([]model.KeyValue, 0)
+			for _, tag := range span.Tags {
+				if _, ok := otelLibraryKeys[tag.Key]; !ok {
+					filteredTags = append(filteredTags, tag)
+					continue
+				}
+				span.Process.Tags = append(span.Process.Tags, tag)
+			}
+			span.Tags = filteredTags
+			model.KeyValues(span.Process.Tags).Sort()
+		}
+		return trace, nil
+	})
+}

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -77,6 +77,8 @@ func TestOTelTagAdjuster(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
+			beforeTags := testCase.span.Tags
+
 			trace := &model.Trace{
 				Spans: []*model.Span{testCase.span},
 			}
@@ -84,6 +86,10 @@ func TestOTelTagAdjuster(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expected.Tags, trace.Spans[0].Tags)
 			assert.Equal(t, testCase.expected.Process.Tags, trace.Spans[0].Process.Tags)
+
+			newTag := model.String("new_key", "new_value")
+			beforeTags[0] = newTag
+			assert.Equal(t, newTag, testCase.span.Tags[0], "span.Tags still points to the same underlying array")
 		})
 	}
 }

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package adjuster
 
 import (

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -36,6 +36,7 @@ func TestOTelTagAdjuster(t *testing.T) {
 					model.String("random_key", "random_value"),
 					model.String(string(semconv.OTelLibraryNameKey), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
 					model.String(string(semconv.OTelLibraryVersionKey), "0.45.0"),
+					model.String("another_key", "another_value"),
 				},
 				Process: &model.Process{
 					Tags: model.KeyValues{},

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -45,6 +45,7 @@ func TestOTelTagAdjuster(t *testing.T) {
 			expected: &model.Span{
 				Tags: model.KeyValues{
 					model.String("random_key", "random_value"),
+					model.String("another_key", "another_value"),
 				},
 				Process: &model.Process{
 					Tags: model.KeyValues{

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -1,0 +1,73 @@
+package adjuster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+func TestOTelTagAdjuster(t *testing.T) {
+	testCases := []struct {
+		description string
+		span        *model.Span
+		expected    *model.Span
+	}{
+		{
+			description: "span with otel library tags",
+			span: &model.Span{
+				Tags: model.KeyValues{
+					model.String("random_key", "random_value"),
+					model.String(string(semconv.OTelLibraryNameKey), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
+					model.String(string(semconv.OTelLibraryVersionKey), "0.45.0"),
+				},
+				Process: &model.Process{
+					Tags: model.KeyValues{},
+				},
+			},
+			expected: &model.Span{
+				Tags: model.KeyValues{
+					model.String("random_key", "random_value"),
+				},
+				Process: &model.Process{
+					Tags: model.KeyValues{
+						model.String(string(semconv.OTelLibraryNameKey), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"),
+						model.String(string(semconv.OTelLibraryVersionKey), "0.45.0"),
+					},
+				},
+			},
+		},
+		{
+			description: "span without otel library tags",
+			span: &model.Span{
+				Tags: model.KeyValues{
+					model.String("random_key", "random_value"),
+				},
+				Process: &model.Process{
+					Tags: model.KeyValues{},
+				},
+			},
+			expected: &model.Span{
+				Tags: model.KeyValues{
+					model.String("random_key", "random_value"),
+				},
+				Process: &model.Process{
+					Tags: model.KeyValues{},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			trace := &model.Trace{
+				Spans: []*model.Span{testCase.span},
+			}
+			trace, err := OTelTagAdjuster().Adjust(trace)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected.Tags, trace.Spans[0].Tags)
+			assert.Equal(t, testCase.expected.Process.Tags, trace.Spans[0].Process.Tags)
+		})
+	}
+}

--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -30,7 +30,7 @@ import (
 	promapi "github.com/prometheus/client_golang/api/prometheus/v1"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 

--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4534

## Description of the changes
- Apply OTel resource discovery(detectors) since OTel has plenty of detectors under the hood. Link https://pkg.go.dev/go.opentelemetry.io/otel/sdk@v1.19.0/resource
- Add OTel tags to process tags adjuster and we need to adjust only `otel.libray.name` and `otel.library.version`. Found here https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/adf5bb501bc65d24ae48088bde37f3c0b13353d0/pkg/translator/jaeger/traces_to_jaegerproto.go#L172
- Bump all OTel semconv to v1.21.0 since telemetrySDK detector use v1.21.0 semconv.

## How was this change tested?
- Added a new unit test for the adjuster
- Tested manual in local by running `set OTEL_EXPORTER_OTLP_ENDPOINT http://localhost:4318; go run main.go all --otel-exporter=otlp` and `make run-all-in-one`, and ordered a ride in HotROD app.
<img width="1440" alt="image" src="https://github.com/jaegertracing/jaeger/assets/46216691/57220ac9-ec60-40ef-a903-ee815a36dbdf">


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
