### PR TITLE
Use image digests for docker-compose files

### DIFF
--- a/docker-compose/cassandra/v3/docker-compose.yaml
+++ b/docker-compose/cassandra/v3/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: index.docker.io/library/cassandra@sha256:b5cde1e2b16451fa511e4a1cda4177853903879f9bab0b8f27445451a07f7ef7 # 3.11
     ports:
       - "9042:9042"
       - "9160:9160"

--- a/docker-compose/cassandra/v4/docker-compose.yaml
+++ b/docker-compose/cassandra/v4/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   cassandra:
-    image: cassandra:4.1
+    image: index.docker.io/library/cassandra@sha256:52510388c3c29080a9cb6056e49939905a8e36eb9ae191fda32e574b5c591b70 # 4.1
     ports:
       - "9042:9042"
       - "9160:9160"

--- a/docker-compose/elasticsearch/v7/docker-compose.yml
+++ b/docker-compose/elasticsearch/v7/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.22
+    image: docker.elastic.co/elasticsearch/elasticsearch@sha256:a0e01a200a316bac8d661e1acae368fd40c9c618847205a12f443c09c36e6eb3 # 7.17.22
     environment:
       - discovery.type=single-node
       - http.host=0.0.0.0

--- a/docker-compose/elasticsearch/v8/docker-compose.yml
+++ b/docker-compose/elasticsearch/v8/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.1
+    image: docker.elastic.co/elasticsearch/elasticsearch@sha256:03ee4816f20c429ba83d000a0e202d8beaee5041a6db19bf5c0f892dc96ac236 # 8.14.1
     environment:
       - discovery.type=single-node
       - http.host=0.0.0.0

--- a/docker-compose/kafka-integration-test/docker-compose.yml
+++ b/docker-compose/kafka-integration-test/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   kafka:
-    image: bitnami/kafka:3.7.0
+    image: index.docker.io/bitnami/kafka@sha256:9abe5ce1ce14e0ff3041075c5183202fb5c47ea28ad270bfcb067f7ade304d8b # 3.7.0
     ports:
       - "9092:9092"
     environment:

--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   microsim:
     networks:
       - backend
-    image: yurishkuro/microsim:0.2.0
+    image: index.docker.io/yurishkuro/microsim@sha256:8cdacca2912d0f5fef3350be4bf7472215c3ec7e50ddfbc9cf11fbf59599aae5 # 0.2.0
     command: "-j http://otel_collector:14278/api/traces -d 24h -s 500ms"
     depends_on:
       - otel_collector

--- a/docker-compose/opensearch/v1/docker-compose.yml
+++ b/docker-compose/opensearch/v1/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:1.3.17
+    image: index.docker.io/opensearchproject/opensearch@sha256:4431caf5c156452bd17c15c534eae45f2e315272cdec5dcf08315dc644a22a38 # 1.3.17
     environment:
       - discovery.type=single-node
       - plugins.security.disabled=true

--- a/docker-compose/opensearch/v2/docker-compose.yml
+++ b/docker-compose/opensearch/v2/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.14.0
+    image: index.docker.io/opensearchproject/opensearch@sha256:466a49f379bb8889af29d615475e69b7b990898c6987d28470cd7105df9046ff # 2.14.0
     environment:
       - discovery.type=single-node
       - plugins.security.disabled=true


### PR DESCRIPTION
## Which problem is this PR solving?
- Hey, I noticed you have some docker-compose files that are using floating tags to reference images. Pinning images and actions to their commit hash ensures that the same version of the image or action is used every time the workflow runs. This is important for reproducibility and security and it is a [security practice recommended by GitHub](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
## Description of the changes
- The following PR used [frizbee](https://github.com/stacklok/frizbee) CLI to update the docker-compose files and pin the container images referenced by tags to their commit hash.

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
