### PR TITLE
feat: Add esmapping-generator into jaeger binary

### DIFF
--- a/cmd/esmapping-generator/generator/esmapping_generator.go
+++ b/cmd/esmapping-generator/generator/esmapping_generator.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package generator
+
+import (
+	"fmt"
+
+	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
+	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app/renderer"
+	"github.com/jaegertracing/jaeger/pkg/es"
+	"github.com/jaegertracing/jaeger/plugin/storage/es/mappings"
+)
+
+func GenerateMappings(options app.Options) (string, error) {
+	if _, err := mappings.MappingTypeFromString(options.Mapping); err != nil {
+		return "", fmt.Errorf("invalid mapping type '%s': please pass either 'jaeger-service' or 'jaeger-span' as the mapping type %w", options.Mapping, err)
+	}
+
+	parsedMapping, err := renderer.GetMappingAsString(es.TextTemplateBuilder{}, &options)
+	if err != nil {
+		return "", fmt.Errorf("failed to render mapping to string: %w", err)
+	}
+
+	return parsedMapping, nil
+}

--- a/cmd/esmapping-generator/generator/esmapping_generator_test.go
+++ b/cmd/esmapping-generator/generator/esmapping_generator_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package generator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/crossdock/crossdock-go/assert"
+	"github.com/crossdock/crossdock-go/require"
+
+	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestGenerateMappings(t *testing.T) {
+	tests := []struct {
+		name      string
+		options   app.Options
+		expectErr bool
+	}{
+		{
+			name: "valid jaeger-span mapping",
+			options: app.Options{
+				Mapping:       "jaeger-span",
+				EsVersion:     7,
+				Shards:        5,
+				Replicas:      1,
+				IndexPrefix:   "jaeger-index",
+				UseILM:        "false",
+				ILMPolicyName: "jaeger-ilm-policy",
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid jaeger-service mapping",
+			options: app.Options{
+				Mapping:       "jaeger-service",
+				EsVersion:     7,
+				Shards:        5,
+				Replicas:      1,
+				IndexPrefix:   "jaeger-service-index",
+				UseILM:        "true",
+				ILMPolicyName: "service-ilm-policy",
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid mapping type",
+			options: app.Options{
+				Mapping: "invalid-mapping",
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing mapping flag",
+			options: app.Options{
+				Mapping: "",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GenerateMappings(tt.options)
+			if tt.expectErr {
+				require.Error(t, err, "Expected an error")
+			} else {
+				require.NoError(t, err, "Did not expect an error")
+
+				var parsed map[string]interface{}
+				err = json.Unmarshal([]byte(result), &parsed)
+				require.NoError(t, err, "Expected valid JSON output")
+
+				assert.NotEmpty(t, parsed["index_patterns"], "Expected index_patterns to be present")
+				assert.NotEmpty(t, parsed["mappings"], "Expected mappings to be present")
+				assert.NotEmpty(t, parsed["settings"], "Expected settings to be present")
+			}
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/cmd/esmapping-generator/main.go
+++ b/cmd/esmapping-generator/main.go
@@ -7,41 +7,17 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
-
 	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
-	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app/renderer"
-	"github.com/jaegertracing/jaeger/pkg/es"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/mapping"
 	"github.com/jaegertracing/jaeger/pkg/version"
-	"github.com/jaegertracing/jaeger/plugin/storage/es/mappings"
 )
 
 func main() {
-	logger, _ := zap.NewDevelopment()
 	options := app.Options{}
-	command := &cobra.Command{
-		Use:   "jaeger-esmapping-generator",
-		Short: "Jaeger esmapping-generator prints rendered mappings as string",
-		Long:  `Jaeger esmapping-generator renders passed templates with provided values and prints rendered output to stdout`,
-		Run: func(_ *cobra.Command, _ /* args */ []string) {
-			if _, err := mappings.MappingTypeFromString(options.Mapping); err != nil {
-				logger.Fatal("please pass either 'jaeger-service' or 'jaeger-span' as argument")
-			}
+	esmappingsCmd := mapping.Command(options)
+	esmappingsCmd.AddCommand(version.Command())
 
-			parsedMapping, err := renderer.GetMappingAsString(es.TextTemplateBuilder{}, &options)
-			if err != nil {
-				logger.Fatal(err.Error())
-			}
-			print(parsedMapping)
-		},
-	}
-
-	options.AddFlags(command)
-
-	command.AddCommand(version.Command())
-
-	if err := command.Execute(); err != nil {
+	if err := esmappingsCmd.Execute(); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/esmapping-generator/main.go
+++ b/cmd/esmapping-generator/main.go
@@ -7,14 +7,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/mapping"
 	"github.com/jaegertracing/jaeger/pkg/version"
 )
 
 func main() {
-	options := app.Options{}
-	esmappingsCmd := mapping.Command(options)
+	esmappingsCmd := mapping.Command()
 	esmappingsCmd.AddCommand(version.Command())
 
 	if err := esmappingsCmd.Execute(); err != nil {

--- a/cmd/jaeger/main.go
+++ b/cmd/jaeger/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
 	"github.com/jaegertracing/jaeger/cmd/internal/docs"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/mapping"
@@ -18,11 +17,10 @@ import (
 
 func main() {
 	v := viper.New()
-	options := app.Options{}
 	command := internal.Command()
 	command.AddCommand(version.Command())
 	command.AddCommand(docs.Command(v))
-	command.AddCommand(mapping.Command(options))
+	command.AddCommand(mapping.Command())
 	config.AddFlags(
 		v,
 		command,

--- a/cmd/jaeger/main.go
+++ b/cmd/jaeger/main.go
@@ -8,17 +8,21 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
 	"github.com/jaegertracing/jaeger/cmd/internal/docs"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/mapping"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/version"
 )
 
 func main() {
 	v := viper.New()
+	options := app.Options{}
 	command := internal.Command()
 	command.AddCommand(version.Command())
 	command.AddCommand(docs.Command(v))
+	command.AddCommand(mapping.Command(options))
 	config.AddFlags(
 		v,
 		command,

--- a/internal/storage/elasticsearch/mapping/command.go
+++ b/internal/storage/elasticsearch/mapping/command.go
@@ -13,7 +13,8 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/generator"
 )
 
-func Command(options app.Options) *cobra.Command {
+func Command() *cobra.Command {
+	options := app.Options{}
 	command := &cobra.Command{
 		Use:   "elasticsearch-mappings",
 		Short: "Jaeger esmapping-generator prints rendered mappings as string",

--- a/internal/storage/elasticsearch/mapping/command.go
+++ b/internal/storage/elasticsearch/mapping/command.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package mapping
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
+	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/generator"
+)
+
+func Command(options app.Options) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "elasticsearch-mappings",
+		Short: "Jaeger esmapping-generator prints rendered mappings as string",
+		Long:  "Jaeger esmapping-generator renders passed templates with provided values and prints rendered output to stdout",
+		Run: func(_ *cobra.Command, _ /* args */ []string) {
+			result, err := generator.GenerateMappings(options)
+			if err != nil {
+				log.Fatalf("Error generating mappings: %v", err)
+			}
+			fmt.Println(result)
+		},
+	}
+	options.AddFlags(command)
+
+	return command
+}

--- a/internal/storage/elasticsearch/mapping/command_test.go
+++ b/internal/storage/elasticsearch/mapping/command_test.go
@@ -10,21 +10,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 )
 
 func TestCommandExecute(t *testing.T) {
-	o := app.Options{
-		Mapping:       "jaeger-span",
-		EsVersion:     7,
-		Shards:        5,
-		Replicas:      1,
-		IndexPrefix:   "jaeger-index",
-		UseILM:        "false",
-		ILMPolicyName: "jaeger-ilm-policy",
-	}
-	cmd := Command(o)
+	cmd := Command()
 
 	// TempFile to capture output
 	tempFile, err := os.CreateTemp("", "command-output-*.txt")

--- a/internal/storage/elasticsearch/mapping/command_test.go
+++ b/internal/storage/elasticsearch/mapping/command_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package mapping
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/cmd/esmapping-generator/app"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestCommandExecute(t *testing.T) {
+	o := app.Options{
+		Mapping:       "jaeger-span",
+		EsVersion:     7,
+		Shards:        5,
+		Replicas:      1,
+		IndexPrefix:   "jaeger-index",
+		UseILM:        "false",
+		ILMPolicyName: "jaeger-ilm-policy",
+	}
+	cmd := Command(o)
+
+	oldStdout := os.Stdout
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	err = cmd.ParseFlags([]string{
+		"--mapping=jaeger-span",
+		"--es-version=7",
+		"--shards=5",
+		"--replicas=1",
+		"--index-prefix=jaeger-index",
+		"--use-ilm=false",
+		"--ilm-policy-name=jaeger-ilm-policy",
+	})
+	require.NoError(t, err)
+	require.NoError(t, cmd.Execute())
+
+	_ = w.Close()
+	<-done
+
+	capturedOutput := buf.String()
+
+	assert.True(t, strings.HasPrefix(capturedOutput, "{"), "Output should be JSON starting with '{'")
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(capturedOutput), "}"), "Output should end with '}'")
+
+	assert.Contains(t, capturedOutput, `"index_patterns":`, "Output should contain 'index_patterns'")
+	assert.Contains(t, capturedOutput, `"index.number_of_shards":`, "Output should contain 'index.number_of_shards'")
+	assert.Contains(t, capturedOutput, `"index.number_of_replicas":`, "Output should contain 'index.number_of_replicas'")
+	assert.Contains(t, capturedOutput, `"mappings":`, "Output should contain 'mappings'")
+
+	var jsonOutput map[string]any
+	err = json.Unmarshal([]byte(capturedOutput), &jsonOutput)
+	require.NoError(t, err, "Output should be valid JSON")
+}
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- part of #6283  

## Description of the changes
- Decoupled the Esmapping generation logic from cmd/esmappnig-generator/main.go and kept it into reusable renderer package and then reimplemented the subcommand in the plugin/storage/es/esmapping-generator.go file and then registered in jaeger/main.go. 

## How was this change tested?
- go test ./... -count=1

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
