### PR TITLE
Fix command in v2 example

### DIFF
--- a/examples/hotrod/docker-compose-v2.yml
+++ b/examples/hotrod/docker-compose-v2.yml
@@ -4,7 +4,9 @@
 services:
   jaeger:
     image: ${REGISTRY:-}jaegertracing/jaeger:${JAEGER_VERSION:-latest}
-    command: ["--feature-gates=-component.UseLocalHostAsDefaultHost"]
+    command:
+      - --set=receivers.otlp.protocols.grpc.endpoint="0.0.0.0:4317"
+      - --set=receivers.otlp.protocols.http.endpoint="0.0.0.0:4318"
     ports:
       - "16686:16686"
       - "4317:4317"


### PR DESCRIPTION
## Which problem is this PR solving?
The `component.UseLocalHostAsDefaultHost` gate has been removed from otel collector since v0.112.0. The example failed to start `jaeger` because of the invalid argument.

## Description of the changes
- Remove the invalid command line argument.
- Set endpoints for `otlpreceiver` explicitly.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
