### PR TITLE
Change Storage v2 API to use streaming

### DIFF
--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -108,28 +108,6 @@ func initializeTestService(optionAppliers ...testOption) *testQueryService {
 	return &tqs
 }
 
-// type fakeReader struct{}
-
-// func (*fakeReader) GetTrace(_ context.Context, _ pcommon.TraceID) (ptrace.Traces, error) {
-// 	panic("not implemented")
-// }
-
-// func (*fakeReader) GetServices(_ context.Context) ([]string, error) {
-// 	panic("not implemented")
-// }
-
-// func (*fakeReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
-// 	panic("not implemented")
-// }
-
-// func (*fakeReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
-// 	panic("not implemented")
-// }
-
-// func (*fakeReader) FindTraceIDs(_ context.Context, _ tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
-// 	panic("not implemented")
-// }
-
 // Test QueryService.GetTrace()
 func TestGetTraceSuccess(t *testing.T) {
 	tqs := initializeTestService()

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/model"
@@ -27,7 +25,7 @@ import (
 	"github.com/jaegertracing/jaeger/storage_v2/depstore"
 	depsmocks "github.com/jaegertracing/jaeger/storage_v2/depstore/mocks"
 	"github.com/jaegertracing/jaeger/storage_v2/factoryadapter"
-	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
+	tracestoremocks "github.com/jaegertracing/jaeger/storage_v2/tracestore/mocks"
 )
 
 const millisToNanosMultiplier = int64(time.Millisecond / time.Nanosecond)
@@ -110,27 +108,27 @@ func initializeTestService(optionAppliers ...testOption) *testQueryService {
 	return &tqs
 }
 
-type fakeReader struct{}
+// type fakeReader struct{}
 
-func (*fakeReader) GetTrace(_ context.Context, _ pcommon.TraceID) (ptrace.Traces, error) {
-	panic("not implemented")
-}
+// func (*fakeReader) GetTrace(_ context.Context, _ pcommon.TraceID) (ptrace.Traces, error) {
+// 	panic("not implemented")
+// }
 
-func (*fakeReader) GetServices(_ context.Context) ([]string, error) {
-	panic("not implemented")
-}
+// func (*fakeReader) GetServices(_ context.Context) ([]string, error) {
+// 	panic("not implemented")
+// }
 
-func (*fakeReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
-	panic("not implemented")
-}
+// func (*fakeReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
+// 	panic("not implemented")
+// }
 
-func (*fakeReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
-	panic("not implemented")
-}
+// func (*fakeReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
+// 	panic("not implemented")
+// }
 
-func (*fakeReader) FindTraceIDs(_ context.Context, _ tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
-	panic("not implemented")
-}
+// func (*fakeReader) FindTraceIDs(_ context.Context, _ tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
+// 	panic("not implemented")
+// }
 
 // Test QueryService.GetTrace()
 func TestGetTraceSuccess(t *testing.T) {
@@ -158,7 +156,7 @@ func TestGetTraceNotFound(t *testing.T) {
 }
 
 func TestGetTrace_V1ReaderNotFound(t *testing.T) {
-	fr := &fakeReader{}
+	fr := new(tracestoremocks.Reader)
 	qs := QueryService{
 		traceReader: fr,
 	}
@@ -195,7 +193,7 @@ func TestGetServices(t *testing.T) {
 }
 
 func TestGetServices_V1ReaderNotFound(t *testing.T) {
-	fr := &fakeReader{}
+	fr := new(tracestoremocks.Reader)
 	qs := QueryService{
 		traceReader: fr,
 	}
@@ -222,7 +220,7 @@ func TestGetOperations(t *testing.T) {
 }
 
 func TestGetOperations_V1ReaderNotFound(t *testing.T) {
-	fr := &fakeReader{}
+	fr := new(tracestoremocks.Reader)
 	qs := QueryService{
 		traceReader: fr,
 	}
@@ -253,7 +251,7 @@ func TestFindTraces(t *testing.T) {
 }
 
 func TestFindTraces_V1ReaderNotFound(t *testing.T) {
-	fr := &fakeReader{}
+	fr := new(tracestoremocks.Reader)
 	qs := QueryService{
 		traceReader: fr,
 	}

--- a/pkg/iter/iter.go
+++ b/pkg/iter/iter.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package iter is a backport of Go 1.23 official "iter" package, until we upgrade.
+package iter
+
+type (
+	Seq[V any]     func(yield func(V) bool)
+	Seq2[K, V any] func(yield func(K, V) bool)
+)
+
+func CollectWithErrors[V any](seq Seq2[V, error]) ([]V, error) {
+	var result []V
+	var err error
+	seq(func(v V, e error) bool {
+		if e != nil {
+			err = e
+			return false
+		}
+		result = append(result, v)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func FlattenWithErrors[V any](seq Seq2[[]V, error]) ([]V, error) {
+	var result []V
+	var err error
+	seq(func(v []V, e error) bool {
+		if e != nil {
+			err = e
+			return false
+		}
+		result = append(result, v...)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/iter/iter_test.go
+++ b/pkg/iter/iter_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package iter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectWithErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		seq      Seq2[string, error]
+		expected []string
+		err      error
+	}{
+		{
+			name: "no errors",
+			seq: func(yield func(string, error) bool) {
+				yield("a", nil)
+				yield("b", nil)
+				yield("c", nil)
+			},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name: "first error",
+			seq: func(yield func(string, error) bool) {
+				yield("a", nil)
+				yield("b", nil)
+				yield("c", assert.AnError)
+			},
+			err: assert.AnError,
+		},
+		{
+			name: "second error",
+			seq: func(yield func(string, error) bool) {
+				yield("a", nil)
+				yield("b", assert.AnError)
+				yield("c", nil)
+			},
+			err: assert.AnError,
+		},
+		{
+			name: "third error",
+			seq: func(yield func(string, error) bool) {
+				yield("a", nil)
+				yield("b", nil)
+				yield("c", assert.AnError)
+			},
+			err: assert.AnError,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := CollectWithErrors(test.seq)
+			if test.err != nil {
+				require.ErrorIs(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, result)
+			}
+		})
+	}
+}
+
+func TestFlattenWithErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		seq      Seq2[[]string, error]
+		expected []string
+		err      error
+	}{
+		{
+			name: "no errors",
+			seq: func(yield func([]string, error) bool) {
+				yield([]string{"a", "b", "c"}, nil)
+				yield([]string{"d", "e", "f"}, nil)
+				yield([]string{"g", "h", "i"}, nil)
+			},
+			expected: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"},
+		},
+		{
+			name: "first error",
+			seq: func(yield func([]string, error) bool) {
+				yield([]string{"a", "b", "c"}, nil)
+				yield([]string{"d", "e", "f"}, assert.AnError)
+				yield([]string{"g", "h", "i"}, nil)
+			},
+			err: assert.AnError,
+		},
+		{
+			name: "second error",
+			seq: func(yield func([]string, error) bool) {
+				yield([]string{"a", "b", "c"}, nil)
+				yield([]string{"d", "e", "f"}, nil)
+				yield([]string{"g", "h", "i"}, assert.AnError)
+			},
+			err: assert.AnError,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := FlattenWithErrors(test.seq)
+			if test.err != nil {
+				require.ErrorIs(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/iter/package_test.go
+++ b/pkg/iter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package iter
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/pkg/iter"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/jaegertracing/jaeger/storage_v2/depstore"
@@ -19,6 +20,8 @@ import (
 )
 
 var errV1ReaderNotAvailable = errors.New("spanstore.Reader is not a wrapper around v1 reader")
+
+var _ tracestore.Reader = (*TraceReader)(nil)
 
 type TraceReader struct {
 	spanReader spanstore.Reader
@@ -37,13 +40,17 @@ func NewTraceReader(spanReader spanstore.Reader) *TraceReader {
 	}
 }
 
-func (tr *TraceReader) GetTrace(ctx context.Context, traceID pcommon.TraceID) (ptrace.Traces, error) {
-	t, err := tr.spanReader.GetTrace(ctx, model.TraceIDFromOTEL(traceID))
-	if err != nil {
-		return ptrace.NewTraces(), err
+func (tr *TraceReader) GetTrace(ctx context.Context, traceID pcommon.TraceID) iter.Seq2[ptrace.Traces, error] {
+	return func(yield func(ptrace.Traces, error) bool) {
+		t, err := tr.spanReader.GetTrace(ctx, model.TraceIDFromOTEL(traceID))
+		if err != nil {
+			yield(ptrace.NewTraces(), err)
+			return
+		}
+		batch := &model.Batch{Spans: t.GetSpans()}
+		tr, err := model2otel.ProtoToTraces([]*model.Batch{batch})
+		yield(tr, err)
 	}
-	batch := &model.Batch{Spans: t.GetSpans()}
-	return model2otel.ProtoToTraces([]*model.Batch{batch})
 }
 
 func (tr *TraceReader) GetServices(ctx context.Context) ([]string, error) {
@@ -71,30 +78,39 @@ func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.Opera
 func (tr *TraceReader) FindTraces(
 	ctx context.Context,
 	query tracestore.TraceQueryParameters,
-) ([]ptrace.Traces, error) {
-	t, err := tr.spanReader.FindTraces(ctx, query.ToSpanStoreQueryParameters())
-	if err != nil || t == nil {
-		return nil, err
+) iter.Seq2[[]ptrace.Traces, error] {
+	return func(yield func([]ptrace.Traces, error) bool) {
+		t, err := tr.spanReader.FindTraces(ctx, query.ToSpanStoreQueryParameters())
+		if err != nil || t == nil {
+			yield(nil, err)
+			return
+		}
+		for _, trace := range t {
+			batch := &model.Batch{Spans: trace.GetSpans()}
+			otelTrace, _ := model2otel.ProtoToTraces([]*model.Batch{batch})
+			if !yield([]ptrace.Traces{otelTrace}, nil) {
+				return
+			}
+		}
 	}
-	otelTraces := []ptrace.Traces{}
-	for _, trace := range t {
-		batch := &model.Batch{Spans: trace.GetSpans()}
-		otelTrace, _ := model2otel.ProtoToTraces([]*model.Batch{batch})
-		otelTraces = append(otelTraces, otelTrace)
-	}
-	return otelTraces, nil
 }
 
-func (tr *TraceReader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
-	t, err := tr.spanReader.FindTraceIDs(ctx, query.ToSpanStoreQueryParameters())
-	if err != nil || t == nil {
-		return nil, err
+func (tr *TraceReader) FindTraceIDs(
+	ctx context.Context,
+	query tracestore.TraceQueryParameters,
+) iter.Seq2[[]pcommon.TraceID, error] {
+	return func(yield func([]pcommon.TraceID, error) bool) {
+		t, err := tr.spanReader.FindTraceIDs(ctx, query.ToSpanStoreQueryParameters())
+		if err != nil || t == nil {
+			yield(nil, err)
+			return
+		}
+		traceIDs := make([]pcommon.TraceID, 0, len(t))
+		for _, traceID := range t {
+			traceIDs = append(traceIDs, traceID.ToOTELTraceID())
+		}
+		yield(traceIDs, nil)
 	}
-	traceIDs := []pcommon.TraceID{}
-	for _, traceID := range t {
-		traceIDs = append(traceIDs, traceID.ToOTELTraceID())
-	}
-	return traceIDs, nil
 }
 
 type DependencyReader struct {

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -22,6 +22,7 @@ import (
 	spanStoreMocks "github.com/jaegertracing/jaeger/storage/spanstore/mocks"
 	"github.com/jaegertracing/jaeger/storage_v2/depstore"
 	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
+	tracestoremocks "github.com/jaegertracing/jaeger/storage_v2/tracestore/mocks"
 )
 
 func TestGetV1Reader_NoError(t *testing.T) {
@@ -34,30 +35,8 @@ func TestGetV1Reader_NoError(t *testing.T) {
 	require.Equal(t, memstore, v1Reader)
 }
 
-type fakeReader struct{}
-
-func (*fakeReader) GetTrace(_ context.Context, _ pcommon.TraceID) iter.Seq2[ptrace.Traces, error] {
-	panic("not implemented")
-}
-
-func (*fakeReader) GetServices(_ context.Context) ([]string, error) {
-	panic("not implemented")
-}
-
-func (*fakeReader) GetOperations(_ context.Context, _ tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
-	panic("not implemented")
-}
-
-func (*fakeReader) FindTraces(_ context.Context, _ tracestore.TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error] {
-	panic("not implemented")
-}
-
-func (*fakeReader) FindTraceIDs(_ context.Context, _ tracestore.TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error] {
-	panic("not implemented")
-}
-
 func TestGetV1Reader_Error(t *testing.T) {
-	fr := &fakeReader{}
+	fr := new(tracestoremocks.Reader)
 	_, err := GetV1Reader(fr)
 	require.ErrorIs(t, err, errV1ReaderNotAvailable)
 }

--- a/storage_v2/tracestore/mocks/Reader.go
+++ b/storage_v2/tracestore/mocks/Reader.go
@@ -10,7 +10,9 @@ package mocks
 import (
 	context "context"
 
+	iter "github.com/jaegertracing/jaeger/pkg/iter"
 	mock "github.com/stretchr/testify/mock"
+
 	pcommon "go.opentelemetry.io/collector/pdata/pcommon"
 
 	ptrace "go.opentelemetry.io/collector/pdata/ptrace"
@@ -24,63 +26,43 @@ type Reader struct {
 }
 
 // FindTraceIDs provides a mock function with given fields: ctx, query
-func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) ([]pcommon.TraceID, error) {
+func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error] {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindTraceIDs")
 	}
 
-	var r0 []pcommon.TraceID
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) ([]pcommon.TraceID, error)); ok {
-		return rf(ctx, query)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) []pcommon.TraceID); ok {
+	var r0 iter.Seq2[[]pcommon.TraceID, error]
+	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error]); ok {
 		r0 = rf(ctx, query)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]pcommon.TraceID)
+			r0 = ret.Get(0).(iter.Seq2[[]pcommon.TraceID, error])
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, tracestore.TraceQueryParameters) error); ok {
-		r1 = rf(ctx, query)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // FindTraces provides a mock function with given fields: ctx, query
-func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryParameters) ([]ptrace.Traces, error) {
+func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error] {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindTraces")
 	}
 
-	var r0 []ptrace.Traces
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) ([]ptrace.Traces, error)); ok {
-		return rf(ctx, query)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) []ptrace.Traces); ok {
+	var r0 iter.Seq2[[]ptrace.Traces, error]
+	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error]); ok {
 		r0 = rf(ctx, query)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]ptrace.Traces)
+			r0 = ret.Get(0).(iter.Seq2[[]ptrace.Traces, error])
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, tracestore.TraceQueryParameters) error); ok {
-		r1 = rf(ctx, query)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // GetOperations provides a mock function with given fields: ctx, query
@@ -144,31 +126,23 @@ func (_m *Reader) GetServices(ctx context.Context) ([]string, error) {
 }
 
 // GetTrace provides a mock function with given fields: ctx, traceID
-func (_m *Reader) GetTrace(ctx context.Context, traceID pcommon.TraceID) (ptrace.Traces, error) {
+func (_m *Reader) GetTrace(ctx context.Context, traceID pcommon.TraceID) iter.Seq2[ptrace.Traces, error] {
 	ret := _m.Called(ctx, traceID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTrace")
 	}
 
-	var r0 ptrace.Traces
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, pcommon.TraceID) (ptrace.Traces, error)); ok {
-		return rf(ctx, traceID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, pcommon.TraceID) ptrace.Traces); ok {
+	var r0 iter.Seq2[ptrace.Traces, error]
+	if rf, ok := ret.Get(0).(func(context.Context, pcommon.TraceID) iter.Seq2[ptrace.Traces, error]); ok {
 		r0 = rf(ctx, traceID)
 	} else {
-		r0 = ret.Get(0).(ptrace.Traces)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(iter.Seq2[ptrace.Traces, error])
+		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, pcommon.TraceID) error); ok {
-		r1 = rf(ctx, traceID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // NewReader creates a new instance of Reader. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/storage_v2/tracestore/reader.go
+++ b/storage_v2/tracestore/reader.go
@@ -14,14 +14,14 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
-// ErrTraceNotFound is returned by Reader's GetTrace if no data is found for given trace ID.
-var ErrTraceNotFound = spanstore.ErrTraceNotFound
-
 // Reader finds and loads traces and other data from storage.
 type Reader interface {
-	// GetTrace retrieves the trace with a given id.
-	// If the trace is too large it may be returned in multiple chucks.
-	// If no spans are stored for this trace, it returns ErrTraceNotFound.
+	// GetTrace returns an iterator that retrieves all spans of the trace with a given id.
+	// The iterator is single-use: once consumed, it cannot be used again.
+	//
+	// If the trace is too large it may be returned in multiple chunks.
+	//
+	// If no spans are stored for this trace, it returns an empty iterator.
 	GetTrace(ctx context.Context, traceID pcommon.TraceID) iter.Seq2[ptrace.Traces, error]
 
 	// GetServices returns all service names known to the backend from spans
@@ -32,22 +32,30 @@ type Reader interface {
 	// known to the backend from spans within its retention period.
 	GetOperations(ctx context.Context, query OperationQueryParameters) ([]Operation, error)
 
-	// FindTraces returns all traces matching query parameters. There's currently
-	// an implementation-dependent ambiguity whether all query filters (such as
-	// multiple tags) must apply to the same span within a trace, or can be satisfied
-	// by different spans.
+	// FindTraces returns an iterator that retrieves traces matching query parameters.
+	// The iterator is single-use: once consumed, it cannot be used again.
 	//
-	// There is no guarantee that all spans for a single trace are returned in a single chunk.
-	// However, there is a guarantees that all spans for a single trace are returned in
+	// There is no guarantee that all spans for a single trace are returned in a single chunk
+	// (same as GetTrace: it the trace is too large it may be returned in multiple chunks).
+	// However, it is guaranteed that all spans for a single trace are returned in
 	// one or more consecutive chunks, as if the total output is grouped by trace ID.
 	//
-	// If no matching traces are found, the function returns en empty iterator.
+	// If no matching traces are found, the function returns an empty iterator.
+	//
+	// There's currently an implementation-dependent ambiguity whether all query filters
+	// (such as multiple tags) must apply to the same span within a trace, or can be satisfied
+	// by different spans.
 	FindTraces(ctx context.Context, query TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error]
 
-	// FindTraceIDs does the same search as FindTraces, but returns only the list
-	// of matching trace IDs.
+	// FindTraceIDs returns an iterator that retrieves IDs of traces matching query parameters.
+	// The iterator is single-use: once consumed, it cannot be used again.
 	//
 	// If no matching traces are found, the function returns an empty iterator.
+	//
+	// This function behaves identically to FindTraces, except that it returns only the list
+	// of matching trace IDs. This is useful in some contexts, such as batch jobs, where a
+	// large list of trace IDs may be queried first and then the full traces are loaded
+	// in batches.
 	FindTraceIDs(ctx context.Context, query TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error]
 }
 

--- a/storage_v2/tracestore/reader.go
+++ b/storage_v2/tracestore/reader.go
@@ -36,7 +36,7 @@ type Reader interface {
 	// The iterator is single-use: once consumed, it cannot be used again.
 	//
 	// There is no guarantee that all spans for a single trace are returned in a single chunk
-	// (same as GetTrace: it the trace is too large it may be returned in multiple chunks).
+	// (same as GetTrace: if the trace is too large, it may be returned in multiple chunks).
 	// However, it is guaranteed that all spans for a single trace are returned in
 	// one or more consecutive chunks, as if the total output is grouped by trace ID.
 	//


### PR DESCRIPTION
## Which problem is this PR solving?
- v1 storage API was fully synchronous that required buffering add span data in memory, even though our gRPC Remote Storage API supported streaming.

## Description of the changes
- Change `tracestore.Reader` interface to use function iterators in the style of Go 1.23 `iter` package
- Add a sort of a backport of `iter` package until we can upgrade to Go 1.23

## How was this change tested?
- CI
