### PR TITLE
[storage][v2] Implement `GetTrace` in v2 factory adapter

### DIFF
--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -37,8 +37,14 @@ func NewTraceReader(spanReader spanstore.Reader) *TraceReader {
 	}
 }
 
-func (*TraceReader) GetTrace(_ context.Context, _ pcommon.TraceID) (ptrace.Traces, error) {
-	panic("not implemented")
+func (tr *TraceReader) GetTrace(ctx context.Context, traceID pcommon.TraceID) (ptrace.Traces, error) {
+	tid, _ := model.TraceIDFromBytes(traceID[:])
+	t, err := tr.spanReader.GetTrace(ctx, tid)
+	if err != nil {
+		return ptrace.NewTraces(), err
+	}
+	batch := &model.Batch{Spans: t.GetSpans()}
+	return model2otel.ProtoToTraces([]*model.Batch{batch})
 }
 
 func (tr *TraceReader) GetServices(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #5079

## Description of the changes
- This PR implements `GetTrace` in the v2 factory adapter

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
