### PR TITLE
Temporarily lower codecov threshold below 95%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,7 +21,9 @@ coverage:
     project:
       default:
         enabled: yes
-        target: 95%
+        # Temporarily lower threshold below 95% 
+        # Tacked in https://github.com/jaegertracing/jaeger/issues/5194
+        target: 94.44%
     patch:
       default:
         enabled: yes

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,9 +21,9 @@ coverage:
     project:
       default:
         enabled: yes
-        # Temporarily lower threshold below 95% 
+        # Temporarily lower threshold below 95%
         # Tacked in https://github.com/jaegertracing/jaeger/issues/5194
-        target: 94.44%
+        target: 94.4%
     patch:
       default:
         enabled: yes

--- a/plugin/storage/grpc/shared/grpc_handler_test.go
+++ b/plugin/storage/grpc/shared/grpc_handler_test.go
@@ -91,8 +91,10 @@ func withGRPCServer(fn func(r *grpcServerTest)) {
 		streamWriter:  streamWriter,
 	}
 
+	handler := NewGRPCHandlerWithPlugins(impl, impl, impl)
+	defer handler.Close(context.Background(), &storage_v1.CloseWriterRequest{})
 	r := &grpcServerTest{
-		server: NewGRPCHandlerWithPlugins(impl, impl, impl),
+		server: handler,
 		impl:   impl,
 	}
 	fn(r)


### PR DESCRIPTION
## Which problem is this PR solving?
- As mentioned in #5194, our coverage dropped below 95%. Until it's fixed we cannot "merge on green" any PRs that are not violating coverage restrictions, including dependabot PRs.

## Description of the changes
- Temporarily lower codecov threshold to 94.4% (the current level is 94.43%), until the above issue is fixed.
