### PR TITLE
ci: Keep the UI asset's .gz file timestamps the same as the original file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,9 @@ cmd/query/app/ui/actual/index.html.gz: jaeger-ui/packages/jaeger-ui/build/index.
 	rm -rf cmd/query/app/ui/actual/*
 	cp -r jaeger-ui/packages/jaeger-ui/build/* cmd/query/app/ui/actual/
 	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs gzip --no-name
+	# copy the timestamp for index.html.gz from the original file
 	touch -t $$(date -r jaeger-ui/packages/jaeger-ui/build/index.html '+%Y%m%d%H%M.%S') cmd/query/app/ui/actual/index.html.gz
+	ls -lF cmd/query/app/ui/actual/
 
 jaeger-ui/packages/jaeger-ui/build/index.html:
 	$(MAKE) rebuild-ui

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,8 @@ jaeger-ui/packages/jaeger-ui/build/index.html:
 .PHONY: rebuild-ui
 rebuild-ui:
 	bash ./scripts/rebuild-ui.sh
+	@echo "NOTE: This target only rebuilds the UI assets inside jaeger-ui/packages/jaeger-ui/build/."
+	@echo "NOTE: To make them usable from query-service run 'make build-ui'."
 
 .PHONY: build-all-in-one-linux
 build-all-in-one-linux:

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ cmd/query/app/ui/actual/index.html.gz: jaeger-ui/packages/jaeger-ui/build/index.
 	rm -rf cmd/query/app/ui/actual/*
 	cp -r jaeger-ui/packages/jaeger-ui/build/* cmd/query/app/ui/actual/
 	find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs gzip --no-name
+	touch -t $$(date -r jaeger-ui/packages/jaeger-ui/build/index.html '+%Y%m%d%H%M.%S') cmd/query/app/ui/actual/index.html.gz
 
 jaeger-ui/packages/jaeger-ui/build/index.html:
 	$(MAKE) rebuild-ui


### PR DESCRIPTION
## Which problem is this PR solving?
- `make rebuild-ui` and `make build-ui` did not update the UI assets according to the latest release

## Description of the changes
- This changes the timestamp of the copied `index.html.gz` asset file to match the timestamp of the original asset. In turn, the timestamp of that asset matches the date of the UI release. This allows the combination of rebuild/build targets to always bring the UI assets in sync with the actual commit pinned in the ui-submodule.

## How was this change tested?
- validated that CI runs normally
- ran manually on different versions of UI to ensure assets get copied again
