### PR TITLE
[chore][fix] Rename `NewWriteDecorator` to `NewWriter`

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -217,7 +217,7 @@ func NewClient(c *Configuration, logger *zap.Logger, metricsFactory metrics.Fact
 		return nil, err
 	}
 
-	sm := spanstoremetrics.NewWriterDecorator(metricsFactory, "bulk_index")
+	sm := spanstoremetrics.NewWriter(metricsFactory, "bulk_index")
 	m := sync.Map{}
 
 	bulkProc, err := rawClient.BulkProcessor().

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -72,7 +72,7 @@ func NewSpanWriter(p SpanWriterParams) *SpanWriter {
 		client: p.Client,
 		logger: p.Logger,
 		writerMetrics: spanWriterMetrics{
-			indexCreate: spanstoremetrics.NewWriterDecorator(p.MetricsFactory, "index_create"),
+			indexCreate: spanstoremetrics.NewWriter(p.MetricsFactory, "index_create"),
 		},
 		serviceWriter:    serviceOperationStorage.Write,
 		spanConverter:    dbmodel.NewFromDomain(p.AllTagsAsFields, p.TagKeysAsFields, p.TagDotReplacement),

--- a/storage/spanstore/spanstoremetrics/write_metrics.go
+++ b/storage/spanstore/spanstoremetrics/write_metrics.go
@@ -19,8 +19,8 @@ type WriteMetrics struct {
 	LatencyErr metrics.Timer   `metric:"latency-err"`
 }
 
-// NewWriterDecorator takes a metrics scope and creates a metrics struct
-func NewWriterDecorator(factory metrics.Factory, tableName string) *WriteMetrics {
+// NewWriter takes a metrics scope and creates a metrics struct
+func NewWriter(factory metrics.Factory, tableName string) *WriteMetrics {
 	t := &WriteMetrics{}
 	metrics.Init(t, factory.Namespace(metrics.NSOptions{Name: tableName, Tags: nil}), nil)
 	return t

--- a/storage/spanstore/spanstoremetrics/write_metrics_test.go
+++ b/storage/spanstore/spanstoremetrics/write_metrics_test.go
@@ -53,7 +53,7 @@ func TestTableEmit(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		mf := metricstest.NewFactory(time.Second)
-		tm := NewWriterDecorator(mf, "a_table")
+		tm := NewWriter(mf, "a_table")
 		tm.Emit(tc.err, 50*time.Millisecond)
 		counts, gauges := mf.Snapshot()
 		assert.Equal(t, tc.counts, counts)


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6219 

## Description of the changes
- In https://github.com/jaegertracing/jaeger/pull/6255, `NewMetricsWriter` was renamed to `NewWriterDecorator`. However, `MetricWriter` is not a decorator and simply a helper so this PR changes the function to be called `spanstoremetrics.NewWriter`. 

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
