### PR TITLE
Completely remove "grpc-plugin" as storage type

### DIFF
--- a/plugin/storage/factory.go
+++ b/plugin/storage/factory.go
@@ -46,7 +46,6 @@ const (
 	memoryStorageType        = "memory"
 	kafkaStorageType         = "kafka"
 	grpcStorageType          = "grpc"
-	grpcPluginDeprecated     = "grpc-plugin"
 	badgerStorageType        = "badger"
 	blackholeStorageType     = "blackhole"
 

--- a/plugin/storage/factory_config.go
+++ b/plugin/storage/factory_config.go
@@ -66,13 +66,6 @@ func FactoryConfigFromEnvAndCLI(args []string, log io.Writer) FactoryConfig {
 	if spanStorageType == "" {
 		spanStorageType = cassandraStorageType
 	}
-	if spanStorageType == grpcPluginDeprecated {
-		fmt.Fprintf(log,
-			"WARNING: `%s` storage type is deprecated and will be remove from v1.60. Use `%s`.\n\n",
-			grpcPluginDeprecated, grpcStorageType,
-		)
-		spanStorageType = grpcStorageType
-	}
 	spanWriterTypes := strings.Split(spanStorageType, ",")
 	if len(spanWriterTypes) > 1 {
 		fmt.Fprintf(log,


### PR DESCRIPTION
## Which problem is this PR solving?
- Last part of #4647
- In accordance with our deprecation policy, this CLI value can be removed in v1.60 (next release)

## Description of the changes
- No longer accept `grpc-plugin` as a storage type. The valid value is `grpc`.
