### PR TITLE
[bug] Use correct argument as jaeger-version

### DIFF
--- a/.github/workflows/ci-elasticsearch.yml
+++ b/.github/workflows/ci-elasticsearch.yml
@@ -53,9 +53,6 @@ jobs:
       with:
         go-version: 1.22.x
 
-    - name: Install tools
-      run: make install-ci
-
     - uses: docker/setup-qemu-action@5927c834f5b4fdf503fca6f4c7eccda82949e1ee # v3.1.0
     - name: Run ${{ matrix.version.distribution }} integration tests
       id: test-execution

--- a/.github/workflows/ci-lint-shell-scripts.yml
+++ b/.github/workflows/ci-lint-shell-scripts.yml
@@ -1,4 +1,4 @@
-name: Validation Of Shell Scripts
+name: Lint Shell Scripts
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  validation-of-shell-scripts:
+  link-shell-scripts:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +20,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: check out code 
+    - name: check out code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Install shellcheck
@@ -28,9 +28,3 @@ jobs:
 
     - name: Run shellcheck
       run: shellcheck scripts/*.sh
-
-
-
-
-
-

--- a/.github/workflows/ci-opensearch.yml
+++ b/.github/workflows/ci-opensearch.yml
@@ -50,9 +50,6 @@ jobs:
       with:
         go-version: 1.22.x
 
-    - name: Install tools
-      run: make install-ci
-
     - uses: docker/setup-qemu-action@5927c834f5b4fdf503fca6f4c7eccda82949e1ee # v3.1.0
 
     - name: Run ${{ matrix.version.distribution }} integration tests

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -139,8 +139,8 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 	require.True(t, ok)
 	query, ok := extensions["jaeger_query"].(map[string]any)
 	require.True(t, ok)
-	trace_storage := query["trace_storage"].(string)
-	extensions["storage_cleaner"] = map[string]string{"trace_storage": trace_storage}
+	traceStorage := query["trace_storage"].(string)
+	extensions["storage_cleaner"] = map[string]string{"trace_storage": traceStorage}
 
 	jaegerStorage, ok := extensions["jaeger_storage"].(map[string]any)
 	require.True(t, ok)
@@ -148,15 +148,15 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 	switch storage {
 	case "elasticsearch":
 		elasticsearch, ok := jaegerStorage["elasticsearch"].(map[string]any)
-		require.True(t, ok)
-		esMain, ok := elasticsearch["es_main"].(map[string]any)
+		require.True(t, ok, "expecting 'elasticsearch'")
+		esMain, ok := elasticsearch["some_storage"].(map[string]any)
 		require.True(t, ok)
 		esMain["service_cache_ttl"] = "1ms"
 
 	case "opensearch":
 		opensearch, ok := jaegerStorage["opensearch"].(map[string]any)
 		require.True(t, ok)
-		osMain, ok := opensearch["os_main"].(map[string]any)
+		osMain, ok := opensearch["some_storage"].(map[string]any)
 		require.True(t, ok)
 		osMain["service_cache_ttl"] = "1ms"
 

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -131,35 +131,37 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 	err = yaml.Unmarshal(data, &config)
 	require.NoError(t, err)
 
-	service, ok := config["service"].(map[string]any)
+	serviceAny, ok := config["service"]
 	require.True(t, ok)
+	service := serviceAny.(map[string]any)
 	service["extensions"] = append(service["extensions"].([]any), "storage_cleaner")
 
-	extensions, ok := config["extensions"].(map[string]any)
+	extensionsAny, ok := config["extensions"]
 	require.True(t, ok)
-	query, ok := extensions["jaeger_query"].(map[string]any)
+	extensions := extensionsAny.(map[string]any)
+	queryAny, ok := extensions["jaeger_query"]
 	require.True(t, ok)
-	traceStorage := query["trace_storage"].(string)
+	traceStorageAny, ok := queryAny.(map[string]any)["trace_storage"]
+	require.True(t, ok)
+	traceStorage := traceStorageAny.(string)
 	extensions["storage_cleaner"] = map[string]string{"trace_storage": traceStorage}
 
-	jaegerStorage, ok := extensions["jaeger_storage"].(map[string]any)
+	jaegerStorageAny, ok := extensions["jaeger_storage"]
 	require.True(t, ok)
+	jaegerStorage := jaegerStorageAny.(map[string]any)
+	backendsAny, ok := jaegerStorage["backends"]
+	require.True(t, ok)
+	backends := backendsAny.(map[string]any)
 
 	switch storage {
-	case "elasticsearch":
-		elasticsearch, ok := jaegerStorage["elasticsearch"].(map[string]any)
-		require.True(t, ok, "expecting 'elasticsearch'")
-		esMain, ok := elasticsearch["some_storage"].(map[string]any)
-		require.True(t, ok)
+	case "elasticsearch", "opensearch":
+		someStoreAny, ok := backends["some_storage"]
+		require.True(t, ok, "expecting 'some_storage' entry, found: %v", jaegerStorage)
+		someStore := someStoreAny.(map[string]any)
+		esMainAny, ok := someStore[storage]
+		require.True(t, ok, "expecting '%s' entry, found %v", storage, someStore)
+		esMain := esMainAny.(map[string]any)
 		esMain["service_cache_ttl"] = "1ms"
-
-	case "opensearch":
-		opensearch, ok := jaegerStorage["opensearch"].(map[string]any)
-		require.True(t, ok)
-		osMain, ok := opensearch["some_storage"].(map[string]any)
-		require.True(t, ok)
-		osMain["service_cache_ttl"] = "1ms"
-
 	default:
 		// Do Nothing
 	}

--- a/cmd/jaeger/internal/integration/e2e_integration_test.go
+++ b/cmd/jaeger/internal/integration/e2e_integration_test.go
@@ -3,5 +3,8 @@ package integration
 import "testing"
 
 func TestCreateStorageCleanerConfig(t *testing.T) {
+	// Ensure that we can parse the existing configs correctly.
+	// This is faster to run than the full integration test.
 	createStorageCleanerConfig(t, "../../config-elasticsearch.yaml", "elasticsearch")
+	createStorageCleanerConfig(t, "../../config-opensearch.yaml", "opensearch")
 }

--- a/cmd/jaeger/internal/integration/e2e_integration_test.go
+++ b/cmd/jaeger/internal/integration/e2e_integration_test.go
@@ -1,0 +1,7 @@
+package integration
+
+import "testing"
+
+func TestCreateStorageCleanerConfig(t *testing.T) {
+	createStorageCleanerConfig(t, "../../config-elasticsearch.yaml", "elasticsearch")
+}

--- a/cmd/jaeger/internal/integration/e2e_integration_test.go
+++ b/cmd/jaeger/internal/integration/e2e_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package integration
 
 import "testing"

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 
 PS4='T$(date "+%H:%M:%S") '
-set -euxf -o pipefail
+set -euf -o pipefail
 
 # use global variables to reflect status of db
 db_is_up=
 
 usage() {
-  echo $"Usage: $0 <elasticsearch|opensearch> <version>"
+  echo "Usage: $0 <backend> <backend_version> <jaeger_version>"
+  echo "  backend:         elasticsearch | opensearch"
+  echo "  backend_version: major version, e.g. 7.x"
+  echo "  jaeger_version:  major version, e.g. v1 | v2"
   exit 1
 }
 
 check_arg() {
   if [ ! $# -eq 3 ]; then
-    echo "ERROR: need exactly three arguments, <elasticsearch|opensearch> <image> <jaeger-version>"
+    echo "ERROR: need exactly three arguments"
     usage
   fi
 }
@@ -102,7 +105,9 @@ main() {
   local es_version=$2
   local j_version=$3
 
-  # bring_up_storage "${distro}" "${es_version}"
+  set -x
+
+  bring_up_storage "${distro}" "${es_version}"
 
   if [[ "${j_version}" == "v2" ]]; then
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -100,7 +100,7 @@ main() {
   check_arg "$@"
   local distro=$1
   local es_version=$2
-  local j_version=$2
+  local j_version=$3
 
   bring_up_storage "${distro}" "${es_version}"
 
@@ -111,7 +111,7 @@ main() {
     make index-cleaner-integration-test
     make index-rollover-integration-test
   else
-    echo "ERROR: Invalid jaeger_version=${j_version} argument value, expecing v1/v2".
+    echo "ERROR: Invalid argument value jaeger_version=${j_version}, expecing v1/v2".
     exit 1
   fi
 }

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -112,6 +112,7 @@ main() {
     make index-rollover-integration-test
   else
     echo "ERROR: Invalid jaeger_version=${j_version} argument value, expecing v1/v2".
+    exit 1
   fi
 }
 

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -102,7 +102,7 @@ main() {
   local es_version=$2
   local j_version=$3
 
-  bring_up_storage "${distro}" "${es_version}"
+  # bring_up_storage "${distro}" "${es_version}"
 
   if [[ "${j_version}" == "v2" ]]; then
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -106,10 +106,12 @@ main() {
 
   if [[ "${j_version}" == "v2" ]]; then
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
-  else
+  elif [[ "${j_version}" == "v1" ]]; then
     STORAGE=${distro} make storage-integration-test
     make index-cleaner-integration-test
     make index-rollover-integration-test
+  else
+    echo "ERROR: Invalid jaeger_version=${j_version} argument value, expecing v1/v2".
   fi
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- There is a typo in the test script that means v2 test was never executed: https://github.com/jaegertracing/jaeger/blob/7b7e5ccb8ecb3a66ea3a6b06ecca63bff97897e9/scripts/es-integration-test.sh#L102-L103
- Even with the typo fixed the way the configs are parsed in the e2e tests (in order to add a storage cleaner extension) did not match the recent config changes (which would've caught the issue if not for the typo above).

## Description of the changes
- Fix typo. Expand usage printout to illustrate expected argument values
- Fix config parsing to reflect the new structure.

## How was this change tested?
- Added unit test for config parsing, made sure it's successful
- CI shows v2 test is being executed https://github.com/jaegertracing/jaeger/actions/runs/9830991980/job/27137813884?pr=5716#step:8:230
```
T23:12:04 make jaeger-v2-storage-integration-test
...
=== RUN   TestESStorage
    e2e_integration.go:50: Starting Jaeger-v2 in the background with config file /tmp/TestESStorage88065053/001/storageCleaner_config.yaml
    e2e_integration.go:58: Writing the Jaeger-v2 output logs into /tmp/TestESStorage88065053/002/jaeger_output_logs.txt
    e2e_integration.go:66: Writing the Jaeger-v2 error logs into /tmp/TestESStorage88065053/003/jaeger_error_logs.txt
    e2e_integration.go:81: Checking if Jaeger-v2 is available on http://localhost:16686/
    e2e_integration.go:94: Jaeger-v2 is ready
    logger.go:146: 2024-07-07T23:15:00.796Z	INFO	integration/span_writer.go:36	Creating the span writer	{"port": 4317}
    logger.go:146: 2024-07-07T23:15:00.797Z	INFO	integration/span_reader.go:38	Creating the span reader	{"port": 16685}
```
