### PR TITLE
Fix goroutine leaks in cmd/remote-storage/app

### DIFF
--- a/cmd/remote-storage/app/package_test.go
+++ b/cmd/remote-storage/app/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/remote-storage/app/package_test.go
+++ b/cmd/remote-storage/app/package_test.go
@@ -1,0 +1,11 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -397,8 +397,21 @@ func TestServerHandlesPortZero(t *testing.T) {
 		flagsSvc.Logger,
 	)
 	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	once := sync.Once{}
+
+	go func() {
+		for s := range server.HealthCheckStatus() {
+			flagsSvc.HC().Set(s)
+			if s == healthcheck.Unavailable {
+				once.Do(wg.Done)
+			}
+		}
+	}()
+
 	require.NoError(t, server.Start())
-	defer server.Close()
 
 	const line = "Starting GRPC server"
 	message := logs.FilterMessage(line)
@@ -407,6 +420,11 @@ func TestServerHandlesPortZero(t *testing.T) {
 	onlyEntry := message.All()[0]
 	hostPort := onlyEntry.ContextMap()["addr"].(string)
 	validateGRPCServer(t, hostPort, server.grpcServer)
+
+	server.Close()
+	wg.Wait()
+
+	assert.Equal(t, healthcheck.Unavailable, flagsSvc.HC().Get())
 }
 
 func validateGRPCServer(t *testing.T, hostPort string, server *grpc.Server) {

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -322,6 +322,8 @@ func TestServerGRPCTLS(t *testing.T) {
 				GRPCHostPort: ":0",
 				TLSGRPC:      test.TLS,
 			}
+			defer serverOptions.TLSGRPC.Close()
+			defer test.clientTLS.Close()
 			flagsSvc := flags.NewService(ports.QueryAdminHTTP)
 			flagsSvc.Logger = zap.NewNop()
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of [5006](https://github.com/jaegertracing/jaeger/issues/5006)

## Description of the changes
- Identified two tests `TestServerGRPCTLS` and `TestServerHandlesPortZero` which are failing and causing goroutine leaks

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
