### PR TITLE
Add OTel resource detector to Jaeger components

### DIFF
--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -72,12 +72,22 @@ func initOTEL(ctx context.Context, svc string) (*sdktrace.TracerProvider, error)
 	// Register the trace exporter with a TracerProvider, using a batch
 	// span processor to aggregate spans before export.
 	bsp := sdktrace.NewBatchSpanProcessor(traceExporter)
+
+	res, err := resource.New(
+		context.Background(),
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(semconv.ServiceNameKey.String(svc)),
+		resource.WithTelemetrySDK(),
+		resource.WithHost(),
+		resource.WithOSType(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	tracerProvider := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(bsp),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(svc),
-		)),
+		sdktrace.WithResource(res),
 	)
 
 	once.Do(func() {

--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -74,7 +74,7 @@ func initOTEL(ctx context.Context, svc string) (*sdktrace.TracerProvider, error)
 	bsp := sdktrace.NewBatchSpanProcessor(traceExporter)
 
 	res, err := resource.New(
-		context.Background(),
+		ctx,
 		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(semconv.ServiceNameKey.String(svc)),
 		resource.WithTelemetrySDK(),


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4534
- Continuation from #4844

## Description of the changes
- Add OTel resources to Jaeger components and tracegen tool.

## How was this change tested?
- Tested manually in local
<img width="1440" alt="image" src="https://github.com/jaegertracing/jaeger/assets/46216691/28bfb121-0c5a-42b1-a3e3-2c5915c90b17">
<img width="1440" alt="image" src="https://github.com/jaegertracing/jaeger/assets/46216691/3b6d993a-2fac-4c65-97c2-e3dca581a3a1">


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
