### PR TITLE
Add Goleak check to cmd/jaeger/internal/exporters/storageexporter

### DIFF
--- a/cmd/jaeger/internal/exporters/storageexporter/package_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/package_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storageexporter
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutils.IgnoreOpenCensusWorkerLeak())
+}

--- a/cmd/jaeger/internal/exporters/storageexporter/package_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/package_test.go
@@ -17,8 +17,9 @@ package storageexporter
 import (
 	"testing"
 
-	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"go.uber.org/goleak"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Which problem is this PR solving?
- part of #5006 

## Description of the changes
- Added Goroutine leak test for internal/exporters/storageexporter.

## How was this change tested?
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
