### PR TITLE
[jaeger-v2] Add support for artificial jaeger storage receiver

### DIFF
--- a/cmd/jaeger/integration/receivers/storagereceiver/README.md
+++ b/cmd/jaeger/integration/receivers/storagereceiver/README.md
@@ -9,7 +9,7 @@
 
 The following settings are required:
 
-- `trace_storage` (no default): Jaeger's storage extension name
+- `trace_storage` (no default): name of a storage backend defined in `jaegerstorage` extension
 
 The following settings can be optionally configured:
 

--- a/cmd/jaeger/integration/receivers/storagereceiver/README.md
+++ b/cmd/jaeger/integration/receivers/storagereceiver/README.md
@@ -1,4 +1,23 @@
+# Storage Receiver
+
 `storagereceiver` is a fake receiver that creates an artificial stream of traces by:
 
 - repeatedly querying one of Jaeger storage backends for all traces (by service).
 - tracking new traces / spans and passing them to the next component in the pipeline.
+
+# Getting Started
+
+The following settings are required:
+
+- `trace_storage` (no default): Jaeger's storage extension name
+
+The following settings can be optionally configured:
+
+- `pull_interval` (default = 0s): The delay between each iteration of pulling traces.
+
+```yaml
+receivers:
+  jaeger_storage_receiver:
+    trace_storage: external-storage
+    pull_interval: 0s
+```

--- a/cmd/jaeger/integration/receivers/storagereceiver/README.md
+++ b/cmd/jaeger/integration/receivers/storagereceiver/README.md
@@ -1,0 +1,4 @@
+`storagereceiver` is a fake receiver that creates an artificial stream of traces by:
+
+- repeatedly querying one of Jaeger storage backends for all traces (by service).
+- tracking new traces / spans and passing them to the next component in the pipeline.

--- a/cmd/jaeger/integration/receivers/storagereceiver/config.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/config.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagereceiver
+
+import (
+	"github.com/asaskevich/govalidator"
+)
+
+type Config struct {
+	TraceStorage string `valid:"required" mapstructure:"trace_storage"`
+}
+
+func (cfg *Config) Validate() error {
+	_, err := govalidator.ValidateStruct(cfg)
+	return err
+}

--- a/cmd/jaeger/integration/receivers/storagereceiver/config.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/config.go
@@ -4,11 +4,14 @@
 package storagereceiver
 
 import (
+	"time"
+
 	"github.com/asaskevich/govalidator"
 )
 
 type Config struct {
-	TraceStorage string `valid:"required" mapstructure:"trace_storage"`
+	TraceStorage string        `valid:"required" mapstructure:"trace_storage"`
+	PullInterval time.Duration `mapstructure:"pull_interval"`
 }
 
 func (cfg *Config) Validate() error {

--- a/cmd/jaeger/integration/receivers/storagereceiver/config_test.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/config_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagereceiver
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	t.Parallel()
+
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		id          component.ID
+		expected    component.Config
+		expectedErr error
+	}{
+		{
+			id:          component.NewIDWithName(componentType, ""),
+			expectedErr: errors.New("non zero value required"),
+		},
+		{
+			id: component.NewIDWithName(componentType, "external-storage"),
+			expected: &Config{
+				TraceStorage: "external-storage",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, component.UnmarshalConfig(sub, cfg))
+
+			if tt.expectedErr != nil {
+				require.ErrorContains(t, component.ValidateConfig(cfg), tt.expectedErr.Error())
+			} else {
+				require.NoError(t, component.ValidateConfig(cfg))
+				assert.Equal(t, tt.expected, cfg)
+			}
+		})
+	}
+}

--- a/cmd/jaeger/integration/receivers/storagereceiver/config_test.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/config_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,9 +31,17 @@ func TestLoadConfig(t *testing.T) {
 			expectedErr: errors.New("non zero value required"),
 		},
 		{
-			id: component.NewIDWithName(componentType, "external-storage"),
+			id: component.NewIDWithName(componentType, "defaults"),
 			expected: &Config{
-				TraceStorage: "external-storage",
+				TraceStorage: "storage",
+				PullInterval: 0,
+			},
+		},
+		{
+			id: component.NewIDWithName(componentType, "filled"),
+			expected: &Config{
+				TraceStorage: "storage",
+				PullInterval: 2 * time.Second,
 			},
 		},
 	}

--- a/cmd/jaeger/integration/receivers/storagereceiver/factory.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/factory.go
@@ -29,5 +29,5 @@ func createDefaultConfig() component.Config {
 func createTracesReceiver(ctx context.Context, set receiver.CreateSettings, config component.Config, nextConsumer consumer.Traces) (receiver.Traces, error) {
 	cfg := config.(*Config)
 
-	return newReceiver(cfg, set.TelemetrySettings, nextConsumer)
+	return newTracesReceiver(cfg, set, nextConsumer)
 }

--- a/cmd/jaeger/integration/receivers/storagereceiver/factory.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/factory.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagereceiver
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+// componentType is the name of this extension in configuration.
+const componentType = component.Type("jaeger_storage_receiver")
+
+func NewFactory() receiver.Factory {
+	return receiver.NewFactory(
+		componentType,
+		createDefaultConfig,
+		receiver.WithTraces(createTracesReceiver, component.StabilityLevelDevelopment),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{}
+}
+
+func createTracesReceiver(ctx context.Context, set receiver.CreateSettings, config component.Config, nextConsumer consumer.Traces) (receiver.Traces, error) {
+	cfg := config.(*Config)
+
+	return newReceiver(cfg, set.TelemetrySettings, nextConsumer)
+}

--- a/cmd/jaeger/integration/receivers/storagereceiver/factory_test.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/factory_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagereceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	require.NotNil(t, cfg, "failed to create default config")
+	require.NoError(t, componenttest.CheckConfigStruct(cfg))
+}
+
+func TestCreateTracesReceiver(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	f := NewFactory()
+	r, err := f.CreateTracesReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, r)
+}

--- a/cmd/jaeger/integration/receivers/storagereceiver/package_test.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/package_test.go
@@ -1,16 +1,5 @@
 // Copyright (c) 2024 The Jaeger Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package storagereceiver
 

--- a/cmd/jaeger/integration/receivers/storagereceiver/package_test.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/package_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagereceiver
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagereceiver
+
+import (
+	"context"
+	"fmt"
+
+	jaeger2otlp "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage"
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+type storageReceiver struct {
+	cancelConsumeLoop context.CancelFunc
+	config            *Config
+	logger            *zap.Logger
+	consumedTraces    map[model.TraceID]*consumedTrace
+	nextConsumer      consumer.Traces
+	spanReader        spanstore.Reader
+}
+
+type consumedTrace struct {
+	spanIDs map[model.SpanID]struct{}
+}
+
+func newReceiver(config *Config, otel component.TelemetrySettings, nextConsumer consumer.Traces) (*storageReceiver, error) {
+	return &storageReceiver{
+		config:         config,
+		logger:         otel.Logger,
+		consumedTraces: make(map[model.TraceID]*consumedTrace),
+		nextConsumer:   nextConsumer,
+	}, nil
+}
+
+func (r *storageReceiver) Start(_ context.Context, host component.Host) error {
+	f, err := jaegerstorage.GetStorageFactory(r.config.TraceStorage, host)
+	if err != nil {
+		return fmt.Errorf("cannot find storage factory: %w", err)
+	}
+
+	if r.spanReader, err = f.CreateSpanReader(); err != nil {
+		return fmt.Errorf("cannot create span reader: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancelConsumeLoop = cancel
+
+	go func() {
+		if err := r.consumeLoop(ctx); err != nil {
+			host.ReportFatalError(err)
+		}
+	}()
+
+	return nil
+}
+
+func (r *storageReceiver) consumeLoop(ctx context.Context) error {
+	for {
+		services, err := r.spanReader.GetServices(ctx)
+		if err != nil {
+			r.logger.Error("Failed to get services from consumer", zap.Error(err))
+			return err
+		}
+
+		for _, svc := range services {
+			if err := r.consumeTraces(ctx, svc); err != nil {
+				r.logger.Error("Failed to consume traces from consumer", zap.Error(err))
+			}
+			if ctx.Err() != nil {
+				r.logger.Error("Consumer stopped", zap.Error(ctx.Err()))
+				return ctx.Err()
+			}
+		}
+	}
+}
+
+func (r *storageReceiver) consumeTraces(ctx context.Context, serviceName string) error {
+	traces, err := r.spanReader.FindTraces(ctx, &spanstore.TraceQueryParameters{
+		ServiceName: serviceName,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, trace := range traces {
+		traceID := trace.Spans[0].TraceID
+		if _, ok := r.consumedTraces[traceID]; !ok {
+			r.consumedTraces[traceID] = &consumedTrace{
+				spanIDs: make(map[model.SpanID]struct{}),
+			}
+		}
+		if len(trace.Spans) > len(r.consumedTraces[traceID].spanIDs) {
+			r.consumeSpans(ctx, r.consumedTraces[traceID], trace.Spans)
+		}
+	}
+
+	return nil
+}
+
+func (r *storageReceiver) consumeSpans(ctx context.Context, tc *consumedTrace, spans []*model.Span) error {
+	// Spans are consumed one at a time because we don't know whether all spans
+	// in a trace have been completely exported
+	for _, span := range spans {
+		if _, ok := tc.spanIDs[span.SpanID]; !ok {
+			tc.spanIDs[span.SpanID] = struct{}{}
+			td, err := jaeger2otlp.ProtoToTraces([]*model.Batch{
+				{
+					Spans:   []*model.Span{span},
+					Process: span.Process,
+				},
+			})
+			if err != nil {
+				return err
+			}
+			r.nextConsumer.ConsumeTraces(ctx, td)
+		}
+	}
+
+	return nil
+}
+
+func (r *storageReceiver) Shutdown(_ context.Context) error {
+	r.cancelConsumeLoop()
+	return nil
+}

--- a/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
@@ -132,6 +132,8 @@ func (r *storageReceiver) consumeSpans(ctx context.Context, tc *consumedTrace, s
 }
 
 func (r *storageReceiver) Shutdown(_ context.Context) error {
-	r.cancelConsumeLoop()
+	if r.cancelConsumeLoop != nil {
+		r.cancelConsumeLoop()
+	}
 	return nil
 }

--- a/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
@@ -102,9 +102,7 @@ func (r *storageReceiver) consumeTraces(ctx context.Context, serviceName string)
 				spanIDs: make(map[model.SpanID]struct{}),
 			}
 		}
-		if len(trace.Spans) > len(r.consumedTraces[traceID].spanIDs) {
-			r.consumeSpans(ctx, r.consumedTraces[traceID], trace.Spans)
-		}
+		r.consumeSpans(ctx, r.consumedTraces[traceID], trace.Spans)
 	}
 
 	return nil

--- a/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/receiver.go
@@ -6,6 +6,7 @@ package storagereceiver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	jaeger2otlp "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 	"go.opentelemetry.io/collector/component"
@@ -80,6 +81,8 @@ func (r *storageReceiver) consumeLoop(ctx context.Context) error {
 			r.settings.Logger.Error("Consumer stopped", zap.Error(ctx.Err()))
 			return ctx.Err()
 		}
+
+		time.Sleep(r.config.PullInterval)
 	}
 }
 

--- a/cmd/jaeger/integration/receivers/storagereceiver/receiver_test.go
+++ b/cmd/jaeger/integration/receivers/storagereceiver/receiver_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package storagereceiver
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	jaeger2otlp "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"google.golang.org/grpc"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage"
+	"github.com/jaegertracing/jaeger/model"
+	grpcCfg "github.com/jaegertracing/jaeger/plugin/storage/grpc/config"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+	"github.com/jaegertracing/jaeger/storage/spanstore/mocks"
+)
+
+type storageHost struct {
+	t                *testing.T
+	storageExtension component.Component
+}
+
+func (host storageHost) GetExtensions() map[component.ID]component.Component {
+	myMap := make(map[component.ID]component.Component)
+	myMap[jaegerstorage.ID] = host.storageExtension
+	return myMap
+}
+
+func (host storageHost) ReportFatalError(err error) {
+	host.t.Fatal(err)
+}
+
+func (storageHost) GetFactory(_ component.Kind, _ component.Type) component.Factory {
+	return nil
+}
+
+func (storageHost) GetExporters() map[component.DataType]map[component.ID]component.Component {
+	return nil
+}
+
+var (
+	services = []string{"example-service-1", "example-service-2"}
+	spans    = []*model.Span{
+		{
+			TraceID: model.NewTraceID(0, 1),
+			SpanID:  model.NewSpanID(1),
+			Process: &model.Process{
+				ServiceName: services[0],
+			},
+		},
+		{
+			TraceID: model.NewTraceID(0, 1),
+			SpanID:  model.NewSpanID(2),
+			Process: &model.Process{
+				ServiceName: services[0],
+			},
+		},
+		{
+			TraceID: model.NewTraceID(0, 2),
+			SpanID:  model.NewSpanID(3),
+			Process: &model.Process{
+				ServiceName: services[1],
+			},
+		},
+		{
+			TraceID: model.NewTraceID(0, 2),
+			SpanID:  model.NewSpanID(4),
+			Process: &model.Process{
+				ServiceName: services[1],
+			},
+		},
+	}
+)
+
+func TestReceiverNoStorageError(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.TraceStorage = "foo"
+
+	r, err := newTracesReceiver(
+		cfg,
+		receivertest.NewNopCreateSettings(),
+		consumertest.NewNop(),
+	)
+	require.NoError(t, err)
+
+	err = r.Start(context.Background(), componenttest.NewNopHost())
+	require.ErrorContains(t, err, "cannot find storage factory")
+}
+
+func TestReceiverStart(t *testing.T) {
+	ctx := context.Background()
+	host := newStorageHost(t, "external-storage")
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.TraceStorage = "external-storage"
+
+	r, err := newTracesReceiver(
+		cfg,
+		receivertest.NewNopCreateSettings(),
+		consumertest.NewNop(),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Start(ctx, host))
+	require.NoError(t, r.Shutdown(ctx))
+}
+
+func TestReceiverStartConsume(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.TraceStorage = "external-storage"
+
+	r, _ := newTracesReceiver(cfg, receivertest.NewNopCreateSettings(), sink)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	r.cancelConsumeLoop = cancelFunc
+
+	tests := []struct {
+		name           string
+		services       []string
+		traces         []*model.Trace
+		tracesErr      error
+		expectedTraces []*model.Trace
+	}{
+		{
+			name: "empty service",
+		},
+		{
+			name:      "find traces error",
+			services:  []string{"example-service"},
+			tracesErr: errors.New("failed to find traces"),
+		},
+		{
+			name:     "consume first trace",
+			services: []string{services[0]},
+			traces: []*model.Trace{
+				{Spans: []*model.Span{spans[0]}},
+			},
+			expectedTraces: []*model.Trace{
+				{Spans: []*model.Span{spans[0]}},
+			},
+		},
+		{
+			name:     "consume second trace",
+			services: services,
+			traces: []*model.Trace{
+				{Spans: []*model.Span{spans[0]}},
+				{Spans: []*model.Span{spans[2], spans[3]}},
+			},
+			expectedTraces: []*model.Trace{
+				{Spans: []*model.Span{spans[0]}},
+				{Spans: []*model.Span{spans[2]}},
+				{Spans: []*model.Span{spans[3]}},
+			},
+		},
+		{
+			name:     "re-consume first trace with new spans",
+			services: services,
+			traces: []*model.Trace{
+				{Spans: []*model.Span{spans[0], spans[1]}},
+				{Spans: []*model.Span{spans[2], spans[3]}},
+			},
+			expectedTraces: []*model.Trace{
+				{Spans: []*model.Span{spans[0]}},
+				{Spans: []*model.Span{spans[2]}},
+				{Spans: []*model.Span{spans[3]}},
+				// span at index 1 is consumed last
+				{Spans: []*model.Span{spans[1]}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := new(mocks.Reader)
+			reader.On("GetServices", mock.AnythingOfType("*context.cancelCtx")).Return(test.services, nil)
+			for _, service := range test.services {
+				reader.On(
+					"FindTraces",
+					mock.AnythingOfType("*context.cancelCtx"),
+					&spanstore.TraceQueryParameters{ServiceName: service},
+				).Return(test.traces, test.tracesErr)
+			}
+			r.spanReader = reader
+
+			require.NoError(t, r.Shutdown(ctx))
+			err := r.consumeLoop(ctx)
+			require.EqualError(t, err, context.Canceled.Error())
+
+			expectedTraces := make([]ptrace.Traces, 0)
+			for _, trace := range test.expectedTraces {
+				td, err := jaeger2otlp.ProtoToTraces([]*model.Batch{
+					{
+						Spans:   []*model.Span{trace.Spans[0]},
+						Process: trace.Spans[0].Process,
+					},
+				})
+				require.NoError(t, err)
+				expectedTraces = append(expectedTraces, td)
+			}
+			actualTraces := sink.AllTraces()
+			assert.Equal(t, expectedTraces, actualTraces)
+		})
+	}
+}
+
+func newStorageHost(t *testing.T, traceStorage string) *storageHost {
+	ctx := context.Background()
+
+	lis, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "failed to listen")
+
+	s := grpc.NewServer()
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+	t.Cleanup(s.Stop)
+
+	f := jaegerstorage.NewFactory()
+	cfg := &jaegerstorage.Config{
+		GRPC: map[string]grpcCfg.Configuration{
+			traceStorage: {
+				RemoteServerAddr:     lis.Addr().String(),
+				RemoteConnectTimeout: 1 * time.Second,
+			},
+		},
+	}
+	set := extension.CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+		BuildInfo:         component.NewDefaultBuildInfo(),
+	}
+	ext, err := f.CreateExtension(ctx, set, cfg)
+	require.NoError(t, err)
+
+	host := &storageHost{
+		t:                t,
+		storageExtension: ext,
+	}
+
+	err = host.storageExtension.Start(ctx, host)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, ext.Shutdown(ctx))
+	})
+	return host
+}

--- a/cmd/jaeger/integration/receivers/storagereceiver/testdata/config.yaml
+++ b/cmd/jaeger/integration/receivers/storagereceiver/testdata/config.yaml
@@ -1,3 +1,6 @@
 jaeger_storage_receiver:
-jaeger_storage_receiver/external-storage:
-  trace_storage: external-storage
+jaeger_storage_receiver/defaults:
+  trace_storage: storage
+jaeger_storage_receiver/filled:
+  trace_storage: storage
+  pull_interval: 2s

--- a/cmd/jaeger/integration/receivers/storagereceiver/testdata/config.yaml
+++ b/cmd/jaeger/integration/receivers/storagereceiver/testdata/config.yaml
@@ -1,0 +1,3 @@
+jaeger_storage_receiver:
+jaeger_storage_receiver/external-storage:
+  trace_storage: external-storage

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/mostynb/go-grpc-compression v1.2.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.95.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.95.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.95.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.95.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.95.0
 	go.opentelemetry.io/collector/config/configretry v0.95.0
 	go.opentelemetry.io/collector/config/configtls v0.95.0
+	go.opentelemetry.io/collector/confmap v0.95.0
 	go.opentelemetry.io/collector/connector v0.95.0
 	go.opentelemetry.io/collector/connector/forwardconnector v0.95.0
 	go.opentelemetry.io/collector/consumer v0.95.0
@@ -193,7 +194,6 @@ require (
 	go.opentelemetry.io/collector/config/configopaque v1.2.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.95.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.95.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.95.0 // indirect
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.95.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/envprovider v0.95.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.95.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsc
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.95.0/go.mod h1:JA4OR3ejNiVrG1L+HsLXekHGkU4LHeD7ebXMe0zZSxA=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.95.0 h1:wekNbHuqsHao7v0/6w0ty8wv6uBcTmPliiUzKcSfMc4=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.95.0/go.mod h1:7d0BqjL7V6jiKJHw2Z5mt5K8Da5q4xIgInTlmvzgQ5w=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.95.0 h1:kAKp9f7twLmxEnHnDteXeeuXn7+xhECQHaW2X0vhTOs=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.95.0/go.mod h1:+XVL5+bnrakE7W+zNPsUUaIsf6GiC6P/I14MBzxRXz0=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.95.0 h1:KZp0nW49QOTfUwYWRc7Hfuz2jlOxvDI/tjnfcLXmDAU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.95.0/go.mod h1:Tr3WvLJcvvWd0Ci8W7zpUHBQ0ORwRRhK7WCe32XVzeU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.95.0 h1:rvP/CsLCRB4YhwUonXBepCFKD1JmvJx15u6q9uohx/s=


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #4843
- Separate Jaeger storage receiver PR from and will be used by jaeger-v2 Kafka PR #4971

## Description of the changes
- Implement Jaeger storage receiver to be used by Jaeger-v2 Kafka integration test.

## How was this change tested?
- Added some unit tests.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
