### PR TITLE
Upgrade golangci-lint to v1.55.2 and fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters:
     # Check declaration order of types, consts, vars and funcs.
     - decorder
 
-    # Checks if package imports are in a list of acceptable packages.
+    # Checks if package imports are in a list of acceptable packages (see cfg below).
     - depguard
 
     # Check for two durations multiplied together.
@@ -90,12 +90,26 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      - io/ioutil
-    packages-with-error-message:
-      - io/ioutil: "Use os or io instead of io/ioutil"
+    rules:
+      disallowed-deps:
+        deny:
+          - pkg: go.uber.org/atomic
+            desc: "Use 'sync/atomic' instead of go.uber.org/atomic"
+          - pkg: io/ioutil
+            desc: "Use os or io instead of io/ioutil"
+          - pkg: github.com/hashicorp/go-multierror
+            desc: "Use errors.Join instead of github.com/hashicorp/go-multierror"
+          - pkg: go.uber.org/multierr
+            desc: "Use errors.Join instead of github.com/hashicorp/go-multierror"
+      # crossdock-go provides assert/require similar to stretchr/testify
+      # but we never want to use them outside of the crossdock tests.
+      disallow-crossdock:
+        deny:
+          - pkg: github.com/crossdock/crossdock-go
+            desc: "Do not refer to crossdock from other packages"
+        files:
+          - "!**/crossdock/**"
+
   goimports:
     local-prefixes: github.com/jaegertracing/jaeger
   gosec:

--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,7 @@ draft-release:
 
 .PHONY: install-test-tools
 install-test-tools:
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 	$(GO) install mvdan.cc/gofumpt@latest
 
 .PHONY: install-build-tools

--- a/cmd/agent/app/reporter/client_metrics.go
+++ b/cmd/agent/app/reporter/client_metrics.go
@@ -17,9 +17,9 @@ package reporter
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -75,7 +75,7 @@ type ClientMetricsReporter struct {
 	params        ClientMetricsReporterParams
 	clientMetrics *clientMetrics
 	shutdown      chan struct{}
-	closed        *atomic.Bool
+	closed        atomic.Bool
 
 	// map from client-uuid to *lastReceivedClientStats
 	lastReceivedClientStats sync.Map
@@ -104,7 +104,6 @@ func WrapWithClientMetrics(params ClientMetricsReporterParams) *ClientMetricsRep
 		params:        params,
 		clientMetrics: cm,
 		shutdown:      make(chan struct{}),
-		closed:        atomic.NewBool(false),
 	}
 	go r.expireClientMetricsLoop()
 	return r

--- a/cmd/collector/app/root_span_handler_test.go
+++ b/cmd/collector/app/root_span_handler_test.go
@@ -15,10 +15,10 @@
 package app
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -30,11 +30,11 @@ type mockAggregator struct {
 }
 
 func (t *mockAggregator) RecordThroughput(service, operation string, samplerType model.SamplerType, probability float64) {
-	t.callCount.Inc()
+	t.callCount.Add(1)
 }
 func (t *mockAggregator) Start() {}
 func (t *mockAggregator) Close() error {
-	t.closeCount.Inc()
+	t.closeCount.Add(1)
 	return nil
 }
 

--- a/cmd/es-rollover/app/actions_test.go
+++ b/cmd/es-rollover/app/actions_test.go
@@ -20,9 +20,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/crossdock/crossdock-go/assert"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 

--- a/cmd/es-rollover/app/index_options_test.go
+++ b/cmd/es-rollover/app/index_options_test.go
@@ -17,7 +17,7 @@ package app
 import (
 	"testing"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRolloverIndices(t *testing.T) {

--- a/cmd/es-rollover/app/init/action_test.go
+++ b/cmd/es-rollover/app/init/action_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"

--- a/cmd/es-rollover/app/lookback/time_reference_test.go
+++ b/cmd/es-rollover/app/lookback/time_reference_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTimeReference(t *testing.T) {

--- a/cmd/es-rollover/app/rollover/action_test.go
+++ b/cmd/es-rollover/app/rollover/action_test.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
 	"github.com/jaegertracing/jaeger/pkg/es/client"

--- a/cmd/internal/flags/service_test.go
+++ b/cmd/internal/flags/service_test.go
@@ -17,12 +17,12 @@ import (
 	"flag"
 	"os"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
@@ -86,7 +86,7 @@ func TestStartErrors(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			stopped := atomic.NewBool(false)
+			var stopped atomic.Bool
 			shutdown := func() {
 				stopped.Store(true)
 			}

--- a/pkg/es/filter/alias_test.go
+++ b/pkg/es/filter/alias_test.go
@@ -17,7 +17,7 @@ package filter
 import (
 	"testing"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/jaegertracing/jaeger/pkg/es/client"
 )

--- a/pkg/es/filter/date_test.go
+++ b/pkg/es/filter/date_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/jaegertracing/jaeger/pkg/es/client"
 )

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	uatomic "go.uber.org/atomic"
 	"go.uber.org/goleak"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -280,7 +279,8 @@ func TestResizeOldQueueIsDrained(t *testing.T) {
 	readyToConsume.Add(1)
 	expected.Add(5) // we expect 5 items to be processed
 
-	consumed := uatomic.NewInt32(5)
+	var consumed atomic.Int32
+	consumed.Store(5)
 
 	first := true
 	q.StartConsumers(1, func(item interface{}) {
@@ -292,7 +292,7 @@ func TestResizeOldQueueIsDrained(t *testing.T) {
 
 		readyToConsume.Wait()
 
-		if consumed.Sub(1) >= 0 {
+		if consumed.Add(-1) >= 0 {
 			// we mark only the first 5 items as done
 			// we *might* get one item more in the queue given the right conditions
 			// but this small difference is OK -- making sure we are processing *exactly* N items

--- a/plugin/sampling/leaderelection/leader_election.go
+++ b/plugin/sampling/leaderelection/leader_election.go
@@ -17,9 +17,9 @@ package leaderelection
 import (
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	dl "github.com/jaegertracing/jaeger/pkg/distributedlock"
@@ -41,7 +41,7 @@ type ElectionParticipant interface {
 type DistributedElectionParticipant struct {
 	ElectionParticipantOptions
 	lock         dl.Lock
-	isLeader     *atomic.Bool
+	isLeader     atomic.Bool
 	resourceName string
 	closeChan    chan struct{}
 	wg           sync.WaitGroup
@@ -60,7 +60,6 @@ func NewElectionParticipant(lock dl.Lock, resourceName string, options ElectionP
 		ElectionParticipantOptions: options,
 		lock:                       lock,
 		resourceName:               resourceName,
-		isLeader:                   atomic.NewBool(false),
 		closeChan:                  make(chan struct{}),
 	}
 }

--- a/plugin/sampling/leaderelection/leader_election_test.go
+++ b/plugin/sampling/leaderelection/leader_election_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 
 	lmocks "github.com/jaegertracing/jaeger/pkg/distributedlock/mocks"
@@ -67,7 +66,6 @@ func TestAcquireLock(t *testing.T) {
 				},
 				lock:         mockLock,
 				resourceName: "sampling_lock",
-				isLeader:     atomic.NewBool(false),
 			}
 
 			p.setLeader(test.isLeader)
@@ -78,7 +76,7 @@ func TestAcquireLock(t *testing.T) {
 	}
 }
 
-func TestRunAcquireLockLoop_followerOnly(t *testing.T) {
+func TestRunAcquireLockLoopFollowerOnly(t *testing.T) {
 	logger, logBuffer := testutils.NewLogger()
 	mockLock := &lmocks.Lock{}
 	mockLock.On("Acquire", "sampling_lock", time.Duration(5*time.Millisecond)).Return(false, errTestLock)

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -395,7 +395,10 @@ func TestAutoUpdateStrategyWithURL(t *testing.T) {
 	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
 
 	// verify that reloading in no-op
-	value := store.reloadSamplingStrategy(store.samplingStrategyLoader(mockServer.URL), *mockStrategy.Load())
+	value := store.reloadSamplingStrategy(
+		store.samplingStrategyLoader(mockServer.URL),
+		*mockStrategy.Load(),
+	)
 	assert.Equal(t, *mockStrategy.Load(), value)
 
 	// update original strategies with new probability of 0.9

--- a/plugin/storage/badger/lock_test.go
+++ b/plugin/storage/badger/lock_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAcquire(t *testing.T) {

--- a/plugin/storage/grpc/shared/streaming_writer.go
+++ b/plugin/storage/grpc/shared/streaming_writer.go
@@ -18,8 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
-	"go.uber.org/atomic"
+	"sync/atomic"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
@@ -36,13 +35,12 @@ const (
 type streamingSpanWriter struct {
 	client     storage_v1.StreamingSpanWriterPluginClient
 	streamPool chan storage_v1.StreamingSpanWriterPlugin_WriteSpanStreamClient
-	closed     *atomic.Bool
+	closed     atomic.Bool
 }
 
 func newStreamingSpanWriter(client storage_v1.StreamingSpanWriterPluginClient) *streamingSpanWriter {
 	s := &streamingSpanWriter{
 		client:     client,
-		closed:     atomic.NewBool(false),
 		streamPool: make(chan storage_v1.StreamingSpanWriterPlugin_WriteSpanStreamClient, defaultMaxPoolSize),
 	}
 	return s

--- a/plugin/storage/memory/lock_test.go
+++ b/plugin/storage/memory/lock_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAcquire(t *testing.T) {

--- a/plugin/storage/memory/sampling_test.go
+++ b/plugin/storage/memory/sampling_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
 )


### PR DESCRIPTION
## Description of the changes
- Upgrade linter version
- Update configuration of depguard
  - Disable uber-go/atomic and crossdock as deps
- Replace invalid crossdock imports with stretchr/testify
- Replace uber-go/atomic usage with sync/atomic
  - in most cases pointers to atomics are not necessary, and likewise initialization to zero values
- Fix other test and linter errors revealed by new linter
