### PR TITLE
Use math.MaxUint64 instead of 0xffffffffffffffff

### DIFF
--- a/model/adjuster/span_id_deduper.go
+++ b/model/adjuster/span_id_deduper.go
@@ -17,6 +17,7 @@ package adjuster
 
 import (
 	"errors"
+	"math"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -42,7 +43,7 @@ const (
 	warningTooManySpans = "cannot assign unique span ID, too many spans in the trace"
 )
 
-var maxSpanID = model.NewSpanID(0xffffffffffffffff)
+var maxSpanID = model.NewSpanID(math.MaxUint64)
 
 type spanIDDeduper struct {
 	trace     *model.Trace


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?

- Use the variables included in the go standard library to make the code clearer

## Description of the changes
- Math MaxUint64 is a constant currently defined in the go standard library and can be used directly without having to define it repeatedly

## How was this change tested?
- no need

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
