### PR TITLE
Fix grpc tests sleep between connections

### DIFF
--- a/pkg/discovery/grpcresolver/grpc_resolver_test.go
+++ b/pkg/discovery/grpcresolver/grpc_resolver_test.go
@@ -88,6 +88,9 @@ func makeSureConnectionsUp(t *testing.T, count int, testc grpc_testing.TestServi
 	for si := 0; si < count; si++ {
 		connected := false
 		for i := 0; i < 3000; i++ { // 3000 * 10ms = 30s
+			if i != 0 {
+				time.Sleep(time.Millisecond * 10)
+			}
 			_, err := testc.EmptyCall(context.Background(), &grpc_testing.Empty{}, grpc.Peer(&p))
 			if err != nil {
 				continue
@@ -98,7 +101,6 @@ func makeSureConnectionsUp(t *testing.T, count int, testc grpc_testing.TestServi
 				t.Logf("connected to peer #%d (%v) on iteration %d", si, p.Addr, i)
 				break
 			}
-			time.Sleep(time.Millisecond * 10)
 		}
 		assert.True(t, connected, "Connection #%d was still not up. Connections so far: %+v", si, addrs)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

Previously there was no sleep when `testc.EmptyCall` returned an error, so it was easy to blow throw 3000 attempts with no sleep whatsoever.

## Description of the changes

Sleep at the beginning of call iterations (except the first one).

## How was this change tested?

It no longer fails in our internal aarch64 CI with this patch.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
