### PR TITLE
[jaeger-v2] Consolidate Options And NamespaceConfig For Badger Storage

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerstorage/config.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config.go
@@ -39,12 +39,12 @@ type Config struct {
 }
 
 type Backend struct {
-	Memory        *memory.Configuration   `mapstructure:"memory"`
-	Badger        *badger.NamespaceConfig `mapstructure:"badger"`
-	GRPC          *grpc.ConfigV2          `mapstructure:"grpc"`
-	Cassandra     *cassandra.Options      `mapstructure:"cassandra"`
-	Elasticsearch *esCfg.Configuration    `mapstructure:"elasticsearch"`
-	Opensearch    *esCfg.Configuration    `mapstructure:"opensearch"`
+	Memory        *memory.Configuration `mapstructure:"memory"`
+	Badger        *badger.Config        `mapstructure:"badger"`
+	GRPC          *grpc.ConfigV2        `mapstructure:"grpc"`
+	Cassandra     *cassandra.Options    `mapstructure:"cassandra"`
+	Elasticsearch *esCfg.Configuration  `mapstructure:"elasticsearch"`
+	Opensearch    *esCfg.Configuration  `mapstructure:"opensearch"`
 }
 
 type MetricBackends struct {
@@ -62,8 +62,8 @@ func (cfg *Backend) Unmarshal(conf *confmap.Conf) error {
 		}
 	}
 	if conf.IsSet("badger") {
-		v := badger.DefaultNamespaceConfig()
-		cfg.Badger = &v
+		v := badger.NewConfig()
+		cfg.Badger = v
 	}
 	if conf.IsSet("grpc") {
 		v := grpc.DefaultConfigV2()

--- a/cmd/jaeger/internal/extension/jaegerstorage/config.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config.go
@@ -62,7 +62,7 @@ func (cfg *Backend) Unmarshal(conf *confmap.Conf) error {
 		}
 	}
 	if conf.IsSet("badger") {
-		v := badger.NewConfig()
+		v := badger.DefaultConfig()
 		cfg.Badger = v
 	}
 	if conf.IsSet("grpc") {

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -123,7 +123,7 @@ func TestBadger(t *testing.T) {
 	ext := makeStorageExtenion(t, &Config{
 		Backends: map[string]Backend{
 			"foo": {
-				Badger: &badger.NamespaceConfig{
+				Badger: &badger.Config{
 					Ephemeral:             true,
 					MaintenanceInterval:   5,
 					MetricsUpdateInterval: 10,

--- a/plugin/storage/badger/config.go
+++ b/plugin/storage/badger/config.go
@@ -11,6 +11,15 @@ import (
 	"github.com/asaskevich/govalidator"
 )
 
+const (
+	defaultMaintenanceInterval   time.Duration = 5 * time.Minute
+	defaultMetricsUpdateInterval time.Duration = 10 * time.Second
+	defaultTTL                   time.Duration = time.Hour * 72
+	defaultDataDir               string        = string(os.PathSeparator) + "data"
+	defaultValueDir              string        = defaultDataDir + string(os.PathSeparator) + "values"
+	defaultKeysDir               string        = defaultDataDir + string(os.PathSeparator) + "keys"
+)
+
 // Config is badger's internal configuration data.
 type Config struct {
 	// TTL holds time-to-live configuration for the badger store.
@@ -48,15 +57,6 @@ type Directories struct {
 	// Values contains the directory in which the values are stored.
 	Values string `mapstructure:"values"`
 }
-
-const (
-	defaultMaintenanceInterval   time.Duration = 5 * time.Minute
-	defaultMetricsUpdateInterval time.Duration = 10 * time.Second
-	defaultTTL                   time.Duration = time.Hour * 72
-	defaultDataDir               string        = string(os.PathSeparator) + "data"
-	defaultValueDir              string        = defaultDataDir + string(os.PathSeparator) + "values"
-	defaultKeysDir               string        = defaultDataDir + string(os.PathSeparator) + "keys"
-)
 
 func DefaultConfig() *Config {
 	defaultBadgerDataDir := getCurrentExecutableDir()

--- a/plugin/storage/badger/config.go
+++ b/plugin/storage/badger/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Jaeger Authors.
+// Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package badger

--- a/plugin/storage/badger/config.go
+++ b/plugin/storage/badger/config.go
@@ -97,49 +97,45 @@ func getCurrentExecutableDir() string {
 }
 
 // AddFlags adds flags for Config.
-func (c Config) AddFlags(flagSet *flag.FlagSet) {
-	addFlags(flagSet, c)
-}
-
-func addFlags(flagSet *flag.FlagSet, config Config) {
+func (c *Config) AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool(
 		prefix+suffixEphemeral,
-		config.Ephemeral,
+		c.Ephemeral,
 		"Mark this storage ephemeral, data is stored in tmpfs.",
 	)
 	flagSet.Duration(
 		prefix+suffixSpanstoreTTL,
-		config.TTL.Spans,
+		c.TTL.Spans,
 		"How long to store the data. Format is time.Duration (https://golang.org/pkg/time/#Duration)",
 	)
 	flagSet.String(
 		prefix+suffixKeyDirectory,
-		config.Directories.Keys,
+		c.Directories.Keys,
 		"Path to store the keys (indexes), this directory should reside in SSD disk. Set ephemeral to false if you want to define this setting.",
 	)
 	flagSet.String(
 		prefix+suffixValueDirectory,
-		config.Directories.Values,
+		c.Directories.Values,
 		"Path to store the values (spans). Set ephemeral to false if you want to define this setting.",
 	)
 	flagSet.Bool(
 		prefix+suffixSyncWrite,
-		config.SyncWrites,
+		c.SyncWrites,
 		"If all writes should be synced immediately to physical disk. This will impact write performance.",
 	)
 	flagSet.Duration(
 		prefix+suffixMaintenanceInterval,
-		config.MaintenanceInterval,
+		c.MaintenanceInterval,
 		"How often the maintenance thread for values is ran. Format is time.Duration (https://golang.org/pkg/time/#Duration)",
 	)
 	flagSet.Duration(
 		prefix+suffixMetricsInterval,
-		config.MetricsUpdateInterval,
+		c.MetricsUpdateInterval,
 		"How often the badger metrics are collected by Jaeger. Format is time.Duration (https://golang.org/pkg/time/#Duration)",
 	)
 	flagSet.Bool(
 		prefix+suffixReadOnly,
-		config.ReadOnly,
+		c.ReadOnly,
 		"Allows to open badger database in read only mode. Multiple instances can open same database in read-only mode. Values still in the write-ahead-log must be replayed before opening.",
 	)
 }

--- a/plugin/storage/badger/config_test.go
+++ b/plugin/storage/badger/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Jaeger Authors.
+// Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package badger

--- a/plugin/storage/badger/config_test.go
+++ b/plugin/storage/badger/config_test.go
@@ -7,53 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-
-	"github.com/jaegertracing/jaeger/pkg/config"
 )
-
-func TestDefaultConfigParsing(t *testing.T) {
-	cfg := NewConfig()
-	v, command := config.Viperize(cfg.AddFlags)
-	command.ParseFlags([]string{})
-	cfg.InitFromViper(v, zap.NewNop())
-
-	assert.True(t, cfg.Ephemeral)
-	assert.False(t, cfg.SyncWrites)
-	assert.Equal(t, time.Duration(72*time.Hour), cfg.TTL.Spans)
-}
-
-func TestParseConfig(t *testing.T) {
-	cfg := NewConfig()
-	v, command := config.Viperize(cfg.AddFlags)
-	command.ParseFlags([]string{
-		"--badger.ephemeral=false",
-		"--badger.consistency=true",
-		"--badger.directory-key=/var/lib/badger",
-		"--badger.directory-value=/mnt/slow/badger",
-		"--badger.span-store-ttl=168h",
-	})
-	cfg.InitFromViper(v, zap.NewNop())
-
-	assert.False(t, cfg.Ephemeral)
-	assert.True(t, cfg.SyncWrites)
-	assert.Equal(t, time.Duration(168*time.Hour), cfg.TTL.Spans)
-	assert.Equal(t, "/var/lib/badger", cfg.Directories.Keys)
-	assert.Equal(t, "/mnt/slow/badger", cfg.Directories.Values)
-	assert.False(t, cfg.ReadOnly)
-}
-
-func TestReadOnlyConfig(t *testing.T) {
-	cfg := NewConfig()
-	v, command := config.Viperize(cfg.AddFlags)
-	command.ParseFlags([]string{
-		"--badger.read-only=true",
-	})
-	cfg.InitFromViper(v, zap.NewNop())
-	assert.True(t, cfg.ReadOnly)
-}
 
 func TestValidate_DoesNotReturnErrorWhenValid(t *testing.T) {
 	tests := []struct {

--- a/plugin/storage/badger/config_test.go
+++ b/plugin/storage/badger/config_test.go
@@ -14,20 +14,20 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/config"
 )
 
-func TestDefaultOptionsParsing(t *testing.T) {
-	opts := NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+func TestDefaultConfigParsing(t *testing.T) {
+	cfg := NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{})
-	opts.InitFromViper(v, zap.NewNop())
+	cfg.InitFromViper(v, zap.NewNop())
 
-	assert.True(t, opts.GetPrimary().Ephemeral)
-	assert.False(t, opts.GetPrimary().SyncWrites)
-	assert.Equal(t, time.Duration(72*time.Hour), opts.GetPrimary().TTL.Spans)
+	assert.True(t, cfg.Ephemeral)
+	assert.False(t, cfg.SyncWrites)
+	assert.Equal(t, time.Duration(72*time.Hour), cfg.TTL.Spans)
 }
 
-func TestParseOptions(t *testing.T) {
-	opts := NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+func TestParseConfig(t *testing.T) {
+	cfg := NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=false",
 		"--badger.consistency=true",
@@ -35,38 +35,38 @@ func TestParseOptions(t *testing.T) {
 		"--badger.directory-value=/mnt/slow/badger",
 		"--badger.span-store-ttl=168h",
 	})
-	opts.InitFromViper(v, zap.NewNop())
+	cfg.InitFromViper(v, zap.NewNop())
 
-	assert.False(t, opts.GetPrimary().Ephemeral)
-	assert.True(t, opts.GetPrimary().SyncWrites)
-	assert.Equal(t, time.Duration(168*time.Hour), opts.GetPrimary().TTL.Spans)
-	assert.Equal(t, "/var/lib/badger", opts.GetPrimary().Directories.Keys)
-	assert.Equal(t, "/mnt/slow/badger", opts.GetPrimary().Directories.Values)
-	assert.False(t, opts.GetPrimary().ReadOnly)
+	assert.False(t, cfg.Ephemeral)
+	assert.True(t, cfg.SyncWrites)
+	assert.Equal(t, time.Duration(168*time.Hour), cfg.TTL.Spans)
+	assert.Equal(t, "/var/lib/badger", cfg.Directories.Keys)
+	assert.Equal(t, "/mnt/slow/badger", cfg.Directories.Values)
+	assert.False(t, cfg.ReadOnly)
 }
 
-func TestReadOnlyOptions(t *testing.T) {
-	opts := NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+func TestReadOnlyConfig(t *testing.T) {
+	cfg := NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.read-only=true",
 	})
-	opts.InitFromViper(v, zap.NewNop())
-	assert.True(t, opts.GetPrimary().ReadOnly)
+	cfg.InitFromViper(v, zap.NewNop())
+	assert.True(t, cfg.ReadOnly)
 }
 
 func TestValidate_DoesNotReturnErrorWhenValid(t *testing.T) {
 	tests := []struct {
-		name   string
-		config *NamespaceConfig
+		name string
+		cfg  *Config
 	}{
 		{
-			name:   "non-required fields not set",
-			config: &NamespaceConfig{},
+			name: "non-required fields not set",
+			cfg:  &Config{},
 		},
 		{
 			name: "all fields are set",
-			config: &NamespaceConfig{
+			cfg: &Config{
 				TTL: TTL{
 					Spans: time.Second,
 				},
@@ -85,7 +85,7 @@ func TestValidate_DoesNotReturnErrorWhenValid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.config.Validate()
+			err := test.cfg.Validate()
 			require.NoError(t, err)
 		})
 	}

--- a/plugin/storage/badger/dependencystore/storage_test.go
+++ b/plugin/storage/badger/dependencystore/storage_test.go
@@ -28,7 +28,7 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 		require.NoError(tb, f.Close())
 	}()
 
-	cfg := badger.NewConfig()
+	cfg := badger.DefaultConfig()
 	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",

--- a/plugin/storage/badger/dependencystore/storage_test.go
+++ b/plugin/storage/badger/dependencystore/storage_test.go
@@ -28,8 +28,8 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 		require.NoError(tb, f.Close())
 	}()
 
-	opts := badger.NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+	cfg := badger.NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",
 		"--badger.consistency=false",

--- a/plugin/storage/badger/factory.go
+++ b/plugin/storage/badger/factory.go
@@ -77,7 +77,7 @@ type Factory struct {
 // NewFactory creates a new Factory.
 func NewFactory() *Factory {
 	return &Factory{
-		Config:          NewConfig(),
+		Config:          DefaultConfig(),
 		maintenanceDone: make(chan bool),
 	}
 }
@@ -88,7 +88,7 @@ func NewFactoryWithConfig(
 	logger *zap.Logger,
 ) (*Factory, error) {
 	f := NewFactory()
-	f.configureFromConfig(&cfg)
+	f.configure(&cfg)
 	err := f.Initialize(metricsFactory, logger)
 	if err != nil {
 		return nil, err
@@ -104,11 +104,11 @@ func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
 // InitFromViper implements plugin.Configurable
 func (f *Factory) InitFromViper(v *viper.Viper, logger *zap.Logger) {
 	f.Config.InitFromViper(v, logger)
-	f.configureFromConfig(f.Config)
+	f.configure(f.Config)
 }
 
-// configureFromConfig initializes Factory from supplied Config.
-func (f *Factory) configureFromConfig(config *Config) {
+// configure initializes Factory from supplied Config.
+func (f *Factory) configure(config *Config) {
 	f.Config = config
 }
 

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -183,26 +183,24 @@ func TestBadgerMetrics(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestConfigureFromOptions(t *testing.T) {
+func TestConfigureFromConfig(t *testing.T) {
 	f := NewFactory()
-	opts := &Options{
-		Primary: NamespaceConfig{
-			MaintenanceInterval: 42 * time.Second,
-		},
+	config := &Config{
+		MaintenanceInterval: 42 * time.Second,
 	}
-	f.configureFromOptions(opts)
-	assert.Equal(t, opts, f.Options)
+	f.configureFromConfig(config)
+	assert.Equal(t, config, f.Config)
 }
 
 func TestBadgerStorageFactoryWithConfig(t *testing.T) {
-	cfg := NamespaceConfig{}
+	cfg := Config{}
 	_, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "Error Creating Dir")
 
 	tmp := os.TempDir()
 	defer os.Remove(tmp)
-	cfg = NamespaceConfig{
+	cfg = Config{
 		Directories: Directories{
 			Keys:   tmp,
 			Values: tmp,

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -183,12 +183,12 @@ func TestBadgerMetrics(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestConfigureFromConfig(t *testing.T) {
+func TestConfigure(t *testing.T) {
 	f := NewFactory()
 	config := &Config{
 		MaintenanceInterval: 42 * time.Second,
 	}
-	f.configureFromConfig(config)
+	f.configure(config)
 	assert.Equal(t, config, f.Config)
 }
 

--- a/plugin/storage/badger/options.go
+++ b/plugin/storage/badger/options.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package badger
+
+import (
+	"flag"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+const (
+	prefix                    = "badger"
+	suffixKeyDirectory        = ".directory-key"
+	suffixValueDirectory      = ".directory-value"
+	suffixEphemeral           = ".ephemeral"
+	suffixSpanstoreTTL        = ".span-store-ttl"
+	suffixSyncWrite           = ".consistency"
+	suffixMaintenanceInterval = ".maintenance-interval"
+	suffixMetricsInterval     = ".metrics-update-interval" // Intended only for testing purposes
+	suffixReadOnly            = ".read-only"
+)
+
+// AddFlags adds flags for Config.
+func (c *Config) AddFlags(flagSet *flag.FlagSet) {
+	flagSet.Bool(
+		prefix+suffixEphemeral,
+		c.Ephemeral,
+		"Mark this storage ephemeral, data is stored in tmpfs.",
+	)
+	flagSet.Duration(
+		prefix+suffixSpanstoreTTL,
+		c.TTL.Spans,
+		"How long to store the data. Format is time.Duration (https://golang.org/pkg/time/#Duration)",
+	)
+	flagSet.String(
+		prefix+suffixKeyDirectory,
+		c.Directories.Keys,
+		"Path to store the keys (indexes), this directory should reside in SSD disk. Set ephemeral to false if you want to define this setting.",
+	)
+	flagSet.String(
+		prefix+suffixValueDirectory,
+		c.Directories.Values,
+		"Path to store the values (spans). Set ephemeral to false if you want to define this setting.",
+	)
+	flagSet.Bool(
+		prefix+suffixSyncWrite,
+		c.SyncWrites,
+		"If all writes should be synced immediately to physical disk. This will impact write performance.",
+	)
+	flagSet.Duration(
+		prefix+suffixMaintenanceInterval,
+		c.MaintenanceInterval,
+		"How often the maintenance thread for values is ran. Format is time.Duration (https://golang.org/pkg/time/#Duration)",
+	)
+	flagSet.Duration(
+		prefix+suffixMetricsInterval,
+		c.MetricsUpdateInterval,
+		"How often the badger metrics are collected by Jaeger. Format is time.Duration (https://golang.org/pkg/time/#Duration)",
+	)
+	flagSet.Bool(
+		prefix+suffixReadOnly,
+		c.ReadOnly,
+		"Allows to open badger database in read only mode. Multiple instances can open same database in read-only mode. Values still in the write-ahead-log must be replayed before opening.",
+	)
+}
+
+// InitFromViper initializes Config with properties from viper.
+func (c *Config) InitFromViper(v *viper.Viper, logger *zap.Logger) {
+	initFromViper(c, v, logger)
+}
+
+func initFromViper(config *Config, v *viper.Viper, _ *zap.Logger) {
+	config.Ephemeral = v.GetBool(prefix + suffixEphemeral)
+	config.Directories.Keys = v.GetString(prefix + suffixKeyDirectory)
+	config.Directories.Values = v.GetString(prefix + suffixValueDirectory)
+	config.SyncWrites = v.GetBool(prefix + suffixSyncWrite)
+	config.TTL.Spans = v.GetDuration(prefix + suffixSpanstoreTTL)
+	config.MaintenanceInterval = v.GetDuration(prefix + suffixMaintenanceInterval)
+	config.MetricsUpdateInterval = v.GetDuration(prefix + suffixMetricsInterval)
+	config.ReadOnly = v.GetBool(prefix + suffixReadOnly)
+}

--- a/plugin/storage/badger/options.go
+++ b/plugin/storage/badger/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Jaeger Authors.
+// Copyright (c) 2018 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package badger

--- a/plugin/storage/badger/options_test.go
+++ b/plugin/storage/badger/options_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package badger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/pkg/config"
+)
+
+func TestDefaultConfigParsing(t *testing.T) {
+	cfg := DefaultConfig()
+	v, command := config.Viperize(cfg.AddFlags)
+	command.ParseFlags([]string{})
+	cfg.InitFromViper(v, zap.NewNop())
+
+	assert.True(t, cfg.Ephemeral)
+	assert.False(t, cfg.SyncWrites)
+	assert.Equal(t, time.Duration(72*time.Hour), cfg.TTL.Spans)
+}
+
+func TestParseConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	v, command := config.Viperize(cfg.AddFlags)
+	command.ParseFlags([]string{
+		"--badger.ephemeral=false",
+		"--badger.consistency=true",
+		"--badger.directory-key=/var/lib/badger",
+		"--badger.directory-value=/mnt/slow/badger",
+		"--badger.span-store-ttl=168h",
+	})
+	cfg.InitFromViper(v, zap.NewNop())
+
+	assert.False(t, cfg.Ephemeral)
+	assert.True(t, cfg.SyncWrites)
+	assert.Equal(t, time.Duration(168*time.Hour), cfg.TTL.Spans)
+	assert.Equal(t, "/var/lib/badger", cfg.Directories.Keys)
+	assert.Equal(t, "/mnt/slow/badger", cfg.Directories.Values)
+	assert.False(t, cfg.ReadOnly)
+}
+
+func TestReadOnlyConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	v, command := config.Viperize(cfg.AddFlags)
+	command.ParseFlags([]string{
+		"--badger.read-only=true",
+	})
+	cfg.InitFromViper(v, zap.NewNop())
+	assert.True(t, cfg.ReadOnly)
+}

--- a/plugin/storage/badger/options_test.go
+++ b/plugin/storage/badger/options_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Jaeger Authors.
+// Copyright (c) 2018 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package badger

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -373,8 +373,8 @@ func TestPersist(t *testing.T) {
 			require.NoError(t, f.Close())
 		}()
 
-		opts := badger.NewOptions()
-		v, command := config.Viperize(opts.AddFlags)
+		cfg := badger.NewConfig()
+		v, command := config.Viperize(cfg.AddFlags)
 
 		keyParam := fmt.Sprintf("--badger.directory-key=%s", dir)
 		valueParam := fmt.Sprintf("--badger.directory-value=%s", dir)
@@ -438,8 +438,8 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 		require.NoError(tb, f.Close())
 	}()
 
-	opts := badger.NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+	cfg := badger.NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",
 		"--badger.consistency=false",
@@ -598,8 +598,8 @@ func BenchmarkServiceIndexLimitFetch(b *testing.B) {
 func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
 	assertion := require.New(tb)
 	f := badger.NewFactory()
-	opts := badger.NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+	cfg := badger.NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 
 	dir := filepath.Join(tb.TempDir(), "badger-testRun")
 	err := os.MkdirAll(dir, 0o700)

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -373,7 +373,7 @@ func TestPersist(t *testing.T) {
 			require.NoError(t, f.Close())
 		}()
 
-		cfg := badger.NewConfig()
+		cfg := badger.DefaultConfig()
 		v, command := config.Viperize(cfg.AddFlags)
 
 		keyParam := fmt.Sprintf("--badger.directory-key=%s", dir)
@@ -438,7 +438,7 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 		require.NoError(tb, f.Close())
 	}()
 
-	cfg := badger.NewConfig()
+	cfg := badger.DefaultConfig()
 	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",
@@ -598,7 +598,7 @@ func BenchmarkServiceIndexLimitFetch(b *testing.B) {
 func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
 	assertion := require.New(tb)
 	f := badger.NewFactory()
-	cfg := badger.NewConfig()
+	cfg := badger.DefaultConfig()
 	v, command := config.Viperize(cfg.AddFlags)
 
 	dir := filepath.Join(tb.TempDir(), "badger-testRun")

--- a/plugin/storage/badger/stats_linux.go
+++ b/plugin/storage/badger/stats_linux.go
@@ -12,11 +12,11 @@ func (f *Factory) diskStatisticsUpdate() error {
 	// In case of ephemeral these are the same, but we'll report them separately for consistency
 	var keyDirStatfs unix.Statfs_t
 	// Error ignored to satisfy Codecov
-	_ = unix.Statfs(f.Options.GetPrimary().Directories.Keys, &keyDirStatfs)
+	_ = unix.Statfs(f.Config.Directories.Keys, &keyDirStatfs)
 
 	var valDirStatfs unix.Statfs_t
 	// Error ignored to satisfy Codecov
-	_ = unix.Statfs(f.Options.GetPrimary().Directories.Values, &valDirStatfs)
+	_ = unix.Statfs(f.Config.Directories.Values, &valDirStatfs)
 
 	// Using Bavail instead of Bfree to get non-priviledged user space available
 	//nolint: gosec // G115

--- a/plugin/storage/badger/stats_linux_test.go
+++ b/plugin/storage/badger/stats_linux_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestDiskStatisticsUpdate(t *testing.T) {
 	f := NewFactory()
-	cfg := NewConfig()
+	cfg := DefaultConfig()
 	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",

--- a/plugin/storage/badger/stats_linux_test.go
+++ b/plugin/storage/badger/stats_linux_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestDiskStatisticsUpdate(t *testing.T) {
 	f := NewFactory()
-	opts := NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+	cfg := NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",
 		"--badger.consistency=false",

--- a/plugin/storage/badger/stats_test.go
+++ b/plugin/storage/badger/stats_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestDiskStatisticsUpdate(t *testing.T) {
 	f := NewFactory()
-	cfg := NewConfig()
+	cfg := DefaultConfig()
 	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",

--- a/plugin/storage/badger/stats_test.go
+++ b/plugin/storage/badger/stats_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestDiskStatisticsUpdate(t *testing.T) {
 	f := NewFactory()
-	opts := NewOptions()
-	v, command := config.Viperize(opts.AddFlags)
+	cfg := NewConfig()
+	v, command := config.Viperize(cfg.AddFlags)
 	command.ParseFlags([]string{
 		"--badger.ephemeral=true",
 		"--badger.consistency=false",

--- a/plugin/storage/integration/badgerstore_test.go
+++ b/plugin/storage/integration/badgerstore_test.go
@@ -22,7 +22,7 @@ type BadgerIntegrationStorage struct {
 
 func (s *BadgerIntegrationStorage) initialize(t *testing.T) {
 	s.factory = badger.NewFactory()
-	s.factory.Options.Primary.Ephemeral = false
+	s.factory.Config.Ephemeral = false
 
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	err := s.factory.Initialize(metrics.NullFactory, logger)


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5926

## Description of the changes
- Removed the `Options` struct and renamed `NamespaceConfig` to `Namespace` for Badger Storage 
- Moved v2-related configuration items to `config.go` while leaving v1 cli flags in `options.go`

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
