### PR TITLE
feat: automatically publish readme to docker hub

### DIFF
--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -26,6 +26,7 @@ local_test_only='N'
 platforms="linux/amd64"
 namespace="jaegertracing"
 overwrite='N'
+upload_success='N'
 
 while getopts "bc:d:f:hlop:t:" opt; do
 	# shellcheck disable=SC2220 # we don't need a *) case
@@ -107,7 +108,7 @@ else
 	    if [[ "$overwrite" == 'N' ]]; then
 	      check_overwrite "${IMAGE_TAGS[@]}"
 	    fi
-	    bash scripts/upload-docker-readme.sh "${component_name}" "${dir_arg}"/README.md
+	    upload_success='Y'
     else
 	    echo 'skipping docker images upload, because not on tagged release or main branch'
 	    PUSHTAG="type=image,push=false"
@@ -127,6 +128,10 @@ docker buildx build --output "${PUSHTAG}" ${target_arg} ${base_debug_img_arg} \
 	"${dir_arg}"
 echo "::endgroup::"
 echo "Finished building${upload_comment} ${component_name} =============="
+
+if [[ "$upload_success" == "Y" ]]; then
+  bash scripts/upload-docker-readme.sh "${component_name}" "${dir_arg}"/README.md
+fi
 
 echo "::group:: docker prune"
 df -h /

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -26,7 +26,7 @@ local_test_only='N'
 platforms="linux/amd64"
 namespace="jaegertracing"
 overwrite='N'
-upload_success='N'
+upload_readme='N'
 
 while getopts "bc:d:f:hlop:t:" opt; do
 	# shellcheck disable=SC2220 # we don't need a *) case
@@ -108,7 +108,7 @@ else
 	    if [[ "$overwrite" == 'N' ]]; then
 	      check_overwrite "${IMAGE_TAGS[@]}"
 	    fi
-	    upload_success='Y'
+	    upload_readme='Y'
     else
 	    echo 'skipping docker images upload, because not on tagged release or main branch'
 	    PUSHTAG="type=image,push=false"
@@ -129,9 +129,11 @@ docker buildx build --output "${PUSHTAG}" ${target_arg} ${base_debug_img_arg} \
 echo "::endgroup::"
 echo "Finished building${upload_comment} ${component_name} =============="
 
-if [[ "$upload_success" == "Y" ]]; then
+echo "::group:: docker upload ${dir_arg}/README.md"
+if [[ "$upload_readme" == "Y" ]]; then
   bash scripts/upload-docker-readme.sh "${component_name}" "${dir_arg}"/README.md
 fi
+echo "::endgroup::"
 
 echo "::group:: docker prune"
 df -h /

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -107,6 +107,7 @@ else
 	    if [[ "$overwrite" == 'N' ]]; then
 	      check_overwrite "${IMAGE_TAGS[@]}"
 	    fi
+	    bash scripts/upload-docker-readme.sh ${component_name} ${dir_arg}/README.md
     else
 	    echo 'skipping docker images upload, because not on tagged release or main branch'
 	    PUSHTAG="type=image,push=false"

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -107,7 +107,7 @@ else
 	    if [[ "$overwrite" == 'N' ]]; then
 	      check_overwrite "${IMAGE_TAGS[@]}"
 	    fi
-	    bash scripts/upload-docker-readme.sh ${component_name} ${dir_arg}/README.md
+	    bash scripts/upload-docker-readme.sh "${component_name}" "${dir_arg}"/README.md
     else
 	    echo 'skipping docker images upload, because not on tagged release or main branch'
 	    PUSHTAG="type=image,push=false"

--- a/scripts/build-upload-a-docker-image.sh
+++ b/scripts/build-upload-a-docker-image.sh
@@ -129,11 +129,11 @@ docker buildx build --output "${PUSHTAG}" ${target_arg} ${base_debug_img_arg} \
 echo "::endgroup::"
 echo "Finished building${upload_comment} ${component_name} =============="
 
-echo "::group:: docker upload ${dir_arg}/README.md"
 if [[ "$upload_readme" == "Y" ]]; then
+  echo "::group:: docker upload ${dir_arg}/README.md"
   bash scripts/upload-docker-readme.sh "${component_name}" "${dir_arg}"/README.md
+  echo "::endgroup::"
 fi
-echo "::endgroup::"
 
 echo "::group:: docker prune"
 df -h /

--- a/scripts/upload-docker-readme.sh
+++ b/scripts/upload-docker-readme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 # Copyright (c) 2024 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
+
 set -euxf -o pipefail
 
 usage() {
@@ -26,7 +26,7 @@ dockerhub_url="https://hub.docker.com/v2/repositories/$repository/"
 quay_url="https://quay.io/api/v1/repository/${repository}"
 
 if [ ! -f "$abs_readme_path" ]; then
-  echo "Warning: the dedicated README file for Docker image $repo was not found at path $abs_readme_path"
+  echo "❗Warning: no README file found at path $abs_readme_path"
   echo "It is recommended to have a dedicated README file for each Docker image"
   exit 0
 fi
@@ -52,7 +52,7 @@ response_body="${dockerhub_response:0:${#dockerhub_response}-3}"
 if [ "$http_code" -eq 200 ]; then
   echo "Successfully updated Docker Hub README for $repository"
 else
-  echo "Failed to update Docker Hub README for $repository with status code $http_code"
+  echo "🛑 Failed to update Docker Hub README for $repository with status code $http_code"
   echo "Full response: $response_body"
 fi
 

--- a/scripts/upload-docker-readme.sh
+++ b/scripts/upload-docker-readme.sh
@@ -30,9 +30,9 @@ dockerhub_response=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH "$dockerhub
     -H "Authorization: JWT $DOCKERHUB_TOKEN" \
     -d "$body")
 
-dockerhub_status_code=$(echo "$dockerhub_response")
+dockerhub_status_code="$dockerhub_response"
 
-if [ $dockerhub_status_code -eq 200 ]; then
+if [ "$dockerhub_status_code" -eq 200 ]; then
   echo "Successfully updated Docker Hub README for $dockerhub_repository"
 else
   echo "Failed to update Docker Hub README for $dockerhub_repository with status code $dockerhub_status_code"

--- a/scripts/upload-docker-readme.sh
+++ b/scripts/upload-docker-readme.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright (c) 2024 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+set -euxf -o pipefail
+repo="$1"
+readme_path="$2"
+abs_readme_path=$(realpath "$readme_path")
+
+DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:-}
+dockerhub_repository="jaegertracing/$repo"
+dockerhub_url="https://hub.docker.com/v2/repositories/$dockerhub_repository/"
+
+if [ ! -f "$abs_readme_path" ]; then
+  echo "Warning: the dedicated README file for Docker image $repo was not found at path $abs_readme_path"
+  echo "It is recommended to have a dedicated README file for each Docker image"
+  exit 0
+fi
+
+readme_content=$(<"$abs_readme_path")
+
+set +x
+
+body=$(jq -n \
+  --arg full_desc "$readme_content" \
+  '{full_description: $full_desc}')
+
+dockerhub_response=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH "$dockerhub_url" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: JWT $DOCKERHUB_TOKEN" \
+    -d "$body")
+
+dockerhub_status_code=$(echo "$dockerhub_response")
+
+if [ $dockerhub_status_code -eq 200 ]; then
+  echo "Successfully updated Docker Hub README for $dockerhub_repository"
+else
+  echo "Failed to update Docker Hub README for $dockerhub_repository with status code $dockerhub_status_code"
+  echo "Full response: $dockerhub_response"
+fi

--- a/scripts/upload-docker-readme.test.sh
+++ b/scripts/upload-docker-readme.test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) 2024 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Mock variables

--- a/scripts/upload-docker-readme.test.sh
+++ b/scripts/upload-docker-readme.test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Mock variables
+dockerhub_repository="jaegertracing/test-docker"
+http_code=""
+response_body=""
+
+simulate_update() {
+  local status=$1
+  if [ "$status" -eq 200 ]; then
+    http_code=200
+    response_body="Successfully updated README."
+  else
+    http_code="$status"
+    response_body="Error: Unable to update README."
+  fi
+}
+
+# Test 1: Successful update
+echo "Running test: Successful update"
+simulate_update 200
+if [ "$http_code" -eq 200 ]; then
+  echo "Successfully updated Docker Hub README for $dockerhub_repository"
+else
+  echo "Failed to update Docker Hub README for $dockerhub_repository with status code $http_code"
+  echo "Full response: $response_body"
+fi
+
+# Test 2: Failed update
+echo "Running test: Failed update"
+simulate_update 403
+if [ "$http_code" -eq 200 ]; then
+  echo "Successfully updated Docker Hub README for $dockerhub_repository"
+else
+  echo "Failed to update Docker Hub README for $dockerhub_repository with status code $http_code"
+  echo "Full response: $response_body"
+fi


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes: #3842 

## Description of the changes
- Added a shell script that publishes README.md files along with docker images to docker hub

## How was this change tested?
- Locally as well as on fork

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
