### PR TITLE
Configure Renovate bot to add sign-offs to commits for DCO

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":gitSignOff"
   ],
   "labels": [
     "changelog:dependencies"


### PR DESCRIPTION
## Which problem is this PR solving?
- DCO checks are failing on Renovate PRs

## Description of the changes
- Enable sign-off option

## How was this change tested?
- Will check PRs after this is merged
