### PR TITLE
chore: use testify instead of t.Fatal

### DIFF
--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -153,8 +153,7 @@ func TestStartStopRace(t *testing.T) {
 	// Before the bug was fixed this test was failing as expected when
 	// run with -race flag.
 
-	err = agent.Run()
-	require.NoErrorf(t, err, "error from agent.Run()")
+	require.NoError(t, agent.Run())
 
 	t.Log("stopping agent")
 	agent.Stop()
@@ -189,8 +188,7 @@ func TestStartStopWithSocketBufferSet(t *testing.T) {
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metricsFactory)
 	require.NoError(t, err)
 
-	err = agent.Run()
-	require.NoErrorf(t, err, "error from agent.Run()")
+	require.NoError(t, agent.Run())
 
 	t.Log("stopping agent")
 	agent.Stop()

--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -44,7 +44,7 @@ func TestAgentSamplingEndpoint(t *testing.T) {
 			}
 			select {
 			case err := <-errorch:
-				require.NoErrorf(t, err, "error from agent")
+				require.NoError(t, err, "error from agent")
 				break wait_loop
 			default:
 				time.Sleep(time.Millisecond)

--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -44,9 +44,7 @@ func TestAgentSamplingEndpoint(t *testing.T) {
 			}
 			select {
 			case err := <-errorch:
-				if err != nil {
-					t.Fatalf("error from agent: %s", err)
-				}
+				require.NoErrorf(t, err, "error from agent")
 				break wait_loop
 			default:
 				time.Sleep(time.Millisecond)
@@ -155,9 +153,8 @@ func TestStartStopRace(t *testing.T) {
 	// Before the bug was fixed this test was failing as expected when
 	// run with -race flag.
 
-	if err := agent.Run(); err != nil {
-		t.Fatalf("error from agent.Run(): %s", err)
-	}
+	err = agent.Run()
+	require.NoErrorf(t, err, "error from agent.Run()")
 
 	t.Log("stopping agent")
 	agent.Stop()
@@ -192,9 +189,8 @@ func TestStartStopWithSocketBufferSet(t *testing.T) {
 	agent, err := cfg.CreateAgent(fakeCollectorProxy{}, zap.NewNop(), metricsFactory)
 	require.NoError(t, err)
 
-	if err := agent.Run(); err != nil {
-		t.Fatalf("error from agent.Run(): %s", err)
-	}
+	err = agent.Run()
+	require.NoErrorf(t, err, "error from agent.Run()")
 
 	t.Log("stopping agent")
 	agent.Stop()

--- a/internal/metrics/prometheus/factory_test.go
+++ b/internal/metrics/prometheus/factory_test.go
@@ -401,7 +401,7 @@ func findMetric(t *testing.T, snapshot []*promModel.MetricFamily, name string, t
 			continue
 		}
 		for _, m := range mf.GetMetric() {
-			require.Equalf(t, len(m.GetLabel()), len(tags), "Mismatching labels for metric %v: want %v, have %v", name, tags, m.GetLabel())
+			require.Lenf(t, m.GetLabel(), len(tags), "Mismatching labels for metric %v: want %v, have %v", name, tags, m.GetLabel())
 			match := true
 			for _, l := range m.GetLabel() {
 				if v, ok := tags[l.GetName()]; !ok || v != l.GetValue() {

--- a/internal/metrics/prometheus/factory_test.go
+++ b/internal/metrics/prometheus/factory_test.go
@@ -401,9 +401,7 @@ func findMetric(t *testing.T, snapshot []*promModel.MetricFamily, name string, t
 			continue
 		}
 		for _, m := range mf.GetMetric() {
-			if len(m.GetLabel()) != len(tags) {
-				t.Fatalf("Mismatching labels for metric %v: want %v, have %v", name, tags, m.GetLabel())
-			}
+			require.Equalf(t, len(m.GetLabel()), len(tags), "Mismatching labels for metric %v: want %v, have %v", name, tags, m.GetLabel())
 			match := true
 			for _, l := range m.GetLabel() {
 				if v, ok := tags[l.GetName()]; !ok || v != l.GetValue() {

--- a/pkg/gogocodec/codec_test.go
+++ b/pkg/gogocodec/codec_test.go
@@ -97,9 +97,7 @@ func BenchmarkCodecUnmarshal25Spans(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var trace model.Trace
 		err := c.Unmarshal(bytes, &trace)
-		if err != nil {
-			b.Fatal(err)
-		}
+		require.NoError(b, err)
 	}
 }
 

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -156,8 +156,7 @@ func healthCheck() error {
 
 func testElasticsearchStorage(t *testing.T, allTagsAsFields bool) {
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")
-	err := healthCheck()
-	require.NoError(t, err)
+	require.NoError(t, healthCheck())
 	s := &ESStorageIntegration{
 		StorageIntegration: StorageIntegration{
 			Fixtures:        LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -180,8 +180,7 @@ func TestElasticsearchStorage_AllTagsAsObjectFields(t *testing.T) {
 
 func TestElasticsearchStorage_IndexTemplates(t *testing.T) {
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")
-	err := healthCheck()
-	require.NoError(t, err)
+	require.NoError(t, healthCheck())
 	s := &ESStorageIntegration{}
 	s.initializeES(t, true)
 	esVersion, err := s.getVersion()

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -156,9 +156,8 @@ func healthCheck() error {
 
 func testElasticsearchStorage(t *testing.T, allTagsAsFields bool) {
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")
-	if err := healthCheck(); err != nil {
-		t.Fatal(err)
-	}
+	err := healthCheck()
+	require.NoError(t, err)
 	s := &ESStorageIntegration{
 		StorageIntegration: StorageIntegration{
 			Fixtures:        LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
@@ -182,9 +181,8 @@ func TestElasticsearchStorage_AllTagsAsObjectFields(t *testing.T) {
 
 func TestElasticsearchStorage_IndexTemplates(t *testing.T) {
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")
-	if err := healthCheck(); err != nil {
-		t.Fatal(err)
-	}
+	err := healthCheck()
+	require.NoError(t, err)
 	s := &ESStorageIntegration{}
 	s.initializeES(t, true)
 	esVersion, err := s.getVersion()


### PR DESCRIPTION
## Description of the changes
- Replaces `t.Fatal` calls with `"github.com/stretchr/testify/require"` use

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
