### PR TITLE
Avoid changing a correct order of span references

### DIFF
--- a/model/adjuster/parent_reference.go
+++ b/model/adjuster/parent_reference.go
@@ -26,7 +26,7 @@ func ParentReference() Adjuster {
 		for _, span := range trace.Spans {
 			firstChildOfRef := -1
 			firstOtherRef := -1
-			for i := 1; i < len(span.References); i++ {
+			for i := 0; i < len(span.References); i++ {
 				if span.References[i].TraceID == span.TraceID {
 					if span.References[i].RefType == model.SpanRefType_CHILD_OF {
 						firstChildOfRef = i
@@ -40,7 +40,7 @@ func ParentReference() Adjuster {
 			if swap == -1 {
 				swap = firstOtherRef
 			}
-			if swap != -1 {
+			if swap != 0 && swap != -1 {
 				span.References[swap], span.References[0] = span.References[0], span.References[swap]
 			}
 		}

--- a/model/adjuster/parent_reference_test.go
+++ b/model/adjuster/parent_reference_test.go
@@ -57,6 +57,11 @@ func TestParentReference(t *testing.T) {
 			expected: []model.SpanRef{childOf(b)},
 		},
 		{
+			name:     "local, local follows - keep order",
+			incoming: []model.SpanRef{childOf(a), followsFrom(a)},
+			expected: []model.SpanRef{childOf(a), followsFrom(a)},
+		},
+		{
 			name:     "local and remote child in order",
 			incoming: []model.SpanRef{childOf(a), childOf(b)},
 			expected: []model.SpanRef{childOf(a), childOf(b)},


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5122

## Description of the changes
- Avoid changing order in the case described above.

## How was this change tested?
- A test case is added.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
