### PR TITLE
Add unit tests for scripts/compute-tags.sh

### DIFF
--- a/.github/workflows/ci-lint-shell-scripts.yml
+++ b/.github/workflows/ci-lint-shell-scripts.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install shunit2
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
-        repository: https://github.com/kward/shunit2.git
+        repository: kward/shunit2
         path: .tools/shunit2
 
     - name: Run unit tests for scripts

--- a/.github/workflows/ci-lint-shell-scripts.yml
+++ b/.github/workflows/ci-lint-shell-scripts.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: check out code
+    - name: Check out code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Install shellcheck
@@ -28,3 +28,13 @@ jobs:
 
     - name: Run shellcheck
       run: shellcheck scripts/*.sh
+
+    - name: Install shunit2
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: https://github.com/kward/shunit2.git
+        path: .tools/shunit2
+
+    - name: Run unit tests for scripts
+      run: |
+        SHUNIT2=.tools/shunit2 bash scripts/compute-tags.test.sh

--- a/scripts/compute-tags.test.sh
+++ b/scripts/compute-tags.test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+computeTags=$(dirname $0)/compute-tags.sh
+
+# suppress command echoing by compute-tags.sh
+export QUIET=1
+
+testRequireImageName() {
+    err=$(bash $computeTags 2>&1)
+    assertContains "$err" 'expecting Docker image name'
+}
+
+testRequireBranch() {
+    err=$(bash $computeTags foo/bar 2>&1)
+    assertContains "$err" "$err" 'expecting BRANCH env var'
+}
+
+testRequireGithubSha() {
+    err=$(BRANCH=abcd bash $computeTags foo/bar 2>&1)
+    assertContains "$err" "$err" 'expecting GITHUB_SHA env var'
+}
+
+out=""
+expect() {
+    echo '   Actual:' $out
+    while [ "$#" -gt 0 ]; do
+        echo '   checking' $1
+        assertContains "actual !!$out!!" "$out" "--tag docker.io/$1"
+        assertContains "actual !!$out!!" "$out" "--tag quay.io/$1"
+        shift
+    done
+}
+
+testRandomBranch() {
+    out=$(BRANCH=branch GITHUB_SHA=sha bash $computeTags foo/bar)
+    expected=(
+        "foo/bar"
+        "foo/bar:latest"
+        "foo/bar-snapshot:sha"
+        "foo/bar-snapshot:latest"
+    )
+    expect "${expected[@]}"
+}
+
+testMainBranch() {
+    out=$(BRANCH=main GITHUB_SHA=sha bash $computeTags foo/bar)
+    # TODO we do not want :latest tag in this scenario for non-snapshot images
+    expected=(
+        "foo/bar"
+        "foo/bar:latest"
+        "foo/bar-snapshot:sha"
+        "foo/bar-snapshot:latest"
+    )
+    expect "${expected[@]}"
+}
+
+testSemVerBranch() {
+    out=$(BRANCH=v1.2.3 GITHUB_SHA=sha bash $computeTags foo/bar)
+    # TODO we want :latest tag in this scenario, it's currently not produced
+    expected=(
+        "foo/bar"
+        "foo/bar:1"
+        "foo/bar:1.2"
+        "foo/bar:1.2.3"
+        "foo/bar-snapshot:sha"
+        "foo/bar-snapshot:latest"
+    )
+    expect "${expected[@]}"
+}
+
+source ${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}/shunit2

--- a/scripts/compute-tags.test.sh
+++ b/scripts/compute-tags.test.sh
@@ -6,6 +6,10 @@ computeTags="$(dirname $0)/compute-tags.sh"
 # suppress command echoing by compute-tags.sh
 export QUIET=1
 
+# unset env vars that were possibly set by the caller, since we test against them
+unset BRANCH
+unset GITHUB_SHA
+
 testRequireImageName() {
     err=$(bash "$computeTags" 2>&1)
     assertContains "$err" 'expecting Docker image name'

--- a/scripts/compute-tags.test.sh
+++ b/scripts/compute-tags.test.sh
@@ -1,30 +1,31 @@
 #!/bin/bash
 
-computeTags=$(dirname $0)/compute-tags.sh
+# shellcheck disable=SC2086
+computeTags="$(dirname $0)/compute-tags.sh"
 
 # suppress command echoing by compute-tags.sh
 export QUIET=1
 
 testRequireImageName() {
-    err=$(bash $computeTags 2>&1)
+    err=$(bash "$computeTags" 2>&1)
     assertContains "$err" 'expecting Docker image name'
 }
 
 testRequireBranch() {
-    err=$(bash $computeTags foo/bar 2>&1)
+    err=$(bash "$computeTags" foo/bar 2>&1)
     assertContains "$err" "$err" 'expecting BRANCH env var'
 }
 
 testRequireGithubSha() {
-    err=$(BRANCH=abcd bash $computeTags foo/bar 2>&1)
+    err=$(BRANCH=abcd bash "$computeTags" foo/bar 2>&1)
     assertContains "$err" "$err" 'expecting GITHUB_SHA env var'
 }
 
 out=""
 expect() {
-    echo '   Actual:' $out
+    echo '   Actual:' "$out"
     while [ "$#" -gt 0 ]; do
-        echo '   checking' $1
+        echo '   checking' "$1"
         assertContains "actual !!$out!!" "$out" "--tag docker.io/$1"
         assertContains "actual !!$out!!" "$out" "--tag quay.io/$1"
         shift
@@ -32,7 +33,7 @@ expect() {
 }
 
 testRandomBranch() {
-    out=$(BRANCH=branch GITHUB_SHA=sha bash $computeTags foo/bar)
+    out=$(BRANCH=branch GITHUB_SHA=sha bash "$computeTags" foo/bar)
     expected=(
         "foo/bar"
         "foo/bar:latest"
@@ -43,7 +44,7 @@ testRandomBranch() {
 }
 
 testMainBranch() {
-    out=$(BRANCH=main GITHUB_SHA=sha bash $computeTags foo/bar)
+    out=$(BRANCH=main GITHUB_SHA=sha bash "$computeTags" foo/bar)
     # TODO we do not want :latest tag in this scenario for non-snapshot images
     expected=(
         "foo/bar"
@@ -55,7 +56,7 @@ testMainBranch() {
 }
 
 testSemVerBranch() {
-    out=$(BRANCH=v1.2.3 GITHUB_SHA=sha bash $computeTags foo/bar)
+    out=$(BRANCH=v1.2.3 GITHUB_SHA=sha bash "$computeTags" foo/bar)
     # TODO we want :latest tag in this scenario, it's currently not produced
     expected=(
         "foo/bar"
@@ -68,4 +69,6 @@ testSemVerBranch() {
     expect "${expected[@]}"
 }
 
-source ${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}/shunit2
+SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
+# shellcheck disable=SC1091
+source "${SHUNIT2}/shunit2"

--- a/scripts/compute-tags.test.sh
+++ b/scripts/compute-tags.test.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# This script uses https://github.com/kward/shunit2 to run unit tests.
+# The path to this repo must be provided via SHUNIT2 env var.
+
+SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
+
 # shellcheck disable=SC2086
 computeTags="$(dirname $0)/compute-tags.sh"
 
@@ -16,7 +21,7 @@ testRequireImageName() {
 }
 
 testRequireBranch() {
-    err=$(bash "$computeTags" foo/bar 2>&1)
+    err=$(GITHUB_SHA=sha bash "$computeTags" foo/bar 2>&1)
     assertContains "$err" "$err" 'expecting BRANCH env var'
 }
 
@@ -73,6 +78,5 @@ testSemVerBranch() {
     expect "${expected[@]}"
 }
 
-SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
 # shellcheck disable=SC1091
 source "${SHUNIT2}/shunit2"


### PR DESCRIPTION
## Which problem is this PR solving?
- To address #5721, add unit tests first

## Description of the changes
- Add unit tests and call them from scripts linting workflow
- Minor refactoring of `scripts/compute-tags.sh` to make it easier to read

## How was this change tested?
```
$ GREP=ggrep SHUNIT2=/Users/ysh/dev/shunit2 bash scripts/compute-tags.test.sh
testRequireImageName
testRequireBranch
testRequireGithubSha
testRandomBranch
   Actual: --tag docker.io/foo/bar --tag quay.io/foo/bar --tag docker.io/foo/bar:latest --tag quay.io/foo/bar:latest --tag docker.io/foo/bar-snapshot:sha --tag quay.io/foo/bar-snapshot:sha --tag docker.io/foo/bar-snapshot:latest --tag quay.io/foo/bar-snapshot:latest
   checking foo/bar
   checking foo/bar:latest
   checking foo/bar-snapshot:sha
   checking foo/bar-snapshot:latest
testMainBranch
   Actual: --tag docker.io/foo/bar --tag quay.io/foo/bar --tag docker.io/foo/bar:latest --tag quay.io/foo/bar:latest --tag docker.io/foo/bar-snapshot:sha --tag quay.io/foo/bar-snapshot:sha --tag docker.io/foo/bar-snapshot:latest --tag quay.io/foo/bar-snapshot:latest
   checking foo/bar
   checking foo/bar:latest
   checking foo/bar-snapshot:sha
   checking foo/bar-snapshot:latest
testSemVerBranch
   Actual: --tag docker.io/foo/bar --tag quay.io/foo/bar --tag docker.io/foo/bar:1.2.3 --tag quay.io/foo/bar:1.2.3 --tag docker.io/foo/bar:1.2 --tag quay.io/foo/bar:1.2 --tag docker.io/foo/bar:1 --tag quay.io/foo/bar:1 --tag docker.io/foo/bar-snapshot:sha --tag quay.io/foo/bar-snapshot:sha --tag docker.io/foo/bar-snapshot:latest --tag quay.io/foo/bar-snapshot:latest
   checking foo/bar
   checking foo/bar:1
   checking foo/bar:1.2
   checking foo/bar:1.2.3
   checking foo/bar-snapshot:sha
   checking foo/bar-snapshot:latest

Ran 6 tests.

OK
```