### PR TITLE
Respect environment variables when creating internal tracer

### DIFF
--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -113,7 +113,7 @@ func otelResource(ctx context.Context, svc string) (*resource.Resource, error) {
 
 func defaultGRPCOptions() []otlptracegrpc.Option {
 	var options []otlptracegrpc.Option
-	if strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")) == "true" {
+	if !(strings.HasPrefix(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"), "https://") || strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")) == "false") {
 		options = append(options, otlptracegrpc.WithInsecure())
 	}
 	return options

--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -5,6 +5,8 @@ package jtracer
 
 import (
 	"context"
+	"os"
+	"strings"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -109,9 +111,18 @@ func otelResource(ctx context.Context, svc string) (*resource.Resource, error) {
 	)
 }
 
+func defaultGRPCOptions() []otlptracegrpc.Option {
+	var options []otlptracegrpc.Option
+	if strings.HasPrefix(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"), "https://") ||
+		strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")) == "false" {
+		options = append(options, otlptracegrpc.WithInsecure())
+	}
+	return options
+}
+
 func otelExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
 	client := otlptracegrpc.NewClient(
-		otlptracegrpc.WithInsecure(),
+		defaultGRPCOptions()...,
 	)
 	return otlptrace.New(ctx, client)
 }

--- a/pkg/jtracer/jtracer.go
+++ b/pkg/jtracer/jtracer.go
@@ -113,8 +113,7 @@ func otelResource(ctx context.Context, svc string) (*resource.Resource, error) {
 
 func defaultGRPCOptions() []otlptracegrpc.Option {
 	var options []otlptracegrpc.Option
-	if strings.HasPrefix(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"), "https://") ||
-		strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")) == "false" {
+	if strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")) == "true" {
 		options = append(options, otlptracegrpc.WithInsecure())
 	}
 	return options


### PR DESCRIPTION

## Which problem is this PR solving?
Resolves #6122 

## Description of the changes
- The changes include using the `otlptracegrpc.WithInsecure()` based on `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_INSECURE` env variables.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
