### PR TITLE
chore: Add Dynamic Loading Bar Functionality to release-notes.py

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -61,6 +61,14 @@ def categorize_pull_request(label):
             return category
     return UNCATTEGORIZED  # Default category if no matching prefix is found
 
+def updateProgress(iteration, total_iterations):
+    progress = (iteration + 1) / total_iterations
+    percentage = progress * 100
+    sys.stdout.write('\r[' + '='*int(progress*50) + ' '*(50-int(progress*50)) + f'] {percentage:.2f}%')
+    sys.stdout.flush()
+    if iteration >= total_iterations - 1:
+        print()
+    return iteration + 1
 
 def main(token, repo, num_commits, exclude_dependabot):
     accept_header = "application/vnd.github.groot-preview+json"
@@ -88,11 +96,10 @@ def main(token, repo, num_commits, exclude_dependabot):
     other_results = []
     commits_with_multiple_labels = []
 
-    progress = 0
+    progress_iterator = 0
     for commit in commits:
-        if not (progress % 10):
-            print(f"Processing commit {progress + 1}")
-        progress = progress + 1
+        # Update the progress bar
+        progress_iterator = updateProgress(progress_iterator, num_commits)
 
         sha = commit['sha']
         author = commit['author']['login']


### PR DESCRIPTION
## Which problem is this PR solving?
- related to: https://github.com/jaegertracing/jaeger/pull/4850

## Description of the changes
- This PR adds a Dynamic Loading Bar Functionality to `release-notes.py`
- Knowing exactly what percentage our script is completed processing at each second provides a better UX

## How was this change tested?
- Locally
![npaefr0x](https://github.com/jaegertracing/jaeger/assets/94157520/e956a443-f5a3-4162-bec0-9adce9dd43bf)


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
