### PR TITLE
Fix ES integration test race conditions

### DIFF
--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -81,14 +81,14 @@ func NewSpanWriter(p SpanWriterParams) *SpanWriter {
 }
 
 // CreateTemplates creates index templates.
-func (s *SpanWriter) CreateTemplates(spanTemplate, serviceTemplate string, indexPrefix cfg.IndexPrefix) error {
+func (s *SpanWriter) CreateTemplates(ctx context.Context, spanTemplate, serviceTemplate string, indexPrefix cfg.IndexPrefix) error {
 	jaegerSpanIdx := indexPrefix.Apply("jaeger-span")
 	jaegerServiceIdx := indexPrefix.Apply("jaeger-service")
-	_, err := s.client().CreateTemplate(jaegerSpanIdx).Body(spanTemplate).Do(context.Background())
+	_, err := s.client().CreateTemplate(jaegerSpanIdx).Body(spanTemplate).Do(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create template %q: %w", jaegerSpanIdx, err)
 	}
-	_, err = s.client().CreateTemplate(jaegerServiceIdx).Body(serviceTemplate).Do(context.Background())
+	_, err = s.client().CreateTemplate(jaegerServiceIdx).Body(serviceTemplate).Do(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create template %q: %w", jaegerServiceIdx, err)
 	}


### PR DESCRIPTION
# Fix ES integration test race conditions

## Which problem is this PR solving?
Resolves #6094 - ES integration test race condition where spans are written before templates are fully created.

## Description of the changes
1. Added template creation synchronization in factory.go:
   - Added 30s timeout context
   - Added retry mechanism with exponential backoff
   - Ensure templates are created before returning writer

2. Updated writer.go's CreateTemplates:
   - Added context parameter for proper timeout handling
   - Using passed context in ES client calls

3. Sequence is now:

Before: Start -> Create Writer -> Start Template Creation -> Return Writer -> Write Spans (fails since template still creating)
After:  Start -> Create Writer -> Create Templates -> Retry if needed -> Templates Ready -> Return Writer -> Write Spans