### PR TITLE
Update docker-compose-v2.yml

### DIFF
--- a/examples/hotrod/docker-compose-v2.yml
+++ b/examples/hotrod/docker-compose-v2.yml
@@ -4,6 +4,9 @@
 services:
   jaeger:
     image: ${REGISTRY:-}jaegertracing/jaeger:${JAEGER_VERSION:-latest}
+    command:
+      - --set=receivers.otlp.protocols.grpc.endpoint="0.0.0.0:4317"
+      - --set=receivers.otlp.protocols.http.endpoint="0.0.0.0:4318"
     ports:
       - "16686:16686"
       - "4317:4317"


### PR DESCRIPTION
main branch should be consistent with 2.0.0 here, otherwise it will cause ports 4317 and 4318 to work on localhost, and the hotrod service will not be able to connect to port 4318


![image](https://github.com/user-attachments/assets/2a452811-6b35-48f2-abff-ea27ccd9475b)
![image](https://github.com/user-attachments/assets/2534a7b0-d931-4917-bb95-6f30a1dbf910)



<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
