### PR TITLE
Do not use image tag without version

### DIFF
--- a/scripts/compute-tags.sh
+++ b/scripts/compute-tags.sh
@@ -28,8 +28,6 @@ tags() {
     IMAGE_TAGS="${IMAGE_TAGS}--tag docker.io/${1} --tag quay.io/${1}"
 }
 
-tags "${BASE_BUILD_IMAGE}"
-
 ## If we are on a release tag, let's extract the version number.
 ## The other possible values are 'main' or another branch name.
 if [[ $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5721
- The previous PR #5781 didn't quite work because we were still applying tags like `--tag docker.io/foo/bar` (without a version), which evidently leads Docker to treat them as `:latest`, which is exactly what we are trying to avoid for `main` branch

## Description of the changes
- Remove usage of no-version tags `--tag docker.io/foo/bar`  completely
- Fix unit tests, make them stricter

## How was this change tested?
- Unit tests
