### PR TITLE
Define GOBIN targets for tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ SED=sed
 GO=go
 GOOS ?= $(shell $(GO) env GOOS)
 GOARCH ?= $(shell $(GO) env GOARCH)
+GOBIN ?= $(shell $(GO) env GOPATH)/bin
 GOBUILD=CGO_ENABLED=0 installsuffix=cgo $(GO) build -trimpath
 GOTEST_QUIET=$(GO) test $(RACE)
 GOTEST=$(GOTEST_QUIET) -v

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ _prepare-winres:
 	$(MAKE) _prepare-winres-helper NAME="Jaeger ES-Rollover"      PKGPATH="cmd/es-rollover"
 
 .PHONY: _prepare-winres-helper
-_prepare-winres-helper:
+_prepare-winres-helper: $(GOBIN)/goversioninfo
 	echo $$VERSIONINFO | $(GOVERSIONINFO) -o="$(PKGPATH)/$(SYSOFILE)" -
 
 .PHONY: build-binaries-linux

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ include docker/Makefile
 include Makefile.Protobuf.mk
 include Makefile.Thrift.mk
 include Makefile.Crossdock.mk
+include Makefile.tools.mk
 
 .DEFAULT_GOAL := test-and-lint
 
@@ -436,17 +437,13 @@ draft-release:
 	./scripts/draft-release.py
 
 .PHONY: install-test-tools
-install-test-tools:
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
-	$(GO) install mvdan.cc/gofumpt@latest
+install-test-tools: $(GOBIN)/golangci-lint $(GOBIN)/gofumpt
 
 .PHONY: install-build-tools
-install-build-tools:
-	$(GO) install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+install-build-tools: $(GOBIN)/goversioninfo
 
 .PHONY: install-tools
-install-tools: install-test-tools install-build-tools
-	$(GO) install github.com/vektra/mockery/v2@v2.14.0
+install-tools: install-test-tools install-build-tools $(GOBIN)/mockery
 
 .PHONY: install-ci
 install-ci: install-test-tools install-build-tools

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ _prepare-winres:
 	$(MAKE) _prepare-winres-helper NAME="Jaeger ES-Rollover"      PKGPATH="cmd/es-rollover"
 
 .PHONY: _prepare-winres-helper
-_prepare-winres-helper: $(GOBIN)/goversioninfo
+_prepare-winres-helper:
 	echo $$VERSIONINFO | $(GOVERSIONINFO) -o="$(PKGPATH)/$(SYSOFILE)" -
 
 .PHONY: build-binaries-linux

--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -1,0 +1,11 @@
+$(GOBIN)/golangci-lint:
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+
+$(GOBIN)/gofumpt:
+	$(GO) install mvdan.cc/gofumpt@latest
+
+$(GOBIN)/goversioninfo:
+	$(GO) install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+
+ $(GOBIN)/mockery:
+	$(GO) install github.com/vektra/mockery/v2@v2.14.0


### PR DESCRIPTION
## Which problem is this PR solving?
-  avoid tools reinstall 

## Description of the changes
-  define targets for tools so they are not reinstalled once they are installed in GOBIN dir

## How was this change tested?
-  CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
