### PR TITLE
[adaptive sampling] Clean-up after previous refactoring

### DIFF
--- a/plugin/sampling/strategyprovider/adaptive/aggregator.go
+++ b/plugin/sampling/strategyprovider/adaptive/aggregator.go
@@ -22,6 +22,12 @@ const (
 	maxProbabilities = 10
 )
 
+// aggregator is a kind of trace processor that watches for root spans
+// and calculates how many traces per service / per endpoint are being
+// produced. It periodically flushes these stats ("throughput") to storage.
+//
+// It also invokes PostAggregator which actually computes adaptive sampling
+// probabilities based on the observed throughput.
 type aggregator struct {
 	sync.Mutex
 

--- a/plugin/sampling/strategyprovider/adaptive/post_aggregator_test.go
+++ b/plugin/sampling/strategyprovider/adaptive/post_aggregator_test.go
@@ -4,7 +4,6 @@
 package adaptive
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -20,7 +19,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	epmocks "github.com/jaegertracing/jaeger/plugin/sampling/leaderelection/mocks"
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategyprovider/adaptive/calculationstrategy"
-	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	smocks "github.com/jaegertracing/jaeger/storage/samplingstore/mocks"
 )
 
@@ -405,113 +403,6 @@ func TestRunCalculationLoop_GetThroughputError(t *testing.T) {
 	require.NoError(t, agg.Close())
 }
 
-func TestLoadProbabilities(t *testing.T) {
-	mockStorage := &smocks.Store{}
-	mockStorage.On("GetLatestProbabilities").Return(make(model.ServiceOperationProbabilities), nil)
-
-	p := &Provider{storage: mockStorage}
-	require.Nil(t, p.probabilities)
-	p.loadProbabilities()
-	require.NotNil(t, p.probabilities)
-}
-
-func TestRunUpdateProbabilitiesLoop(t *testing.T) {
-	mockStorage := &smocks.Store{}
-	mockStorage.On("GetLatestProbabilities").Return(make(model.ServiceOperationProbabilities), nil)
-	mockEP := &epmocks.ElectionParticipant{}
-	mockEP.On("Start").Return(nil)
-	mockEP.On("Close").Return(nil)
-	mockEP.On("IsLeader").Return(false)
-
-	p := &Provider{
-		storage:                 mockStorage,
-		shutdown:                make(chan struct{}),
-		followerRefreshInterval: time.Millisecond,
-		electionParticipant:     mockEP,
-	}
-	defer close(p.shutdown)
-	require.Nil(t, p.probabilities)
-	require.Nil(t, p.strategyResponses)
-	go p.runUpdateProbabilitiesLoop()
-
-	for i := 0; i < 1000; i++ {
-		p.RLock()
-		if p.probabilities != nil && p.strategyResponses != nil {
-			p.RUnlock()
-			break
-		}
-		p.RUnlock()
-		time.Sleep(time.Millisecond)
-	}
-	p.RLock()
-	assert.NotNil(t, p.probabilities)
-	assert.NotNil(t, p.strategyResponses)
-	p.RUnlock()
-}
-
-func TestRealisticRunCalculationLoop(t *testing.T) {
-	t.Skip("Skipped realistic calculation loop test")
-	logger := zap.NewNop()
-	// NB: This is an extremely long test since it uses near realistic (1/6th scale) processor config values
-	testThroughputs := []*model.Throughput{
-		{Service: "svcA", Operation: "GET", Count: 10},
-		{Service: "svcA", Operation: "POST", Count: 9},
-		{Service: "svcA", Operation: "PUT", Count: 5},
-		{Service: "svcA", Operation: "DELETE", Count: 20},
-	}
-	mockStorage := &smocks.Store{}
-	mockStorage.On("GetThroughput", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
-		Return(testThroughputs, nil)
-	mockStorage.On("GetLatestProbabilities").Return(make(model.ServiceOperationProbabilities), nil)
-	mockStorage.On("InsertProbabilitiesAndQPS", "host", mock.AnythingOfType("model.ServiceOperationProbabilities"),
-		mock.AnythingOfType("model.ServiceOperationQPS")).Return(nil)
-	mockEP := &epmocks.ElectionParticipant{}
-	mockEP.On("Start").Return(nil)
-	mockEP.On("Close").Return(nil)
-	mockEP.On("IsLeader").Return(true)
-	cfg := Options{
-		TargetSamplesPerSecond:     1.0,
-		DeltaTolerance:             0.2,
-		InitialSamplingProbability: 0.001,
-		CalculationInterval:        time.Second * 10,
-		AggregationBuckets:         1,
-		Delay:                      time.Second * 10,
-	}
-	s := NewProvider(cfg, logger, mockEP, mockStorage)
-	s.Start()
-
-	for i := 0; i < 100; i++ {
-		strategy, _ := s.GetSamplingStrategy(context.Background(), "svcA")
-		if len(strategy.OperationSampling.PerOperationStrategies) != 0 {
-			break
-		}
-		time.Sleep(250 * time.Millisecond)
-	}
-	s.Close()
-
-	strategy, err := s.GetSamplingStrategy(context.Background(), "svcA")
-	require.NoError(t, err)
-	require.Len(t, strategy.OperationSampling.PerOperationStrategies, 4)
-	strategies := strategy.OperationSampling.PerOperationStrategies
-
-	for _, s := range strategies {
-		switch s.Operation {
-		case "GET":
-			assert.Equal(t, 0.001, s.ProbabilisticSampling.SamplingRate,
-				"Already at 1QPS, no probability change")
-		case "POST":
-			assert.Equal(t, 0.001, s.ProbabilisticSampling.SamplingRate,
-				"Within epsilon of 1QPS, no probability change")
-		case "PUT":
-			assert.InEpsilon(t, 0.002, s.ProbabilisticSampling.SamplingRate, 0.025,
-				"Under sampled, double probability")
-		case "DELETE":
-			assert.InEpsilon(t, 0.0005, s.ProbabilisticSampling.SamplingRate, 0.025,
-				"Over sampled, halve probability")
-		}
-	}
-}
-
 func TestPrependBucket(t *testing.T) {
 	p := &PostAggregator{Options: Options{AggregationBuckets: 1}}
 	p.prependThroughputBucket(&throughputBucket{interval: time.Minute})
@@ -545,41 +436,6 @@ func TestConstructorFailure(t *testing.T) {
 	cfg.BucketsForCalculation = -1
 	_, err = newPostAggregator(cfg, "host", nil, nil, metrics.NullFactory, logger)
 	require.EqualError(t, err, "BucketsForCalculation cannot be less than 1")
-}
-
-func TestGenerateStrategyResponses(t *testing.T) {
-	probabilities := model.ServiceOperationProbabilities{
-		"svcA": map[string]float64{
-			"GET": 0.5,
-		},
-	}
-	p := &Provider{
-		probabilities: probabilities,
-		Options: Options{
-			InitialSamplingProbability: 0.001,
-			MinSamplesPerSecond:        0.0001,
-		},
-	}
-	p.generateStrategyResponses()
-
-	expectedResponse := map[string]*api_v2.SamplingStrategyResponse{
-		"svcA": {
-			StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
-			OperationSampling: &api_v2.PerOperationSamplingStrategies{
-				DefaultSamplingProbability:       0.001,
-				DefaultLowerBoundTracesPerSecond: 0.0001,
-				PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
-					{
-						Operation: "GET",
-						ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
-							SamplingRate: 0.5,
-						},
-					},
-				},
-			},
-		},
-	}
-	assert.Equal(t, expectedResponse, p.strategyResponses)
 }
 
 func TestUsingAdaptiveSampling(t *testing.T) {

--- a/plugin/sampling/strategyprovider/adaptive/provider_test.go
+++ b/plugin/sampling/strategyprovider/adaptive/provider_test.go
@@ -8,14 +8,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
-	epmocks "github.com/jaegertracing/jaeger/plugin/sampling/leaderelection/mocks"
-	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
-	smocks "github.com/jaegertracing/jaeger/storage/samplingstore/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
+	epmocks "github.com/jaegertracing/jaeger/plugin/sampling/leaderelection/mocks"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
+	smocks "github.com/jaegertracing/jaeger/storage/samplingstore/mocks"
 )
 
 func TestProviderLoadProbabilities(t *testing.T) {

--- a/plugin/sampling/strategyprovider/adaptive/provider_test.go
+++ b/plugin/sampling/strategyprovider/adaptive/provider_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2018 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package adaptive
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/model"
+	epmocks "github.com/jaegertracing/jaeger/plugin/sampling/leaderelection/mocks"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
+	smocks "github.com/jaegertracing/jaeger/storage/samplingstore/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestProviderLoadProbabilities(t *testing.T) {
+	mockStorage := &smocks.Store{}
+	mockStorage.On("GetLatestProbabilities").Return(make(model.ServiceOperationProbabilities), nil)
+
+	p := &Provider{storage: mockStorage}
+	require.Nil(t, p.probabilities)
+	p.loadProbabilities()
+	require.NotNil(t, p.probabilities)
+}
+
+func TestProviderRunUpdateProbabilitiesLoop(t *testing.T) {
+	mockStorage := &smocks.Store{}
+	mockStorage.On("GetLatestProbabilities").Return(make(model.ServiceOperationProbabilities), nil)
+	mockEP := &epmocks.ElectionParticipant{}
+	mockEP.On("Start").Return(nil)
+	mockEP.On("Close").Return(nil)
+	mockEP.On("IsLeader").Return(false)
+
+	p := &Provider{
+		storage:                 mockStorage,
+		shutdown:                make(chan struct{}),
+		followerRefreshInterval: time.Millisecond,
+		electionParticipant:     mockEP,
+	}
+	defer close(p.shutdown)
+	require.Nil(t, p.probabilities)
+	require.Nil(t, p.strategyResponses)
+	go p.runUpdateProbabilitiesLoop()
+
+	for i := 0; i < 1000; i++ {
+		p.RLock()
+		if p.probabilities != nil && p.strategyResponses != nil {
+			p.RUnlock()
+			break
+		}
+		p.RUnlock()
+		time.Sleep(time.Millisecond)
+	}
+	p.RLock()
+	assert.NotNil(t, p.probabilities)
+	assert.NotNil(t, p.strategyResponses)
+	p.RUnlock()
+}
+
+func TestProviderRealisticRunCalculationLoop(t *testing.T) {
+	t.Skip("Skipped realistic calculation loop test")
+	logger := zap.NewNop()
+	// NB: This is an extremely long test since it uses near realistic (1/6th scale) processor config values
+	testThroughputs := []*model.Throughput{
+		{Service: "svcA", Operation: "GET", Count: 10},
+		{Service: "svcA", Operation: "POST", Count: 9},
+		{Service: "svcA", Operation: "PUT", Count: 5},
+		{Service: "svcA", Operation: "DELETE", Count: 20},
+	}
+	mockStorage := &smocks.Store{}
+	mockStorage.On("GetThroughput", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return(testThroughputs, nil)
+	mockStorage.On("GetLatestProbabilities").Return(make(model.ServiceOperationProbabilities), nil)
+	mockStorage.On("InsertProbabilitiesAndQPS", "host", mock.AnythingOfType("model.ServiceOperationProbabilities"),
+		mock.AnythingOfType("model.ServiceOperationQPS")).Return(nil)
+	mockEP := &epmocks.ElectionParticipant{}
+	mockEP.On("Start").Return(nil)
+	mockEP.On("Close").Return(nil)
+	mockEP.On("IsLeader").Return(true)
+	cfg := Options{
+		TargetSamplesPerSecond:     1.0,
+		DeltaTolerance:             0.2,
+		InitialSamplingProbability: 0.001,
+		CalculationInterval:        time.Second * 10,
+		AggregationBuckets:         1,
+		Delay:                      time.Second * 10,
+	}
+	s := NewProvider(cfg, logger, mockEP, mockStorage)
+	s.Start()
+
+	for i := 0; i < 100; i++ {
+		strategy, _ := s.GetSamplingStrategy(context.Background(), "svcA")
+		if len(strategy.OperationSampling.PerOperationStrategies) != 0 {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	s.Close()
+
+	strategy, err := s.GetSamplingStrategy(context.Background(), "svcA")
+	require.NoError(t, err)
+	require.Len(t, strategy.OperationSampling.PerOperationStrategies, 4)
+	strategies := strategy.OperationSampling.PerOperationStrategies
+
+	for _, s := range strategies {
+		switch s.Operation {
+		case "GET":
+			assert.Equal(t, 0.001, s.ProbabilisticSampling.SamplingRate,
+				"Already at 1QPS, no probability change")
+		case "POST":
+			assert.Equal(t, 0.001, s.ProbabilisticSampling.SamplingRate,
+				"Within epsilon of 1QPS, no probability change")
+		case "PUT":
+			assert.InEpsilon(t, 0.002, s.ProbabilisticSampling.SamplingRate, 0.025,
+				"Under sampled, double probability")
+		case "DELETE":
+			assert.InEpsilon(t, 0.0005, s.ProbabilisticSampling.SamplingRate, 0.025,
+				"Over sampled, halve probability")
+		}
+	}
+}
+
+func TestProviderGenerateStrategyResponses(t *testing.T) {
+	probabilities := model.ServiceOperationProbabilities{
+		"svcA": map[string]float64{
+			"GET": 0.5,
+		},
+	}
+	p := &Provider{
+		probabilities: probabilities,
+		Options: Options{
+			InitialSamplingProbability: 0.001,
+			MinSamplesPerSecond:        0.0001,
+		},
+	}
+	p.generateStrategyResponses()
+
+	expectedResponse := map[string]*api_v2.SamplingStrategyResponse{
+		"svcA": {
+			StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
+			OperationSampling: &api_v2.PerOperationSamplingStrategies{
+				DefaultSamplingProbability:       0.001,
+				DefaultLowerBoundTracesPerSecond: 0.0001,
+				PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
+					{
+						Operation: "GET",
+						ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
+							SamplingRate: 0.5,
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expectedResponse, p.strategyResponses)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Previous refactoring left the code in a mixed up state

## Description of the changes
- move provider / aggregator / post-aggregator into separate files named accordingly
- do the same for tests
- no actual code changes, just moving code around

## How was this change tested?
- CI
