### PR TITLE
Remove elasticsearch v5/v6 from tests

### DIFF
--- a/cmd/esmapping-generator/app/renderer/render_test.go
+++ b/cmd/esmapping-generator/app/renderer/render_test.go
@@ -57,14 +57,6 @@ func Test_getMappingAsString(t *testing.T) {
 			want: "ES version 7",
 		},
 		{
-			name: "ES version 6", args: app.Options{Mapping: "jaeger-span", EsVersion: 6, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "false", ILMPolicyName: "jaeger-test-policy"},
-			want: "ES version 6",
-		},
-		{
-			name: "Parse Error version 6", args: app.Options{Mapping: "jaeger-span", EsVersion: 6, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "false", ILMPolicyName: "jaeger-test-policy"},
-			wantErr: errors.New("parse error"),
-		},
-		{
 			name: "Parse Error version 7", args: app.Options{Mapping: "jaeger-span", EsVersion: 7, Shards: 5, Replicas: 1, IndexPrefix: "test", UseILM: "true", ILMPolicyName: "jaeger-test-policy"},
 			wantErr: errors.New("parse error"),
 		},

--- a/plugin/storage/es/dependencystore/storage_test.go
+++ b/plugin/storage/es/dependencystore/storage_test.go
@@ -99,10 +99,6 @@ func TestWriteDependencies(t *testing.T) {
 	}{
 		{
 			expectedError: "",
-			esVersion:     6,
-		},
-		{
-			expectedError: "",
 			esVersion:     7,
 		},
 	}

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -201,7 +201,7 @@ func TestElasticsearchStorage_IndexTemplates(t *testing.T) {
 	esVersion, err := s.getVersion()
 	require.NoError(t, err)
 	// TODO abstract this into pkg/es/client.IndexManagementLifecycleAPI
-	if esVersion <= 7 {
+	if esVersion == 7 {
 		serviceTemplateExists, err := s.client.IndexTemplateExists(indexPrefix + "-jaeger-service").Do(context.Background())
 		require.NoError(t, err)
 		assert.True(t, serviceTemplateExists)

--- a/plugin/storage/integration/es_index_rollover_test.go
+++ b/plugin/storage/integration/es_index_rollover_test.go
@@ -33,11 +33,7 @@ func TestIndexRollover_FailIfILMNotPresent(t *testing.T) {
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")
 	client, err := createESClient()
 	require.NoError(t, err)
-	esVersion, err := getVersion(client)
 	require.NoError(t, err)
-	if esVersion < 7 {
-		t.Skip("Integration test - " + t.Name() + " against ElasticSearch skipped for ES version " + fmt.Sprint(esVersion))
-	}
 	// make sure ES is clean
 	cleanES(t, client, defaultILMPolicyName)
 	envVars := []string{"ES_USE_ILM=true"}
@@ -65,8 +61,6 @@ func TestIndexRollover_CreateIndicesWithILM(t *testing.T) {
 func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 	client, err := createESClient()
 	require.NoError(t, err)
-
-	esVersion, err := getVersion(client)
 	require.NoError(t, err)
 
 	envVars := []string{
@@ -77,27 +71,16 @@ func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 		envVars = append(envVars, "ES_ILM_POLICY_NAME="+ilmPolicyName)
 	}
 
-	if esVersion < 7 {
-		cleanES(t, client, "")
-		// Run the ES rollover test with adaptive sampling disabled (set to false).
-		err := runEsRollover("init", envVars, false)
-		require.EqualError(t, err, "exit status 1")
-		indices, err1 := client.IndexNames()
-		require.NoError(t, err1)
-		assert.Empty(t, indices)
-
-	} else {
-		expectedIndices := []string{"jaeger-span-000001", "jaeger-service-000001", "jaeger-dependencies-000001"}
-		t.Run("NoPrefix", func(t *testing.T) {
-			runIndexRolloverWithILMTest(t, client, "", expectedIndices, envVars, ilmPolicyName, false)
-		})
-		t.Run("WithPrefix", func(t *testing.T) {
-			runIndexRolloverWithILMTest(t, client, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, false)
-		})
-		t.Run("WithAdaptiveSampling", func(t *testing.T) {
-			runIndexRolloverWithILMTest(t, client, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, true)
-		})
-	}
+	expectedIndices := []string{"jaeger-span-000001", "jaeger-service-000001", "jaeger-dependencies-000001"}
+	t.Run("NoPrefix", func(t *testing.T) {
+		runIndexRolloverWithILMTest(t, client, "", expectedIndices, envVars, ilmPolicyName, false)
+	})
+	t.Run("WithPrefix", func(t *testing.T) {
+		runIndexRolloverWithILMTest(t, client, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, false)
+	})
+	t.Run("WithAdaptiveSampling", func(t *testing.T) {
+		runIndexRolloverWithILMTest(t, client, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, true)
+	})
 }
 
 func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, prefix string, expectedIndices, envVars []string, ilmPolicyName string, adaptiveSampling bool) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of  #5439 

## Description of the changes
- Removed instances of v5/v6 in the tests.

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
