### PR TITLE
ci: Set default to fix 'unbound variable' error on main

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -2,7 +2,8 @@
 
 set -exu
 
-if [[ "$1" == "pr-only" ]]; then
+arg1=${1:-'not-pr'}
+if [[ "$arg1" == "pr-only" ]]; then
   is_pull_request=true
 else
   is_pull_request=false


### PR DESCRIPTION
## Which problem is this PR solving?
Build failed on `main`:
```
scripts/build-all-in-one-image.sh: line 5: $1: unbound variable
```

## Description of the changes
- Use default value for `$1` var

## How was this change tested?
- locally
