### PR TITLE
[fix][query] Correct query server legacy condition

### DIFF
--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -82,7 +82,7 @@ func NewServer(
 	}
 
 	var grpcServer *grpc.Server
-	if separatePorts {
+	if !separatePorts {
 		grpcServer, err = createGRPCServerLegacy(ctx, options, tm)
 	} else {
 		grpcServer, err = createGRPCServerOTEL(ctx, options, tm, telset)


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6026 

## Description of the changes
- Fixes an issue from https://github.com/jaegertracing/jaeger/pull/6055 where the condition for routing to the legacy implementation was accidentally flipped. 

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
