### PR TITLE
Define contents permissions on "dependabot validate" workflow

### DIFF
--- a/.github/workflows/ci-lint-dependabot-config.yml
+++ b/.github/workflows/ci-lint-dependabot-config.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - '.github/dependabot.yml'
       - '.github/workflows/validate-dependabot-config.yml'
+
+# See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Which problem is this PR solving?
- Related to #5815

## Description of the changes
- Define contents permissions on "dependabot validate" workflow
- Was done with the help of https://app.stepsecurity.io/secureworkflow

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
