### PR TITLE
[v2][query] Add interface for adjuster to operate on OTLP data format

### DIFF
--- a/cmd/query/app/querysvc/adjuster/adjuster.go
+++ b/cmd/query/app/querysvc/adjuster/adjuster.go
@@ -1,0 +1,57 @@
+package adjuster
+
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// Adjuster defines an interface for modifying a trace object.
+// It returns the adjusted trace object, which is also updated in place.
+// If the adjuster encounters an issue that prevents it from applying
+// modifications, it should return the original trace object along with an error.
+type Adjuster interface {
+	Adjust(ptrace.Traces) (ptrace.Traces, error)
+}
+
+// Func is a type alias that wraps a function and makes an Adjuster from it.
+type Func func(trace ptrace.Traces) (ptrace.Traces, error)
+
+// Adjust implements Adjuster interface for the Func alias.
+func (f Func) Adjust(trace ptrace.Traces) (ptrace.Traces, error) {
+	return f(trace)
+}
+
+// Sequence creates an adjuster that combines a series of adjusters
+// applied in order. Errors from each step are accumulated and returned
+// in the end as a single wrapper error. Errors do not interrupt the
+// sequence of adapters.
+func Sequence(adjusters ...Adjuster) Adjuster {
+	return sequence{adjusters: adjusters}
+}
+
+// FailFastSequence is similar to Sequence() but returns immediately
+// if any adjuster returns an error.
+func FailFastSequence(adjusters ...Adjuster) Adjuster {
+	return sequence{adjusters: adjusters, failFast: true}
+}
+
+type sequence struct {
+	adjusters []Adjuster
+	failFast  bool
+}
+
+func (c sequence) Adjust(trace ptrace.Traces) (ptrace.Traces, error) {
+	var errs []error
+	for _, adjuster := range c.adjusters {
+		var err error
+		trace, err = adjuster.Adjust(trace)
+		if err != nil {
+			if c.failFast {
+				return trace, err
+			}
+			errs = append(errs, err)
+		}
+	}
+	return trace, errors.Join(errs...)
+}

--- a/cmd/query/app/querysvc/adjuster/adjuster.go
+++ b/cmd/query/app/querysvc/adjuster/adjuster.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package adjuster
 
 import (

--- a/cmd/query/app/querysvc/adjuster/adjuster_test.go
+++ b/cmd/query/app/querysvc/adjuster/adjuster_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package adjuster_test
 
 import (
@@ -5,11 +8,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc/adjuster"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc/adjuster"
 )
 
 func TestSequences(t *testing.T) {

--- a/cmd/query/app/querysvc/adjuster/adjuster_test.go
+++ b/cmd/query/app/querysvc/adjuster/adjuster_test.go
@@ -1,0 +1,64 @@
+package adjuster_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc/adjuster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestSequences(t *testing.T) {
+	// mock adjuster that increments last byte of span ID
+	adj := adjuster.Func(func(trace ptrace.Traces) (ptrace.Traces, error) {
+		span := trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+		spanId := span.SpanID()
+		spanId[7]++
+		span.SetSpanID(spanId)
+		return trace, nil
+	})
+
+	adjErr := errors.New("mock adjuster error")
+	failingAdj := adjuster.Func(func(trace ptrace.Traces) (ptrace.Traces, error) {
+		return trace, adjErr
+	})
+
+	tests := []struct {
+		name       string
+		adjuster   adjuster.Adjuster
+		err        string
+		lastSpanID pcommon.SpanID
+	}{
+		{
+			name:       "normal sequence",
+			adjuster:   adjuster.Sequence(adj, failingAdj, adj, failingAdj),
+			err:        fmt.Sprintf("%s\n%s", adjErr, adjErr),
+			lastSpanID: [8]byte{0, 0, 0, 0, 0, 0, 0, 2},
+		},
+		{
+			name:       "fail fast sequence",
+			adjuster:   adjuster.FailFastSequence(adj, failingAdj, adj, failingAdj),
+			err:        adjErr.Error(),
+			lastSpanID: [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			trace := ptrace.NewTraces()
+			span := trace.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 0})
+
+			adjTrace, err := test.adjuster.Adjust(trace)
+			adjTraceSpan := adjTrace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+
+			assert.Equal(t, span, adjTraceSpan, "same trace & span returned")
+			assert.EqualValues(t, test.lastSpanID, span.SpanID(), "expect span ID to be incremented")
+			require.EqualError(t, err, test.err)
+		})
+	}
+}

--- a/cmd/query/app/querysvc/adjuster/adjuster_test.go
+++ b/cmd/query/app/querysvc/adjuster/adjuster_test.go
@@ -56,8 +56,8 @@ func TestSequences(t *testing.T) {
 			adjTrace, err := test.adjuster.Adjust(trace)
 			adjTraceSpan := adjTrace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 
-			assert.Equal(t, span, adjTraceSpan, "same trace & span returned")
-			assert.EqualValues(t, test.lastSpanID, span.SpanID(), "expect span ID to be incremented")
+			assert.Equal(t, span, adjTraceSpan)
+			assert.EqualValues(t, test.lastSpanID, span.SpanID())
 			require.EqualError(t, err, test.err)
 		})
 	}

--- a/cmd/query/app/querysvc/adjuster/package_test.go
+++ b/cmd/query/app/querysvc/adjuster/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package adjuster
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6344

## Description of the changes
- This PR adds an interface for `Adjuster` to operate on the OTLP model format so that it can be used by the v2 query service. The v1 interface/implementation can be found in `model/adjuster`. 
- In the following PRs, we'll implement all the standard adjusters in `model/adjuster` to implement the new interface. 

## How was this change tested?
- Unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
