### PR TITLE
Enable testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,9 @@ linters:
     # Finds sending HTTP request without context.Context.
     - noctx
 
+    # Checks usage of github.com/stretchr/testify.
+    - testifylint
+
     # TODO consider adding more linters, cf. https://olegk.dev/go-linters-configuration-the-right-version
 
 linters-settings:
@@ -133,6 +136,21 @@ linters-settings:
       - fieldalignment
       # Disable shadow
       - shadow
+  testifylint:
+    disable:
+      - bool-compare
+      - compares
+      - float-compare
+      - go-require
+      - require-error
+    enable:
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - len
+      - suite-dont-use-pkg
+      - suite-extra-assert-call
 
 run:
   go: "1.20"

--- a/cmd/agent/app/customtransport/buffered_read_transport_test.go
+++ b/cmd/agent/app/customtransport/buffered_read_transport_test.go
@@ -29,12 +29,12 @@ func TestTBufferedReadTransport(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte("testString"))
 	trans, err := NewTBufferedReadTransport(buffer)
 	require.NotNil(t, trans)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(10), trans.RemainingBytes())
 
 	firstRead := make([]byte, 4)
 	n, err := trans.Read(firstRead)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 4, n)
 	require.Equal(t, []byte("test"), firstRead)
 	require.Equal(t, uint64(6), trans.RemainingBytes())
@@ -52,20 +52,20 @@ func TestTBufferedReadTransportEmptyFunctions(t *testing.T) {
 	byteArr := make([]byte, 1)
 	trans, err := NewTBufferedReadTransport(bytes.NewBuffer(byteArr))
 	require.NotNil(t, trans)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = trans.Open()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = trans.Close()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = trans.Flush(context.Background())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	n, err := trans.Write(byteArr)
 	require.Equal(t, 1, n)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	isOpen := trans.IsOpen()
 	require.True(t, isOpen)

--- a/cmd/agent/app/flags_test.go
+++ b/cmd/agent/app/flags_test.go
@@ -44,7 +44,7 @@ func TestBindFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	b.InitFromViper(v)
-	assert.Equal(t, 3, len(b.Processors))
+	assert.Len(t, b.Processors, 3)
 	assert.Equal(t, ":8080", b.HTTPServer.HostPort)
 	assert.Equal(t, ":1111", b.Processors[2].Server.HostPort)
 	assert.Equal(t, 4242, b.Processors[2].Server.MaxPacketSize)

--- a/cmd/agent/app/reporter/flags_test.go
+++ b/cmd/agent/app/reporter/flags_test.go
@@ -44,7 +44,7 @@ func TestBindFlags_NoJaegerTags(t *testing.T) {
 	b := &Options{}
 	b.InitFromViper(v, zap.NewNop())
 	assert.Equal(t, Type("grpc"), b.ReporterType)
-	assert.Len(t, b.AgentTags, 0)
+	assert.Empty(t, b.AgentTags)
 }
 
 func TestBindFlags(t *testing.T) {

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -220,7 +220,7 @@ func TestProxyBuilder(t *testing.T) {
 				assert.NotNil(t, proxy.GetReporter())
 				assert.NotNil(t, proxy.GetManager())
 
-				assert.Nil(t, proxy.Close())
+				assert.NoError(t, proxy.Close())
 				assert.EqualError(t, proxy.Close(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
 			}
 		})
@@ -377,7 +377,7 @@ func TestProxyClientTLS(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.Nil(t, proxy.Close())
+			require.NoError(t, proxy.Close())
 		})
 	}
 }

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -68,7 +68,7 @@ func TestMultipleCollectors(t *testing.T) {
 	assert.True(t, len(g) > 0)
 	assert.True(t, len(c) > 0)
 	assert.Equal(t, true, bothServers)
-	require.Nil(t, proxy.Close())
+	require.NoError(t, proxy.Close())
 }
 
 func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server), opts ...grpc.ServerOption) (*grpc.Server, net.Addr) {

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -90,7 +90,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 		if test.err != "" {
 			assert.EqualError(t, err, test.err)
 		} else {
-			assert.Equal(t, 1, len(handler.requests))
+			assert.Len(t, handler.requests, 1)
 			assert.Equal(t, test.expected, handler.requests[0].GetBatch())
 		}
 	}
@@ -124,7 +124,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 		if test.err != "" {
 			assert.EqualError(t, err, test.err)
 		} else {
-			assert.Equal(t, 1, len(handler.requests))
+			assert.Len(t, handler.requests, 1)
 			assert.Equal(t, test.expected, handler.requests[0].GetBatch())
 		}
 	}

--- a/cmd/agent/app/servers/tbuffered_server_test.go
+++ b/cmd/agent/app/servers/tbuffered_server_test.go
@@ -61,7 +61,7 @@ func TestTBufferedServerSendReceive(t *testing.T) {
 
 		select {
 		case readBuf := <-server.DataChan():
-			assert.NotEqual(t, 0, len(readBuf.GetBytes()))
+			assert.NotEmpty(t, readBuf.GetBytes())
 
 			inMemReporter := testutils.NewInMemoryReporter()
 			protoFact := thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{})

--- a/cmd/anonymizer/app/anonymizer/anonymizer_test.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer_test.go
@@ -153,7 +153,7 @@ func TestAnonymizer_Hash(t *testing.T) {
 	data := "foobar"
 	expected := "340d8765a4dda9c2"
 	actual := hash(data)
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestAnonymizer_AnonymizeSpan_AllTrue(t *testing.T) {
@@ -170,9 +170,9 @@ func TestAnonymizer_AnonymizeSpan_AllTrue(t *testing.T) {
 		},
 	}
 	_ = anonymizer.AnonymizeSpan(span1)
-	assert.Equal(t, 3, len(span1.Tags))
-	assert.Equal(t, 1, len(span1.Logs))
-	assert.Equal(t, 3, len(span1.Process.Tags))
+	assert.Len(t, span1.Tags, 3)
+	assert.Len(t, span1.Logs, 1)
+	assert.Len(t, span1.Process.Tags, 3)
 }
 
 func TestAnonymizer_AnonymizeSpan_AllFalse(t *testing.T) {
@@ -189,9 +189,9 @@ func TestAnonymizer_AnonymizeSpan_AllFalse(t *testing.T) {
 		},
 	}
 	_ = anonymizer.AnonymizeSpan(span2)
-	assert.Equal(t, 2, len(span2.Tags))
-	assert.Equal(t, 0, len(span2.Logs))
-	assert.Equal(t, 0, len(span2.Process.Tags))
+	assert.Len(t, span2.Tags, 2)
+	assert.Empty(t, span2.Logs)
+	assert.Empty(t, span2.Process.Tags)
 }
 
 func TestAnonymizer_MapString_Present(t *testing.T) {

--- a/cmd/collector/app/handler/http_thrift_handler_test.go
+++ b/cmd/collector/app/handler/http_thrift_handler_test.go
@@ -127,7 +127,7 @@ func TestViaClient(t *testing.T) {
 		break
 	}
 
-	assert.Equal(t, 1, len(handler.jaegerBatchesHandler.(*mockJaegerHandler).getBatches()))
+	assert.Len(t, handler.jaegerBatchesHandler.(*mockJaegerHandler).getBatches(), 1)
 }
 
 func TestBadBody(t *testing.T) {

--- a/cmd/collector/app/handler/otlp_receiver_test.go
+++ b/cmd/collector/app/handler/otlp_receiver_test.go
@@ -176,20 +176,20 @@ func TestApplyOTLPGRPCServerSettings(t *testing.T) {
 	}
 	applyGRPCSettings(otlpReceiverConfig.GRPC, grpcOpts)
 	out := otlpReceiverConfig.GRPC
-	assert.Equal(t, out.NetAddr.Endpoint, ":54321")
-	assert.EqualValues(t, out.MaxRecvMsgSizeMiB, 42)
+	assert.Equal(t, ":54321", out.NetAddr.Endpoint)
+	assert.EqualValues(t, 42, out.MaxRecvMsgSizeMiB)
 	require.NotNil(t, out.Keepalive)
 	require.NotNil(t, out.Keepalive.ServerParameters)
-	assert.Equal(t, out.Keepalive.ServerParameters.MaxConnectionAge, 33*time.Second)
-	assert.Equal(t, out.Keepalive.ServerParameters.MaxConnectionAgeGrace, 37*time.Second)
+	assert.Equal(t, 33*time.Second, out.Keepalive.ServerParameters.MaxConnectionAge)
+	assert.Equal(t, 37*time.Second, out.Keepalive.ServerParameters.MaxConnectionAgeGrace)
 	require.NotNil(t, out.TLSSetting)
-	assert.Equal(t, out.TLSSetting.CAFile, "ca")
-	assert.Equal(t, out.TLSSetting.CertFile, "cert")
-	assert.Equal(t, out.TLSSetting.KeyFile, "key")
-	assert.Equal(t, out.TLSSetting.ClientCAFile, "clientca")
-	assert.Equal(t, out.TLSSetting.MinVersion, "1.1")
-	assert.Equal(t, out.TLSSetting.MaxVersion, "1.3")
-	assert.Equal(t, out.TLSSetting.ReloadInterval, 24*time.Hour)
+	assert.Equal(t, "ca", out.TLSSetting.CAFile)
+	assert.Equal(t, "cert", out.TLSSetting.CertFile)
+	assert.Equal(t, "key", out.TLSSetting.KeyFile)
+	assert.Equal(t, "clientca", out.TLSSetting.ClientCAFile)
+	assert.Equal(t, "1.1", out.TLSSetting.MinVersion)
+	assert.Equal(t, "1.3", out.TLSSetting.MaxVersion)
+	assert.Equal(t, 24*time.Hour, out.TLSSetting.ReloadInterval)
 }
 
 func TestApplyOTLPHTTPServerSettings(t *testing.T) {
@@ -218,15 +218,15 @@ func TestApplyOTLPHTTPServerSettings(t *testing.T) {
 
 	out := otlpReceiverConfig.HTTP
 
-	assert.Equal(t, out.Endpoint, ":12345")
+	assert.Equal(t, ":12345", out.Endpoint)
 	require.NotNil(t, out.TLSSetting)
-	assert.Equal(t, out.TLSSetting.CAFile, "ca")
-	assert.Equal(t, out.TLSSetting.CertFile, "cert")
-	assert.Equal(t, out.TLSSetting.KeyFile, "key")
-	assert.Equal(t, out.TLSSetting.ClientCAFile, "clientca")
-	assert.Equal(t, out.TLSSetting.MinVersion, "1.1")
-	assert.Equal(t, out.TLSSetting.MaxVersion, "1.3")
-	assert.Equal(t, out.TLSSetting.ReloadInterval, 24*time.Hour)
-	assert.Equal(t, out.CORS.AllowedHeaders, []string{"Content-Type", "Accept", "X-Requested-With"})
-	assert.Equal(t, out.CORS.AllowedOrigins, []string{"http://example.domain.com", "http://*.domain.com"})
+	assert.Equal(t, "ca", out.TLSSetting.CAFile)
+	assert.Equal(t, "cert", out.TLSSetting.CertFile)
+	assert.Equal(t, "key", out.TLSSetting.KeyFile)
+	assert.Equal(t, "clientca", out.TLSSetting.ClientCAFile)
+	assert.Equal(t, "1.1", out.TLSSetting.MinVersion)
+	assert.Equal(t, "1.3", out.TLSSetting.MaxVersion)
+	assert.Equal(t, 24*time.Hour, out.TLSSetting.ReloadInterval)
+	assert.Equal(t, []string{"Content-Type", "Accept", "X-Requested-With"}, out.CORS.AllowedHeaders)
+	assert.Equal(t, []string{"http://example.domain.com", "http://*.domain.com"}, out.CORS.AllowedOrigins)
 }

--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
@@ -54,7 +54,7 @@ func TestSpanDurationSanitizer(t *testing.T) {
 	span = &zipkincore.Span{Duration: &positiveDuration}
 	actual = sanitizer.Sanitize(span)
 	assert.Equal(t, positiveDuration, *actual.Duration)
-	assert.Len(t, actual.BinaryAnnotations, 0)
+	assert.Empty(t, actual.BinaryAnnotations)
 
 	sanitizer = NewSpanDurationSanitizer()
 	nilDurationSpan := &zipkincore.Span{}
@@ -110,7 +110,7 @@ func TestSpanParentIDSanitizer(t *testing.T) {
 				assert.Equal(t, zeroParentIDTag, string(actual.BinaryAnnotations[0].Key))
 			}
 		} else {
-			assert.Len(t, actual.BinaryAnnotations, 0)
+			assert.Empty(t, actual.BinaryAnnotations)
 		}
 	}
 }
@@ -159,12 +159,12 @@ func TestSpanErrorSanitizer(t *testing.T) {
 			assert.Equal(t, zipkincore.AnnotationType_BOOL, sanitized.BinaryAnnotations[0].AnnotationType)
 
 			if test.addErrMsgAnno {
-				assert.Equal(t, 2, len(sanitized.BinaryAnnotations))
+				assert.Len(t, sanitized.BinaryAnnotations, 2)
 				assert.Equal(t, "error.message", sanitized.BinaryAnnotations[1].Key)
 				assert.Equal(t, "message", string(sanitized.BinaryAnnotations[1].Value))
 				assert.Equal(t, zipkincore.AnnotationType_STRING, sanitized.BinaryAnnotations[1].AnnotationType)
 			} else {
-				assert.Equal(t, 1, len(sanitized.BinaryAnnotations))
+				assert.Len(t, sanitized.BinaryAnnotations, 1)
 			}
 		}
 	}

--- a/cmd/collector/app/server/grpc_test.go
+++ b/cmd/collector/app/server/grpc_test.go
@@ -61,7 +61,7 @@ func TestFailServe(t *testing.T) {
 		SamplingStore: &mockSamplingStore{},
 		Logger:        logger,
 		OnError: func(e error) {
-			assert.Equal(t, 1, len(logs.All()))
+			assert.Len(t, logs.All(), 1)
 			assert.Equal(t, "Could not launch gRPC service", logs.All()[0].Message)
 			wg.Done()
 		},

--- a/cmd/collector/app/server/http_test.go
+++ b/cmd/collector/app/server/http_test.go
@@ -63,7 +63,7 @@ func TestCreateTLSHTTPServerError(t *testing.T) {
 		TLSConfig:   tlsCfg,
 	}
 	_, err := StartHTTPServer(params)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestSpanCollectorHTTP(t *testing.T) {
@@ -224,7 +224,7 @@ func TestSpanCollectorHTTPS(t *testing.T) {
 			}
 
 			if clientClose != nil {
-				require.Nil(t, clientClose())
+				require.NoError(t, clientClose())
 			}
 
 			client := &http.Client{

--- a/cmd/collector/app/server/zipkin_test.go
+++ b/cmd/collector/app/server/zipkin_test.go
@@ -227,7 +227,7 @@ func TestSpanCollectorZipkinTLS(t *testing.T) {
 				require.Error(t, clientError)
 			} else {
 				require.NoError(t, clientError)
-				require.Nil(t, conn.Close())
+				require.NoError(t, conn.Close())
 			}
 
 			client := &http.Client{

--- a/cmd/collector/app/zipkin/zipkindeser/json_test.go
+++ b/cmd/collector/app/zipkin/zipkindeser/json_test.go
@@ -137,7 +137,7 @@ func TestUnmarshalSpan(t *testing.T) {
 	spans, err := decode([]byte(spanJSON))
 	require.NoError(t, err)
 	assert.NotNil(t, spans)
-	assert.Equal(t, 1, len(spans))
+	assert.Len(t, spans, 1)
 	assert.Equal(t, "bar", spans[0].Name)
 	assert.Equal(t, false, spans[0].Debug)
 	assert.Equal(t, "1234567891234567", spans[0].ParentID)
@@ -145,15 +145,15 @@ func TestUnmarshalSpan(t *testing.T) {
 	assert.Equal(t, "1234567891234567", spans[0].ID)
 	assert.Equal(t, int64(15145), *spans[0].Duration)
 	assert.Equal(t, int64(156), *spans[0].Timestamp)
-	assert.Equal(t, 1, len(spans[0].Annotations))
-	assert.Equal(t, 1, len(spans[0].BinaryAnnotations))
+	assert.Len(t, spans[0].Annotations, 1)
+	assert.Len(t, spans[0].BinaryAnnotations, 1)
 
 	spans, err = decode([]byte(m.CreateSpan("bar", "1234567891234567", "1234567891234567", "1234567891234567",
 		156, 15145, false, "", "")))
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(spans))
-	assert.Equal(t, 0, len(spans[0].Annotations))
-	assert.Equal(t, 0, len(spans[0].BinaryAnnotations))
+	assert.Len(t, spans, 1)
+	assert.Empty(t, spans[0].Annotations)
+	assert.Empty(t, spans[0].BinaryAnnotations)
 }
 
 func TestIncorrectSpanIds(t *testing.T) {

--- a/cmd/collector/app/zipkin/zipkindeser/jsonv2_test.go
+++ b/cmd/collector/app/zipkin/zipkindeser/jsonv2_test.go
@@ -33,7 +33,7 @@ func TestFixtures(t *testing.T) {
 	loadJSON(t, "fixtures/zipkin_01.json", &spans)
 	tSpans, err := SpansV2ToThrift(spans)
 	require.NoError(t, err)
-	assert.Equal(t, len(tSpans), 1)
+	assert.Len(t, tSpans, 1)
 	var pid int64 = 1
 	var ts int64 = 1
 	var d int64 = 10
@@ -60,7 +60,7 @@ func TestLCFromLocalEndpoint(t *testing.T) {
 	loadJSON(t, "fixtures/zipkin_02.json", &spans)
 	tSpans, err := SpansV2ToThrift(spans)
 	require.NoError(t, err)
-	assert.Equal(t, len(tSpans), 1)
+	assert.Len(t, tSpans, 1)
 	var ts int64 = 1
 	var d int64 = 10
 	tSpan := &zipkincore.Span{
@@ -80,7 +80,7 @@ func TestMissingKafkaEndpoint(t *testing.T) {
 	loadJSON(t, "fixtures/zipkin_03.json", &spans)
 	tSpans, err := SpansV2ToThrift(spans)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(tSpans))
+	assert.Len(t, tSpans, 1)
 	var ts int64 = 1597704629675602
 	var d int64 = 9550570
 	var parentId int64 = 0xc26551047c72d19
@@ -138,7 +138,7 @@ func TestKindToThrift(t *testing.T) {
 	}
 	for _, test := range tests {
 		banns := kindToThrift(test.ts, test.d, test.kind, nil)
-		assert.Equal(t, banns, test.expected)
+		assert.Equal(t, test.expected, banns)
 	}
 }
 
@@ -156,7 +156,7 @@ func TestRemoteEndpToThrift(t *testing.T) {
 	for _, test := range tests {
 		banns, err := remoteEndpToThrift(nil, test.kind)
 		require.NoError(t, err)
-		assert.Equal(t, banns, test.expected)
+		assert.Equal(t, test.expected, banns)
 	}
 }
 
@@ -174,7 +174,7 @@ func TestErrIds(t *testing.T) {
 		tSpan, err := spanV2ToThrift(&test.span)
 		require.Error(t, err)
 		require.Nil(t, tSpan)
-		assert.Equal(t, err.Error(), "strconv.ParseUint: parsing \"z\": invalid syntax")
+		assert.Equal(t, "strconv.ParseUint: parsing \"z\": invalid syntax", err.Error())
 	}
 }
 
@@ -191,7 +191,7 @@ func TestErrEndpoints(t *testing.T) {
 		tSpan, err := spanV2ToThrift(&test.span)
 		require.Error(t, err)
 		require.Nil(t, tSpan)
-		assert.Equal(t, err.Error(), "wrong ipv4")
+		assert.Equal(t, "wrong ipv4", err.Error())
 	}
 }
 
@@ -200,7 +200,7 @@ func TestErrSpans(t *testing.T) {
 	tSpans, err := SpansV2ToThrift(models.ListOfSpans{&models.Span{ID: &id}})
 	require.Error(t, err)
 	require.Nil(t, tSpans)
-	assert.Equal(t, err.Error(), "strconv.ParseUint: parsing \"z\": invalid syntax")
+	assert.Equal(t, "strconv.ParseUint: parsing \"z\": invalid syntax", err.Error())
 }
 
 func loadJSON(t *testing.T, fileName string, i interface{}) {

--- a/cmd/collector/app/zipkin/zipkindeser/protov2_test.go
+++ b/cmd/collector/app/zipkin/zipkindeser/protov2_test.go
@@ -32,7 +32,7 @@ func TestProtoSpanFixtures(t *testing.T) {
 	loadJSON(t, "fixtures/zipkin_proto_01.json", &spans)
 	tSpans, err := ProtoSpansV2ToThrift(&spans)
 	require.NoError(t, err)
-	assert.Equal(t, len(tSpans), 1)
+	assert.Len(t, tSpans, 1)
 	var pid int64 = 1
 	var ts int64 = 1
 	var d int64 = 10
@@ -59,7 +59,7 @@ func TestLCFromProtoSpanLocalEndpoint(t *testing.T) {
 	loadProto(t, "fixtures/zipkin_proto_02.json", &spans)
 	tSpans, err := ProtoSpansV2ToThrift(&spans)
 	require.NoError(t, err)
-	assert.Equal(t, len(tSpans), 1)
+	assert.Len(t, tSpans, 1)
 	var ts int64 = 1
 	var d int64 = 10
 	tSpan := &zipkincore.Span{
@@ -134,7 +134,7 @@ func TestProtoKindToThrift(t *testing.T) {
 	}
 	for _, test := range tests {
 		banns := protoKindToThrift(test.ts, test.d, test.kind, nil)
-		assert.Equal(t, banns, test.expected)
+		assert.Equal(t, test.expected, banns)
 	}
 }
 

--- a/cmd/ingester/app/consumer/offset/concurrent_list_test.go
+++ b/cmd/ingester/app/consumer/offset/concurrent_list_test.go
@@ -92,12 +92,12 @@ func TestMultipleInsertsAndResets(t *testing.T) {
 	}
 	l.insert(50)
 
-	assert.Equal(t, 101, len(l.offsets))
+	assert.Len(t, l.offsets, 101)
 	assert.Equal(t, int64(50), l.offsets[100])
 
 	r := l.setToHighestContiguous()
 	assert.Equal(t, int64(50), r)
-	assert.Equal(t, 101, len(l.offsets))
+	assert.Len(t, l.offsets, 101)
 
 	for i := 51; i < 99; i++ {
 		l.insert(int64(i))
@@ -105,7 +105,7 @@ func TestMultipleInsertsAndResets(t *testing.T) {
 
 	r = l.setToHighestContiguous()
 	assert.Equal(t, int64(98), r)
-	assert.Equal(t, 101, len(l.offsets))
+	assert.Len(t, l.offsets, 101)
 }
 
 // Heaps algorithm as per https://stackoverflow.com/questions/30226438/generate-all-permutations-in-go

--- a/cmd/ingester/app/processor/span_processor_test.go
+++ b/cmd/ingester/app/processor/span_processor_test.go
@@ -56,7 +56,7 @@ func TestSpanProcessor_Process(t *testing.T) {
 			assert.NotNil(t, span.Process, "sanitizer must fix Process=nil data issue")
 		})
 
-	assert.Nil(t, processor.Process(message))
+	assert.NoError(t, processor.Process(message))
 
 	message.AssertExpectations(t)
 	mockWriter.AssertExpectations(t)

--- a/cmd/internal/flags/admin_test.go
+++ b/cmd/internal/flags/admin_test.go
@@ -151,7 +151,7 @@ func TestAdminServerTLS(t *testing.T) {
 			dialer := &net.Dialer{Timeout: 2 * time.Second}
 			conn, clientError := tls.DialWithDialer(dialer, "tcp", fmt.Sprintf("localhost:%d", ports.CollectorAdminHTTP), clientTLSCfg)
 			require.NoError(t, clientError)
-			require.Nil(t, conn.Close())
+			require.NoError(t, conn.Close())
 
 			client := &http.Client{
 				Transport: &http.Transport{

--- a/cmd/query/app/apiv3/grpc_gateway_test.go
+++ b/cmd/query/app/apiv3/grpc_gateway_test.go
@@ -142,7 +142,7 @@ func testGRPCGatewayWithTenancy(t *testing.T, basePath string, serverTLS tlscfg.
 	var spansResponse api_v3.SpansResponseChunk
 	err = jsonpb.Unmarshal(envelope.Result, &spansResponse)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(spansResponse.GetResourceSpans()))
+	assert.Len(t, spansResponse.GetResourceSpans(), 1)
 	assert.Equal(t, uint64ToTraceID(t, traceID.High, traceID.Low), spansResponse.GetResourceSpans()[0].GetScopeSpans()[0].GetSpans()[0].GetTraceId())
 }
 

--- a/cmd/query/app/apiv3/grpc_handler_test.go
+++ b/cmd/query/app/apiv3/grpc_handler_test.go
@@ -77,7 +77,7 @@ func TestGetTrace(t *testing.T) {
 	require.NoError(t, err)
 	spansChunk, err := getTraceStream.Recv()
 	require.NoError(t, err)
-	require.Equal(t, 1, len(spansChunk.GetResourceSpans()))
+	require.Len(t, spansChunk.GetResourceSpans(), 1)
 	assert.Equal(t, "foobar", spansChunk.GetResourceSpans()[0].GetScopeSpans()[0].GetSpans()[0].GetName())
 }
 
@@ -173,7 +173,7 @@ func TestFindTraces(t *testing.T) {
 	require.NoError(t, err)
 	recv, err := responseStream.Recv()
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(recv.GetResourceSpans()))
+	assert.Len(t, recv.GetResourceSpans(), 1)
 }
 
 func TestFindTraces_query_nil(t *testing.T) {

--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -61,7 +61,7 @@ func TestGetArchivedTraceSuccess(t *testing.T) {
 		var response structuredTraceResponse
 		err := getJSON(ts.server.URL+"/api/traces/"+mockTraceID.String(), &response)
 		assert.NoError(t, err)
-		assert.Len(t, response.Errors, 0)
+		assert.Empty(t, response.Errors)
 		assert.Len(t, response.Traces, 1)
 		assert.Equal(t, traceID.String(), string(response.Traces[0].TraceID))
 	}, querysvc.QueryServiceOptions{ArchiveSpanReader: mockReader})

--- a/cmd/query/app/handler_deps_test.go
+++ b/cmd/query/app/handler_deps_test.go
@@ -319,9 +319,9 @@ func TestGetDependenciesSuccess(t *testing.T) {
 	assert.NotEmpty(t, response.Data)
 	data := response.Data.([]interface{})[0]
 	actual := data.(map[string]interface{})
-	assert.Equal(t, actual["parent"], "killer")
-	assert.Equal(t, actual["child"], "queen")
-	assert.Equal(t, actual["callCount"], 12.00) // recovered type is float
+	assert.Equal(t, "killer", actual["parent"])
+	assert.Equal(t, "queen", actual["child"])
+	assert.Equal(t, 12.00, actual["callCount"]) // recovered type is float
 	assert.NoError(t, err)
 }
 

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -151,7 +151,7 @@ func TestGetTraceSuccess(t *testing.T) {
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces/123456`, &response)
 	assert.NoError(t, err)
-	assert.Len(t, response.Errors, 0)
+	assert.Empty(t, response.Errors)
 }
 
 type logData struct {
@@ -188,9 +188,9 @@ func TestLogOnServerError(t *testing.T) {
 	h := NewAPIHandler(qs, &tenancy.Manager{}, apiHandlerOptions...)
 	e := errors.New("test error")
 	h.handleError(&testHttp.TestResponseWriter{}, e, http.StatusInternalServerError)
-	require.Equal(t, 1, len(*l.logs))
+	require.Len(t, *l.logs, 1)
 	assert.Equal(t, "HTTP handler, Internal Server Error", (*l.logs)[0].e.Message)
-	assert.Equal(t, 1, len((*l.logs)[0].f))
+	assert.Len(t, (*l.logs)[0].f, 1)
 	assert.Equal(t, e, (*l.logs)[0].f[0].Interface)
 }
 
@@ -321,7 +321,7 @@ func TestGetTrace(t *testing.T) {
 			var response structuredResponse
 			err := getJSON(ts.server.URL+`/api/traces/123456aBC`+testCase.suffix, &response) // trace ID in mixed lower/upper case
 			assert.NoError(t, err)
-			assert.Len(t, response.Errors, 0)
+			assert.Empty(t, response.Errors)
 
 			assert.Len(t, exporter.GetSpans(), 1, "HTTP request was traced and span reported")
 			assert.Equal(t, "/api/traces/{traceID}", exporter.GetSpans()[0].Name)
@@ -392,7 +392,7 @@ func TestSearchSuccess(t *testing.T) {
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms`, &response)
 	assert.NoError(t, err)
-	assert.Len(t, response.Errors, 0)
+	assert.Empty(t, response.Errors)
 }
 
 func TestSearchByTraceIDSuccess(t *testing.T) {
@@ -404,7 +404,7 @@ func TestSearchByTraceIDSuccess(t *testing.T) {
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2`, &response)
 	assert.NoError(t, err)
-	assert.Len(t, response.Errors, 0)
+	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 2)
 }
 
@@ -422,7 +422,7 @@ func TestSearchByTraceIDSuccessWithArchive(t *testing.T) {
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2`, &response)
 	assert.NoError(t, err)
-	assert.Len(t, response.Errors, 0)
+	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 2)
 }
 
@@ -902,7 +902,7 @@ func TestSearchTenancyHTTP(t *testing.T) {
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2`, &response)
 	require.Error(t, err)
 	assert.Equal(t, "401 error from server: missing tenant header", err.Error())
-	assert.Len(t, response.Errors, 0)
+	assert.Empty(t, response.Errors)
 	assert.Nil(t, response.Data)
 
 	err = getJSONCustomHeaders(
@@ -910,7 +910,7 @@ func TestSearchTenancyHTTP(t *testing.T) {
 		map[string]string{"x-tenant": "acme"},
 		&response)
 	assert.NoError(t, err)
-	assert.Len(t, response.Errors, 0)
+	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 2)
 }
 
@@ -970,7 +970,7 @@ func TestSearchTenancyFlowTenantHTTP(t *testing.T) {
 		map[string]string{"x-tenant": "acme"},
 		&responseAcme)
 	assert.NoError(t, err)
-	assert.Len(t, responseAcme.Errors, 0)
+	assert.Empty(t, responseAcme.Errors)
 	assert.Len(t, responseAcme.Data, 2)
 
 	var responseMegacorp structuredResponse
@@ -979,6 +979,6 @@ func TestSearchTenancyFlowTenantHTTP(t *testing.T) {
 		map[string]string{"x-tenant": "megacorp"},
 		&responseMegacorp)
 	assert.Contains(t, err.Error(), "storage error")
-	assert.Len(t, responseMegacorp.Errors, 0)
+	assert.Empty(t, responseMegacorp.Errors)
 	assert.Nil(t, responseMegacorp.Data)
 }

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -70,7 +70,7 @@ func TestCreateTLSServerSinglePortError(t *testing.T) {
 	_, err := NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8080", TLSGRPC: tlsCfg, TLSHTTP: tlsCfg},
 		tenancy.NewManager(&tenancy.Options{}), jtracer.NoOp())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestCreateTLSGrpcServerError(t *testing.T) {
@@ -84,7 +84,7 @@ func TestCreateTLSGrpcServerError(t *testing.T) {
 	_, err := NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8081", TLSGRPC: tlsCfg},
 		tenancy.NewManager(&tenancy.Options{}), jtracer.NoOp())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestCreateTLSHttpServerError(t *testing.T) {
@@ -98,7 +98,7 @@ func TestCreateTLSHttpServerError(t *testing.T) {
 	_, err := NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8081", TLSHTTP: tlsCfg},
 		tenancy.NewManager(&tenancy.Options{}), jtracer.NoOp())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 var testCases = []struct {
@@ -343,7 +343,7 @@ func TestServerHTTPTLS(t *testing.T) {
 			server, err := NewServer(flagsSvc.Logger, querySvc, nil,
 				serverOptions, tenancy.NewManager(&tenancy.Options{}),
 				jtracer.NoOp())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NoError(t, server.Start())
 
 			var wg sync.WaitGroup
@@ -395,7 +395,7 @@ func TestServerHTTPTLS(t *testing.T) {
 				require.NoError(t, clientError)
 			}
 			if clientClose != nil {
-				require.Nil(t, clientClose())
+				require.NoError(t, clientClose())
 			}
 
 			if test.HTTPTLSEnabled && test.TLS.ClientCAPath != "" {
@@ -408,7 +408,7 @@ func TestServerHTTPTLS(t *testing.T) {
 				readMock.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).Return([]*model.Trace{mockTrace}, nil).Once()
 				queryString := "/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms"
 				req, err := http.NewRequest(http.MethodGet, "https://localhost:"+fmt.Sprintf("%d", ports.QueryHTTP)+queryString, nil)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				req.Header.Add("Accept", "application/json")
 
 				resp, err2 := client.Do(req)
@@ -505,7 +505,7 @@ func TestServerGRPCTLS(t *testing.T) {
 			server, err := NewServer(flagsSvc.Logger, querySvc, nil,
 				serverOptions, tenancy.NewManager(&tenancy.Options{}),
 				jtracer.NoOp())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NoError(t, server.Start())
 
 			var wg sync.WaitGroup
@@ -547,7 +547,7 @@ func TestServerGRPCTLS(t *testing.T) {
 				require.NoError(t, clientError)
 				assert.Equal(t, expectedServices, res.Services)
 			}
-			require.Nil(t, client.conn.Close())
+			require.NoError(t, client.conn.Close())
 			server.Close()
 			wg.Wait()
 			assert.Equal(t, healthcheck.Unavailable, flagsSvc.HC().Get())
@@ -567,7 +567,7 @@ func TestServerBadHostPort(t *testing.T) {
 		tenancy.NewManager(&tenancy.Options{}),
 		jtracer.NoOp())
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	_, err = NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{
 			HTTPHostPort: "127.0.0.1:8081",
@@ -579,7 +579,7 @@ func TestServerBadHostPort(t *testing.T) {
 		tenancy.NewManager(&tenancy.Options{}),
 		jtracer.NoOp())
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestServerInUseHostPort(t *testing.T) {
@@ -647,7 +647,7 @@ func TestServerSinglePort(t *testing.T) {
 		},
 		tenancy.NewManager(&tenancy.Options{}),
 		jtracer.NoOp())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NoError(t, server.Start())
 
 	var wg sync.WaitGroup
@@ -696,7 +696,7 @@ func TestServerGracefulExit(t *testing.T) {
 
 	server, err := NewServer(flagsSvc.Logger, querySvc, nil, &QueryOptions{GRPCHostPort: hostPort, HTTPHostPort: hostPort},
 		tenancy.NewManager(&tenancy.Options{}), tracer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NoError(t, server.Start())
 	go func() {
 		for s := range server.HealthCheckStatus() {
@@ -726,7 +726,7 @@ func TestServerHandlesPortZero(t *testing.T) {
 		&QueryOptions{GRPCHostPort: ":0", HTTPHostPort: ":0"},
 		tenancy.NewManager(&tenancy.Options{}),
 		tracer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NoError(t, server.Start())
 	defer server.Close()
 
@@ -786,7 +786,7 @@ func TestServerHTTPTenancy(t *testing.T) {
 	server, err := NewServer(zap.NewNop(), querySvc, nil,
 		serverOptions, tenancyMgr,
 		jtracer.NoOp())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NoError(t, server.Start())
 
 	for _, test := range testCases {
@@ -799,7 +799,7 @@ func TestServerHTTPTenancy(t *testing.T) {
 			if test.tenant != "" {
 				req.Header.Add(tenancyMgr.Header, test.tenant)
 			}
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			req.Header.Add("Accept", "application/json")
 
 			client := &http.Client{}
@@ -817,7 +817,7 @@ func TestServerHTTPTenancy(t *testing.T) {
 				resp.Body.Close()
 			}
 			if conn != nil {
-				require.Nil(t, conn.Close())
+				require.NoError(t, conn.Close())
 			}
 		})
 	}

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -138,7 +138,7 @@ func TestBearerTokenPropagation(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 
-			assert.Equal(t, resp.StatusCode, http.StatusOK)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		})
 	}
 }

--- a/cmd/query/app/util_test.go
+++ b/cmd/query/app/util_test.go
@@ -33,6 +33,6 @@ func Test_getUniqueOperationNames(t *testing.T) {
 
 	expNames := []string{"operation1", "operation2"}
 	names := getUniqueOperationNames(operations)
-	assert.Equal(t, 2, len(names))
+	assert.Len(t, names, 2)
 	assert.ElementsMatch(t, expNames, names)
 }

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -336,7 +336,7 @@ func TestServerGRPCTLS(t *testing.T) {
 				tm,
 				flagsSvc.Logger,
 			)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NoError(t, server.Start())
 
 			var wg sync.WaitGroup
@@ -376,7 +376,7 @@ func TestServerGRPCTLS(t *testing.T) {
 				require.NoError(t, clientError)
 				assert.Equal(t, expectedServices, res.Services)
 			}
-			require.Nil(t, client.conn.Close())
+			require.NoError(t, client.conn.Close())
 			server.Close()
 			wg.Wait()
 			assert.Equal(t, healthcheck.Unavailable, flagsSvc.HC().Get())
@@ -396,7 +396,7 @@ func TestServerHandlesPortZero(t *testing.T) {
 		tenancy.NewManager(&tenancy.Options{}),
 		flagsSvc.Logger,
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NoError(t, server.Start())
 	defer server.Close()
 

--- a/model/adjuster/bad_span_references_test.go
+++ b/model/adjuster/bad_span_references_test.go
@@ -41,8 +41,8 @@ func TestSpanReferencesAdjuster(t *testing.T) {
 	}
 	trace, err := SpanReferences().Adjust(trace)
 	assert.NoError(t, err)
-	assert.Len(t, trace.Spans[0].References, 0)
-	assert.Len(t, trace.Spans[1].References, 0)
+	assert.Empty(t, trace.Spans[0].References)
+	assert.Empty(t, trace.Spans[1].References)
 	assert.Len(t, trace.Spans[2].References, 2)
 	assert.Contains(t, trace.Spans[2].Warnings[0], "Invalid span reference removed")
 }

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -211,7 +211,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 			} else {
 				for i, span := range trace.Spans {
 					if testCase.trace[i].adjusted == testCase.trace[i].startTime {
-						assert.Len(t, span.Warnings, 0, "no warnings in span %s", span.SpanID)
+						assert.Empty(t, span.Warnings, "no warnings in span %s", span.SpanID)
 					} else {
 						assert.Len(t, span.Warnings, 1, "warning about adjutment added to span %s", span.SpanID)
 					}

--- a/model/adjuster/span_id_deduper_test.go
+++ b/model/adjuster/span_id_deduper_test.go
@@ -108,6 +108,6 @@ func TestSpanIDDeduperError(t *testing.T) {
 	deduper.maxUsedID = maxSpanID - 1
 	deduper.dedupeSpanIDs()
 	if assert.Len(t, trace.Spans[1].Warnings, 1) {
-		assert.Equal(t, trace.Spans[1].Warnings[0], "cannot assign unique span ID, too many spans in the trace")
+		assert.Equal(t, "cannot assign unique span ID, too many spans in the trace", trace.Spans[1].Warnings[0])
 	}
 }

--- a/model/converter/json/from_domain_test.go
+++ b/model/converter/json/from_domain_test.go
@@ -64,7 +64,7 @@ func TestMarshalJSON(t *testing.T) {
 	require.NoError(t, jsonpb.Unmarshal(bb, &trace2))
 	trace1.NormalizeTimestamps()
 	trace2.NormalizeTimestamps()
-	assert.Equal(t, trace1, &trace2)
+	assert.Equal(t, &trace2, trace1)
 }
 
 func TestFromDomain(t *testing.T) {

--- a/model/converter/thrift/jaeger/to_domain_test.go
+++ b/model/converter/thrift/jaeger/to_domain_test.go
@@ -102,7 +102,7 @@ func TestUnknownJaegerType(t *testing.T) {
 		Key:   "sneh",
 	})
 	expected := model.String("sneh", "Unknown VType: Tag({Key:sneh VType:<UNSET> VStr:<nil> VDouble:<nil> VBool:<nil> VLong:<nil> VBinary:[]})")
-	assert.Equal(t, mkv, expected)
+	assert.Equal(t, expected, mkv)
 }
 
 func TestToDomain_ToDomainProcess(t *testing.T) {

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -78,7 +78,7 @@ func TestToDomainNoServiceNameError(t *testing.T) {
 	zSpans := getZipkinSpans(t, `[{ "trace_id": -1, "id": 31 }]`)
 	trace, err := ToDomain(zSpans)
 	assert.EqualError(t, err, "cannot find service name in Zipkin span [traceID=ffffffffffffffff, spanID=1f]")
-	assert.Equal(t, 1, len(trace.Spans))
+	assert.Len(t, trace.Spans, 1)
 	assert.Equal(t, "unknown-service-name", trace.Spans[0].Process.ServiceName)
 }
 
@@ -86,8 +86,8 @@ func TestToDomainServiceNameInBinAnnotation(t *testing.T) {
 	zSpans := getZipkinSpans(t, `[{ "trace_id": -1, "id": 31,
 	"binary_annotations": [{"key": "foo", "host": {"service_name": "bar", "ipv4": 23456}}] }]`)
 	trace, err := ToDomain(zSpans)
-	require.Nil(t, err)
-	assert.Equal(t, 1, len(trace.Spans))
+	require.NoError(t, err)
+	assert.Len(t, trace.Spans, 1)
 	assert.Equal(t, "bar", trace.Spans[0].Process.ServiceName)
 }
 
@@ -97,7 +97,7 @@ func TestToDomainWithDurationFromServerAnnotations(t *testing.T) {
 	{"value": "ss", "timestamp": 10, "host": {"service_name": "bar", "ipv4": 23456}}
 	]}]`)
 	trace, err := ToDomain(zSpans)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1000, int(trace.Spans[0].StartTime.Nanosecond()))
 	assert.Equal(t, 9000, int(trace.Spans[0].Duration))
 }
@@ -108,7 +108,7 @@ func TestToDomainWithDurationFromClientAnnotations(t *testing.T) {
 	{"value": "cr", "timestamp": 10, "host": {"service_name": "bar", "ipv4": 23456}}
 	]}]`)
 	trace, err := ToDomain(zSpans)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1000, int(trace.Spans[0].StartTime.Nanosecond()))
 	assert.Equal(t, 9000, int(trace.Spans[0].Duration))
 }
@@ -147,14 +147,14 @@ func TestToDomainMultipleSpanKinds(t *testing.T) {
 
 	for _, test := range tests {
 		trace, err := ToDomain(getZipkinSpans(t, test.json))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
-		assert.Equal(t, 2, len(trace.Spans))
-		assert.Equal(t, 1, len(trace.Spans[0].Tags))
+		assert.Len(t, trace.Spans, 2)
+		assert.Len(t, trace.Spans[0].Tags, 1)
 		assert.Equal(t, test.tagFirstKey, trace.Spans[0].Tags[0].Key)
 		assert.Equal(t, test.tagFirstVal.String(), trace.Spans[0].Tags[0].VStr)
 
-		assert.Equal(t, 1, len(trace.Spans[1].Tags))
+		assert.Len(t, trace.Spans[1].Tags, 1)
 		assert.Equal(t, test.tagSecondKey, trace.Spans[1].Tags[0].Key)
 		assert.Equal(t, time.Duration(1000), trace.Spans[1].Duration)
 		assert.Equal(t, test.tagSecondVal.String(), trace.Spans[1].Tags[0].VStr)

--- a/model/ids_test.go
+++ b/model/ids_test.go
@@ -95,7 +95,7 @@ func TestSpanIDFromBytes(t *testing.T) {
 	for _, data := range errTests {
 		_, err := model.SpanIDFromBytes(data)
 		require.Error(t, err)
-		assert.Equal(t, "invalid length for SpanID", err.Error())
+		assert.EqualError(t, err, "invalid length for SpanID")
 	}
 
 	spanID, err := model.SpanIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 13})

--- a/model/ids_test.go
+++ b/model/ids_test.go
@@ -95,7 +95,7 @@ func TestSpanIDFromBytes(t *testing.T) {
 	for _, data := range errTests {
 		_, err := model.SpanIDFromBytes(data)
 		require.Error(t, err)
-		assert.Equal(t, err.Error(), "invalid length for SpanID")
+		assert.Equal(t, "invalid length for SpanID", err.Error())
 	}
 
 	spanID, err := model.SpanIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 13})
@@ -112,7 +112,7 @@ func TestTraceIDFromBytes(t *testing.T) {
 	for _, data := range errTests {
 		_, err := model.TraceIDFromBytes(data)
 		require.Error(t, err)
-		assert.Equal(t, err.Error(), "invalid length for TraceID")
+		assert.Equal(t, "invalid length for TraceID", err.Error())
 	}
 
 	tests := []struct {
@@ -125,6 +125,6 @@ func TestTraceIDFromBytes(t *testing.T) {
 	for _, test := range tests {
 		traceID, err := model.TraceIDFromBytes(test.data)
 		require.NoError(t, err)
-		assert.Equal(t, traceID, test.expected)
+		assert.Equal(t, test.expected, traceID)
 	}
 }

--- a/pkg/bearertoken/context_test.go
+++ b/pkg/bearertoken/context_test.go
@@ -27,5 +27,5 @@ func Test_GetBearerToken(t *testing.T) {
 	ctx = ContextWithBearerToken(ctx, token)
 	contextToken, ok := GetBearerToken(ctx)
 	assert.True(t, ok)
-	assert.Equal(t, contextToken, token)
+	assert.Equal(t, token, contextToken)
 }

--- a/pkg/bearertoken/http_test.go
+++ b/pkg/bearertoken/http_test.go
@@ -37,7 +37,7 @@ func Test_PropagationHandler(t *testing.T) {
 		return func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			token, ok := GetBearerToken(ctx)
-			assert.Equal(t, token, bearerToken)
+			assert.Equal(t, bearerToken, token)
 			assert.True(t, ok)
 			stop.Done()
 		}
@@ -75,12 +75,12 @@ func Test_PropagationHandler(t *testing.T) {
 			server := httptest.NewServer(r)
 			defer server.Close()
 			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			if testCase.sendHeader {
 				req.Header.Add(testCase.headerName, testCase.headerValue)
 			}
 			_, err = httpClient.Do(req)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			stop.Wait()
 		})
 	}

--- a/pkg/cassandra/metrics/table_test.go
+++ b/pkg/cassandra/metrics/table_test.go
@@ -123,7 +123,7 @@ func TestTableExec(t *testing.T) {
 		err := tm.Exec(tc.q, useLogger)
 		if tc.q.err == nil {
 			assert.NoError(t, err)
-			assert.Len(t, logBuf.Bytes(), 0)
+			assert.Empty(t, logBuf.Bytes())
 		} else {
 			assert.Error(t, err, tc.q.err.Error())
 			if tc.log {
@@ -134,7 +134,7 @@ func TestTableExec(t *testing.T) {
 					"error": "failed",
 				}, logBuf.JSONLine(0))
 			} else {
-				assert.Len(t, logBuf.Bytes(), 0)
+				assert.Empty(t, logBuf.Bytes())
 			}
 		}
 		counts, _ := mf.Snapshot()

--- a/pkg/discovery/notifier_test.go
+++ b/pkg/discovery/notifier_test.go
@@ -64,5 +64,5 @@ func TestDispatcher(t *testing.T) {
 	assert.Len(t, d.observers, 1)
 
 	d.Unregister(f2)
-	assert.Len(t, d.observers, 0)
+	assert.Empty(t, d.observers)
 }

--- a/pkg/es/client/index_client_test.go
+++ b/pkg/es/client/index_client_test.go
@@ -283,7 +283,7 @@ func TestClientDeleteIndices(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.errContains)
 			} else {
-				assert.Equal(t, len(test.indices), deletedIndicesCount)
+				assert.Len(t, test.indices, deletedIndicesCount)
 			}
 		})
 	}

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -206,7 +206,7 @@ func TestResizeUp(t *testing.T) {
 	assert.False(t, q.Produce("d")) // dropped
 	assert.EqualValues(t, 2, q.Capacity())
 	assert.EqualValues(t, q.Capacity(), q.Size())
-	assert.EqualValues(t, q.Capacity(), len(*q.items))
+	assert.Len(t, *q.items, q.Capacity())
 
 	resized = true
 	assert.True(t, q.Resize(4))
@@ -219,7 +219,7 @@ func TestResizeUp(t *testing.T) {
 
 	assert.EqualValues(t, 4, q.Capacity())
 	assert.EqualValues(t, q.Capacity(), q.Size()) // the combined queues are at the capacity right now
-	assert.EqualValues(t, 2, len(*q.items))       // the new internal queue should have two items only
+	assert.Len(t, *q.items, 2)                    // the new internal queue should have two items only
 
 	released = true
 	releaseConsumers.Done()
@@ -256,14 +256,14 @@ func TestResizeDown(t *testing.T) {
 	assert.True(t, q.Produce("e")) // dropped
 	assert.EqualValues(t, 4, q.Capacity())
 	assert.EqualValues(t, q.Capacity(), q.Size())
-	assert.EqualValues(t, q.Capacity(), len(*q.items))
+	assert.Len(t, *q.items, q.Capacity())
 
 	assert.True(t, q.Resize(2))
 	assert.False(t, q.Produce("f")) // dropped
 
 	assert.EqualValues(t, 2, q.Capacity())
-	assert.EqualValues(t, 4, q.Size())      // the queue will eventually drain, but it will live for a while over capacity
-	assert.EqualValues(t, 0, len(*q.items)) // the new queue is empty, as the old queue is still full and over capacity
+	assert.EqualValues(t, 4, q.Size()) // the queue will eventually drain, but it will live for a while over capacity
+	assert.Empty(t, *q.items)          // the new queue is empty, as the old queue is still full and over capacity
 
 	released = true
 	releaseConsumers.Done()

--- a/plugin/metrics/disabled/reader_test.go
+++ b/plugin/metrics/disabled/reader_test.go
@@ -16,7 +16,6 @@ package disabled
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +32,7 @@ func TestGetLatencies(t *testing.T) {
 	qParams := &metricsstore.LatenciesQueryParameters{}
 	r, err := reader.GetLatencies(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.True(t, errors.Is(err, ErrDisabled))
+	assert.ErrorIs(t, err, ErrDisabled)
 	assert.EqualError(t, err, ErrDisabled.Error())
 }
 
@@ -45,7 +44,7 @@ func TestGetCallRates(t *testing.T) {
 	qParams := &metricsstore.CallRateQueryParameters{}
 	r, err := reader.GetCallRates(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.True(t, errors.Is(err, ErrDisabled))
+	assert.ErrorIs(t, err, ErrDisabled)
 	assert.EqualError(t, err, ErrDisabled.Error())
 }
 
@@ -57,7 +56,7 @@ func TestGetErrorRates(t *testing.T) {
 	qParams := &metricsstore.ErrorRateQueryParameters{}
 	r, err := reader.GetErrorRates(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.True(t, errors.Is(err, ErrDisabled))
+	assert.ErrorIs(t, err, ErrDisabled)
 	assert.EqualError(t, err, ErrDisabled.Error())
 }
 
@@ -69,6 +68,6 @@ func TestGetMinStepDurations(t *testing.T) {
 	qParams := &metricsstore.MinStepDurationQueryParameters{}
 	r, err := reader.GetMinStepDuration(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.True(t, errors.Is(err, ErrDisabled))
+	assert.ErrorIs(t, err, ErrDisabled)
 	assert.EqualError(t, err, ErrDisabled.Error())
 }

--- a/plugin/sampling/calculationstrategy/percentage_increase_capped_calculator_test.go
+++ b/plugin/sampling/calculationstrategy/percentage_increase_capped_calculator_test.go
@@ -35,6 +35,6 @@ func TestPercentageIncreaseCappedCalculator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		probability := calculator.Calculate(tt.targetQPS, tt.curQPS, tt.oldProbability)
-		assert.InDelta(t, probability, tt.expectedProbability, 0.0001, tt.testName)
+		assert.InDelta(t, tt.expectedProbability, probability, 0.0001, tt.testName)
 	}
 }

--- a/plugin/sampling/strategystore/adaptive/processor_test.go
+++ b/plugin/sampling/strategystore/adaptive/processor_test.go
@@ -102,13 +102,13 @@ func TestAggregateThroughput(t *testing.T) {
 
 	opThroughput, ok := throughput["GET"]
 	require.True(t, ok)
-	assert.Equal(t, opThroughput.Count, int64(8))
-	assert.Equal(t, opThroughput.Probabilities, map[string]struct{}{"0.1": {}, "0.2": {}})
+	assert.Equal(t, int64(8), opThroughput.Count)
+	assert.Equal(t, map[string]struct{}{"0.1": {}, "0.2": {}}, opThroughput.Probabilities)
 
 	opThroughput, ok = throughput["PUT"]
 	require.True(t, ok)
-	assert.Equal(t, opThroughput.Count, int64(5))
-	assert.Equal(t, opThroughput.Probabilities, map[string]struct{}{"0.1": {}})
+	assert.Equal(t, int64(5), opThroughput.Count)
+	assert.Equal(t, map[string]struct{}{"0.1": {}}, opThroughput.Probabilities)
 
 	throughput, ok = aggregatedThroughput["svcB"]
 	require.True(t, ok)
@@ -116,8 +116,8 @@ func TestAggregateThroughput(t *testing.T) {
 
 	opThroughput, ok = throughput["GET"]
 	require.True(t, ok)
-	assert.Equal(t, opThroughput.Count, int64(3))
-	assert.Equal(t, opThroughput.Probabilities, map[string]struct{}{"0.1": {}})
+	assert.Equal(t, int64(3), opThroughput.Count)
+	assert.Equal(t, map[string]struct{}{"0.1": {}}, opThroughput.Probabilities)
 }
 
 func TestInitializeThroughput(t *testing.T) {
@@ -133,10 +133,10 @@ func TestInitializeThroughput(t *testing.T) {
 
 	require.Len(t, p.throughputs, 2)
 	require.Len(t, p.throughputs[0].throughput, 2)
-	assert.Equal(t, p.throughputs[0].interval, time.Minute)
+	assert.Equal(t, time.Minute, p.throughputs[0].interval)
 	assert.Equal(t, p.throughputs[0].endTime, time.Time{}.Add(time.Minute*20))
 	require.Len(t, p.throughputs[1].throughput, 1)
-	assert.Equal(t, p.throughputs[1].interval, time.Minute)
+	assert.Equal(t, time.Minute, p.throughputs[1].interval)
 	assert.Equal(t, p.throughputs[1].endTime, time.Time{}.Add(time.Minute*19))
 }
 
@@ -147,7 +147,7 @@ func TestInitializeThroughputFailure(t *testing.T) {
 	p := &Processor{storage: mockStorage, Options: Options{CalculationInterval: time.Minute, AggregationBuckets: 1}}
 	p.initializeThroughput(time.Time{}.Add(time.Minute * 20))
 
-	assert.Len(t, p.throughputs, 0)
+	assert.Empty(t, p.throughputs)
 }
 
 func TestCalculateQPS(t *testing.T) {

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -166,7 +166,7 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 
 	require.NotNil(t, s.OperationSampling)
 	os := s.OperationSampling
-	assert.EqualValues(t, os.DefaultSamplingProbability, 0.8)
+	assert.EqualValues(t, 0.8, os.DefaultSamplingProbability)
 	require.Len(t, os.PerOperationStrategies, 4)
 
 	assert.Equal(t, "op6", os.PerOperationStrategies[0].Operation)
@@ -187,7 +187,7 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 
 	require.NotNil(t, s.OperationSampling)
 	os = s.OperationSampling
-	assert.EqualValues(t, os.DefaultSamplingProbability, 0.001)
+	assert.EqualValues(t, 0.001, os.DefaultSamplingProbability)
 	require.Len(t, os.PerOperationStrategies, 5)
 	assert.Equal(t, "op3", os.PerOperationStrategies[0].Operation)
 	assert.EqualValues(t, 0.3, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)
@@ -244,7 +244,7 @@ func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 
 	require.NotNil(t, s.OperationSampling)
 	os := s.OperationSampling
-	assert.EqualValues(t, os.DefaultSamplingProbability, defaultSamplingProbability)
+	assert.EqualValues(t, defaultSamplingProbability, os.DefaultSamplingProbability)
 	require.Len(t, os.PerOperationStrategies, 1)
 	assert.Equal(t, "op1", os.PerOperationStrategies[0].Operation)
 	assert.EqualValues(t, 0.2, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)
@@ -258,7 +258,7 @@ func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 
 	require.NotNil(t, s.OperationSampling)
 	os = s.OperationSampling
-	assert.EqualValues(t, os.DefaultSamplingProbability, 0.001)
+	assert.EqualValues(t, 0.001, os.DefaultSamplingProbability)
 	require.Len(t, os.PerOperationStrategies, 2)
 	assert.Equal(t, "op3", os.PerOperationStrategies[0].Operation)
 	assert.EqualValues(t, 0.3, os.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate)

--- a/plugin/storage/badger/dependencystore/storage_test.go
+++ b/plugin/storage/badger/dependencystore/storage_test.go
@@ -93,7 +93,7 @@ func TestDependencyReader(t *testing.T) {
 		links, err = dr.GetDependencies(context.Background(), time.Now(), time.Hour)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, links)
-		assert.Equal(t, spans-1, len(links))                // First span does not create a dependency
+		assert.Len(t, links, spans-1)                       // First span does not create a dependency
 		assert.Equal(t, uint64(traces), links[0].CallCount) // Each trace calls the same services
 	})
 }

--- a/plugin/storage/badger/spanstore/cache_test.go
+++ b/plugin/storage/badger/spanstore/cache_test.go
@@ -40,7 +40,7 @@ func TestExpiredItems(t *testing.T) {
 
 		services, err := cache.GetServices()
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(services)) // Everything should be expired
+		assert.Empty(t, services) // Everything should be expired
 
 		// Expired service for operations
 
@@ -49,7 +49,7 @@ func TestExpiredItems(t *testing.T) {
 
 		operations, err := cache.GetOperations("service1")
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(operations)) // Everything should be expired
+		assert.Empty(t, operations) // Everything should be expired
 
 		// Expired operations, stable service
 
@@ -60,7 +60,7 @@ func TestExpiredItems(t *testing.T) {
 
 		operations, err = cache.GetOperations("service1")
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(operations)) // Everything should be expired
+		assert.Empty(t, operations) // Everything should be expired
 	})
 }
 

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -85,7 +85,7 @@ func TestWriteReadBack(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			assert.Equal(t, spans, len(tr.Spans))
+			assert.Len(t, tr.Spans, spans)
 		}
 	})
 }
@@ -190,23 +190,23 @@ func TestIndexSeeks(t *testing.T) {
 
 		trs, err := sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(trs))
-		assert.Equal(t, spans, len(trs[0].Spans))
+		assert.Len(t, trs, 1)
+		assert.Len(t, trs[0].Spans, spans)
 
 		params.OperationName = "operation-1"
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(trs))
+		assert.Len(t, trs, 1)
 
 		params.ServiceName = "service-10" // this should not match
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(trs))
+		assert.Empty(t, trs)
 
 		params.OperationName = "operation-4"
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(trs))
+		assert.Empty(t, trs)
 
 		// Multi-index hits
 
@@ -220,8 +220,8 @@ func TestIndexSeeks(t *testing.T) {
 		params.DurationMin = time.Duration(1 * time.Millisecond)
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(trs))
-		assert.Equal(t, spans, len(trs[0].Spans))
+		assert.Len(t, trs, 1)
+		assert.Len(t, trs[0].Spans, spans)
 
 		// Query limited amount of hits
 
@@ -230,7 +230,7 @@ func TestIndexSeeks(t *testing.T) {
 		params.NumTraces = 2
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(trs))
+		assert.Len(t, trs, 2)
 		assert.Equal(t, traceOrder[59], trs[0].Spans[0].TraceID.Low)
 		assert.Equal(t, traceOrder[55], trs[1].Spans[0].TraceID.Low)
 		testOrder(trs)
@@ -245,7 +245,7 @@ func TestIndexSeeks(t *testing.T) {
 		}
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 9, len(trs)) // Returns 23, we limited to 9
+		assert.Len(t, trs, 9) // Returns 23, we limited to 9
 
 		// Check the newest items are returned
 		assert.Equal(t, traceOrder[50], trs[0].Spans[0].TraceID.Low)
@@ -258,7 +258,7 @@ func TestIndexSeeks(t *testing.T) {
 		params.NumTraces = 7
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 7, len(trs))
+		assert.Len(t, trs, 7)
 		assert.Equal(t, traceOrder[59], trs[0].Spans[0].TraceID.Low)
 		assert.Equal(t, traceOrder[53], trs[6].Spans[0].TraceID.Low)
 		testOrder(trs)
@@ -271,8 +271,8 @@ func TestIndexSeeks(t *testing.T) {
 
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 5, len(trs))
-		assert.Equal(t, spans, len(trs[0].Spans))
+		assert.Len(t, trs, 5)
+		assert.Len(t, trs[0].Spans, spans)
 		testOrder(trs)
 
 		// StartTime and Duration queries
@@ -282,7 +282,7 @@ func TestIndexSeeks(t *testing.T) {
 
 		trs, err = sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 6, len(trs))
+		assert.Len(t, trs, 6)
 		assert.Equal(t, traceOrder[56], trs[0].Spans[0].TraceID.Low)
 		assert.Equal(t, traceOrder[51], trs[5].Spans[0].TraceID.Low)
 		testOrder(trs)
@@ -300,7 +300,7 @@ func TestFindNothing(t *testing.T) {
 
 		trs, err := sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Len(t, trs, 0)
+		assert.Empty(t, trs)
 
 		tr, err := sr.GetTrace(context.Background(), model.TraceID{High: 0, Low: 0})
 		assert.Equal(t, spanstore.ErrTraceNotFound, err)
@@ -370,8 +370,8 @@ func TestMenuSeeks(t *testing.T) {
 		serviceList, err := sr.GetServices(context.Background())
 		assert.NoError(t, err)
 
-		assert.Equal(t, spans, len(operations))
-		assert.Equal(t, services, len(serviceList))
+		assert.Len(t, operations, spans)
+		assert.Len(t, serviceList, services)
 	})
 }
 
@@ -438,7 +438,7 @@ func TestPersist(t *testing.T) {
 
 		services, err := sr.GetServices(context.Background())
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(services))
+		assert.Len(t, services, 1)
 	})
 }
 
@@ -703,6 +703,6 @@ func TestRandomTraceID(t *testing.T) {
 		}
 		traces, err := sr.FindTraces(context.Background(), params)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(traces))
+		assert.Len(t, traces, 1)
 	})
 }

--- a/plugin/storage/badger/spanstore/rw_internal_test.go
+++ b/plugin/storage/badger/spanstore/rw_internal_test.go
@@ -42,7 +42,7 @@ func TestEncodingTypes(t *testing.T) {
 
 		tr, err := rw.GetTrace(context.Background(), model.TraceID{Low: 0, High: 1})
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(tr.Spans))
+		assert.Len(t, tr.Spans, 1)
 	})
 
 	// Unknown encoding write
@@ -125,7 +125,7 @@ func TestDuplicateTraceIDDetection(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 128, len(traces))
+		assert.Len(t, traces, 128)
 	})
 }
 
@@ -182,7 +182,7 @@ func TestMergeJoin(t *testing.T) {
 	}
 
 	merged := mergeJoinIds(left, right)
-	assert.Equal(16, len(merged))
+	assert.Len(merged, 16)
 
 	// Check order
 	assert.Equal(uint32(15), binary.BigEndian.Uint32(merged[15]))
@@ -195,6 +195,6 @@ func TestMergeJoin(t *testing.T) {
 	// Different size, some equalities
 
 	merged = mergeJoinIds(left[0:3], right[1:7])
-	assert.Equal(2, len(merged))
+	assert.Len(merged, 2)
 	assert.Equal(uint32(2), binary.BigEndian.Uint32(merged[1]))
 }

--- a/plugin/storage/blackhole/blackhole_test.go
+++ b/plugin/storage/blackhole/blackhole_test.go
@@ -57,7 +57,7 @@ func TestStoreGetServices(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		serviceNames, err := store.GetServices(context.Background())
 		assert.NoError(t, err)
-		assert.Len(t, serviceNames, 0)
+		assert.Empty(t, serviceNames)
 	})
 }
 
@@ -68,7 +68,7 @@ func TestStoreGetAllOperations(t *testing.T) {
 			spanstore.OperationQueryParameters{},
 		)
 		assert.NoError(t, err)
-		assert.Len(t, operations, 0)
+		assert.Empty(t, operations)
 	})
 }
 
@@ -76,7 +76,7 @@ func TestStoreFindTraces(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		traces, err := store.FindTraces(context.Background(), nil)
 		assert.NoError(t, err)
-		assert.Len(t, traces, 0)
+		assert.Empty(t, traces)
 	})
 }
 
@@ -84,6 +84,6 @@ func TestStoreFindTraceIDs(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		traceIDs, err := store.FindTraceIDs(context.Background(), nil)
 		assert.NoError(t, err)
-		assert.Len(t, traceIDs, 0)
+		assert.Empty(t, traceIDs)
 	})
 }

--- a/plugin/storage/cassandra/factory_test.go
+++ b/plugin/storage/cassandra/factory_test.go
@@ -184,7 +184,7 @@ func TestWriterOptions(t *testing.T) {
 	opts.InitFromViper(v)
 
 	options, _ = writerOptions(opts)
-	assert.Len(t, options, 0)
+	assert.Empty(t, options)
 }
 
 func TestInitFromOptions(t *testing.T) {

--- a/plugin/storage/cassandra/options_test.go
+++ b/plugin/storage/cassandra/options_test.go
@@ -114,6 +114,6 @@ func TestEmptyBlackWhiteLists(t *testing.T) {
 	command.ParseFlags([]string{})
 	opts.InitFromViper(v)
 
-	assert.Len(t, opts.TagIndexBlacklist(), 0)
-	assert.Len(t, opts.TagIndexWhitelist(), 0)
+	assert.Empty(t, opts.TagIndexBlacklist())
+	assert.Empty(t, opts.TagIndexWhitelist())
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/tag_filter_exact_match_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/tag_filter_exact_match_test.go
@@ -54,19 +54,19 @@ func TestBlacklistFilter(t *testing.T) {
 		tf := NewBlacklistFilter(test.filter)
 		actualKVs := tf.filter(inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 
 		actualKVs = tf.FilterLogFields(nil, inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 
 		actualKVs = tf.FilterProcessTags(nil, inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 
 		actualKVs = tf.FilterTags(nil, inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 	}
 }
 
@@ -102,18 +102,18 @@ func TestWhitelistFilter(t *testing.T) {
 		tf := NewWhitelistFilter(test.filter)
 		actualKVs := tf.filter(inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 
 		actualKVs = tf.FilterLogFields(nil, inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 
 		actualKVs = tf.FilterProcessTags(nil, inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 
 		actualKVs = tf.FilterTags(nil, inputKVs)
 		actualKVs.Sort()
-		assert.Equal(t, actualKVs, expectedKVs)
+		assert.Equal(t, expectedKVs, actualKVs)
 	}
 }

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -222,7 +222,7 @@ func TestILMDisableTemplateCreation(t *testing.T) {
 	defer f.Close()
 	require.NoError(t, err)
 	_, err = f.CreateSpanWriter()
-	assert.Nil(t, err) // as the createTemplate is not called, CreateSpanWriter should not return an error
+	assert.NoError(t, err) // as the createTemplate is not called, CreateSpanWriter should not return an error
 }
 
 func TestArchiveDisabled(t *testing.T) {
@@ -231,10 +231,10 @@ func TestArchiveDisabled(t *testing.T) {
 	f.newClientFn = (&mockClientBuilder{}).NewClient
 	w, err := f.CreateArchiveSpanWriter()
 	assert.Nil(t, w)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	r, err := f.CreateArchiveSpanReader()
 	assert.Nil(t, r)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestArchiveEnabled(t *testing.T) {

--- a/plugin/storage/es/mappings/mapping_test.go
+++ b/plugin/storage/es/mappings/mapping_test.go
@@ -74,7 +74,7 @@ func TestMappingBuilder_GetMapping(t *testing.T) {
 			wantbytes, err = FIXTURES.ReadFile("fixtures/" + tt.mapping + fileSuffix + ".json")
 			require.NoError(t, err)
 			want := string(wantbytes)
-			assert.Equal(t, got, want)
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
@@ -82,8 +82,8 @@ func TestEmptyTags(t *testing.T) {
 	span := model.Span{Tags: tags, Process: &model.Process{Tags: tags}}
 	converter := NewFromDomain(false, nil, ":")
 	dbSpan := converter.FromDomainEmbedProcess(&span)
-	assert.Equal(t, 0, len(dbSpan.Tags))
-	assert.Equal(t, 0, len(dbSpan.Tag))
+	assert.Empty(t, dbSpan.Tags)
+	assert.Empty(t, dbSpan.Tag)
 }
 
 func TestTagMap(t *testing.T) {
@@ -96,9 +96,9 @@ func TestTagMap(t *testing.T) {
 	converter := NewFromDomain(false, []string{"a", "b.b", "b*"}, ":")
 	dbSpan := converter.FromDomainEmbedProcess(&span)
 
-	assert.Equal(t, 1, len(dbSpan.Tags))
+	assert.Len(t, dbSpan.Tags, 1)
 	assert.Equal(t, "foo", dbSpan.Tags[0].Key)
-	assert.Equal(t, 1, len(dbSpan.Process.Tags))
+	assert.Len(t, dbSpan.Process.Tags, 1)
 	assert.Equal(t, "foo", dbSpan.Process.Tags[0].Key)
 
 	tagsMap := map[string]interface{}{}

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -877,7 +877,7 @@ func TestSpanReader_FindTracesNoTraceIDs(t *testing.T) {
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
 		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 		require.NoError(t, err)
-		assert.Len(t, traces, 0)
+		assert.Empty(t, traces)
 	})
 }
 
@@ -911,7 +911,7 @@ func TestSpanReader_FindTracesReadTraceFailure(t *testing.T) {
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
 		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 		require.EqualError(t, err, "read error")
-		assert.Len(t, traces, 0)
+		assert.Empty(t, traces)
 	})
 }
 
@@ -950,7 +950,7 @@ func TestSpanReader_FindTracesSpanCollectionFailure(t *testing.T) {
 		traces, err := r.reader.FindTraces(context.Background(), traceQuery)
 		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 		require.Error(t, err)
-		assert.Len(t, traces, 0)
+		assert.Empty(t, traces)
 	})
 }
 
@@ -972,12 +972,12 @@ func TestFindTraceIDs(t *testing.T) {
 func TestTraceIDsStringsToModelsConversion(t *testing.T) {
 	traceIDs, err := convertTraceIDsStringsToModels([]string{"1", "2", "3"})
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(traceIDs))
+	assert.Len(t, traceIDs, 3)
 	assert.Equal(t, model.NewTraceID(0, 1), traceIDs[0])
 
 	traceIDs, err = convertTraceIDsStringsToModels([]string{"dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl"})
 	assert.EqualError(t, err, "making traceID from string 'dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl' failed: TraceID cannot be longer than 32 hex characters: dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl")
-	assert.Equal(t, 0, len(traceIDs))
+	assert.Empty(t, traceIDs)
 }
 
 func mockMultiSearchService(r *spanReaderTest) *mock.Call {
@@ -1048,7 +1048,7 @@ func TestTraceQueryParameterValidation(t *testing.T) {
 	tqp.StartTimeMin = time.Now().Add(-1 * time.Hour)
 	tqp.StartTimeMax = time.Now()
 	err = validateQuery(tqp)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tqp.DurationMin = time.Hour
 	tqp.DurationMax = time.Minute

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -125,7 +125,7 @@ func TestSpanWriterIndices(t *testing.T) {
 	for _, testCase := range testCases {
 		w := NewSpanWriter(testCase.params)
 		spanIndexName, serviceIndexName := w.spanServiceIndex(date)
-		assert.Equal(t, testCase.indices, []string{spanIndexName, serviceIndexName})
+		assert.Equal(t, []string{spanIndexName, serviceIndexName}, testCase.indices)
 	}
 }
 

--- a/plugin/storage/factory_config_test.go
+++ b/plugin/storage/factory_config_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestFactoryConfigFromEnv(t *testing.T) {
 	f := FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
-	assert.Equal(t, 1, len(f.SpanWriterTypes))
+	assert.Len(t, f.SpanWriterTypes, 1)
 	assert.Equal(t, cassandraStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, cassandraStorageType, f.SpanReaderType)
 	assert.Equal(t, cassandraStorageType, f.DependenciesStorageType)
@@ -35,7 +35,7 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	t.Setenv(SamplingStorageTypeEnvVar, cassandraStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
-	assert.Equal(t, 1, len(f.SpanWriterTypes))
+	assert.Len(t, f.SpanWriterTypes, 1)
 	assert.Equal(t, elasticsearchStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
 	assert.Equal(t, memoryStorageType, f.DependenciesStorageType)
@@ -44,14 +44,14 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	t.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType+","+kafkaStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
-	assert.Equal(t, 2, len(f.SpanWriterTypes))
+	assert.Len(t, f.SpanWriterTypes, 2)
 	assert.Equal(t, []string{elasticsearchStorageType, kafkaStorageType}, f.SpanWriterTypes)
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
 
 	t.Setenv(SpanStorageTypeEnvVar, badgerStorageType)
 
 	f = FactoryConfigFromEnvAndCLI(nil, nil)
-	assert.Equal(t, 1, len(f.SpanWriterTypes))
+	assert.Len(t, f.SpanWriterTypes, 1)
 	assert.Equal(t, badgerStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, badgerStorageType, f.SpanReaderType)
 }
@@ -70,7 +70,7 @@ func TestFactoryConfigFromEnvDeprecated(t *testing.T) {
 	for _, testCase := range testCases {
 		log := new(bytes.Buffer)
 		f := FactoryConfigFromEnvAndCLI(testCase.args, log)
-		assert.Equal(t, 1, len(f.SpanWriterTypes))
+		assert.Len(t, f.SpanWriterTypes, 1)
 		assert.Equal(t, testCase.value, f.SpanWriterTypes[0])
 		assert.Equal(t, testCase.value, f.SpanReaderType)
 		assert.Equal(t, testCase.value, f.DependenciesStorageType)

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -379,15 +379,15 @@ func TestParsingDownsamplingRatio(t *testing.T) {
 	assert.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
 
-	assert.Equal(t, f.FactoryConfig.DownsamplingRatio, 1.0)
-	assert.Equal(t, f.FactoryConfig.DownsamplingHashSalt, "jaeger")
+	assert.Equal(t, 1.0, f.FactoryConfig.DownsamplingRatio)
+	assert.Equal(t, "jaeger", f.FactoryConfig.DownsamplingHashSalt)
 
 	err = command.ParseFlags([]string{
 		"--downsampling.ratio=0.5",
 	})
 	assert.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
-	assert.Equal(t, f.FactoryConfig.DownsamplingRatio, 0.5)
+	assert.Equal(t, 0.5, f.FactoryConfig.DownsamplingRatio)
 }
 
 func TestDefaultDownsamplingWithAddFlags(t *testing.T) {
@@ -397,8 +397,8 @@ func TestDefaultDownsamplingWithAddFlags(t *testing.T) {
 	assert.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
 
-	assert.Equal(t, f.FactoryConfig.DownsamplingRatio, defaultDownsamplingRatio)
-	assert.Equal(t, f.FactoryConfig.DownsamplingHashSalt, defaultDownsamplingHashSalt)
+	assert.Equal(t, defaultDownsamplingRatio, f.FactoryConfig.DownsamplingRatio)
+	assert.Equal(t, defaultDownsamplingHashSalt, f.FactoryConfig.DownsamplingHashSalt)
 
 	err = command.ParseFlags([]string{
 		"--downsampling.ratio=0.5",

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -282,9 +282,9 @@ func TestWithConfiguration(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
-	assert.Equal(t, f.options.Configuration.PluginBinary, "noop-grpc-plugin")
-	assert.Equal(t, f.options.Configuration.PluginConfigurationFile, "config.json")
-	assert.Equal(t, f.options.Configuration.PluginLogLevel, "debug")
+	assert.Equal(t, "noop-grpc-plugin", f.options.Configuration.PluginBinary)
+	assert.Equal(t, "config.json", f.options.Configuration.PluginConfigurationFile)
+	assert.Equal(t, "debug", f.options.Configuration.PluginLogLevel)
 	assert.NoError(t, f.Close())
 }
 

--- a/plugin/storage/grpc/options_test.go
+++ b/plugin/storage/grpc/options_test.go
@@ -37,9 +37,9 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.NoError(t, err)
 	opts.InitFromViper(v)
 
-	assert.Equal(t, opts.Configuration.PluginBinary, "noop-grpc-plugin")
-	assert.Equal(t, opts.Configuration.PluginConfigurationFile, "config.json")
-	assert.Equal(t, opts.Configuration.PluginLogLevel, "debug")
+	assert.Equal(t, "noop-grpc-plugin", opts.Configuration.PluginBinary)
+	assert.Equal(t, "config.json", opts.Configuration.PluginConfigurationFile)
+	assert.Equal(t, "debug", opts.Configuration.PluginLogLevel)
 	assert.Equal(t, false, opts.Configuration.TenancyOpts.Enabled)
 	assert.Equal(t, "x-scope-orgid", opts.Configuration.TenancyOpts.Header)
 }
@@ -55,10 +55,10 @@ func TestRemoteOptionsWithFlags(t *testing.T) {
 	assert.NoError(t, err)
 	opts.InitFromViper(v)
 
-	assert.Equal(t, opts.Configuration.PluginBinary, "")
-	assert.Equal(t, opts.Configuration.RemoteServerAddr, "localhost:2001")
-	assert.Equal(t, opts.Configuration.RemoteTLS.Enabled, true)
-	assert.Equal(t, opts.Configuration.RemoteConnectTimeout, 60*time.Second)
+	assert.Equal(t, "", opts.Configuration.PluginBinary)
+	assert.Equal(t, "localhost:2001", opts.Configuration.RemoteServerAddr)
+	assert.Equal(t, true, opts.Configuration.RemoteTLS.Enabled)
+	assert.Equal(t, 60*time.Second, opts.Configuration.RemoteConnectTimeout)
 }
 
 func TestRemoteOptionsNoTLSWithFlags(t *testing.T) {
@@ -72,10 +72,10 @@ func TestRemoteOptionsNoTLSWithFlags(t *testing.T) {
 	assert.NoError(t, err)
 	opts.InitFromViper(v)
 
-	assert.Equal(t, opts.Configuration.PluginBinary, "")
-	assert.Equal(t, opts.Configuration.RemoteServerAddr, "localhost:2001")
-	assert.Equal(t, opts.Configuration.RemoteTLS.Enabled, false)
-	assert.Equal(t, opts.Configuration.RemoteConnectTimeout, 60*time.Second)
+	assert.Equal(t, "", opts.Configuration.PluginBinary)
+	assert.Equal(t, "localhost:2001", opts.Configuration.RemoteServerAddr)
+	assert.Equal(t, false, opts.Configuration.RemoteTLS.Enabled)
+	assert.Equal(t, 60*time.Second, opts.Configuration.RemoteConnectTimeout)
 }
 
 func TestFailedTLSFlags(t *testing.T) {

--- a/plugin/storage/grpc/shared/grpc_client_test.go
+++ b/plugin/storage/grpc/shared/grpc_client_test.go
@@ -263,7 +263,7 @@ func TestGRPCClientFindTraces(t *testing.T) {
 		s, err := r.client.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 		assert.NoError(t, err)
 		assert.NotNil(t, s)
-		assert.Equal(t, 2, len(s))
+		assert.Len(t, s, 2)
 	})
 }
 

--- a/plugin/storage/memory/factory_test.go
+++ b/plugin/storage/memory/factory_test.go
@@ -57,7 +57,7 @@ func TestWithConfiguration(t *testing.T) {
 	v, command := config.Viperize(f.AddFlags)
 	command.ParseFlags([]string{"--memory.max-traces=100"})
 	f.InitFromViper(v, zap.NewNop())
-	assert.Equal(t, f.options.Configuration.MaxTraces, 100)
+	assert.Equal(t, 100, f.options.Configuration.MaxTraces)
 }
 
 func TestInitFromOptions(t *testing.T) {

--- a/plugin/storage/memory/memory_test.go
+++ b/plugin/storage/memory/memory_test.go
@@ -192,8 +192,8 @@ func TestStoreWithLimit(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.Equal(t, maxTraces, len(store.getTenant("").traces))
-	assert.Equal(t, maxTraces, len(store.getTenant("").ids))
+	assert.Len(t, store.getTenant("").traces, maxTraces)
+	assert.Len(t, store.getTenant("").ids, maxTraces)
 }
 
 func TestStoreGetTraceSuccess(t *testing.T) {
@@ -211,7 +211,7 @@ func TestStoreGetAndMutateTrace(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, trace.Spans, 1)
 		assert.Equal(t, testingSpan, trace.Spans[0])
-		assert.Len(t, trace.Spans[0].Warnings, 0)
+		assert.Empty(t, trace.Spans[0].Warnings)
 
 		trace.Spans[0].Warnings = append(trace.Spans[0].Warnings, "the end is near")
 
@@ -219,7 +219,7 @@ func TestStoreGetAndMutateTrace(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, trace.Spans, 1)
 		assert.Equal(t, testingSpan, trace.Spans[0])
-		assert.Len(t, trace.Spans[0].Warnings, 0)
+		assert.Empty(t, trace.Spans[0].Warnings)
 	})
 }
 
@@ -293,7 +293,7 @@ func TestStoreGetOperationsNotFound(t *testing.T) {
 			spanstore.OperationQueryParameters{ServiceName: "notAService"},
 		)
 		assert.NoError(t, err)
-		assert.Len(t, operations, 0)
+		assert.Empty(t, operations)
 	})
 }
 
@@ -301,7 +301,7 @@ func TestStoreGetEmptyTraceSet(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
 		traces, err := store.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
 		assert.NoError(t, err)
-		assert.Len(t, traces, 0)
+		assert.Empty(t, traces)
 	})
 }
 

--- a/plugin/storage/memory/sampling_test.go
+++ b/plugin/storage/memory/sampling_test.go
@@ -53,7 +53,7 @@ func TestInsertThroughtput(t *testing.T) {
 		}
 		assert.NoError(t, samplingStore.InsertThroughput(throughputs))
 		ret, _ := samplingStore.GetThroughput(start, start.Add(time.Second*time.Duration(1)))
-		assert.Equal(t, 2, len(ret))
+		assert.Len(t, ret, 2)
 
 		for i := 0; i < 10; i++ {
 			in := []*model.Throughput{
@@ -61,7 +61,7 @@ func TestInsertThroughtput(t *testing.T) {
 			}
 			samplingStore.InsertThroughput(in)
 		}
-		assert.Equal(t, 5, len(samplingStore.throughputs))
+		assert.Len(t, samplingStore.throughputs, 5)
 	})
 }
 
@@ -70,11 +70,11 @@ func TestGetThroughput(t *testing.T) {
 		start := time.Now()
 		ret, err := samplingStore.GetThroughput(start, start.Add(time.Second*time.Duration(1)))
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(ret))
+		assert.Len(t, ret, 1)
 		ret1, _ := samplingStore.GetThroughput(start, start)
-		assert.Equal(t, 0, len(ret1))
+		assert.Empty(t, ret1)
 		ret2, _ := samplingStore.GetThroughput(start, start.Add(time.Hour*time.Duration(1)))
-		assert.Equal(t, 2, len(ret2))
+		assert.Len(t, ret2, 2)
 	})
 }
 
@@ -100,9 +100,9 @@ func TestGetLatestProbability(t *testing.T) {
 		// With some pregenerated data
 		ret, err := samplingStore.GetLatestProbabilities()
 		assert.NoError(t, err)
-		assert.Equal(t, ret, model.ServiceOperationProbabilities{"svc-1": {"op-1": 0.01}})
+		assert.Equal(t, model.ServiceOperationProbabilities{"svc-1": {"op-1": 0.01}}, ret)
 		assert.NoError(t, samplingStore.InsertProbabilitiesAndQPS("utfhyolf", model.ServiceOperationProbabilities{"another-service": {"hello": 0.009}}, model.ServiceOperationQPS{"new-srv": {"op": 5}}))
 		ret, _ = samplingStore.GetLatestProbabilities()
-		assert.NotEqual(t, ret, model.ServiceOperationProbabilities{"svc-1": {"op-1": 0.01}})
+		assert.NotEqual(t, model.ServiceOperationProbabilities{"svc-1": {"op-1": 0.01}}, ret)
 	})
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Follow testify best practices 

## Description of the changes
- Add testifylint linter to golangci-lint and fix issues
- This only enables the easiest rules to fix as it can modify many files here:
      - empty
      - error-is-as
      - error-nil
      - expected-actual
      - len
      - suite-dont-use-pkg
      - suite-extra-assert-call

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
