### PR TITLE
Enable debug builds for ppc64le

### DIFF
--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -1,16 +1,15 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.22.3-alpine AS build
 ARG TARGETARCH
 ENV GOPATH /go
 RUN apk add --update --no-cache ca-certificates make git build-base mailcap
-#Once go-delve adds support for s390x (see PR #2948), remove this entire conditional.
-#Once go-delve adds support for ppc64le (see PR go-delve/delve#1564), remove this entire conditional.
-RUN if [[ "$TARGETARCH" == "s390x"  ||  "$TARGETARCH" == "ppc64le" ]] ; then \
+# Remove once go-delve adds support for s390x (https://github.com/go-delve/delve/issues/2883)
+RUN if [[ "$TARGETARCH" == "s390x" ]] ; then \
 	touch /go/bin/dlv; \
     else \
         go install github.com/go-delve/delve/cmd/dlv@latest; \
     fi
 
-FROM golang:1.22-alpine
+FROM golang:1.22.3-alpine
 COPY --from=build /go/bin/dlv /go/bin/dlv
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /etc/mime.types /etc/mime.types


### PR DESCRIPTION
## Which problem is this PR solving?
- ppc64le was previously excluded because delve did not support it. It does now.

## Description of the changes
- remove ppc64le exclusion.

## How was this change tested?
- CI
