### PR TITLE
Added Label Validation in SPM Integration Test

### DIFF
--- a/scripts/spm-integration-test.sh
+++ b/scripts/spm-integration-test.sh
@@ -115,16 +115,12 @@ validate_service_metrics() {
      # Validate if labels are correct
     local url="http://localhost:16686/api/metrics/calls?service=${service}&groupByOperation=true&endTs=&lookback=${fiveMinutes}&step=${fifteenSec}&ratePer=${oneMinute}"
 
-    local response=$(curl -s "$url")
-    mapfile -t labels < <(echo "$response" | jq -r '.metrics[0].labels[].name')
+    local labels=$(curl -s $url | jq -r '.metrics[0].labels[].name' | sort | tr '\n' ' ')
+    local exp_labels="operation service_name "
 
-    local exp_labels=("operation" "service_name")
-
-    local diff_labels=($(echo ${labels[@]} ${exp_labels[@]} | tr ' ' '\n' | sort | uniq -u | tr '\n' ' '))
-    
-    if [ ${#diff_labels[@]} -ne 0 ]; then
-        echo "Labels are not same as expected labels: ${exp_labels[@]}"
-        return 1
+    if [[ "$labels" != "$exp_labels" ]]; then
+      echo "❌ ERROR: Obtained labels: '$labels' are not same as expected labels: '$exp_labels'"
+      return 1
     fi
     return 0
 }

--- a/scripts/spm-integration-test.sh
+++ b/scripts/spm-integration-test.sh
@@ -111,6 +111,21 @@ validate_service_metrics() {
       echo "⏳ Expecting at least 4 non-zero data points"
       return 1
     fi
+    
+     # Validate if labels are correct
+    local url="http://localhost:16686/api/metrics/calls?service=${service}&groupByOperation=true&endTs=&lookback=${fiveMinutes}&step=${fifteenSec}&ratePer=${oneMinute}"
+
+    local response=$(curl -s "$url")
+    mapfile -t labels < <(echo "$response" | jq -r '.metrics[0].labels[].name')
+
+    local exp_labels=("operation" "service_name")
+
+    local diff_labels=($(echo ${labels[@]} ${exp_labels[@]} | tr ' ' '\n' | sort | uniq -u | tr '\n' ' '))
+    
+    if [ ${#diff_labels[@]} -ne 0 ]; then
+        echo "Labels are not same as expected labels: ${exp_labels[@]}"
+        return 1
+    fi
     return 0
 }
 

--- a/scripts/spm-integration-test.sh
+++ b/scripts/spm-integration-test.sh
@@ -115,7 +115,8 @@ validate_service_metrics() {
      # Validate if labels are correct
     local url="http://localhost:16686/api/metrics/calls?service=${service}&groupByOperation=true&endTs=&lookback=${fiveMinutes}&step=${fifteenSec}&ratePer=${oneMinute}"
 
-    local labels=$(curl -s $url | jq -r '.metrics[0].labels[].name' | sort | tr '\n' ' ')
+    local labels
+    labels=$(curl -s "$url" | jq -r '.metrics[0].labels[].name' | sort | tr '\n' ' ')
     local exp_labels="operation service_name "
 
     if [[ "$labels" != "$exp_labels" ]]; then


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5608 

## Description of the changes
- The changes include requesting metric with `groupByOperation` to get labels along with `operation`. This is then compared with the expected label set = `"operation service_name"`

## How was this change tested?
- jaeger/scripts/spm-integration-test.sh

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
