### PR TITLE
Add goleak checks in 2 packages

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerstorage
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/pkg/version/package_test.go
+++ b/pkg/version/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}


### PR DESCRIPTION


## Which problem is this PR solving?
- Partially addresses: #5006

## Description of the changes
- Added `testutils.VerifyGoLeaks` in the following packages:
  - `cmd/jaeger/internal/extension/jaegerstorage/`
  - `/pkg/version/`

## How was this change tested?
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
