### PR TITLE
Add endpoints to allow uploading OTLP traces

### DIFF
--- a/model/model.pb.go
+++ b/model/model.pb.go
@@ -597,6 +597,22 @@ func (*Batch) ProtoMessage()    {}
 func (*Batch) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4c16552f9fdb66d8, []int{6}
 }
+
+func (m *Batch)ConvertToTraces()(*Trace){
+   ret_trace := Trace{}
+   ret_trace.Spans = m.Spans
+   for _,v := range ret_trace.Spans{
+      v.Process = m.Process
+   }
+   ret_trace.ProcessMap = append(ret_trace.ProcessMap, Trace_ProcessMapping{
+      ProcessID: m.Process.ServiceName,
+      Process: *m.Process,
+   })
+   return &ret_trace
+
+}
+
+
 func (m *Batch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }


### PR DESCRIPTION
Signed-off-by: Navin Shrinivas <karupal2002@gmail.com>

partial work for issue #4949

<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
-  Resolved #4949 

## Description of the changes
- Adds an endpoint that converts OTLP traces to jaeger traces

## How was this change tested?
- Tested using example traces placed in `idl/otel-proto/examples/traces.json`

The commit in the PR is rather rough, looking for feedback as it's only a draft PR for now. I haven't formatted and there are some extra prints here and there that I used.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
