### PR TITLE
Split v1 and v2 ES/OS integration tests

### DIFF
--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -19,15 +19,22 @@ jobs:
   elasticsearch:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version:
         - major: 7.x
           image: 7.14.0
           distribution: elasticsearch
+          jaeger: v1
         - major: 8.x
           image: 8.8.2
           distribution: elasticsearch
-    name: ${{ matrix.version.distribution }} ${{ matrix.version.major }}
+          jaeger: v1
+        - major: 8.x
+          image: 8.8.2
+          distribution: elasticsearch
+          jaeger: v2
+    name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -53,7 +60,7 @@ jobs:
 
     - name: Run elasticsearch integration tests
       id: test-execution
-      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}
+      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }} ${{ matrix.version.jaeger }}
 
     - name: Output Elasticsearch logs
       run: docker logs ${{ steps.test-execution.outputs.cid }}

--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -58,11 +58,11 @@ jobs:
 
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
-    - name: Run elasticsearch integration tests
+    - name: Run ${{ matrix.version.distribution }} integration tests
       id: test-execution
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }} ${{ matrix.version.jaeger }}
 
-    - name: Output Elasticsearch logs
+    - name: Output ${{ matrix.version.distribution }} logs
       run: docker logs ${{ steps.test-execution.outputs.cid }}
       if: ${{ failure() }}
 
@@ -70,4 +70,4 @@ jobs:
       uses: ./.github/actions/upload-codecov
       with:
         files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
-        flags: elasticsearch-${{ matrix.version.major }}
+        flags: ${{ matrix.version.distribution }}-${{ matrix.version.major }}-${{ matrix.version.jaeger }}

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -19,15 +19,22 @@ jobs:
   opensearch:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version:
         - major: 1.x
           image: 1.3.7
           distribution: opensearch
+          jaeger: v1
         - major: 2.x
           image: 2.3.0
           distribution: opensearch
-    name: ${{ matrix.version.distribution }} ${{ matrix.version.major }}
+          jaeger: v1
+        - major: 2.x
+          image: 2.3.0
+          distribution: opensearch
+          jaeger: v2
+    name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -53,7 +60,7 @@ jobs:
 
     - name: Run opensearch integration tests
       id: test-execution
-      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }}
+      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }} ${{ matrix.version.jaeger }}
 
     - name: Output Opensearch logs
       run: docker logs ${{ steps.test-execution.outputs.cid }}

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -58,11 +58,11 @@ jobs:
 
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
-    - name: Run opensearch integration tests
+    - name: Run ${{ matrix.version.distribution }} integration tests
       id: test-execution
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.image }} ${{ matrix.version.jaeger }}
 
-    - name: Output Opensearch logs
+    - name: Output ${{ matrix.version.distribution }} logs
       run: docker logs ${{ steps.test-execution.outputs.cid }}
       if: ${{ failure() }}
 
@@ -70,4 +70,4 @@ jobs:
       uses: ./.github/actions/upload-codecov
       with:
         files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
-        flags: opensearch-${{ matrix.version.major }}
+        flags: ${{ matrix.version.distribution }}-${{ matrix.version.major }}-${{ matrix.version.jaeger }}

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -12,8 +12,8 @@ usage() {
 }
 
 check_arg() {
-  if [ ! $# -eq 2 ]; then
-    echo "ERROR: need exactly two arguments, <elasticsearch|opensearch> <image>"
+  if [ ! $# -eq 3 ]; then
+    echo "ERROR: need exactly two arguments, <elasticsearch|opensearch> <image> <jaeger-version>"
     usage
   fi
 }

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -132,13 +132,18 @@ teardown_storage() {
 main() {
   check_arg "$@"
   local distro=$1
-  local version=$2
+  local es_version=$2
+  local j_version=$2
 
-  bring_up_storage "${distro}" "${version}"
-  STORAGE=${distro} make storage-integration-test
-  STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
-  make index-cleaner-integration-test
-  make index-rollover-integration-test
+  bring_up_storage "${distro}" "${es_version}"
+
+  if [[ "${j_version}" == "v2" ]]; then
+    STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
+  else
+    STORAGE=${distro} make storage-integration-test
+    make index-cleaner-integration-test
+    make index-rollover-integration-test
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
## Which problem is this PR solving?
- ES tests are often failing due to v2 tests instability
- One one test fails the other matrix jobs are also cancelled

## Description of the changes
- Separate v1 and v2 tests into different matrix steps
- Turn off fail-fast to prevent other jobs from being cancelled

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
