### PR TITLE
Added Empty Tests for Examples

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,6 +11,7 @@ ignore:
   - "thrift-gen/*/*"
   - "**/thrift-0.9.2/*"
   - "**/main.go"
+  - "examples/hotrod"
 
 coverage:
   precision: 2

--- a/examples/hotrod/cmd/.nocover
+++ b/examples/hotrod/cmd/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/cmd/empty_test.go
+++ b/examples/hotrod/cmd/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/cmd/empty_test.go
+++ b/examples/hotrod/cmd/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/cmd/empty_test.go
+++ b/examples/hotrod/cmd/empty_test.go
@@ -16,9 +16,15 @@ package cmd
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/delay/.nocover
+++ b/examples/hotrod/pkg/delay/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/pkg/delay/empty_test.go
+++ b/examples/hotrod/pkg/delay/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/delay/empty_test.go
+++ b/examples/hotrod/pkg/delay/empty_test.go
@@ -16,9 +16,15 @@ package delay
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/delay/empty_test.go
+++ b/examples/hotrod/pkg/delay/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delay
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/pkg/httperr/.nocover
+++ b/examples/hotrod/pkg/httperr/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/pkg/httperr/empty_test.go
+++ b/examples/hotrod/pkg/httperr/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/httperr/empty_test.go
+++ b/examples/hotrod/pkg/httperr/empty_test.go
@@ -16,9 +16,15 @@ package httperr
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/httperr/empty_test.go
+++ b/examples/hotrod/pkg/httperr/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httperr
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/pkg/log/.nocover
+++ b/examples/hotrod/pkg/log/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/pkg/log/empty_test.go
+++ b/examples/hotrod/pkg/log/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/log/empty_test.go
+++ b/examples/hotrod/pkg/log/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/pkg/log/empty_test.go
+++ b/examples/hotrod/pkg/log/empty_test.go
@@ -16,9 +16,15 @@ package log
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/pool/.nocover
+++ b/examples/hotrod/pkg/pool/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/pkg/pool/empty_test.go
+++ b/examples/hotrod/pkg/pool/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/pool/empty_test.go
+++ b/examples/hotrod/pkg/pool/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pool
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/pkg/pool/empty_test.go
+++ b/examples/hotrod/pkg/pool/empty_test.go
@@ -16,9 +16,15 @@ package pool
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/tracing/.nocover
+++ b/examples/hotrod/pkg/tracing/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/pkg/tracing/empty_test.go
+++ b/examples/hotrod/pkg/tracing/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/tracing/empty_test.go
+++ b/examples/hotrod/pkg/tracing/empty_test.go
@@ -16,9 +16,15 @@ package tracing
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/pkg/tracing/empty_test.go
+++ b/examples/hotrod/pkg/tracing/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/services/config/.nocover
+++ b/examples/hotrod/services/config/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/services/config/empty_test.go
+++ b/examples/hotrod/services/config/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/config/empty_test.go
+++ b/examples/hotrod/services/config/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/services/config/empty_test.go
+++ b/examples/hotrod/services/config/empty_test.go
@@ -16,9 +16,15 @@ package config
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/customer/.nocover
+++ b/examples/hotrod/services/customer/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/services/customer/empty_test.go
+++ b/examples/hotrod/services/customer/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/customer/empty_test.go
+++ b/examples/hotrod/services/customer/empty_test.go
@@ -16,9 +16,15 @@ package customer
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/customer/empty_test.go
+++ b/examples/hotrod/services/customer/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package customer
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/services/driver/.nocover
+++ b/examples/hotrod/services/driver/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/services/driver/empty_test.go
+++ b/examples/hotrod/services/driver/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/driver/empty_test.go
+++ b/examples/hotrod/services/driver/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/services/driver/empty_test.go
+++ b/examples/hotrod/services/driver/empty_test.go
@@ -16,9 +16,15 @@ package driver
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/frontend/.nocover
+++ b/examples/hotrod/services/frontend/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/services/frontend/empty_test.go
+++ b/examples/hotrod/services/frontend/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/frontend/empty_test.go
+++ b/examples/hotrod/services/frontend/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}

--- a/examples/hotrod/services/frontend/empty_test.go
+++ b/examples/hotrod/services/frontend/empty_test.go
@@ -16,9 +16,15 @@ package frontend
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/route/.nocover
+++ b/examples/hotrod/services/route/.nocover
@@ -1,1 +1,0 @@
-examples

--- a/examples/hotrod/services/route/empty_test.go
+++ b/examples/hotrod/services/route/empty_test.go
@@ -20,11 +20,6 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestDummy(t *testing.T) {
-	// This is a dummy test in the root package.
-	// Without it `go test -v .` prints "testing: warning: no tests to run".
-}
-
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/route/empty_test.go
+++ b/examples/hotrod/services/route/empty_test.go
@@ -16,9 +16,15 @@ package route
 
 import (
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestDummy(t *testing.T) {
 	// This is a dummy test in the root package.
 	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/examples/hotrod/services/route/empty_test.go
+++ b/examples/hotrod/services/route/empty_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+	// This is a dummy test in the root package.
+	// Without it `go test -v .` prints "testing: warning: no tests to run".
+}


### PR DESCRIPTION
@yurishkuro, do we also need goleak tests in examples?

## Which problem is this PR solving?
- Part of #5068 

## Description of the changes
- Added Empty Tests for `./examples` to reduce noise in `make nocover`.

## How was this change tested?
- go test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
