### PR TITLE
Clean up obselete 'version' tag from docker-compose files

### DIFF
--- a/cmd/tracegen/docker-compose.yml
+++ b/cmd/tracegen/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
     jaeger:
       image: jaegertracing/all-in-one:latest

--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
     crossdock:
         image: crossdock/crossdock

--- a/crossdock/jaeger-docker-compose.yml
+++ b/crossdock/jaeger-docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
     jaeger-remote-storage:
       image: jaegertracing/jaeger-remote-storage

--- a/docker-compose/cassandra/v3/docker-compose.yaml
+++ b/docker-compose/cassandra/v3/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   cassandra:
     image: cassandra:3.11

--- a/docker-compose/cassandra/v4/docker-compose.yaml
+++ b/docker-compose/cassandra/v4/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   cassandra:
     image: cassandra:4.1

--- a/docker-compose/elasticsearch/v6/docker-compose.yml
+++ b/docker-compose/elasticsearch/v6/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.23

--- a/docker-compose/elasticsearch/v7/docker-compose.yml
+++ b/docker-compose/elasticsearch/v7/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.22

--- a/docker-compose/elasticsearch/v8/docker-compose.yml
+++ b/docker-compose/elasticsearch/v8/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.14.1

--- a/docker-compose/jaeger-docker-compose.yml
+++ b/docker-compose/jaeger-docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
     hotrod:
       image: jaegertracing/example-hotrod:latest

--- a/docker-compose/kafka-integration-test/docker-compose.yml
+++ b/docker-compose/kafka-integration-test/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   kafka:
     image: bitnami/kafka:3.7.0

--- a/docker-compose/kafka/docker-compose.yml
+++ b/docker-compose/kafka/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 services:
   zookeeper:
     image: bitnami/zookeeper

--- a/docker-compose/monitor/docker-compose-v2.yml
+++ b/docker-compose/monitor/docker-compose-v2.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   jaeger:
     networks:

--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   jaeger:
     networks:

--- a/docker-compose/opensearch/v1/docker-compose.yml
+++ b/docker-compose/opensearch/v1/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   opensearch:
     image: opensearchproject/opensearch:1.3.17

--- a/docker-compose/opensearch/v2/docker-compose.yml
+++ b/docker-compose/opensearch/v2/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   opensearch:
     image: opensearchproject/opensearch:2.15.0

--- a/examples/grafana-integration/docker-compose.yaml
+++ b/examples/grafana-integration/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   grafana:
     image: grafana/grafana:10.2.2

--- a/examples/hotrod/docker-compose-v2.yml
+++ b/examples/hotrod/docker-compose-v2.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 # To run a specific version of Jaeger, use environment variable, e.g.:
 #     JAEGER_VERSION=1.52 docker compose up
 

--- a/examples/hotrod/docker-compose.yml
+++ b/examples/hotrod/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 # To run a specific version of Jaeger, use environment variable, e.g.:
 #     JAEGER_VERSION=1.52 docker compose up
 

--- a/examples/reverse-proxy/docker-compose.yml
+++ b/examples/reverse-proxy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   jaeger:
     image: jaegertracing/all-in-one:latest


### PR DESCRIPTION
## Description of the changes
- As the latest updates in docker compose has deprecated the 'version' tag.This Pr aims to cleanup the version tags in the various docker-compose files so as to cleanup the log currently displaying ```'version' is obselete ``` when we run a docker-compose file.

## Checklist
- [ :white_check_mark: ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ :white_check_mark:  ] I have signed all commits
- [ :x:] I have added unit tests for the new functionality
- [ :white_check_mark: ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
