### PR TITLE
Pass username/password to Cassandra docker-compose health check

### DIFF
--- a/docker-compose/cassandra/v4/docker-compose.yaml
+++ b/docker-compose/cassandra/v4/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   cassandra:
     image: cassandra:4.1
+    container_name: "cassandra-4"
     ports:
       - "9042:9042"
       - "9160:9160"
@@ -11,7 +12,7 @@ services:
     networks:
       - cassandra-net
     healthcheck:
-      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      test: ["CMD", "cqlsh", "-u", "cassandra", "-p", "cassandra", "-e", "describe keyspaces"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker-compose/cassandra/v5/docker-compose.yaml
+++ b/docker-compose/cassandra/v5/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   cassandra:
     image: cassandra:5.0
+    container_name: "cassandra-5"
     ports:
       - "9042:9042"
       - "9160:9160"
@@ -11,7 +12,7 @@ services:
     networks:
       - cassandra-net
     healthcheck:
-      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      test: ["CMD", "cqlsh", "-u", "cassandra", "-p", "cassandra", "-e", "describe keyspaces"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/scripts/cassandra-integration-test.sh
+++ b/scripts/cassandra-integration-test.sh
@@ -31,7 +31,7 @@ healthcheck_cassandra() {
   local container_name="cassandra-${cas_version}"
   local status="unhealthy"
   while [[ ${status} != "healthy" ]]; do
-    status=$(docker inspect -f '{{ .State.Health.Status }}' ${container_name})
+    status=$(docker inspect -f '{{ .State.Health.Status }}' "${container_name}")
     echo "healthcheck status=${status}"
     # Since the healthcheck in cassandra is done at the interval of 30s
     sleep 30;


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6215 

## Description of the changes
- Added the username and password values for health check cmd
- Added `healthcheck_cassandra` point to make sure the container is healthy as per the cmd.

## How was this change tested?
- bash scripts/cassandra-integration-test.sh 4 v004 v1 
- bash scripts/cassandra-integration-test.sh 4 v004 v2

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
