### PR TITLE
modified:  reader getting operations by spanKind

### DIFF
--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -302,7 +302,7 @@ func (s *SpanReader) GetOperations(
 	defer span.End()
 	currentTime := time.Now()
 	jaegerIndices := s.timeRangeIndices(s.serviceIndexPrefix, s.serviceIndexDateLayout, currentTime.Add(-s.maxSpanAge), currentTime, s.serviceIndexRolloverFrequency)
-	operations, err := s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query.ServiceName, s.maxDocCount)
+	operations, err := s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query, s.maxDocCount)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,8 @@ func (s *SpanReader) GetOperations(
 	var result []spanstore.Operation
 	for _, operation := range operations {
 		result = append(result, spanstore.Operation{
-			Name: operation,
+			Name:     operation,
+			SpanKind: query.SpanKind,
 		})
 	}
 	return result, err


### PR DESCRIPTION
## Which problem is this PR solving?
https://github.com/jaegertracing/jaeger/issues/1923#issuecomment-1962833079

## Description of the changes
- updated service_operation.go for retrieving operations based on the spanKind (if mentioned returns based on spanKind otherwise returns all operations) 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
