### PR TITLE
[fix]: Close previous es.Client when creating new one on password file change

### DIFF
--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -43,7 +43,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -61,7 +61,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - name: Build binaries
       run: make ${{ matrix.platform.task }}

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -41,7 +41,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -44,7 +44,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -50,7 +50,7 @@ jobs:
         go-version: 1.21.x
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -40,7 +40,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -47,7 +47,7 @@ jobs:
         go-version: 1.21.x
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -41,7 +41,7 @@ jobs:
       uses: ./.github/actions/setup-branch
 
     - name: Install tools
-      run: make install-ci
+      run: make install-build-ci
 
     - name: Configure GPG Key
       id: import_gpg

--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -31,7 +31,7 @@ jobs:
         echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
 
     - name: Install tools
-      run: make install-ci
+      run: make install-test-ci
 
     - name: Run unit tests
       run: make test-ci

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
         go-version: 1.21.x
 
     - name: Install tools
-      run: make install-ci
+      run: make install-test-ci
 
     - name: Run unit tests
       run: make test-ci

--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,13 @@ changelog:
 draft-release:
 	./scripts/draft-release.py
 
+.PHONY: install-tools
+install-tools:
+	$(GO) install github.com/vektra/mockery/v2@v2.14.0
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
+	$(GO) install mvdan.cc/gofumpt@latest
+	$(GO) install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+
 .PHONY: install-test-tools
 install-test-tools:
     $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
@@ -409,6 +416,9 @@ install-build-ci: install-build-tools
 
 .PHONY: install-test-ci
 install-test-ci: install-test-tools 
+
+.PHONY: install-ci
+install-ci: install-tools
 
 
 .PHONY: test-ci

--- a/Makefile
+++ b/Makefile
@@ -394,14 +394,22 @@ changelog:
 draft-release:
 	./scripts/draft-release.py
 
-.PHONY: install-tools
-install-tools:
-	$(GO) install github.com/vektra/mockery/v2@v2.14.0
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
+.PHONY: install-test-tools
+install-test-tools:
+    $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
 	$(GO) install mvdan.cc/gofumpt@latest
 
-.PHONY: install-ci
-install-ci: install-tools
+.PHONY: install-build-tools
+install-build-tools:
+    $(GO) install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+    
+
+PHONY: install-build-ci
+install-build-ci: install-build-tools
+
+.PHONY: install-test-ci
+install-test-ci: install-test-tools 
+
 
 .PHONY: test-ci
 test-ci: build-examples cover

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -308,11 +308,15 @@ func (f *Factory) onClientPasswordChange(cfg *config.Configuration, client *atom
 	newCfg := *cfg // copy by value
 	newCfg.Password = newPassword
 	newCfg.PasswordFilePath = "" // avoid error that both are set
-	primaryClient, err := f.newClientFn(&newCfg, f.logger, f.metricsFactory)
+	newClient, err := f.newClientFn(&newCfg, f.logger, f.metricsFactory)
 	if err != nil {
 		f.logger.Error("failed to recreate Elasticsearch client with new password", zap.Error(err))
 	} else {
-		client.Store(&primaryClient)
+		oldClient := client.Swap(&newClient)
+		if oldClient != nil {
+			oldClient.Close()
+		}
+
 	}
 }
 


### PR DESCRIPTION
It was observed that the last logged request to the server used a Basic Auth string that resembled the old password, even after a new password was set. This could potentially happen if the es.Client object continued sending pings to the server without being properly closed.
This commit addresses the issue by ensuring that the es.Client object is correctly closed when needed, preventing any further requests with outdated passwords.

Resolves https://github.com/jaegertracing/jaeger/issues/4743
#4751 