### PR TITLE
Fix permission failed on checks-run

### DIFF
--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -7,6 +7,7 @@ on:
 # See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
+  checks: write
 
 jobs:
   unit-tests-go-tip:

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -14,6 +14,7 @@ concurrency:
 # See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
+  checks: write
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/pull/5035#issuecomment-1869152935

## Description of the changes
- The logs from https://github.com/jaegertracing/jaeger/actions/runs/7324976182/job/19949034415#step:8:67 show:
> github.GithubException.GithubException: 403 {"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest/checks/runs#create-a-check-run"}

This is because it needs write permission on the PR check runs to provide a summary.

- The alternative is to disable test summary in the PR checks.

## How was this change tested?
- Ran this in my fork earlier.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
