### PR TITLE
[v2] Enable remote sampling extension and include in e2e tests

### DIFF
--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -23,10 +23,8 @@ jobs:
         mode:
         - name: v1
           binary: all-in-one
-          skip_sampling: false
         - name: v2
           binary: jaeger
-          skip_sampling: true
 
     steps:
     - name: Harden Runner
@@ -61,7 +59,7 @@ jobs:
       run: |
         case ${GITHUB_EVENT_NAME} in
           pull_request)
-            echo "BUILD_FLAGS=-l -D -p linux/amd64" >> ${GITHUB_ENV}
+            echo "BUILD_FLAGS=-l -D -p linux/$(go env GOARCH)" >> ${GITHUB_ENV}
             ;;
           *)
             echo "BUILD_FLAGS=" >> ${GITHUB_ENV}
@@ -76,5 +74,3 @@ jobs:
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        # SKIP_SAMPLING is used by integration tests, see https://github.com/jaegertracing/jaeger/issues/5531
-        SKIP_SAMPLING: ${{ matrix.mode.skip_sampling }}

--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -159,11 +159,11 @@ func getAPITrace(t *testing.T) {
 }
 
 func getSamplingStrategy(t *testing.T) {
-	// TODO once jaeger-v2 can pass this test, remove from .github/workflows/ci-all-in-one-build.yml
-	if os.Getenv("SKIP_SAMPLING") == "true" {
-		t.Skip("skipping sampling strategy check because SKIP_SAMPLING=true is set")
-	}
-	_, body := httpGet(t, agentAddr+getSamplingStrategyURL)
+	// TODO should we test refreshing the strategy file?
+
+	r, body := httpGet(t, agentAddr+getSamplingStrategyURL)
+	t.Logf("Sampling strategy response: %s", string(body))
+	require.EqualValues(t, http.StatusOK, r.StatusCode)
 
 	var queryResponse api_v2.SamplingStrategyResponse
 	require.NoError(t, jsonpb.Unmarshal(bytes.NewReader(body), &queryResponse))

--- a/cmd/jaeger/Dockerfile
+++ b/cmd/jaeger/Dockerfile
@@ -1,6 +1,8 @@
 ARG base_image
 ARG debug_image
 
+# ------------- Begin PROD image -------------
+
 FROM $base_image AS release
 ARG TARGETARCH
 ARG USER_UID=10001
@@ -14,8 +16,11 @@ EXPOSE 6831/udp
 # Agent jaeger.thrift binary
 EXPOSE 6832/udp
 
-# Agent config HTTP
+# Sampling config HTTP
 EXPOSE 5778
+
+# Sampling config gRPC
+EXPOSE 5779
 
 # Collector OTLP gRPC
 EXPOSE 4317
@@ -35,15 +40,14 @@ EXPOSE 9411
 # Web HTTP
 EXPOSE 16686
 
-# Default configuration file for setting sampling strategies
-# ENV SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json
-# COPY sampling_strategies.json /etc/jaeger/
-
-COPY jaeger-linux-$TARGETARCH /go/bin/jaeger-linux
+COPY jaeger-linux-$TARGETARCH /cmd/jaeger/jaeger-linux
+COPY sampling-strategies.json /cmd/jaeger/sampling-strategies.json
 
 VOLUME ["/tmp"]
-ENTRYPOINT ["/go/bin/jaeger-linux"]
+ENTRYPOINT ["/cmd/jaeger/jaeger-linux"]
 USER ${USER_UID}
+
+# ------------- Begin DEBUG image -------------
 
 FROM $debug_image AS debug
 ARG TARGETARCH=amd64
@@ -58,8 +62,11 @@ EXPOSE 6831/udp
 # Agent jaeger.thrift binary
 EXPOSE 6832/udp
 
-# Agent config HTTP
+# Sampling config HTTP
 EXPOSE 5778
+
+# Sampling config gRPC
+EXPOSE 5779
 
 # Collector OTLP gRPC
 EXPOSE 4317
@@ -82,12 +89,9 @@ EXPOSE 16686
 # Delve
 EXPOSE 12345
 
-# Default configuration file for setting sampling strategies
-# ENV SAMPLING_STRATEGIES_FILE=/etc/jaeger/sampling_strategies.json
-# COPY sampling_strategies.json /etc/jaeger/
-
-COPY jaeger-debug-linux-$TARGETARCH /go/bin/jaeger-linux
+COPY jaeger-debug-linux-$TARGETARCH /cmd/jaeger/jaeger-linux
+COPY sampling-strategies.json /cmd/jaeger/sampling-strategies.json
 
 VOLUME ["/tmp"]
-ENTRYPOINT ["/go/bin/dlv", "exec", "/go/bin/jaeger-linux", "--headless", "--listen=:12345", "--api-version=2", "--accept-multiclient", "--log", "--"]
+ENTRYPOINT ["/go/bin/dlv", "exec", "/cmd/jaeger/jaeger-linux", "--headless", "--listen=:12345", "--api-version=2", "--accept-multiclient", "--log", "--"]
 USER ${USER_UID}

--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -1,5 +1,5 @@
 service:
-  extensions: [jaeger_storage, jaeger_query]
+  extensions: [jaeger_storage, jaeger_query, remote_sampling]
   pipelines:
     traces:
       receivers: [otlp, jaeger, zipkin]
@@ -12,7 +12,7 @@ service:
       level: detailed
       address: 0.0.0.0:8888
     # TODO Initialize telemetery tracer once OTEL released new feature.
-    # https://github.com/open-telemetry/opentelemetry-collector/issues/10663 
+    # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:
   jaeger_query:
@@ -23,6 +23,16 @@ extensions:
       some_storage:
         memory:
           max_traces: 100000
+
+  remote_sampling:
+    # We can either use file or adaptive sampling strategy in remote_sampling
+    file:
+      path: ./cmd/jaeger/sampling-strategies.json
+    # adaptive:
+    #   sampling_store: some_store
+    #   initial_sampling_probability: 0.1
+    http:
+    grpc:
 
 receivers:
   otlp:

--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -227,7 +227,12 @@ func (ext *rsExtension) startHTTPServer(ctx context.Context, host component.Host
 			SamplingProvider: ext.strategyProvider,
 		},
 		MetricsFactory: metrics.NullFactory,
-		BasePath:       "/api", // TODO is /api correct?
+
+		// In v1 the sampling endpoint in the collector was at /api/sampling, because
+		// the collector reused the same port for multiple services. In v2, the extension
+		// always uses a separate port, making /api prefix unnecessary. So we mimic the behavior
+		// of jaeger-agent port 5778 which serves sampling strategies at /sampling endpoint.
+		BasePath: "",
 	})
 	httpMux := http.NewServeMux()
 	handler.RegisterRoutesWithHTTP(httpMux)

--- a/cmd/jaeger/internal/extension/remotesampling/factory.go
+++ b/cmd/jaeger/internal/extension/remotesampling/factory.go
@@ -34,11 +34,11 @@ func NewFactory() extension.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		HTTP: &confighttp.ServerConfig{
-			Endpoint: ports.PortToHostPort(ports.CollectorHTTP + 100),
+			Endpoint: ports.PortToHostPort(ports.AgentConfigServerHTTP),
 		},
 		GRPC: &configgrpc.ServerConfig{
 			NetAddr: confignet.AddrConfig{
-				Endpoint:  ports.PortToHostPort(ports.CollectorGRPC + 100),
+				Endpoint:  ports.PortToHostPort(ports.AgentConfigServerHTTP + 1),
 				Transport: confignet.TransportTypeTCP,
 			},
 		},

--- a/cmd/jaeger/sampling-strategies.json
+++ b/cmd/jaeger/sampling-strategies.json
@@ -1,7 +1,7 @@
 {
   "default_strategy": {
     "type": "probabilistic",
-    "param": 0.1
+    "param": 1
   },
   "service_strategies": [
     {
@@ -12,7 +12,7 @@
     {
       "service": "bar",
       "type": "ratelimiting",
-      "param": 1
+      "param": 0.9
     }
   ]
 }

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -63,6 +63,7 @@ make build-ui
 run_integration_test() {
   local image_name="$1"
   CID=$(docker run -d -p 16686:16686 -p 5778:5778 "${image_name}:${GITHUB_SHA}")
+
   if ! make all-in-one-integration-test ; then
       echo "---- integration test failed unexpectedly ----"
       echo "--- check the docker log below for details ---"
@@ -90,6 +91,7 @@ fi
 
 # build all-in-one image locally for integration test (the -l switch)
 bash scripts/build-upload-a-docker-image.sh -l -b -c "${BINARY}" -d "cmd/${BINARY}" -p "${platforms}" -t release
+
 run_integration_test "localhost:5000/$repo"
 
 # build all-in-one image and upload to dockerhub/quay.io


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5531

## Description of the changes
- Enable remote sampling extension in v2 all-in-one configuration
- Fix Dockerfile to copy this into the image in the appropriate location
- Change the default ports for the extension to match OTEL & agent 5778/5779
- Re-enable sampling e2e tests for v2 all-in-one

## How was this change tested?
- `make all-in-one-integration-test`
- CI
