### PR TITLE
[refactor] Fix package misspelling: telemetery->telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,7 @@ Dependencies upgrades only.
 
 #### 🚧 Experimental Features
 
-* Implement telemetery struct for v1 components initialization ([@Wise-Wizard](https://github.com/Wise-Wizard) in [#5695](https://github.com/jaegertracing/jaeger/pull/5695))
+* Implement telemetry struct for v1 components initialization ([@Wise-Wizard](https://github.com/Wise-Wizard) in [#5695](https://github.com/jaegertracing/jaeger/pull/5695))
 * Support default configs for storage backends ([@yurishkuro](https://github.com/yurishkuro) in [#5691](https://github.com/jaegertracing/jaeger/pull/5691))
 * Simplify configs organization ([@yurishkuro](https://github.com/yurishkuro) in [#5690](https://github.com/jaegertracing/jaeger/pull/5690))
 * Create metrics.factory adapter for otel metrics ([@Wise-Wizard](https://github.com/Wise-Wizard) in [#5661](https://github.com/jaegertracing/jaeger/pull/5661))

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	metricsPlugin "github.com/jaegertracing/jaeger/plugin/metrics"
@@ -159,11 +159,11 @@ by default uses only in-memory database.`,
 				log.Fatal(err)
 			}
 
-			telset := telemetery.Setting{
+			telset := telemetry.Setting{
 				Logger:         svc.Logger,
 				TracerProvider: tracer.OTEL,
 				Metrics:        queryMetricsFactory,
-				ReportStatus:   telemetery.HCAdapter(svc.HC()),
+				ReportStatus:   telemetry.HCAdapter(svc.HC()),
 				LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 					return noop.NewMeterProvider()
 				},
@@ -222,7 +222,7 @@ func startQuery(
 	depReader dependencystore.Reader,
 	metricsQueryService querysvc.MetricsQueryService,
 	tm *tenancy.Manager,
-	telset telemetery.Setting,
+	telset telemetry.Setting,
 ) *queryApp.Server {
 	spanReader = spanstoremetrics.NewReaderDecorator(spanReader, telset.Metrics)
 	qs := querysvc.NewQueryService(spanReader, depReader, *queryOpts)

--- a/cmd/jaeger/config-badger.yaml
+++ b/cmd/jaeger/config-badger.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: info
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/config-cassandra.yaml
+++ b/cmd/jaeger/config-cassandra.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: debug
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/config-elasticsearch.yaml
+++ b/cmd/jaeger/config-elasticsearch.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: debug
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/config-opensearch.yaml
+++ b/cmd/jaeger/config-opensearch.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: debug
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/config-remote-storage.yaml
+++ b/cmd/jaeger/config-remote-storage.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: debug
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/config-tail-sampling-always-sample.yaml
+++ b/cmd/jaeger/config-tail-sampling-always-sample.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: debug
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/config-tail-sampling-service-name-policy.yaml
+++ b/cmd/jaeger/config-tail-sampling-service-name-policy.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: debug
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/config.yaml
+++ b/cmd/jaeger/config.yaml
@@ -13,7 +13,7 @@ service:
       address: 0.0.0.0:8888
     logs:
       level: debug
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -13,7 +13,7 @@ service:
       address: "${env:JAEGER_LISTEN_HOST:-localhost}:8888"
     logs:
       level: info
-    # TODO Initialize telemetery tracer once OTEL released new feature.
+    # TODO Initialize telemetry tracer once OTEL released new feature.
     # https://github.com/open-telemetry/opentelemetry-collector/issues/10663
 
 extensions:

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -19,7 +19,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/plugin/metrics/disabled"
 	"github.com/jaegertracing/jaeger/storage/metricsstore"
@@ -94,7 +94,7 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("could not initialize a tracer: %w", err)
 	}
 	s.closeTracer = tracerProvider.Close
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger:         s.telset.Logger,
 		TracerProvider: tracerProvider.OTEL,
 		Metrics:        queryMetricsFactory,

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/plugin/metrics/prometheus"
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 	"github.com/jaegertracing/jaeger/plugin/storage/cassandra"
@@ -130,7 +130,7 @@ func (s *storageExt) Start(_ context.Context, host component.Host) error {
 		case cfg.Badger != nil:
 			factory, err = badger.NewFactoryWithConfig(*cfg.Badger, mf, s.telset.Logger)
 		case cfg.GRPC != nil:
-			telset := telemetery.Setting{
+			telset := telemetry.Setting{
 				Logger:  s.telset.Logger,
 				Host:    host,
 				Metrics: mf,

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -29,7 +29,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/netutils"
 	"github.com/jaegertracing/jaeger/pkg/recoveryhandler"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
@@ -48,7 +48,7 @@ type Server struct {
 	httpServer    *httpServer
 	separatePorts bool
 	bgFinished    sync.WaitGroup
-	telemetery.Setting
+	telemetry.Setting
 }
 
 // NewServer creates and initializes Server
@@ -58,7 +58,7 @@ func NewServer(
 	metricsQuerySvc querysvc.MetricsQueryService,
 	options *QueryOptions,
 	tm *tenancy.Manager,
-	telset telemetery.Setting,
+	telset telemetry.Setting,
 ) (*Server, error) {
 	_, httpPort, err := net.SplitHostPort(options.HTTP.Endpoint)
 	if err != nil {
@@ -98,7 +98,7 @@ func registerGRPCHandlers(
 	server *grpc.Server,
 	querySvc *querysvc.QueryService,
 	metricsQuerySvc querysvc.MetricsQueryService,
-	telset telemetery.Setting,
+	telset telemetry.Setting,
 ) {
 	reflection.Register(server)
 	handler := NewGRPCHandler(querySvc, metricsQuerySvc, GRPCHandlerOptions{
@@ -121,7 +121,7 @@ func createGRPCServer(
 	ctx context.Context,
 	options *QueryOptions,
 	tm *tenancy.Manager,
-	telset telemetery.Setting,
+	telset telemetry.Setting,
 ) (*grpc.Server, error) {
 	var grpcOpts []configgrpc.ToServerOption
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
@@ -164,7 +164,7 @@ func initRouter(
 	metricsQuerySvc querysvc.MetricsQueryService,
 	queryOpts *QueryOptions,
 	tenancyMgr *tenancy.Manager,
-	telset telemetery.Setting,
+	telset telemetry.Setting,
 ) (http.Handler, io.Closer) {
 	apiHandlerOptions := []HandlerOption{
 		HandlerOptions.Logger(telset.Logger),
@@ -206,7 +206,7 @@ func createHTTPServer(
 	metricsQuerySvc querysvc.MetricsQueryService,
 	queryOpts *QueryOptions,
 	tm *tenancy.Manager,
-	telset telemetery.Setting,
+	telset telemetry.Setting,
 ) (*httpServer, error) {
 	handler, staticHandlerCloser := initRouter(querySvc, metricsQuerySvc, queryOpts, tm, telset)
 	handler = recoveryhandler.NewRecoveryHandler(telset.Logger, true)(handler)

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/ports"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
@@ -49,11 +49,11 @@ import (
 
 var testCertKeyLocation = "../../../pkg/config/tlscfg/testdata"
 
-func initTelSet(logger *zap.Logger, tracerProvider *jtracer.JTracer, hc *healthcheck.HealthCheck) telemetery.Setting {
-	return telemetery.Setting{
+func initTelSet(logger *zap.Logger, tracerProvider *jtracer.JTracer, hc *healthcheck.HealthCheck) telemetry.Setting {
+	return telemetry.Setting{
 		Logger:         logger,
 		TracerProvider: tracerProvider.OTEL,
-		ReportStatus:   telemetery.HCAdapter(hc),
+		ReportStatus:   telemetry.HCAdapter(hc),
 		Host:           componenttest.NewNopHost(),
 		LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 			return noop.NewMeterProvider()

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/jaegertracing/jaeger/ports"
@@ -88,10 +88,10 @@ func runQueryService(t *testing.T, esURL string) *Server {
 	require.NoError(t, err)
 
 	querySvc := querysvc.NewQueryService(spanReader, nil, querysvc.QueryServiceOptions{})
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger:         flagsSvc.Logger,
 		TracerProvider: jtracer.NoOp().OTEL,
-		ReportStatus:   telemetery.HCAdapter(flagsSvc.HC()),
+		ReportStatus:   telemetry.HCAdapter(flagsSvc.HC()),
 		LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 			return noop.NewMeterProvider()
 		},

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	metricsPlugin "github.com/jaegertracing/jaeger/plugin/metrics"
@@ -107,10 +107,10 @@ func main() {
 				dependencyReader,
 				*queryServiceOptions)
 			tm := tenancy.NewManager(&queryOpts.Tenancy)
-			telset := telemetery.Setting{
+			telset := telemetry.Setting{
 				Logger:         logger,
 				TracerProvider: jt.OTEL,
-				ReportStatus:   telemetery.HCAdapter(svc.HC()),
+				ReportStatus:   telemetry.HCAdapter(svc.HC()),
 				LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 					return noop.NewMeterProvider()
 				},

--- a/cmd/remote-storage/app/server.go
+++ b/cmd/remote-storage/app/server.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
 	"github.com/jaegertracing/jaeger/storage"
@@ -32,11 +32,11 @@ type Server struct {
 	grpcConn   net.Listener
 	grpcServer *grpc.Server
 	wg         sync.WaitGroup
-	telemetery.Setting
+	telemetry.Setting
 }
 
 // NewServer creates and initializes Server.
-func NewServer(options *Options, storageFactory storage.Factory, tm *tenancy.Manager, telset telemetery.Setting) (*Server, error) {
+func NewServer(options *Options, storageFactory storage.Factory, tm *tenancy.Manager, telset telemetry.Setting) (*Server, error) {
 	handler, err := createGRPCHandler(storageFactory, telset.Logger)
 	if err != nil {
 		return nil, err

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/grpctest"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/ports"
 	"github.com/jaegertracing/jaeger/proto-gen/storage_v1"
@@ -45,7 +45,7 @@ func TestNewServer_CreateStorageErrors(t *testing.T) {
 	factory.On("CreateSpanWriter").Return(nil, nil)
 	factory.On("CreateDependencyReader").Return(nil, errors.New("no deps")).Once()
 	factory.On("CreateDependencyReader").Return(nil, nil)
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger:       zap.NewNop(),
 		ReportStatus: func(*componentstatus.Event) {},
 		LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
@@ -119,9 +119,9 @@ func TestNewServer_TLSConfigError(t *testing.T) {
 		KeyPath:      "invalid/path",
 		ClientCAPath: "invalid/path",
 	}
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger:       zap.NewNop(),
-		ReportStatus: telemetery.HCAdapter(healthcheck.New()),
+		ReportStatus: telemetry.HCAdapter(healthcheck.New()),
 	}
 	storageMocks := newStorageMocks()
 	_, err := NewServer(
@@ -327,9 +327,9 @@ func TestServerGRPCTLS(t *testing.T) {
 			storageMocks.reader.On("GetServices", mock.AnythingOfType("*context.valueCtx")).Return(expectedServices, nil)
 
 			tm := tenancy.NewManager(&tenancy.Options{Enabled: true})
-			telset := telemetery.Setting{
+			telset := telemetry.Setting{
 				Logger:       flagsSvc.Logger,
-				ReportStatus: telemetery.HCAdapter(flagsSvc.HC()),
+				ReportStatus: telemetry.HCAdapter(flagsSvc.HC()),
 			}
 			server, err := NewServer(
 				serverOptions,
@@ -376,9 +376,9 @@ func TestServerHandlesPortZero(t *testing.T) {
 	zapCore, logs := observer.New(zap.InfoLevel)
 	flagsSvc.Logger = zap.New(zapCore)
 	storageMocks := newStorageMocks()
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger:       flagsSvc.Logger,
-		ReportStatus: telemetery.HCAdapter(flagsSvc.HC()),
+		ReportStatus: telemetry.HCAdapter(flagsSvc.HC()),
 	}
 	server, err := NewServer(
 		&Options{GRPCHostPort: ":0"},

--- a/cmd/remote-storage/main.go
+++ b/cmd/remote-storage/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/remote-storage/app"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/plugin/storage"
@@ -70,9 +70,9 @@ func main() {
 			}
 
 			tm := tenancy.NewManager(&opts.Tenancy)
-			telset := telemetery.Setting{
+			telset := telemetry.Setting{
 				Logger:       svc.Logger,
-				ReportStatus: telemetery.HCAdapter(svc.HC()),
+				ReportStatus: telemetry.HCAdapter(svc.HC()),
 				LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 					return noop.NewMeterProvider()
 				},

--- a/pkg/telemetry/settings.go
+++ b/pkg/telemetry/settings.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package telemetery
+package telemetry
 
 import (
 	"go.opentelemetry.io/collector/component"

--- a/pkg/telemetry/settings_test.go
+++ b/pkg/telemetry/settings_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package telemetery_test
+package telemetry_test
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
@@ -65,7 +65,7 @@ func TestHCAdapter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hc := healthcheck.New()
-			hcAdapter := telemetery.HCAdapter(hc)
+			hcAdapter := telemetry.HCAdapter(hc)
 			event := componentstatus.NewEvent(tt.status)
 			hcAdapter(event)
 			assert.Equal(t, tt.expectedHC, hc.Get())

--- a/plugin/storage/grpc/factory.go
+++ b/plugin/storage/grpc/factory.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/plugin"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
@@ -64,7 +64,7 @@ func NewFactory() *Factory {
 // NewFactoryWithConfig is used from jaeger(v2).
 func NewFactoryWithConfig(
 	cfg Config,
-	telset telemetery.Setting,
+	telset telemetry.Setting,
 ) (*Factory, error) {
 	f := NewFactory()
 	f.config = cfg

--- a/plugin/storage/grpc/factory_test.go
+++ b/plugin/storage/grpc/factory_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared/mocks"
@@ -110,7 +110,7 @@ func TestNewFactoryError(t *testing.T) {
 			Auth: &configauth.Authentication{},
 		},
 	}
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger: zap.NewNop(),
 		LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 			return noop.NewMeterProvider()
@@ -188,7 +188,7 @@ func TestGRPCStorageFactoryWithConfig(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger: zap.NewNop(),
 		LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 			return noop.NewMeterProvider()

--- a/plugin/storage/integration/remote_memory_storage.go
+++ b/plugin/storage/integration/remote_memory_storage.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
-	"github.com/jaegertracing/jaeger/pkg/telemetery"
+	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
@@ -51,9 +51,9 @@ func StartNewRemoteMemoryStorage(t *testing.T) *RemoteMemoryStorage {
 	require.NoError(t, storageFactory.Initialize(metrics.NullFactory, logger))
 
 	t.Logf("Starting in-process remote storage server on %s", opts.GRPCHostPort)
-	telset := telemetery.Setting{
+	telset := telemetry.Setting{
 		Logger:       logger,
-		ReportStatus: telemetery.HCAdapter(healthcheck.New()),
+		ReportStatus: telemetry.HCAdapter(healthcheck.New()),
 		LeveledMeterProvider: func(_ configtelemetry.Level) metric.MeterProvider {
 			return noop.NewMeterProvider()
 		},


### PR DESCRIPTION
Per title

* rename folder first pkg/telemetery->pkg/telemetry
* then run this command
```
grep -rl telemetery . | xargs gsed -i 's/telemetery/telemetry/g'
```