### PR TITLE
[fix][ci] Change the prometheus healthcheck endpoint 

### DIFF
--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -81,7 +81,7 @@ docker compose -f docker-compose-v2.yml up
 **Tips:**
 - Let the application run for a couple of minutes to ensure there is enough time series data to plot in the dashboard.
 - Navigate to Jaeger UI at http://localhost:16686/ and inspect the Monitor tab. Select `redis` service from the dropdown to see more than one endpoint.
-- To visualize the raw metrics stored on the Prometheus server (for debugging and local development use cases), use the built-in Prometheus UI at http://localhost:9090/graph. For example, http://localhost:9090/graph?g0.expr=traces_span_metrics_calls_total&g0.tab=0&g0.range_input=5m
+- To visualize the raw metrics stored on the Prometheus server (for debugging and local development use cases), use the built-in Prometheus UI at http://localhost:9090/query. For example, http://localhost:9090/query?g0.expr=traces_span_metrics_calls_total&g0.tab=0&g0.range_input=5m
 
 **Warning:** The included [docker-compose.yml](./docker-compose.yml) file uses the `latest` version of Jaeger and other components. If your local Docker registry already contains older versions, which may still be tagged as `latest`, you may want to delete those images before running the full set, to ensure consistent behavior:
 

--- a/scripts/spm-integration-test.sh
+++ b/scripts/spm-integration-test.sh
@@ -66,7 +66,7 @@ check_service_health() {
 wait_for_services() {
   echo "Waiting for services to be up and running..."
   check_service_health "Jaeger" "http://localhost:16686"
-  check_service_health "Prometheus" "http://localhost:9090/graph"
+  check_service_health "Prometheus" "http://localhost:9090/query"
 }
 
 # Function to validate the service metrics


### PR DESCRIPTION
## Description of the changes
- The SPM integration test in the CI has been failing consistently. It looks like the default endpoint for prometheus has changed from `localhost:9090/graph` to `localhost:9090/query`. This PR fixes that in the integration test and in the README. 

## How was this change tested?
- Integration test passes
- Ran the `docker-compose/monitor/docker-compose-v2.yml` example and verified that the prometheus UI displays the metrics at the new endpoint. 
<img width="1462" alt="Screenshot 2024-11-16 at 1 44 55 PM" src="https://github.com/user-attachments/assets/7192e8c3-5ca8-4695-a03a-35f7ee063cac">

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
