### PR TITLE
Update expected codecov flags count to 19

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: yes
-    after_n_builds: 11
+    after_n_builds: 19
   strict_yaml_branch: main  # only use the latest copy on the main branch
 
 ignore:


### PR DESCRIPTION
## Which problem is this PR solving?
We are now running 19 different uploads of codecov

<img width="403" alt="image" src="https://github.com/user-attachments/assets/d31594c5-6b76-4e12-bb98-60902addd976">

However, the current configuration was only waiting for 11, which resulted in false positives like this:

<img width="904" alt="image" src="https://github.com/user-attachments/assets/182f1578-53aa-476c-80e6-2d71428ce66c">

I.e. a comment about non-covered code which is actually covered, but its result uploads came after the 11 other results.

## Description of the changes
- Bump expected count to 19, the current number of distinct flags/uploads.
