### PR TITLE
[V3/API] Add time window for GetTrace http_gateway

### DIFF
--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -135,9 +135,25 @@ func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 	if h.tryParamError(w, err, paramTraceID) {
 		return
 	}
-	// TODO: add start time & end time
 	request := spanstore.GetTraceParameters{
 		TraceID: traceID,
+	}
+	http_query := r.URL.Query()
+	startTime := http_query.Get(paramStartTime)
+	if startTime != "" {
+		timeParsed, err := time.Parse(time.RFC3339Nano, startTime)
+		if h.tryParamError(w, err, paramStartTime) {
+			return
+		}
+		request.StartTime = timeParsed.UTC()
+	}
+	endTime := http_query.Get(paramEndTime)
+	if endTime != "" {
+		timeParsed, err := time.Parse(time.RFC3339Nano, endTime)
+		if h.tryParamError(w, err, paramEndTime) {
+			return
+		}
+		request.EndTime = timeParsed.UTC()
 	}
 	trc, err := h.QueryService.GetTrace(r.Context(), request)
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -90,25 +91,111 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.Contains(t, string(w.Body.String()), e, "writes error message to body")
 }
 
-func TestHTTPGatewayGetTraceErrors(t *testing.T) {
+func TestHTTPGatewayGetTrace(t *testing.T) {
+	traceId, _ := model.TraceIDFromString("123")
+	testCases := []struct {
+		name          string
+		expectedQuery spanstore.GetTraceParameters
+		params        map[string]string
+	}{
+		{
+			"TestGetTrace",
+			spanstore.GetTraceParameters{
+				TraceID: traceId,
+			},
+			map[string]string{},
+		},
+		{
+			"TestGetTraceWithTimeWindow",
+			spanstore.GetTraceParameters{
+				TraceID:   traceId,
+				StartTime: time.Date(2000, time.January, 0o2, 12, 30, 8, 999999998, time.UTC),
+				EndTime:   time.Date(2000, time.April, 0o5, 13, 55, 16, 999999992, time.UTC),
+			},
+			map[string]string{
+				"start_time": "2000-01-02T12:30:08.999999998Z",
+				"end_time":   "2000-04-05T21:55:16.999999992+08:00",
+			},
+		},
+	}
+
+	testUri := "/api/v3/traces/123"
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := setupHTTPGatewayNoServer(t, "")
+			gw.reader.
+				On("GetTrace", matchContext, tc.expectedQuery).
+				Return(&model.Trace{}, nil).Once()
+
+			q := url.Values{}
+			for k, v := range tc.params {
+				q.Set(k, v)
+			}
+			testUrl := testUri
+			if len(tc.params) > 0 {
+				testUrl += "?" + q.Encode()
+			}
+
+			r, err := http.NewRequest(http.MethodGet, testUrl, nil)
+			require.NoError(t, err)
+			w := httptest.NewRecorder()
+			gw.router.ServeHTTP(w, r)
+			gw.reader.AssertCalled(t, "GetTrace", matchContext, tc.expectedQuery)
+		})
+	}
+}
+
+func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		requestUrl    string
+		expectedError string
+	}{
+		{
+			"TestGetTrace",
+			"/api/v3/traces/xyz",
+			"malformed parameter trace_id",
+		},
+		{
+			"TestGetTraceWithInvalidStartTime",
+			"/api/v3/traces/123?start_time=abc",
+			"malformed parameter start_time",
+		},
+		{
+			"TestGetTraceWithInvalidEndTime",
+			"/api/v3/traces/123?end_time=xyz",
+			"malformed parameter end_time",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := setupHTTPGatewayNoServer(t, "")
+			gw.reader.
+				On("GetTrace", matchContext, matchGetTraceParameters).
+				Return(&model.Trace{}, nil).Once()
+
+			r, err := http.NewRequest(http.MethodGet, tc.requestUrl, nil)
+			require.NoError(t, err)
+			w := httptest.NewRecorder()
+			gw.router.ServeHTTP(w, r)
+			assert.Contains(t, w.Body.String(), tc.expectedError)
+		})
+	}
+}
+
+func TestHTTPGatewayGetTraceInternalErrors(t *testing.T) {
 	gw := setupHTTPGatewayNoServer(t, "")
-
-	// malformed trace id
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces/xyz", nil)
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
-	gw.router.ServeHTTP(w, r)
-	assert.Contains(t, w.Body.String(), "malformed parameter trace_id")
-
 	// error from span reader
 	const simErr = "simulated error"
 	gw.reader.
 		On("GetTrace", matchContext, matchGetTraceParameters).
 		Return(nil, errors.New(simErr)).Once()
 
-	r, err = http.NewRequest(http.MethodGet, "/api/v3/traces/123", nil)
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces/123", nil)
 	require.NoError(t, err)
-	w = httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
 	assert.Contains(t, w.Body.String(), simErr)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #4150 

## Description of the changes
- Add time window at HTTP API layer
- Should be merged after https://github.com/jaegertracing/jaeger/pull/6242/

## How was this change tested?
- unit test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
