### PR TITLE
Fix password in integration test

### DIFF
--- a/plugin/storage/integration/cassandra_test.go
+++ b/plugin/storage/integration/cassandra_test.go
@@ -52,7 +52,7 @@ func (*CassandraStorageIntegration) initializeCassandraFactory(t *testing.T, fla
 
 func (s *CassandraStorageIntegration) initializeCassandra(t *testing.T) {
 	username := os.Getenv("CASSANDRA_USERNAME")
-	password := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
 	f := s.initializeCassandraFactory(t, []string{
 		"--cassandra.basic.allowed-authenticators=org.apache.cassandra.auth.PasswordAuthenticator",
 		"--cassandra.password=" + password,


### PR DESCRIPTION
## Which problem is this PR solving?
Minor fix in cassandra initialization for integration test

## Description of the changes
- Changed environment variable used for initialization


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
