### PR TITLE
Add optional time window for GetTrace & SearchTrace of http_handler

### DIFF
--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -7,6 +7,7 @@ package app
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -110,6 +111,25 @@ func TestArchiveTrace_Success(t *testing.T) {
 			Return(mockTrace, nil).Once()
 		var response structuredResponse
 		err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String(), []string{}, &response)
+		require.NoError(t, err)
+	}, querysvc.QueryServiceOptions{ArchiveSpanWriter: mockWriter})
+}
+
+func TestArchiveTrace_SucessWithTimeWindow(t *testing.T) {
+	mockWriter := &spanstoremocks.Writer{}
+	mockWriter.On("WriteSpan", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*model.Span")).
+		Return(nil).Times(2)
+	withTestServer(t, func(ts *testServer) {
+		// make main reader return NotFound
+		expectedQuery := spanstore.GetTraceParameters{
+			TraceID:   mockTraceID,
+			StartTime: time.UnixMicro(1),
+			EndTime:   time.UnixMicro(2),
+		}
+		ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), expectedQuery).
+			Return(mockTrace, nil).Once()
+		var response structuredTraceResponse
+		err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String()+"?start=1&end=2", []string{}, &response)
 		require.NoError(t, err)
 	}, querysvc.QueryServiceOptions{ArchiveSpanWriter: mockWriter})
 }

--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -173,6 +173,8 @@ func TestArchiveTrace_BadTimeWindow(t *testing.T) {
 				var response structuredTraceResponse
 				err := postJSON(ts.server.URL+"/api/archive/"+mockTraceID.String()+"?"+tc.query, []string{}, &response)
 				require.Error(t, err)
+				require.ErrorContains(t, err, "400 error from server")
+				require.ErrorContains(t, err, "unable to parse param")
 			}, querysvc.QueryServiceOptions{ArchiveSpanWriter: mockWriter})
 		})
 	}

--- a/cmd/query/app/handler_archive_test.go
+++ b/cmd/query/app/handler_archive_test.go
@@ -120,7 +120,6 @@ func TestArchiveTrace_SucessWithTimeWindow(t *testing.T) {
 	mockWriter.On("WriteSpan", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*model.Span")).
 		Return(nil).Times(2)
 	withTestServer(t, func(ts *testServer) {
-		// make main reader return NotFound
 		expectedQuery := spanstore.GetTraceParameters{
 			TraceID:   mockTraceID,
 			StartTime: time.UnixMicro(1),
@@ -167,7 +166,6 @@ func TestArchiveTrace_BadTimeWindow(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			withTestServer(t, func(ts *testServer) {
-				// make main reader return NotFound
 				ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("spanstore.GetTraceParameters")).
 					Return(mockTrace, nil).Once()
 				var response structuredTraceResponse

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -444,13 +444,14 @@ func (aH *APIHandler) parseMicroseconds(w http.ResponseWriter, r *http.Request, 
 }
 
 func (aH *APIHandler) parseGetTraceParameters(w http.ResponseWriter, r *http.Request) (spanstore.GetTraceParameters, bool) {
-	query := spanstore.GetTraceParameters{}
 	traceID, traceIdOk := aH.parseTraceID(w, r)
 	startTime, startTimeOk := aH.parseMicroseconds(w, r, startTimeParam)
 	endTime, endTimeOk := aH.parseMicroseconds(w, r, endTimeParam)
-	query.TraceID = traceID
-	query.StartTime = startTime
-	query.EndTime = endTime
+	query := spanstore.GetTraceParameters{
+		TraceID:   traceID,
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
 	return query, traceIdOk && startTimeOk && endTimeOk
 }
 

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -444,15 +444,23 @@ func (aH *APIHandler) parseMicroseconds(w http.ResponseWriter, r *http.Request, 
 }
 
 func (aH *APIHandler) parseGetTraceParameters(w http.ResponseWriter, r *http.Request) (spanstore.GetTraceParameters, bool) {
-	traceID, traceIdOk := aH.parseTraceID(w, r)
-	startTime, startTimeOk := aH.parseMicroseconds(w, r, startTimeParam)
-	endTime, endTimeOk := aH.parseMicroseconds(w, r, endTimeParam)
-	query := spanstore.GetTraceParameters{
-		TraceID:   traceID,
-		StartTime: startTime,
-		EndTime:   endTime,
+	query := spanstore.GetTraceParameters{}
+	traceID, ok := aH.parseTraceID(w, r)
+	if !ok {
+		return query, false
 	}
-	return query, traceIdOk && startTimeOk && endTimeOk
+	startTime, ok := aH.parseMicroseconds(w, r, startTimeParam)
+	if !ok {
+		return query, false
+	}
+	endTime, ok := aH.parseMicroseconds(w, r, endTimeParam)
+	if !ok {
+		return query, false
+	}
+	query.TraceID = traceID
+	query.StartTime = startTime
+	query.EndTime = endTime
+	return query, true
 }
 
 // getTrace implements the REST API /traces/{trace-id}

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -490,6 +490,8 @@ func (aH *APIHandler) archiveTrace(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+
+	// QueryService.ArchiveTrace can now archive this traceID.
 	err := aH.queryService.ArchiveTrace(r.Context(), query)
 	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		aH.handleError(w, err, http.StatusNotFound)

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -455,13 +455,12 @@ func TestSearchByTraceIDSuccess(t *testing.T) {
 
 func TestSearchByTraceIDWithTimeWindowSuccess(t *testing.T) {
 	ts := initializeTestServer(t)
-	traceId1, _ := model.TraceIDFromString("1")
 	expectedQuery1 := spanstore.GetTraceParameters{
-		TraceID:   traceId1,
+		TraceID:   mockTraceID,
 		StartTime: time.UnixMicro(1),
 		EndTime:   time.UnixMicro(2),
 	}
-	traceId2, _ := model.TraceIDFromString("2")
+	traceId2 := model.NewTraceID(0, 456789)
 	expectedQuery2 := spanstore.GetTraceParameters{
 		TraceID:   traceId2,
 		StartTime: time.UnixMicro(1),
@@ -473,7 +472,7 @@ func TestSearchByTraceIDWithTimeWindowSuccess(t *testing.T) {
 		Return(mockTrace, nil)
 
 	var response structuredResponse
-	err := getJSON(ts.server.URL+`/api/traces?traceID=1&traceID=2&start=1&end=2`, &response)
+	err := getJSON(ts.server.URL+`/api/traces?traceID=`+mockTraceID.String()+`&traceID=`+traceId2.String()+`&start=1&end=2`, &response)
 	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 2)
@@ -527,9 +526,8 @@ func TestSearchByTraceIDSuccessWithArchiveAndTimeWindow(t *testing.T) {
 	ts := initializeTestServerWithOptions(t, &tenancy.Manager{}, querysvc.QueryServiceOptions{
 		ArchiveSpanReader: archiveReadMock,
 	})
-	expectedTraceId, _ := model.TraceIDFromString("1")
 	expectedQuery := spanstore.GetTraceParameters{
-		TraceID:   expectedTraceId,
+		TraceID:   mockTraceID,
 		StartTime: time.UnixMicro(1),
 		EndTime:   time.UnixMicro(2),
 	}
@@ -539,7 +537,7 @@ func TestSearchByTraceIDSuccessWithArchiveAndTimeWindow(t *testing.T) {
 		Return(mockTrace, nil)
 
 	var response structuredResponse
-	err := getJSON(ts.server.URL+`/api/traces?traceID=1&start=1&end=2`, &response)
+	err := getJSON(ts.server.URL+`/api/traces?traceID=`+mockTraceID.String()+`&start=1&end=2`, &response)
 	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 1)

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -404,6 +404,30 @@ func TestGetTraceBadTraceID(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestGetTraceBadTimeWindow(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "Bad start time",
+			query: "start=a",
+		},
+		{
+			name:  "Bad end time",
+			query: "end=b",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := initializeTestServer(t)
+			var response structuredResponse
+			err := getJSON(ts.server.URL+`/api/traces/123456?`+tc.query, &response)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestSearchSuccess(t *testing.T) {
 	ts := initializeTestServer(t)
 	ts.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
@@ -443,6 +467,30 @@ func TestSearchByTraceIDWithTimeWindowSuccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 	assert.Len(t, response.Data, 1)
+}
+
+func TestSearchTraceBadTimeWindow(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "Bad start time",
+			query: "start=a",
+		},
+		{
+			name:  "Bad end time",
+			query: "end=b",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := initializeTestServer(t)
+			var response structuredResponse
+			err := getJSON(ts.server.URL+`/api/traces?traceID=1&`+tc.query, &response)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestSearchByTraceIDSuccessWithArchive(t *testing.T) {

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -200,16 +200,14 @@ func TestGetTraceDedupeSuccess(t *testing.T) {
 
 func TestGetTraceWithTimeWindowSuccess(t *testing.T) {
 	ts := initializeTestServer(t)
-	start_time := time.Date(1970, time.January, 1, 0, 0, 0, 1000, time.UTC).Local()
-	end_time := time.Date(1970, time.January, 1, 0, 0, 0, 2000, time.UTC).Local()
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), spanstore.GetTraceParameters{
-		TraceID:   model.TraceID{High: 0, Low: 0x123456},
-		StartTime: start_time,
-		EndTime:   end_time,
+		TraceID:   mockTraceID,
+		StartTime: time.UnixMicro(1),
+		EndTime:   time.UnixMicro(2),
 	}).Return(mockTrace, nil).Once()
 
 	var response structuredResponse
-	err := getJSON(ts.server.URL+`/api/traces/123456?start=1&end=2`, &response)
+	err := getJSON(ts.server.URL+`/api/traces/`+mockTraceID.String()+`?start=1&end=2`, &response)
 	require.NoError(t, err)
 	assert.Empty(t, response.Errors)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4150

## Description of the changes
- add optional time window when fetching trace by id

## How was this change tested?
- unittest

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
