### PR TITLE
Adding artifacthub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![OpenSSF Scorecard][openssf-img]][openssf]
 [![OpenSSF Best Practices][openssf-bp-img]][openssf-bp] 
 [![CLOMonitor][clomonitor-img]][clomonitor]
+[![Artifact Hub][artifacthub-img]][artifacthub]
 
 <img src="https://raw.githubusercontent.com/cncf/artwork/main/other/cncf-member/graduated/color/cncf-graduated-color.svg" width="250">
 
@@ -249,6 +250,9 @@ Copyright (c) The Jaeger Authors. [Apache 2.0 License](./LICENSE).
 [openssf-bp]: https://www.bestpractices.dev/projects/1273
 [clomonitor-img]: https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/jaeger/badge
 [clomonitor]: https://clomonitor.io/projects/cncf/jaeger
+[artifacthub-img]: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/jaegertracing
+[artifacthub]: https://artifacthub.io/packages/search?repo=jaegertracing
+
 
 [dapper]: https://research.google.com/pubs/pub36356.html
 [ubeross]: https://uber.github.io


### PR DESCRIPTION
## Which problem is this PR solving?
This adds the artifact hub badge for Jaeger, which will be official once the last PR is pushed from the helm chart repo.

https://github.com/jaegertracing/jaeger/issues/5363

## Description of the changes
Add new image on README.md

## How was this change tested?
Tested on Github branch

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [NA] I have added unit tests for the new functionality
- [NA] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
