### PR TITLE
Fix goroutine leaks in cmd/query/app

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -95,6 +95,11 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("could not start jaeger-query: %w", err)
 	}
 
+	go func() {
+		for range s.server.HealthCheckStatus() {
+		}
+	}()
+
 	return nil
 }
 

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -986,12 +986,14 @@ func TestSearchTenancyRejectionHTTP(t *testing.T) {
 	// We don't set tenant header
 	resp, err := httpClient.Do(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 	tm := tenancy.NewManager(&tenancyOptions)
 	req.Header.Set(tm.Header, "acme")
 	resp, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	// Skip unmarshal of response; it is enough that it succeeded
 }

--- a/cmd/query/app/package_test.go
+++ b/cmd/query/app/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -366,5 +366,11 @@ func (s *Server) Close() error {
 		s.cmuxServer.Close()
 		errs = append(errs, s.conn.Close())
 	}
+	if s.httpConn != nil {
+		errs = append(errs, s.httpConn.Close())
+	}
+	if s.grpcConn != nil {
+		errs = append(errs, s.grpcConn.Close())
+	}
 	return errors.Join(errs...)
 }

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -186,7 +186,6 @@ func createHTTPServer(
 	}).RegisterRoutes(r)
 
 	apiHandler.RegisterRoutes(r)
-	staticHandlerCloser := RegisterStaticHandler(r, logger, queryOpts, querySvc.GetCapabilities())
 	var handler http.Handler = r
 	handler = additionalHeadersHandler(handler, queryOpts.AdditionalHeaders)
 	if queryOpts.BearerTokenPropagation {
@@ -202,18 +201,19 @@ func createHTTPServer(
 			ErrorLog:          errorLog,
 			ReadHeaderTimeout: 2 * time.Second,
 		},
-		staticHandlerCloser: staticHandlerCloser,
 	}
 
 	if queryOpts.TLSHTTP.Enabled {
 		tlsCfg, err := queryOpts.TLSHTTP.Config(logger) // This checks if the certificates are correctly provided
 		if err != nil {
-			staticHandlerCloser.Close()
 			return nil, err
 		}
 		server.TLSConfig = tlsCfg
 
 	}
+
+	server.staticHandlerCloser = RegisterStaticHandler(r, logger, queryOpts, querySvc.GetCapabilities())
+
 	return server, nil
 }
 

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -345,13 +345,6 @@ func (s *Server) Close() error {
 	errs = append(errs, s.httpServer.Close())
 	if !s.separatePorts {
 		s.cmuxServer.Close()
-		errs = append(errs, s.conn.Close())
-	}
-	if s.httpConn != nil {
-		errs = append(errs, s.httpConn.Close())
-	}
-	if s.grpcConn != nil {
-		errs = append(errs, s.grpcConn.Close())
 	}
 	return errors.Join(errs...)
 }

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -370,6 +370,8 @@ func TestServerHTTPTLS(t *testing.T) {
 				var err0 error
 
 				clientTLSCfg, err0 = test.clientTLS.Config(zap.NewNop())
+				defer test.clientTLS.Close()
+
 				require.NoError(t, err0)
 				dialer := &net.Dialer{Timeout: 2 * time.Second}
 				conn, err1 := tls.DialWithDialer(dialer, "tcp", "localhost:"+fmt.Sprintf("%d", ports.QueryHTTP), clientTLSCfg)
@@ -529,6 +531,7 @@ func TestServerGRPCTLS(t *testing.T) {
 			if serverOptions.TLSGRPC.Enabled {
 				clientTLSCfg, err0 := test.clientTLS.Config(zap.NewNop())
 				require.NoError(t, err0)
+				defer test.clientTLS.Close()
 				creds := credentials.NewTLS(clientTLSCfg)
 				client = newGRPCClientWithTLS(t, ports.PortToHostPort(ports.QueryGRPC), creds)
 

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -620,13 +620,6 @@ func TestServerInUseHostPort(t *testing.T) {
 			err = server.Start()
 			require.Error(t, err)
 
-			if server.grpcConn != nil {
-				server.grpcConn.Close()
-			}
-			if server.httpConn != nil {
-				server.httpConn.Close()
-			}
-
 			server.Close()
 		})
 	}

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -623,6 +623,8 @@ func TestServerInUseHostPort(t *testing.T) {
 			if server.httpConn != nil {
 				server.httpConn.Close()
 			}
+
+			server.Close()
 		})
 	}
 }

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -46,7 +46,7 @@ var (
 )
 
 // RegisterStaticHandler adds handler for static assets to the router.
-func RegisterStaticHandler(r *mux.Router, logger *zap.Logger, qOpts *QueryOptions, qCapabilities querysvc.StorageCapabilities) {
+func RegisterStaticHandler(r *mux.Router, logger *zap.Logger, qOpts *QueryOptions, qCapabilities querysvc.StorageCapabilities) io.Closer {
 	staticHandler, err := NewStaticAssetsHandler(qOpts.StaticAssets.Path, StaticAssetsHandlerOptions{
 		BasePath:            qOpts.BasePath,
 		UIConfigPath:        qOpts.UIConfig,
@@ -59,6 +59,8 @@ func RegisterStaticHandler(r *mux.Router, logger *zap.Logger, qOpts *QueryOption
 	}
 
 	staticHandler.RegisterRoutes(r)
+
+	return staticHandler
 }
 
 // StaticAssetsHandler handles static assets
@@ -236,4 +238,11 @@ func (sH *StaticAssetsHandler) RegisterRoutes(router *mux.Router) {
 func (sH *StaticAssetsHandler) notFound(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write(sH.indexHTML.Load().([]byte))
+}
+
+func (sH *StaticAssetsHandler) Close() error {
+	if sH.watcher != nil {
+		return sH.watcher.Close()
+	}
+	return nil
 }

--- a/cmd/query/app/static_handler.go
+++ b/cmd/query/app/static_handler.go
@@ -241,8 +241,5 @@ func (sH *StaticAssetsHandler) notFound(w http.ResponseWriter, r *http.Request) 
 }
 
 func (sH *StaticAssetsHandler) Close() error {
-	if sH.watcher != nil {
-		return sH.watcher.Close()
-	}
-	return nil
+	return sH.watcher.Close()
 }

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -87,6 +87,7 @@ func runQueryService(t *testing.T, esURL string) *Server {
 	// set AllowTokenFromContext manually because we don't register the respective CLI flag from query svc
 	f.Options.Primary.AllowTokenFromContext = true
 	require.NoError(t, f.Initialize(metrics.NullFactory, flagsSvc.Logger))
+	defer f.Close()
 
 	spanReader, err := f.CreateSpanReader()
 	require.NoError(t, err)

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -137,6 +137,7 @@ func TestBearerTokenPropagation(t *testing.T) {
 			resp, err := client.Do(req)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
+			defer resp.Body.Close()
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		})

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/olivere/elastic"
@@ -30,6 +31,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
@@ -122,10 +124,23 @@ func TestBearerTokenPropagation(t *testing.T) {
 	t.Logf("mock ES server started on %s", esSrv.URL)
 
 	querySrv := runQueryService(t, esSrv.URL)
-	defer querySrv.Close()
 	queryAddr := querySrv.httpConn.Addr().String()
 	// Will try to load service names, this should return 200.
 	url := fmt.Sprintf("http://%s/api/services", queryAddr)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	once := sync.Once{}
+
+	go func() {
+		for s := range querySrv.HealthCheckStatus() {
+			if s == healthcheck.Unavailable {
+				once.Do(func() {
+					wg.Done()
+				})
+			}
+		}
+	}()
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -142,4 +157,7 @@ func TestBearerTokenPropagation(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		})
 	}
+
+	querySrv.Close()
+	wg.Wait()
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Solves part of https://github.com/jaegertracing/jaeger/issues/5006

## Description of the changes
- There were a number of causes of goroutine leaks, so I took the approach of addressing these in the initial commits, and then introducing the actual `testutils.VerifyGoLeaks` call in the final commit
- See the individual commit messages for more details on each change
- Note that this change involved making some changes to the public function signatures of packages under `cmd`, which would technically be a breaking change if there are any external packages importing this as a library (raised in https://github.com/jaegertracing/jaeger/issues/5006#issuecomment-2016490940).

## How was this change tested?
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
