### PR TITLE
[es] Remove unused indexCache

### DIFF
--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -424,19 +424,16 @@ func TestSpanWriterParamsTTL(t *testing.T) {
 	logger, _ := testutils.NewLogger()
 	metricsFactory := metricstest.NewFactory(0)
 	testCases := []struct {
-		indexTTL         time.Duration
 		serviceTTL       time.Duration
 		name             string
 		expectedAddCalls int
 	}{
 		{
-			indexTTL:         0,
 			serviceTTL:       0,
 			name:             "uses defaults",
 			expectedAddCalls: 1,
 		},
 		{
-			indexTTL:         1 * time.Nanosecond,
 			serviceTTL:       1 * time.Nanosecond,
 			name:             "uses provided values",
 			expectedAddCalls: 3,
@@ -451,7 +448,6 @@ func TestSpanWriterParamsTTL(t *testing.T) {
 				Logger:          logger,
 				MetricsFactory:  metricsFactory,
 				ServiceCacheTTL: test.serviceTTL,
-				IndexCacheTTL:   test.indexTTL,
 			}
 			w := NewSpanWriter(params)
 


### PR DESCRIPTION
## Which problem is this PR solving?
- The cache was initialized with incorrect parameter, and when I looked around it wasn't even used anywhere

## Description of the changes
- delete indexCache and indexCacheTTL argument

## How was this change tested?
```
$ go test ./plugin/storage/es/spanstore
ok      github.com/jaegertracing/jaeger/plugin/storage/es/spanstore     0.471s
```
