### PR TITLE
exp(jaeger-v2): Simplify all-in-one configuration

### DIFF
--- a/cmd/jaeger-v2/internal/all-in-one.yaml
+++ b/cmd/jaeger-v2/internal/all-in-one.yaml
@@ -1,0 +1,38 @@
+service:
+  extensions: [jaeger_storage, jaeger_query]
+  pipelines:
+    traces:
+      receivers: [otlp, jaeger, zipkin]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter]
+
+extensions:
+  jaeger_query:
+    trace_storage: memstore
+
+  jaeger_storage:
+    memory:
+      memstore:
+        max_traces: 100000
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+  jaeger:
+    protocols:
+      grpc:
+      thrift_binary:
+      thrift_compact:
+      thrift_http:
+
+  zipkin:
+
+processors:
+  batch:
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: memstore

--- a/cmd/jaeger-v2/internal/exporters/storageexporter/factory.go
+++ b/cmd/jaeger-v2/internal/exporters/storageexporter/factory.go
@@ -10,8 +10,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-
-	"github.com/jaegertracing/jaeger/cmd/jaeger-v2/internal/extension/jaegerstorage"
 )
 
 // componentType is the name of this extension in configuration.
@@ -30,9 +28,7 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{
-		TraceStorage: jaegerstorage.DefaultMemoryStore,
-	}
+	return &Config{}
 }
 
 func createTracesExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Traces, error) {

--- a/cmd/jaeger-v2/internal/extension/jaegerquery/factory.go
+++ b/cmd/jaeger-v2/internal/extension/jaegerquery/factory.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/extension"
 
-	"github.com/jaegertracing/jaeger/cmd/jaeger-v2/internal/extension/jaegerstorage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -26,7 +25,6 @@ func NewFactory() extension.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		TraceStoragePrimary: jaegerstorage.DefaultMemoryStore,
 		HTTPServerSettings: confighttp.HTTPServerSettings{
 			Endpoint: ports.PortToHostPort(ports.QueryHTTP),
 		},

--- a/cmd/jaeger-v2/internal/extension/jaegerstorage/factory.go
+++ b/cmd/jaeger-v2/internal/extension/jaegerstorage/factory.go
@@ -8,17 +8,10 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
-
-	memoryCfg "github.com/jaegertracing/jaeger/pkg/memory/config"
 )
 
-const (
-	// componentType is the name of this extension in configuration.
-	componentType = component.Type("jaeger_storage")
-
-	// DefaultMemoryStore is the name of the memory storage included in the default configuration.
-	DefaultMemoryStore = "memstore"
-)
+// componentType is the name of this extension in configuration.
+const componentType = component.Type("jaeger_storage")
 
 // ID is the identifier of this extension.
 var ID = component.NewID(componentType)
@@ -33,13 +26,7 @@ func NewFactory() extension.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{
-		Memory: map[string]memoryCfg.Configuration{
-			DefaultMemoryStore: {
-				MaxTraces: 100_000,
-			},
-		},
-	}
+	return &Config{}
 }
 
 // createExtension creates the extension based on this config.


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #4843 
- Improvement on #4842, where all-in-one configuration was created via createDefaultConfig methods of extensions called by OTel automatically. This resulted in the memstore always being present in the config and always instantiated, which is not the desired behavior.

## Description of the changes
- The cmd.RunE interceptor is changed to provide an internal value to the `--config` flag if no flag was present on cmd line
- This avoids creating the collector manually, once we set the flag we always delegate back to official OTel code
- The value for the config is embedded in the binary and passed using `yaml:...`, which is one of the official config providers in OTel

## How was this change tested?
- Ran all-in-one manually
