### PR TITLE
Pass startTime & endTime in Trace Get request

### DIFF
--- a/cmd/query/app/apiv3/grpc_handler_test.go
+++ b/cmd/query/app/apiv3/grpc_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
@@ -125,6 +126,8 @@ func TestGetTraceTraceIDError(t *testing.T) {
 
 	getTraceStream, err := tsc.client.GetTrace(context.Background(), &api_v3.GetTraceRequest{
 		TraceId: "Z",
+		StartTime: time.Unix(1, 2),
+		EndTime: time.Unix(3, 4),
 	})
 	require.NoError(t, err)
 	recv, err := getTraceStream.Recv()


### PR DESCRIPTION
Test would fail on proto marshal

```
Running tool: /usr/bin/go test -timeout 30s -run ^TestGetTraceTraceIDError$ github.com/jaegertracing/jaeger/cmd/query/app/apiv3

--- FAIL: TestGetTraceTraceIDError (0.00s)
    /home/xxx/projects/go/jaeger/cmd/query/app/apiv3/grpc_handler_test.go:132: 
        	Error Trace:	/home/xxx/projects/go/jaeger/cmd/query/app/apiv3/grpc_handler_test.go:132
        	Error:      	Received unexpected error:
        	            	rpc error: code = Internal desc = grpc: error while marshaling: proto: time.Time does not implement Marshal
        	Test:       	TestGetTraceTraceIDError
FAIL
FAIL	github.com/jaegertracing/jaeger/cmd/query/app/apiv3	0.007s
FAIL
```