### PR TITLE
Investigate reason for zero values in SPM metrics  

### DIFF
--- a/docker-compose/monitor/docker-compose-v2.yml
+++ b/docker-compose/monitor/docker-compose-v2.yml
@@ -46,6 +46,6 @@ services:
       - GF_AUTH_DISABLE_LOGIN_FORM=true
     ports:
       - 3000:3000
-
+      
 networks:
   backend:

--- a/scripts/spm-integration-test.sh
+++ b/scripts/spm-integration-test.sh
@@ -89,13 +89,19 @@ validate_service_metrics() {
     echo "Metric datapoints found for service '$service': " "${metric_points[@]}"
     # Check that atleast some values are non-zero after the threshold
     local non_zero_count=0
-    local expected_non_zero_count=4
+    local expected_non_zero_count=5
     local zero_count=0
     local expected_max_zero_count=4
+    local flag=false # Becomes true after first non-zero value 
     for value in "${metric_points[@]}"; do
       if [[ $(echo "$value > 0.0" | bc) == "1" ]]; then
+        flag=true
         non_zero_count=$((non_zero_count + 1))
       else
+        if [ $flag == true ]; then
+          echo "❌ ERROR: Zero values appearing after a non-zero value not expected"
+          return 1
+        fi
         zero_count=$((zero_count + 1))
       fi
 


### PR DESCRIPTION


## Which problem is this PR solving?
-  Part of #5632

## Description of the changes
- Added changes to the spm script to detect zero values occurring in the middle

## How was this change tested?
- `make dev-v2`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
