### PR TITLE
Update Renovate bot to not apply patches to e2e test dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
         "docker-compose/opensearch/v1/docker-compose.yml",
         "docker-compose/opensearch/v2/docker-compose.yml"
       ],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["major", "patch"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Which problem is this PR solving?
Updates #5607 to also turn off patches for the e2e test dependencies

## Description of the changes
Adds "patch" to the matchUpdateTypes array so that Renovatebot will not automate PRs for patches on the e2e test dependencies

## How was this change tested?
Tested in fork and verified it wouldn't apply patches for those specified docker-compose files.

## Checklist
- [ x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ n/a] I have added unit tests for the new functionality
- [ n/a] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
