### PR TITLE
Pring EOL notice from v1 binaries

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -45,6 +45,7 @@ import (
 
 // all-in-one/main is a standalone full-stack jaeger backend, backed by a memory store
 func main() {
+	flags.PrintV1EOL()
 	setupcontext.SetAllInOne()
 
 	svc := flags.NewService(ports.CollectorAdminHTTP)

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -35,6 +35,7 @@ import (
 const serviceName = "jaeger-collector"
 
 func main() {
+	cmdFlags.PrintV1EOL()
 	svc := cmdFlags.NewService(ports.CollectorAdminHTTP)
 
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -30,6 +30,7 @@ import (
 )
 
 func main() {
+	flags.PrintV1EOL()
 	svc := flags.NewService(ports.IngesterAdminHTTP)
 
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))

--- a/cmd/internal/flags/service.go
+++ b/cmd/internal/flags/service.go
@@ -46,7 +46,7 @@ func PrintV1EOL() {
 	println(`
 *******************************************************************************
 
-******** WARNING: End-of-life Notice for Jaeger v1
+🛑  WARNING: End-of-life Notice for Jaeger v1
 
 You are currently running a v1 version of Jaeger, which is deprecated and will
 reach end-of-life on December 31st, 2025. This means there will be no further
@@ -60,7 +60,7 @@ documentation:  https://www.jaegertracing.io/docs/latest/migration/
 
 Tracking issue: https://github.com/jaegertracing/jaeger/issues/6321
 
-******** WARNING: End-of-life Notice for Jaeger v1
+🛑  WARNING: End-of-life Notice for Jaeger v1
 
 *******************************************************************************
 `)

--- a/cmd/internal/flags/service.go
+++ b/cmd/internal/flags/service.go
@@ -42,6 +42,30 @@ type Service struct {
 	signalsChannel chan os.Signal
 }
 
+func PrintV1EOL() {
+	println(`
+*******************************************************************************
+
+******** WARNING: End-of-life Notice for Jaeger v1
+
+You are currently running a v1 version of Jaeger, which is deprecated and will
+reach end-of-life on December 31st, 2025. This means there will be no further
+development, bug fixes, or security patches for v1 after this date.
+
+We strongly recommend migrating to Jaeger v2 for continued support and access
+to new features.
+
+For detailed migration instructions, please refer to the official Jaeger
+documentation:  https://www.jaegertracing.io/docs/latest/migration/
+
+Tracking issue: https://github.com/jaegertracing/jaeger/issues/6321
+
+******** WARNING: End-of-life Notice for Jaeger v1
+
+*******************************************************************************
+`)
+}
+
 // NewService creates a new Service.
 func NewService(adminPort int) *Service {
 	signalsChannel := make(chan os.Signal, 1)

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -36,6 +36,7 @@ import (
 )
 
 func main() {
+	flags.PrintV1EOL()
 	svc := flags.NewService(ports.QueryAdminHTTP)
 
 	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6321

## Description of the changes
- Print EOL notice from core v1 binaries

## How was this change tested?
```
$ go run ./cmd/all-in-one
2024/12/07 13:02:54 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined

*******************************************************************************

🛑  WARNING: End-of-life Notice for Jaeger v1

You are currently running a v1 version of Jaeger, which is deprecated and will
reach end-of-life on December 31st, 2025. This means there will be no further
development, bug fixes, or security patches for v1 after this date.

We strongly recommend migrating to Jaeger v2 for continued support and access
to new features.

For detailed migration instructions, please refer to the official Jaeger
documentation:  https://www.jaegertracing.io/docs/latest/migration/

Tracking issue: https://github.com/jaegertracing/jaeger/issues/6321

🛑  WARNING: End-of-life Notice for Jaeger v1

*******************************************************************************

2024/12/07 13:02:54 application version: git-commit=, git-version=, build-date=
{"level":"info","ts":1733594574.315758,"caller":"flags/service.go:123","msg":"Mounting metrics handler on admin server","route":"/metrics"}
```