### PR TITLE
[fix][grpc] Disable tracing in grpc storage writer clients

### DIFF
--- a/cmd/jaeger/internal/integration/grpc_test.go
+++ b/cmd/jaeger/internal/integration/grpc_test.go
@@ -4,11 +4,9 @@
 package integration
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/integration"
-	"github.com/jaegertracing/jaeger/ports"
 )
 
 type GRPCStorageIntegration struct {
@@ -32,8 +30,6 @@ func TestGRPCStorage(t *testing.T) {
 	s := &GRPCStorageIntegration{
 		E2EStorageIntegration: E2EStorageIntegration{
 			ConfigFile: "../../config-remote-storage.yaml",
-			// TODO this should be removed in favor of default health check endpoint
-			HealthCheckEndpoint: fmt.Sprintf("http://localhost:%d/", ports.QueryHTTP),
 		},
 	}
 	s.CleanUp = s.cleanUp

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -132,14 +132,19 @@ func (f *Factory) newRemoteStorage(
 
 	baseOpts = append(baseOpts, grpc.WithUnaryInterceptor(bearertoken.NewUnaryClientInterceptor()))
 	baseOpts = append(baseOpts, grpc.WithStreamInterceptor(bearertoken.NewStreamClientInterceptor()))
-	opts := append(baseOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracedTelset.TracerProvider))))
+	opts := make([]grpc.DialOption, len(baseOpts))
+	copy(opts, baseOpts)
+	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracedTelset.TracerProvider))))
+
 	tracedRemoteConn, err := newClient(tracedTelset, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating traced remote storage client: %w", err)
 	}
 	f.tracedRemoteConn = tracedRemoteConn
-	untracedOpts := append(
-		baseOpts,
+	untracedOpts := make([]grpc.DialOption, len(baseOpts))
+	copy(untracedOpts, baseOpts)
+	untracedOpts = append(
+		untracedOpts,
 		grpc.WithStatsHandler(
 			otelgrpc.NewClientHandler(
 				otelgrpc.WithTracerProvider(untracedTelset.TracerProvider))))

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -132,8 +132,7 @@ func (f *Factory) newRemoteStorage(
 
 	baseOpts = append(baseOpts, grpc.WithUnaryInterceptor(bearertoken.NewUnaryClientInterceptor()))
 	baseOpts = append(baseOpts, grpc.WithStreamInterceptor(bearertoken.NewStreamClientInterceptor()))
-	opts := make([]grpc.DialOption, len(baseOpts))
-	copy(opts, baseOpts)
+	opts := append([]grpc.DialOption{}, baseOpts...)
 	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracedTelset.TracerProvider))))
 
 	tracedRemoteConn, err := newClient(tracedTelset, opts...)
@@ -141,8 +140,7 @@ func (f *Factory) newRemoteStorage(
 		return nil, fmt.Errorf("error creating traced remote storage client: %w", err)
 	}
 	f.tracedRemoteConn = tracedRemoteConn
-	untracedOpts := make([]grpc.DialOption, len(baseOpts))
-	copy(untracedOpts, baseOpts)
+	untracedOpts := append([]grpc.DialOption{}, baseOpts...)
 	untracedOpts = append(
 		untracedOpts,
 		grpc.WithStatsHandler(

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -130,7 +130,7 @@ func TestNewFactoryError(t *testing.T) {
 		}
 		_, err = f.newRemoteStorage(component.TelemetrySettings{}, component.TelemetrySettings{}, newClientFn)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "error creating remote storage client")
+		require.Contains(t, err.Error(), "error creating untraced remote storage client")
 	})
 }
 

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -130,7 +130,7 @@ func TestNewFactoryError(t *testing.T) {
 		}
 		_, err = f.newRemoteStorage(component.TelemetrySettings{}, component.TelemetrySettings{}, newClientFn)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "error creating untraced remote storage client")
+		require.Contains(t, err.Error(), "error creating traced remote storage client")
 	})
 }
 

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -125,10 +125,10 @@ func TestNewFactoryError(t *testing.T) {
 		f, err := NewFactoryWithConfig(Config{}, metrics.NullFactory, zap.NewNop(), componenttest.NewNopHost())
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, f.Close()) })
-		newClientFn := func(_ ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
+		newClientFn := func(_ component.TelemetrySettings, _ ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 			return nil, errors.New("test error")
 		}
-		_, err = f.newRemoteStorage(component.TelemetrySettings{}, newClientFn)
+		_, err = f.newRemoteStorage(component.TelemetrySettings{}, component.TelemetrySettings{}, newClientFn)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error creating remote storage client")
 	})

--- a/plugin/storage/grpc/shared/grpc_client.go
+++ b/plugin/storage/grpc/shared/grpc_client.go
@@ -46,15 +46,15 @@ type GRPCClient struct {
 	streamWriterClient  storage_v1.StreamingSpanWriterPluginClient
 }
 
-func NewGRPCClient(c *grpc.ClientConn) *GRPCClient {
+func NewGRPCClient(c *grpc.ClientConn, noTracingConn *grpc.ClientConn) *GRPCClient {
 	return &GRPCClient{
 		readerClient:        storage_v1.NewSpanReaderPluginClient(c),
-		writerClient:        storage_v1.NewSpanWriterPluginClient(c),
+		writerClient:        storage_v1.NewSpanWriterPluginClient(noTracingConn),
 		archiveReaderClient: storage_v1.NewArchiveSpanReaderPluginClient(c),
-		archiveWriterClient: storage_v1.NewArchiveSpanWriterPluginClient(c),
+		archiveWriterClient: storage_v1.NewArchiveSpanWriterPluginClient(noTracingConn),
 		capabilitiesClient:  storage_v1.NewPluginCapabilitiesClient(c),
 		depsReaderClient:    storage_v1.NewDependenciesReaderPluginClient(c),
-		streamWriterClient:  storage_v1.NewStreamingSpanWriterPluginClient(c),
+		streamWriterClient:  storage_v1.NewStreamingSpanWriterPluginClient(noTracingConn),
 	}
 }
 

--- a/plugin/storage/grpc/shared/grpc_client.go
+++ b/plugin/storage/grpc/shared/grpc_client.go
@@ -46,15 +46,15 @@ type GRPCClient struct {
 	streamWriterClient  storage_v1.StreamingSpanWriterPluginClient
 }
 
-func NewGRPCClient(c *grpc.ClientConn, noTracingConn *grpc.ClientConn) *GRPCClient {
+func NewGRPCClient(tracedConn *grpc.ClientConn, untracedConn *grpc.ClientConn) *GRPCClient {
 	return &GRPCClient{
-		readerClient:        storage_v1.NewSpanReaderPluginClient(c),
-		writerClient:        storage_v1.NewSpanWriterPluginClient(noTracingConn),
-		archiveReaderClient: storage_v1.NewArchiveSpanReaderPluginClient(c),
-		archiveWriterClient: storage_v1.NewArchiveSpanWriterPluginClient(noTracingConn),
-		capabilitiesClient:  storage_v1.NewPluginCapabilitiesClient(c),
-		depsReaderClient:    storage_v1.NewDependenciesReaderPluginClient(c),
-		streamWriterClient:  storage_v1.NewStreamingSpanWriterPluginClient(noTracingConn),
+		readerClient:        storage_v1.NewSpanReaderPluginClient(tracedConn),
+		writerClient:        storage_v1.NewSpanWriterPluginClient(untracedConn),
+		archiveReaderClient: storage_v1.NewArchiveSpanReaderPluginClient(tracedConn),
+		archiveWriterClient: storage_v1.NewArchiveSpanWriterPluginClient(untracedConn),
+		capabilitiesClient:  storage_v1.NewPluginCapabilitiesClient(tracedConn),
+		depsReaderClient:    storage_v1.NewDependenciesReaderPluginClient(tracedConn),
+		streamWriterClient:  storage_v1.NewStreamingSpanWriterPluginClient(untracedConn),
 	}
 }
 

--- a/plugin/storage/grpc/shared/grpc_client_test.go
+++ b/plugin/storage/grpc/shared/grpc_client_test.go
@@ -104,7 +104,7 @@ func withGRPCClient(fn func(r *grpcClientTest)) {
 
 func TestNewGRPCClient(t *testing.T) {
 	conn := &grpc.ClientConn{}
-	client := NewGRPCClient(conn)
+	client := NewGRPCClient(conn, conn)
 	assert.NotNil(t, client)
 
 	assert.Implements(t, (*storage_v1.SpanReaderPluginClient)(nil), client.readerClient)


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Fixes #5971 
- Towards #6113 and #5859

## Description of the changes
- This PR fixes an issue where the GRPC remote storage client was provided a tracer which was resulting in an infinite loop of trace generation. This infinite loop would happen when we would try to write a trace to storage which would generate a new trace that needed to be written and so on. This PR provides a fix for this by using a noop tracer for the writer clients so that we do not generate traces on the write paths but still do so when reading. 
- This is likely just a temporary fix and we'll want to monitor https://github.com/open-telemetry/opentelemetry-collector/issues/10663 for a better long-term fix.

## How was this change tested?
- Added the healthcheck endpoint which was previously failing in #6113.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`

## Co-Authors 
This PR is a continuation of https://github.com/jaegertracing/jaeger/pull/5979
Co-authored-by: cx <1249843194@qq.com>
