### PR TITLE
fix: Close factory in plugin/storage/es/ test

### DIFF
--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -259,6 +259,7 @@ func TestArchiveEnabled(t *testing.T) {
 	r, err := f.CreateArchiveSpanReader()
 	require.NoError(t, err)
 	assert.NotNil(t, r)
+	defer f.Close()
 }
 
 func TestConfigureFromOptions(t *testing.T) {

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -253,13 +253,13 @@ func TestArchiveEnabled(t *testing.T) {
 	f.newClientFn = (&mockClientBuilder{}).NewClient
 	err := f.Initialize(metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
+	defer f.Close() // Ensure resources are cleaned up if initialization is successful
 	w, err := f.CreateArchiveSpanWriter()
 	require.NoError(t, err)
 	assert.NotNil(t, w)
 	r, err := f.CreateArchiveSpanReader()
 	require.NoError(t, err)
 	assert.NotNil(t, r)
-	defer f.Close()
 }
 
 func TestConfigureFromOptions(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5083

## Description of the changes
- Added f.close() in TestArhiveEnabled based on https://github.com/jaegertracing/jaeger/issues/5083#issuecomment-1902790414

## How was this change tested?
-  CI workflow

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
