### PR TITLE
Require Renovate bot to run go mod tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,9 @@
   "labels": [
     "changelog:dependencies"
   ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
   "suppressNotifications": ["prEditedNotification"]
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- It turns out by default the Renovate bot does not run `go mod tidy`, so it leaves unused entries in the go.mod/sum files.

## Description of the changes
- Enable both tidy and upgrading imports on major version changes

## How was this change tested?
- CI
