### PR TITLE
[v2] Change e2e jaeger-v2 binary log output to temp file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,8 @@ ignore:
   - "**/thrift-0.9.2/*"
   - "**/main.go"
   - "examples/hotrod"
+  - "plugin/storage/integration"
+  - "cmd/jaeger/internal/integration"
 
 coverage:
   precision: 2

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -95,6 +95,10 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 	t.Cleanup(func() {
 		require.NoError(t, cmd.Process.Kill())
 		if t.Failed() {
+			// A Github Actions special annotation to create a foldable section
+			// in the Github runner output.
+			// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+			fmt.Println("::group::Jaeger-v2 binary logs")
 			outLogs, err := os.ReadFile(outFile.Name())
 			require.NoError(t, err)
 			t.Logf("Jaeger-v2 output logs:\n%s", outLogs)
@@ -102,6 +106,8 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 			errLogs, err := os.ReadFile(errFile.Name())
 			require.NoError(t, err)
 			t.Logf("Jaeger-v2 error logs:\n%s", errLogs)
+			// End of Github Actions foldable section annotation.
+			fmt.Println("::endgroup::")
 		}
 	})
 

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -101,11 +101,11 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 			fmt.Println("::group::Jaeger-v2 binary logs")
 			outLogs, err := os.ReadFile(outFile.Name())
 			require.NoError(t, err)
-			t.Logf("Jaeger-v2 output logs:\n%s", outLogs)
+			fmt.Printf("Jaeger-v2 output logs:\n%s", outLogs)
 
 			errLogs, err := os.ReadFile(errFile.Name())
 			require.NoError(t, err)
-			t.Logf("Jaeger-v2 error logs:\n%s", errLogs)
+			fmt.Printf("Jaeger-v2 error logs:\n%s", errLogs)
 			// End of Github Actions foldable section annotation.
 			fmt.Println("::endgroup::")
 		}

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -93,6 +93,7 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 	}, 30*time.Second, 500*time.Millisecond, "Jaeger-v2 did not start")
 	t.Log("Jaeger-v2 is ready")
 	t.Cleanup(func() {
+		require.NoError(t, cmd.Process.Kill())
 		if t.Failed() {
 			outLogs, err := os.ReadFile(outFile.Name())
 			require.NoError(t, err)
@@ -102,7 +103,6 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 			require.NoError(t, err)
 			t.Logf("Jaeger-v2 error logs:\n%s", errLogs)
 		}
-		require.NoError(t, cmd.Process.Kill())
 	})
 
 	s.SpanWriter, err = createSpanWriter(logger, otlpPort)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5421

## Description of the changes
- Instead of throwing binary logs to the parent's output, it now writes the logs to a temp file and only outputs the logs if the test fails. This behavior is similar to the current v1 tests that run `docker logs` if failed.
- Here's the outcome if the test fails.
```
=== NAME  TestGRPCStorage
    e2e_integration.go:88: Jaeger-v2 logs:
        2024/05/08 00:41:25 application version: git-commit=, git-version=, build-date=
        2024-05-08T00:41:25.557+0700	info	service@v0.99.0/service.go:99	Setting up own telemetry...
        2024-05-08T00:41:25.557+0700	info	service@v0.99.0/telemetry.go:103	Serving metrics	{"address": ":8888", "level": "Normal"}
        2024-05-08T00:41:25.557+0700	info	exporter@v0.99.0/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "traces", "name": "jaeger_storage_exporter"}
        2024-05-08T00:41:25.557+0700	info	service@v0.99.0/service.go:166	Starting jaeger...	{"Version": "git-commit=, git-version=, build-date=", "NumCPU": 8}
        ...
        2024-05-08T00:41:28.151+0700	warn	app/grpc_handler.go:105	trace not found	{"kind": "extension", "name": "jaeger_query", "id": "0000000000000011", "error": "trace not found"}
        2024-05-08T00:41:29.159+0700	warn	app/grpc_handler.go:105	trace not found	{"kind": "extension", "name": "jaeger_query", "id": "0000000000000001", "error": "trace not found"}
        2024-05-08T00:42:20.300+0700	info	exporterhelper/retry_sender.go:118	Exporting failed. Will retry the request after interval.	{"kind": "exporter", "data_type": "traces", "name": "jaeger_storage_exporter", "error": "plugin error: rpc error: code = Unavailable desc = error reading from server: read tcp [::1]:60235->[::1]:17271: read: connection reset by peer", "interval": "4.858861617s"}
--- ❌ FAIL: TestGRPCStorage (71.93s)
    ...
    --- ✅ PASS: TestGRPCStorage/GetLargeSpans (50.57s)
    --- ❌ FAIL: TestGRPCStorage/FindTraces (17.11s)
        --- ✅ PASS: TestGRPCStorage/FindTraces/Tags_in_one_spot_-_Tags (0.02s)
        ...
        --- ❌ FAIL: TestGRPCStorage/FindTraces/Operation_name_+_max_Duration (5.13s)
        ...
        --- ✅ PASS: TestGRPCStorage/FindTraces/Multiple_Traces (0.02s)
❌ FAIL
coverage: 13.0% of statements in ./...
❌ FAIL	github.com/jaegertracing/jaeger/cmd/jaeger/internal/integration	72.620s
❌ FAIL
```

## How was this change tested?
- Run locally the `STORAGE=grpc SPAN_STORAGE_TYPE=memory make jaeger-v2-storage-integration-test` command with success and fail scenario. 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
