### PR TITLE
Fix the spelling of `remote` in log message

### DIFF
--- a/plugin/storage/grpc/options.go
+++ b/plugin/storage/grpc/options.go
@@ -77,7 +77,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) error {
 	opt.Configuration.RemoteConnectTimeout = v.GetDuration(remoteConnectionTimeout)
 	opt.Configuration.TenancyOpts = tenancy.InitFromViper(v)
 	if opt.Configuration.PluginBinary != "" {
-		log.Printf(deprecatedSidecar + "using sidecar model of grpc-plugin storage, please upgrade to 'reomte' gRPC storage. https://github.com/jaegertracing/jaeger/issues/4647")
+		log.Printf(deprecatedSidecar + "using sidecar model of grpc-plugin storage, please upgrade to 'remote' gRPC storage. https://github.com/jaegertracing/jaeger/issues/4647")
 	}
 	return nil
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes a misspelling of `remote` in a log message 

## Description of the changes
- Change `reomte` to `remote`

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
