### PR TITLE
Stop running integration tests for Elasticsearch v5/v6

### DIFF
--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -21,12 +21,6 @@ jobs:
     strategy:
       matrix:
         version:
-        - major: 5.x
-          image: 5.6.16
-          distribution: elasticsearch
-        - major: 6.x
-          image: 6.8.18
-          distribution: elasticsearch
         - major: 7.x
           image: 7.14.0
           distribution: elasticsearch


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5439

## Description of the changes
- Stop running integration tests for Elasticsearch v5/v6

## How was this change tested?
- CI
