### PR TITLE
Fix release script broken by recent linting cleanup

### DIFF
--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -51,7 +51,6 @@ function package {
 
 set -e
 
-readonly VERSION
 VERSION="$(make echo-version | perl -lne 'print $1 if /^v(\d+.\d+.\d+)$/' )"
 echo "Working on version: $VERSION"
 if [ -z "$VERSION" ]; then


### PR DESCRIPTION
## Which problem is this PR solving?
```
Run bash scripts/package-deploy.sh
+ set -e
+ readonly VERSION
++ make echo-version
++ perl -lne 'print $1 if /^v(\d+.\d+.\d+)$/'
+ VERSION=1.51.0
scripts/package-deploy.sh: line 55: VERSION: readonly variable
Error: Process completed with exit code 1.
```
## Description of the changes
- remove `readonly` declaration

## How was this change tested?
- will rerun script after merging, no other way to test
