### PR TITLE
[prometheus] Use OTEL helper instead of tlscfg package

### DIFF
--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -7,15 +7,14 @@ import (
 	"time"
 
 	"github.com/asaskevich/govalidator"
-
-	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
+	"go.opentelemetry.io/collector/config/configtls"
 )
 
 // Configuration describes the options to customize the storage behavior.
 type Configuration struct {
 	ServerURL      string        `valid:"required" mapstructure:"endpoint"`
 	ConnectTimeout time.Duration `mapstructure:"connect_timeout"`
-	TLS            tlscfg.Options
+	TLS            configtls.ClientConfig
 
 	TokenFilePath            string `mapstructure:"token_file_path"`
 	TokenOverrideFromContext bool   `mapstructure:"token_override_from_context"`

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -5,7 +5,6 @@ package metricsstore
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -316,7 +316,6 @@ func logErrorToSpan(span trace.Span, err error) {
 }
 
 func getHTTPRoundTripper(c *config.Configuration, _ *zap.Logger) (rt http.RoundTripper, err error) {
-	var ctlsConfig *tls.Config
 	ctlsConfig, err := c.TLS.LoadTLSConfig(context.Background())
 	if err != nil {
 		return nil, err

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -317,8 +317,7 @@ func logErrorToSpan(span trace.Span, err error) {
 
 func getHTTPRoundTripper(c *config.Configuration, _ *zap.Logger) (rt http.RoundTripper, err error) {
 	var ctlsConfig *tls.Config
-	ctx := context.Background()
-	ctlsConfig, err = c.TLS.LoadTLSConfig(ctx)
+	ctlsConfig, err := c.TLS.LoadTLSConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/metrics/prometheus/metricsstore/reader.go
+++ b/plugin/metrics/prometheus/metricsstore/reader.go
@@ -315,12 +315,12 @@ func logErrorToSpan(span trace.Span, err error) {
 	span.SetStatus(codes.Error, err.Error())
 }
 
-func getHTTPRoundTripper(c *config.Configuration, logger *zap.Logger) (rt http.RoundTripper, err error) {
+func getHTTPRoundTripper(c *config.Configuration, _ *zap.Logger) (rt http.RoundTripper, err error) {
 	var ctlsConfig *tls.Config
-	if c.TLS.Enabled {
-		if ctlsConfig, err = c.TLS.Config(logger); err != nil {
-			return nil, err
-		}
+	ctx := context.Background()
+	ctlsConfig, err = c.TLS.LoadTLSConfig(ctx)
+	if err != nil {
+		return nil, err
 	}
 	// KeepAlive and TLSHandshake timeouts are kept to existing Prometheus client's
 	// DefaultRoundTripper to simplify user configuration and may be made configurable when required.


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #4316 

## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
