### PR TITLE
Add a new workflow for testing the release workflow

### DIFF
--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -57,22 +57,24 @@ jobs:
 
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
-    - name: Define PR_ONLY var if running on a Pull Request
+    - name: Define LOCAL_FLAG var if running on a Pull Request
       run: |
         case ${GITHUB_EVENT_NAME} in
           pull_request)
-            echo "PR_ONLY=pr-only" >> ${GITHUB_ENV}
+            echo "LOCAL_FLAG=-l" >> ${GITHUB_ENV}
             ;;
           *)
-            echo "PR_ONLY=" >> ${GITHUB_ENV}
+            echo "LOCAL_FLAG=" >> ${GITHUB_ENV}
             ;;
         esac
 
     - name: Build, test, and publish all-in-one image
       run: |
-        BINARY=${{ matrix.mode.binary }} \
-          SKIP_SAMPLING=${{ matrix.mode.skip_sampling }} \
-          bash scripts/build-all-in-one-image.sh ${{ env.PR_ONLY }}
+        bash scripts/build-all-in-one-image.sh \
+          ${{ env.LOCAL_FLAG }} \
+          -b ${{ matrix.mode.binary }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        # SKIP_SAMPLING is used by integration tests, see https://github.com/jaegertracing/jaeger/issues/5531
+        SKIP_SAMPLING: =${{ matrix.mode.skip_sampling }}

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -18,7 +18,8 @@ permissions:
 jobs:
   all-in-one:
     # runs-on: ubuntu-latest
-    runs-on: ubuntu-latest-16-cores
+    # runs-on: ubuntu-latest-16-cores
+    runs-on: equinix-4cpu-16gb
     strategy:
       matrix:
         mode:

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -17,7 +17,8 @@ permissions:
 
 jobs:
   all-in-one:
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
         mode:
@@ -29,6 +30,9 @@ jobs:
           skip_sampling: true
 
     steps:
+    - name: Disk size
+      run: df -g /
+
     - name: Harden Runner
       uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
       with:

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -17,9 +17,7 @@ permissions:
 
 jobs:
   all-in-one:
-    # runs-on: ubuntu-latest
-    # runs-on: ubuntu-latest-16-cores
-    runs-on: equinix-4cpu-16gb
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         mode:

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -29,9 +29,6 @@ jobs:
           skip_sampling: true
 
     steps:
-    - name: Disk size
-      run: df -g /
-
     - name: Harden Runner
       uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
       with:

--- a/.github/workflows/ci-all-in-one-build.yml
+++ b/.github/workflows/ci-all-in-one-build.yml
@@ -77,4 +77,4 @@ jobs:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
         # SKIP_SAMPLING is used by integration tests, see https://github.com/jaegertracing/jaeger/issues/5531
-        SKIP_SAMPLING: =${{ matrix.mode.skip_sampling }}
+        SKIP_SAMPLING: ${{ matrix.mode.skip_sampling }}

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -48,12 +48,13 @@ jobs:
 
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
-    - name: Build only linux/amd64 docker image for Pull Request
+    - name: Build only linux/amd64 container images for a Pull Request
       if: github.ref_name != 'main'
-      run: bash scripts/build-upload-docker-images.sh pr-only
+      run: bash scripts/build-upload-docker-images.sh -D -p linux/amd64
 
-    - name: Build and upload all docker images
+    - name: Build and upload all container images
       if: github.ref_name == 'main'
+      # -d: include images with debugger
       run: bash scripts/build-upload-docker-images.sh
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-release-testing.yml
+++ b/.github/workflows/ci-release-testing.yml
@@ -13,9 +13,13 @@ jobs:
     permissions:
       contents: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
 
     steps:
+
+    - name: Disk size
+      run: df -g /
+
     - name: Harden Runner
       uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
       with:

--- a/.github/workflows/ci-release-testing.yml
+++ b/.github/workflows/ci-release-testing.yml
@@ -1,9 +1,6 @@
 name: Publish release
 
 on:
-  release:
-    types:
-      - published
   # allow running release workflow manually
   workflow_dispatch:
 
@@ -15,20 +12,9 @@ jobs:
   publish-release:
     permissions:
       contents: write
-      deployments: write
-    if: github.repository == 'jaegertracing/jaeger'
     runs-on: ubuntu-latest
 
     steps:
-    - name: Clean up some disk space
-      # We had an issue where the workflow was running out of disk space,
-      # because it downloads so many Docker images for different platforms.
-      # Here we delete some stuff from the VM that we do not use.
-      # Inspired by https://github.com/jlumbroso/free-disk-space.
-      run: |
-        sudo rm -rf /usr/local/lib/android || true
-        df -h /
-
     - name: Harden Runner
       uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
       with:
@@ -76,31 +62,16 @@ jobs:
       id: package-binaries
       run: bash scripts/package-deploy.sh
 
-    - name: Upload binaries
-      uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
-      with:
-        file: '{deploy/*.tar.gz,deploy/*.zip,deploy/*.sha256sum.txt,deploy/*.asc}'
-        file_glob: true
-        overwrite: true
-        tag: ${{ env.BRANCH }}
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Clean up some more disk space
-      # Delete the release artifacts after uploading them.
-      run: |
-        rm -rf deploy || true
-        df -h /
-
     - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
-    - name: Build and upload all container images
-      run: bash scripts/build-upload-docker-images.sh
+    - name: Build all container images (do not push)
+      run: bash scripts/build-upload-docker-images.sh -l
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
-    - name: Build, test, and publish all-in-one image
-      run: bash scripts/build-all-in-one-image.sh
+    - name: Build and test all-in-one image (do not push)
+      run: bash scripts/build-all-in-one-image.sh -l
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/ci-release-testing.yml
+++ b/.github/workflows/ci-release-testing.yml
@@ -12,6 +12,7 @@ jobs:
   publish-release:
     permissions:
       contents: write
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-release-testing.yml
+++ b/.github/workflows/ci-release-testing.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
 
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
 
     steps:
 
@@ -93,14 +93,3 @@ jobs:
         output-file: jaeger-SBOM.spdx.json
         upload-release-assets: false
         upload-artifact: false
-
-    - name: Upload SBOM
-      # Upload SBOM manually, because anchore/sbom-action does not do that
-      # when the workflow is triggered manually, only from a release.
-      # See https://github.com/jaegertracing/jaeger/issues/4817
-      uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2.7.0
-      with:
-        file: jaeger-SBOM.spdx.json
-        overwrite: true
-        tag: ${{ env.BRANCH }}
-        repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,10 @@ _prepare-winres-helper:
 	echo $$VERSIONINFO | $(GOVERSIONINFO) -o="$(PKGPATH)/$(SYSOFILE)" -
 
 .PHONY: build-binaries-linux
-build-binaries-linux:
+build-binaries-linux: build-binaries-amd64
+
+.PHONY: build-binaries-amd64
+build-binaries-amd64:
 	GOOS=linux GOARCH=amd64 $(MAKE) _build-platform-binaries
 
 .PHONY: build-binaries-windows

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -26,15 +26,15 @@ while getopts "b:hlDp:" opt; do
 		add_debugger='N'
 		;;
 	l)
-    # in the local-only mode the images will only be pushed to local registry
-    LOCAL_FLAG='-l'
+		# in the local-only mode the images will only be pushed to local registry
+		LOCAL_FLAG='-l'
 		;;
 	p)
 		platforms=${OPTARG}
 		;;
-  ?)
-    print_help
-    ;;
+	?)
+		print_help
+		;;
 	esac
 done
 

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -3,12 +3,12 @@
 set -euf -o pipefail
 
 print_help() {
-  echo "Usage: $0 [-l] [-D] [-b binary] [-p platforms]"
-  echo "-l: Enable local-only mode that only pushes images to local registry"
-  echo "-D: Disable building of images with debugger"
+  echo "Usage: $0 [-b binary] [-D] [-l] [-p platforms]"
   echo "-b: Which binary to build: 'all-in-one' (default) or 'jaeger' (v2)"
-  echo "-p: Comma-separated list of platforms to build for (default: all supported)"
+  echo "-D: Disable building of images with debugger"
   echo "-h: Print help"
+  echo "-l: Enable local-only mode that only pushes images to local registry"
+  echo "-p: Comma-separated list of platforms to build for (default: all supported)"
   exit 1
 }
 
@@ -17,7 +17,7 @@ platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 LOCAL_FLAG=''
 BINARY='all-in-one'
 
-while getopts "b:hlDp:" opt; do
+while getopts "b:Dhlp:" opt; do
 	case "${opt}" in
 	b)
 		BINARY=${OPTARG}

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -1,16 +1,44 @@
 #!/bin/bash
 
-set -exu
+set -euf -o pipefail
 
-arg1=${1:-'not-pr'}
-if [[ "$arg1" == "pr-only" ]]; then
-  is_pull_request=true
-else
-  is_pull_request=false
-fi
+print_help() {
+  echo "Usage: $0 [-l] [-D] [-b binary] [-p platforms]"
+  echo "-l: Enable local-only mode that only pushes images to local registry"
+  echo "-D: Disable building of images with debugger"
+  echo "-b: Which binary to build: 'all-in-one' (default) or 'jaeger' (v2)"
+  echo "-p: Comma-separated list of platforms to build for (default: all supported)"
+  echo "-h: Print help"
+  exit 1
+}
 
-# alternative can be jaeger (the v2 binary)
-BINARY=${BINARY:-'all-in-one'}
+add_debugger='Y'
+platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+LOCAL_FLAG=''
+BINARY='all-in-one'
+
+while getopts "bhlDp:" opt; do
+	case "${opt}" in
+	b)
+		BINARY=${OPTARG}
+		;;
+	D)
+		add_debugger='N'
+		;;
+	l)
+    # in the local-only mode the images will only be pushed to local registry
+    LOCAL_FLAG='-l'
+		;;
+	p)
+		platforms=${OPTARG}
+		;;
+  ?)
+    print_help
+    ;;
+	esac
+done
+
+set -x
 
 # Set default GOARCH variable to the host GOARCH, the target architecture can
 # be overrided by passing architecture value to the script:
@@ -38,24 +66,26 @@ run_integration_test() {
   if ! make all-in-one-integration-test ; then
       echo "---- integration test failed unexpectedly ----"
       echo "--- check the docker log below for details ---"
-      docker logs "$CID"
+      echo "::group::docker logs"
+        docker logs "$CID"
+      echo "::endgroup::"
+      docker kill "$CID"
       exit 1
   fi
   docker kill "$CID"
 }
 
-if [[ "${is_pull_request}" == "true" ]]; then
+# Loop through each platform (separated by commas)
+for platform in $(echo "$platforms" | tr ',' ' '); do
+  # Extract the architecture from the platform string
+  arch=${platform##*/}  # Remove everything before the last slash
+  make "build-${BINARY}" GOOS=linux GOARCH="${arch}"
+done
+
+if [[ "${add_debugger}" == "N" ]]; then
   make create-baseimg
-  # build current architecture only for pull requests
-  platforms="linux/${GOARCH}"
-  make "build-${BINARY}" GOOS=linux "GOARCH=${GOARCH}"
 else
   make create-baseimg-debugimg
-  platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
-  make "build-${BINARY}" GOOS=linux GOARCH=amd64
-  make "build-${BINARY}" GOOS=linux GOARCH=s390x
-  make "build-${BINARY}" GOOS=linux GOARCH=ppc64le
-  make "build-${BINARY}" GOOS=linux GOARCH=arm64
 fi
 
 # build all-in-one image locally for integration test (the -l switch)
@@ -63,17 +93,17 @@ bash scripts/build-upload-a-docker-image.sh -l -b -c "${BINARY}" -d "cmd/${BINAR
 run_integration_test "localhost:5000/$repo"
 
 # build all-in-one image and upload to dockerhub/quay.io
-bash scripts/build-upload-a-docker-image.sh -b -c "${BINARY}" -d "cmd/${BINARY}" -p "${platforms}" -t release
+bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c "${BINARY}" -d "cmd/${BINARY}" -p "${platforms}" -t release
 
-# build debug image if not on a pull request
-if [[ "${is_pull_request}" == "false" ]]; then
+# build debug image if requested
+if [[ "${add_debugger}" == "Y" ]]; then
   make "build-${BINARY}" GOOS=linux GOARCH="$GOARCH" DEBUG_BINARY=1
   repo="${repo}-debug"
 
-  # build all-in-one DEBUG image locally for integration test (the -l switch)
+  # build locally for integration test (the -l switch)
   bash scripts/build-upload-a-docker-image.sh -l -b -c "${BINARY}-debug" -d "cmd/${BINARY}" -t debug
   run_integration_test "localhost:5000/$repo"
 
-  # build all-in-one-debug image and upload to dockerhub/quay.io
-  bash scripts/build-upload-a-docker-image.sh -b -c "${BINARY}-debug" -d "cmd/${BINARY}" -t debug
+  # build & upload official image
+  bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c "${BINARY}-debug" -d "cmd/${BINARY}" -t debug
 fi

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -17,7 +17,7 @@ platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 LOCAL_FLAG=''
 BINARY='all-in-one'
 
-while getopts "bhlDp:" opt; do
+while getopts "b:hlDp:" opt; do
 	case "${opt}" in
 	b)
 		BINARY=${OPTARG}

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -1,40 +1,69 @@
 #!/bin/bash
 
-set -euxf -o pipefail
+set -euf -o pipefail
 
-mode=${1-main}
+print_help() {
+  echo "Usage: $0 [-l] [-D] [-p platforms]"
+  echo "-l: Enable local-only mode that only pushes images to local registry"
+  echo "-D: Disable building of images with debugger"
+  echo "-p: Comma-separated list of platforms to build for (default: all supported)"
+  echo "-h: Print help"
+  exit 1
+}
 
-make build-binaries-linux
+add_debugger='Y'
+platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+LOCAL_FLAG=''
 
-if [[ "$mode" == "pr-only" ]]; then
+while getopts "hlDp:" opt; do
+	case "${opt}" in
+	D)
+		add_debugger='N'
+		;;
+	l)
+    # in the local-only mode the images will only be pushed to local registry
+    LOCAL_FLAG='-l'
+		;;
+	p)
+		platforms=${OPTARG}
+		;;
+  ?)
+    print_help
+    ;;
+	esac
+done
+
+set -x
+
+# Loop through each platform (separated by commas)
+for platform in $(echo "$platforms" | tr ',' ' '); do
+  # Extract the architecture from the platform string
+  arch=${platform##*/}  # Remove everything before the last slash
+  make "build-binaries-$arch"
+done
+
+if [[ "${add_debugger}" == "N" ]]; then
   make create-baseimg
-  # build artifacts for linux/amd64 only for pull requests
-  platforms="linux/amd64"
 else
   make create-baseimg-debugimg
-  platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
-  # build multi-arch binaries
-  make build-binaries-s390x
-  make build-binaries-ppc64le
-  make build-binaries-arm64
 fi
 
 # build/upload raw and debug images of Jaeger backend components
 for component in agent collector query ingester remote-storage
 do
-  bash scripts/build-upload-a-docker-image.sh -b -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}" -t release
+  bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}" -t release
   # do not need debug image built for PRs
-  if [[ "$mode" != "pr-only" ]]; then
-    bash scripts/build-upload-a-docker-image.sh -b -c "jaeger-${component}-debug" -d "cmd/${component}" -t debug
+  if [[ "${add_debugger}" == "Y" ]]; then
+    bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c "jaeger-${component}-debug" -d "cmd/${component}" -t debug
   fi
 done
 
-bash scripts/build-upload-a-docker-image.sh -b -c jaeger-es-index-cleaner -d cmd/es-index-cleaner -p "${platforms}" -t release
-bash scripts/build-upload-a-docker-image.sh -b -c jaeger-es-rollover -d cmd/es-rollover  -p "${platforms}" -t release
-bash scripts/build-upload-a-docker-image.sh -c jaeger-cassandra-schema -d plugin/storage/cassandra/ -p "${platforms}"
+bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c jaeger-es-index-cleaner -d cmd/es-index-cleaner -p "${platforms}" -t release
+bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c jaeger-es-rollover -d cmd/es-rollover  -p "${platforms}" -t release
+bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -c jaeger-cassandra-schema -d plugin/storage/cassandra/ -p "${platforms}"
 
 # build/upload images for jaeger-tracegen and jaeger-anonymizer
 for component in tracegen anonymizer
 do
-  bash scripts/build-upload-a-docker-image.sh -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}"
+  bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}"
 done

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -21,15 +21,15 @@ while getopts "hlDp:" opt; do
 		add_debugger='N'
 		;;
 	l)
-    # in the local-only mode the images will only be pushed to local registry
-    LOCAL_FLAG='-l'
+		# in the local-only mode the images will only be pushed to local registry
+		LOCAL_FLAG='-l'
 		;;
 	p)
 		platforms=${OPTARG}
 		;;
-  ?)
-    print_help
-    ;;
+	?)
+		print_help
+		;;
 	esac
 done
 

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -3,11 +3,11 @@
 set -euf -o pipefail
 
 print_help() {
-  echo "Usage: $0 [-l] [-D] [-p platforms]"
-  echo "-l: Enable local-only mode that only pushes images to local registry"
-  echo "-D: Disable building of images with debugger"
-  echo "-p: Comma-separated list of platforms to build for (default: all supported)"
+  echo "Usage: $0 [-D] [-l] [-p platforms]"
   echo "-h: Print help"
+  echo "-D: Disable building of images with debugger"
+  echo "-l: Enable local-only mode that only pushes images to local registry"
+  echo "-p: Comma-separated list of platforms to build for (default: all supported)"
   exit 1
 }
 
@@ -15,7 +15,7 @@ add_debugger='Y'
 platforms="linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 LOCAL_FLAG=''
 
-while getopts "hlDp:" opt; do
+while getopts "Dhlp:" opt; do
 	case "${opt}" in
 	D)
 		add_debugger='N'


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5529. Right now there is no way to test the release workflow outside of actually doing a release.

## Description of the changes
- Refactor CI scripts for better control of "test runs"
- Add a new release testing workflow that does not attempt to publish artifacts

## How was this change tested?
- CI
