### PR TITLE
test[es]: Force batch size 1 in test

### DIFF
--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -303,12 +303,14 @@ func testPasswordFromFile(t *testing.T, f *Factory, getClient func() es.Client, 
 		Servers:          []string{server.URL},
 		LogLevel:         "debug",
 		PasswordFilePath: pwdFile,
+		BulkSize:         1, // we want immediate flush
 	}
 	f.archiveConfig = &escfg.Configuration{
 		Enabled:          true,
 		Servers:          []string{server.URL},
 		LogLevel:         "debug",
 		PasswordFilePath: pwdFile,
+		BulkSize:         1, // we want immediate flush
 	}
 	require.NoError(t, f.Initialize(metrics.NullFactory, zaptest.NewLogger(t)))
 	defer f.Close()

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -303,14 +303,14 @@ func testPasswordFromFile(t *testing.T, f *Factory, getClient func() es.Client, 
 		Servers:          []string{server.URL},
 		LogLevel:         "debug",
 		PasswordFilePath: pwdFile,
-		BulkSize:         1, // we want immediate flush
+		BulkSize:         -1, // disable bulk; we want immediate flush
 	}
 	f.archiveConfig = &escfg.Configuration{
 		Enabled:          true,
 		Servers:          []string{server.URL},
 		LogLevel:         "debug",
 		PasswordFilePath: pwdFile,
-		BulkSize:         1, // we want immediate flush
+		BulkSize:         -1, // disable bulk; we want immediate flush
 	}
 	require.NoError(t, f.Initialize(metrics.NullFactory, zaptest.NewLogger(t)))
 	defer f.Close()


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4743

The test is still failing: https://github.com/jaegertracing/jaeger/actions/runs/6577136964/job/17868105418#step:7:461

From the logs we can see that the new client is started to be used (HEAD requests with new password), but then a bulk request with password1 comes in and breaks the test. 

## Description of the changes
- Set BulkSize to -1, which according to the driver docs disables bulk processing.

## How was this change tested?
- Local test is successful, but the issue is difficult to reproduce
