### PR TITLE
add-keys_test.go

### DIFF
--- a/.lh/internal/metricstest/keys_test.go.json
+++ b/.lh/internal/metricstest/keys_test.go.json
@@ -3,11 +3,15 @@
     "activeCommit": 0,
     "commits": [
         {
-            "activePatchIndex": 0,
+            "activePatchIndex": 1,
             "patches": [
                 {
                     "date": 1709648601451,
                     "content": "Index: \n===================================================================\n--- \n+++ \n"
+                },
+                {
+                    "date": 1709650531003,
+                    "content": "Index: \n===================================================================\n--- \n+++ \n@@ -4,36 +4,36 @@\n \t\"testing\"\n )\n \n func TestGetKey(t *testing.T) {\n-\t// Test case 1: Basic case with a single tag\n+\t// Case 1: Basic case with a single tag\n \tname := \"metricName\"\n \ttags := map[string]string{\"tag1\": \"value1\"}\n \texpected := \"metricName|tag1=value1\"\n \tresult := GetKey(name, tags, \"|\", \"=\")\n \tif result != expected {\n \t\tt.Errorf(\"Test case 1 failed. Expected: %s, Got: %s\", expected, result)\n \t}\n \n-\t// Test case 2: Multiple tags with sorting\n+\t// Case 2: Multiple tags with sorting\n \tname = \"metricName\"\n \ttags = map[string]string{\"tag2\": \"value2\", \"tag1\": \"value1\"}\n \texpected = \"metricName|tag1=value1|tag2=value2\"\n \tresult = GetKey(name, tags, \"|\", \"=\")\n \tif result != expected {\n \t\tt.Errorf(\"Test case 2 failed. Expected: %s, Got: %s\", expected, result)\n \t}\n \n-\t// Test case 3: Case with no tags\n+\t// Case 3: Case with no tags\n \tname = \"metricName\"\n \ttags = map[string]string{}\n \texpected = \"metricName\"\n \tresult = GetKey(name, tags, \"|\", \"=\")\n \tif result != expected {\n \t\tt.Errorf(\"Test case 3 failed. Expected: %s, Got: %s\", expected, result)\n \t}\n \n-\t// Test case 4: Case with multiple tags and special characters\n+\t// Case 4: Case with multiple tags and special characters\n \tname = \"metricName\"\n \ttags = map[string]string{\"tag2\": \"value 2\", \"tag1\": \"value!@#1\"}\n \texpected = \"metricName|tag1=value!@#1|tag2=value 2\"\n \tresult = GetKey(name, tags, \"|\", \"=\")\n"
                 }
             ],
             "date": 1709648601451,

--- a/.lh/internal/metricstest/keys_test.go.json
+++ b/.lh/internal/metricstest/keys_test.go.json
@@ -1,0 +1,18 @@
+{
+    "sourceFile": "internal/metricstest/keys_test.go",
+    "activeCommit": 0,
+    "commits": [
+        {
+            "activePatchIndex": 0,
+            "patches": [
+                {
+                    "date": 1709648601451,
+                    "content": "Index: \n===================================================================\n--- \n+++ \n"
+                }
+            ],
+            "date": 1709648601451,
+            "name": "Commit-0",
+            "content": "package metricstest\n\nimport (\n\t\"testing\"\n)\n\nfunc TestGetKey(t *testing.T) {\n\t// Test case 1: Basic case with a single tag\n\tname := \"metricName\"\n\ttags := map[string]string{\"tag1\": \"value1\"}\n\texpected := \"metricName|tag1=value1\"\n\tresult := GetKey(name, tags, \"|\", \"=\")\n\tif result != expected {\n\t\tt.Errorf(\"Test case 1 failed. Expected: %s, Got: %s\", expected, result)\n\t}\n\n\t// Test case 2: Multiple tags with sorting\n\tname = \"metricName\"\n\ttags = map[string]string{\"tag2\": \"value2\", \"tag1\": \"value1\"}\n\texpected = \"metricName|tag1=value1|tag2=value2\"\n\tresult = GetKey(name, tags, \"|\", \"=\")\n\tif result != expected {\n\t\tt.Errorf(\"Test case 2 failed. Expected: %s, Got: %s\", expected, result)\n\t}\n\n\t// Test case 3: Case with no tags\n\tname = \"metricName\"\n\ttags = map[string]string{}\n\texpected = \"metricName\"\n\tresult = GetKey(name, tags, \"|\", \"=\")\n\tif result != expected {\n\t\tt.Errorf(\"Test case 3 failed. Expected: %s, Got: %s\", expected, result)\n\t}\n\n\t// Test case 4: Case with multiple tags and special characters\n\tname = \"metricName\"\n\ttags = map[string]string{\"tag2\": \"value 2\", \"tag1\": \"value!@#1\"}\n\texpected = \"metricName|tag1=value!@#1|tag2=value 2\"\n\tresult = GetKey(name, tags, \"|\", \"=\")\n\tif result != expected {\n\t\tt.Errorf(\"Test case 4 failed. Expected: %s, Got: %s\", expected, result)\n\t}\n}\n"
+        }
+    ]
+}

--- a/internal/metricstest/keys_test.go
+++ b/internal/metricstest/keys_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetKey(t *testing.T) {
-	// Test case 1: Basic case with a single tag
+	// Case 1: Basic case with a single tag
 	name := "metricName"
 	tags := map[string]string{"tag1": "value1"}
 	expected := "metricName|tag1=value1"
@@ -14,7 +14,7 @@ func TestGetKey(t *testing.T) {
 		t.Errorf("Test case 1 failed. Expected: %s, Got: %s", expected, result)
 	}
 
-	// Test case 2: Multiple tags with sorting
+	// Case 2: Multiple tags with sorting
 	name = "metricName"
 	tags = map[string]string{"tag2": "value2", "tag1": "value1"}
 	expected = "metricName|tag1=value1|tag2=value2"
@@ -23,7 +23,7 @@ func TestGetKey(t *testing.T) {
 		t.Errorf("Test case 2 failed. Expected: %s, Got: %s", expected, result)
 	}
 
-	// Test case 3: Case with no tags
+	// Case 3: Case with no tags
 	name = "metricName"
 	tags = map[string]string{}
 	expected = "metricName"
@@ -32,7 +32,7 @@ func TestGetKey(t *testing.T) {
 		t.Errorf("Test case 3 failed. Expected: %s, Got: %s", expected, result)
 	}
 
-	// Test case 4: Case with multiple tags and special characters
+	// Case 4: Case with multiple tags and special characters
 	name = "metricName"
 	tags = map[string]string{"tag2": "value 2", "tag1": "value!@#1"}
 	expected = "metricName|tag1=value!@#1|tag2=value 2"

--- a/internal/metricstest/keys_test.go
+++ b/internal/metricstest/keys_test.go
@@ -1,0 +1,43 @@
+package metricstest
+
+import (
+	"testing"
+)
+
+func TestGetKey(t *testing.T) {
+	// Test case 1: Basic case with a single tag
+	name := "metricName"
+	tags := map[string]string{"tag1": "value1"}
+	expected := "metricName|tag1=value1"
+	result := GetKey(name, tags, "|", "=")
+	if result != expected {
+		t.Errorf("Test case 1 failed. Expected: %s, Got: %s", expected, result)
+	}
+
+	// Test case 2: Multiple tags with sorting
+	name = "metricName"
+	tags = map[string]string{"tag2": "value2", "tag1": "value1"}
+	expected = "metricName|tag1=value1|tag2=value2"
+	result = GetKey(name, tags, "|", "=")
+	if result != expected {
+		t.Errorf("Test case 2 failed. Expected: %s, Got: %s", expected, result)
+	}
+
+	// Test case 3: Case with no tags
+	name = "metricName"
+	tags = map[string]string{}
+	expected = "metricName"
+	result = GetKey(name, tags, "|", "=")
+	if result != expected {
+		t.Errorf("Test case 3 failed. Expected: %s, Got: %s", expected, result)
+	}
+
+	// Test case 4: Case with multiple tags and special characters
+	name = "metricName"
+	tags = map[string]string{"tag2": "value 2", "tag1": "value!@#1"}
+	expected = "metricName|tag1=value!@#1|tag2=value 2"
+	result = GetKey(name, tags, "|", "=")
+	if result != expected {
+		t.Errorf("Test case 4 failed. Expected: %s, Got: %s", expected, result)
+	}
+}


### PR DESCRIPTION


## Which problem is this PR solving?

Resolves ：https://github.com/jaegertracing/jaeger/pull/5129

## Description of the changes
- Added 4 new unit tests in internal/metricstest/keys_test.go covering various scenarios for the GetKey function. These include:

1. A basic case with a single tag.
2. Multiple tags with sorting.
3. A case with no tags.
4. Multiple tags and special characters.


## How was this change tested?
- Testing:
The new tests have been executed locally, and all passed successfully. Here's the output for reference:

```
=== RUN   TestGetKey
--- PASS: TestGetKey (0.00s)
PASS
ok      command-line-arguments  0.281s
```


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`



Thank you for considering my pull request.

Best regards,

@take0420