### PR TITLE
Use local images for ES integration tests

### DIFF
--- a/plugin/storage/integration/es_index_cleaner_test.go
+++ b/plugin/storage/integration/es_index_cleaner_test.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -27,15 +28,27 @@ import (
 )
 
 const (
-	archiveIndexName      = "jaeger-span-archive"
-	dependenciesIndexName = "jaeger-dependencies-2019-01-01"
-	samplingIndexName     = "jaeger-sampling-2019-01-01"
-	spanIndexName         = "jaeger-span-2019-01-01"
-	serviceIndexName      = "jaeger-service-2019-01-01"
-	indexCleanerImage     = "jaegertracing/jaeger-es-index-cleaner:latest"
-	rolloverImage         = "jaegertracing/jaeger-es-rollover:1.57.0"
-	rolloverNowEnvVar     = `CONDITIONS='{"max_age":"0s"}'`
+	archiveIndexName         = "jaeger-span-archive"
+	dependenciesIndexName    = "jaeger-dependencies-2019-01-01"
+	samplingIndexName        = "jaeger-sampling-2019-01-01"
+	spanIndexName            = "jaeger-span-2019-01-01"
+	serviceIndexName         = "jaeger-service-2019-01-01"
+	defaultIndexCleanerImage = "jaegertracing/jaeger-es-index-cleaner:latest"
+	defaultRolloverImage     = "jaegertracing/jaeger-es-rollover:1.57.0"
+	rolloverNowEnvVar        = `CONDITIONS='{"max_age":"0s"}'`
 )
+
+var (
+	indexCleanerImage = getEnvOrDefault("JAEGER_ES_INDEX_CLEANER_IMAGE", defaultIndexCleanerImage)
+	rolloverImage     = getEnvOrDefault("JAEGER_ES_ROLLOVER_IMAGE", defaultRolloverImage)
+)
+
+func getEnvOrDefault(key, defaultValue string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
+}
 
 func TestIndexCleaner_doNotFailOnEmptyStorage(t *testing.T) {
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5709 

## Description of the changes
- Added a new function build_local_images() that builds the local images for the index cleaner and rollover containers.
- The function sets environment variables JAEGER_ES_INDEX_CLEANER_IMAGE and JAEGER_ES_ROLLOVER_IMAGE with the locally built image names.
- Modified the indexCleanerImage and rolloverImage variables to use the getEnvOrDefault function. This allows them to use the environment variables set by the es-integration-test.sh script if they exist, or fall back to the default values if they don't.

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
