### PR TITLE
Add goleak tests to cmd/collector/app/handler

### DIFF
--- a/cmd/collector/app/handler/package_test.go
+++ b/cmd/collector/app/handler/package_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package handler
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutils.IgnoreOpenCensusWorkerLeak())
+}

--- a/cmd/collector/app/handler/zipkin_receiver_tls_test.go
+++ b/cmd/collector/app/handler/zipkin_receiver_tls_test.go
@@ -176,6 +176,7 @@ func TestSpanCollectorZipkinTLS(t *testing.T) {
 			opts := &flags.CollectorOptions{}
 			opts.Zipkin.HTTPHostPort = ports.PortToHostPort(ports.CollectorZipkin)
 			opts.Zipkin.TLS = test.serverTLS
+			defer test.serverTLS.Close()
 
 			server, err := StartZipkinReceiver(opts, logger, spanProcessor, tm)
 			if test.expectServerFail {
@@ -188,6 +189,7 @@ func TestSpanCollectorZipkinTLS(t *testing.T) {
 			}()
 
 			clientTLSCfg, err0 := test.clientTLS.Config(zap.NewNop())
+			defer test.clientTLS.Close()
 			require.NoError(t, err0)
 			dialer := &net.Dialer{Timeout: 2 * time.Second}
 			conn, clientError := tls.DialWithDialer(dialer, "tcp", fmt.Sprintf("localhost:%d", ports.CollectorZipkin), clientTLSCfg)


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5006 

## Description of the changes
- Added TestMain to package folders
- Added make goleak into unit test ci

## How was this change tested?
- please run make goleak 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
