### PR TITLE
[v2][storage] Implement `GetServices` and `GetOperations` in v2 factory adapter

### DIFF
--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -40,8 +40,8 @@ func (*TraceReader) GetTrace(_ context.Context, _ pcommon.TraceID) (ptrace.Trace
 	panic("not implemented")
 }
 
-func (*TraceReader) GetServices(_ context.Context) ([]string, error) {
-	panic("not implemented")
+func (tr *TraceReader) GetServices(ctx context.Context) ([]string, error) {
+	return tr.spanReader.GetServices(ctx)
 }
 
 func (*TraceReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -44,8 +44,22 @@ func (tr *TraceReader) GetServices(ctx context.Context) ([]string, error) {
 	return tr.spanReader.GetServices(ctx)
 }
 
-func (*TraceReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
-	panic("not implemented")
+func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
+	o, err := tr.spanReader.GetOperations(ctx, spanstore.OperationQueryParameters{
+		ServiceName: query.ServiceName,
+		SpanKind:    query.SpanKind,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var operations []tracestore.Operation
+	for _, operation := range o {
+		operations = append(operations, tracestore.Operation{
+			Name:     operation.Name,
+			SpanKind: operation.SpanKind,
+		})
+	}
+	return operations, nil
 }
 
 func (*TraceReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -49,9 +49,6 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 		ServiceName: query.ServiceName,
 		SpanKind:    query.SpanKind,
 	})
-	if err != nil {
-		return nil, err
-	}
 	var operations []tracestore.Operation
 	for _, operation := range o {
 		operations = append(operations, tracestore.Operation{
@@ -59,7 +56,7 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 			SpanKind: operation.SpanKind,
 		})
 	}
-	return operations, nil
+	return operations, err
 }
 
 func (*TraceReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -5,7 +5,6 @@ package factoryadapter
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -79,26 +78,6 @@ func TestTraceReader_GetServicesDelegatesToSpanReader(t *testing.T) {
 	services, err := traceReader.GetServices(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, expectedServices, services)
-}
-
-func TestTraceReader_GetOperationsDelegatesError(t *testing.T) {
-	sr := new(spanStoreMocks.Reader)
-	testErr := errors.New("test error")
-	sr.On("GetOperations",
-		mock.Anything,
-		spanstore.OperationQueryParameters{
-			ServiceName: "service-a",
-			SpanKind:    "server",
-		}).Return(nil, testErr)
-	traceReader := &TraceReader{
-		spanReader: sr,
-	}
-	operations, err := traceReader.GetOperations(context.Background(), tracestore.OperationQueryParameters{
-		ServiceName: "service-a",
-		SpanKind:    "server",
-	})
-	require.ErrorIs(t, err, testErr)
-	require.Nil(t, operations)
 }
 
 func TestTraceReader_GetOperationsDelegatesResponse(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #5079 

## Description of the changes
- This PR implements `GetServices` and `GetOperations` in the v2 `factoryadapter`

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
