### PR TITLE
Add jaeger-v2 binary as new release artifact

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -43,8 +43,8 @@ jobs:
       with:
         go-version: 1.23.x
 
-    - name: Print Jaeger version
-      run: make echo-version
+    - name: Print Jaeger version for no reason
+      run: make echo-v1 echo-v2
 
     - name: Install tools
       run: make install-test-tools

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,8 +53,10 @@ jobs:
       # Many scripts depend on BRANCH variable. We do not want to
       # use ./.github/actions/setup-branch here because it may set
       # BRANCH=main when the workflow is triggered manually.
+      #
+      # TODO this currently utilizes 1.x version tag
       run: |
-        BRANCH=$(make echo-version)
+        BRANCH=$(make echo-v1)
         echo "BRANCH=${BRANCH}" >> ${GITHUB_ENV}
         echo Validate that the latest tag ${BRANCH} is in semver format
         echo ${BRANCH} | grep -E '^v[0-9]+.[0-9]+.[0-9]+$'

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,13 @@ include Makefile.Windows.mk
 .PHONY: test-and-lint
 test-and-lint: test fmt lint
 
-.PHONY: echo-version
-echo-version:
-	@echo "$(GIT_CLOSEST_TAG)"
+.PHONY: echo-v1
+echo-v1:
+	@echo "$(GIT_CLOSEST_TAG_V1)"
+
+.PHONY: echo-v2
+echo-v2:
+	@echo "$(GIT_CLOSEST_TAG_V2)"
 
 .PHONY: echo-all-pkgs
 echo-all-pkgs:

--- a/scripts/compute-version.sh
+++ b/scripts/compute-version.sh
@@ -28,9 +28,6 @@ while getopts "sv" opt; do
 	v)
 		verbose="true"
 		;;
-	*)
-		usage
-		;;
 	esac
 done
 

--- a/scripts/package-deploy.sh
+++ b/scripts/package-deploy.sh
@@ -6,10 +6,20 @@ set -euxf -o pipefail
 
 TARCMD=${TARCMD:-tar}
 
+dry_run="false"
+while getopts "d" opt; do
+	# shellcheck disable=SC2220 # we don't need a *) case
+	case "${opt}" in
+	d)
+		dry_run="true"
+		;;
+	esac
+done
+
 # stage-platform-files stages the different the platform ($1) into the package
 # staging dir ($2). If you pass in a file extension ($3) it will be used when
 # copying on the source
-function stage-platform-files {
+function stage-platform-files-v1 {
     local -r PLATFORM=$1
     local -r PACKAGE_STAGING_DIR=$2
     local -r FILE_EXTENSION=${3:-}
@@ -21,6 +31,16 @@ function stage-platform-files {
     cp "./cmd/ingester/ingester-${PLATFORM}"      "${PACKAGE_STAGING_DIR}/jaeger-ingester${FILE_EXTENSION}"
     cp "./examples/hotrod/hotrod-${PLATFORM}"     "${PACKAGE_STAGING_DIR}/example-hotrod${FILE_EXTENSION}"
 }
+
+function stage-platform-files-v2 {
+    local -r PLATFORM=$1
+    local -r PACKAGE_STAGING_DIR=$2
+    local -r FILE_EXTENSION=${3:-}
+
+    cp "./cmd/jaeger/jaeger-${PLATFORM}"          "${PACKAGE_STAGING_DIR}/jaeger${FILE_EXTENSION}"
+    cp "./examples/hotrod/hotrod-${PLATFORM}"     "${PACKAGE_STAGING_DIR}/example-hotrod${FILE_EXTENSION}"
+}
+
 # stage-tool-platform-files stages the different tool files in the platform ($1) into the package
 # staging dir ($2). If you pass in a file extension ($3) it will be used when
 # copying on the source
@@ -40,53 +60,48 @@ function package {
     local -r COMPRESSION=$1
     local -r PLATFORM=$2
     local -r FILE_EXTENSION=${3:-}
-    local -r PACKAGE_NAME=jaeger-$VERSION-$PLATFORM
-    local -r PACKAGE_STAGING_DIR=$PACKAGE_NAME
-    local -r TOOLS_PACKAGE_NAME=jaeger-tools-$VERSION-$PLATFORM
-    local -r TOOLS_PACKAGE_STAGING_DIR=$TOOLS_PACKAGE_NAME
+    local -r PACKAGE_NAME_V1=jaeger-${VERSION_V1}-$PLATFORM
+    local -r PACKAGE_NAME_V2=jaeger-${VERSION_V2}-$PLATFORM
+    local -r TOOLS_PACKAGE_NAME=jaeger-tools-${VERSION_V1}-$PLATFORM
 
-    if [ -d "$PACKAGE_STAGING_DIR" ]
-    then
-        rm -vrf "$PACKAGE_STAGING_DIR"
-    fi
-    if [ -d "$TOOLS_PACKAGE_STAGING_DIR" ]
-    then
-        rm -vrf "$TOOLS_PACKAGE_STAGING_DIR"
-    fi
-    mkdir "$PACKAGE_STAGING_DIR"
-    mkdir "$TOOLS_PACKAGE_STAGING_DIR"
-    stage-platform-files "$PLATFORM" "$PACKAGE_STAGING_DIR" "$FILE_EXTENSION"
-    stage-tool-platform-files "$PLATFORM" "$TOOLS_PACKAGE_STAGING_DIR" "$FILE_EXTENSION"
+    PACKAGES=("$PACKAGE_NAME_V1" "$PACKAGE_NAME_V2" "$TOOLS_PACKAGE_NAME")
+    for d in "${PACKAGES[@]}"; do
+      if [ -d "$d" ]; then
+        rm -vrf "$d"
+      fi
+      mkdir "$d"
+    done
+    stage-platform-files-v1 "$PLATFORM" "$PACKAGE_NAME_V1" "$FILE_EXTENSION"
+    stage-platform-files-v2 "$PLATFORM" "$PACKAGE_NAME_V2" "$FILE_EXTENSION"
+    stage-tool-platform-files "$PLATFORM" "$TOOLS_PACKAGE_NAME" "$FILE_EXTENSION"
     # Create a checksum file for all the files being packaged in the archive. Sorted by filename.
-    find "$PACKAGE_STAGING_DIR" -type f -exec shasum -b -a 256 {} \; | sort -k2 | tee "./deploy/$PACKAGE_NAME.sha256sum.txt"
-    find "$TOOLS_PACKAGE_STAGING_DIR" -type f -exec shasum -b -a 256 {} \; | sort -k2 | tee "./deploy/$TOOLS_PACKAGE_NAME.sha256sum.txt"
+    for d in "${PACKAGES[@]}"; do
+      find "$d" -type f -exec shasum -b -a 256 {} \; | sort -k2 | tee "./deploy/$d.sha256sum.txt"
+    done
 
     if [ "$COMPRESSION" == "zip" ]
     then
-        local -r ARCHIVE_NAME="$PACKAGE_NAME.zip"
+      for d in "${PACKAGES[@]}"; do
+        local ARCHIVE_NAME="$d.zip"
         echo "Packaging into $ARCHIVE_NAME:"
-        zip -r "./deploy/$ARCHIVE_NAME" "$PACKAGE_STAGING_DIR"
-        local -r TOOLS_ARCHIVE_NAME="$TOOLS_PACKAGE_NAME.zip"
-        echo "Packaging into $TOOLS_ARCHIVE_NAME:"
-        zip -r "./deploy/$TOOLS_ARCHIVE_NAME" "$TOOLS_PACKAGE_STAGING_DIR"
+        zip -r "./deploy/$ARCHIVE_NAME" "$d"
+      done
     else
-        local -r ARCHIVE_NAME="$PACKAGE_NAME.tar.gz"
+      for d in "${PACKAGES[@]}"; do
+        local ARCHIVE_NAME="$d.tar.gz"
         echo "Packaging into $ARCHIVE_NAME:"
-        ${TARCMD} --sort=name -czvf "./deploy/$ARCHIVE_NAME" "$PACKAGE_STAGING_DIR"
-        local -r TOOLS_ARCHIVE_NAME="$TOOLS_PACKAGE_NAME.tar.gz"
-        echo "Packaging into $TOOLS_ARCHIVE_NAME:"
-        ${TARCMD} --sort=name -czvf "./deploy/$TOOLS_ARCHIVE_NAME" "$TOOLS_PACKAGE_STAGING_DIR"
+        ${TARCMD} --sort=name -czvf "./deploy/$ARCHIVE_NAME" "$d"
+      done
     fi
-
-    rm -rf "$PACKAGE_STAGING_DIR"
-    rm -rf "$TOOLS_PACKAGE_STAGING_DIR"
+    for d in "${PACKAGES[@]}"; do
+      rm -vrf "$d"
+    done
 }
 
-set -e
-
-VERSION="$(make echo-version | perl -lne 'print $1 if /^v(\d+.\d+.\d+)$/' )"
-echo "Working on version: $VERSION"
-if [ -z "$VERSION" ]; then
+VERSION_V1="$(make echo-v1 | perl -lne 'print $1 if /^v(\d+.\d+.\d+)$/' )"
+VERSION_V2="$(make echo-v2 | perl -lne 'print $1 if /^v(\d+.\d+.\d+(-rc\d+)?)$/' )"
+echo "Working on versions: $VERSION_V1 and $VERSION_V2"
+if [ -z "$VERSION_V1" ] || [ -z "$VERSION_V2" ]; then
     # We want to halt if for some reason the version string is empty as this is an obvious error case
     >&2 echo 'Failed to detect a version string'
     exit 1
@@ -97,16 +112,22 @@ rm -rf deploy
 mkdir deploy
 
 package tar linux-amd64
-package tar darwin-amd64
-package tar darwin-arm64
-package tar windows-amd64 .exe
-package zip windows-amd64 .exe
-package tar linux-s390x
-package tar linux-arm64
-package tar linux-ppc64le
+if [[ "$dry_run" == "false" ]]; then
+  package tar darwin-amd64
+  package tar darwin-arm64
+  package tar windows-amd64 .exe
+  package zip windows-amd64 .exe
+  package tar linux-s390x
+  package tar linux-arm64
+  package tar linux-ppc64le
+fi
 
 # Create a checksum file for all non-checksum files in the deploy directory. Strips the leading 'deploy/' directory from filepaths. Sort by filename.
-find deploy \( ! -name '*sha256sum.txt' \) -type f -exec shasum -b -a 256 {} \; | sed -r 's#(\w+\s+\*?)deploy/(.*)#\1\2#' | sort -k2 | tee "./deploy/jaeger-${VERSION}.sha256sum.txt"
+find deploy \( ! -name '*sha256sum.txt' \) -type f -exec shasum -b -a 256 {} \; \
+  | sed -r 's#(\w+\s+\*?)deploy/(.*)#\1\2#' \
+  | sort -k2 \
+  | tee "./deploy/jaeger-${VERSION_V1}.sha256sum.txt" \
+  | tee "./deploy/jaeger-${VERSION_V2}.sha256sum.txt"
 
 # Use gpg to sign the (g)zip files (excluding checksum files) into .asc files.
 find deploy \( ! -name '*sha256sum.txt' \) -type f -exec gpg --armor --detach-sign {} \;


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5889

## Description of the changes
- Replace `make echo-version` with two separate v1/v2 targets, using new vars introduced in #5890
- Refactor `scripts/package-deploy.sh` to publish 2.x bundle

## How was this change tested?
- `$ TARCMD=gtar bash scripts/package-deploy.sh -d`
