### PR TITLE
ci: Simplify check-label workflow

### DIFF
--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -21,7 +21,9 @@ jobs:
 
       - name: Check PR author
         id: check_author
-        run: echo "::set-output name=is_dependabot::$(echo ${{ github.event.pull_request.user.login }} | grep -o 'dependabot')"
+        run: |
+          is_dependabot=$(echo ${{ github.event.pull_request.user.login }} | grep -o 'dependabot')
+          echo "is_dependabot=$is_dependabot" >> $GITHUB_OUTPUT
 
       - name: Check PR label
         if: steps.check_author.outputs.is_dependabot != 'dependabot'

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -19,14 +19,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check PR author
-        id: check_author
-        run: |
-          is_dependabot=$(echo ${{ github.event.pull_request.user.login }} | grep -o 'dependabot')
-          echo "is_dependabot=$is_dependabot" >> $GITHUB_OUTPUT
-
       - name: Check PR label
-        if: steps.check_author.outputs.is_dependabot != 'dependabot'
+        if: github.event.pull_request.user.login != 'dependabot'
         run: |
           LABEL_NAME="changelog:"
           if [[ $(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq -r '.labels[].name' | grep -c "^$LABEL_NAME") -eq 0 ]]; then


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a deprecation in the workflow as [outlined here](https://github.com/jaegertracing/jaeger-ui/issues/2067)

## Description of the changes
Removed the `set-output` command in favor of the new environment variable by GitHub.

## How was this change tested?
NA

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
