### PR TITLE
[ci]:Improve Kafka integration test self-sufficiency

### DIFF
--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -31,7 +31,7 @@ jobs:
         go-version: 1.21.x
 
     - name: Run kafka integration tests
-      run: bash scripts/kafka-integration-test.sh
+      run: bash scripts/kafka-integration-test.sh -k
 
     - name: Output Kafka logs
       run: docker logs "${{ job.services.kafka.id }}"
@@ -48,29 +48,3 @@ jobs:
         flags: kafka
         fail_ci_if_error: true
         token: ${{ env.CODECOV_TOKEN }}
-
-    services:
-      zookeeper:
-        image: bitnami/zookeeper
-        ports:
-          - 2181:2181
-        options: >-
-          --health-cmd "echo mntr | nc -w 2 -q 2 localhost 2181"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        env:
-          ALLOW_ANONYMOUS_LOGIN: yes
-      kafka:
-        image: bitnami/kafka:3.6.0
-        ports:
-          - 9092:9092
-        options: >-
-          --health-cmd "kafka-broker-api-versions.sh --version"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        env:
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181

--- a/scripts/kafka-integration-test.sh
+++ b/scripts/kafka-integration-test.sh
@@ -3,9 +3,48 @@
 set -e
 
 export STORAGE=kafka
-while true; do
+
+# Function to start Kafka
+start_kafka() {
+    echo "Starting Kafka..."
+    
+    docker run --name kafka -d \
+    -p 9092:9092 \
+    -e KAFKA_CFG_NODE_ID=0 \
+    -e KAFKA_CFG_PROCESS_ROLES=controller,broker \
+    -e KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@localhost:9093 \
+    -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 \
+    -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 \
+    -e KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
+    -e KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+    -e KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT \
+    bitnami/kafka:3.6
+}
+
+# Check if the -k parameter is provided or not
+if [ "$1" == "-k" ]; then
+    start_kafka
+fi
+
+# Set the timeout in seconds
+timeout=180
+# Set the interval between checks in seconds
+interval=5
+
+# Calculate the end time
+end_time=$((SECONDS + timeout))
+
+while [ $SECONDS -lt $end_time ]; do
     if nc -z localhost 9092; then
         break
     fi
+    sleep $interval
 done
+
+# Check if Kafka is still not available after the timeout
+if ! nc -z localhost 9092; then
+    echo "Timed out waiting for Kafka to start"
+    exit 1
+fi
+
 make storage-integration-test


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4982 

## Description of the changes
- Introduced a -k parameter to the kafka-integration-test.sh script.
- Modified the script to wait for Kafka availability before proceeding.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
