### PR TITLE
add missing otel exporter port in docker compose file

### DIFF
--- a/examples/grafana-integration/docker-compose.yaml
+++ b/examples/grafana-integration/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
     ports:
       - '6831:6831'
       - '16686:16686'
+      - "4318:4318"
     logging:
       driver: loki
       options:


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
