### PR TITLE
[fix] Print Kafka logs on test failure

### DIFF
--- a/.github/workflows/ci-e2e-kafka.yml
+++ b/.github/workflows/ci-e2e-kafka.yml
@@ -38,10 +38,6 @@ jobs:
       id: test-execution
       run: bash scripts/kafka-integration-test.sh -j ${{ matrix.jaeger-version }}
 
-    - name: Output Kafka logs on failure
-      run: docker compose -f ${{ steps.test-execution.outputs.docker_compose_file }} logs
-      if: ${{ failure() }}
-
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:

--- a/scripts/kafka-integration-test.sh
+++ b/scripts/kafka-integration-test.sh
@@ -10,6 +10,7 @@ echo "docker_compose_file=${compose_file}" >> "${GITHUB_OUTPUT:-/dev/null}"
 
 jaeger_version=""
 manage_kafka="true"
+success="false"
 
 print_help() {
   echo "Usage: $0 [-K] -j <jaeger_version>"
@@ -43,10 +44,16 @@ setup_kafka() {
   docker compose -f "${compose_file}" up -d kafka
 }
 
-teardown_kafka() {
+dump_logs() {
   echo "::group::Kafka logs"
   docker compose -f "${compose_file}" logs
   echo "::endgroup::"
+}
+
+teardown_kafka() {
+   if [[ "$success" == "false" ]]; then
+    dump_logs
+  fi
   echo "Stopping Kafka..."
   docker compose -f "${compose_file}" down
 }
@@ -101,6 +108,8 @@ main() {
   wait_for_kafka
 
   run_integration_test
+
+  success="true"
 }
 
 main "$@"

--- a/scripts/kafka-integration-test.sh
+++ b/scripts/kafka-integration-test.sh
@@ -44,6 +44,9 @@ setup_kafka() {
 }
 
 teardown_kafka() {
+  echo "::group::Kafka logs"
+  docker compose -f "${compose_file}" logs
+  echo "::endgroup::"
   echo "Stopping Kafka..."
   docker compose -f "${compose_file}" down
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Description of the changes
- Add Kafka service logging before shutdown in Kafka integration test script

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
