### PR TITLE
[storage integration tests] Remove Refresh

### DIFF
--- a/cmd/jaeger/internal/integration/grpc_test.go
+++ b/cmd/jaeger/internal/integration/grpc_test.go
@@ -21,7 +21,6 @@ func (s *GRPCStorageIntegration) initialize(t *testing.T) {
 
 	s.remoteStorage = integration.StartNewRemoteMemoryStorage(t, logger)
 
-	s.Refresh = func(_ *testing.T) {}
 	s.CleanUp = s.cleanUp
 }
 

--- a/plugin/storage/integration/badgerstore_test.go
+++ b/plugin/storage/integration/badgerstore_test.go
@@ -46,7 +46,6 @@ func (s *BadgerIntegrationStorage) initialize(t *testing.T) {
 	s.SamplingStore, err = s.factory.CreateSamplingStore(0)
 	require.NoError(t, err)
 
-	s.Refresh = func(_ *testing.T) {}
 	s.CleanUp = s.cleanUp
 
 	s.logger, _ = testutils.NewLogger()

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -42,7 +42,6 @@ func newCassandraStorageIntegration() *CassandraStorageIntegration {
 			GetDependenciesReturnsSource: true,
 			SkipArchiveTest:              true,
 
-			Refresh: func(_ *testing.T) {},
 			SkipList: []string{
 				"Tags_+_Operation_name_+_Duration_range",
 				"Tags_+_Duration_range",

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -107,11 +107,11 @@ func (s *ESStorageIntegration) initializeES(t *testing.T, allTagsAsFields bool) 
 	s.CleanUp = func(t *testing.T) {
 		s.esCleanUp(t, allTagsAsFields)
 	}
-	s.Refresh = s.esRefresh
 	s.esCleanUp(t, allTagsAsFields)
-	// TODO: remove this flag after ES support returning spanKind when get operations
-	s.GetOperationsMissingSpanKind = true
 	s.SkipArchiveTest = false
+	// TODO: remove this flag after ES supports returning spanKind
+	//  Issue https://github.com/jaegertracing/jaeger/issues/1923
+	s.GetOperationsMissingSpanKind = true
 }
 
 func (s *ESStorageIntegration) esCleanUp(t *testing.T, allTagsAsFields bool) {
@@ -193,13 +193,6 @@ func (s *ESStorageIntegration) initSpanstore(t *testing.T, allTagsAsFields bool)
 	s.DependencyReader, err = f.CreateDependencyReader()
 	require.NoError(t, err)
 	s.DependencyWriter = s.DependencyReader.(dependencystore.Writer)
-}
-
-func (s *ESStorageIntegration) esRefresh(t *testing.T) {
-	err := s.bulkProcessor.Flush()
-	require.NoError(t, err)
-	_, err = s.client.Refresh().Do(context.Background())
-	require.NoError(t, err)
 }
 
 func healthCheck() error {

--- a/plugin/storage/integration/grpc_test.go
+++ b/plugin/storage/integration/grpc_test.go
@@ -70,7 +70,6 @@ func (s *GRPCStorageIntegrationTestSuite) initialize(t *testing.T) {
 
 	// TODO DependencyWriter is not implemented in grpc store
 
-	s.Refresh = func(_ *testing.T) {}
 	s.CleanUp = s.cleanUp
 }
 

--- a/plugin/storage/integration/kafka_test.go
+++ b/plugin/storage/integration/kafka_test.go
@@ -98,7 +98,6 @@ func (s *KafkaIntegrationTestSuite) initialize(t *testing.T) {
 
 	s.SpanWriter = spanWriter
 	s.SpanReader = &ingester{traceStore}
-	s.Refresh = func(_ *testing.T) {}
 	s.CleanUp = func(_ *testing.T) {}
 	s.SkipArchiveTest = true
 }

--- a/plugin/storage/integration/memstore_test.go
+++ b/plugin/storage/integration/memstore_test.go
@@ -42,7 +42,6 @@ func (s *MemStorageIntegrationTestSuite) initialize(_ *testing.T) {
 
 	// TODO DependencyWriter is not implemented in memory store
 
-	s.Refresh = func(t *testing.T) {}
 	s.CleanUp = s.initialize
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Refresh was only used by Elasticsearch tests, and required too many low-level clients to do correctly.
- Meanwhile, since all the tests are using waitForCondition checks, forcing a refresh isn't necessary, the test will simply wait for ES background indexing to finish

## Description of the changes
- Remove Refresh as a concept from integration tests

## How was this change tested?
- CI
