### PR TITLE
Skip building HotROD for all platforms for pull requests

### DIFF
--- a/.github/workflows/ci-docker-hotrod.yml
+++ b/.github/workflows/ci-docker-hotrod.yml
@@ -44,8 +44,21 @@ jobs:
 
     - uses: docker/setup-qemu-action@5927c834f5b4fdf503fca6f4c7eccda82949e1ee # v3.1.0
 
+    - name: Define BUILD_FLAGS var if running on a Pull Request
+      run: |
+        case ${GITHUB_EVENT_NAME} in
+          pull_request)
+            echo "BUILD_FLAGS=-l -p linux/amd64" >> ${GITHUB_ENV}
+            ;;
+          *)
+            echo "BUILD_FLAGS=" >> ${GITHUB_ENV}
+            ;;
+        esac
+
     - name: Build, test, and publish hotrod image
-      run: bash scripts/hotrod-integration-test.sh
+      run: |
+        bash scripts/hotrod-integration-test.sh \
+          ${{ env.BUILD_FLAGS }} 
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION

## Which problem is this PR solving?
- This PR address issue #5743 

## Description of the changes
-  To Skip building HotROD for all platforms for pull requests, We are adding `BUILD_FLAGS=-l -p linux/amd64` in 
   `.github/workflows/ci-hotrod.yml` while executing  `scripts/hotrod-integration-test.sh`. 
   Where,
   -  -l for local build only (no pushing to public registry)
   -  '-p' to only build for specified platforms and not all.

## How was this change tested?
-  I only tested how the flags are being passed to the script file. 
-  GitHub Actions related stuff is yet to be tested.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
