### PR TITLE
Add target docker-images-jaeger-backend in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ include docker/Makefile
 include Makefile.Protobuf.mk
 include Makefile.Thrift.mk
 include Makefile.Crossdock.mk
+include Makefile.Integration.mk
 
 .DEFAULT_GOAL := test-and-lint
 

--- a/Makefile.Crossdock.mk
+++ b/Makefile.Crossdock.mk
@@ -33,7 +33,7 @@ build-crossdock-fresh: build-crossdock-linux
 
 .PHONY: crossdock-docker-images-jaeger-backend
 crossdock-docker-images-jaeger-backend: PLATFORMS=linux/amd64
-crossdock-docker-images-jaeger-backend: create-baseimg create-debugimg
+crossdock-docker-images-jaeger-backend: create-baseimg 
 	for component in "jaeger-agent" "jaeger-collector" "jaeger-query" "jaeger-ingester" "all-in-one" ; do \
 		regex="jaeger-(.*)"; \
 		component_suffix=$$component; \

--- a/Makefile.Integration.mk
+++ b/Makefile.Integration.mk
@@ -1,0 +1,18 @@
+.PHONY: docker-images-jaeger-backend
+docker-images-jaeger-backend: PLATFORMS=linux/amd64
+docker-images-jaeger-backend: create-baseimg 
+	for component in "jaeger-agent" "jaeger-collector" "jaeger-query" "jaeger-ingester" "all-in-one" ; do \
+		regex="jaeger-(.*)"; \
+		component_suffix=$$component; \
+		if [[ $$component =~ $$regex ]]; then \
+			component_suffix="$${BASH_REMATCH[1]}"; \
+		fi; \
+		docker buildx build --target $(TARGET) \
+			--tag $(DOCKER_NAMESPACE)/$$component$(SUFFIX):${DOCKER_TAG} \
+			--build-arg base_image=$(BASE_IMAGE) \
+			--build-arg debug_image=$(DEBUG_IMAGE) \
+			--build-arg TARGETARCH=$(GOARCH) \
+			--load \
+			cmd/$$component_suffix; \
+		echo "Finished building $$component ==============" ; \
+	done;


### PR DESCRIPTION
## Which problem is this PR solving?
- 

## Description of the changes
- Added new target `docker-images-jaeger-backend` in `Makefile.Integration.mk`

## How was this change tested?
- `make build`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
