### PR TITLE
[bug-kafka-consumer] set the passedin rackid in consumer config

### DIFF
--- a/cmd/ingester/app/builder/builder.go
+++ b/cmd/ingester/app/builder/builder.go
@@ -58,6 +58,7 @@ func CreateConsumer(logger *zap.Logger, metricsFactory metrics.Factory, spanWrit
 		ClientID:             options.ClientID,
 		ProtocolVersion:      options.ProtocolVersion,
 		AuthenticationConfig: options.AuthenticationConfig,
+		RackID:               options.RackID,
 	}
 	saramaConsumer, err := consumerConfig.NewConsumer(logger)
 	if err != nil {

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -78,11 +78,10 @@ func (p *Options) Config(logger *zap.Logger) (*tls.Config, error) {
 		}
 	}
 
-	// #nosec G402
 	tlsCfg := &tls.Config{
 		RootCAs:            certPool,
 		ServerName:         p.ServerName,
-		InsecureSkipVerify: p.SkipHostVerify,
+		InsecureSkipVerify: p.SkipHostVerify, /* #nosec G402*/
 		CipherSuites:       cipherSuiteIds,
 		MinVersion:         minVersionId,
 		MaxVersion:         maxVersionId,

--- a/storage/spanstore/downsampling_writer_test.go
+++ b/storage/spanstore/downsampling_writer_test.go
@@ -70,6 +70,7 @@ func TestDownSamplingWriter_hashBytes(t *testing.T) {
 	}
 	c := NewDownsamplingWriter(&noopWriteSpanStore{}, downsamplingOptions)
 	h := c.sampler.hasherPool.Get().(*hasher)
+	//nolint:testifylint
 	assert.Equal(t, h.hashBytes(), h.hashBytes())
 	c.sampler.hasherPool.Put(h)
 	trace := model.TraceID{
@@ -81,6 +82,7 @@ func TestDownSamplingWriter_hashBytes(t *testing.T) {
 	}
 	_, _ = span.TraceID.MarshalTo(h.buffer)
 	// Same traceID should always be hashed to same uint64 in DownSamplingWriter.
+	//nolint:testifylint
 	assert.Equal(t, h.hashBytes(), h.hashBytes())
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
RackID option was exposed in this PR but it was not properly parsed from passed flags and set in on Sarama client

## Description of the changes
- configures Parsed RackID on ConsumerConfig

## How was this change tested?
- Tested by printing the config passed to sarama client

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
