### PR TITLE
[jaeger-v2] Add Elasticsearch storage backend integration test

### DIFF
--- a/cmd/jaeger/internal/integration/elasticsearch_test.go
+++ b/cmd/jaeger/internal/integration/elasticsearch_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"testing"
+)
+
+func TestElasticsearchStorage(t *testing.T) {
+	s := &StorageIntegration{
+		Name:       "elasticsearch",
+		ConfigFile: "fixtures/elasticsearch_config.yaml",
+	}
+	s.Test(t)
+}

--- a/cmd/jaeger/internal/integration/fixtures/elasticsearch_config.yaml
+++ b/cmd/jaeger/internal/integration/fixtures/elasticsearch_config.yaml
@@ -1,0 +1,25 @@
+service:
+  extensions: [jaeger_storage]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [jaeger_storage_exporter]
+
+extensions:
+  jaeger_storage:
+    elasticsearch:
+      es_main:
+        server_urls: http://localhost:9200
+        log_level: "error"
+        index_prefix: "jaeger-main"
+        use_aliases: true
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: es_main


### PR DESCRIPTION
## Which problem is this PR solving?
- part of #4843

## Description of the changes
- added integration test for elasticsearch
- not modified the workflow's yet. once tests works i'll modify them too.

## How was this change tested?
- run integration test script 
- ``` export STORAGE=elasticsearch```
- ```./scripts/es-integration-test.sh elasticsearch 8.12.0 v2```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
