### PR TITLE
Remove custom GOCACHE location

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -26,9 +26,10 @@ jobs:
 
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version: 1.21.x
+        cache-dependency-path: ./go.sum
 
     - name: Run unit tests
       run: make test-ci

--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,8 @@ else
 endif
 GOOS ?= $(shell $(GO) env GOOS)
 GOARCH ?= $(shell $(GO) env GOARCH)
-GOCACHE=$(abspath .gocache)
-GOBUILD=GOCACHE=$(GOCACHE) CGO_ENABLED=0 installsuffix=cgo $(GO) build -trimpath
-GOTEST_QUIET=GOCACHE=$(GOCACHE) $(GO) test $(RACE)
+GOBUILD=CGO_ENABLED=0 installsuffix=cgo $(GO) build -trimpath
+GOTEST_QUIET=$(GO) test $(RACE)
 GOTEST=$(GOTEST_QUIET) -v
 GOFMT=gofmt
 GOFUMPT=gofumpt


### PR DESCRIPTION
## Which problem is this PR solving?
- Even though we're using setup-go v4.1 where caching is supposed to be enabled by default, it does not seem to work as the dependencies are still being downloaded when we run the tests

## Description of the changes
- remove custom GOCACHE
- point to go.sum file

## How was this change tested?
- CI
- the change itself did not seem to help, still seeing lots of "downloading" when running the tests
- needs more investigation, but I suggest we still merge this as an improvement
