### PR TITLE
ci: Pass variable instead of calling make build-xxx-debug

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -58,10 +58,10 @@ bash scripts/build-upload-a-docker-image.sh -b -c all-in-one -d cmd/all-in-one -
 
 # build debug image if not on a pull request
 if [ "$mode" != "pr-only" ]; then
-  make build-all-in-one-debug GOOS=linux GOARCH="$GOARCH"
+  make build-all-in-one GOOS=linux GOARCH="$GOARCH" DEBUG_BINARY=1
   repo=${repo}-debug
 
-  # build all-in-one-debug image locally for integration test
+  # build all-in-one DEBUG image locally for integration test
   bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one-debug -d cmd/all-in-one -t debug
   run_integration_test localhost:5000/$repo
 

--- a/scripts/build-crossdock.sh
+++ b/scripts/build-crossdock.sh
@@ -11,7 +11,7 @@ make build-and-run-crossdock
 if [[ "$BRANCH" == "main" ]]; then
   echo 'upload images to dockerhub/quay.io'
   REPO=jaegertracing/test-driver
-  IFS=" " read -r -a IMAGE_TAGS <<< "$(bash scripts/compute-tags.sh '$REPO')"
+  IFS=" " read -r -a IMAGE_TAGS <<< "$(bash scripts/compute-tags.sh ${REPO})"
   IMAGE_TAGS+=("--tag" "docker.io/${REPO}:${COMMIT}" "--tag" "quay.io/${REPO}:${COMMIT}")
   bash scripts/docker-login.sh
   docker buildx build --push \


### PR DESCRIPTION
## Which problem is this PR solving?
- Follow up to $4882
- Crossdock and all-in-one workflows failed on `main` branch

## Description of the changes
- `build-all-in-one-debug` target was removed, call `make build-all-in-one DEBUG_BINARY=1`
- fix invalid variable quoting in `scripts/build-crossdock.sh`

## How was this change tested?
- Will check CI once this is merged
