### PR TITLE
[test] Explicitly test writing traces with duplicate span ids

### DIFF
--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -387,8 +387,6 @@ func (s *StorageIntegration) writeLargeTraceWithDuplicateSpanIds(t *testing.T) *
 		newSpan := new(model.Span)
 		*newSpan = *repeatedSpan
 		switch {
-		case i == 0:
-			newSpan.SpanID = repeatedSpan.SpanID
 		case i%1000 == 0 || i%100 == 0:
 			newSpan.SpanID = repeatedSpan.SpanID
 		default:

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -255,7 +255,7 @@ func (s *StorageIntegration) testGetLargeSpanWithDuplicateIDs(t *testing.T) {
 		}
 	}
 
-	assert.Positivef(t, duplicateCount, "Duplicate SpanIDs should be present in the trace")
+	assert.Positive(t, duplicateCount, "Duplicate SpanIDs should be present in the trace")
 }
 
 func (s *StorageIntegration) testGetOperations(t *testing.T) {

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -224,11 +224,11 @@ func (s *StorageIntegration) testGetLargeSpan(t *testing.T) {
 	}
 }
 
-func (s *StorageIntegration) testGetLargeSpanWithDuplicateIds(t *testing.T) {
+func (s *StorageIntegration) testGetLargeSpanWithDuplicateIDs(t *testing.T) {
 	s.skipIfNeeded(t)
 	defer s.cleanUp(t)
 
-	t.Log("Testing Large Trace over 10K with duplicate ids...")
+	t.Log("Testing Large Trace over 10K with duplicate IDs...")
 
 	expected := s.loadParseAndWriteLargeTraceWithDuplicateSpanIds(t)
 	expectedTraceID := expected.Spans[0].TraceID
@@ -239,20 +239,23 @@ func (s *StorageIntegration) testGetLargeSpanWithDuplicateIds(t *testing.T) {
 		actual, err = s.SpanReader.GetTrace(context.Background(), expectedTraceID)
 		return err == nil && len(actual.Spans) >= len(expected.Spans)
 	})
+
 	if !assert.True(t, found) {
 		CompareTraces(t, expected, actual)
-	} else {
-		duplicateCount := 0
-		seenIDs := make(map[model.SpanID]int)
-
-		for _, span := range actual.Spans {
-			seenIDs[span.SpanID]++
-			if seenIDs[span.SpanID] > 1 {
-				duplicateCount++
-			}
-		}
-		assert.Greater(t, duplicateCount, 0, "Duplicate SpanIDs should be present in the trace")
+		return
 	}
+
+	duplicateCount := 0
+	seenIDs := make(map[model.SpanID]int)
+
+	for _, span := range actual.Spans {
+		seenIDs[span.SpanID]++
+		if seenIDs[span.SpanID] > 1 {
+			duplicateCount++
+		}
+	}
+
+	assert.Greater(t, duplicateCount, 0, "Duplicate SpanIDs should be present in the trace")
 }
 
 func (s *StorageIntegration) testGetOperations(t *testing.T) {

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -255,7 +255,7 @@ func (s *StorageIntegration) testGetLargeSpanWithDuplicateIDs(t *testing.T) {
 		}
 	}
 
-	assert.Greater(t, duplicateCount, 0, "Duplicate SpanIDs should be present in the trace")
+	assert.Positivef(t, duplicateCount, "Duplicate SpanIDs should be present in the trace")
 }
 
 func (s *StorageIntegration) testGetOperations(t *testing.T) {
@@ -428,15 +428,19 @@ func (s *StorageIntegration) loadParseAndWriteLargeTraceWithDuplicateSpanIds(t *
 	for i := 1; i < 10008; i++ {
 		s := new(model.Span)
 		*s = *span
-		if i%1000 == 0 {
+		switch {
+		case i%1000 == 0:
 			s.SpanID = span.SpanID
-		} else if i%100 == 0 && i%1000 != 0 {
+
+		case i%100 == 0 && i%1000 != 0:
 			s.SpanID = span.SpanID
-		} else {
+
+		default:
 			s.SpanID = model.SpanID(i)
+
+			s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
+			trace.Spans = append(trace.Spans, s)
 		}
-		s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
-		trace.Spans = append(trace.Spans, s)
 	}
 	s.writeTrace(t, trace)
 	return trace
@@ -627,5 +631,6 @@ func (s *StorageIntegration) RunSpanStoreTests(t *testing.T) {
 	t.Run("GetOperations", s.testGetOperations)
 	t.Run("GetTrace", s.testGetTrace)
 	t.Run("GetLargeSpans", s.testGetLargeSpan)
+	t.Run("GetLargeSpansWithDuplicateIDs", s.testGetLargeSpanWithDuplicateIDs)
 	t.Run("FindTraces", s.testFindTraces)
 }

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -437,10 +437,10 @@ func (s *StorageIntegration) loadParseAndWriteLargeTraceWithDuplicateSpanIds(t *
 
 		default:
 			s.SpanID = model.SpanID(i)
-
-			s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
-			trace.Spans = append(trace.Spans, s)
 		}
+		s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
+		trace.Spans = append(trace.Spans, s)
+
 	}
 	s.writeTrace(t, trace)
 	return trace

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -440,7 +440,6 @@ func (s *StorageIntegration) loadParseAndWriteLargeTraceWithDuplicateSpanIds(t *
 		}
 		s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
 		trace.Spans = append(trace.Spans, s)
-
 	}
 	s.writeTrace(t, trace)
 	return trace

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -235,7 +235,6 @@ func (s *StorageIntegration) testGetLargeSpan(t *testing.T) {
 			duplicateCount++
 		}
 	}
-
 	assert.Positive(t, duplicateCount, "Duplicate SpanIDs should be present in the trace")
 }
 

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -209,25 +209,6 @@ func (s *StorageIntegration) testGetLargeSpan(t *testing.T) {
 	s.skipIfNeeded(t)
 	defer s.cleanUp(t)
 
-	t.Log("Testing Large Trace over 10K ...")
-	expected := s.loadParseAndWriteLargeTraceWithUniqueSpanIds(t)
-	expectedTraceID := expected.Spans[0].TraceID
-
-	var actual *model.Trace
-	found := s.waitForCondition(t, func(_ *testing.T) bool {
-		var err error
-		actual, err = s.SpanReader.GetTrace(context.Background(), expectedTraceID)
-		return err == nil && len(actual.Spans) >= len(expected.Spans)
-	})
-	if !assert.True(t, found) {
-		CompareTraces(t, expected, actual)
-	}
-}
-
-func (s *StorageIntegration) testGetLargeSpanWithDuplicateIDs(t *testing.T) {
-	s.skipIfNeeded(t)
-	defer s.cleanUp(t)
-
 	t.Log("Testing Large Trace over 10K with duplicate IDs...")
 
 	expected := s.loadParseAndWriteLargeTraceWithDuplicateSpanIds(t)
@@ -395,25 +376,6 @@ func (s *StorageIntegration) writeTrace(t *testing.T, trace *model.Trace) {
 
 func (s *StorageIntegration) loadParseAndWriteExampleTrace(t *testing.T) *model.Trace {
 	trace := s.getTraceFixture(t, "example_trace")
-	s.writeTrace(t, trace)
-	return trace
-}
-
-func (s *StorageIntegration) loadParseAndWriteLargeTraceWithUniqueSpanIds(t *testing.T) *model.Trace {
-	trace := s.getTraceFixture(t, "example_trace")
-	span := trace.Spans[0]
-	span.SpanID = model.SpanID(0)
-	spns := make([]*model.Span, 1, 10008)
-	trace.Spans = spns
-	trace.Spans[0] = span
-	for i := 1; i < 10008; i++ {
-		s := new(model.Span)
-		*s = *span
-		//nolint: gosec // G115
-		s.SpanID = model.SpanID(i)
-		s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
-		trace.Spans = append(trace.Spans, s)
-	}
 	s.writeTrace(t, trace)
 	return trace
 }
@@ -630,6 +592,5 @@ func (s *StorageIntegration) RunSpanStoreTests(t *testing.T) {
 	t.Run("GetOperations", s.testGetOperations)
 	t.Run("GetTrace", s.testGetTrace)
 	t.Run("GetLargeSpans", s.testGetLargeSpan)
-	t.Run("GetLargeSpansWithDuplicateIDs", s.testGetLargeSpanWithDuplicateIDs)
 	t.Run("FindTraces", s.testFindTraces)
 }

--- a/plugin/storage/integration/integration.go
+++ b/plugin/storage/integration/integration.go
@@ -387,7 +387,7 @@ func (s *StorageIntegration) writeLargeTraceWithDuplicateSpanIds(t *testing.T) *
 		newSpan := new(model.Span)
 		*newSpan = *repeatedSpan
 		switch {
-		case i%1000 == 0 || i%100 == 0:
+		case i%100 == 0:
 			newSpan.SpanID = repeatedSpan.SpanID
 		default:
 			newSpan.SpanID = model.SpanID(i)


### PR DESCRIPTION
Signed-off-by: vaidikcode <vaidikbhardwaj00@gmail.com>



## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->
#4466 
## Description of the changes
- 
added new testGetLargeSpanWithDuplicateIds with a method to generate duplicate span ids and also fixed testGetLargeSpan to generate unique ids
## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
