### PR TITLE
chore: use Contains or ErrorContains with testify

### DIFF
--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -10,7 +10,6 @@ import (
 	"expvar"
 	"flag"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -150,9 +149,9 @@ func TestBuilderWithProcessorErrors(t *testing.T) {
 		_, err := cfg.CreateAgent(&fakeCollectorProxy{}, zap.NewNop(), metrics.NullFactory)
 		require.Error(t, err)
 		if testCase.err != "" {
-			assert.Contains(t, err.Error(), testCase.err)
+			assert.ErrorContains(t, err, testCase.err)
 		} else if testCase.errContains != "" {
-			assert.True(t, strings.Contains(err.Error(), testCase.errContains), "error must contain %s", testCase.errContains)
+			assert.ErrorContains(t, err, testCase.errContains, "error must contain %s", testCase.errContains)
 		}
 	}
 }

--- a/cmd/agent/app/configmanager/grpc/manager_test.go
+++ b/cmd/agent/app/configmanager/grpc/manager_test.go
@@ -38,8 +38,7 @@ func TestSamplingManager_GetSamplingStrategy_error(t *testing.T) {
 	manager := NewConfigManager(conn)
 	resp, err := manager.GetSamplingStrategy(context.Background(), "any")
 	require.Nil(t, resp)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get sampling strategy")
+	assert.ErrorContains(t, err, "failed to get sampling strategy")
 }
 
 func TestSamplingManager_GetBaggageRestrictions(t *testing.T) {

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -128,8 +128,7 @@ func TestBuilderWithCollectors(t *testing.T) {
 					assert.Equal(t, conn.Target(), test.target)
 				}
 			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.expectedError)
+				assert.ErrorContains(t, err, test.expectedError)
 			}
 		})
 	}

--- a/cmd/agent/app/reporter/grpc/flags_test.go
+++ b/cmd/agent/app/reporter/grpc/flags_test.go
@@ -57,6 +57,5 @@ func TestBindTLSFlagFailure(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = new(ConnBuilder).InitFromViper(v)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to process TLS options")
+	assert.ErrorContains(t, err, "failed to process TLS options")
 }

--- a/cmd/agent/app/reporter/grpc/reporter_test.go
+++ b/cmd/agent/app/reporter/grpc/reporter_test.go
@@ -123,8 +123,7 @@ func TestReporter_SendFailure(t *testing.T) {
 	defer conn.Close()
 	rep := NewReporter(conn, nil, zap.NewNop())
 	err = rep.send(context.Background(), nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to export spans:")
+	assert.ErrorContains(t, err, "failed to export spans:")
 }
 
 func TestReporter_AddProcessTags_EmptyTags(t *testing.T) {
@@ -211,6 +210,6 @@ func TestReporter_MultitenantEmitBatch(t *testing.T) {
 	}
 	for _, test := range tests {
 		err = rep.EmitBatch(context.Background(), test.in)
-		assert.Contains(t, err.Error(), test.err)
+		assert.ErrorContains(t, err, test.err)
 	}
 }

--- a/cmd/anonymizer/app/uiconv/extractor_test.go
+++ b/cmd/anonymizer/app/uiconv/extractor_test.go
@@ -66,7 +66,7 @@ func TestExtractorTraceOutputFileError(t *testing.T) {
 		reader,
 		zap.NewNop(),
 	)
-	require.Contains(t, err.Error(), "cannot create output file")
+	require.ErrorContains(t, err, "cannot create output file")
 }
 
 func TestExtractorTraceScanError(t *testing.T) {
@@ -86,7 +86,7 @@ func TestExtractorTraceScanError(t *testing.T) {
 	require.NoError(t, err)
 
 	err = extractor.Run()
-	require.Contains(t, err.Error(), "failed when scanning the file")
+	require.ErrorContains(t, err, "failed when scanning the file")
 }
 
 func loadJSON(t *testing.T, fileName string, i any) {

--- a/cmd/anonymizer/app/uiconv/module_test.go
+++ b/cmd/anonymizer/app/uiconv/module_test.go
@@ -46,7 +46,7 @@ func TestModule_TraceNonExistent(t *testing.T) {
 		TraceID:      "2be38093ead7a083",
 	}
 	err := Extract(config, zap.NewNop())
-	require.Contains(t, err.Error(), "cannot open captured file")
+	require.ErrorContains(t, err, "cannot open captured file")
 }
 
 func TestModule_TraceOutputFileError(t *testing.T) {
@@ -65,5 +65,5 @@ func TestModule_TraceOutputFileError(t *testing.T) {
 	defer os.Chmod("fixtures", 0o755)
 
 	err = Extract(config, zap.NewNop())
-	require.Contains(t, err.Error(), "cannot create output file")
+	require.ErrorContains(t, err, "cannot create output file")
 }

--- a/cmd/anonymizer/app/uiconv/reader_test.go
+++ b/cmd/anonymizer/app/uiconv/reader_test.go
@@ -39,7 +39,7 @@ func TestReaderTraceSuccess(t *testing.T) {
 func TestReaderTraceNonExistent(t *testing.T) {
 	inputFile := "fixtures/trace_non_existent.json"
 	_, err := newSpanReader(inputFile, zap.NewNop())
-	require.Contains(t, err.Error(), "cannot open captured file")
+	require.ErrorContains(t, err, "cannot open captured file")
 }
 
 func TestReaderTraceEmpty(t *testing.T) {
@@ -48,7 +48,7 @@ func TestReaderTraceEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = r.NextSpan()
-	require.Contains(t, err.Error(), "cannot read file")
+	require.ErrorContains(t, err, "cannot read file")
 	assert.Equal(t, 0, r.spansRead)
 	assert.True(t, r.eofReached)
 }
@@ -70,7 +70,7 @@ func TestReaderTraceInvalidJson(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = r.NextSpan()
-	require.Contains(t, err.Error(), "cannot unmarshal span")
+	require.ErrorContains(t, err, "cannot unmarshal span")
 	assert.Equal(t, 0, r.spansRead)
 	assert.True(t, r.eofReached)
 }

--- a/cmd/collector/app/collector_test.go
+++ b/cmd/collector/app/collector_test.go
@@ -104,8 +104,7 @@ func TestCollector_StartErrors(t *testing.T) {
 				TenancyMgr:       tm,
 			})
 			err := c.Start(options)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), expErr)
+			require.ErrorContains(t, err, expErr)
 			require.NoError(t, c.Close())
 		})
 	}

--- a/cmd/collector/app/flags/flags_test.go
+++ b/cmd/collector/app/flags/flags_test.go
@@ -65,8 +65,7 @@ func TestCollectorOptionsWithFailedTLSFlags(t *testing.T) {
 			})
 			require.NoError(t, err)
 			_, err = c.InitFromViper(v, zap.NewNop())
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "failed to parse")
+			assert.ErrorContains(t, err, "failed to parse")
 		})
 	}
 }
@@ -91,8 +90,7 @@ func TestCollectorOptionsWithFlags_CheckTLSReloadInterval(t *testing.T) {
 				prefix + ".tls.reload-interval=24h",
 			})
 			if _, ok := otlpPrefixes[prefix]; !ok {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unknown flag")
+				assert.ErrorContains(t, err, "unknown flag")
 			} else {
 				require.NoError(t, err)
 			}

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -193,9 +193,8 @@ func TestPostSpansWithError(t *testing.T) {
 					},
 				},
 			})
-			require.Error(t, err)
+			require.ErrorContains(t, err, test.expectedError)
 			require.Nil(t, r)
-			assert.Contains(t, err.Error(), test.expectedError)
 			assert.Contains(t, logBuf.String(), test.expectedLog)
 			assert.Len(t, processor.getSpans(), 1)
 		})

--- a/cmd/collector/app/handler/otlp_receiver_test.go
+++ b/cmd/collector/app/handler/otlp_receiver_test.go
@@ -92,16 +92,14 @@ func TestStartOtlpReceiver_Error(t *testing.T) {
 	opts := optionsWithPorts(":-1")
 	tm := &tenancy.Manager{}
 	_, err := StartOTLPReceiver(opts, logger, spanProcessor, tm)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not start the OTLP receiver")
+	require.ErrorContains(t, err, "could not start the OTLP receiver")
 
 	newTraces := func(consumer.ConsumeTracesFunc, ...consumer.Option) (consumer.Traces, error) {
 		return nil, errors.New("mock error")
 	}
 	f := otlpreceiver.NewFactory()
 	_, err = startOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, newTraces, f.CreateTraces)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not create the OTLP consumer")
+	require.ErrorContains(t, err, "could not create the OTLP consumer")
 
 	createTracesReceiver := func(
 		context.Context, receiver.Settings, component.Config, consumer.Traces,
@@ -109,8 +107,7 @@ func TestStartOtlpReceiver_Error(t *testing.T) {
 		return nil, errors.New("mock error")
 	}
 	_, err = startOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, consumer.NewTraces, createTracesReceiver)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not create the OTLP receiver")
+	assert.ErrorContains(t, err, "could not create the OTLP receiver")
 }
 
 func TestOtelHost_ReportFatalError(t *testing.T) {

--- a/cmd/collector/app/handler/zipkin_receiver_test.go
+++ b/cmd/collector/app/handler/zipkin_receiver_test.go
@@ -141,16 +141,14 @@ func TestStartZipkinReceiver_Error(t *testing.T) {
 	opts.Zipkin.HTTPHostPort = ":-1"
 
 	_, err := StartZipkinReceiver(opts, logger, spanProcessor, tm)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not start Zipkin receiver")
+	require.ErrorContains(t, err, "could not start Zipkin receiver")
 
 	newTraces := func(consumer.ConsumeTracesFunc, ...consumer.Option) (consumer.Traces, error) {
 		return nil, errors.New("mock error")
 	}
 	f := zipkinreceiver.NewFactory()
 	_, err = startZipkinReceiver(opts, logger, spanProcessor, tm, f, newTraces, f.CreateTraces)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not create Zipkin consumer")
+	require.ErrorContains(t, err, "could not create Zipkin consumer")
 
 	createTracesReceiver := func(
 		context.Context, receiver.Settings, component.Config, consumer.Traces,
@@ -158,6 +156,5 @@ func TestStartZipkinReceiver_Error(t *testing.T) {
 		return nil, errors.New("mock error")
 	}
 	_, err = startZipkinReceiver(opts, logger, spanProcessor, tm, f, consumer.NewTraces, createTracesReceiver)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not create Zipkin receiver")
+	assert.ErrorContains(t, err, "could not create Zipkin receiver")
 }

--- a/cmd/es-rollover/app/init/action_test.go
+++ b/cmd/es-rollover/app/init/action_test.go
@@ -6,7 +6,6 @@ package init
 import (
 	"errors"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,7 +68,7 @@ func TestIndexCreateIfNotExist(t *testing.T) {
 			indexClient.On("CreateIndex", "jaeger-span").Return(test.returnErr)
 			err := createIndexIfNotExist(indexClient, "jaeger-span")
 			if test.containsError != "" {
-				assert.True(t, strings.Contains(err.Error(), test.containsError))
+				assert.ErrorContains(t, err, test.containsError)
 			} else {
 				assert.Equal(t, test.expectedErr, err)
 			}

--- a/cmd/internal/docs/command_test.go
+++ b/cmd/internal/docs/command_test.go
@@ -5,7 +5,6 @@ package docs
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -36,7 +35,7 @@ func TestOutputFormats(t *testing.T) {
 		if err == nil {
 			f, err := os.ReadFile(test.file)
 			require.NoError(t, err)
-			assert.True(t, strings.Contains(string(f), "documentation"))
+			assert.Contains(t, string(f), "documentation")
 		} else {
 			assert.Equal(t, test.err, err.Error())
 		}
@@ -55,7 +54,7 @@ func TestDocsForParent(t *testing.T) {
 	require.NoError(t, err)
 	f, err := os.ReadFile("root_command.md")
 	require.NoError(t, err)
-	assert.True(t, strings.Contains(string(f), "some description"))
+	assert.Contains(t, string(f), "some description")
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/internal/env/command_test.go
+++ b/cmd/internal/env/command_test.go
@@ -5,7 +5,6 @@ package env
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,8 +17,8 @@ func TestCommand(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.Run(cmd, nil)
-	assert.True(t, strings.Contains(buf.String(), "METRICS_BACKEND"))
-	assert.True(t, strings.Contains(buf.String(), "SPAN_STORAGE"))
+	assert.Contains(t, buf.String(), "METRICS_BACKEND")
+	assert.Contains(t, buf.String(), "SPAN_STORAGE")
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/internal/flags/admin_test.go
+++ b/cmd/internal/flags/admin_test.go
@@ -95,8 +95,7 @@ func TestAdminWithFailedFlags(t *testing.T) {
 	})
 	require.NoError(t, err)
 	err = adminServer.initFromViper(v, logger)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse admin server TLS options")
+	assert.ErrorContains(t, err, "failed to parse admin server TLS options")
 }
 
 func TestAdminServerTLS(t *testing.T) {

--- a/cmd/internal/flags/service_test.go
+++ b/cmd/internal/flags/service_test.go
@@ -70,8 +70,7 @@ func TestStartErrors(t *testing.T) {
 			require.NoError(t, err)
 			err = s.Start(v)
 			if test.expErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.expErr)
+				require.ErrorContains(t, err, test.expErr)
 				return
 			}
 			require.NoError(t, err)

--- a/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
@@ -75,7 +75,6 @@ func TestExporterStartBadNameError(t *testing.T) {
 		},
 	}
 	err := exp.start(context.Background(), host)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot find storage factory")
 }
 
@@ -95,7 +94,6 @@ func TestExporterStartBadSpanstoreError(t *testing.T) {
 		},
 	}
 	err := exp.start(context.Background(), host)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "mocked error")
 }
 

--- a/cmd/jaeger/internal/integration/storagecleaner/extension_test.go
+++ b/cmd/jaeger/internal/integration/storagecleaner/extension_test.go
@@ -131,8 +131,7 @@ func TestGetStorageFactoryError(t *testing.T) {
 		factory: nil,
 	})
 	err := s.Start(context.Background(), host)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot find storage factory")
+	require.ErrorContains(t, err, "cannot find storage factory")
 }
 
 func TestStorageExtensionStartError(t *testing.T) {
@@ -160,7 +159,7 @@ func TestStorageExtensionStartError(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return startStatus.Load() != nil
 	}, 5*time.Second, 100*time.Millisecond)
-	require.Contains(t, startStatus.Load().Err().Error(), "error starting cleaner server")
+	require.ErrorContains(t, startStatus.Load().Err(), "error starting cleaner server")
 }
 
 type testHost struct {

--- a/cmd/query/app/apiv3/grpc_handler_test.go
+++ b/cmd/query/app/apiv3/grpc_handler_test.go
@@ -112,8 +112,7 @@ func TestGetTraceStorageError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	recv, err := getTraceStream.Recv()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "storage_error")
+	require.ErrorContains(t, err, "storage_error")
 	assert.Nil(t, recv)
 }
 
@@ -129,8 +128,7 @@ func TestGetTraceTraceIDError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	recv, err := getTraceStream.Recv()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "strconv.ParseUint:")
+	require.ErrorContains(t, err, "strconv.ParseUint:")
 	assert.Nil(t, recv)
 }
 
@@ -170,8 +168,7 @@ func TestFindTracesQueryNil(t *testing.T) {
 	responseStream, err := tsc.client.FindTraces(context.Background(), &api_v3.FindTracesRequest{})
 	require.NoError(t, err)
 	recv, err := responseStream.Recv()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing query")
+	require.ErrorContains(t, err, "missing query")
 	assert.Nil(t, recv)
 
 	responseStream, err = tsc.client.FindTraces(context.Background(), &api_v3.FindTracesRequest{
@@ -182,8 +179,7 @@ func TestFindTracesQueryNil(t *testing.T) {
 	})
 	require.NoError(t, err)
 	recv, err = responseStream.Recv()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "start time min and max are required parameters")
+	require.ErrorContains(t, err, "start time min and max are required parameters")
 	assert.Nil(t, recv)
 }
 
@@ -202,8 +198,7 @@ func TestFindTracesStorageError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	recv, err := responseStream.Recv()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "storage_error")
+	require.ErrorContains(t, err, "storage_error")
 	assert.Nil(t, recv)
 }
 
@@ -223,8 +218,7 @@ func TestGetServicesStorageError(t *testing.T) {
 		nil, fmt.Errorf("storage_error")).Once()
 
 	response, err := tsc.client.GetServices(context.Background(), &api_v3.GetServicesRequest{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "storage_error")
+	require.ErrorContains(t, err, "storage_error")
 	assert.Nil(t, response)
 }
 
@@ -252,7 +246,6 @@ func TestGetOperationsStorageError(t *testing.T) {
 		nil, fmt.Errorf("storage_error")).Once()
 
 	response, err := tsc.client.GetOperations(context.Background(), &api_v3.GetOperationsRequest{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "storage_error")
+	require.ErrorContains(t, err, "storage_error")
 	assert.Nil(t, response)
 }

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -179,8 +179,7 @@ func TestQueryOptions_FailedTLSFlags(t *testing.T) {
 			})
 			require.NoError(t, err)
 			_, err = new(QueryOptions).InitFromViper(v, zap.NewNop())
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "failed to process "+test+" TLS options")
+			assert.ErrorContains(t, err, "failed to process "+test+" TLS options")
 		})
 	}
 }

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -1152,7 +1152,7 @@ func TestTenancyContextFlowGRPC(t *testing.T) {
 					assert.Equal(t, expected.expectedTrace.Spans[0].TraceID, spanResChunk.Spans[0].TraceID)
 				}
 				if expected.expectedTraceErr != nil {
-					assert.Contains(t, err.Error(), expected.expectedTraceErr.Error())
+					assert.ErrorContains(t, err, expected.expectedTraceErr.Error())
 				}
 			})
 		}

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -779,8 +779,7 @@ func TestMetricsReaderError(t *testing.T) {
 			err := getJSON(ts.server.URL+tc.urlPath, &response)
 
 			// Verify
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.wantErrorMessage)
+			assert.ErrorContains(t, err, tc.wantErrorMessage)
 		})
 	}
 }
@@ -814,8 +813,7 @@ func TestMetricsQueryDisabled(t *testing.T) {
 			err := getJSON(ts.server.URL+tc.urlPath, &response)
 
 			// Verify
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.wantErrorMessage)
+			assert.ErrorContains(t, err, tc.wantErrorMessage)
 		})
 	}
 }
@@ -993,7 +991,7 @@ func TestSearchTenancyFlowTenantHTTP(t *testing.T) {
 		ts.server.URL+`/api/traces?traceID=1&traceID=2`,
 		map[string]string{"x-tenant": "megacorp"},
 		&responseMegacorp)
-	assert.Contains(t, err.Error(), "storage error")
+	require.ErrorContains(t, err, "storage error")
 	assert.Empty(t, responseMegacorp.Errors)
 	assert.Nil(t, responseMegacorp.Data)
 }

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -305,8 +305,7 @@ func TestParameterErrors(t *testing.T) {
 			err := getJSON(ts.server.URL+tc.urlPath, &response)
 
 			// Verify
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.wantErrorMessage)
+			assert.ErrorContains(t, err, tc.wantErrorMessage)
 		})
 	}
 }

--- a/cmd/query/app/static_handler_test.go
+++ b/cmd/query/app/static_handler_test.go
@@ -32,8 +32,7 @@ func TestNotExistingUiConfig(t *testing.T) {
 	handler, err := NewStaticAssetsHandler("/foo/bar", StaticAssetsHandlerOptions{
 		Logger: zap.NewNop(),
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no such file or directory")
+	require.ErrorContains(t, err, "no such file or directory")
 	assert.Nil(t, handler)
 }
 
@@ -169,8 +168,7 @@ func TestNewStaticAssetsHandlerErrors(t *testing.T) {
 			BasePath: base,
 			Logger:   zap.NewNop(),
 		})
-		require.Errorf(t, err, "basePath=%s", base)
-		assert.Contains(t, err.Error(), "invalid base path")
+		assert.ErrorContainsf(t, err, "invalid base path", "basePath=%s", base)
 	}
 }
 

--- a/cmd/remote-storage/app/flags_test.go
+++ b/cmd/remote-storage/app/flags_test.go
@@ -31,6 +31,5 @@ func TestFailedTLSFlags(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = new(Options).InitFromViper(v, zap.NewNop())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to process gRPC TLS options")
+	assert.ErrorContains(t, err, "failed to process gRPC TLS options")
 }

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -55,16 +55,13 @@ func TestNewServer_CreateStorageErrors(t *testing.T) {
 		)
 	}
 	_, err := f()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no reader")
+	require.ErrorContains(t, err, "no reader")
 
 	_, err = f()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no writer")
+	require.ErrorContains(t, err, "no writer")
 
 	_, err = f()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no deps")
+	require.ErrorContains(t, err, "no deps")
 
 	s, err := f()
 	require.NoError(t, err)
@@ -127,8 +124,7 @@ func TestNewServer_TLSConfigError(t *testing.T) {
 		tenancy.NewManager(&tenancy.Options{}),
 		telset,
 	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid TLS config")
+	assert.ErrorContains(t, err, "invalid TLS config")
 }
 
 func TestCreateGRPCHandler(t *testing.T) {
@@ -138,8 +134,7 @@ func TestCreateGRPCHandler(t *testing.T) {
 
 	storageMocks.writer.On("WriteSpan", mock.Anything, mock.Anything).Return(errors.New("writer error"))
 	_, err = h.WriteSpan(context.Background(), &storage_v1.WriteSpanRequest{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "writer error")
+	require.ErrorContains(t, err, "writer error")
 
 	storageMocks.depReader.On(
 		"GetDependencies",
@@ -148,20 +143,16 @@ func TestCreateGRPCHandler(t *testing.T) {
 		mock.Anything, // lookback
 	).Return(nil, errors.New("deps error"))
 	_, err = h.GetDependencies(context.Background(), &storage_v1.GetDependenciesRequest{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "deps error")
+	require.ErrorContains(t, err, "deps error")
 
 	err = h.GetArchiveTrace(nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not implemented")
+	require.ErrorContains(t, err, "not implemented")
 
 	_, err = h.WriteArchiveSpan(context.Background(), nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not implemented")
+	require.ErrorContains(t, err, "not implemented")
 
 	err = h.WriteSpanStream(nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not implemented")
+	assert.ErrorContains(t, err, "not implemented")
 }
 
 var testCases = []struct {

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -83,14 +83,11 @@ func TestTraceIDUnmarshalJSONPBErrors(t *testing.T) {
 	// for code coverage
 	var id model.TraceID
 	_, err := id.MarshalText()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported method")
+	require.ErrorContains(t, err, "unsupported method")
 	err = id.UnmarshalText(nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported method")
+	require.ErrorContains(t, err, "unsupported method")
 	_, err = id.MarshalTo(make([]byte, 1))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "buffer is too short")
+	assert.ErrorContains(t, err, "buffer is too short")
 }
 
 var (
@@ -156,18 +153,14 @@ func TestSpanIDUnmarshalJSONErrors(t *testing.T) {
 	// for code coverage
 	var id model.SpanID
 	_, err := id.MarshalText()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported method")
+	require.ErrorContains(t, err, "unsupported method")
 	err = id.UnmarshalText(nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported method")
+	require.ErrorContains(t, err, "unsupported method")
 
 	err = id.UnmarshalJSONPB(nil, []byte(""))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid length for SpanID")
+	require.ErrorContains(t, err, "invalid length for SpanID")
 	err = id.UnmarshalJSONPB(nil, []byte("123"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "illegal base64 data")
+	assert.ErrorContains(t, err, "illegal base64 data")
 }
 
 func TestIsRPCClientServer(t *testing.T) {

--- a/model/spanref_test.go
+++ b/model/spanref_test.go
@@ -33,8 +33,7 @@ func TestSpanRefTypeToFromJSON(t *testing.T) {
 	assert.Equal(t, sr, sr2)
 	var sr3 model.SpanRef
 	err = jsonpb.Unmarshal(bytes.NewReader([]byte(`{"refType":"BAD"}`)), &sr3)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown value")
+	assert.ErrorContains(t, err, "unknown value")
 }
 
 func TestMaybeAddParentSpanID(t *testing.T) {

--- a/pkg/bearertoken/grpc_test.go
+++ b/pkg/bearertoken/grpc_test.go
@@ -75,7 +75,6 @@ func TestClientInterceptors(t *testing.T) {
 			if test.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
 				require.ErrorContains(t, err, test.expectedErr)
 			}
 
@@ -91,7 +90,6 @@ func TestClientInterceptors(t *testing.T) {
 			if test.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, test.expectedErr)
 			}
 		})
@@ -157,7 +155,6 @@ func TestServerInterceptors(t *testing.T) {
 			if test.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
 				require.ErrorContains(t, err, test.expectedErr)
 			}
 
@@ -172,7 +169,6 @@ func TestServerInterceptors(t *testing.T) {
 			if test.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, test.expectedErr)
 			}
 		})

--- a/pkg/clientcfg/clientcfghttp/handler_test.go
+++ b/pkg/clientcfg/clientcfghttp/handler_test.go
@@ -306,15 +306,13 @@ func TestEncodeErrors(t *testing.T) {
 			_, err := server.handler.encodeThriftLegacy(&api_v2.SamplingStrategyResponse{
 				StrategyType: -1,
 			})
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "ConvertSamplingResponseFromDomain failed")
+			require.ErrorContains(t, err, "ConvertSamplingResponseFromDomain failed")
 			server.metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "thrift", "status": "5xx"}, Value: 1},
 			}...)
 
 			_, err = server.handler.encodeProto(nil)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "SamplingStrategyResponseToJSON failed")
+			require.ErrorContains(t, err, "SamplingStrategyResponseToJSON failed")
 			server.metricsFactory.AssertCounterMetrics(t, []metricstest.ExpectedMetric{
 				{Name: "http-server.errors", Tags: map[string]string{"source": "proto", "status": "5xx"}, Value: 1},
 			}...)

--- a/pkg/config/tlscfg/cert_watcher_test.go
+++ b/pkg/config/tlscfg/cert_watcher_test.go
@@ -330,8 +330,7 @@ func TestAddCertsToWatch_err(t *testing.T) {
 	}
 	for _, test := range tests {
 		watcher, err := newCertWatcher(test.opts, nil, nil, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no such file or directory")
+		require.ErrorContains(t, err, "no such file or directory")
 		assert.Nil(t, watcher)
 	}
 }

--- a/pkg/config/tlscfg/flags_test.go
+++ b/pkg/config/tlscfg/flags_test.go
@@ -136,8 +136,7 @@ func TestServerCertReloadInterval(t *testing.T) {
 				"--" + test.config.Prefix + ".tls.reload-interval=24h",
 			})
 			if !test.config.EnableCertReloadInterval {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unknown flag")
+				assert.ErrorContains(t, err, "unknown flag")
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -156,8 +156,7 @@ func TestOptionsToConfig(t *testing.T) {
 			}
 			cfg, err := test.options.Config(zap.NewNop())
 			if test.expectError != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.expectError)
+				require.ErrorContains(t, err, test.expectError)
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, cfg)

--- a/pkg/es/client/cluster_client_test.go
+++ b/pkg/es/client/cluster_client_test.go
@@ -224,8 +224,7 @@ func TestVersion(t *testing.T) {
 			}
 			result, err := c.Version()
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				require.ErrorContains(t, err, test.errContains)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/es/client/ilm_client_test.go
+++ b/pkg/es/client/ilm_client_test.go
@@ -58,8 +58,7 @@ func TestExists(t *testing.T) {
 			}
 			result, err := c.Exists("jaeger-ilm-policy")
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				require.ErrorContains(t, err, test.errContains)
 			}
 			assert.Equal(t, test.expectedResult, result)
 		})

--- a/pkg/es/client/index_client_test.go
+++ b/pkg/es/client/index_client_test.go
@@ -150,8 +150,7 @@ func TestClientGetIndices(t *testing.T) {
 
 			indices, err := c.GetJaegerIndices(test.prefix)
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				require.ErrorContains(t, err, test.errContains)
 				assert.Nil(t, indices)
 			} else {
 				require.NoError(t, err)
@@ -269,8 +268,7 @@ func TestClientDeleteIndices(t *testing.T) {
 			assert.Equal(t, test.triggerAPI, apiTriggered)
 
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				assert.ErrorContains(t, err, test.errContains)
 			} else {
 				assert.Len(t, test.indices, deletedIndicesCount)
 			}
@@ -341,8 +339,7 @@ func TestClientCreateIndex(t *testing.T) {
 			}
 			err := c.CreateIndex(indexName)
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				assert.ErrorContains(t, err, test.errContains)
 			}
 		})
 	}
@@ -402,8 +399,7 @@ func TestClientCreateAliases(t *testing.T) {
 			}
 			err := c.CreateAlias(aliases)
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				assert.ErrorContains(t, err, test.errContains)
 			}
 		})
 	}
@@ -462,8 +458,7 @@ func TestClientDeleteAliases(t *testing.T) {
 			}
 			err := c.DeleteAlias(aliases)
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				assert.ErrorContains(t, err, test.errContains)
 			}
 		})
 	}
@@ -526,8 +521,7 @@ func TestClientCreateTemplate(t *testing.T) {
 			}
 			err := c.CreateTemplate(templateContent, templateName)
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				assert.ErrorContains(t, err, test.errContains)
 			}
 		})
 	}
@@ -580,8 +574,7 @@ func TestRollover(t *testing.T) {
 			}
 			err := c.Rollover("jaeger-span", mapConditions)
 			if test.errContains != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errContains)
+				assert.ErrorContains(t, err, test.errContains)
 			}
 		})
 	}

--- a/pkg/gzipfs/gzip_test.go
+++ b/pkg/gzipfs/gzip_test.go
@@ -103,8 +103,7 @@ func TestFS(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			f, err := testFS.Open(c.path)
 			if c.expectedErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), c.expectedErr)
+				require.ErrorContains(t, err, c.expectedErr)
 				return
 			}
 			require.NoError(t, err)

--- a/plugin/metrics/prometheus/metricsstore/reader_test.go
+++ b/plugin/metrics/prometheus/metricsstore/reader_test.go
@@ -86,8 +86,7 @@ func TestNewMetricsReaderInvalidAddress(t *testing.T) {
 		ServerURL:      "\n",
 		ConnectTimeout: defaultTimeout,
 	}, logger, tracer)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to initialize prometheus client")
+	require.ErrorContains(t, err, "failed to initialize prometheus client")
 	assert.Nil(t, reader)
 }
 
@@ -142,8 +141,7 @@ func TestMetricsServerError(t *testing.T) {
 	require.NoError(t, err)
 	m, err := reader.GetCallRates(context.Background(), &params)
 	assert.NotNil(t, m)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed executing metrics query")
+	require.ErrorContains(t, err, "failed executing metrics query")
 	require.Len(t, exp.GetSpans(), 1, "HTTP request was traced and span reported")
 	assert.Equal(t, codes.Error, exp.GetSpans()[0].Status.Code)
 }
@@ -848,8 +846,7 @@ func TestGetRoundTripperTokenError(t *testing.T) {
 	_, err := getHTTPRoundTripper(&config.Configuration{
 		TokenFilePath: tokenFilePath,
 	}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get token from file")
+	assert.ErrorContains(t, err, "failed to get token from file")
 }
 
 func TestInvalidCertFile(t *testing.T) {

--- a/plugin/sampling/strategyprovider/static/provider_test.go
+++ b/plugin/sampling/strategyprovider/static/provider_test.go
@@ -95,7 +95,7 @@ func mockStrategyServer(t *testing.T) (*httptest.Server, *atomic.Pointer[string]
 
 func TestStrategyStoreWithFile(t *testing.T) {
 	_, err := NewProvider(Options{StrategiesFile: "fileNotFound.json"}, zap.NewNop())
-	assert.Contains(t, err.Error(), "failed to read strategies file fileNotFound.json")
+	require.ErrorContains(t, err, "failed to read strategies file fileNotFound.json")
 
 	_, err = NewProvider(Options{StrategiesFile: "fixtures/bad_strategies.json"}, zap.NewNop())
 	require.EqualError(t, err,
@@ -542,13 +542,13 @@ func TestSamplingStrategyLoader(t *testing.T) {
 	// invalid file path
 	loader := provider.samplingStrategyLoader("not-exists")
 	_, err := loader()
-	assert.Contains(t, err.Error(), "failed to read strategies file not-exists")
+	require.ErrorContains(t, err, "failed to read strategies file not-exists")
 
 	// status code other than 200
 	mockServer, _ := mockStrategyServer(t)
 	loader = provider.samplingStrategyLoader(mockServer.URL + "/bad-status")
 	_, err = loader()
-	assert.Contains(t, err.Error(), "receiving 404 Not Found while downloading strategies file")
+	require.ErrorContains(t, err, "receiving 404 Not Found while downloading strategies file")
 
 	// should download content from URL
 	loader = provider.samplingStrategyLoader(mockServer.URL + "/bad-content")

--- a/plugin/storage/badger/factory_test.go
+++ b/plugin/storage/badger/factory_test.go
@@ -195,7 +195,6 @@ func TestConfigure(t *testing.T) {
 func TestBadgerStorageFactoryWithConfig(t *testing.T) {
 	cfg := Config{}
 	_, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
-	require.Error(t, err)
 	require.ErrorContains(t, err, "Error Creating Dir")
 
 	tmp := os.TempDir()

--- a/plugin/storage/cassandra/dependencystore/storage_test.go
+++ b/plugin/storage/cassandra/dependencystore/storage_test.go
@@ -7,7 +7,6 @@ package dependencystore
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -233,7 +232,7 @@ func TestDependencyStoreGetDependencies(t *testing.T) {
 					require.EqualError(t, err, testCase.expectedError)
 				}
 				for _, expectedLog := range testCase.expectedLogs {
-					assert.True(t, strings.Contains(s.logBuffer.String(), expectedLog), "Log must contain %s, but was %s", expectedLog, s.logBuffer.String())
+					assert.Contains(t, s.logBuffer.String(), expectedLog, "Log must contain %s, but was %s", expectedLog, s.logBuffer.String())
 				}
 				if len(testCase.expectedLogs) == 0 {
 					assert.Equal(t, "", s.logBuffer.String())

--- a/plugin/storage/cassandra/factory_test.go
+++ b/plugin/storage/cassandra/factory_test.go
@@ -237,7 +237,6 @@ func TestNewFactoryWithConfig(t *testing.T) {
 	t.Run("invalid configuration", func(t *testing.T) {
 		cfg := Options{}
 		_, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
-		require.Error(t, err)
 		require.ErrorContains(t, err, "Servers: non zero value required")
 	})
 }

--- a/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
+++ b/plugin/storage/cassandra/spanstore/dbmodel/converter_test.go
@@ -237,8 +237,7 @@ func TestFailingFromDBSpanBadRefs(t *testing.T) {
 func failingDBSpanTransform(t *testing.T, dbSpan *Span, errMsg string) {
 	jSpan, err := ToDomain(dbSpan)
 	assert.Nil(t, jSpan)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), errMsg)
+	assert.ErrorContains(t, err, errMsg)
 }
 
 func TestFailingFromDBLogs(t *testing.T) {
@@ -255,13 +254,12 @@ func TestFailingFromDBLogs(t *testing.T) {
 	}
 	jLogs, err := converter{}.fromDBLogs(someDBLogs)
 	assert.Nil(t, jLogs)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), notValidTagTypeErrStr)
+	assert.ErrorContains(t, err, notValidTagTypeErrStr)
 }
 
 func TestDBTagTypeError(t *testing.T) {
 	_, err := converter{}.fromDBTag(&KeyValue{ValueType: "x"})
-	assert.Contains(t, err.Error(), notValidTagTypeErrStr)
+	assert.ErrorContains(t, err, notValidTagTypeErrStr)
 }
 
 func TestGenerateHashCode(t *testing.T) {

--- a/plugin/storage/cassandra/spanstore/reader_test.go
+++ b/plugin/storage/cassandra/spanstore/reader_test.go
@@ -177,8 +177,7 @@ func TestSpanReaderGetTrace(t *testing.T) {
 					require.NoError(t, err)
 					assert.NotNil(t, trace)
 				} else {
-					require.Error(t, err)
-					assert.Contains(t, err.Error(), testCase.expectedErr)
+					require.ErrorContains(t, err, testCase.expectedErr)
 					assert.Nil(t, trace)
 				}
 			})

--- a/plugin/storage/es/factory_test.go
+++ b/plugin/storage/es/factory_test.go
@@ -317,7 +317,6 @@ func TestESStorageFactoryWithConfigError(t *testing.T) {
 		LogLevel: "error",
 	}
 	_, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
-	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to create primary Elasticsearch client")
 }
 

--- a/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
+++ b/plugin/storage/es/spanstore/dbmodel/to_domain_test.go
@@ -188,8 +188,7 @@ func TestRevertKeyValueOfType(t *testing.T) {
 		t.Run(test.err, func(t *testing.T) {
 			tag := test.kv
 			_, err := td.convertKeyValue(tag)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), test.err)
+			assert.ErrorContains(t, err, test.err)
 		})
 	}
 }

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -204,7 +204,7 @@ func TestSpanWriter_WriteSpan(t *testing.T) {
 				}
 
 				for _, expectedLog := range testCase.expectedLogs {
-					assert.True(t, strings.Contains(w.logBuffer.String(), expectedLog), "Log must contain %s, but was %s", expectedLog, w.logBuffer.String())
+					assert.Contains(t, w.logBuffer.String(), expectedLog, "Log must contain %s, but was %s", expectedLog, w.logBuffer.String())
 				}
 				if len(testCase.expectedLogs) == 0 {
 					assert.Equal(t, "", w.logBuffer.String())

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -107,8 +107,7 @@ func TestNewFactoryError(t *testing.T) {
 	}
 	t.Run("with_config", func(t *testing.T) {
 		_, err := NewFactoryWithConfig(*cfg, metrics.NullFactory, zap.NewNop(), componenttest.NewNopHost())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "authenticator")
+		assert.ErrorContains(t, err, "authenticator")
 	})
 
 	t.Run("viper", func(t *testing.T) {
@@ -116,8 +115,7 @@ func TestNewFactoryError(t *testing.T) {
 		f.InitFromViper(viper.New(), zap.NewNop())
 		f.config = *cfg
 		err := f.Initialize(metrics.NullFactory, zap.NewNop())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "authenticator")
+		assert.ErrorContains(t, err, "authenticator")
 	})
 
 	t.Run("client", func(t *testing.T) {
@@ -129,8 +127,7 @@ func TestNewFactoryError(t *testing.T) {
 			return nil, errors.New("test error")
 		}
 		_, err = f.newRemoteStorage(component.TelemetrySettings{}, component.TelemetrySettings{}, newClientFn)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "error creating traced remote storage client")
+		assert.ErrorContains(t, err, "error creating traced remote storage client")
 	})
 }
 
@@ -282,8 +279,7 @@ func TestStreamingSpanWriterFactory_CapabilitiesNil(t *testing.T) {
 	writer, err := f.CreateSpanWriter()
 	require.NoError(t, err)
 	err = writer.WriteSpan(context.Background(), nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not streaming writer")
+	assert.ErrorContains(t, err, "not streaming writer")
 }
 
 func TestStreamingSpanWriterFactory_Capabilities(t *testing.T) {
@@ -307,18 +303,15 @@ func TestStreamingSpanWriterFactory_Capabilities(t *testing.T) {
 	writer, err := f.CreateSpanWriter()
 	require.NoError(t, err)
 	err = writer.WriteSpan(context.Background(), nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not streaming writer", "unary writer when Capabilities return error")
+	require.ErrorContains(t, err, "not streaming writer", "unary writer when Capabilities return error")
 
 	writer, err = f.CreateSpanWriter()
 	require.NoError(t, err)
 	err = writer.WriteSpan(context.Background(), nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not streaming writer", "unary writer when Capabilities return false")
+	require.ErrorContains(t, err, "not streaming writer", "unary writer when Capabilities return false")
 
 	writer, err = f.CreateSpanWriter()
 	require.NoError(t, err)
 	err = writer.WriteSpan(context.Background(), nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "I am streaming writer", "streaming writer when Capabilities return true")
+	assert.ErrorContains(t, err, "I am streaming writer", "streaming writer when Capabilities return true")
 }


### PR DESCRIPTION
## Description of the changes
- use `Contains` or `ErrorContains` with testify
- remove useless `Error` check before `ErrorContains` check

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
