### PR TITLE
Enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,6 +105,9 @@ linters:
     # Checks usage of github.com/stretchr/testify.
     - testifylint
 
+    # Detects the possibility to use variables/constants from the Go standard library.
+    - usestdlibvars
+
     # TODO consider adding more linters, cf. https://olegk.dev/go-linters-configuration-the-right-version
 
 linters-settings:

--- a/cmd/anonymizer/app/anonymizer/anonymizer_test.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer_test.go
@@ -4,6 +4,7 @@
 package anonymizer
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ import (
 
 var tags = []model.KeyValue{
 	model.Bool("error", true),
-	model.String("http.method", "POST"),
+	model.String("http.method", http.MethodPost),
 	model.Bool("foobar", true),
 }
 
@@ -127,7 +128,7 @@ func TestAnonymizer_SaveMapping(t *testing.T) {
 func TestAnonymizer_FilterStandardTags(t *testing.T) {
 	expected := []model.KeyValue{
 		model.Bool("error", true),
-		model.String("http.method", "POST"),
+		model.String("http.method", http.MethodPost),
 	}
 	actual := filterStandardTags(tags)
 	assert.Equal(t, expected, actual)

--- a/cmd/anonymizer/app/writer/writer_test.go
+++ b/cmd/anonymizer/app/writer/writer_test.go
@@ -4,6 +4,7 @@
 package writer
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 
 var tags = []model.KeyValue{
 	model.Bool("error", true),
-	model.String("http.method", "POST"),
+	model.String("http.method", http.MethodPost),
 	model.Bool("foobar", true),
 }
 

--- a/cmd/internal/status/command.go
+++ b/cmd/internal/status/command.go
@@ -30,7 +30,7 @@ func Command(v *viper.Viper, adminPort int) *cobra.Command {
 			url := convert(v.GetString(statusHTTPHostPort))
 			ctx, cx := context.WithTimeout(context.Background(), time.Second)
 			defer cx()
-			req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return err

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -760,12 +760,12 @@ func TestServerHTTPTenancy(t *testing.T) {
 		{
 			name: "no tenant",
 			// no value for tenant header
-			status: 401,
+			status: http.StatusUnauthorized,
 		},
 		{
 			name:   "tenant",
 			tenant: "acme",
-			status: 200,
+			status: http.StatusOK,
 		},
 	}
 

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// when method is HEAD, report back with a 200 when ready to run tests
-		if r.Method == "HEAD" {
+		if r.Method == http.MethodHead {
 			if !handler.isInitialized() {
 				http.Error(w, "Components not ready", http.StatusServiceUnavailable)
 			}
@@ -92,7 +92,7 @@ func (h *clientHandler) isInitialized() bool {
 }
 
 func is2xxStatusCode(statusCode int) bool {
-	return statusCode >= 200 && statusCode <= 299
+	return statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices
 }
 
 func httpHealthCheck(logger *zap.Logger, service, healthURL string) {

--- a/examples/hotrod/pkg/tracing/http.go
+++ b/examples/hotrod/pkg/tracing/http.go
@@ -48,7 +48,7 @@ func (c *HTTPClient) GetJSON(ctx context.Context, _ string /* endpoint */, url s
 
 	defer res.Body.Close()
 
-	if res.StatusCode >= 400 {
+	if res.StatusCode >= http.StatusBadRequest {
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err

--- a/examples/hotrod/pkg/tracing/rpcmetrics/metrics.go
+++ b/examples/hotrod/pkg/tracing/rpcmetrics/metrics.go
@@ -5,6 +5,7 @@
 package rpcmetrics
 
 import (
+	"net/http"
 	"sync"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -45,13 +46,13 @@ type Metrics struct {
 
 func (m *Metrics) recordHTTPStatusCode(statusCode int64) {
 	switch {
-	case statusCode >= 200 && statusCode < 300:
+	case statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices:
 		m.HTTPStatusCode2xx.Inc(1)
-	case statusCode >= 300 && statusCode < 400:
+	case statusCode >= http.StatusMultipleChoices && statusCode < http.StatusBadRequest:
 		m.HTTPStatusCode3xx.Inc(1)
-	case statusCode >= 400 && statusCode < 500:
+	case statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError:
 		m.HTTPStatusCode4xx.Inc(1)
-	case statusCode >= 500 && statusCode < 600:
+	case statusCode >= http.StatusInternalServerError && statusCode < 600:
 		m.HTTPStatusCode5xx.Inc(1)
 	}
 }

--- a/model/adjuster/sort_tags_and_log_fields_test.go
+++ b/model/adjuster/sort_tags_and_log_fields_test.go
@@ -5,6 +5,7 @@
 package adjuster
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,7 +89,7 @@ func TestSortTagsAndLogFieldsDoesSortFields(t *testing.T) {
 func TestSortTagsAndLogFieldsDoesSortTags(t *testing.T) {
 	testCases := []model.KeyValues{
 		{
-			model.String("http.method", "GET"),
+			model.String("http.method", http.MethodGet),
 			model.String("http.url", "http://wikipedia.org"),
 			model.Int64("http.status_code", 200),
 			model.String("guid:x-request-id", "f61defd2-7a77-11ef-b54f-4fbb67a6d181"),

--- a/pkg/bearertoken/transport_test.go
+++ b/pkg/bearertoken/transport_test.go
@@ -78,7 +78,7 @@ func TestRoundTripper(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(nil)
 			defer server.Close()
-			req, err := http.NewRequestWithContext(tc.requestContext, "GET", server.URL, nil)
+			req, err := http.NewRequestWithContext(tc.requestContext, http.MethodGet, server.URL, nil)
 			require.NoError(t, err)
 
 			tr := RoundTripper{

--- a/pkg/clientcfg/clientcfghttp/handler_test.go
+++ b/pkg/clientcfg/clientcfghttp/handler_test.go
@@ -283,14 +283,14 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			withServer("", probabilistic(0.001), restrictions("luggage", 10), withGorilla, func(ts *testServer) {
 				handler := ts.handler
 
-				req := httptest.NewRequest("GET", "http://localhost:80/?service=X", nil)
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:80/?service=X", nil)
 				w := &mockWriter{header: make(http.Header)}
 				handler.serveSamplingHTTP(w, req, handler.encodeThriftLegacy)
 
 				ts.metricsFactory.AssertCounterMetrics(t,
 					metricstest.ExpectedMetric{Name: "http-server.errors", Tags: map[string]string{"source": "write", "status": "5xx"}, Value: 1})
 
-				req = httptest.NewRequest("GET", "http://localhost:80/baggageRestrictions?service=X", nil)
+				req = httptest.NewRequest(http.MethodGet, "http://localhost:80/baggageRestrictions?service=X", nil)
 				handler.serveBaggageHTTP(w, req)
 
 				ts.metricsFactory.AssertCounterMetrics(t,

--- a/pkg/es/wrapper/wrapper.go
+++ b/pkg/es/wrapper/wrapper.go
@@ -7,6 +7,7 @@ package eswrapper
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	esV8 "github.com/elastic/go-elasticsearch/v8"
@@ -193,7 +194,7 @@ func (c TemplateCreatorWrapperV8) Do(context.Context) (*elastic.IndicesPutTempla
 	if err != nil {
 		return nil, fmt.Errorf("error creating index template %s: %w", c.templateName, err)
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("error creating index template %s: %s", c.templateName, resp)
 	}
 	return nil, nil // no response expected by span writer

--- a/pkg/version/handler.go
+++ b/pkg/version/handler.go
@@ -18,7 +18,7 @@ func RegisterHandler(mu *http.ServeMux, logger *zap.Logger) {
 		logger.Fatal("Could not get Jaeger version", zap.Error(err))
 	}
 	mu.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		w.Write(jsonData)
 	})
 }

--- a/plugin/sampling/strategyprovider/adaptive/aggregator_test.go
+++ b/plugin/sampling/strategyprovider/adaptive/aggregator_test.go
@@ -4,6 +4,7 @@
 package adaptive
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -37,12 +38,12 @@ func TestAggregator(t *testing.T) {
 
 	a, err := NewAggregator(testOpts, logger, metricsFactory, mockEP, mockStorage)
 	require.NoError(t, err)
-	a.RecordThroughput("A", "GET", model.SamplerTypeProbabilistic, 0.001)
-	a.RecordThroughput("B", "POST", model.SamplerTypeProbabilistic, 0.001)
-	a.RecordThroughput("C", "GET", model.SamplerTypeProbabilistic, 0.001)
-	a.RecordThroughput("A", "POST", model.SamplerTypeProbabilistic, 0.001)
-	a.RecordThroughput("A", "GET", model.SamplerTypeProbabilistic, 0.001)
-	a.RecordThroughput("A", "GET", model.SamplerTypeLowerBound, 0.001)
+	a.RecordThroughput("A", http.MethodGet, model.SamplerTypeProbabilistic, 0.001)
+	a.RecordThroughput("B", http.MethodPost, model.SamplerTypeProbabilistic, 0.001)
+	a.RecordThroughput("C", http.MethodGet, model.SamplerTypeProbabilistic, 0.001)
+	a.RecordThroughput("A", http.MethodPost, model.SamplerTypeProbabilistic, 0.001)
+	a.RecordThroughput("A", http.MethodGet, model.SamplerTypeProbabilistic, 0.001)
+	a.RecordThroughput("A", http.MethodGet, model.SamplerTypeLowerBound, 0.001)
 
 	a.Start()
 	defer a.Close()
@@ -74,17 +75,17 @@ func TestIncrementThroughput(t *testing.T) {
 	require.NoError(t, err)
 	// 20 different probabilities
 	for i := 0; i < 20; i++ {
-		a.RecordThroughput("A", "GET", model.SamplerTypeProbabilistic, 0.001*float64(i))
+		a.RecordThroughput("A", http.MethodGet, model.SamplerTypeProbabilistic, 0.001*float64(i))
 	}
-	assert.Len(t, a.(*aggregator).currentThroughput["A"]["GET"].Probabilities, 10)
+	assert.Len(t, a.(*aggregator).currentThroughput["A"][http.MethodGet].Probabilities, 10)
 
 	a, err = NewAggregator(testOpts, logger, metricsFactory, mockEP, mockStorage)
 	require.NoError(t, err)
 	// 20 of the same probabilities
 	for i := 0; i < 20; i++ {
-		a.RecordThroughput("A", "GET", model.SamplerTypeProbabilistic, 0.001)
+		a.RecordThroughput("A", http.MethodGet, model.SamplerTypeProbabilistic, 0.001)
 	}
-	assert.Len(t, a.(*aggregator).currentThroughput["A"]["GET"].Probabilities, 1)
+	assert.Len(t, a.(*aggregator).currentThroughput["A"][http.MethodGet].Probabilities, 1)
 }
 
 func TestLowerboundThroughput(t *testing.T) {
@@ -100,9 +101,9 @@ func TestLowerboundThroughput(t *testing.T) {
 
 	a, err := NewAggregator(testOpts, logger, metricsFactory, mockEP, mockStorage)
 	require.NoError(t, err)
-	a.RecordThroughput("A", "GET", model.SamplerTypeLowerBound, 0.001)
-	assert.EqualValues(t, 0, a.(*aggregator).currentThroughput["A"]["GET"].Count)
-	assert.Empty(t, a.(*aggregator).currentThroughput["A"]["GET"].Probabilities["0.001000"])
+	a.RecordThroughput("A", http.MethodGet, model.SamplerTypeLowerBound, 0.001)
+	assert.EqualValues(t, 0, a.(*aggregator).currentThroughput["A"][http.MethodGet].Count)
+	assert.Empty(t, a.(*aggregator).currentThroughput["A"][http.MethodGet].Probabilities["0.001000"])
 }
 
 func TestRecordThroughput(t *testing.T) {
@@ -132,7 +133,7 @@ func TestRecordThroughput(t *testing.T) {
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name and operation but no probabilistic sampling tags
-	span.OperationName = "GET"
+	span.OperationName = http.MethodGet
 	a.HandleRootSpan(span, logger)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
@@ -142,7 +143,7 @@ func TestRecordThroughput(t *testing.T) {
 		model.String("sampler.param", "0.001"),
 	}
 	a.HandleRootSpan(span, logger)
-	assert.EqualValues(t, 1, a.(*aggregator).currentThroughput["A"]["GET"].Count)
+	assert.EqualValues(t, 1, a.(*aggregator).currentThroughput["A"][http.MethodGet].Count)
 }
 
 func TestRecordThroughputFunc(t *testing.T) {
@@ -173,7 +174,7 @@ func TestRecordThroughputFunc(t *testing.T) {
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name and operation but no probabilistic sampling tags
-	span.OperationName = "GET"
+	span.OperationName = http.MethodGet
 	a.HandleRootSpan(span, logger)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
@@ -183,5 +184,5 @@ func TestRecordThroughputFunc(t *testing.T) {
 		model.String("sampler.param", "0.001"),
 	}
 	a.HandleRootSpan(span, logger)
-	assert.EqualValues(t, 1, a.(*aggregator).currentThroughput["A"]["GET"].Count)
+	assert.EqualValues(t, 1, a.(*aggregator).currentThroughput["A"][http.MethodGet].Count)
 }

--- a/plugin/sampling/strategyprovider/static/provider.go
+++ b/plugin/sampling/strategyprovider/static/provider.go
@@ -104,7 +104,7 @@ func (h *samplingProvider) downloadSamplingStrategies(samplingURL string) ([]byt
 
 	ctx, cx := context.WithTimeout(context.Background(), time.Second)
 	defer cx()
-	req, err := http.NewRequestWithContext(ctx, "GET", samplingURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, samplingURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot construct HTTP request: %w", err)
 	}

--- a/plugin/sampling/strategyprovider/static/provider_test.go
+++ b/plugin/sampling/strategyprovider/static/provider_test.go
@@ -73,15 +73,15 @@ func mockStrategyServer(t *testing.T) (*httptest.Server, *atomic.Pointer[string]
 			return
 
 		case "/bad-status":
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 			return
 
 		case "/service-unavailable":
-			w.WriteHeader(503)
+			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 
 		default:
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(*strategy.Load()))
 		}

--- a/plugin/storage/cassandra/samplingstore/storage_test.go
+++ b/plugin/storage/cassandra/samplingstore/storage_test.go
@@ -6,6 +6,7 @@ package samplingstore
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -329,12 +330,12 @@ func TestStringToThroughput(t *testing.T) {
 func TestProbabilitiesAndQPSToString(t *testing.T) {
 	probabilities := model.ServiceOperationProbabilities{
 		"svc,1": map[string]float64{
-			"GET": 0.001,
+			http.MethodGet: 0.001,
 		},
 	}
 	qps := model.ServiceOperationQPS{
 		"svc,1": map[string]float64{
-			"GET": 62.3,
+			http.MethodGet: 62.3,
 		},
 	}
 	str := probabilitiesAndQPSToString(probabilities, qps)
@@ -348,17 +349,17 @@ func TestStringToProbabilitiesAndQPS(t *testing.T) {
 
 	assert.Len(t, probabilities, 2)
 	assert.Equal(t, map[string]*model.ProbabilityAndQPS{
-		"GET": {
+		http.MethodGet: {
 			Probability: 0.001,
 			QPS:         63.2,
 		},
-		"PUT": {
+		http.MethodPut: {
 			Probability: 0.002,
 			QPS:         0.0,
 		},
 	}, probabilities["svc1"])
 	assert.Equal(t, map[string]*model.ProbabilityAndQPS{
-		"GET": {
+		http.MethodGet: {
 			Probability: 0.5,
 			QPS:         34.2,
 		},
@@ -371,8 +372,8 @@ func TestStringToProbabilities(t *testing.T) {
 	probabilities := s.stringToProbabilities(testStr)
 
 	assert.Len(t, probabilities, 2)
-	assert.Equal(t, map[string]float64{"GET": 0.001, "PUT": 0.002}, probabilities["svc1"])
-	assert.Equal(t, map[string]float64{"GET": 0.5}, probabilities["svc2"])
+	assert.Equal(t, map[string]float64{http.MethodGet: 0.001, http.MethodPut: 0.002}, probabilities["svc1"])
+	assert.Equal(t, map[string]float64{http.MethodGet: 0.5}, probabilities["svc2"])
 }
 
 func TestProbabilitiesSetToString(t *testing.T) {

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -5,6 +5,7 @@
 package es
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -117,7 +118,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "2006.01.02", aux.Indices.Services.DateLayout)
 	assert.Equal(t, "2006.01.02.15", aux.Indices.Spans.DateLayout)
 	assert.True(t, primary.UseILM)
-	assert.Equal(t, "POST", aux.SendGetBodyAs)
+	assert.Equal(t, http.MethodPost, aux.SendGetBodyAs)
 }
 
 func TestEmptyRemoteReadClusters(t *testing.T) {


### PR DESCRIPTION
#### Description
- enable [usestdlibvars](https://golangci-lint.run/usage/linters/#usestdlibvars) linter
- uses standard constants or vars instead of their values.

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->
