### PR TITLE
[storage][v2] Add reader adapter that just exposes the underlying v1 reader

### DIFF
--- a/storage_v2/factoryadapter/factory.go
+++ b/storage_v2/factoryadapter/factory.go
@@ -35,8 +35,12 @@ func (f *Factory) Close(_ context.Context) error {
 }
 
 // CreateTraceReader implements spanstore.Factory.
-func (*Factory) CreateTraceReader() (spanstore.Reader, error) {
-	panic("not implemented")
+func (f *Factory) CreateTraceReader() (spanstore.Reader, error) {
+	spanReader, err := f.ss.CreateSpanReader()
+	if err != nil {
+		return nil, err
+	}
+	return NewTraceReader(spanReader), nil
 }
 
 // CreateTraceWriter implements spanstore.Factory.

--- a/storage_v2/factoryadapter/factory_test.go
+++ b/storage_v2/factoryadapter/factory_test.go
@@ -37,14 +37,19 @@ func TestAdapterClose(t *testing.T) {
 }
 
 func TestAdapterCreateTraceReader(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("create trace reader did not panic")
-		}
-	}()
+	f1 := new(factoryMocks.Factory)
+	f1.On("CreateSpanReader").Return(new(spanstoreMocks.Reader), nil)
+	f := NewFactory(f1)
+	_, err := f.CreateTraceReader()
+	require.NoError(t, err)
+}
 
-	f := &Factory{}
-	f.CreateTraceReader()
+func TestAdapterCreateTraceReaderError(t *testing.T) {
+	f1 := new(factoryMocks.Factory)
+	f1.On("CreateSpanReader").Return(nil, errors.New("mock error"))
+	f := NewFactory(f1)
+	_, err := f.CreateTraceReader()
+	require.ErrorContains(t, err, "mock error")
 }
 
 func TestAdapterCreateTraceWriterError(t *testing.T) {

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package factoryadapter
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	spanstore_v1 "github.com/jaegertracing/jaeger/storage/spanstore"
+	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+)
+
+var errV1ReaderNotAvailable = errors.New("spanstore.Reader is not a wrapper around v1 reader")
+
+type TraceReader struct {
+	spanReader spanstore_v1.Reader
+}
+
+func GetV1Reader(reader spanstore.Reader) (spanstore_v1.Reader, error) {
+	if tr, ok := reader.(*TraceReader); ok {
+		return tr.spanReader, nil
+	}
+	return nil, errV1ReaderNotAvailable
+}
+
+func NewTraceReader(spanReader spanstore_v1.Reader) *TraceReader {
+	return &TraceReader{
+		spanReader: spanReader,
+	}
+}
+
+func (*TraceReader) GetTrace(_ context.Context, _ pcommon.TraceID) (ptrace.Traces, error) {
+	panic("not implemented")
+}
+
+func (*TraceReader) GetServices(_ context.Context) ([]string, error) {
+	panic("not implemented")
+}
+
+func (*TraceReader) GetOperations(_ context.Context, _ spanstore.OperationQueryParameters) ([]spanstore.Operation, error) {
+	panic("not implemented")
+}
+
+func (*TraceReader) FindTraces(_ context.Context, _ spanstore.TraceQueryParameters) ([]ptrace.Traces, error) {
+	panic("not implemented")
+}
+
+func (*TraceReader) FindTraceIDs(_ context.Context, _ spanstore.TraceQueryParameters) ([]pcommon.TraceID, error) {
+	panic("not implemented")
+}

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package factoryadapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/plugin/storage/memory"
+	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+)
+
+func TestGetV1Reader_NoError(t *testing.T) {
+	memstore := memory.NewStore()
+	traceReader := &TraceReader{
+		spanReader: memstore,
+	}
+	v1Reader, err := GetV1Reader(traceReader)
+	require.NoError(t, err)
+	require.Equal(t, memstore, v1Reader)
+}
+
+type fakeReader struct{}
+
+func (*fakeReader) GetTrace(_ context.Context, _ pcommon.TraceID) (ptrace.Traces, error) {
+	panic("not implemented")
+}
+
+func (*fakeReader) GetServices(_ context.Context) ([]string, error) {
+	panic("not implemented")
+}
+
+func (*fakeReader) GetOperations(_ context.Context, _ spanstore.OperationQueryParameters) ([]spanstore.Operation, error) {
+	panic("not implemented")
+}
+
+func (*fakeReader) FindTraces(_ context.Context, _ spanstore.TraceQueryParameters) ([]ptrace.Traces, error) {
+	panic("not implemented")
+}
+
+func (*fakeReader) FindTraceIDs(_ context.Context, _ spanstore.TraceQueryParameters) ([]pcommon.TraceID, error) {
+	panic("not implemented")
+}
+
+func TestGetV1Reader_Error(t *testing.T) {
+	fr := &fakeReader{}
+	_, err := GetV1Reader(fr)
+	require.ErrorIs(t, err, errV1ReaderNotAvailable)
+}
+
+func TestTraceReader_GetTracePanics(t *testing.T) {
+	memstore := memory.NewStore()
+	traceReader := &TraceReader{
+		spanReader: memstore,
+	}
+	require.Panics(t, func() { traceReader.GetTrace(context.Background(), pcommon.NewTraceIDEmpty()) })
+}
+
+func TestTraceReader_GetServicesPanics(t *testing.T) {
+	memstore := memory.NewStore()
+	traceReader := &TraceReader{
+		spanReader: memstore,
+	}
+	require.Panics(t, func() { traceReader.GetServices(context.Background()) })
+}
+
+func TestTraceReader_GetOperationsPanics(t *testing.T) {
+	memstore := memory.NewStore()
+	traceReader := &TraceReader{
+		spanReader: memstore,
+	}
+	require.Panics(
+		t,
+		func() { traceReader.GetOperations(context.Background(), spanstore.OperationQueryParameters{}) },
+	)
+}
+
+func TestTraceReader_FindTracesPanics(t *testing.T) {
+	memstore := memory.NewStore()
+	traceReader := &TraceReader{
+		spanReader: memstore,
+	}
+	require.Panics(
+		t,
+		func() { traceReader.FindTraces(context.Background(), spanstore.TraceQueryParameters{}) },
+	)
+}
+
+func TestTraceReader_FindTraceIDsPanics(t *testing.T) {
+	memstore := memory.NewStore()
+	traceReader := &TraceReader{
+		spanReader: memstore,
+	}
+	require.Panics(
+		t,
+		func() { traceReader.FindTraceIDs(context.Background(), spanstore.TraceQueryParameters{}) },
+	)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #5079 

## Description of the changes
- This PR implements the v2 `spanstore.Reader` interface in the factory adapter through the `TraceReader`, which is currently just a wrapper around the v1 `spanstore.Reader`. The `TraceReader` provides a function `GetV1Reader` that exposes the underlying v1 reader which will be used in https://github.com/jaegertracing/jaeger/pull/6170. 

## How was this change tested?
- Added unit tests for new functions

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
