### PR TITLE
Enable Lint Rule: unexported-naming

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -207,9 +207,6 @@ linters-settings:
         # definitely a good one, needs cleanup first
         - name: argument-limit
           disabled: true
-        # another good one, needs cleanup first
-        - name: unexported-naming
-          disabled: true
         # maybe enable, needs invesitgation of the impact
         - name: import-alias-naming
           disabled: true

--- a/cmd/collector/app/flags/flags_test.go
+++ b/cmd/collector/app/flags/flags_test.go
@@ -90,7 +90,7 @@ func TestCollectorOptionsWithFlags_CheckTLSReloadInterval(t *testing.T) {
 		"--collector.otlp.http",
 		"--collector.otlp.grpc",
 	}
-	OTLPPrefixes := map[string]struct{}{
+	otlpPrefixes := map[string]struct{}{
 		"--collector.otlp.http": {},
 		"--collector.otlp.grpc": {},
 	}
@@ -101,7 +101,7 @@ func TestCollectorOptionsWithFlags_CheckTLSReloadInterval(t *testing.T) {
 				prefix + ".tls.enabled=true",
 				prefix + ".tls.reload-interval=24h",
 			})
-			if _, ok := OTLPPrefixes[prefix]; !ok {
+			if _, ok := otlpPrefixes[prefix]; !ok {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unknown flag")
 			} else {

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -174,8 +174,8 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 }
 
 func purge(t *testing.T) {
-	Addr := fmt.Sprintf("http://0.0.0.0:%s%s", storagecleaner.Port, storagecleaner.URL)
-	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, Addr, nil)
+	addr := fmt.Sprintf("http://0.0.0.0:%s%s", storagecleaner.Port, storagecleaner.URL)
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, addr, nil)
 	require.NoError(t, err)
 
 	client := &http.Client{}

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -338,16 +338,16 @@ func TestServerHTTPTLS(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			TLSGRPC := disabledTLSCfg
+			tlsGrpc := disabledTLSCfg
 			if test.GRPCTLSEnabled {
-				TLSGRPC = enabledTLSCfg
+				tlsGrpc = enabledTLSCfg
 			}
 
 			serverOptions := &QueryOptions{
 				GRPCHostPort: ports.GetAddressFromCLIOptions(ports.QueryGRPC, ""),
 				HTTPHostPort: ports.GetAddressFromCLIOptions(ports.QueryHTTP, ""),
 				TLSHTTP:      test.TLS,
-				TLSGRPC:      TLSGRPC,
+				TLSGRPC:      tlsGrpc,
 				QueryOptionsBase: QueryOptionsBase{
 					BearerTokenPropagation: true,
 				},
@@ -478,14 +478,14 @@ func TestServerGRPCTLS(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			TLSHTTP := disabledTLSCfg
+			tlsHttp := disabledTLSCfg
 			if test.HTTPTLSEnabled {
-				TLSHTTP = enabledTLSCfg
+				tlsHttp = enabledTLSCfg
 			}
 			serverOptions := &QueryOptions{
 				GRPCHostPort: ports.GetAddressFromCLIOptions(ports.QueryGRPC, ""),
 				HTTPHostPort: ports.GetAddressFromCLIOptions(ports.QueryHTTP, ""),
-				TLSHTTP:      TLSHTTP,
+				TLSHTTP:      tlsHttp,
 				TLSGRPC:      test.TLS,
 				QueryOptionsBase: QueryOptionsBase{
 					BearerTokenPropagation: true,


### PR DESCRIPTION
## Which problem is this PR solving?
- <!-- Example: Resolves #123 --> Partial Fix for #5506

## Description of the changes
- Enabled unexported-naming in revive linter. 
- Changed local variables to start with lowercase letters.

## How was this change tested?
- `make lint` `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`