### PR TITLE
Fix SPM make build

### DIFF
--- a/Makefile.Crossdock.mk
+++ b/Makefile.Crossdock.mk
@@ -32,8 +32,8 @@ build-crossdock-fresh: build-crossdock-linux
 	make crossdock-fresh
 
 .PHONY: crossdock-docker-images-jaeger-backend
-crossdock-docker-images-jaeger-backend: PLATFORMS=linux/amd64
-crossdock-docker-images-jaeger-backend: create-baseimg create-debugimg
+crossdock-docker-images-jaeger-backend: PLATFORMS=linux/$(shell go env GOARCH)
+crossdock-docker-images-jaeger-backend: create-baseimg create-fake-debugimg
 	for component in "jaeger-agent" "jaeger-collector" "jaeger-query" "jaeger-ingester" "all-in-one" ; do \
 		regex="jaeger-(.*)"; \
 		component_suffix=$$component; \

--- a/docker-compose/monitor/Makefile
+++ b/docker-compose/monitor/Makefile
@@ -1,9 +1,14 @@
 .PHONY: build
-build: export DOCKER_TAG = dev
 build: clean-jaeger
-	cd ../../ && \
-	make build-all-in-one-linux && \
-	make docker-images-jaeger-backend
+	cd ../../ && make build-all-in-one-linux
+	cd ../../ && make create-baseimg PLATFORMS=linux/$(shell go env GOARCH)
+	cd ../../ && docker buildx build --target release \
+		--tag jaegertracing/all-in-one:dev \
+		--build-arg base_image=localhost:5000/baseimg_alpine:latest \
+		--build-arg debug_image=not-used \
+		--build-arg TARGETARCH=$(shell go env GOARCH) \
+		--load \
+		cmd/all-in-one
 
 # starts up the system required for SPM using the latest otel image and a development jaeger image.
 # Note: the jaeger "dev" image can be built with "make build".

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -17,6 +17,11 @@ create-debugimg: prepare-docker-buildx
 		--platform=$(PLATFORMS) \
 		docker/debug
 
+create-fake-debugimg: prepare-docker-buildx
+	docker buildx build -t $(DEBUG_IMAGE) --push \
+		--platform=$(PLATFORMS) \
+		docker/base
+
 .PHONY: prepare-docker-buildx
 prepare-docker-buildx:
 	docker buildx inspect jaeger-build > /dev/null || docker buildx create --use --name=jaeger-build --buildkitd-flags="--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --driver-opt="network=host"


### PR DESCRIPTION
## Which problem is this PR solving?
- SPM Makefile was calling a target that was removed in previous refactoring

## Description of the changes
- Build the image directly instead of calling much more expensive target
- Change crossdock target to not build debug image with devle, which is expensive

## How was this change tested?
- `make build && make dev`
