### PR TITLE
[v2] Use only version number for BuildInfo

### DIFF
--- a/cmd/jaeger/internal/command.go
+++ b/cmd/jaeger/internal/command.go
@@ -30,7 +30,7 @@ func Command() *cobra.Command {
 	info := component.BuildInfo{
 		Command:     "jaeger",
 		Description: description,
-		Version:     version.Get().String(),
+		Version:     version.Get().GitVersion,
 	}
 
 	settings := otelcol.CollectorSettings{


### PR DESCRIPTION
## Which problem is this PR solving?
We were passing the whole VersionInfo to OTEL's BuildInfo, which resulted in the metrics being labeled with a very long string: `service_version="git-commit=600d82c5815289ba13197ce80b742c0f4411df78, git-version=v2.0.0, build-date=2024-11-26T15:15:15Z"`

## Description of the changes
Only pass the actual version. The metrics become much more readable: `jaeger_query_responses_count{operation="get_services",service_instance_id="06f22e3e-3ad7-4067-8b0f-15d35b329712",service_name="jaeger",service_version="v2.0.0"}`

## How was this change tested?
`$ curl -s http://localhost:8888/metrics | grep -v '^#' | grep 'get_services'`
