### PR TITLE
enable errorlint linter on cmd package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,12 @@ issues:
       text: "exitAfterDefer"
     - linters: [gocritic]
       text: "appendAssign"
+    - path: model/
+      linters: [errorlint]
+    - path: pkg/
+      linters: [errorlint]
+    - path: plugin/
+      linters: [errorlint]
   max-issues-per-linter: 0
   max-same-issues: 0
 
@@ -25,6 +31,7 @@ linters:
     - bidichk
     - contextcheck
     - depguard
+    - errorlint
     - gocritic
     - gofumpt
     - goimports

--- a/cmd/anonymizer/app/query/query.go
+++ b/cmd/anonymizer/app/query/query.go
@@ -77,7 +77,7 @@ func (q *Query) QueryTrace(traceID string) ([]model.Span, error) {
 	}
 
 	var spans []model.Span
-	for received, err := stream.Recv(); (err == nil || !errors.Is(err, io.EOF)); received, err = stream.Recv() {
+	for received, err := stream.Recv(); !(err != nil && errors.Is(err, io.EOF)); received, err = stream.Recv() {
 		if err != nil {
 			return nil, unwrapNotFoundErr(err)
 		}

--- a/cmd/anonymizer/app/query/query.go
+++ b/cmd/anonymizer/app/query/query.go
@@ -77,7 +77,7 @@ func (q *Query) QueryTrace(traceID string) ([]model.Span, error) {
 	}
 
 	var spans []model.Span
-	for received, err := stream.Recv(); !errors.Is(err, io.EOF); received, err = stream.Recv() {
+	for received, err := stream.Recv(); (err == nil || !errors.Is(err, io.EOF)); received, err = stream.Recv() {
 		if err != nil {
 			return nil, unwrapNotFoundErr(err)
 		}

--- a/cmd/anonymizer/app/query/query.go
+++ b/cmd/anonymizer/app/query/query.go
@@ -16,6 +16,7 @@ package query
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -76,7 +77,7 @@ func (q *Query) QueryTrace(traceID string) ([]model.Span, error) {
 	}
 
 	var spans []model.Span
-	for received, err := stream.Recv(); err != io.EOF; received, err = stream.Recv() {
+	for received, err := stream.Recv(); !errors.Is(err, io.EOF); received, err = stream.Recv() {
 		if err != nil {
 			return nil, unwrapNotFoundErr(err)
 		}

--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -16,6 +16,7 @@ package uiconv
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -63,7 +64,7 @@ func (e *Extractor) Run() error {
 			spans = append(spans, *span)
 		}
 	}
-	if err != io.EOF {
+	if !errors.Is(err, io.EOF) {
 		return fmt.Errorf("failed when scanning the file: %w", err)
 	}
 	trace := uimodel.Trace{

--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -64,7 +64,7 @@ func (e *Extractor) Run() error {
 			spans = append(spans, *span)
 		}
 	}
-	if !errors.Is(err, io.EOF) {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("failed when scanning the file: %w", err)
 	}
 	trace := uimodel.Trace{

--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -64,7 +64,7 @@ func (e *Extractor) Run() error {
 			spans = append(spans, *span)
 		}
 	}
-	if err != nil && !errors.Is(err, io.EOF) {
+	if !(err != nil && errors.Is(err, io.EOF)) {
 		return fmt.Errorf("failed when scanning the file: %w", err)
 	}
 	trace := uimodel.Trace{

--- a/cmd/collector/app/handler/grpc_handler.go
+++ b/cmd/collector/app/handler/grpc_handler.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -91,7 +92,7 @@ func (c *batchConsumer) consume(ctx context.Context, batch *model.Batch) error {
 		Tenant:           tenant,
 	})
 	if err != nil {
-		if err == processor.ErrBusy {
+		if errors.Is(err, processor.ErrBusy) {
 			return status.Errorf(codes.ResourceExhausted, err.Error())
 		}
 		c.logger.Error("cannot process spans", zap.Error(err))

--- a/cmd/es-rollover/app/init/action.go
+++ b/cmd/es-rollover/app/init/action.go
@@ -16,6 +16,7 @@ package init
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -81,7 +82,8 @@ func (c Action) Do() error {
 func createIndexIfNotExist(c client.IndexAPI, index string) error {
 	err := c.CreateIndex(index)
 	if err != nil {
-		if esErr, ok := err.(client.ResponseError); ok {
+		var esErr client.ResponseError
+		if errors.As(err, &esErr) {
 			if esErr.StatusCode != http.StatusBadRequest || esErr.Body == nil {
 				return esErr.Err
 			}

--- a/cmd/internal/flags/admin.go
+++ b/cmd/internal/flags/admin.go
@@ -17,6 +17,7 @@ package flags
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -148,8 +149,8 @@ func (s *AdminServer) serveWithListener(l net.Listener) {
 		} else {
 			err = s.server.Serve(l)
 		}
-		switch err {
-		case nil, http.ErrServerClosed:
+		switch {
+		case err == nil, errors.Is(err, http.ErrServerClosed):
 			// normal exit, nothing to do
 		default:
 			s.logger.Error("failed to serve", zap.Error(err))

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -17,6 +17,7 @@ package app
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -175,7 +176,7 @@ func stringSliceAsHeader(slice []string) (http.Header, error) {
 	tp := textproto.NewReader(reader)
 
 	header, err := tp.ReadMIMEHeader()
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("failed to parse headers")
 	}
 

--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -101,7 +101,7 @@ func (g *GRPCHandler) GetTrace(r *api_v2.GetTraceRequest, stream api_v2.QuerySer
 		return errUninitializedTraceID
 	}
 	trace, err := g.queryService.GetTrace(stream.Context(), r.TraceID)
-	if err == spanstore.ErrTraceNotFound {
+	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		g.logger.Error(msgTraceNotFound, zap.Error(err))
 		return status.Errorf(codes.NotFound, "%s: %v", msgTraceNotFound, err)
 	}
@@ -121,7 +121,7 @@ func (g *GRPCHandler) ArchiveTrace(ctx context.Context, r *api_v2.ArchiveTraceRe
 		return nil, errUninitializedTraceID
 	}
 	err := g.queryService.ArchiveTrace(ctx, r.TraceID)
-	if err == spanstore.ErrTraceNotFound {
+	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		g.logger.Error("trace not found", zap.Error(err))
 		return nil, status.Errorf(codes.NotFound, "%s: %v", msgTraceNotFound, err)
 	}

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -261,14 +261,14 @@ func (aH *APIHandler) search(w http.ResponseWriter, r *http.Request) {
 }
 
 func (aH *APIHandler) tracesByIDs(ctx context.Context, traceIDs []model.TraceID) ([]*model.Trace, []structuredError, error) {
-	var errors []structuredError
+	var structuredErrors []structuredError
 	retMe := make([]*model.Trace, 0, len(traceIDs))
 	for _, traceID := range traceIDs {
 		if trace, err := aH.queryService.GetTrace(ctx, traceID); err != nil {
-			if err != spanstore.ErrTraceNotFound {
+			if !errors.Is(err, spanstore.ErrTraceNotFound) {
 				return nil, nil, err
 			}
-			errors = append(errors, structuredError{
+			structuredErrors = append(structuredErrors, structuredError{
 				Msg:     err.Error(),
 				TraceID: ui.TraceID(traceID.String()),
 			})
@@ -276,7 +276,7 @@ func (aH *APIHandler) tracesByIDs(ctx context.Context, traceIDs []model.TraceID)
 			retMe = append(retMe, trace)
 		}
 	}
-	return retMe, errors, nil
+	return retMe, structuredErrors, nil
 }
 
 func (aH *APIHandler) dependencies(w http.ResponseWriter, r *http.Request) {
@@ -428,7 +428,7 @@ func (aH *APIHandler) getTrace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	trace, err := aH.queryService.GetTrace(r.Context(), traceID)
-	if err == spanstore.ErrTraceNotFound {
+	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		aH.handleError(w, err, http.StatusNotFound)
 		return
 	}
@@ -467,7 +467,7 @@ func (aH *APIHandler) archiveTrace(w http.ResponseWriter, r *http.Request) {
 
 	// QueryService.ArchiveTrace can now archive this traceID.
 	err := aH.queryService.ArchiveTrace(r.Context(), traceID)
-	if err == spanstore.ErrTraceNotFound {
+	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		aH.handleError(w, err, http.StatusNotFound)
 		return
 	}

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -65,7 +65,7 @@ func NewQueryService(spanReader spanstore.Reader, dependencyReader dependencysto
 // GetTrace is the queryService implementation of spanstore.Reader.GetTrace
 func (qs QueryService) GetTrace(ctx context.Context, traceID model.TraceID) (*model.Trace, error) {
 	trace, err := qs.spanReader.GetTrace(ctx, traceID)
-	if err == spanstore.ErrTraceNotFound {
+	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		if qs.options.ArchiveSpanReader == nil {
 			return nil, err
 		}
@@ -130,7 +130,7 @@ func (opts *QueryServiceOptions) InitArchiveStorage(storageFactory storage.Facto
 		return false
 	}
 	reader, err := archiveFactory.CreateArchiveSpanReader()
-	if err == storage.ErrArchiveStorageNotConfigured || err == storage.ErrArchiveStorageNotSupported {
+	if errors.Is(err, storage.ErrArchiveStorageNotConfigured) || errors.Is(err, storage.ErrArchiveStorageNotSupported) {
 		logger.Info("Archive storage not created", zap.String("reason", err.Error()))
 		return false
 	}
@@ -139,7 +139,7 @@ func (opts *QueryServiceOptions) InitArchiveStorage(storageFactory storage.Facto
 		return false
 	}
 	writer, err := archiveFactory.CreateArchiveSpanWriter()
-	if err == storage.ErrArchiveStorageNotConfigured || err == storage.ErrArchiveStorageNotSupported {
+	if errors.Is(err, storage.ErrArchiveStorageNotConfigured) || errors.Is(err, storage.ErrArchiveStorageNotSupported) {
 		logger.Info("Archive storage not created", zap.String("reason", err.Error()))
 		return false
 	}

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -284,8 +284,8 @@ func (s *Server) Start() error {
 		} else {
 			err = s.httpServer.Serve(s.httpConn)
 		}
-		switch err {
-		case nil, http.ErrServerClosed, cmux.ErrListenerClosed, cmux.ErrServerClosed:
+		switch {
+		case err == nil, errors.Is(err, http.ErrServerClosed), errors.Is(err, cmux.ErrListenerClosed), errors.Is(err, cmux.ErrServerClosed):
 			// normal exit, nothing to do
 		default:
 			s.logger.Error("Could not start HTTP server", zap.Error(err))


### PR DESCRIPTION
## Which problem is this PR solving?
- enable errorlint linter for files in cmd package 

## Description of the changes
- this exclude errorlint on several packages to apply it progressively

## How was this change tested?
- unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
