### PR TITLE
Fix groutine leaks in cmd/anonymizer/app/writer

### DIFF
--- a/cmd/anonymizer/app/anonymizer/anonymizer.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer.go
@@ -15,6 +15,7 @@
 package anonymizer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -57,6 +58,8 @@ type Anonymizer struct {
 	lock        sync.Mutex
 	mapping     mapping
 	options     Options
+	ctx         context.Context
+	cancel      context.CancelFunc
 }
 
 // Options represents the various options with which the anonymizer can be configured.
@@ -70,6 +73,7 @@ type Options struct {
 // New creates new Anonymizer. The mappingFile stores the mapping from original to
 // obfuscated strings, in case later investigations require looking at the original traces.
 func New(mappingFile string, options Options, logger *zap.Logger) *Anonymizer {
+	ctx, cancel := context.WithCancel(context.Background())
 	a := &Anonymizer{
 		mappingFile: mappingFile,
 		logger:      logger,
@@ -78,6 +82,8 @@ func New(mappingFile string, options Options, logger *zap.Logger) *Anonymizer {
 			Operations: make(map[string]string),
 		},
 		options: options,
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 	if _, err := os.Stat(filepath.Clean(mappingFile)); err == nil {
 		dat, err := os.ReadFile(filepath.Clean(mappingFile))
@@ -89,11 +95,22 @@ func New(mappingFile string, options Options, logger *zap.Logger) *Anonymizer {
 		}
 	}
 	go func() {
-		for range time.NewTicker(10 * time.Second).C {
-			a.SaveMapping()
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				a.SaveMapping()
+			case <-a.ctx.Done():
+				return // Exit the goroutine when the context is canceled
+			}
 		}
 	}()
 	return a
+}
+
+func (a *Anonymizer) Stop() {
+	a.cancel()
 }
 
 // SaveMapping writes the mapping from original to obfuscated strings to a file.

--- a/cmd/anonymizer/app/writer/package_test.go
+++ b/cmd/anonymizer/app/writer/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package writer
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/cmd/anonymizer/app/writer/writer_test.go
+++ b/cmd/anonymizer/app/writer/writer_test.go
@@ -53,8 +53,9 @@ func TestNew(t *testing.T) {
 			AnonymizedFile: tempDir + "/anonymized.json",
 			MappingFile:    tempDir + "/mapping.json",
 		}
-		_, err := New(config, nopLogger)
+		writer, err := New(config, nopLogger)
 		require.NoError(t, err)
+		defer writer.anonymizer.Stop()
 	})
 
 	t.Run("CapturedFile does not exist", func(t *testing.T) {
@@ -75,6 +76,7 @@ func TestNew(t *testing.T) {
 		}
 		_, err := New(config, nopLogger)
 		require.ErrorContains(t, err, "cannot create output file")
+		// defer writer.anonymizer.Stop()
 	})
 }
 
@@ -92,6 +94,7 @@ func TestWriter_WriteSpan(t *testing.T) {
 		writer, err := New(config, nopLogger)
 		require.NoError(t, err)
 		defer writer.Close()
+		defer writer.anonymizer.Stop()
 
 		for i := 0; i < 9; i++ {
 			err = writer.WriteSpan(span)
@@ -110,6 +113,7 @@ func TestWriter_WriteSpan(t *testing.T) {
 		writer, err := New(config, zap.NewNop())
 		require.NoError(t, err)
 		defer writer.Close()
+		defer writer.anonymizer.Stop()
 
 		err = writer.WriteSpan(span)
 		require.ErrorIs(t, err, ErrMaxSpansCountReached)


### PR DESCRIPTION

## Which problem is this PR solving?
- part of #5006

## Description of the changes
- Fix groutine leaks in cmd/anonymizer/app/writer

## How was this change tested?
- `go test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
