### PR TITLE
[bug] Fix syntax for invoking upload-codecov action

### DIFF
--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -49,5 +49,5 @@ jobs:
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:
-        file: cover.out
+        files: cover.out
         flags: cassandra-${{ matrix.version.major }}-${{ matrix.jaeger-version }}

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -42,5 +42,5 @@ jobs:
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:
-        file: cover.out
+        files: cover.out
         flags: unittests


### PR DESCRIPTION
## Which problem is this PR solving?
- Noticed the following logs, not sure how it worked (probably default matched the file name)
```
Unexpected input(s) 'file', valid inputs are ['files', 'flags']
```

## Description of the changes
- Change calls to this action to always specify `files` param

## How was this change tested?
- CI

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
