### PR TITLE
Add references to Jaeger v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <img align="right" width="290" height="290" src="https://www.jaegertracing.io/img/jaeger-vector.svg">
 
 [![Slack chat][slack-img]](#get-in-touch)
-[![Project+Community stats][community-badge]][community-stats]
 [![Unit Tests][ci-img]][ci]
 [![Coverage Status][cov-img]][cov]
+[![Project+Community stats][community-badge]][community-stats]
 [![FOSSA Status][fossa-img]][fossa]
 [![OpenSSF Scorecard][openssf-img]][openssf]
 [![OpenSSF Best Practices][openssf-bp-img]][openssf-bp] 
@@ -15,6 +15,8 @@
 <img src="https://raw.githubusercontent.com/cncf/artwork/main/other/cncf-member/graduated/color/cncf-graduated-color.svg" width="250">
 
 # Jaeger - a Distributed Tracing System
+
+💥💥💥 Jaeger v2 is coming! Read the [blog post](https://medium.com/jaegertracing/towards-jaeger-v2-moar-opentelemetry-2f8239bee48e) and [try it out](./cmd/jaeger).
 
 ```mermaid
 graph TD

--- a/cmd/jaeger/README.md
+++ b/cmd/jaeger/README.md
@@ -1,7 +1,9 @@
 # jaeger
 
 This is experimental Jaeger V2 based on OpenTelemetry collector.
-See https://github.com/jaegertracing/jaeger/issues/4843.
+Read the [blog post](https://medium.com/jaegertracing/towards-jaeger-v2-moar-opentelemetry-2f8239bee48e).
+
+Tracking issue: https://github.com/jaegertracing/jaeger/issues/4843.
 
 ```mermaid
 flowchart LR
@@ -31,3 +33,12 @@ flowchart LR
         Query
     end
 ```
+
+## Try it out
+
+* Download `docker-compose-v2.yml` from https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/docker-compose-v2.yml
+* Optional: find the latest Jaeger version (see https://www.jaegertracing.io/download/) and pass it via environment variable `JAEGER_VERSION`. Otherwise `docker compose` will use the `latest` tag, which is fine for the first time you download the images, but once they are in your local registry the `latest` tag is never updated and you may be running stale (and possibly incompatible) verions of Jaeger and the HotROD app.
+* Run Jaeger backend and HotROD demo, e.g.:
+  * `JAEGER_VERSION=1.59 docker compose -f path-to-yml-file-v2 up`
+* Access Jaeger UI at http://localhost:16686 and HotROD app at http://localhost:8080
+* Shutdown / cleanup with `docker compose -f path-to-yml-file down`

--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -19,6 +19,8 @@ As of Jaeger v1.42.0 this application was upgraded to use the OpenTelemetry SDK 
 
 ## Running
 
+💥💥💥 Try it with Jaeger v2!  See [cmd/jaeger](../../cmd/jaeger).
+
 ### Run everything via `docker compose`
 
 * Download `docker-compose.yml` from https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/docker-compose.yml

--- a/examples/hotrod/docker-compose-v2.yml
+++ b/examples/hotrod/docker-compose-v2.yml
@@ -1,0 +1,35 @@
+version: '3.7'
+# To run a specific version of Jaeger, use environment variable, e.g.:
+#     JAEGER_VERSION=1.52 docker compose up
+
+services:
+  jaeger:
+    image: ${REGISTRY:-}jaegertracing/jaeger:${JAEGER_VERSION:-latest}
+    command: ["--feature-gates=-component.UseLocalHostAsDefaultHost"]
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    environment:
+      - LOG_LEVEL=debug
+    networks:
+      - jaeger-example
+
+  hotrod:
+    image: ${REGISTRY:-}jaegertracing/example-hotrod:${JAEGER_VERSION:-latest}
+    # To run the latest trunk build, find the tag at Docker Hub and use the line below
+    # https://hub.docker.com/r/jaegertracing/example-hotrod-snapshot/tags
+    #image: jaegertracing/example-hotrod-snapshot:0ab8f2fcb12ff0d10830c1ee3bb52b745522db6c
+    ports:
+      - "8080:8080"
+      - "8083:8083"
+    command: ["all"]
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+    networks:
+      - jaeger-example
+    depends_on:
+      - jaeger
+
+networks:
+  jaeger-example:


### PR DESCRIPTION
* add reference to the blog post to the main README
* add reference to v2 instructions to HotROD README
* create `examples/hotrod/docker-compose-v2.yml` to run with v2
* add "Try it out" section to `cmd/jaeger/README.md`