### PR TITLE
Replaced the deprecated logging exporter to debug exporter

### DIFF
--- a/cmd/jaeger/internal/components.go
+++ b/cmd/jaeger/internal/components.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/connector/forwardconnector"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/loggingexporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
@@ -80,7 +80,7 @@ func (b builders) build() (otelcol.Factories, error) {
 
 	factories.Exporters, err = b.exporter(
 		// standard
-		loggingexporter.NewFactory(),
+		debugexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
 		// add-ons

--- a/cmd/jaeger/internal/components.go
+++ b/cmd/jaeger/internal/components.go
@@ -80,7 +80,6 @@ func (b builders) build() (otelcol.Factories, error) {
 
 	factories.Exporters, err = b.exporter(
 		// standard
-		// loggingexporter.NewFactory(), // deprecated, replaced with debugexporter
 		debugexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),

--- a/cmd/jaeger/internal/components.go
+++ b/cmd/jaeger/internal/components.go
@@ -80,6 +80,7 @@ func (b builders) build() (otelcol.Factories, error) {
 
 	factories.Exporters, err = b.exporter(
 		// standard
+		// loggingexporter.NewFactory(), // deprecated, replaced with debugexporter
 		debugexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -212,11 +212,11 @@ require (
 	go.opentelemetry.io/collector/config/internal v0.96.0 // indirect
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.0 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.0 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.0
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.0 // indirect
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.0 // indirect
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.0
 	go.opentelemetry.io/collector/extension/auth v0.96.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	go.opentelemetry.io/collector/connector/forwardconnector v0.96.0
 	go.opentelemetry.io/collector/consumer v0.96.0
 	go.opentelemetry.io/collector/exporter v0.96.0
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.96.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.0
 	go.opentelemetry.io/collector/extension v0.96.0

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,6 @@ go.opentelemetry.io/collector/exporter v0.96.0 h1:SmOSaP+zUNq0nl+BcllsCSsYePdUNI
 go.opentelemetry.io/collector/exporter v0.96.0/go.mod h1:DcuGaxcINhOV2LgojDI56r3830cUtuCsNadINMIU23c=
 go.opentelemetry.io/collector/exporter/debugexporter v0.96.0 h1:88v2GWCIuYgd3e4KdwF0JLklIgBzETBw0e3dkEJ7BbI=
 go.opentelemetry.io/collector/exporter/debugexporter v0.96.0/go.mod h1:mZjJ0G6Pn6aSS7T4UeEjXSHt3pgslvaZa/4Uam8DKuo=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.96.0 h1:fKHt4iTcD7C0utDzeww6ZYVlDYaC0dw9wtzVwLha4CM=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.96.0/go.mod h1:vpuKdiIQ6yjwZbKiiAs/MV8rZMKiQfPF55vX8UxO8fk=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.96.0 h1:vZEd10B/zj7WkBWSVegDkGOwv7FZhUwyk60E2zkYwL4=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.96.0/go.mod h1:tzJFwn1fR88rdGKkpvygMawu2Prc53bFhuKFk3EnpS8=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.0 h1:c7pBEGYxlsnPPfs4ECIr2E+mEh25OTV+v20tv3pCIyU=


### PR DESCRIPTION
Hi, it's my first very basic PR.

I removed `loggingexporter` since it's deprecated and replaced it with the `debugexporter`.