### PR TITLE
Add Go Leak Check for Badgerstore, gRPC and Memstore e2e Tests

### DIFF
--- a/plugin/storage/integration/badgerstore_test.go
+++ b/plugin/storage/integration/badgerstore_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/badger"
 )
 
@@ -47,6 +48,9 @@ func (s *BadgerIntegrationStorage) cleanUp(t *testing.T) {
 
 func TestBadgerStorage(t *testing.T) {
 	SkipUnlessEnv(t, "badger")
+	t.Cleanup(func() {
+		testutils.VerifyGoLeaksOnce(t)
+	})
 	s := &BadgerIntegrationStorage{
 		StorageIntegration: StorageIntegration{
 			SkipArchiveTest: true,

--- a/plugin/storage/integration/grpc_test.go
+++ b/plugin/storage/integration/grpc_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/grpc"
 )
 
@@ -61,6 +62,9 @@ func (s *GRPCStorageIntegrationTestSuite) cleanUp(t *testing.T) {
 
 func TestGRPCRemoteStorage(t *testing.T) {
 	SkipUnlessEnv(t, "grpc")
+	t.Cleanup(func() {
+		testutils.VerifyGoLeaksOnce(t)
+	})
 	s := &GRPCStorageIntegrationTestSuite{
 		flags: []string{
 			"--grpc-storage.server=localhost:17271",

--- a/plugin/storage/integration/memstore_test.go
+++ b/plugin/storage/integration/memstore_test.go
@@ -36,6 +36,9 @@ func (s *MemStorageIntegrationTestSuite) initialize(_ *testing.T) {
 
 func TestMemoryStorage(t *testing.T) {
 	SkipUnlessEnv(t, "memory")
+	t.Cleanup(func() {
+		testutils.VerifyGoLeaksOnce(t)
+	})
 	s := &MemStorageIntegrationTestSuite{}
 	s.initialize(t)
 	s.RunAll(t)


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a part of #5006 

## Description of the changes
- Added go leak check for badgerstore, grpc and Memstore

## How was this change tested?
- Integration Tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
