### PR TITLE
Avoid git warnings on shallow checkout

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -14,7 +14,7 @@ concurrency:
 # See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
-  
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -30,11 +30,14 @@ jobs:
       with:
         go-version: 1.22.x
 
+    - name: Print Jaeger version
+      run: make echo-version
+
     - name: Install tools
       run: make install-test-tools
 
     - name: Lint
       run: make lint
-    
+
     - name: Ensure PR is not on main branch
       uses: ./.github/actions/block-pr-not-on-main


### PR DESCRIPTION
## Which problem is this PR solving?
Many of GH workflows are logging warnings like this:
```
Run make install-test-tools
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
```
This is because we typically do a shallow checkout of the repo without tags.

## Description of the changes
- Check for shallow checkout and don't run `git describe`

## How was this change tested?
- CI `lint`: no warnings logged when calling `make`
```
$ make echo-version
GIT_CLOSEST_TAG=0.0.0
```
