### PR TITLE
golangci-lint: enable and fix thelper linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,9 @@ linters:
     # Checks usage of github.com/stretchr/testify.
     - testifylint
 
+    # Thelper detects tests helpers which is not start with t.Helper() method.
+    - thelper
+
     # TODO consider adding more linters, cf. https://olegk.dev/go-linters-configuration-the-right-version
 
 linters-settings:

--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -72,6 +72,7 @@ func TestAgentMetricsEndpoint(t *testing.T) {
 }
 
 func withRunningAgent(t *testing.T, testcase func(string, chan error)) {
+	t.Helper()
 	resetDefaultPrometheusRegistry()
 	cfg := Builder{
 		Processors: []ProcessorConfiguration{

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -56,6 +56,7 @@ func (*mockSamplingHandler) GetSamplingStrategy(context.Context, *api_v2.Samplin
 }
 
 func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server)) (*grpc.Server, net.Addr) {
+	t.Helper()
 	server := grpc.NewServer()
 	lis, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -44,6 +44,7 @@ var (
 )
 
 func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TProtocolFactory, handler AgentProcessor) (string, Processor) {
+	t.Helper()
 	transport, err := thriftudp.NewTUDPServerTransport("127.0.0.1:0")
 	require.NoError(t, err)
 
@@ -70,6 +71,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 
 // revive:disable-next-line function-result-limit
 func initCollectorAndReporter(t *testing.T) (*metricstest.Factory, *testutils.GrpcCollector, reporter.Reporter, *grpc.ClientConn) {
+	t.Helper()
 	grpcCollector := testutils.StartGRPCCollector(t)
 	conn, err := grpc.NewClient(grpcCollector.Listener().Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
@@ -177,6 +179,7 @@ func TestJaegerProcessor(t *testing.T) {
 }
 
 func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.GrpcCollector, metricsFactory *metricstest.Factory) {
+	t.Helper()
 	sizeF := func() int {
 		return len(collector.GetJaegerBatches())
 	}
@@ -187,6 +190,7 @@ func assertJaegerProcessorCorrectness(t *testing.T, collector *testutils.GrpcCol
 }
 
 func assertZipkinProcessorCorrectness(t *testing.T, collector *testutils.GrpcCollector, metricsFactory *metricstest.Factory) {
+	t.Helper()
 	sizeF := func() int {
 		return len(collector.GetJaegerBatches())
 	}
@@ -205,6 +209,7 @@ func assertCollectorReceivedData(
 	nameF func() string,
 	format string,
 ) {
+	t.Helper()
 	require.Eventually(t,
 		func() bool { return sizeF() == 1 },
 		5*time.Second,

--- a/cmd/agent/app/reporter/client_metrics_test.go
+++ b/cmd/agent/app/reporter/client_metrics_test.go
@@ -28,6 +28,7 @@ type clientMetricsTest struct {
 }
 
 func (tr *clientMetricsTest) assertLog(t *testing.T, msg, clientUUID string) {
+	t.Helper()
 	logs := tr.logs.FilterMessageSnippet(msg)
 	if clientUUID == "" {
 		assert.Equal(t, 0, logs.Len(), "not expecting log '%s", msg)

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -365,6 +365,7 @@ func (f *fakeInterceptor) intercept(ctx context.Context, method string, req, rep
 }
 
 func (f *fakeInterceptor) assertCalled(t *testing.T) {
+	t.Helper()
 	assert.True(t, f.isCalled)
 }
 

--- a/cmd/agent/app/reporter/grpc/collector_proxy_test.go
+++ b/cmd/agent/app/reporter/grpc/collector_proxy_test.go
@@ -63,6 +63,7 @@ func TestMultipleCollectors(t *testing.T) {
 }
 
 func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server), opts ...grpc.ServerOption) (*grpc.Server, net.Addr) {
+	t.Helper()
 	server := grpc.NewServer(opts...)
 	lis, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)

--- a/cmd/agent/app/servers/thriftudp/transport_test.go
+++ b/cmd/agent/app/servers/thriftudp/transport_test.go
@@ -219,6 +219,7 @@ func TestResetInFlush(t *testing.T) {
 }
 
 func withLocalServer(t *testing.T, f func(addr string)) {
+	t.Helper()
 	conn, err := net.ListenUDP(localListenAddr.Network(), localListenAddr)
 	require.NoError(t, err, "ListenUDP failed")
 

--- a/cmd/agent/app/testutils/mock_grpc_collector.go
+++ b/cmd/agent/app/testutils/mock_grpc_collector.go
@@ -28,6 +28,7 @@ var _ api_v2.CollectorServiceServer = (*GrpcCollector)(nil)
 
 // StartGRPCCollector starts GRPC collector on a random port
 func StartGRPCCollector(t *testing.T) *GrpcCollector {
+	t.Helper()
 	server := grpc.NewServer()
 	lis, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)

--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -65,6 +65,7 @@ func TestAllInOne(t *testing.T) {
 }
 
 func healthCheck(t *testing.T) {
+	t.Helper()
 	require.Eventuallyf(t,
 		func() bool {
 			resp, err := http.Get(queryAddr + "/")
@@ -100,6 +101,7 @@ func healthCheckV2(t *testing.T) {
 }
 
 func httpGet(t *testing.T, url string) (*http.Response, []byte) {
+	t.Helper()
 	t.Logf("Executing HTTP GET %s", url)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	require.NoError(t, err)

--- a/cmd/anonymizer/app/query/query_test.go
+++ b/cmd/anonymizer/app/query/query_test.go
@@ -54,6 +54,7 @@ type testServer struct {
 }
 
 func newTestServer(t *testing.T) *testServer {
+	t.Helper()
 	spanReader := &spanstoremocks.Reader{}
 	metricsReader, err := disabled.NewMetricsReader()
 	require.NoError(t, err)

--- a/cmd/anonymizer/app/uiconv/extractor_test.go
+++ b/cmd/anonymizer/app/uiconv/extractor_test.go
@@ -90,6 +90,7 @@ func TestExtractorTraceScanError(t *testing.T) {
 }
 
 func loadJSON(t *testing.T, fileName string, i any) {
+	t.Helper()
 	b, err := os.ReadFile(fileName)
 	require.NoError(t, err)
 	err = json.Unmarshal(b, i)

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -71,6 +71,7 @@ func TestBySvcMetrics(t *testing.T) {
 	}
 
 	testFn := func(t *testing.T, test TestCase) {
+		t.Helper()
 		mb := metricstest.NewFactory(time.Hour)
 		defer mb.Backend.Stop()
 		logger := zap.NewNop()

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -21,6 +21,7 @@ func TestIndexFilter_prefix(t *testing.T) {
 }
 
 func testIndexFilter(t *testing.T, prefix string) {
+	t.Helper()
 	time20200807 := time.Date(2020, time.August, 0o6, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
 	indices := []client.Index{
 		{

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -81,6 +81,7 @@ func newConsumer(
 	processor processor.SpanProcessor,
 	consumer consumer.Consumer,
 ) *Consumer {
+	t.Helper()
 	logger, _ := zap.NewDevelopment()
 	consumerParams := Params{
 		MetricsFactory:   metricsFactory,

--- a/cmd/internal/flags/service_test.go
+++ b/cmd/internal/flags/service_test.go
@@ -93,6 +93,7 @@ func TestStartErrors(t *testing.T) {
 }
 
 func waitForEqual(t *testing.T, expected any, getter func() any) {
+	t.Helper()
 	for i := 0; i < 1000; i++ {
 		value := getter()
 		if reflect.DeepEqual(value, expected) {

--- a/cmd/internal/printconfig/command_test.go
+++ b/cmd/internal/printconfig/command_test.go
@@ -54,6 +54,7 @@ func addFlags(flagSet *flag.FlagSet) {
 }
 
 func setConfig(t *testing.T) *viper.Viper {
+	t.Helper()
 	v, command := config.Viperize(addFlags, tenancy.AddFlags)
 	err := command.ParseFlags([]string{
 		"--test-plugin.binary=noop-test-plugin",
@@ -67,7 +68,8 @@ func setConfig(t *testing.T) *viper.Viper {
 	return v
 }
 
-func runPrintConfigCommand(v *viper.Viper, t *testing.T, allFlag bool) string {
+func runPrintConfigCommand(t *testing.T, v *viper.Viper, allFlag bool) string {
+	t.Helper()
 	buf := new(bytes.Buffer)
 	printCmd := Command(v)
 	printCmd.SetOut(buf)
@@ -105,7 +107,7 @@ func TestAllFlag(t *testing.T) {
 `
 
 	v := setConfig(t)
-	actual := runPrintConfigCommand(v, t, true)
+	actual := runPrintConfigCommand(t, v, true)
 	assert.Equal(t, expected, actual)
 }
 
@@ -124,7 +126,7 @@ func TestPrintConfigCommand(t *testing.T) {
 -----------------------------------------------------------------
 `
 	v := setConfig(t)
-	actual := runPrintConfigCommand(v, t, false)
+	actual := runPrintConfigCommand(t, v, false)
 	assert.Equal(t, expected, actual)
 }
 

--- a/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
@@ -163,6 +163,7 @@ func TestExporter(t *testing.T) {
 }
 
 func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
+	t.Helper()
 	telemetrySettings := component.TelemetrySettings{
 		Logger:         zaptest.NewLogger(t),
 		TracerProvider: nooptrace.NewTracerProvider(),

--- a/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func loadConf(t *testing.T, config string) *confmap.Conf {
+	t.Helper()
 	d := t.TempDir()
 	f := filepath.Join(d, "config.yaml")
 	require.NoError(t, os.WriteFile(f, []byte(config), 0o644))

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -197,6 +197,7 @@ func TestMetricsStorageStartError(t *testing.T) {
 }
 
 func testElasticsearchOrOpensearch(t *testing.T, cfg Backend) {
+	t.Helper()
 	ext := makeStorageExtenion(t, &Config{
 		Backends: map[string]Backend{
 			"foo": cfg,
@@ -264,6 +265,7 @@ func noopTelemetrySettings() component.TelemetrySettings {
 }
 
 func makeStorageExtenion(t *testing.T, config *Config) component.Component {
+	t.Helper()
 	extensionFactory := NewFactory()
 	ctx := context.Background()
 	ext, err := extensionFactory.CreateExtension(ctx,
@@ -279,6 +281,7 @@ func makeStorageExtenion(t *testing.T, config *Config) component.Component {
 }
 
 func startStorageExtension(t *testing.T, memstoreName string, promstoreName string) component.Component {
+	t.Helper()
 	config := &Config{
 		Backends: map[string]Backend{
 			memstoreName: {

--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
+	t.Helper()
 	telemetrySettings := component.TelemetrySettings{
 		Logger:         zaptest.NewLogger(t),
 		TracerProvider: nooptrace.NewTracerProvider(),
@@ -66,6 +67,7 @@ func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
 }
 
 func makeRemoteSamplingExtension(t *testing.T, cfg component.Config) component.Host {
+	t.Helper()
 	extensionFactory := NewFactory()
 	samplingExtension, err := extensionFactory.CreateExtension(
 		context.Background(),

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -61,6 +61,7 @@ type Binary struct {
 }
 
 func (b *Binary) Start(t *testing.T) {
+	t.Helper()
 	outFile, err := os.OpenFile(
 		filepath.Join(t.TempDir(), "output_logs.txt"),
 		os.O_CREATE|os.O_WRONLY,
@@ -113,6 +114,7 @@ func (b *Binary) Start(t *testing.T) {
 // it also initialize the SpanWriter and SpanReader below.
 // This function should be called before any of the tests start.
 func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
+	t.Helper()
 	// set environment variable overrides
 	for key, value := range s.EnvVarOverrides {
 		t.Setenv(key, value)
@@ -160,6 +162,7 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 }
 
 func (s *E2EStorageIntegration) doHealthCheck(t *testing.T) bool {
+	t.Helper()
 	healthCheckEndpoint := s.HealthCheckEndpoint
 	if healthCheckEndpoint == "" {
 		healthCheckEndpoint = "http://localhost:13133/status"
@@ -212,11 +215,13 @@ func (s *E2EStorageIntegration) doHealthCheck(t *testing.T) bool {
 // e2eCleanUp closes the SpanReader and SpanWriter gRPC connection.
 // This function should be called after all the tests are finished.
 func (s *E2EStorageIntegration) e2eCleanUp(t *testing.T) {
+	t.Helper()
 	require.NoError(t, s.SpanReader.(io.Closer).Close())
 	require.NoError(t, s.SpanWriter.(io.Closer).Close())
 }
 
 func createStorageCleanerConfig(t *testing.T, configFile string, storage string) string {
+	t.Helper()
 	data, err := os.ReadFile(configFile)
 	require.NoError(t, err)
 	var config map[string]any
@@ -271,6 +276,7 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 }
 
 func purge(t *testing.T) {
+	t.Helper()
 	addr := fmt.Sprintf("http://0.0.0.0:%s%s", storagecleaner.Port, storagecleaner.URL)
 	t.Logf("Purging storage via %s", addr)
 	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, addr, nil)

--- a/cmd/jaeger/internal/integration/grpc_test.go
+++ b/cmd/jaeger/internal/integration/grpc_test.go
@@ -18,10 +18,12 @@ type GRPCStorageIntegration struct {
 }
 
 func (s *GRPCStorageIntegration) initialize(t *testing.T) {
+	t.Helper()
 	s.remoteStorage = integration.StartNewRemoteMemoryStorage(t)
 }
 
 func (s *GRPCStorageIntegration) cleanUp(t *testing.T) {
+	t.Helper()
 	s.remoteStorage.Close(t)
 	s.initialize(t)
 }

--- a/cmd/jaeger/internal/integration/tailsampling_test.go
+++ b/cmd/jaeger/internal/integration/tailsampling_test.go
@@ -88,6 +88,7 @@ func (ts *TailSamplingIntegration) testTailSamplingProccessor(t *testing.T) {
 
 // generateTraces generates 5 traces using `tracegen` with one service per trace
 func (*TailSamplingIntegration) generateTraces(t *testing.T) {
+	t.Helper()
 	tracegenCmd := exec.Command("go", "run", "../../../../cmd/tracegen", "-traces", "5", "-services", "5")
 	out, err := tracegenCmd.CombinedOutput()
 	require.NoError(t, err)

--- a/cmd/jaeger/internal/processors/adaptivesampling/processor_test.go
+++ b/cmd/jaeger/internal/processors/adaptivesampling/processor_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
+	t.Helper()
 	telemetrySettings := component.TelemetrySettings{
 		Logger:         zaptest.NewLogger(t),
 		TracerProvider: nooptrace.NewTracerProvider(),
@@ -60,6 +61,7 @@ func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
 var _ component.Config = (*Config)(nil)
 
 func makeRemoteSamplingExtension(t *testing.T, cfg component.Config) component.Host {
+	t.Helper()
 	extensionFactory := remotesampling.NewFactory()
 	samplingExtension, err := extensionFactory.CreateExtension(
 		context.Background(),

--- a/cmd/query/app/apiv3/gateway_test.go
+++ b/cmd/query/app/apiv3/gateway_test.go
@@ -47,6 +47,7 @@ type testGateway struct {
 }
 
 func (gw *testGateway) execRequest(t *testing.T, url string) ([]byte, int) {
+	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, gw.url+url, nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -60,6 +61,7 @@ func (gw *testGateway) execRequest(t *testing.T, url string) ([]byte, int) {
 }
 
 func (*testGateway) verifySnapshot(t *testing.T, body []byte) []byte {
+	t.Helper()
 	// reformat JSON body with indentation, to make diffing easier
 	var data any
 	require.NoError(t, json.Unmarshal(body, &data), "response: %s", string(body))
@@ -78,6 +80,7 @@ func (*testGateway) verifySnapshot(t *testing.T, body []byte) []byte {
 }
 
 func parseResponse(t *testing.T, body []byte, obj gogoproto.Message) {
+	t.Helper()
 	require.NoError(t, gogojsonpb.Unmarshal(bytes.NewBuffer(body), obj))
 }
 
@@ -104,6 +107,7 @@ func runGatewayTests(
 	tenancyOptions tenancy.Options,
 	setupRequest func(*http.Request),
 ) {
+	t.Helper()
 	gw := setupHTTPGateway(t, basePath, tenancyOptions)
 	gw.setupRequest = setupRequest
 	t.Run("GetServices", gw.runGatewayGetServices)
@@ -157,6 +161,7 @@ func (gw *testGateway) runGatewayFindTraces(t *testing.T) {
 }
 
 func (gw *testGateway) getTracesAndVerify(t *testing.T, url string, expectedTraceID model.TraceID) {
+	t.Helper()
 	body, statusCode := gw.execRequest(t, url)
 	require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
 	body = gw.verifySnapshot(t, body)

--- a/cmd/query/app/apiv3/grpc_handler_test.go
+++ b/cmd/query/app/apiv3/grpc_handler_test.go
@@ -31,6 +31,7 @@ var (
 )
 
 func newGrpcServer(t *testing.T, handler *Handler) (*grpc.Server, net.Addr) {
+	t.Helper()
 	server := grpc.NewServer()
 	api_v3.RegisterQueryServiceServer(server, handler)
 
@@ -52,6 +53,7 @@ type testServerClient struct {
 }
 
 func newTestServerClient(t *testing.T) *testServerClient {
+	t.Helper()
 	tsc := &testServerClient{
 		reader: &spanstoremocks.Reader{},
 	}

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -63,6 +63,7 @@ func setupHTTPGateway(
 	basePath string,
 	tenancyOptions tenancy.Options,
 ) *testGateway {
+	t.Helper()
 	gw := setupHTTPGatewayNoServer(t, basePath, tenancyOptions)
 
 	httpServer := httptest.NewServer(gw.router)

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -135,6 +135,7 @@ type grpcClient struct {
 }
 
 func newGRPCServer(t *testing.T, q *querysvc.QueryService, mq querysvc.MetricsQueryService, logger *zap.Logger, tracer *jtracer.JTracer, tenancyMgr *tenancy.Manager) (*grpc.Server, net.Addr) {
+	t.Helper()
 	lis, _ := net.Listen("tcp", ":0")
 	var grpcOpts []grpc.ServerOption
 	if tenancyMgr.Enabled {
@@ -163,6 +164,7 @@ func newGRPCServer(t *testing.T, q *querysvc.QueryService, mq querysvc.MetricsQu
 }
 
 func newGRPCClient(t *testing.T, addr string) *grpcClient {
+	t.Helper()
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 
@@ -188,6 +190,7 @@ func withMetricsQuery() testOption {
 }
 
 func withServerAndClient(t *testing.T, actualTest func(server *grpcServer, client *grpcClient), options ...testOption) {
+	t.Helper()
 	server := initializeTenantedTestServerGRPCWithOptions(t, &tenancy.Manager{}, options...)
 	client := newGRPCClient(t, server.lisAddr.String())
 	defer server.server.Stop()
@@ -213,6 +216,7 @@ func TestGetTraceSuccessGRPC(t *testing.T) {
 }
 
 func assertGRPCError(t *testing.T, err error, code codes.Code, msg string) {
+	t.Helper()
 	s, ok := status.FromError(err)
 	require.True(t, ok, "expecting gRPC status")
 	assert.Equal(t, code, s.Code())
@@ -893,6 +897,7 @@ func TestMetricsQueryNilRequestGRPC(t *testing.T) {
 }
 
 func initializeTenantedTestServerGRPCWithOptions(t *testing.T, tm *tenancy.Manager, options ...testOption) *grpcServer {
+	t.Helper()
 	archiveSpanReader := &spanstoremocks.Reader{}
 	archiveSpanWriter := &spanstoremocks.Writer{}
 
@@ -934,6 +939,7 @@ func initializeTenantedTestServerGRPCWithOptions(t *testing.T, tm *tenancy.Manag
 }
 
 func withTenantedServerAndClient(t *testing.T, tm *tenancy.Manager, actualTest func(server *grpcServer, client *grpcClient), options ...testOption) {
+	t.Helper()
 	server := initializeTenantedTestServerGRPCWithOptions(t, tm, options...)
 	client := newGRPCClient(t, server.lisAddr.String())
 	defer server.server.Stop()

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -93,6 +93,7 @@ type structuredTraceResponse struct {
 }
 
 func initializeTestServerWithHandler(t *testing.T, queryOptions querysvc.QueryServiceOptions, options ...HandlerOption) *testServer {
+	t.Helper()
 	return initializeTestServerWithOptions(
 		t,
 		&tenancy.Manager{},
@@ -116,6 +117,7 @@ func initializeTestServerWithOptions(
 	queryOptions querysvc.QueryServiceOptions,
 	options ...HandlerOption,
 ) *testServer {
+	t.Helper()
 	options = append(options, HandlerOptions.Logger(zaptest.NewLogger(t)))
 	readStorage := &spanstoremocks.Reader{}
 	dependencyStorage := &depsmocks.Reader{}
@@ -136,6 +138,7 @@ func initializeTestServerWithOptions(
 }
 
 func initializeTestServer(t *testing.T, options ...HandlerOption) *testServer {
+	t.Helper()
 	return initializeTestServerWithHandler(t, querysvc.QueryServiceOptions{}, options...)
 }
 
@@ -147,6 +150,7 @@ type testServer struct {
 }
 
 func withTestServer(t *testing.T, doTest func(s *testServer), queryOptions querysvc.QueryServiceOptions, options ...HandlerOption) {
+	t.Helper()
 	ts := initializeTestServerWithOptions(t, &tenancy.Manager{}, queryOptions, options...)
 	doTest(ts)
 }
@@ -265,6 +269,7 @@ func TestGetTrace(t *testing.T) {
 	}
 
 	makeMockTrace := func(t *testing.T) *model.Trace {
+		t.Helper()
 		out := new(bytes.Buffer)
 		err := new(jsonpb.Marshaler).Marshal(out, mockTrace)
 		require.NoError(t, err)
@@ -277,6 +282,7 @@ func TestGetTrace(t *testing.T) {
 	}
 
 	extractTraces := func(t *testing.T, response *structuredResponse) []ui.Trace {
+		t.Helper()
 		var traces []ui.Trace
 		bytes, err := json.Marshal(response.Data)
 		require.NoError(t, err)
@@ -475,6 +481,7 @@ func TestSearchFailures(t *testing.T) {
 }
 
 func testIndividualSearchFailures(t *testing.T, urlStr, errMsg string) {
+	t.Helper()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("Query", mock.AnythingOfType("spanstore.TraceQueryParameters")).
 		Return([]*model.Trace{}, nil).Once()

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -460,6 +460,7 @@ func TestServerHTTPTLS(t *testing.T) {
 }
 
 func newGRPCClientWithTLS(t *testing.T, addr string, creds credentials.TransportCredentials) *grpcClient {
+	t.Helper()
 	var conn *grpc.ClientConn
 	var err error
 

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -323,6 +323,7 @@ func TestLoadIndexHTMLReadError(t *testing.T) {
 }
 
 func waitUntil(t *testing.T, f func() bool, iterations int, sleepInterval time.Duration, timeoutErrMsg string) {
+	t.Helper()
 	for i := 0; i < iterations; i++ {
 		if f() {
 			return

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -55,6 +55,7 @@ func (*elasticsearchHandlerMock) ServeHTTP(w http.ResponseWriter, r *http.Reques
 }
 
 func runMockElasticsearchServer(t *testing.T) *httptest.Server {
+	t.Helper()
 	handler := &elasticsearchHandlerMock{
 		test: t,
 	}
@@ -64,6 +65,7 @@ func runMockElasticsearchServer(t *testing.T) *httptest.Server {
 }
 
 func runQueryService(t *testing.T, esURL string) *Server {
+	t.Helper()
 	flagsSvc := flags.NewService(ports.QueryAdminHTTP)
 	flagsSvc.Logger = zaptest.NewLogger(t)
 

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -295,6 +295,7 @@ type grpcClient struct {
 }
 
 func newGRPCClient(t *testing.T, addr string, creds credentials.TransportCredentials, tm *tenancy.Manager) *grpcClient {
+	t.Helper()
 	dialOpts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(tenancy.NewClientUnaryInterceptor(tm)),
 	}
@@ -407,6 +408,7 @@ func TestServerHandlesPortZero(t *testing.T) {
 }
 
 func validateGRPCServer(t *testing.T, hostPort string) {
+	t.Helper()
 	grpctest.ReflectionServiceValidator{
 		HostPort: hostPort,
 		ExpectedServices: []string{

--- a/internal/grpctest/reflection.go
+++ b/internal/grpctest/reflection.go
@@ -22,6 +22,7 @@ type ReflectionServiceValidator struct {
 
 // Execute performs validation.
 func (v ReflectionServiceValidator) Execute(t *testing.T) {
+	t.Helper()
 	conn, err := grpc.NewClient(
 		v.HostPort,
 		grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/internal/metrics/benchmark_test.go
+++ b/internal/metrics/benchmark_test.go
@@ -27,6 +27,7 @@ func setupPrometheusFactory() metrics.Factory {
 }
 
 func setupOTELFactory(b *testing.B) metrics.Factory {
+	b.Helper()
 	registry := prometheus.NewRegistry()
 	exporter, err := promExporter.New(promExporter.WithRegisterer(registry))
 	require.NoError(b, err)
@@ -37,6 +38,7 @@ func setupOTELFactory(b *testing.B) metrics.Factory {
 }
 
 func benchmarkCounter(b *testing.B, factory metrics.Factory) {
+	b.Helper()
 	counter := factory.Counter(metrics.Options{
 		Name: "test_counter",
 		Tags: map[string]string{"tag1": "value1"},
@@ -48,6 +50,7 @@ func benchmarkCounter(b *testing.B, factory metrics.Factory) {
 }
 
 func benchmarkGauge(b *testing.B, factory metrics.Factory) {
+	b.Helper()
 	gauge := factory.Gauge(metrics.Options{
 		Name: "test_gauge",
 		Tags: map[string]string{"tag1": "value1"},
@@ -59,6 +62,7 @@ func benchmarkGauge(b *testing.B, factory metrics.Factory) {
 }
 
 func benchmarkTimer(b *testing.B, factory metrics.Factory) {
+	b.Helper()
 	timer := factory.Timer(metrics.TimerOptions{
 		Name: "test_timer",
 		Tags: map[string]string{"tag1": "value1"},
@@ -70,6 +74,7 @@ func benchmarkTimer(b *testing.B, factory metrics.Factory) {
 }
 
 func benchmarkHistogram(b *testing.B, factory metrics.Factory) {
+	b.Helper()
 	histogram := factory.Histogram(metrics.HistogramOptions{
 		Name: "test_histogram",
 		Tags: map[string]string{"tag1": "value1"},

--- a/internal/metrics/otelmetrics/factory_test.go
+++ b/internal/metrics/otelmetrics/factory_test.go
@@ -24,6 +24,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestFactory(t *testing.T, registry *promReg.Registry) metrics.Factory {
+	t.Helper()
 	exporter, err := prometheus.New(prometheus.WithRegisterer(registry), prometheus.WithoutScopeInfo())
 	require.NoError(t, err)
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
@@ -31,6 +32,7 @@ func newTestFactory(t *testing.T, registry *promReg.Registry) metrics.Factory {
 }
 
 func findMetric(t *testing.T, registry *promReg.Registry, name string) *promModel.MetricFamily {
+	t.Helper()
 	metricFamilies, err := registry.Gather()
 	require.NoError(t, err)
 

--- a/internal/metrics/prometheus/factory_test.go
+++ b/internal/metrics/prometheus/factory_test.go
@@ -396,6 +396,7 @@ func TestHistogramDefaultBuckets(t *testing.T) {
 }
 
 func findMetric(t *testing.T, snapshot []*promModel.MetricFamily, name string, tags map[string]string) *promModel.Metric {
+	t.Helper()
 	for _, mf := range snapshot {
 		if mf.GetName() != name {
 			continue

--- a/internal/metricstest/metricstest.go
+++ b/internal/metricstest/metricstest.go
@@ -21,17 +21,20 @@ type ExpectedMetric struct {
 
 // AssertCounterMetrics checks if counter metrics exist.
 func (f *Factory) AssertCounterMetrics(t *testing.T, expectedMetrics ...ExpectedMetric) {
+	t.Helper()
 	counters, _ := f.Snapshot()
 	assertMetrics(t, counters, expectedMetrics...)
 }
 
 // AssertGaugeMetrics checks if gauge metrics exist.
 func (f *Factory) AssertGaugeMetrics(t *testing.T, expectedMetrics ...ExpectedMetric) {
+	t.Helper()
 	_, gauges := f.Snapshot()
 	assertMetrics(t, gauges, expectedMetrics...)
 }
 
 func assertMetrics(t *testing.T, actualMetrics map[string]int64, expectedMetrics ...ExpectedMetric) {
+	t.Helper()
 	for _, expected := range expectedMetrics {
 		key := GetKey(expected.Name, expected.Tags, "|", "=")
 		assert.EqualValues(t,

--- a/model/converter/json/from_domain_test.go
+++ b/model/converter/json/from_domain_test.go
@@ -86,15 +86,18 @@ func TestFromDomainEmbedProcess(t *testing.T) {
 }
 
 func loadFixturesUI(t *testing.T, i int) ([]byte, []byte) {
+	t.Helper()
 	return loadFixtures(t, i, false)
 }
 
 func loadFixturesES(t *testing.T, i int) ([]byte, []byte) {
+	t.Helper()
 	return loadFixtures(t, i, true)
 }
 
 // Loads and returns domain model and JSON model fixtures with given number i.
 func loadFixtures(t *testing.T, i int, processEmbedded bool) ([]byte, []byte) {
+	t.Helper()
 	var in string
 	if processEmbedded {
 		in = fmt.Sprintf("fixtures/domain_es_%02d.json", i)
@@ -115,6 +118,7 @@ func loadFixtures(t *testing.T, i int, processEmbedded bool) ([]byte, []byte) {
 }
 
 func testJSONEncoding(t *testing.T, i int, expectedStr []byte, object any, processEmbedded bool) {
+	t.Helper()
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetIndent("", "  ")

--- a/model/converter/json/json_span_compare_test.go
+++ b/model/converter/json/json_span_compare_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func CompareJSONSpans(t *testing.T, expected *esJson.Span, actual *esJson.Span) {
+	t.Helper()
 	sortJSONSpan(expected)
 	sortJSONSpan(actual)
 

--- a/model/converter/json/sampling_test.go
+++ b/model/converter/json/sampling_test.go
@@ -69,6 +69,7 @@ func TestSamplingStrategyResponseToJSON(t *testing.T) {
 }
 
 func compareProtoAndThriftJSON(t *testing.T, thriftObj *api_v1.SamplingStrategyResponse) {
+	t.Helper()
 	protoObj, err := thriftconv.ConvertSamplingResponseToDomain(thriftObj)
 	require.NoError(t, err)
 

--- a/model/converter/thrift/jaeger/to_domain_test.go
+++ b/model/converter/thrift/jaeger/to_domain_test.go
@@ -60,24 +60,28 @@ func TestToDomain(t *testing.T) {
 }
 
 func loadSpans(t *testing.T, file string) []*model.Span {
+	t.Helper()
 	var trace model.Trace
 	loadJSONPB(t, file, &trace)
 	return trace.Spans
 }
 
 func loadJSONPB(t *testing.T, fileName string, obj proto.Message) {
+	t.Helper()
 	jsonFile, err := os.Open(fileName)
 	require.NoError(t, err, "Failed to open json fixture file %s", fileName)
 	require.NoError(t, jsonpb.Unmarshal(jsonFile, obj), fileName)
 }
 
 func loadBatch(t *testing.T, file string) *jaeger.Batch {
+	t.Helper()
 	var batch jaeger.Batch
 	loadJSON(t, file, &batch)
 	return &batch
 }
 
 func loadJSON(t *testing.T, fileName string, obj any) {
+	t.Helper()
 	jsonFile, err := os.Open(fileName)
 	require.NoError(t, err, "Failed to load json fixture file %s", fileName)
 	jsonParser := json.NewDecoder(jsonFile)

--- a/model/converter/thrift/zipkin/to_domain_test.go
+++ b/model/converter/thrift/zipkin/to_domain_test.go
@@ -175,30 +175,35 @@ func TestValidateBase64Values(t *testing.T) {
 }
 
 func loadZipkinSpans(t *testing.T, file string) []*z.Span {
+	t.Helper()
 	var zSpans []*z.Span
 	loadJSON(t, file, &zSpans)
 	return zSpans
 }
 
 func loadJaegerTrace(t *testing.T, file string) *model.Trace {
+	t.Helper()
 	var trace model.Trace
 	loadJSONPB(t, file, &trace)
 	return &trace
 }
 
 func loadJSONPB(t *testing.T, fileName string, obj proto.Message) {
+	t.Helper()
 	jsonFile, err := os.Open(fileName)
 	require.NoError(t, err, "Failed to open json fixture file %s", fileName)
 	require.NoError(t, jsonpb.Unmarshal(jsonFile, obj), fileName)
 }
 
 func getZipkinSpans(t *testing.T, s string) []*z.Span {
+	t.Helper()
 	var zSpans []*z.Span
 	require.NoError(t, json.Unmarshal([]byte(s), &zSpans))
 	return zSpans
 }
 
 func loadJSON(t *testing.T, fileName string, i any) {
+	t.Helper()
 	jsonFile, err := os.Open(fileName)
 	require.NoError(t, err, "Failed to load json fixture file %s", fileName)
 	jsonParser := json.NewDecoder(jsonFile)

--- a/pkg/cassandra/gocql/testutils/udt.go
+++ b/pkg/cassandra/gocql/testutils/udt.go
@@ -31,6 +31,7 @@ type UDTTestCase struct {
 
 // Run runs a test case
 func (testCase UDTTestCase) Run(t *testing.T) {
+	t.Helper()
 	for _, ff := range testCase.Fields {
 		field := ff // capture loop var
 		t.Run(testCase.ObjName+"-"+field.Name, func(t *testing.T) {

--- a/pkg/clientcfg/clientcfghttp/handler_test.go
+++ b/pkg/clientcfg/clientcfghttp/handler_test.go
@@ -85,6 +85,7 @@ func TestHTTPHandlerWithBasePath(t *testing.T) {
 }
 
 func testGorillaHTTPHandler(t *testing.T, basePath string) {
+	t.Helper()
 	withServer(basePath, rateLimiting(42), restrictions("luggage", 10), true, func(ts *testServer) {
 		tests := []struct {
 			endpoint  string
@@ -148,6 +149,7 @@ func testGorillaHTTPHandler(t *testing.T, basePath string) {
 }
 
 func testHTTPHandler(t *testing.T, basePath string) {
+	t.Helper()
 	withServer(basePath, rateLimiting(42), restrictions("luggage", 10), false, func(ts *testServer) {
 		tests := []struct {
 			endpoint  string

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -30,6 +30,7 @@ const (
 )
 
 func copyToTempFile(t *testing.T, pattern string, filename string) (file *os.File, closeFn func()) {
+	t.Helper()
 	tempFile, err := os.CreateTemp("", pattern+"_")
 	require.NoError(t, err)
 
@@ -47,6 +48,7 @@ func copyToTempFile(t *testing.T, pattern string, filename string) (file *os.Fil
 }
 
 func copyFile(t *testing.T, dest string, src string) {
+	t.Helper()
 	certData, err := os.ReadFile(src)
 	require.NoError(t, err)
 	err = syncWrite(dest, certData, 0o644)
@@ -341,6 +343,7 @@ func assertLogs(t *testing.T,
 	logMsg string,
 	fields [][2]string,
 ) {
+	t.Helper()
 	errMsg := "Expecting log '" + logMsg + "'"
 	for _, field := range fields {
 		errMsg = errMsg + " " + field[0] + "=" + field[1]

--- a/pkg/discovery/grpcresolver/grpc_resolver_test.go
+++ b/pkg/discovery/grpcresolver/grpc_resolver_test.go
@@ -53,6 +53,7 @@ func (d erroredDiscoverer) Instances() ([]string, error) {
 }
 
 func startTestServers(t *testing.T, count int) *test {
+	t.Helper()
 	testInstance := &test{}
 	for i := 0; i < count; i++ {
 		lis, err := net.Listen("tcp", "localhost:0")
@@ -71,6 +72,7 @@ func startTestServers(t *testing.T, count int) *test {
 }
 
 func makeSureConnectionsUp(t *testing.T, count int, testc grpc_testing.TestServiceClient) {
+	t.Helper()
 	var p peer.Peer
 	addrs := make(map[string]struct{})
 	// Make sure connections to all servers are up.
@@ -96,6 +98,7 @@ func makeSureConnectionsUp(t *testing.T, count int, testc grpc_testing.TestServi
 }
 
 func assertRoundRobinCall(t *testing.T, connections int, testc grpc_testing.TestServiceClient) {
+	t.Helper()
 	addrs := make(map[string]struct{})
 	var p peer.Peer
 	for i := 0; i < connections; i++ {

--- a/pkg/es/config/config_test.go
+++ b/pkg/es/config/config_test.go
@@ -56,6 +56,7 @@ var mockEsServerResponseWithVersion8 = []byte(`
 `)
 
 func copyToTempFile(t *testing.T, pattern string, filename string) (file *os.File) {
+	t.Helper()
 	tempDir := t.TempDir()
 	tempFilePath := tempDir + "/" + pattern
 	tempFile, err := os.Create(tempFilePath)

--- a/pkg/fswatcher/fswatcher_test.go
+++ b/pkg/fswatcher/fswatcher_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func createTestFiles(t *testing.T) (file1 string, file2 string, file3 string) {
+	t.Helper()
 	testDir1 := t.TempDir()
 
 	file1 = filepath.Join(testDir1, "test1.doc")
@@ -222,6 +223,7 @@ func (df delayedFormat) String() string {
 }
 
 func assertLogs(t *testing.T, f func() bool, errorMsg string, logObserver *observer.ObservedLogs) {
+	t.Helper()
 	assert.Eventuallyf(t, f,
 		10*time.Second, 10*time.Millisecond,
 		errorMsg,

--- a/pkg/healthcheck/internal_test.go
+++ b/pkg/healthcheck/internal_test.go
@@ -52,6 +52,7 @@ func TestHttpCall(t *testing.T) {
 }
 
 func parseHealthCheckResponse(t *testing.T, resp *http.Response) healthCheckResponse {
+	t.Helper()
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	var hr healthCheckResponse

--- a/pkg/kafka/auth/config_test.go
+++ b/pkg/kafka/auth/config_test.go
@@ -77,7 +77,8 @@ func Test_InitFromViper(t *testing.T) {
 }
 
 // Test plaintext with different mechanisms
-func testPlaintext(v *viper.Viper, t *testing.T, configPrefix string, logger *zap.Logger, mechanism string, saramaConfig *sarama.Config) {
+func testPlaintext(t *testing.T, v *viper.Viper, configPrefix string, logger *zap.Logger, mechanism string, saramaConfig *sarama.Config) {
+	t.Helper()
 	v.Set(configPrefix+plainTextPrefix+suffixPlainTextMechanism, mechanism)
 	authConfig := &AuthenticationConfig{}
 	err := authConfig.InitFromViper(configPrefix, v)
@@ -159,7 +160,7 @@ func TestSetConfiguration(t *testing.T) {
 
 			if len(tt.plainTextMechanisms) > 0 {
 				for _, mechanism := range tt.plainTextMechanisms {
-					testPlaintext(v, t, configPrefix, logger, mechanism, saramaConfig)
+					testPlaintext(t, v, configPrefix, logger, mechanism, saramaConfig)
 				}
 			} else {
 				err = authConfig.SetConfiguration(saramaConfig, logger)

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -24,6 +24,7 @@ import (
 // We want to test the overflow behavior, so we block the consumer
 // by holding a startLock before submitting items to the queue.
 func helper(t *testing.T, startConsumers func(q *BoundedQueue, consumerFn func(item any))) {
+	t.Helper()
 	mFact := metricstest.NewFactory(0)
 	counter := mFact.Counter(metrics.Options{Name: "dropped", Tags: nil})
 	gauge := mFact.Gauge(metrics.Options{Name: "size", Tags: nil})
@@ -121,6 +122,7 @@ type consumerState struct {
 }
 
 func newConsumerState(t *testing.T) *consumerState {
+	t.Helper()
 	return &consumerState{
 		t:        t,
 		consumed: make(map[string]bool),

--- a/pkg/testutils/leakcheck.go
+++ b/pkg/testutils/leakcheck.go
@@ -36,5 +36,6 @@ func VerifyGoLeaks(m *testing.M) {
 //
 //	defer testutils.VerifyGoLeaksOnce(t)
 func VerifyGoLeaksOnce(t *testing.T) {
+	t.Helper()
 	goleak.VerifyNone(t, IgnoreGlogFlushDaemonLeak(), IgnoreOpenCensusWorkerLeak())
 }

--- a/pkg/testutils/logger.go
+++ b/pkg/testutils/logger.go
@@ -37,6 +37,7 @@ func newRecordingCore() (zapcore.Core, *Buffer) {
 
 // NewEchoLogger is similar to NewLogger, but the logs are also echoed to t.Log.
 func NewEchoLogger(t *testing.T) (*zap.Logger, *Buffer) {
+	t.Helper()
 	core, buf := newRecordingCore()
 	echo := zaptest.NewLogger(t).Core()
 	logger := zap.New(zapcore.NewTee(core, echo))

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -55,6 +55,7 @@ var defaultConfig = config.Configuration{
 }
 
 func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExporter, func()) {
+	t.Helper()
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
@@ -713,6 +714,7 @@ type fakePromServer struct {
 }
 
 func newFakePromServer(t *testing.T) *fakePromServer {
+	t.Helper()
 	s := &fakePromServer{}
 	s.Server = httptest.NewServer(
 		http.HandlerFunc(
@@ -869,6 +871,7 @@ func TestInvalidCertFile(t *testing.T) {
 }
 
 func startMockPrometheusServer(t *testing.T, wantPromQlQuery string, wantWarnings []string) *httptest.Server {
+	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(wantWarnings) > 0 {
 			sendResponse(t, w, "testdata/warning_response.json")
@@ -894,6 +897,7 @@ func startMockPrometheusServer(t *testing.T, wantPromQlQuery string, wantWarning
 }
 
 func sendResponse(t *testing.T, w http.ResponseWriter, responseFile string) {
+	t.Helper()
 	bytes, err := os.ReadFile(responseFile)
 	require.NoError(t, err)
 
@@ -919,6 +923,7 @@ func buildTestBaseQueryParametersFrom(tc metricsTestCase) metricsstore.BaseQuery
 }
 
 func prepareMetricsReaderAndServer(t *testing.T, config config.Configuration, wantPromQlQuery string, wantWarnings []string, tracer trace.TracerProvider) (metricsstore.Reader, *httptest.Server) {
+	t.Helper()
 	mockPrometheus := startMockPrometheusServer(t, wantPromQlQuery, wantWarnings)
 
 	logger := zap.NewNop()
@@ -934,6 +939,7 @@ func prepareMetricsReaderAndServer(t *testing.T, config config.Configuration, wa
 }
 
 func assertMetrics(t *testing.T, gotMetrics *metrics.MetricFamily, wantLabels map[string]string, wantName, wantDescription string) {
+	t.Helper()
 	assert.Len(t, gotMetrics.Metrics, 1)
 	assert.Equal(t, wantName, gotMetrics.Name)
 	assert.Equal(t, wantDescription, gotMetrics.Help)

--- a/plugin/sampling/strategyprovider/static/provider_test.go
+++ b/plugin/sampling/strategyprovider/static/provider_test.go
@@ -63,6 +63,7 @@ func strategiesJSON(probability float32) string {
 // Returns strategies in JSON format. Used for testing
 // URL option for sampling strategies.
 func mockStrategyServer(t *testing.T) (*httptest.Server, *atomic.Pointer[string]) {
+	t.Helper()
 	var strategy atomic.Pointer[string]
 	value := strategiesJSON(0.8)
 	strategy.Store(&value)

--- a/plugin/storage/badger/dependencystore/storage_test.go
+++ b/plugin/storage/badger/dependencystore/storage_test.go
@@ -23,6 +23,7 @@ import (
 
 // Opens a badger db and runs a test on it.
 func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, dr dependencystore.Reader)) {
+	tb.Helper()
 	f := badger.NewFactory()
 	defer func() {
 		require.NoError(tb, f.Close())

--- a/plugin/storage/badger/samplingstore/storage_test.go
+++ b/plugin/storage/badger/samplingstore/storage_test.go
@@ -22,6 +22,7 @@ func newTestSamplingStore(db *badger.DB) *SamplingStore {
 
 func TestInsertThroughput(t *testing.T) {
 	runWithBadger(t, func(t *testing.T, store *SamplingStore) {
+		t.Helper()
 		throughputs := []*samplemodel.Throughput{
 			{Service: "my-svc", Operation: "op"},
 			{Service: "our-svc", Operation: "op2"},
@@ -33,6 +34,7 @@ func TestInsertThroughput(t *testing.T) {
 
 func TestGetThroughput(t *testing.T) {
 	runWithBadger(t, func(t *testing.T, store *SamplingStore) {
+		t.Helper()
 		start := time.Now()
 		expected := []*samplemodel.Throughput{
 			{Service: "my-svc", Operation: "op"},
@@ -49,6 +51,7 @@ func TestGetThroughput(t *testing.T) {
 
 func TestInsertProbabilitiesAndQPS(t *testing.T) {
 	runWithBadger(t, func(t *testing.T, store *SamplingStore) {
+		t.Helper()
 		err := store.InsertProbabilitiesAndQPS(
 			"dell11eg843d",
 			samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
@@ -60,6 +63,7 @@ func TestInsertProbabilitiesAndQPS(t *testing.T) {
 
 func TestGetLatestProbabilities(t *testing.T) {
 	runWithBadger(t, func(t *testing.T, store *SamplingStore) {
+		t.Helper()
 		err := store.InsertProbabilitiesAndQPS(
 			"dell11eg843d",
 			samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
@@ -114,6 +118,7 @@ func TestDecodeThroughtputValue(t *testing.T) {
 }
 
 func runWithBadger(t *testing.T, test func(t *testing.T, store *SamplingStore)) {
+	t.Helper()
 	opts := badger.DefaultOptions("")
 
 	opts.SyncWrites = false

--- a/plugin/storage/badger/spanstore/cache_test.go
+++ b/plugin/storage/badger/spanstore/cache_test.go
@@ -19,7 +19,8 @@ import (
 */
 
 func TestExpiredItems(t *testing.T) {
-	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+	runWithBadger(t, func(t *testing.T, store *badger.DB) {
+		t.Helper()
 		cache := NewCacheStore(store, time.Duration(-1*time.Hour), false)
 
 		expireTime := uint64(time.Now().Add(cache.ttl).Unix())
@@ -56,7 +57,8 @@ func TestExpiredItems(t *testing.T) {
 }
 
 func TestOldReads(t *testing.T) {
-	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+	runWithBadger(t, func(t *testing.T, store *badger.DB) {
+		t.Helper()
 		timeNow := model.TimeAsEpochMicroseconds(time.Now())
 		s1Key := createIndexKey(serviceNameIndexKey, []byte("service1"), timeNow, model.TraceID{High: 0, Low: 0})
 		s1o1Key := createIndexKey(operationNameIndexKey, []byte("service1operation1"), timeNow, model.TraceID{High: 0, Low: 0})
@@ -95,7 +97,8 @@ func TestOldReads(t *testing.T) {
 }
 
 // func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
-func runWithBadger(t *testing.T, test func(store *badger.DB, t *testing.T)) {
+func runWithBadger(t *testing.T, test func(t *testing.T, store *badger.DB)) {
+	t.Helper()
 	opts := badger.DefaultOptions("")
 
 	opts.SyncWrites = false
@@ -110,5 +113,5 @@ func runWithBadger(t *testing.T, test func(store *badger.DB, t *testing.T)) {
 
 	require.NoError(t, err)
 
-	test(store, t)
+	test(t, store)
 }

--- a/plugin/storage/badger/spanstore/read_write_test.go
+++ b/plugin/storage/badger/spanstore/read_write_test.go
@@ -368,6 +368,7 @@ func TestPersist(t *testing.T) {
 	dir := t.TempDir()
 
 	p := func(t *testing.T, dir string, test func(t *testing.T, sw spanstore.Writer, sr spanstore.Reader)) {
+		t.Helper()
 		f := badger.NewFactory()
 		defer func() {
 			require.NoError(t, f.Close())
@@ -400,6 +401,7 @@ func TestPersist(t *testing.T) {
 	}
 
 	p(t, dir, func(t *testing.T, sw spanstore.Writer, _ spanstore.Reader) {
+		t.Helper()
 		s := model.Span{
 			TraceID: model.TraceID{
 				Low:  uint64(1),
@@ -418,6 +420,7 @@ func TestPersist(t *testing.T) {
 	})
 
 	p(t, dir, func(t *testing.T, _ spanstore.Writer, sr spanstore.Reader) {
+		t.Helper()
 		trace, err := sr.GetTrace(context.Background(), model.TraceID{
 			Low:  uint64(1),
 			High: 1,
@@ -433,6 +436,7 @@ func TestPersist(t *testing.T) {
 
 // Opens a badger db and runs a test on it.
 func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
+	tb.Helper()
 	f := badger.NewFactory()
 	defer func() {
 		require.NoError(tb, f.Close())
@@ -528,6 +532,7 @@ func makeWriteSupports(tagsCount, spans int) ([]model.KeyValue, []string, []stri
 }
 
 func makeReadBenchmark(b *testing.B, _ time.Time, params *spanstore.TraceQueryParameters, outputFile string) {
+	b.Helper()
 	runLargeFactoryTest(b, func(_ testing.TB, sw spanstore.Writer, sr spanstore.Reader) {
 		tid := time.Now()
 
@@ -596,6 +601,7 @@ func BenchmarkServiceIndexLimitFetch(b *testing.B) {
 
 // Opens a badger db and runs a test on it.
 func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
+	tb.Helper()
 	assertion := require.New(tb)
 	f := badger.NewFactory()
 	cfg := badger.DefaultConfig()

--- a/plugin/storage/badger/spanstore/rw_internal_test.go
+++ b/plugin/storage/badger/spanstore/rw_internal_test.go
@@ -20,7 +20,8 @@ import (
 
 func TestEncodingTypes(t *testing.T) {
 	// JSON encoding
-	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+	runWithBadger(t, func(t *testing.T, store *badger.DB) {
+		t.Helper()
 		testSpan := createDummySpan()
 
 		cache := NewCacheStore(store, time.Duration(1*time.Hour), true)
@@ -37,7 +38,8 @@ func TestEncodingTypes(t *testing.T) {
 	})
 
 	// Unknown encoding write
-	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+	runWithBadger(t, func(t *testing.T, store *badger.DB) {
+		t.Helper()
 		testSpan := createDummySpan()
 
 		cache := NewCacheStore(store, time.Duration(1*time.Hour), true)
@@ -50,7 +52,8 @@ func TestEncodingTypes(t *testing.T) {
 	})
 
 	// Unknown encoding reader
-	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+	runWithBadger(t, func(t *testing.T, store *badger.DB) {
+		t.Helper()
 		testSpan := createDummySpan()
 
 		cache := NewCacheStore(store, time.Duration(1*time.Hour), true)
@@ -90,7 +93,8 @@ func TestDecodeErrorReturns(t *testing.T) {
 }
 
 func TestDuplicateTraceIDDetection(t *testing.T) {
-	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+	runWithBadger(t, func(t *testing.T, store *badger.DB) {
+		t.Helper()
 		testSpan := createDummySpan()
 		cache := NewCacheStore(store, time.Duration(1*time.Hour), true)
 		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour))

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -235,6 +235,7 @@ func TestFailingFromDBSpanBadRefs(t *testing.T) {
 }
 
 func failingDBSpanTransform(t *testing.T, dbSpan *Span, errMsg string) {
+	t.Helper()
 	jSpan, err := ToDomain(dbSpan)
 	assert.Nil(t, jSpan)
 	require.Error(t, err)

--- a/plugin/storage/cassandra/spanstore/dbmodel/tag_filter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/tag_filter_test.go
@@ -60,6 +60,7 @@ func TestChainedTagFilter(t *testing.T) {
 }
 
 func compareTags(t *testing.T, expected, actual model.KeyValues) {
+	t.Helper()
 	if !assert.EqualValues(t, expected, actual) {
 		for _, diff := range pretty.Diff(expected, actual) {
 			t.Log(diff)

--- a/plugin/storage/cassandra/spanstore/operation_names_test.go
+++ b/plugin/storage/cassandra/spanstore/operation_names_test.go
@@ -36,6 +36,7 @@ func withOperationNamesStorage(t *testing.T,
 	schemaVersion schemaVersion,
 	fn func(s *operationNameStorageTest),
 ) {
+	t.Helper()
 	session := &mocks.Session{}
 	logger, logBuffer := testutils.NewLogger()
 	metricsFactory := metricstest.NewFactory(0)

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -37,6 +37,7 @@ type spanReaderTest struct {
 }
 
 func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExporter, func()) {
+	t.Helper()
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
@@ -49,6 +50,7 @@ func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExpo
 }
 
 func withSpanReader(t *testing.T, fn func(r *spanReaderTest)) {
+	t.Helper()
 	session := &mocks.Session{}
 	query := &mocks.Query{}
 	session.On("Query",

--- a/plugin/storage/cassandra/spanstore/writer_test.go
+++ b/plugin/storage/cassandra/spanstore/writer_test.go
@@ -35,6 +35,7 @@ type spanWriterTest struct {
 
 func withSpanWriter(t *testing.T, writeCacheTTL time.Duration, fn func(w *spanWriterTest), options ...Option,
 ) {
+	t.Helper()
 	session := &mocks.Session{}
 	query := &mocks.Query{}
 	session.On("Query",

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -342,6 +342,7 @@ func TestPasswordFromFile(t *testing.T) {
 }
 
 func testPasswordFromFile(t *testing.T, f *Factory, getClient func() es.Client, getWriter func() (spanstore.Writer, error)) {
+	t.Helper()
 	const (
 		pwd1 = "first password"
 		pwd2 = "second password"

--- a/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/from_domain_test.go
@@ -43,6 +43,7 @@ func TestFromDomainEmbedProcess(t *testing.T) {
 
 // Loads and returns domain model and JSON model fixtures with given number i.
 func loadFixtures(t *testing.T, i int) ([]byte, []byte) {
+	t.Helper()
 	in := fmt.Sprintf("fixtures/domain_%02d.json", i)
 	inStr, err := os.ReadFile(in)
 	require.NoError(t, err)
@@ -53,6 +54,7 @@ func loadFixtures(t *testing.T, i int) ([]byte, []byte) {
 }
 
 func testJSONEncoding(t *testing.T, i int, expectedStr []byte, object any) {
+	t.Helper()
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetIndent("", "  ")

--- a/plugin/storage/es/spanstore/dbmodel/json_span_compare_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/json_span_compare_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func CompareJSONSpans(t *testing.T, expected *Span, actual *Span) {
+	t.Helper()
 	sortJSONSpan(expected)
 	sortJSONSpan(actual)
 

--- a/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
@@ -28,6 +28,7 @@ func TestToDomain(t *testing.T) {
 }
 
 func testToDomain(t *testing.T, testParentSpanID bool) {
+	t.Helper()
 	for i := 1; i <= NumberOfFixtures; i++ {
 		span, err := loadESSpanFixture(i)
 		require.NoError(t, err)
@@ -60,12 +61,14 @@ func loadESSpanFixture(i int) (Span, error) {
 }
 
 func failingSpanTransform(t *testing.T, embeddedSpan *Span, errMsg string) {
+	t.Helper()
 	domainSpan, err := NewToDomain(":").SpanToDomain(embeddedSpan)
 	assert.Nil(t, domainSpan)
 	require.EqualError(t, err, errMsg)
 }
 
 func failingSpanTransformAnyMsg(t *testing.T, embeddedSpan *Span) {
+	t.Helper()
 	domainSpan, err := NewToDomain(":").SpanToDomain(embeddedSpan)
 	assert.Nil(t, domainSpan)
 	require.Error(t, err)
@@ -286,6 +289,7 @@ func TestFailureBadProcessFieldTag(t *testing.T) {
 }
 
 func CompareModelSpans(t *testing.T, expected *model.Span, actual *model.Span) {
+	t.Helper()
 	model.SortSpan(expected)
 	model.SortSpan(actual)
 

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -85,6 +85,7 @@ type spanReaderTest struct {
 }
 
 func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExporter, func()) {
+	t.Helper()
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
@@ -97,6 +98,7 @@ func tracerProvider(t *testing.T) (trace.TracerProvider, *tracetest.InMemoryExpo
 }
 
 func withSpanReader(t *testing.T, fn func(r *spanReaderTest)) {
+	t.Helper()
 	client := &mocks.Client{}
 	tracer, exp, closer := tracerProvider(t)
 	defer closer()
@@ -119,6 +121,7 @@ func withSpanReader(t *testing.T, fn func(r *spanReaderTest)) {
 }
 
 func withArchiveSpanReader(t *testing.T, readAlias bool, fn func(r *spanReaderTest)) {
+	t.Helper()
 	client := &mocks.Client{}
 	tracer, exp, closer := tracerProvider(t)
 	defer closer()
@@ -622,7 +625,8 @@ func TestSpanReader_indexWithDate(t *testing.T) {
 	})
 }
 
-func testGet(typ string, t *testing.T) {
+func testGet(t *testing.T, typ string) {
+	t.Helper()
 	goodAggregations := make(map[string]*json.RawMessage)
 	rawMessage := []byte(`{"buckets": [{"key": "123","doc_count": 16}]}`)
 	goodAggregations[typ] = (*json.RawMessage)(&rawMessage)
@@ -965,7 +969,7 @@ func TestFindTraceIDs(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.aggregrationID, func(t *testing.T) {
-			testGet(testCase.aggregrationID, t)
+			testGet(t, testCase.aggregrationID)
 		})
 	}
 }

--- a/plugin/storage/es/spanstore/service_operation_test.go
+++ b/plugin/storage/es/spanstore/service_operation_test.go
@@ -82,11 +82,11 @@ func TestWriteServiceError(*testing.T) {
 }
 
 func TestSpanReader_GetServices(t *testing.T) {
-	testGet(servicesAggregation, t)
+	testGet(t, servicesAggregation)
 }
 
 func TestSpanReader_GetOperations(t *testing.T) {
-	testGet(operationsAggregation, t)
+	testGet(t, operationsAggregation)
 }
 
 func TestSpanReader_GetServicesEmptyIndex(t *testing.T) {

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -86,6 +86,7 @@ func makeMockServices() *ClientPluginServices {
 }
 
 func makeFactory(t *testing.T) *Factory {
+	t.Helper()
 	f := NewFactory()
 	f.InitFromViper(viper.New(), zap.NewNop())
 	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))

--- a/plugin/storage/integration/badgerstore_test.go
+++ b/plugin/storage/integration/badgerstore_test.go
@@ -21,6 +21,7 @@ type BadgerIntegrationStorage struct {
 }
 
 func (s *BadgerIntegrationStorage) initialize(t *testing.T) {
+	t.Helper()
 	s.factory = badger.NewFactory()
 	s.factory.Config.Ephemeral = false
 
@@ -42,6 +43,7 @@ func (s *BadgerIntegrationStorage) initialize(t *testing.T) {
 }
 
 func (s *BadgerIntegrationStorage) cleanUp(t *testing.T) {
+	t.Helper()
 	require.NoError(t, s.factory.Purge(context.Background()))
 }
 

--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -37,10 +37,12 @@ func newCassandraStorageIntegration() *CassandraStorageIntegration {
 }
 
 func (s *CassandraStorageIntegration) cleanUp(t *testing.T) {
+	t.Helper()
 	require.NoError(t, s.factory.Purge(context.Background()))
 }
 
 func (*CassandraStorageIntegration) initializeCassandraFactory(t *testing.T, flags []string) *cassandra.Factory {
+	t.Helper()
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	f := cassandra.NewFactory()
 	v, command := config.Viperize(f.AddFlags)
@@ -51,6 +53,7 @@ func (*CassandraStorageIntegration) initializeCassandraFactory(t *testing.T, fla
 }
 
 func (s *CassandraStorageIntegration) initializeCassandra(t *testing.T) {
+	t.Helper()
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_USERNAME")
 	f := s.initializeCassandraFactory(t, []string{
@@ -84,6 +87,7 @@ func (s *CassandraStorageIntegration) initializeCassandra(t *testing.T) {
 }
 
 func (s *CassandraStorageIntegration) initializeDependencyReaderAndWriter(t *testing.T, f *cassandra.Factory) {
+	t.Helper()
 	var (
 		err error
 		ok  bool

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -72,6 +72,7 @@ func (s *ESStorageIntegration) getVersion() (uint, error) {
 }
 
 func (s *ESStorageIntegration) initializeES(t *testing.T, allTagsAsFields bool) {
+	t.Helper()
 	rawClient, err := elastic.NewClient(
 		elastic.SetURL(queryURL),
 		elastic.SetSniff(false))
@@ -87,16 +88,19 @@ func (s *ESStorageIntegration) initializeES(t *testing.T, allTagsAsFields bool) 
 	s.initSpanstore(t, allTagsAsFields)
 
 	s.CleanUp = func(t *testing.T) {
+		t.Helper()
 		s.esCleanUp(t)
 	}
 	s.esCleanUp(t)
 }
 
 func (s *ESStorageIntegration) esCleanUp(t *testing.T) {
+	t.Helper()
 	require.NoError(t, s.factory.Purge(context.Background()))
 }
 
 func (*ESStorageIntegration) initializeESFactory(t *testing.T, allTagsAsFields bool) *es.Factory {
+	t.Helper()
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	f := es.NewFactory()
 	v, command := config.Viperize(f.AddFlags)
@@ -124,6 +128,7 @@ func (*ESStorageIntegration) initializeESFactory(t *testing.T, allTagsAsFields b
 }
 
 func (s *ESStorageIntegration) initSpanstore(t *testing.T, allTagsAsFields bool) {
+	t.Helper()
 	f := s.initializeESFactory(t, allTagsAsFields)
 	s.factory = f
 	var err error
@@ -155,6 +160,7 @@ func healthCheck() error {
 }
 
 func testElasticsearchStorage(t *testing.T, allTagsAsFields bool) {
+	t.Helper()
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")
 	if err := healthCheck(); err != nil {
 		t.Fatal(err)
@@ -209,6 +215,7 @@ func TestElasticsearchStorage_IndexTemplates(t *testing.T) {
 }
 
 func (s *ESStorageIntegration) cleanESIndexTemplates(t *testing.T, prefix string) error {
+	t.Helper()
 	version, err := s.getVersion()
 	require.NoError(t, err)
 	if version > 7 {

--- a/plugin/storage/integration/es_index_cleaner_test.go
+++ b/plugin/storage/integration/es_index_cleaner_test.go
@@ -133,6 +133,7 @@ func TestIndexCleaner(t *testing.T) {
 }
 
 func runIndexCleanerTest(t *testing.T, client *elastic.Client, v8Client *elasticsearch8.Client, prefix string, expectedIndices, envVars []string, adaptiveSampling bool) {
+	t.Helper()
 	// make sure ES is clean
 	_, err := client.DeleteIndex("*").Do(context.Background())
 	require.NoError(t, err)
@@ -237,6 +238,7 @@ func createESV8Client() (*elasticsearch8.Client, error) {
 }
 
 func cleanESIndexTemplates(t *testing.T, client *elastic.Client, v8Client *elasticsearch8.Client, prefix string) {
+	t.Helper()
 	s := &ESStorageIntegration{
 		client:   client,
 		v8Client: v8Client,

--- a/plugin/storage/integration/es_index_rollover_test.go
+++ b/plugin/storage/integration/es_index_rollover_test.go
@@ -47,6 +47,7 @@ func TestIndexRollover_CreateIndicesWithILM(t *testing.T) {
 }
 
 func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
+	t.Helper()
 	client, err := createESClient()
 	require.NoError(t, err)
 	esVersion, err := getVersion(client)
@@ -75,6 +76,7 @@ func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 }
 
 func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, prefix string, expectedIndices, envVars []string, ilmPolicyName string, adaptiveSampling bool) {
+	t.Helper()
 	writeAliases := []string{"jaeger-service-write", "jaeger-span-write", "jaeger-dependencies-write"}
 	if adaptiveSampling {
 		writeAliases = append(writeAliases, "jaeger-sampling-write")
@@ -140,6 +142,7 @@ func createILMPolicy(client *elastic.Client, policyName string) error {
 }
 
 func cleanES(t *testing.T, client *elastic.Client, policyName string) {
+	t.Helper()
 	_, err := client.DeleteIndex("*").Do(context.Background())
 	require.NoError(t, err)
 	esVersion, err := getVersion(client)

--- a/plugin/storage/integration/grpc_test.go
+++ b/plugin/storage/integration/grpc_test.go
@@ -24,6 +24,7 @@ type GRPCStorageIntegrationTestSuite struct {
 }
 
 func (s *GRPCStorageIntegrationTestSuite) initialize(t *testing.T) {
+	t.Helper()
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	s.remoteStorage = StartNewRemoteMemoryStorage(t)
 
@@ -50,11 +51,13 @@ func (s *GRPCStorageIntegrationTestSuite) initialize(t *testing.T) {
 }
 
 func (s *GRPCStorageIntegrationTestSuite) close(t *testing.T) {
+	t.Helper()
 	require.NoError(t, s.factory.Close())
 	s.remoteStorage.Close(t)
 }
 
 func (s *GRPCStorageIntegrationTestSuite) cleanUp(t *testing.T) {
+	t.Helper()
 	s.close(t)
 	s.initialize(t)
 }

--- a/plugin/storage/integration/kafka_test.go
+++ b/plugin/storage/integration/kafka_test.go
@@ -32,6 +32,7 @@ type KafkaIntegrationTestSuite struct {
 }
 
 func (s *KafkaIntegrationTestSuite) initialize(t *testing.T) {
+	t.Helper()
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	const encoding = "json"
 	const groupID = "kafka-integration-test"

--- a/plugin/storage/integration/remote_memory_storage.go
+++ b/plugin/storage/integration/remote_memory_storage.go
@@ -32,6 +32,7 @@ type RemoteMemoryStorage struct {
 }
 
 func StartNewRemoteMemoryStorage(t *testing.T) *RemoteMemoryStorage {
+	t.Helper()
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	opts := &app.Options{
 		GRPCHostPort: ports.PortToHostPort(ports.RemoteStorageGRPC),
@@ -83,6 +84,7 @@ func StartNewRemoteMemoryStorage(t *testing.T) *RemoteMemoryStorage {
 }
 
 func (s *RemoteMemoryStorage) Close(t *testing.T) {
+	t.Helper()
 	require.NoError(t, s.server.Close())
 	require.NoError(t, s.storageFactory.Close())
 }

--- a/plugin/storage/integration/trace_compare.go
+++ b/plugin/storage/integration/trace_compare.go
@@ -16,6 +16,7 @@ import (
 
 // CompareSliceOfTraces compares two trace slices
 func CompareSliceOfTraces(t *testing.T, expected []*model.Trace, actual []*model.Trace) {
+	t.Helper()
 	require.Equal(t, len(expected), len(actual), "Unequal number of expected vs. actual traces")
 	model.SortTraces(expected)
 	model.SortTraces(actual)
@@ -52,6 +53,7 @@ func dedupeSpans(trace *model.Trace) {
 
 // CompareTraces compares two traces
 func CompareTraces(t *testing.T, expected *model.Trace, actual *model.Trace) {
+	t.Helper()
 	if expected.Spans == nil {
 		require.Nil(t, actual.Spans)
 		return
@@ -82,6 +84,7 @@ func CompareTraces(t *testing.T, expected *model.Trace, actual *model.Trace) {
 }
 
 func checkSize(t *testing.T, expected *model.Trace, actual *model.Trace) {
+	t.Helper()
 	require.Equal(t, len(expected.Spans), len(actual.Spans))
 	for i := range expected.Spans {
 		expectedSpan := expected.Spans[i]

--- a/plugin/storage/kafka/marshalling_test.go
+++ b/plugin/storage/kafka/marshalling_test.go
@@ -23,6 +23,7 @@ func TestJSONMarshallerAndUnmarshaller(t *testing.T) {
 }
 
 func testMarshallerAndUnmarshaller(t *testing.T, marshaller Marshaller, unmarshaller Unmarshaller) {
+	t.Helper()
 	bytes, err := marshaller.Marshal(sampleSpan)
 
 	require.NoError(t, err)

--- a/plugin/storage/kafka/writer_test.go
+++ b/plugin/storage/kafka/writer_test.go
@@ -65,6 +65,7 @@ type spanWriterTest struct {
 var _ spanstore.Writer = &SpanWriter{}
 
 func withSpanWriter(t *testing.T, fn func(span *model.Span, w *spanWriterTest)) {
+	t.Helper()
 	serviceMetrics := metricstest.NewFactory(100 * time.Millisecond)
 	defer serviceMetrics.Stop()
 	saramaConfig := sarama.NewConfig()

--- a/storage/metricsstore/metrics/decorator_test.go
+++ b/storage/metricsstore/metrics/decorator_test.go
@@ -77,6 +77,7 @@ func checkExpectedExistingAndNonExistentCounters(t *testing.T,
 	existingKeys,
 	nonExistentKeys []string,
 ) {
+	t.Helper()
 	for k, v := range expectedCounters {
 		assert.EqualValues(t, v, actualCounters[k], k)
 	}

--- a/storage/spanstore/metrics/decorator_test.go
+++ b/storage/spanstore/metrics/decorator_test.go
@@ -70,6 +70,7 @@ func checkExpectedExistingAndNonExistentCounters(t *testing.T,
 	existingKeys,
 	nonExistentKeys []string,
 ) {
+	t.Helper()
 	for k, v := range expectedCounters {
 		assert.EqualValues(t, v, actualCounters[k], k)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- [Thelper](https://golangci-lint.run/usage/linters/#thelper) detects tests helpers which is not start with t.Helper() method.

## Description of the changes
- Add Thelper linter to golangci-lint and fix issues

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
