### PR TITLE
[jaeger-v2] Add HotROD integration test for jaeger-v2

### DIFF
--- a/.github/workflows/ci-docker-hotrod.yml
+++ b/.github/workflows/ci-docker-hotrod.yml
@@ -18,6 +18,10 @@ permissions:
 jobs:
   hotrod:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jaeger-version: [v1, v2]
     steps:
     - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
       with:
@@ -53,7 +57,7 @@ jobs:
         esac
 
     - name: Build, test, and publish hotrod image
-      run: bash scripts/build-hotrod-image.sh ${{ env.BUILD_FLAGS }}
+      run: bash scripts/build-hotrod-image.sh ${{ env.BUILD_FLAGS }} -v ${{ matrix.jaeger-version }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/ci-docker-hotrod.yml
+++ b/.github/workflows/ci-docker-hotrod.yml
@@ -21,11 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode:
-        - name: v1
-          binary: all-in-one
-        - name: v2
-          binary: jaeger
+        jaeger-version: [v1, v2]
           
     steps:
     - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -62,7 +58,7 @@ jobs:
         esac
 
     - name: Build, test, and publish hotrod image
-      run: bash scripts/build-hotrod-image.sh ${{ env.BUILD_FLAGS }} -b ${{ matrix.mode.binary }}
+      run: bash scripts/build-hotrod-image.sh ${{ env.BUILD_FLAGS }} -v ${{ matrix.jaeger-version }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/ci-docker-hotrod.yml
+++ b/.github/workflows/ci-docker-hotrod.yml
@@ -21,7 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jaeger-version: [v1, v2]
+        mode:
+        - name: v1
+          binary: all-in-one
+        - name: v2
+          binary: jaeger
+          
     steps:
     - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
       with:
@@ -57,7 +62,7 @@ jobs:
         esac
 
     - name: Build, test, and publish hotrod image
-      run: bash scripts/build-hotrod-image.sh ${{ env.BUILD_FLAGS }} -v ${{ matrix.jaeger-version }}
+      run: bash scripts/build-hotrod-image.sh ${{ env.BUILD_FLAGS }} -b ${{ matrix.mode.binary }}
       env:
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/examples/hotrod/docker-compose-v2.yml
+++ b/examples/hotrod/docker-compose-v2.yml
@@ -4,7 +4,9 @@
 services:
   jaeger:
     image: ${REGISTRY:-}jaegertracing/jaeger:${JAEGER_VERSION:-latest}
-    command: ["--feature-gates=-component.UseLocalHostAsDefaultHost"]
+    command:
+      - --set=receivers.otlp.protocols.grpc.endpoint="0.0.0.0:4317"
+      - --set=receivers.otlp.protocols.http.endpoint="0.0.0.0:4318"
     ports:
       - "16686:16686"
       - "4317:4317"

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -88,11 +88,11 @@ bash scripts/build-upload-a-docker-image.sh -l -c example-hotrod -d examples/hot
 # Build all-in-one (for v1) or jaeger (for v2) image locally (-l) for integration test
 if [[ "$BINARY" == "all-in-one" ]]; then
     # Build all-in-one image for v1
-    make build BINARY="$BINARY"
+    make build-all-in-one
     bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one -d cmd/all-in-one -p "${current_platform}" -t release
 else
     # Build jaeger image for v2
-    make build BINARY="$BINARY"
+    make build-jaeger
     bash scripts/build-upload-a-docker-image.sh -l -b -c jaeger -d cmd/jaeger -p "${current_platform}" -t release
 fi
 

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -86,7 +86,6 @@ done
 bash scripts/build-upload-a-docker-image.sh -l -c example-hotrod -d examples/hotrod -p "${current_platform}"
 
 # Build all-in-one (for v1) or jaeger (for v2) image locally (-l) for integration test
-make build BINARY="$BINARY"
 if [[ "$BINARY" == "all-in-one" ]]; then
     # Build all-in-one image for v1
     make build BINARY="$BINARY"

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -34,9 +34,9 @@ while getopts "hlop:" opt; do
 	p)
 		platforms=${OPTARG}
 		;;
-  v)
-    jaeger_version=${OPTARG}
-    ;;
+	v)
+		jaeger_version=${OPTARG}
+		;;
 	*)
 		print_help
 		;;

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -87,7 +87,15 @@ bash scripts/build-upload-a-docker-image.sh -l -c example-hotrod -d examples/hot
 
 # Build all-in-one (for v1) or jaeger (for v2) image locally (-l) for integration test
 make build BINARY="$BINARY"
-bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one -d cmd/all-in-one -p "${current_platform}" -t release
+if [[ "$BINARY" == "all-in-one" ]]; then
+    # Build all-in-one image for v1
+    make build BINARY="$BINARY"
+    bash scripts/build-upload-a-docker-image.sh -l -b -c all-in-one -d cmd/all-in-one -p "${current_platform}" -t release
+else
+    # Build jaeger image for v2
+    make build BINARY="$BINARY"
+    bash scripts/build-upload-a-docker-image.sh -l -b -c jaeger -d cmd/jaeger -p "${current_platform}" -t release
+fi
 
 echo '::group:: docker compose'
 JAEGER_VERSION=$GITHUB_SHA REGISTRY="localhost:5000/" docker compose -f "$docker_compose_file" up -d

--- a/scripts/build-hotrod-image.sh
+++ b/scripts/build-hotrod-image.sh
@@ -22,7 +22,7 @@ jaeger_version="v1"
 FLAGS=()
 success="false"
 
-while getopts "hlop:" opt; do
+while getopts "hlop:v:" opt; do
 	case "${opt}" in
 	l)
 		# in the local-only mode the images will only be pushed to local registry


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6137 

## Description of the changes
- Currently in `.github/workflows/ci-docker-hotrod.yml`, we are only testing internally via `.scripts/build-hotrod-image.sh` for `examples/hotrod/docker-compose.yml` while `examples/hotrod/docker-compose-v2.yml` isnt getting covered

- For this, in `.github/workflows/ci-docker-hotrod.yml` we are passing `-b` flag to specify the jaeger binary (`all-in-one` or `jaeger`)

## How was this change tested?
- For the flags and normal bash scirpt code i tested it manually in seperate bash file so that atleast ensures the basic code test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
