### PR TITLE
Change storage_v2 GetTrace to GetTraces plural

### DIFF
--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -49,7 +49,10 @@ func (tr *TraceReader) GetTraces(
 			// TODO start/end times are not supported by v1 reader
 			// https://github.com/jaegertracing/jaeger/pull/6242
 			t, err := tr.spanReader.GetTrace(ctx, model.TraceIDFromOTEL(idParams.TraceID))
-			if err != nil && !errors.Is(err, spanstore.ErrTraceNotFound) {
+			if err != nil {
+				if errors.Is(err, spanstore.ErrTraceNotFound) {
+					continue
+				}
 				yield(nil, err)
 				return
 			}

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -40,7 +40,10 @@ func NewTraceReader(spanReader spanstore.Reader) *TraceReader {
 	}
 }
 
-func (tr *TraceReader) GetTraces(ctx context.Context, traceIDs ...pcommon.TraceID) iter.Seq2[[]ptrace.Traces, error] {
+func (tr *TraceReader) GetTraces(
+	ctx context.Context,
+	traceIDs ...pcommon.TraceID,
+) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
 		for _, traceID := range traceIDs {
 			t, err := tr.spanReader.GetTrace(ctx, model.TraceIDFromOTEL(traceID))
@@ -61,7 +64,10 @@ func (tr *TraceReader) GetServices(ctx context.Context) ([]string, error) {
 	return tr.spanReader.GetServices(ctx)
 }
 
-func (tr *TraceReader) GetOperations(ctx context.Context, query tracestore.OperationQueryParameters) ([]tracestore.Operation, error) {
+func (tr *TraceReader) GetOperations(
+	ctx context.Context,
+	query tracestore.OperationQueryParameters,
+) ([]tracestore.Operation, error) {
 	o, err := tr.spanReader.GetOperations(ctx, spanstore.OperationQueryParameters{
 		ServiceName: query.ServiceName,
 		SpanKind:    query.SpanKind,

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -46,7 +46,8 @@ func (tr *TraceReader) GetTraces(
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
 		for _, idParams := range traceIDs {
-			// start/end times are not supported by v1 reader
+			// TODO start/end times are not supported by v1 reader
+			// https://github.com/jaegertracing/jaeger/pull/6242
 			t, err := tr.spanReader.GetTrace(ctx, model.TraceIDFromOTEL(idParams.TraceID))
 			if err != nil && !errors.Is(err, spanstore.ErrTraceNotFound) {
 				yield(nil, err)

--- a/storage_v2/factoryadapter/reader.go
+++ b/storage_v2/factoryadapter/reader.go
@@ -42,11 +42,12 @@ func NewTraceReader(spanReader spanstore.Reader) *TraceReader {
 
 func (tr *TraceReader) GetTraces(
 	ctx context.Context,
-	traceIDs ...pcommon.TraceID,
+	traceIDs ...tracestore.GetTraceParams,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
-		for _, traceID := range traceIDs {
-			t, err := tr.spanReader.GetTrace(ctx, model.TraceIDFromOTEL(traceID))
+		for _, idParams := range traceIDs {
+			// start/end times are not supported by v1 reader
+			t, err := tr.spanReader.GetTrace(ctx, model.TraceIDFromOTEL(idParams.TraceID))
 			if err != nil && !errors.Is(err, spanstore.ErrTraceNotFound) {
 				yield(nil, err)
 				return
@@ -87,7 +88,7 @@ func (tr *TraceReader) GetOperations(
 
 func (tr *TraceReader) FindTraces(
 	ctx context.Context,
-	query tracestore.TraceQueryParameters,
+	query tracestore.TraceQueryParams,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
 		traces, err := tr.spanReader.FindTraces(ctx, query.ToSpanStoreQueryParameters())
@@ -107,7 +108,7 @@ func (tr *TraceReader) FindTraces(
 
 func (tr *TraceReader) FindTraceIDs(
 	ctx context.Context,
-	query tracestore.TraceQueryParameters,
+	query tracestore.TraceQueryParams,
 ) iter.Seq2[[]pcommon.TraceID, error] {
 	return func(yield func([]pcommon.TraceID, error) bool) {
 		traceIDs, err := tr.spanReader.FindTraceIDs(ctx, query.ToSpanStoreQueryParameters())

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -122,7 +122,7 @@ func TestTraceReader_GetTracesErrorResponse(t *testing.T) {
 			traces, err := iter.FlattenWithErrors(traceReader.GetTraces(
 				context.Background(), traceID(1), traceID(2),
 			))
-			assert.ErrorIs(t, err, test.expectedErr)
+			require.ErrorIs(t, err, test.expectedErr)
 			assert.Len(t, traces, test.expectedIters)
 		})
 	}

--- a/storage_v2/factoryadapter/reader_test.go
+++ b/storage_v2/factoryadapter/reader_test.go
@@ -64,7 +64,9 @@ func TestTraceReader_GetTracesDelegatesSuccessResponse(t *testing.T) {
 	}
 	traces, err := iter.FlattenWithErrors(traceReader.GetTraces(
 		context.Background(),
-		pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}),
+		tracestore.GetTraceParams{
+			TraceID: pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}),
+		},
 	))
 	require.NoError(t, err)
 	require.Len(t, traces, 1)
@@ -87,7 +89,9 @@ func TestTraceReader_GetTracesErrorResponse(t *testing.T) {
 	}
 	traces, err := iter.FlattenWithErrors(traceReader.GetTraces(
 		context.Background(),
-		pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}),
+		tracestore.GetTraceParams{
+			TraceID: pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}),
+		},
 	))
 	require.ErrorIs(t, err, testErr)
 	require.Empty(t, traces)
@@ -103,8 +107,10 @@ func TestTraceReader_GetTracesEarlyStop(t *testing.T) {
 	traceReader := &TraceReader{
 		spanReader: sr,
 	}
-	traceID := func(i byte) pcommon.TraceID {
-		return pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, i})
+	traceID := func(i byte) tracestore.GetTraceParams {
+		return tracestore.GetTraceParams{
+			TraceID: pcommon.TraceID([]byte{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, i}),
+		}
 	}
 	called := 0
 	traceReader.GetTraces(
@@ -259,7 +265,7 @@ func TestTraceReader_FindTracesDelegatesSuccessResponse(t *testing.T) {
 	}
 	traces, err := iter.FlattenWithErrors(traceReader.FindTraces(
 		context.Background(),
-		tracestore.TraceQueryParameters{
+		tracestore.TraceQueryParams{
 			ServiceName:   "service",
 			OperationName: "operation",
 			Tags:          map[string]string{"tag-a": "val-a"},
@@ -322,7 +328,7 @@ func TestTraceReader_FindTracesEdgeCases(t *testing.T) {
 			}
 			traces, err := iter.FlattenWithErrors(traceReader.FindTraces(
 				context.Background(),
-				tracestore.TraceQueryParameters{},
+				tracestore.TraceQueryParams{},
 			))
 			require.ErrorIs(t, err, test.err)
 			require.Equal(t, test.expectedTraces, traces)
@@ -342,7 +348,7 @@ func TestTraceReader_FindTracesEarlyStop(t *testing.T) {
 	}
 	called := 0
 	traceReader.FindTraces(
-		context.Background(), tracestore.TraceQueryParameters{},
+		context.Background(), tracestore.TraceQueryParams{},
 	)(func(tr []ptrace.Traces, err error) bool {
 		require.NoError(t, err)
 		require.Len(t, tr, 1)
@@ -352,7 +358,7 @@ func TestTraceReader_FindTracesEarlyStop(t *testing.T) {
 	assert.Equal(t, 3, called)
 	called = 0
 	traceReader.FindTraces(
-		context.Background(), tracestore.TraceQueryParameters{},
+		context.Background(), tracestore.TraceQueryParams{},
 	)(func(tr []ptrace.Traces, err error) bool {
 		require.NoError(t, err)
 		require.Len(t, tr, 1)
@@ -420,7 +426,7 @@ func TestTraceReader_FindTraceIDsDelegatesResponse(t *testing.T) {
 			}
 			traceIDs, err := iter.FlattenWithErrors(traceReader.FindTraceIDs(
 				context.Background(),
-				tracestore.TraceQueryParameters{
+				tracestore.TraceQueryParams{
 					ServiceName:   "service",
 					OperationName: "operation",
 					Tags:          map[string]string{"tag-a": "val-a"},

--- a/storage_v2/tracestore/mocks/Reader.go
+++ b/storage_v2/tracestore/mocks/Reader.go
@@ -26,7 +26,7 @@ type Reader struct {
 }
 
 // FindTraceIDs provides a mock function with given fields: ctx, query
-func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error] {
+func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]pcommon.TraceID, error] {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
@@ -34,7 +34,7 @@ func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryP
 	}
 
 	var r0 iter.Seq2[[]pcommon.TraceID, error]
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error]); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParams) iter.Seq2[[]pcommon.TraceID, error]); ok {
 		r0 = rf(ctx, query)
 	} else {
 		if ret.Get(0) != nil {
@@ -46,7 +46,7 @@ func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryP
 }
 
 // FindTraces provides a mock function with given fields: ctx, query
-func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error] {
+func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
@@ -54,7 +54,7 @@ func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryPar
 	}
 
 	var r0 iter.Seq2[[]ptrace.Traces, error]
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error]); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error]); ok {
 		r0 = rf(ctx, query)
 	} else {
 		if ret.Get(0) != nil {
@@ -126,7 +126,7 @@ func (_m *Reader) GetServices(ctx context.Context) ([]string, error) {
 }
 
 // GetTraces provides a mock function with given fields: ctx, traceIDs
-func (_m *Reader) GetTraces(ctx context.Context, traceIDs ...pcommon.TraceID) iter.Seq2[[]ptrace.Traces, error] {
+func (_m *Reader) GetTraces(ctx context.Context, traceIDs ...tracestore.GetTraceParams) iter.Seq2[[]ptrace.Traces, error] {
 	_va := make([]interface{}, len(traceIDs))
 	for _i := range traceIDs {
 		_va[_i] = traceIDs[_i]
@@ -141,7 +141,7 @@ func (_m *Reader) GetTraces(ctx context.Context, traceIDs ...pcommon.TraceID) it
 	}
 
 	var r0 iter.Seq2[[]ptrace.Traces, error]
-	if rf, ok := ret.Get(0).(func(context.Context, ...pcommon.TraceID) iter.Seq2[[]ptrace.Traces, error]); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, ...tracestore.GetTraceParams) iter.Seq2[[]ptrace.Traces, error]); ok {
 		r0 = rf(ctx, traceIDs...)
 	} else {
 		if ret.Get(0) != nil {

--- a/storage_v2/tracestore/mocks/Reader.go
+++ b/storage_v2/tracestore/mocks/Reader.go
@@ -125,20 +125,27 @@ func (_m *Reader) GetServices(ctx context.Context) ([]string, error) {
 	return r0, r1
 }
 
-// GetTrace provides a mock function with given fields: ctx, traceID
-func (_m *Reader) GetTrace(ctx context.Context, traceID pcommon.TraceID) iter.Seq2[ptrace.Traces, error] {
-	ret := _m.Called(ctx, traceID)
+// GetTraces provides a mock function with given fields: ctx, traceIDs
+func (_m *Reader) GetTraces(ctx context.Context, traceIDs ...pcommon.TraceID) iter.Seq2[[]ptrace.Traces, error] {
+	_va := make([]interface{}, len(traceIDs))
+	for _i := range traceIDs {
+		_va[_i] = traceIDs[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetTrace")
+		panic("no return value specified for GetTraces")
 	}
 
-	var r0 iter.Seq2[ptrace.Traces, error]
-	if rf, ok := ret.Get(0).(func(context.Context, pcommon.TraceID) iter.Seq2[ptrace.Traces, error]); ok {
-		r0 = rf(ctx, traceID)
+	var r0 iter.Seq2[[]ptrace.Traces, error]
+	if rf, ok := ret.Get(0).(func(context.Context, ...pcommon.TraceID) iter.Seq2[[]ptrace.Traces, error]); ok {
+		r0 = rf(ctx, traceIDs...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(iter.Seq2[ptrace.Traces, error])
+			r0 = ret.Get(0).(iter.Seq2[[]ptrace.Traces, error])
 		}
 	}
 

--- a/storage_v2/tracestore/reader.go
+++ b/storage_v2/tracestore/reader.go
@@ -16,7 +16,7 @@ import (
 
 // Reader finds and loads traces and other data from storage.
 type Reader interface {
-	// GetTraces returns an iterator that retrieves all traces with a given IDs.
+	// GetTraces returns an iterator that retrieves all traces with given IDs.
 	// The iterator is single-use: once consumed, it cannot be used again.
 	//
 	// Chunking requirements:
@@ -24,9 +24,9 @@ type Reader interface {
 	// - Large traces MAY be split across multiple, *consecutive* ptrace.Traces chunks.
 	//
 	// Edge cases:
-	// - If no spans are found for any given trace ID, it will be ignored.
+	// - If no spans are found for any given trace ID, the ID is ignored.
 	// - If none of the trace IDs are found in the storage, an empty iterator is returned.
-	// - If an error is encountered, the iterator will return the error and stop.
+	// - If an error is encountered, the iterator returns the error and stops.
 	GetTraces(ctx context.Context, traceIDs ...pcommon.TraceID) iter.Seq2[[]ptrace.Traces, error]
 
 	// GetServices returns all service names known to the backend from spans
@@ -40,9 +40,10 @@ type Reader interface {
 	// FindTraces returns an iterator that retrieves traces matching query parameters.
 	// The iterator is single-use: once consumed, it cannot be used again.
 	//
-	// The chunking behavior is the same as for GetTraces.
+	// The chunking rules is the same as for GetTraces.
 	//
 	// If no matching traces are found, the function returns an empty iterator.
+	// If an error is encountered, the iterator returns the error and stops.
 	//
 	// There's currently an implementation-dependent ambiguity whether all query filters
 	// (such as multiple tags) must apply to the same span within a trace, or can be satisfied
@@ -53,6 +54,7 @@ type Reader interface {
 	// The iterator is single-use: once consumed, it cannot be used again.
 	//
 	// If no matching traces are found, the function returns an empty iterator.
+	// If an error is encountered, the iterator returns the error and stops.
 	//
 	// This function behaves identically to FindTraces, except that it returns only the list
 	// of matching trace IDs. This is useful in some contexts, such as batch jobs, where a

--- a/storage_v2/tracestore/reader.go
+++ b/storage_v2/tracestore/reader.go
@@ -63,13 +63,16 @@ type Reader interface {
 	FindTraceIDs(ctx context.Context, query TraceQueryParams) iter.Seq2[[]pcommon.TraceID, error]
 }
 
-// GetTraceParams contains single-trace parameters for a GetTraces.
+// GetTraceParams contains single-trace parameters for a GetTraces request.
 // Some storage backends (e.g. Tempo) perform GetTraces much more efficiently
 // if they know the approximate time range of the trace.
 type GetTraceParams struct {
-	TraceID pcommon.TraceID // required
-	Start   time.Time       // optional
-	End     time.Time       // optional
+	// TraceID is the ID of the trace to retrieve. Required.
+	TraceID pcommon.TraceID
+	// Start of the time interval to search for trace ID. Optional.
+	Start time.Time
+	// End of the time interval to search for trace ID. Optional.
+	End time.Time
 }
 
 // TraceQueryParams contains parameters of a trace query.

--- a/storage_v2/tracestore/reader_test.go
+++ b/storage_v2/tracestore/reader_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestToSpanStoreQueryParameters(t *testing.T) {
 	now := time.Now()
-	query := &TraceQueryParameters{
+	query := &TraceQueryParams{
 		ServiceName:   "service",
 		OperationName: "operation",
 		Tags:          map[string]string{"tag-a": "val-a"},


### PR DESCRIPTION
## Which problem is this PR solving?
- GetTrace returns a single trace. The use case for FindTraceIDs specifically exists for loading traces in batches, but there's really no capability in Jaeger to do that: if you loaded 10K IDs you need to make 10K RPCs to load 10K traces. 
- Part of #5079

## Description of the changes
- Change it to `GetTraces(...TraceID)`
- Also add start/end times (per #4150)

## How was this change tested?
- CI, unit tests
