### PR TITLE
Use real metrics factory instead of NullFactory

### DIFF
--- a/plugin/sampling/strategyprovider/adaptive/factory.go
+++ b/plugin/sampling/strategyprovider/adaptive/factory.go
@@ -37,11 +37,10 @@ type Factory struct {
 // NewFactory creates a new Factory.
 func NewFactory() *Factory {
 	return &Factory{
-		options:        &Options{},
-		logger:         zap.NewNop(),
-		metricsFactory: metrics.NullFactory,
-		lock:           nil,
-		store:          nil,
+		options: &Options{},
+		logger:  zap.NewNop(),
+		lock:    nil,
+		store:   nil,
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Some components were still using `metrics.NullFactory`

## Description of the changes
- Create real factory from OTEL MetricsProvider

## How was this change tested?
- CI
