### PR TITLE
Document the triage process

### DIFF
--- a/BUG-TRIAGE.md
+++ b/BUG-TRIAGE.md
@@ -1,0 +1,32 @@
+# Jaeger Bug Triage
+
+This procedure describes the steps project maintainers and approvers should take to triage a bug report.
+
+Bugs should be created using the [Bug Report](https://github.com/jaegertracing/jaeger/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml&title=%5BBug%5D%3A+) issue template.
+This template automatically applies the `bug` and `triage` labels.
+
+## Gather Required Information
+
+The first step is to ensure the bug report is unique and complete.
+If the bug report is not unique, leave a comment with a link to the existing bug and close the issue.
+If the bug report is not complete, leave a comment requesting additional details and apply the `needs-info` label.
+When the user provides additional details, remove the `needs-info` label and repeat this step.
+
+## Categorize
+
+Once a bug report is complete, we can determine if it is truly a bug or not.
+A bug is defined as code that does not work the way it was intended to work when written.
+A change required by specification may not be a bug if the code is working as intended.
+If a bug report is determined not to be a bug, remove the `bug` label and apply the appropriate labels as follows:
+
+- `documentation` feature is working as intended but documentation is incorrect or incomplete
+- `enhancement` new feature request 
+
+If there is a bug report which is a simple fix these could be tagged with the following labels.
+- `good first issue` this is a good issue for a new contributor to tackle to get comfortable with our project
+- `help wanted` these are features that the maintainers would like help on due to time constraints
+
+## Triage Complete
+
+The final step is to remove the `triage` label.
+This indicates that all above steps have been taken and an issue is ready to be worked on.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ also supported). Logs are written to standard out using the structured logging l
 
 ### Security
 
-Third-party security audits of Jaeger are available in https://github.com/jaegertracing/security-audits. Please see [Issue #1718](https://github.com/jaegertracing/jaeger/issues/1718) for the summary of available security mechanisms in Jaeger.
+Third-party security audits of Jaeger are available in https://github.com/jaegertracing/security-audits. Please see [Issue #1718](https://github.com/jaegertracing/jaeger/issues/1718) for the summary of available security mechanisms in Jaeger. For more details please see [SECURITY](./SECURITY.md).
 
 ### Backwards compatibility with Zipkin
 
@@ -220,6 +220,10 @@ Have questions, suggestions, bug reports? Reach the project community via these 
  * [Slack chat room `#jaeger`][slack] (need to join [CNCF Slack][slack-join] for the first time)
  * [`jaeger-tracing` mail group](https://groups.google.com/forum/#!forum/jaeger-tracing)
  * GitHub [issues](https://github.com/jaegertracing/jaeger/issues) and [discussions](https://github.com/jaegertracing/jaeger/discussions)
+
+## Bug Report
+
+For bug reports, open an issue with the [Bug](https://github.com/jaegertracing/jaeger/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml&title=%5BBug%5D%3A+) type. The process used to handle your request is handled in [BUG-TRIAGE](./BUG-TRIAGE.md)
 
 ## Adopters
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -124,3 +124,6 @@ oF+qZY4uEvqFvYo8
 ## Securing a Jaeger installation
 
 If you are looking to secure your Jaeger installation, check out our documentation on the topic: [Securing Jaeger Installation](https://www.jaegertracing.io/docs/latest/security/).
+
+## Securing a Jaeger installation
+If you would like additional infromation about Jaeger security, you can find our [Threat Model](./THREAT-MODEL.md) and our [SECURITY-INSIGHTS](./SECURITY-INSIGHTS.yml) for additional information.


### PR DESCRIPTION
## Description of the changes
Cleanup some of the existing documentation and fix some pointers to the files we have in the base repo

Created a triage policy and use of a triage tag which needs to be added to the template : https://github.com/jaegertracing/.github/pull/4

## How was this change tested?
Text only changes

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [NA] I have added unit tests for the new functionality
- [NA] I have run lint and test steps successfully
