### PR TITLE
Moving global write permissions down into the CI jobs

### DIFF
--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -10,6 +10,9 @@ on:
       - labeled
       - unlabeled
 
+permissions:  
+  contents: read
+
 jobs:
   check-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -8,13 +8,14 @@ on:
   workflow_dispatch:
 
 # See https://github.com/jaegertracing/jaeger/issues/4017
-# and https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 permissions:
-  deployments: write
-  contents: write
+  contents: read
 
 jobs:
   publish-release:
+    permissions:
+      contents: write
+      deployments: write
     if: github.repository == 'jaegertracing/jaeger'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
 
-# See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions:
   contents: read
-  checks: write
 
 jobs:
   unit-tests-go-tip:
+    permissions:
+      checks: write
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -11,13 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
   cancel-in-progress: true
 
-# See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions:
   contents: read
-  checks: write
 
 jobs:
   unit-tests:
+    permissions:
+      checks: write    
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner


### PR DESCRIPTION
This attempts to solve the following issue with our security rating around token permissions on the scorecard : https://securityscorecards.dev/viewer/?uri=github.com/jaegertracing/jaeger


![image](https://github.com/jaegertracing/jaeger/assets/1859948/512902d6-48b2-45b6-b971-a33af75dca70)

## Which problem is this PR solving?
Part of https://github.com/jaegertracing/jaeger/issues/5363

## Description of the changes
Moving write permissions into the jobs 

## How was this change tested?
It will be tested after the PR is submitted as the jobs do not fully run on my fork.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [NA] I have added unit tests for the new functionality
- [NA] I have run lint and test steps successfully
