### PR TITLE
Prepare v1.55.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,19 +25,19 @@ run `make changelog` to generate content
 -------------------
 #### ✨ New Features:
 
-* Support uploading traces to ui in opentelemetry format (otlp json) ([@NavinShrinivas](https://github.com/NavinShrinivas) in [#5155](https://github.com/jaegertracing/jaeger/pull/5155))
+* Support uploading traces to UI in OpenTelemetry format (OTLP/JSON) ([@NavinShrinivas](https://github.com/NavinShrinivas) in [#5155](https://github.com/jaegertracing/jaeger/pull/5155))
+* Add Elasticsearch storage support for adaptive sampling ([@Pushkarm029](https://github.com/Pushkarm029) in [#5158](https://github.com/jaegertracing/jaeger/pull/5158))
 
 #### 🐞 Bug fixes, Minor Improvements:
 
-* Add the print-config subcommand ([@gmafrac](https://github.com/gmafrac) in [#5200](https://github.com/jaegertracing/jaeger/pull/5200))
-* Return more detailed errors from es storage ([@yurishkuro](https://github.com/yurishkuro) in [#5209](https://github.com/jaegertracing/jaeger/pull/5209))
+* Add the `print-config` subcommand ([@gmafrac](https://github.com/gmafrac) in [#5200](https://github.com/jaegertracing/jaeger/pull/5200))
+* Return more detailed errors from ES storage ([@yurishkuro](https://github.com/yurishkuro) in [#5209](https://github.com/jaegertracing/jaeger/pull/5209))
 * Bump go version ([@yurishkuro](https://github.com/yurishkuro) in [#5180](https://github.com/jaegertracing/jaeger/pull/5180))
 
 #### 🚧 Experimental Features:
 
-* [jaeger-v2] add support for grpc storarge ([@james-ryans](https://github.com/james-ryans) in [#5228](https://github.com/jaegertracing/jaeger/pull/5228))
-* Add elasticsearch storage support for adaptive sampling ([@Pushkarm029](https://github.com/Pushkarm029) in [#5158](https://github.com/jaegertracing/jaeger/pull/5158))
-* [jaeger-v2] add support for elasticsearch ([@akagami-harsh](https://github.com/akagami-harsh) in [#5152](https://github.com/jaegertracing/jaeger/pull/5152))
+* [jaeger-v2] Add support for gRPC storarge ([@james-ryans](https://github.com/james-ryans) in [#5228](https://github.com/jaegertracing/jaeger/pull/5228))
+* [jaeger-v2] Add support for Elasticsearch ([@akagami-harsh](https://github.com/akagami-harsh) in [#5152](https://github.com/jaegertracing/jaeger/pull/5152))
 
 ### UI Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,29 @@ run `make changelog` to generate content
 
 </details>
 
+1.55.0 (2024-03-04)
+-------------------
+#### ✨ New Features:
+
+* Support uploading traces to ui in opentelemetry format (otlp json) ([@NavinShrinivas](https://github.com/NavinShrinivas) in [#5155](https://github.com/jaegertracing/jaeger/pull/5155))
+
+#### 🐞 Bug fixes, Minor Improvements:
+
+* Add the print-config subcommand ([@gmafrac](https://github.com/gmafrac) in [#5200](https://github.com/jaegertracing/jaeger/pull/5200))
+* Return more detailed errors from es storage ([@yurishkuro](https://github.com/yurishkuro) in [#5209](https://github.com/jaegertracing/jaeger/pull/5209))
+* Bump go version ([@yurishkuro](https://github.com/yurishkuro) in [#5180](https://github.com/jaegertracing/jaeger/pull/5180))
+
+#### 🚧 Experimental Features:
+
+* [jaeger-v2] add support for grpc storarge ([@james-ryans](https://github.com/james-ryans) in [#5228](https://github.com/jaegertracing/jaeger/pull/5228))
+* Add elasticsearch storage support for adaptive sampling ([@Pushkarm029](https://github.com/Pushkarm029) in [#5158](https://github.com/jaegertracing/jaeger/pull/5158))
+* [jaeger-v2] add support for elasticsearch ([@akagami-harsh](https://github.com/akagami-harsh) in [#5152](https://github.com/jaegertracing/jaeger/pull/5152))
+
+### UI Changes
+
+* UI pinned to version [1.39.0](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#v1390-2024-03-04).
+
+
 1.54.0 (2024-02-06)
 -------------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,13 @@
         git fetch
         git checkout {new_version} //e.g. v1.5.0
         ```
+or:
+        ```
+        git submodule init
+        cd jaeger-ui
+        git checkout main
+        git pull
+        ```
       * If there are no changes, indicate this with "No changes" ([example](https://github.com/jaegertracing/jaeger/pull/4131/files)).
     * Rotate the below release managers table placing yourself at the bottom. The date should be the first Wednesday of the month.
 2. After the PR is merged, create a release on Github:
@@ -53,8 +60,8 @@ Here are the release managers for future versions with the tentative release dat
 
 | Version | Release Manager | Tentative release date |
 |---------|-----------------|------------------------|
-| 1.55.0  | @jkowall        | 6 March 2024           |
 | 1.56.0  | @yurishkuro     | 3 April 2024           |
 | 1.57.0  | @albertteoh     | 1 May 2024             |
 | 1.58.0  | @pavolloffay    | 5 June 2024            |
 | 1.59.0  | @joe-elliott    | 3 July 2024            |
+| 1.55.0  | @jkowall        | 7 August 2024          |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,17 +7,12 @@
     * The section can be split into sub-section if necessary, e.g. UI Changes, Backend Changes, Bug Fixes, etc.
     * If the jaeger-ui submodule has changes cut a new release and also upgrade the submodule versions then commit, for example:
         ```
-        cd jaeger-ui
-        git ls-remote --tags origin
-        git fetch
-        git checkout {new_version} //e.g. v1.5.0
-        ```
-or:
-        ```
         git submodule init
+        git submodule update
         cd jaeger-ui
         git checkout main
         git pull
+        git checkout {new_version} //e.g. v1.5.0
         ```
       * If there are no changes, indicate this with "No changes" ([example](https://github.com/jaegertracing/jaeger/pull/4131/files)).
     * Rotate the below release managers table placing yourself at the bottom. The date should be the first Wednesday of the month.


### PR DESCRIPTION
Prepares Jaeger for release 1.55.0.

Includes jaeger-ui submodule updates.

I can add more updates for the RELEASE.md if needed based on the Slack discussion. Thank you.