### PR TITLE
Normalize metric names due to breaking change

### DIFF
--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -13,12 +13,14 @@ services:
       - PROMETHEUS_QUERY_SUPPORT_SPANMETRICS_CONNECTOR=${PROMETHEUS_QUERY_SUPPORT_SPANMETRICS_CONNECTOR:-true}
       - PROMETHEUS_QUERY_NAMESPACE=${PROMETHEUS_QUERY_NAMESPACE:-}
       - PROMETHEUS_QUERY_DURATION_UNIT=${PROMETHEUS_QUERY_DURATION_UNIT:-}
+      - PROMETHEUS_QUERY_NORMALIZE_CALLS=true
+      - PROMETHEUS_QUERY_NORMALIZE_DURATION=true
     ports:
       - "16686:16686"
   otel_collector:
     networks:
       - backend
-    image: otel/opentelemetry-collector-contrib:${OTEL_IMAGE_TAG:-0.80.0}
+    image: otel/opentelemetry-collector-contrib:${OTEL_IMAGE_TAG:-0.89.0}
     volumes:
       - ${OTEL_CONFIG_SRC:-./otel-collector-config-connector.yml}:/etc/otelcol/otel-collector-config.yml
     command: --config /etc/otelcol/otel-collector-config.yml


### PR DESCRIPTION
## Which problem is this PR solving?
[OpenTelemetry Collector Contrib v0.85.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.85.0) introduces a breaking change to enable normalized metric names by default:

> `prometheusexporters`: Append prometheus type and unit suffixes by default in prometheus exporters. (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26488)
Suffixes can be disabled by setting add_metric_suffixes to false on the exporter.

Motivated by [this support question](https://cloud-native.slack.com/archives/CGG7NFUJ3/p1699539239671519).

## Description of the changes
- Updates the otel version in the example to the latest v0.89.0 release, which includes this breaking change.
- Enable normalized metric name support.
- Jaeger documentation/troubleshooting tips relating to this problem will added in another PR.

## How was this change tested?
- Ran locally before the change to confirm no metrics appeared in the Monitor tab after only version bump of OTEL image to v0.89.0.
- Added the `PROMETHEUS_QUERY_NORMALIZE_CALLS=true` and `PROMETHEUS_QUERY_NORMALIZE_DURATION=true` env vars to confirm metrics appear again.

<img width="1709" alt="Screenshot 2023-11-18 at 12 31 16 pm" src="https://github.com/jaegertracing/jaeger/assets/26584478/d36bc6bc-e99f-4858-903b-30da9aedda67">


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
~- [ ] I have added unit tests for the new functionality~
~- [ ] I have run lint and test steps successfully~

