### PR TITLE
Improve unit test speed

### DIFF
--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -197,6 +197,7 @@ func withServerAndClient(t *testing.T, actualTest func(server *grpcServer, clien
 }
 
 func TestGetTraceSuccessGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 			Return(mockTrace, nil).Once()
@@ -220,6 +221,7 @@ func assertGRPCError(t *testing.T, err error, code codes.Code, msg string) {
 }
 
 func TestGetTraceEmptyTraceIDFailure_GRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 			Return(mockTrace, nil).Once()
@@ -237,6 +239,7 @@ func TestGetTraceEmptyTraceIDFailure_GRPC(t *testing.T) {
 }
 
 func TestGetTraceDBFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 			Return(nil, errStorageGRPC).Once()
@@ -253,6 +256,7 @@ func TestGetTraceDBFailureGRPC(t *testing.T) {
 }
 
 func TestGetTraceNotFoundGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 			Return(nil, spanstore.ErrTraceNotFound).Once()
@@ -278,6 +282,7 @@ func TestGetTraceNilRequestOnHandlerGRPC(t *testing.T) {
 }
 
 func TestArchiveTraceSuccessGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 			Return(mockTrace, nil).Once()
@@ -293,6 +298,7 @@ func TestArchiveTraceSuccessGRPC(t *testing.T) {
 }
 
 func TestArchiveTraceNotFoundGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 			Return(nil, spanstore.ErrTraceNotFound).Once()
@@ -308,6 +314,7 @@ func TestArchiveTraceNotFoundGRPC(t *testing.T) {
 }
 
 func TestArchiveTraceEmptyTraceFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(_ *grpcServer, client *grpcClient) {
 		_, err := client.ArchiveTrace(context.Background(), &api_v2.ArchiveTraceRequest{
 			TraceID: model.TraceID{},
@@ -324,6 +331,7 @@ func TestArchiveTraceNilRequestOnHandlerGRPC(t *testing.T) {
 }
 
 func TestArchiveTraceFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 			Return(mockTrace, nil).Once()
@@ -366,6 +374,7 @@ func TestFindTracesSuccessGRPC(t *testing.T) {
 }
 
 func TestFindTracesSuccess_SpanStreamingGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
 			Return([]*model.Trace{mockLargeTraceGRPC}, nil).Once()
@@ -393,6 +402,7 @@ func TestFindTracesSuccess_SpanStreamingGRPC(t *testing.T) {
 }
 
 func TestFindTracesMissingQuery_GRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(_ *grpcServer, client *grpcClient) {
 		res, err := client.FindTraces(context.Background(), &api_v2.FindTracesRequest{
 			Query: nil,
@@ -406,6 +416,7 @@ func TestFindTracesMissingQuery_GRPC(t *testing.T) {
 }
 
 func TestFindTracesFailure_GRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		mockErrorGRPC := fmt.Errorf("whatsamattayou")
 
@@ -433,12 +444,14 @@ func TestFindTracesFailure_GRPC(t *testing.T) {
 
 // test from GRPCHandler and not grpcClient as Generated Go client panics with `nil` request
 func TestFindTracesNilRequestOnHandlerGRPC(t *testing.T) {
+	t.Parallel()
 	grpcHandler := &GRPCHandler{}
 	err := grpcHandler.FindTraces(nil, nil)
 	require.EqualError(t, err, errNilRequest.Error())
 }
 
 func TestGetServicesSuccessGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		expectedServices := []string{"trifle", "bling"}
 		server.spanReader.On("GetServices", mock.AnythingOfType("*context.valueCtx")).Return(expectedServices, nil).Once()
@@ -451,6 +464,7 @@ func TestGetServicesSuccessGRPC(t *testing.T) {
 }
 
 func TestGetServicesFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetServices", mock.AnythingOfType("*context.valueCtx")).Return(nil, errStorageGRPC).Once()
 		_, err := client.GetServices(context.Background(), &api_v2.GetServicesRequest{})
@@ -460,6 +474,7 @@ func TestGetServicesFailureGRPC(t *testing.T) {
 }
 
 func TestGetOperationsSuccessGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		expectedOperations := []spanstore.Operation{
 			{Name: ""},
@@ -486,6 +501,7 @@ func TestGetOperationsSuccessGRPC(t *testing.T) {
 }
 
 func TestGetOperationsFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		server.spanReader.On("GetOperations",
 			mock.AnythingOfType("*context.valueCtx"),
@@ -508,6 +524,7 @@ func TestGetOperationsNilRequestOnHandlerGRPC(t *testing.T) {
 }
 
 func TestGetDependenciesSuccessGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		expectedDependencies := []model.DependencyLink{{Parent: "killer", Child: "queen", CallCount: 12}}
 		endTs := time.Now().UTC()
@@ -527,6 +544,7 @@ func TestGetDependenciesSuccessGRPC(t *testing.T) {
 }
 
 func TestGetDependenciesFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		endTs := time.Now().UTC()
 		server.depReader.On(
@@ -545,6 +563,7 @@ func TestGetDependenciesFailureGRPC(t *testing.T) {
 }
 
 func TestGetDependenciesFailureUninitializedTimeGRPC(t *testing.T) {
+	t.Parallel()
 	timeInputs := []struct {
 		startTime time.Time
 		endTime   time.Time
@@ -589,6 +608,7 @@ func TestSendSpanChunksError(t *testing.T) {
 }
 
 func TestGetMetricsSuccessGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		baseQueryParam := &metrics.MetricsQueryBaseRequest{
 			ServiceNames: []string{"foo"},
@@ -635,6 +655,7 @@ func TestGetMetricsSuccessGRPC(t *testing.T) {
 }
 
 func TestGetMetricsReaderDisabledGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(_ *grpcServer, client *grpcClient) {
 		baseQueryParam := &metrics.MetricsQueryBaseRequest{
 			ServiceNames: []string{"foo"},
@@ -674,6 +695,7 @@ func TestGetMetricsReaderDisabledGRPC(t *testing.T) {
 }
 
 func TestGetMetricsUseDefaultParamsGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		baseQueryParam := &metrics.MetricsQueryBaseRequest{
 			ServiceNames: []string{"foo"},
@@ -703,6 +725,7 @@ func TestGetMetricsUseDefaultParamsGRPC(t *testing.T) {
 }
 
 func TestGetMetricsOverrideDefaultParamsGRPC(t *testing.T) {
+	t.Parallel()
 	loc, _ := time.LoadLocation("UTC")
 	endTime := time.Now().In(loc)
 	lookback := time.Minute
@@ -744,6 +767,7 @@ func TestGetMetricsOverrideDefaultParamsGRPC(t *testing.T) {
 }
 
 func TestGetMetricsFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		baseQueryParam := &metrics.MetricsQueryBaseRequest{
 			ServiceNames: []string{"foo"},
@@ -795,6 +819,7 @@ func TestGetMetricsFailureGRPC(t *testing.T) {
 }
 
 func TestGetMinStepDurationSuccessGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		m := server.metricsQueryService.(*metricsmocks.Reader)
 		m.On("GetMinStepDuration", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*metricsstore.MinStepDurationQueryParameters")).
@@ -807,6 +832,7 @@ func TestGetMinStepDurationSuccessGRPC(t *testing.T) {
 }
 
 func TestGetMinStepDurationFailureGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		m := server.metricsQueryService.(*metricsmocks.Reader)
 		m.On("GetMinStepDuration", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*metricsstore.MinStepDurationQueryParameters")).
@@ -821,6 +847,7 @@ func TestGetMinStepDurationFailureGRPC(t *testing.T) {
 }
 
 func TestGetMetricsInvalidParametersGRPC(t *testing.T) {
+	t.Parallel()
 	withServerAndClient(t, func(server *grpcServer, client *grpcClient) {
 		for _, tc := range []struct {
 			name          string
@@ -886,6 +913,7 @@ func TestGetMetricsInvalidParametersGRPC(t *testing.T) {
 }
 
 func TestMetricsQueryNilRequestGRPC(t *testing.T) {
+	t.Parallel()
 	grpcHandler := &GRPCHandler{}
 	bqp, err := grpcHandler.newBaseQueryParameters(nil)
 	assert.Empty(t, bqp)
@@ -952,6 +980,7 @@ func withOutgoingMetadata(t *testing.T, ctx context.Context, headerName, headerV
 }
 
 func TestSearchTenancyGRPC(t *testing.T) {
+	t.Parallel()
 	tm := tenancy.NewManager(&tenancy.Options{
 		Enabled: true,
 	})
@@ -988,6 +1017,7 @@ func TestSearchTenancyGRPC(t *testing.T) {
 }
 
 func TestServicesTenancyGRPC(t *testing.T) {
+	t.Parallel()
 	tm := tenancy.NewManager(&tenancy.Options{
 		Enabled: true,
 	})
@@ -1007,6 +1037,7 @@ func TestServicesTenancyGRPC(t *testing.T) {
 }
 
 func TestSearchTenancyGRPCExplicitList(t *testing.T) {
+	t.Parallel()
 	tm := tenancy.NewManager(&tenancy.Options{
 		Enabled: true,
 		Header:  "non-standard-tenant-header",
@@ -1089,6 +1120,7 @@ func TestSearchTenancyGRPCExplicitList(t *testing.T) {
 }
 
 func TestTenancyContextFlowGRPC(t *testing.T) {
+	t.Parallel()
 	tm := tenancy.NewManager(&tenancy.Options{
 		Enabled: true,
 	})
@@ -1162,6 +1194,7 @@ func TestTenancyContextFlowGRPC(t *testing.T) {
 }
 
 func TestNewGRPCHandlerWithEmptyOptions(t *testing.T) {
+	t.Parallel()
 	disabledReader, err := disabled.NewMetricsReader()
 	require.NoError(t, err)
 

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -152,6 +152,7 @@ func withTestServer(t *testing.T, doTest func(s *testServer), queryOptions query
 }
 
 func TestGetTraceSuccess(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Once()
@@ -174,6 +175,7 @@ func extractTraces(t *testing.T, response *structuredResponse) []ui.Trace {
 // TestGetTraceDedupeSuccess partially verifies that the standard adjusteres
 // are defined in correct order.
 func TestGetTraceDedupeSuccess(t *testing.T) {
+	t.Parallel()
 	dupedMockTrace := &model.Trace{
 		Spans:    append(mockTrace.Spans, mockTrace.Spans...),
 		Warnings: []string{},
@@ -195,6 +197,7 @@ func TestGetTraceDedupeSuccess(t *testing.T) {
 }
 
 func TestLogOnServerError(t *testing.T) {
+	t.Parallel()
 	zapCore, logs := observer.New(zap.InfoLevel)
 	logger := zap.New(zapCore)
 	readStorage := &spanstoremocks.Reader{}
@@ -222,6 +225,7 @@ func (*httpResponseErrWriter) Header() http.Header {
 }
 
 func TestWriteJSON(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name         string
 		data         any
@@ -267,7 +271,9 @@ func TestWriteJSON(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 			apiHandler := &APIHandler{
 				logger: zap.NewNop(),
 			}
@@ -287,6 +293,7 @@ func TestWriteJSON(t *testing.T) {
 }
 
 func TestGetTrace(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		suffix      string
 		numSpanRefs int
@@ -337,6 +344,7 @@ func TestGetTrace(t *testing.T) {
 }
 
 func TestGetTraceDBFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(nil, errStorage).Once()
@@ -347,6 +355,7 @@ func TestGetTraceDBFailure(t *testing.T) {
 }
 
 func TestGetTraceNotFound(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(nil, spanstore.ErrTraceNotFound).Once()
@@ -357,6 +366,7 @@ func TestGetTraceNotFound(t *testing.T) {
 }
 
 func TestGetTraceAdjustmentFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServerWithHandler(
 		t,
 		querysvc.QueryServiceOptions{
@@ -376,6 +386,7 @@ func TestGetTraceAdjustmentFailure(t *testing.T) {
 }
 
 func TestGetTraceBadTraceID(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 
 	var response structuredResponse
@@ -384,6 +395,7 @@ func TestGetTraceBadTraceID(t *testing.T) {
 }
 
 func TestSearchSuccess(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
 		Return([]*model.Trace{mockTrace}, nil).Once()
@@ -395,6 +407,7 @@ func TestSearchSuccess(t *testing.T) {
 }
 
 func TestSearchByTraceIDSuccess(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Twice()
@@ -407,6 +420,7 @@ func TestSearchByTraceIDSuccess(t *testing.T) {
 }
 
 func TestSearchByTraceIDSuccessWithArchive(t *testing.T) {
+	t.Parallel()
 	archiveReadMock := &spanstoremocks.Reader{}
 	ts := initializeTestServerWithOptions(t, &tenancy.Manager{}, querysvc.QueryServiceOptions{
 		ArchiveSpanReader: archiveReadMock,
@@ -424,6 +438,7 @@ func TestSearchByTraceIDSuccessWithArchive(t *testing.T) {
 }
 
 func TestSearchByTraceIDNotFound(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(nil, spanstore.ErrTraceNotFound).Once()
@@ -436,6 +451,7 @@ func TestSearchByTraceIDNotFound(t *testing.T) {
 }
 
 func TestSearchByTraceIDFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	whatsamattayou := "whatsamattayou"
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
@@ -447,6 +463,7 @@ func TestSearchByTraceIDFailure(t *testing.T) {
 }
 
 func TestSearchModelConversionFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServerWithOptions(
 		t,
 		&tenancy.Manager{},
@@ -466,6 +483,7 @@ func TestSearchModelConversionFailure(t *testing.T) {
 }
 
 func TestSearchDBFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
 		Return(nil, fmt.Errorf("whatsamattayou")).Once()
@@ -476,6 +494,7 @@ func TestSearchDBFailure(t *testing.T) {
 }
 
 func TestSearchFailures(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		urlStr string
 		errMsg string
@@ -505,6 +524,7 @@ func testIndividualSearchFailures(t *testing.T, urlStr, errMsg string) {
 }
 
 func TestGetServicesSuccess(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	expectedServices := []string{"trifle", "bling"}
 	ts.spanReader.On("GetServices", mock.AnythingOfType("*context.valueCtx")).Return(expectedServices, nil).Once()
@@ -520,6 +540,7 @@ func TestGetServicesSuccess(t *testing.T) {
 }
 
 func TestGetServicesStorageFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On("GetServices", mock.AnythingOfType("*context.valueCtx")).Return(nil, errStorage).Once()
 
@@ -529,6 +550,7 @@ func TestGetServicesStorageFailure(t *testing.T) {
 }
 
 func TestGetOperationsSuccess(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	expectedOperations := []spanstore.Operation{{Name: ""}, {Name: "get", SpanKind: "server"}}
 	ts.spanReader.On(
@@ -558,6 +580,7 @@ func TestGetOperationsSuccess(t *testing.T) {
 }
 
 func TestGetOperationsNoServiceName(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	var response structuredResponse
 	err := getJSON(ts.server.URL+"/api/operations", &response)
@@ -565,6 +588,7 @@ func TestGetOperationsNoServiceName(t *testing.T) {
 }
 
 func TestGetOperationsStorageFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On(
 		"GetOperations",
@@ -577,6 +601,7 @@ func TestGetOperationsStorageFailure(t *testing.T) {
 }
 
 func TestGetOperationsLegacySuccess(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	expectedOperationNames := []string{"", "get"}
 	expectedOperations := []spanstore.Operation{
@@ -598,6 +623,7 @@ func TestGetOperationsLegacySuccess(t *testing.T) {
 }
 
 func TestGetOperationsLegacyStorageFailure(t *testing.T) {
+	t.Parallel()
 	ts := initializeTestServer(t)
 	ts.spanReader.On(
 		"GetOperations",
@@ -609,6 +635,7 @@ func TestGetOperationsLegacyStorageFailure(t *testing.T) {
 }
 
 func TestTransformOTLPSuccess(t *testing.T) {
+	t.Parallel()
 	reformat := func(in []byte) []byte {
 		obj := new(any)
 		require.NoError(t, json.Unmarshal(in, obj))
@@ -637,6 +664,7 @@ func TestTransformOTLPSuccess(t *testing.T) {
 }
 
 func TestTransformOTLPReadError(t *testing.T) {
+	t.Parallel()
 	withTestServer(t, func(ts *testServer) {
 		bytesReader := &IoReaderMock{}
 		bytesReader.On("Read", mock.AnythingOfType("[]uint8")).Return(0, errors.New("Mocked error"))
@@ -646,6 +674,7 @@ func TestTransformOTLPReadError(t *testing.T) {
 }
 
 func TestTransformOTLPBadPayload(t *testing.T) {
+	t.Parallel()
 	withTestServer(t, func(ts *testServer) {
 		response := new(any)
 		request := "Bad Payload"
@@ -655,6 +684,7 @@ func TestTransformOTLPBadPayload(t *testing.T) {
 }
 
 func TestGetMetricsSuccess(t *testing.T) {
+	t.Parallel()
 	mr := &metricsmocks.Reader{}
 	apiHandlerOptions := []HandlerOption{
 		HandlerOptions.MetricsQueryService(mr),
@@ -740,6 +770,7 @@ func TestGetMetricsSuccess(t *testing.T) {
 }
 
 func TestMetricsReaderError(t *testing.T) {
+	t.Parallel()
 	metricsReader := &metricsmocks.Reader{}
 	ts := initializeTestServer(t, HandlerOptions.MetricsQueryService(metricsReader))
 
@@ -786,6 +817,7 @@ func TestMetricsReaderError(t *testing.T) {
 }
 
 func TestMetricsQueryDisabled(t *testing.T) {
+	t.Parallel()
 	disabledReader, err := disabled.NewMetricsReader()
 	require.NoError(t, err)
 
@@ -821,6 +853,7 @@ func TestMetricsQueryDisabled(t *testing.T) {
 }
 
 func TestGetMinStep(t *testing.T) {
+	t.Parallel()
 	metricsReader := &metricsmocks.Reader{}
 	ts := initializeTestServer(t, HandlerOptions.MetricsQueryService(metricsReader))
 	defer ts.server.Close()
@@ -908,6 +941,7 @@ func parsedError(code int, err string) string {
 }
 
 func TestSearchTenancyHTTP(t *testing.T) {
+	t.Parallel()
 	tenancyOptions := tenancy.Options{
 		Enabled: true,
 	}
@@ -934,6 +968,7 @@ func TestSearchTenancyHTTP(t *testing.T) {
 }
 
 func TestSearchTenancyRejectionHTTP(t *testing.T) {
+	t.Parallel()
 	tenancyOptions := tenancy.Options{
 		Enabled: true,
 	}
@@ -960,6 +995,7 @@ func TestSearchTenancyRejectionHTTP(t *testing.T) {
 }
 
 func TestSearchTenancyFlowTenantHTTP(t *testing.T) {
+	t.Parallel()
 	tenancyOptions := tenancy.Options{
 		Enabled: true,
 	}

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -106,6 +106,7 @@ func initializeTestService(optionAppliers ...testOption) *testQueryService {
 
 // Test QueryService.GetTrace()
 func TestGetTraceSuccess(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 	tqs.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Once()
@@ -119,6 +120,7 @@ func TestGetTraceSuccess(t *testing.T) {
 
 // Test QueryService.GetTrace() without ArchiveSpanReader
 func TestGetTraceNotFound(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 	tqs.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(nil, spanstore.ErrTraceNotFound).Once()
@@ -131,6 +133,7 @@ func TestGetTraceNotFound(t *testing.T) {
 
 // Test QueryService.GetTrace() with ArchiveSpanReader
 func TestGetTraceFromArchiveStorage(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService(withArchiveSpanReader())
 	tqs.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(nil, spanstore.ErrTraceNotFound).Once()
@@ -146,6 +149,7 @@ func TestGetTraceFromArchiveStorage(t *testing.T) {
 
 // Test QueryService.GetServices() for success.
 func TestGetServices(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 	expectedServices := []string{"trifle", "bling"}
 	tqs.spanReader.On("GetServices", mock.AnythingOfType("*context.valueCtx")).Return(expectedServices, nil).Once()
@@ -159,6 +163,7 @@ func TestGetServices(t *testing.T) {
 
 // Test QueryService.GetOperations() for success.
 func TestGetOperations(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 	expectedOperations := []spanstore.Operation{{Name: "", SpanKind: ""}, {Name: "get", SpanKind: ""}}
 	operationQuery := spanstore.OperationQueryParameters{ServiceName: "abc/trifle"}
@@ -177,6 +182,7 @@ func TestGetOperations(t *testing.T) {
 
 // Test QueryService.FindTraces() for success.
 func TestFindTraces(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 	tqs.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
 		Return([]*model.Trace{mockTrace}, nil).Once()
@@ -198,6 +204,7 @@ func TestFindTraces(t *testing.T) {
 
 // Test QueryService.ArchiveTrace() with no ArchiveSpanWriter.
 func TestArchiveTraceNoOptions(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 
 	type contextKey string
@@ -208,6 +215,7 @@ func TestArchiveTraceNoOptions(t *testing.T) {
 
 // Test QueryService.ArchiveTrace() with ArchiveSpanWriter but invalid traceID.
 func TestArchiveTraceWithInvalidTraceID(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService(withArchiveSpanReader(), withArchiveSpanWriter())
 	tqs.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(nil, spanstore.ErrTraceNotFound).Once()
@@ -222,6 +230,7 @@ func TestArchiveTraceWithInvalidTraceID(t *testing.T) {
 
 // Test QueryService.ArchiveTrace(), save error with ArchiveSpanWriter.
 func TestArchiveTraceWithArchiveWriterError(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService(withArchiveSpanWriter())
 	tqs.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Once()
@@ -237,6 +246,7 @@ func TestArchiveTraceWithArchiveWriterError(t *testing.T) {
 
 // Test QueryService.ArchiveTrace() with correctly configured ArchiveSpanWriter.
 func TestArchiveTraceSuccess(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService(withArchiveSpanWriter())
 	tqs.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("model.TraceID")).
 		Return(mockTrace, nil).Once()
@@ -251,6 +261,7 @@ func TestArchiveTraceSuccess(t *testing.T) {
 
 // Test QueryService.Adjust()
 func TestTraceAdjustmentFailure(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService(withAdjuster())
 
 	_, err := tqs.queryService.Adjust(mockTrace)
@@ -260,6 +271,7 @@ func TestTraceAdjustmentFailure(t *testing.T) {
 
 // Test QueryService.GetDependencies()
 func TestGetDependencies(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 	expectedDependencies := []model.DependencyLink{
 		{
@@ -282,6 +294,7 @@ func TestGetDependencies(t *testing.T) {
 
 // Test QueryService.GetCapacities()
 func TestGetCapabilities(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService()
 	expectedStorageCapabilities := StorageCapabilities{
 		ArchiveStorage: false,
@@ -290,6 +303,7 @@ func TestGetCapabilities(t *testing.T) {
 }
 
 func TestGetCapabilitiesWithSupportsArchive(t *testing.T) {
+	t.Parallel()
 	tqs := initializeTestService(withArchiveSpanReader(), withArchiveSpanWriter())
 
 	expectedStorageCapabilities := StorageCapabilities{

--- a/crossdock/services/query_test.go
+++ b/crossdock/services/query_test.go
@@ -34,6 +34,7 @@ func (*testQueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestGetTraces(t *testing.T) {
+	t.Parallel()
 	handler := &testQueryHandler{}
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -54,6 +55,7 @@ func TestGetTraces(t *testing.T) {
 }
 
 func TestGetTracesReadAllErr(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Length", "1")
 	}))

--- a/pkg/tenancy/http_test.go
+++ b/pkg/tenancy/http_test.go
@@ -56,7 +56,9 @@ func TestProgationHandler(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			handler := &testHttpHandler{}
 			propH := ExtractTenantHTTPHandler(test.tenancyMgr, handler)
 			req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader(""))
@@ -92,7 +94,9 @@ func TestMetadataAnnotator(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader(""))
 			for k, vs := range test.requestHeaders {
 				for _, v := range vs {


### PR DESCRIPTION


## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->
#6111 
## Description of the changes
- 
I referred to blog post discussed in #6111 and noted that t.Parallel() should only be used for tests with blocking operations like database queries or CPU-heavy tasks on a single core. For fast unit tests, the overhead of t.Parallel() can make them slower than running sequentially. I also applied t.Parallel() to test tables.
## How was this change tested?
- 
unit tests
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
