### PR TITLE
[hotrod] Fix connectivity in docker compose

### DIFF
--- a/cmd/jaeger/internal/integration/storagecleaner/README.md
+++ b/cmd/jaeger/internal/integration/storagecleaner/README.md
@@ -1,37 +1,10 @@
 # storage_cleaner
 
-This module implements an extension that allows purging the backend storage by making an HTTP POST request to it. 
+This module implements an extension that allows purging the backend storage by making an HTTP POST request to it.
 
 The storage_cleaner extension is intended to be used only in tests, providing a way to clear the storage between test runs. Making a POST request to the exposed endpoint will delete all data in storage.
 
-
-```mermaid
-flowchart LR
-    Receiver --> Processor
-    Processor --> Exporter
-    JaegerStorageExension -->|"(1) get storage"| Exporter
-    Exporter -->|"(2) write trace"| Storage
-
-    E2E_test -->|"(1) POST /purge"| HTTP_endpoint
-    JaegerStorageExension -->|"(2) getStorage()"| HTTP_endpoint
-    HTTP_endpoint -.->|"(3) storage.(*storage.Purger).Purge()"| Storage
-
-    subgraph Jaeger Collector
-        Receiver
-        Processor
-        Exporter
-        
-        Storage
-        StorageCleanerExtension
-        HTTP_endpoint
-        subgraph JaegerStorageExension
-            Storage
-        end
-        subgraph StorageCleanerExtension
-            HTTP_endpoint
-        end
-    end
-```
+See [Architecture Diagram](../README.md) in the parent directory.
 
 # Getting Started
 
@@ -44,4 +17,3 @@ extensions:
   storage_cleaner:
     trace_storage: storage_name
 ```
-

--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -24,6 +24,45 @@ The following diagram illustrates the relationship between these components:
 
 ![SPM diagram](./diagram.png)
 
+```mermaid
+flowchart LR
+    SDK -->|traces| Receiver
+    Receiver --> MG
+    Receiver --> Batch
+    MG --> ExpMetrics
+    Batch --> ExpTraces
+    ExpMetrics -->|metrics| Prometheus[(Prometheus)]
+    ExpTraces -->|traces| Jaeger[Jaeger
+     Collector]
+    Prometheus -.-> JaegerUI
+    Jaeger --> Storage[(Storage)]
+    Storage -.-> JaegerUI[Jaeger
+     Query
+     and UI]
+
+    style Prometheus fill:red,color:white
+    style Jaeger fill:blue,color:white
+    style JaegerUI fill:blue,color:white
+    style Storage fill:gray,color:white
+
+    subgraph Application
+        SDK[OTel
+         SDK]
+    end
+
+    subgraph OTEL[OTel Collector]
+        Receiver
+        Batch
+        MG[Span
+         Metrics
+         Connector]
+        ExpTraces[Traces
+         Exporter]
+        ExpMetrics[Metrics
+         Exporter]
+    end
+```
+
 # Getting Started
 
 ## Quickstart
@@ -160,7 +199,7 @@ quantile = 'quantile=' floatValue
   - The quantile to compute the latency 'P' value. Valid range (0,1].
   - Mandatory for 'latencies' type.
 
-groupByOperation = 'groupByOperation=' boolValue 
+groupByOperation = 'groupByOperation=' boolValue
 boolValue = '1' | 't' | 'T' | 'true' | 'TRUE' | 'True' | 0 | 'f' | 'F' | 'false' | 'FALSE' | 'False'
   - A boolean value which will determine if the metrics query will also group by operation.
   - Optional with default: false

--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -8,9 +8,14 @@ services:
     image: jaegertracing/all-in-one:${JAEGER_VERSION:-latest}
     ports:
       - "16686:16686"
+      - "4317:4317"
       - "4318:4318"
     environment:
       - LOG_LEVEL=debug
+      # Since v0.105 the OTEL Collector components default hostname to 'localhost'.
+      # However, that does not work inside a Docker container, so we listen on all IPs.
+      - COLLECTOR_OTLP_GRPC_HOST_PORT=0.0.0.0:4317
+      - COLLECTOR_OTLP_HTTP_HOST_PORT=0.0.0.0:4318
     networks:
       - jaeger-example
   hotrod:


### PR DESCRIPTION
## Which problem is this PR solving?
- HotROD demo stopped working. Since v0.105 the OTEL Collector components default hostname to 'localhost. However, that does not work inside a Docker container (at least on MacOS & Docker Desktop).

## Description of the changes
- Make OTLP receivers listen on all IPs (0.0.0.0)
- Unrelated, but added a mermaid diagram for SPM, as I needed it for the slides for a presentation

## How was this change tested?
- Go through HotROD demo workflow
