### PR TITLE
Call testutils.VerifyGoLeaks in cmd/internal/printconfig tests

### DIFF
--- a/cmd/internal/printconfig/command_test.go
+++ b/cmd/internal/printconfig/command_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 const (
@@ -125,4 +126,8 @@ func TestPrintConfigCommand(t *testing.T) {
 	v := setConfig(t)
 	actual := runPrintConfigCommand(v, t, false)
 	assert.Equal(t, expected, actual)
+}
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Solves part of https://github.com/jaegertracing/jaeger/issues/5006

## Description of the changes
- There doesn't seem to be goroutine leaks in this package, so there's no reason for it to be excluded

## How was this change tested?
- `go test ./cmd/internal/printconfig`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
