### PR TITLE
[storage][v2] Implement `FindTraces` in v2 factory adapter

### DIFF
--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/jaegertracing/jaeger/storage_v2/depstore"
 	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
+	model2otel "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 )
 
 var errV1ReaderNotAvailable = errors.New("spanstore.Reader is not a wrapper around v1 reader")
@@ -62,8 +63,30 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 	return operations, nil
 }
 
-func (*TraceReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
-	panic("not implemented")
+func (tr *TraceReader) FindTraces(ctx context.Context, query tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
+	t, err := tr.spanReader.FindTraces(ctx, &spanstore.TraceQueryParameters{
+		ServiceName:   query.ServiceName,
+		OperationName: query.OperationName,
+		Tags:          query.Tags,
+		StartTimeMin:  query.StartTimeMin,
+		StartTimeMax:  query.StartTimeMax,
+		DurationMin:   query.DurationMin,
+		DurationMax:   query.DurationMax,
+		NumTraces:     query.NumTraces,
+	})
+	if err != nil || t == nil {
+		return nil, err
+	}
+	otelTraces := []ptrace.Traces{}
+	for _, trace := range t {
+		batch := &model.Batch{Spans: trace.GetSpans()}
+		otelTrace, err := model2otel.ProtoToTraces([]*model.Batch{batch})
+		if err != nil {
+			return nil, err
+		}
+		otelTraces = append(otelTraces, otelTrace)
+	}
+	return otelTraces, nil
 }
 
 func (tr *TraceReader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 
+	model2otel "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/jaegertracing/jaeger/storage_v2/depstore"
 	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
-	model2otel "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 )
 
 var errV1ReaderNotAvailable = errors.New("spanstore.Reader is not a wrapper around v1 reader")

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -63,17 +63,11 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 	return operations, nil
 }
 
-func (tr *TraceReader) FindTraces(ctx context.Context, query tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
-	t, err := tr.spanReader.FindTraces(ctx, &spanstore.TraceQueryParameters{
-		ServiceName:   query.ServiceName,
-		OperationName: query.OperationName,
-		Tags:          query.Tags,
-		StartTimeMin:  query.StartTimeMin,
-		StartTimeMax:  query.StartTimeMax,
-		DurationMin:   query.DurationMin,
-		DurationMax:   query.DurationMax,
-		NumTraces:     query.NumTraces,
-	})
+func (tr *TraceReader) FindTraces(
+	ctx context.Context,
+	query tracestore.TraceQueryParameters,
+) ([]ptrace.Traces, error) {
+	t, err := tr.spanReader.FindTraces(ctx, query.ToSpanStoreQueryParameters())
 	if err != nil || t == nil {
 		return nil, err
 	}
@@ -90,16 +84,7 @@ func (tr *TraceReader) FindTraces(ctx context.Context, query tracestore.TraceQue
 }
 
 func (tr *TraceReader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
-	t, err := tr.spanReader.FindTraceIDs(ctx, &spanstore.TraceQueryParameters{
-		ServiceName:   query.ServiceName,
-		OperationName: query.OperationName,
-		Tags:          query.Tags,
-		StartTimeMin:  query.StartTimeMin,
-		StartTimeMax:  query.StartTimeMax,
-		DurationMin:   query.DurationMin,
-		DurationMax:   query.DurationMax,
-		NumTraces:     query.NumTraces,
-	})
+	t, err := tr.spanReader.FindTraceIDs(ctx, query.ToSpanStoreQueryParameters())
 	if err != nil || t == nil {
 		return nil, err
 	}

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -74,10 +74,7 @@ func (tr *TraceReader) FindTraces(
 	otelTraces := []ptrace.Traces{}
 	for _, trace := range t {
 		batch := &model.Batch{Spans: trace.GetSpans()}
-		otelTrace, err := model2otel.ProtoToTraces([]*model.Batch{batch})
-		if err != nil {
-			return nil, err
-		}
+		otelTrace, _ := model2otel.ProtoToTraces([]*model.Batch{batch})
 		otelTraces = append(otelTraces, otelTrace)
 	}
 	return otelTraces, nil

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -117,6 +117,11 @@ func TestTraceReader_GetOperationsDelegatesResponse(t *testing.T) {
 			expectedOperations: nil,
 		},
 		{
+			name:               "empty response",
+			operations:         []spanstore.Operation{},
+			expectedOperations: []tracestore.Operation{},
+		},
+		{
 			name:               "error response",
 			operations:         nil,
 			expectedOperations: nil,

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -213,42 +213,17 @@ func TestTraceReader_FindTracesDelegatesSuccessResponse(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, traces, len(modelTraces))
-	require.EqualValues(
-		t,
-		[]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3},
-		traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID())
-	require.EqualValues(
-		t,
-		[]byte{0, 0, 0, 0, 0, 0, 0, 1},
-		traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).SpanID())
-	require.Equal(
-		t,
-		"operation-a",
-		traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
-	require.EqualValues(
-		t,
-		[]byte{0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5},
-		traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).TraceID())
-	require.EqualValues(
-		t,
-		[]byte{0, 0, 0, 0, 0, 0, 0, 2},
-		traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).SpanID())
-	require.Equal(
-		t,
-		"operation-b",
-		traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Name())
-	require.EqualValues(
-		t,
-		[]byte{0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 7},
-		traces[1].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID())
-	require.EqualValues(
-		t,
-		[]byte{0, 0, 0, 0, 0, 0, 0, 3},
-		traces[1].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).SpanID())
-	require.Equal(
-		t,
-		"operation-c",
-		traces[1].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+	traceASpans := traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	traceBSpans := traces[1].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.EqualValues(t, []byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}, traceASpans.At(0).TraceID())
+	require.EqualValues(t, []byte{0, 0, 0, 0, 0, 0, 0, 1}, traceASpans.At(0).SpanID())
+	require.Equal(t, "operation-a", traceASpans.At(0).Name())
+	require.EqualValues(t, []byte{0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5}, traceASpans.At(1).TraceID())
+	require.EqualValues(t, []byte{0, 0, 0, 0, 0, 0, 0, 2}, traceASpans.At(1).SpanID())
+	require.Equal(t, "operation-b", traceASpans.At(1).Name())
+	require.EqualValues(t, []byte{0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 7}, traceBSpans.At(0).TraceID())
+	require.EqualValues(t, []byte{0, 0, 0, 0, 0, 0, 0, 3}, traceBSpans.At(0).SpanID())
+	require.Equal(t, "operation-c", traceBSpans.At(0).Name())
 }
 
 func TestTraceReader_FindTracesEdgeCases(t *testing.T) {

--- a/storage_v2/tracestore/reader.go
+++ b/storage_v2/tracestore/reader.go
@@ -58,6 +58,19 @@ type TraceQueryParameters struct {
 	NumTraces     int
 }
 
+func (t *TraceQueryParameters) ToSpanStoreQueryParameters() *spanstore.TraceQueryParameters {
+	return &spanstore.TraceQueryParameters{
+		ServiceName:   t.ServiceName,
+		OperationName: t.OperationName,
+		Tags:          t.Tags,
+		StartTimeMin:  t.StartTimeMin,
+		StartTimeMax:  t.StartTimeMax,
+		DurationMin:   t.DurationMin,
+		DurationMax:   t.DurationMax,
+		NumTraces:     t.NumTraces,
+	}
+}
+
 // OperationQueryParameters contains parameters of query operations, empty spanKind means get operations for all kinds of span.
 type OperationQueryParameters struct {
 	ServiceName string

--- a/storage_v2/tracestore/reader_test.go
+++ b/storage_v2/tracestore/reader_test.go
@@ -1,0 +1,34 @@
+package tracestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/crossdock/crossdock-go/require"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+func TestToSpanStoreQueryParameters(t *testing.T) {
+	now := time.Now()
+	query := &TraceQueryParameters{
+		ServiceName:   "service",
+		OperationName: "operation",
+		Tags:          map[string]string{"tag-a": "val-a"},
+		StartTimeMin:  now,
+		StartTimeMax:  now.Add(time.Minute),
+		DurationMin:   time.Minute,
+		DurationMax:   time.Hour,
+		NumTraces:     10,
+	}
+	expected := &spanstore.TraceQueryParameters{
+		ServiceName:   "service",
+		OperationName: "operation",
+		Tags:          map[string]string{"tag-a": "val-a"},
+		StartTimeMin:  now,
+		StartTimeMax:  now.Add(time.Minute),
+		DurationMin:   time.Minute,
+		DurationMax:   time.Hour,
+		NumTraces:     10,
+	}
+	require.Equal(t, expected, query.ToSpanStoreQueryParameters())
+}

--- a/storage_v2/tracestore/reader_test.go
+++ b/storage_v2/tracestore/reader_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package tracestore
 
 import (
@@ -5,6 +8,7 @@ import (
 	"time"
 
 	"github.com/crossdock/crossdock-go/require"
+
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 

--- a/storage_v2/tracestore/reader_test.go
+++ b/storage_v2/tracestore/reader_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crossdock/crossdock-go/require"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #5079

## Description of the changes
- This PR implements `FindTraces` in the v2 factory adapter

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
