### PR TITLE
Enable publishing of versioned jaeger-v2 artifacts

### DIFF
--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -57,22 +57,11 @@ jobs:
             ;;
         esac
 
-    - name: Customize the build based on v1/v2 version
-      run: |
-        if [[ "${{ matrix.jaeger_version }}" == "v1" ]]; then
-          echo "HEALTHCHECK_V2=false" >> $GITHUB_ENV
-          echo "JAEGER_BINARY=all-in-one" >> $GITHUB_ENV
-        elif [[ "${{ matrix.jaeger_version }}" == "v2" ]]; then
-          echo "HEALTHCHECK_V2=true" >> $GITHUB_ENV
-          echo "JAEGER_BINARY=jaeger" >> $GITHUB_ENV
-        fi
-
     - name: Build, test, and publish all-in-one image
       run: |
         bash scripts/build-all-in-one-image.sh \
           ${{ env.BUILD_FLAGS }} \
-          -b ${{ env.JAEGER_BINARY }}
+          "${{ matrix.jaeger_version }}"
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        HEALTHCHECK_V2: ${{ env.HEALTHCHECK_V2 }}

--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -57,8 +57,7 @@ jobs:
             ;;
         esac
 
-    - name: Determine healthcheck setting
-      id: healthcheck
+    - name: Customize the build based on v1/v2 version
       run: |
         if [[ "${{ matrix.jaeger_version }}" == "v1" ]]; then
           echo "HEALTHCHECK_V2=false" >> $GITHUB_ENV

--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -20,11 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mode:
-        - name: v1
-          binary: all-in-one
-        - name: v2
-          binary: jaeger
+        jaeger_version: [v1, v2]
 
     steps:
     - uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
@@ -64,17 +60,19 @@ jobs:
     - name: Determine healthcheck setting
       id: healthcheck
       run: |
-        if [[ "${{ matrix.mode.name }}" == "v1" ]]; then
+        if [[ "${{ matrix.jaeger_version }}" == "v1" ]]; then
           echo "HEALTHCHECK_V2=false" >> $GITHUB_ENV
-        elif [[ "${{ matrix.mode.name }}" == "v2" ]]; then
+          echo "JAEGER_BINARY=all-in-one" >> $GITHUB_ENV
+        elif [[ "${{ matrix.jaeger_version }}" == "v2" ]]; then
           echo "HEALTHCHECK_V2=true" >> $GITHUB_ENV
+          echo "JAEGER_BINARY=jaeger" >> $GITHUB_ENV
         fi
 
     - name: Build, test, and publish all-in-one image
       run: |
         bash scripts/build-all-in-one-image.sh \
           ${{ env.BUILD_FLAGS }} \
-          -b ${{ matrix.mode.binary }}
+          -b ${{ env.JAEGER_BINARY }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,22 +1,25 @@
 name: Publish release
 
 on:
-  release:
-    types:
-      - published
-  # allow running release workflow manually
-  workflow_dispatch:
-    # Determine the version numbers that will be assigned to the release.
-    inputs:
-      version_v1:
-        required: true
-        type: string
-        description: Version number for 1.x components. Don't include a leading `v`.
+  # Disable auto-run, once we sunset 1.x components we might go back to auto-release.
+  #
+  # release:
+  #   types:
+  #     - published
 
-      version_v2:
-        required: true
-        type: string
-        description: Version number for 2.x components. Don't include a leading `v`.
+  workflow_dispatch:
+    inputs:
+      # Disable version inputs for now, the build always uses the latest tags.
+      #
+      # version_v1:
+      #   required: true
+      #   type: string
+      #   description: Version number for 1.x components. Don't include a leading `v`.
+
+      # version_v2:
+      #   required: true
+      #   type: string
+      #   description: Version number for 2.x components. Don't include a leading `v`.
 
       dry_run:
         required: true
@@ -27,10 +30,6 @@ on:
         required: true
         type: boolean
         description: Allow overwriting artifacts.
-
-# See https://github.com/jaegertracing/jaeger/issues/4017
-permissions:
-  contents: read
 
 jobs:
   publish-release:
@@ -71,28 +70,31 @@ jobs:
     - name: Determine parameters
       id: params
       run: |
+        docker_flags=()
         if [[ "${{ inputs.dry_run }}" == "true" ]]; then
-          echo "local_build=-l" >> $GITHUB_OUTPUT
+          docker_flags=("${docker_flags[@]}" -l -p linux/amd64)
           echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-          echo "linux_platforms=linux/amd64" >> $GITHUB_OUTPUT
           echo "gpg_key_override=-k skip" >> $GITHUB_OUTPUT
         else
-          echo "local_build=" >> $GITHUB_OUTPUT
           echo "platforms=$(make echo-platforms)" >> $GITHUB_OUTPUT
-          echo "linux_platforms=$(make echo-linux-platforms)" >> $GITHUB_OUTPUT
         fi
+        if [[ "${{ inputs.overwrite }}" == "true" ]]; then
+          docker_flags=("${docker_flags[@]}" -o)
+        fi
+        echo "docker_flags=${docker_flags[@]}" >> $GITHUB_OUTPUT
 
     - name: Export BRANCH variable and validate it is a semver
       # Many scripts depend on BRANCH variable. We do not want to
       # use ./.github/actions/setup-branch here because it may set
       # BRANCH=main when the workflow is triggered manually.
       #
-      # TODO this currently utilizes 1.x version tag
+      # TODO this currently utilizes 1.x version tag, which is ok for v1
+      # binaries, but for tools/utils we may need to change in the future.
       run: |
         BRANCH=$(make echo-v1)
-        echo "BRANCH=${BRANCH}" >> ${GITHUB_ENV}
         echo Validate that the latest tag ${BRANCH} is in semver format
         echo ${BRANCH} | grep -E '^v[0-9]+.[0-9]+.[0-9]+$'
+        echo "BRANCH=${BRANCH}" >> ${GITHUB_ENV}
 
     - run: make install-ci
 
@@ -107,8 +109,10 @@ jobs:
       run: make build-all-platforms PLATFORMS=${{ steps.params.outputs.platforms }}
 
     - name: Package binaries
-      id: package-binaries
-      run: bash scripts/package-deploy.sh -p ${{ steps.params.outputs.platforms }} ${{ steps.params.outputs.gpg_key_override }}
+      run: |
+        bash scripts/package-deploy.sh \
+          -p ${{ steps.params.outputs.platforms }} \
+          ${{ steps.params.outputs.gpg_key_override }}
 
     - name: Upload binaries
       if: ${{ inputs.dry_run != true }}
@@ -131,17 +135,27 @@ jobs:
       # -B skips building the binaries since we already did that above
       run: |
         bash scripts/build-upload-docker-images.sh -B \
-          -p ${{ steps.params.outputs.linux_platforms }} \
-          ${{ steps.params.outputs.local_build }}
+          ${{ steps.params.outputs.docker_flags }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
-    - name: Build, test, and publish all-in-one image
+    - name: Build, test, and publish all-in-one v1 image
       run: |
+        BRANCH=$(make echo-v1) \
         bash scripts/build-all-in-one-image.sh \
-          -p ${{ steps.params.outputs.linux_platforms }} \
-          ${{ steps.params.outputs.local_build }}
+          -b all-in-one \
+          ${{ steps.params.outputs.docker_flags }}
+      env:
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Build, test, and publish v2 image
+      run: |
+        BRANCH=$(make echo-v2) \
+        bash scripts/build-all-in-one-image.sh \
+          -b jaeger \
+          ${{ steps.params.outputs.docker_flags }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
@@ -149,8 +163,7 @@ jobs:
     - name: Build, test, and publish hotrod image
       run: |
         bash scripts/build-hotrod-image.sh \
-          -p ${{ steps.params.outputs.linux_platforms }} \
-          ${{ steps.params.outputs.local_build }}
+          ${{ steps.params.outputs.docker_flags }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
@@ -165,11 +178,11 @@ jobs:
     - name: Upload SBOM
       # Upload SBOM manually, because anchore/sbom-action does not do that
       # when the workflow is triggered manually, only from a release.
-      # See https://github.com/jaegertracing/jaeger/issues/4817
       uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # 2.9.0
       if: ${{ inputs.dry_run != true }}
       with:
         file: jaeger-SBOM.spdx.json
         overwrite: ${{ inputs.overwrite }}
+        # TODO this will only work for 1.x artifacts
         tag: ${{ env.BRANCH }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -97,8 +97,6 @@ jobs:
         echo ${BRANCH} | grep -E '^v[0-9]+.[0-9]+.[0-9]+$'
         echo "BRANCH=${BRANCH}" >> ${GITHUB_ENV}
 
-    - run: make install-ci
-
     - name: Configure GPG Key
       if: ${{ inputs.dry_run != true }}
       uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -82,6 +82,7 @@ jobs:
           docker_flags=("${docker_flags[@]}" -o)
         fi
         echo "docker_flags=${docker_flags[@]}" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
 
     - name: Export BRANCH variable and validate it is a semver
       # Many scripts depend on BRANCH variable. We do not want to

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -143,8 +143,8 @@ jobs:
       run: |
         BRANCH=$(make echo-v1) \
         bash scripts/build-all-in-one-image.sh \
-          -b all-in-one \
-          ${{ steps.params.outputs.docker_flags }}
+          ${{ steps.params.outputs.docker_flags }} \
+          v1
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
@@ -153,8 +153,8 @@ jobs:
       run: |
         BRANCH=$(make echo-v2) \
         bash scripts/build-all-in-one-image.sh \
-          -b jaeger \
-          ${{ steps.params.outputs.docker_flags }}
+          ${{ steps.params.outputs.docker_flags }} \
+          v2
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -89,11 +89,11 @@ for platform in $(echo "$platforms" | tr ',' ' '); do
   make "build-${BINARY}" GOOS=linux GOARCH="${arch}"
 done
 
+baseimg_target='create-baseimg-debugimg'
 if [[ "${add_debugger}" == "N" ]]; then
-  make create-baseimg
-else
-  make create-baseimg-debugimg
+  baseimg_target='create-baseimg'
 fi
+make "$baseimg_target" LINUX_PLATFORMS="$platforms"
 
 # build all-in-one image locally for integration test (the explicit -l switch)
 bash scripts/build-upload-a-docker-image.sh -l -b -c "${BINARY}" -d "cmd/${BINARY}" -p "${platforms}" -t release

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -51,12 +51,10 @@ fi
 
 case $1 in
   v1)
-    JAEGER_MAJOR=v1
     BINARY='all-in-one'
     export HEALTHCHECK_V2=false
     ;;
   v2)
-    JAEGER_MAJOR=v2
     BINARY='jaeger'
     export HEALTHCHECK_V2=true
     ;;

--- a/scripts/build-all-in-one-image.sh
+++ b/scripts/build-all-in-one-image.sh
@@ -21,7 +21,7 @@ platforms="$(make echo-linux-platforms)"
 FLAGS=()
 BINARY='all-in-one'
 
-while getopts "b:Dhlp:" opt; do
+while getopts "b:Dhlop:" opt; do
 	case "${opt}" in
 	b)
 		BINARY=${OPTARG}
@@ -31,10 +31,10 @@ while getopts "b:Dhlp:" opt; do
 		;;
 	l)
 		# in the local-only mode the images will only be pushed to local registry
-    FLAGS=("${FLAGS[@]}" -l)
+		FLAGS=("${FLAGS[@]}" -l)
 		;;
 	o)
-    FLAGS=("${FLAGS[@]}" -o)
+		FLAGS=("${FLAGS[@]}" -o)
 		;;
 	p)
 		platforms=${OPTARG}

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -55,7 +55,7 @@ teardown() {
 trap teardown EXIT
 
 make prepare-docker-buildx
-make create-baseimg
+make create-baseimg LINUX_PLATFORMS="$platforms"
 
 # Build hotrod binary for each target platform (separated by commas)
 for platform in $(echo "$platforms" | tr ',' ' '); do

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -euxf -o pipefail
+set -euf -o pipefail
 
 print_help() {
   echo "Usage: $0 [-h] [-l] [-o] [-p platforms]"
@@ -37,6 +37,8 @@ while getopts "hlop:" opt; do
 		;;
 	esac
 done
+
+set -x
 
 dump_logs() {
   local compose_file=$1

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -20,7 +20,7 @@ current_platform="$(go env GOOS)/$(go env GOARCH)"
 FLAGS=()
 success="false"
 
-while getopts "hlp:" opt; do
+while getopts "hlop:" opt; do
 	case "${opt}" in
 	l)
 		# in the local-only mode the images will only be pushed to local registry

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -6,9 +6,10 @@
 set -euxf -o pipefail
 
 print_help() {
-  echo "Usage: $0 [-h] [-l] [-p platforms]"
+  echo "Usage: $0 [-h] [-l] [-o] [-p platforms]"
   echo "-h: Print help"
   echo "-l: Enable local-only mode that only pushes images to local registry"
+  echo "-o: overwrite image in the target remote repository even if the semver tag already exists"
   echo "-p: Comma-separated list of platforms to build for (default: all supported)"
   exit 1
 }
@@ -16,14 +17,17 @@ print_help() {
 docker_compose_file="./examples/hotrod/docker-compose.yml"
 platforms="$(make echo-linux-platforms)"
 current_platform="$(go env GOOS)/$(go env GOARCH)"
-LOCAL_FLAG=''
+FLAGS=()
 success="false"
 
 while getopts "hlp:" opt; do
 	case "${opt}" in
 	l)
 		# in the local-only mode the images will only be pushed to local registry
-		LOCAL_FLAG='-l'
+    FLAGS=("${FLAGS[@]}" -l)
+		;;
+	o)
+    FLAGS=("${FLAGS[@]}" -o)
 		;;
 	p)
 		platforms=${OPTARG}
@@ -130,4 +134,4 @@ success="true"
 
 # Ensure the image is published after successful test (maybe with -l flag if on a pull request).
 # This is where all those multi-platform binaries we built earlier are utilized.
-bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -c example-hotrod -d examples/hotrod -p "${platforms}"
+bash scripts/build-upload-a-docker-image.sh "${FLAGS[@]}" -c example-hotrod -d examples/hotrod -p "${platforms}"

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -27,7 +27,7 @@ while getopts "hlop:" opt; do
     FLAGS=("${FLAGS[@]}" -l)
 		;;
 	o)
-    FLAGS=("${FLAGS[@]}" -o)
+		FLAGS=("${FLAGS[@]}" -o)
 		;;
 	p)
 		platforms=${OPTARG}

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -6,12 +6,13 @@
 set -euf -o pipefail
 
 print_help() {
-  echo "Usage: $0 [-c] [-D] [-h] [-l] [-p platforms]"
+  echo "Usage: $0 [-c] [-D] [-h] [-l] [-o] [-p platforms]"
   echo "-h: Print help"
   echo "-b: add base_image and debug_image arguments to the build command"
   echo "-c: name of the component to build"
   echo "-d: directory for the Dockerfile"
   echo "-f: override the name of the Dockerfile (-d still respected)"
+  echo "-o: overwrite image in the target remote repository even if the semver tag already exists"
   echo "-p: Comma-separated list of platforms to build for (default: all supported)"
   echo "-t: Release target (release|debug) if required by the Dockerfile"
   exit 1
@@ -24,8 +25,9 @@ target_arg=""
 local_test_only='N'
 platforms="linux/amd64"
 namespace="jaegertracing"
+overwrite='N'
 
-while getopts "bc:d:f:hlp:t:" opt; do
+while getopts "bc:d:f:hlop:t:" opt; do
 	# shellcheck disable=SC2220 # we don't need a *) case
 	case "${opt}" in
 	b)
@@ -42,6 +44,9 @@ while getopts "bc:d:f:hlp:t:" opt; do
 		;;
 	l)
 		local_test_only='Y'
+		;;
+	o)
+		overwrite='Y'
 		;;
 	p)
 		platforms=${OPTARG}
@@ -63,6 +68,25 @@ fi
 
 docker_file_arg="${dir_arg}/${docker_file_arg}"
 
+check_overwrite() {
+  for image in "$@"; do
+    if [[ "$image" == "--tag" ]]; then
+      continue
+    fi
+    if [[ $image =~ -snapshot ]]; then
+      continue
+    fi
+    tag=${image#*:}
+    if [[ $tag =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+      echo "Checking if image $image already exists"
+      if docker manifest inspect "$image" >/dev/null 2>&1; then
+        echo "❌ ERROR: Image $image already exists and overwrite=$overwrite"
+        exit 1
+      fi
+    fi
+  done
+}
+
 upload_comment=""
 
 if [[ "${local_test_only}" = "Y" ]]; then
@@ -74,15 +98,18 @@ else
     IFS=" " read -r -a IMAGE_TAGS <<< "$(bash scripts/compute-tags.sh ${namespace}/${component_name})"
     echo "::endgroup::"
 
-    # Only push multi-arch images to dockerhub/quay.io for main branch or for release tags vM.N.P
+    # Only push multi-arch images to dockerhub/quay.io for main branch or for release tags vM.N.P{-rcX}
     if [[ "$BRANCH" == "main" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	    echo "will build docker images and upload to dockerhub/quay.io, BRANCH=$BRANCH"
 	    bash scripts/docker-login.sh
-	    PUSHTAG="type=image, push=true"
+	    PUSHTAG="type=image,push=true"
 	    upload_comment=" and uploading"
+		if [[ "$overwrite" == 'N' ]]; then
+		  check_overwrite "${IMAGE_TAGS[@]}"
+		fi
     else
 	    echo 'skipping docker images upload, because not on tagged release or main branch'
-	    PUSHTAG="type=image, push=false"
+	    PUSHTAG="type=image,push=false"
     fi
 fi
 

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -18,7 +18,7 @@ print_help() {
   exit 1
 }
 
-BRANCH=${BRANCH:?'expecting BRANCH env var'}
+echo "BRANCH=${BRANCH:?'expecting BRANCH env var'}"
 base_debug_img_arg=""
 docker_file_arg="Dockerfile"
 target_arg=""

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -104,9 +104,9 @@ else
 	    bash scripts/docker-login.sh
 	    PUSHTAG="type=image,push=true"
 	    upload_comment=" and uploading"
-		if [[ "$overwrite" == 'N' ]]; then
-		  check_overwrite "${IMAGE_TAGS[@]}"
-		fi
+	    if [[ "$overwrite" == 'N' ]]; then
+	      check_overwrite "${IMAGE_TAGS[@]}"
+	    fi
     else
 	    echo 'skipping docker images upload, because not on tagged release or main branch'
 	    PUSHTAG="type=image,push=false"

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -91,7 +91,7 @@ upload_comment=""
 
 if [[ "${local_test_only}" = "Y" ]]; then
     IMAGE_TAGS=("--tag" "localhost:5000/${namespace}/${component_name}:${GITHUB_SHA}")
-    PUSHTAG="type=image, push=true"
+    PUSHTAG="type=image,push=true"
 else
     echo "::group:: compute tags ${component_name}"
     # shellcheck disable=SC2086

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -35,9 +35,9 @@ while getopts "BDhlop:" opt; do
     # in the local-only mode the images will only be pushed to local registry
     FLAGS=("${FLAGS[@]}" -l)
     ;;
-	o)
+  o)
     FLAGS=("${FLAGS[@]}" -o)
-		;;
+    ;;
   p)
     platforms=${OPTARG}
     ;;

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -56,11 +56,11 @@ if [[ "$build_binaries" == "Y" ]]; then
   done
 fi
 
+baseimg_target='create-baseimg-debugimg'
 if [[ "${add_debugger}" == "N" ]]; then
-  make create-baseimg
-else
-  make create-baseimg-debugimg
+  baseimg_target='create-baseimg'
 fi
+make "$baseimg_target" LINUX_PLATFORMS="$platforms"
 
 # build/upload raw and debug images of Jaeger backend components
 for component in agent collector query ingester remote-storage

--- a/scripts/build-upload-docker-images.sh
+++ b/scripts/build-upload-docker-images.sh
@@ -6,11 +6,12 @@
 set -euf -o pipefail
 
 print_help() {
-  echo "Usage: $0 [-B] [-D] [-h] [-l] [-p platforms]"
+  echo "Usage: $0 [-B] [-D] [-h] [-l] [-o] [-p platforms]"
   echo "-h: Print help"
   echo "-B: Skip building of the binaries (e.g. when they were already built)"
   echo "-D: Disable building of images with debugger"
   echo "-l: Enable local-only mode that only pushes images to local registry"
+  echo "-o: overwrite image in the target remote repository even if the semver tag already exists"
   echo "-p: Comma-separated list of platforms to build for (default: all supported)"
   exit 1
 }
@@ -18,9 +19,9 @@ print_help() {
 add_debugger='Y'
 build_binaries='Y'
 platforms="$(make echo-linux-platforms)"
-LOCAL_FLAG=''
+FLAGS=()
 
-while getopts "BDhlp:" opt; do
+while getopts "BDhlop:" opt; do
   case "${opt}" in
   B)
     build_binaries='N'
@@ -32,8 +33,11 @@ while getopts "BDhlp:" opt; do
     ;;
   l)
     # in the local-only mode the images will only be pushed to local registry
-    LOCAL_FLAG='-l'
+    FLAGS=("${FLAGS[@]}" -l)
     ;;
+	o)
+    FLAGS=("${FLAGS[@]}" -o)
+		;;
   p)
     platforms=${OPTARG}
     ;;
@@ -61,19 +65,19 @@ fi
 # build/upload raw and debug images of Jaeger backend components
 for component in agent collector query ingester remote-storage
 do
-  bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}" -t release
+  bash scripts/build-upload-a-docker-image.sh "${FLAGS[@]}" -b -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}" -t release
   # do not need debug image built for PRs
   if [[ "${add_debugger}" == "Y" ]]; then
-    bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c "jaeger-${component}-debug" -d "cmd/${component}" -t debug
+    bash scripts/build-upload-a-docker-image.sh "${FLAGS[@]}" -b -c "jaeger-${component}-debug" -d "cmd/${component}" -t debug
   fi
 done
 
-bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c jaeger-es-index-cleaner -d cmd/es-index-cleaner -p "${platforms}" -t release
-bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -b -c jaeger-es-rollover -d cmd/es-rollover  -p "${platforms}" -t release
-bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -c jaeger-cassandra-schema -d plugin/storage/cassandra/ -p "${platforms}"
+bash scripts/build-upload-a-docker-image.sh "${FLAGS[@]}" -b -c jaeger-es-index-cleaner -d cmd/es-index-cleaner -p "${platforms}" -t release
+bash scripts/build-upload-a-docker-image.sh "${FLAGS[@]}" -b -c jaeger-es-rollover -d cmd/es-rollover  -p "${platforms}" -t release
+bash scripts/build-upload-a-docker-image.sh "${FLAGS[@]}" -c jaeger-cassandra-schema -d plugin/storage/cassandra/ -p "${platforms}"
 
 # build/upload images for jaeger-tracegen and jaeger-anonymizer
 for component in tracegen anonymizer
 do
-  bash scripts/build-upload-a-docker-image.sh ${LOCAL_FLAG} -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}"
+  bash scripts/build-upload-a-docker-image.sh "${FLAGS[@]}" -c "jaeger-${component}" -d "cmd/${component}" -p "${platforms}"
 done

--- a/scripts/compute-tags.sh
+++ b/scripts/compute-tags.sh
@@ -16,8 +16,6 @@ set -u
 BASE_BUILD_IMAGE=${1:?'expecting Docker image name as argument, such as jaegertracing/jaeger'}
 BRANCH=${BRANCH:?'expecting BRANCH env var'}
 GITHUB_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
-# allow substituting for ggrep, since default grep on MacOS doesn't grok -P flag.
-GREP=${GREP:-"grep"}
 
 # accumulate output in this variable
 IMAGE_TAGS=""
@@ -33,8 +31,8 @@ tags() {
 
 ## If we are on a release tag, let's extract the version number.
 ## The other possible values are 'main' or another branch name.
-if [[ $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    MAJOR_MINOR_PATCH=$(echo "${BRANCH}" | ${GREP} -Po "([\d\.]+)")
+if [[ $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+    MAJOR_MINOR_PATCH=${BRANCH#v}
     tags "${BASE_BUILD_IMAGE}:${MAJOR_MINOR_PATCH}"
     tags "${BASE_BUILD_IMAGE}:latest"
 elif [[ $BRANCH != "main" ]]; then

--- a/scripts/compute-tags.test.sh
+++ b/scripts/compute-tags.test.sh
@@ -8,6 +8,7 @@
 
 SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
 
+# allow substituting for ggrep, since default grep on MacOS doesn't grok -P flag.
 # if running on MacOS, `brew install grep` and run with GREP=ggrep
 GREP=${GREP:-grep}
 
@@ -102,6 +103,18 @@ testSemVerBranch() {
     expected=(
         "foo/bar:latest"
         "foo/bar:1.2.3"
+        "foo/bar-snapshot:sha"
+        "foo/bar-snapshot:latest"
+    )
+    expect "${expected[@]}"
+    expect_not "foo/bar"
+}
+
+testSemVerRCBranch() {
+    out=$(BRANCH=v1.22.33-rc12 GITHUB_SHA=sha bash "$computeTags" foo/bar)
+    expected=(
+        "foo/bar:latest"
+        "foo/bar:1.22.33-rc12"
         "foo/bar-snapshot:sha"
         "foo/bar-snapshot:latest"
     )

--- a/scripts/compute-version.sh
+++ b/scripts/compute-version.sh
@@ -9,7 +9,7 @@ set -euf -o pipefail
 SED=${SED:-sed}
 
 usage() {
-  echo "Usage: $0 -v -s <jaeger_version>"
+  echo "Usage: $0 [-s] [-v] <jaeger_version>"
   echo "  -s  split semver into 4 parts: semver major minor patch"
   echo "  -v  verbose"
   echo "  jaeger_version:  major version, v1 | v2"


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5889

## Description of the changes
- simplify all-in-one publishing by minimizing number of parameters passed from workflow (v1/v2 only instead of binary name and healthcheck flag - those are now set inside the script)
- implement overwrite `-o` flag in docker scripts to avoid accidental overriding of numbered releases
- simplify flags management in docker scripts via FLAGS array instead of individual variables
- fix base image building to respect selected platforms (by default it was building all)
- allow `scripts/compute-version.sh` to accept semver with `-rcN` suffix

## How was this change tested?
- CI
- ran publish-release workflow manually https://github.com/jaegertracing/jaeger/actions/runs/10865002272/job/30150937690
