### PR TITLE
Use changelog:dependencies label for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    labels: [ "changelog:dependencies" ]
     # Groups are updated together in one pull request
     groups:
       otel:
@@ -28,3 +29,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels: [ "changelog:dependencies" ]

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -89,8 +89,11 @@ def main(token, repo, num_commits, exclude_dependabot):
     commits_with_multiple_labels = []
 
     progress = 0
-    print('Loading PRs')
     for commit in commits:
+        if not (progress % 10):
+            print(f"Processing commit {progress + 1}")
+        progress = progress + 1
+
         sha = commit['sha']
         author = commit['author']['login']
 
@@ -143,10 +146,6 @@ def main(token, repo, num_commits, exclude_dependabot):
             other_results.append(result)
         else:
             category_results[category].append(result)
-
-        progress = progress + 1
-        if progress % 10 == 0:
-            print(f"Processed {progress} PRs")
 
     # Print categorized pull requests
     print()

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -51,7 +51,8 @@ categories = [
     {'title': '#### 🚧 Experimental Features', 'label': 'changelog:exprimental'},
     {'title': '#### 👷 CI Improvements', 'label': 'changelog:ci'},
     {'title': None, 'label': 'changelog:test'},
-    {'title': None, 'label': 'changelog:skip'}
+    {'title': None, 'label': 'changelog:skip'},
+    {'title': None, 'label': 'changelog:dependencies'},
 ]
 
 def categorize_pull_request(label):
@@ -87,6 +88,8 @@ def main(token, repo, num_commits, exclude_dependabot):
     other_results = []
     commits_with_multiple_labels = []
 
+    progress = 0
+    print('Loading PRs')
     for commit in commits:
         sha = commit['sha']
         author = commit['author']['login']
@@ -109,7 +112,7 @@ def main(token, repo, num_commits, exclude_dependabot):
         if not pulls:
             short_sha = sha[:7]
             commit_url = commit['html_url']
-            
+
             result = f'* {msg} ([@{author}]({author_url}) in [{short_sha}]({commit_url}))'
             other_results.append(result)
             continue
@@ -134,12 +137,16 @@ def main(token, repo, num_commits, exclude_dependabot):
                 if changelog_labels[0].startswith(cat['label']):
                     category = cat['title']
                     break
-            
+
         result = f'* {msg} ([@{author}]({author_url}) in [#{pull_id}]({pull_url}))'
         if category == UNCATTEGORIZED:
             other_results.append(result)
         else:
             category_results[category].append(result)
+
+        progress = progress + 1
+        if progress % 10 == 0:
+            print(f"Processed {progress} PRs")
 
     # Print categorized pull requests
     print()
@@ -152,7 +159,7 @@ def main(token, repo, num_commits, exclude_dependabot):
 
     # Print pull requests in the 'UNCATTEGORIZED' category
     if other_results:
-        print(f'#### {UNCATTEGORIZED}:')
+        print(f'#### 💩💩💩 The following commits cannot be categorized (missing changeglog labels):\n')
         for result in other_results:
             print(result)
         print()


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4799

## Description of the changes
- Configure dependabot to use `changelog:dependencies` label
- Skip that label in release notes
- Print progress when loading PRs

## How was this change tested?
- local run

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
