### PR TITLE
[chore][docs] Add documentation to ElasticSearch configuration

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -155,6 +155,7 @@ type Sniffing struct {
 	// Enabled, if set to true, enables sniffing for the ElasticSearch client.
 	Enabled bool `mapstructure:"enabled"`
 	// UseHTTPS, if set to true, sets the HTTP scheme to HTTPS when performing sniffing.
+	// For ESV8, the scheme is set to HTTPS by default, so this configuration is ignored.
 	UseHTTPS bool `mapstructure:"use_https"`
 }
 
@@ -188,6 +189,8 @@ type BasicAuthentication struct {
 // when making HTTP requests. Note that TokenFilePath and AllowTokenFromContext
 // should not both be enabled. If both TokenFilePath and AllowTokenFromContext are set,
 // the TokenFilePath will be ignored.
+// For more information about token-based authentication in elasticsearch, check out
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/token-authentication-services.html.
 type BearerTokenAuthentication struct {
 	// FilePath contains the path to a file containing a bearer token.
 	FilePath string `mapstructure:"file_path"`


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6059

## Description of the changes
- Added some remaining documentation to the ElasticSearch configuration that was left over from #6090

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
