### PR TITLE
[dependabot config] Remove invalid path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,6 @@ updates:
 
   - package-ecosystem: docker
     directories:
-      - "/"
       - /cmd/agent
       - /cmd/all-in-one
       - /cmd/anonymizer


### PR DESCRIPTION
## Which problem is this PR solving?
- The `/` path is invalid since there is no Dockerfile in the root dir. Unfortunately, dependabot fails the whole run on this error, instead of working through all the dirs
- Part of #5552

## Description of the changes
- Remove invalid path

## How was this change tested?
- Only testable after merge
