### PR TITLE
Splited the install-tools into test/build groups

### DIFF
--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -43,7 +43,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -61,7 +61,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - name: Build binaries
       run: make ${{ matrix.platform.task }}

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -41,7 +41,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -44,7 +44,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -50,7 +50,7 @@ jobs:
         go-version: 1.21.x
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -40,7 +40,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -47,7 +47,7 @@ jobs:
         go-version: 1.21.x
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -41,7 +41,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - name: Configure GPG Key
       id: import_gpg

--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -31,7 +31,7 @@ jobs:
         echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
 
     - name: Install tools
-      run: make install-ci
+      run: make install-test-ci
 
     - name: Run unit tests
       run: make test-ci

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
         go-version: 1.21.x
 
     - name: Install tools
-      run: make install-ci
+      run: make install-test-ci
 
     - name: Run unit tests
       run: make test-ci

--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,13 @@ changelog:
 draft-release:
 	./scripts/draft-release.py
 
+.PHONY: install-tools
+install-tools:
+	$(GO) install github.com/vektra/mockery/v2@v2.14.0
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
+	$(GO) install mvdan.cc/gofumpt@latest
+	$(GO) install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+
 .PHONY: install-test-tools
 install-test-tools:
     $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
@@ -409,6 +416,9 @@ install-build-ci: install-build-tools
 
 .PHONY: install-test-ci
 install-test-ci: install-test-tools 
+
+.PHONY: install-ci
+install-ci: install-tools
 
 
 .PHONY: test-ci

--- a/Makefile
+++ b/Makefile
@@ -395,11 +395,7 @@ draft-release:
 	./scripts/draft-release.py
 
 .PHONY: install-tools
-install-tools:
-	$(GO) install github.com/vektra/mockery/v2@v2.14.0
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
-	$(GO) install mvdan.cc/gofumpt@latest
-	$(GO) install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+install-tools: install-tools: install-build-tools install-test-tools
 
 .PHONY: install-test-tools
 install-test-tools:

--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,7 @@ install-tools:
 .PHONY: install-test-tools
 install-test-tools:
     $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
-	$(GO) install mvdan.cc/gofumpt@latest
+    $(GO) install mvdan.cc/gofumpt@latest
 
 .PHONY: install-build-tools
 install-build-tools:
@@ -418,7 +418,7 @@ install-build-ci: install-build-tools
 install-test-ci: install-test-tools 
 
 .PHONY: install-ci
-install-ci: install-tools
+install-ci: install-tools install-test-ci install-build-ci
 
 
 .PHONY: test-ci

--- a/Makefile
+++ b/Makefile
@@ -394,14 +394,22 @@ changelog:
 draft-release:
 	./scripts/draft-release.py
 
-.PHONY: install-tools
-install-tools:
-	$(GO) install github.com/vektra/mockery/v2@v2.14.0
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
+.PHONY: install-test-tools
+install-test-tools:
+    $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
 	$(GO) install mvdan.cc/gofumpt@latest
 
-.PHONY: install-ci
-install-ci: install-tools
+.PHONY: install-build-tools
+install-build-tools:
+    $(GO) install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+    
+
+PHONY: install-build-ci
+install-build-ci: install-build-tools
+
+.PHONY: install-test-ci
+install-test-ci: install-test-tools 
+
 
 .PHONY: test-ci
 test-ci: build-examples cover


### PR DESCRIPTION
Refactor CI installation process: split install-tools into mockery/testing/build sub-targets, divide install-ci into install-test-ci and install-build-ci, and update workflows accordingly.
#4846 
#4848 
