### PR TITLE
Enhance release-notes script to add missing parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### A message to people of Russia 🇷🇺
+### 🇷🇺 A message to people of Russia
 
 If you currently live in Russia, please read [this message](./_To_People_of_Russia.md).
 
@@ -15,7 +15,7 @@ next release (yyyy-mm-dd)
 
 run `make changelog` to generate content
 
-### UI Changes
+### 📊 UI Changes
 
 ...
 
@@ -23,6 +23,8 @@ run `make changelog` to generate content
 
 1.55.0 (2024-03-04)
 -------------------
+### Backend Changes
+
 #### ✨ New Features:
 
 * Support uploading traces to UI in OpenTelemetry format (OTLP/JSON) ([@NavinShrinivas](https://github.com/NavinShrinivas) in [#5155](https://github.com/jaegertracing/jaeger/pull/5155))
@@ -39,7 +41,7 @@ run `make changelog` to generate content
 * [jaeger-v2] Add support for gRPC storarge ([@james-ryans](https://github.com/james-ryans) in [#5228](https://github.com/jaegertracing/jaeger/pull/5228))
 * [jaeger-v2] Add support for Elasticsearch ([@akagami-harsh](https://github.com/akagami-harsh) in [#5152](https://github.com/jaegertracing/jaeger/pull/5152))
 
-### UI Changes
+### 📊 UI Changes
 
 * UI pinned to version [1.39.0](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#v1390-2024-03-04).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,11 @@
        * Title "Release X.Y.Z"
        * Tag `vX.Y.Z` (note the `v` prefix) and choose appropriate branch
        * Copy the new CHANGELOG.md section into the release notes
+       * Extra: GitHub has a button "generate release notes". Those are not formatted as we want,
+         but it has a nice feature of explicitly listing first-time contributors.
+         Before doing the previous step, you can click that button and then remove everything
+         except the New Contributors section. Change the header to `### 👏 New Contributors`,
+         then copy the main changelog above it. [Example](https://github.com/jaegertracing/jaeger/releases/tag/v1.55.0).
 3. The release tag will trigger a build of the docker images. Since forks don't have jaegertracingbot dockerhub token, they can never publish images to jaegertracing organisation.
    1. Check the images are available on [Docker Hub](https://hub.docker.com/r/jaegertracing/).
    2. For monitoring and troubleshooting, refer to the [jaegertracing/jaeger GithubActions tab](https://github.com/jaegertracing/jaeger/actions).

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -156,12 +156,19 @@ def main(token, repo, num_commits, exclude_dependabot):
 
     # Print categorized pull requests
     print()
+    print('### Backend Changes')
+    print()
     for category, results in category_results.items():
         if results and category:
-            print(f'{category}:\n')
+            print(f'{category}\n')
             for result in results:
                 print(result)
             print()
+
+    print()
+    print('### 📊 UI Changes')
+    print()
+    print('* UI pinned to version [x.y.z](https://github.com/jaegertracing/jaeger-ui/blob/main/CHANGELOG.md#---ANCHOR---).')
 
     # Print pull requests in the 'UNCATTEGORIZED' category
     if other_results:
@@ -180,7 +187,7 @@ def main(token, repo, num_commits, exclude_dependabot):
         print()
 
     if skipped_dependabot:
-        print(f"(Skipped {skipped_dependabot} dependabot commit{'' if skipped_dependabot == 1 else 's'})")
+        print(f"(Skipped dependabot commits: {skipped_dependabot})")
 
 
 def get_pull_request_labels(token, repo, pull_number):


### PR DESCRIPTION
The script was only generating level-4 headers. Changed it to generate the complete changelog, including the UI placeholder. Tweak release instructions.