### PR TITLE
[v2] Remove retries and increase timeout for e2e tests

### DIFF
--- a/cmd/jaeger/internal/exporters/storageexporter/factory.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/factory.go
@@ -40,7 +40,7 @@ func createTracesExporter(ctx context.Context, set exporter.CreateSettings, conf
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// Disable Timeout/RetryOnFailure and SendingQueue
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
-		exporterhelper.WithRetry(configretry.NewDefaultBackOffConfig()),
+		exporterhelper.WithRetry(configretry.BackOffConfig{Enabled: false}),
 		exporterhelper.WithQueue(exporterhelper.QueueSettings{Enabled: false}),
 		exporterhelper.WithStart(ex.start),
 		exporterhelper.WithShutdown(ex.close),

--- a/cmd/jaeger/internal/integration/span_writer.go
+++ b/cmd/jaeger/internal/integration/span_writer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	jaeger2otlp "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -37,6 +38,8 @@ func createSpanWriter(logger *zap.Logger, port int) (*spanWriter, error) {
 	factory := otlpexporter.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*otlpexporter.Config)
 	cfg.Endpoint = fmt.Sprintf("localhost:%d", port)
+	cfg.Timeout = 30 * time.Second
+	cfg.RetryConfig.Enabled = false
 	cfg.QueueConfig.Enabled = false
 	cfg.TLSSetting = configtls.ClientConfig{
 		Insecure: true,


### PR DESCRIPTION
## Which problem is this PR solving?
- Retrying write spans doesn't solve the problem (even though it reduces the failure rates), CI tests are still failing.

## Description of the changes
- Instead of retrying the requests, we increase the timeout from 5s (default) to 30s

## How was this change tested?
- Run `STORAGE=grpc SPAN_STORAGE_TYPE=memory make jaeger-v2-storage-integration-test` in local.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
