### PR TITLE
Fix regex for publishing v2 image

### DIFF
--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -99,7 +99,7 @@ else
     echo "::endgroup::"
 
     # Only push multi-arch images to dockerhub/quay.io for main branch or for release tags vM.N.P{-rcX}
-    if [[ "$BRANCH" == "main" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    if [[ "$BRANCH" == "main" || $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
 	    echo "will build docker images and upload to dockerhub/quay.io, BRANCH=$BRANCH"
 	    bash scripts/docker-login.sh
 	    PUSHTAG="type=image,push=true"


### PR DESCRIPTION
## Which problem is this PR solving?
- Release attempt did not publish v2 image 
```
[[ v2.0.0-rc1 =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+ echo 'skipping docker images upload, because not on tagged release or main branch'
```

## Description of the changes
- Fix the regex to include -rc suffix

## How was this change tested?
- CI
