### PR TITLE
Remove --otel-exporter=otlp argument from HotROD docker-compose

### DIFF
--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -17,8 +17,7 @@ services:
     ports:
       - "8080:8080"
       - "8083:8083"
-    # TODO remove "--otel-exporter=otlp" after 1.49 release
-    command: ["all", "--otel-exporter=otlp"]
+    command: ["all"]
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
     networks:


### PR DESCRIPTION
Removed `--otel-exporter=otlp` argument from the hotrod

## Which problem is this PR solving?
Updated hotrod docker compose yaml.

## Description of the changes
Removed `--otel-exporter=otlp` argument from the hotrod

## How was this change tested?
local run

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
