### PR TITLE
Remove support for Elasticsearch v5 and v6 #5439

### DIFF
--- a/plugin/storage/es/README.md
+++ b/plugin/storage/es/README.md
@@ -50,7 +50,7 @@ To locally test the ElasticSearch storage plugin,
 * have [ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html) running on port 9200
 * run `STORAGE=es make storage-integration-test` in the top folder.
 
-All integration tests also run on pull request via GitHub Actions. This integration test is against ElasticSearch v7.3.0 and v.8.x.
+All integration tests also run on pull request via GitHub Actions. This integration test is against ElasticSearch v7.x and v8.x.
 
 * The script used in GitHub Actions can be found under `scripts/es-integration-test.sh`,
 and that script be run from the top folder to integration test ElasticSearch as well.

--- a/plugin/storage/es/README.md
+++ b/plugin/storage/es/README.md
@@ -50,7 +50,7 @@ To locally test the ElasticSearch storage plugin,
 * have [ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html) running on port 9200
 * run `STORAGE=es make storage-integration-test` in the top folder.
 
-All integration tests also run on pull request via GitHub Actions. This integration test is against ElasticSearch v5.6.16, v6.8.2 and v7.3.0.
+All integration tests also run on pull request via GitHub Actions. This integration test is against ElasticSearch v7.3.0 and v.8.x.
 
 * The script used in GitHub Actions can be found under `scripts/es-integration-test.sh`,
 and that script be run from the top folder to integration test ElasticSearch as well.


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #5439  

## Description of the changes

- Updated documentation to reflect current supported versions (v7 and v8).

## How was this change tested?

- Verified that no references to Elasticsearch v5 and v6 remain in the codebase and documentation.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
