### PR TITLE
exp: Publish jaeger v2 image

### DIFF
--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -58,27 +58,22 @@ else
   make "build-${BINARY}" GOOS=linux GOARCH=arm64
 fi
 
-# build all-in-one image locally for integration test
+# build all-in-one image locally for integration test (the -l switch)
 bash scripts/build-upload-a-docker-image.sh -l -b -c "${BINARY}" -d "cmd/${BINARY}" -p "${platforms}" -t release
 run_integration_test "localhost:5000/$repo"
 
-# skip building and uploading real Docker images if it's not all-in-one
-if [[ "${BINARY}" != "all-in-one" ]]; then
-  exit
-fi
-
 # build all-in-one image and upload to dockerhub/quay.io
-bash scripts/build-upload-a-docker-image.sh -b -c all-in-one -d cmd/all-in-one -p "${platforms}" -t release
+bash scripts/build-upload-a-docker-image.sh -b -c "${BINARY}" -d "cmd/${BINARY}" -p "${platforms}" -t release
 
 # build debug image if not on a pull request
 if [[ "${is_pull_request}" == "false" ]]; then
-  make build-all-in-one GOOS=linux GOARCH="$GOARCH" DEBUG_BINARY=1
+  make "build-${BINARY}" GOOS=linux GOARCH="$GOARCH" DEBUG_BINARY=1
   repo="${repo}-debug"
 
-  # build all-in-one DEBUG image locally for integration test
-  bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one-debug -d cmd/all-in-one -t debug
+  # build all-in-one DEBUG image locally for integration test (the -l switch)
+  bash scripts/build-upload-a-docker-image.sh -l -b -c "${BINARY}-debug" -d "cmd/${BINARY}" -t debug
   run_integration_test "localhost:5000/$repo"
 
   # build all-in-one-debug image and upload to dockerhub/quay.io
-  bash scripts/build-upload-a-docker-image.sh -b -c all-in-one-debug -d cmd/all-in-one -t debug
+  bash scripts/build-upload-a-docker-image.sh -b -c "${BINARY}-debug" -d "cmd/${BINARY}" -t debug
 fi


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #4843

## Description of the changes
- Remove early exit and allow `jaeger` binary to be published to Docker Hub / quay.io
- The repositories in the respective hubs were created manually

## How was this change tested?
- Publishing only works on the main branch, will see how it goes once erged
