### PR TITLE
testifylint: enable compares

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,11 +145,11 @@ linters-settings:
       - shadow
   testifylint:
     disable:
-      - compares
       - float-compare
       - go-require
     enable:
       - bool-compare
+      - compares
       - empty
       - error-is-as
       - error-nil

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -165,7 +165,7 @@ func TestBuilderWithCollectors(t *testing.T) {
 				if test.checkSuffixOnly {
 					assert.True(t, strings.HasSuffix(conn.Target(), test.target))
 				} else {
-					assert.True(t, conn.Target() == test.target)
+					assert.Equal(t, conn.Target(), test.target)
 				}
 			} else {
 				require.Error(t, err)
@@ -399,11 +399,11 @@ func assertConnectionState(t *testing.T, conn *grpc.ClientConn, expectedState st
 	for {
 		s := conn.GetState()
 		if s == connectivity.Ready {
-			assert.True(t, s.String() == expectedState)
+			assert.Equal(t, expectedState, s.String())
 			break
 		}
 		if s == connectivity.TransientFailure {
-			assert.True(t, s.String() == expectedState)
+			assert.Equal(t, expectedState, s.String())
 			break
 		}
 	}

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -68,8 +68,8 @@ func TestMultipleCollectors(t *testing.T) {
 		}
 	}
 	c, g := mFactory.Snapshot()
-	assert.True(t, len(g) > 0)
-	assert.True(t, len(c) > 0)
+	assert.NotEmpty(t, g)
+	assert.NotEmpty(t, c)
 	assert.True(t, bothServers)
 	require.NoError(t, proxy.Close())
 }

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -710,7 +710,7 @@ func TestServerGracefulExit(t *testing.T) {
 	server.Close()
 
 	for _, logEntry := range logs.All() {
-		assert.True(t, logEntry.Level != zap.ErrorLevel,
+		assert.NotEqual(t, zap.ErrorLevel, logEntry.Level,
 			"Error log found on server exit: %v", logEntry)
 	}
 }

--- a/crossdock/services/tracehandler_test.go
+++ b/crossdock/services/tracehandler_test.go
@@ -276,7 +276,7 @@ func TestCreateTracesLoop(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
-	assert.True(t, h.CallCount() > 0)
+	assert.Greater(t, h.CallCount(), int64(0))
 }
 
 func TestValidateAdaptiveSamplingTraces(t *testing.T) {

--- a/model/adjuster/adjuster_test.go
+++ b/model/adjuster/adjuster_test.go
@@ -62,7 +62,7 @@ func TestSequences(t *testing.T) {
 
 		adjTrace, err := testCase.adjuster.Adjust(&trace)
 
-		assert.True(t, span == adjTrace.Spans[0], "same trace & span returned")
+		assert.Equal(t, span, adjTrace.Spans[0], "same trace & span returned")
 		assert.EqualValues(t, testCase.lastSpanID, span.SpanID, "expect span ID to be incremented")
 		require.EqualError(t, err, testCase.err)
 	}

--- a/model/converter/thrift/zipkin/process_hashtable_test.go
+++ b/model/converter/thrift/zipkin/process_hashtable_test.go
@@ -34,11 +34,11 @@ func TestProcessHashtable(t *testing.T) {
 		model.String("host", "facebook.com"),
 	})
 	ht := newProcessHashtable()
-	assert.True(t, p1 == ht.add(p1))
-	assert.True(t, p2 == ht.add(p2))
-	assert.True(t, p1 == ht.add(p1))
-	assert.True(t, p2 == ht.add(p2))
-	assert.True(t, p1 == ht.add(p1dup))
+	assert.Equal(t, p1, ht.add(p1))
+	assert.Equal(t, p2, ht.add(p2))
+	assert.Equal(t, p1, ht.add(p1))
+	assert.Equal(t, p2, ht.add(p2))
+	assert.Equal(t, p1, ht.add(p1dup))
 }
 
 func TestProcessHashtableCollision(t *testing.T) {
@@ -54,8 +54,8 @@ func TestProcessHashtableCollision(t *testing.T) {
 	p2 := model.NewProcess("s2", []model.KeyValue{
 		model.String("host", "facebook.com"),
 	})
-	assert.True(t, p1 == ht.add(p1))
-	assert.True(t, p2 == ht.add(p2))
-	assert.True(t, p1 == ht.add(p1))
-	assert.True(t, p2 == ht.add(p2))
+	assert.Equal(t, p1, ht.add(p1))
+	assert.Equal(t, p2, ht.add(p2))
+	assert.Equal(t, p1, ht.add(p1))
+	assert.Equal(t, p2, ht.add(p2))
 }

--- a/pkg/es/client/index_client_test.go
+++ b/pkg/es/client/index_client_test.go
@@ -248,7 +248,7 @@ func TestClientDeleteIndices(t *testing.T) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
 				assert.Equal(t, fmt.Sprintf("%ds", masterTimeoutSeconds), req.URL.Query().Get("master_timeout"))
-				assert.True(t, len(req.URL.Path) <= maxURLPathLength)
+				assert.LessOrEqual(t, len(req.URL.Path), maxURLPathLength)
 
 				// removes leading '/' and trailing ','
 				// example: /jaeger-span-000001,  =>  jaeger-span-000001

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -66,7 +66,7 @@ func TestInitMetrics(t *testing.T) {
 
 	stopwatch := metrics.StartStopwatch(testMetrics.Timer)
 	stopwatch.Stop()
-	assert.True(t, 0 < stopwatch.ElapsedTime())
+	assert.Greater(t, stopwatch.ElapsedTime(), time.Duration(0))
 }
 
 var (

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -333,7 +333,6 @@ func TestDeepCopy(t *testing.T) {
 		},
 	}
 	cp := deepCopy(s)
-	assert.False(t, cp == s)
 	assert.EqualValues(t, cp, s)
 }
 

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -333,7 +333,7 @@ func TestDeepCopy(t *testing.T) {
 		},
 	}
 	cp := deepCopy(s)
-	assert.False(t, cp == s) //nolint:testifylint // assert.NotEquals does not apply here
+	assert.NotSame(t, cp, s)
 	assert.EqualValues(t, cp, s)
 }
 

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -333,6 +333,7 @@ func TestDeepCopy(t *testing.T) {
 		},
 	}
 	cp := deepCopy(s)
+	assert.NotEqual(t, cp, s)
 	assert.EqualValues(t, cp, s)
 }
 

--- a/plugin/sampling/strategystore/static/strategy_store_test.go
+++ b/plugin/sampling/strategystore/static/strategy_store_test.go
@@ -333,7 +333,7 @@ func TestDeepCopy(t *testing.T) {
 		},
 	}
 	cp := deepCopy(s)
-	assert.NotEqual(t, cp, s)
+	assert.False(t, cp == s) //nolint:testifylint // assert.NotEquals does not apply here
 	assert.EqualValues(t, cp, s)
 }
 

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -94,7 +94,7 @@ func TestMaintenanceRun(t *testing.T) {
 	// Safeguard
 	mFactory := metricstest.NewFactory(0)
 	_, gs := mFactory.Snapshot()
-	assert.True(t, gs[lastMaintenanceRunName] == 0)
+	assert.Equal(t, int64(0), gs[lastMaintenanceRunName])
 	f.Initialize(mFactory, zap.NewNop())
 
 	waiter := func(previousValue int64) int64 {
@@ -106,7 +106,7 @@ func TestMaintenanceRun(t *testing.T) {
 			sleeps++
 			_, gs = mFactory.Snapshot()
 		}
-		assert.True(t, gs[lastMaintenanceRunName] > previousValue)
+		assert.Greater(t, gs[lastMaintenanceRunName], previousValue)
 		return gs[lastMaintenanceRunName]
 	}
 
@@ -120,7 +120,7 @@ func TestMaintenanceRun(t *testing.T) {
 
 	waiter(runtime)
 	_, gs = mFactory.Snapshot()
-	assert.True(t, gs[lastValueLogCleanedName] > 0)
+	assert.Greater(t, gs[lastValueLogCleanedName], int64(0))
 
 	err := io.Closer(f).Close()
 	require.NoError(t, err)
@@ -178,14 +178,14 @@ func TestBadgerMetrics(t *testing.T) {
 			sleeps++
 			_, gs = mFactory.Snapshot()
 		}
-		assert.True(t, gs["badger_v3_memtable_gets_total"] == previousValue)
+		assert.Equal(t, gs["badger_v3_memtable_gets_total"], previousValue)
 		return gs["badger_v3_memtable_gets_total"]
 	}
 
 	vlogSize := waiter(0)
 	_, gs := mFactory.Snapshot()
-	assert.True(t, vlogSize == 0)
-	assert.True(t, gs["badger_v3_memtable_gets_total"] == 0) // IntVal metric
+	assert.EqualValues(t, 0, vlogSize)
+	assert.EqualValues(t, int64(0), gs["badger_v3_memtable_gets_total"]) // IntVal metric
 
 	_, found = gs["badger_v3_lsm_size_bytes"] // Map metric
 	assert.True(t, found)

--- a/plugin/storage/badger/stats_linux_test.go
+++ b/plugin/storage/badger/stats_linux_test.go
@@ -42,6 +42,6 @@ func TestDiskStatisticsUpdate(t *testing.T) {
 	err = f.diskStatisticsUpdate()
 	require.NoError(t, err)
 	_, gs := mFactory.Snapshot()
-	assert.True(t, gs[keyLogSpaceAvailableName] > int64(0))
-	assert.True(t, gs[valueLogSpaceAvailableName] > int64(0))
+	assert.Greater(t, gs[keyLogSpaceAvailableName], int64(0))
+	assert.Greater(t, gs[valueLogSpaceAvailableName], int64(0))
 }

--- a/plugin/storage/integration/trace_compare.go
+++ b/plugin/storage/integration/trace_compare.go
@@ -75,10 +75,10 @@ func checkSize(t *testing.T, expected *model.Trace, actual *model.Trace) {
 	for i := range expected.Spans {
 		expectedSpan := expected.Spans[i]
 		actualSpan := actual.Spans[i]
-		require.True(t, len(expectedSpan.Tags) == len(actualSpan.Tags))
-		require.True(t, len(expectedSpan.Logs) == len(actualSpan.Logs))
+		require.Equal(t, len(expectedSpan.Tags), len(actualSpan.Tags))
+		require.Equal(t, len(expectedSpan.Logs), len(actualSpan.Logs))
 		if expectedSpan.Process != nil && actualSpan.Process != nil {
-			require.True(t, len(expectedSpan.Process.Tags) == len(actualSpan.Process.Tags))
+			require.Equal(t, len(expectedSpan.Process.Tags), len(actualSpan.Process.Tags))
 		}
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Apply compares rule of testifylint

## Description of the changes
-  More appropriate testify API with clearer failure message.

## How was this change tested?
- CI 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
