### PR TITLE
ci(hotrod): Print HotROD container logs in case of test failure

### DIFF
--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -49,3 +49,7 @@ jobs:
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Print logs from hotrod
+      run: docker logs example-hotrod
+      if: failure()

--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -10,10 +10,12 @@ make build-examples GOOS=linux GOARCH=arm64
 REPO=jaegertracing/example-hotrod
 platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 make prepare-docker-buildx
-#build image locally for integration test
+
+# build image locally (-l) for integration test
 bash scripts/build-upload-a-docker-image.sh -l -c example-hotrod -d examples/hotrod -p "${platforms}"
 
-export CID=$(docker run -d -p 8080:8080 localhost:5000/$REPO:${GITHUB_SHA})
+# pass --name example-hotrod so that we can do `docker logs example-hotrod` later
+export CID=$(docker run -d --name example-hotrod -p 8080:8080 localhost:5000/$REPO:${GITHUB_SHA})
 i=0
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080)" != "200" && ${i} -lt 30 ]]; do
   sleep 1


### PR DESCRIPTION
## Which problem is this PR solving?
- The HotROD CIT was failing in #4844, but no logs were shown to understand why

## Description of the changes
- Run container with `--name example-hotrod`
- Add `docker logs example-hotrod` to CIT workflow in case of failure
