### PR TITLE
Allow specifying version for HotROD docker-compose

### DIFF
--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -24,7 +24,9 @@ As of Jaeger v1.42.0 this application was upgraded to use the OpenTelemetry SDK 
 ### Run everything via `docker-compose`
 
 * Download `docker-compose.yml` from https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/docker-compose.yml
-* Run Jaeger backend and HotROD demo with `docker-compose -f path-to-yml-file up`
+* Optional: find the latest Jaeger version (see https://www.jaegertracing.io/download/) and pass it via environment variable `JAEGER_VERSION`. Otherwise `docker compose` will use the `latest` tag, which is fine for the first time you download the images, but once they are in your local registry the `latest` tag is never updated and you may be running stale (and possibly incompatible) verions of Jaeger and the HotROD app.
+* Run Jaeger backend and HotROD demo, e.g.:
+  * `JAEGER_VERSION=1.52 docker-compose -f path-to-yml-file up`
 * Access Jaeger UI at http://localhost:16686 and HotROD app at http://localhost:8080
 * Shutdown / cleanup with `docker-compose -f path-to-yml-file down`
 

--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:${JAEGER_VERSION:-latest}
     ports:
       - "16686:16686"
       - "4318:4318"
@@ -10,7 +10,7 @@ services:
     networks:
       - jaeger-example
   hotrod:
-    image: jaegertracing/example-hotrod:latest
+    image: jaegertracing/example-hotrod:${JAEGER_VERSION:-latest}
     # To run the latest trunk build, find the tag at Docker Hub and use the line below
     # https://hub.docker.com/r/jaegertracing/example-hotrod-snapshot/tags
     #image: jaegertracing/example-hotrod-snapshot:0ab8f2fcb12ff0d10830c1ee3bb52b745522db6c

--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -1,4 +1,8 @@
 version: '3.7'
+
+# To run a specific version of Jaeger, use environment variable, e.g.:
+#     JAEGER_VERSION=1.52 docker compose up
+
 services:
   jaeger:
     image: jaegertracing/all-in-one:${JAEGER_VERSION:-latest}


### PR DESCRIPTION
## Which problem is this PR solving?
- `examples/hotrod/docker-compose.yml` always used `latest` tag, which is not being refreshed by Docker unless you proactively do that. There was no way to override that.

## Description of the changes
- Add `JAEGER_VERSION` environment variable

## How was this change tested?
- Previously my `latest` tags were pointing to stale versions, and the example was not actually working (likely due to earlier changes to introducing OTEL SDK)
- After this change: `$ JAEGER_VERSION=1.52 docker compose up` downloaded new versions and the tracing was working
