### PR TITLE
Use docker compose for cassandra integration tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -136,3 +136,10 @@ updates:
     allow:
       - dependency-name: "bitnami/kafka"
         update-types: ["version-update:semver-minor"]
+  - package-ecosystem: docker
+    directory: /docker-compose/cassandra
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: "cassandra"
+        update-types: ["version-update:semver-minor"]

--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -24,11 +24,9 @@ jobs:
         version:
         - distribution: cassandra
           major: 3.x
-          image: 3.11
           schema: v003
         - distribution: cassandra
           major: 4.x
-          image: 4.0
           schema: v004
     name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.jaeger-version }}
     steps:
@@ -45,7 +43,7 @@ jobs:
 
     - name: Run cassandra integration tests
       id: test-execution
-      run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.image }} ${{ matrix.version.schema }} ${{ matrix.jaeger-version }}
+      run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.major }} ${{ matrix.version.schema }} ${{ matrix.jaeger-version }}
 
     - name: Output Cassandra logs
       run: docker logs ${{ steps.test-execution.outputs.cid }}

--- a/.github/workflows/ci-cassandra.yml
+++ b/.github/workflows/ci-cassandra.yml
@@ -46,7 +46,7 @@ jobs:
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.major }} ${{ matrix.version.schema }} ${{ matrix.jaeger-version }}
 
     - name: Output Cassandra logs
-      run: docker logs ${{ steps.test-execution.outputs.cid }}
+      run: docker compose -f ${{ steps.test-execution.outputs.docker_compose_file }} logs
       if: ${{ failure() }}
 
     - name: Upload coverage to codecov

--- a/docker-compose/cassandra/v3.yaml
+++ b/docker-compose/cassandra/v3.yaml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  cassandra:
+    image: cassandra:3.11
+    ports:
+      - "9042:9042"
+      - "9160:9160"
+    networks:
+      - cassandra-net
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+         
+networks:
+  cassandra-net:
+    driver: bridge

--- a/docker-compose/cassandra/v4.yaml
+++ b/docker-compose/cassandra/v4.yaml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  cassandra:
+    image: cassandra:4.0
+    ports:
+      - "9042:9042"
+      - "9160:9160"
+    networks:
+      - cassandra-net
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+networks:
+  cassandra-net:
+    driver: bridge

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -17,7 +17,7 @@ check_arg() {
 setup_cassandra() {
   local major_version=$1
   local compose_file=$2
-  docker-compose -f "$compose_file" up -d
+  docker compose -f "$compose_file" up -d
   echo "docker_compose_file=${compose_file}" >> "${GITHUB_OUTPUT:-/dev/null}"
 }
 

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -15,22 +15,15 @@ check_arg() {
 }
 
 setup_cassandra() {
-  local tag=$1
-  local image=cassandra
-  local params=(
-    --detach
-    --publish 9042:9042
-    --publish 9160:9160
-  )
-  local cid
-  cid=$(docker run "${params[@]}" "${image}:${tag}")
-  echo "cid=${cid}" >> "$GITHUB_OUTPUT"
-  echo "${cid}"
+  local major_version=$1
+  local compose_file=$2
+  docker-compose -f "$compose_file" up -d
+  echo "docker_compose_file=${compose_file}" >> "${GITHUB_OUTPUT:-/dev/null}"
 }
 
 teardown_cassandra() {
-  local cid=$1
-  docker kill "${cid}"
+  local compose_file=$1
+  docker compose -f "$compose_file" down
   exit "${exit_status}"
 }
 
@@ -53,13 +46,14 @@ apply_schema() {
 
 run_integration_test() {
   local version=$1
+  local major_version=${version%%.*}
   local schema_version=$2
   local jaegerVersion=$3
   local primaryKeyspace="jaeger_v1_dc1"
   local archiveKeyspace="jaeger_v1_dc1_archive"
+  local compose_file="docker-compose/cassandra/v3.yaml"
 
-  local cid
-  cid=$(setup_cassandra "${version}")
+  setup_cassandra "${major_version}" "${compose_file}"
 
   apply_schema "$schema_version" "$primaryKeyspace"
   apply_schema "$schema_version" "$archiveKeyspace"
@@ -76,7 +70,7 @@ run_integration_test() {
   fi
 
   # shellcheck disable=SC2064
-  trap "teardown_cassandra ${cid}" EXIT
+  trap "teardown_cassandra ${compose_file}" EXIT
 }
 
 

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -15,8 +15,7 @@ check_arg() {
 }
 
 setup_cassandra() {
-  local major_version=$1
-  local compose_file=$2
+  local compose_file=$1
   docker compose -f "$compose_file" up -d
   echo "docker_compose_file=${compose_file}" >> "${GITHUB_OUTPUT:-/dev/null}"
 }
@@ -51,9 +50,9 @@ run_integration_test() {
   local jaegerVersion=$3
   local primaryKeyspace="jaeger_v1_dc1"
   local archiveKeyspace="jaeger_v1_dc1_archive"
-  local compose_file="docker-compose/cassandra/v3.yaml"
+  local compose_file="docker-compose/cassandra/v$major_version.yaml"
 
-  setup_cassandra "${major_version}" "${compose_file}"
+  setup_cassandra "${compose_file}"
 
   apply_schema "$schema_version" "$primaryKeyspace"
   apply_schema "$schema_version" "$archiveKeyspace"


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/5485

## Description of the changes
- updated `cassaandra-integration-test.sh` to use docker compose 
- update dependabot

## How was this change tested?
- `bash scripts/cassandra-integration-test.sh 3 v003 v1`    ` bash scripts/cassandra-integration-test.sh 3 v003 v2 ` bash `scripts/cassandra-integration-test.sh 4 v004 v1` `scripts/cassandra-integration-test.sh 4 v004 v2`
 
## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
