### PR TITLE
Fix false positive goleak test

### DIFF
--- a/pkg/cassandra/gocql/testutils/udt_test.go
+++ b/pkg/cassandra/gocql/testutils/udt_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gocql/gocql"
 
-	"github.com/jaegertracing/jaeger/pkg/cassandra/gocql/testutils"
-	goleakTestutils "github.com/jaegertracing/jaeger/pkg/testutils"
+	gocqlutils "github.com/jaegertracing/jaeger/pkg/cassandra/gocql/testutils"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 // CustomUDT is a custom type that implements gocql.UDTMarshaler and gocql.UDTUnmarshaler interfaces.
@@ -49,7 +49,7 @@ func TestUDTTestCase(t *testing.T) {
 	}
 
 	// Define UDT fields for testing
-	udtFields := []testutils.UDTField{
+	udtFields := []gocqlutils.UDTField{
 		{
 			Name:  "Field1",
 			Type:  gocql.TypeBigInt,
@@ -71,7 +71,7 @@ func TestUDTTestCase(t *testing.T) {
 	}
 
 	// Create a UDTTestCase
-	testCase := testutils.UDTTestCase{
+	testCase := gocqlutils.UDTTestCase{
 		Obj:     udtInstance,
 		ObjName: "CustomUDT",
 		New:     func() gocql.UDTUnmarshaler { return &CustomUDT{} },
@@ -82,5 +82,5 @@ func TestUDTTestCase(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	goleakTestutils.VerifyGoLeaks(m)
+	testutils.VerifyGoLeaks(m)
 }

--- a/pkg/testutils/leakcheck_test.go
+++ b/pkg/testutils/leakcheck_test.go
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testutils
+package testutils_test
 
 import (
 	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 func TestVerifyGoLeaksOnce(t *testing.T) {
-	defer VerifyGoLeaksOnce(t)
+	defer testutils.VerifyGoLeaksOnce(t)
 }
 
 func TestMain(m *testing.M) {
-	VerifyGoLeaks(m)
+	testutils.VerifyGoLeaks(m)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- The testutils package itself was being flagged as missing goleak check. The check was there, but without the package name, and the lint script was flagging it as false positive.
- Similar issue in `pkg/cassandra/gocql/testutils`
- Part of #5006

## Description of the changes
1. Change package name of the test file so that the functions can be called with the usual package package name `testutils`.
2. change competing `testutils` import labels to satisfy the linter

## How was this change tested?
- `make goleak` no longer shows this package
