### PR TITLE
Return more detailed errors from ES storage

### DIFF
--- a/pkg/es/errors.go
+++ b/pkg/es/errors.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package es
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/olivere/elastic"
+)
+
+// DetailedError creates a more detailed error if the error stack contains elastic.Error.
+// This is useful because by default olivere/elastic returns errors that print like this:
+//
+//	elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]
+//
+// This is pretty useless because it masks the underlying root cause.
+// DetailedError would instead return an error like this:
+//
+//	<same as above>: RootCause[... detailed error message ...]
+func DetailedError(err error) error {
+	var esErr *elastic.Error
+	if errors.As(err, &esErr) {
+		if esErr.Details != nil && len(esErr.Details.RootCause) > 0 {
+			rc := esErr.Details.RootCause[0]
+			if rc != nil {
+				return fmt.Errorf("%w: RootCause[%s [type=%s]]", err, rc.Reason, rc.Type)
+			}
+		}
+	}
+	return err
+}

--- a/pkg/es/errors_test.go
+++ b/pkg/es/errors_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/olivere/elastic"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetailedError(t *testing.T) {
-	assert.ErrorContains(t, fmt.Errorf("some err"), "some err", "no panic")
+	require.ErrorContains(t, fmt.Errorf("some err"), "some err", "no panic")
 
 	esErr := &elastic.Error{
 		Status: 400,
@@ -27,9 +27,9 @@ func TestDetailedError(t *testing.T) {
 			},
 		},
 	}
-	assert.ErrorContains(t, DetailedError(esErr), "actual reason")
+	require.ErrorContains(t, DetailedError(esErr), "actual reason")
 
 	esErr.Details.RootCause[0] = nil
-	assert.ErrorContains(t, DetailedError(esErr), "useless reason")
-	assert.NotContains(t, DetailedError(esErr).Error(), "actual reason")
+	require.ErrorContains(t, DetailedError(esErr), "useless reason")
+	require.NotContains(t, DetailedError(esErr).Error(), "actual reason")
 }

--- a/pkg/es/errors_test.go
+++ b/pkg/es/errors_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package es
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/olivere/elastic"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetailedError(t *testing.T) {
+	assert.ErrorContains(t, fmt.Errorf("some err"), "some err", "no panic")
+
+	esErr := &elastic.Error{
+		Status: 400,
+		Details: &elastic.ErrorDetails{
+			Type:   "type1",
+			Reason: "useless reason, e.g. all shards failed",
+			RootCause: []*elastic.ErrorDetails{
+				{
+					Type:   "type2",
+					Reason: "actual reason",
+				},
+			},
+		},
+	}
+	assert.ErrorContains(t, DetailedError(esErr), "actual reason")
+
+	esErr.Details.RootCause[0] = nil
+	assert.ErrorContains(t, DetailedError(esErr), "useless reason")
+	assert.NotContains(t, DetailedError(esErr).Error(), "actual reason")
+}

--- a/plugin/storage/es/spanstore/service_operation.go
+++ b/plugin/storage/es/spanstore/service_operation.go
@@ -87,7 +87,7 @@ func (s *ServiceOperationStorage) getServices(context context.Context, indices [
 
 	searchResult, err := searchService.Do(context)
 	if err != nil {
-		return nil, fmt.Errorf("search services failed: %w", err)
+		return nil, fmt.Errorf("search services failed: %w", es.DetailedError(err))
 	}
 	if searchResult.Aggregations == nil {
 		return []string{}, nil
@@ -118,7 +118,7 @@ func (s *ServiceOperationStorage) getOperations(context context.Context, indices
 
 	searchResult, err := searchService.Do(context)
 	if err != nil {
-		return nil, fmt.Errorf("search operations failed: %w", err)
+		return nil, fmt.Errorf("search operations failed: %w", es.DetailedError(err))
 	}
 	if searchResult.Aggregations == nil {
 		return []string{}, nil


### PR DESCRIPTION
## Which problem is this PR solving?
- In many cases when ES operations fail, the only error returned to the UI or written to Jaeger log is `all shards fail`, which is pretty useless for the actual troubleshooting.
- Meanwhile, the driver actually returns an error struct that contains a `RootCause` field.

## Description of the changes
- Inspect the error and include root cause if present

## How was this change tested?
Run all-in-one and `curl 'http://localhost:16686/api/services'`

Before:
`$ curl 'http://localhost:16686/api/services'`
`{"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"search services failed: elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]"}]}`

After:
`$ curl 'http://localhost:16686/api/services'`
`{"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":500,"msg":"search services failed: elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]: RootCause[Fielddata is disabled on [serviceName] in [jaeger-service-]. Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [serviceName] in order to load field data by uninverting the inverted index. Note that this can use significant memory. [type=illegal_argument_exception]]"}]}`
