### PR TITLE
Set desired providers/converters instead of relying on defaults

### DIFF
--- a/cmd/jaeger/internal/command.go
+++ b/cmd/jaeger/internal/command.go
@@ -10,6 +10,13 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
+	"go.opentelemetry.io/collector/confmap/provider/envprovider"
+	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
+	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
+	"go.opentelemetry.io/collector/confmap/provider/httpsprovider"
+	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/otelcol"
 
 	"github.com/jaegertracing/jaeger/pkg/version"
@@ -30,6 +37,20 @@ func Command() *cobra.Command {
 	settings := otelcol.CollectorSettings{
 		BuildInfo: info,
 		Factories: Components,
+		ConfigProviderSettings: otelcol.ConfigProviderSettings{
+			ResolverSettings: confmap.ResolverSettings{
+				ProviderFactories: []confmap.ProviderFactory{
+					envprovider.NewFactory(),
+					fileprovider.NewFactory(),
+					httpprovider.NewFactory(),
+					httpsprovider.NewFactory(),
+					yamlprovider.NewFactory(),
+				},
+				ConverterFactories: []confmap.ConverterFactory{
+					expandconverter.NewFactory(),
+				},
+			},
+		},
 	}
 
 	cmd := otelcol.NewCommand(settings)

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,12 @@ require (
 	go.opentelemetry.io/collector/config/configretry v0.102.1
 	go.opentelemetry.io/collector/config/configtls v0.102.1
 	go.opentelemetry.io/collector/confmap v0.102.1
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.102.1
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.102.1
 	go.opentelemetry.io/collector/connector v0.102.1
 	go.opentelemetry.io/collector/connector/forwardconnector v0.102.1
 	go.opentelemetry.io/collector/consumer v0.102.1
@@ -186,12 +192,6 @@ require (
 	go.opentelemetry.io/collector/config/configopaque v1.9.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.102.1 // indirect
 	go.opentelemetry.io/collector/config/internal v0.102.1 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.102.1 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.102.1 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.102.1 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.102.1 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.102.1 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.102.1 // indirect
 	go.opentelemetry.io/collector/exporter/debugexporter v0.102.1
 	go.opentelemetry.io/collector/extension/auth v0.102.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.9.0 // indirect


### PR DESCRIPTION
## Which problem is this PR solving?
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/10290

## Description of the changes
Updates the `otelcol.CollectorSettings` passed to `otelcol.NewCommand` to include desired providers and converters instead of relying on `otelcol.NewCommand` to provide defaults.

These providers/converters as the exact same being set by defaults [here](https://github.com/open-telemetry/opentelemetry-collector/blob/6888f8f7a45fd6dff4dfc29a82802c95459f619c/otelcol/configprovider.go#L134), which will probably stop getting set in the future.

## How was this change tested?
- unit tests

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
