### PR TITLE
Relax regex in draft-release.py

### DIFF
--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -8,11 +8,11 @@ import re
 import subprocess
 
 generic_release_header_pattern = re.compile(
-    r".*(1\.\d+\.\d+)", flags=0
+    r".*v?(1\.\d+\.\d+)", flags=0
 )
 
 jaeger_release_header_pattern = re.compile(
-    r".*(1\.\d+\.\d+) */ *(2\.\d+\.\d+) \(\d{4}-\d{2}-\d{2}\)", flags=0
+    r".*v?(1\.\d+\.\d+) */ *v?(2\.\d+\.\d+) \(\d{4}-\d{2}-\d{2}\)", flags=0
 )
 
 underline_pattern = re.compile(r"^[-]+$", flags=0)


### PR DESCRIPTION
## Which problem is this PR solving?
- The script expects changelog header with digits only, but last release was with `v` prefix (as it was shown in the header template).

## Description of the changes
- Relax regex in the script to allow `v` prefix as well

## How was this change tested?
- `make draft-release` was run to create 2.0.0 release
