### PR TITLE
CI: Add the label-check workflow to verify changelog labels on each PR

### DIFF
--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -13,7 +13,12 @@ jobs:
   check-label:
     runs-on: ubuntu-latest
     steps:
+      - name: Check PR author
+        id: check_author
+        run: echo "::set-output name=is_dependabot::$(echo ${{ github.event.pull_request.user.login }} | grep -o 'dependabot')"
+
       - name: Check PR label
+        if: steps.check_author.outputs.is_dependabot != 'dependabot'
         run: |
           LABEL_NAME="changelog:"
           if [[ $(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq -r '.labels[].name' | grep -c "^$LABEL_NAME") -eq 0 ]]; then

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -1,0 +1,24 @@
+name: Verify PR Label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check PR label
+        run: |
+          LABEL_NAME="changelog:" # Specify your desired label prefix here
+          if [[ $(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq -r '.labels[].name' | grep -c "^$LABEL_NAME") -eq 0 ]]; then
+            echo "Error: Missing required label $LABEL_NAME on this pull request."
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -8,6 +8,8 @@ on:
       - synchronize
       - edited
       - ready_for_review
+      - labeled
+      - unlabeled
 
 jobs:
   check-label:

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -1,13 +1,8 @@
 name: Verify PR Label
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-  label:
-    types:
-      - created
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
 
 jobs:
   check-label:

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -5,17 +5,17 @@ on:
     types:
       - opened
       - synchronize
+  label:
+    types:
+      - created
 
 jobs:
   check-label:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
       - name: Check PR label
         run: |
-          LABEL_NAME="changelog:" # Specify your desired label prefix here
+          LABEL_NAME="changelog:"
           if [[ $(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq -r '.labels[].name' | grep -c "^$LABEL_NAME") -eq 0 ]]; then
             echo "Error: Missing required label $LABEL_NAME on this pull request."
             exit 1

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           LABEL_NAME="changelog:"
           if [[ $(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq -r '.labels[].name' | grep -c "^$LABEL_NAME") -eq 0 ]]; then
-            echo "Error: Missing required label $LABEL_NAME on this pull request."
+            echo "Error: Pull request is missing a required label of the form '${LABEL_NAME}***'."
             exit 1
           fi
         env:

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - edited
       - ready_for_review
       - labeled
       - unlabeled

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -1,8 +1,13 @@
 name: Verify PR Label
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
 
 jobs:
   check-label:


### PR DESCRIPTION
## Which problem is this PR solving?
- part of: https://github.com/jaegertracing/jaeger/issues/4799
- [x] Add a GitHub Action that will verify that a PR has a specific categorization label before it can be merged. We already have a bunch of those labels changelog:*** labels

## Description of the changes
- This workflow would first check if the PR is created by @dependabot or not. If no, it would proceed to check for the labels on that pull request. For example:
- A new PR is created. The Label Check workflow would fail
- A maintainer adds some label `bug` on the PR, workflow would again run, but would still fail since the label `bug` doesn't start with `changelog:`
- The maintainer now adds some label `changelog:**`, this time, Label Check CI would pass.

## How was this change tested?
- Without any label, failed GH Action: https://github.com/anshgoyalevil/jaeger/actions/runs/6531596646/attempts/2
- With the Label `changelog: feature`: Passing GH Action: https://github.com/anshgoyalevil/jaeger/actions/runs/6531596646/attempts/3
- With the label `bug` and not `changelog: feature`: https://github.com/anshgoyalevil/jaeger/actions/runs/6531596646/attempts/4
- With three labels `bug`, `documentation`, and `changelog: feature`: https://github.com/anshgoyalevil/jaeger/actions/runs/6531596646

## How to test this PR?
- Play with the labels by applying or removing them and see the Verify Label action fail/pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`.
