### PR TITLE
[jaeger-v2] Add support for GRPC storarge

### DIFF
--- a/cmd/jaeger/grpc_config.yaml
+++ b/cmd/jaeger/grpc_config.yaml
@@ -1,0 +1,35 @@
+service:
+  extensions: [jaeger_storage, jaeger_query]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter]
+
+extensions:
+  jaeger_query:
+    trace_storage: external-storage
+    trace_storage_archive: external-storage-archive
+    ui_config: ./cmd/jaeger/config-ui.json
+
+  jaeger_storage:
+    grpc:
+      external-storage:
+        server: localhost:17271
+        connection-timeout: 5s
+      external-storage-archive:
+        server: localhost:17281
+        connection-timeout: 5s
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: external-storage

--- a/cmd/jaeger/internal/extension/jaegerstorage/config.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config.go
@@ -9,12 +9,14 @@ import (
 
 	memoryCfg "github.com/jaegertracing/jaeger/pkg/memory/config"
 	badgerCfg "github.com/jaegertracing/jaeger/plugin/storage/badger"
+	grpcCfg "github.com/jaegertracing/jaeger/plugin/storage/grpc/config"
 )
 
 // Config has the configuration for jaeger-query,
 type Config struct {
 	Memory map[string]memoryCfg.Configuration   `mapstructure:"memory"`
 	Badger map[string]badgerCfg.NamespaceConfig `mapstructure:"badger"`
+	GRPC   map[string]grpcCfg.Configuration     `mapstructure:"grpc"`
 	// TODO add other storage types here
 	// TODO how will this work with 3rd party storage implementations?
 	//      Option: instead of looking for specific name, check interface.

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -17,6 +17,8 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 	badgerCfg "github.com/jaegertracing/jaeger/plugin/storage/badger"
+	"github.com/jaegertracing/jaeger/plugin/storage/grpc"
+	grpcCfg "github.com/jaegertracing/jaeger/plugin/storage/grpc/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/memory"
 	"github.com/jaegertracing/jaeger/storage"
 )
@@ -107,10 +109,17 @@ func (s *storageExt) Start(ctx context.Context, host component.Host) error {
 		cfg:         s.config.Badger,
 		builder:     badger.NewFactoryWithConfig,
 	}
+	grpcStarter := &starter[grpcCfg.Configuration, *grpc.Factory]{
+		ext:         s,
+		storageKind: "grpc",
+		cfg:         s.config.GRPC,
+		builder:     grpc.NewFactoryWithConfig,
+	}
 
 	builders := []func(ctx context.Context, host component.Host) error{
 		memStarter.build,
 		badgerStarter.build,
+		grpcStarter.build,
 		// TODO add support for other backends
 	}
 	for _, builder := range builders {

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -60,6 +60,21 @@ func NewFactory() *Factory {
 	return &Factory{}
 }
 
+// NewFactoryWithConfig is used from jaeger(v2).
+func NewFactoryWithConfig(
+	cfg config.Configuration,
+	metricsFactory metrics.Factory,
+	logger *zap.Logger,
+) (*Factory, error) {
+	f := NewFactory()
+	f.InitFromOptions(Options{Configuration: cfg})
+	err := f.Initialize(metricsFactory, logger)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
 // AddFlags implements plugin.Configurable
 func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
 	f.options.AddFlags(flagSet)

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -143,6 +143,12 @@ func TestGRPCStorageFactory(t *testing.T) {
 	assert.Equal(t, f.store.DependencyReader(), depReader)
 }
 
+func TestGRPCStorageFactoryWithConfig(t *testing.T) {
+	cfg := grpcConfig.Configuration{}
+	_, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
+	require.ErrorContains(t, err, "grpc-plugin builder failed to create a store: error connecting to remote storage")
+}
+
 func TestGRPCStorageFactory_Capabilities(t *testing.T) {
 	f := NewFactory()
 	v := viper.New()


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #4843
- Separate GRPC storage PR from and will be used by jaeger-v2 Kafka PR #4971 

## Description of the changes
- Implement GRPC storage backend for Jaeger-V2 storage

## How was this change tested?
- Run two `jaegertracing/jaeger-remote-storage` at `17271` and `17281` ports
- Execute `go run -tags=ui ./cmd/jaeger --config ./cmd/jaeger/grpc_config.yaml`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
