### PR TITLE
[fix] Fallback to system CA certs pool

### DIFF
--- a/cmd/ingester/app/flags_test.go
+++ b/cmd/ingester/app/flags_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configtls"
 
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/kafka/auth"
@@ -66,12 +67,18 @@ func TestTLSFlags(t *testing.T) {
 			expected: auth.AuthenticationConfig{Authentication: "kerberos", Kerberos: kerb, PlainText: plain},
 		},
 		{
-			flags:    []string{"--kafka.consumer.authentication=tls"},
-			expected: auth.AuthenticationConfig{Authentication: "tls", Kerberos: kerb, PlainText: plain},
-		},
-		{
-			flags:    []string{"--kafka.consumer.authentication=tls", "--kafka.consumer.tls.enabled=false"},
-			expected: auth.AuthenticationConfig{Authentication: "tls", Kerberos: kerb, PlainText: plain},
+			flags: []string{"--kafka.consumer.authentication=tls"},
+			expected: auth.AuthenticationConfig{
+				Authentication: "tls",
+				Kerberos:       kerb,
+				// TODO this test is unclear - if tls.enabled != true, why is it not tls.Insecure=true?
+				TLS: configtls.ClientConfig{
+					Config: configtls.Config{
+						IncludeSystemCACertsPool: true,
+					},
+				},
+				PlainText: plain,
+			},
 		},
 	}
 

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -142,7 +142,7 @@ func (o *Options) ToOtelClientConfig() configtls.ClientConfig {
 
 			// when no truststore given, use SystemCertPool
 			// https://github.com/jaegertracing/jaeger/issues/6334
-			IncludeSystemCACertsPool: len(o.CAPath) == 0,
+			IncludeSystemCACertsPool: o.Enabled && (len(o.CAPath) == 0),
 		},
 	}
 }

--- a/pkg/config/tlscfg/options.go
+++ b/pkg/config/tlscfg/options.go
@@ -139,6 +139,10 @@ func (o *Options) ToOtelClientConfig() configtls.ClientConfig {
 			MinVersion:     o.MinVersion,
 			MaxVersion:     o.MaxVersion,
 			ReloadInterval: o.ReloadInterval,
+
+			// when no truststore given, use SystemCertPool
+			// https://github.com/jaegertracing/jaeger/issues/6334
+			IncludeSystemCACertsPool: len(o.CAPath) == 0,
 		},
 	}
 }

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -190,6 +190,9 @@ func TestToOtelClientConfig(t *testing.T) {
 			},
 			expected: configtls.ClientConfig{
 				Insecure: true,
+				Config: configtls.Config{
+					IncludeSystemCACertsPool: true,
+				},
 			},
 		},
 		{

--- a/pkg/config/tlscfg/options_test.go
+++ b/pkg/config/tlscfg/options_test.go
@@ -190,9 +190,6 @@ func TestToOtelClientConfig(t *testing.T) {
 			},
 			expected: configtls.ClientConfig{
 				Insecure: true,
-				Config: configtls.Config{
-					IncludeSystemCACertsPool: true,
-				},
 			},
 		},
 		{

--- a/plugin/storage/kafka/options_test.go
+++ b/plugin/storage/kafka/options_test.go
@@ -184,12 +184,31 @@ func TestTLSFlags(t *testing.T) {
 			expected: auth.AuthenticationConfig{Authentication: "kerberos", Kerberos: kerb, TLS: configtls.ClientConfig{}, PlainText: plain},
 		},
 		{
-			flags:    []string{"--kafka.producer.authentication=tls"},
-			expected: auth.AuthenticationConfig{Authentication: "tls", Kerberos: kerb, TLS: configtls.ClientConfig{}, PlainText: plain},
+			flags: []string{"--kafka.producer.authentication=tls"},
+			expected: auth.AuthenticationConfig{
+				Authentication: "tls",
+				Kerberos:       kerb,
+				TLS: configtls.ClientConfig{
+					Config: configtls.Config{
+						IncludeSystemCACertsPool: true,
+					},
+				},
+				PlainText: plain,
+			},
 		},
 		{
-			flags:    []string{"--kafka.producer.authentication=tls", "--kafka.producer.tls.enabled=false"},
-			expected: auth.AuthenticationConfig{Authentication: "tls", Kerberos: kerb, TLS: configtls.ClientConfig{}, PlainText: plain},
+			flags: []string{"--kafka.producer.authentication=tls", "--kafka.producer.tls.enabled=false"},
+			expected: auth.AuthenticationConfig{
+				Authentication: "tls",
+				Kerberos:       kerb,
+				// TODO this test is unclear - if tls.enabled=false, why is it not tls.Insecure=true?
+				TLS: configtls.ClientConfig{
+					Config: configtls.Config{
+						IncludeSystemCACertsPool: true,
+					},
+				},
+				PlainText: plain,
+			},
 		},
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6334

## Description of the changes
- Restore pre-OTEL behavior of using system cert pool if no CAFile is specified.

## How was this change tested?
- unit tests
