### PR TITLE
Fix rebuild-ui.sh script

### DIFF
--- a/scripts/rebuild-ui.sh
+++ b/scripts/rebuild-ui.sh
@@ -7,7 +7,11 @@ set -euxf -o pipefail
 
 cd jaeger-ui
 
-git fetch --all --unshallow --tags
+git fetch --all --tags
+is_shallow_repo=$(git rev-parse --is-shallow-repository)
+if [[ "$is_shallow_repo" == "true" ]]; then
+    git fetch --unshallow
+fi
 git log --oneline --decorate=full -n 10 | cat
 
 last_tag=$(git describe --tags --dirty 2>/dev/null)

--- a/scripts/rebuild-ui.sh
+++ b/scripts/rebuild-ui.sh
@@ -7,11 +7,10 @@ set -euxf -o pipefail
 
 cd jaeger-ui
 
-git fetch --all --tags
-is_shallow_repo=$(git rev-parse --is-shallow-repository)
-if [[ "$is_shallow_repo" == "true" ]]; then
+if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
     git fetch --unshallow
 fi
+git fetch --all --tags
 git log --oneline --decorate=full -n 10 | cat
 
 last_tag=$(git describe --tags --dirty 2>/dev/null)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6097

## Description of the changes
- run `git fetch --unshallow` only on shallow repos

## How was this change tested?
- 

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
