### PR TITLE
[bug] [hotrod] Delay env var mapping until logger is initialized

### DIFF
--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -56,8 +56,6 @@ func init() {
 
 // onInitialize is called before the command is executed.
 func onInitialize() {
-	jaegerclientenv2otel.MapJaegerToOtelEnvVars(logger)
-
 	zapOptions := []zap.Option{
 		zap.AddStacktrace(zapcore.FatalLevel),
 		zap.AddCallerSkip(1),
@@ -68,6 +66,9 @@ func onInitialize() {
 		)
 	}
 	logger, _ = zap.NewDevelopment(zapOptions...)
+
+	jaegerclientenv2otel.MapJaegerToOtelEnvVars(logger)
+
 	metricsFactory = prometheus.New().Namespace(metrics.NSOptions{Name: "hotrod", Tags: nil})
 
 	if config.MySQLGetDelay != fixDBConnDelay {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5759 

## Description of the changes
- Invoke mapping function (which takes logger) after the logger is initialized
- It is safe to do because none of the env vars control the logic for logger initialization

## How was this change tested?
- `$ JAEGER_AGENT_PORT=xyz go run ./examples/hotrod  all`
- Before the change this command would cause a panic
