### PR TITLE
Added unit tests in internal/tracegen

### DIFF
--- a/internal/tracegen/.nocover
+++ b/internal/tracegen/.nocover
@@ -1,1 +1,0 @@
-Test utility

--- a/internal/tracegen/config_test.go
+++ b/internal/tracegen/config_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracegen
+
+import (
+	"errors"
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+func Test_Run(t *testing.T) {
+	logger := zap.NewNop()
+	tp := sdktrace.NewTracerProvider()
+
+	tests := []struct {
+		name        string
+		config      *Config
+		expectedErr error
+	}{
+		{
+			name:        "Empty config",
+			config:      &Config{},
+			expectedErr: errors.New("either `traces` or `duration` must be greater than 0"),
+		},
+		{
+			name: "Non-empty config",
+			config: &Config{
+				Workers:    2,
+				Traces:     10,
+				ChildSpans: 5,
+				Attributes: 20,
+				AttrKeys:   50,
+				AttrValues: 100,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "Negative traces, positive duration",
+			config: &Config{
+				Traces:   -7,
+				Duration: 7,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracers := []trace.Tracer{tp.Tracer("Test-Tracer")}
+			err := Run(tt.config, tracers, logger)
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func Test_Flags(t *testing.T) {
+	fs := &flag.FlagSet{}
+	config := &Config{}
+	expectedConfig := &Config{
+		Workers:       1,
+		Traces:        1,
+		ChildSpans:    1,
+		Attributes:    11,
+		AttrKeys:      97,
+		AttrValues:    1000,
+		Debug:         false,
+		Firehose:      false,
+		Pause:         1000,
+		Duration:      0,
+		Service:       "tracegen",
+		Services:      1,
+		TraceExporter: "otlp-http",
+	}
+
+	config.Flags(fs)
+	assert.Equal(t, expectedConfig, config)
+}

--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracegen
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func Test_SimulateTraces(t *testing.T) {
+	logger, buf := testutils.NewLogger()
+	tp := sdktrace.NewTracerProvider()
+	tracers := []trace.Tracer{tp.Tracer("stdout")}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var running uint32 = 1
+
+	worker := &worker{
+		logger:  logger,
+		tracers: tracers,
+		wg:      &wg,
+		id:      7,
+		running: &running,
+		Config: Config{
+			Traces:   7,
+			Duration: time.Second,
+			Pause:    time.Second,
+			Service:  "stdout",
+			Debug:    true,
+			Firehose: true,
+		},
+	}
+	expectedOutput := `{"level":"info","msg":"Worker 7 generated 7 traces"}` + "\n"
+
+	worker.simulateTraces()
+	assert.Equal(t, expectedOutput, buf.String())
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Partially fixes #5068 

## Description of the changes
- This commit adds tests for the `internal/tracegen` package.

## How was this change tested?
- make test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`