### PR TITLE
Enable get-return lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -213,9 +213,6 @@ linters-settings:
         # maybe enable, needs invesitgation of the impact
         - name: import-alias-naming
           disabled: true
-        # maybe enable, needs invesitgation of the impact
-        - name: get-return
-          disabled: true
         # investigate, could be real bugs. But didn't recent Go version changed loop variables semantics?
         - name: range-val-address
           disabled: true

--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -59,9 +59,9 @@ func TestAllInOne(t *testing.T) {
 	t.Run("healthCheckV2", healthCheckV2)
 	t.Run("checkWebUI", checkWebUI)
 	t.Run("createTrace", createTrace)
-	t.Run("getAPITrace", getAPITrace)
-	t.Run("getSamplingStrategy", getSamplingStrategy)
-	t.Run("getServicesAPIV3", getServicesAPIV3)
+	t.Run("getAPITrace", extractAPITrace)
+	t.Run("getSamplingStrategy", extractSamplingStrategy)
+	t.Run("getServicesAPIV3", extractServicesAPIV3)
 }
 
 func healthCheck(t *testing.T) {
@@ -152,7 +152,7 @@ type response struct {
 	Data []*ui.Trace `json:"data"`
 }
 
-func getAPITrace(t *testing.T) {
+func extractAPITrace(t *testing.T) {
 	var queryResponse response
 	for i := 0; i < 20; i++ {
 		_, body := httpGet(t, queryAddr+getTraceURL+traceID)
@@ -169,7 +169,7 @@ func getAPITrace(t *testing.T) {
 	require.Len(t, queryResponse.Data[0].Spans, 1)
 }
 
-func getSamplingStrategy(t *testing.T) {
+func extractSamplingStrategy(t *testing.T) {
 	// TODO should we test refreshing the strategy file?
 
 	r, body := httpGet(t, samplingAddr+getSamplingStrategyURL)
@@ -183,7 +183,7 @@ func getSamplingStrategy(t *testing.T) {
 	assert.InDelta(t, 1.0, queryResponse.ProbabilisticSampling.SamplingRate, 0.01)
 }
 
-func getServicesAPIV3(t *testing.T) {
+func extractServicesAPIV3(t *testing.T) {
 	_, body := httpGet(t, queryAddr+getServicesAPIV3URL)
 
 	var servicesResponse struct {

--- a/cmd/query/app/apiv3/gateway_test.go
+++ b/cmd/query/app/apiv3/gateway_test.go
@@ -142,7 +142,7 @@ func (gw *testGateway) runGatewayGetOperations(t *testing.T) {
 func (gw *testGateway) runGatewayGetTrace(t *testing.T) {
 	trace, traceID := makeTestTrace()
 	gw.reader.On("GetTrace", matchContext, traceID).Return(trace, nil).Once()
-	gw.getTracesAndVerify(t, "/api/v3/traces/"+traceID.String(), traceID)
+	gw.extractTracesAndVerify(t, "/api/v3/traces/"+traceID.String(), traceID)
 }
 
 func (gw *testGateway) runGatewayFindTraces(t *testing.T) {
@@ -151,10 +151,10 @@ func (gw *testGateway) runGatewayFindTraces(t *testing.T) {
 	gw.reader.
 		On("FindTraces", matchContext, qp).
 		Return([]*model.Trace{trace}, nil).Once()
-	gw.getTracesAndVerify(t, "/api/v3/traces?"+q.Encode(), traceID)
+	gw.extractTracesAndVerify(t, "/api/v3/traces?"+q.Encode(), traceID)
 }
 
-func (gw *testGateway) getTracesAndVerify(t *testing.T, url string, expectedTraceID model.TraceID) {
+func (gw *testGateway) extractTracesAndVerify(t *testing.T, url string, expectedTraceID model.TraceID) {
 	body, statusCode := gw.execRequest(t, url)
 	require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
 	body = gw.verifySnapshot(t, body)

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -52,10 +52,10 @@ type HTTPGateway struct {
 // RegisterRoutes registers HTTP endpoints for APIv3 into provided mux.
 // The called can create a subrouter if it needs to prepend a base path.
 func (h *HTTPGateway) RegisterRoutes(router *mux.Router) {
-	h.addRoute(router, h.getTrace, routeGetTrace).Methods(http.MethodGet)
+	h.addRoute(router, h.extractTrace, routeGetTrace).Methods(http.MethodGet)
 	h.addRoute(router, h.findTraces, routeFindTraces).Methods(http.MethodGet)
-	h.addRoute(router, h.getServices, routeGetServices).Methods(http.MethodGet)
-	h.addRoute(router, h.getOperations, routeGetOperations).Methods(http.MethodGet)
+	h.addRoute(router, h.extractServices, routeGetServices).Methods(http.MethodGet)
+	h.addRoute(router, h.extractOperations, routeGetOperations).Methods(http.MethodGet)
 }
 
 // addRoute adds a new endpoint to the router with given path and handler function.
@@ -129,7 +129,7 @@ func (*HTTPGateway) marshalResponse(response proto.Message, w http.ResponseWrite
 	_ = new(jsonpb.Marshaler).Marshal(w, response)
 }
 
-func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
+func (h *HTTPGateway) extractTrace(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	traceIDVar := vars[paramTraceID]
 	traceID, err := model.TraceIDFromString(traceIDVar)
@@ -211,7 +211,7 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 	return queryParams, false
 }
 
-func (h *HTTPGateway) getServices(w http.ResponseWriter, r *http.Request) {
+func (h *HTTPGateway) extractServices(w http.ResponseWriter, r *http.Request) {
 	services, err := h.QueryService.GetServices(r.Context())
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {
 		return
@@ -221,7 +221,7 @@ func (h *HTTPGateway) getServices(w http.ResponseWriter, r *http.Request) {
 	}, w)
 }
 
-func (h *HTTPGateway) getOperations(w http.ResponseWriter, r *http.Request) {
+func (h *HTTPGateway) extractOperations(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	queryParams := spanstore.OperationQueryParameters{
 		ServiceName: query.Get("service"),


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
#5506 

## Description of the changes
- Changed functions name `get` prefix -> `extract` prefix to bypass the linter

## How was this change tested?
- `make lint ``make test`

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
