### PR TITLE
Fix new warnings from the linter upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,13 @@ issues:
       text: "exitAfterDefer"
     - linters: [gocritic]
       text: "appendAssign"
+  exclude-dirs-use-default: false
+  exclude-dirs:
+    - mocks
+    - thrift-0.9.2
+    - .*-gen
+  exclude-files:
+    - ".*.pb.go$"
   max-issues-per-linter: 0
   max-same-issues: 0
 
@@ -136,10 +143,7 @@ linters-settings:
       - G107
       - G404
       - G601
-  gosimple:
-    go: "1.21"
   govet:
-    check-shadowing: false
     enable-all: true
     disable:
       # There is rarely performance differences due to padding,
@@ -235,10 +239,3 @@ linters-settings:
 run:
   go: "1.21"
   timeout: 20m
-  skip-dirs-use-default: false
-  skip-dirs:
-    - mocks
-    - thrift-0.9.2
-    - .*-gen
-  skip-files:
-    - ".*.pb.go$"


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5585

## Description of the changes
Fix new warnings from the `golangci-lint` linter upgrade.

## How was this change tested?

The configuration has been verified with the command `golangci-lint config verify`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`

---

These warnings came from: https://github.com/golangci/golangci-lint/blob/master/pkg/config/loader.go#L374