### PR TITLE
[test] Add per-test goleak check for storage/es

### DIFF
--- a/pkg/testutils/leakcheck.go
+++ b/pkg/testutils/leakcheck.go
@@ -35,6 +35,17 @@ func IgnoreOpenCensusWorkerLeak() goleak.Option {
 }
 
 // VerifyGoLeaks verifies that unit tests do not leak any goroutines.
+// It should be called in TestMain.
 func VerifyGoLeaks(m *testing.M) {
 	goleak.VerifyTestMain(m, IgnoreGlogFlushDaemonLeak(), IgnoreOpenCensusWorkerLeak())
+}
+
+// VerifyGoLeaksOnce verifies that a given unit test does not leak any goroutines.
+// Occasionally useful to troubleshoot specific tests that are flaky due to leaks,
+// since VerifyGoLeaks cannot distiguish which specific test caused the leak.
+// It should be called via defer or from Cleanup:
+//
+//	defer testutils.VerifyGoLeaksOnce(t)
+func VerifyGoLeaksOnce(t *testing.T) {
+	goleak.VerifyNone(t, IgnoreGlogFlushDaemonLeak(), IgnoreOpenCensusWorkerLeak())
 }

--- a/pkg/testutils/leakcheck_test.go
+++ b/pkg/testutils/leakcheck_test.go
@@ -18,6 +18,10 @@ import (
 	"testing"
 )
 
+func TestVerifyGoLeaksOnes(t *testing.T) {
+	defer VerifyGoLeaksOnce(t)
+}
+
 func TestMain(m *testing.M) {
 	VerifyGoLeaks(m)
 }

--- a/pkg/testutils/leakcheck_test.go
+++ b/pkg/testutils/leakcheck_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 )
 
-func TestVerifyGoLeaksOnes(t *testing.T) {
+func TestVerifyGoLeaksOnce(t *testing.T) {
 	defer VerifyGoLeaksOnce(t)
 }
 

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -264,6 +264,7 @@ func TestInitFromOptions(t *testing.T) {
 }
 
 func TestPasswordFromFile(t *testing.T) {
+	defer testutils.VerifyGoLeaksOnce(t)
 	t.Run("primary client", func(t *testing.T) {
 		f := NewFactory()
 		testPasswordFromFile(t, f, f.getPrimaryClient, f.CreateSpanWriter)
@@ -375,6 +376,7 @@ func TestFactoryESClientsAreNil(t *testing.T) {
 }
 
 func TestPasswordFromFileErrors(t *testing.T) {
+	defer testutils.VerifyGoLeaksOnce(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(mockEsServerResponse)
 	}))


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5083

## Description of the changes
- Add goleak checks to individual tests suspected of causing the leaks, this might help confirming which ones are at fault, since the main VerifyGoLeak check cannot distinguish between tests in the package.

## How was this change tested?
```
$ go test -count 100 ./plugin/storage/es
ok  	github.com/jaegertracing/jaeger/plugin/storage/es	8.246s
```
