### PR TITLE
Separate test report collection from the main target

### DIFF
--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -23,8 +23,16 @@ jobs:
     - name: Install Go Tip
       uses: ./.github/actions/setup-go-tip
 
+    - name: Install test deps
+      # even though the same target runs from test-ci, running it separately makes for cleaner log in GH workflow
+      run: make install-test-tools
+
     - name: Run unit tests
       run: make test-ci
+
+    - name: Prepare unit tests report
+      if: always()
+      run: make test-report
 
     - name: Publish Unit Test Summary 📑
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -32,8 +32,16 @@ jobs:
         go-version: 1.21.x
         cache-dependency-path: ./go.sum
 
+    - name: Install test deps
+      # even though the same target runs from test-ci, running it separately makes for cleaner log in GH workflow
+      run: make install-test-tools
+
     - name: Run unit tests
       run: make test-ci
+
+    - name: Prepare unit tests report
+      if: always()
+      run: make test-report
 
     - name: Publish Unit Test Summary 📑
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ install-ci: install-test-tools install-build-tools
 
 .PHONY: test-ci
 test-ci: GOTEST := $(GOTEST_QUIET) -json
-test-ci: install-test-tools build-examples cover test-report
+test-ci: install-test-tools build-examples cover
 
 .PHONY: test-report
 test-report:


### PR DESCRIPTION
## Which problem is this PR solving?
- When the tests fail, the target `test-report` is never run and thus no summary can be created

## Description of the changes
- Invoke the target from the GH workflow as an explicit `if: always()` step
