### PR TITLE
Parallelize the unit tests

### DIFF
--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -223,6 +223,7 @@ func TestCreateCollectorProxy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			flags := &flag.FlagSet{}
 			grpc.AddFlags(flags)
 			reporter.AddFlags(flags)

--- a/cmd/agent/app/reporter/grpc/builder_test.go
+++ b/cmd/agent/app/reporter/grpc/builder_test.go
@@ -300,10 +300,12 @@ func TestProxyClientTLS(t *testing.T) {
 			expectError: false,
 		},
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			var opts []grpc.ServerOption
 			if test.serverTLS.Enabled {
 				tlsCfg, err := test.serverTLS.Config(zap.NewNop())


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6111 

## Description of the changes
- Added t.parallel to tests where it made significant improvement 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
