### PR TITLE
Add metrics storage to storage capabilities

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -69,7 +69,7 @@ func (s *server) Start(_ context.Context, host component.Host) error {
 	}
 	qs := querysvc.NewQueryService(spanReader, depReader, opts)
 
-	mqs, err := s.createMetricReader(host)
+	mqs, err := s.createMetricReader(&opts, host)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func (s *server) addArchiveStorage(opts *querysvc.QueryServiceOptions, host comp
 	return nil
 }
 
-func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, error) {
+func (s *server) createMetricReader(opts *querysvc.QueryServiceOptions, host component.Host) (metricsstore.Reader, error) {
 	if s.config.MetricStorage == "" {
 		s.telset.Logger.Info("Metric storage not configured")
 		return disabled.NewMetricsReader()
@@ -143,6 +143,7 @@ func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, e
 	if err != nil {
 		return nil, fmt.Errorf("cannot create metrics reader %w", err)
 	}
+	opts.MetricsReader = metricsReader
 	return metricsReader, err
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -69,7 +69,8 @@ func (s *server) Start(_ context.Context, host component.Host) error {
 	}
 	qs := querysvc.NewQueryService(spanReader, depReader, opts)
 
-	mqs, err := s.createMetricReader(&opts, host)
+	mqs, err := s.createMetricReader(host)
+	opts.MetricsReader = mqs
 	if err != nil {
 		return err
 	}
@@ -128,7 +129,7 @@ func (s *server) addArchiveStorage(opts *querysvc.QueryServiceOptions, host comp
 	return nil
 }
 
-func (s *server) createMetricReader(opts *querysvc.QueryServiceOptions, host component.Host) (metricsstore.Reader, error) {
+func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, error) {
 	if s.config.MetricStorage == "" {
 		s.telset.Logger.Info("Metric storage not configured")
 		return disabled.NewMetricsReader()
@@ -143,7 +144,6 @@ func (s *server) createMetricReader(opts *querysvc.QueryServiceOptions, host com
 	if err != nil {
 		return nil, fmt.Errorf("cannot create metrics reader %w", err)
 	}
-	opts.MetricsReader = metricsReader
 	return metricsReader, err
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server_test.go
@@ -293,6 +293,7 @@ func TestServerAddMetricsStorage(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		qSvcOpts       *querysvc.QueryServiceOptions
 		config         *Config
 		extension      component.Component
 		expectedOutput string
@@ -301,6 +302,7 @@ func TestServerAddMetricsStorage(t *testing.T) {
 		{
 			name:           "Metrics storage unset",
 			config:         &Config{},
+			qSvcOpts:       &querysvc.QueryServiceOptions{},
 			expectedOutput: `{"level":"info","msg":"Metric storage not configured"}` + "\n",
 			expectedErr:    "",
 		},
@@ -309,6 +311,7 @@ func TestServerAddMetricsStorage(t *testing.T) {
 			config: &Config{
 				MetricStorage: "random-value",
 			},
+			qSvcOpts:       &querysvc.QueryServiceOptions{},
 			expectedOutput: "",
 			expectedErr:    "cannot find metrics storage factory: cannot find extension",
 		},
@@ -324,7 +327,7 @@ func TestServerAddMetricsStorage(t *testing.T) {
 			if tt.extension != nil {
 				host = storagetest.NewStorageHost().WithExtension(jaegerstorage.ID, tt.extension)
 			}
-			_, err := server.createMetricReader(host)
+			_, err := server.createMetricReader(tt.qSvcOpts, host)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/cmd/jaeger/internal/extension/jaegerquery/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server_test.go
@@ -293,7 +293,6 @@ func TestServerAddMetricsStorage(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		qSvcOpts       *querysvc.QueryServiceOptions
 		config         *Config
 		extension      component.Component
 		expectedOutput string

--- a/cmd/jaeger/internal/extension/jaegerquery/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server_test.go
@@ -302,7 +302,6 @@ func TestServerAddMetricsStorage(t *testing.T) {
 		{
 			name:           "Metrics storage unset",
 			config:         &Config{},
-			qSvcOpts:       &querysvc.QueryServiceOptions{},
 			expectedOutput: `{"level":"info","msg":"Metric storage not configured"}` + "\n",
 			expectedErr:    "",
 		},
@@ -311,7 +310,6 @@ func TestServerAddMetricsStorage(t *testing.T) {
 			config: &Config{
 				MetricStorage: "random-value",
 			},
-			qSvcOpts:       &querysvc.QueryServiceOptions{},
 			expectedOutput: "",
 			expectedErr:    "cannot find metrics storage factory: cannot find extension",
 		},
@@ -327,7 +325,7 @@ func TestServerAddMetricsStorage(t *testing.T) {
 			if tt.extension != nil {
 				host = storagetest.NewStorageHost().WithExtension(jaegerstorage.ID, tt.extension)
 			}
-			_, err := server.createMetricReader(tt.qSvcOpts, host)
+			_, err := server.createMetricReader(host)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jaegertracing/jaeger/model/adjuster"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
+	"github.com/jaegertracing/jaeger/storage/metricsstore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
@@ -38,13 +39,14 @@ const (
 type QueryServiceOptions struct {
 	ArchiveSpanReader spanstore.Reader
 	ArchiveSpanWriter spanstore.Writer
+	MetricsReader     metricsstore.Reader
 	Adjuster          adjuster.Adjuster
 }
 
 // StorageCapabilities is a feature flag for query service
 type StorageCapabilities struct {
 	ArchiveStorage bool `json:"archiveStorage"`
-	// TODO: Maybe add metrics Storage here
+	MetricStorage  bool `json:"metricsStorage"`
 	// SupportRegex     bool
 	// SupportTagFilter bool
 }
@@ -134,6 +136,7 @@ func (qs QueryService) GetDependencies(ctx context.Context, endTs time.Time, loo
 func (qs QueryService) GetCapabilities() StorageCapabilities {
 	return StorageCapabilities{
 		ArchiveStorage: qs.options.hasArchiveStorage(),
+		MetricStorage:  qs.options.hasMetricStorage(),
 	}
 }
 
@@ -170,4 +173,10 @@ func (opts *QueryServiceOptions) InitArchiveStorage(storageFactory storage.Facto
 // hasArchiveStorage returns true if archive storage reader/writer are initialized.
 func (opts *QueryServiceOptions) hasArchiveStorage() bool {
 	return opts.ArchiveSpanReader != nil && opts.ArchiveSpanWriter != nil
+}
+
+// hasMetricsStorage returns true if metric storage reader is initialized.
+func (opts *QueryServiceOptions) hasMetricStorage() bool {
+	// TODO: NEED to pass the reader when the metricsreader is created
+	return opts.MetricsReader != nil
 }

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -87,7 +87,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 			logAccess:                   true,
 			UIConfigPath:                "",
 			expectedUIConfig:            "JAEGER_CONFIG=DEFAULT_CONFIG;",
-			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":false};`,
+			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":false,"metricsStorage":false};`,
 		},
 		{
 			basePath:                    "/",
@@ -96,7 +96,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 			expectedBaseHTML:            `<base href="/"`,
 			UIConfigPath:                "fixture/ui-config.json",
 			expectedUIConfig:            `JAEGER_CONFIG = {"x":"y"};`,
-			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":false};`,
+			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":false,"metricsStorage":false};`,
 		},
 		{
 			basePath:                    "/jaeger",
@@ -106,7 +106,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 			archiveStorage:              true,
 			UIConfigPath:                "fixture/ui-config.js",
 			expectedUIConfig:            "function UIConfig(){",
-			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":true};`,
+			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":true,"metricsStorage":false};`,
 		},
 	}
 	httpClient = &http.Client{


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5632 

## Description of the changes
- Added metrics storage to storage capabilities in the query service

## How was this change tested?
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
