### PR TITLE
[refactor] Normalize jaegerstorage names

### DIFF
--- a/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
@@ -175,9 +175,11 @@ func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
 		extension.Settings{
 			TelemetrySettings: telemetrySettings,
 		},
-		&jaegerstorage.Config{Backends: map[string]jaegerstorage.Backend{
-			memstoreName: {Memory: &memory.Configuration{MaxTraces: 10000}},
-		}},
+		&jaegerstorage.Config{
+			TraceBackends: map[string]jaegerstorage.TraceBackend{
+				memstoreName: {Memory: &memory.Configuration{MaxTraces: 10000}},
+			},
+		},
 	)
 	require.NoError(t, err)
 

--- a/cmd/jaeger/internal/extension/jaegerstorage/config.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config.go
@@ -25,8 +25,8 @@ import (
 
 var (
 	_ component.ConfigValidator = (*Config)(nil)
-	_ confmap.Unmarshaler       = (*Backend)(nil)
-	_ confmap.Unmarshaler       = (*MetricBackends)(nil)
+	_ confmap.Unmarshaler       = (*TraceBackend)(nil)
+	_ confmap.Unmarshaler       = (*MetricBackend)(nil)
 )
 
 // Config contains configuration(s) for jaeger trace storage.
@@ -35,11 +35,12 @@ var (
 // We tried to alias this type directly to a map, but conf did not populated it correctly.
 // Note also that the Backend struct has a custom unmarshaler.
 type Config struct {
-	Backends       map[string]Backend        `mapstructure:"backends"`
-	MetricBackends map[string]MetricBackends `mapstructure:"metric_backends"`
+	TraceBackends  map[string]TraceBackend  `mapstructure:"backends"`
+	MetricBackends map[string]MetricBackend `mapstructure:"metric_backends"`
 }
 
-type Backend struct {
+// TraceBackend contains configuration for a single trace storage backend.
+type TraceBackend struct {
 	Memory        *memory.Configuration `mapstructure:"memory"`
 	Badger        *badger.Config        `mapstructure:"badger"`
 	GRPC          *grpc.Config          `mapstructure:"grpc"`
@@ -48,14 +49,15 @@ type Backend struct {
 	Opensearch    *esCfg.Configuration  `mapstructure:"opensearch"`
 }
 
-type MetricBackends struct {
+// MetricBackend contains configuration for a single metric storage backend.
+type MetricBackend struct {
 	Prometheus *promCfg.Configuration `mapstructure:"prometheus"`
 }
 
 // Unmarshal implements confmap.Unmarshaler. This allows us to provide
 // defaults for different configs. It cannot be done in createDefaultConfig()
 // because at that time we don't know which backends the user wants to use.
-func (cfg *Backend) Unmarshal(conf *confmap.Conf) error {
+func (cfg *TraceBackend) Unmarshal(conf *confmap.Conf) error {
 	// apply defaults
 	if conf.IsSet("memory") {
 		cfg.Memory = &memory.Configuration{
@@ -96,19 +98,19 @@ func (cfg *Backend) Unmarshal(conf *confmap.Conf) error {
 }
 
 func (cfg *Config) Validate() error {
-	if len(cfg.Backends) == 0 {
+	if len(cfg.TraceBackends) == 0 {
 		return errors.New("at least one storage is required")
 	}
-	for name, b := range cfg.Backends {
-		empty := Backend{}
+	for name, b := range cfg.TraceBackends {
+		empty := TraceBackend{}
 		if reflect.DeepEqual(b, empty) {
-			return fmt.Errorf("no backend defined for storage '%s'", name)
+			return fmt.Errorf("empty backend configuration for storage '%s'", name)
 		}
 	}
 	return nil
 }
 
-func (cfg *MetricBackends) Unmarshal(conf *confmap.Conf) error {
+func (cfg *MetricBackend) Unmarshal(conf *confmap.Conf) error {
 	// apply defaults
 	if conf.IsSet("prometheus") {
 		v := prometheus.DefaultConfig()

--- a/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
@@ -50,7 +50,7 @@ backends:
 `)
 	cfg := createDefaultConfig().(*Config)
 	require.NoError(t, conf.Unmarshal(cfg))
-	assert.NotEmpty(t, cfg.Backends["some_storage"].Memory.MaxTraces)
+	assert.NotEmpty(t, cfg.TraceBackends["some_storage"].Memory.MaxTraces)
 }
 
 func TestConfigDefaultBadger(t *testing.T) {
@@ -61,7 +61,7 @@ backends:
 `)
 	cfg := createDefaultConfig().(*Config)
 	require.NoError(t, conf.Unmarshal(cfg))
-	assert.NotEmpty(t, cfg.Backends["some_storage"].Badger.TTL.Spans)
+	assert.NotEmpty(t, cfg.TraceBackends["some_storage"].Badger.TTL.Spans)
 }
 
 func TestConfigDefaultGRPC(t *testing.T) {
@@ -72,7 +72,7 @@ backends:
 `)
 	cfg := createDefaultConfig().(*Config)
 	require.NoError(t, conf.Unmarshal(cfg))
-	assert.NotEmpty(t, cfg.Backends["some_storage"].GRPC.Timeout)
+	assert.NotEmpty(t, cfg.TraceBackends["some_storage"].GRPC.Timeout)
 }
 
 func TestConfigDefaultCassandra(t *testing.T) {
@@ -83,7 +83,7 @@ backends:
 `)
 	cfg := createDefaultConfig().(*Config)
 	require.NoError(t, conf.Unmarshal(cfg))
-	assert.NotEmpty(t, cfg.Backends["some_storage"].Cassandra.Primary.Connection.Servers)
+	assert.NotEmpty(t, cfg.TraceBackends["some_storage"].Cassandra.Primary.Connection.Servers)
 }
 
 func TestConfigDefaultElasticsearch(t *testing.T) {
@@ -94,7 +94,7 @@ backends:
 `)
 	cfg := createDefaultConfig().(*Config)
 	require.NoError(t, conf.Unmarshal(cfg))
-	assert.NotEmpty(t, cfg.Backends["some_storage"].Elasticsearch.Servers)
+	assert.NotEmpty(t, cfg.TraceBackends["some_storage"].Elasticsearch.Servers)
 }
 
 func TestConfigDefaultOpensearch(t *testing.T) {
@@ -105,7 +105,7 @@ backends:
 `)
 	cfg := createDefaultConfig().(*Config)
 	require.NoError(t, conf.Unmarshal(cfg))
-	assert.NotEmpty(t, cfg.Backends["some_storage"].Opensearch.Servers)
+	assert.NotEmpty(t, cfg.TraceBackends["some_storage"].Opensearch.Servers)
 }
 
 func TestConfigDefaultPrometheus(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
@@ -39,7 +39,7 @@ backends:
 `)
 	cfg := createDefaultConfig().(*Config)
 	require.NoError(t, conf.Unmarshal(cfg))
-	require.EqualError(t, cfg.Validate(), "no backend defined for storage 'some_storage'")
+	require.EqualError(t, cfg.Validate(), "empty backend configuration for storage 'some_storage'")
 }
 
 func TestConfigDefaultMemory(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -118,7 +118,7 @@ func newStorageExt(config *Config, telset component.TelemetrySettings) *storageE
 func (s *storageExt) Start(_ context.Context, host component.Host) error {
 	baseFactory := otelmetrics.NewFactory(s.telset.MeterProvider)
 	mf := baseFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
-	for storageName, cfg := range s.config.Backends {
+	for storageName, cfg := range s.config.TraceBackends {
 		s.telset.Logger.Sugar().Infof("Initializing storage '%s'", storageName)
 		var factory storage.Factory
 		var err error = errors.New("empty configuration")

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -123,7 +123,7 @@ func TestGetFactory(t *testing.T) {
 
 func TestBadger(t *testing.T) {
 	ext := makeStorageExtenion(t, &Config{
-		Backends: map[string]Backend{
+		TraceBackends: map[string]TraceBackend{
 			"foo": {
 				Badger: &badger.Config{
 					Ephemeral:             true,
@@ -141,7 +141,7 @@ func TestBadger(t *testing.T) {
 
 func TestGRPC(t *testing.T) {
 	ext := makeStorageExtenion(t, &Config{
-		Backends: map[string]Backend{
+		TraceBackends: map[string]TraceBackend{
 			"foo": {
 				GRPC: &grpc.Config{
 					ClientConfig: configgrpc.ClientConfig{
@@ -159,7 +159,7 @@ func TestGRPC(t *testing.T) {
 
 func TestPrometheus(t *testing.T) {
 	ext := makeStorageExtenion(t, &Config{
-		MetricBackends: map[string]MetricBackends{
+		MetricBackends: map[string]MetricBackend{
 			"foo": {
 				Prometheus: &promCfg.Configuration{
 					ServerURL: "localhost:12345",
@@ -175,7 +175,7 @@ func TestPrometheus(t *testing.T) {
 
 func TestStartError(t *testing.T) {
 	ext := makeStorageExtenion(t, &Config{
-		Backends: map[string]Backend{
+		TraceBackends: map[string]TraceBackend{
 			"foo": {},
 		},
 	})
@@ -186,7 +186,7 @@ func TestStartError(t *testing.T) {
 
 func TestMetricsStorageStartError(t *testing.T) {
 	ext := makeStorageExtenion(t, &Config{
-		MetricBackends: map[string]MetricBackends{
+		MetricBackends: map[string]MetricBackend{
 			"foo": {
 				Prometheus: &promCfg.Configuration{},
 			},
@@ -196,9 +196,9 @@ func TestMetricsStorageStartError(t *testing.T) {
 	require.ErrorContains(t, err, "failed to initialize metrics storage 'foo'")
 }
 
-func testElasticsearchOrOpensearch(t *testing.T, cfg Backend) {
+func testElasticsearchOrOpensearch(t *testing.T, cfg TraceBackend) {
 	ext := makeStorageExtenion(t, &Config{
-		Backends: map[string]Backend{
+		TraceBackends: map[string]TraceBackend{
 			"foo": cfg,
 		},
 	})
@@ -220,7 +220,7 @@ func TestXYZsearch(t *testing.T) {
 	}))
 	defer server.Close()
 	t.Run("Elasticsearch", func(t *testing.T) {
-		testElasticsearchOrOpensearch(t, Backend{
+		testElasticsearchOrOpensearch(t, TraceBackend{
 			Elasticsearch: &esCfg.Configuration{
 				Servers:  []string{server.URL},
 				LogLevel: "error",
@@ -228,7 +228,7 @@ func TestXYZsearch(t *testing.T) {
 		})
 	})
 	t.Run("OpenSearch", func(t *testing.T) {
-		testElasticsearchOrOpensearch(t, Backend{
+		testElasticsearchOrOpensearch(t, TraceBackend{
 			Opensearch: &esCfg.Configuration{
 				Servers:  []string{server.URL},
 				LogLevel: "error",
@@ -241,7 +241,7 @@ func TestCassandraError(t *testing.T) {
 	// since we cannot successfully create storage factory for Cassandra
 	// without running a Cassandra server, we only test the error case.
 	ext := makeStorageExtenion(t, &Config{
-		Backends: map[string]Backend{
+		TraceBackends: map[string]TraceBackend{
 			"cassandra": {
 				Cassandra: &cassandra.Options{},
 			},
@@ -280,14 +280,14 @@ func makeStorageExtenion(t *testing.T, config *Config) component.Component {
 
 func startStorageExtension(t *testing.T, memstoreName string, promstoreName string) component.Component {
 	config := &Config{
-		Backends: map[string]Backend{
+		TraceBackends: map[string]TraceBackend{
 			memstoreName: {
 				Memory: &memory.Configuration{
 					MaxTraces: 10000,
 				},
 			},
 		},
-		MetricBackends: map[string]MetricBackends{
+		MetricBackends: map[string]MetricBackend{
 			promstoreName: {
 				Prometheus: &promCfg.Configuration{
 					ServerURL: "localhost:12345",

--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -50,7 +50,7 @@ func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
 		extension.Settings{
 			TelemetrySettings: telemetrySettings,
 		},
-		&jaegerstorage.Config{Backends: map[string]jaegerstorage.Backend{
+		&jaegerstorage.Config{TraceBackends: map[string]jaegerstorage.TraceBackend{
 			memstoreName: {Memory: &memory.Configuration{MaxTraces: 10000}},
 		}},
 	)

--- a/cmd/jaeger/internal/processors/adaptivesampling/processor_test.go
+++ b/cmd/jaeger/internal/processors/adaptivesampling/processor_test.go
@@ -42,9 +42,11 @@ func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
 		extension.Settings{
 			TelemetrySettings: telemetrySettings,
 		},
-		&jaegerstorage.Config{Backends: map[string]jaegerstorage.Backend{
-			memstoreName: {Memory: &memory.Configuration{MaxTraces: 10000}},
-		}},
+		&jaegerstorage.Config{
+			TraceBackends: map[string]jaegerstorage.TraceBackend{
+				memstoreName: {Memory: &memory.Configuration{MaxTraces: 10000}},
+			},
+		},
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description of the changes
- Make config struct naming more consistent
  - Backends -> TraceBackends
  - Backend -> TraceBackend
  - MetricBackends -> MetricBackend

## How was this change tested?
- CI
