### PR TITLE
fix(badger): Add missing SamplingStoreFactory.CreateLock method

### DIFF
--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -53,9 +53,7 @@ var ( // interface comformance checks
 	// TODO badger could implement archive storage
 	// _ storage.ArchiveFactory       = (*Factory)(nil)
 
-	// TODO CreateLock function is missing
-	// Being fixed in https://github.com/jaegertracing/jaeger/pull/4966
-	// _ storage.SamplingStoreFactory = (*Factory)(nil)
+	_ storage.SamplingStoreFactory = (*Factory)(nil)
 )
 
 // Factory implements storage.Factory for Badger backend.

--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/pkg/distributedlock"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/plugin"
 	depStore "github.com/jaegertracing/jaeger/plugin/storage/badger/dependencystore"
@@ -184,6 +185,11 @@ func (f *Factory) CreateDependencyReader() (dependencystore.Reader, error) {
 // CreateSamplingStore implements storage.SamplingStoreFactory
 func (f *Factory) CreateSamplingStore(maxBuckets int) (samplingstore.Store, error) {
 	return badgerSampling.NewSamplingStore(f.store), nil
+}
+
+// CreateLock implements storage.SamplingStoreFactory
+func (f *Factory) CreateLock() (distributedlock.Lock, error) {
+	return &lock{}, nil
 }
 
 // Close Implements io.Closer and closes the underlying storage

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -68,6 +68,10 @@ func TestForCodecov(t *testing.T) {
 	_, err = f.CreateDependencyReader()
 	assert.NoError(t, err)
 
+	lock, err := f.CreateLock()
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
 	// Now, remove the badger directories
 	err = os.RemoveAll(f.tmpDir)
 	assert.NoError(t, err)

--- a/plugin/storage/badger/lock.go
+++ b/plugin/storage/badger/lock.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package badger
 
 import "time"

--- a/plugin/storage/badger/lock.go
+++ b/plugin/storage/badger/lock.go
@@ -1,0 +1,15 @@
+package badger
+
+import "time"
+
+type lock struct{}
+
+// Acquire always returns true for badgerdb as no lock is needed
+func (l *lock) Acquire(resource string, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+// Forfeit always returns true for badgerdb as no lock is needed
+func (l *lock) Forfeit(resource string) (bool, error) {
+	return true, nil
+}

--- a/plugin/storage/badger/lock_test.go
+++ b/plugin/storage/badger/lock_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package badger
 
 import (

--- a/plugin/storage/badger/lock_test.go
+++ b/plugin/storage/badger/lock_test.go
@@ -1,0 +1,22 @@
+package badger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/crossdock/crossdock-go/assert"
+)
+
+func TestAcquire(t *testing.T) {
+	l := &lock{}
+	ok, err := l.Acquire("resource", time.Duration(1))
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestForfeit(t *testing.T) {
+	l := &lock{}
+	ok, err := l.Forfeit("resource")
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -294,7 +294,7 @@ func TestCreateError(t *testing.T) {
 }
 
 func TestAllSamplingStorageTypes(t *testing.T) {
-	assert.Equal(t, AllSamplingStorageTypes(), []string{"cassandra", "memory"})
+	assert.Equal(t, []string{"cassandra", "memory", "badger"}, AllSamplingStorageTypes())
 }
 
 func TestCreateSamplingStoreFactory(t *testing.T) {


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #4963

## Description of the changes
-   Implement missing `CreateLock` method on `SamplingStoreFactory` interface for badger

## How was this change tested?
-  run the Integration and make test command

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
