### PR TITLE
[v2][adjuster] Implement ip attribute adjuster to operate on otlp data model

### DIFF
--- a/cmd/query/app/querysvc/adjuster/adjuster.go
+++ b/cmd/query/app/querysvc/adjuster/adjuster.go
@@ -18,11 +18,11 @@ type Adjuster interface {
 }
 
 // Func is a type alias that wraps a function and makes an Adjuster from it.
-type Func func(trace ptrace.Traces) (ptrace.Traces, error)
+type Func func(traces ptrace.Traces) (ptrace.Traces, error)
 
 // Adjust implements Adjuster interface for the Func alias.
-func (f Func) Adjust(trace ptrace.Traces) (ptrace.Traces, error) {
-	return f(trace)
+func (f Func) Adjust(traces ptrace.Traces) (ptrace.Traces, error) {
+	return f(traces)
 }
 
 // Sequence creates an adjuster that combines a series of adjusters
@@ -44,17 +44,17 @@ type sequence struct {
 	failFast  bool
 }
 
-func (c sequence) Adjust(trace ptrace.Traces) (ptrace.Traces, error) {
+func (c sequence) Adjust(traces ptrace.Traces) (ptrace.Traces, error) {
 	var errs []error
 	for _, adjuster := range c.adjusters {
 		var err error
-		trace, err = adjuster.Adjust(trace)
+		traces, err = adjuster.Adjust(traces)
 		if err != nil {
 			if c.failFast {
-				return trace, err
+				return traces, err
 			}
 			errs = append(errs, err)
 		}
 	}
-	return trace, errors.Join(errs...)
+	return traces, errors.Join(errs...)
 }

--- a/cmd/query/app/querysvc/adjuster/ipattribute.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute.go
@@ -21,56 +21,57 @@ var ipAttributesToCorrect = map[string]struct{}{
 // which usually contain IPv4 packed into uint32, with their string
 // representation (e.g. "8.8.8.8"").
 func IPAttribute() Adjuster {
-	adjustAttributes := func(attributes pcommon.Map) {
-		adjusted := make(map[string]string)
-
-		attributes.Range(func(k string, v pcommon.Value) bool {
-			if _, ok := ipAttributesToCorrect[k]; !ok {
-				return true
-			}
-			var value uint32
-			switch v.Type() {
-			case pcommon.ValueTypeInt:
-				//nolint: gosec // G115
-				value = uint32(v.Int())
-			case pcommon.ValueTypeDouble:
-				value = uint32(v.Double())
-			default:
-				return true
-			}
-			var buf [4]byte
-			binary.BigEndian.PutUint32(buf[:], value)
-			var sBuf bytes.Buffer
-			for i, b := range buf {
-				if i > 0 {
-					sBuf.WriteRune('.')
-				}
-				sBuf.WriteString(strconv.FormatUint(uint64(b), 10))
-			}
-			adjusted[k] = sBuf.String()
-			return true
-		})
-
-		for k, v := range adjusted {
-			attributes.PutStr(k, v)
-		}
-	}
-
 	return Func(func(traces ptrace.Traces) (ptrace.Traces, error) {
+		adjuster := ipAttributeAdjuster{}
 		resourceSpans := traces.ResourceSpans()
 		for i := 0; i < resourceSpans.Len(); i++ {
 			rs := resourceSpans.At(i)
-			adjustAttributes(rs.Resource().Attributes())
+			adjuster.adjust(rs.Resource().Attributes())
 			scopeSpans := rs.ScopeSpans()
 			for j := 0; j < scopeSpans.Len(); j++ {
 				ss := scopeSpans.At(j)
 				spans := ss.Spans()
 				for k := 0; k < spans.Len(); k++ {
 					span := spans.At(k)
-					adjustAttributes(span.Attributes())
+					adjuster.adjust(span.Attributes())
 				}
 			}
 		}
 		return traces, nil
 	})
+}
+
+type ipAttributeAdjuster struct{}
+
+func (ipAttributeAdjuster) adjust(attributes pcommon.Map) {
+	adjusted := make(map[string]string)
+	attributes.Range(func(k string, v pcommon.Value) bool {
+		if _, ok := ipAttributesToCorrect[k]; !ok {
+			return true
+		}
+		var value uint32
+		switch v.Type() {
+		case pcommon.ValueTypeInt:
+			//nolint: gosec // G115
+			value = uint32(v.Int())
+		case pcommon.ValueTypeDouble:
+			value = uint32(v.Double())
+		default:
+			return true
+		}
+		var buf [4]byte
+		binary.BigEndian.PutUint32(buf[:], value)
+		var sBuf bytes.Buffer
+		for i, b := range buf {
+			if i > 0 {
+				sBuf.WriteRune('.')
+			}
+			sBuf.WriteString(strconv.FormatUint(uint64(b), 10))
+		}
+		adjusted[k] = sBuf.String()
+		return true
+	})
+	for k, v := range adjusted {
+		attributes.PutStr(k, v)
+	}
 }

--- a/cmd/query/app/querysvc/adjuster/ipattribute.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute.go
@@ -60,6 +60,7 @@ func IPAttribute() Adjuster {
 		resourceSpans := traces.ResourceSpans()
 		for i := 0; i < resourceSpans.Len(); i++ {
 			rs := resourceSpans.At(i)
+			adjustAttributes(rs.Resource().Attributes())
 			scopeSpans := rs.ScopeSpans()
 			for j := 0; j < scopeSpans.Len(); j++ {
 				ss := scopeSpans.At(j)

--- a/cmd/query/app/querysvc/adjuster/ipattribute.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute.go
@@ -1,0 +1,72 @@
+package adjuster
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+var ipAttributesToCorrect = map[string]struct{}{
+	"ip":        {},
+	"peer.ipv4": {},
+}
+
+// IPAttribute returns an adjuster that replaces numeric "ip" attributes,
+// which usually contain IPv4 packed into uint32, with their string
+// representation (e.g. "8.8.8.8"").
+func IPAttribute() Adjuster {
+	adjustAttributes := func(attributes pcommon.Map) {
+		adjusted := make(map[string]string)
+
+		attributes.Range(func(k string, v pcommon.Value) bool {
+			if _, ok := ipAttributesToCorrect[k]; !ok {
+				return true
+			}
+			var value uint32
+			switch v.Type() {
+			case pcommon.ValueTypeInt:
+				//nolint: gosec // G115
+				value = uint32(v.Int())
+			case pcommon.ValueTypeDouble:
+				value = uint32(v.Double())
+			default:
+				return true
+			}
+			var buf [4]byte
+			binary.BigEndian.PutUint32(buf[:], value)
+			var sBuf bytes.Buffer
+			for i, b := range buf {
+				if i > 0 {
+					sBuf.WriteRune('.')
+				}
+				sBuf.WriteString(strconv.FormatUint(uint64(b), 10))
+			}
+			adjusted[k] = sBuf.String()
+			return true
+		})
+
+		for k, v := range adjusted {
+			attributes.PutStr(k, v)
+		}
+	}
+
+	return Func(func(traces ptrace.Traces) (ptrace.Traces, error) {
+		resourceSpans := traces.ResourceSpans()
+		for i := 0; i < resourceSpans.Len(); i++ {
+			rs := resourceSpans.At(i)
+			scopeSpans := rs.ScopeSpans()
+			for j := 0; j < scopeSpans.Len(); j++ {
+				ss := scopeSpans.At(j)
+				spans := ss.Spans()
+				for k := 0; k < spans.Len(); k++ {
+					span := spans.At(k)
+					adjustAttributes(span.Attributes())
+				}
+			}
+		}
+		return traces, nil
+	})
+}

--- a/cmd/query/app/querysvc/adjuster/ipattribute.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package adjuster
 
 import (

--- a/cmd/query/app/querysvc/adjuster/ipattribute_test.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute_test.go
@@ -1,0 +1,47 @@
+package adjuster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestIPAttributeAdjuster(t *testing.T) {
+	traces := ptrace.NewTraces()
+	spans := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans()
+
+	spanA := spans.AppendEmpty()
+	spanA.Attributes().PutInt("a", 42)
+	spanA.Attributes().PutStr("ip", "not integer")
+	spanA.Attributes().PutInt("ip", 1<<24|2<<16|3<<8|4)
+	spanA.Attributes().PutStr("peer.ipv4", "something")
+
+	spanB := spans.AppendEmpty()
+	spanB.Attributes().PutDouble("ip", 1<<25|2<<16|3<<8|4)
+
+	trace, err := IPAttribute().Adjust(traces)
+	require.NoError(t, err)
+
+	span := trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	attributesA := span.At(0).Attributes()
+
+	val, ok := attributesA.Get("a")
+	require.True(t, ok)
+	require.EqualValues(t, 42, val.Int())
+
+	val, ok = attributesA.Get("ip")
+	require.True(t, ok)
+	require.EqualValues(t, "1.2.3.4", val.Str())
+
+	val, ok = attributesA.Get("peer.ipv4")
+	require.True(t, ok)
+	require.EqualValues(t, "something", val.Str())
+
+	attributesB := span.At(1).Attributes()
+
+	val, ok = attributesB.Get("ip")
+	require.True(t, ok)
+	require.EqualValues(t, "2.2.3.4", val.Str())
+
+}

--- a/cmd/query/app/querysvc/adjuster/ipattribute_test.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute_test.go
@@ -12,13 +12,19 @@ import (
 
 func TestIPAttributeAdjuster(t *testing.T) {
 	traces := ptrace.NewTraces()
-	spans := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans()
+	resourceSpans := traces.ResourceSpans().AppendEmpty()
+
+	resourceSpans.Resource().Attributes().PutInt("a", 42)
+	resourceSpans.Resource().Attributes().PutInt("ip", 1<<26|2<<16|3<<8|4)
+	resourceSpans.Resource().Attributes().PutStr("peer.ipv4", "something")
+
+	spans := resourceSpans.ScopeSpans().AppendEmpty().Spans()
 
 	spanA := spans.AppendEmpty()
 	spanA.Attributes().PutInt("a", 42)
 	spanA.Attributes().PutStr("ip", "not integer")
 	spanA.Attributes().PutInt("ip", 1<<24|2<<16|3<<8|4)
-	spanA.Attributes().PutStr("peer.ipv4", "something")
+	spanA.Attributes().PutStr("peer.ipv4", "something else")
 
 	spanB := spans.AppendEmpty()
 	spanB.Attributes().PutDouble("ip", 1<<25|2<<16|3<<8|4)
@@ -26,10 +32,25 @@ func TestIPAttributeAdjuster(t *testing.T) {
 	trace, err := IPAttribute().Adjust(traces)
 	require.NoError(t, err)
 
-	span := trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	resourceSpan := trace.ResourceSpans().At(0)
+	resourceAttributes := resourceSpan.Resource().Attributes()
+
+	val, ok := resourceAttributes.Get("a")
+	require.True(t, ok)
+	require.EqualValues(t, 42, val.Int())
+
+	val, ok = resourceAttributes.Get("ip")
+	require.True(t, ok)
+	require.EqualValues(t, "4.2.3.4", val.Str())
+
+	val, ok = resourceAttributes.Get("peer.ipv4")
+	require.True(t, ok)
+	require.EqualValues(t, "something", val.Str())
+
+	span := resourceSpan.ScopeSpans().At(0).Spans()
 	attributesA := span.At(0).Attributes()
 
-	val, ok := attributesA.Get("a")
+	val, ok = attributesA.Get("a")
 	require.True(t, ok)
 	require.EqualValues(t, 42, val.Int())
 
@@ -39,7 +60,7 @@ func TestIPAttributeAdjuster(t *testing.T) {
 
 	val, ok = attributesA.Get("peer.ipv4")
 	require.True(t, ok)
-	require.EqualValues(t, "something", val.Str())
+	require.EqualValues(t, "something else", val.Str())
 
 	attributesB := span.At(1).Attributes()
 

--- a/cmd/query/app/querysvc/adjuster/ipattribute_test.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package adjuster
 
 import (
@@ -43,5 +46,4 @@ func TestIPAttributeAdjuster(t *testing.T) {
 	val, ok = attributesB.Get("ip")
 	require.True(t, ok)
 	require.EqualValues(t, "2.2.3.4", val.Str())
-
 }

--- a/cmd/query/app/querysvc/adjuster/ipattribute_test.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute_test.go
@@ -6,7 +6,9 @@ package adjuster
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -14,57 +16,66 @@ func TestIPAttributeAdjuster(t *testing.T) {
 	traces := ptrace.NewTraces()
 	resourceSpans := traces.ResourceSpans().AppendEmpty()
 
-	resourceSpans.Resource().Attributes().PutInt("a", 42)
-	resourceSpans.Resource().Attributes().PutInt("ip", 1<<26|2<<16|3<<8|4)
-	resourceSpans.Resource().Attributes().PutStr("peer.ipv4", "something")
+	resourceAttributes := resourceSpans.Resource().Attributes()
+	resourceAttributes.PutInt("a", 42)
+	resourceAttributes.PutInt("ip", 1<<26|2<<16|3<<8|4)
+	resourceAttributes.PutStr("peer.ipv4", "something")
 
 	spans := resourceSpans.ScopeSpans().AppendEmpty().Spans()
 
-	spanA := spans.AppendEmpty()
-	spanA.Attributes().PutInt("a", 42)
-	spanA.Attributes().PutStr("ip", "not integer")
-	spanA.Attributes().PutInt("ip", 1<<24|2<<16|3<<8|4)
-	spanA.Attributes().PutStr("peer.ipv4", "something else")
+	createSpan := func(attrs map[string]any) {
+		span := spans.AppendEmpty()
+		for key, value := range attrs {
+			switch v := value.(type) {
+			case int:
+				span.Attributes().PutInt(key, int64(v))
+			case string:
+				span.Attributes().PutStr(key, v)
+			case float64:
+				span.Attributes().PutDouble(key, v)
+			}
+		}
+	}
 
-	spanB := spans.AppendEmpty()
-	spanB.Attributes().PutDouble("ip", 1<<25|2<<16|3<<8|4)
+	createSpan(map[string]any{
+		"a":         42,
+		"ip":        int(1<<24 | 2<<16 | 3<<8 | 4),
+		"peer.ipv4": "something else",
+	})
+
+	createSpan(map[string]any{
+		"ip": float64(1<<25 | 2<<16 | 3<<8 | 4),
+	})
+
+	assertAttribute := func(attributes pcommon.Map, key string, expected any) {
+		val, ok := attributes.Get(key)
+		require.True(t, ok)
+		switch v := expected.(type) {
+		case int:
+			require.EqualValues(t, v, val.Int())
+		case string:
+			require.EqualValues(t, v, val.Str())
+		}
+	}
 
 	trace, err := IPAttribute().Adjust(traces)
 	require.NoError(t, err)
 
 	resourceSpan := trace.ResourceSpans().At(0)
-	resourceAttributes := resourceSpan.Resource().Attributes()
+	assert.Equal(t, 3, resourceSpan.Resource().Attributes().Len())
 
-	val, ok := resourceAttributes.Get("a")
-	require.True(t, ok)
-	require.EqualValues(t, 42, val.Int())
+	assertAttribute(resourceSpan.Resource().Attributes(), "a", 42)
+	assertAttribute(resourceSpan.Resource().Attributes(), "ip", "4.2.3.4")
+	assertAttribute(resourceSpan.Resource().Attributes(), "peer.ipv4", "something")
 
-	val, ok = resourceAttributes.Get("ip")
-	require.True(t, ok)
-	require.EqualValues(t, "4.2.3.4", val.Str())
+	gotSpans := resourceSpan.ScopeSpans().At(0).Spans()
+	assert.Equal(t, 2, gotSpans.Len())
 
-	val, ok = resourceAttributes.Get("peer.ipv4")
-	require.True(t, ok)
-	require.EqualValues(t, "something", val.Str())
+	assert.Equal(t, 3, gotSpans.At(0).Attributes().Len())
+	assertAttribute(gotSpans.At(0).Attributes(), "a", 42)
+	assertAttribute(gotSpans.At(0).Attributes(), "ip", "1.2.3.4")
+	assertAttribute(gotSpans.At(0).Attributes(), "peer.ipv4", "something else")
 
-	span := resourceSpan.ScopeSpans().At(0).Spans()
-	attributesA := span.At(0).Attributes()
-
-	val, ok = attributesA.Get("a")
-	require.True(t, ok)
-	require.EqualValues(t, 42, val.Int())
-
-	val, ok = attributesA.Get("ip")
-	require.True(t, ok)
-	require.EqualValues(t, "1.2.3.4", val.Str())
-
-	val, ok = attributesA.Get("peer.ipv4")
-	require.True(t, ok)
-	require.EqualValues(t, "something else", val.Str())
-
-	attributesB := span.At(1).Attributes()
-
-	val, ok = attributesB.Get("ip")
-	require.True(t, ok)
-	require.EqualValues(t, "2.2.3.4", val.Str())
+	assert.Equal(t, 1, gotSpans.At(1).Attributes().Len())
+	assertAttribute(gotSpans.At(1).Attributes(), "ip", "2.2.3.4")
 }

--- a/cmd/query/app/querysvc/adjuster/ipattribute_test.go
+++ b/cmd/query/app/querysvc/adjuster/ipattribute_test.go
@@ -18,7 +18,7 @@ func TestIPAttributeAdjuster(t *testing.T) {
 
 	resourceAttributes := resourceSpans.Resource().Attributes()
 	resourceAttributes.PutInt("a", 42)
-	resourceAttributes.PutInt("ip", 1<<26|2<<16|3<<8|4)
+	resourceAttributes.PutInt("ip", 1<<24|2<<16|3<<8|4)
 	resourceAttributes.PutStr("peer.ipv4", "something")
 
 	spans := resourceSpans.ScopeSpans().AppendEmpty().Spans()
@@ -39,12 +39,12 @@ func TestIPAttributeAdjuster(t *testing.T) {
 
 	createSpan(map[string]any{
 		"a":         42,
-		"ip":        int(1<<24 | 2<<16 | 3<<8 | 4),
+		"ip":        int(1<<25 | 2<<16 | 3<<8 | 4),
 		"peer.ipv4": "something else",
 	})
 
 	createSpan(map[string]any{
-		"ip": float64(1<<25 | 2<<16 | 3<<8 | 4),
+		"ip": float64(1<<26 | 2<<16 | 3<<8 | 4),
 	})
 
 	assertAttribute := func(attributes pcommon.Map, key string, expected any) {
@@ -65,7 +65,7 @@ func TestIPAttributeAdjuster(t *testing.T) {
 	assert.Equal(t, 3, resourceSpan.Resource().Attributes().Len())
 
 	assertAttribute(resourceSpan.Resource().Attributes(), "a", 42)
-	assertAttribute(resourceSpan.Resource().Attributes(), "ip", "4.2.3.4")
+	assertAttribute(resourceSpan.Resource().Attributes(), "ip", "1.2.3.4")
 	assertAttribute(resourceSpan.Resource().Attributes(), "peer.ipv4", "something")
 
 	gotSpans := resourceSpan.ScopeSpans().At(0).Spans()
@@ -73,9 +73,9 @@ func TestIPAttributeAdjuster(t *testing.T) {
 
 	assert.Equal(t, 3, gotSpans.At(0).Attributes().Len())
 	assertAttribute(gotSpans.At(0).Attributes(), "a", 42)
-	assertAttribute(gotSpans.At(0).Attributes(), "ip", "1.2.3.4")
+	assertAttribute(gotSpans.At(0).Attributes(), "ip", "2.2.3.4")
 	assertAttribute(gotSpans.At(0).Attributes(), "peer.ipv4", "something else")
 
 	assert.Equal(t, 1, gotSpans.At(1).Attributes().Len())
-	assertAttribute(gotSpans.At(1).Attributes(), "ip", "2.2.3.4")
+	assertAttribute(gotSpans.At(1).Attributes(), "ip", "4.2.3.4")
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards https://github.com/jaegertracing/jaeger/issues/6344

## Description of the changes
- This PR implements the `IPTag` adjuster to operate on the OTLP data model. In the OTLP model, tags are dubbed as attributes so the adjuster was renamed to `IPAttribute`.

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
