### PR TITLE
Add breaking change to 1.50 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ next release (yyyy-mm-dd)
 #### ⛔ Breaking Changes
 
 * [sampling] Remove support for SAMPLING_TYPE env var and 'static' value ([@yurishkuro](https://github.com/yurishkuro) in [#4735](https://github.com/jaegertracing/jaeger/pull/4735))
+* Use non-root user in built containers ([@nikzayn](https://github.com/nikzayn) in [#4783](https://github.com/jaegertracing/jaeger/pull/4783)) - this change may cause issues with existing installations using Badger storage, because the existing files would be owned by a different user and would not be writeable after Jaeger upgrade. The workaround is to manually chown the files to the new user (uid=10001).
 
 #### New Features
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4906

## Description of the changes
- Add #4783 to breaking changes for v1.50.0

## Other
* [ ] once this PR is merged, update release notes on GitHub
