### PR TITLE
Pin GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -30,7 +30,7 @@ jobs:
       uses: ./.github/actions/block-pr-not-on-main
 
     - name: Set up Python 3.x for DCO check
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
         python-version: '3.x'
 

--- a/.github/workflows/ci-lint-dependabot-config.yml
+++ b/.github/workflows/ci-lint-dependabot-config.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: marocchino/validate-dependabot@v3
+      - uses: marocchino/validate-dependabot@d8ae5c0d03dd75fbd0ad5f8ab4ba8101ebbd4b37 # v3.0.0
         id: validate


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
fixed the pinned dependencies issue reported by [scorecard](https://scorecard.dev/viewer/?uri=github.com/jaegertracing/jaeger).
Part of  #5815 

## Description of the changes
- pinned the github actions by hash.

## How was this change tested?
- 

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
