### PR TITLE
test: Add test for kafka/auth/options.go file

### DIFF
--- a/pkg/kafka/auth/options_test.go
+++ b/pkg/kafka/auth/options_test.go
@@ -1,10 +1,13 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (
 	"flag"
 	"testing"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddFlags(t *testing.T) {

--- a/pkg/kafka/auth/options_test.go
+++ b/pkg/kafka/auth/options_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/crossdock/crossdock-go/assert"
+)
+
+func TestAddFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		configPrefix  string
+		expectedFlags map[string]string
+	}{
+		{
+			name:         "Default configuration with testprefix",
+			configPrefix: "testprefix",
+			expectedFlags: map[string]string{
+				"testprefix" + suffixAuthentication:                       none,
+				"testprefix" + kerberosPrefix + suffixKerberosServiceName: defaultKerberosServiceName,
+				"testprefix" + kerberosPrefix + suffixKerberosRealm:       defaultKerberosRealm,
+				"testprefix" + kerberosPrefix + suffixKerberosUsername:    defaultKerberosUsername,
+				"testprefix" + kerberosPrefix + suffixKerberosPassword:    defaultKerberosPassword,
+				"testprefix" + kerberosPrefix + suffixKerberosConfig:      defaultKerberosConfig,
+				"testprefix" + kerberosPrefix + suffixKerberosUseKeyTab:   "false",
+				"testprefix" + plainTextPrefix + suffixPlainTextUsername:  defaultPlainTextUsername,
+				"testprefix" + plainTextPrefix + suffixPlainTextPassword:  defaultPlainTextPassword,
+				"testprefix" + plainTextPrefix + suffixPlainTextMechanism: defaultPlainTextMechanism,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+
+			AddFlags(tt.configPrefix, flagSet)
+
+			for flagName, expectedValue := range tt.expectedFlags {
+				flag := flagSet.Lookup(flagName)
+				assert.NotNil(t, flag, "Expected flag %q to be registered", flagName)
+				assert.Equal(t, expectedValue, flag.DefValue, "Default value of flag %q", flagName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Test for options.go

## Description of the changes
- Add test for options.go file.

## How was this change tested?
- 

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
