### PR TITLE
[test] Use locks to avoid race condition

### DIFF
--- a/plugin/sampling/strategystore/adaptive/processor_test.go
+++ b/plugin/sampling/strategystore/adaptive/processor_test.go
@@ -373,7 +373,10 @@ func TestRunCalculationLoop(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	probabilities := agg.(*aggregator).postAggregator.probabilities
+	postAgg := agg.(*aggregator).postAggregator
+	postAgg.Lock()
+	probabilities := postAgg.probabilities
+	postAgg.Unlock()
 	require.Len(t, probabilities["svcA"], 2)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Test failed with a race condition in an unrelated PR: https://github.com/jaegertracing/jaeger/actions/runs/9307158853/job/25617867008?pr=5496#step:8:196

## Description of the changes
- Grab the lock before reading fields

## How was this change tested?
```
$ go test -race -count 10 ./plugin/sampling/strategystore/adaptive/
ok  	github.com/jaegertracing/jaeger/plugin/sampling/strategystore/adaptive	1.556s
```
