### PR TITLE
[chore] Rename `spanstore` to `tracestore` for v2 storage

### DIFF
--- a/cmd/jaeger/internal/exporters/storageexporter/exporter.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter.go
@@ -13,13 +13,13 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/sanitizer"
-	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 type storageExporter struct {
 	config      *Config
 	logger      *zap.Logger
-	traceWriter spanstore.Writer
+	traceWriter tracestore.Writer
 	sanitizer   sanitizer.Func
 }
 

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jaegertracing/jaeger/plugin/storage/memory"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage_v2/factoryadapter"
-	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 var _ Extension = (*storageExt)(nil)
@@ -74,7 +74,7 @@ func GetMetricStorageFactory(name string, host component.Host) (storage.MetricSt
 	return mf, nil
 }
 
-func GetStorageFactoryV2(name string, host component.Host) (spanstore.Factory, error) {
+func GetStorageFactoryV2(name string, host component.Host) (tracestore.Factory, error) {
 	f, err := GetStorageFactory(name, host)
 	if err != nil {
 		return nil, err

--- a/storage_v2/factoryadapter/factory.go
+++ b/storage_v2/factoryadapter/factory.go
@@ -8,25 +8,25 @@ import (
 	"io"
 
 	storage_v1 "github.com/jaegertracing/jaeger/storage"
-	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 type Factory struct {
 	ss storage_v1.Factory
 }
 
-func NewFactory(ss storage_v1.Factory) spanstore.Factory {
+func NewFactory(ss storage_v1.Factory) tracestore.Factory {
 	return &Factory{
 		ss: ss,
 	}
 }
 
-// Initialize implements spanstore.Factory.
+// Initialize implements tracestore.Factory.
 func (*Factory) Initialize(_ context.Context) error {
 	panic("not implemented")
 }
 
-// Close implements spanstore.Factory.
+// Close implements tracestore.Factory.
 func (f *Factory) Close(_ context.Context) error {
 	if closer, ok := f.ss.(io.Closer); ok {
 		return closer.Close()
@@ -34,8 +34,8 @@ func (f *Factory) Close(_ context.Context) error {
 	return nil
 }
 
-// CreateTraceReader implements spanstore.Factory.
-func (f *Factory) CreateTraceReader() (spanstore.Reader, error) {
+// CreateTraceReader implements tracestore.Factory.
+func (f *Factory) CreateTraceReader() (tracestore.Reader, error) {
 	spanReader, err := f.ss.CreateSpanReader()
 	if err != nil {
 		return nil, err
@@ -43,8 +43,8 @@ func (f *Factory) CreateTraceReader() (spanstore.Reader, error) {
 	return NewTraceReader(spanReader), nil
 }
 
-// CreateTraceWriter implements spanstore.Factory.
-func (f *Factory) CreateTraceWriter() (spanstore.Writer, error) {
+// CreateTraceWriter implements tracestore.Factory.
+func (f *Factory) CreateTraceWriter() (tracestore.Writer, error) {
 	spanWriter, err := f.ss.CreateSpanWriter()
 	if err != nil {
 		return nil, err

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	spanstore_v1 "github.com/jaegertracing/jaeger/storage/spanstore"
-	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 var errV1ReaderNotAvailable = errors.New("spanstore.Reader is not a wrapper around v1 reader")
@@ -20,7 +20,7 @@ type TraceReader struct {
 	spanReader spanstore_v1.Reader
 }
 
-func GetV1Reader(reader spanstore.Reader) (spanstore_v1.Reader, error) {
+func GetV1Reader(reader tracestore.Reader) (spanstore_v1.Reader, error) {
 	if tr, ok := reader.(*TraceReader); ok {
 		return tr.spanReader, nil
 	}
@@ -41,14 +41,14 @@ func (*TraceReader) GetServices(_ context.Context) ([]string, error) {
 	panic("not implemented")
 }
 
-func (*TraceReader) GetOperations(_ context.Context, _ spanstore.OperationQueryParameters) ([]spanstore.Operation, error) {
+func (*TraceReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
 	panic("not implemented")
 }
 
-func (*TraceReader) FindTraces(_ context.Context, _ spanstore.TraceQueryParameters) ([]ptrace.Traces, error) {
+func (*TraceReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
 	panic("not implemented")
 }
 
-func (*TraceReader) FindTraceIDs(_ context.Context, _ spanstore.TraceQueryParameters) ([]pcommon.TraceID, error) {
+func (*TraceReader) FindTraceIDs(_ context.Context, _ tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
 	panic("not implemented")
 }

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -10,24 +10,24 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
-	spanstore_v1 "github.com/jaegertracing/jaeger/storage/spanstore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 var errV1ReaderNotAvailable = errors.New("spanstore.Reader is not a wrapper around v1 reader")
 
 type TraceReader struct {
-	spanReader spanstore_v1.Reader
+	spanReader spanstore.Reader
 }
 
-func GetV1Reader(reader tracestore.Reader) (spanstore_v1.Reader, error) {
+func GetV1Reader(reader tracestore.Reader) (spanstore.Reader, error) {
 	if tr, ok := reader.(*TraceReader); ok {
 		return tr.spanReader, nil
 	}
 	return nil, errV1ReaderNotAvailable
 }
 
-func NewTraceReader(spanReader spanstore_v1.Reader) *TraceReader {
+func NewTraceReader(spanReader spanstore.Reader) *TraceReader {
 	return &TraceReader{
 		spanReader: spanReader,
 	}

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger/plugin/storage/memory"
-	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 func TestGetV1Reader_NoError(t *testing.T) {
@@ -35,15 +35,15 @@ func (*fakeReader) GetServices(_ context.Context) ([]string, error) {
 	panic("not implemented")
 }
 
-func (*fakeReader) GetOperations(_ context.Context, _ spanstore.OperationQueryParameters) ([]spanstore.Operation, error) {
+func (*fakeReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
 	panic("not implemented")
 }
 
-func (*fakeReader) FindTraces(_ context.Context, _ spanstore.TraceQueryParameters) ([]ptrace.Traces, error) {
+func (*fakeReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
 	panic("not implemented")
 }
 
-func (*fakeReader) FindTraceIDs(_ context.Context, _ spanstore.TraceQueryParameters) ([]pcommon.TraceID, error) {
+func (*fakeReader) FindTraceIDs(_ context.Context, _ tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
 	panic("not implemented")
 }
 
@@ -76,7 +76,7 @@ func TestTraceReader_GetOperationsPanics(t *testing.T) {
 	}
 	require.Panics(
 		t,
-		func() { traceReader.GetOperations(context.Background(), spanstore.OperationQueryParameters{}) },
+		func() { traceReader.GetOperations(context.Background(), tracestore.OperationQueryParameters{}) },
 	)
 }
 
@@ -87,7 +87,7 @@ func TestTraceReader_FindTracesPanics(t *testing.T) {
 	}
 	require.Panics(
 		t,
-		func() { traceReader.FindTraces(context.Background(), spanstore.TraceQueryParameters{}) },
+		func() { traceReader.FindTraces(context.Background(), tracestore.TraceQueryParameters{}) },
 	)
 }
 
@@ -98,6 +98,6 @@ func TestTraceReader_FindTraceIDsPanics(t *testing.T) {
 	}
 	require.Panics(
 		t,
-		func() { traceReader.FindTraceIDs(context.Background(), spanstore.TraceQueryParameters{}) },
+		func() { traceReader.FindTraceIDs(context.Background(), tracestore.TraceQueryParameters{}) },
 	)
 }

--- a/storage_v2/factoryadapter/writer.go
+++ b/storage_v2/factoryadapter/writer.go
@@ -11,20 +11,20 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	spanstore_v1 "github.com/jaegertracing/jaeger/storage/spanstore"
-	"github.com/jaegertracing/jaeger/storage_v2/spanstore"
+	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 type TraceWriter struct {
 	spanWriter spanstore_v1.Writer
 }
 
-func NewTraceWriter(spanWriter spanstore_v1.Writer) spanstore.Writer {
+func NewTraceWriter(spanWriter spanstore_v1.Writer) tracestore.Writer {
 	return &TraceWriter{
 		spanWriter: spanWriter,
 	}
 }
 
-// WriteTraces implements spanstore.Writer.
+// WriteTraces implements tracestore.Writer.
 func (t *TraceWriter) WriteTraces(ctx context.Context, td ptrace.Traces) error {
 	batches := otlp2jaeger.ProtoFromTraces(td)
 	var errs []error

--- a/storage_v2/factoryadapter/writer.go
+++ b/storage_v2/factoryadapter/writer.go
@@ -10,15 +10,15 @@ import (
 	otlp2jaeger "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
-	spanstore_v1 "github.com/jaegertracing/jaeger/storage/spanstore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 type TraceWriter struct {
-	spanWriter spanstore_v1.Writer
+	spanWriter spanstore.Writer
 }
 
-func NewTraceWriter(spanWriter spanstore_v1.Writer) tracestore.Writer {
+func NewTraceWriter(spanWriter spanstore.Writer) tracestore.Writer {
 	return &TraceWriter{
 		spanWriter: spanWriter,
 	}

--- a/storage_v2/tracestore/empty_test.go
+++ b/storage_v2/tracestore/empty_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package spanstore
+package tracestore
 
 import (
 	"testing"

--- a/storage_v2/tracestore/factory.go
+++ b/storage_v2/tracestore/factory.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package spanstore
+package tracestore
 
 import (
 	"github.com/jaegertracing/jaeger/storage_v2"

--- a/storage_v2/tracestore/reader.go
+++ b/storage_v2/tracestore/reader.go
@@ -10,11 +10,11 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
-	spanstore_v1 "github.com/jaegertracing/jaeger/storage/spanstore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 // ErrTraceNotFound is returned by Reader's GetTrace if no data is found for given trace ID.
-var ErrTraceNotFound = spanstore_v1.ErrTraceNotFound
+var ErrTraceNotFound = spanstore.ErrTraceNotFound
 
 // Reader finds and loads traces and other data from storage.
 type Reader interface {

--- a/storage_v2/tracestore/reader.go
+++ b/storage_v2/tracestore/reader.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package spanstore
+package tracestore
 
 import (
 	"context"

--- a/storage_v2/tracestore/writer.go
+++ b/storage_v2/tracestore/writer.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package spanstore
+package tracestore
 
 import (
 	"context"


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #5079 and #6170 

## Description of the changes
- Renames `storage_v2/spanstore` to `storage_v2/tracestore` to address https://github.com/jaegertracing/jaeger/pull/6170#pullrequestreview-2471293046

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
