### PR TITLE
testifylint: enable require-error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,7 +141,6 @@ linters-settings:
       - compares
       - float-compare
       - go-require
-      - require-error
     enable:
       - bool-compare
       - empty
@@ -149,6 +148,7 @@ linters-settings:
       - error-nil
       - expected-actual
       - len
+      - require-error
       - suite-dont-use-pkg
       - suite-extra-assert-call
 

--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -39,7 +39,7 @@ func TestAgentStartError(t *testing.T) {
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
 	require.NoError(t, err)
 	agent.httpServer.Addr = "bad-address"
-	assert.Error(t, agent.Run())
+	require.Error(t, agent.Run())
 }
 
 func TestAgentSamplingEndpoint(t *testing.T) {
@@ -67,7 +67,7 @@ func TestAgentSamplingEndpoint(t *testing.T) {
 		resp, err := http.Get(url)
 		require.NoError(t, err)
 		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "collector error: no peers available\n", string(body))
 	})
 }
@@ -78,7 +78,7 @@ func TestAgentMetricsEndpoint(t *testing.T) {
 		resp, err := http.Get(url)
 		require.NoError(t, err)
 		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Contains(t, string(body), "# HELP")
 	})
 }
@@ -129,7 +129,7 @@ func withRunningAgent(t *testing.T, testcase func(string, chan error)) {
 	testcase(agent.HTTPAddr(), ch)
 
 	agent.Stop()
-	assert.NoError(t, <-ch)
+	require.NoError(t, <-ch)
 
 	for i := 0; i < 1000; i++ {
 		if strings.Contains(logBuf.String(), "agent's http server exiting") {

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -128,7 +128,7 @@ func TestBuilderFromConfig(t *testing.T) {
 func TestBuilderWithExtraReporter(t *testing.T) {
 	cfg := &Builder{}
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, agent)
 }
 
@@ -159,7 +159,7 @@ func TestBuilderWithProcessorErrors(t *testing.T) {
 			},
 		}
 		_, err := cfg.CreateAgent(&fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
-		assert.Error(t, err)
+		require.Error(t, err)
 		if testCase.err != "" {
 			assert.Contains(t, err.Error(), testCase.err)
 		} else if testCase.errContains != "" {
@@ -262,7 +262,7 @@ func TestCreateCollectorProxy(t *testing.T) {
 			Logger:  zap.NewNop(),
 		}, builders)
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 			assert.Nil(t, proxy)
 		} else {
 			require.NoError(t, err)
@@ -280,7 +280,7 @@ func TestCreateCollectorProxy_UnknownReporter(t *testing.T) {
 	}
 	proxy, err := CreateCollectorProxy(ProxyBuilderOptions{}, builders)
 	assert.Nil(t, proxy)
-	assert.EqualError(t, err, "unknown reporter type ")
+	require.EqualError(t, err, "unknown reporter type ")
 }
 
 func TestPublishOpts(t *testing.T) {
@@ -305,7 +305,7 @@ func TestPublishOpts(t *testing.T) {
 	forkFactory := metricstest.NewFactory(time.Second)
 	metricsFactory := fork.New("internal", forkFactory, baseMetrics)
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metricsFactory)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, agent)
 
 	forkFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -62,7 +62,7 @@ func TestSamplingManager_GetBaggageRestrictions(t *testing.T) {
 	manager := NewConfigManager(nil)
 	rest, err := manager.GetBaggageRestrictions(context.Background(), "foo")
 	require.Nil(t, rest)
-	assert.EqualError(t, err, "baggage not implemented")
+	require.EqualError(t, err, "baggage not implemented")
 }
 
 type mockSamplingHandler struct{}

--- a/cmd/agent/app/configmanager/metrics_test.go
+++ b/cmd/agent/app/configmanager/metrics_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -73,10 +72,10 @@ func TestMetrics(t *testing.T) {
 			if test.err != nil {
 				s, err := mgr.GetSamplingStrategy(context.Background(), test.err.Error())
 				require.Nil(t, s)
-				assert.EqualError(t, err, test.err.Error())
+				require.EqualError(t, err, test.err.Error())
 				b, err := mgr.GetBaggageRestrictions(context.Background(), test.err.Error())
 				require.Nil(t, b)
-				assert.EqualError(t, err, test.err.Error())
+				require.EqualError(t, err, test.err.Error())
 			} else {
 				s, err := mgr.GetSamplingStrategy(context.Background(), "")
 				require.NoError(t, err)

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -92,7 +92,7 @@ func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.Gr
 
 func TestNewThriftProcessor_ZeroCount(t *testing.T) {
 	_, err := NewThriftProcessor(nil, 0, nil, nil, nil, zaptest.NewLogger(t))
-	assert.EqualError(t, err, "number of processors must be greater than 0, called with 0")
+	require.EqualError(t, err, "number of processors must be greater than 0, called with 0")
 }
 
 func TestProcessorWithCompactZipkin(t *testing.T) {

--- a/cmd/agent/app/reporter/client_metrics_test.go
+++ b/cmd/agent/app/reporter/client_metrics_test.go
@@ -75,7 +75,7 @@ func testClientMetricsWithParams(params ClientMetricsReporterParams, fn func(tr 
 
 func TestClientMetricsReporter_Zipkin(t *testing.T) {
 	testClientMetrics(func(tr *clientMetricsTest) {
-		assert.NoError(t, tr.r.EmitZipkinBatch(context.Background(), []*zipkincore.Span{{}}))
+		require.NoError(t, tr.r.EmitZipkinBatch(context.Background(), []*zipkincore.Span{{}}))
 		assert.Len(t, tr.mr.ZipkinSpans(), 1)
 	})
 }
@@ -181,7 +181,7 @@ func TestClientMetricsReporter_Jaeger(t *testing.T) {
 				}
 
 				err := tr.r.EmitBatch(context.Background(), batch)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Len(t, tr.mr.Spans(), i+1)
 
 				tr.assertLog(t, "new client", test.expLog)
@@ -248,7 +248,7 @@ func TestClientMetricsReporter_Expire(t *testing.T) {
 			assert.EqualValues(t, 0, getGauge(), "start with gauge=0")
 
 			err := tr.r.EmitBatch(context.Background(), batch)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, tr.mr.Spans(), 1)
 
 			// we want this test to pass asap, but need to account for possible CPU contention in the CI

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -220,8 +220,8 @@ func TestProxyBuilder(t *testing.T) {
 				assert.NotNil(t, proxy.GetReporter())
 				assert.NotNil(t, proxy.GetManager())
 
-				assert.NoError(t, proxy.Close())
-				assert.EqualError(t, proxy.Close(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
+				require.NoError(t, proxy.Close())
+				require.EqualError(t, proxy.Close(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
 			}
 		})
 	}
@@ -423,5 +423,5 @@ func TestBuilderWithAdditionalDialOptions(t *testing.T) {
 	assert.NotNil(t, r)
 
 	err = r.Invoke(context.Background(), "test", map[string]string{}, map[string]string{}, []grpc.CallOption{}...)
-	assert.Error(t, err, "should error because no server is running")
+	require.Error(t, err, "should error because no server is running")
 }

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -88,7 +88,7 @@ func TestReporter_EmitZipkinBatch(t *testing.T) {
 	for _, test := range tests {
 		err = rep.EmitZipkinBatch(context.Background(), []*zipkincore.Span{test.in})
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 		} else {
 			assert.Len(t, handler.requests, 1)
 			assert.Equal(t, test.expected, handler.requests[0].GetBatch())
@@ -122,7 +122,7 @@ func TestReporter_EmitBatch(t *testing.T) {
 	for _, test := range tests {
 		err = rep.EmitBatch(context.Background(), test.in)
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 		} else {
 			assert.Len(t, handler.requests, 1)
 			assert.Equal(t, test.expected, handler.requests[0].GetBatch())

--- a/cmd/agent/app/reporter/reporter_test.go
+++ b/cmd/agent/app/reporter/reporter_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
@@ -39,8 +40,8 @@ func TestMultiReporter(t *testing.T) {
 			{},
 		},
 	})
-	assert.NoError(t, e1)
-	assert.NoError(t, e2)
+	require.NoError(t, e1)
+	require.NoError(t, e2)
 	assert.Len(t, r1.ZipkinSpans(), 1)
 	assert.Len(t, r1.Spans(), 1)
 	assert.Len(t, r2.ZipkinSpans(), 1)
@@ -60,8 +61,8 @@ func TestMultiReporterErrors(t *testing.T) {
 			{},
 		},
 	})
-	assert.EqualError(t, e1, fmt.Sprintf("%s\n%s", errMsg, errMsg))
-	assert.EqualError(t, e2, fmt.Sprintf("%s\n%s", errMsg, errMsg))
+	require.EqualError(t, e1, fmt.Sprintf("%s\n%s", errMsg, errMsg))
+	require.EqualError(t, e2, fmt.Sprintf("%s\n%s", errMsg, errMsg))
 }
 
 type mockReporter struct {

--- a/cmd/agent/app/servers/server_test.go
+++ b/cmd/agent/app/servers/server_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -34,7 +35,7 @@ func TestReadBuf_Read(t *testing.T) {
 	b := &ReadBuf{bytes: []byte("hello"), n: 5}
 	r := make([]byte, 5)
 	n, err := b.Read(r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5, n)
 	assert.Equal(t, "hello", string(r))
 }

--- a/cmd/agent/app/servers/thriftudp/transport_test.go
+++ b/cmd/agent/app/servers/thriftudp/transport_test.go
@@ -238,7 +238,7 @@ func withLocalServer(t *testing.T, f func(addr string)) {
 
 func TestCreateClient(t *testing.T) {
 	_, err := createClient(nil, nil)
-	assert.EqualError(t, err, "dial udp: missing address")
+	require.EqualError(t, err, "dial udp: missing address")
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/agent/app/testutils/in_memory_reporter_test.go
+++ b/cmd/agent/app/testutils/in_memory_reporter_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -35,8 +36,8 @@ func TestInMemoryReporter(t *testing.T) {
 			{},
 		},
 	})
-	assert.NoError(t, e1)
-	assert.NoError(t, e2)
+	require.NoError(t, e1)
+	require.NoError(t, e2)
 	assert.Len(t, r.ZipkinSpans(), 1)
 	assert.Len(t, r.Spans(), 1)
 }

--- a/cmd/agent/app/testutils/thriftudp_client_test.go
+++ b/cmd/agent/app/testutils/thriftudp_client_test.go
@@ -19,13 +19,12 @@ import (
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewZipkinThriftUDPClient(t *testing.T) {
 	_, _, err := NewZipkinThriftUDPClient("256.2.3:0")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, cl, err := NewZipkinThriftUDPClient("127.0.0.1:12345")
 	require.NoError(t, err)
@@ -36,7 +35,7 @@ func TestNewJaegerThriftUDPClient(t *testing.T) {
 	compactFactory := thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{})
 
 	_, _, err := NewJaegerThriftUDPClient("256.2.3:0", compactFactory)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, cl, err := NewJaegerThriftUDPClient("127.0.0.1:12345", compactFactory)
 	require.NoError(t, err)

--- a/cmd/anonymizer/app/anonymizer/anonymizer_test.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -81,7 +82,7 @@ func TestNew(t *testing.T) {
 	tempDir := t.TempDir()
 
 	file, err := os.CreateTemp(tempDir, "mapping.json")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = file.Write([]byte(`
 {
@@ -93,7 +94,7 @@ func TestNew(t *testing.T) {
 	}
 }
 `))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	anonymizer := New(file.Name(), Options{}, nopLogger)
 	assert.NotNil(t, anonymizer)

--- a/cmd/collector/app/collector_test.go
+++ b/cmd/collector/app/collector_test.go
@@ -69,7 +69,7 @@ func TestNewCollector(t *testing.T) {
 	collectorOpts := optionsForEphemeralPorts()
 	require.NoError(t, c.Start(collectorOpts))
 	assert.NotNil(t, c.SpanHandlers())
-	assert.NoError(t, c.Close())
+	require.NoError(t, c.Close())
 }
 
 func TestCollector_StartErrors(t *testing.T) {
@@ -208,8 +208,8 @@ func TestAggregator(t *testing.T) {
 		},
 	}
 	_, err := c.spanProcessor.ProcessSpans(spans, processor.SpansOptions{SpanFormat: processor.JaegerSpanFormat})
-	assert.NoError(t, err)
-	assert.NoError(t, c.Close())
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
 
 	// spans are processed by background workers, so we may need to wait
 	for i := 0; i < 1000; i++ {

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -419,7 +419,7 @@ func TestBatchConsumer(t *testing.T) {
 					{OperationName: "test-op", Process: &model.Process{ServiceName: "foo"}},
 				},
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.transport, processor.getTransport())
 			assert.Equal(t, tc.expectedSpanFormat, processor.getSpanFormat())
 		})

--- a/cmd/collector/app/handler/http_thrift_handler_test.go
+++ b/cmd/collector/app/handler/http_thrift_handler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	jaegerClient "github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/transport"
 
@@ -74,24 +75,24 @@ func TestThriftFormat(t *testing.T) {
 	batch := jaeger.Batch{Process: process, Spans: spans}
 	tser := thrift.NewTSerializer()
 	someBytes, err := tser.Write(context.Background(), &batch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, someBytes)
 	server, handler := initializeTestServer(nil)
 	defer server.Close()
 
 	statusCode, resBodyStr, err := postBytes("application/x-thrift", server.URL+`/api/traces`, someBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusAccepted, statusCode)
 	assert.EqualValues(t, "", resBodyStr)
 
 	statusCode, resBodyStr, err = postBytes("application/x-thrift; charset=utf-8", server.URL+`/api/traces`, someBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusAccepted, statusCode)
 	assert.EqualValues(t, "", resBodyStr)
 
 	handler.jaegerBatchesHandler.(*mockJaegerHandler).err = fmt.Errorf("Bad times ahead")
 	statusCode, resBodyStr, err = postBytes("application/vnd.apache.thrift.binary", server.URL+`/api/traces`, someBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusInternalServerError, statusCode)
 	assert.EqualValues(t, "Cannot submit Jaeger batch: Bad times ahead\n", resBodyStr)
 }
@@ -135,7 +136,7 @@ func TestBadBody(t *testing.T) {
 	defer server.Close()
 	bodyBytes := []byte("not good")
 	statusCode, resBodyStr, err := postBytes("application/x-thrift", server.URL+`/api/traces`, bodyBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusBadRequest, statusCode)
 	assert.EqualValues(t, "Unable to process request body: Unknown data type 110\n", resBodyStr)
 }
@@ -144,7 +145,7 @@ func TestWrongFormat(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
 	statusCode, resBodyStr, err := postBytes("nosoupforyou", server.URL+`/api/traces`, []byte{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusBadRequest, statusCode)
 	assert.EqualValues(t, "Unsupported content type: nosoupforyou\n", resBodyStr)
 }
@@ -153,7 +154,7 @@ func TestMalformedFormat(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
 	statusCode, resBodyStr, err := postBytes("application/json; =iammalformed", server.URL+`/api/traces`, []byte{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusBadRequest, statusCode)
 	assert.EqualValues(t, "Cannot parse content type: mime: invalid media parameter\n", resBodyStr)
 }
@@ -161,7 +162,7 @@ func TestMalformedFormat(t *testing.T) {
 func TestCannotReadBodyFromRequest(t *testing.T) {
 	handler := NewAPIHandler(&mockJaegerHandler{})
 	req, err := http.NewRequest(http.MethodPost, "whatever", &errReader{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	rw := dummyResponseWriter{}
 	handler.SaveSpan(&rw, req)
 	assert.EqualValues(t, http.StatusInternalServerError, rw.myStatusCode)

--- a/cmd/collector/app/handler/otlp_receiver_test.go
+++ b/cmd/collector/app/handler/otlp_receiver_test.go
@@ -54,7 +54,7 @@ func TestStartOtlpReceiver(t *testing.T) {
 	rec, err := StartOTLPReceiver(optionsWithPorts(":0"), logger, spanProcessor, tm)
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, rec.Shutdown(context.Background()))
+		require.NoError(t, rec.Shutdown(context.Background()))
 	}()
 
 	// Ideally, we want to test with a real gRPC client, but OTEL repos only have those as internal packages.

--- a/cmd/collector/app/handler/thrift_span_handler_test.go
+++ b/cmd/collector/app/handler/thrift_span_handler_test.go
@@ -57,7 +57,7 @@ func TestJaegerSpanHandler(t *testing.T) {
 			assert.Equal(t, tc.expectedErr, err)
 		} else {
 			assert.Len(t, res, 1)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.True(t, res[0].Ok)
 		}
 	}
@@ -131,7 +131,7 @@ func TestZipkinSpanHandler(t *testing.T) {
 				assert.Equal(t, tc.expectedErr, err)
 			} else {
 				assert.Len(t, res, len(spans))
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				for i := range res {
 					assert.True(t, res[i].Ok)
 				}

--- a/cmd/collector/app/sampling/grpc_handler_test.go
+++ b/cmd/collector/app/sampling/grpc_handler_test.go
@@ -51,7 +51,7 @@ func TestNewGRPCHandler(t *testing.T) {
 	for _, test := range tests {
 		resp, err := h.GetSamplingStrategy(context.Background(), test.req)
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 			require.Nil(t, resp)
 		} else {
 			require.NoError(t, err)

--- a/cmd/collector/app/sanitizer/cache/auto_refresh_cache_test.go
+++ b/cmd/collector/app/sanitizer/cache/auto_refresh_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 
@@ -95,7 +96,7 @@ func TestInitialize(t *testing.T) {
 
 	mS.On("Load").Return(testCache1, nil)
 	mE.On("Load").Return(nil, errDefault)
-	assert.NoError(t, c.Initialize())
+	require.NoError(t, c.Initialize())
 	assert.Equal(t, "rt-supply", c.Get("supply"))
 }
 
@@ -105,7 +106,7 @@ func TestInitialize_error(t *testing.T) {
 
 	mS.On("Load").Return(nil, errDefault)
 	mE.On("Load").Return(nil, errDefault)
-	assert.NoError(t, c.Initialize())
+	require.NoError(t, c.Initialize())
 	assert.True(t, c.IsEmpty())
 }
 
@@ -113,18 +114,18 @@ func TestWarmCache(t *testing.T) {
 	c, mE, mS := getCache(t)
 	mS.On("Load").Return(testCache1, nil).Times(1)
 	err := c.warmCache()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "rt-supply", c.Get("supply"))
 
 	mS.On("Load").Return(nil, errDefault).Times(1)
 	mE.On("Load").Return(testCache2, nil).Times(1)
 	err = c.warmCache()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "rt-demand", c.Get("demand"), "External load should've succeeded")
 
 	mS.On("Load").Return(nil, errDefault).Times(1)
 	mE.On("Load").Return(nil, errDefault).Times(1)
-	assert.Error(t, c.warmCache(), "Both loads should've failed")
+	require.Error(t, c.warmCache(), "Both loads should've failed")
 }
 
 func TestRefreshFromStorage(t *testing.T) {

--- a/cmd/collector/app/server/grpc_test.go
+++ b/cmd/collector/app/server/grpc_test.go
@@ -45,7 +45,7 @@ func TestFailToListen(t *testing.T) {
 		Logger:        logger,
 	})
 	assert.Nil(t, server)
-	assert.EqualError(t, err, "failed to listen on gRPC port: listen tcp: address -1: invalid port")
+	require.EqualError(t, err, "failed to listen on gRPC port: listen tcp: address -1: invalid port")
 }
 
 func TestFailServe(t *testing.T) {

--- a/cmd/collector/app/server/http_test.go
+++ b/cmd/collector/app/server/http_test.go
@@ -44,7 +44,7 @@ func TestFailToListenHTTP(t *testing.T) {
 		Logger:   logger,
 	})
 	assert.Nil(t, server)
-	assert.EqualError(t, err, "listen tcp: address -1: invalid port")
+	require.EqualError(t, err, "listen tcp: address -1: invalid port")
 }
 
 func TestCreateTLSHTTPServerError(t *testing.T) {
@@ -63,7 +63,7 @@ func TestCreateTLSHTTPServerError(t *testing.T) {
 		TLSConfig:   tlsCfg,
 	}
 	_, err := StartHTTPServer(params)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestSpanCollectorHTTP(t *testing.T) {
@@ -82,7 +82,7 @@ func TestSpanCollectorHTTP(t *testing.T) {
 	serveHTTP(server.Config, server.Listener, params)
 
 	response, err := http.Post(server.URL, "", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, response)
 }
 
@@ -204,7 +204,7 @@ func TestSpanCollectorHTTPS(t *testing.T) {
 			server, err := StartHTTPServer(params)
 			require.NoError(t, err)
 			defer func() {
-				assert.NoError(t, server.Close())
+				require.NoError(t, server.Close())
 			}()
 
 			clientTLSCfg, err0 := test.clientTLS.Config(logger)

--- a/cmd/collector/app/server/zipkin_test.go
+++ b/cmd/collector/app/server/zipkin_test.go
@@ -42,7 +42,7 @@ func TestFailToListenZipkin(t *testing.T) {
 		Logger:   logger,
 	})
 	assert.Nil(t, server)
-	assert.EqualError(t, err, "listen tcp: address -1: invalid port")
+	require.EqualError(t, err, "listen tcp: address -1: invalid port")
 }
 
 func TestSpanCollectorZipkin(t *testing.T) {
@@ -60,7 +60,7 @@ func TestSpanCollectorZipkin(t *testing.T) {
 	serveZipkin(server.Config, server.Listener, params)
 
 	response, err := http.Post(server.URL, "", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, response)
 }
 

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -244,9 +244,9 @@ func TestSpanProcessor(t *testing.T) {
 	res, err := p.ProcessSpans(
 		[]*model.Span{{}}, // empty span should be enriched by sanitizers
 		processor.SpansOptions{SpanFormat: processor.JaegerSpanFormat})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []bool{true}, res)
-	assert.NoError(t, p.Close())
+	require.NoError(t, p.Close())
 	assert.Len(t, w.spans, 1)
 	assert.NotNil(t, w.spans[0].Process)
 	assert.NotEmpty(t, w.spans[0].Process.ServiceName)
@@ -273,10 +273,10 @@ func TestSpanProcessorErrors(t *testing.T) {
 			},
 		},
 	}, processor.SpansOptions{SpanFormat: processor.JaegerSpanFormat})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []bool{true}, res)
 
-	assert.NoError(t, p.Close())
+	require.NoError(t, p.Close())
 
 	assert.Equal(t, map[string]string{
 		"level": "error",
@@ -311,7 +311,7 @@ func TestSpanProcessorBusy(t *testing.T) {
 		Options.QueueSize(1),
 		Options.ReportBusy(true),
 	).(*spanProcessor)
-	defer assert.NoError(t, p.Close())
+	defer require.NoError(t, p.Close())
 
 	// block the writer so that the first span is read from the queue and blocks the processor,
 	// and either the second or the third span is rejected since the queue capacity is just 1.
@@ -336,7 +336,7 @@ func TestSpanProcessorBusy(t *testing.T) {
 		},
 	}, processor.SpansOptions{SpanFormat: processor.JaegerSpanFormat})
 
-	assert.Error(t, err, "expecting busy error")
+	require.Error(t, err, "expecting busy error")
 	assert.Nil(t, res)
 }
 
@@ -346,7 +346,7 @@ func TestSpanProcessorWithNilProcess(t *testing.T) {
 
 	w := &fakeSpanWriter{}
 	p := NewSpanProcessor(w, nil, Options.ServiceMetrics(serviceMetrics)).(*spanProcessor)
-	defer assert.NoError(t, p.Close())
+	defer require.NoError(t, p.Close())
 
 	p.saveSpan(&model.Span{}, "")
 
@@ -366,7 +366,7 @@ func TestSpanProcessorWithCollectorTags(t *testing.T) {
 	w := &fakeSpanWriter{}
 	p := NewSpanProcessor(w, nil, Options.CollectorTags(testCollectorTags)).(*spanProcessor)
 
-	defer assert.NoError(t, p.Close())
+	defer require.NoError(t, p.Close())
 	span := &model.Span{
 		Process: model.NewProcess("unit-test-service", []model.KeyValue{
 			{
@@ -454,7 +454,7 @@ func TestSpanProcessorCountSpan(t *testing.T) {
 			}
 			p := NewSpanProcessor(w, nil, opts...).(*spanProcessor)
 			defer func() {
-				assert.NoError(t, p.Close())
+				require.NoError(t, p.Close())
 			}()
 			p.background(10*time.Millisecond, p.updateGauges)
 
@@ -620,9 +620,9 @@ func TestAdditionalProcessors(t *testing.T) {
 			},
 		},
 	}, processor.SpansOptions{SpanFormat: processor.JaegerSpanFormat})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []bool{true}, res)
-	assert.NoError(t, p.Close())
+	require.NoError(t, p.Close())
 
 	// additional processor is called
 	count := 0
@@ -637,9 +637,9 @@ func TestAdditionalProcessors(t *testing.T) {
 			},
 		},
 	}, processor.SpansOptions{SpanFormat: processor.JaegerSpanFormat})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []bool{true}, res)
-	assert.NoError(t, p.Close())
+	require.NoError(t, p.Close())
 	assert.Equal(t, 1, count)
 }
 
@@ -658,9 +658,9 @@ func TestSpanProcessorContextPropagation(t *testing.T) {
 	}, processor.SpansOptions{
 		Tenant: dummyTenant,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []bool{true}, res)
-	assert.NoError(t, p.Close())
+	require.NoError(t, p.Close())
 
 	// Verify that the dummy tenant from SpansOptions context made it to writer
 	assert.True(t, w.tenants[dummyTenant])
@@ -705,6 +705,6 @@ func TestSpanProcessorWithOnDroppedSpanOption(t *testing.T) {
 		{OperationName: "op2"},
 		{OperationName: "op3"},
 	}, opts)
-	assert.EqualError(t, err, processor.ErrBusy.Error())
+	require.EqualError(t, err, processor.ErrBusy.Error())
 	assert.Equal(t, []string{"op3"}, droppedOperations)
 }

--- a/cmd/collector/app/zipkin/http_handler_test.go
+++ b/cmd/collector/app/zipkin/http_handler_test.go
@@ -58,7 +58,7 @@ func initTracer(t *testing.T, zexp *zipkin.Exporter) (trace.TracerProvider, func
 		sdktrace.WithSyncer(zexp),
 	)
 	closer := func() {
-		assert.NoError(t, tp.Shutdown(context.Background()))
+		require.NoError(t, tp.Shutdown(context.Background()))
 	}
 	return tp, closer
 }
@@ -117,7 +117,7 @@ func TestThriftFormat(t *testing.T) {
 	defer server.Close()
 	bodyBytes := zipkinTrift.SerializeThrift(context.Background(), []*zipkincore.Span{{}})
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, bodyBytes, createHeader("application/x-thrift"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusAccepted, statusCode)
 	assert.EqualValues(t, "", resBodyStr)
 }
@@ -138,7 +138,7 @@ func TestZipkinJsonV1Format(t *testing.T) {
 
 	t.Run("good span", func(t *testing.T) {
 		statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, []byte(spanJSON), createHeader("application/json"))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.EqualValues(t, http.StatusAccepted, statusCode)
 		assert.EqualValues(t, "", resBodyStr)
 		waitForSpans(t, handler.zipkinSpansHandler.(*mockZipkinHandler), 1)
@@ -150,7 +150,7 @@ func TestZipkinJsonV1Format(t *testing.T) {
 
 	t.Run("good span with utf8", func(t *testing.T) {
 		statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, []byte(spanJSON), createHeader("application/json; charset=utf-8"))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.EqualValues(t, http.StatusAccepted, statusCode)
 		assert.EqualValues(t, "", resBodyStr)
 	})
@@ -212,7 +212,7 @@ func TestGzipEncoding(t *testing.T) {
 	header := createHeader("application/x-thrift")
 	header.Add("Content-Encoding", "gzip")
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, gzipEncode(bodyBytes), header)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusAccepted, statusCode)
 	assert.EqualValues(t, "", resBodyStr)
 }
@@ -223,7 +223,7 @@ func TestGzipBadBody(t *testing.T) {
 	header := createHeader("")
 	header.Add("Content-Encoding", "gzip")
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, []byte("not good"), header)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusBadRequest, statusCode)
 	assert.EqualValues(t, "Unable to process request body: unexpected EOF\n", resBodyStr)
 }
@@ -232,7 +232,7 @@ func TestMalformedContentType(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, []byte{}, createHeader("application/json; =iammalformed;"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusBadRequest, statusCode)
 	assert.EqualValues(t, "Cannot parse Content-Type: mime: invalid media parameter\n", resBodyStr)
 }
@@ -241,7 +241,7 @@ func TestUnsupportedContentType(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
 	statusCode, _, err := postBytes(server.URL+`/api/v1/spans`, []byte{}, createHeader("text/html"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusBadRequest, statusCode)
 }
 
@@ -249,7 +249,7 @@ func TestFormatBadBody(t *testing.T) {
 	server, _ := initializeTestServer(nil)
 	defer server.Close()
 	statusCode, resBodyStr, err := postBytes(server.URL+`/api/v1/spans`, []byte("not good"), createHeader("application/x-thrift"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, http.StatusBadRequest, statusCode)
 	assert.Contains(t, resBodyStr, "Unable to process request body:")
 }
@@ -257,7 +257,7 @@ func TestFormatBadBody(t *testing.T) {
 func TestCannotReadBodyFromRequest(t *testing.T) {
 	handler := NewAPIHandler(&mockZipkinHandler{})
 	req, err := http.NewRequest(http.MethodPost, "whatever", &errReader{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	rw := dummyResponseWriter{}
 
 	tests := []struct {

--- a/cmd/es-rollover/app/actions_test.go
+++ b/cmd/es-rollover/app/actions_test.go
@@ -115,7 +115,7 @@ func TestExecuteAction(t *testing.T) {
 
 			assert.Equal(t, test.expectedExecuteAction, executedAction)
 			if test.configError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				assert.Equal(t, test.expectedError, err)
 			}

--- a/cmd/es-rollover/app/init/action_test.go
+++ b/cmd/es-rollover/app/init/action_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
 	"github.com/jaegertracing/jaeger/pkg/es/client"
@@ -260,7 +261,7 @@ func TestRolloverAction(t *testing.T) {
 
 			err := initAction.Do()
 			if test.expectedErr != nil {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.expectedErr, err)
 			}
 

--- a/cmd/es-rollover/app/lookback/action_test.go
+++ b/cmd/es-rollover/app/lookback/action_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
@@ -147,7 +148,7 @@ func TestLookBackAction(t *testing.T) {
 
 			err := lookbackAction.Do()
 			if test.expectedErr != nil {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.expectedErr, err)
 			}
 		})

--- a/cmd/es-rollover/app/rollover/action_test.go
+++ b/cmd/es-rollover/app/rollover/action_test.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
 	"github.com/jaegertracing/jaeger/pkg/es/client"
@@ -136,9 +136,9 @@ func TestRolloverAction(t *testing.T) {
 			test.setupCallExpectations(indexClient, &test)
 			err := rolloverAction.Do()
 			if test.expectedError || test.unmarshalErrExpected {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			indexClient.AssertExpectations(t)
 		})

--- a/cmd/esmapping-generator/app/renderer/render_test.go
+++ b/cmd/esmapping-generator/app/renderer/render_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
@@ -90,9 +91,9 @@ func Test_getMappingAsString(t *testing.T) {
 
 			// Validate
 			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
+				require.EqualError(t, err, tt.wantErr.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.want, got)
 		})

--- a/cmd/ingester/app/consumer/committing_processor_test.go
+++ b/cmd/ingester/app/consumer/committing_processor_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	kafka "github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/mocks"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
@@ -43,7 +44,7 @@ func TestNewCommittingProcessor(t *testing.T) {
 	msg := &kafka.Message{}
 	msg.On("Offset").Return(msgOffset)
 
-	assert.NoError(t, committingProcessor.Process(msg))
+	require.NoError(t, committingProcessor.Process(msg))
 
 	spanProcessor.AssertExpectations(t)
 	assert.Equal(t, msgOffset, offsetMarker.capturedOffset)
@@ -56,7 +57,7 @@ func TestNewCommittingProcessorError(t *testing.T) {
 	committingProcessor := NewCommittingProcessor(spanProcessor, offsetMarker)
 	msg := &kafka.Message{}
 
-	assert.Error(t, committingProcessor.Process(msg))
+	require.Error(t, committingProcessor.Process(msg))
 
 	spanProcessor.AssertExpectations(t)
 	assert.Equal(t, int64(0), offsetMarker.capturedOffset)
@@ -71,5 +72,5 @@ func (f fakeProcessorMessage) Value() []byte {
 func TestNewCommittingProcessorErrorNoKafkaMessage(t *testing.T) {
 	committingProcessor := NewCommittingProcessor(&mocks.SpanProcessor{}, &fakeOffsetMarker{})
 
-	assert.Error(t, committingProcessor.Process(fakeProcessorMessage{}))
+	require.Error(t, committingProcessor.Process(fakeProcessorMessage{}))
 }

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -48,7 +48,7 @@ const (
 
 func TestConstructor(t *testing.T) {
 	newConsumer, err := New(Params{MetricsFactory: metrics.NullFactory})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newConsumer)
 }
 

--- a/cmd/ingester/app/consumer/processor_factory_test.go
+++ b/cmd/ingester/app/consumer/processor_factory_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	kmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/mocks"
@@ -30,7 +31,7 @@ import (
 func Test_NewFactory(t *testing.T) {
 	params := ProcessorFactoryParams{}
 	newFactory, err := NewProcessorFactory(params)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newFactory)
 }
 

--- a/cmd/ingester/app/processor/decorator/retry_test.go
+++ b/cmd/ingester/app/processor/decorator/retry_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
@@ -40,7 +41,7 @@ func TestNewRetryingProcessor(t *testing.T) {
 	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor)
 
-	assert.NoError(t, rp.Process(msg))
+	require.NoError(t, rp.Process(msg))
 
 	mockProcessor.AssertExpectations(t)
 	c, _ := lf.Snapshot()
@@ -62,7 +63,7 @@ func TestNewRetryingProcessorError(t *testing.T) {
 	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
-	assert.Error(t, rp.Process(msg))
+	require.Error(t, rp.Process(msg))
 
 	mockProcessor.AssertNumberOfCalls(t, "Process", 3)
 	c, _ := lf.Snapshot()
@@ -85,7 +86,7 @@ func TestNewRetryingProcessorNoErrorPropagation(t *testing.T) {
 	lf := metricstest.NewFactory(0)
 	rp := NewRetryingProcessor(lf, mockProcessor, opts...)
 
-	assert.NoError(t, rp.Process(msg))
+	require.NoError(t, rp.Process(msg))
 	mockProcessor.AssertNumberOfCalls(t, "Process", 2)
 	c, _ := lf.Snapshot()
 	assert.Equal(t, int64(1), c["span-processor.retry-exhausted"])

--- a/cmd/ingester/app/processor/span_processor_test.go
+++ b/cmd/ingester/app/processor/span_processor_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	cmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/mocks"
 	"github.com/jaegertracing/jaeger/model"
@@ -56,7 +57,7 @@ func TestSpanProcessor_Process(t *testing.T) {
 			assert.NotNil(t, span.Process, "sanitizer must fix Process=nil data issue")
 		})
 
-	assert.NoError(t, processor.Process(message))
+	require.NoError(t, processor.Process(message))
 
 	message.AssertExpectations(t)
 	mockWriter.AssertExpectations(t)
@@ -76,7 +77,7 @@ func TestSpanProcessor_ProcessError(t *testing.T) {
 	message.On("Value").Return(data)
 	unmarshallerMock.On("Unmarshal", data).Return(nil, errors.New("moocow"))
 
-	assert.Error(t, processor.Process(message))
+	require.Error(t, processor.Process(message))
 
 	message.AssertExpectations(t)
 	writer.AssertExpectations(t)

--- a/cmd/internal/flags/admin_test.go
+++ b/cmd/internal/flags/admin_test.go
@@ -47,7 +47,7 @@ func TestAdminServerHandlesPortZero(t *testing.T) {
 
 	adminServer.initFromViper(v, logger)
 
-	assert.NoError(t, adminServer.Serve())
+	require.NoError(t, adminServer.Serve())
 	defer adminServer.Close()
 
 	message := logs.FilterMessage("Admin server started")

--- a/cmd/internal/flags/service_test.go
+++ b/cmd/internal/flags/service_test.go
@@ -77,14 +77,14 @@ func TestStartErrors(t *testing.T) {
 			s := NewService( /*default port=*/ 0)
 			v, cmd := config.Viperize(s.AddFlags)
 			err := cmd.ParseFlags(test.flags)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = s.Start(v)
 			if test.expErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.expErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var stopped atomic.Bool
 			shutdown := func() {

--- a/cmd/internal/status/command_test.go
+++ b/cmd/internal/status/command_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -42,7 +42,7 @@ func TestReady(t *testing.T) {
 	cmd := Command(v, 80)
 	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://")})
 	err := cmd.Execute()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestOnlyPortConfig(t *testing.T) {
@@ -52,7 +52,7 @@ func TestOnlyPortConfig(t *testing.T) {
 	cmd := Command(v, 80)
 	cmd.ParseFlags([]string{"--status.http.host-port=:" + strings.Split(ts.URL, ":")[len(strings.Split(ts.URL, ":"))-1]})
 	err := cmd.Execute()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUnready(t *testing.T) {
@@ -62,14 +62,14 @@ func TestUnready(t *testing.T) {
 	cmd := Command(v, 80)
 	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://")})
 	err := cmd.Execute()
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestNoService(t *testing.T) {
 	v := viper.New()
 	cmd := Command(v, 12345)
 	err := cmd.Execute()
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/query/app/additional_headers_test.go
+++ b/cmd/query/app/additional_headers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAdditionalHeadersHandler(t *testing.T) {
@@ -38,10 +39,10 @@ func TestAdditionalHeadersHandler(t *testing.T) {
 	defer server.Close()
 
 	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	resp, err := server.Client().Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for k, v := range additionalHeaders {
 		assert.Equal(t, v, resp.Header[k])

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -80,20 +80,20 @@ func TestStringSliceAsHeader(t *testing.T) {
 
 	assert.Equal(t, []string{"https://mozilla.org"}, parsedHeaders["Access-Control-Allow-Origin"])
 	assert.Equal(t, []string{"X-My-Custom-Header", "X-Another-Custom-Header"}, parsedHeaders["Access-Control-Expose-Headers"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	malformedHeaders := append(headers, "this is not a valid header")
 	parsedHeaders, err = stringSliceAsHeader(malformedHeaders)
 	assert.Nil(t, parsedHeaders)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	parsedHeaders, err = stringSliceAsHeader([]string{})
 	assert.Nil(t, parsedHeaders)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	parsedHeaders, err = stringSliceAsHeader(nil)
 	assert.Nil(t, parsedHeaders)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestBuildQueryServiceOptions(t *testing.T) {

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -220,7 +220,7 @@ func TestGetTraceSuccessGRPC(t *testing.T) {
 
 		spanResChunk, _ := res.Recv()
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, spanResChunk.Spans[0].TraceID, mockTraceID)
 	})
 }
@@ -241,10 +241,10 @@ func TestGetTraceEmptyTraceIDFailure_GRPC(t *testing.T) {
 			TraceID: model.TraceID{},
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		spanResChunk, err := res.Recv()
-		assert.ErrorIs(t, err, errUninitializedTraceID)
+		require.ErrorIs(t, err, errUninitializedTraceID)
 		assert.Nil(t, spanResChunk)
 	})
 }
@@ -257,7 +257,7 @@ func TestGetTraceDBFailureGRPC(t *testing.T) {
 		res, err := client.GetTrace(context.Background(), &api_v2.GetTraceRequest{
 			TraceID: mockTraceID,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		spanResChunk, err := res.Recv()
 		assertGRPCError(t, err, codes.Internal, "failed to fetch spans from the backend")
@@ -276,7 +276,7 @@ func TestGetTraceNotFoundGRPC(t *testing.T) {
 		res, err := client.GetTrace(context.Background(), &api_v2.GetTraceRequest{
 			TraceID: mockTraceID,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		spanResChunk, err := res.Recv()
 		assertGRPCError(t, err, codes.NotFound, "trace not found")
 		assert.Nil(t, spanResChunk)
@@ -287,7 +287,7 @@ func TestGetTraceNotFoundGRPC(t *testing.T) {
 func TestGetTraceNilRequestOnHandlerGRPC(t *testing.T) {
 	grpcHandler := &GRPCHandler{}
 	err := grpcHandler.GetTrace(nil, nil)
-	assert.EqualError(t, err, errNilRequest.Error())
+	require.EqualError(t, err, errNilRequest.Error())
 }
 
 func TestArchiveTraceSuccessGRPC(t *testing.T) {
@@ -301,7 +301,7 @@ func TestArchiveTraceSuccessGRPC(t *testing.T) {
 			TraceID: mockTraceID,
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -325,7 +325,7 @@ func TestArchiveTraceEmptyTraceFailureGRPC(t *testing.T) {
 		_, err := client.ArchiveTrace(context.Background(), &api_v2.ArchiveTraceRequest{
 			TraceID: model.TraceID{},
 		})
-		assert.ErrorIs(t, err, errUninitializedTraceID)
+		require.ErrorIs(t, err, errUninitializedTraceID)
 	})
 }
 
@@ -333,7 +333,7 @@ func TestArchiveTraceEmptyTraceFailureGRPC(t *testing.T) {
 func TestArchiveTraceNilRequestOnHandlerGRPC(t *testing.T) {
 	grpcHandler := &GRPCHandler{}
 	_, err := grpcHandler.ArchiveTrace(context.Background(), nil)
-	assert.EqualError(t, err, errNilRequest.Error())
+	require.EqualError(t, err, errNilRequest.Error())
 }
 
 func TestArchiveTraceFailureGRPC(t *testing.T) {
@@ -368,7 +368,7 @@ func TestFindTracesSuccessGRPC(t *testing.T) {
 		})
 
 		spanResChunk, _ := res.Recv()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		spansArr := make([]model.Span, 0, len(mockTraceGRPC.Spans))
 		for _, span := range mockTraceGRPC.Spans {
@@ -393,14 +393,14 @@ func TestFindTracesSuccess_SpanStreamingGRPC(t *testing.T) {
 		res, err := client.FindTraces(context.Background(), &api_v2.FindTracesRequest{
 			Query: queryParams,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		spanResChunk, err := res.Recv()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, spanResChunk.Spans, 10)
 
 		spanResChunk, err = res.Recv()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, spanResChunk.Spans, 1)
 	})
 }
@@ -410,10 +410,10 @@ func TestFindTracesMissingQuery_GRPC(t *testing.T) {
 		res, err := client.FindTraces(context.Background(), &api_v2.FindTracesRequest{
 			Query: nil,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		spanResChunk, err := res.Recv()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, spanResChunk)
 	})
 }
@@ -436,10 +436,10 @@ func TestFindTracesFailure_GRPC(t *testing.T) {
 		res, err := client.FindTraces(context.Background(), &api_v2.FindTracesRequest{
 			Query: queryParams,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		spanResChunk, err := res.Recv()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, spanResChunk)
 	})
 }
@@ -448,7 +448,7 @@ func TestFindTracesFailure_GRPC(t *testing.T) {
 func TestFindTracesNilRequestOnHandlerGRPC(t *testing.T) {
 	grpcHandler := &GRPCHandler{}
 	err := grpcHandler.FindTraces(nil, nil)
-	assert.EqualError(t, err, errNilRequest.Error())
+	require.EqualError(t, err, errNilRequest.Error())
 }
 
 func TestGetServicesSuccessGRPC(t *testing.T) {
@@ -457,7 +457,7 @@ func TestGetServicesSuccessGRPC(t *testing.T) {
 		server.spanReader.On("GetServices", mock.AnythingOfType("*context.valueCtx")).Return(expectedServices, nil).Once()
 
 		res, err := client.GetServices(context.Background(), &api_v2.GetServicesRequest{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		actualServices := res.Services
 		assert.Equal(t, expectedServices, actualServices)
 	})
@@ -488,7 +488,7 @@ func TestGetOperationsSuccessGRPC(t *testing.T) {
 		res, err := client.GetOperations(context.Background(), &api_v2.GetOperationsRequest{
 			Service: "abc/trifle",
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, len(expectedOperations), len(res.Operations))
 		for i, actualOp := range res.Operations {
 			assert.Equal(t, expectedOperations[i].Name, actualOp.Name)
@@ -517,7 +517,7 @@ func TestGetOperationsFailureGRPC(t *testing.T) {
 func TestGetOperationsNilRequestOnHandlerGRPC(t *testing.T) {
 	grpcHandler := &GRPCHandler{}
 	_, err := grpcHandler.GetOperations(context.Background(), nil)
-	assert.EqualError(t, err, errNilRequest.Error())
+	require.EqualError(t, err, errNilRequest.Error())
 }
 
 func TestGetDependenciesSuccessGRPC(t *testing.T) {
@@ -531,7 +531,7 @@ func TestGetDependenciesSuccessGRPC(t *testing.T) {
 			StartTime: endTs.Add(time.Duration(-1) * defaultDependencyLookbackDuration),
 			EndTime:   endTs,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedDependencies, res.Dependencies)
 	})
 }
@@ -568,7 +568,7 @@ func TestGetDependenciesFailureUninitializedTimeGRPC(t *testing.T) {
 				EndTime:   input.endTime,
 			})
 
-			assert.Error(t, err)
+			require.Error(t, err)
 		})
 	}
 }
@@ -577,7 +577,7 @@ func TestGetDependenciesFailureUninitializedTimeGRPC(t *testing.T) {
 func TestGetDependenciesNilRequestOnHandlerGRPC(t *testing.T) {
 	grpcHandler := &GRPCHandler{}
 	_, err := grpcHandler.GetDependencies(context.Background(), nil)
-	assert.EqualError(t, err, errNilRequest.Error())
+	require.EqualError(t, err, errNilRequest.Error())
 }
 
 func TestSendSpanChunksError(t *testing.T) {
@@ -592,7 +592,7 @@ func TestSendSpanChunksError(t *testing.T) {
 	}, func(*api_v2.SpansResponseChunk) error {
 		return expectedErr
 	})
-	assert.EqualError(t, err, expectedErr.Error())
+	require.EqualError(t, err, expectedErr.Error())
 }
 
 func TestGetMetricsSuccessGRPC(t *testing.T) {
@@ -896,7 +896,7 @@ func TestMetricsQueryNilRequestGRPC(t *testing.T) {
 	grpcHandler := &GRPCHandler{}
 	bqp, err := grpcHandler.newBaseQueryParameters(nil)
 	assert.Empty(t, bqp)
-	assert.EqualError(t, err, errNilRequest.Error())
+	require.EqualError(t, err, errNilRequest.Error())
 }
 
 func initializeTenantedTestServerGRPCWithOptions(t *testing.T, tm *tenancy.Manager, options ...testOption) *grpcServer {

--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
@@ -41,7 +42,7 @@ func TestGetArchivedTrace_NotFound(t *testing.T) {
 					Return(nil, spanstore.ErrTraceNotFound).Once()
 				var response structuredResponse
 				err := getJSON(ts.server.URL+"/api/traces/"+mockTraceID.String(), &response)
-				assert.EqualError(t, err,
+				require.EqualError(t, err,
 					`404 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":404,"msg":"trace not found"}]}`+"\n",
 				)
 			}, querysvc.QueryServiceOptions{ArchiveSpanReader: archiveReader}) // nil is ok
@@ -60,7 +61,7 @@ func TestGetArchivedTraceSuccess(t *testing.T) {
 			Return(nil, spanstore.ErrTraceNotFound).Once()
 		var response structuredTraceResponse
 		err := getJSON(ts.server.URL+"/api/traces/"+mockTraceID.String(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, response.Errors)
 		assert.Len(t, response.Traces, 1)
 		assert.Equal(t, traceID.String(), string(response.Traces[0].TraceID))
@@ -72,7 +73,7 @@ func TestArchiveTrace_BadTraceID(t *testing.T) {
 	withTestServer(func(ts *testServer) {
 		var response structuredResponse
 		err := postJSON(ts.server.URL+"/api/archive/badtraceid", []string{}, &response)
-		assert.Error(t, err)
+		require.Error(t, err)
 	}, querysvc.QueryServiceOptions{})
 }
 
@@ -89,7 +90,7 @@ func TestArchiveTrace_TraceNotFound(t *testing.T) {
 			Return(nil, spanstore.ErrTraceNotFound).Once()
 		var response structuredResponse
 		err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String(), []string{}, &response)
-		assert.EqualError(t, err, `404 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":404,"msg":"trace not found"}]}`+"\n")
+		require.EqualError(t, err, `404 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":404,"msg":"trace not found"}]}`+"\n")
 	}, querysvc.QueryServiceOptions{ArchiveSpanReader: mockReader, ArchiveSpanWriter: mockWriter})
 }
 
@@ -97,7 +98,7 @@ func TestArchiveTrace_NoStorage(t *testing.T) {
 	withTestServer(func(ts *testServer) {
 		var response structuredResponse
 		err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String(), []string{}, &response)
-		assert.EqualError(t, err, `500 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"archive span storage was not configured"}]}`+"\n")
+		require.EqualError(t, err, `500 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"archive span storage was not configured"}]}`+"\n")
 	}, querysvc.QueryServiceOptions{})
 }
 
@@ -110,7 +111,7 @@ func TestArchiveTrace_Success(t *testing.T) {
 			Return(mockTrace, nil).Once()
 		var response structuredResponse
 		err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String(), []string{}, &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}, querysvc.QueryServiceOptions{ArchiveSpanWriter: mockWriter})
 }
 
@@ -123,6 +124,6 @@ func TestArchiveTrace_WriteErrors(t *testing.T) {
 			Return(mockTrace, nil).Once()
 		var response structuredResponse
 		err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String(), []string{}, &response)
-		assert.EqualError(t, err, `500 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"cannot save\ncannot save"}]}`+"\n")
+		require.EqualError(t, err, `500 error from server: {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"cannot save\ncannot save"}]}`+"\n")
 	}, querysvc.QueryServiceOptions{ArchiveSpanWriter: mockWriter})
 }

--- a/cmd/query/app/handler_deps_test.go
+++ b/cmd/query/app/handler_deps_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	ui "github.com/jaegertracing/jaeger/model/json"
@@ -322,7 +323,7 @@ func TestGetDependenciesSuccess(t *testing.T) {
 	assert.Equal(t, "killer", actual["parent"])
 	assert.Equal(t, "queen", actual["child"])
 	assert.Equal(t, 12.00, actual["callCount"]) // recovered type is float
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetDependenciesCassandraFailure(t *testing.T) {
@@ -333,7 +334,7 @@ func TestGetDependenciesCassandraFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/dependencies?endTs=1476374248550&service=testing", &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetDependenciesEndTimeParsingFailure(t *testing.T) {
@@ -342,7 +343,7 @@ func TestGetDependenciesEndTimeParsingFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/dependencies?endTs=shazbot&service=testing", &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetDependenciesLookbackParsingFailure(t *testing.T) {
@@ -351,5 +352,5 @@ func TestGetDependenciesLookbackParsingFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/dependencies?endTs=1476374248550&service=testing&lookback=shazbot", &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -150,7 +150,7 @@ func TestGetTraceSuccess(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces/123456`, &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 }
 
@@ -320,7 +320,7 @@ func TestGetTrace(t *testing.T) {
 
 			var response structuredResponse
 			err := getJSON(ts.server.URL+`/api/traces/123456aBC`+testCase.suffix, &response) // trace ID in mixed lower/upper case
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Empty(t, response.Errors)
 
 			assert.Len(t, exporter.GetSpans(), 1, "HTTP request was traced and span reported")
@@ -341,7 +341,7 @@ func TestGetTraceDBFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces/123456`, &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetTraceNotFound(t *testing.T) {
@@ -352,7 +352,7 @@ func TestGetTraceNotFound(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces/123456`, &response)
-	assert.EqualError(t, err, parsedError(404, "trace not found"))
+	require.EqualError(t, err, parsedError(404, "trace not found"))
 }
 
 func TestGetTraceAdjustmentFailure(t *testing.T) {
@@ -369,7 +369,7 @@ func TestGetTraceAdjustmentFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces/123456`, &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, response.Errors, 1)
 	assert.EqualValues(t, errAdjustment.Error(), response.Errors[0].Msg)
 }
@@ -380,7 +380,7 @@ func TestGetTraceBadTraceID(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces/chumbawumba`, &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestSearchSuccess(t *testing.T) {
@@ -391,7 +391,7 @@ func TestSearchSuccess(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms`, &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 }
 
@@ -403,7 +403,7 @@ func TestSearchByTraceIDSuccess(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2`, &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 2)
 }
@@ -421,7 +421,7 @@ func TestSearchByTraceIDSuccessWithArchive(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2`, &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 2)
 }
@@ -434,7 +434,7 @@ func TestSearchByTraceIDNotFound(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1`, &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, response.Errors, 1)
 	assert.Equal(t, structuredError{Msg: "trace not found", TraceID: ui.TraceID("0000000000000001")}, response.Errors[0])
 }
@@ -448,7 +448,7 @@ func TestSearchByTraceIDFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1`, &response)
-	assert.EqualError(t, err, parsedError(500, whatsamattayou))
+	require.EqualError(t, err, parsedError(500, whatsamattayou))
 }
 
 func TestSearchModelConversionFailure(t *testing.T) {
@@ -465,7 +465,7 @@ func TestSearchModelConversionFailure(t *testing.T) {
 		Return([]*model.Trace{mockTrace}, nil).Once()
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms`, &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, response.Errors, 1)
 	assert.EqualValues(t, errAdjustment.Error(), response.Errors[0].Msg)
 }
@@ -478,7 +478,7 @@ func TestSearchDBFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms`, &response)
-	assert.EqualError(t, err, parsedError(500, "whatsamattayou"))
+	require.EqualError(t, err, parsedError(500, "whatsamattayou"))
 }
 
 func TestSearchFailures(t *testing.T) {
@@ -508,7 +508,7 @@ func testIndividualSearchFailures(t *testing.T, urlStr, errMsg string) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+urlStr, &response)
-	assert.EqualError(t, err, errMsg)
+	require.EqualError(t, err, errMsg)
 }
 
 func TestGetServicesSuccess(t *testing.T) {
@@ -519,7 +519,7 @@ func TestGetServicesSuccess(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/services", &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	actualServices := make([]string, len(expectedServices))
 	for i, s := range response.Data.([]interface{}) {
 		actualServices[i] = s.(string)
@@ -534,7 +534,7 @@ func TestGetServicesStorageFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/services", &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetOperationsSuccess(t *testing.T) {
@@ -559,7 +559,7 @@ func TestGetOperationsSuccess(t *testing.T) {
 	}
 
 	err := getJSON(ts.server.URL+"/api/operations?service=abc%2Ftrifle&spanKind=server", &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, len(expectedOperations), len(response.Operations))
 	for i, op := range response.Operations {
 		assert.Equal(t, expectedOperations[i].Name, op.Name)
@@ -573,7 +573,7 @@ func TestGetOperationsNoServiceName(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/operations", &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetOperationsStorageFailure(t *testing.T) {
@@ -586,7 +586,7 @@ func TestGetOperationsStorageFailure(t *testing.T) {
 
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/operations?service=trifle", &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetOperationsLegacySuccess(t *testing.T) {
@@ -607,7 +607,7 @@ func TestGetOperationsLegacySuccess(t *testing.T) {
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/services/abc%2Ftrifle/operations", &response)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedOperationNames, response.Data.([]interface{}))
 }
 
@@ -620,7 +620,7 @@ func TestGetOperationsLegacyStorageFailure(t *testing.T) {
 		mock.AnythingOfType("spanstore.OperationQueryParameters")).Return(nil, errStorage).Once()
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/services/trifle/operations", &response)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetMetricsSuccess(t *testing.T) {
@@ -909,7 +909,7 @@ func TestSearchTenancyHTTP(t *testing.T) {
 		ts.server.URL+`/api/traces?traceID=1&traceID=2`,
 		map[string]string{"x-tenant": "acme"},
 		&response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 2)
 }
@@ -926,11 +926,11 @@ func TestSearchTenancyRejectionHTTP(t *testing.T) {
 		Return(mockTrace, nil).Twice()
 
 	req, err := http.NewRequest(http.MethodGet, ts.server.URL+`/api/traces?traceID=1&traceID=2`, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Add("Accept", "application/json")
 	// We don't set tenant header
 	resp, err := httpClient.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 	tm := tenancy.NewManager(&tenancyOptions)
@@ -969,7 +969,7 @@ func TestSearchTenancyFlowTenantHTTP(t *testing.T) {
 		ts.server.URL+`/api/traces?traceID=1&traceID=2`,
 		map[string]string{"x-tenant": "acme"},
 		&responseAcme)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, responseAcme.Errors)
 	assert.Len(t, responseAcme.Data, 2)
 

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -157,7 +157,7 @@ func TestParseTraceQuery(t *testing.T) {
 		test := tc // capture loop var
 		t.Run(test.urlStr, func(t *testing.T) {
 			request, err := http.NewRequest(http.MethodGet, test.urlStr, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			parser := &queryParser{
 				timeNow: func() time.Time {
 					return timeNow
@@ -165,7 +165,7 @@ func TestParseTraceQuery(t *testing.T) {
 			}
 			actualQuery, err := parser.parseTraceQueryParams(request)
 			if test.errMsg == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				if !assert.Equal(t, test.expectedQuery, actualQuery) {
 					for _, s := range pretty.Diff(test.expectedQuery, actualQuery) {
 						t.Log(s)

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 
@@ -123,7 +124,7 @@ func TestGetTraceSuccess(t *testing.T) {
 	type contextKey string
 	ctx := context.Background()
 	res, err := tqs.queryService.GetTrace(context.WithValue(ctx, contextKey("foo"), "bar"), mockTraceID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, res, mockTrace)
 }
 
@@ -150,7 +151,7 @@ func TestGetTraceFromArchiveStorage(t *testing.T) {
 	type contextKey string
 	ctx := context.Background()
 	res, err := tqs.queryService.GetTrace(context.WithValue(ctx, contextKey("foo"), "bar"), mockTraceID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, res, mockTrace)
 }
 
@@ -163,7 +164,7 @@ func TestGetServices(t *testing.T) {
 	type contextKey string
 	ctx := context.Background()
 	actualServices, err := tqs.queryService.GetServices(context.WithValue(ctx, contextKey("foo"), "bar"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedServices, actualServices)
 }
 
@@ -181,7 +182,7 @@ func TestGetOperations(t *testing.T) {
 	type contextKey string
 	ctx := context.Background()
 	actualOperations, err := tqs.queryService.GetOperations(context.WithValue(ctx, contextKey("foo"), "bar"), operationQuery)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedOperations, actualOperations)
 }
 
@@ -202,7 +203,7 @@ func TestFindTraces(t *testing.T) {
 		NumTraces:     200,
 	}
 	traces, err := tqs.queryService.FindTraces(context.WithValue(ctx, contextKey("foo"), "bar"), params)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, traces, 1)
 }
 
@@ -242,7 +243,7 @@ func TestArchiveTraceWithArchiveWriterError(t *testing.T) {
 	ctx := context.Background()
 	joinErr := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), mockTraceID)
 	// There are two spans in the mockTrace, ArchiveTrace should return a wrapped error.
-	assert.EqualError(t, joinErr, "cannot save\ncannot save")
+	require.EqualError(t, joinErr, "cannot save\ncannot save")
 }
 
 // Test QueryService.ArchiveTrace() with correctly configured ArchiveSpanWriter.
@@ -256,7 +257,7 @@ func TestArchiveTraceSuccess(t *testing.T) {
 	type contextKey string
 	ctx := context.Background()
 	err := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), mockTraceID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test QueryService.Adjust()
@@ -264,7 +265,7 @@ func TestTraceAdjustmentFailure(t *testing.T) {
 	tqs := initializeTestService(withAdjuster())
 
 	_, err := tqs.queryService.Adjust(mockTrace)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.EqualValues(t, errAdjustment.Error(), err.Error())
 }
 
@@ -282,7 +283,7 @@ func TestGetDependencies(t *testing.T) {
 	tqs.depsReader.On("GetDependencies", endTs, defaultDependencyLookbackDuration).Return(expectedDependencies, nil).Times(1)
 
 	actualDependencies, err := tqs.queryService.GetDependencies(context.Background(), time.Unix(0, 1476374248550*millisToNanosMultiplier), defaultDependencyLookbackDuration)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedDependencies, actualDependencies)
 }
 

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -55,7 +55,7 @@ func TestServerError(t *testing.T) {
 			HTTPHostPort: ":-1",
 		},
 	}
-	assert.Error(t, srv.Start())
+	require.Error(t, srv.Start())
 }
 
 func TestCreateTLSServerSinglePortError(t *testing.T) {
@@ -70,7 +70,7 @@ func TestCreateTLSServerSinglePortError(t *testing.T) {
 	_, err := NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8080", TLSGRPC: tlsCfg, TLSHTTP: tlsCfg},
 		tenancy.NewManager(&tenancy.Options{}), jtracer.NoOp())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCreateTLSGrpcServerError(t *testing.T) {
@@ -84,7 +84,7 @@ func TestCreateTLSGrpcServerError(t *testing.T) {
 	_, err := NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8081", TLSGRPC: tlsCfg},
 		tenancy.NewManager(&tenancy.Options{}), jtracer.NoOp())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCreateTLSHttpServerError(t *testing.T) {
@@ -98,7 +98,7 @@ func TestCreateTLSHttpServerError(t *testing.T) {
 	_, err := NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8081", TLSHTTP: tlsCfg},
 		tenancy.NewManager(&tenancy.Options{}), jtracer.NoOp())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 var testCases = []struct {
@@ -343,8 +343,8 @@ func TestServerHTTPTLS(t *testing.T) {
 			server, err := NewServer(flagsSvc.Logger, querySvc, nil,
 				serverOptions, tenancy.NewManager(&tenancy.Options{}),
 				jtracer.NoOp())
-			assert.NoError(t, err)
-			assert.NoError(t, server.Start())
+			require.NoError(t, err)
+			require.NoError(t, server.Start())
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -408,7 +408,7 @@ func TestServerHTTPTLS(t *testing.T) {
 				readMock.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).Return([]*model.Trace{mockTrace}, nil).Once()
 				queryString := "/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms"
 				req, err := http.NewRequest(http.MethodGet, "https://localhost:"+fmt.Sprintf("%d", ports.QueryHTTP)+queryString, nil)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				req.Header.Add("Accept", "application/json")
 
 				resp, err2 := client.Do(req)
@@ -505,8 +505,8 @@ func TestServerGRPCTLS(t *testing.T) {
 			server, err := NewServer(flagsSvc.Logger, querySvc, nil,
 				serverOptions, tenancy.NewManager(&tenancy.Options{}),
 				jtracer.NoOp())
-			assert.NoError(t, err)
-			assert.NoError(t, server.Start())
+			require.NoError(t, err)
+			require.NoError(t, server.Start())
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -567,7 +567,7 @@ func TestServerBadHostPort(t *testing.T) {
 		tenancy.NewManager(&tenancy.Options{}),
 		jtracer.NoOp())
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = NewServer(zap.NewNop(), &querysvc.QueryService{}, nil,
 		&QueryOptions{
 			HTTPHostPort: "127.0.0.1:8081",
@@ -579,7 +579,7 @@ func TestServerBadHostPort(t *testing.T) {
 		tenancy.NewManager(&tenancy.Options{}),
 		jtracer.NoOp())
 
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestServerInUseHostPort(t *testing.T) {
@@ -612,10 +612,10 @@ func TestServerInUseHostPort(t *testing.T) {
 				tenancy.NewManager(&tenancy.Options{}),
 				jtracer.NoOp(),
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = server.Start()
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			if server.grpcConn != nil {
 				server.grpcConn.Close()
@@ -647,8 +647,8 @@ func TestServerSinglePort(t *testing.T) {
 		},
 		tenancy.NewManager(&tenancy.Options{}),
 		jtracer.NoOp())
-	assert.NoError(t, err)
-	assert.NoError(t, server.Start())
+	require.NoError(t, err)
+	require.NoError(t, server.Start())
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -674,7 +674,7 @@ func TestServerSinglePort(t *testing.T) {
 	defer cancel()
 
 	res, err := client.GetServices(ctx, &api_v2.GetServicesRequest{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedServices, res.Services)
 
 	server.Close()
@@ -696,8 +696,8 @@ func TestServerGracefulExit(t *testing.T) {
 
 	server, err := NewServer(flagsSvc.Logger, querySvc, nil, &QueryOptions{GRPCHostPort: hostPort, HTTPHostPort: hostPort},
 		tenancy.NewManager(&tenancy.Options{}), tracer)
-	assert.NoError(t, err)
-	assert.NoError(t, server.Start())
+	require.NoError(t, err)
+	require.NoError(t, server.Start())
 	go func() {
 		for s := range server.HealthCheckStatus() {
 			flagsSvc.HC().Set(s)
@@ -726,8 +726,8 @@ func TestServerHandlesPortZero(t *testing.T) {
 		&QueryOptions{GRPCHostPort: ":0", HTTPHostPort: ":0"},
 		tenancy.NewManager(&tenancy.Options{}),
 		tracer)
-	assert.NoError(t, err)
-	assert.NoError(t, server.Start())
+	require.NoError(t, err)
+	require.NoError(t, server.Start())
 	defer server.Close()
 
 	message := logs.FilterMessage("Query server started")
@@ -799,7 +799,7 @@ func TestServerHTTPTenancy(t *testing.T) {
 			if test.tenant != "" {
 				req.Header.Add(tenancyMgr.Header, test.tenant)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("Accept", "application/json")
 
 			client := &http.Client{}
@@ -807,7 +807,7 @@ func TestServerHTTPTenancy(t *testing.T) {
 			if test.errMsg == "" {
 				require.NoError(t, err2)
 			} else {
-				assert.Error(t, err2)
+				require.Error(t, err2)
 				if err != nil {
 					assert.Equal(t, test.errMsg, err2.Error())
 				}

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -165,7 +165,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 
 func TestNewStaticAssetsHandlerErrors(t *testing.T) {
 	_, err := NewStaticAssetsHandler("fixture", StaticAssetsHandlerOptions{UIConfigPath: "fixture/invalid-config"})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	for _, base := range []string{"x", "x/", "/x/"} {
 		_, err := NewStaticAssetsHandler("fixture", StaticAssetsHandlerOptions{UIConfigPath: "fixture/ui-config.json", BasePath: base})
@@ -227,9 +227,9 @@ func TestLoadUIConfig(t *testing.T) {
 		t.Run(description, func(t *testing.T) {
 			config, err := loadUIConfig(testCase.configFile)
 			if testCase.expectedError != "" {
-				assert.EqualError(t, err, testCase.expectedError)
+				require.EqualError(t, err, testCase.expectedError)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.EqualValues(t, testCase.expected, config)
 		})

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -89,7 +89,7 @@ func TestServerStart_BadPortErrors(t *testing.T) {
 			GRPCHostPort: ":-1",
 		},
 	}
-	assert.Error(t, srv.Start())
+	require.Error(t, srv.Start())
 }
 
 type storageMocks struct {
@@ -336,8 +336,8 @@ func TestServerGRPCTLS(t *testing.T) {
 				tm,
 				flagsSvc.Logger,
 			)
-			assert.NoError(t, err)
-			assert.NoError(t, server.Start())
+			require.NoError(t, err)
+			require.NoError(t, server.Start())
 
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/crossdock/services/agent_test.go
+++ b/crossdock/services/agent_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	p2json "github.com/jaegertracing/jaeger/model/converter/json"
@@ -56,7 +57,7 @@ func TestGetSamplingRateInternal(t *testing.T) {
 	for _, test := range tests {
 		rate, err := getSamplingRate(test.operation, test.response)
 		if test.shouldErr {
-			assert.EqualError(t, err, errSamplingRateMissing.Error())
+			require.EqualError(t, err, errSamplingRateMissing.Error())
 		}
 		assert.EqualValues(t, test.rate, rate)
 	}
@@ -94,15 +95,15 @@ func TestGetSamplingRate(t *testing.T) {
 	// Test with no http server
 	agent := NewAgentService("", zap.NewNop())
 	_, err := agent.GetSamplingRate("svc", "op")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	agent = NewAgentService(server.URL, zap.NewNop())
 	rate, err := agent.GetSamplingRate("svc", "op")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, 1, rate)
 
 	_, err = agent.GetSamplingRate("bad_svc", "op")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetSamplingRateReadAllErr(t *testing.T) {
@@ -111,5 +112,5 @@ func TestGetSamplingRateReadAllErr(t *testing.T) {
 	}))
 	agent := NewAgentService(server.URL, zap.NewNop())
 	_, err := agent.GetSamplingRate("svc", "op")
-	assert.EqualError(t, err, "unexpected EOF")
+	require.EqualError(t, err, "unexpected EOF")
 }

--- a/crossdock/services/query_test.go
+++ b/crossdock/services/query_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	ui "github.com/jaegertracing/jaeger/model/json"
@@ -51,16 +52,16 @@ func TestGetTraces(t *testing.T) {
 	// Test with no http server
 	query := NewQueryService("", zap.NewNop())
 	_, err := query.GetTraces("svc", "op", map[string]string{"key": "value"})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	query = NewQueryService(server.URL, zap.NewNop())
 	traces, err := query.GetTraces("svc", "op", map[string]string{"key": "value"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, traces, 1)
 	assert.EqualValues(t, "traceid", traces[0].TraceID)
 
 	_, err = query.GetTraces("bad_svc", "op", map[string]string{"key": "value"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetTracesReadAllErr(t *testing.T) {
@@ -69,5 +70,5 @@ func TestGetTracesReadAllErr(t *testing.T) {
 	}))
 	query := NewQueryService(server.URL, zap.NewNop())
 	_, err := query.GetTraces("svc", "op", map[string]string{"key": "value"})
-	assert.EqualError(t, err, "unexpected EOF")
+	require.EqualError(t, err, "unexpected EOF")
 }

--- a/crossdock/services/tracehandler_test.go
+++ b/crossdock/services/tracehandler_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go"
 	"go.uber.org/zap"
 
@@ -104,9 +105,9 @@ func TestRunTest(t *testing.T) {
 	for _, test := range tests {
 		err := handler.runTest("service", &test.request, test.f, validateTracesWithCount)
 		if test.shouldErr {
-			assert.Error(t, err)
+			require.Error(t, err)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 }
@@ -174,9 +175,9 @@ func TestValidateTracesWithCount(t *testing.T) {
 	for _, test := range tests {
 		err := validateTracesWithCount(&test.expected, test.actual)
 		if test.errMsg == "" {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		} else {
-			assert.EqualError(t, err, test.errMsg)
+			require.EqualError(t, err, test.errMsg)
 		}
 	}
 }
@@ -225,17 +226,17 @@ func TestCreateTrace(t *testing.T) {
 	}
 
 	err := handler.createTrace("svc", &traceRequest{Operation: "op"})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	handler.getClientURL = func(service string) string {
 		return server.URL
 	}
 
 	err = handler.createTrace("svc", &traceRequest{Operation: badOperation})
-	assert.EqualError(t, err, "retrieved 400 status code from client service")
+	require.EqualError(t, err, "retrieved 400 status code from client service")
 
 	err = handler.createTrace("svc", &traceRequest{Operation: "op"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTraceHandlerGetTraces(t *testing.T) {
@@ -387,9 +388,9 @@ func TestValidateAdaptiveSamplingTraces(t *testing.T) {
 	for _, test := range tests {
 		err := validateAdaptiveSamplingTraces(&test.expected, test.actual)
 		if test.errMsg == "" {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		} else {
-			assert.EqualError(t, err, test.errMsg)
+			require.EqualError(t, err, test.errMsg)
 		}
 	}
 }
@@ -450,9 +451,9 @@ func TestAdaptiveSamplingTestInternal(t *testing.T) {
 
 			_, err := handler.adaptiveSamplingTest("svc", &traceRequest{Operation: "op"})
 			if test.errMsg != "" {
-				assert.EqualError(t, err, test.errMsg)
+				require.EqualError(t, err, test.errMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/model/adjuster/adjuster_test.go
+++ b/model/adjuster/adjuster_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/adjuster"
@@ -63,6 +64,6 @@ func TestSequences(t *testing.T) {
 
 		assert.True(t, span == adjTrace.Spans[0], "same trace & span returned")
 		assert.EqualValues(t, testCase.lastSpanID, span.SpanID, "expect span ID to be incremented")
-		assert.EqualError(t, err, testCase.err)
+		require.EqualError(t, err, testCase.err)
 	}
 }

--- a/model/adjuster/bad_span_references_test.go
+++ b/model/adjuster/bad_span_references_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -40,7 +41,7 @@ func TestSpanReferencesAdjuster(t *testing.T) {
 		},
 	}
 	trace, err := SpanReferences().Adjust(trace)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, trace.Spans[0].References)
 	assert.Empty(t, trace.Spans[1].References)
 	assert.Len(t, trace.Spans[2].References, 2)

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -199,7 +199,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			adjuster := ClockSkew(tt.maxAdjust)
 			trace, err := adjuster.Adjust(makeTrace(testCase.trace))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if testCase.err != "" {
 				var err string
 				for _, span := range trace.Spans {

--- a/model/adjuster/ip_tag_test.go
+++ b/model/adjuster/ip_tag_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -47,7 +48,7 @@ func TestIPTagAdjuster(t *testing.T) {
 		},
 	}
 	trace, err := IPTagAdjuster().Adjust(trace)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedSpanTags := model.KeyValues{
 		model.Int64("a", 42),

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -83,7 +84,7 @@ func TestOTelTagAdjuster(t *testing.T) {
 				Spans: []*model.Span{testCase.span},
 			}
 			trace, err := OTelTagAdjuster().Adjust(trace)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testCase.expected.Tags, trace.Spans[0].Tags)
 			assert.Equal(t, testCase.expected.Process.Tags, trace.Spans[0].Process.Tags)
 

--- a/model/adjuster/parent_reference_test.go
+++ b/model/adjuster/parent_reference_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -102,7 +103,7 @@ func TestParentReference(t *testing.T) {
 				},
 			}
 			trace, err := ParentReference().Adjust(trace)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testCase.expected, trace.Spans[0].References)
 		})
 	}

--- a/model/adjuster/sort_log_fields_test.go
+++ b/model/adjuster/sort_log_fields_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -90,7 +91,7 @@ func TestSortLogFields(t *testing.T) {
 			},
 		}
 		trace, err := SortLogFields().Adjust(trace)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, testCase.expected, model.KeyValues(trace.Spans[0].Logs[0].Fields))
 	}
 }

--- a/model/adjuster/span_id_deduper_test.go
+++ b/model/adjuster/span_id_deduper_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -66,7 +67,7 @@ func TestSpanIDDeduperTriggered(t *testing.T) {
 	trace := newTrace()
 	deduper := SpanIDDeduper()
 	trace, err := deduper.Adjust(trace)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	clientSpan := trace.Spans[0]
 	assert.Equal(t, clientSpanID, clientSpan.SpanID, "client span ID should not change")
@@ -86,7 +87,7 @@ func TestSpanIDDeduperNotTriggered(t *testing.T) {
 
 	deduper := SpanIDDeduper()
 	trace, err := deduper.Adjust(trace)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	serverSpanID := clientSpanID // for better readability
 	serverSpan := trace.Spans[0]

--- a/model/converter/json/from_domain_test.go
+++ b/model/converter/json/from_domain_test.go
@@ -140,7 +140,7 @@ func testJSONEncoding(t *testing.T, i int, expectedStr []byte, object interface{
 
 	if !assert.Equal(t, string(expectedStr), buf.String()) {
 		err := os.WriteFile(outFile+"-actual.json", buf.Bytes(), 0o644)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 

--- a/model/converter/json/json_span_compare_test.go
+++ b/model/converter/json/json_span_compare_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	esJson "github.com/jaegertracing/jaeger/model/json"
 )
@@ -35,7 +36,7 @@ func CompareJSONSpans(t *testing.T, expected *esJson.Span, actual *esJson.Span) 
 			t.Log(err)
 		}
 		out, err := json.Marshal(actual)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Logf("Actual trace: %s", string(out))
 	}
 }

--- a/model/converter/json/sampling_test.go
+++ b/model/converter/json/sampling_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestSamplingStrategyResponseToJSON_Error(t *testing.T) {
 	_, err := SamplingStrategyResponseToJSON(nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // TestSamplingStrategyResponseToJSON verifies that the function outputs
@@ -94,7 +94,7 @@ func compareProtoAndThriftJSON(t *testing.T, thriftObj *api_v1.SamplingStrategyR
 
 func TestSamplingStrategyResponseFromJSON(t *testing.T) {
 	_, err := SamplingStrategyResponseFromJSON([]byte("broken"))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	s1 := &api_v2.SamplingStrategyResponse{
 		StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,

--- a/model/converter/thrift/jaeger/sampling_from_domain_test.go
+++ b/model/converter/thrift/jaeger/sampling_from_domain_test.go
@@ -38,7 +38,7 @@ func TestConvertStrategyTypeFromDomain(t *testing.T) {
 	for _, test := range tests {
 		st, err := convertStrategyTypeFromDomain(test.in)
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 		} else {
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, st)
@@ -73,7 +73,7 @@ func TestConvertRateLimitingFromDomain(t *testing.T) {
 	for _, test := range tests {
 		st, err := convertRateLimitingFromDomain(test.in)
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 			require.Nil(t, st)
 		} else {
 			require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestConvertSamplingResponseFromDomain(t *testing.T) {
 	for _, test := range tests {
 		r, err := ConvertSamplingResponseFromDomain(test.in)
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 			require.Nil(t, r)
 		} else {
 			require.NoError(t, err)

--- a/model/converter/thrift/jaeger/sampling_to_domain_test.go
+++ b/model/converter/thrift/jaeger/sampling_to_domain_test.go
@@ -38,7 +38,7 @@ func TestConvertStrategyTypeToDomain(t *testing.T) {
 	for _, test := range tests {
 		st, err := convertStrategyTypeToDomain(test.in)
 		if test.err != nil {
-			assert.EqualError(t, test.err, err.Error())
+			require.EqualError(t, test.err, err.Error())
 		} else {
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, st)
@@ -111,7 +111,7 @@ func TestConvertSamplingResponseToDomain(t *testing.T) {
 	for _, test := range tests {
 		r, err := ConvertSamplingResponseToDomain(test.in)
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 			require.Nil(t, r)
 		} else {
 			require.NoError(t, err)

--- a/model/converter/thrift/jaeger/to_domain_test.go
+++ b/model/converter/thrift/jaeger/to_domain_test.go
@@ -55,7 +55,7 @@ func TestToDomain(t *testing.T) {
 					t.Log(err)
 				}
 				out, err := json.Marshal(actualSpans)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				t.Logf("Actual trace %v: %s", i, string(out))
 			}
 		})

--- a/model/converter/thrift/zipkin/deserialize_test.go
+++ b/model/converter/thrift/zipkin/deserialize_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 )
@@ -28,7 +28,7 @@ func TestDeserializeWithBadListStart(t *testing.T) {
 	ctx := context.Background()
 	spanBytes := SerializeThrift(ctx, []*zipkincore.Span{{}})
 	_, err := DeserializeThrift(ctx, append([]byte{0, 255, 255}, spanBytes...))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDeserializeWithCorruptedList(t *testing.T) {
@@ -36,12 +36,12 @@ func TestDeserializeWithCorruptedList(t *testing.T) {
 	spanBytes := SerializeThrift(ctx, []*zipkincore.Span{{}})
 	spanBytes[2] = 255
 	_, err := DeserializeThrift(ctx, spanBytes)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDeserialize(t *testing.T) {
 	ctx := context.Background()
 	spanBytes := SerializeThrift(ctx, []*zipkincore.Span{{}})
 	_, err := DeserializeThrift(ctx, spanBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -49,14 +49,14 @@ func TestToDomain(t *testing.T) {
 		name := in + " -> " + out + " : " + zSpans[0].Name
 		t.Run(name, func(t *testing.T) {
 			trace, err := ToDomain(zSpans)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			trace.NormalizeTimestamps()
 			if !assert.Equal(t, expectedTrace, trace) {
 				for _, err := range pretty.Diff(expectedTrace, trace) {
 					t.Log(err)
 				}
 				out, err := json.Marshal(trace)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				t.Logf("Actual trace: %s", string(out))
 			}
 		})
@@ -64,7 +64,7 @@ func TestToDomain(t *testing.T) {
 			t.Run("ToDomainSpans", func(t *testing.T) {
 				zSpan := zSpans[0]
 				jSpans, err := ToDomainSpan(zSpan)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				for _, jSpan := range jSpans {
 					jSpan.NormalizeTimestamps()
 					assert.Equal(t, expectedTrace.Spans[0], jSpan)
@@ -77,7 +77,7 @@ func TestToDomain(t *testing.T) {
 func TestToDomainNoServiceNameError(t *testing.T) {
 	zSpans := getZipkinSpans(t, `[{ "trace_id": -1, "id": 31 }]`)
 	trace, err := ToDomain(zSpans)
-	assert.EqualError(t, err, "cannot find service name in Zipkin span [traceID=ffffffffffffffff, spanID=1f]")
+	require.EqualError(t, err, "cannot find service name in Zipkin span [traceID=ffffffffffffffff, spanID=1f]")
 	assert.Len(t, trace.Spans, 1)
 	assert.Equal(t, "unknown-service-name", trace.Spans[0].Process.ServiceName)
 }
@@ -165,7 +165,7 @@ func TestInvalidAnnotationTypeError(t *testing.T) {
 	_, err := toDomain{}.transformBinaryAnnotation(&z.BinaryAnnotation{
 		AnnotationType: -1,
 	})
-	assert.EqualError(t, err, "unknown zipkin annotation type: -1")
+	require.EqualError(t, err, "unknown zipkin annotation type: -1")
 }
 
 // TestZipkinEncoding is just for reference to explain the base64 strings

--- a/model/ids_test.go
+++ b/model/ids_test.go
@@ -95,7 +95,7 @@ func TestSpanIDFromBytes(t *testing.T) {
 	for _, data := range errTests {
 		_, err := model.SpanIDFromBytes(data)
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid length for SpanID")
+		require.EqualError(t, err, "invalid length for SpanID")
 	}
 
 	spanID, err := model.SpanIDFromBytes([]byte{0, 0, 0, 0, 0, 0, 0, 13})

--- a/model/keyvalue_test.go
+++ b/model/keyvalue_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -145,7 +146,7 @@ func TestKeyValueAsStringAndValue(t *testing.T) {
 	t.Run("invalid type", func(t *testing.T) {
 		kv := model.KeyValue{Key: "x", VType: model.ValueType(-1)}
 		assert.Equal(t, "unknown type -1", kv.AsString())
-		assert.EqualError(t, kv.Value().(error), "unknown type -1")
+		require.EqualError(t, kv.Value().(error), "unknown type -1")
 	})
 }
 
@@ -163,7 +164,7 @@ func TestKeyValueHash(t *testing.T) {
 		testCase := tt // capture loop var
 		t.Run(testCase.kv.String(), func(t *testing.T) {
 			out := new(bytes.Buffer)
-			assert.NoError(t, testCase.kv.Hash(out))
+			require.NoError(t, testCase.kv.Hash(out))
 		})
 	}
 }

--- a/model/keyvalues_test.go
+++ b/model/keyvalues_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -105,7 +106,7 @@ func TestKeyValuesHashErrors(t *testing.T) {
 	w := &mockHashWwiter{
 		answers: make([]mockHashWwiterAnswer, 3),
 	}
-	assert.EqualError(t, kvs.Hash(w), "unknown type -1")
+	require.EqualError(t, kvs.Hash(w), "unknown type -1")
 }
 
 // No memory allocations for IsLess and Equal

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -53,21 +53,18 @@ func TestTraceIDMarshalJSONPB(t *testing.T) {
 			ref := model.SpanRef{TraceID: model.NewTraceID(testCase.hi, testCase.lo)}
 			out := new(bytes.Buffer)
 			err := new(jsonpb.Marshaler).Marshal(out, &ref)
-			if assert.NoError(t, err) {
-				assert.Equal(t, expected, out.String())
-				assert.Equal(t, testCase.hex, ref.TraceID.String())
-			}
+			require.NoError(t, err)
+			assert.Equal(t, expected, out.String())
+			assert.Equal(t, testCase.hex, ref.TraceID.String())
 
 			ref = model.SpanRef{}
 			err = jsonpb.Unmarshal(bytes.NewReader([]byte(expected)), &ref)
-			if assert.NoError(t, err) {
-				assert.Equal(t, testCase.hi, ref.TraceID.High)
-				assert.Equal(t, testCase.lo, ref.TraceID.Low)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.hi, ref.TraceID.High)
+			assert.Equal(t, testCase.lo, ref.TraceID.Low)
 			traceID, err := model.TraceIDFromString(testCase.hex)
-			if assert.NoError(t, err) {
-				assert.Equal(t, ref.TraceID, traceID)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, ref.TraceID, traceID)
 		})
 	}
 }
@@ -88,10 +85,10 @@ func TestTraceIDUnmarshalJSONPBErrors(t *testing.T) {
 			var ref model.SpanRef
 			json := fmt.Sprintf(`{"traceId":"%s"}`, testCase.in)
 			err := jsonpb.Unmarshal(bytes.NewReader([]byte(json)), &ref)
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			_, err = model.TraceIDFromString(testCase.in)
-			assert.Error(t, err)
+			require.Error(t, err)
 		})
 	}
 	// for code coverage
@@ -131,20 +128,17 @@ func TestSpanIDMarshalJSON(t *testing.T) {
 			ref := model.SpanRef{SpanID: model.SpanID(testCase.id)}
 			out := new(bytes.Buffer)
 			err := new(jsonpb.Marshaler).Marshal(out, &ref)
-			if assert.NoError(t, err) {
-				assert.Equal(t, expected, out.String())
-			}
+			require.NoError(t, err)
+			assert.Equal(t, expected, out.String())
 			assert.Equal(t, testCase.hex, ref.SpanID.String())
 
 			ref = model.SpanRef{}
 			err = jsonpb.Unmarshal(bytes.NewReader([]byte(expected)), &ref)
-			if assert.NoError(t, err) {
-				assert.Equal(t, model.NewSpanID(testCase.id), ref.SpanID)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, model.NewSpanID(testCase.id), ref.SpanID)
 			spanID, err := model.SpanIDFromString(testCase.hex)
-			if assert.NoError(t, err) {
-				assert.Equal(t, model.NewSpanID(testCase.id), spanID)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, model.NewSpanID(testCase.id), spanID)
 		})
 	}
 }
@@ -164,10 +158,10 @@ func TestSpanIDUnmarshalJSONErrors(t *testing.T) {
 		t.Run(in, func(t *testing.T) {
 			var ref model.SpanRef
 			err := jsonpb.Unmarshal(bytes.NewReader([]byte(in)), &ref)
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			_, err = model.SpanIDFromString(testCase.in)
-			assert.Error(t, err)
+			require.Error(t, err)
 		})
 	}
 	// for code coverage

--- a/model/spanref_test.go
+++ b/model/spanref_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -36,17 +37,15 @@ func TestSpanRefTypeToFromJSON(t *testing.T) {
 	}
 	out := new(bytes.Buffer)
 	err := new(jsonpb.Marshaler).Marshal(out, &sr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `{"traceId":"AAAAAAAAAAAAAAAAAAAAQg==","spanId":"AAAAAAAAAEM=","refType":"FOLLOWS_FROM"}`, out.String())
 	var sr2 model.SpanRef
-	if assert.NoError(t, jsonpb.Unmarshal(out, &sr2)) {
-		assert.Equal(t, sr, sr2)
-	}
+	require.NoError(t, jsonpb.Unmarshal(out, &sr2))
+	assert.Equal(t, sr, sr2)
 	var sr3 model.SpanRef
 	err = jsonpb.Unmarshal(bytes.NewReader([]byte(`{"refType":"BAD"}`)), &sr3)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "unknown value")
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown value")
 }
 
 func TestMaybeAddParentSpanID(t *testing.T) {

--- a/model/trace_test.go
+++ b/model/trace_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -46,8 +47,8 @@ func TestTraceNormalizeTimestamps(t *testing.T) {
 	s1 := "2017-01-26T16:46:31.639875-05:00"
 	s2 := "2017-01-26T21:46:31.639875-04:00"
 	var tt1, tt2 time.Time
-	assert.NoError(t, tt1.UnmarshalText([]byte(s1)))
-	assert.NoError(t, tt2.UnmarshalText([]byte(s2)))
+	require.NoError(t, tt1.UnmarshalText([]byte(s1)))
+	require.NoError(t, tt2.UnmarshalText([]byte(s2)))
 
 	trace := &model.Trace{
 		Spans: []*model.Span{

--- a/pkg/bearertoken/http_test.go
+++ b/pkg/bearertoken/http_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -75,12 +76,12 @@ func Test_PropagationHandler(t *testing.T) {
 			server := httptest.NewServer(r)
 			defer server.Close()
 			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if testCase.sendHeader {
 				req.Header.Add(testCase.headerName, testCase.headerValue)
 			}
 			_, err = httpClient.Do(req)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			stop.Wait()
 		})
 	}

--- a/pkg/bearertoken/transport_test.go
+++ b/pkg/bearertoken/transport_test.go
@@ -101,10 +101,10 @@ func TestRoundTripper(t *testing.T) {
 
 			if tc.wantError {
 				assert.Nil(t, resp)
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				assert.NotNil(t, resp)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/cassandra/gocql/testutils/udt.go
+++ b/pkg/cassandra/gocql/testutils/udt.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // UDTField describes a field in a gocql User Defined Type
@@ -57,17 +58,17 @@ func (testCase UDTTestCase) Run(t *testing.T) {
 			typeInfo := *(*gocql.NativeType)(unsafe.Pointer(&nt)) /* nolint #nosec */
 			data, err := testCase.Obj.MarshalUDT(field.Name, typeInfo)
 			if field.Err {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, field.ValIn, data)
 			}
 			obj := testCase.New()
 			err = obj.UnmarshalUDT(field.Name, typeInfo, field.ValIn)
 			if field.Err {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/cassandra/metrics/table_test.go
+++ b/pkg/cassandra/metrics/table_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -122,10 +123,10 @@ func TestTableExec(t *testing.T) {
 		}
 		err := tm.Exec(tc.q, useLogger)
 		if tc.q.err == nil {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Empty(t, logBuf.Bytes())
 		} else {
-			assert.Error(t, err, tc.q.err.Error())
+			require.Error(t, err, tc.q.err.Error())
 			if tc.log {
 				assert.Equal(t, map[string]string{
 					"level": "error",

--- a/pkg/clientcfg/clientcfghttp/cfgmgr_test.go
+++ b/pkg/clientcfg/clientcfghttp/cfgmgr_test.go
@@ -71,6 +71,6 @@ func TestConfigManager(t *testing.T) {
 	t.Run("GetBaggageRestrictionsError", func(t *testing.T) {
 		mgr.BaggageManager = nil
 		_, err := mgr.GetBaggageRestrictions(context.Background(), "foo")
-		assert.EqualError(t, err, "baggage restrictions not implemented")
+		require.EqualError(t, err, "baggage restrictions not implemented")
 	})
 }

--- a/pkg/clientcfg/clientcfghttp/handler_test.go
+++ b/pkg/clientcfg/clientcfghttp/handler_test.go
@@ -221,7 +221,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 				assert.Equal(t, testCase.statusCode, resp.StatusCode)
 				if testCase.body != "" {
 					body, err := io.ReadAll(resp.Body)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, testCase.body, string(body))
 				}
 

--- a/pkg/config/string_slice_test.go
+++ b/pkg/config/string_slice_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringSlice(t *testing.T) {
@@ -46,17 +47,17 @@ func TestStringSliceTreatedAsStringSlice(t *testing.T) {
 	flagset.Var(f, "test", "test")
 
 	err := flagset.Set("test", "asdf")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = flagset.Set("test", "blerg")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = flagset.Set("test", "other,thing")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// add go flag set to pflag
 	pflagset := pflag.FlagSet{}
 	pflagset.AddGoFlagSet(flagset)
 	actual, err := pflagset.GetStringSlice("test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, []string{"asdf", "blerg", "other,thing"}, actual)
 }

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -182,7 +182,7 @@ func TestOptionsToConfig(t *testing.T) {
 					assert.Equal(t, &c, cert)
 				}
 			}
-			assert.NoError(t, test.options.Close())
+			require.NoError(t, test.options.Close())
 		})
 	}
 }

--- a/pkg/discovery/discoverer_test.go
+++ b/pkg/discovery/discoverer_test.go
@@ -19,11 +19,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFixedDiscoverer(t *testing.T) {
 	d := FixedDiscoverer([]string{"a", "b"})
 	instances, err := d.Instances()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"a", "b"}, instances)
 }

--- a/pkg/discovery/grpcresolver/grpc_resolver_test.go
+++ b/pkg/discovery/grpcresolver/grpc_resolver_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -66,7 +67,7 @@ func startTestServers(t *testing.T, count int) *test {
 	testInstance := &test{}
 	for i := 0; i < count; i++ {
 		lis, err := net.Listen("tcp", "localhost:0")
-		assert.NoError(t, err, "failed to listen on tcp")
+		require.NoError(t, err, "failed to listen on tcp")
 		s := grpc.NewServer()
 		grpc_testing.RegisterTestServiceServer(s, &testServer{})
 		testInstance.servers = append(testInstance.servers, s)
@@ -108,7 +109,7 @@ func assertRoundRobinCall(t *testing.T, connections int, testc grpc_testing.Test
 	var p peer.Peer
 	for i := 0; i < connections; i++ {
 		_, err := testc.EmptyCall(context.Background(), &grpc_testing.Empty{}, grpc.Peer(&p))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		addrs[p.Addr.String()] = struct{}{}
 	}
 	assert.Len(t, addrs, connections, "must call each of the servers once")
@@ -148,7 +149,7 @@ func TestGRPCResolverRoundRobin(t *testing.T) {
 			res := New(notifier, discoverer, zap.NewNop(), test.minPeers)
 
 			cc, err := grpc.Dial(res.Scheme()+":///round_robin", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(GRPCServiceConfig))
-			assert.NoError(t, err, "could not dial using resolver's scheme")
+			require.NoError(t, err, "could not dial using resolver's scheme")
 			defer cc.Close()
 
 			testc := grpc_testing.NewTestServiceClient(cc)

--- a/pkg/fswatcher/fswatcher_test.go
+++ b/pkg/fswatcher/fswatcher_test.go
@@ -60,13 +60,13 @@ func TestFSWatcherAddFiles(t *testing.T) {
 	w, err := New([]string{file1}, nil, nil)
 	require.NoError(t, err)
 	assert.IsType(t, &FSWatcher{}, w)
-	assert.NoError(t, w.Close())
+	require.NoError(t, w.Close())
 
 	// Add one empty-name file and one readable file
 	w, err = New([]string{"", file1}, nil, nil)
 	require.NoError(t, err)
 	assert.IsType(t, &FSWatcher{}, w)
-	assert.NoError(t, w.Close())
+	require.NoError(t, w.Close())
 
 	// Add one readable file and one unreadable file
 	_, err = New([]string{file1, "invalid-file-name"}, nil, nil)
@@ -76,13 +76,13 @@ func TestFSWatcherAddFiles(t *testing.T) {
 	w, err = New([]string{file1, file2}, nil, nil)
 	require.NoError(t, err)
 	assert.IsType(t, &FSWatcher{}, w)
-	assert.NoError(t, w.Close())
+	require.NoError(t, w.Close())
 
 	// Add two readable files from two different repos
 	w, err = New([]string{file1, file3}, nil, nil)
 	require.NoError(t, err)
 	assert.IsType(t, &FSWatcher{}, w)
-	assert.NoError(t, w.Close())
+	require.NoError(t, w.Close())
 }
 
 func TestFSWatcherWithMultipleFiles(t *testing.T) {

--- a/pkg/httpmetrics/metrics_test.go
+++ b/pkg/httpmetrics/metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metrics/prometheus"
@@ -39,7 +40,7 @@ func TestNewMetricsHandler(t *testing.T) {
 	handler := Wrap(dummyHandlerFunc, mb, zap.NewNop())
 
 	req, err := http.NewRequest(http.MethodGet, "/subdir/qwerty", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
 	for i := 0; i < 1000; i++ {
@@ -81,6 +82,6 @@ func TestIllegalPrometheusLabel(t *testing.T) {
 
 	invalidUtf8 := []byte{0xC0, 0xAE, 0xC0, 0xAE}
 	req, err := http.NewRequest(http.MethodGet, string(invalidUtf8), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 }

--- a/pkg/jtracer/jtracer_test.go
+++ b/pkg/jtracer/jtracer_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -49,7 +48,7 @@ func TestNewHelperProviderError(t *testing.T) {
 			return nil, fakeErr
 		})
 	require.Error(t, err)
-	assert.EqualError(t, err, fakeErr.Error())
+	require.EqualError(t, err, fakeErr.Error())
 }
 
 func TestInitHelperExporterError(t *testing.T) {
@@ -65,7 +64,7 @@ func TestInitHelperExporterError(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	assert.EqualError(t, err, fakeErr.Error())
+	require.EqualError(t, err, fakeErr.Error())
 }
 
 func TestInitHelperResourceError(t *testing.T) {
@@ -80,7 +79,7 @@ func TestInitHelperResourceError(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Nil(t, tp)
-	assert.EqualError(t, err, fakeErr.Error())
+	require.EqualError(t, err, fakeErr.Error())
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -40,7 +41,7 @@ func TestInitMetrics(t *testing.T) {
 	globalTags := map[string]string{"key": "value"}
 
 	err := metrics.Init(&testMetrics, f, globalTags)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testMetrics.Gauge.Update(10)
 	testMetrics.Counter.Inc(5)
@@ -95,21 +96,21 @@ var (
 )
 
 func TestInitMetricsFailures(t *testing.T) {
-	assert.EqualError(t, metrics.Init(&noMetricTag, nil, nil), "Field NoMetricTag is missing a tag 'metric'")
+	require.EqualError(t, metrics.Init(&noMetricTag, nil, nil), "Field NoMetricTag is missing a tag 'metric'")
 
-	assert.EqualError(t, metrics.Init(&badTags, nil, nil),
+	require.EqualError(t, metrics.Init(&badTags, nil, nil),
 		"Field [BadTags]: Tag [noValue] is not of the form key=value in 'tags' string [1=one,noValue]")
 
-	assert.EqualError(t, metrics.Init(&invalidMetricType, nil, nil),
+	require.EqualError(t, metrics.Init(&invalidMetricType, nil, nil),
 		"Field InvalidMetricType is not a pointer to timer, gauge, or counter")
 
-	assert.EqualError(t, metrics.Init(&badHistogramBucket, nil, nil),
+	require.EqualError(t, metrics.Init(&badHistogramBucket, nil, nil),
 		"Field [BadHistogramBucket]: Bucket [a] could not be converted to float64 in 'buckets' string [1,2,a,4]")
 
-	assert.EqualError(t, metrics.Init(&badTimerBucket, nil, nil),
+	require.EqualError(t, metrics.Init(&badTimerBucket, nil, nil),
 		"Field [BadTimerBucket]: Buckets are not currently initialized for timer metrics")
 
-	assert.EqualError(t, metrics.Init(&invalidBuckets, nil, nil),
+	require.EqualError(t, metrics.Init(&invalidBuckets, nil, nil),
 		"Field [InvalidBuckets]: Buckets should only be defined for Timer and Histogram metric types")
 }
 

--- a/pkg/netutils/port_test.go
+++ b/pkg/netutils/port_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -61,7 +62,7 @@ func TestGetPort(t *testing.T) {
 	for _, c := range cases {
 		port, err := GetPort(&c.address)
 		if c.expectedError != "" {
-			assert.EqualError(t, err, c.expectedError)
+			require.EqualError(t, err, c.expectedError)
 		} else {
 			assert.Equal(t, c.expected, port)
 		}

--- a/pkg/recoveryhandler/zap_test.go
+++ b/pkg/recoveryhandler/zap_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
@@ -34,7 +35,7 @@ func TestNewRecoveryHandler(t *testing.T) {
 
 	recovery := NewRecoveryHandler(logger, false)(handlerFunc)
 	req, err := http.NewRequest(http.MethodGet, "/subdir/asdf", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	res := httptest.NewRecorder()
 	recovery.ServeHTTP(res, req)

--- a/pkg/tenancy/grpc_test.go
+++ b/pkg/tenancy/grpc_test.go
@@ -89,7 +89,7 @@ func TestTenancyInterceptors(t *testing.T) {
 			}
 			err := interceptor(0, &ss, &ssi, handler)
 			if test.errMsg == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
 				assert.Equal(t, test.errMsg, err.Error())
@@ -104,7 +104,7 @@ func TestTenancyInterceptors(t *testing.T) {
 			}
 			_, err = uinterceptor(test.ctx, iface, usi, uhandler)
 			if test.errMsg == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
 				assert.Equal(t, test.errMsg, err.Error())

--- a/plugin/metrics/disabled/factory_test.go
+++ b/plugin/metrics/disabled/factory_test.go
@@ -28,7 +28,7 @@ var _ storage.MetricsFactory = new(Factory)
 
 func TestPrometheusFactory(t *testing.T) {
 	f := NewFactory()
-	assert.NoError(t, f.Initialize(zap.NewNop()))
+	require.NoError(t, f.Initialize(zap.NewNop()))
 
 	err := f.Initialize(nil)
 	require.NoError(t, err)
@@ -37,6 +37,6 @@ func TestPrometheusFactory(t *testing.T) {
 	f.InitFromViper(nil, zap.NewNop())
 
 	reader, err := f.CreateMetricsReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, reader)
 }

--- a/plugin/metrics/disabled/reader_test.go
+++ b/plugin/metrics/disabled/reader_test.go
@@ -32,8 +32,8 @@ func TestGetLatencies(t *testing.T) {
 	qParams := &metricsstore.LatenciesQueryParameters{}
 	r, err := reader.GetLatencies(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.ErrorIs(t, err, ErrDisabled)
-	assert.EqualError(t, err, ErrDisabled.Error())
+	require.ErrorIs(t, err, ErrDisabled)
+	require.EqualError(t, err, ErrDisabled.Error())
 }
 
 func TestGetCallRates(t *testing.T) {
@@ -44,8 +44,8 @@ func TestGetCallRates(t *testing.T) {
 	qParams := &metricsstore.CallRateQueryParameters{}
 	r, err := reader.GetCallRates(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.ErrorIs(t, err, ErrDisabled)
-	assert.EqualError(t, err, ErrDisabled.Error())
+	require.ErrorIs(t, err, ErrDisabled)
+	require.EqualError(t, err, ErrDisabled.Error())
 }
 
 func TestGetErrorRates(t *testing.T) {
@@ -56,8 +56,8 @@ func TestGetErrorRates(t *testing.T) {
 	qParams := &metricsstore.ErrorRateQueryParameters{}
 	r, err := reader.GetErrorRates(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.ErrorIs(t, err, ErrDisabled)
-	assert.EqualError(t, err, ErrDisabled.Error())
+	require.ErrorIs(t, err, ErrDisabled)
+	require.EqualError(t, err, ErrDisabled.Error())
 }
 
 func TestGetMinStepDurations(t *testing.T) {
@@ -68,6 +68,6 @@ func TestGetMinStepDurations(t *testing.T) {
 	qParams := &metricsstore.MinStepDurationQueryParameters{}
 	r, err := reader.GetMinStepDuration(context.Background(), qParams)
 	assert.Zero(t, r)
-	assert.ErrorIs(t, err, ErrDisabled)
-	assert.EqualError(t, err, ErrDisabled.Error())
+	require.ErrorIs(t, err, ErrDisabled)
+	require.EqualError(t, err, ErrDisabled.Error())
 }

--- a/plugin/metrics/factory_test.go
+++ b/plugin/metrics/factory_test.go
@@ -48,7 +48,7 @@ func TestUnsupportedMetricsStorageType(t *testing.T) {
 	f, err := NewFactory(withConfig("foo"))
 	require.Error(t, err)
 	assert.Nil(t, f)
-	assert.EqualError(t, err, `unknown metrics type "foo". Valid types are [prometheus]`)
+	require.EqualError(t, err, `unknown metrics type "foo". Valid types are [prometheus]`)
 }
 
 func TestDisabledMetricsStorageType(t *testing.T) {
@@ -75,7 +75,7 @@ func TestCreateMetricsReader(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, reader)
 
-	assert.EqualError(t, err, `no "foo" backend registered for metrics store`)
+	require.EqualError(t, err, `no "foo" backend registered for metrics store`)
 }
 
 type configurable struct {

--- a/plugin/metrics/prometheus/factory_test.go
+++ b/plugin/metrics/prometheus/factory_test.go
@@ -33,19 +33,19 @@ var _ storage.MetricsFactory = new(Factory)
 
 func TestPrometheusFactory(t *testing.T) {
 	f := NewFactory()
-	assert.NoError(t, f.Initialize(zap.NewNop()))
+	require.NoError(t, f.Initialize(zap.NewNop()))
 	assert.NotNil(t, f.logger)
 	assert.Equal(t, "prometheus", f.options.Primary.namespace)
 
 	listener, err := net.Listen("tcp", "localhost:")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, listener)
 	defer listener.Close()
 
 	f.options.Primary.ServerURL = "http://" + listener.Addr().String()
 	reader, err := f.CreateMetricsReader()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, reader)
 }
 

--- a/plugin/metrics/prometheus/metricsstore/dbmodel/to_domain_test.go
+++ b/plugin/metrics/prometheus/metricsstore/dbmodel/to_domain_test.go
@@ -78,7 +78,7 @@ func TestUnexpectedMetricsFamilyType(t *testing.T) {
 	assert.Empty(t, mf)
 
 	require.Error(t, err)
-	assert.EqualError(t, err, "unexpected metrics ValueType: vector")
+	require.EqualError(t, err, "unexpected metrics ValueType: vector")
 }
 
 func TestMain(m *testing.M) {

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -72,7 +72,7 @@ func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExpo
 		sdktrace.WithSyncer(exporter),
 	)
 	closer := func() {
-		assert.NoError(t, tp.Shutdown(context.Background()))
+		require.NoError(t, tp.Shutdown(context.Background()))
 	}
 	return tp, exporter, closer
 }
@@ -684,7 +684,7 @@ func TestGetErrorRatesErrors(t *testing.T) {
 
 			_, err = reader.GetErrorRates(context.Background(), &params)
 			require.Error(t, err)
-			assert.EqualError(t, err, tc.wantErr)
+			require.EqualError(t, err, tc.wantErr)
 		})
 	}
 }
@@ -787,7 +787,7 @@ func TestGetRoundTripperTokenFile(t *testing.T) {
 
 	file, err := os.CreateTemp("", "token_")
 	require.NoError(t, err)
-	defer func() { assert.NoError(t, os.Remove(file.Name())) }()
+	defer func() { require.NoError(t, os.Remove(file.Name())) }()
 
 	_, err = file.Write([]byte(wantBearer))
 	require.NoError(t, err)
@@ -822,7 +822,7 @@ func TestGetRoundTripperTokenFile(t *testing.T) {
 func TestGetRoundTripperTokenFromContext(t *testing.T) {
 	file, err := os.CreateTemp("", "token_")
 	require.NoError(t, err)
-	defer func() { assert.NoError(t, os.Remove(file.Name())) }()
+	defer func() { require.NoError(t, os.Remove(file.Name())) }()
 	_, err = file.Write([]byte("token from file"))
 	require.NoError(t, err)
 	require.NoError(t, file.Close())

--- a/plugin/pkg/distributedlock/cassandra/lock_test.go
+++ b/plugin/pkg/distributedlock/cassandra/lock_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
@@ -89,9 +90,9 @@ func TestExtendLease(t *testing.T) {
 				s.session.On("Query", mock.AnythingOfType("string"), captureArgs).Return(query)
 				err := s.lock.extendLease(samplingLock, time.Second*60)
 				if testCase.expectedErrMsg == "" {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				} else {
-					assert.EqualError(t, err, testCase.expectedErrMsg)
+					require.EqualError(t, err, testCase.expectedErrMsg)
 				}
 
 				expectedArgs := []interface{}{60, localhost, samplingLock, localhost}
@@ -179,9 +180,9 @@ func TestAcquire(t *testing.T) {
 				s.session.On("Query", stringMatcher("UPDATE leases"), matchEverything()).Return(secondQuery)
 				acquired, err := s.lock.Acquire(samplingLock, 0)
 				if testCase.expectedErrMsg == "" {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				} else {
-					assert.EqualError(t, err, testCase.expectedErrMsg)
+					require.EqualError(t, err, testCase.expectedErrMsg)
 				}
 
 				assert.Equal(t, testCase.acquired, acquired)
@@ -236,9 +237,9 @@ func TestForfeit(t *testing.T) {
 				s.session.On("Query", mock.AnythingOfType("string"), captureArgs).Return(query)
 				applied, err := s.lock.Forfeit(samplingLock)
 				if testCase.expectedErrMsg == "" {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				} else {
-					assert.EqualError(t, err, testCase.expectedErrMsg)
+					require.EqualError(t, err, testCase.expectedErrMsg)
 				}
 				assert.Equal(t, testCase.applied, applied)
 

--- a/plugin/sampling/leaderelection/leader_election_test.go
+++ b/plugin/sampling/leaderelection/leader_election_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	lmocks "github.com/jaegertracing/jaeger/pkg/distributedlock/mocks"
@@ -89,7 +90,7 @@ func TestRunAcquireLockLoopFollowerOnly(t *testing.T) {
 	)
 
 	defer func() {
-		assert.NoError(t, p.Close())
+		require.NoError(t, p.Close())
 	}()
 	go p.Start()
 

--- a/plugin/sampling/strategystore/adaptive/factory_test.go
+++ b/plugin/sampling/strategystore/adaptive/factory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
@@ -70,9 +71,9 @@ func TestFactory(t *testing.T) {
 	assert.Equal(t, time.Second, f.options.LeaderLeaseRefreshInterval)
 	assert.Equal(t, time.Second*2, f.options.FollowerLeaseRefreshInterval)
 
-	assert.NoError(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
 	_, _, err := f.CreateStrategyStore()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestBadConfigFail(t *testing.T) {
@@ -91,9 +92,9 @@ func TestBadConfigFail(t *testing.T) {
 
 		f.InitFromViper(v, zap.NewNop())
 
-		assert.NoError(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
+		require.NoError(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
 		_, _, err := f.CreateStrategyStore()
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -101,13 +102,13 @@ func TestSamplingStoreFactoryFails(t *testing.T) {
 	f := NewFactory()
 
 	// nil fails
-	assert.Error(t, f.Initialize(metrics.NullFactory, nil, zap.NewNop()))
+	require.Error(t, f.Initialize(metrics.NullFactory, nil, zap.NewNop()))
 
 	// fail if lock fails
-	assert.Error(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{lockFailsWith: errors.New("fail")}, zap.NewNop()))
+	require.Error(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{lockFailsWith: errors.New("fail")}, zap.NewNop()))
 
 	// fail if store fails
-	assert.Error(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{storeFailsWith: errors.New("fail")}, zap.NewNop()))
+	require.Error(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{storeFailsWith: errors.New("fail")}, zap.NewNop()))
 }
 
 type mockSamplingStoreFactory struct {

--- a/plugin/sampling/strategystore/adaptive/processor_test.go
+++ b/plugin/sampling/strategystore/adaptive/processor_test.go
@@ -371,7 +371,7 @@ func TestRunCalculationLoop(t *testing.T) {
 	p.Close()
 
 	strategy, err := p.GetSamplingStrategy(context.Background(), "svcA")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, strategy.OperationSampling.PerOperationStrategies, 2)
 }
 
@@ -493,7 +493,7 @@ func TestRealisticRunCalculationLoop(t *testing.T) {
 	p.Close()
 
 	strategy, err := p.GetSamplingStrategy(context.Background(), "svcA")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, strategy.OperationSampling.PerOperationStrategies, 4)
 	strategies := strategy.OperationSampling.PerOperationStrategies
 
@@ -537,17 +537,17 @@ func TestConstructorFailure(t *testing.T) {
 		AggregationBuckets:         0,
 	}
 	_, err := newProcessor(cfg, "host", nil, nil, metrics.NullFactory, logger)
-	assert.EqualError(t, err, "CalculationInterval and AggregationBuckets must be greater than 0")
+	require.EqualError(t, err, "CalculationInterval and AggregationBuckets must be greater than 0")
 
 	cfg.CalculationInterval = 0
 	_, err = newProcessor(cfg, "host", nil, nil, metrics.NullFactory, logger)
-	assert.EqualError(t, err, "CalculationInterval and AggregationBuckets must be greater than 0")
+	require.EqualError(t, err, "CalculationInterval and AggregationBuckets must be greater than 0")
 
 	cfg.CalculationInterval = time.Millisecond
 	cfg.AggregationBuckets = 1
 	cfg.BucketsForCalculation = -1
 	_, err = newProcessor(cfg, "host", nil, nil, metrics.NullFactory, logger)
-	assert.EqualError(t, err, "BucketsForCalculation cannot be less than 1")
+	require.EqualError(t, err, "BucketsForCalculation cannot be less than 1")
 }
 
 func TestGenerateStrategyResponses(t *testing.T) {
@@ -879,7 +879,7 @@ func TestErrors(t *testing.T) {
 
 	p, err := newProcessor(cfg, "host", mockStorage, mockEP, metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
-	assert.Error(t, p.Start())
+	require.Error(t, p.Start())
 
 	// close errors
 	mockEP = &epmocks.ElectionParticipant{}
@@ -889,6 +889,6 @@ func TestErrors(t *testing.T) {
 
 	p, err = newProcessor(cfg, "host", mockStorage, mockEP, metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
-	assert.NoError(t, p.Start())
-	assert.Error(t, p.Close())
+	require.NoError(t, p.Start())
+	require.Error(t, p.Close())
 }

--- a/plugin/sampling/strategystore/factory_config_test.go
+++ b/plugin/sampling/strategystore/factory_config_test.go
@@ -63,7 +63,7 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 
 			f, err := FactoryConfigFromEnv()
 			if tc.expectsError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 

--- a/plugin/sampling/strategystore/factory_test.go
+++ b/plugin/sampling/strategystore/factory_test.go
@@ -66,7 +66,7 @@ func TestNewFactory(t *testing.T) {
 	for _, tc := range tests {
 		f, err := NewFactory(FactoryConfig{StrategyStoreType: Kind(tc.strategyStoreType)})
 		if tc.expectError {
-			assert.Error(t, err)
+			require.Error(t, err)
 			continue
 		}
 		assert.NotEmpty(t, f.factories)
@@ -76,20 +76,20 @@ func TestNewFactory(t *testing.T) {
 		mock := new(mockFactory)
 		f.factories[Kind(tc.strategyStoreType)] = mock
 
-		assert.NoError(t, f.Initialize(metrics.NullFactory, mockSSFactory, zap.NewNop()))
+		require.NoError(t, f.Initialize(metrics.NullFactory, mockSSFactory, zap.NewNop()))
 		_, _, err = f.CreateStrategyStore()
 		require.NoError(t, err)
 
 		// force the mock to return errors
 		mock.retError = true
-		assert.EqualError(t, f.Initialize(metrics.NullFactory, mockSSFactory, zap.NewNop()), "error initializing store")
+		require.EqualError(t, f.Initialize(metrics.NullFactory, mockSSFactory, zap.NewNop()), "error initializing store")
 		_, _, err = f.CreateStrategyStore()
-		assert.EqualError(t, err, "error creating store")
+		require.EqualError(t, err, "error creating store")
 
 		// request something that doesn't exist
 		f.StrategyStoreType = "doesntexist"
 		_, _, err = f.CreateStrategyStore()
-		assert.EqualError(t, err, "no doesntexist strategy store registered")
+		require.EqualError(t, err, "no doesntexist strategy store registered")
 	}
 }
 

--- a/plugin/sampling/strategystore/static/factory_test.go
+++ b/plugin/sampling/strategystore/static/factory_test.go
@@ -17,7 +17,7 @@ package static
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	ss "github.com/jaegertracing/jaeger/cmd/collector/app/sampling/strategystore"
@@ -37,7 +37,7 @@ func TestFactory(t *testing.T) {
 	command.ParseFlags([]string{"--sampling.strategies-file=fixtures/strategies.json"})
 	f.InitFromViper(v, zap.NewNop())
 
-	assert.NoError(t, f.Initialize(metrics.NullFactory, nil, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, nil, zap.NewNop()))
 	_, _, err := f.CreateStrategyStore()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -96,7 +96,7 @@ func TestStrategyStoreWithFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to read strategies file fileNotFound.json")
 
 	_, err = NewStrategyStore(Options{StrategiesFile: "fixtures/bad_strategies.json"}, zap.NewNop())
-	assert.EqualError(t, err,
+	require.EqualError(t, err,
 		"failed to unmarshal strategies: json: cannot unmarshal string into Go value of type static.strategies")
 
 	// Test default strategy

--- a/plugin/storage/badger/dependencystore/storage_test.go
+++ b/plugin/storage/badger/dependencystore/storage_test.go
@@ -48,13 +48,13 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 	f.InitFromViper(v, zap.NewNop())
 
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
 
 	sw, err := f.CreateSpanWriter()
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
 
 	dr, err := f.CreateDependencyReader()
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
 
 	test(tb, sw, dr)
 }
@@ -63,7 +63,7 @@ func TestDependencyReader(t *testing.T) {
 	runFactoryTest(t, func(tb testing.TB, sw spanstore.Writer, dr dependencystore.Reader) {
 		tid := time.Now()
 		links, err := dr.GetDependencies(context.Background(), tid, time.Hour)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, links)
 
 		traces := 40
@@ -87,11 +87,11 @@ func TestDependencyReader(t *testing.T) {
 					s.References = []model.SpanRef{model.NewChildOfRef(s.TraceID, model.SpanID(j-1))}
 				}
 				err := sw.WriteSpan(context.Background(), &s)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 		links, err = dr.GetDependencies(context.Background(), time.Now(), time.Hour)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, links)
 		assert.Len(t, links, spans-1)                       // First span does not create a dependency
 		assert.Equal(t, uint64(traces), links[0].CallCount) // Each trace calls the same services

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 	"time"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -46,7 +47,7 @@ func TestInitializationErrors(t *testing.T) {
 	f.InitFromViper(v, zap.NewNop())
 
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestForCodecov(t *testing.T) {
@@ -56,29 +57,29 @@ func TestForCodecov(t *testing.T) {
 	f.InitFromViper(v, zap.NewNop())
 
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get all the writers, readers, etc
 	_, err = f.CreateSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateDependencyReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lock, err := f.CreateLock()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, lock)
 
 	// Now, remove the badger directories
 	err = os.RemoveAll(f.tmpDir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Now try to close, since the files have been deleted this should throw an error
 	err = f.Close()
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMaintenanceRun(t *testing.T) {
@@ -122,7 +123,7 @@ func TestMaintenanceRun(t *testing.T) {
 	assert.True(t, gs[lastValueLogCleanedName] > 0)
 
 	err := io.Closer(f).Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestMaintenanceCodecov this test is not intended to test anything, but hopefully increase coverage by triggering a log line
@@ -147,7 +148,7 @@ func TestMaintenanceCodecov(t *testing.T) {
 	}
 
 	err := f.store.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	waiter() // This should trigger the logging of error
 }
 
@@ -190,7 +191,7 @@ func TestBadgerMetrics(t *testing.T) {
 	assert.True(t, found)
 
 	err := f.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestInitFromOptions(t *testing.T) {

--- a/plugin/storage/badger/lock_test.go
+++ b/plugin/storage/badger/lock_test.go
@@ -19,18 +19,19 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAcquire(t *testing.T) {
 	l := &lock{}
 	ok, err := l.Acquire("resource", time.Duration(1))
 	assert.True(t, ok)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestForfeit(t *testing.T) {
 	l := &lock{}
 	ok, err := l.Forfeit("resource")
 	assert.True(t, ok)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/plugin/storage/badger/options_test.go
+++ b/plugin/storage/badger/options_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/config"

--- a/plugin/storage/badger/samplingstore/storage_test.go
+++ b/plugin/storage/badger/samplingstore/storage_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	samplemodel "github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
 )
@@ -36,7 +37,7 @@ func TestInsertThroughput(t *testing.T) {
 			{Service: "our-svc", Operation: "op2"},
 		}
 		err := store.InsertThroughput(throughputs)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -48,10 +49,10 @@ func TestGetThroughput(t *testing.T) {
 			{Service: "our-svc", Operation: "op2"},
 		}
 		err := store.InsertThroughput(expected)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		actual, err := store.GetThroughput(start, start.Add(time.Second*time.Duration(10)))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
 }
@@ -63,7 +64,7 @@ func TestInsertProbabilitiesAndQPS(t *testing.T) {
 			samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
 			samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -74,17 +75,17 @@ func TestGetLatestProbabilities(t *testing.T) {
 			samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
 			samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = store.InsertProbabilitiesAndQPS(
 			"newhostname",
 			samplemodel.ServiceOperationProbabilities{"new-srv2": {"op": 0.123}},
 			samplemodel.ServiceOperationQPS{"new-srv2": {"op": 1}},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		expected := samplemodel.ServiceOperationProbabilities{"new-srv2": {"op": 0.123}}
 		actual, err := store.GetLatestProbabilities()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
 }
@@ -97,16 +98,16 @@ func TestDecodeProbabilitiesValue(t *testing.T) {
 	}
 
 	marshalBytes, err := json.Marshal(expected)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// This should pass without error
 	actual, err := decodeProbabilitiesValue(marshalBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
 	// Simulate data corruption by removing the first byte.
 	corruptedBytes := marshalBytes[1:]
 	_, err = decodeProbabilitiesValue(corruptedBytes)
-	assert.Error(t, err) // Expect an error
+	require.Error(t, err) // Expect an error
 }
 
 func TestDecodeThroughtputValue(t *testing.T) {
@@ -116,9 +117,9 @@ func TestDecodeThroughtputValue(t *testing.T) {
 	}
 
 	marshalBytes, err := json.Marshal(expected)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	acrual, err := decodeThroughtputValue(marshalBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, acrual)
 }
 
@@ -131,9 +132,9 @@ func runWithBadger(t *testing.T, test func(t *testing.T, store *SamplingStore)) 
 	opts.ValueDir = dir
 
 	store, err := badger.Open(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, store.Close())
+		require.NoError(t, store.Close())
 	}()
 	ss := newTestSamplingStore(store)
 	test(t, ss)

--- a/plugin/storage/badger/spanstore/cache_test.go
+++ b/plugin/storage/badger/spanstore/cache_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -39,7 +40,7 @@ func TestExpiredItems(t *testing.T) {
 		cache.Update("service1", "op2", expireTime)
 
 		services, err := cache.GetServices()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, services) // Everything should be expired
 
 		// Expired service for operations
@@ -48,7 +49,7 @@ func TestExpiredItems(t *testing.T) {
 		cache.Update("service1", "op2", expireTime)
 
 		operations, err := cache.GetOperations("service1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
 
 		// Expired operations, stable service
@@ -59,7 +60,7 @@ func TestExpiredItems(t *testing.T) {
 		cache.services["service1"] = uint64(time.Now().Unix() + 1e10)
 
 		operations, err = cache.GetOperations("service1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
 	})
 }
@@ -117,7 +118,7 @@ func runWithBadger(t *testing.T, test func(store *badger.DB, t *testing.T)) {
 		store.Close()
 	}()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	test(store, t)
 }

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -74,7 +74,7 @@ func TestWriteReadBack(t *testing.T) {
 					},
 				}
 				err := sw.WriteSpan(context.Background(), &s)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 
@@ -83,7 +83,7 @@ func TestWriteReadBack(t *testing.T) {
 				Low:  uint64(i),
 				High: 1,
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Len(t, tr.Spans, spans)
 		}
@@ -100,32 +100,32 @@ func TestValidation(t *testing.T) {
 
 		params.OperationName = "no-service"
 		_, err := sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "service name must be set")
+		require.EqualError(t, err, "service name must be set")
 		params.ServiceName = "find-service"
 
 		_, err = sr.FindTraces(context.Background(), nil)
-		assert.EqualError(t, err, "malformed request object")
+		require.EqualError(t, err, "malformed request object")
 
 		params.StartTimeMin = params.StartTimeMax.Add(1 * time.Hour)
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "min start time is above max")
+		require.EqualError(t, err, "min start time is above max")
 		params.StartTimeMin = tid
 
 		params.DurationMax = time.Duration(1 * time.Millisecond)
 		params.DurationMin = time.Duration(1 * time.Minute)
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "min duration is above max")
+		require.EqualError(t, err, "min duration is above max")
 
 		params = &spanstore.TraceQueryParameters{
 			StartTimeMin: tid,
 		}
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "start and end time must be set")
+		require.EqualError(t, err, "start and end time must be set")
 
 		params.StartTimeMax = tid.Add(1 * time.Minute)
 		params.Tags = map[string]string{"A": "B"}
 		_, err = sr.FindTraces(context.Background(), params)
-		assert.EqualError(t, err, "service name must be set")
+		require.EqualError(t, err, "service name must be set")
 	})
 }
 
@@ -171,7 +171,7 @@ func TestIndexSeeks(t *testing.T) {
 				}
 
 				err := sw.WriteSpan(context.Background(), &s)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 
@@ -189,23 +189,23 @@ func TestIndexSeeks(t *testing.T) {
 		}
 
 		trs, err := sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 1)
 		assert.Len(t, trs[0].Spans, spans)
 
 		params.OperationName = "operation-1"
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 1)
 
 		params.ServiceName = "service-10" // this should not match
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, trs)
 
 		params.OperationName = "operation-4"
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, trs)
 
 		// Multi-index hits
@@ -219,7 +219,7 @@ func TestIndexSeeks(t *testing.T) {
 		params.Tags = tags
 		params.DurationMin = time.Duration(1 * time.Millisecond)
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 1)
 		assert.Len(t, trs[0].Spans, spans)
 
@@ -229,7 +229,7 @@ func TestIndexSeeks(t *testing.T) {
 		delete(params.Tags, "k11")
 		params.NumTraces = 2
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 2)
 		assert.Equal(t, traceOrder[59], trs[0].Spans[0].TraceID.Low)
 		assert.Equal(t, traceOrder[55], trs[1].Spans[0].TraceID.Low)
@@ -244,7 +244,7 @@ func TestIndexSeeks(t *testing.T) {
 			NumTraces:    9,
 		}
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 9) // Returns 23, we limited to 9
 
 		// Check the newest items are returned
@@ -257,7 +257,7 @@ func TestIndexSeeks(t *testing.T) {
 		params.DurationMax = 0
 		params.NumTraces = 7
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 7)
 		assert.Equal(t, traceOrder[59], trs[0].Spans[0].TraceID.Low)
 		assert.Equal(t, traceOrder[53], trs[6].Spans[0].TraceID.Low)
@@ -270,7 +270,7 @@ func TestIndexSeeks(t *testing.T) {
 		}
 
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 5)
 		assert.Len(t, trs[0].Spans, spans)
 		testOrder(trs)
@@ -281,7 +281,7 @@ func TestIndexSeeks(t *testing.T) {
 		params.DurationMax = time.Duration(56 * time.Millisecond) // trace 56 (max)
 
 		trs, err = sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trs, 6)
 		assert.Equal(t, traceOrder[56], trs[0].Spans[0].TraceID.Low)
 		assert.Equal(t, traceOrder[51], trs[5].Spans[0].TraceID.Low)
@@ -299,7 +299,7 @@ func TestFindNothing(t *testing.T) {
 		}
 
 		trs, err := sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, trs)
 
 		tr, err := sr.GetTrace(context.Background(), model.TraceID{High: 0, Low: 0})
@@ -329,7 +329,7 @@ func TestWriteDuplicates(t *testing.T) {
 					Duration:  time.Duration(i + j),
 				}
 				err := sw.WriteSpan(context.Background(), &s)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 	})
@@ -357,7 +357,7 @@ func TestMenuSeeks(t *testing.T) {
 					Duration:  time.Duration(i + j),
 				}
 				err := sw.WriteSpan(context.Background(), &s)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 
@@ -365,10 +365,10 @@ func TestMenuSeeks(t *testing.T) {
 			context.Background(),
 			spanstore.OperationQueryParameters{ServiceName: "service-1"},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		serviceList, err := sr.GetServices(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, operations, spans)
 		assert.Len(t, serviceList, services)
@@ -399,13 +399,13 @@ func TestPersist(t *testing.T) {
 		f.InitFromViper(v, zap.NewNop())
 
 		err := f.Initialize(metrics.NullFactory, zap.NewNop())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		sw, err := f.CreateSpanWriter()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		sr, err := f.CreateSpanReader()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		test(t, sw, sr)
 	}
@@ -425,7 +425,7 @@ func TestPersist(t *testing.T) {
 			Duration:  time.Duration(1 * time.Hour),
 		}
 		err := sw.WriteSpan(context.Background(), &s)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	p(t, dir, func(t *testing.T, sw spanstore.Writer, sr spanstore.Reader) {
@@ -433,11 +433,11 @@ func TestPersist(t *testing.T) {
 			Low:  uint64(1),
 			High: 1,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "operation-p", trace.Spans[0].OperationName)
 
 		services, err := sr.GetServices(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, services, 1)
 	})
 }
@@ -458,13 +458,13 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 	f.InitFromViper(v, zap.NewNop())
 
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
 
 	sw, err := f.CreateSpanWriter()
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
 
 	sr, err := f.CreateSpanReader()
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
 
 	test(tb, sw, sr)
 }
@@ -607,14 +607,14 @@ func BenchmarkServiceIndexLimitFetch(b *testing.B) {
 
 // Opens a badger db and runs a test on it.
 func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
-	assert := assert.New(tb)
+	assertion := require.New(tb)
 	f := badger.NewFactory()
 	opts := badger.NewOptions("badger")
 	v, command := config.Viperize(opts.AddFlags)
 
 	dir := filepath.Join(tb.TempDir(), "badger-testRun")
 	err := os.MkdirAll(dir, 0o700)
-	assert.NoError(err)
+	assertion.NoError(err)
 	keyParam := fmt.Sprintf("--badger.directory-key=%s", dir)
 	valueParam := fmt.Sprintf("--badger.directory-value=%s", dir)
 
@@ -628,13 +628,13 @@ func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Wr
 	f.InitFromViper(v, zap.NewNop())
 
 	err = f.Initialize(metrics.NullFactory, zap.NewNop())
-	assert.NoError(err)
+	assertion.NoError(err)
 
 	sw, err := f.CreateSpanWriter()
-	assert.NoError(err)
+	assertion.NoError(err)
 
 	sr, err := f.CreateSpanReader()
-	assert.NoError(err)
+	assertion.NoError(err)
 
 	defer func() {
 		err := f.Close()
@@ -668,7 +668,7 @@ func TestRandomTraceID(t *testing.T) {
 			Duration:  1 * time.Second,
 		}
 		err := sw.WriteSpan(context.Background(), &s1)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		s2 := model.Span{
 			TraceID: model.TraceID{
@@ -691,7 +691,7 @@ func TestRandomTraceID(t *testing.T) {
 			Duration:  1 * time.Second,
 		}
 		err = sw.WriteSpan(context.Background(), &s2)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		params := &spanstore.TraceQueryParameters{
 			StartTimeMin: time.Now().Add(-1 * time.Minute),
@@ -702,7 +702,7 @@ func TestRandomTraceID(t *testing.T) {
 			},
 		}
 		traces, err := sr.FindTraces(context.Background(), params)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, traces, 1)
 	})
 }

--- a/plugin/storage/badger/spanstore/rw_internal_test.go
+++ b/plugin/storage/badger/spanstore/rw_internal_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -38,10 +39,10 @@ func TestEncodingTypes(t *testing.T) {
 
 		sw.encodingType = jsonEncoding
 		err := sw.WriteSpan(context.Background(), &testSpan)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		tr, err := rw.GetTrace(context.Background(), model.TraceID{Low: 0, High: 1})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, tr.Spans, 1)
 	})
 
@@ -55,7 +56,7 @@ func TestEncodingTypes(t *testing.T) {
 
 		sw.encodingType = 0x04
 		err := sw.WriteSpan(context.Background(), &testSpan)
-		assert.EqualError(t, err, "unknown encoding type: 0x04")
+		require.EqualError(t, err, "unknown encoding type: 0x04")
 	})
 
 	// Unknown encoding reader
@@ -67,7 +68,7 @@ func TestEncodingTypes(t *testing.T) {
 		rw := NewTraceReader(store, cache)
 
 		err := sw.WriteSpan(context.Background(), &testSpan)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		startTime := model.TimeAsEpochMicroseconds(testSpan.StartTime)
 
@@ -84,7 +85,7 @@ func TestEncodingTypes(t *testing.T) {
 		})
 
 		_, err = rw.GetTrace(context.Background(), model.TraceID{Low: 0, High: 1})
-		assert.EqualError(t, err, "unknown encoding type: 0x04")
+		require.EqualError(t, err, "unknown encoding type: 0x04")
 	})
 }
 
@@ -92,10 +93,10 @@ func TestDecodeErrorReturns(t *testing.T) {
 	garbage := []byte{0x08}
 
 	_, err := decodeValue(garbage, protoEncoding)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = decodeValue(garbage, jsonEncoding)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDuplicateTraceIDDetection(t *testing.T) {
@@ -113,7 +114,7 @@ func TestDuplicateTraceIDDetection(t *testing.T) {
 				testSpan.SpanID = model.SpanID(rand.Uint64())
 				testSpan.StartTime = origStartTime.Add(time.Duration(rand.Int31n(8000)) * time.Millisecond)
 				err := sw.WriteSpan(context.Background(), &testSpan)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 
@@ -124,7 +125,7 @@ func TestDuplicateTraceIDDetection(t *testing.T) {
 			StartTimeMin: testSpan.StartTime.Add(-1 * time.Hour),
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, traces, 128)
 	})
 }

--- a/plugin/storage/badger/stats_linux_test.go
+++ b/plugin/storage/badger/stats_linux_test.go
@@ -17,7 +17,8 @@ package badger
 import (
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -35,11 +36,11 @@ func TestDiskStatisticsUpdate(t *testing.T) {
 	f.InitFromViper(v, zap.NewNop())
 	mFactory := metricstest.NewFactory(0)
 	err := f.Initialize(mFactory, zap.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer f.Close()
 
 	err = f.diskStatisticsUpdate()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, gs := mFactory.Snapshot()
 	assert.True(t, gs[keyLogSpaceAvailableName] > int64(0))
 	assert.True(t, gs[valueLogSpaceAvailableName] > int64(0))

--- a/plugin/storage/badger/stats_test.go
+++ b/plugin/storage/badger/stats_test.go
@@ -20,7 +20,7 @@ package badger
 import (
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/config"
@@ -37,10 +37,10 @@ func TestDiskStatisticsUpdate(t *testing.T) {
 	})
 	f.InitFromViper(v, zap.NewNop())
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer f.Close()
 
 	// We're not expecting any value in !linux, just no error
 	err = f.diskStatisticsUpdate()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/plugin/storage/blackhole/blackhole_test.go
+++ b/plugin/storage/blackhole/blackhole_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -33,7 +34,7 @@ func withBlackhole(f func(store *Store)) {
 func TestStoreGetDependencies(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		links, err := store.GetDependencies(context.Background(), time.Now(), time.Hour)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, links)
 	})
 }
@@ -41,14 +42,14 @@ func TestStoreGetDependencies(t *testing.T) {
 func TestStoreWriteSpan(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		err := store.WriteSpan(context.Background(), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
 func TestStoreGetTrace(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		trace, err := store.GetTrace(context.Background(), model.NewTraceID(1, 2))
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, trace)
 	})
 }
@@ -56,7 +57,7 @@ func TestStoreGetTrace(t *testing.T) {
 func TestStoreGetServices(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		serviceNames, err := store.GetServices(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, serviceNames)
 	})
 }
@@ -67,7 +68,7 @@ func TestStoreGetAllOperations(t *testing.T) {
 			context.Background(),
 			spanstore.OperationQueryParameters{},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, operations)
 	})
 }
@@ -75,7 +76,7 @@ func TestStoreGetAllOperations(t *testing.T) {
 func TestStoreFindTraces(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		traces, err := store.FindTraces(context.Background(), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, traces)
 	})
 }
@@ -83,7 +84,7 @@ func TestStoreFindTraces(t *testing.T) {
 func TestStoreFindTraceIDs(t *testing.T) {
 	withBlackhole(func(store *Store) {
 		traceIDs, err := store.FindTraceIDs(context.Background(), nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, traceIDs)
 	})
 }

--- a/plugin/storage/blackhole/factory_test.go
+++ b/plugin/storage/blackhole/factory_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -29,21 +30,21 @@ var _ storage.Factory = new(Factory)
 
 func TestStorageFactory(t *testing.T) {
 	f := NewFactory()
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, reader)
 	writer, err := f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, writer)
 	reader, err = f.CreateArchiveSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, reader)
 	writer, err = f.CreateArchiveSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, writer)
 	depReader, err := f.CreateDependencyReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, depReader)
 }

--- a/plugin/storage/cassandra/dependencystore/storage_test.go
+++ b/plugin/storage/cassandra/dependencystore/storage_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -70,7 +71,7 @@ func TestVersionIsValid(t *testing.T) {
 
 func TestInvalidVersion(t *testing.T) {
 	_, err := NewDependencyStore(&mocks.Session{}, metrics.NullFactory, zap.NewNop(), versionEnumEnd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDependencyStoreWrite(t *testing.T) {
@@ -112,7 +113,7 @@ func TestDependencyStoreWrite(t *testing.T) {
 					},
 				}
 				err := s.storage.WriteDependencies(ts, dependencies)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				assert.Len(t, args, 3)
 				if d, ok := args[0].(time.Time); ok {
@@ -231,7 +232,7 @@ func TestDependencyStoreGetDependencies(t *testing.T) {
 				deps, err := s.storage.GetDependencies(context.Background(), time.Now(), 48*time.Hour)
 
 				if testCase.expectedError == "" {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					expected := []model.DependencyLink{
 						{Parent: "a", Child: "b", CallCount: 1, Source: model.JaegerDependencyLinkSource},
 						{Parent: "b", Child: "c", CallCount: 1, Source: model.JaegerDependencyLinkSource},
@@ -240,7 +241,7 @@ func TestDependencyStoreGetDependencies(t *testing.T) {
 					}
 					assert.Equal(t, expected, deps)
 				} else {
-					assert.EqualError(t, err, testCase.expectedError)
+					require.EqualError(t, err, testCase.expectedError)
 				}
 				for _, expectedLog := range testCase.expectedLogs {
 					assert.True(t, strings.Contains(s.logBuffer.String(), expectedLog), "Log must contain %s, but was %s", expectedLog, s.logBuffer.String())

--- a/plugin/storage/cassandra/factory_test.go
+++ b/plugin/storage/cassandra/factory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
@@ -56,7 +57,7 @@ func TestCassandraFactory(t *testing.T) {
 	// after InitFromViper, f.primaryConfig points to a real session builder that will fail in unit tests,
 	// so we override it with a mock.
 	f.primaryConfig = newMockSessionBuilder(nil, errors.New("made-up error"))
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	require.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
 
 	var (
 		session = &mocks.Session{}
@@ -66,43 +67,43 @@ func TestCassandraFactory(t *testing.T) {
 	query.On("Exec").Return(nil)
 	f.primaryConfig = newMockSessionBuilder(session, nil)
 	f.archiveConfig = newMockSessionBuilder(nil, errors.New("made-up error"))
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	require.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
 
 	f.archiveConfig = nil
-	assert.NoError(t, f.Initialize(metrics.NullFactory, logger))
+	require.NoError(t, f.Initialize(metrics.NullFactory, logger))
 	assert.Contains(t, logBuf.String(), "Cassandra archive storage configuration is empty, skipping")
 
 	_, err := f.CreateSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateDependencyReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateArchiveSpanReader()
-	assert.EqualError(t, err, "archive storage not configured")
+	require.EqualError(t, err, "archive storage not configured")
 
 	_, err = f.CreateArchiveSpanWriter()
-	assert.EqualError(t, err, "archive storage not configured")
+	require.EqualError(t, err, "archive storage not configured")
 
 	f.archiveConfig = newMockSessionBuilder(session, nil)
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	_, err = f.CreateArchiveSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateArchiveSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateLock()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateSamplingStore(0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, f.Close())
+	require.NoError(t, f.Close())
 }
 
 func TestExclusiveWhitelistBlacklist(t *testing.T) {
@@ -119,7 +120,7 @@ func TestExclusiveWhitelistBlacklist(t *testing.T) {
 	// after InitFromViper, f.primaryConfig points to a real session builder that will fail in unit tests,
 	// so we override it with a mock.
 	f.primaryConfig = newMockSessionBuilder(nil, errors.New("made-up error"))
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	require.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
 
 	var (
 		session = &mocks.Session{}
@@ -129,20 +130,20 @@ func TestExclusiveWhitelistBlacklist(t *testing.T) {
 	query.On("Exec").Return(nil)
 	f.primaryConfig = newMockSessionBuilder(session, nil)
 	f.archiveConfig = newMockSessionBuilder(nil, errors.New("made-up error"))
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	require.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
 
 	f.archiveConfig = nil
-	assert.NoError(t, f.Initialize(metrics.NullFactory, logger))
+	require.NoError(t, f.Initialize(metrics.NullFactory, logger))
 	assert.Contains(t, logBuf.String(), "Cassandra archive storage configuration is empty, skipping")
 
 	_, err := f.CreateSpanWriter()
-	assert.EqualError(t, err, "only one of TagIndexBlacklist and TagIndexWhitelist can be specified")
+	require.EqualError(t, err, "only one of TagIndexBlacklist and TagIndexWhitelist can be specified")
 
 	f.archiveConfig = &mockSessionBuilder{}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	_, err = f.CreateArchiveSpanWriter()
-	assert.EqualError(t, err, "only one of TagIndexBlacklist and TagIndexWhitelist can be specified")
+	require.EqualError(t, err, "only one of TagIndexBlacklist and TagIndexWhitelist can be specified")
 }
 
 func TestWriterOptions(t *testing.T) {

--- a/plugin/storage/cassandra/samplingstore/storage_test.go
+++ b/plugin/storage/cassandra/samplingstore/storage_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 
@@ -78,7 +79,7 @@ func TestInsertThroughput(t *testing.T) {
 			},
 		}
 		err := s.store.InsertThroughput(throughput)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, args, 3)
 		if _, ok := args[0].(int64); !ok {
@@ -121,7 +122,7 @@ func TestInsertProbabilitiesAndQPS(t *testing.T) {
 		}
 
 		err := s.store.InsertProbabilitiesAndQPS(hostname, probabilities, qps)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, args, 4)
 		if d, ok := args[0].(int); ok {
@@ -198,7 +199,7 @@ func TestGetThroughput(t *testing.T) {
 				throughput, err := s.store.GetThroughput(testTime, testTime)
 
 				if testCase.expectedError == "" {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Len(t, throughput, 2)
 					assert.Equal(t,
 						model.Throughput{
@@ -219,7 +220,7 @@ func TestGetThroughput(t *testing.T) {
 						*throughput[1],
 					)
 				} else {
-					assert.EqualError(t, err, testCase.expectedError)
+					require.EqualError(t, err, testCase.expectedError)
 				}
 			})
 		})
@@ -278,10 +279,10 @@ func TestGetLatestProbabilities(t *testing.T) {
 				probabilities, err := s.store.GetLatestProbabilities()
 
 				if testCase.expectedError == "" {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, 0.84, probabilities["svc"]["op"])
 				} else {
-					assert.EqualError(t, err, testCase.expectedError)
+					require.EqualError(t, err, testCase.expectedError)
 				}
 			})
 		})

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -203,7 +203,7 @@ func TestFromSpan(t *testing.T) {
 		}
 		expectedSpan := getTestJaegerSpan()
 		actualJSpan, err := ToDomain(testDBSpan)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if !assert.EqualValues(t, expectedSpan, actualJSpan) {
 			for _, diff := range pretty.Diff(expectedSpan, actualJSpan) {
 				t.Log(diff)
@@ -281,13 +281,13 @@ func TestGenerateHashCode(t *testing.T) {
 	hc1, err1 := model.HashCode(span1)
 	hc2, err2 := model.HashCode(span2)
 	assert.Equal(t, hc1, hc2)
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
+	require.NoError(t, err1)
+	require.NoError(t, err2)
 
 	span2.Tags = append(span2.Tags, model.String("xyz", "some new tag"))
 	hc2, err2 = model.HashCode(span2)
 	assert.NotEqual(t, hc1, hc2)
-	assert.NoError(t, err2)
+	require.NoError(t, err2)
 }
 
 func TestFromDBTagsWithoutWarnings(t *testing.T) {
@@ -295,7 +295,7 @@ func TestFromDBTagsWithoutWarnings(t *testing.T) {
 	dbSpan := FromDomain(span)
 
 	tags, err := converter{}.fromDBTags(dbSpan.Tags)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, tags, span.Tags)
 }
 
@@ -305,7 +305,7 @@ func TestFromDBTagsWithWarnings(t *testing.T) {
 	dbSpan := FromDomain(span)
 
 	tags, err := converter{}.fromDBTags(dbSpan.Tags)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, tags, span.Tags)
 }
 
@@ -315,7 +315,7 @@ func TestFromDBLogsWithWarnings(t *testing.T) {
 	dbSpan := FromDomain(span)
 
 	logs, err := converter{}.fromDBLogs(dbSpan.Logs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, logs, span.Logs)
 }
 
@@ -325,7 +325,7 @@ func TestFromDBProcessWithWarnings(t *testing.T) {
 	dbSpan := FromDomain(span)
 
 	process, err := converter{}.fromDBProcess(dbSpan.Process)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, process, span.Process)
 }
 
@@ -335,7 +335,7 @@ func TestFromDBWarnings(t *testing.T) {
 	dbSpan := FromDomain(span)
 
 	warnings, err := converter{}.fromDBWarnings(dbSpan.Tags)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, warnings, span.Warnings)
 }
 

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -104,13 +105,13 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 					ServiceName:   "service-a",
 					OperationName: "Operation-b",
 				})
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				err = s.storage.Write(dbmodel.Operation{
 					ServiceName:   "service-c",
 					OperationName: "operation-d",
 				})
-				assert.EqualError(t, err,
+				require.EqualError(t, err,
 					"failed to Exec query 'select from "+
 						schemas[test.schemaVersion].tableName+
 						"': exec error")
@@ -133,7 +134,7 @@ func TestOperationNamesStorageWrite(t *testing.T) {
 					ServiceName:   "service-a",
 					OperationName: "Operation-b",
 				})
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				counts2, _ := s.metricsFactory.Snapshot()
 				expCounts := counts
@@ -185,12 +186,12 @@ func TestOperationNamesStorageGetServices(t *testing.T) {
 					ServiceName: "service-a",
 				})
 				if test.expErr == nil {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					// expect one empty operation result
 					// because mock iter.Scan(&placeholder) does not write to `placeholder`
 					assert.Equal(t, []spanstore.Operation{{}}, services)
 				} else {
-					assert.EqualError(
+					require.EqualError(
 						t,
 						err,
 						fmt.Sprintf("error reading %s from storage: %s",

--- a/plugin/storage/cassandra/spanstore/service_names_test.go
+++ b/plugin/storage/cassandra/spanstore/service_names_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -74,9 +75,9 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 				s.session.On("Query", mock.AnythingOfType("string"), emptyArgs).Return(query)
 
 				err := s.storage.Write("service-a")
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				err = s.storage.Write("service-b")
-				assert.EqualError(t, err, "failed to Exec query 'select from service_names': exec error")
+				require.EqualError(t, err, "failed to Exec query 'select from service_names': exec error")
 				assert.Equal(t, map[string]string{
 					"level": "error",
 					"msg":   "Failed to exec query",
@@ -91,7 +92,7 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 
 				// write again
 				err = s.storage.Write("service-a")
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				counts2, _ := s.metricsFactory.Snapshot()
 				expCounts := counts
@@ -133,11 +134,11 @@ func TestServiceNamesStorageGetServices(t *testing.T) {
 
 			services, err := s.storage.GetServices()
 			if expErr == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// expect empty string because mock iter.Scan(&placeholder) does not write to `placeholder`
 				assert.Equal(t, []string{""}, services)
 			} else {
-				assert.EqualError(t, err, "error reading service_names from storage: "+expErr.Error())
+				require.EqualError(t, err, "error reading service_names from storage: "+expErr.Error())
 			}
 		})
 	}

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -213,9 +214,9 @@ func TestSpanWriter(t *testing.T) {
 				err := w.writer.WriteSpan(context.Background(), span)
 
 				if testCase.expectedError == "" {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				} else {
-					assert.EqualError(t, err, testCase.expectedError)
+					require.EqualError(t, err, testCase.expectedError)
 				}
 				for _, expectedLog := range testCase.expectedLogs {
 					assert.Contains(t, w.logBuffer.String(), expectedLog)
@@ -261,9 +262,9 @@ func TestSpanWriterSaveServiceNameAndOperationName(t *testing.T) {
 					OperationName: "operation",
 				})
 			if testCase.expectedError == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, testCase.expectedError)
+				require.EqualError(t, err, testCase.expectedError)
 			}
 		})
 	}
@@ -325,7 +326,7 @@ func TestStorageMode_IndexOnly(t *testing.T) {
 
 		err := w.writer.WriteSpan(context.Background(), span)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		serviceNameQuery.AssertExpectations(t)
 		serviceOperationNameQuery.AssertExpectations(t)
 		durationNoOperationQuery.AssertExpectations(t)
@@ -350,7 +351,7 @@ func TestStorageMode_IndexOnly_WithFilter(t *testing.T) {
 			},
 		}
 		err := w.writer.WriteSpan(context.Background(), span)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		w.session.AssertExpectations(t)
 		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceOperationIndex), matchEverything())
 		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex), matchEverything())
@@ -397,7 +398,7 @@ func TestStorageMode_IndexOnly_FirehoseSpan(t *testing.T) {
 		w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
 
 		err := w.writer.WriteSpan(context.Background(), span)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		w.session.AssertExpectations(t)
 		w.session.AssertNotCalled(t, "Query", stringMatcher(tagIndex), matchEverything())
 		w.session.AssertNotCalled(t, "Query", stringMatcher(durationIndex), matchEverything())
@@ -428,7 +429,7 @@ func TestStorageMode_StoreWithoutIndexing(t *testing.T) {
 
 		err := w.writer.WriteSpan(context.Background(), span)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		spanQuery.AssertExpectations(t)
 		w.session.AssertExpectations(t)
 		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex), matchEverything())

--- a/plugin/storage/es/dependencystore/storage_test.go
+++ b/plugin/storage/es/dependencystore/storage_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/olivere/elastic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 
@@ -121,9 +122,9 @@ func TestWriteDependencies(t *testing.T) {
 			writeService.On("Add", mock.Anything).Return(nil, testCase.writeError)
 			err := r.storage.WriteDependencies(fixedTime, []model.DependencyLink{})
 			if testCase.expectedError != "" {
-				assert.EqualError(t, err, testCase.expectedError)
+				require.EqualError(t, err, testCase.expectedError)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -195,10 +196,10 @@ func TestGetDependencies(t *testing.T) {
 
 			actual, err := r.storage.GetDependencies(context.Background(), fixedTime, 24*time.Hour)
 			if testCase.expectedError != "" {
-				assert.EqualError(t, err, testCase.expectedError)
+				require.EqualError(t, err, testCase.expectedError)
 				assert.Nil(t, actual)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.EqualValues(t, testCase.expectedOutput, actual)
 			}
 		})

--- a/plugin/storage/es/mappings/mapping_test.go
+++ b/plugin/storage/es/mappings/mapping_test.go
@@ -157,9 +157,9 @@ func TestMappingBuilder_fixMapping(t *testing.T) {
 			}
 			_, err := mappingBuilder.fixMapping("test")
 			if test.err != "" {
-				assert.EqualError(t, err, test.err)
+				require.EqualError(t, err, test.err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -311,9 +311,9 @@ func TestMappingBuilder_GetSpanServiceMappings(t *testing.T) {
 			}
 			_, _, err := mappingBuilder.GetSpanServiceMappings()
 			if test.err != "" {
-				assert.EqualError(t, err, test.err)
+				require.EqualError(t, err, test.err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -329,7 +329,7 @@ func TestMappingBuilder_GetDependenciesMappings(t *testing.T) {
 		TemplateBuilder: &tb,
 	}
 	_, err := mappingBuilder.GetDependenciesMappings()
-	assert.EqualError(t, err, "template load error")
+	require.EqualError(t, err, "template load error")
 }
 
 func TestMain(m *testing.M) {

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -136,7 +136,7 @@ func TestMaxSpanAgeSetErrorInArchiveMode(t *testing.T) {
 	_, command := config.Viperize(opts.AddFlags)
 	flags := []string{"--es-archive.max-span-age=24h"}
 	err := command.ParseFlags(flags)
-	assert.EqualError(t, err, "unknown flag: --es-archive.max-span-age")
+	require.EqualError(t, err, "unknown flag: --es-archive.max-span-age")
 }
 
 func TestMaxDocCount(t *testing.T) {

--- a/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
@@ -73,7 +73,7 @@ func testJSONEncoding(t *testing.T, i int, expectedStr []byte, object interface{
 
 	if !assert.Equal(t, string(expectedStr), buf.String()) {
 		err := os.WriteFile(outFile+"-actual.json", buf.Bytes(), 0o644)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 

--- a/plugin/storage/es/spanstore/dbmodel/json_span_compare_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/json_span_compare_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func CompareJSONSpans(t *testing.T, expected *Span, actual *Span) {
@@ -33,7 +34,7 @@ func CompareJSONSpans(t *testing.T, expected *Span, actual *Span) {
 			t.Log(err)
 		}
 		out, err := json.Marshal(actual)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Logf("Actual trace: %s", string(out))
 	}
 }

--- a/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
@@ -73,13 +73,13 @@ func loadESSpanFixture(i int) (Span, error) {
 func failingSpanTransform(t *testing.T, embeddedSpan *Span, errMsg string) {
 	domainSpan, err := NewToDomain(":").SpanToDomain(embeddedSpan)
 	assert.Nil(t, domainSpan)
-	assert.EqualError(t, err, errMsg)
+	require.EqualError(t, err, errMsg)
 }
 
 func failingSpanTransformAnyMsg(t *testing.T, embeddedSpan *Span) {
 	domainSpan, err := NewToDomain(":").SpanToDomain(embeddedSpan)
 	assert.Nil(t, domainSpan)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFailureBadTypeTags(t *testing.T) {
@@ -305,7 +305,7 @@ func CompareModelSpans(t *testing.T, expected *model.Span, actual *model.Span) {
 			t.Log(err)
 		}
 		out, err := json.Marshal(actual)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Logf("Actual trace: %s", string(out))
 	}
 }

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -101,7 +101,7 @@ func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExpo
 		sdktrace.WithSyncer(exporter),
 	)
 	closer := func() {
-		assert.NoError(t, tp.Shutdown(context.Background()))
+		require.NoError(t, tp.Shutdown(context.Background()))
 	}
 	return tp, exporter, closer
 }
@@ -723,7 +723,7 @@ func TestSpanReader_bucketToStringArrayError(t *testing.T) {
 		buckets[2] = &elastic.AggregationBucketKeyItem{Key: 2}
 
 		_, err := bucketToStringArray(buckets)
-		assert.EqualError(t, err, "non-string key found in aggregation")
+		require.EqualError(t, err, "non-string key found in aggregation")
 	})
 }
 
@@ -971,12 +971,12 @@ func TestFindTraceIDs(t *testing.T) {
 
 func TestTraceIDsStringsToModelsConversion(t *testing.T) {
 	traceIDs, err := convertTraceIDsStringsToModels([]string{"1", "2", "3"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, traceIDs, 3)
 	assert.Equal(t, model.NewTraceID(0, 1), traceIDs[0])
 
 	traceIDs, err = convertTraceIDsStringsToModels([]string{"dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl"})
-	assert.EqualError(t, err, "making traceID from string 'dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl' failed: TraceID cannot be longer than 32 hex characters: dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl")
+	require.EqualError(t, err, "making traceID from string 'dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl' failed: TraceID cannot be longer than 32 hex characters: dsfjsdklfjdsofdfsdbfkgbgoaemlrksdfbsdofgerjl")
 	assert.Empty(t, traceIDs)
 }
 
@@ -1022,7 +1022,7 @@ func mockSearchService(r *spanReaderTest) *mock.Call {
 func TestTraceQueryParameterValidation(t *testing.T) {
 	var malformedtqp *spanstore.TraceQueryParameters
 	err := validateQuery(malformedtqp)
-	assert.EqualError(t, err, ErrMalformedRequestObject.Error())
+	require.EqualError(t, err, ErrMalformedRequestObject.Error())
 
 	tqp := &spanstore.TraceQueryParameters{
 		ServiceName: "",
@@ -1031,29 +1031,29 @@ func TestTraceQueryParameterValidation(t *testing.T) {
 		},
 	}
 	err = validateQuery(tqp)
-	assert.EqualError(t, err, ErrServiceNameNotSet.Error())
+	require.EqualError(t, err, ErrServiceNameNotSet.Error())
 
 	tqp.ServiceName = serviceName
 
 	tqp.StartTimeMin = time.Time{} // time.Unix(0,0) doesn't work because timezones
 	tqp.StartTimeMax = time.Time{}
 	err = validateQuery(tqp)
-	assert.EqualError(t, err, ErrStartAndEndTimeNotSet.Error())
+	require.EqualError(t, err, ErrStartAndEndTimeNotSet.Error())
 
 	tqp.StartTimeMin = time.Now()
 	tqp.StartTimeMax = time.Now().Add(-1 * time.Hour)
 	err = validateQuery(tqp)
-	assert.EqualError(t, err, ErrStartTimeMinGreaterThanMax.Error())
+	require.EqualError(t, err, ErrStartTimeMinGreaterThanMax.Error())
 
 	tqp.StartTimeMin = time.Now().Add(-1 * time.Hour)
 	tqp.StartTimeMax = time.Now()
 	err = validateQuery(tqp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tqp.DurationMin = time.Hour
 	tqp.DurationMax = time.Minute
 	err = validateQuery(tqp)
-	assert.EqualError(t, err, ErrDurationMinGreaterThanMax.Error())
+	require.EqualError(t, err, ErrDurationMinGreaterThanMax.Error())
 }
 
 func TestSpanReader_buildTraceIDAggregation(t *testing.T) {
@@ -1272,7 +1272,7 @@ func TestSpanReader_ArchiveTraces(t *testing.T) {
 		trace, err := r.reader.GetTrace(context.Background(), model.TraceID{})
 		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 		require.Nil(t, trace)
-		assert.EqualError(t, err, "trace not found")
+		require.EqualError(t, err, "trace not found")
 	})
 }
 
@@ -1288,7 +1288,7 @@ func TestSpanReader_ArchiveTraces_ReadAlias(t *testing.T) {
 		trace, err := r.reader.GetTrace(context.Background(), model.TraceID{})
 		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
 		require.Nil(t, trace)
-		assert.EqualError(t, err, "trace not found")
+		require.EqualError(t, err, "trace not found")
 	})
 }
 
@@ -1297,7 +1297,7 @@ func TestConvertTraceIDsStringsToModels(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []model.TraceID{model.NewTraceID(0, 1), model.NewTraceID(0, 2)}, ids)
 	_, err = convertTraceIDsStringsToModels([]string{"1", "2", "01", "02", "001", "002", "blah"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBuildTraceByIDQuery(t *testing.T) {

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -203,7 +203,7 @@ func TestSpanWriter_WriteSpan(t *testing.T) {
 					indexServicePut.AssertNumberOfCalls(t, "Add", 1)
 					indexSpanPut.AssertNumberOfCalls(t, "Add", 1)
 				} else {
-					assert.EqualError(t, err, testCase.expectedError)
+					require.EqualError(t, err, testCase.expectedError)
 				}
 
 				for _, expectedLog := range testCase.expectedLogs {
@@ -295,7 +295,7 @@ func TestCreateTemplates(t *testing.T) {
 			w.client.On("CreateTemplate", prefix+"jaeger-service").Return(test.serviceTemplateService())
 			err := w.writer.CreateTemplates(mock.Anything, mock.Anything, test.indexPrefix)
 			if test.err != "" {
-				assert.Error(t, err, test.err)
+				require.Error(t, err, test.err)
 			}
 		})
 	}

--- a/plugin/storage/factory_test.go
+++ b/plugin/storage/factory_test.go
@@ -81,7 +81,7 @@ func TestNewFactory(t *testing.T) {
 	expected := "unknown storage type" // could be 'x' or 'y' since code iterates through map.
 	assert.Equal(t, expected, err.Error()[0:len(expected)])
 
-	assert.NoError(t, f.Close())
+	require.NoError(t, f.Close())
 }
 
 func TestClose(t *testing.T) {
@@ -93,7 +93,7 @@ func TestClose(t *testing.T) {
 		},
 		FactoryConfig: FactoryConfig{SpanWriterTypes: []string{storageType}},
 	}
-	assert.EqualError(t, f.Close(), err.Error())
+	require.EqualError(t, f.Close(), err.Error())
 }
 
 func TestInitialize(t *testing.T) {
@@ -108,12 +108,12 @@ func TestInitialize(t *testing.T) {
 	m := metrics.NullFactory
 	l := zap.NewNop()
 	mock.On("Initialize", m, l).Return(nil)
-	assert.NoError(t, f.Initialize(m, l))
+	require.NoError(t, f.Initialize(m, l))
 
 	mock = new(mocks.Factory)
 	f.factories[cassandraStorageType] = mock
 	mock.On("Initialize", m, l).Return(errors.New("init-error"))
-	assert.EqualError(t, f.Initialize(m, l), "init-error")
+	require.EqualError(t, f.Initialize(m, l), "init-error")
 }
 
 func TestCreate(t *testing.T) {
@@ -135,21 +135,21 @@ func TestCreate(t *testing.T) {
 
 	r, err := f.CreateSpanReader()
 	assert.Equal(t, spanReader, r)
-	assert.EqualError(t, err, "span-reader-error")
+	require.EqualError(t, err, "span-reader-error")
 
 	w, err := f.CreateSpanWriter()
 	assert.Nil(t, w)
-	assert.EqualError(t, err, "span-writer-error")
+	require.EqualError(t, err, "span-writer-error")
 
 	d, err := f.CreateDependencyReader()
 	assert.Equal(t, depReader, d)
-	assert.EqualError(t, err, "dep-reader-error")
+	require.EqualError(t, err, "dep-reader-error")
 
 	_, err = f.CreateArchiveSpanReader()
-	assert.EqualError(t, err, "archive storage not supported")
+	require.EqualError(t, err, "archive storage not supported")
 
 	_, err = f.CreateArchiveSpanWriter()
-	assert.EqualError(t, err, "archive storage not supported")
+	require.EqualError(t, err, "archive storage not supported")
 
 	mock.On("CreateSpanWriter").Return(spanWriter, nil)
 	m := metrics.NullFactory
@@ -157,13 +157,13 @@ func TestCreate(t *testing.T) {
 	mock.On("Initialize", m, l).Return(nil)
 	f.Initialize(m, l)
 	w, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, spanWriter, w)
 }
 
 func TestCreateDownsamplingWriter(t *testing.T) {
 	f, err := NewFactory(defaultCfg())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, f.factories[cassandraStorageType])
 	mock := new(mocks.Factory)
 	f.factories[cassandraStorageType] = mock
@@ -187,7 +187,7 @@ func TestCreateDownsamplingWriter(t *testing.T) {
 			f.DownsamplingRatio = param.ratio
 			f.Initialize(m, l)
 			newWriter, err := f.CreateSpanWriter()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Currently directly assertEqual doesn't work since DownsamplingWriter initializes with different
 			// address for hashPool. The following workaround checks writer type instead
 			assert.True(t, strings.HasPrefix(reflect.TypeOf(newWriter).String(), param.writerType))
@@ -213,7 +213,7 @@ func TestCreateMulti(t *testing.T) {
 
 	w, err := f.CreateSpanWriter()
 	assert.Nil(t, w)
-	assert.EqualError(t, err, "span-writer-error")
+	require.EqualError(t, err, "span-writer-error")
 
 	mock.On("CreateSpanWriter").Return(spanWriter, nil)
 	mock2.On("CreateSpanWriter").Return(spanWriter2, nil)
@@ -223,7 +223,7 @@ func TestCreateMulti(t *testing.T) {
 	mock2.On("Initialize", m, l).Return(nil)
 	f.Initialize(m, l)
 	w, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, spanstore.NewCompositeWriter(spanWriter, spanWriter2), w)
 }
 
@@ -246,11 +246,11 @@ func TestCreateArchive(t *testing.T) {
 
 	ar, err := f.CreateArchiveSpanReader()
 	assert.Equal(t, archiveSpanReader, ar)
-	assert.EqualError(t, err, "archive-span-reader-error")
+	require.EqualError(t, err, "archive-span-reader-error")
 
 	aw, err := f.CreateArchiveSpanWriter()
 	assert.Equal(t, archiveSpanWriter, aw)
-	assert.EqualError(t, err, "archive-span-writer-error")
+	require.EqualError(t, err, "archive-span-writer-error")
 }
 
 func TestCreateError(t *testing.T) {
@@ -265,31 +265,31 @@ func TestCreateError(t *testing.T) {
 	{
 		r, err := f.CreateSpanReader()
 		assert.Nil(t, r)
-		assert.EqualError(t, err, expectedErr)
+		require.EqualError(t, err, expectedErr)
 	}
 
 	{
 		w, err := f.CreateSpanWriter()
 		assert.Nil(t, w)
-		assert.EqualError(t, err, expectedErr)
+		require.EqualError(t, err, expectedErr)
 	}
 
 	{
 		d, err := f.CreateDependencyReader()
 		assert.Nil(t, d)
-		assert.EqualError(t, err, expectedErr)
+		require.EqualError(t, err, expectedErr)
 	}
 
 	{
 		r, err := f.CreateArchiveSpanReader()
 		assert.Nil(t, r)
-		assert.EqualError(t, err, expectedErr)
+		require.EqualError(t, err, expectedErr)
 	}
 
 	{
 		w, err := f.CreateArchiveSpanWriter()
 		assert.Nil(t, w)
-		assert.EqualError(t, err, expectedErr)
+		require.EqualError(t, err, expectedErr)
 	}
 }
 
@@ -306,13 +306,13 @@ func TestCreateSamplingStoreFactory(t *testing.T) {
 	// if not specified sampling store is chosen from available factories
 	ssFactory, err := f.CreateSamplingStoreFactory()
 	assert.Equal(t, f.factories[cassandraStorageType], ssFactory)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// if not specified and there's no compatible factories then return nil
 	delete(f.factories, cassandraStorageType)
 	ssFactory, err = f.CreateSamplingStoreFactory()
 	assert.Nil(t, ssFactory)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// if an incompatible factory is specified return err
 	cfg := defaultCfg()
@@ -321,7 +321,7 @@ func TestCreateSamplingStoreFactory(t *testing.T) {
 	require.NoError(t, err)
 	ssFactory, err = f.CreateSamplingStoreFactory()
 	assert.Nil(t, ssFactory)
-	assert.EqualError(t, err, "storage factory of type elasticsearch does not support sampling store")
+	require.EqualError(t, err, "storage factory of type elasticsearch does not support sampling store")
 
 	// if a compatible factory is specified then return it
 	cfg.SamplingStorageType = "cassandra"
@@ -329,7 +329,7 @@ func TestCreateSamplingStoreFactory(t *testing.T) {
 	require.NoError(t, err)
 	ssFactory, err = f.CreateSamplingStoreFactory()
 	assert.Equal(t, ssFactory, f.factories["cassandra"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 type configurable struct {
@@ -376,7 +376,7 @@ func TestParsingDownsamplingRatio(t *testing.T) {
 		"--downsampling.ratio=1.5",
 		"--downsampling.hashsalt=jaeger",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
 
 	assert.Equal(t, 1.0, f.FactoryConfig.DownsamplingRatio)
@@ -385,7 +385,7 @@ func TestParsingDownsamplingRatio(t *testing.T) {
 	err = command.ParseFlags([]string{
 		"--downsampling.ratio=0.5",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
 	assert.Equal(t, 0.5, f.FactoryConfig.DownsamplingRatio)
 }
@@ -394,7 +394,7 @@ func TestDefaultDownsamplingWithAddFlags(t *testing.T) {
 	f := Factory{}
 	v, command := config.Viperize(f.AddFlags)
 	err := command.ParseFlags([]string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
 
 	assert.Equal(t, defaultDownsamplingRatio, f.FactoryConfig.DownsamplingRatio)
@@ -403,7 +403,7 @@ func TestDefaultDownsamplingWithAddFlags(t *testing.T) {
 	err = command.ParseFlags([]string{
 		"--downsampling.ratio=0.5",
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestPublishOpts(t *testing.T) {

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -129,17 +129,17 @@ func TestGRPCStorageFactory(t *testing.T) {
 			dependencyReader: new(dependencyStoreMocks.Reader),
 		},
 	}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanReader(), reader)
 	writer, err := f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanWriter(), writer)
 	depReader, err := f.CreateDependencyReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.DependencyReader(), depReader)
 }
 
@@ -165,17 +165,17 @@ func TestGRPCStorageFactory_Capabilities(t *testing.T) {
 		},
 		writerType: "streaming",
 	}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateArchiveSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, reader)
 	writer, err := f.CreateArchiveSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, writer)
 	writer, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.streamingSpanWriter.StreamingSpanWriter(), writer)
 }
 
@@ -200,17 +200,17 @@ func TestGRPCStorageFactory_CapabilitiesDisabled(t *testing.T) {
 			spanWriter:    new(spanStoreMocks.Writer),
 		},
 	}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateArchiveSpanReader()
-	assert.EqualError(t, err, storage.ErrArchiveStorageNotSupported.Error())
+	require.EqualError(t, err, storage.ErrArchiveStorageNotSupported.Error())
 	assert.Nil(t, reader)
 	writer, err := f.CreateArchiveSpanWriter()
-	assert.EqualError(t, err, storage.ErrArchiveStorageNotSupported.Error())
+	require.EqualError(t, err, storage.ErrArchiveStorageNotSupported.Error())
 	assert.Nil(t, writer)
 	writer, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanWriter(), writer)
 }
 
@@ -232,17 +232,17 @@ func TestGRPCStorageFactory_CapabilitiesError(t *testing.T) {
 			spanWriter:    new(spanStoreMocks.Writer),
 		},
 	}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateArchiveSpanReader()
-	assert.EqualError(t, err, customError.Error())
+	require.EqualError(t, err, customError.Error())
 	assert.Nil(t, reader)
 	writer, err := f.CreateArchiveSpanWriter()
-	assert.EqualError(t, err, customError.Error())
+	require.EqualError(t, err, customError.Error())
 	assert.Nil(t, writer)
 	writer, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanWriter(), writer)
 }
 
@@ -258,7 +258,7 @@ func TestGRPCStorageFactory_CapabilitiesNil(t *testing.T) {
 			spanWriter:    new(spanStoreMocks.Writer),
 		},
 	}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateArchiveSpanReader()
@@ -268,7 +268,7 @@ func TestGRPCStorageFactory_CapabilitiesNil(t *testing.T) {
 	assert.Equal(t, err, storage.ErrArchiveStorageNotSupported)
 	assert.Nil(t, writer)
 	writer, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanWriter(), writer)
 }
 
@@ -280,12 +280,12 @@ func TestWithConfiguration(t *testing.T) {
 		"--grpc-storage-plugin.binary=noop-grpc-plugin",
 		"--grpc-storage-plugin.configuration-file=config.json",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.InitFromViper(v, zap.NewNop())
 	assert.Equal(t, "noop-grpc-plugin", f.options.Configuration.PluginBinary)
 	assert.Equal(t, "config.json", f.options.Configuration.PluginConfigurationFile)
 	assert.Equal(t, "debug", f.options.Configuration.PluginLogLevel)
-	assert.NoError(t, f.Close())
+	require.NoError(t, f.Close())
 }
 
 func TestInitFromOptions(t *testing.T) {
@@ -313,9 +313,9 @@ func TestStreamingSpanWriterFactory_CapabilitiesNil(t *testing.T) {
 		},
 		writerType: "streaming",
 	}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	writer, err := f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanWriter(), writer)
 }
 
@@ -339,12 +339,12 @@ func TestStreamingSpanWriterFactory_Capabilities(t *testing.T) {
 		},
 		writerType: "streaming",
 	}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	writer, err := f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanWriter(), writer) // get unary writer when Capabilities return error
 
 	writer, err = f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store.SpanWriter(), writer) // get unary writer when Capabilities return false
 }

--- a/plugin/storage/grpc/options_test.go
+++ b/plugin/storage/grpc/options_test.go
@@ -34,7 +34,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--grpc-storage-plugin.log-level=debug",
 		"--multi-tenancy.header=x-scope-orgid",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	opts.InitFromViper(v)
 
 	assert.Equal(t, "noop-grpc-plugin", opts.Configuration.PluginBinary)
@@ -52,7 +52,7 @@ func TestRemoteOptionsWithFlags(t *testing.T) {
 		"--grpc-storage.tls.enabled=true",
 		"--grpc-storage.connection-timeout=60s",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	opts.InitFromViper(v)
 
 	assert.Equal(t, "", opts.Configuration.PluginBinary)
@@ -69,7 +69,7 @@ func TestRemoteOptionsNoTLSWithFlags(t *testing.T) {
 		"--grpc-storage.tls.enabled=false",
 		"--grpc-storage.connection-timeout=60s",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	opts.InitFromViper(v)
 
 	assert.Equal(t, "", opts.Configuration.PluginBinary)

--- a/plugin/storage/grpc/shared/archive_test.go
+++ b/plugin/storage/grpc/shared/archive_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -43,7 +44,7 @@ func TestArchiveWriter_WriteSpan(t *testing.T) {
 	writer := &archiveWriter{client: archiveSpanWriter}
 
 	err := writer.WriteSpan(context.Background(), mockSpan)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestArchiveReader_GetTrace(t *testing.T) {
@@ -70,7 +71,7 @@ func TestArchiveReader_GetTrace(t *testing.T) {
 	reader := &archiveReader{client: archiveSpanReader}
 
 	trace, err := reader.GetTrace(context.Background(), mockTraceID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, trace)
 }
 
@@ -90,23 +91,23 @@ func TestArchiveReaderGetTrace_NoTrace(t *testing.T) {
 func TestArchiveReader_FindTraceIDs(t *testing.T) {
 	reader := archiveReader{client: &mocks.ArchiveSpanReaderPluginClient{}}
 	_, err := reader.FindTraceIDs(context.Background(), nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestArchiveReader_FindTraces(t *testing.T) {
 	reader := archiveReader{client: &mocks.ArchiveSpanReaderPluginClient{}}
 	_, err := reader.FindTraces(context.Background(), nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestArchiveReader_GetOperations(t *testing.T) {
 	reader := archiveReader{client: &mocks.ArchiveSpanReaderPluginClient{}}
 	_, err := reader.GetOperations(context.Background(), spanstore.OperationQueryParameters{})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestArchiveReader_GetServices(t *testing.T) {
 	reader := archiveReader{client: &mocks.ArchiveSpanReaderPluginClient{}}
 	_, err := reader.GetServices(context.Background())
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/plugin/storage/grpc/shared/grpc_client_test.go
+++ b/plugin/storage/grpc/shared/grpc_client_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -148,7 +149,7 @@ func TestGRPCClientGetServices(t *testing.T) {
 			Return(&storage_v1.GetServicesResponse{Services: []string{"service-a"}}, nil)
 
 		s, err := r.client.GetServices(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []string{"service-a"}, s)
 	})
 }
@@ -163,7 +164,7 @@ func TestGRPCClientGetOperationsV1(t *testing.T) {
 
 		s, err := r.client.GetOperations(context.Background(),
 			spanstore.OperationQueryParameters{ServiceName: "service-a"})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []spanstore.Operation{{Name: "operation-a"}}, s)
 	})
 }
@@ -178,7 +179,7 @@ func TestGRPCClientGetOperationsV2(t *testing.T) {
 
 		s, err := r.client.GetOperations(context.Background(),
 			spanstore.OperationQueryParameters{ServiceName: "service-a"})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []spanstore.Operation{{Name: "operation-a", SpanKind: "server"}}, s)
 	})
 }
@@ -200,7 +201,7 @@ func TestGRPCClientGetTrace(t *testing.T) {
 		}
 
 		s, err := r.client.GetTrace(context.Background(), mockTraceID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &model.Trace{
 			Spans: expectedSpans,
 		}, s)
@@ -216,7 +217,7 @@ func TestGRPCClientGetTrace_StreamError(t *testing.T) {
 		}).Return(traceClient, nil)
 
 		s, err := r.client.GetTrace(context.Background(), mockTraceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, s)
 	})
 }
@@ -261,7 +262,7 @@ func TestGRPCClientFindTraces(t *testing.T) {
 		}).Return(traceClient, nil)
 
 		s, err := r.client.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, s)
 		assert.Len(t, s, 2)
 	})
@@ -274,7 +275,7 @@ func TestGRPCClientFindTraces_Error(t *testing.T) {
 		}).Return(nil, errors.New("an error"))
 
 		s, err := r.client.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, s)
 	})
 }
@@ -288,7 +289,7 @@ func TestGRPCClientFindTraces_RecvError(t *testing.T) {
 		}).Return(traceClient, nil)
 
 		s, err := r.client.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, s)
 	})
 }
@@ -302,7 +303,7 @@ func TestGRPCClientFindTraceIDs(t *testing.T) {
 		}, nil)
 
 		s, err := r.client.FindTraceIDs(context.Background(), &spanstore.TraceQueryParameters{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []model.TraceID{mockTraceID, mockTraceID2}, s)
 	})
 }
@@ -314,7 +315,7 @@ func TestGRPCClientWriteSpan(t *testing.T) {
 		}).Return(&storage_v1.WriteSpanResponse{}, nil)
 
 		err := r.client.SpanWriter().WriteSpan(context.Background(), &mockTraceSpans[0])
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -323,7 +324,7 @@ func TestGRPCClientCloseWriter(t *testing.T) {
 		r.spanWriter.On("Close", mock.Anything, &storage_v1.CloseWriterRequest{}).Return(&storage_v1.CloseWriterResponse{}, nil)
 
 		err := r.client.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -333,7 +334,7 @@ func TestGRPCClientCloseNotSupported(t *testing.T) {
 			nil, status.Errorf(codes.Unimplemented, "method not implemented"))
 
 		err := r.client.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -353,7 +354,7 @@ func TestGRPCClientGetDependencies(t *testing.T) {
 		}).Return(&storage_v1.GetDependenciesResponse{Dependencies: deps}, nil)
 
 		s, err := r.client.GetDependencies(context.Background(), end, lookback)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, deps, s)
 	})
 }
@@ -365,7 +366,7 @@ func TestGrpcClientWriteArchiveSpan(t *testing.T) {
 		}).Return(&storage_v1.WriteSpanResponse{}, nil)
 
 		err := r.client.ArchiveSpanWriter().WriteSpan(context.Background(), &mockTraceSpans[0])
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -376,7 +377,7 @@ func TestGrpcClientWriteArchiveSpan_Error(t *testing.T) {
 		}).Return(nil, status.Error(codes.Internal, "internal error"))
 
 		err := r.client.ArchiveSpanWriter().WriteSpan(context.Background(), &mockTraceSpans[0])
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -386,7 +387,7 @@ func TestGrpcClientStreamWriterWriteSpan(t *testing.T) {
 		r.streamWriter.On("WriteSpanStream", mock.Anything).Return(stream, nil)
 		stream.On("Send", &storage_v1.WriteSpanRequest{Span: &mockTraceSpans[0]}).Return(nil)
 		err := r.client.StreamingSpanWriter().WriteSpan(context.Background(), &mockTraceSpans[0])
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -407,7 +408,7 @@ func TestGrpcClientGetArchiveTrace(t *testing.T) {
 		}
 
 		s, err := r.client.ArchiveSpanReader().GetTrace(context.Background(), mockTraceID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &model.Trace{
 			Spans: expectedSpans,
 		}, s)
@@ -423,7 +424,7 @@ func TestGrpcClientGetArchiveTrace_StreamError(t *testing.T) {
 		}).Return(traceClient, nil)
 
 		s, err := r.client.ArchiveSpanReader().GetTrace(context.Background(), mockTraceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, s)
 	})
 }
@@ -435,7 +436,7 @@ func TestGrpcClientGetArchiveTrace_NoTrace(t *testing.T) {
 		}).Return(nil, spanstore.ErrTraceNotFound)
 
 		s, err := r.client.ArchiveSpanReader().GetTrace(context.Background(), mockTraceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, s)
 	})
 }
@@ -460,7 +461,7 @@ func TestGrpcClientCapabilities(t *testing.T) {
 			Return(&storage_v1.CapabilitiesResponse{ArchiveSpanReader: true, ArchiveSpanWriter: true, StreamingSpanWriter: true}, nil)
 
 		capabilities, err := r.client.Capabilities()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &Capabilities{
 			ArchiveSpanReader:   true,
 			ArchiveSpanWriter:   true,
@@ -475,7 +476,7 @@ func TestGrpcClientCapabilities_NotSupported(t *testing.T) {
 			Return(&storage_v1.CapabilitiesResponse{}, nil)
 
 		capabilities, err := r.client.Capabilities()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &Capabilities{
 			ArchiveSpanReader:   false,
 			ArchiveSpanWriter:   false,
@@ -490,7 +491,7 @@ func TestGrpcClientCapabilities_MissingMethod(t *testing.T) {
 			Return(nil, status.Error(codes.Unimplemented, "method not found"))
 
 		capabilities, err := r.client.Capabilities()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &Capabilities{}, capabilities)
 	})
 }
@@ -501,6 +502,6 @@ func TestGrpcClientArchiveSupported_CommonGrpcError(t *testing.T) {
 			Return(nil, status.Error(codes.Internal, "internal error"))
 
 		_, err := r.client.Capabilities()
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/plugin/storage/grpc/shared/grpc_handler_test.go
+++ b/plugin/storage/grpc/shared/grpc_handler_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -103,7 +104,7 @@ func TestGRPCServerGetServices(t *testing.T) {
 			Return([]string{"service-a"}, nil)
 
 		s, err := r.server.GetServices(context.Background(), &storage_v1.GetServicesRequest{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &storage_v1.GetServicesResponse{Services: []string{"service-a"}}, s)
 	})
 }
@@ -124,7 +125,7 @@ func TestGRPCServerGetOperations(t *testing.T) {
 		resp, err := r.server.GetOperations(context.Background(), &storage_v1.GetOperationsRequest{
 			Service: "service-a",
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, len(expOperations), len(resp.Operations))
 		for i, operation := range resp.Operations {
 			assert.Equal(t, expOperations[i].Name, operation.Name)
@@ -150,7 +151,7 @@ func TestGRPCServerGetTrace(t *testing.T) {
 		err := r.server.GetTrace(&storage_v1.GetTraceRequest{
 			TraceID: mockTraceID,
 		}, traceSteam)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -196,7 +197,7 @@ func TestGRPCServerFindTraces(t *testing.T) {
 		err := r.server.FindTraces(&storage_v1.FindTracesRequest{
 			Query: &storage_v1.TraceQueryParameters{},
 		}, traceSteam)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -208,7 +209,7 @@ func TestGRPCServerFindTraceIDs(t *testing.T) {
 		s, err := r.server.FindTraceIDs(context.Background(), &storage_v1.FindTraceIDsRequest{
 			Query: &storage_v1.TraceQueryParameters{},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &storage_v1.FindTraceIDsResponse{TraceIDs: []model.TraceID{mockTraceID, mockTraceID2}}, s)
 	})
 }
@@ -221,7 +222,7 @@ func TestGRPCServerWriteSpan(t *testing.T) {
 		s, err := r.server.WriteSpan(context.Background(), &storage_v1.WriteSpanRequest{
 			Span: &mockTraceSpans[0],
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &storage_v1.WriteSpanResponse{}, s)
 	})
 }
@@ -239,9 +240,9 @@ func TestGRPCServerWriteSpanStream(t *testing.T) {
 			Return(nil)
 
 		err := r.server.WriteSpanStream(stream)
-		assert.Error(t, err)
+		require.Error(t, err)
 		err = r.server.WriteSpanStream(stream)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -255,7 +256,7 @@ func TestGRPCServerWriteSpanStreamWithGRPCError(t *testing.T) {
 		r.impl.streamWriter.On("WriteSpan", context.Background(), &mockTraceSpans[0]).Return(nil)
 
 		err := r.server.WriteSpanStream(stream)
-		assert.ErrorContains(t, err, context.DeadlineExceeded.Error())
+		require.ErrorContains(t, err, context.DeadlineExceeded.Error())
 	})
 }
 
@@ -276,7 +277,7 @@ func TestGRPCServerGetDependencies(t *testing.T) {
 			StartTime: end.Add(-lookback),
 			EndTime:   end,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &storage_v1.GetDependenciesResponse{Dependencies: deps}, s)
 	})
 }
@@ -298,7 +299,7 @@ func TestGRPCServerGetArchiveTrace(t *testing.T) {
 		err := r.server.GetArchiveTrace(&storage_v1.GetTraceRequest{
 			TraceID: mockTraceID,
 		}, traceSteam)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -328,7 +329,7 @@ func TestGRPCServerGetArchiveTrace_Error(t *testing.T) {
 		err := r.server.GetArchiveTrace(&storage_v1.GetTraceRequest{
 			TraceID: mockTraceID,
 		}, traceSteam)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -364,7 +365,7 @@ func TestGRPCServerGetArchiveTrace_StreamError(t *testing.T) {
 		err := r.server.GetArchiveTrace(&storage_v1.GetTraceRequest{
 			TraceID: mockTraceID,
 		}, traceSteam)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -387,7 +388,7 @@ func TestGRPCServerWriteArchiveSpan(t *testing.T) {
 		s, err := r.server.WriteArchiveSpan(context.Background(), &storage_v1.WriteSpanRequest{
 			Span: &mockTraceSpans[0],
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &storage_v1.WriteSpanResponse{}, s)
 	})
 }
@@ -400,14 +401,14 @@ func TestGRPCServerWriteArchiveSpan_Error(t *testing.T) {
 		_, err := r.server.WriteArchiveSpan(context.Background(), &storage_v1.WriteSpanRequest{
 			Span: &mockTraceSpans[0],
 		})
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
 func TestGRPCServerCapabilities(t *testing.T) {
 	withGRPCServer(func(r *grpcServerTest) {
 		capabilities, err := r.server.Capabilities(context.Background(), &storage_v1.CapabilitiesRequest{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, &storage_v1.CapabilitiesResponse{ArchiveSpanReader: true, ArchiveSpanWriter: true, StreamingSpanWriter: true}, capabilities)
 	})
 }
@@ -418,7 +419,7 @@ func TestGRPCServerCapabilities_NoArchive(t *testing.T) {
 		r.server.impl.ArchiveSpanWriter = func() spanstore.Writer { return nil }
 
 		capabilities, err := r.server.Capabilities(context.Background(), &storage_v1.CapabilitiesRequest{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expected := &storage_v1.CapabilitiesResponse{
 			ArchiveSpanReader:   false,
 			ArchiveSpanWriter:   false,
@@ -433,7 +434,7 @@ func TestGRPCServerCapabilities_NoStreamWriter(t *testing.T) {
 		r.server.impl.StreamingSpanWriter = func() spanstore.Writer { return nil }
 
 		capabilities, err := r.server.Capabilities(context.Background(), &storage_v1.CapabilitiesRequest{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		expected := &storage_v1.CapabilitiesResponse{
 			ArchiveSpanReader: true,
 			ArchiveSpanWriter: true,

--- a/plugin/storage/integration/badgerstore_test.go
+++ b/plugin/storage/integration/badgerstore_test.go
@@ -19,7 +19,7 @@ package integration
 import (
 	"testing"
 
-	assert "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -85,7 +85,7 @@ func (s *BadgerIntegrationStorage) refresh() error {
 
 func TestBadgerStorage(t *testing.T) {
 	s := &BadgerIntegrationStorage{}
-	assert.NoError(t, s.initialize())
+	require.NoError(t, s.initialize())
 	s.IntegrationTestAll(t)
 	defer s.clear()
 }

--- a/plugin/storage/integration/es_index_rollover_test.go
+++ b/plugin/storage/integration/es_index_rollover_test.go
@@ -49,7 +49,7 @@ func TestIndexRollover_FailIfILMNotPresent(t *testing.T) {
 	cleanES(t, client, defaultILMPolicyName)
 	envVars := []string{"ES_USE_ILM=true"}
 	err = runEsRollover("init", envVars)
-	assert.EqualError(t, err, "exit status 1")
+	require.EqualError(t, err, "exit status 1")
 	indices, err := client.IndexNames()
 	require.NoError(t, err)
 	assert.Empty(t, indices)
@@ -85,7 +85,7 @@ func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 	if esVersion < 7 {
 		cleanES(t, client, "")
 		err := runEsRollover("init", envVars)
-		assert.EqualError(t, err, "exit status 1")
+		require.EqualError(t, err, "exit status 1")
 		indices, err1 := client.IndexNames()
 		require.NoError(t, err1)
 		assert.Empty(t, indices)

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -102,7 +102,7 @@ func (s *StorageIntegration) skipIfNeeded(t *testing.T) {
 	for _, pat := range s.SkipList {
 		escapedPat := regexp.QuoteMeta(pat)
 		ok, err := regexp.MatchString(escapedPat, t.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if ok {
 			t.Skip()
 			return
@@ -413,7 +413,7 @@ func (s *StorageIntegration) testGetDependencies(t *testing.T) {
 	require.NoError(t, s.DependencyWriter.WriteDependencies(time.Now(), expected))
 	s.refresh(t)
 	actual, err := s.DependencyReader.GetDependencies(context.Background(), time.Now(), 5*time.Minute)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	sort.Slice(actual, func(i, j int) bool {
 		return actual[i].Parent < actual[j].Parent
 	})

--- a/plugin/storage/integration/trace_compare.go
+++ b/plugin/storage/integration/trace_compare.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/kr/pretty"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -40,8 +39,8 @@ func CompareSliceOfTraces(t *testing.T, expected []*model.Trace, actual []*model
 		}
 		out, err := json.Marshal(actual)
 		out2, err2 := json.Marshal(expected)
-		assert.NoError(t, err)
-		assert.NoError(t, err2)
+		require.NoError(t, err)
+		require.NoError(t, err2)
 		t.Logf("Actual traces: %s", string(out))
 		t.Logf("Expected traces: %s", string(out2))
 		t.Fail()
@@ -65,7 +64,7 @@ func CompareTraces(t *testing.T, expected *model.Trace, actual *model.Trace) {
 			t.Logf("Expected and actual differ: %v\n", d)
 		}
 		out, err := json.Marshal(actual)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Logf("Actual trace: %s", string(out))
 		t.Fail()
 	}

--- a/plugin/storage/kafka/factory_test.go
+++ b/plugin/storage/kafka/factory_test.go
@@ -54,22 +54,22 @@ func TestKafkaFactory(t *testing.T) {
 		err: errors.New("made-up error"),
 		t:   t,
 	}
-	assert.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	require.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
 
 	f.Builder = &mockProducerBuilder{t: t}
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	assert.IsType(t, &protobufMarshaller{}, f.marshaller)
 
 	_, err := f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = f.CreateSpanReader()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = f.CreateDependencyReader()
-	assert.Error(t, err)
+	require.Error(t, err)
 
-	assert.NoError(t, f.Close())
+	require.NoError(t, f.Close())
 }
 
 func TestKafkaFactoryEncoding(t *testing.T) {
@@ -89,9 +89,9 @@ func TestKafkaFactoryEncoding(t *testing.T) {
 			f.InitFromViper(v, zap.NewNop())
 
 			f.Builder = &mockProducerBuilder{t: t}
-			assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+			require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 			assert.IsType(t, test.marshaller, f.marshaller)
-			assert.NoError(t, f.Close())
+			require.NoError(t, f.Close())
 		})
 	}
 }
@@ -103,7 +103,7 @@ func TestKafkaFactoryMarshallerErr(t *testing.T) {
 	f.InitFromViper(v, zap.NewNop())
 
 	f.Builder = &mockProducerBuilder{t: t}
-	assert.Error(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.Error(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 }
 
 func TestKafkaFactoryDoesNotLogPassword(t *testing.T) {
@@ -153,7 +153,7 @@ func TestKafkaFactoryDoesNotLogPassword(t *testing.T) {
 			logger.Sync()
 
 			assert.NotContains(t, logbuf.String(), "SECRET", "log output must not contain password in clear text")
-			assert.NoError(t, f.Close())
+			require.NoError(t, f.Close())
 		})
 	}
 }

--- a/plugin/storage/kafka/marshalling_test.go
+++ b/plugin/storage/kafka/marshalling_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model/converter/thrift/zipkin"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
@@ -35,12 +36,12 @@ func TestJSONMarshallerAndUnmarshaller(t *testing.T) {
 func testMarshallerAndUnmarshaller(t *testing.T, marshaller Marshaller, unmarshaller Unmarshaller) {
 	bytes, err := marshaller.Marshal(sampleSpan)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
 
 	resultSpan, err := unmarshaller.Unmarshal(bytes)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, sampleSpan, resultSpan)
 }
 
@@ -58,7 +59,7 @@ func TestZipkinThriftUnmarshaller(t *testing.T) {
 	unmarshaller := NewZipkinThriftUnmarshaller()
 	resultSpan, err := unmarshaller.Unmarshal(bytes)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, operationName, resultSpan.OperationName)
 }
 
@@ -71,12 +72,12 @@ func TestZipkinThriftUnmarshallerErrorNoService(t *testing.T) {
 	})
 	unmarshaller := NewZipkinThriftUnmarshaller()
 	_, err := unmarshaller.Unmarshal(bytes)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestZipkinThriftUnmarshallerErrorCorrupted(t *testing.T) {
 	bytes := []byte("foo")
 	unmarshaller := NewZipkinThriftUnmarshaller()
 	_, err := unmarshaller.Unmarshal(bytes)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/plugin/storage/kafka/options_test.go
+++ b/plugin/storage/kafka/options_test.go
@@ -121,16 +121,16 @@ func TestCompressionLevel(t *testing.T) {
 
 func TestFailedCompressionLevelScenario(t *testing.T) {
 	_, err := getCompressionLevel("gzip", 14)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = getCompressionLevel("lz4", 18)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = getCompressionLevel("zstd", 25)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = getCompressionLevel("test", 1)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCompressionModes(t *testing.T) {
@@ -149,7 +149,7 @@ func TestCompressionModes(t *testing.T) {
 
 func TestCompressionModeFailures(t *testing.T) {
 	_, err := getCompressionMode("test")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRequiredAcks(t *testing.T) {
@@ -168,7 +168,7 @@ func TestRequiredAcks(t *testing.T) {
 
 func TestRequiredAcksFailures(t *testing.T) {
 	_, err := getRequiredAcks("test")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestTLSFlags(t *testing.T) {

--- a/plugin/storage/kafka/writer_test.go
+++ b/plugin/storage/kafka/writer_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/Shopify/sarama"
 	saramaMocks "github.com/Shopify/sarama/mocks"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -99,7 +99,7 @@ func TestKafkaWriter(t *testing.T) {
 		w.producer.ExpectInputAndSucceed()
 
 		err := w.writer.WriteSpan(context.Background(), span)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		for i := 0; i < 100; i++ {
 			time.Sleep(time.Microsecond)
@@ -130,7 +130,7 @@ func TestKafkaWriterErr(t *testing.T) {
 	withSpanWriter(t, func(span *model.Span, w *spanWriterTest) {
 		w.producer.ExpectInputAndFail(sarama.ErrRequestTimedOut)
 		err := w.writer.WriteSpan(context.Background(), span)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		for i := 0; i < 100; i++ {
 			time.Sleep(time.Microsecond)
@@ -164,7 +164,7 @@ func TestMarshallerErr(t *testing.T) {
 		w.writer.marshaller = marshaller
 
 		err := w.writer.WriteSpan(context.Background(), span)
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		w.writer.Close()
 

--- a/plugin/storage/memory/factory_test.go
+++ b/plugin/storage/memory/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/metrics/fork"
@@ -33,22 +34,22 @@ var _ storage.Factory = new(Factory)
 
 func TestMemoryStorageFactory(t *testing.T) {
 	f := NewFactory()
-	assert.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateSpanReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, reader)
 	writer, err := f.CreateSpanWriter()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, writer)
 	depReader, err := f.CreateDependencyReader()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.store, depReader)
 	samplingStore, err := f.CreateSamplingStore(2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 2, samplingStore.(*SamplingStore).maxBuckets)
 	lock, err := f.CreateLock()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, lock)
 }
 
@@ -78,7 +79,7 @@ func TestPublishOpts(t *testing.T) {
 	forkFactory := metricstest.NewFactory(time.Second)
 	defer forkFactory.Stop()
 	metricsFactory := fork.New("internal", forkFactory, baseMetrics)
-	assert.NoError(t, f.Initialize(metricsFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(metricsFactory, zap.NewNop()))
 
 	forkFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "internal." + limit,

--- a/plugin/storage/memory/lock_test.go
+++ b/plugin/storage/memory/lock_test.go
@@ -19,18 +19,19 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAcquire(t *testing.T) {
 	l := &lock{}
 	ok, err := l.Acquire("resource", time.Duration(1))
 	assert.True(t, ok)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestForfeit(t *testing.T) {
 	l := &lock{}
 	ok, err := l.Forfeit("resource")
 	assert.True(t, ok)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/plugin/storage/memory/memory_test.go
+++ b/plugin/storage/memory/memory_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/memory/config"
@@ -135,23 +136,23 @@ func TestStoreGetEmptyDependencies(t *testing.T) {
 	// assert.Equal(t, testingSpan, testingSpan1B) // @@@
 	withMemoryStore(func(store *Store) {
 		links, err := store.GetDependencies(context.Background(), time.Now(), time.Hour)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, links)
 	})
 }
 
 func TestStoreGetDependencies(t *testing.T) {
 	withMemoryStore(func(store *Store) {
-		assert.NoError(t, store.WriteSpan(context.Background(), testingSpan))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan1))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan2))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan2_1))
+		require.NoError(t, store.WriteSpan(context.Background(), testingSpan))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan1))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan2))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan2_1))
 		links, err := store.GetDependencies(context.Background(), time.Now(), time.Hour)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, links)
 
 		links, err = store.GetDependencies(context.Background(), time.Unix(0, 0).Add(time.Hour), time.Hour)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []model.DependencyLink{{
 			Parent:    "serviceName",
 			Child:     "childService",
@@ -163,7 +164,7 @@ func TestStoreGetDependencies(t *testing.T) {
 func TestStoreWriteSpan(t *testing.T) {
 	withMemoryStore(func(store *Store) {
 		err := store.WriteSpan(context.Background(), testingSpan)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -179,7 +180,7 @@ func TestStoreWithLimit(t *testing.T) {
 				ServiceName: "TestStoreWithLimit",
 			},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = store.WriteSpan(context.Background(), &model.Span{
 			TraceID: id,
@@ -189,7 +190,7 @@ func TestStoreWithLimit(t *testing.T) {
 			},
 			OperationName: "childOperationName",
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	assert.Len(t, store.getTenant("").traces, maxTraces)
@@ -199,7 +200,7 @@ func TestStoreWithLimit(t *testing.T) {
 func TestStoreGetTraceSuccess(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
 		trace, err := store.GetTrace(context.Background(), testingSpan.TraceID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trace.Spans, 1)
 		assert.Equal(t, testingSpan, trace.Spans[0])
 	})
@@ -208,7 +209,7 @@ func TestStoreGetTraceSuccess(t *testing.T) {
 func TestStoreGetAndMutateTrace(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
 		trace, err := store.GetTrace(context.Background(), testingSpan.TraceID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trace.Spans, 1)
 		assert.Equal(t, testingSpan, trace.Spans[0])
 		assert.Empty(t, trace.Spans[0].Warnings)
@@ -216,7 +217,7 @@ func TestStoreGetAndMutateTrace(t *testing.T) {
 		trace.Spans[0].Warnings = append(trace.Spans[0].Warnings, "the end is near")
 
 		trace, err = store.GetTrace(context.Background(), testingSpan.TraceID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trace.Spans, 1)
 		assert.Equal(t, testingSpan, trace.Spans[0])
 		assert.Empty(t, trace.Spans[0].Warnings)
@@ -229,14 +230,14 @@ func TestStoreGetTraceError(t *testing.T) {
 			Spans: []*model.Span{nonSerializableSpan},
 		}
 		_, err := store.GetTrace(context.Background(), testingSpan.TraceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
 func TestStoreGetTraceFailure(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
 		trace, err := store.GetTrace(context.Background(), model.TraceID{})
-		assert.EqualError(t, err, spanstore.ErrTraceNotFound.Error())
+		require.EqualError(t, err, spanstore.ErrTraceNotFound.Error())
 		assert.Nil(t, trace)
 	})
 }
@@ -244,7 +245,7 @@ func TestStoreGetTraceFailure(t *testing.T) {
 func TestStoreGetServices(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
 		serviceNames, err := store.GetServices(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, serviceNames, 1)
 		assert.EqualValues(t, testingSpan.Process.ServiceName, serviceNames[0])
 	})
@@ -252,15 +253,15 @@ func TestStoreGetServices(t *testing.T) {
 
 func TestStoreGetAllOperationsFound(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
-		assert.NoError(t, store.WriteSpan(context.Background(), testingSpan))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan1))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan2))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan2_1))
+		require.NoError(t, store.WriteSpan(context.Background(), testingSpan))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan1))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan2))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan2_1))
 		operations, err := store.GetOperations(
 			context.Background(),
 			spanstore.OperationQueryParameters{ServiceName: childSpan1.Process.ServiceName},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, operations, 3)
 		assert.EqualValues(t, childSpan1.OperationName, operations[0].Name)
 	})
@@ -268,10 +269,10 @@ func TestStoreGetAllOperationsFound(t *testing.T) {
 
 func TestStoreGetServerOperationsFound(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
-		assert.NoError(t, store.WriteSpan(context.Background(), testingSpan))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan1))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan2))
-		assert.NoError(t, store.WriteSpan(context.Background(), childSpan2_1))
+		require.NoError(t, store.WriteSpan(context.Background(), testingSpan))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan1))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan2))
+		require.NoError(t, store.WriteSpan(context.Background(), childSpan2_1))
 		expected := []spanstore.Operation{
 			{Name: childSpan1.OperationName, SpanKind: "server"},
 		}
@@ -280,7 +281,7 @@ func TestStoreGetServerOperationsFound(t *testing.T) {
 				ServiceName: childSpan1.Process.ServiceName,
 				SpanKind:    "server",
 			})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, operations, 1)
 		assert.Equal(t, expected, operations)
 	})
@@ -292,7 +293,7 @@ func TestStoreGetOperationsNotFound(t *testing.T) {
 			context.Background(),
 			spanstore.OperationQueryParameters{ServiceName: "notAService"},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, operations)
 	})
 }
@@ -300,7 +301,7 @@ func TestStoreGetOperationsNotFound(t *testing.T) {
 func TestStoreGetEmptyTraceSet(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
 		traces, err := store.FindTraces(context.Background(), &spanstore.TraceQueryParameters{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, traces)
 	})
 }
@@ -308,9 +309,9 @@ func TestStoreGetEmptyTraceSet(t *testing.T) {
 func TestStoreFindTracesError(t *testing.T) {
 	withPopulatedMemoryStore(func(store *Store) {
 		err := store.WriteSpan(context.Background(), nonSerializableSpan)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, err = store.FindTraces(context.Background(), &spanstore.TraceQueryParameters{ServiceName: "naughtyService"})
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -355,7 +356,7 @@ func TestStoreFindTracesLimitGetsMostRecent(t *testing.T) {
 		NumTraces:   querySize,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if assert.Len(t, gotTraces, len(expectedTraces)) {
 		for i := range gotTraces {
 			assert.EqualValues(t, expectedTraces[i].Spans[0].StartTime.Unix(), gotTraces[i].Spans[0].StartTime.Unix())
@@ -430,7 +431,7 @@ func TestStoreGetTrace(t *testing.T) {
 		withPopulatedMemoryStore(func(store *Store) {
 			testS.query.NumTraces = 10
 			traces, err := store.FindTraces(context.Background(), testS.query)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if testS.traceFound {
 				assert.Len(t, traces, 1)
 				assert.Len(t, traces[0].Spans, 1)
@@ -446,7 +447,7 @@ func TestStore_FindTraceIDs(t *testing.T) {
 	withMemoryStore(func(store *Store) {
 		traceIDs, err := store.FindTraceIDs(context.Background(), nil)
 		assert.Nil(t, traceIDs)
-		assert.EqualError(t, err, "not implemented")
+		require.EqualError(t, err, "not implemented")
 	})
 }
 
@@ -455,17 +456,17 @@ func TestTenantStore(t *testing.T) {
 		ctxAcme := tenancy.WithTenant(context.Background(), "acme")
 		ctxWonka := tenancy.WithTenant(context.Background(), "wonka")
 
-		assert.NoError(t, store.WriteSpan(ctxAcme, testingSpan))
-		assert.NoError(t, store.WriteSpan(ctxWonka, testingSpan2))
+		require.NoError(t, store.WriteSpan(ctxAcme, testingSpan))
+		require.NoError(t, store.WriteSpan(ctxWonka, testingSpan2))
 
 		// Can we retrieve the spans with correct tenancy
 		trace1, err := store.GetTrace(ctxAcme, testingSpan.TraceID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trace1.Spans, 1)
 		assert.Equal(t, testingSpan, trace1.Spans[0])
 
 		trace2, err := store.GetTrace(ctxWonka, testingSpan2.TraceID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, trace2.Spans, 1)
 		assert.Equal(t, testingSpan2, trace2.Spans[0])
 
@@ -473,7 +474,7 @@ func TestTenantStore(t *testing.T) {
 		traces1, err := store.FindTraces(ctxAcme, &spanstore.TraceQueryParameters{
 			ServiceName: "serviceName",
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, traces1, 1)
 		assert.Len(t, traces1[0].Spans, 1)
 		assert.Equal(t, testingSpan, traces1[0].Spans[0])
@@ -481,20 +482,20 @@ func TestTenantStore(t *testing.T) {
 		traces2, err := store.FindTraces(ctxWonka, &spanstore.TraceQueryParameters{
 			ServiceName: "serviceName2",
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, traces2, 1)
 		assert.Len(t, traces2[0].Spans, 1)
 		assert.Equal(t, testingSpan2, traces2[0].Spans[0])
 
 		// Do the spans fail with incorrect tenancy?
 		_, err = store.GetTrace(ctxAcme, testingSpan2.TraceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		_, err = store.GetTrace(ctxWonka, testingSpan.TraceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		_, err = store.GetTrace(context.Background(), testingSpan.TraceID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 

--- a/plugin/storage/memory/sampling_test.go
+++ b/plugin/storage/memory/sampling_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
 )
@@ -51,7 +52,7 @@ func TestInsertThroughtput(t *testing.T) {
 			{Service: "my-svc", Operation: "op"},
 			{Service: "our-svc", Operation: "op2"},
 		}
-		assert.NoError(t, samplingStore.InsertThroughput(throughputs))
+		require.NoError(t, samplingStore.InsertThroughput(throughputs))
 		ret, _ := samplingStore.GetThroughput(start, start.Add(time.Second*time.Duration(1)))
 		assert.Len(t, ret, 2)
 
@@ -69,7 +70,7 @@ func TestGetThroughput(t *testing.T) {
 	withPopulatedSamplingStore(func(samplingStore *SamplingStore) {
 		start := time.Now()
 		ret, err := samplingStore.GetThroughput(start, start.Add(time.Second*time.Duration(1)))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, ret, 1)
 		ret1, _ := samplingStore.GetThroughput(start, start)
 		assert.Empty(t, ret1)
@@ -80,10 +81,10 @@ func TestGetThroughput(t *testing.T) {
 
 func TestInsertProbabilitiesAndQPS(t *testing.T) {
 	withMemorySamplingStore(func(samplingStore *SamplingStore) {
-		assert.NoError(t, samplingStore.InsertProbabilitiesAndQPS("dell11eg843d", model.ServiceOperationProbabilities{"new-srv": {"op": 0.1}}, model.ServiceOperationQPS{"new-srv": {"op": 4}}))
+		require.NoError(t, samplingStore.InsertProbabilitiesAndQPS("dell11eg843d", model.ServiceOperationProbabilities{"new-srv": {"op": 0.1}}, model.ServiceOperationQPS{"new-srv": {"op": 4}}))
 		assert.NotEmpty(t, 1, samplingStore.probabilitiesAndQPS)
 		// Only latest one is kept in memory
-		assert.NoError(t, samplingStore.InsertProbabilitiesAndQPS("lncol73", model.ServiceOperationProbabilities{"my-app": {"hello": 0.3}}, model.ServiceOperationQPS{"new-srv": {"op": 7}}))
+		require.NoError(t, samplingStore.InsertProbabilitiesAndQPS("lncol73", model.ServiceOperationProbabilities{"my-app": {"hello": 0.3}}, model.ServiceOperationQPS{"new-srv": {"op": 7}}))
 		assert.Equal(t, 0.3, samplingStore.probabilitiesAndQPS.probabilities["my-app"]["hello"])
 	})
 }
@@ -92,16 +93,16 @@ func TestGetLatestProbability(t *testing.T) {
 	withMemorySamplingStore(func(samplingStore *SamplingStore) {
 		// No priod data
 		ret, err := samplingStore.GetLatestProbabilities()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, ret)
 	})
 
 	withPopulatedSamplingStore(func(samplingStore *SamplingStore) {
 		// With some pregenerated data
 		ret, err := samplingStore.GetLatestProbabilities()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, model.ServiceOperationProbabilities{"svc-1": {"op-1": 0.01}}, ret)
-		assert.NoError(t, samplingStore.InsertProbabilitiesAndQPS("utfhyolf", model.ServiceOperationProbabilities{"another-service": {"hello": 0.009}}, model.ServiceOperationQPS{"new-srv": {"op": 5}}))
+		require.NoError(t, samplingStore.InsertProbabilitiesAndQPS("utfhyolf", model.ServiceOperationProbabilities{"another-service": {"hello": 0.009}}, model.ServiceOperationQPS{"new-srv": {"op": 5}}))
 		ret, _ = samplingStore.GetLatestProbabilities()
 		assert.NotEqual(t, model.ServiceOperationProbabilities{"svc-1": {"op-1": 0.01}}, ret)
 	})

--- a/storage/spanstore/composite_test.go
+++ b/storage/spanstore/composite_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	. "github.com/jaegertracing/jaeger/storage/spanstore"
@@ -43,15 +43,15 @@ func (n *noopWriteSpanStore) WriteSpan(ctx context.Context, span *model.Span) er
 
 func TestCompositeWriteSpanStoreSuccess(t *testing.T) {
 	c := NewCompositeWriter(&noopWriteSpanStore{}, &noopWriteSpanStore{})
-	assert.NoError(t, c.WriteSpan(context.Background(), nil))
+	require.NoError(t, c.WriteSpan(context.Background(), nil))
 }
 
 func TestCompositeWriteSpanStoreSecondFailure(t *testing.T) {
 	c := NewCompositeWriter(&errProneWriteSpanStore{}, &errProneWriteSpanStore{})
-	assert.EqualError(t, c.WriteSpan(context.Background(), nil), fmt.Sprintf("%s\n%s", errIWillAlwaysFail, errIWillAlwaysFail))
+	require.EqualError(t, c.WriteSpan(context.Background(), nil), fmt.Sprintf("%s\n%s", errIWillAlwaysFail, errIWillAlwaysFail))
 }
 
 func TestCompositeWriteSpanStoreFirstFailure(t *testing.T) {
 	c := NewCompositeWriter(&errProneWriteSpanStore{}, &noopWriteSpanStore{})
-	assert.EqualError(t, c.WriteSpan(context.Background(), nil), errIWillAlwaysFail.Error())
+	require.EqualError(t, c.WriteSpan(context.Background(), nil), errIWillAlwaysFail.Error())
 }

--- a/storage/spanstore/downsampling_writer_test.go
+++ b/storage/spanstore/downsampling_writer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -53,11 +54,11 @@ func TestDownSamplingWriter_WriteSpan(t *testing.T) {
 		HashSalt: "jaeger-test",
 	}
 	c := NewDownsamplingWriter(&errorWriteSpanStore{}, downsamplingOptions)
-	assert.NoError(t, c.WriteSpan(context.Background(), span))
+	require.NoError(t, c.WriteSpan(context.Background(), span))
 
 	downsamplingOptions.Ratio = 1
 	c = NewDownsamplingWriter(&errorWriteSpanStore{}, downsamplingOptions)
-	assert.Error(t, c.WriteSpan(context.Background(), span))
+	require.Error(t, c.WriteSpan(context.Background(), span))
 }
 
 // This test is to make sure h.hash.Reset() works and same traceID will always hash to the same value.


### PR DESCRIPTION
## Which problem is this PR solving?
- Apply require-error rule of testifylint

## Description of the changes
-  use require instead of assert on errors testing 

## How was this change tested?
- CI 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
