### PR TITLE
[jaeger-v2] Add Attributes Processor to Binary

### DIFF
--- a/cmd/jaeger/internal/components.go
+++ b/cmd/jaeger/internal/components.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
@@ -108,6 +109,7 @@ func (b builders) build() (otelcol.Factories, error) {
 		batchprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),
 		tailsamplingprocessor.NewFactory(),
+		attributesprocessor.NewFactory(),
 		// add-ons
 		adaptivesampling.NewFactory(),
 	)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension v0.111.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.111.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.111.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.111.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.111.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.111.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.111.0
@@ -101,6 +102,7 @@ require (
 	github.com/antchfx/xmlquery v1.4.1 // indirect
 	github.com/antchfx/xpath v1.3.1 // indirect
 	github.com/ebitengine/purego v0.8.0 // indirect
+	github.com/expr-lang/expr v1.16.9 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/envoyproxy/go-control-plane v0.13.0/go.mod h1:GRaKG3dwvFoTg4nj7aXdZnv
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.1.0 h1:tntQDh69XqOCOZsDz0lVJQez/2L6Uu2PdjCQwWCJ3bM=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
+github.com/expr-lang/expr v1.16.9 h1:WUAzmR0JNI9JCiF0/ewwHB1gmcGw5wW7nWt8gc6PpCI=
+github.com/expr-lang/expr v1.16.9/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -444,6 +446,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometh
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.111.0/go.mod h1:xJ8w6JN/tfRpUXTU6jx/bYmTIcy7OTz7PVFVR/SdqC8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.111.0 h1:9vE440Q98eNLd/estFIDgX1jczzU978yGarFLIMieEU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.111.0/go.mod h1:HK8p16A0OoXqhehCTW3QxgWNeshuIDucGUpGwpw88Og=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.111.0 h1:h5TnZkApRY8MbauD64R2CXKY3SvkjL3+H0xzdee8Yx0=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.111.0/go.mod h1:5sDugbmzTH9mwv+/bHHeDh3GxG2OFcgsBNvAeb5HQS0=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.111.0 h1:DF+kp5Gtg5B95VncWJb1oOIvf9PGpZ/gxWAHLdIrTEk=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.111.0/go.mod h1:UzFds6+yARb/SHnC93hMeGWKJIDA131nm2dxZW+kTsc=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.111.0 h1:aExPDvXM72YkrpUr/zzHisB2hthAglMyyMakXSoAjCI=


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6040

## Description of the changes
- Added the [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor/README.md) to the Jaeger V2 binary to replace `--collector.tags`. See the [migration guide](https://docs.google.com/document/d/18B1yTMewRft2N0nW9K-ecVRTt5VaNgnrPTW1eL236t4/edit?usp=sharing) for more details. 

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
