### PR TITLE
[fix] Fix call to `GetDependencies` in grpc handler

### DIFF
--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -223,7 +223,7 @@ func (g *GRPCHandler) GetDependencies(ctx context.Context, r *api_v2.GetDependen
 		return nil, status.Errorf(codes.InvalidArgument, "StartTime and EndTime must be initialized.")
 	}
 
-	dependencies, err := g.queryService.GetDependencies(ctx, startTime, endTime.Sub(startTime))
+	dependencies, err := g.queryService.GetDependencies(ctx, endTime, endTime.Sub(startTime))
 	if err != nil {
 		g.logger.Error("failed to fetch dependencies", zap.Error(err))
 		return nil, status.Errorf(codes.Internal, "failed to fetch dependencies: %v", err)

--- a/cmd/query/app/grpc_handler_test.go
+++ b/cmd/query/app/grpc_handler_test.go
@@ -513,7 +513,7 @@ func TestGetDependenciesSuccessGRPC(t *testing.T) {
 		endTs := time.Now().UTC()
 		server.depReader.On("GetDependencies",
 			mock.Anything, // context.Context
-			endTs.Add(time.Duration(-1)*defaultDependencyLookbackDuration),
+			endTs,
 			defaultDependencyLookbackDuration,
 		).Return(expectedDependencies, nil).Times(1)
 
@@ -532,7 +532,7 @@ func TestGetDependenciesFailureGRPC(t *testing.T) {
 		server.depReader.On(
 			"GetDependencies",
 			mock.Anything, // context.Context
-			endTs.Add(time.Duration(-1)*defaultDependencyLookbackDuration),
+			endTs,
 			defaultDependencyLookbackDuration).Return(nil, errStorageGRPC).Times(1)
 
 		_, err := client.GetDependencies(context.Background(), &api_v2.GetDependenciesRequest{


### PR DESCRIPTION
## Description of the changes
- This PR fixes a bug in the query GRPC handler which currently passes `startTime` to `GetDependencies` instead of `endTime`

## How was this change tested?
- Fixed unit test expectations

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
