### PR TITLE
[v2] Dump storage docker logs in Github CI if e2e test failed

### DIFF
--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -44,7 +44,12 @@ jobs:
         go-version: 1.22.x
 
     - name: Run cassandra integration tests
+      id: test-execution
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.image }} ${{ matrix.version.schema }} ${{ matrix.jaeger-version }}
+
+    - name: Output Cassandra logs
+      run: docker logs ${{ steps.test-execution.outputs.cid }}
+      if: ${{ failure() }}
 
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -58,7 +58,12 @@ jobs:
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
     - name: Run elasticsearch integration tests
+      id: test-execution
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}
+
+    - name: Output Elasticsearch logs
+      run: docker logs ${{ steps.test-execution.outputs.cid }}
+      if: ${{ failure() }}
 
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -52,7 +52,12 @@ jobs:
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
     - name: Run opensearch integration tests
+      id: test-execution
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}
+
+    - name: Output Opensearch logs
+      run: docker logs ${{ steps.test-execution.outputs.cid }}
+      if: ${{ failure() }}
 
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -24,7 +24,7 @@ setup_cassandra() {
   )
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
-  echo "${cid}" >> "$GITHUB_OUTPUT"
+  echo "cid=${cid}" >> "$GITHUB_OUTPUT"
 }
 
 teardown_cassandra() {

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -18,14 +18,13 @@ setup_cassandra() {
   local tag=$1
   local image=cassandra
   local params=(
-    --rm
     --detach
     --publish 9042:9042
     --publish 9160:9160
   )
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
-  echo "${cid}"
+  echo "${cid}" >> "$GITHUB_OUTPUT"
 }
 
 teardown_cassandra() {

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -25,6 +25,7 @@ setup_cassandra() {
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
   echo "cid=${cid}" >> "$GITHUB_OUTPUT"
+  echo "${cid}"
 }
 
 teardown_cassandra() {

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -42,7 +42,7 @@ setup_es() {
 
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
-  echo "${cid}" >> "$GITHUB_OUTPUT"
+  echo "cid=${cid}" >> "$GITHUB_OUTPUT"
 }
 
 setup_opensearch() {
@@ -57,7 +57,7 @@ setup_opensearch() {
   )
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
-  echo "${cid}" >> "$GITHUB_OUTPUT"
+  echo "cid=${cid}" >> "$GITHUB_OUTPUT"
 }
 
 wait_for_storage() {

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -42,7 +42,7 @@ setup_es() {
 
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
-  echo "${cid}"
+  echo "${cid}" >> "$GITHUB_OUTPUT"
 }
 
 setup_opensearch() {
@@ -57,7 +57,7 @@ setup_opensearch() {
   )
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
-  echo "${cid}"
+  echo "${cid}" >> "$GITHUB_OUTPUT"
 }
 
 wait_for_storage() {

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -43,6 +43,7 @@ setup_es() {
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
   echo "cid=${cid}" >> "$GITHUB_OUTPUT"
+  echo "${cid}"
 }
 
 setup_opensearch() {
@@ -58,6 +59,7 @@ setup_opensearch() {
   local cid
   cid=$(docker run "${params[@]}" "${image}:${tag}")
   echo "cid=${cid}" >> "$GITHUB_OUTPUT"
+  echo "${cid}"
 }
 
 wait_for_storage() {


### PR DESCRIPTION
## Which problem is this PR solving?
- Helps debugging unstable e2e tests in #5418

## Description of the changes
- Add more visibility to CI workflows by dumping related storage docker logs if the tests failed.
- Made changes to Cassandra, Elasticsearch, and Opensearch.

## How was this change tested?
- Not tested, unable to test locally.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
