### PR TITLE
Enable Lint Rules: struct-tag & unexported-return

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -207,9 +207,6 @@ linters-settings:
         # investigate, could be real bugs. But didn't recent Go version changed loop variables semantics?
         - name: range-val-address
           disabled: true
-        # enable after cleanup: "tag on not-exported field"
-        - name: struct-tag
-          disabled: true
         # this is idiocy, promotes less readable code. Don't enable.
         - name: var-declaration
           disabled: true
@@ -218,9 +215,6 @@ linters-settings:
           disabled: true
         # "no nested structs are allowed" - don't enable, doesn't make sense
         - name: nested-structs
-          disabled: true
-        # enable after cleanup
-        - name: unexported-return
           disabled: true
         # looks useful, but requires refactoring: "calls to log.Fatal only in main() or init() functions"
         - name: deep-exit

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -40,7 +40,7 @@ type Options struct {
 	MaxVersion     string        `mapstructure:"max_version"`
 	SkipHostVerify bool          `mapstructure:"skip_host_verify"`
 	ReloadInterval time.Duration `mapstructure:"reload_interval"`
-	certWatcher    *certWatcher  `mapstructure:"-"`
+	CertWatcher    *certWatcher  `mapstructure:"-"`
 }
 
 var systemCertPool = x509.SystemCertPool // to allow overriding in unit test
@@ -102,18 +102,18 @@ func (o *Options) Config(logger *zap.Logger) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.certWatcher = certWatcher
+	o.CertWatcher = certWatcher
 
 	if (o.CertPath == "" && o.KeyPath != "") || (o.CertPath != "" && o.KeyPath == "") {
 		return nil, fmt.Errorf("for client auth via TLS, either both client certificate and key must be supplied, or neither")
 	}
 	if o.CertPath != "" && o.KeyPath != "" {
 		tlsCfg.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-			return o.certWatcher.certificate(), nil
+			return o.CertWatcher.certificate(), nil
 		}
 		// GetClientCertificate is used on the client side when server is configured with tls.RequireAndVerifyClientCert e.g. mTLS
 		tlsCfg.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			return o.certWatcher.certificate(), nil
+			return o.CertWatcher.certificate(), nil
 		}
 	}
 
@@ -169,8 +169,8 @@ var _ io.Closer = (*Options)(nil)
 
 // Close shuts down the embedded certificate watcher.
 func (o *Options) Close() error {
-	if o.certWatcher != nil {
-		return o.certWatcher.Close()
+	if o.CertWatcher != nil {
+		return o.CertWatcher.Close()
 	}
 	return nil
 }

--- a/plugin/storage/grpc/shared/grpc_client_test.go
+++ b/plugin/storage/grpc/shared/grpc_client_test.go
@@ -73,7 +73,7 @@ var (
 )
 
 type grpcClientTest struct {
-	client        *grpcClient
+	client        *GRPCClient
 	spanReader    *grpcMocks.SpanReaderPluginClient
 	spanWriter    *grpcMocks.SpanWriterPluginClient
 	archiveReader *grpcMocks.ArchiveSpanReaderPluginClient
@@ -93,7 +93,7 @@ func withGRPCClient(fn func(r *grpcClientTest)) {
 	capabilities := new(grpcMocks.PluginCapabilitiesClient)
 
 	r := &grpcClientTest{
-		client: &grpcClient{
+		client: &GRPCClient{
 			readerClient:        spanReader,
 			writerClient:        spanWriter,
 			archiveReaderClient: archiveReader,


### PR DESCRIPTION
## Which problem is this PR solving?
-  Partial Fix for #5506

## Description of the changes
- Enabled struct-tag & unexported-return in revive linter
- Only use tags on exported fields
- Converted exported function to have an exported return type

## How was this change tested?
- `make lint` `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
  - 