### PR TITLE
[storage][v2] Implement `FindTraceIDs` in v2 factory adapter

### DIFF
--- a/model/ids.go
+++ b/model/ids.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/gogo/protobuf/jsonpb"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 const (
@@ -143,6 +144,13 @@ func (t *TraceID) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("cannot unmarshal TraceID from string '%s': %w", string(data), err)
 	}
 	return t.Unmarshal(b)
+}
+
+func (t *TraceID) ToOTELTraceID() pcommon.TraceID {
+	traceID := [16]byte{}
+	binary.BigEndian.PutUint64(traceID[:8], t.High)
+	binary.BigEndian.PutUint64(traceID[8:], t.Low)
+	return traceID
 }
 
 // ------- SpanID -------

--- a/model/ids.go
+++ b/model/ids.go
@@ -146,6 +146,9 @@ func (t *TraceID) UnmarshalJSON(data []byte) error {
 	return t.Unmarshal(b)
 }
 
+// ToOTELTraceID converts the TraceID to OTEL's representation of a trace identitfier.
+// This was taken from
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/coreinternal/idutils/big_endian_converter.go.
 func (t *TraceID) ToOTELTraceID() pcommon.TraceID {
 	traceID := [16]byte{}
 	binary.BigEndian.PutUint64(traceID[:8], t.High)

--- a/model/ids_test.go
+++ b/model/ids_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/prototest"
@@ -116,4 +117,14 @@ func TestTraceIDFromBytes(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, test.expected, traceID)
 	}
+}
+
+func TestToOTELTraceID(t *testing.T) {
+	modelTraceID := model.TraceID{
+		Low:  3,
+		High: 2,
+	}
+	otelTraceID := modelTraceID.ToOTELTraceID()
+	expected := []byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}
+	require.Equal(t, pcommon.TraceID(expected), otelTraceID)
 }

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -49,7 +49,7 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 		ServiceName: query.ServiceName,
 		SpanKind:    query.SpanKind,
 	})
-	var operations []tracestore.Operation
+	operations := []tracestore.Operation{}
 	for _, operation := range o {
 		operations = append(operations, tracestore.Operation{
 			Name:     operation.Name,

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -49,6 +49,9 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 		ServiceName: query.ServiceName,
 		SpanKind:    query.SpanKind,
 	})
+	if err != nil || o == nil {
+		return nil, err
+	}
 	operations := []tracestore.Operation{}
 	for _, operation := range o {
 		operations = append(operations, tracestore.Operation{
@@ -56,7 +59,7 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 			SpanKind: operation.SpanKind,
 		})
 	}
-	return operations, err
+	return operations, nil
 }
 
 func (*TraceReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
@@ -74,11 +77,14 @@ func (tr *TraceReader) FindTraceIDs(ctx context.Context, query tracestore.TraceQ
 		DurationMax:   query.DurationMax,
 		NumTraces:     query.NumTraces,
 	})
+	if err != nil || t == nil {
+		return nil, err
+	}
 	traceIDs := []pcommon.TraceID{}
 	for _, traceID := range t {
 		traceIDs = append(traceIDs, traceID.ToOTELTraceID())
 	}
-	return traceIDs, err
+	return traceIDs, nil
 }
 
 type DependencyReader struct {

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -74,7 +74,7 @@ func (tr *TraceReader) FindTraceIDs(ctx context.Context, query tracestore.TraceQ
 		DurationMax:   query.DurationMax,
 		NumTraces:     query.NumTraces,
 	})
-	var traceIDs []pcommon.TraceID
+	traceIDs := []pcommon.TraceID{}
 	for _, traceID := range t {
 		traceIDs = append(traceIDs, traceID.ToOTELTraceID())
 	}

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -63,8 +63,22 @@ func (*TraceReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParamet
 	panic("not implemented")
 }
 
-func (*TraceReader) FindTraceIDs(_ context.Context, _ tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
-	panic("not implemented")
+func (tr *TraceReader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
+	t, err := tr.spanReader.FindTraceIDs(ctx, &spanstore.TraceQueryParameters{
+		ServiceName:   query.ServiceName,
+		OperationName: query.OperationName,
+		Tags:          query.Tags,
+		StartTimeMin:  query.StartTimeMin,
+		StartTimeMax:  query.StartTimeMax,
+		DurationMin:   query.DurationMin,
+		DurationMax:   query.DurationMax,
+		NumTraces:     query.NumTraces,
+	})
+	var traceIDs []pcommon.TraceID
+	for _, traceID := range t {
+		traceIDs = append(traceIDs, traceID.ToOTELTraceID())
+	}
+	return traceIDs, err
 }
 
 type DependencyReader struct {

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -114,12 +114,12 @@ func TestTraceReader_GetOperationsDelegatesResponse(t *testing.T) {
 		{
 			name:               "nil response",
 			operations:         nil,
-			expectedOperations: nil,
+			expectedOperations: []tracestore.Operation{},
 		},
 		{
 			name:               "error response",
 			operations:         nil,
-			expectedOperations: nil,
+			expectedOperations: []tracestore.Operation{},
 			err:                errors.New("test error"),
 		},
 	}

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -114,12 +114,12 @@ func TestTraceReader_GetOperationsDelegatesResponse(t *testing.T) {
 		{
 			name:               "nil response",
 			operations:         nil,
-			expectedOperations: []tracestore.Operation{},
+			expectedOperations: nil,
 		},
 		{
 			name:               "error response",
 			operations:         nil,
-			expectedOperations: []tracestore.Operation{},
+			expectedOperations: nil,
 			err:                errors.New("test error"),
 		},
 	}
@@ -185,12 +185,12 @@ func TestTraceReader_FindTraceIDsDelegatesResponse(t *testing.T) {
 		{
 			name:             "nil response",
 			modelTraceIDs:    nil,
-			expectedTraceIDs: []pcommon.TraceID{},
+			expectedTraceIDs: nil,
 		},
 		{
 			name:             "error response",
 			modelTraceIDs:    nil,
-			expectedTraceIDs: []pcommon.TraceID{},
+			expectedTraceIDs: nil,
 			err:              errors.New("test error"),
 		},
 	}

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -159,15 +159,79 @@ func TestTraceReader_FindTracesPanics(t *testing.T) {
 	)
 }
 
-func TestTraceReader_FindTraceIDsPanics(t *testing.T) {
-	memstore := memory.NewStore()
-	traceReader := &TraceReader{
-		spanReader: memstore,
+func TestTraceReader_FindTraceIDsDelegatesResponse(t *testing.T) {
+	tests := []struct {
+		name             string
+		modelTraceIDs    []model.TraceID
+		expectedTraceIDs []pcommon.TraceID
+		err              error
+	}{
+		{
+			name: "successful response",
+			modelTraceIDs: []model.TraceID{
+				{Low: 3, High: 2},
+				{Low: 4, High: 3},
+			},
+			expectedTraceIDs: []pcommon.TraceID{
+				pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}),
+				pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4}),
+			},
+		},
+		{
+			name:             "empty response",
+			modelTraceIDs:    []model.TraceID{},
+			expectedTraceIDs: []pcommon.TraceID{},
+		},
+		{
+			name:             "nil response",
+			modelTraceIDs:    nil,
+			expectedTraceIDs: []pcommon.TraceID{},
+		},
+		{
+			name:             "error response",
+			modelTraceIDs:    nil,
+			expectedTraceIDs: []pcommon.TraceID{},
+			err:              errors.New("test error"),
+		},
 	}
-	require.Panics(
-		t,
-		func() { traceReader.FindTraceIDs(context.Background(), tracestore.TraceQueryParameters{}) },
-	)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sr := new(spanStoreMocks.Reader)
+			now := time.Now()
+			sr.On(
+				"FindTraceIDs",
+				mock.Anything,
+				&spanstore.TraceQueryParameters{
+					ServiceName:   "service",
+					OperationName: "operation",
+					Tags:          map[string]string{"tag-a": "val-a"},
+					StartTimeMin:  now,
+					StartTimeMax:  now.Add(time.Minute),
+					DurationMin:   time.Minute,
+					DurationMax:   time.Hour,
+					NumTraces:     10,
+				},
+			).Return(test.modelTraceIDs, test.err)
+			traceReader := &TraceReader{
+				spanReader: sr,
+			}
+			traceIDs, err := traceReader.FindTraceIDs(
+				context.Background(),
+				tracestore.TraceQueryParameters{
+					ServiceName:   "service",
+					OperationName: "operation",
+					Tags:          map[string]string{"tag-a": "val-a"},
+					StartTimeMin:  now,
+					StartTimeMax:  now.Add(time.Minute),
+					DurationMin:   time.Minute,
+					DurationMax:   time.Hour,
+					NumTraces:     10,
+				},
+			)
+			require.ErrorIs(t, err, test.err)
+			require.Equal(t, test.expectedTraceIDs, traceIDs)
+		})
+	}
 }
 
 func TestDependencyReader_GetDependencies(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #5079

## Description of the changes
- This PR implements `FindTraceIDs` in the v2 factory adapter

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
