### PR TITLE
fix: update Jaeger dashboard to use Time Series panel in Grafana

### DIFF
--- a/monitoring/jaeger-mixin/dashboard-for-grafana.json
+++ b/monitoring/jaeger-mixin/dashboard-for-grafana.json
@@ -1,931 +1,1344 @@
 {
    "annotations": {
-      "list": [ ]
+     "list": [
+       {
+         "builtIn": 1,
+         "datasource": {
+           "type": "grafana",
+           "uid": "-- Grafana --"
+         },
+         "enable": true,
+         "hide": true,
+         "iconColor": "rgba(0, 211, 255, 1)",
+         "name": "Annotations & Alerts",
+         "type": "dashboard"
+       }
+     ]
    },
    "editable": true,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": {
-                  "error": "#E24D42",
-                  "success": "#7EB26D"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 1,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum(rate(jaeger_tracer_reporter_spans_total[1m])) - sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "success",
-                     "refId": "B",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "span creation rate",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m])) by (namespace) / sum(rate(jaeger_tracer_reporter_spans_total[1m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "% spans dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": 1,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Services",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": {
-                  "error": "#E24D42",
-                  "success": "#7EB26D"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(jaeger_agent_reporter_batches_failures_total[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) - sum(rate(jaeger_agent_reporter_batches_failures_total[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "success",
-                     "refId": "B",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "batch ingest rate",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(jaeger_agent_reporter_batches_failures_total[1m])) by (cluster) / sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) by (cluster)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "% batches dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": 1,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Agent",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": {
-                  "error": "#E24D42",
-                  "success": "#7EB26D"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(jaeger_collector_spans_dropped_total[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum(rate(jaeger_collector_spans_received_total[1m])) - sum(rate(jaeger_collector_spans_dropped_total[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "success",
-                     "refId": "B",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "span ingest rate",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(jaeger_collector_spans_dropped_total[1m])) by (instance) / sum(rate(jaeger_collector_spans_received_total[1m])) by (instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "% spans dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": 1,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Collector",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "jaeger_collector_queue_length",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "span queue length",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 8,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.95, sum(rate(jaeger_collector_in_queue_latency_bucket[1m])) by (le, instance))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "span queue time - 95 percentile",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Collector Queue",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": {
-                  "error": "#E24D42",
-                  "success": "#7EB26D"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(jaeger_query_requests_total{result=\"err\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum(rate(jaeger_query_requests_total[1m])) - sum(rate(jaeger_query_requests_total{result=\"err\"}[1m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "success",
-                     "refId": "B",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "qps",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(jaeger_query_latency_bucket[1m])) by (le, instance))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "latency - 99 percentile",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Query",
-         "titleSize": "h6"
-      }
-   ],
-   "schemaVersion": 14,
-   "style": "dark",
-   "tags": [ ],
-   "templating": {
-      "list": [
+   "id": 31566,
+   "links": [],
+   "panels": [
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "000000001"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 0
+       },
+       "id": 11,
+       "panels": [],
+       "targets": [
          {
-            "current": {
-               "text": "Prometheus",
-               "value": "Prometheus"
-            },
-            "hide": 0,
-            "label": null,
-            "name": "datasource",
-            "options": [ ],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "type": "datasource"
+           "datasource": {
+             "type": "prometheus",
+             "uid": "000000001"
+           },
+           "refId": "A"
          }
-      ]
+       ],
+       "title": "Services",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "success"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#7EB26D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 1
+       },
+       "id": 1,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_tracer_reporter_spans_total[1m])) - sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "success",
+           "refId": "B",
+           "step": 10
+         }
+       ],
+       "title": "span creation rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "max": 1,
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 1
+       },
+       "id": 2,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_tracer_reporter_spans_total{result=~\"dropped|err\"}[1m])) by (namespace) / sum(rate(jaeger_tracer_reporter_spans_total[1m])) by (namespace)",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{namespace}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "% spans dropped",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "000000001"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 8
+       },
+       "id": 12,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "000000001"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Agent",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "success"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#7EB26D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 9
+       },
+       "id": 3,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_agent_reporter_batches_failures_total[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) - sum(rate(jaeger_agent_reporter_batches_failures_total[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "success",
+           "refId": "B",
+           "step": 10
+         }
+       ],
+       "title": "batch ingest rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "max": 1,
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 9
+       },
+       "id": 4,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_agent_reporter_batches_failures_total[1m])) by (cluster) / sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) by (cluster)",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{cluster}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "% batches dropped",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "000000001"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 16
+       },
+       "id": 13,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "000000001"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Collector",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "success"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#7EB26D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 17
+       },
+       "id": 5,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_collector_spans_dropped_total[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_collector_spans_received_total[1m])) - sum(rate(jaeger_collector_spans_dropped_total[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "success",
+           "refId": "B",
+           "step": 10
+         }
+       ],
+       "title": "span ingest rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "max": 1,
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 17
+       },
+       "id": 6,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_collector_spans_dropped_total[1m])) by (instance) / sum(rate(jaeger_collector_spans_received_total[1m])) by (instance)",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "% spans dropped",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "000000001"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 24
+       },
+       "id": 14,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "000000001"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Collector Queue",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 25
+       },
+       "id": 7,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "jaeger_collector_queue_length",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "span queue length",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 25
+       },
+       "id": 8,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.95, sum(rate(jaeger_collector_in_queue_latency_bucket[1m])) by (le, instance))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "span queue time - 95 percentile",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "000000001"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 32
+       },
+       "id": 15,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "000000001"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Query",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "success"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#7EB26D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 33
+       },
+       "id": 9,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_query_requests_total{result=\"err\"}[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum(rate(jaeger_query_requests_total[1m])) - sum(rate(jaeger_query_requests_total{result=\"err\"}[1m]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "success",
+           "refId": "B",
+           "step": 10
+         }
+       ],
+       "title": "qps",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 33
+       },
+       "id": 10,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "multi",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.11",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum(rate(jaeger_query_latency_bucket[1m])) by (le, instance))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "latency - 99 percentile",
+       "type": "timeseries"
+     }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 39,
+   "tags": [],
+   "templating": {
+     "list": [
+       {
+         "current": {
+           "selected": false,
+           "text": "Prometheus",
+           "value": "000000001"
+         },
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "type": "datasource"
+       }
+     ]
    },
    "time": {
-      "from": "now-1h",
-      "to": "now"
+     "from": "now-1h",
+     "to": "now"
    },
    "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
    },
    "timezone": "utc",
    "title": "Jaeger",
-   "uid": "",
-   "version": 0
-}
+   "uid": "de3cnltj62sqof",
+   "version": 1,
+   "weekStart": ""
+ }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #5833 

## Description of the changes
This PR updates the Jaeger dashboard JSON to replace the deprecated Grafana old Angular plugin with the Time Series panel. This change ensures compatibility with newer versions of Grafana. 

## How was this change tested?
The updated dashboard has been tested with Grafana version 11 to confirm proper rendering and functionality.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
