### PR TITLE
Add Purge method for cassandra

### DIFF
--- a/plugin/storage/cassandra/factory.go
+++ b/plugin/storage/cassandra/factory.go
@@ -16,6 +16,7 @@
 package cassandra
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"io"
@@ -250,4 +251,8 @@ func (f *Factory) Close() error {
 // PrimarySession is used from integration tests to clean database between tests
 func (f *Factory) PrimarySession() cassandra.Session {
 	return f.primarySession
+}
+
+func (f *Factory) Purge(_ context.Context) error {
+	return f.primarySession.Query("TRUNCATE traces").Exec()
 }

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -23,7 +23,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	dbsession "github.com/jaegertracing/jaeger/pkg/cassandra"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
@@ -32,8 +31,6 @@ import (
 
 type CassandraStorageIntegration struct {
 	StorageIntegration
-
-	session dbsession.Session
 	factory *cassandra.Factory
 }
 
@@ -78,7 +75,6 @@ func (s *CassandraStorageIntegration) initializeCassandra(t *testing.T) {
 		"--cassandra.keyspace=jaeger_v1_dc1",
 	})
 	s.factory = f
-	s.session = f.PrimarySession()
 	var err error
 	s.SpanWriter, err = f.CreateSpanWriter()
 	require.NoError(t, err)

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -16,6 +16,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,7 @@ type CassandraStorageIntegration struct {
 	StorageIntegration
 
 	session dbsession.Session
+	factory *cassandra.Factory
 }
 
 func newCassandraStorageIntegration() *CassandraStorageIntegration {
@@ -58,7 +60,7 @@ func newCassandraStorageIntegration() *CassandraStorageIntegration {
 }
 
 func (s *CassandraStorageIntegration) cleanUp(t *testing.T) {
-	require.NoError(t, s.session.Query("TRUNCATE traces").Exec())
+	require.NoError(t, s.factory.Purge(context.Background()))
 }
 
 func (s *CassandraStorageIntegration) initializeCassandraFactory(t *testing.T, flags []string) *cassandra.Factory {
@@ -75,6 +77,7 @@ func (s *CassandraStorageIntegration) initializeCassandra(t *testing.T) {
 	f := s.initializeCassandraFactory(t, []string{
 		"--cassandra.keyspace=jaeger_v1_dc1",
 	})
+	s.factory = f
 	s.session = f.PrimarySession()
 	var err error
 	s.SpanWriter, err = f.CreateSpanWriter()


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/pull/5398#discussion_r1589755830

## Description of the changes
- added purge for method for cassandra

## How was this change tested?
- via integration tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
