### PR TITLE
ci: Enable linting of code in examples/

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters-settings:
 run:
   go: "1.20"
   timeout: 20m
+  skip-dirs-use-default: false
   skip-dirs:
     - mocks
     - thrift-0.9.2

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
 SHELL := /bin/bash
 JAEGER_IMPORT_PATH = github.com/jaegertracing/jaeger
 STORAGE_PKGS = ./plugin/storage/integration/...
@@ -15,7 +18,6 @@ ALL_SRC = $(shell find . -name '*.go' \
 				   -not -name 'model.pb.go' \
 				   -not -name 'model_test.pb.go' \
 				   -not -name 'storage_test.pb.go' \
-				   -not -path './examples/*' \
 				   -not -path './vendor/*' \
 				   -not -path '*/mocks/*' \
 				   -not -path '*/*-gen/*' \
@@ -175,7 +177,6 @@ lint:
 	./scripts/import-order-cleanup.sh stdout > $(IMPORT_LOG)
 	@[ ! -s "$(FMT_LOG)" -a ! -s "$(IMPORT_LOG)" ] || (echo "License check or import ordering failures, run 'make fmt'" | cat - $(FMT_LOG) $(IMPORT_LOG) && false)
 	./scripts/check-semconv-version.sh
-
 	./scripts/check-go-version.sh
 
 .PHONY: build-examples

--- a/examples/hotrod/cmd/.nocover
+++ b/examples/hotrod/cmd/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/cmd/frontend.go
+++ b/examples/hotrod/cmd/frontend.go
@@ -33,7 +33,6 @@ var frontendCmd = &cobra.Command{
 	Short: "Starts Frontend service",
 	Long:  `Starts Frontend service.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		options.FrontendHostPort = net.JoinHostPort("0.0.0.0", strconv.Itoa(frontendPort))
 		options.DriverHostPort = net.JoinHostPort("0.0.0.0", strconv.Itoa(driverPort))
 		options.CustomerHostPort = net.JoinHostPort("0.0.0.0", strconv.Itoa(customerPort))

--- a/examples/hotrod/pkg/delay/.nocover
+++ b/examples/hotrod/pkg/delay/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/pkg/httperr/.nocover
+++ b/examples/hotrod/pkg/httperr/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/pkg/log/.nocover
+++ b/examples/hotrod/pkg/log/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/pkg/pool/.nocover
+++ b/examples/hotrod/pkg/pool/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/pkg/tracing/.nocover
+++ b/examples/hotrod/pkg/tracing/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/pkg/tracing/rpcmetrics/metrics.go
+++ b/examples/hotrod/pkg/tracing/rpcmetrics/metrics.go
@@ -55,13 +55,14 @@ type Metrics struct {
 }
 
 func (m *Metrics) recordHTTPStatusCode(statusCode int64) {
-	if statusCode >= 200 && statusCode < 300 {
+	switch {
+	case statusCode >= 200 && statusCode < 300:
 		m.HTTPStatusCode2xx.Inc(1)
-	} else if statusCode >= 300 && statusCode < 400 {
+	case statusCode >= 300 && statusCode < 400:
 		m.HTTPStatusCode3xx.Inc(1)
-	} else if statusCode >= 400 && statusCode < 500 {
+	case statusCode >= 400 && statusCode < 500:
 		m.HTTPStatusCode4xx.Inc(1)
-	} else if statusCode >= 500 && statusCode < 600 {
+	case statusCode >= 500 && statusCode < 600:
 		m.HTTPStatusCode5xx.Inc(1)
 	}
 }

--- a/examples/hotrod/pkg/tracing/rpcmetrics/observer_test.go
+++ b/examples/hotrod/pkg/tracing/rpcmetrics/observer_test.go
@@ -82,7 +82,7 @@ func TestObserver(t *testing.T) {
 				span.SetName(testCase.opNameOverride)
 			}
 			if testCase.err {
-				span.SetStatus(codes.Error, "An error occured")
+				span.SetStatus(codes.Error, "An error occurred")
 			}
 			span.End(finishOptions)
 		}
@@ -138,7 +138,7 @@ func TestTags(t *testing.T) {
 				)
 				span.SetAttributes(testCase.attr)
 				if testCase.err {
-					span.SetStatus(codes.Error, "An error occured")
+					span.SetStatus(codes.Error, "An error occurred")
 				}
 				span.End()
 				testTracer.metrics.AssertCounterMetrics(t, testCase.metrics...)

--- a/examples/hotrod/services/config/.nocover
+++ b/examples/hotrod/services/config/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/services/customer/.nocover
+++ b/examples/hotrod/services/customer/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/services/customer/server.go
+++ b/examples/hotrod/services/customer/server.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -54,7 +55,12 @@ func NewServer(hostPort string, otelExporter string, metricsFactory metrics.Fact
 func (s *Server) Run() error {
 	mux := s.createServeMux()
 	s.logger.Bg().Info("Starting", zap.String("address", "http://"+s.hostPort))
-	return http.ListenAndServe(s.hostPort, mux)
+	server := &http.Server{
+		Addr:              s.hostPort,
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	return server.ListenAndServe()
 }
 
 func (s *Server) createServeMux() http.Handler {

--- a/examples/hotrod/services/driver/.nocover
+++ b/examples/hotrod/services/driver/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/services/driver/driver.pb.go
+++ b/examples/hotrod/services/driver/driver.pb.go
@@ -28,9 +28,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -51,18 +53,23 @@ func (*DriverLocationRequest) ProtoMessage()    {}
 func (*DriverLocationRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cdcd28b7ebdcd54f, []int{0}
 }
+
 func (m *DriverLocationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DriverLocationRequest.Unmarshal(m, b)
 }
+
 func (m *DriverLocationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DriverLocationRequest.Marshal(b, m, deterministic)
 }
+
 func (m *DriverLocationRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_DriverLocationRequest.Merge(m, src)
 }
+
 func (m *DriverLocationRequest) XXX_Size() int {
 	return xxx_messageInfo_DriverLocationRequest.Size(m)
 }
+
 func (m *DriverLocationRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_DriverLocationRequest.DiscardUnknown(m)
 }
@@ -90,18 +97,23 @@ func (*DriverLocation) ProtoMessage()    {}
 func (*DriverLocation) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cdcd28b7ebdcd54f, []int{1}
 }
+
 func (m *DriverLocation) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DriverLocation.Unmarshal(m, b)
 }
+
 func (m *DriverLocation) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DriverLocation.Marshal(b, m, deterministic)
 }
+
 func (m *DriverLocation) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_DriverLocation.Merge(m, src)
 }
+
 func (m *DriverLocation) XXX_Size() int {
 	return xxx_messageInfo_DriverLocation.Size(m)
 }
+
 func (m *DriverLocation) XXX_DiscardUnknown() {
 	xxx_messageInfo_DriverLocation.DiscardUnknown(m)
 }
@@ -135,18 +147,23 @@ func (*DriverLocationResponse) ProtoMessage()    {}
 func (*DriverLocationResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cdcd28b7ebdcd54f, []int{2}
 }
+
 func (m *DriverLocationResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DriverLocationResponse.Unmarshal(m, b)
 }
+
 func (m *DriverLocationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DriverLocationResponse.Marshal(b, m, deterministic)
 }
+
 func (m *DriverLocationResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_DriverLocationResponse.Merge(m, src)
 }
+
 func (m *DriverLocationResponse) XXX_Size() int {
 	return xxx_messageInfo_DriverLocationResponse.Size(m)
 }
+
 func (m *DriverLocationResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_DriverLocationResponse.DiscardUnknown(m)
 }
@@ -188,8 +205,10 @@ var fileDescriptor_cdcd28b7ebdcd54f = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.

--- a/examples/hotrod/services/frontend/.nocover
+++ b/examples/hotrod/services/frontend/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/services/frontend/server.go
+++ b/examples/hotrod/services/frontend/server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/trace"
@@ -75,7 +76,12 @@ func NewServer(options ConfigOptions, tracer trace.TracerProvider, logger log.Fa
 func (s *Server) Run() error {
 	mux := s.createServeMux()
 	s.logger.Bg().Info("Starting", zap.String("address", "http://"+path.Join(s.hostPort, s.basepath)))
-	return http.ListenAndServe(s.hostPort, mux)
+	server := &http.Server{
+		Addr:              s.hostPort,
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	return server.ListenAndServe()
 }
 
 func (s *Server) createServeMux() http.Handler {

--- a/examples/hotrod/services/route/.nocover
+++ b/examples/hotrod/services/route/.nocover
@@ -1,0 +1,1 @@
+examples

--- a/examples/hotrod/services/route/server.go
+++ b/examples/hotrod/services/route/server.go
@@ -53,7 +53,12 @@ func NewServer(hostPort string, tracer trace.TracerProvider, logger log.Factory)
 func (s *Server) Run() error {
 	mux := s.createServeMux()
 	s.logger.Bg().Info("Starting", zap.String("address", "http://"+s.hostPort))
-	return http.ListenAndServe(s.hostPort, mux)
+	server := &http.Server{
+		Addr:              s.hostPort,
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	return server.ListenAndServe()
 }
 
 func (s *Server) createServeMux() http.Handler {

--- a/examples/hotrod/services/route/stats.go
+++ b/examples/hotrod/services/route/stats.go
@@ -23,8 +23,10 @@ import (
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/tracing"
 )
 
-var routeCalcByCustomer = expvar.NewMap("route.calc.by.customer.sec")
-var routeCalcBySession = expvar.NewMap("route.calc.by.session.sec")
+var (
+	routeCalcByCustomer = expvar.NewMap("route.calc.by.customer.sec")
+	routeCalcBySession  = expvar.NewMap("route.calc.by.session.sec")
+)
 
 var stats = []struct {
 	expvar     *expvar.Map


### PR DESCRIPTION
## Which problem is this PR solving?
- The HotROD source code was never formatted or linted because golangci-lint was automatically excluding /examples/

## Description of the changes
- Disable linter's default skip dirs (which include /examples/)
- Fix linter errors
