### PR TITLE
[jaeger-v2] Enable queueing configuration in storage exporter

### DIFF
--- a/cmd/jaeger/internal/exporters/storageexporter/config.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/config.go
@@ -17,7 +17,7 @@ var (
 // Config defines configuration for jaeger_storage_exporter.
 type Config struct {
 	TraceStorage string                     `mapstructure:"trace_storage" valid:"required"`
-	QueueConfig  exporterhelper.QueueConfig `mapstructure:"sending_queue" valid:"optional"`
+	QueueConfig  exporterhelper.QueueConfig `mapstructure:"queue" valid:"optional"`
 }
 
 func (cfg *Config) Validate() error {

--- a/cmd/jaeger/internal/exporters/storageexporter/config.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/config.go
@@ -6,6 +6,7 @@ package storageexporter
 import (
 	"github.com/asaskevich/govalidator"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 var (
@@ -15,7 +16,8 @@ var (
 
 // Config defines configuration for jaeger_storage_exporter.
 type Config struct {
-	TraceStorage string `valid:"required" mapstructure:"trace_storage"`
+	TraceStorage string                     `mapstructure:"trace_storage" valid:"required"`
+	QueueConfig  exporterhelper.QueueConfig `mapstructure:"sending_queue" valid:"optional"`
 }
 
 func (cfg *Config) Validate() error {

--- a/cmd/jaeger/internal/exporters/storageexporter/factory.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/factory.go
@@ -38,10 +38,10 @@ func createTracesExporter(ctx context.Context, set exporter.Settings, config com
 	return exporterhelper.NewTracesExporter(ctx, set, cfg,
 		ex.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		// Disable Timeout/RetryOnFailure and SendingQueue
+		// Disable Timeout/RetryOnFailure
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(configretry.BackOffConfig{Enabled: false}),
-		exporterhelper.WithQueue(exporterhelper.QueueConfig{Enabled: false}),
+		exporterhelper.WithQueue(cfg.QueueConfig),
 		exporterhelper.WithStart(ex.start),
 		exporterhelper.WithShutdown(ex.close),
 	)


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6040

## Description of the changes
- Added the `sending_queue` configuration to `jaeger_storage_exporter`  from`exporterhelper` which will allow for enabling a queue when writing spans to any backend store.
- This will allow for achieving parity in jaeger-v2 with the v1 collector's `--collector.queue-size` flag as `sending_queue` has a configuration for `queue_size`.
- [Migration guide](https://docs.google.com/document/d/18B1yTMewRft2N0nW9K-ecVRTt5VaNgnrPTW1eL236t4/edit?usp=sharing) updated for the mapping between v1 and v2

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
