### PR TITLE
Adding first pass at the SECURITY-INSIGHTS.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Coverage Status][cov-img]][cov]
 [![FOSSA Status][fossa-img]](https://app.fossa.io/projects/git%2Bgithub.com%2Fjaegertracing%2Fjaeger?ref=badge_shield)
 [![Artifact Hub][artifacthub-img]](https://artifacthub.io/packages/helm/jaegertracing/jaeger)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1273/badge)](https://bestpractices.coreinfrastructure.org/projects/1273)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jaegertracing/jaeger/badge)](https://securityscorecards.dev/viewer/?uri=github.com/jaegertracing/jaeger)
 
 <img src="https://github.com/cncf/artwork/blob/master/other/cncf-member/graduated/color/cncf-graduated-color.svg" width="250">
 

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,55 @@
+header:
+  schema-version: 1.0.0
+  last-updated: '2023-10-20'
+  last-reviewed: '2023-10-20'
+  expiration-date: '2024-10-20T01:00:00.000Z'
+  project-url: https://github.com/jaegertracing/jaeger/
+  changelog: https://github.com/jaegertracing/jaeger/blob/main/CHANGELOG.md
+  license: https://github.com/jaegertracing/jaeger/blob/main/LICENSE
+project-lifecycle:
+  bug-fixes-only: false
+  core-maintainers:
+  - https://github.com/orgs/jaegertracing/teams/jaeger-maintainers
+  roadmap: https://www.jaegertracing.io/roadmap/
+  release-cycle: https://github.com/jaegertracing/jaeger/blob/main/RELEASE.md#release-managers
+  status: active 
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  contributing-policy: https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md 
+  code-of-conduct: https://github.com/jaegertracing/jaeger/blob/main/CODE_OF_CONDUCT.md
+documentation:
+- https://www.jaegertracing.io/docs/
+distribution-points:
+- https://github.com/jaegertracing/jaeger/
+- https://hub.docker.com/r/jaegertracing/
+security-artifacts:
+  threat-model:
+    threat-model-created: false
+security-testing:
+- tool-type: sca
+  tool-name: Dependabot
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: true
+  comment: |
+    Dependabot is enabled for this repo.
+security-contacts:
+- type: website
+  value: https://github.com/jaegertracing/jaeger/blob/main/SECURITY.md
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  security-policy: https://github.com/jaegertracing/jaeger/blob/main/SECURITY.md
+  email-contact: jaeger-tracing@googlegroups.com
+  comment: |
+    The first and best way to report a vulnerability is by using private security issues in GitHub or opening an issue on Github. We are also available on the CNCF Slack in the jaeger channel.
+dependencies:
+  third-party-packages: true
+  dependencies-lists:
+  - https://github.com/foo/packages.json
+  sbom:
+  - sbom-file: https://github.com/jaegertracing/jaeger/releases/latest/download/jaeger-SBOM.spdx.json 
+    sbom-format: SPDX
+    sbom-url: https://github.com/anchore/sbom-action 

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -9,7 +9,7 @@ header:
 project-lifecycle:
   bug-fixes-only: false
   core-maintainers:
-  - https://github.com/orgs/jaegertracing/teams/jaeger-maintainers
+  - https://github.com/jaegertracing/jaeger/blob/main/README.md#maintainers
   roadmap: https://www.jaegertracing.io/roadmap/
   release-cycle: https://github.com/jaegertracing/jaeger/blob/main/RELEASE.md#release-managers
   status: active 
@@ -23,6 +23,7 @@ documentation:
 distribution-points:
 - https://github.com/jaegertracing/jaeger/
 - https://hub.docker.com/r/jaegertracing/
+- https://quay.io/organization/jaegertracing/ 
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -46,9 +47,6 @@ vulnerability-reporting:
   comment: |
     The first and best way to report a vulnerability is by using private security issues in GitHub or opening an issue on Github. We are also available on the CNCF Slack in the jaeger channel.
 dependencies:
-  third-party-packages: true
-  dependencies-lists:
-  - https://github.com/foo/packages.json
   sbom:
   - sbom-file: https://github.com/jaegertracing/jaeger/releases/latest/download/jaeger-SBOM.spdx.json 
     sbom-format: SPDX


### PR DESCRIPTION
## Which problem is this PR solving?
- Adding first pass at SECURITY-INSIGHTS.yml file

## Description of the changes
- Adding file based on the project configuration to satisfy new requirements from CLOMonitor

## How was this change tested?
- No testing needed as this file is not used internally to the project

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [NOT NEEDED] I have added unit tests for the new functionality
- [NOT NEEDED] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
