### PR TITLE
[fix][test] Fix query server unit tests to check for status code

### DIFF
--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -449,7 +449,7 @@ func TestServerHTTPTLS(t *testing.T) {
 				require.NoError(t, clientClose())
 			}
 
-			if test.HTTPTLSEnabled && test.TLS.ClientCAFile != "" {
+			if test.HTTPTLSEnabled {
 				client := &http.Client{
 					Transport: &http.Transport{
 						TLSClientConfig: clientTLSCfg,

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -403,10 +403,9 @@ func TestServerHTTPTLS(t *testing.T) {
 				require.NoError(t, server.Close())
 			})
 
-			clientTLSCfg, err := test.clientTLS.LoadTLSConfig(context.Background())
-			require.NoError(t, err)
-
 			if test.HTTPTLSEnabled {
+				clientTLSCfg, err := test.clientTLS.LoadTLSConfig(context.Background())
+				require.NoError(t, err)
 				client := &http.Client{
 					Transport: &http.Transport{
 						TLSClientConfig: clientTLSCfg,

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -461,15 +461,18 @@ func TestServerHTTPTLS(t *testing.T) {
 				require.NoError(t, err)
 				req.Header.Add("Accept", "application/json")
 
-				resp, err2 := client.Do(req)
-				if err2 == nil {
-					resp.Body.Close()
-				}
+				resp, err := client.Do(req)
+				t.Cleanup(func() {
+					if err == nil {
+						resp.Body.Close()
+					}
+				})
 
 				if test.expectClientError {
-					require.Error(t, err2)
+					require.Error(t, err)
 				} else {
-					require.NoError(t, err2)
+					require.NoError(t, err)
+					require.Equal(t, resp.StatusCode, http.StatusOK)
 				}
 			}
 		})

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -428,7 +428,7 @@ func TestServerHTTPTLS(t *testing.T) {
 					require.Error(t, err)
 				} else {
 					require.NoError(t, err)
-					require.Equal(t, resp.StatusCode, http.StatusOK)
+					require.Equal(t, http.StatusOK, resp.StatusCode)
 				}
 			}
 		})

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -6,7 +6,6 @@ package app
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -135,7 +134,6 @@ var testCases = []struct {
 	HTTPTLSEnabled    bool
 	GRPCTLSEnabled    bool
 	clientTLS         configtls.ClientConfig
-	expectError       bool
 	expectClientError bool
 	expectServerFail  bool
 }{
@@ -147,7 +145,6 @@ var testCases = []struct {
 		clientTLS: configtls.ClientConfig{
 			Insecure: true,
 		},
-		expectError:       false,
 		expectClientError: false,
 		expectServerFail:  false,
 	},
@@ -165,7 +162,6 @@ var testCases = []struct {
 			Insecure:   true,
 			ServerName: "example.com",
 		},
-		expectError:       true,
 		expectClientError: true,
 		expectServerFail:  false,
 	},
@@ -186,7 +182,6 @@ var testCases = []struct {
 				CAFile: testCertKeyLocation + "/example-CA-cert.pem",
 			},
 		},
-		expectError:       true,
 		expectClientError: true,
 		expectServerFail:  false,
 	},
@@ -207,7 +202,6 @@ var testCases = []struct {
 				CAFile: testCertKeyLocation + "/example-CA-cert.pem",
 			},
 		},
-		expectError:       false,
 		expectClientError: false,
 		expectServerFail:  false,
 	},
@@ -229,7 +223,6 @@ var testCases = []struct {
 				CAFile: testCertKeyLocation + "/example-CA-cert.pem",
 			},
 		},
-		expectError:       false,
 		expectServerFail:  false,
 		expectClientError: true,
 	},
@@ -253,7 +246,6 @@ var testCases = []struct {
 				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
 			},
 		},
-		expectError:       false,
 		expectServerFail:  false,
 		expectClientError: false,
 	},
@@ -278,7 +270,6 @@ var testCases = []struct {
 				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
 			},
 		},
-		expectError:       false,
 		expectServerFail:  false,
 		expectClientError: true,
 	},
@@ -302,7 +293,6 @@ var testCases = []struct {
 				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
 			},
 		},
-		expectError:       false,
 		expectServerFail:  false,
 		expectClientError: false,
 	},
@@ -326,7 +316,6 @@ var testCases = []struct {
 				KeyFile:  testCertKeyLocation + "/example-client-key.pem",
 			},
 		},
-		expectError:       false,
 		expectServerFail:  false,
 		expectClientError: false,
 	},
@@ -362,7 +351,6 @@ func TestServerHTTPTLS(t *testing.T) {
 		HTTPTLSEnabled    bool
 		GRPCTLSEnabled    bool
 		clientTLS         configtls.ClientConfig
-		expectError       bool
 		expectClientError bool
 		expectServerFail  bool
 	}, testlen)
@@ -415,39 +403,8 @@ func TestServerHTTPTLS(t *testing.T) {
 				require.NoError(t, server.Close())
 			})
 
-			var clientError error
-			var clientClose func() error
-			var clientTLSCfg *tls.Config
-
-			if serverOptions.HTTP.TLSSetting != nil {
-				var err0 error
-				clientTLSCfg, err0 = test.clientTLS.LoadTLSConfig(context.Background())
-
-				require.NoError(t, err0)
-				dialer := &net.Dialer{Timeout: 2 * time.Second}
-				conn, err1 := tls.DialWithDialer(dialer, "tcp", server.HTTPAddr(), clientTLSCfg)
-				clientError = err1
-				clientClose = nil
-				if conn != nil {
-					clientClose = conn.Close
-				}
-			} else {
-				conn, err1 := net.DialTimeout("tcp", server.HTTPAddr(), 2*time.Second)
-				clientError = err1
-				clientClose = nil
-				if conn != nil {
-					clientClose = conn.Close
-				}
-			}
-
-			if test.expectError {
-				require.Error(t, clientError)
-			} else {
-				require.NoError(t, clientError)
-			}
-			if clientClose != nil {
-				require.NoError(t, clientClose())
-			}
+			clientTLSCfg, err := test.clientTLS.LoadTLSConfig(context.Background())
+			require.NoError(t, err)
 
 			if test.HTTPTLSEnabled {
 				client := &http.Client{
@@ -505,7 +462,6 @@ func TestServerGRPCTLS(t *testing.T) {
 		HTTPTLSEnabled    bool
 		GRPCTLSEnabled    bool
 		clientTLS         configtls.ClientConfig
-		expectError       bool
 		expectClientError bool
 		expectServerFail  bool
 	}, testlen)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6230 

## Description of the changes
- We had a bug report come in #6230 which wasn't caught by our unit tests. The reason here was because the test was not checking the status code of the response received from the server but rather just the error returned from doing `Client.Do`. 
- - This PR also cleans up the tests to remove the manual dial call and an unnecessary filter in the test body. 

## How was this change tested?
- This test passes on main because of the patch that was landed in https://github.com/jaegertracing/jaeger/pull/6239. 
- To verify that this test would have caught the bug, I ran this test on the v1.63.0 release. Running this test caused failures in the following tests, all of which were returning `400` instead of `200`.
```
TestServerHTTPTLS/should_pass_with_TLS_client_to_trusted_TLS_server_with_correct_hostname
TestServerHTTPTLS/should_pass_with_TLS_client_with_cert_to_trusted_TLS_server_requiring_cert
TestServerHTTPTLS/should_pass_with_TLS_client_with_cert_to_trusted_TLS_HTTP_server_requiring_cert_and_insecure_GRPC_server
```
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
