### PR TITLE
testifylint: enable go-require

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -221,8 +221,6 @@ linters-settings:
         - name: comment-spacings
           disabled: true
   testifylint:
-    disable:
-      - go-require
     enable-all: true
 
 run:

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -62,7 +62,7 @@ func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server
 	beforeServe(server)
 	go func() {
 		err := server.Serve(lis)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	return server, lis.Addr()
 }

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -70,7 +70,7 @@ func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		require.NoError(t, server.Serve(lis))
+		assert.NoError(t, server.Serve(lis))
 		wg.Done()
 	}()
 	t.Cleanup(func() {

--- a/cmd/agent/app/servers/thriftudp/transport_test.go
+++ b/cmd/agent/app/servers/thriftudp/transport_test.go
@@ -96,7 +96,7 @@ func TestTUDPServerTransportIsOpen(t *testing.T) {
 	go func() {
 		time.Sleep(2 * time.Millisecond)
 		err = trans.Close()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 

--- a/cmd/agent/app/testutils/mock_grpc_collector.go
+++ b/cmd/agent/app/testutils/mock_grpc_collector.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -33,7 +34,7 @@ func StartGRPCCollector(t *testing.T) *GrpcCollector {
 	handler := &mockSpanHandler{t: t}
 	api_v2.RegisterCollectorServiceServer(server, handler)
 	go func() {
-		require.NoError(t, server.Serve(lis))
+		assert.NoError(t, server.Serve(lis))
 	}()
 	return &GrpcCollector{
 		mockSpanHandler: handler,

--- a/cmd/anonymizer/app/query/query_test.go
+++ b/cmd/anonymizer/app/query/query_test.go
@@ -74,7 +74,7 @@ func newTestServer(t *testing.T) *testServer {
 	var exited sync.WaitGroup
 	exited.Add(1)
 	go func() {
-		require.NoError(t, server.Serve(lis))
+		assert.NoError(t, server.Serve(lis))
 		exited.Done()
 	}()
 	t.Cleanup(func() {

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -91,7 +91,7 @@ func initializeGRPCTestServer(t *testing.T, beforeServe func(s *grpc.Server)) (*
 	require.NoError(t, err)
 	go func() {
 		err := server.Serve(lis)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	return server, lis.Addr()
 }

--- a/cmd/query/app/apiv3/grpc_handler_test.go
+++ b/cmd/query/app/apiv3/grpc_handler_test.go
@@ -38,7 +38,7 @@ func newGrpcServer(t *testing.T, handler *Handler) (*grpc.Server, net.Addr) {
 	require.NoError(t, err)
 	go func() {
 		err := server.Serve(lis)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	t.Cleanup(func() { server.Stop() })
 	return server, lis.Addr()

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -156,7 +156,7 @@ func newGRPCServer(t *testing.T, q *querysvc.QueryService, mq querysvc.MetricsQu
 
 	go func() {
 		err := grpcServer.Serve(lis)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	return grpcServer, lis.Addr()

--- a/internal/grpctest/reflection_test.go
+++ b/internal/grpctest/reflection_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -24,7 +25,7 @@ func TestReflectionServiceValidator(t *testing.T) {
 
 	go func() {
 		err := server.Serve(listener)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	defer server.Stop()
 

--- a/pkg/es/client/index_client_test.go
+++ b/pkg/es/client/index_client_test.go
@@ -385,10 +385,11 @@ func TestClientCreateAliases(t *testing.T) {
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
 				body, err := io.ReadAll(req.Body)
-				require.NoError(t, err)
-				assert.Equal(t, expectedRequestBody, string(body))
-				res.WriteHeader(test.responseCode)
-				res.Write([]byte(test.response))
+				if assert.NoError(t, err) {
+					assert.Equal(t, expectedRequestBody, string(body))
+					res.WriteHeader(test.responseCode)
+					res.Write([]byte(test.response))
+				}
 			}))
 			defer testServer.Close()
 
@@ -445,7 +446,7 @@ func TestClientDeleteAliases(t *testing.T) {
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
 				body, err := io.ReadAll(req.Body)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, expectedRequestBody, string(body))
 				res.WriteHeader(test.responseCode)
 				res.Write([]byte(test.response))
@@ -508,7 +509,7 @@ func TestClientCreateTemplate(t *testing.T) {
 				assert.Equal(t, http.MethodPut, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
 				body, err := io.ReadAll(req.Body)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, templateContent, string(body))
 
 				res.WriteHeader(test.responseCode)
@@ -562,7 +563,7 @@ func TestRollover(t *testing.T) {
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "Basic foobar", req.Header.Get("Authorization"))
 				body, err := io.ReadAll(req.Body)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, expectedRequestBody, string(body))
 
 				res.WriteHeader(test.responseCode)

--- a/pkg/es/config/config_test.go
+++ b/pkg/es/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -85,25 +86,25 @@ func TestNewClient(t *testing.T) {
 	defer certFilePath.Close()
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		require.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, http.MethodGet, req.Method)
 		res.WriteHeader(http.StatusOK)
 		res.Write(mockEsServerResponseWithVersion0)
 	}))
 	defer testServer.Close()
 	testServer1 := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		require.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, http.MethodGet, req.Method)
 		res.WriteHeader(http.StatusOK)
 		res.Write(mockEsServerResponseWithVersion1)
 	}))
 	defer testServer1.Close()
 	testServer2 := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		require.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, http.MethodGet, req.Method)
 		res.WriteHeader(http.StatusOK)
 		res.Write(mockEsServerResponseWithVersion2)
 	}))
 	defer testServer2.Close()
 	testServer8 := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		require.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, http.MethodGet, req.Method)
 		res.WriteHeader(http.StatusOK)
 		res.Write(mockEsServerResponseWithVersion8)
 	}))

--- a/pkg/hostname/hostname_test.go
+++ b/pkg/hostname/hostname_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
@@ -24,13 +23,13 @@ func TestAsIdentifier(t *testing.T) {
 	go func() {
 		var err error
 		hostname1, err = AsIdentifier()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 	go func() {
 		var err error
 		hostname2, err = AsIdentifier()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 	wg.Wait()

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -501,13 +501,13 @@ func TestGetErrorRatesZero(t *testing.T) {
 		defer r.Body.Close()
 
 		u, err := url.Parse("http://" + r.Host + r.RequestURI + "?" + string(body))
-		require.NoError(t, err)
-
-		q := u.Query()
-		promQuery := q.Get("query")
-		assert.Equal(t, wantPromQLQueries[callCount], promQuery)
-		sendResponse(t, w, responses[callCount])
-		callCount++
+		if assert.NoError(t, err) {
+			q := u.Query()
+			promQuery := q.Get("query")
+			assert.Equal(t, wantPromQLQueries[callCount], promQuery)
+			sendResponse(t, w, responses[callCount])
+			callCount++
+		}
 	}))
 
 	logger := zap.NewNop()
@@ -564,7 +564,7 @@ func TestGetErrorRatesNull(t *testing.T) {
 		defer r.Body.Close()
 
 		u, err := url.Parse("http://" + r.Host + r.RequestURI + "?" + string(body))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		q := u.Query()
 		promQuery := q.Get("query")
@@ -635,7 +635,7 @@ func TestGetErrorRatesErrors(t *testing.T) {
 				defer r.Body.Close()
 
 				u, err := url.Parse("http://" + r.Host + r.RequestURI + "?" + string(body))
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				q := u.Query()
 				promQuery := q.Get("query")
@@ -879,7 +879,7 @@ func startMockPrometheusServer(t *testing.T, wantPromQlQuery string, wantWarning
 		defer r.Body.Close()
 
 		u, err := url.Parse("http://" + r.Host + r.RequestURI + "?" + string(body))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		q := u.Query()
 		promQuery := q.Get("query")

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -354,10 +354,12 @@ func testPasswordFromFile(t *testing.T, f *Factory, getClient func() es.Client, 
 		t.Logf("request to fake ES server: %v", r)
 		// epecting header in the form Authorization:[Basic OmZpcnN0IHBhc3N3b3Jk]
 		h := strings.Split(r.Header.Get("Authorization"), " ")
-		require.Len(t, h, 2)
-		require.Equal(t, "Basic", h[0])
+		if !assert.Len(t, h, 2) {
+			return
+		}
+		assert.Equal(t, "Basic", h[0])
 		authBytes, err := base64.StdEncoding.DecodeString(h[1])
-		require.NoError(t, err, "header: %s", h)
+		assert.NoError(t, err, "header: %s", h)
 		auth := string(authBytes)
 		authReceived.Store(auth, auth)
 		t.Logf("request to fake ES server contained auth=%s", auth)


### PR DESCRIPTION
## Which problem is this PR solving?
- Apply go-require rule of testifylint

## Description of the changes
-  More appropriate testify API with clearer failure message.

## How was this change tested?
- CI 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
