### PR TITLE
[v2] Replace e2e span_reader grpc.DialContext with NewClient

### DIFF
--- a/cmd/jaeger/internal/integration/span_reader.go
+++ b/cmd/jaeger/internal/integration/span_reader.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math"
 	"strings"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -39,10 +38,7 @@ func createSpanReader(port int) (*spanReader, error) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	cc, err := grpc.DialContext(ctx, ports.PortToHostPort(port), opts...)
+	cc, err := grpc.NewClient(ports.PortToHostPort(port), opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- gRPC Dial & DialContext is now deprecated and requires to be replaced with NewClient https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md#the-wrong-way-grpcdial

## Description of the changes
- Replaces grpc.DialContext with NewClient at `cmd/jaeger/internal/integration/span_reader.go`

## How was this change tested?
- Run `STORAGE=grpc SPAN_STORAGE_TYPE=memory make jaeger-v2-storage-integration-test` locally.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
