### PR TITLE
Add goleak check to packages with empty tests

### DIFF
--- a/cmd/collector/app/processor/empty_test.go
+++ b/cmd/collector/app/processor/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package processor
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/cmd/collector/app/sampling/model/empty_test.go
+++ b/cmd/collector/app/sampling/model/empty_test.go
@@ -14,8 +14,12 @@
 
 package model
 
-// import "testing"
+import (
+	"testing"
 
-// func TestNothing(t *testing.T) {
-// 	// just get the code coverage
-// }
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/cmd/collector/app/sampling/strategystore/empty_test.go
+++ b/cmd/collector/app/sampling/strategystore/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package strategystore
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/cmd/ingester/app/builder/empty_test.go
+++ b/cmd/ingester/app/builder/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package builder
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/cmd/query/app/ui/empty_test.go
+++ b/cmd/query/app/ui/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package ui
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/empty_test.go
+++ b/empty_test.go
@@ -14,9 +14,17 @@
 
 package jaeger
 
-import "testing"
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/model/json/empty_test.go
+++ b/model/json/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package json
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/cassandra/config/empty_test.go
+++ b/pkg/cassandra/config/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package config
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/cassandra/empty_test.go
+++ b/pkg/cassandra/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package cassandra
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/cassandra/gocql/empty_test.go
+++ b/pkg/cassandra/gocql/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package gocql
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/distributedlock/empty_test.go
+++ b/pkg/distributedlock/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package distributedlock
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/es/empty_test.go
+++ b/pkg/es/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package es
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/es/wrapper/empty_test.go
+++ b/pkg/es/wrapper/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package eswrapper
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/kafka/auth/empty_test.go
+++ b/pkg/kafka/auth/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package auth
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/kafka/consumer/empty_test.go
+++ b/pkg/kafka/consumer/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package consumer
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/kafka/producer/empty_test.go
+++ b/pkg/kafka/producer/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package producer
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/memory/config/empty_test.go
+++ b/pkg/memory/config/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package config
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/prometheus/config/empty_test.go
+++ b/pkg/prometheus/config/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package config
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/plugin/empty_test.go
+++ b/plugin/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package plugin
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/plugin/storage/grpc/config/empty_test.go
+++ b/plugin/storage/grpc/config/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package config
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/ports/ports_test.go
+++ b/ports/ports_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
 func TestPortToHostPort(t *testing.T) {
@@ -50,4 +51,8 @@ func TestFormatHostPort(t *testing.T) {
 	assert.Equal(t, ":831", FormatHostPort(":831"))
 	assert.Equal(t, "", FormatHostPort(""))
 	assert.Equal(t, "localhost:42", FormatHostPort("localhost:42"))
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/storage/dependencystore/empty_test.go
+++ b/storage/dependencystore/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package dependencystore
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/storage/empty_test.go
+++ b/storage/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package storage
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/storage/metricsstore/empty_test.go
+++ b/storage/metricsstore/empty_test.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package metricsstore
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/storage/metricsstore/metrics/decorator_test.go
+++ b/storage/metricsstore/metrics/decorator_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	protometrics "github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
@@ -151,4 +152,8 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 	}
 
 	checkExpectedExistingAndNonExistentCounters(t, counters, wantCounts, gauges, wantExistingKeys, wantNonExistentKeys)
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/storage/spanstore/interface_test.go
+++ b/storage/spanstore/interface_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Jaeger Authors.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package samplingstore
+package spanstore
 
 import (
 	"testing"

--- a/storage/spanstore/metrics/package_test.go
+++ b/storage/spanstore/metrics/package_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Jaeger Authors.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package samplingstore
+package metrics
 
 import (
 	"testing"


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5006

## Description of the changes
- Add goleak checks to all packages with empty_test.go as well as ./storage/... (which mostly contains APIs)

## How was this change tested?
- CI
