### PR TITLE
Bump Go version

### DIFF
--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -44,7 +44,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Setup Node.js version
       uses: ./.github/actions/setup-node.js

--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -52,7 +52,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Setup Node.js version
       uses: ./.github/actions/setup-node.js

--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -40,7 +40,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Run cassandra integration tests
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.image }} ${{ matrix.version.schema }}

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Setup Node.js version
       uses: ./.github/actions/setup-node.js

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -50,7 +50,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/ci-grpc-badger.yml
+++ b/.github/workflows/ci-grpc-badger.yml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Run Badger storage integration tests
       run: make badger-storage-integration-test

--- a/.github/workflows/ci-hotrod.yml
+++ b/.github/workflows/ci-hotrod.yml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Export BRANCH variable
       uses: ./.github/actions/setup-branch

--- a/.github/workflows/ci-kafka.yml
+++ b/.github/workflows/ci-kafka.yml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Run kafka integration tests
       run: bash scripts/kafka-integration-test.sh -k

--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Install tools
       run: make install-test-tools

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -44,7 +44,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Install tools
       run: make install-ci

--- a/.github/workflows/ci-protogen-tests.yml
+++ b/.github/workflows/ci-protogen-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Verify Protobuf types are up to date
       run: make proto && git diff --name-status --exit-code

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -43,7 +43,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Setup Node.js version
       uses: ./.github/actions/setup-node.js

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache-dependency-path: ./go.sum
 
     - name: Install test deps

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Add GOPATH
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,7 +131,7 @@ linters-settings:
       - G404
       - G601
   gosimple:
-    go: "1.20"
+    go: "1.21"
   govet:
     check-shadowing: false
     enable-all: true
@@ -160,7 +160,7 @@ linters-settings:
       - suite-extra-assert-call
 
 run:
-  go: "1.20"
+  go: "1.21"
   timeout: 20m
   skip-dirs-use-default: false
   skip-dirs:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 VERSION := 1.0.0
 ROOT_IMAGE ?= alpine:3.16
 CERT_IMAGE := $(ROOT_IMAGE)
-GOLANG_IMAGE := golang:1.21-alpine
+GOLANG_IMAGE := golang:1.22-alpine
 
 DOCKER_REGISTRY ?= localhost:5000
 BASE_IMAGE ?= $(DOCKER_REGISTRY)/baseimg_alpine:latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaegertracing/jaeger
 
-go 1.20
+go 1.21
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2


### PR DESCRIPTION
## Which problem is this PR solving?
- Go version linter started failing because Go 1.22 was released

## Description of the changes
```shell
$ ./scripts/check-go-version.sh -u
```

## How was this change tested?
- CI
