### PR TITLE
Support extra custom query parameters in requests to Prometheus backend

### DIFF
--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -19,10 +19,11 @@ type Configuration struct {
 	TokenFilePath            string `mapstructure:"token_file_path"`
 	TokenOverrideFromContext bool   `mapstructure:"token_override_from_context"`
 
-	MetricNamespace   string `mapstructure:"metric_namespace"`
-	LatencyUnit       string `mapstructure:"latency_unit"`
-	NormalizeCalls    bool   `mapstructure:"normalize_calls"`
-	NormalizeDuration bool   `mapstructure:"normalize_duration"`
+	MetricNamespace      string            `mapstructure:"metric_namespace"`
+	LatencyUnit          string            `mapstructure:"latency_unit"`
+	NormalizeCalls       bool              `mapstructure:"normalize_calls"`
+	NormalizeDuration    bool              `mapstructure:"normalize_duration"`
+	AdditionalParameters map[string]string `mapstructure:"additional_parameters"`
 }
 
 func (c *Configuration) Validate() error {

--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -25,7 +25,6 @@ type Configuration struct {
 	NormalizeDuration bool   `mapstructure:"normalize_duration"`
 	// ExtraQueryParams is used to provide extra parameters to be appended
 	// to the URL of queries going out to the metrics backend.
-	// is being called for metric read/write
 	ExtraQueryParams map[string]string `mapstructure:"extra_query_parameters"`
 }
 

--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -19,11 +19,13 @@ type Configuration struct {
 	TokenFilePath            string `mapstructure:"token_file_path"`
 	TokenOverrideFromContext bool   `mapstructure:"token_override_from_context"`
 
-	MetricNamespace      string            `mapstructure:"metric_namespace"`
-	LatencyUnit          string            `mapstructure:"latency_unit"`
-	NormalizeCalls       bool              `mapstructure:"normalize_calls"`
-	NormalizeDuration    bool              `mapstructure:"normalize_duration"`
-	AdditionalParameters map[string]string `mapstructure:"additional_parameters"`
+	MetricNamespace   string `mapstructure:"metric_namespace"`
+	LatencyUnit       string `mapstructure:"latency_unit"`
+	NormalizeCalls    bool   `mapstructure:"normalize_calls"`
+	NormalizeDuration bool   `mapstructure:"normalize_duration"`
+	// ExtraQueryParams is used to provide extra query parameters to the backend which
+	// is being called for metric read/write
+	ExtraQueryParams map[string]string `mapstructure:"extra_query_parameters"`
 }
 
 func (c *Configuration) Validate() error {

--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -23,7 +23,8 @@ type Configuration struct {
 	LatencyUnit       string `mapstructure:"latency_unit"`
 	NormalizeCalls    bool   `mapstructure:"normalize_calls"`
 	NormalizeDuration bool   `mapstructure:"normalize_duration"`
-	// ExtraQueryParams is used to provide extra query parameters to the backend which
+	// ExtraQueryParams is used to provide extra parameters to be appended
+	// to the URL of queries going out to the metrics backend.
 	// is being called for metric read/write
 	ExtraQueryParams map[string]string `mapstructure:"extra_query_parameters"`
 }

--- a/plugin/metricstore/prometheus/metricstore/reader.go
+++ b/plugin/metricstore/prometheus/metricstore/reader.go
@@ -64,7 +64,7 @@ type (
 
 	promClient struct {
 		api.Client
-		params map[string]string
+		extraParams map[string]string
 	}
 )
 
@@ -73,7 +73,7 @@ func (p promClient) URL(ep string, args map[string]string) *url.URL {
 	u := p.Client.URL(ep, args)
 
 	query := u.Query()
-	for k, v := range p.params {
+	for k, v := range p.extraParams {
 		query.Set(k, v)
 	}
 	u.RawQuery = query.Encode()
@@ -96,8 +96,8 @@ func createPromClient(logger *zap.Logger, cfg config.Configuration) (api.Client,
 	}
 
 	customClient := promClient{
-		Client: client,
-		params: cfg.AdditionalParameters,
+		Client:      client,
+		extraParams: cfg.ExtraQueryParams,
 	}
 
 	return customClient, nil
@@ -105,8 +105,6 @@ func createPromClient(logger *zap.Logger, cfg config.Configuration) (api.Client,
 
 // NewMetricsReader returns a new MetricsReader.
 func NewMetricsReader(cfg config.Configuration, logger *zap.Logger, tracer trace.TracerProvider) (*MetricsReader, error) {
-	logger.Info("Creating metrics reader", zap.Any("configuration", cfg))
-
 	const operationLabel = "span_name"
 
 	promClient, err := createPromClient(logger, cfg)

--- a/plugin/metricstore/prometheus/metricstore/reader.go
+++ b/plugin/metricstore/prometheus/metricstore/reader.go
@@ -74,15 +74,15 @@ func (p promClient) URL(ep string, args map[string]string) *url.URL {
 
 	query := u.Query()
 	for k, v := range p.extraParams {
-		query.Set(k, v)
+		query.Add(k, v)
 	}
 	u.RawQuery = query.Encode()
 
 	return u
 }
 
-func createPromClient(logger *zap.Logger, cfg config.Configuration) (api.Client, error) {
-	roundTripper, err := getHTTPRoundTripper(&cfg, logger)
+func createPromClient(cfg config.Configuration) (api.Client, error) {
+	roundTripper, err := getHTTPRoundTripper(&cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func createPromClient(logger *zap.Logger, cfg config.Configuration) (api.Client,
 func NewMetricsReader(cfg config.Configuration, logger *zap.Logger, tracer trace.TracerProvider) (*MetricsReader, error) {
 	const operationLabel = "span_name"
 
-	promClient, err := createPromClient(logger, cfg)
+	promClient, err := createPromClient(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +346,7 @@ func logErrorToSpan(span trace.Span, err error) {
 	span.SetStatus(codes.Error, err.Error())
 }
 
-func getHTTPRoundTripper(c *config.Configuration, _ *zap.Logger) (rt http.RoundTripper, err error) {
+func getHTTPRoundTripper(c *config.Configuration) (rt http.RoundTripper, err error) {
 	ctlsConfig, err := c.TLS.LoadTLSConfig(context.Background())
 	if err != nil {
 		return nil, err

--- a/plugin/metricstore/prometheus/metricstore/reader.go
+++ b/plugin/metricstore/prometheus/metricstore/reader.go
@@ -70,15 +70,15 @@ type (
 
 // URL decorator enables adding additional query parameters to the request sent to prometheus backend
 func (p promClient) URL(ep string, args map[string]string) *url.URL {
-	url := p.Client.URL(ep, args)
+	u := p.Client.URL(ep, args)
 
-	query := url.Query()
+	query := u.Query()
 	for k, v := range p.params {
 		query.Set(k, v)
 	}
-	url.RawQuery = query.Encode()
+	u.RawQuery = query.Encode()
 
-	return url
+	return u
 }
 
 func createPromClient(logger *zap.Logger, cfg config.Configuration) (api.Client, error) {

--- a/plugin/metricstore/prometheus/metricstore/reader_test.go
+++ b/plugin/metricstore/prometheus/metricstore/reader_test.go
@@ -863,7 +863,7 @@ func TestInvalidCertFile(t *testing.T) {
 	assert.Nil(t, reader)
 }
 
-func TestCreatePromClientWithAdditionalParameters(t *testing.T) {
+func TestCreatePromClientWithExtraQueryParameters(t *testing.T) {
 	expParams := map[string]string{
 		"param1": "value1",
 		"param2": "value2",
@@ -871,8 +871,8 @@ func TestCreatePromClientWithAdditionalParameters(t *testing.T) {
 
 	logger := zap.NewNop()
 	cfg := config.Configuration{
-		ServerURL:            "http://localhost:1234",
-		AdditionalParameters: expParams,
+		ServerURL:        "http://localhost:1234",
+		ExtraQueryParams: expParams,
 	}
 
 	customClient, err := createPromClient(logger, cfg)

--- a/plugin/metricstore/prometheus/metricstore/reader_test.go
+++ b/plugin/metricstore/prometheus/metricstore/reader_test.go
@@ -888,8 +888,7 @@ func TestCreatePromClientWithExtraQueryParameters(t *testing.T) {
 
 	for k, v := range expParams {
 		sort.Strings(q[k])
-		recV := q[k]
-		require.Equal(t, v, recV)
+		require.Equal(t, v, q[k])
 	}
 }
 

--- a/plugin/metricstore/prometheus/metricstore/reader_test.go
+++ b/plugin/metricstore/prometheus/metricstore/reader_test.go
@@ -878,9 +878,9 @@ func TestCreatePromClientWithAdditionalParameters(t *testing.T) {
 	customClient, err := createPromClient(logger, cfg)
 	require.NoError(t, err)
 
-	url := customClient.URL("", nil)
+	u := customClient.URL("", nil)
 
-	q := url.Query()
+	q := u.Query()
 
 	for k, v := range expParams {
 		recV := q.Get(k)

--- a/plugin/metricstore/prometheus/metricstore/reader_test.go
+++ b/plugin/metricstore/prometheus/metricstore/reader_test.go
@@ -863,6 +863,31 @@ func TestInvalidCertFile(t *testing.T) {
 	assert.Nil(t, reader)
 }
 
+func TestCreatePromClientWithAdditionalParameters(t *testing.T) {
+	expParams := map[string]string{
+		"param1": "value1",
+		"param2": "value2",
+	}
+
+	logger := zap.NewNop()
+	cfg := config.Configuration{
+		ServerURL:            "http://localhost:1234",
+		AdditionalParameters: expParams,
+	}
+
+	customClient, err := createPromClient(logger, cfg)
+	require.NoError(t, err)
+
+	url := customClient.URL("", nil)
+
+	q := url.Query()
+
+	for k, v := range expParams {
+		recV := q.Get(k)
+		require.Equal(t, v, recV)
+	}
+}
+
 func startMockPrometheusServer(t *testing.T, wantPromQlQuery string, wantWarnings []string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(wantWarnings) > 0 {

--- a/plugin/metricstore/prometheus/metricstore/reader_test.go
+++ b/plugin/metricstore/prometheus/metricstore/reader_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -737,13 +738,12 @@ func TestGetRoundTripperTLSConfig(t *testing.T) {
 		{"tls disabled", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := zap.NewNop()
 			config := &config.Configuration{
 				ConnectTimeout:           9 * time.Millisecond,
 				TLS:                      configtls.ClientConfig{},
 				TokenOverrideFromContext: true,
 			}
-			rt, err := getHTTPRoundTripper(config, logger)
+			rt, err := getHTTPRoundTripper(config)
 			require.NoError(t, err)
 
 			server := newFakePromServer(t)
@@ -781,7 +781,7 @@ func TestGetRoundTripperTokenFile(t *testing.T) {
 		ConnectTimeout:           time.Second,
 		TokenFilePath:            file.Name(),
 		TokenOverrideFromContext: false,
-	}, nil)
+	})
 	require.NoError(t, err)
 
 	server := newFakePromServer(t)
@@ -815,7 +815,7 @@ func TestGetRoundTripperTokenFromContext(t *testing.T) {
 		ConnectTimeout:           time.Second,
 		TokenFilePath:            file.Name(),
 		TokenOverrideFromContext: true,
-	}, nil)
+	})
 	require.NoError(t, err)
 
 	server := newFakePromServer(t)
@@ -842,7 +842,7 @@ func TestGetRoundTripperTokenError(t *testing.T) {
 
 	_, err := getHTTPRoundTripper(&config.Configuration{
 		TokenFilePath: tokenFilePath,
-	}, nil)
+	})
 	assert.ErrorContains(t, err, "failed to get token from file")
 }
 
@@ -864,18 +864,22 @@ func TestInvalidCertFile(t *testing.T) {
 }
 
 func TestCreatePromClientWithExtraQueryParameters(t *testing.T) {
-	expParams := map[string]string{
+	extraParams := map[string]string{
 		"param1": "value1",
 		"param2": "value2",
 	}
 
-	logger := zap.NewNop()
 	cfg := config.Configuration{
-		ServerURL:        "http://localhost:1234",
-		ExtraQueryParams: expParams,
+		ServerURL:        "http://localhost:1234?param1=value0",
+		ExtraQueryParams: extraParams,
 	}
 
-	customClient, err := createPromClient(logger, cfg)
+	expParams := map[string][]string{
+		"param1": {"value0", "value1"},
+		"param2": {"value2"},
+	}
+
+	customClient, err := createPromClient(cfg)
 	require.NoError(t, err)
 
 	u := customClient.URL("", nil)
@@ -883,7 +887,8 @@ func TestCreatePromClientWithExtraQueryParameters(t *testing.T) {
 	q := u.Query()
 
 	for k, v := range expParams {
-		recV := q.Get(k)
+		sort.Strings(q[k])
+		recV := q[k]
 		require.Equal(t, v, recV)
 	}
 }

--- a/plugin/metricstore/prometheus/options.go
+++ b/plugin/metricstore/prometheus/options.go
@@ -51,11 +51,10 @@ func DefaultConfig() config.Configuration {
 		ServerURL:      defaultServerURL,
 		ConnectTimeout: defaultConnectTimeout,
 
-		MetricNamespace:      defaultMetricNamespace,
-		LatencyUnit:          defaultLatencyUnit,
-		NormalizeCalls:       defaultNormalizeCalls,
-		NormalizeDuration:    defaultNormalizeCalls,
-		AdditionalParameters: nil,
+		MetricNamespace:   defaultMetricNamespace,
+		LatencyUnit:       defaultLatencyUnit,
+		NormalizeCalls:    defaultNormalizeCalls,
+		NormalizeDuration: defaultNormalizeCalls,
 	}
 }
 

--- a/plugin/metricstore/prometheus/options.go
+++ b/plugin/metricstore/prometheus/options.go
@@ -51,10 +51,11 @@ func DefaultConfig() config.Configuration {
 		ServerURL:      defaultServerURL,
 		ConnectTimeout: defaultConnectTimeout,
 
-		MetricNamespace:   defaultMetricNamespace,
-		LatencyUnit:       defaultLatencyUnit,
-		NormalizeCalls:    defaultNormalizeCalls,
-		NormalizeDuration: defaultNormalizeCalls,
+		MetricNamespace:      defaultMetricNamespace,
+		LatencyUnit:          defaultLatencyUnit,
+		NormalizeCalls:       defaultNormalizeCalls,
+		NormalizeDuration:    defaultNormalizeCalls,
+		AdditionalParameters: nil,
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4221 

## Description of the changes
- Wrapped the client in `promClient` to decorate url with additional parameters

## How was this change tested?
- `TestCreatePromClientWithAdditionalParameters`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
