### PR TITLE
Move Go Tip installation into sub-action

### DIFF
--- a/.github/actions/setup-go-tip/action.yml
+++ b/.github/actions/setup-go-tip/action.yml
@@ -1,0 +1,23 @@
+# Inspired by https://github.com/actions/setup-go/issues/21#issuecomment-997208686
+name: 'Install Go Tip'
+description: 'Install Go Tip toolchain'
+runs:
+  using: "composite"
+  steps:
+    - name: Install Go Tip
+      shell: bash
+      run: |
+        set -euo pipefail
+        tip=$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}')
+        echo "Go Tip version: ${tip}"
+        curl -fsSL https://storage.googleapis.com/go-build-snap/go/linux-amd64/${tip}.tar.gz -o gotip.tar.gz
+        echo "Downloaded bundle:"
+        ls -lah gotip.tar.gz
+        export GOROOT="$HOME/sdk/gotip"
+        mkdir -p $GOROOT
+        tar -C $GOROOT -xzf gotip.tar.gz
+        export PATH="$GOROOT/bin/:$PATH"
+        echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+        echo "PATH=$PATH" >> $GITHUB_ENV
+        echo "Active Go version:"
+        go version

--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -19,16 +19,8 @@ jobs:
 
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-    # From https://github.com/actions/setup-go/issues/21#issuecomment-997208686
-    - name: Install Go tip
-      run: |
-        curl -sL https://storage.googleapis.com/go-build-snap/go/linux-amd64/$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}').tar.gz -o gotip.tar.gz
-        ls -lah gotip.tar.gz
-        mkdir -p ~/sdk/gotip
-        tar -C ~/sdk/gotip -xzf gotip.tar.gz
-        ~/sdk/gotip/bin/go version
-        echo "GOROOT=$HOME/sdk/gotip" >> $GITHUB_ENV
-        echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
+    - name: Install Go Tip
+      uses: ./.github/actions/setup-go-tip
 
     - name: Install tools
       run: make install-test-tools


### PR DESCRIPTION
## Which problem is this PR solving?
- Unit tests on Go Tip sometimes fail because Go Tip fails to install, but the output is non-descriptive, e.g. https://github.com/jaegertracing/jaeger/actions/runs/7263410887/job/19788655227

<img width="497" alt="image" src="https://github.com/jaegertracing/jaeger/assets/3523016/8535776d-eaf6-4b2d-be9d-380d58ac4d37">

## Description of the changes
- Move Go Tip installation into a separate sub-action
- Add some debug logging to see the progress to make it easier to debug in case of failures (right now it's hard to tell which step is actually failing and resulting in the errors above)

## How was this change tested?
- Tested in personal repo: https://github.com/yurishkuro/test-project-3/actions/runs/7264047725/job/19790690846

<img width="756" alt="image" src="https://github.com/jaegertracing/jaeger/assets/3523016/1ac72a21-e127-42b6-9e9b-6f83c110dba7">
