### PR TITLE
Ensure hotrod image is published at the end of e2e test

### DIFF
--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -86,5 +86,5 @@ if [[ "$span_count" -lt "$EXPECTED_SPANS" ]]; then
   exit 1
 fi
 
-# Ensure the image is published after succesful test (no -l flag)
+# Ensure the image is published after successful test (no -l flag)
 bash scripts/build-upload-a-docker-image.sh -c example-hotrod -d examples/hotrod -p "${platforms}"


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes a bug introduced in https://github.com/jaegertracing/jaeger/pull/5740/files#r1683565379

## Description of the changes
- Continue the script on successful test
- Publish the image at the end

## How was this change tested?
- CI
