### PR TITLE
Use OTEL helpers for TLS config instead of tlscfg in es-rollover

### DIFF
--- a/cmd/es-rollover/app/actions.go
+++ b/cmd/es-rollover/app/actions.go
@@ -4,14 +4,16 @@
 package app
 
 import (
+	"context"
 	"crypto/tls"
+	"flag"
 	"net/http"
 	"time"
 
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/pkg/es/client"
 )
 
@@ -35,30 +37,54 @@ type Action interface {
 	Do() error
 }
 
+type ClientConfig struct {
+	configtls.ClientConfig `mapstructure:",squash"`
+	Enabled                bool
+}
+
+func (c *ClientConfig) AddFlags(flags *flag.FlagSet) {
+	flags.BoolVar(&c.Enabled, "es.tls.enabled", false, "Enable TLS when talking to the remote server(s)")
+	flags.StringVar(&c.CAFile, "es.tls.ca", "", "Path to a TLS CA (Certification Authority) file used to verify the remote server(s) (by default will use the system truststore)")
+	flags.StringVar(&c.CertFile, "es.tls.cert", "", "Path to a TLS Certificate file, used to identify this process to the remote server(s)")
+	flags.StringVar(&c.KeyFile, "es.tls.key", "", "Path to a TLS Private Key file, used to identify this process to the remote server(s)")
+	flags.StringVar(&c.ServerName, "es.tls.server-name", "", "Override the TLS server name we expect in the certificate of the remote server(s)")
+	flags.BoolVar(&c.InsecureSkipVerify, "es.tls.skip-host-verify", false, "(insecure) Skip server's certificate chain and host name verification")
+}
+
 // ActionExecuteOptions are the options passed to the execute action function
 type ActionExecuteOptions struct {
-	Args     []string
-	Viper    *viper.Viper
-	Logger   *zap.Logger
-	TLSFlags tlscfg.ClientFlagsConfig
+	Args      []string
+	Viper     *viper.Viper
+	Logger    *zap.Logger
+	TLSConfig *ClientConfig
 }
 
 // ActionCreatorFunction type is the function type in charge of create the action to be executed
 type ActionCreatorFunction func(client.Client, Config) Action
 
+func getTLSConfig(tlsConfig *ClientConfig, logger *zap.Logger) (*tls.Config, error) {
+	if tlsConfig == nil {
+		return nil, nil
+	}
+
+	if tlsConfig.Insecure {
+		logger.Info("TLS is disabled")
+		return nil, nil
+	}
+
+	ctx := context.Background()
+
+	return tlsConfig.LoadTLSConfig(ctx)
+}
+
 // ExecuteAction execute the action returned by the createAction function
 func ExecuteAction(opts ActionExecuteOptions, createAction ActionCreatorFunction) error {
 	cfg := Config{}
 	cfg.InitFromViper(opts.Viper)
-	tlsOpts, err := opts.TLSFlags.InitFromViper(opts.Viper)
+	tlsCfg, err := getTLSConfig(opts.TLSConfig, opts.Logger)
 	if err != nil {
 		return err
 	}
-	tlsCfg, err := tlsOpts.Config(opts.Logger)
-	if err != nil {
-		return err
-	}
-	defer tlsOpts.Close()
 
 	esClient := newESClient(opts.Args[0], &cfg, tlsCfg)
 	action := createAction(esClient, cfg)

--- a/cmd/es-rollover/app/actions_test.go
+++ b/cmd/es-rollover/app/actions_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/pkg/es/client"
 )
 
@@ -74,10 +73,10 @@ func TestExecuteAction(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			v := viper.New()
-			tlsFlags := tlscfg.ClientFlagsConfig{Prefix: "es"}
+			tlfConfig := &ClientConfig{}
 			command := cobra.Command{}
 			flags := &flag.FlagSet{}
-			tlsFlags.AddFlags(flags)
+			tlfConfig.AddFlags(flags)
 			command.PersistentFlags().AddGoFlagSet(flags)
 			v.BindPFlags(command.PersistentFlags())
 			cmdLine := append([]string{"--es.tls.enabled=true"}, test.flags...)
@@ -85,10 +84,10 @@ func TestExecuteAction(t *testing.T) {
 			require.NoError(t, err)
 			executedAction := false
 			err = ExecuteAction(ActionExecuteOptions{
-				Args:     args,
-				Viper:    v,
-				Logger:   logger,
-				TLSFlags: tlsFlags,
+				Args:      args,
+				Viper:     v,
+				Logger:    logger,
+				TLSConfig: tlfConfig,
 			}, func(c client.Client, _ Config) Action {
 				assert.Equal(t, "https://localhost:9300", c.Endpoint)
 				transport, ok := c.Client.Transport.(*http.Transport)

--- a/cmd/es-rollover/main.go
+++ b/cmd/es-rollover/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app/lookback"
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app/rollover"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/pkg/es/client"
 )
 
@@ -30,7 +29,7 @@ func main() {
 		Long:  "Jaeger es-rollover manages Jaeger indices",
 	}
 
-	tlsFlags := tlscfg.ClientFlagsConfig{Prefix: "es"}
+	tlsConfig := &app.ClientConfig{}
 
 	// Init command
 	initCfg := &initialize.Config{}
@@ -42,10 +41,10 @@ func main() {
 		SilenceUsage: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return app.ExecuteAction(app.ActionExecuteOptions{
-				Args:     args,
-				Viper:    v,
-				Logger:   logger,
-				TLSFlags: tlsFlags,
+				Args:      args,
+				Viper:     v,
+				Logger:    logger,
+				TLSConfig: tlsConfig,
 			}, func(c client.Client, cfg app.Config) app.Action {
 				initCfg.Config = cfg
 				initCfg.InitFromViper(v)
@@ -80,10 +79,10 @@ func main() {
 		RunE: func(_ *cobra.Command, args []string) error {
 			rolloverCfg.InitFromViper(v)
 			return app.ExecuteAction(app.ActionExecuteOptions{
-				Args:     args,
-				Viper:    v,
-				Logger:   logger,
-				TLSFlags: tlsFlags,
+				Args:      args,
+				Viper:     v,
+				Logger:    logger,
+				TLSConfig: tlsConfig,
 			}, func(c client.Client, cfg app.Config) app.Action {
 				rolloverCfg.Config = cfg
 				rolloverCfg.InitFromViper(v)
@@ -109,10 +108,10 @@ func main() {
 		RunE: func(_ *cobra.Command, args []string) error {
 			lookbackCfg.InitFromViper(v)
 			return app.ExecuteAction(app.ActionExecuteOptions{
-				Args:     args,
-				Viper:    v,
-				Logger:   logger,
-				TLSFlags: tlsFlags,
+				Args:      args,
+				Viper:     v,
+				Logger:    logger,
+				TLSConfig: tlsConfig,
 			}, func(c client.Client, cfg app.Config) app.Action {
 				lookbackCfg.Config = cfg
 				lookbackCfg.InitFromViper(v)
@@ -129,7 +128,7 @@ func main() {
 		},
 	}
 
-	addPersistentFlags(v, rootCmd, tlsFlags.AddFlags, app.AddFlags)
+	addPersistentFlags(v, rootCmd, tlsConfig.AddFlags, app.AddFlags)
 	addSubCommand(v, rootCmd, initCommand, initCfg.AddFlags)
 	addSubCommand(v, rootCmd, rolloverCommand, rolloverCfg.AddFlags)
 	addSubCommand(v, rootCmd, lookbackCommand, lookbackCfg.AddFlags)


### PR DESCRIPTION

## Which problem is this PR solving?
- Part of #4316 
- 
## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
