### PR TITLE
[query] Change HTTP and TLS server configurations to use OTEL configurations

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/config.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/config.go
@@ -6,8 +6,6 @@ package jaegerquery
 import (
 	"github.com/asaskevich/govalidator"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/confighttp"
 
 	queryApp "github.com/jaegertracing/jaeger/cmd/query/app"
 )
@@ -19,10 +17,6 @@ type Config struct {
 	queryApp.QueryOptionsBase `mapstructure:",squash"`
 	// Storage holds configuration related to the various data stores that are to be queried.
 	Storage Storage `mapstructure:"storage"`
-	// HTTP holds the HTTP configuration that the query service uses to serve requests.
-	HTTP confighttp.ServerConfig `mapstructure:"http"`
-	// GRPC holds the GRPC configuration that the query service uses to serve requests.
-	GRPC configgrpc.ServerConfig `mapstructure:"grpc"`
 }
 
 type Storage struct {

--- a/cmd/jaeger/internal/extension/jaegerquery/config.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/config.go
@@ -14,7 +14,7 @@ var _ component.ConfigValidator = (*Config)(nil)
 
 // Config represents the configuration for jaeger-query,
 type Config struct {
-	queryApp.QueryOptionsBase `mapstructure:",squash"`
+	queryApp.QueryOptions `mapstructure:",squash"`
 	// Storage holds configuration related to the various data stores that are to be queried.
 	Storage Storage `mapstructure:"storage"`
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/factory.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/factory.go
@@ -28,7 +28,7 @@ func NewFactory() extension.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		QueryOptionsBase: app.QueryOptionsBase{
+		QueryOptions: app.QueryOptions{
 			HTTP: confighttp.ServerConfig{
 				Endpoint: ports.PortToHostPort(ports.QueryHTTP),
 			},

--- a/cmd/jaeger/internal/extension/jaegerquery/factory.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/factory.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/extension"
 
+	"github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -27,13 +28,15 @@ func NewFactory() extension.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		HTTP: confighttp.ServerConfig{
-			Endpoint: ports.PortToHostPort(ports.QueryHTTP),
-		},
-		GRPC: configgrpc.ServerConfig{
-			NetAddr: confignet.AddrConfig{
-				Endpoint:  ports.PortToHostPort(ports.QueryGRPC),
-				Transport: confignet.TransportTypeTCP,
+		QueryOptionsBase: app.QueryOptionsBase{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: ports.PortToHostPort(ports.QueryHTTP),
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
+					Endpoint:  ports.PortToHostPort(ports.QueryGRPC),
+					Transport: confignet.TransportTypeTCP,
+				},
 			},
 		},
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -159,11 +159,8 @@ func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, e
 }
 
 func (s *server) makeQueryOptions() *queryApp.QueryOptions {
-	return &queryApp.QueryOptions{
-		QueryOptionsBase: s.config.QueryOptionsBase,
-
-		// TODO handle TLS
-	}
+	// TODO handle TLS
+	return &s.config.QueryOptions
 }
 
 func (s *server) Shutdown(ctx context.Context) error {

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -162,9 +162,6 @@ func (s *server) makeQueryOptions() *queryApp.QueryOptions {
 	return &queryApp.QueryOptions{
 		QueryOptionsBase: s.config.QueryOptionsBase,
 
-		// TODO utilize OTEL helpers for creating HTTP/GRPC servers
-		HTTPHostPort: s.config.HTTP.Endpoint,
-		GRPCHostPort: s.config.GRPC.NetAddr.Endpoint,
 		// TODO handle TLS
 	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -159,7 +159,6 @@ func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, e
 }
 
 func (s *server) makeQueryOptions() *queryApp.QueryOptions {
-	// TODO handle TLS
 	return &s.config.QueryOptions
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -10,9 +10,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
-	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 
@@ -163,14 +160,8 @@ func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, e
 
 func (s *server) makeQueryOptions() *queryApp.QueryOptions {
 	return &queryApp.QueryOptions{
-		HTTP: confighttp.ServerConfig{
-			Endpoint: s.config.HTTP.Endpoint,
-		},
-		GRPC: configgrpc.ServerConfig{
-			NetAddr: confignet.AddrConfig{
-				Endpoint: s.config.GRPC.NetAddr.Endpoint,
-			},
-		},
+		HTTP: s.config.HTTP,
+		GRPC: s.config.GRPC,
 		// TODO handle TLS
 	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -159,11 +159,8 @@ func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, e
 }
 
 func (s *server) makeQueryOptions() *queryApp.QueryOptions {
-	return &queryApp.QueryOptions{
-		HTTP: s.config.HTTP,
-		GRPC: s.config.GRPC,
-		// TODO handle TLS
-	}
+	// TODO handle TLS
+	return &s.config.QueryOptions
 }
 
 func (s *server) Shutdown(ctx context.Context) error {

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -10,6 +10,9 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 
@@ -159,8 +162,17 @@ func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, e
 }
 
 func (s *server) makeQueryOptions() *queryApp.QueryOptions {
-	// TODO handle TLS
-	return &s.config.QueryOptions
+	return &queryApp.QueryOptions{
+		HTTP: confighttp.ServerConfig{
+			Endpoint: s.config.HTTP.Endpoint,
+		},
+		GRPC: configgrpc.ServerConfig{
+			NetAddr: confignet.AddrConfig{
+				Endpoint: s.config.GRPC.NetAddr.Endpoint,
+			},
+		},
+		// TODO handle TLS
+	}
 }
 
 func (s *server) Shutdown(ctx context.Context) error {

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -108,7 +108,7 @@ func (s *server) Start(_ context.Context, host component.Host) error {
 		// TODO propagate healthcheck updates up to the collector's runtime
 		qs,
 		mqs,
-		s.makeQueryOptions(),
+		&s.config.QueryOptions,
 		tm,
 		telset,
 	)
@@ -156,10 +156,6 @@ func (s *server) createMetricReader(host component.Host) (metricsstore.Reader, e
 		return nil, fmt.Errorf("cannot create metrics reader %w", err)
 	}
 	return metricsReader, err
-}
-
-func (s *server) makeQueryOptions() *queryApp.QueryOptions {
-	return &s.config.QueryOptions
 }
 
 func (s *server) Shutdown(ctx context.Context) error {

--- a/cmd/query/app/additional_headers_handler.go
+++ b/cmd/query/app/additional_headers_handler.go
@@ -5,13 +5,15 @@ package app
 
 import (
 	"net/http"
+
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
-func additionalHeadersHandler(h http.Handler, additionalHeaders http.Header) http.Handler {
+func additionalHeadersHandler(h http.Handler, additionalHeaders map[string]configopaque.String) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header := w.Header()
-		for key, values := range additionalHeaders {
-			header[key] = values
+		for key, value := range additionalHeaders {
+			header[key] = []string{value.String()}
 		}
 
 		h.ServeHTTP(w, r)

--- a/cmd/query/app/additional_headers_handler.go
+++ b/cmd/query/app/additional_headers_handler.go
@@ -9,11 +9,11 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 )
 
-func additionalHeadersHandler(h http.Handler, additionalHeaders map[string]configopaque.String) http.Handler {
+func responseHeadersHandler(h http.Handler, responseHeaders map[string]configopaque.String) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header := w.Header()
-		for key, value := range additionalHeaders {
-			header[key] = []string{value.String()}
+		for key, value := range responseHeaders {
+			header.Set(key, value.String())
 		}
 
 		h.ServeHTTP(w, r)

--- a/cmd/query/app/additional_headers_test.go
+++ b/cmd/query/app/additional_headers_test.go
@@ -10,14 +10,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 func TestAdditionalHeadersHandler(t *testing.T) {
-	additionalHeaders := http.Header{}
-	additionalHeaders.Add("Access-Control-Allow-Origin", "https://mozilla.org")
-	additionalHeaders.Add("Access-Control-Expose-Headers", "X-My-Custom-Header")
-	additionalHeaders.Add("Access-Control-Expose-Headers", "X-Another-Custom-Header")
-	additionalHeaders.Add("Access-Control-Request-Headers", "field1, field2")
+	additionalHeaders := make(map[string]configopaque.String)
+	additionalHeaders["Access-Control-Allow-Origin"] = "https://mozilla.org"
+	additionalHeaders["Access-Control-Expose-Headers"] = "X-My-Custom-Header"
+	additionalHeaders["Access-Control-Expose-Headers"] = "X-Another-Custom-Header"
+	additionalHeaders["Access-Control-Request-Headers"] = "field1, field2"
 
 	emptyHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte{})
@@ -34,6 +35,6 @@ func TestAdditionalHeadersHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	for k, v := range additionalHeaders {
-		assert.Equal(t, v, resp.Header[k])
+		assert.Equal(t, []string{v.String()}, resp.Header[k])
 	}
 }

--- a/cmd/query/app/additional_headers_test.go
+++ b/cmd/query/app/additional_headers_test.go
@@ -13,18 +13,18 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 )
 
-func TestAdditionalHeadersHandler(t *testing.T) {
-	additionalHeaders := make(map[string]configopaque.String)
-	additionalHeaders["Access-Control-Allow-Origin"] = "https://mozilla.org"
-	additionalHeaders["Access-Control-Expose-Headers"] = "X-My-Custom-Header"
-	additionalHeaders["Access-Control-Expose-Headers"] = "X-Another-Custom-Header"
-	additionalHeaders["Access-Control-Request-Headers"] = "field1, field2"
+func TestResponseHeadersHandler(t *testing.T) {
+	responseHeaders := make(map[string]configopaque.String)
+	responseHeaders["Access-Control-Allow-Origin"] = "https://mozilla.org"
+	responseHeaders["Access-Control-Expose-Headers"] = "X-My-Custom-Header"
+	responseHeaders["Access-Control-Expose-Headers"] = "X-Another-Custom-Header"
+	responseHeaders["Access-Control-Request-Headers"] = "field1, field2"
 
 	emptyHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte{})
 	})
 
-	handler := additionalHeadersHandler(emptyHandler, additionalHeaders)
+	handler := responseHeadersHandler(emptyHandler, responseHeaders)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -34,7 +34,7 @@ func TestAdditionalHeadersHandler(t *testing.T) {
 	resp, err := server.Client().Do(req)
 	require.NoError(t, err)
 
-	for k, v := range additionalHeaders {
+	for k, v := range responseHeaders {
 		assert.Equal(t, []string{v.String()}, resp.Header[k])
 	}
 }

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -104,14 +104,12 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper, logger *zap.Logger) (*Q
 	if err != nil {
 		return qOpts, fmt.Errorf("failed to process gRPC TLS options: %w", err)
 	}
-	otelTLSCfg := tlsGrpc.ToOtelServerConfig()
-	qOpts.GRPC.TLSSetting = otelTLSCfg
+	qOpts.GRPC.TLSSetting = tlsGrpc.ToOtelServerConfig()
 	tlsHTTP, err := tlsHTTPFlagsConfig.InitFromViper(v)
 	if err != nil {
 		return qOpts, fmt.Errorf("failed to process HTTP TLS options: %w", err)
 	}
-	otelHTTPCfg := tlsHTTP.ToOtelServerConfig()
-	qOpts.HTTP.TLSSetting = otelHTTPCfg
+	qOpts.HTTP.TLSSetting = tlsHTTP.ToOtelServerConfig()
 	qOpts.BasePath = v.GetString(queryBasePath)
 	qOpts.UIConfig.AssetsPath = v.GetString(queryStaticFiles)
 	qOpts.UIConfig.LogAccess = v.GetBool(queryLogStaticAssetsAccess)

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -60,8 +60,8 @@ type UIConfig struct {
 	LogAccess bool `mapstructure:"log_access" valid:"optional"`
 }
 
-// QueryOptionsBase holds configuration for query service shared with jaeger-v2
-type QueryOptionsBase struct {
+// QueryOptions holds configuration for query service shared with jaeger-v2
+type QueryOptions struct {
 	// BasePath is the base path for all HTTP routes.
 	BasePath string `mapstructure:"base_path"`
 	// UIConfig contains configuration related to the Jaeger UIConfig.
@@ -78,22 +78,6 @@ type QueryOptionsBase struct {
 	HTTP confighttp.ServerConfig `mapstructure:"http"`
 	// GRPC holds the GRPC configuration that the query service uses to serve requests.
 	GRPC configgrpc.ServerConfig `mapstructure:"grpc"`
-}
-
-// QueryOptions holds configuration for query service
-type QueryOptions struct {
-	QueryOptionsBase
-
-	// // AdditionalHeaders
-	// AdditionalHeaders http.Header
-	// // HTTPHostPort is the host:port address that the query service listens in on for http requests
-	// HTTPHostPort string
-	// // GRPCHostPort is the host:port address that the query service listens in on for gRPC requests
-	// GRPCHostPort string
-	// // TLSGRPC configures secure transport (Consumer to Query service GRPC API)
-	// TLSGRPC tlscfg.Options
-	// // TLSHTTP configures secure transport (Consumer to Query service HTTP API)
-	// TLSHTTP tlscfg.Options
 }
 
 // AddFlags adds flags for QueryOptions

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -105,13 +105,13 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper, logger *zap.Logger) (*Q
 		return qOpts, fmt.Errorf("failed to process gRPC TLS options: %w", err)
 	}
 	otelTLSCfg := tlsGrpc.ToOtelServerConfig()
-	qOpts.GRPC.TLSSetting = &otelTLSCfg
+	qOpts.GRPC.TLSSetting = otelTLSCfg
 	tlsHTTP, err := tlsHTTPFlagsConfig.InitFromViper(v)
 	if err != nil {
 		return qOpts, fmt.Errorf("failed to process HTTP TLS options: %w", err)
 	}
 	otelHTTPCfg := tlsHTTP.ToOtelServerConfig()
-	qOpts.HTTP.TLSSetting = &otelHTTPCfg
+	qOpts.HTTP.TLSSetting = otelHTTPCfg
 	qOpts.BasePath = v.GetString(queryBasePath)
 	qOpts.UIConfig.AssetsPath = v.GetString(queryStaticFiles)
 	qOpts.UIConfig.LogAccess = v.GetBool(queryLogStaticAssetsAccess)

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -5,13 +5,13 @@
 package app
 
 import (
-	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/pkg/config"
@@ -39,12 +39,12 @@ func TestQueryBuilderFlags(t *testing.T) {
 	assert.True(t, qOpts.UIConfig.LogAccess)
 	assert.Equal(t, "some.json", qOpts.UIConfig.ConfigFile)
 	assert.Equal(t, "/jaeger", qOpts.BasePath)
-	assert.Equal(t, "127.0.0.1:8080", qOpts.HTTPHostPort)
-	assert.Equal(t, "127.0.0.1:8081", qOpts.GRPCHostPort)
-	assert.Equal(t, http.Header{
-		"Access-Control-Allow-Origin": []string{"blerg"},
-		"Whatever":                    []string{"thing"},
-	}, qOpts.AdditionalHeaders)
+	assert.Equal(t, "127.0.0.1:8080", qOpts.HTTP.Endpoint)
+	assert.Equal(t, "127.0.0.1:8081", qOpts.GRPC.NetAddr.Endpoint)
+	assert.Equal(t, map[string]configopaque.String{
+		"Access-Control-Allow-Origin": "blerg",
+		"Whatever":                    "thing",
+	}, qOpts.HTTP.ResponseHeaders)
 	assert.Equal(t, 10*time.Second, qOpts.MaxClockSkewAdjust)
 }
 
@@ -55,7 +55,7 @@ func TestQueryBuilderBadHeadersFlags(t *testing.T) {
 	})
 	qOpts, err := new(QueryOptions).InitFromViper(v, zap.NewNop())
 	require.NoError(t, err)
-	assert.Nil(t, qOpts.AdditionalHeaders)
+	assert.Nil(t, qOpts.HTTP.ResponseHeaders)
 }
 
 func TestStringSliceAsHeader(t *testing.T) {
@@ -161,8 +161,8 @@ func TestQueryOptionsPortAllocationFromFlags(t *testing.T) {
 			qOpts, err := new(QueryOptions).InitFromViper(v, zap.NewNop())
 			require.NoError(t, err)
 
-			assert.Equal(t, test.expectedHTTPHostPort, qOpts.HTTPHostPort)
-			assert.Equal(t, test.expectedGRPCHostPort, qOpts.GRPCHostPort)
+			assert.Equal(t, test.expectedHTTPHostPort, qOpts.HTTP.Endpoint)
+			assert.Equal(t, test.expectedGRPCHostPort, qOpts.GRPC.NetAddr.Endpoint)
 		})
 	}
 }

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -59,17 +60,17 @@ func NewServer(querySvc *querysvc.QueryService,
 	tm *tenancy.Manager,
 	telset telemetery.Setting,
 ) (*Server, error) {
-	_, httpPort, err := net.SplitHostPort(options.HTTPHostPort)
+	_, httpPort, err := net.SplitHostPort(options.HTTP.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid HTTP server host:port: %w", err)
 	}
-	_, grpcPort, err := net.SplitHostPort(options.GRPCHostPort)
+	_, grpcPort, err := net.SplitHostPort(options.GRPC.NetAddr.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid gRPC server host:port: %w", err)
 	}
 	separatePorts := grpcPort != httpPort || grpcPort == "0" || httpPort == "0"
 
-	if (options.TLSHTTP.Enabled || options.TLSGRPC.Enabled) && !separatePorts {
+	if (options.HTTP.TLSSetting != nil || options.GRPC.TLSSetting != nil) && !separatePorts {
 		return nil, errors.New("server with TLS enabled can not use same host ports for gRPC and HTTP.  Use dedicated HTTP and gRPC host ports instead")
 	}
 
@@ -96,8 +97,8 @@ func NewServer(querySvc *querysvc.QueryService,
 func createGRPCServer(querySvc *querysvc.QueryService, metricsQuerySvc querysvc.MetricsQueryService, options *QueryOptions, tm *tenancy.Manager, telset telemetery.Setting) (*grpc.Server, error) {
 	var grpcOpts []grpc.ServerOption
 
-	if options.TLSGRPC.Enabled {
-		tlsCfg, err := options.TLSGRPC.Config(telset.Logger)
+	if options.GRPC.TLSSetting != nil {
+		tlsCfg, err := options.GRPC.TLSSetting.LoadTLSConfig(context.Background())
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +172,7 @@ func createHTTPServer(
 
 	apiHandler.RegisterRoutes(r)
 	var handler http.Handler = r
-	handler = additionalHeadersHandler(handler, queryOpts.AdditionalHeaders)
+	handler = additionalHeadersHandler(handler, queryOpts.HTTP.ResponseHeaders)
 	if queryOpts.BearerTokenPropagation {
 		handler = bearertoken.PropagationHandler(telset.Logger, handler)
 	}
@@ -187,8 +188,8 @@ func createHTTPServer(
 		},
 	}
 
-	if queryOpts.TLSHTTP.Enabled {
-		tlsCfg, err := queryOpts.TLSHTTP.Config(telset.Logger) // This checks if the certificates are correctly provided
+	if queryOpts.HTTP.TLSSetting != nil {
+		tlsCfg, err := queryOpts.HTTP.TLSSetting.LoadTLSConfig(context.Background()) // This checks if the certificates are correctly provided
 		if err != nil {
 			return nil, err
 		}
@@ -211,12 +212,12 @@ func (hS httpServer) Close() error {
 func (s *Server) initListener() (cmux.CMux, error) {
 	if s.separatePorts { // use separate ports and listeners each for gRPC and HTTP requests
 		var err error
-		s.grpcConn, err = net.Listen("tcp", s.queryOptions.GRPCHostPort)
+		s.grpcConn, err = net.Listen("tcp", s.queryOptions.GRPC.NetAddr.Endpoint)
 		if err != nil {
 			return nil, err
 		}
 
-		s.httpConn, err = net.Listen("tcp", s.queryOptions.HTTPHostPort)
+		s.httpConn, err = net.Listen("tcp", s.queryOptions.HTTP.Endpoint)
 		if err != nil {
 			return nil, err
 		}
@@ -229,7 +230,7 @@ func (s *Server) initListener() (cmux.CMux, error) {
 	}
 
 	//  old behavior using cmux
-	conn, err := net.Listen("tcp", s.queryOptions.HTTPHostPort)
+	conn, err := net.Listen("tcp", s.queryOptions.HTTP.Endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +245,7 @@ func (s *Server) initListener() (cmux.CMux, error) {
 	s.Logger.Info(
 		"Query server started",
 		zap.Int("port", tcpPort),
-		zap.String("addr", s.queryOptions.HTTPHostPort))
+		zap.String("addr", s.queryOptions.HTTP.Endpoint))
 
 	// cmux server acts as a reverse-proxy between HTTP and GRPC backends.
 	cmuxServer := cmux.New(s.conn)
@@ -286,9 +287,9 @@ func (s *Server) Start() error {
 	s.bgFinished.Add(1)
 	go func() {
 		defer s.bgFinished.Done()
-		s.Logger.Info("Starting HTTP server", zap.Int("port", httpPort), zap.String("addr", s.queryOptions.HTTPHostPort))
+		s.Logger.Info("Starting HTTP server", zap.Int("port", httpPort), zap.String("addr", s.queryOptions.HTTP.Endpoint))
 		var err error
-		if s.queryOptions.TLSHTTP.Enabled {
+		if s.queryOptions.HTTP.TLSSetting != nil {
 			err = s.httpServer.ServeTLS(s.httpConn, "", "")
 		} else {
 			err = s.httpServer.Serve(s.httpConn)
@@ -298,14 +299,14 @@ func (s *Server) Start() error {
 			s.ReportStatus(componentstatus.NewFatalErrorEvent(err))
 			return
 		}
-		s.Logger.Info("HTTP server stopped", zap.Int("port", httpPort), zap.String("addr", s.queryOptions.HTTPHostPort))
+		s.Logger.Info("HTTP server stopped", zap.Int("port", httpPort), zap.String("addr", s.queryOptions.HTTP.Endpoint))
 	}()
 
 	// Start GRPC server concurrently
 	s.bgFinished.Add(1)
 	go func() {
 		defer s.bgFinished.Done()
-		s.Logger.Info("Starting GRPC server", zap.Int("port", grpcPort), zap.String("addr", s.queryOptions.GRPCHostPort))
+		s.Logger.Info("Starting GRPC server", zap.Int("port", grpcPort), zap.String("addr", s.queryOptions.GRPC.NetAddr.Endpoint))
 
 		err := s.grpcServer.Serve(s.grpcConn)
 		if err != nil && !errors.Is(err, cmux.ErrListenerClosed) && !errors.Is(err, cmux.ErrServerClosed) {
@@ -313,7 +314,7 @@ func (s *Server) Start() error {
 			s.ReportStatus(componentstatus.NewFatalErrorEvent(err))
 			return
 		}
-		s.Logger.Info("GRPC server stopped", zap.Int("port", grpcPort), zap.String("addr", s.queryOptions.GRPCHostPort))
+		s.Logger.Info("GRPC server stopped", zap.Int("port", grpcPort), zap.String("addr", s.queryOptions.GRPC.NetAddr.Endpoint))
 	}()
 
 	// Start cmux server concurrently.
@@ -321,7 +322,7 @@ func (s *Server) Start() error {
 		s.bgFinished.Add(1)
 		go func() {
 			defer s.bgFinished.Done()
-			s.Logger.Info("Starting CMUX server", zap.Int("port", tcpPort), zap.String("addr", s.queryOptions.HTTPHostPort))
+			s.Logger.Info("Starting CMUX server", zap.Int("port", tcpPort), zap.String("addr", s.queryOptions.HTTP.Endpoint))
 
 			err := cmuxServer.Serve()
 			// TODO: find a way to avoid string comparison. Even though cmux has ErrServerClosed, it's not returned here.
@@ -330,7 +331,7 @@ func (s *Server) Start() error {
 				s.ReportStatus(componentstatus.NewFatalErrorEvent(err))
 				return
 			}
-			s.Logger.Info("CMUX server stopped", zap.Int("port", tcpPort), zap.String("addr", s.queryOptions.HTTPHostPort))
+			s.Logger.Info("CMUX server stopped", zap.Int("port", tcpPort), zap.String("addr", s.queryOptions.HTTP.Endpoint))
 		}()
 	}
 	return nil
@@ -346,10 +347,7 @@ func (s *Server) GRPCAddr() string {
 
 // Close stops HTTP, GRPC servers and closes the port listener.
 func (s *Server) Close() error {
-	errs := []error{
-		s.queryOptions.TLSGRPC.Close(),
-		s.queryOptions.TLSHTTP.Close(),
-	}
+	errs := []error{}
 
 	s.Logger.Info("Closing HTTP server")
 	if err := s.httpServer.Close(); err != nil {

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -172,7 +172,7 @@ func createHTTPServer(
 
 	apiHandler.RegisterRoutes(r)
 	var handler http.Handler = r
-	handler = additionalHeadersHandler(handler, queryOpts.HTTP.ResponseHeaders)
+	handler = responseHeadersHandler(handler, queryOpts.HTTP.ResponseHeaders)
 	if queryOpts.BearerTokenPropagation {
 		handler = bearertoken.PropagationHandler(telset.Logger, handler)
 	}

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -347,7 +347,7 @@ func (s *Server) GRPCAddr() string {
 
 // Close stops HTTP, GRPC servers and closes the port listener.
 func (s *Server) Close() error {
-	errs := []error{}
+	var errs []error
 
 	s.Logger.Info("Closing HTTP server")
 	if err := s.httpServer.Close(); err != nil {

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -234,7 +234,8 @@ var testCases = []struct {
 			Config: configtls.Config{
 				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
 				CertFile: testCertKeyLocation + "/example-client-cert.pem",
-				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
+			},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -258,7 +259,8 @@ var testCases = []struct {
 			Config: configtls.Config{
 				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
 				CertFile: testCertKeyLocation + "/example-client-cert.pem",
-				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
+			},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -281,7 +283,8 @@ var testCases = []struct {
 			Config: configtls.Config{
 				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
 				CertFile: testCertKeyLocation + "/example-client-cert.pem",
-				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
+			},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -304,7 +307,8 @@ var testCases = []struct {
 			Config: configtls.Config{
 				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
 				CertFile: testCertKeyLocation + "/example-client-cert.pem",
-				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
+			},
 		},
 		expectError:       false,
 		expectServerFail:  false,

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
@@ -26,7 +30,6 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/internal/grpctest"
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/telemetery"
@@ -50,7 +53,9 @@ func initTelSet(logger *zap.Logger, tracerProvider *jtracer.JTracer, hc *healthc
 func TestServerError(t *testing.T) {
 	srv := &Server{
 		queryOptions: &QueryOptions{
-			HTTPHostPort: ":-1",
+			QueryOptionsBase: QueryOptionsBase{
+				HTTP: confighttp.ServerConfig{Endpoint: ":-1"},
+			},
 		},
 	}
 	require.Error(t, srv.Start())
@@ -58,53 +63,70 @@ func TestServerError(t *testing.T) {
 
 func TestCreateTLSServerSinglePortError(t *testing.T) {
 	// When TLS is enabled, and the host-port of both servers are the same, this leads to error, as TLS-enabled server is required to run on dedicated port.
-	tlsCfg := tlscfg.Options{
-		Enabled:      true,
-		CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-		KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-		ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
+	tlsCfg := configtls.ServerConfig{
+		ClientCAFile: testCertKeyLocation + "/example-CA-cert.pem",
+		Config: configtls.Config{
+			CertFile: testCertKeyLocation + "/example-server-cert.pem",
+			KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+		},
 	}
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
-		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8080", TLSGRPC: tlsCfg, TLSHTTP: tlsCfg},
+		&QueryOptions{
+			QueryOptionsBase: QueryOptionsBase{
+				HTTP: confighttp.ServerConfig{Endpoint: ":8080", TLSSetting: &tlsCfg},
+				GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8080"}, TLSSetting: &tlsCfg},
+			},
+		},
 		tenancy.NewManager(&tenancy.Options{}), telset)
 	require.Error(t, err)
 }
 
 func TestCreateTLSGrpcServerError(t *testing.T) {
-	tlsCfg := tlscfg.Options{
-		Enabled:      true,
-		CertPath:     "invalid/path",
-		KeyPath:      "invalid/path",
-		ClientCAPath: "invalid/path",
+	tlsCfg := configtls.ServerConfig{
+		ClientCAFile: "invalid/path",
+		Config: configtls.Config{
+			CertFile: "invalid/path",
+			KeyFile:  "invalid/path",
+		},
 	}
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
-		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8081", TLSGRPC: tlsCfg},
+		&QueryOptions{
+			QueryOptionsBase: QueryOptionsBase{
+				HTTP: confighttp.ServerConfig{Endpoint: ":8080"},
+				GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8081"}, TLSSetting: &tlsCfg},
+			},
+		},
 		tenancy.NewManager(&tenancy.Options{}), telset)
 	require.Error(t, err)
 }
 
 func TestCreateTLSHttpServerError(t *testing.T) {
-	tlsCfg := tlscfg.Options{
-		Enabled:      true,
-		CertPath:     "invalid/path",
-		KeyPath:      "invalid/path",
-		ClientCAPath: "invalid/path",
+	tlsCfg := configtls.ServerConfig{
+		ClientCAFile: "invalid/path",
+		Config: configtls.Config{
+			CertFile: "invalid/path",
+			KeyFile:  "invalid/path",
+		},
 	}
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
-		&QueryOptions{HTTPHostPort: ":8080", GRPCHostPort: ":8081", TLSHTTP: tlsCfg},
-		tenancy.NewManager(&tenancy.Options{}), telset)
+		&QueryOptions{
+			QueryOptionsBase: QueryOptionsBase{
+				HTTP: confighttp.ServerConfig{Endpoint: ":8080", TLSSetting: &tlsCfg},
+				GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8081"}},
+			},
+		}, tenancy.NewManager(&tenancy.Options{}), telset)
 	require.Error(t, err)
 }
 
 var testCases = []struct {
 	name              string
-	TLS               tlscfg.Options
+	TLS               *configtls.ServerConfig
 	HTTPTLSEnabled    bool
 	GRPCTLSEnabled    bool
-	clientTLS         tlscfg.Options
+	clientTLS         configtls.ClientConfig
 	expectError       bool
 	expectClientError bool
 	expectServerFail  bool
@@ -114,11 +136,8 @@ var testCases = []struct {
 		name:           "Should pass with insecure connection",
 		HTTPTLSEnabled: false,
 		GRPCTLSEnabled: false,
-		TLS: tlscfg.Options{
-			Enabled: false,
-		},
-		clientTLS: tlscfg.Options{
-			Enabled: false,
+		clientTLS: configtls.ClientConfig{
+			Insecure: true,
 		},
 		expectError:       false,
 		expectClientError: false,
@@ -128,13 +147,14 @@ var testCases = []struct {
 		name:           "should fail with TLS client to untrusted TLS server",
 		HTTPTLSEnabled: true,
 		GRPCTLSEnabled: true,
-		TLS: tlscfg.Options{
-			Enabled:  true,
-			CertPath: testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:  testCertKeyLocation + "/example-server-key.pem",
+		TLS: &configtls.ServerConfig{
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
+		clientTLS: configtls.ClientConfig{
+			Insecure:   true,
 			ServerName: "example.com",
 		},
 		expectError:       true,
@@ -145,15 +165,18 @@ var testCases = []struct {
 		name:           "should fail with TLS client to trusted TLS server with incorrect hostname",
 		HTTPTLSEnabled: true,
 		GRPCTLSEnabled: true,
-		TLS: tlscfg.Options{
-			Enabled:  true,
-			CertPath: testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:  testCertKeyLocation + "/example-server-key.pem",
+		TLS: &configtls.ServerConfig{
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
-			CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
+		clientTLS: configtls.ClientConfig{
+			Insecure:   false,
 			ServerName: "nonEmpty",
+			Config: configtls.Config{
+				CAFile: testCertKeyLocation + "/example-CA-cert.pem",
+			},
 		},
 		expectError:       true,
 		expectClientError: true,
@@ -163,15 +186,18 @@ var testCases = []struct {
 		name:           "should pass with TLS client to trusted TLS server with correct hostname",
 		HTTPTLSEnabled: true,
 		GRPCTLSEnabled: true,
-		TLS: tlscfg.Options{
-			Enabled:  true,
-			CertPath: testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:  testCertKeyLocation + "/example-server-key.pem",
+		TLS: &configtls.ServerConfig{
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
-			CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
+		clientTLS: configtls.ClientConfig{
+			Insecure:   false,
 			ServerName: "example.com",
+			Config: configtls.Config{
+				CAFile: testCertKeyLocation + "/example-CA-cert.pem",
+			},
 		},
 		expectError:       false,
 		expectClientError: false,
@@ -181,16 +207,19 @@ var testCases = []struct {
 		name:           "should fail with TLS client without cert to trusted TLS server requiring cert",
 		HTTPTLSEnabled: true,
 		GRPCTLSEnabled: true,
-		TLS: tlscfg.Options{
-			Enabled:      true,
-			CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-			ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
+		TLS: &configtls.ServerConfig{
+			ClientCAFile: testCertKeyLocation + "/example-CA-cert.pem",
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
-			CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
+		clientTLS: configtls.ClientConfig{
+			Insecure:   false,
 			ServerName: "example.com",
+			Config: configtls.Config{
+				CAFile: testCertKeyLocation + "/example-CA-cert.pem",
+			},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -200,18 +229,20 @@ var testCases = []struct {
 		name:           "should pass with TLS client with cert to trusted TLS server requiring cert",
 		HTTPTLSEnabled: true,
 		GRPCTLSEnabled: true,
-		TLS: tlscfg.Options{
-			Enabled:      true,
-			CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-			ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
+		TLS: &configtls.ServerConfig{
+			ClientCAFile: testCertKeyLocation + "/example-CA-cert.pem",
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
-			CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
+		clientTLS: configtls.ClientConfig{
+			Insecure:   false,
 			ServerName: "example.com",
-			CertPath:   testCertKeyLocation + "/example-client-cert.pem",
-			KeyPath:    testCertKeyLocation + "/example-client-key.pem",
+			Config: configtls.Config{
+				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
+				CertFile: testCertKeyLocation + "/example-client-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -221,18 +252,21 @@ var testCases = []struct {
 		name:           "should fail with TLS client without cert to trusted TLS server requiring cert from a different CA",
 		HTTPTLSEnabled: true,
 		GRPCTLSEnabled: true,
-		TLS: tlscfg.Options{
-			Enabled:      true,
-			CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-			ClientCAPath: testCertKeyLocation + "/wrong-CA-cert.pem", // NB: wrong CA
+		TLS: &configtls.ServerConfig{
+			ClientCAFile: testCertKeyLocation + "/wrong-CA-cert.pem", // NB: wrong CA
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
-			CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
+
+		clientTLS: configtls.ClientConfig{
+			Insecure:   false,
 			ServerName: "example.com",
-			CertPath:   testCertKeyLocation + "/example-client-cert.pem",
-			KeyPath:    testCertKeyLocation + "/example-client-key.pem",
+			Config: configtls.Config{
+				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
+				CertFile: testCertKeyLocation + "/example-client-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -242,18 +276,20 @@ var testCases = []struct {
 		name:           "should pass with TLS client with cert to trusted TLS HTTP server requiring cert and insecure GRPC server",
 		HTTPTLSEnabled: true,
 		GRPCTLSEnabled: false,
-		TLS: tlscfg.Options{
-			Enabled:      true,
-			CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-			ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
+		TLS: &configtls.ServerConfig{
+			ClientCAFile: testCertKeyLocation + "/example-CA-cert.pem",
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
-			CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
+		clientTLS: configtls.ClientConfig{
+			Insecure:   false,
 			ServerName: "example.com",
-			CertPath:   testCertKeyLocation + "/example-client-cert.pem",
-			KeyPath:    testCertKeyLocation + "/example-client-key.pem",
+			Config: configtls.Config{
+				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
+				CertFile: testCertKeyLocation + "/example-client-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -263,18 +299,20 @@ var testCases = []struct {
 		name:           "should pass with TLS client with cert to trusted GRPC TLS server requiring cert and insecure HTTP server",
 		HTTPTLSEnabled: false,
 		GRPCTLSEnabled: true,
-		TLS: tlscfg.Options{
-			Enabled:      true,
-			CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-			KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-			ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
+		TLS: &configtls.ServerConfig{
+			ClientCAFile: testCertKeyLocation + "/example-CA-cert.pem",
+			Config: configtls.Config{
+				CertFile: testCertKeyLocation + "/example-server-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+			},
 		},
-		clientTLS: tlscfg.Options{
-			Enabled:    true,
-			CAPath:     testCertKeyLocation + "/example-CA-cert.pem",
+		clientTLS: configtls.ClientConfig{
+			Insecure:   false,
 			ServerName: "example.com",
-			CertPath:   testCertKeyLocation + "/example-client-cert.pem",
-			KeyPath:    testCertKeyLocation + "/example-client-key.pem",
+			Config: configtls.Config{
+				CAFile:   testCertKeyLocation + "/example-CA-cert.pem",
+				CertFile: testCertKeyLocation + "/example-client-cert.pem",
+				KeyFile:  testCertKeyLocation + "/example-client-key.pem"},
 		},
 		expectError:       false,
 		expectServerFail:  false,
@@ -308,30 +346,27 @@ func TestServerHTTPTLS(t *testing.T) {
 
 	tests := make([]struct {
 		name              string
-		TLS               tlscfg.Options
+		TLS               *configtls.ServerConfig
 		HTTPTLSEnabled    bool
 		GRPCTLSEnabled    bool
-		clientTLS         tlscfg.Options
+		clientTLS         configtls.ClientConfig
 		expectError       bool
 		expectClientError bool
 		expectServerFail  bool
 	}, testlen)
 	copy(tests, testCases)
 
-	tests[testlen-1].clientTLS = tlscfg.Options{Enabled: false}
+	tests[testlen-1].clientTLS = configtls.ClientConfig{Insecure: true}
 	tests[testlen-1].name = "Should pass with insecure HTTP Client and insecure HTTP server with secure GRPC Server"
-	tests[testlen-1].TLS = tlscfg.Options{
-		Enabled: false,
-	}
+	tests[testlen-1].TLS = nil
 
-	disabledTLSCfg := tlscfg.Options{
-		Enabled: false,
-	}
-	enabledTLSCfg := tlscfg.Options{
-		Enabled:      true,
-		CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-		KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-		ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
+	var disabledTLSCfg *configtls.ServerConfig
+	enabledTLSCfg := &configtls.ServerConfig{
+		ClientCAFile: testCertKeyLocation + "/example-CA-cert.pem",
+		Config: configtls.Config{
+			CertFile: testCertKeyLocation + "/example-server-cert.pem",
+			KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+		},
 	}
 
 	for _, test := range tests {
@@ -342,12 +377,18 @@ func TestServerHTTPTLS(t *testing.T) {
 			}
 
 			serverOptions := &QueryOptions{
-				GRPCHostPort: ":0",
-				HTTPHostPort: ":0",
-				TLSHTTP:      test.TLS,
-				TLSGRPC:      tlsGrpc,
 				QueryOptionsBase: QueryOptionsBase{
 					BearerTokenPropagation: true,
+					HTTP: confighttp.ServerConfig{
+						Endpoint:   ":0",
+						TLSSetting: test.TLS,
+					},
+					GRPC: configgrpc.ServerConfig{
+						NetAddr: confignet.AddrConfig{
+							Endpoint: ":0",
+						},
+						TLSSetting: tlsGrpc,
+					},
 				},
 			}
 			flagsSvc := flags.NewService(ports.QueryAdminHTTP)
@@ -367,10 +408,9 @@ func TestServerHTTPTLS(t *testing.T) {
 			var clientClose func() error
 			var clientTLSCfg *tls.Config
 
-			if serverOptions.TLSHTTP.Enabled {
+			if serverOptions.HTTP.TLSSetting != nil {
 				var err0 error
-				clientTLSCfg, err0 = test.clientTLS.Config(flagsSvc.Logger)
-				defer test.clientTLS.Close()
+				clientTLSCfg, err0 = test.clientTLS.LoadTLSConfig(context.Background())
 
 				require.NoError(t, err0)
 				dialer := &net.Dialer{Timeout: 2 * time.Second}
@@ -398,7 +438,7 @@ func TestServerHTTPTLS(t *testing.T) {
 				require.NoError(t, clientClose())
 			}
 
-			if test.HTTPTLSEnabled && test.TLS.ClientCAPath != "" {
+			if test.HTTPTLSEnabled && test.TLS.ClientCAFile != "" {
 				client := &http.Client{
 					Transport: &http.Transport{
 						TLSClientConfig: clientTLSCfg,
@@ -447,29 +487,26 @@ func TestServerGRPCTLS(t *testing.T) {
 
 	tests := make([]struct {
 		name              string
-		TLS               tlscfg.Options
+		TLS               *configtls.ServerConfig
 		HTTPTLSEnabled    bool
 		GRPCTLSEnabled    bool
-		clientTLS         tlscfg.Options
+		clientTLS         configtls.ClientConfig
 		expectError       bool
 		expectClientError bool
 		expectServerFail  bool
 	}, testlen)
 	copy(tests, testCases)
-	tests[testlen-2].clientTLS = tlscfg.Options{Enabled: false}
+	tests[testlen-2].clientTLS = configtls.ClientConfig{Insecure: false}
 	tests[testlen-2].name = "should pass with insecure GRPC Client and insecure GRPC server with secure HTTP Server"
-	tests[testlen-2].TLS = tlscfg.Options{
-		Enabled: false,
-	}
+	tests[testlen-2].TLS = nil
 
-	disabledTLSCfg := tlscfg.Options{
-		Enabled: false,
-	}
-	enabledTLSCfg := tlscfg.Options{
-		Enabled:      true,
-		CertPath:     testCertKeyLocation + "/example-server-cert.pem",
-		KeyPath:      testCertKeyLocation + "/example-server-key.pem",
-		ClientCAPath: testCertKeyLocation + "/example-CA-cert.pem",
+	var disabledTLSCfg *configtls.ServerConfig
+	enabledTLSCfg := &configtls.ServerConfig{
+		ClientCAFile: testCertKeyLocation + "/example-CA-cert.pem",
+		Config: configtls.Config{
+			CertFile: testCertKeyLocation + "/example-server-cert.pem",
+			KeyFile:  testCertKeyLocation + "/example-server-key.pem",
+		},
 	}
 
 	for _, test := range tests {
@@ -479,12 +516,18 @@ func TestServerGRPCTLS(t *testing.T) {
 				tlsHttp = enabledTLSCfg
 			}
 			serverOptions := &QueryOptions{
-				GRPCHostPort: ":0",
-				HTTPHostPort: ":0",
-				TLSHTTP:      tlsHttp,
-				TLSGRPC:      test.TLS,
 				QueryOptionsBase: QueryOptionsBase{
 					BearerTokenPropagation: true,
+					HTTP: confighttp.ServerConfig{
+						Endpoint:   ":0",
+						TLSSetting: tlsHttp,
+					},
+					GRPC: configgrpc.ServerConfig{
+						NetAddr: confignet.AddrConfig{
+							Endpoint: ":0",
+						},
+						TLSSetting: test.TLS,
+					},
 				},
 			}
 			flagsSvc := flags.NewService(ports.QueryAdminHTTP)
@@ -502,10 +545,9 @@ func TestServerGRPCTLS(t *testing.T) {
 			})
 
 			var client *grpcClient
-			if serverOptions.TLSGRPC.Enabled {
-				clientTLSCfg, err0 := test.clientTLS.Config(flagsSvc.Logger)
+			if serverOptions.GRPC.TLSSetting != nil {
+				clientTLSCfg, err0 := test.clientTLS.LoadTLSConfig(context.Background())
 				require.NoError(t, err0)
-				defer test.clientTLS.Close()
 				creds := credentials.NewTLS(clientTLSCfg)
 				client = newGRPCClientWithTLS(t, server.GRPCAddr(), creds)
 			} else {
@@ -537,10 +579,16 @@ func TestServerBadHostPort(t *testing.T) {
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
 		&QueryOptions{
-			HTTPHostPort: "8080", // bad string, not :port
-			GRPCHostPort: "127.0.0.1:8081",
 			QueryOptionsBase: QueryOptionsBase{
 				BearerTokenPropagation: true,
+				HTTP: confighttp.ServerConfig{
+					Endpoint: "8080", // bad string, not :port
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: "127.0.0.1:8081",
+					},
+				},
 			},
 		},
 		tenancy.NewManager(&tenancy.Options{}),
@@ -549,10 +597,16 @@ func TestServerBadHostPort(t *testing.T) {
 
 	_, err = NewServer(&querysvc.QueryService{}, nil,
 		&QueryOptions{
-			HTTPHostPort: "127.0.0.1:8081",
-			GRPCHostPort: "9123", // bad string, not :port
 			QueryOptionsBase: QueryOptionsBase{
 				BearerTokenPropagation: true,
+				HTTP: confighttp.ServerConfig{
+					Endpoint: "127.0.0.1:8081",
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: "9123", // bad string, not :port
+					},
+				},
 			},
 		},
 		tenancy.NewManager(&tenancy.Options{}),
@@ -581,10 +635,16 @@ func TestServerInUseHostPort(t *testing.T) {
 				&querysvc.QueryService{},
 				nil,
 				&QueryOptions{
-					HTTPHostPort: tc.httpHostPort,
-					GRPCHostPort: tc.grpcHostPort,
 					QueryOptionsBase: QueryOptionsBase{
 						BearerTokenPropagation: true,
+						HTTP: confighttp.ServerConfig{
+							Endpoint: tc.httpHostPort,
+						},
+						GRPC: configgrpc.ServerConfig{
+							NetAddr: confignet.AddrConfig{
+								Endpoint: tc.grpcHostPort,
+							},
+						},
 					},
 				},
 				tenancy.NewManager(&tenancy.Options{}),
@@ -605,10 +665,16 @@ func TestServerSinglePort(t *testing.T) {
 	telset := initTelSet(flagsSvc.Logger, jtracer.NoOp(), flagsSvc.HC())
 	server, err := NewServer(querySvc.qs, nil,
 		&QueryOptions{
-			GRPCHostPort: hostPort,
-			HTTPHostPort: hostPort,
 			QueryOptionsBase: QueryOptionsBase{
 				BearerTokenPropagation: true,
+				HTTP: confighttp.ServerConfig{
+					Endpoint: hostPort,
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: hostPort,
+					},
+				},
 			},
 		},
 		tenancy.NewManager(&tenancy.Options{}),
@@ -645,7 +711,18 @@ func TestServerGracefulExit(t *testing.T) {
 	querySvc := makeQuerySvc()
 	telset := initTelSet(flagsSvc.Logger, jtracer.NoOp(), flagsSvc.HC())
 	server, err := NewServer(querySvc.qs, nil,
-		&QueryOptions{GRPCHostPort: hostPort, HTTPHostPort: hostPort},
+		&QueryOptions{
+			QueryOptionsBase: QueryOptionsBase{
+				HTTP: confighttp.ServerConfig{
+					Endpoint: hostPort,
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: hostPort,
+					},
+				},
+			},
+		},
 		tenancy.NewManager(&tenancy.Options{}), telset)
 	require.NoError(t, err)
 	require.NoError(t, server.Start())
@@ -678,7 +755,18 @@ func TestServerHandlesPortZero(t *testing.T) {
 	querySvc := &querysvc.QueryService{}
 	telset := initTelSet(flagsSvc.Logger, jtracer.NoOp(), flagsSvc.HC())
 	server, err := NewServer(querySvc, nil,
-		&QueryOptions{GRPCHostPort: ":0", HTTPHostPort: ":0"},
+		&QueryOptions{
+			QueryOptionsBase: QueryOptionsBase{
+				HTTP: confighttp.ServerConfig{
+					Endpoint: ":0",
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: ":0",
+					},
+				},
+			},
+		},
 		tenancy.NewManager(&tenancy.Options{}),
 		telset)
 	require.NoError(t, err)
@@ -719,11 +807,16 @@ func TestServerHTTPTenancy(t *testing.T) {
 	}
 
 	serverOptions := &QueryOptions{
-		HTTPHostPort: ":8080",
-		GRPCHostPort: ":8080",
 		QueryOptionsBase: QueryOptionsBase{
 			Tenancy: tenancy.Options{
 				Enabled: true,
+			}, HTTP: confighttp.ServerConfig{
+				Endpoint: ":8080",
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
+					Endpoint: ":8080",
+				},
 			},
 		},
 	}

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -53,9 +53,7 @@ func initTelSet(logger *zap.Logger, tracerProvider *jtracer.JTracer, hc *healthc
 func TestServerError(t *testing.T) {
 	srv := &Server{
 		queryOptions: &QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				HTTP: confighttp.ServerConfig{Endpoint: ":-1"},
-			},
+			HTTP: confighttp.ServerConfig{Endpoint: ":-1"},
 		},
 	}
 	require.Error(t, srv.Start())
@@ -73,10 +71,8 @@ func TestCreateTLSServerSinglePortError(t *testing.T) {
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				HTTP: confighttp.ServerConfig{Endpoint: ":8080", TLSSetting: &tlsCfg},
-				GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8080"}, TLSSetting: &tlsCfg},
-			},
+			HTTP: confighttp.ServerConfig{Endpoint: ":8080", TLSSetting: &tlsCfg},
+			GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8080"}, TLSSetting: &tlsCfg},
 		},
 		tenancy.NewManager(&tenancy.Options{}), telset)
 	require.Error(t, err)
@@ -93,10 +89,8 @@ func TestCreateTLSGrpcServerError(t *testing.T) {
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				HTTP: confighttp.ServerConfig{Endpoint: ":8080"},
-				GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8081"}, TLSSetting: &tlsCfg},
-			},
+			HTTP: confighttp.ServerConfig{Endpoint: ":8080"},
+			GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8081"}, TLSSetting: &tlsCfg},
 		},
 		tenancy.NewManager(&tenancy.Options{}), telset)
 	require.Error(t, err)
@@ -113,10 +107,8 @@ func TestCreateTLSHttpServerError(t *testing.T) {
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				HTTP: confighttp.ServerConfig{Endpoint: ":8080", TLSSetting: &tlsCfg},
-				GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8081"}},
-			},
+			HTTP: confighttp.ServerConfig{Endpoint: ":8080", TLSSetting: &tlsCfg},
+			GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":8081"}},
 		}, tenancy.NewManager(&tenancy.Options{}), telset)
 	require.Error(t, err)
 }
@@ -377,18 +369,16 @@ func TestServerHTTPTLS(t *testing.T) {
 			}
 
 			serverOptions := &QueryOptions{
-				QueryOptionsBase: QueryOptionsBase{
-					BearerTokenPropagation: true,
-					HTTP: confighttp.ServerConfig{
-						Endpoint:   ":0",
-						TLSSetting: test.TLS,
+				BearerTokenPropagation: true,
+				HTTP: confighttp.ServerConfig{
+					Endpoint:   ":0",
+					TLSSetting: test.TLS,
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: ":0",
 					},
-					GRPC: configgrpc.ServerConfig{
-						NetAddr: confignet.AddrConfig{
-							Endpoint: ":0",
-						},
-						TLSSetting: tlsGrpc,
-					},
+					TLSSetting: tlsGrpc,
 				},
 			}
 			flagsSvc := flags.NewService(ports.QueryAdminHTTP)
@@ -516,18 +506,16 @@ func TestServerGRPCTLS(t *testing.T) {
 				tlsHttp = enabledTLSCfg
 			}
 			serverOptions := &QueryOptions{
-				QueryOptionsBase: QueryOptionsBase{
-					BearerTokenPropagation: true,
-					HTTP: confighttp.ServerConfig{
-						Endpoint:   ":0",
-						TLSSetting: tlsHttp,
+				BearerTokenPropagation: true,
+				HTTP: confighttp.ServerConfig{
+					Endpoint:   ":0",
+					TLSSetting: tlsHttp,
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: ":0",
 					},
-					GRPC: configgrpc.ServerConfig{
-						NetAddr: confignet.AddrConfig{
-							Endpoint: ":0",
-						},
-						TLSSetting: test.TLS,
-					},
+					TLSSetting: test.TLS,
 				},
 			}
 			flagsSvc := flags.NewService(ports.QueryAdminHTTP)
@@ -579,15 +567,13 @@ func TestServerBadHostPort(t *testing.T) {
 	telset := initTelSet(zaptest.NewLogger(t), jtracer.NoOp(), healthcheck.New())
 	_, err := NewServer(&querysvc.QueryService{}, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				BearerTokenPropagation: true,
-				HTTP: confighttp.ServerConfig{
-					Endpoint: "8080", // bad string, not :port
-				},
-				GRPC: configgrpc.ServerConfig{
-					NetAddr: confignet.AddrConfig{
-						Endpoint: "127.0.0.1:8081",
-					},
+			BearerTokenPropagation: true,
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "8080", // bad string, not :port
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
+					Endpoint: "127.0.0.1:8081",
 				},
 			},
 		},
@@ -597,15 +583,13 @@ func TestServerBadHostPort(t *testing.T) {
 
 	_, err = NewServer(&querysvc.QueryService{}, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				BearerTokenPropagation: true,
-				HTTP: confighttp.ServerConfig{
-					Endpoint: "127.0.0.1:8081",
-				},
-				GRPC: configgrpc.ServerConfig{
-					NetAddr: confignet.AddrConfig{
-						Endpoint: "9123", // bad string, not :port
-					},
+			BearerTokenPropagation: true,
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "127.0.0.1:8081",
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
+					Endpoint: "9123", // bad string, not :port
 				},
 			},
 		},
@@ -635,15 +619,13 @@ func TestServerInUseHostPort(t *testing.T) {
 				&querysvc.QueryService{},
 				nil,
 				&QueryOptions{
-					QueryOptionsBase: QueryOptionsBase{
-						BearerTokenPropagation: true,
-						HTTP: confighttp.ServerConfig{
-							Endpoint: tc.httpHostPort,
-						},
-						GRPC: configgrpc.ServerConfig{
-							NetAddr: confignet.AddrConfig{
-								Endpoint: tc.grpcHostPort,
-							},
+					BearerTokenPropagation: true,
+					HTTP: confighttp.ServerConfig{
+						Endpoint: tc.httpHostPort,
+					},
+					GRPC: configgrpc.ServerConfig{
+						NetAddr: confignet.AddrConfig{
+							Endpoint: tc.grpcHostPort,
 						},
 					},
 				},
@@ -665,15 +647,13 @@ func TestServerSinglePort(t *testing.T) {
 	telset := initTelSet(flagsSvc.Logger, jtracer.NoOp(), flagsSvc.HC())
 	server, err := NewServer(querySvc.qs, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				BearerTokenPropagation: true,
-				HTTP: confighttp.ServerConfig{
+			BearerTokenPropagation: true,
+			HTTP: confighttp.ServerConfig{
+				Endpoint: hostPort,
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
 					Endpoint: hostPort,
-				},
-				GRPC: configgrpc.ServerConfig{
-					NetAddr: confignet.AddrConfig{
-						Endpoint: hostPort,
-					},
 				},
 			},
 		},
@@ -712,14 +692,12 @@ func TestServerGracefulExit(t *testing.T) {
 	telset := initTelSet(flagsSvc.Logger, jtracer.NoOp(), flagsSvc.HC())
 	server, err := NewServer(querySvc.qs, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				HTTP: confighttp.ServerConfig{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: hostPort,
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
 					Endpoint: hostPort,
-				},
-				GRPC: configgrpc.ServerConfig{
-					NetAddr: confignet.AddrConfig{
-						Endpoint: hostPort,
-					},
 				},
 			},
 		},
@@ -756,14 +734,12 @@ func TestServerHandlesPortZero(t *testing.T) {
 	telset := initTelSet(flagsSvc.Logger, jtracer.NoOp(), flagsSvc.HC())
 	server, err := NewServer(querySvc, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				HTTP: confighttp.ServerConfig{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: ":0",
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
 					Endpoint: ":0",
-				},
-				GRPC: configgrpc.ServerConfig{
-					NetAddr: confignet.AddrConfig{
-						Endpoint: ":0",
-					},
 				},
 			},
 		},
@@ -807,16 +783,14 @@ func TestServerHTTPTenancy(t *testing.T) {
 	}
 
 	serverOptions := &QueryOptions{
-		QueryOptionsBase: QueryOptionsBase{
-			Tenancy: tenancy.Options{
-				Enabled: true,
-			}, HTTP: confighttp.ServerConfig{
+		Tenancy: tenancy.Options{
+			Enabled: true,
+		}, HTTP: confighttp.ServerConfig{
+			Endpoint: ":8080",
+		},
+		GRPC: configgrpc.ServerConfig{
+			NetAddr: confignet.AddrConfig{
 				Endpoint: ":8080",
-			},
-			GRPC: configgrpc.ServerConfig{
-				NetAddr: confignet.AddrConfig{
-					Endpoint: ":8080",
-				},
 			},
 		},
 	}

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -44,10 +44,8 @@ func TestRegisterStaticHandlerPanic(t *testing.T) {
 			mux.NewRouter(),
 			logger,
 			&QueryOptions{
-				QueryOptionsBase: QueryOptionsBase{
-					UIConfig: UIConfig{
-						AssetsPath: "/foo/bar",
-					},
+				UIConfig: UIConfig{
+					AssetsPath: "/foo/bar",
 				},
 			},
 			querysvc.StorageCapabilities{ArchiveStorage: false},
@@ -111,14 +109,12 @@ func TestRegisterStaticHandler(t *testing.T) {
 				r = r.PathPrefix(testCase.basePath).Subrouter()
 			}
 			closer := RegisterStaticHandler(r, logger, &QueryOptions{
-				QueryOptionsBase: QueryOptionsBase{
-					UIConfig: UIConfig{
-						ConfigFile: testCase.UIConfigPath,
-						AssetsPath: "fixture",
-						LogAccess:  testCase.logAccess,
-					},
-					BasePath: testCase.basePath,
+				UIConfig: UIConfig{
+					ConfigFile: testCase.UIConfigPath,
+					AssetsPath: "fixture",
+					LogAccess:  testCase.logAccess,
 				},
+				BasePath: testCase.basePath,
 			},
 				querysvc.StorageCapabilities{ArchiveStorage: testCase.archiveStorage},
 			)

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/olivere/elastic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/jaegertracing/jaeger/cmd/internal/flags"
@@ -88,10 +91,16 @@ func runQueryService(t *testing.T, esURL string) *Server {
 	}
 	server, err := NewServer(querySvc, nil,
 		&QueryOptions{
-			GRPCHostPort: ":0",
-			HTTPHostPort: ":0",
 			QueryOptionsBase: QueryOptionsBase{
 				BearerTokenPropagation: true,
+				HTTP: confighttp.ServerConfig{
+					Endpoint: ":0",
+				},
+				GRPC: configgrpc.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Endpoint: ":0",
+					},
+				},
 			},
 		},
 		tenancy.NewManager(&tenancy.Options{}),

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -91,15 +91,13 @@ func runQueryService(t *testing.T, esURL string) *Server {
 	}
 	server, err := NewServer(querySvc, nil,
 		&QueryOptions{
-			QueryOptionsBase: QueryOptionsBase{
-				BearerTokenPropagation: true,
-				HTTP: confighttp.ServerConfig{
+			BearerTokenPropagation: true,
+			HTTP: confighttp.ServerConfig{
+				Endpoint: ":0",
+			},
+			GRPC: configgrpc.ServerConfig{
+				NetAddr: confignet.AddrConfig{
 					Endpoint: ":0",
-				},
-				GRPC: configgrpc.ServerConfig{
-					NetAddr: confignet.AddrConfig{
-						Endpoint: ":0",
-					},
 				},
 			},
 		},

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -142,6 +142,28 @@ func (o *Options) ToOtelClientConfig() configtls.ClientConfig {
 	}
 }
 
+// ToOtelServerConfig provides a mapping between from Options to OTEL's TLS Server Configuration.
+func (o *Options) ToOtelServerConfig() configtls.ServerConfig {
+	cfg := configtls.ServerConfig{
+		ClientCAFile: o.ClientCAPath,
+		Config: configtls.Config{
+			CAFile:         o.CAPath,
+			CertFile:       o.CertPath,
+			KeyFile:        o.KeyPath,
+			CipherSuites:   o.CipherSuites,
+			MinVersion:     o.MinVersion,
+			MaxVersion:     o.MaxVersion,
+			ReloadInterval: o.ReloadInterval,
+		},
+	}
+
+	if o.ReloadInterval > 0 {
+		cfg.ReloadClientCAFile = true
+	}
+
+	return cfg
+}
+
 func addCertToPool(caPath string, certPool *x509.CertPool) error {
 	caPEM, err := os.ReadFile(filepath.Clean(caPath))
 	if err != nil {

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -143,8 +143,12 @@ func (o *Options) ToOtelClientConfig() configtls.ClientConfig {
 }
 
 // ToOtelServerConfig provides a mapping between from Options to OTEL's TLS Server Configuration.
-func (o *Options) ToOtelServerConfig() configtls.ServerConfig {
-	cfg := configtls.ServerConfig{
+func (o *Options) ToOtelServerConfig() *configtls.ServerConfig {
+	if !o.Enabled {
+		return nil
+	}
+
+	cfg := &configtls.ServerConfig{
 		ClientCAFile: o.ClientCAPath,
 		Config: configtls.Config{
 			CAFile:         o.CAPath,

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -270,7 +270,7 @@ func TestToOtelServerConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "overrides set",
+			name: "with reload interval",
 			options: Options{
 				Enabled:        true,
 				ClientCAPath:   "path/to/client/ca.pem",

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -231,3 +231,68 @@ func TestToOtelClientConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestToOtelServerConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		options  Options
+		expected configtls.ServerConfig
+	}{
+		{
+			name: "default mapping",
+			options: Options{
+				ClientCAPath: "path/to/client/ca.pem",
+				CAPath:       "path/to/ca.pem",
+				CertPath:     "path/to/cert.pem",
+				KeyPath:      "path/to/key.pem",
+				CipherSuites: []string{"TLS_RSA_WITH_AES_128_CBC_SHA"},
+				MinVersion:   "1.2",
+				MaxVersion:   "1.3",
+			},
+			expected: configtls.ServerConfig{
+				ClientCAFile: "path/to/client/ca.pem",
+				Config: configtls.Config{
+					CAFile:       "path/to/ca.pem",
+					CertFile:     "path/to/cert.pem",
+					KeyFile:      "path/to/key.pem",
+					CipherSuites: []string{"TLS_RSA_WITH_AES_128_CBC_SHA"},
+					MinVersion:   "1.2",
+					MaxVersion:   "1.3",
+				},
+			},
+		},
+		{
+			name: "overrides set",
+			options: Options{
+				ClientCAPath:   "path/to/client/ca.pem",
+				CAPath:         "path/to/ca.pem",
+				CertPath:       "path/to/cert.pem",
+				KeyPath:        "path/to/key.pem",
+				CipherSuites:   []string{"TLS_RSA_WITH_AES_128_CBC_SHA"},
+				MinVersion:     "1.2",
+				MaxVersion:     "1.3",
+				ReloadInterval: 24 * time.Hour,
+			},
+			expected: configtls.ServerConfig{
+				ClientCAFile:       "path/to/client/ca.pem",
+				ReloadClientCAFile: true,
+				Config: configtls.Config{
+					CAFile:         "path/to/ca.pem",
+					CertFile:       "path/to/cert.pem",
+					KeyFile:        "path/to/key.pem",
+					CipherSuites:   []string{"TLS_RSA_WITH_AES_128_CBC_SHA"},
+					MinVersion:     "1.2",
+					MaxVersion:     "1.3",
+					ReloadInterval: 24 * time.Hour,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.options.ToOtelServerConfig()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -236,11 +236,19 @@ func TestToOtelServerConfig(t *testing.T) {
 	testCases := []struct {
 		name     string
 		options  Options
-		expected configtls.ServerConfig
+		expected *configtls.ServerConfig
 	}{
+		{
+			name: "not enabled",
+			options: Options{
+				Enabled: false,
+			},
+			expected: nil,
+		},
 		{
 			name: "default mapping",
 			options: Options{
+				Enabled:      true,
 				ClientCAPath: "path/to/client/ca.pem",
 				CAPath:       "path/to/ca.pem",
 				CertPath:     "path/to/cert.pem",
@@ -249,7 +257,7 @@ func TestToOtelServerConfig(t *testing.T) {
 				MinVersion:   "1.2",
 				MaxVersion:   "1.3",
 			},
-			expected: configtls.ServerConfig{
+			expected: &configtls.ServerConfig{
 				ClientCAFile: "path/to/client/ca.pem",
 				Config: configtls.Config{
 					CAFile:       "path/to/ca.pem",
@@ -264,6 +272,7 @@ func TestToOtelServerConfig(t *testing.T) {
 		{
 			name: "overrides set",
 			options: Options{
+				Enabled:        true,
 				ClientCAPath:   "path/to/client/ca.pem",
 				CAPath:         "path/to/ca.pem",
 				CertPath:       "path/to/cert.pem",
@@ -273,7 +282,7 @@ func TestToOtelServerConfig(t *testing.T) {
 				MaxVersion:     "1.3",
 				ReloadInterval: 24 * time.Hour,
 			},
-			expected: configtls.ServerConfig{
+			expected: &configtls.ServerConfig{
 				ClientCAFile:       "path/to/client/ca.pem",
 				ReloadClientCAFile: true,
 				Config: configtls.Config{


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5996

## Description of the changes
- Removed the custom TLS and HTTP server configurations and replaced them with OTEL's configurations
- 🛑 Breaking change: the hot-reload of certificates will not happen at `reload_interval`s rather than immediately on file changes. This makes Jaeger's behavior similar to OTEL Collector's behavior.

## How was this change tested?
- Unit tests / CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
