### PR TITLE
[adaptive processor] Remove redundant function

### DIFF
--- a/cmd/jaeger/internal/processors/adaptivesampling/processor.go
+++ b/cmd/jaeger/internal/processors/adaptivesampling/processor.go
@@ -75,7 +75,7 @@ func (tp *traceProcessor) processTraces(_ context.Context, td ptrace.Traces) (pt
 			if span.Process == nil {
 				span.Process = batch.Process
 			}
-			adaptive.RecordThroughput(tp.aggregator, span, tp.telset.Logger)
+			tp.aggregator.HandleRootSpan(span, tp.telset.Logger)
 		}
 	}
 	return td, nil

--- a/plugin/sampling/strategyprovider/adaptive/aggregator.go
+++ b/plugin/sampling/strategyprovider/adaptive/aggregator.go
@@ -118,23 +118,6 @@ func (a *aggregator) RecordThroughput(service, operation string, samplerType spa
 	}
 }
 
-func RecordThroughput(agg samplingstrategy.Aggregator, span *span_model.Span, logger *zap.Logger) {
-	// TODO simply checking parentId to determine if a span is a root span is not sufficient. However,
-	// we can be sure that only a root span will have sampler tags.
-	if span.ParentSpanID() != span_model.NewSpanID(0) {
-		return
-	}
-	service := span.Process.ServiceName
-	if service == "" || span.OperationName == "" {
-		return
-	}
-	samplerType, samplerParam := span.GetSamplerParams(logger)
-	if samplerType == span_model.SamplerTypeUnrecognized {
-		return
-	}
-	agg.RecordThroughput(service, span.OperationName, samplerType, samplerParam)
-}
-
 func (a *aggregator) Start() {
 	a.postAggregator.Start()
 

--- a/plugin/sampling/strategyprovider/adaptive/aggregator_test.go
+++ b/plugin/sampling/strategyprovider/adaptive/aggregator_test.go
@@ -161,7 +161,7 @@ func TestRecordThroughputFunc(t *testing.T) {
 
 	// Testing non-root span
 	span := &model.Span{References: []model.SpanRef{{SpanID: model.NewSpanID(1), RefType: model.ChildOf}}}
-	RecordThroughput(a, span, logger)
+	a.HandleRootSpan(span, logger)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name but no operation
@@ -169,12 +169,12 @@ func TestRecordThroughputFunc(t *testing.T) {
 	span.Process = &model.Process{
 		ServiceName: "A",
 	}
-	RecordThroughput(a, span, logger)
+	a.HandleRootSpan(span, logger)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name and operation but no probabilistic sampling tags
 	span.OperationName = "GET"
-	RecordThroughput(a, span, logger)
+	a.HandleRootSpan(span, logger)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name, operation, and probabilistic sampling tags
@@ -182,6 +182,6 @@ func TestRecordThroughputFunc(t *testing.T) {
 		model.String("sampler.type", "probabilistic"),
 		model.String("sampler.param", "0.001"),
 	}
-	RecordThroughput(a, span, logger)
+	a.HandleRootSpan(span, logger)
 	assert.EqualValues(t, 1, a.(*aggregator).currentThroughput["A"]["GET"].Count)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- The function was a duplicate of another public method

## Description of the changes
- Remove the function and redirect callsites to invoke HandleRootSpan instead

## How was this change tested?
- CI
