### PR TITLE
Enable Lint Rule: redefines-builtin-id

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -211,9 +211,6 @@ linters-settings:
         # this is idiocy, promotes less readable code. Don't enable.
         - name: var-declaration
           disabled: true
-        # enable after cleanup
-        - name: redefines-builtin-id
-          disabled: true
         # "no nested structs are allowed" - don't enable, doesn't make sense
         - name: nested-structs
           disabled: true

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
-func close(t *testing.T, c io.Closer) {
+func closeTestGrpcConn(t *testing.T, c io.Closer) {
 	require.NoError(t, c.Close())
 }
 
@@ -27,7 +27,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 		api_v2.RegisterSamplingManagerServer(s, &mockSamplingHandler{})
 	})
 	conn, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	defer close(t, conn)
+	defer closeTestGrpcConn(t, conn)
 	require.NoError(t, err)
 	defer s.GracefulStop()
 	manager := NewConfigManager(conn)
@@ -38,7 +38,7 @@ func TestSamplingManager_GetSamplingStrategy(t *testing.T) {
 
 func TestSamplingManager_GetSamplingStrategy_error(t *testing.T) {
 	conn, err := grpc.NewClient("foo", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	defer close(t, conn)
+	defer closeTestGrpcConn(t, conn)
 	require.NoError(t, err)
 	manager := NewConfigManager(conn)
 	resp, err := manager.GetSamplingStrategy(context.Background(), "any")

--- a/plugin/sampling/strategyprovider/static/provider.go
+++ b/plugin/sampling/strategyprovider/static/provider.go
@@ -375,7 +375,7 @@ func deepCopy(s *api_v2.SamplingStrategyResponse) *api_v2.SamplingStrategyRespon
 	enc := gob.NewEncoder(&buf)
 	dec := gob.NewDecoder(&buf)
 	enc.Encode(*s)
-	var copy api_v2.SamplingStrategyResponse
-	dec.Decode(&copy)
-	return &copy
+	var copyValue api_v2.SamplingStrategyResponse
+	dec.Decode(&copyValue)
+	return &copyValue
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Partial Fix for https://github.com/jaegertracing/jaeger/issues/5506

## Description of the changes
- Enabled redefines-builtin-id in revive linter. Replaced function name which redefinition of the built-in function 

## How was this change tested?
- make lint make test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
