### PR TITLE
ci: add retry logic in the Install Go Tip GitHub Action

### DIFF
--- a/.github/actions/setup-go-tip/action.yml
+++ b/.github/actions/setup-go-tip/action.yml
@@ -15,31 +15,25 @@ runs:
           tip=$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}')
           echo "Go Tip version: ${tip}"
           if curl_output=$(curl -fsSL -w "%{http_code}" -o gotip.tar.gz https://storage.googleapis.com/go-build-snap/go/linux-amd64/${tip}.tar.gz); then
-            http_code=$(tail -n1 <<< "$curl_output")
-            
-            if [[ "$http_code" == "404" ]]; then
-              echo "HTTP 404: File not found"
-            else
-              echo "Downloaded bundle:"
-              ls -lah gotip.tar.gz
-              success=true
-              break
-            fi
+            echo "Downloaded bundle:"
+            ls -lah gotip.tar.gz
+            success=true
+            break
           else
             echo "Failed to download. Retrying in $wait_time seconds..."
             sleep $wait_time
           fi
         done
 
-        if [[ "$success" == true ]]; then
-          export GOROOT="$HOME/sdk/gotip"
-          mkdir -p $GOROOT
-          tar -C $GOROOT -xzf gotip.tar.gz
-          export PATH="$GOROOT/bin/:$PATH"
-          echo "GOROOT=$GOROOT" >> $GITHUB_ENV
-          echo "PATH=$PATH" >> $GITHUB_ENV
-          echo "Active Go version:"
-          go version
-        else
+        if [[ "$success" == false ]]; then
           echo "Failed to download Go Tip after $retries attempts"
+          exit 1
         fi
+        export GOROOT="$HOME/sdk/gotip"
+        mkdir -p $GOROOT
+        tar -C $GOROOT -xzf gotip.tar.gz
+        export PATH="$GOROOT/bin/:$PATH"
+        echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+        echo "PATH=$PATH" >> $GITHUB_ENV
+        echo "Active Go version:"
+        go version

--- a/.github/actions/setup-go-tip/action.yml
+++ b/.github/actions/setup-go-tip/action.yml
@@ -19,16 +19,17 @@ runs:
             ls -lah gotip.tar.gz
             success=true
             break
-          else
-            echo "Failed to download. Retrying in $wait_time seconds..."
-            sleep $wait_time
           fi
+          echo "Failed to download. Retrying in $wait_time seconds..."
+          sleep $wait_time
         done
 
         if [[ "$success" == false ]]; then
           echo "Failed to download Go Tip after $retries attempts"
           exit 1
         fi
+        echo "Downloaded bundle:"
+        ls -lah gotip.tar.gz
         export GOROOT="$HOME/sdk/gotip"
         mkdir -p $GOROOT
         tar -C $GOROOT -xzf gotip.tar.gz

--- a/.github/actions/setup-go-tip/action.yml
+++ b/.github/actions/setup-go-tip/action.yml
@@ -8,16 +8,38 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        tip=$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}')
-        echo "Go Tip version: ${tip}"
-        curl -fsSL https://storage.googleapis.com/go-build-snap/go/linux-amd64/${tip}.tar.gz -o gotip.tar.gz
-        echo "Downloaded bundle:"
-        ls -lah gotip.tar.gz
-        export GOROOT="$HOME/sdk/gotip"
-        mkdir -p $GOROOT
-        tar -C $GOROOT -xzf gotip.tar.gz
-        export PATH="$GOROOT/bin/:$PATH"
-        echo "GOROOT=$GOROOT" >> $GITHUB_ENV
-        echo "PATH=$PATH" >> $GITHUB_ENV
-        echo "Active Go version:"
-        go version
+        retries=10
+        wait_time=30
+        success=false
+        for ((i=1; i<=retries; i++)); do
+          tip=$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}')
+          echo "Go Tip version: ${tip}"
+          if curl_output=$(curl -fsSL -w "%{http_code}" -o gotip.tar.gz https://storage.googleapis.com/go-build-snap/go/linux-amd64/${tip}.tar.gz); then
+            http_code=$(tail -n1 <<< "$curl_output")
+            
+            if [[ "$http_code" == "404" ]]; then
+              echo "HTTP 404: File not found"
+            else
+              echo "Downloaded bundle:"
+              ls -lah gotip.tar.gz
+              success=true
+              break
+            fi
+          else
+            echo "Failed to download. Retrying in $wait_time seconds..."
+            sleep $wait_time
+          fi
+        done
+
+        if [[ "$success" == true ]]; then
+          export GOROOT="$HOME/sdk/gotip"
+          mkdir -p $GOROOT
+          tar -C $GOROOT -xzf gotip.tar.gz
+          export PATH="$GOROOT/bin/:$PATH"
+          echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          echo "Active Go version:"
+          go version
+        else
+          echo "Failed to download Go Tip after $retries attempts"
+        fi

--- a/.github/actions/setup-go-tip/action.yml
+++ b/.github/actions/setup-go-tip/action.yml
@@ -16,8 +16,6 @@ runs:
           echo "Go Tip version: ${tip}"
           url="https://storage.googleapis.com/go-build-snap/go/linux-amd64/${tip}.tar.gz"
           if curl -fsSL -o gotip.tar.gz "$url"; then
-            echo "Downloaded bundle:"
-            ls -lah gotip.tar.gz
             success=true
             break
           fi

--- a/.github/actions/setup-go-tip/action.yml
+++ b/.github/actions/setup-go-tip/action.yml
@@ -8,12 +8,12 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        tip=$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}')
+        echo "Go Tip version: ${tip}"
         retries=10
         wait_time=30
         success=false
         for ((i=1; i<=retries; i++)); do
-          tip=$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}')
-          echo "Go Tip version: ${tip}"
           url="https://storage.googleapis.com/go-build-snap/go/linux-amd64/${tip}.tar.gz"
           if curl -fsSL -o gotip.tar.gz "$url"; then
             success=true


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Fixes #5021 

## Description of the changes
- added retry logic in Go Tip Github Action 

## How was this change tested?
- in below case it ran successfully
- but the logic was not used because the `curl` command did not any return code 
- https://github.com/akagami-harsh/jaeger/actions/runs/7266233916/job/19797565337

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
