### PR TITLE
Revert #5482 - ppc64le is not yet supported by delve

### DIFF
--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:1.22.3-alpine AS build
 ARG TARGETARCH
 ENV GOPATH /go
 RUN apk add --update --no-cache ca-certificates make git build-base mailcap
-# Remove once go-delve adds support for s390x (https://github.com/go-delve/delve/issues/2883)
-RUN if [[ "$TARGETARCH" == "s390x" ]] ; then \
+# TODO: Remove s390x once go-delve adds support for it (https://github.com/go-delve/delve/issues/2883)
+# TODO: Remove ppc64le once support is released (https://github.com/go-delve/delve/issues/1564) - not yet as of delve@v1.22.1
+RUN if [[ "$TARGETARCH" == "s390x" ||  "$TARGETARCH" == "ppc64le" ]] ; then \
 	touch /go/bin/dlv; \
     else \
         go install github.com/go-delve/delve/cmd/dlv@latest; \


### PR DESCRIPTION
## Which problem is this PR solving?
- `ppc64le` was added in #5482, but even though it has been implemented in delve (https://github.com/go-delve/delve/issues/2104), it has not yet been released as of delve@v1.22.1
- since our PR CI does not build all arch, it was not noticed until the CI on the main branch started failing

## Description of the changes
- Add `ppc64le` back to exclusion list

## How was this change tested?
- only after merging
