### PR TITLE
Support default configs for storage backends

### DIFF
--- a/cmd/jaeger/config-badger.yaml
+++ b/cmd/jaeger/config-badger.yaml
@@ -8,26 +8,22 @@ service:
 
 extensions:
   jaeger_query:
-    trace_storage: badger_main
-    trace_storage_archive: badger_archive
+    trace_storage: some_store
+    trace_storage_archive: another_store
     ui_config: ./cmd/jaeger/config-ui.json
 
   jaeger_storage:
-    badger:
-      badger_main:
-        directory_key: "/tmp/jaeger/"
-        directory_value: "/tmp/jaeger/"
-        ephemeral: false
-        maintenance_interval: 5
-        metrics_update_interval: 10
-        span_store_ttl: 72h
-      badger_archive:
-        directory_key: "/tmp/jaeger_archive/"
-        directory_value: "/tmp/jaeger_archive/"
-        ephemeral: false
-        maintenance_interval: 5
-        metrics_update_interval: 10
-        span_store_ttl: 720h
+    backends:
+      some_store:
+        badger:
+          directory_key: "/tmp/jaeger/"
+          directory_value: "/tmp/jaeger/"
+          ephemeral: false
+      another_store:
+        badger:
+          directory_key: "/tmp/jaeger_archive/"
+          directory_value: "/tmp/jaeger_archive/"
+          ephemeral: false
 
 receivers:
   otlp:
@@ -40,4 +36,4 @@ processors:
 
 exporters:
   jaeger_storage_exporter:
-    trace_storage: badger_main
+    trace_storage: some_store

--- a/cmd/jaeger/config-cassandra.yaml
+++ b/cmd/jaeger/config-cassandra.yaml
@@ -8,30 +8,32 @@ service:
 
 extensions:
   jaeger_query:
-    trace_storage: cassandra_main
-    trace_storage_archive: cassandra_archive
+    trace_storage: some_storage
+    trace_storage_archive: another_storage
     ui_config: ./cmd/jaeger/config-ui.json
 
   jaeger_storage:
-    cassandra:
-      cassandra_main:
-        servers: 127.0.0.1
-        port: 9042
-        keyspace: "jaeger_v1_dc1"
-        connections_per_host: 2
-        index:
-          tags: true
-          logs: true
-          process_tags: true
-      cassandra_archive:
-        servers: 127.0.0.1
-        port: 9042
-        keyspace: "jaeger_v1_dc1"
-        connections_per_host: 2
-        index:
-          tags: true
-          logs: true
-          process_tags: true
+    backends:
+      some_storage:
+        cassandra:
+          servers: 127.0.0.1
+          port: 9042
+          keyspace: "jaeger_v1_dc1"
+          connections_per_host: 2
+          index:
+            tags: true
+            logs: true
+            process_tags: true
+      another_storage:
+        cassandra:
+          servers: 127.0.0.1
+          port: 9042
+          keyspace: "jaeger_v1_dc1"
+          connections_per_host: 2
+          index:
+            tags: true
+            logs: true
+            process_tags: true
 receivers:
   otlp:
     protocols:
@@ -50,4 +52,4 @@ processors:
 
 exporters:
   jaeger_storage_exporter:
-    trace_storage: cassandra_main
+    trace_storage: some_storage

--- a/cmd/jaeger/config-cassandra.yaml
+++ b/cmd/jaeger/config-cassandra.yaml
@@ -16,24 +16,10 @@ extensions:
     backends:
       some_storage:
         cassandra:
-          servers: 127.0.0.1
-          port: 9042
           keyspace: "jaeger_v1_dc1"
-          connections_per_host: 2
-          index:
-            tags: true
-            logs: true
-            process_tags: true
       another_storage:
         cassandra:
-          servers: 127.0.0.1
-          port: 9042
           keyspace: "jaeger_v1_dc1"
-          connections_per_host: 2
-          index:
-            tags: true
-            logs: true
-            process_tags: true
 receivers:
   otlp:
     protocols:

--- a/cmd/jaeger/config-elasticsearch.yaml
+++ b/cmd/jaeger/config-elasticsearch.yaml
@@ -8,24 +8,26 @@ service:
 
 extensions:
   jaeger_query:
-    trace_storage: es_main
-    trace_storage_archive: es_archive
+    trace_storage: some_storage
+    trace_storage_archive: another_storage
     ui_config: ./cmd/jaeger/config-ui.json
 
   jaeger_storage:
-    elasticsearch:
-      es_main:
-        server_urls: http://localhost:9200
-        log_level: "error"
-        index_prefix: "jaeger-main"
-        use_aliases: false
-        create_mappings: true
-      es_archive:
-        server_urls: http://localhost:9200
-        log_level: "error"
-        index_prefix: "jaeger-archive"
-        use_aliases: false
-        create_mappings: true
+    backends:
+      some_storage:
+        elasticsearch:
+          server_urls: http://localhost:9200
+          log_level: "error"
+          index_prefix: "jaeger-main"
+          use_aliases: false
+          create_mappings: true
+      another_storage:
+        elasticsearch:
+          server_urls: http://localhost:9200
+          log_level: "error"
+          index_prefix: "jaeger-archive"
+          use_aliases: false
+          create_mappings: true
 
 receivers:
   otlp:
@@ -38,4 +40,4 @@ processors:
 
 exporters:
   jaeger_storage_exporter:
-    trace_storage: es_main
+    trace_storage: some_storage

--- a/cmd/jaeger/config-elasticsearch.yaml
+++ b/cmd/jaeger/config-elasticsearch.yaml
@@ -16,18 +16,10 @@ extensions:
     backends:
       some_storage:
         elasticsearch:
-          server_urls: http://localhost:9200
-          log_level: "error"
           index_prefix: "jaeger-main"
-          use_aliases: false
-          create_mappings: true
       another_storage:
         elasticsearch:
-          server_urls: http://localhost:9200
-          log_level: "error"
           index_prefix: "jaeger-archive"
-          use_aliases: false
-          create_mappings: true
 
 receivers:
   otlp:

--- a/cmd/jaeger/config-opensearch.yaml
+++ b/cmd/jaeger/config-opensearch.yaml
@@ -16,19 +16,11 @@ extensions:
     backends:
       some_storage:
         opensearch:
-          server_urls: http://localhost:9200
-          log_level: "error"
           index_prefix: "jaeger-main"
-          use_aliases: false
-          create_mappings: true
 
       another_storage:
         opensearch:
-          server_urls: http://localhost:9200
-          log_level: "error"
           index_prefix: "jaeger-main"
-          use_aliases: false
-          create_mappings: true
 
 receivers:
   otlp:

--- a/cmd/jaeger/config-opensearch.yaml
+++ b/cmd/jaeger/config-opensearch.yaml
@@ -8,25 +8,27 @@ service:
 
 extensions:
   jaeger_query:
-    trace_storage: os_main
-    trace_storage_archive: os_archive
+    trace_storage: some_storage
+    trace_storage_archive: another_storage
     ui_config: ./cmd/jaeger/config-ui.json
 
   jaeger_storage:
-    opensearch:
-      os_main:
-        server_urls: http://localhost:9200
-        log_level: "error"
-        index_prefix: "jaeger-main"
-        use_aliases: false
-        create_mappings: true
+    backends:
+      some_storage:
+        opensearch:
+          server_urls: http://localhost:9200
+          log_level: "error"
+          index_prefix: "jaeger-main"
+          use_aliases: false
+          create_mappings: true
 
-      os_archive:
-        server_urls: http://localhost:9200
-        log_level: "error"
-        index_prefix: "jaeger-main"
-        use_aliases: false
-        create_mappings: true
+      another_storage:
+        opensearch:
+          server_urls: http://localhost:9200
+          log_level: "error"
+          index_prefix: "jaeger-main"
+          use_aliases: false
+          create_mappings: true
 
 receivers:
   otlp:
@@ -39,4 +41,4 @@ processors:
 
 exporters:
   jaeger_storage_exporter:
-    trace_storage: os_main
+    trace_storage: some_storage

--- a/cmd/jaeger/config-remote-storage.yaml
+++ b/cmd/jaeger/config-remote-storage.yaml
@@ -16,7 +16,6 @@ extensions:
       some-storage:
         grpc:
           endpoint: localhost:17271
-          timeout: 5s
           tls:
             insecure: true
 

--- a/cmd/jaeger/config-remote-storage.yaml
+++ b/cmd/jaeger/config-remote-storage.yaml
@@ -8,16 +8,17 @@ service:
 
 extensions:
   jaeger_query:
-    trace_storage: external-storage
+    trace_storage: some-storage
     ui_config: ./cmd/jaeger/config-ui.json
 
   jaeger_storage:
-    grpc:
-      external-storage:
-        endpoint: localhost:17271
-        timeout: 5s
-        tls:
-          insecure: true
+    backends:
+      some-storage:
+        grpc:
+          endpoint: localhost:17271
+          timeout: 5s
+          tls:
+            insecure: true
 
 receivers:
   otlp:
@@ -30,4 +31,4 @@ processors:
 
 exporters:
   jaeger_storage_exporter:
-    trace_storage: external-storage
+    trace_storage: some-storage

--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -8,12 +8,13 @@ service:
 
 extensions:
   jaeger_query:
-    trace_storage: memstore
+    trace_storage: some_storage
 
   jaeger_storage:
-    memory:
-      memstore:
-        max_traces: 100000
+    backends:
+      some_storage:
+        memory:
+          max_traces: 100000
 
 receivers:
   otlp:
@@ -35,4 +36,4 @@ processors:
 
 exporters:
   jaeger_storage_exporter:
-    trace_storage: memstore
+    trace_storage: some_storage

--- a/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage"
 	"github.com/jaegertracing/jaeger/model"
@@ -103,7 +103,7 @@ func TestExporter(t *testing.T) {
 
 	ctx := context.Background()
 	telemetrySettings := component.TelemetrySettings{
-		Logger:         zap.L(),
+		Logger:         zaptest.NewLogger(t),
 		TracerProvider: nooptrace.NewTracerProvider(),
 		MeterProvider:  noopmetric.NewMeterProvider(),
 	}
@@ -157,14 +157,16 @@ func TestExporter(t *testing.T) {
 }
 
 func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
+	telemetrySettings := component.TelemetrySettings{
+		Logger:         zaptest.NewLogger(t),
+		TracerProvider: nooptrace.NewTracerProvider(),
+		MeterProvider:  noopmetric.NewMeterProvider(),
+	}
 	extensionFactory := jaegerstorage.NewFactory()
 	storageExtension, err := extensionFactory.CreateExtension(
 		context.Background(),
 		extension.Settings{
-			TelemetrySettings: component.TelemetrySettings{
-				Logger:         zap.L(),
-				TracerProvider: nooptrace.NewTracerProvider(),
-			},
+			TelemetrySettings: telemetrySettings,
 		},
 		&jaegerstorage.Config{Backends: map[string]jaegerstorage.Backend{
 			memstoreName: {Memory: &memory.Configuration{MaxTraces: 10000}},

--- a/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
@@ -166,9 +166,10 @@ func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
 				TracerProvider: nooptrace.NewTracerProvider(),
 			},
 		},
-		&jaegerstorage.Config{Memory: map[string]memory.Configuration{
-			memstoreName: {MaxTraces: 10000},
-		}})
+		&jaegerstorage.Config{Backends: map[string]jaegerstorage.Backend{
+			memstoreName: {Memory: &memory.Configuration{MaxTraces: 10000}},
+		}},
+	)
 	require.NoError(t, err)
 
 	host := storagetest.NewStorageHost()

--- a/cmd/jaeger/internal/extension/jaegerstorage/config.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config.go
@@ -48,6 +48,10 @@ func (cfg *Backend) Unmarshal(conf *confmap.Conf) error {
 		v := badger.DefaultNamespaceConfig()
 		cfg.Badger = &v
 	}
+	if conf.IsSet("grpc") {
+		v := grpc.DefaultConfigV2()
+		cfg.GRPC = &v
+	}
 	// TODO add defaults for other storage backends
 	return conf.Unmarshal(cfg)
 }

--- a/cmd/jaeger/internal/extension/jaegerstorage/config.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config.go
@@ -7,18 +7,19 @@ import (
 	"fmt"
 	"reflect"
 
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+
 	esCfg "github.com/jaegertracing/jaeger/pkg/es/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc"
 	"github.com/jaegertracing/jaeger/plugin/storage/memory"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/confmap"
 )
 
 var (
 	_ component.ConfigValidator = (*Config)(nil)
-	// _ confmap.Unmarshaler       = (*Config)(nil)
+	_ confmap.Unmarshaler       = (*Backend)(nil)
 )
 
 // Config contains configuration(s) for jaeger trace storage.

--- a/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
@@ -1,0 +1,50 @@
+package jaegerstorage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func loadConf(t *testing.T, config string) *confmap.Conf {
+	d := t.TempDir()
+	f := filepath.Join(d, "config.yaml")
+	require.NoError(t, os.WriteFile(f, []byte(config), 0644))
+	cm, err := confmaptest.LoadConf(f)
+	require.NoError(t, err)
+	return cm
+}
+
+func TestValidateNoBackends(t *testing.T) {
+	conf := loadConf(t, `
+backends:
+`)
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.EqualError(t, cfg.Validate(), "at least one storage is required")
+}
+
+func TestValidateEmptyBackend(t *testing.T) {
+	conf := loadConf(t, `
+backends:
+  some_storage:
+`)
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.EqualError(t, cfg.Validate(), "no backend defined for storage 'some_storage'")
+}
+
+func TestUnmarshalDefaultMemory(t *testing.T) {
+	conf := loadConf(t, `
+backends:
+  some_storage:
+    memory:
+`)
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.Equal(t, 1_000_000, cfg.Backends["some_storage"].Memory.MaxTraces)
+}

--- a/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package jaegerstorage
 
 import (
@@ -14,7 +17,7 @@ import (
 func loadConf(t *testing.T, config string) *confmap.Conf {
 	d := t.TempDir()
 	f := filepath.Join(d, "config.yaml")
-	require.NoError(t, os.WriteFile(f, []byte(config), 0644))
+	require.NoError(t, os.WriteFile(f, []byte(config), 0o644))
 	cm, err := confmaptest.LoadConf(f)
 	require.NoError(t, err)
 	return cm

--- a/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
@@ -74,3 +74,36 @@ backends:
 	require.NoError(t, conf.Unmarshal(cfg))
 	assert.NotEmpty(t, cfg.Backends["some_storage"].GRPC.Timeout)
 }
+
+func TestConfigDefaultCassandra(t *testing.T) {
+	conf := loadConf(t, `
+backends:
+  some_storage:
+    cassandra:
+`)
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, conf.Unmarshal(cfg))
+	assert.NotEmpty(t, cfg.Backends["some_storage"].Cassandra.Primary.Servers)
+}
+
+func TestConfigDefaultElasticsearch(t *testing.T) {
+	conf := loadConf(t, `
+backends:
+  some_storage:
+    elasticsearch:
+`)
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, conf.Unmarshal(cfg))
+	assert.NotEmpty(t, cfg.Backends["some_storage"].Elasticsearch.Servers)
+}
+
+func TestConfigDefaultOpensearch(t *testing.T) {
+	conf := loadConf(t, `
+backends:
+  some_storage:
+    opensearch:
+`)
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, conf.Unmarshal(cfg))
+	assert.NotEmpty(t, cfg.Backends["some_storage"].Opensearch.Servers)
+}

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage/factoryadapter"
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
@@ -79,42 +78,27 @@ func newStorageExt(config *Config, telset component.TelemetrySettings) *storageE
 	}
 }
 
-func (s *storageExt) makeBuilder(mf metrics.Factory, cfg Backend) func() (storage.Factory, error) {
-	if cfg.Memory != nil {
-		return func() (storage.Factory, error) {
-			return memory.NewFactoryWithConfig(*cfg.Memory, mf, s.telset.Logger), nil
-		}
-	} else if cfg.Badger != nil {
-		return func() (storage.Factory, error) {
-			return badger.NewFactoryWithConfig(*cfg.Badger, mf, s.telset.Logger)
-		}
-	} else if cfg.GRPC != nil {
-		return func() (storage.Factory, error) {
-			return grpc.NewFactoryWithConfig(*cfg.GRPC, mf, s.telset.Logger)
-		}
-	} else if cfg.Cassandra != nil {
-		return func() (storage.Factory, error) {
-			return cassandra.NewFactoryWithConfig(*cfg.Cassandra, mf, s.telset.Logger)
-		}
-	} else if cfg.Elasticsearch != nil {
-		return func() (storage.Factory, error) {
-			return es.NewFactoryWithConfig(*cfg.Elasticsearch, mf, s.telset.Logger)
-		}
-	} else if cfg.Opensearch != nil {
-		return func() (storage.Factory, error) {
-			return es.NewFactoryWithConfig(*cfg.Opensearch, mf, s.telset.Logger)
-		}
-	}
-	return func() (storage.Factory, error) {
-		return nil, errors.New("empty configuration")
-	}
-}
-
-func (s *storageExt) Start(ctx context.Context, host component.Host) error {
+func (s *storageExt) Start(_ context.Context, _ component.Host) error {
 	mf := otelmetrics.NewFactory(s.telset.MeterProvider)
 	for storageName, cfg := range s.config.Backends {
 		s.telset.Logger.Sugar().Infof("Initializing storage '%s'", storageName)
-		factory, err := s.makeBuilder(mf, cfg)()
+		var factory storage.Factory
+		var err error = errors.New("empty configuration")
+		switch {
+		case cfg.Memory != nil:
+			factory, err = memory.NewFactoryWithConfig(*cfg.Memory, mf, s.telset.Logger), nil
+		case cfg.Badger != nil:
+			factory, err = badger.NewFactoryWithConfig(*cfg.Badger, mf, s.telset.Logger)
+		case cfg.GRPC != nil:
+			//nolint: contextcheck
+			factory, err = grpc.NewFactoryWithConfig(*cfg.GRPC, mf, s.telset.Logger)
+		case cfg.Cassandra != nil:
+			factory, err = cassandra.NewFactoryWithConfig(*cfg.Cassandra, mf, s.telset.Logger)
+		case cfg.Elasticsearch != nil:
+			factory, err = es.NewFactoryWithConfig(*cfg.Elasticsearch, mf, s.telset.Logger)
+		case cfg.Opensearch != nil:
+			factory, err = es.NewFactoryWithConfig(*cfg.Opensearch, mf, s.telset.Logger)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to initialize storage '%s': %w", storageName, err)
 		}

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -11,11 +11,9 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
-	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage/factoryadapter"
-	esCfg "github.com/jaegertracing/jaeger/pkg/es/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
@@ -34,7 +32,7 @@ type Extension interface {
 
 type storageExt struct {
 	config    *Config
-	logger    *zap.Logger
+	telset    component.TelemetrySettings
 	factories map[string]storage.Factory
 }
 
@@ -72,97 +70,42 @@ func GetStorageFactoryV2(name string, host component.Host) (spanstore.Factory, e
 	return factoryadapter.NewFactory(f), nil
 }
 
-func newStorageExt(config *Config, otel component.TelemetrySettings) *storageExt {
+func newStorageExt(config *Config, telset component.TelemetrySettings) *storageExt {
 	return &storageExt{
 		config:    config,
-		logger:    otel.Logger,
+		telset:    telset,
 		factories: make(map[string]storage.Factory),
 	}
 }
 
-type starter[Config any, Factory storage.Factory] struct {
-	ext         *storageExt
-	storageKind string
-	cfg         map[string]Config
-	builder     func(Config, metrics.Factory, *zap.Logger) (Factory, error)
-}
-
-func (s *starter[Config, Factory]) build(_ context.Context, _ component.Host) error {
-	for name, cfg := range s.cfg {
-		if _, ok := s.ext.factories[name]; ok {
-			return fmt.Errorf("duplicate %s storage name %s", s.storageKind, name)
-		}
-		factory, err := s.builder(
-			cfg,
-			metrics.NullFactory,
-			s.ext.logger.With(zap.String("storage_name", name)),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to initialize %s storage %s: %w", s.storageKind, name, err)
-		}
-		s.ext.factories[name] = factory
-	}
-	return nil
-}
-
 func (s *storageExt) Start(ctx context.Context, host component.Host) error {
-	memStarter := &starter[memory.Configuration, *memory.Factory]{
-		ext:         s,
-		storageKind: "memory",
-		cfg:         s.config.Memory,
-		// memory factory does not return an error, so need to wrap it
-		builder: func(
-			cfg memory.Configuration,
-			metricsFactory metrics.Factory,
-			logger *zap.Logger,
-		) (*memory.Factory, error) {
-			return memory.NewFactoryWithConfig(cfg, metricsFactory, logger), nil
-		},
-	}
-	badgerStarter := &starter[badger.NamespaceConfig, *badger.Factory]{
-		ext:         s,
-		storageKind: "badger",
-		cfg:         s.config.Badger,
-		builder:     badger.NewFactoryWithConfig,
-	}
-	grpcStarter := &starter[grpc.ConfigV2, *grpc.Factory]{
-		ext:         s,
-		storageKind: "grpc",
-		cfg:         s.config.GRPC,
-		builder:     grpc.NewFactoryWithConfig,
-	}
-	esStarter := &starter[esCfg.Configuration, *es.Factory]{
-		ext:         s,
-		storageKind: "elasticsearch",
-		cfg:         s.config.Elasticsearch,
-		builder:     es.NewFactoryWithConfig,
-	}
-	osStarter := &starter[esCfg.Configuration, *es.Factory]{
-		ext:         s,
-		storageKind: "opensearch",
-		cfg:         s.config.Opensearch,
-		builder:     es.NewFactoryWithConfig,
-	}
-	cassandraStarter := &starter[cassandra.Options, *cassandra.Factory]{
-		ext:         s,
-		storageKind: "cassandra",
-		cfg:         s.config.Cassandra,
-		builder:     cassandra.NewFactoryWithConfig,
-	}
-
-	builders := []func(ctx context.Context, host component.Host) error{
-		memStarter.build,
-		badgerStarter.build,
-		grpcStarter.build,
-		esStarter.build,
-		osStarter.build,
-		cassandraStarter.build,
-		// TODO add support for other backends
-	}
-	for _, builder := range builders {
-		if err := builder(ctx, host); err != nil {
-			return err
+	mf := otelmetrics.NewFactory(s.telset.MeterProvider)
+	for storageName, cfg := range s.config.Backends {
+		s.telset.Logger.Sugar().Infof("Initializing storage '%s'", storageName)
+		var factory storage.Factory
+		var err error
+		if _, ok := s.factories[storageName]; ok {
+			return fmt.Errorf("duplicate storage name '%s'", storageName)
 		}
+		if cfg.Memory != nil {
+			factory = memory.NewFactoryWithConfig(*cfg.Memory, mf, s.telset.Logger)
+		} else if cfg.Badger != nil {
+			factory, err = badger.NewFactoryWithConfig(*cfg.Badger, mf, s.telset.Logger)
+		} else if cfg.GRPC != nil {
+			factory, err = grpc.NewFactoryWithConfig(*cfg.GRPC, mf, s.telset.Logger)
+		} else if cfg.Cassandra != nil {
+			factory, err = cassandra.NewFactoryWithConfig(*cfg.Cassandra, mf, s.telset.Logger)
+		} else if cfg.Elasticsearch != nil {
+			factory, err = es.NewFactoryWithConfig(*cfg.Elasticsearch, mf, s.telset.Logger)
+		} else if cfg.Opensearch != nil {
+			factory, err = es.NewFactoryWithConfig(*cfg.Opensearch, mf, s.telset.Logger)
+		} else {
+			err = fmt.Errorf("empty configuration for storage '%s'", storageName)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to initialize storage '%s': %w", storageName, err)
+		}
+		s.factories[storageName] = factory
 	}
 	return nil
 }

--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -48,6 +48,18 @@ type Configuration struct {
 	TLS                  tlscfg.Options `mapstructure:"tls"`
 }
 
+func DefaultConfiguration() Configuration {
+	return Configuration{
+		Servers:            []string{"127.0.0.1"},
+		Port:               9042,
+		MaxRetryAttempts:   3,
+		Keyspace:           "jaeger_v1_test",
+		ProtoVersion:       4,
+		ConnectionsPerHost: 2,
+		ReconnectInterval:  60 * time.Second,
+	}
+}
+
 // Authenticator holds the authentication properties needed to connect to a Cassandra cluster
 type Authenticator struct {
 	Basic BasicAuthenticator `yaml:"basic" mapstructure:",squash"`

--- a/plugin/storage/badger/options.go
+++ b/plugin/storage/badger/options.go
@@ -64,21 +64,26 @@ const (
 	defaultKeysDir            = defaultDataDir + string(os.PathSeparator) + "keys"
 )
 
+func DefaultNamespaceConfig() NamespaceConfig {
+	defaultBadgerDataDir := getCurrentExecutableDir()
+	return NamespaceConfig{
+		SpanStoreTTL:          defaultTTL,
+		SyncWrites:            false, // Performance over durability
+		Ephemeral:             true,  // Default is ephemeral storage
+		ValueDirectory:        defaultBadgerDataDir + defaultValueDir,
+		KeyDirectory:          defaultBadgerDataDir + defaultKeysDir,
+		MaintenanceInterval:   defaultMaintenanceInterval,
+		MetricsUpdateInterval: defaultMetricsUpdateInterval,
+	}
+}
+
 // NewOptions creates a new Options struct.
 func NewOptions(primaryNamespace string, _ ...string /* otherNamespaces */) *Options {
-	defaultBadgerDataDir := getCurrentExecutableDir()
+	defaultConfig := DefaultNamespaceConfig()
+	defaultConfig.namespace = primaryNamespace
 
 	options := &Options{
-		Primary: NamespaceConfig{
-			namespace:             primaryNamespace,
-			SpanStoreTTL:          defaultTTL,
-			SyncWrites:            false, // Performance over durability
-			Ephemeral:             true,  // Default is ephemeral storage
-			ValueDirectory:        defaultBadgerDataDir + defaultValueDir,
-			KeyDirectory:          defaultBadgerDataDir + defaultKeysDir,
-			MaintenanceInterval:   defaultMaintenanceInterval,
-			MetricsUpdateInterval: defaultMetricsUpdateInterval,
-		},
+		Primary: defaultConfig,
 	}
 
 	return options

--- a/plugin/storage/cassandra/factory.go
+++ b/plugin/storage/cassandra/factory.go
@@ -134,7 +134,7 @@ func (f *Factory) configureFromOptions(o *Options) {
 	f.Options = o
 	// TODO this is a hack because we do not define defaults in Options
 	if o.others == nil {
-		o.others = make(map[string]*namespaceConfig)
+		o.others = make(map[string]*NamespaceConfig)
 	}
 	f.primaryConfig = o.GetPrimary()
 	if cfg := f.Options.Get(archiveStorageConfig); cfg != nil {

--- a/plugin/storage/cassandra/factory_test.go
+++ b/plugin/storage/cassandra/factory_test.go
@@ -204,7 +204,7 @@ func TestConfigureFromOptions(t *testing.T) {
 func TestNewFactoryWithConfig(t *testing.T) {
 	t.Run("valid configuration", func(t *testing.T) {
 		opts := &Options{
-			Primary: namespaceConfig{
+			Primary: NamespaceConfig{
 				Configuration: cassandraCfg.Configuration{
 					Servers: []string{"localhost:9200"},
 				},
@@ -224,7 +224,7 @@ func TestNewFactoryWithConfig(t *testing.T) {
 	t.Run("connection error", func(t *testing.T) {
 		expErr := errors.New("made-up error")
 		opts := &Options{
-			Primary: namespaceConfig{
+			Primary: NamespaceConfig{
 				Configuration: cassandraCfg.Configuration{
 					Servers: []string{"localhost:9200"},
 				},

--- a/plugin/storage/es/factory.go
+++ b/plugin/storage/es/factory.go
@@ -96,7 +96,7 @@ func NewFactoryWithConfig(
 		return nil, err
 	}
 
-	defaultConfig := getDefaultConfig()
+	defaultConfig := DefaultConfig()
 	cfg.ApplyDefaults(&defaultConfig)
 
 	archive := make(map[string]*namespaceConfig)

--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -99,7 +99,7 @@ type namespaceConfig struct {
 // NewOptions creates a new Options struct.
 func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 	// TODO all default values should be defined via cobra flags
-	defaultConfig := getDefaultConfig()
+	defaultConfig := DefaultConfig()
 	options := &Options{
 		Primary: namespaceConfig{
 			Configuration: defaultConfig,
@@ -408,7 +408,7 @@ func initDateLayout(rolloverFreq, sep string) string {
 	return indexLayout
 }
 
-func getDefaultConfig() config.Configuration {
+func DefaultConfig() config.Configuration {
 	return config.Configuration{
 		Username:                     "",
 		Password:                     "",

--- a/plugin/storage/grpc/config.go
+++ b/plugin/storage/grpc/config.go
@@ -47,6 +47,14 @@ type ConfigV2 struct {
 	exporterhelper.TimeoutSettings `mapstructure:",squash"`
 }
 
+func DefaultConfigV2() ConfigV2 {
+	return ConfigV2{
+		TimeoutSettings: exporterhelper.TimeoutSettings{
+			Timeout: defaultConnectionTimeout,
+		},
+	}
+}
+
 func (c *Configuration) TranslateToConfigV2() *ConfigV2 {
 	return &ConfigV2{
 		ClientConfig: configgrpc.ClientConfig{

--- a/plugin/storage/grpc/config_test.go
+++ b/plugin/storage/grpc/config_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"google.golang.org/grpc"
@@ -21,4 +22,9 @@ func TestBuildRemoteNewClientError(t *testing.T) {
 	_, err := newRemoteStorage(c, component.TelemetrySettings{}, newClientFn)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error creating remote storage client")
+}
+
+func TestDefaultConfigV2(t *testing.T) {
+	cfg := DefaultConfigV2()
+	assert.NotEmpty(t, cfg.Timeout)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Many OTEL Collector components provide default configs such that users do not need to provide most settings.
- However, due to our organization of the storage extension config, there was no way to provide defaults

## Description of the changes
- 🛑 **breaking**  Change the main config inside out: instead of static separation by storage types followed by a map of custom names, move the map to the top level followed by static separation by storage type. E.g.
```yaml
# before
    memory:
      some_storage:
        max_traces: 100000
# after
    backends:
      some_storage:
        memory:
          max_traces: 100000
```
- This required an introduction of an extra nesting via `backends`, which is a bit unfortunate, but the OTEL framework requires config to be a struct, it did not work with a map at the top level. Having a struct might actually be beneficial in the future if we need some top-level settings
- Add custom marshaling code where if a specific storage type is detected as set-by-user, then a default is created first (similar mechanism to how extension default configs is created by OTEL Collector, but unfortunately that mechanism is rigid, non-recursive)
- Change sample config files to the new format
- Use names `some_store` and `another_store` in configs to emphasize that those are custom names, not part of the config struct
- Add more unit tests for config

## How was this change tested?
- Unit tests and CI

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
