### PR TITLE
Fix Integration Test Log Dumping For Storage Backends

### DIFF
--- a/.github/workflows/ci-docker-hotrod.yml
+++ b/.github/workflows/ci-docker-hotrod.yml
@@ -57,7 +57,3 @@ jobs:
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-
-    - name: Print logs from hotrod
-      run: docker compose -f ./examples/hotrod/docker-compose.yml logs
-      if: failure()

--- a/.github/workflows/ci-e2e-cassandra.yml
+++ b/.github/workflows/ci-e2e-cassandra.yml
@@ -45,10 +45,6 @@ jobs:
       id: test-execution
       run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.major }} ${{ matrix.version.schema }} ${{ matrix.jaeger-version }}
 
-    - name: Output Cassandra logs
-      run: docker compose -f ${{ steps.test-execution.outputs.docker_compose_file }} logs
-      if: ${{ failure() }}
-
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:

--- a/.github/workflows/ci-e2e-elasticsearch.yml
+++ b/.github/workflows/ci-e2e-elasticsearch.yml
@@ -58,11 +58,6 @@ jobs:
       id: test-execution
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
 
-
-    - name: Output ${{ matrix.version.distribution }} logs
-      run: docker compose -f ${{ steps.test-execution.outputs.docker_compose_file }} logs 
-      if: ${{ failure() }}
-
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:

--- a/.github/workflows/ci-e2e-opensearch.yml
+++ b/.github/workflows/ci-e2e-opensearch.yml
@@ -56,11 +56,6 @@ jobs:
       id: test-execution
       run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
 
-
-    - name: Output ${{ matrix.version.distribution }} logs
-      run: docker compose -f ${{ steps.test-execution.outputs.docker_compose_file }} logs
-      if: ${{ failure() }}
-
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -85,7 +85,7 @@ bring_up_storage() {
     fi
   done
   # shellcheck disable=SC2064
-  trap "teardown_storage ${compose_file}" EXIT
+  trap "teardown_storage ${compose_file} ${distro}" EXIT
   if [ ${db_is_up} != "1" ]; then
     echo "ERROR: unable to start ${distro}"
     exit 1

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -85,7 +85,11 @@ bring_up_storage() {
     fi
   done
   # shellcheck disable=SC2064
-  trap "teardown_storage ${compose_file} ${distro}" EXIT
+  trap "teardown_storage ${compose_file}" EXIT
+  if [ ${db_is_up} != "1" ]; then
+    echo "ERROR: unable to start ${distro}"
+    exit 1
+  fi
 }
 
 dump_logs() {

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -8,6 +8,7 @@ set -euf -o pipefail
 
 # use global variables to reflect status of db
 db_is_up=
+success="false"
 
 usage() {
   echo "Usage: $0 <backend> <backend_version> <jaeger_version>"
@@ -99,7 +100,7 @@ dump_logs() {
 teardown_storage() {
   local compose_file=$1
   local distro=$2
-  if [[ ${db_is_up} != "1" ]]; then
+  if [[ "$success" == "false" ]]; then
     dump_logs "${compose_file}" "${distro}"
   fi
   docker compose -f "${compose_file}" down
@@ -134,6 +135,7 @@ main() {
     echo "ERROR: Invalid argument value jaeger_version=${j_version}, expecing v1/v2".
     exit 1
   fi
+  success="true"
 }
 
 main "$@"

--- a/scripts/es-integration-test.sh
+++ b/scripts/es-integration-test.sh
@@ -55,10 +55,6 @@ wait_for_storage() {
   # if after all the attempts the storage is not accessible, terminate it and exit
   if [[ "$(curl "${params[@]}" "${url}")" != "200" ]]; then
     echo "ERROR: ${distro} is not ready at ${url} after $(( attempt * 10 )) seconds"
-    echo "::group::${distro} logs"
-    docker compose -f "${compose_file}" logs
-    echo "::endgroup::"
-    docker compose -f "${compose_file}" down
     db_is_up=0
   else
     echo "SUCCESS: ${distro} is available at ${url}"
@@ -87,18 +83,25 @@ bring_up_storage() {
       break
     fi
   done
-  if [ ${db_is_up} = "1" ]; then
-    # shellcheck disable=SC2064
-    trap "teardown_storage ${compose_file}" EXIT
-  else
-    echo "ERROR: unable to start ${distro}"
-    exit 1
-  fi
+  # shellcheck disable=SC2064
+  trap "teardown_storage ${compose_file} ${distro}" EXIT
+}
+
+dump_logs() {
+  local compose_file=$1
+  local distro=$2
+  echo "::group::${distro} logs"
+  docker compose -f "${compose_file}" logs
+  echo "::endgroup::"
 }
 
 # terminate the elasticsearch/opensearch container
 teardown_storage() {
   local compose_file=$1
+  local distro=$2
+  if [[ ${db_is_up} != "1" ]]; then
+    dump_logs "${compose_file}" "${distro}"
+  fi
   docker compose -f "${compose_file}" down
 }
 

--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -36,7 +36,7 @@ done
 
 dump_logs() {
   local compose_file=$1
-  echo "::group::🚧 🚧 🚧 Hotrod logs"
+  echo "::group:: Hotrod logs"
   docker compose -f "${compose_file}" logs
   echo "::endgroup::"
 }

--- a/scripts/hotrod-integration-test.sh
+++ b/scripts/hotrod-integration-test.sh
@@ -17,6 +17,7 @@ docker_compose_file="./examples/hotrod/docker-compose.yml"
 platforms="$(make echo-linux-platforms)"
 current_platform="$(go env GOOS)/$(go env GOARCH)"
 LOCAL_FLAG=''
+success="false"
 
 while getopts "lp:h" opt; do
 	case "${opt}" in
@@ -33,8 +34,18 @@ while getopts "lp:h" opt; do
 	esac
 done
 
+dump_logs() {
+  local compose_file=$1
+  echo "::group::🚧 🚧 🚧 Hotrod logs"
+  docker compose -f "${compose_file}" logs
+  echo "::endgroup::"
+}
+
 teardown() {
   echo "Tearing down..."
+  if [[ "$success" == "false" ]]; then
+    dump_logs "${docker_compose_file}"
+  fi
   docker compose -f "$docker_compose_file" down
 }
 trap teardown EXIT
@@ -114,6 +125,8 @@ if [[ "$span_count" -lt "$EXPECTED_SPANS" ]]; then
   echo "Failed to find the trace with the expected number of spans within the timeout period."
   exit 1
 fi
+
+success="true"
 
 # Ensure the image is published after successful test (maybe with -l flag if on a pull request).
 # This is where all those multi-platform binaries we built earlier are utilized.


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #5912 

## Description of the changes
- Removed the log dumps in the CI workflow files and replace them with log dumps in the script files

## How was this change tested?
- I ran the scripts locally and deliberately made them fail to ensure that the logs get printed. I also checked that the logs don't get printed when the scripts pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
