### PR TITLE
[ci] Validate that generated mocks are up to date

### DIFF
--- a/.github/workflows/ci-protogen-tests.yml
+++ b/.github/workflows/ci-protogen-tests.yml
@@ -37,3 +37,6 @@ jobs:
 
     - name: Verify Thrift types are up to date
       run: make thrift && git diff --name-status --exit-code
+
+    - name: Verify Mockery types are up to date
+      run: make generate-mocks && git diff --name-status --exit-code


### PR DESCRIPTION
## Which problem is this PR solving?
- We want mockery version to be up to date with the generated files.
- #5563 upgrades mockery, but does not re-generate the files.

## Description of the changes
- Add a lint check to the workflow for protobuf

## How was this change tested?
- CI
