### PR TITLE
Allow using different container runtime

### DIFF
--- a/Makefile.Protobuf.mk
+++ b/Makefile.Protobuf.mk
@@ -14,9 +14,10 @@
 # instead of the go_package's declared by the imported protof files.
 #
 
+DOCKER=docker
 DOCKER_PROTOBUF_VERSION=0.5.0
 DOCKER_PROTOBUF=jaegertracing/protobuf:$(DOCKER_PROTOBUF_VERSION)
-PROTOC := docker run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${DOCKER_PROTOBUF} --proto_path=${PWD}
+PROTOC := ${DOCKER} run --rm -u ${shell id -u} -v${PWD}:${PWD} -w${PWD} ${DOCKER_PROTOBUF} --proto_path=${PWD}
 
 PATCHED_OTEL_PROTO_DIR = proto-gen/.patched-otel-proto
 


### PR DESCRIPTION
## Which problem is this PR solving?

People can use different container manager in protobuf makefile

```
make DOCKER=podman PWD=${PWD} <makefile-target>

```

## Description of the changes
- 

## How was this change tested?
- unix test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
