### PR TITLE
[spm] Remove Grafana from examples

### DIFF
--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -17,7 +17,6 @@ This environment consists the following backend components:
 - [Jaeger All-in-one](https://www.jaegertracing.io/docs/1.24/getting-started/#all-in-one): the full Jaeger stack in a single container image.
 - [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/): vendor agnostic integration layer for traces and metrics. Its main role in this particular development environment is to receive Jaeger spans, forward these spans untouched to Jaeger All-in-one while simultaneously aggregating metrics out of this span data. To learn more about span metrics aggregation, please refer to the [spanmetrics connector documentation][spanmetricsconnectorreadme].
 - [Prometheus](https://prometheus.io/): a metrics collection and query engine, used to scrape metrics computed by OpenTelemetry Collector, and presents an API for Jaeger All-in-one to query these metrics.
-- [Grafana](https://grafana.com/): a metrics visualization, analytics & monitoring solution supporting multiple metrics databases.
 
 
 The following diagram illustrates the relationship between these components:
@@ -74,16 +73,33 @@ It uses the latest image tags from both Jaeger and OpenTelemetry.
 docker compose up
 ```
 
+**Jaeger v2**
+
+```shell
+docker compose -f docker-compose-v2.yml up
+```
+
 **Tips:**
 - Let the application run for a couple of minutes to ensure there is enough time series data to plot in the dashboard.
 - Navigate to Jaeger UI at http://localhost:16686/ and inspect the Monitor tab. Select `redis` service from the dropdown to see more than one endpoint.
-- To visualize the raw metrics stored on the Prometheus server (for debugging and local development use cases), a Grafana server is included in the docker-compose config, which is preconfigured to read metrics from the Prometheus server.
-  To access Grafana, navigate to http://localhost:3000/, click on the "Explore" and click the "Select metric" dropdown then select `traces_span_metrics_calls_total`, for example.
+- To visualize the raw metrics stored on the Prometheus server (for debugging and local development use cases), use the built-in Prometheus UI at http://localhost:9090/graph. For example, http://localhost:9090/graph?g0.expr=traces_span_metrics_calls_total&g0.tab=0&g0.range_input=5m
 
 **Warning:** The included [docker-compose.yml](./docker-compose.yml) file uses the `latest` version of Jaeger and other components. If your local Docker registry already contains older versions, which may still be tagged as `latest`, you may want to delete those images before running the full set, to ensure consistent behavior:
 
 ```bash
 make clean-all
+```
+
+To use an official published image of Jaeger, specify the version via environment variable:
+
+```shell
+JAEGER_IMAGE_TAG=1.62.0 docker compose up
+```
+
+or for Jaeger v2:
+
+```shell
+JAEGER_IMAGE_TAG=2.0.0-rc2 docker compose -f docker-compose-v2.yml up
 ```
 
 ## Development

--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -78,7 +78,7 @@ docker compose up
 - Let the application run for a couple of minutes to ensure there is enough time series data to plot in the dashboard.
 - Navigate to Jaeger UI at http://localhost:16686/ and inspect the Monitor tab. Select `redis` service from the dropdown to see more than one endpoint.
 - To visualize the raw metrics stored on the Prometheus server (for debugging and local development use cases), a Grafana server is included in the docker-compose config, which is preconfigured to read metrics from the Prometheus server.
-  To access Grafana, navigate to http://localhost:3000/, click on the "Explore" and click the "Select metric" dropdown then select `calls_total`, for example.
+  To access Grafana, navigate to http://localhost:3000/, click on the "Explore" and click the "Select metric" dropdown then select `traces_span_metrics_calls_total`, for example.
 
 **Warning:** The included [docker-compose.yml](./docker-compose.yml) file uses the `latest` version of Jaeger and other components. If your local Docker registry already contains older versions, which may still be tagged as `latest`, you may want to delete those images before running the full set, to ensure consistent behavior:
 

--- a/docker-compose/monitor/docker-compose-v2.yml
+++ b/docker-compose/monitor/docker-compose-v2.yml
@@ -32,19 +32,5 @@ services:
     ports:
       - "9090:9090"
 
-  grafana:
-    networks:
-      - backend
-    image: grafana/grafana:latest
-    volumes:
-      - ./grafana.ini:/etc/grafana/grafana.ini
-      - ./datasource.yml:/etc/grafana/provisioning/datasources/datasource.yaml
-    environment:
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
-    ports:
-      - 3000:3000
-
 networks:
   backend:

--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     environment:
       - METRICS_STORAGE_TYPE=prometheus
       - PROMETHEUS_SERVER_URL=http://prometheus:9090
-      - PROMETHEUS_QUERY_NAMESPACE=${PROMETHEUS_QUERY_NAMESPACE:-}
       - PROMETHEUS_QUERY_DURATION_UNIT=${PROMETHEUS_QUERY_DURATION_UNIT:-}
       - PROMETHEUS_QUERY_NORMALIZE_CALLS=true
       - PROMETHEUS_QUERY_NORMALIZE_DURATION=true
@@ -21,7 +20,7 @@ services:
       backend:
         # This is the host name used in Prometheus scrape configuration.
         aliases: [spm_metrics_source]
-    image: otel/opentelemetry-collector-contrib:${OTEL_IMAGE_TAG:-0.109.0}
+    image: otel/opentelemetry-collector-contrib:${OTEL_IMAGE_TAG:-0.112.0}
     volumes:
       - ${OTEL_CONFIG_SRC:-./otel-collector-config-connector.yml}:/etc/otelcol/otel-collector-config.yml
     command: --config /etc/otelcol/otel-collector-config.yml

--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       - METRICS_STORAGE_TYPE=prometheus
       - PROMETHEUS_SERVER_URL=http://prometheus:9090
+      - PROMETHEUS_QUERY_NAMESPACE=${PROMETHEUS_QUERY_NAMESPACE:-}
       - PROMETHEUS_QUERY_DURATION_UNIT=${PROMETHEUS_QUERY_DURATION_UNIT:-}
       - PROMETHEUS_QUERY_NORMALIZE_CALLS=true
       - PROMETHEUS_QUERY_NORMALIZE_DURATION=true
@@ -48,20 +49,6 @@ services:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
     ports:
       - "9090:9090"
-
-  grafana:
-    networks:
-      - backend
-    image: grafana/grafana:latest
-    volumes:
-      - ./grafana.ini:/etc/grafana/grafana.ini
-      - ./datasource.yml:/etc/grafana/provisioning/datasources/datasource.yaml
-    environment:
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
-    ports:
-      - "3000:3000"
 
 networks:
   backend:


### PR DESCRIPTION
## Which problem is this PR solving?
- Grafana server was not necessary for demonstrating SPM behavior or debugging

## Description of the changes
- Remove grafana service
- Update readme

## How was this change tested?
- Manually (incidentally ran into an odd issue #6150)
