### PR TITLE
bugfix: Set pipefail when running unit tests to preserve exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ index-rollover-integration-test: docker-images-elastic
 
 .PHONY: cover
 cover: nocover
-	$(GOTEST) -tags=memory_storage_integration -timeout 5m -coverprofile cover.out ./... | tee test-results.json
+	bash -c "set -e; set -o pipefail; $(GOTEST) -tags=memory_storage_integration -timeout 5m -coverprofile cover.out ./... | tee test-results.json"
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: nocover


### PR DESCRIPTION
## Which problem is this PR solving?
- When we switched unit test results forwarding using `tee` (#5045), it breaks the CI validation since the exit code from tests is ignored.

## Description of the changes
- Use `set -o pipefail` as we did in all other targets where the test output is piped into something

## How was this change tested?
- Ran local validation to ensure that error code is returned with this change
