### PR TITLE
Collect code coverage from integration tests and upload to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,9 +6,11 @@ codecov:
 
 ignore:
   - "**/*.pb.go"
-  - "**/*-gen/*"
   - "**/mocks/*"
+  - "proto-gen/*/*"
+  - "thrift-gen/*/*"
   - "**/thrift-0.9.2/*"
+  - "swagger-gen/*/*"
 
 coverage:
   precision: 2

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: yes
-    after_n_builds: 3
+    after_n_builds: 11
   strict_yaml_branch: main  # only use the latest copy on the main branch
 
 ignore:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,12 @@ codecov:
     after_n_builds: 3
   strict_yaml_branch: main  # only use the latest copy on the main branch
 
+ignore:
+  - "**/*.pb.go"
+  - "**/*-gen/*"
+  - "**/mocks/*"
+  - "**/thrift-0.9.2/*"
+
 coverage:
   precision: 2
   round: down

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: yes
+    after_n_builds: 3
   strict_yaml_branch: main  # only use the latest copy on the main branch
 
 coverage:

--- a/.github/actions/setup-codecov/action.yml
+++ b/.github/actions/setup-codecov/action.yml
@@ -1,0 +1,13 @@
+# Codecov upload often fails on rate limits if used without a token.
+# See https://github.com/codecov/codecov-action/issues/837
+# This action exposes the token as env.CODECOV_TOKEN.
+# We cannot define it as "secret" as we need it accessible from forks.
+name: 'Setup CODECOV_TOKEN'
+description: 'Make CODECOV_TOKEN var accessible to job'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup CODECOV_TOKEN
+      shell: bash
+      run: |
+        echo "CODECOV_TOKEN=f457b710-93af-4191-8678-bcf51281f98c" >> ${GITHUB_ENV}

--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -15,12 +15,6 @@ concurrency:
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
-env:
-  # Using upload token helps against rate limiting errors.
-  # Cannot define it as secret as we need it accessible from forks.
-  # See https://github.com/codecov/codecov-action/issues/837
-  CODECOV_TOKEN: f457b710-93af-4191-8678-bcf51281f98c
-
 jobs:
   cassandra:
     runs-on: ubuntu-latest
@@ -50,6 +44,9 @@ jobs:
 
     - name: Run cassandra integration tests
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.image }} ${{ matrix.version.schema }}
+
+    - name: Setup CODECOV_TOKEN
+      uses: ./.github/actions/setup-codecov
 
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2

--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -15,6 +15,12 @@ concurrency:
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
+env:
+  # Using upload token helps against rate limiting errors.
+  # Cannot define it as secret as we need it accessible from forks.
+  # See https://github.com/codecov/codecov-action/issues/837
+  CODECOV_TOKEN: f457b710-93af-4191-8678-bcf51281f98c
+
 jobs:
   cassandra:
     runs-on: ubuntu-latest
@@ -44,3 +50,12 @@ jobs:
 
     - name: Run cassandra integration tests
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.image }} ${{ matrix.version.schema }}
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
+      with:
+        file: cover.out
+        verbose: true
+        flags: cassandra-${{ matrix.version.major }}
+        fail_ci_if_error: true
+        token: ${{ env.CODECOV_TOKEN }}

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -59,3 +59,15 @@ jobs:
 
     - name: Run elasticsearch integration tests
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}
+
+    - name: Setup CODECOV_TOKEN
+      uses: ./.github/actions/setup-codecov
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
+      with:
+        files: [cover.out, cover-index-cleaner.out, cover-index-rollover.out]
+        verbose: true
+        flags: elasticsearch-${{ matrix.version.major }}
+        fail_ci_if_error: true
+        token: ${{ env.CODECOV_TOKEN }}

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
       with:
-        files: [cover.out, cover-index-cleaner.out, cover-index-rollover.out]
+        files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
         verbose: true
         flags: elasticsearch-${{ matrix.version.major }}
         fail_ci_if_error: true

--- a/.github/workflows/ci-grpc-badger.yml
+++ b/.github/workflows/ci-grpc-badger.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
       with:
-        files: [cover.out, cover-badger.out]
+        files: cover.out,cover-badger.out
         verbose: true
         flags: grpc-badger
         fail_ci_if_error: true

--- a/.github/workflows/ci-grpc-badger.yml
+++ b/.github/workflows/ci-grpc-badger.yml
@@ -36,4 +36,14 @@ jobs:
     - name: Run gRPC storage integration tests
       run: make grpc-storage-integration-test
 
-# TODO add code coverage reporting
+    - name: Setup CODECOV_TOKEN
+      uses: ./.github/actions/setup-codecov
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
+      with:
+        files: [cover.out, cover-badger.out]
+        verbose: true
+        flags: grpc-badger
+        fail_ci_if_error: true
+        token: ${{ env.CODECOV_TOKEN }}

--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
       with:
-        files: [cover.out]
+        files: cover.out
         verbose: true
         flags: kafka
         fail_ci_if_error: true

--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -37,6 +37,18 @@ jobs:
       run: docker logs "${{ job.services.kafka.id }}"
       if: ${{ failure() }}
 
+    - name: Setup CODECOV_TOKEN
+      uses: ./.github/actions/setup-codecov
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
+      with:
+        files: [cover.out]
+        verbose: true
+        flags: kafka
+        fail_ci_if_error: true
+        token: ${{ env.CODECOV_TOKEN }}
+
     services:
       zookeeper:
         image: bitnami/zookeeper

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -15,6 +15,12 @@ concurrency:
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
+env:
+  # Using upload token helps against rate limiting errors.
+  # Cannot define it as secret as we need it accessible from forks.
+  # See https://github.com/codecov/codecov-action/issues/837
+  CODECOV_TOKEN: f457b710-93af-4191-8678-bcf51281f98c
+
 jobs:
   opensearch:
     runs-on: ubuntu-latest
@@ -53,3 +59,12 @@ jobs:
 
     - name: Run opensearch integration tests
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
+      with:
+        file: cover.out
+        verbose: true
+        flags: opensearch-${{ matrix.version.major }}
+        fail_ci_if_error: true
+        token: ${{ env.CODECOV_TOKEN }}

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -15,12 +15,6 @@ concurrency:
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
-env:
-  # Using upload token helps against rate limiting errors.
-  # Cannot define it as secret as we need it accessible from forks.
-  # See https://github.com/codecov/codecov-action/issues/837
-  CODECOV_TOKEN: f457b710-93af-4191-8678-bcf51281f98c
-
 jobs:
   opensearch:
     runs-on: ubuntu-latest
@@ -60,10 +54,13 @@ jobs:
     - name: Run opensearch integration tests
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}
 
+    - name: Setup CODECOV_TOKEN
+      uses: ./.github/actions/setup-codecov
+
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
       with:
-        file: cover.out
+        files: [cover.out, cover-index-cleaner.out, cover-index-rollover.out]
         verbose: true
         flags: opensearch-${{ matrix.version.major }}
         fail_ci_if_error: true

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
       with:
-        files: [cover.out, cover-index-cleaner.out, cover-index-rollover.out]
+        files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
         verbose: true
         flags: opensearch-${{ matrix.version.major }}
         fail_ci_if_error: true

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -15,12 +15,6 @@ concurrency:
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
-env:
-  # Using upload token helps against rate limiting errors.
-  # Cannot define it as secret as we need it accessible from forks.
-  # See https://github.com/codecov/codecov-action/issues/837
-  CODECOV_TOKEN: f457b710-93af-4191-8678-bcf51281f98c
-
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -38,6 +32,9 @@ jobs:
 
     - name: Run unit tests
       run: make test-ci
+
+    - name: Setup CODECOV_TOKEN
+      uses: ./.github/actions/setup-codecov
 
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ storage-integration-test: go-gen
 	# Expire tests results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	bash -c "set -e; set -o pipefail; $(GOTEST) $(STORAGE_PKGS) | $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -coverprofile cover.out $(STORAGE_PKGS) | $(COLORIZE)"
 
 .PHONY: badger-storage-integration-test
 badger-storage-integration-test:
@@ -167,9 +167,8 @@ echo-all-srcs:
 
 .PHONY: cover
 cover: nocover
-	$(GOTEST) -tags=memory_storage_integration -timeout 5m -coverprofile cover.out ./...
-	grep -E -v 'model.pb.*.go' cover.out > cover-nogen.out
-	mv cover-nogen.out cover.out
+	$(GOTEST) -tags=memory_storage_integration -timeout 5m -coverprofile cover-all.out ./...
+	grep -E -v 'model.pb.*.go' cover-all.out > cover.out
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: nocover

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test: go-gen
 
 .PHONY: all-in-one-integration-test
 all-in-one-integration-test: go-gen
-	$(GOTEST) -tags=integration -coverprofile cover.out ./cmd/all-in-one/...
+	$(GOTEST) -tags=integration ./cmd/all-in-one/...
 
 .PHONY: storage-integration-test
 storage-integration-test: go-gen

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ else
 endif
 
 
-# all .go files that are not auto-generated and should be auto-formatted and linted.
+# All .go files that are not auto-generated and should be auto-formatted and linted.
 ALL_SRC = $(shell find . -name '*.go' \
 				   -not -name 'doc.go' \
 				   -not -name '_*' \
@@ -133,35 +133,34 @@ storage-integration-test: go-gen
 	# Expire tests results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	bash -c "set -e; set -o pipefail; $(GOTEST) -coverprofile cover.out $(STORAGE_PKGS) $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -coverpkg=./... -coverprofile cover.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: badger-storage-integration-test
 badger-storage-integration-test:
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=badger_storage_integration -coverprofile cover-badger.out $(STORAGE_PKGS) $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=badger_storage_integration -coverpkg=./... -coverprofile cover-badger.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: grpc-storage-integration-test
 grpc-storage-integration-test:
 	(cd examples/memstore-plugin/ && go build .)
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=grpc_storage_integration -coverprofile cover.out $(STORAGE_PKGS) $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=grpc_storage_integration -coverpkg=./... -coverprofile cover.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: index-cleaner-integration-test
 index-cleaner-integration-test: docker-images-elastic
 	# Expire test results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_cleaner -coverprofile cover-index-cleaner.out $(STORAGE_PKGS) $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_cleaner -coverpkg=./... -coverprofile cover-index-cleaner.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: index-rollover-integration-test
 index-rollover-integration-test: docker-images-elastic
 	# Expire test results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_rollover -coverprofile cover-index-rollover.out $(STORAGE_PKGS) $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_rollover -coverpkg=./... -coverprofile cover-index-rollover.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: cover
 cover: nocover
-	$(GOTEST) -tags=memory_storage_integration -timeout 5m -coverprofile cover-all.out ./...
-	grep -E -v 'model.pb.*.go' cover-all.out > cover.out
+	$(GOTEST) -tags=memory_storage_integration -timeout 5m -coverprofile cover.out ./...
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: nocover

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ GOFMT=gofmt
 GOFUMPT=gofumpt
 FMT_LOG=.fmt.log
 IMPORT_LOG=.import.log
+COLORIZE ?= | $(SED) 's/PASS/✅ PASS/g' | $(SED) 's/FAIL/❌ FAIL/g' | $(SED) 's/SKIP/☠️ SKIP/g'
 
 GIT_SHA=$(shell git rev-parse HEAD)
 GIT_CLOSEST_TAG=$(shell git describe --abbrev=0 --tags)
@@ -88,9 +89,6 @@ SWAGGER_GEN_DIR=swagger-gen
 
 JAEGER_DOCKER_PROTOBUF=jaegertracing/protobuf:0.4.0
 
-COLOR_PASS=$(shell printf "\033[32mPASS\033[0m")
-COLOR_FAIL=$(shell printf "\033[31mFAIL\033[0m")
-COLORIZE ?=$(SED) ''/PASS/s//$(COLOR_PASS)/'' | $(SED) ''/FAIL/s//$(COLOR_FAIL)/''
 DOCKER_NAMESPACE?=jaegertracing
 DOCKER_TAG?=latest
 
@@ -124,7 +122,7 @@ clean:
 
 .PHONY: test
 test: go-gen
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=memory_storage_integration ./... | $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=memory_storage_integration ./... $(COLORIZE)"
 
 .PHONY: all-in-one-integration-test
 all-in-one-integration-test: go-gen
@@ -135,30 +133,30 @@ storage-integration-test: go-gen
 	# Expire tests results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	bash -c "set -e; set -o pipefail; $(GOTEST) -coverprofile cover.out $(STORAGE_PKGS) | $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -coverprofile cover.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: badger-storage-integration-test
 badger-storage-integration-test:
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=badger_storage_integration -coverprofile cover-badger.out $(STORAGE_PKGS) | $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=badger_storage_integration -coverprofile cover-badger.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: grpc-storage-integration-test
 grpc-storage-integration-test:
 	(cd examples/memstore-plugin/ && go build .)
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=grpc_storage_integration -coverprofile cover.out $(STORAGE_PKGS) | $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=grpc_storage_integration -coverprofile cover.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: index-cleaner-integration-test
 index-cleaner-integration-test: docker-images-elastic
 	# Expire test results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_cleaner -coverprofile cover-index-cleaner.out $(STORAGE_PKGS) | $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_cleaner -coverprofile cover-index-cleaner.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: index-rollover-integration-test
 index-rollover-integration-test: docker-images-elastic
 	# Expire test results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_rollover -coverprofile cover-index-rollover.out $(STORAGE_PKGS) | $(COLORIZE)"
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags index_rollover -coverprofile cover-index-rollover.out $(STORAGE_PKGS) $(COLORIZE)"
 
 .PHONY: cover
 cover: nocover

--- a/cmd/ingester/app/builder/.nocover
+++ b/cmd/ingester/app/builder/.nocover
@@ -1,1 +1,0 @@
-FIXME - refactor to avoid direct Kafka dependency. Cf. collector's builder, which is testable

--- a/cmd/ingester/app/builder/empty_test.go
+++ b/cmd/ingester/app/builder/empty_test.go
@@ -1,0 +1,1 @@
+package builder

--- a/cmd/ingester/app/builder/empty_test.go
+++ b/cmd/ingester/app/builder/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package builder

--- a/pkg/cassandra/config/.nocover
+++ b/pkg/cassandra/config/.nocover
@@ -1,1 +1,0 @@
-requires connection to Cassandra

--- a/pkg/cassandra/config/empty_test.go
+++ b/pkg/cassandra/config/empty_test.go
@@ -1,0 +1,1 @@
+package config

--- a/pkg/cassandra/config/empty_test.go
+++ b/pkg/cassandra/config/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config

--- a/pkg/cassandra/gocql/.nocover
+++ b/pkg/cassandra/gocql/.nocover
@@ -1,1 +1,0 @@
-requires connection to Cassandra

--- a/pkg/cassandra/gocql/empty_test.go
+++ b/pkg/cassandra/gocql/empty_test.go
@@ -1,0 +1,1 @@
+package gocql

--- a/pkg/cassandra/gocql/empty_test.go
+++ b/pkg/cassandra/gocql/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gocql

--- a/pkg/es/wrapper/.nocover
+++ b/pkg/es/wrapper/.nocover
@@ -1,1 +1,0 @@
-requires connection to Elasticsearch

--- a/pkg/es/wrapper/empty_test.go
+++ b/pkg/es/wrapper/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package eswrapper

--- a/pkg/es/wrapper/empty_test.go
+++ b/pkg/es/wrapper/empty_test.go
@@ -1,0 +1,1 @@
+package eswrapper

--- a/pkg/kafka/auth/.nocover
+++ b/pkg/kafka/auth/.nocover
@@ -1,1 +1,0 @@
-requires connection to Kafka

--- a/pkg/kafka/auth/empty_test.go
+++ b/pkg/kafka/auth/empty_test.go
@@ -1,0 +1,1 @@
+package auth

--- a/pkg/kafka/auth/empty_test.go
+++ b/pkg/kafka/auth/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package auth

--- a/pkg/kafka/consumer/.nocover
+++ b/pkg/kafka/consumer/.nocover
@@ -1,1 +1,0 @@
-requires connection to Kafka

--- a/pkg/kafka/consumer/empty_test.go
+++ b/pkg/kafka/consumer/empty_test.go
@@ -1,0 +1,1 @@
+package consumer

--- a/pkg/kafka/consumer/empty_test.go
+++ b/pkg/kafka/consumer/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package consumer

--- a/pkg/kafka/producer/.nocover
+++ b/pkg/kafka/producer/.nocover
@@ -1,1 +1,0 @@
-requires connection to Kafka

--- a/pkg/kafka/producer/empty_test.go
+++ b/pkg/kafka/producer/empty_test.go
@@ -1,0 +1,1 @@
+package producer

--- a/pkg/kafka/producer/empty_test.go
+++ b/pkg/kafka/producer/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package producer

--- a/plugin/storage/badger/samplingstore/storage.go
+++ b/plugin/storage/badger/samplingstore/storage.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/dgraph-io/badger/v3"
@@ -84,7 +83,6 @@ func (s *SamplingStore) GetThroughput(start, end time.Time) ([]*model.Throughput
 			item := it.Item()
 			k := item.Key()
 			startTime := k[1:9]
-			fmt.Printf("key=%s\n", k)
 			val, err := item.ValueCopy(val)
 			if err != nil {
 				return err

--- a/plugin/storage/grpc/config/.nocover
+++ b/plugin/storage/grpc/config/.nocover
@@ -1,1 +1,0 @@
-requires gRPC plugin binary

--- a/plugin/storage/grpc/config/empty_test.go
+++ b/plugin/storage/grpc/config/empty_test.go
@@ -1,0 +1,1 @@
+package config

--- a/plugin/storage/grpc/config/empty_test.go
+++ b/plugin/storage/grpc/config/empty_test.go
@@ -1,1 +1,15 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config

--- a/plugin/storage/integration/.nocover
+++ b/plugin/storage/integration/.nocover
@@ -1,1 +1,0 @@
-FIXME - branches for storage test failures are not covered

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -470,7 +470,6 @@ func (s *StorageIntegration) testGetLatestProbability(t *testing.T) {
 }
 
 func (s *StorageIntegration) insertThroughput(t *testing.T) {
-	fmt.Println("Inside the insertThroughput function")
 	throughputs := []*samplemodel.Throughput{
 		{Service: "my-svc", Operation: "op"},
 		{Service: "our-svc", Operation: "op2"},


### PR DESCRIPTION
## Which problem is this PR solving?
- Some of our code is not testable unless we run integration tests, e.g. places that require db connection
- But we don't collect coverage from integration tests
- Resolves #1516
- Resolves #4965

## Description of the changes
- Add coverage generation to storage tests and upload to codecov
- Remove several `.nocover` since their packages are now included in coverage via integration tests anyway. Add corresponding `empty_test.go` to avoid linter error.
- Remove `println` from badger & sampling storage integration
- Change COLORIZE macro to include `| ...` so that it can be overwritten to nothing for faster std output. When output is piped, even to `| cat -`, the buffering prevents incremental test output, so one cannot easily observe test progress

## How was this change tested?
- CI is green
- [Comment below by codecov](https://github.com/jaegertracing/jaeger/pull/4964#issuecomment-1825819949) shows 11 reports (inside expander, Flags table)
- The global code coverage dropped -0.82%, which is not surprising since some previously excluded packages are now counted, but not all the code in them is exercised even in integration tests (e.g. kafka/auth/tls.go). However, we can ramp it up in future PRs. One area that seems particularly neglected is calling Close on the storage from integration tests, which we're not doing.
