### PR TITLE
Block patch upgrades for GH actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,11 @@
       "groupName": "github-actions deps"
     },
     {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major", "patch", "digest"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["gomod"],
       "matchSourceUrlPrefixes": [
         "go.opentelemetry.io/otel",


### PR DESCRIPTION
## Which problem is this PR solving?
- Patch upgrades for GH actions are unnecessary noise

## Description of the changes
- Restrict updates to major/minor only
