### PR TITLE
Update Renovate bot to not update to major releases #5607

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,11 @@
   "labels": [
     "changelog:dependencies"
   ],
-  "suppressNotifications": ["prEditedNotification"]
+  "suppressNotifications": ["prEditedNotification"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }


### PR DESCRIPTION
Per the tutorial this will limit major updates to on-demand creation via the Dependency Dashboard https://github.com/renovatebot/tutorial

## Which problem is this PR solving?
- Resolves #5607 

## Description of the changes
- Adds a packageRule that limits major releases to on-demand creation instead of automated.

## How was this change tested?
- Was not tested, but based on documentation from renovatebot
https://github.com/renovatebot/tutorial?tab=readme-ov-file#the-dependency-dashboard-includes

## Checklist
- [ x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ x] I have signed all commits
- [ n/a] I have added unit tests for the new functionality
- [ n/a] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
