### PR TITLE
Pre-create badger directory in Docker image

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -41,6 +41,8 @@ ENV SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json
 COPY all-in-one-linux-$TARGETARCH /go/bin/all-in-one-linux
 COPY sampling_strategies.json /etc/jaeger/
 
+RUN mkdir -p /badger && chown -r ${USER_UID} /badger
+
 VOLUME ["/tmp"]
 ENTRYPOINT ["/go/bin/all-in-one-linux"]
 USER ${USER_UID}
@@ -87,6 +89,8 @@ ENV SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json
 
 COPY all-in-one-debug-linux-$TARGETARCH /go/bin/all-in-one-linux
 COPY sampling_strategies.json /etc/jaeger/
+
+RUN mkdir /badger && chown ${USER_UID} /badger
 
 VOLUME ["/tmp"]
 ENTRYPOINT ["/go/bin/dlv", "exec", "/go/bin/all-in-one-linux", "--headless", "--listen=:12345", "--api-version=2", "--accept-multiclient", "--log", "--"]


### PR DESCRIPTION
## Which problem is this PR solving?

#4906

## Description of the changes
- Create directory for badger in a non-root environment so that existing setups do not break.

## How was this change tested?
- Tested permissions in a minimal container.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
