### PR TITLE
Fix: The 'tagType' in ES jaeger-span mapping tags.properties should be 'type'

### DIFF
--- a/plugin/storage/es/mappings/fixtures/jaeger-span-6.json
+++ b/plugin/storage/es/mappings/fixtures/jaeger-span-6.json
@@ -83,7 +83,7 @@
                   "type":"keyword",
                   "ignore_above":256
                 },
-                "tagType":{
+                "type":{
                   "type":"keyword",
                   "ignore_above":256
                 }
@@ -112,7 +112,7 @@
                   "type":"keyword",
                   "ignore_above":256
                 },
-                "tagType":{
+                "type":{
                   "type":"keyword",
                   "ignore_above":256
                 }
@@ -153,7 +153,7 @@
               "type":"keyword",
               "ignore_above":256
             },
-            "tagType":{
+            "type":{
               "type":"keyword",
               "ignore_above":256
             }

--- a/plugin/storage/es/mappings/fixtures/jaeger-span-7.json
+++ b/plugin/storage/es/mappings/fixtures/jaeger-span-7.json
@@ -83,7 +83,7 @@
                 "type":"keyword",
                 "ignore_above":256
               },
-              "tagType":{
+              "type":{
                 "type":"keyword",
                 "ignore_above":256
               }
@@ -112,7 +112,7 @@
                 "type":"keyword",
                 "ignore_above":256
               },
-              "tagType":{
+              "type":{
                 "type":"keyword",
                 "ignore_above":256
               }
@@ -153,7 +153,7 @@
             "type":"keyword",
             "ignore_above":256
           },
-          "tagType":{
+          "type":{
             "type":"keyword",
             "ignore_above":256
           }

--- a/plugin/storage/es/mappings/fixtures/jaeger-span-8.json
+++ b/plugin/storage/es/mappings/fixtures/jaeger-span-8.json
@@ -85,7 +85,7 @@
                   "type": "keyword",
                   "ignore_above": 256
                 },
-                "tagType": {
+                "type": {
                   "type": "keyword",
                   "ignore_above": 256
                 }
@@ -114,7 +114,7 @@
                   "type": "keyword",
                   "ignore_above": 256
                 },
-                "tagType": {
+                "type": {
                   "type": "keyword",
                   "ignore_above": 256
                 }
@@ -155,7 +155,7 @@
               "type": "keyword",
               "ignore_above": 256
             },
-            "tagType": {
+            "type": {
               "type": "keyword",
               "ignore_above": 256
             }

--- a/plugin/storage/es/mappings/jaeger-span-6.json
+++ b/plugin/storage/es/mappings/jaeger-span-6.json
@@ -83,7 +83,7 @@
                   "type":"keyword",
                   "ignore_above":256
                 },
-                "tagType":{
+                "type":{
                   "type":"keyword",
                   "ignore_above":256
                 }
@@ -112,7 +112,7 @@
                   "type":"keyword",
                   "ignore_above":256
                 },
-                "tagType":{
+                "type":{
                   "type":"keyword",
                   "ignore_above":256
                 }
@@ -153,7 +153,7 @@
               "type":"keyword",
               "ignore_above":256
             },
-            "tagType":{
+            "type":{
               "type":"keyword",
               "ignore_above":256
             }

--- a/plugin/storage/es/mappings/jaeger-span-7.json
+++ b/plugin/storage/es/mappings/jaeger-span-7.json
@@ -87,7 +87,7 @@
                 "type":"keyword",
                 "ignore_above":256
               },
-              "tagType":{
+              "type":{
                 "type":"keyword",
                 "ignore_above":256
               }
@@ -116,7 +116,7 @@
                 "type":"keyword",
                 "ignore_above":256
               },
-              "tagType":{
+              "type":{
                 "type":"keyword",
                 "ignore_above":256
               }
@@ -157,7 +157,7 @@
             "type":"keyword",
             "ignore_above":256
           },
-          "tagType":{
+          "type":{
             "type":"keyword",
             "ignore_above":256
           }

--- a/plugin/storage/es/mappings/jaeger-span-8.json
+++ b/plugin/storage/es/mappings/jaeger-span-8.json
@@ -90,7 +90,7 @@
                   "type": "keyword",
                   "ignore_above": 256
                 },
-                "tagType": {
+                "type": {
                   "type": "keyword",
                   "ignore_above": 256
                 }
@@ -119,7 +119,7 @@
                   "type": "keyword",
                   "ignore_above": 256
                 },
-                "tagType": {
+                "type": {
                   "type": "keyword",
                   "ignore_above": 256
                 }
@@ -160,7 +160,7 @@
               "type": "keyword",
               "ignore_above": 256
             },
-            "tagType": {
+            "type": {
               "type": "keyword",
               "ignore_above": 256
             }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #5967 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
