### PR TITLE
[v2][adjuster] Implement adjuster for correct timestamps for clockskew

### DIFF
--- a/cmd/query/app/querysvc/adjuster/clockskew.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew.go
@@ -28,8 +28,8 @@ const (
 // It assumes all spans have unique IDs and should be used after SpanIDUniquifier.
 //
 // The adjuster determines if two spans belong to the same source by deriving a
-// unique string representation of a host based on resource attributes.
-// Specifically, it checks the "ip" attribute of the resource.
+// unique string representation of a host based on resource attributes,
+// such as `host.id`, `host.ip`, or `host.name`.
 // If two spans have the same host key, they are considered to be from
 // the same source, and no clock skew adjustment is expected between them.
 //

--- a/cmd/query/app/querysvc/adjuster/clockskew.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew.go
@@ -1,5 +1,4 @@
-// Copyright (c) 2019 The Jaeger Authors.
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2024 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package adjuster
@@ -10,9 +9,10 @@ import (
 	"net"
 	"time"
 
-	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 )
 
 const (
@@ -88,11 +88,11 @@ func hostKey(resource ptrace.ResourceSpans) string {
 // buildNodesMap creates a mapping of span IDs to their corresponding nodes.
 func (a *clockSkewAdjuster) buildNodesMap() {
 	a.spans = make(map[pcommon.SpanID]*node)
-	resourceSpans := a.traces.ResourceSpans()
-	for i := 0; i < resourceSpans.Len(); i++ {
-		resources := resourceSpans.At(i)
-		hk := hostKey(resources)
-		scopes := resources.ScopeSpans()
+	resources := a.traces.ResourceSpans()
+	for i := 0; i < resources.Len(); i++ {
+		resource := resources.At(i)
+		hk := hostKey(resource)
+		scopes := resource.ScopeSpans()
 		for j := 0; j < scopes.Len(); j++ {
 			spans := scopes.At(j).Spans()
 			for k := 0; k < spans.Len(); k++ {

--- a/cmd/query/app/querysvc/adjuster/clockskew.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew.go
@@ -76,9 +76,13 @@ func hostKey(resource ptrace.ResourceSpans) string {
 		return attr.Str()
 	}
 	if attr, ok := resource.Resource().Attributes().Get(string(otelsemconv.HostIPKey)); ok {
-		ips := attr.Slice()
-		if ips.Len() > 0 {
-			return ips.At(0).AsString()
+		if attr.Type() == pcommon.ValueTypeStr {
+			return attr.Str()
+		} else if attr.Type() == pcommon.ValueTypeSlice {
+			ips := attr.Slice()
+			if ips.Len() > 0 {
+				return ips.At(0).AsString()
+			}
 		}
 	}
 	if attr, ok := resource.Resource().Attributes().Get(string(otelsemconv.HostNameKey)); ok {

--- a/cmd/query/app/querysvc/adjuster/clockskew.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew.go
@@ -80,6 +80,7 @@ func hostKey(resource ptrace.ResourceSpans) string {
 		case pcommon.ValueTypeInt:
 			var buf [4]byte
 			ip := buf[:4]
+			//nolint: gosec // G115
 			binary.BigEndian.PutUint32(ip, uint32(attr.Int()))
 			return net.IP(ip).String()
 		case pcommon.ValueTypeBytes:

--- a/cmd/query/app/querysvc/adjuster/clockskew.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	warningDuplicateSpanID       = "duplicate span IDs; skipping clock skew adjustment"
-	warningFormatInvalidParentID = "invalid parent span IDs=%s; skipping clock skew adjustment"
-	warningMaxDeltaExceeded      = "max clock skew adjustment delta of %v exceeded; not applying calculated delta of %v"
-	warningSkewAdjustDisabled    = "clock skew adjustment disabled; not applying calculated delta of %v"
+	warningDuplicateSpanID     = "duplicate span IDs; skipping clock skew adjustment"
+	warningMissingParentSpanID = "parent span ID=%s is not in the trace; skipping clock skew adjustment"
+	warningMaxDeltaExceeded    = "max clock skew adjustment delta of %v exceeded; not applying calculated delta of %v"
+	warningSkewAdjustDisabled  = "clock skew adjustment disabled; not applying calculated delta of %v"
 )
 
 // ClockSkew returns an Adjuster that corrects span timestamps for clock skew.
@@ -128,7 +128,7 @@ func (a *clockSkewAdjuster) buildSubGraphs() {
 		if p, ok := a.spans[n.span.ParentSpanID()]; ok {
 			p.children = append(p.children, n)
 		} else {
-			warning := fmt.Sprintf(warningFormatInvalidParentID, n.span.ParentSpanID())
+			warning := fmt.Sprintf(warningMissingParentSpanID, n.span.ParentSpanID())
 			jptrace.AddWarning(n.span, warning)
 			// treat spans with invalid parent ID as root spans
 			a.roots[n.span.SpanID()] = n

--- a/cmd/query/app/querysvc/adjuster/clockskew.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package adjuster
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/jaegertracing/jaeger/internal/jptrace"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+const (
+	warningDuplicateSpanID       = "duplicate span IDs; skipping clock skew adjustment"
+	warningFormatInvalidParentID = "invalid parent span IDs=%s; skipping clock skew adjustment"
+	warningMaxDeltaExceeded      = "max clock skew adjustment delta of %v exceeded; not applying calculated delta of %v"
+	warningSkewAdjustDisabled    = "clock skew adjustment disabled; not applying calculated delta of %v"
+)
+
+// ClockSkew returns an adjuster that modifies start time and log timestamps
+// for spans that appear to be "off" with respect to the parent span due to
+// clock skew on different servers. The main condition that it checks is that
+// child spans do not start before or end after their parent spans.
+//
+// The algorithm assumes that all spans have unique IDs, so this adjuster should be used after
+// SpanIDUniquifier.
+func ClockSkew(maxDelta time.Duration) Adjuster {
+	return Func(func(traces ptrace.Traces) {
+		adjuster := &clockSkewAdjuster{
+			traces:   traces,
+			maxDelta: maxDelta,
+		}
+		adjuster.buildNodesMap()
+		adjuster.buildSubGraphs()
+		for _, n := range adjuster.roots {
+			skew := clockSkew{hostKey: n.hostKey}
+			adjuster.adjustNode(n, nil, skew)
+		}
+	})
+}
+
+type clockSkewAdjuster struct {
+	traces   ptrace.Traces
+	spans    map[pcommon.SpanID]*node
+	roots    map[pcommon.SpanID]*node
+	maxDelta time.Duration
+}
+
+type clockSkew struct {
+	delta   time.Duration
+	hostKey string
+}
+
+type node struct {
+	span     ptrace.Span
+	children []*node
+	hostKey  string
+}
+
+// hostKey returns a string representation of the host identity that can be used
+// to determine if two spans originated from the same host.
+//
+// TODO convert process tags to a canonical format somewhere else
+func hostKey(resource ptrace.ResourceSpans) string {
+	if attr, ok := resource.Resource().Attributes().Get("ip"); ok {
+		if attr.Type() == pcommon.ValueTypeStr {
+			return attr.Str()
+		}
+		if attr.Type() == pcommon.ValueTypeInt {
+			var buf [4]byte // avoid heap allocation
+			ip := buf[0:4]  // utils require a slice, not an array
+			//nolint: gosec // G115
+			binary.BigEndian.PutUint32(ip, uint32(attr.Int()))
+			return net.IP(ip).String()
+		}
+		if attr.Type() == pcommon.ValueTypeBytes {
+			if l := attr.Bytes().Len(); l == 4 || l == 16 {
+				return net.IP(attr.Bytes().AsRaw()).String()
+			}
+		}
+	}
+	return ""
+}
+
+// buildNodesMap builds a map of span IDs -> node{}.
+func (a *clockSkewAdjuster) buildNodesMap() {
+	a.spans = make(map[pcommon.SpanID]*node)
+	resourceSpans := a.traces.ResourceSpans()
+	for i := 0; i < resourceSpans.Len(); i++ {
+		resources := resourceSpans.At(i)
+		hk := hostKey(resources)
+		scopes := resources.ScopeSpans()
+		for j := 0; j < scopes.Len(); j++ {
+			scope := scopes.At(j)
+			spans := scope.Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				if _, ok := a.spans[span.SpanID()]; ok {
+					jptrace.AddWarning(span, warningDuplicateSpanID)
+				} else {
+					a.spans[span.SpanID()] = &node{
+						span:    span,
+						hostKey: hk,
+					}
+				}
+			}
+		}
+	}
+}
+
+// finds all spans that have no parent, i.e. where parentID is either 0
+// or points to an ID for which there is no span.
+func (a *clockSkewAdjuster) buildSubGraphs() {
+	a.roots = make(map[pcommon.SpanID]*node)
+	for _, n := range a.spans {
+		if n.span.ParentSpanID() == pcommon.NewSpanIDEmpty() {
+			a.roots[n.span.SpanID()] = n
+			continue
+		}
+		if p, ok := a.spans[n.span.ParentSpanID()]; ok {
+			p.children = append(p.children, n)
+		} else {
+			warning := fmt.Sprintf(warningFormatInvalidParentID, n.span.ParentSpanID())
+			jptrace.AddWarning(n.span, warning)
+			// treat spans with invalid parent ID as root spans
+			a.roots[n.span.SpanID()] = n
+		}
+	}
+}
+
+func (a *clockSkewAdjuster) adjustNode(n *node, parent *node, skew clockSkew) {
+	if (n.hostKey != skew.hostKey || n.hostKey == "") && parent != nil {
+		// Node n is from a different host. The parent has already been adjusted,
+		// so we can compare this node's timestamps against the parent.
+		skew = clockSkew{
+			hostKey: n.hostKey,
+			delta:   a.calculateSkew(n, parent),
+		}
+	}
+	a.adjustTimestamps(n, skew)
+	for _, child := range n.children {
+		a.adjustNode(child, n, skew)
+	}
+}
+
+func (*clockSkewAdjuster) calculateSkew(child *node, parent *node) time.Duration {
+	parentStartTime := parent.span.StartTimestamp().AsTime()
+	childStartTime := child.span.StartTimestamp().AsTime()
+	parentEndTime := parent.span.EndTimestamp().AsTime()
+	childEndTime := child.span.EndTimestamp().AsTime()
+	parentDuration := parentEndTime.Sub(parentStartTime)
+	childDuration := childEndTime.Sub(childStartTime)
+
+	if childDuration > parentDuration {
+		// When the child lasted longer than the parent, it was either
+		// async or the parent may have timed out before child responded.
+		// The only reasonable adjustment we can do in this case is to make
+		// sure the child does not start before parent.
+		if childStartTime.Before(parentStartTime) {
+			return parentStartTime.Sub(childStartTime)
+		}
+		return 0
+	}
+	if !childStartTime.Before(parentStartTime) && !childEndTime.After(parentEndTime) {
+		// child already fits within the parent span, do not adjust
+		return 0
+	}
+	// Assume that network latency is equally split between req and res.
+	latency := (parentDuration - childDuration) / 2
+	// Goal: parentStartTime + latency = childStartTime + adjustment
+	return parentStartTime.Add(latency).Sub(childStartTime)
+}
+
+func (a *clockSkewAdjuster) adjustTimestamps(n *node, skew clockSkew) {
+	if skew.delta == 0 {
+		return
+	}
+	if absDuration(skew.delta) > a.maxDelta {
+		if a.maxDelta == 0 {
+			jptrace.AddWarning(n.span, fmt.Sprintf(warningSkewAdjustDisabled, skew.delta))
+			return
+		}
+		jptrace.AddWarning(n.span, fmt.Sprintf(warningMaxDeltaExceeded, a.maxDelta, skew.delta))
+		return
+	}
+	n.span.SetStartTimestamp(pcommon.NewTimestampFromTime(n.span.StartTimestamp().AsTime().Add(skew.delta)))
+	jptrace.AddWarning(n.span, fmt.Sprintf("This span's timestamps were adjusted by %v", skew.delta))
+	for i := 0; i < n.span.Events().Len(); i++ {
+		event := n.span.Events().At(i)
+		event.SetTimestamp(pcommon.NewTimestampFromTime(event.Timestamp().AsTime().Add(skew.delta)))
+	}
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -1 * d
+	}
+	return d
+}

--- a/cmd/query/app/querysvc/adjuster/clockskew.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew.go
@@ -28,6 +28,12 @@ const (
 // inconsistent with their parent spans due to clock differences between hosts.
 // It assumes all spans have unique IDs and should be used after SpanIDUniquifier.
 //
+// The adjuster determines if two spans belong to the same source by deriving a
+// unique string representation of a host based on resource attributes.
+// Specifically, it checks the "ip" attribute of the resource.
+// If two spans have the same host key, they are considered to be from
+// the same source, and no clock skew adjustment is expected between them.
+//
 // Parameters:
 //   - maxDelta: The maximum allowable time adjustment. Adjustments exceeding
 //     this value will be ignored.

--- a/cmd/query/app/querysvc/adjuster/clockskew_test.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew_test.go
@@ -235,7 +235,16 @@ func TestHostKey(t *testing.T) {
 			expected: "host-123",
 		},
 		{
-			name: "host.ip attribute",
+			name: "string host.ip attribute",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				rs.Resource().Attributes().PutStr("host.ip", "192.168.1.1")
+				return rs
+			}(),
+			expected: "192.168.1.1",
+		},
+		{
+			name: "slice host.ip attribute",
 			resource: func() ptrace.ResourceSpans {
 				rs := ptrace.NewResourceSpans()
 				addresses := rs.Resource().Attributes().PutEmptySlice("host.ip")
@@ -246,7 +255,7 @@ func TestHostKey(t *testing.T) {
 			expected: "192.168.1.1",
 		},
 		{
-			name: "empty host.ip attribute",
+			name: "empty host.ip attribute slice",
 			resource: func() ptrace.ResourceSpans {
 				rs := ptrace.NewResourceSpans()
 				rs.Resource().Attributes().PutEmptySlice("host.ip")

--- a/cmd/query/app/querysvc/adjuster/clockskew_test.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package adjuster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/jptrace"
+)
+
+func TestClockSkewAdjuster(t *testing.T) {
+	type testSpan struct {
+		id, parent          [8]byte
+		startTime, duration int
+		events              []int // timestamps for logs
+		host                string
+		adjusted            int   // start time after adjustment
+		adjustedEvents      []int // adjusted log timestamps
+	}
+
+	toTime := func(t int) time.Time {
+		return time.Unix(0, (time.Duration(t) * time.Millisecond).Nanoseconds())
+	}
+
+	// helper function that constructs a trace from a list of span prototypes
+	makeTrace := func(spanPrototypes []testSpan) ptrace.Traces {
+		trace := ptrace.NewTraces()
+		for _, spanProto := range spanPrototypes {
+			traceID := pcommon.TraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 1})
+			span := ptrace.NewSpan()
+			span.SetTraceID(traceID)
+			span.SetSpanID(spanProto.id)
+			span.SetParentSpanID(spanProto.parent)
+			span.SetStartTimestamp(pcommon.NewTimestampFromTime(toTime(spanProto.startTime)))
+			span.SetEndTimestamp(pcommon.NewTimestampFromTime(toTime(spanProto.startTime + spanProto.duration)))
+
+			events := ptrace.NewSpanEventSlice()
+			for _, log := range spanProto.events {
+				event := events.AppendEmpty()
+				event.SetTimestamp(pcommon.NewTimestampFromTime(toTime(log)))
+				event.Attributes().PutStr("event", "some event")
+			}
+			events.CopyTo(span.Events())
+
+			resource := ptrace.NewResourceSpans()
+			resource.Resource().Attributes().PutStr("ip", spanProto.host)
+
+			span.CopyTo(resource.ScopeSpans().AppendEmpty().Spans().AppendEmpty())
+			resource.CopyTo(trace.ResourceSpans().AppendEmpty())
+		}
+		return trace
+	}
+
+	testCases := []struct {
+		description string
+		trace       []testSpan
+		err         string
+		maxAdjust   time.Duration
+	}{
+		{
+			description: "single span with bad parent",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0, 0, 0, 0, 0, 0, 0, 99}, startTime: 0, duration: 100, host: "a", adjusted: 0},
+			},
+			err: "invalid parent span IDs=0000000000000063; skipping clock skew adjustment", // 99 == 0x63
+		},
+		{
+			description: "single span with empty host key",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 0, duration: 100, adjusted: 0},
+			},
+		},
+		{
+			description: "two spans with the same ID",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 0, duration: 100, host: "a", adjusted: 0},
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 0, duration: 100, host: "a", adjusted: 0},
+			},
+			err: "duplicate span IDs; skipping clock skew adjustment",
+		},
+		{
+			description: "parent-child on the same host",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 0, duration: 100, host: "a", adjusted: 0},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 10, duration: 50, host: "a", adjusted: 10},
+			},
+		},
+		{
+			description: "do not adjust parent-child on the same host",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 0, duration: 50, host: "a", adjusted: 0},
+			},
+		},
+		{
+			description: "do not adjust child that fits inside parent",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 20, duration: 50, host: "b", adjusted: 20},
+			},
+		},
+		{
+			description: "do not adjust child that is longer than parent",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 20, duration: 150, host: "b", adjusted: 20},
+			},
+		},
+		{
+			description: "do not apply positive adjustment due to max skew adjustment",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 0, duration: 50, host: "b", adjusted: 0},
+			},
+			maxAdjust: 10 * time.Millisecond,
+			err:       "max clock skew adjustment delta of 10ms exceeded; not applying calculated delta of 35ms",
+		},
+		{
+			description: "do not apply negative adjustment due to max skew adjustment",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 80, duration: 50, host: "b", adjusted: 80},
+			},
+			maxAdjust: 10 * time.Millisecond,
+			err:       "max clock skew adjustment delta of 10ms exceeded; not applying calculated delta of -45ms",
+		},
+		{
+			description: "do not apply adjustment due to disabled adjustment",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 0, duration: 50, host: "b", adjusted: 0},
+			},
+			err: "clock skew adjustment disabled; not applying calculated delta of 35ms",
+		},
+		{
+			description: "adjust child starting before parent",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				// latency = (100-50) / 2 = 25
+				// delta = (10 - 0) + latency = 35
+				{
+					id: [8]byte{2}, parent: [8]byte{1}, startTime: 0, duration: 50, host: "b", adjusted: 35,
+					events: []int{5, 10}, adjustedEvents: []int{40, 45},
+				},
+			},
+			maxAdjust: time.Second,
+		},
+		{
+			description: "adjust child starting before parent even if it is longer",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 0, duration: 150, host: "b", adjusted: 10},
+			},
+			maxAdjust: time.Second,
+		},
+		{
+			description: "adjust child ending after parent but being shorter",
+			trace: []testSpan{
+				{id: [8]byte{1}, parent: [8]byte{0}, startTime: 10, duration: 100, host: "a", adjusted: 10},
+				// latency: (100 - 70) / 2 = 15
+				// new child start time: 10 + latency = 25, delta = -25
+				{id: [8]byte{2}, parent: [8]byte{1}, startTime: 50, duration: 70, host: "b", adjusted: 25},
+				// same host 'b', so same delta = -25
+				// new start time: 60 + delta = 35
+				{
+					id: [8]byte{3}, parent: [8]byte{2}, startTime: 60, duration: 20, host: "b", adjusted: 35,
+					events: []int{65, 70}, adjustedEvents: []int{40, 45},
+				},
+			},
+			maxAdjust: time.Second,
+		},
+	}
+
+	for _, tt := range testCases {
+		testCase := tt // capture loop var
+		t.Run(testCase.description, func(t *testing.T) {
+			trace := makeTrace(testCase.trace)
+			adjuster := ClockSkew(tt.maxAdjust)
+			adjuster.Adjust(trace)
+
+			var gotErr string
+			for i, proto := range testCase.trace {
+				id := proto.id
+				span := trace.ResourceSpans().At(i).ScopeSpans().At(0).Spans().At(0)
+				require.EqualValues(t, proto.id, span.SpanID(), "expecting span with span ID = %d", id)
+
+				warnings := jptrace.GetWarnings(span)
+				if testCase.err == "" {
+					if proto.adjusted == proto.startTime {
+						assert.Empty(t, warnings, "no warnings in span %s", span.SpanID)
+					} else {
+						assert.Len(t, warnings, 1, "warning about adjutment added to span %s", span.SpanID)
+					}
+				} else {
+					if len(warnings) > 0 {
+						gotErr = warnings[0]
+					}
+				}
+
+				// compare values as int because assert.Equal prints uint64 as hex
+				assert.Equal(
+					t, toTime(proto.adjusted).UTC(), span.StartTimestamp().AsTime(),
+					"adjusted start time of span[ID = %d]", id)
+				for i, logTs := range proto.adjustedEvents {
+					assert.Equal(
+						t, toTime(logTs).UTC(), span.Events().At(i).Timestamp().AsTime(),
+						"adjusted log timestamp of span[ID = %d], log[%d]", id, i)
+				}
+			}
+			assert.Equal(t, testCase.err, gotErr)
+		})
+	}
+}
+
+func TestHostKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource ptrace.ResourceSpans
+		expected string
+	}{
+		{
+			name: "string IP",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				rs.Resource().Attributes().PutStr("ip", "1.2.3.4")
+				return rs
+			}(),
+			expected: "1.2.3.4",
+		},
+		{
+			name: "int IP",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				rs.Resource().Attributes().PutInt("ip", int64(1<<24|2<<16|3<<8|4))
+				return rs
+			}(),
+			expected: "1.2.3.4",
+		},
+		{
+			name: "byte array IP",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				rs.Resource().Attributes().PutEmptyBytes("ip").FromRaw([]byte{1, 2, 3, 4})
+				return rs
+			}(),
+			expected: "1.2.3.4",
+		},
+		{
+			name: "IPv6 byte array",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				rs.Resource().Attributes().PutEmptyBytes("ip").FromRaw([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4})
+				return rs
+			}(),
+			expected: "::102:304",
+		},
+		{
+			name: "invalid byte array",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				rs.Resource().Attributes().PutEmptyBytes("ip").FromRaw([]byte{1, 2, 3, 4, 5})
+				return rs
+			}(),
+			expected: "",
+		},
+		{
+			name: "unsupported type",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				rs.Resource().Attributes().PutDouble("ip", 123.4)
+				return rs
+			}(),
+			expected: "",
+		},
+		{
+			name: "missing IP attribute",
+			resource: func() ptrace.ResourceSpans {
+				rs := ptrace.NewResourceSpans()
+				return rs
+			}(),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hostKey(tt.resource)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/cmd/query/app/querysvc/adjuster/clockskew_test.go
+++ b/cmd/query/app/querysvc/adjuster/clockskew_test.go
@@ -69,7 +69,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 			trace: []testSpan{
 				{id: [8]byte{1}, parent: [8]byte{0, 0, 0, 0, 0, 0, 0, 99}, startTime: 0, duration: 100, host: "a", adjusted: 0},
 			},
-			err: "invalid parent span IDs=0000000000000063; skipping clock skew adjustment", // 99 == 0x63
+			err: "parent span ID=0000000000000063 is not in the trace; skipping clock skew adjustment", // 99 == 0x63
 		},
 		{
 			description: "single span with empty host key",

--- a/pkg/otelsemconv/semconv.go
+++ b/pkg/otelsemconv/semconv.go
@@ -24,6 +24,10 @@ const (
 	DBSystemKey               = semconv.DBSystemKey
 	PeerServiceKey            = semconv.PeerServiceKey
 	HTTPResponseStatusCodeKey = semconv.HTTPResponseStatusCodeKey
+
+	HostIDKey   = semconv.HostIDKey
+	HostIPKey   = semconv.HostIPKey
+	HostNameKey = semconv.HostNameKey
 )
 
 var HTTPResponseStatusCode = semconv.HTTPResponseStatusCode


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6344

## Description of the changes
- Implemented an adjuster to correct timestamps for clockskew. 

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`