### PR TITLE
Fix for unit test failure TestServerSinglePort

### DIFF
--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -616,14 +616,14 @@ func TestServerSinglePort(t *testing.T) {
 		jtracer.NoOp())
 	require.NoError(t, err)
 	require.NoError(t, server.Start())
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, server.Close())
-	})
+	}()
 
 	client := newGRPCClient(t, hostPort)
-	t.Cleanup(func() {
-		require.NoError(t, client.conn.Close())
-	})
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
 
 	// using generous timeout since grpc.NewClient no longer does a handshake.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #5519

## Description of the changes
- Changed the cleanup of the server and client connection to defer statements to ensure they happen after the test logic has completed.

## How was this change tested?
- Forked the repo in local and ran the make test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
