### PR TITLE
FEAT: Add Span Kind support for ES/OS

### DIFF
--- a/cmd/jaeger/internal/integration/elasticsearch_test.go
+++ b/cmd/jaeger/internal/integration/elasticsearch_test.go
@@ -15,9 +15,8 @@ func TestElasticsearchStorage(t *testing.T) {
 	s := &E2EStorageIntegration{
 		ConfigFile: "../../config-elasticsearch.yaml",
 		StorageIntegration: integration.StorageIntegration{
-			CleanUp:                      purge,
-			Fixtures:                     integration.LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
-			GetOperationsMissingSpanKind: true,
+			CleanUp:  purge,
+			Fixtures: integration.LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
 		},
 	}
 	s.e2eInitialize(t, "elasticsearch")

--- a/cmd/jaeger/internal/integration/opensearch_test.go
+++ b/cmd/jaeger/internal/integration/opensearch_test.go
@@ -14,9 +14,8 @@ func TestOpenSearchStorage(t *testing.T) {
 	s := &E2EStorageIntegration{
 		ConfigFile: "../../config-opensearch.yaml",
 		StorageIntegration: integration.StorageIntegration{
-			CleanUp:                      purge,
-			Fixtures:                     integration.LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
-			GetOperationsMissingSpanKind: true,
+			CleanUp:  purge,
+			Fixtures: integration.LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
 		},
 	}
 	s.e2eInitialize(t, "opensearch")

--- a/plugin/storage/es/spanstore/dbmodel/model.go
+++ b/plugin/storage/es/spanstore/dbmodel/model.go
@@ -88,3 +88,9 @@ type Service struct {
 	ServiceName   string `json:"serviceName"`
 	OperationName string `json:"operationName"`
 }
+
+// ServiceWithKind is the JSON struct service:kind:operation documents in ElasticSearch
+type ServiceWithKind struct {
+	Service
+	Kind string `json:"spanKind"`
+}

--- a/plugin/storage/es/spanstore/reader.go
+++ b/plugin/storage/es/spanstore/reader.go
@@ -306,20 +306,12 @@ func (s *SpanReader) GetOperations(
 		currentTime,
 		cfg.RolloverFrequencyAsNegativeDuration(s.serviceIndex.RolloverFrequency),
 	)
-	operations, err := s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query.ServiceName, s.maxDocCount)
+	operations, err := s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query.ServiceName, query.SpanKind, s.maxDocCount)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: https://github.com/jaegertracing/jaeger/issues/1923
-	// 	- return the operations with actual span kind that meet requirement
-	var result []spanstore.Operation
-	for _, operation := range operations {
-		result = append(result, spanstore.Operation{
-			Name: operation,
-		})
-	}
-	return result, err
+	return operations, err
 }
 
 func bucketToStringArray(buckets []*elastic.AggregationBucketKeyItem) ([]string, error) {

--- a/plugin/storage/es/spanstore/reader_test.go
+++ b/plugin/storage/es/spanstore/reader_test.go
@@ -627,33 +627,56 @@ func TestSpanReader_indexWithDate(t *testing.T) {
 	})
 }
 
+type testGetStruct struct {
+	caption        string
+	searchResult   *elastic.SearchResult
+	searchError    error
+	expectedError  func() string
+	expectedOutput map[string]any
+}
+
 func testGet(typ string, t *testing.T) {
+	testGetWithKind(typ, t, false)
+}
+
+func testGetWithKind(typ string, t *testing.T, testKind bool) {
 	goodAggregations := make(map[string]*json.RawMessage)
 	rawMessage := []byte(`{"buckets": [{"key": "123","doc_count": 16}]}`)
 	goodAggregations[typ] = (*json.RawMessage)(&rawMessage)
-
+	var filterRawMessage json.RawMessage
+	if typ == operationsAggregation {
+		if !testKind {
+			filterRawMessage = json.RawMessage(`
+	{
+		"buckets": {
+      		"distinct_operations_without_kind": {
+        		"doc_count": 1,
+        			"operationName": {
+          				"doc_count_error_upper_bound": 0,
+          				"sum_other_doc_count": 0,
+          				"buckets": [
+							{
+								"key": "123",
+								"doc_count": 16
+							}
+					]
+				}
+			}
+		}
+	}
+`)
+		} else {
+			filterRawMessage = rawMessage
+		}
+		goodAggregations[typ] = &filterRawMessage
+	} else {
+		goodAggregations[typ] = (*json.RawMessage)(&rawMessage)
+	}
 	badAggregations := make(map[string]*json.RawMessage)
 	badRawMessage := []byte(`{"buckets": [{bad json]}asdf`)
 	badAggregations[typ] = (*json.RawMessage)(&badRawMessage)
 
-	testCases := []struct {
-		caption        string
-		searchResult   *elastic.SearchResult
-		searchError    error
-		expectedError  func() string
-		expectedOutput map[string]any
-	}{
-		{
-			caption:      typ + " full behavior",
-			searchResult: &elastic.SearchResult{Aggregations: elastic.Aggregations(goodAggregations)},
-			expectedOutput: map[string]any{
-				operationsAggregation: []spanstore.Operation{{Name: "123"}},
-				"default":             []string{"123"},
-			},
-			expectedError: func() string {
-				return ""
-			},
-		},
+	testCases := []testGetStruct{
 		{
 			caption:     typ + " search error",
 			searchError: errors.New("Search failure"),
@@ -672,13 +695,42 @@ func testGet(typ string, t *testing.T) {
 			},
 		},
 	}
+	if testKind {
+		testCases = append(testCases, testGetStruct{
+			caption:      typ + " full behavior with kind",
+			searchResult: &elastic.SearchResult{Aggregations: goodAggregations},
+			expectedOutput: map[string]any{
+				operationsAggregation: []spanstore.Operation{{Name: "123", SpanKind: "server"}},
+				"default":             []string{"123"},
+			},
+			expectedError: func() string {
+				return ""
+			},
+		})
+	} else {
+		testCases = append(testCases, testGetStruct{
+			caption:      typ + " full behavior",
+			searchResult: &elastic.SearchResult{Aggregations: goodAggregations},
+			expectedOutput: map[string]any{
+				operationsAggregation: []spanstore.Operation{{Name: "123"}},
+				"default":             []string{"123"},
+			},
+			expectedError: func() string {
+				return ""
+			},
+		})
+	}
 
 	for _, tc := range testCases {
 		testCase := tc
 		t.Run(testCase.caption, func(t *testing.T) {
 			withSpanReader(t, func(r *spanReaderTest) {
-				mockSearchService(r).Return(testCase.searchResult, testCase.searchError)
-				actual, err := returnSearchFunc(typ, r)
+				if testKind {
+					mockSearchServiceWithSpanKind(r, true).Return(testCase.searchResult, testCase.searchError)
+				} else {
+					mockSearchService(r).Return(testCase.searchResult, testCase.searchError)
+				}
+				actual, err := returnSearchFunc(typ, r, testKind)
 				if testCase.expectedError() != "" {
 					require.EqualError(t, err, testCase.expectedError())
 					assert.Nil(t, actual)
@@ -692,11 +744,17 @@ func testGet(typ string, t *testing.T) {
 	}
 }
 
-func returnSearchFunc(typ string, r *spanReaderTest) (any, error) {
+func returnSearchFunc(typ string, r *spanReaderTest, testKind bool) (any, error) {
 	switch typ {
 	case servicesAggregation:
 		return r.reader.GetServices(context.Background())
 	case operationsAggregation:
+		if testKind {
+			return r.reader.GetOperations(
+				context.Background(),
+				spanstore.OperationQueryParameters{ServiceName: "someservice", SpanKind: "server"},
+			)
+		}
 		return r.reader.GetOperations(
 			context.Background(),
 			spanstore.OperationQueryParameters{ServiceName: "someService"},
@@ -1012,6 +1070,10 @@ func matchTermsAggregation(termsAgg *elastic.TermsAggregation) bool {
 }
 
 func mockSearchService(r *spanReaderTest) *mock.Call {
+	return mockSearchServiceWithSpanKind(r, false)
+}
+
+func mockSearchServiceWithSpanKind(r *spanReaderTest, inputHasSpanKind bool) *mock.Call {
 	searchService := &mocks.SearchService{}
 	searchService.On("Query", mock.Anything).Return(searchService)
 	searchService.On("IgnoreUnavailable", mock.AnythingOfType("bool")).Return(searchService)
@@ -1019,7 +1081,11 @@ func mockSearchService(r *spanReaderTest) *mock.Call {
 		return size == 0 // Aggregations apply size (bucket) limits in their own query objects, and do not apply at the parent query level.
 	})).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(servicesAggregation), mock.MatchedBy(matchTermsAggregation)).Return(searchService)
-	searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.MatchedBy(matchTermsAggregation)).Return(searchService)
+	if inputHasSpanKind {
+		searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.MatchedBy(matchTermsAggregation)).Return(searchService)
+	} else {
+		searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.AnythingOfType("*elastic.FiltersAggregation")).Return(searchService)
+	}
 	searchService.On("Aggregation", stringMatcher(traceIDAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)
 	r.client.On("Search", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(searchService)
 	return searchService.On("Do", mock.Anything)

--- a/plugin/storage/es/spanstore/service_operation.go
+++ b/plugin/storage/es/spanstore/service_operation.go
@@ -6,6 +6,7 @@ package spanstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -15,15 +16,18 @@ import (
 	"github.com/olivere/elastic"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/cache"
 	"github.com/jaegertracing/jaeger/pkg/es"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
 
 const (
-	serviceName = "serviceName"
-
+	serviceName           = "serviceName"
+	spanKind              = "spanKind"
 	operationsAggregation = "distinct_operations"
+	operationsWithoutKind = "distinct_operations_without_kind"
 	servicesAggregation   = "distinct_services"
 )
 
@@ -53,17 +57,28 @@ func NewServiceOperationStorage(
 }
 
 // Write saves a service to operation pair.
-func (s *ServiceOperationStorage) Write(indexName string, jsonSpan *dbmodel.Span) {
+func (s *ServiceOperationStorage) Write(indexName string, jsonSpan *dbmodel.Span, kind model.SpanKind) {
 	// Insert serviceName:operationName document
 	service := dbmodel.Service{
 		ServiceName:   jsonSpan.Process.ServiceName,
 		OperationName: jsonSpan.OperationName,
 	}
-
-	cacheKey := hashCode(service)
-	if !keyInCache(cacheKey, s.serviceCache) {
-		s.client().Index().Index(indexName).Type(serviceType).Id(cacheKey).BodyJson(service).Add()
-		writeCache(cacheKey, s.serviceCache)
+	if kind != model.SpanKindUnspecified {
+		serviceWithKind := dbmodel.ServiceWithKind{
+			Service: service,
+			Kind:    string(kind),
+		}
+		cacheKey := hashCodeWithKind(serviceWithKind)
+		if !keyInCache(cacheKey, s.serviceCache) {
+			s.client().Index().Index(indexName).Type(serviceType).Id(cacheKey).BodyJson(serviceWithKind).Add()
+			writeCache(cacheKey, s.serviceCache)
+		}
+	} else {
+		cacheKey := hashCode(service)
+		if !keyInCache(cacheKey, s.serviceCache) {
+			s.client().Index().Index(indexName).Type(serviceType).Id(cacheKey).BodyJson(service).Add()
+			writeCache(cacheKey, s.serviceCache)
+		}
 	}
 }
 
@@ -96,29 +111,58 @@ func getServicesAggregation(maxDocCount int) elastic.Query {
 		Size(maxDocCount) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
 }
 
-func (s *ServiceOperationStorage) getOperations(ctx context.Context, indices []string, service string, maxDocCount int) ([]string, error) {
+func (s *ServiceOperationStorage) getOperations(ctx context.Context, indices []string, service, kind string, maxDocCount int) ([]spanstore.Operation, error) {
+	var searchService es.SearchService
+	if kind != "" {
+		serviceFilter := getOperationsAggregation(maxDocCount)
+		serviceNameQuery := elastic.NewTermQuery(serviceName, service)
+		serviceKindQuery := elastic.NewTermQuery(spanKind, kind)
+		serviceQuery := elastic.NewBoolQuery().Must(serviceNameQuery, serviceKindQuery)
+		searchService = s.client().Search(indices...).
+			Size(0).
+			Query(serviceQuery).
+			IgnoreUnavailable(true).
+			Aggregation(operationsAggregation, serviceFilter)
+		searchResult, err := searchService.Do(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("search operations failed: %w", es.DetailedError(err))
+		}
+		if searchResult.Aggregations == nil {
+			return []spanstore.Operation{}, nil
+		}
+		bucket, found := searchResult.Aggregations.Terms(operationsAggregation)
+		if !found {
+			return nil, errors.New("could not find aggregation of " + operationsAggregation)
+		}
+		operationNamesBucket := bucket.Buckets
+		return bucketOfOperationNamesToOperationsArray(operationNamesBucket, kind)
+	}
+	serviceFilter := elastic.NewFiltersAggregation().
+		FilterWithName(string(model.SpanKindClient), elastic.NewTermQuery(spanKind, string(model.SpanKindClient))).
+		FilterWithName(string(model.SpanKindServer), elastic.NewTermQuery(spanKind, string(model.SpanKindServer))).
+		FilterWithName(string(model.SpanKindProducer), elastic.NewTermQuery(spanKind, string(model.SpanKindProducer))).
+		FilterWithName(string(model.SpanKindConsumer), elastic.NewTermQuery(spanKind, string(model.SpanKindConsumer))).
+		FilterWithName(string(model.SpanKindInternal), elastic.NewTermQuery(spanKind, string(model.SpanKindInternal))).
+		FilterWithName(operationsWithoutKind, elastic.NewBoolQuery().MustNot(elastic.NewExistsQuery(spanKind))).
+		SubAggregation(operationNameField, elastic.NewTermsAggregation().Field(operationNameField).Size(maxDocCount))
 	serviceQuery := elastic.NewTermQuery(serviceName, service)
-	serviceFilter := getOperationsAggregation(maxDocCount)
-
-	searchService := s.client().Search(indices...).
+	searchService = s.client().Search(indices...).
 		Size(0).
 		Query(serviceQuery).
 		IgnoreUnavailable(true).
 		Aggregation(operationsAggregation, serviceFilter)
-
 	searchResult, err := searchService.Do(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("search operations failed: %w", es.DetailedError(err))
 	}
 	if searchResult.Aggregations == nil {
-		return []string{}, nil
+		return []spanstore.Operation{}, nil
 	}
-	bucket, found := searchResult.Aggregations.Terms(operationsAggregation)
+	bucket, found := searchResult.Aggregations.Filters(operationsAggregation)
 	if !found {
 		return nil, errors.New("could not find aggregation of " + operationsAggregation)
 	}
-	operationNamesBucket := bucket.Buckets
-	return bucketToStringArray(operationNamesBucket)
+	return bucketOfOperationsToOperationsArray(bucket)
 }
 
 func getOperationsAggregation(maxDocCount int) elastic.Query {
@@ -127,9 +171,75 @@ func getOperationsAggregation(maxDocCount int) elastic.Query {
 		Size(maxDocCount) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
 }
 
+func bucketOfOperationNamesToOperationsArray(buckets []*elastic.AggregationBucketKeyItem, kind string) ([]spanstore.Operation, error) {
+	result := make([]spanstore.Operation, len(buckets))
+	for i, keyItem := range buckets {
+		str, ok := keyItem.Key.(string)
+		if !ok {
+			return nil, errors.New("non-string key found in aggregation")
+		}
+		result[i] = spanstore.Operation{
+			Name:     str,
+			SpanKind: kind,
+		}
+	}
+	return result, nil
+}
+
+func bucketOfOperationsToOperationsArray(searchResult *elastic.AggregationBucketFilters) ([]spanstore.Operation, error) {
+	var result []spanstore.Operation
+	for name, bucket := range searchResult.NamedBuckets {
+		if kind, err := model.SpanKindFromString(name); err == nil {
+			if v, ok := bucket.Aggregations[operationNameField]; ok {
+				result, err = addOperationsFromRawData(v, string(kind), result)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			if name == operationsWithoutKind {
+				if v, ok := bucket.Aggregations[operationNameField]; ok {
+					result, err = addOperationsFromRawData(v, "", result)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+func addOperationsFromRawData(raw *json.RawMessage, kind string, result []spanstore.Operation) ([]spanstore.Operation, error) {
+	var items *elastic.AggregationBucketKeyItems
+	err := json.Unmarshal(*raw, &items)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items.Buckets {
+		str, ok := item.Key.(string)
+		if !ok {
+			return nil, errors.New("non-string key found in aggregation")
+		}
+		result = append(result, spanstore.Operation{
+			Name:     str,
+			SpanKind: kind,
+		})
+	}
+	return result, nil
+}
+
 func hashCode(s dbmodel.Service) string {
 	h := fnv.New64a()
 	h.Write([]byte(s.ServiceName))
+	h.Write([]byte(s.OperationName))
+	return strconv.FormatUint(h.Sum64(), 16)
+}
+
+func hashCodeWithKind(s dbmodel.ServiceWithKind) string {
+	h := fnv.New64a()
+	h.Write([]byte(s.ServiceName))
+	h.Write([]byte(s.Kind))
 	h.Write([]byte(s.OperationName))
 	return strconv.FormatUint(h.Sum64(), 16)
 }

--- a/plugin/storage/es/spanstore/service_operation_test.go
+++ b/plugin/storage/es/spanstore/service_operation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/es/mocks"
 	"github.com/jaegertracing/jaeger/plugin/storage/es/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -42,13 +43,48 @@ func TestWriteService(t *testing.T) {
 			},
 		}
 
-		w.writer.writeService(indexName, jsonSpan)
+		w.writer.writeService(indexName, jsonSpan, model.SpanKindUnspecified)
 
 		indexService.AssertNumberOfCalls(t, "Add", 1)
 		assert.Equal(t, "", w.logBuffer.String())
 
 		// test that cache works, will call the index service only once.
-		w.writer.writeService(indexName, jsonSpan)
+		w.writer.writeService(indexName, jsonSpan, model.SpanKindUnspecified)
+		indexService.AssertNumberOfCalls(t, "Add", 1)
+	})
+}
+
+func TestWriteServiceWithKind(t *testing.T) {
+	withSpanWriter(func(w *spanWriterTest) {
+		indexService := &mocks.IndexService{}
+
+		indexName := "jaeger-1995-04-21"
+		serviceHash := "dff8fa7700d2d554"
+
+		indexService.On("Index", stringMatcher(indexName)).Return(indexService)
+		indexService.On("Type", stringMatcher(serviceType)).Return(indexService)
+		indexService.On("Id", stringMatcher(serviceHash)).Return(indexService)
+		indexService.On("BodyJson", mock.AnythingOfType("dbmodel.ServiceWithKind")).Return(indexService)
+		indexService.On("Add")
+
+		w.client.On("Index").Return(indexService)
+
+		jsonSpan := &dbmodel.Span{
+			TraceID:       dbmodel.TraceID("1"),
+			SpanID:        dbmodel.SpanID("0"),
+			OperationName: "operation",
+			Process: dbmodel.Process{
+				ServiceName: "service",
+			},
+		}
+
+		w.writer.writeService(indexName, jsonSpan, model.SpanKindServer)
+
+		indexService.AssertNumberOfCalls(t, "Add", 1)
+		assert.Equal(t, "", w.logBuffer.String())
+
+		// test that cache works, will call the index service only once.
+		w.writer.writeService(indexName, jsonSpan, model.SpanKindServer)
 		indexService.AssertNumberOfCalls(t, "Add", 1)
 	})
 }
@@ -77,7 +113,7 @@ func TestWriteServiceError(*testing.T) {
 			},
 		}
 
-		w.writer.writeService(indexName, jsonSpan)
+		w.writer.writeService(indexName, jsonSpan, model.SpanKindUnspecified)
 	})
 }
 
@@ -87,6 +123,7 @@ func TestSpanReader_GetServices(t *testing.T) {
 
 func TestSpanReader_GetOperations(t *testing.T) {
 	testGet(operationsAggregation, t)
+	testGetWithKind(operationsAggregation, t, true)
 }
 
 func TestSpanReader_GetServicesEmptyIndex(t *testing.T) {

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -31,7 +31,7 @@ type spanWriterMetrics struct {
 	indexCreate *spanstoremetrics.WriteMetrics
 }
 
-type serviceWriter func(string, *dbmodel.Span)
+type serviceWriter func(string, *dbmodel.Span, model.SpanKind)
 
 // SpanWriter is a wrapper around elastic.Client
 type SpanWriter struct {
@@ -124,8 +124,9 @@ func getSpanAndServiceIndexFn(p SpanWriterParams) spanAndServiceIndexFn {
 func (s *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	spanIndexName, serviceIndexName := s.spanServiceIndex(span.StartTime)
 	jsonSpan := s.spanConverter.FromDomainEmbedProcess(span)
+	kind, _ := span.GetSpanKind()
 	if serviceIndexName != "" {
-		s.writeService(serviceIndexName, jsonSpan)
+		s.writeService(serviceIndexName, jsonSpan, kind)
 	}
 	s.writeSpan(spanIndexName, jsonSpan)
 	s.logger.Debug("Wrote span to ES index", zap.String("index", spanIndexName))
@@ -145,8 +146,8 @@ func writeCache(key string, c cache.Cache) {
 	c.Put(key, key)
 }
 
-func (s *SpanWriter) writeService(indexName string, jsonSpan *dbmodel.Span) {
-	s.serviceWriter(indexName, jsonSpan)
+func (s *SpanWriter) writeService(indexName string, jsonSpan *dbmodel.Span, kind model.SpanKind) {
+	s.serviceWriter(indexName, jsonSpan, kind)
 }
 
 func (s *SpanWriter) writeSpan(indexName string, jsonSpan *dbmodel.Span) {

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -469,11 +469,11 @@ func TestSpanWriterParamsTTL(t *testing.T) {
 				OperationName: "bar",
 			}
 
-			w.writeService(serviceIndexName, jsonSpan)
+			w.writeService(serviceIndexName, jsonSpan, model.SpanKindUnspecified)
 			time.Sleep(1 * time.Nanosecond)
-			w.writeService(serviceIndexName, jsonSpan)
+			w.writeService(serviceIndexName, jsonSpan, model.SpanKindUnspecified)
 			time.Sleep(1 * time.Nanosecond)
-			w.writeService(serviceIndexName, jsonSpan)
+			w.writeService(serviceIndexName, jsonSpan, model.SpanKindUnspecified)
 			indexService.AssertNumberOfCalls(t, "Add", test.expectedAddCalls)
 		})
 	}

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -167,9 +167,6 @@ func testElasticsearchStorage(t *testing.T, allTagsAsFields bool) {
 		StorageIntegration: StorageIntegration{
 			Fixtures:        LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
 			SkipArchiveTest: false,
-			// TODO: remove this flag after ES supports returning spanKind
-			//  Issue https://github.com/jaegertracing/jaeger/issues/1923
-			GetOperationsMissingSpanKind: true,
 		},
 	}
 	s.initializeES(t, c, allTagsAsFields)


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes: #1923 

## Description of the changes
- While querying `GetOperations`, operations can now be fetched with kind also. When kind kept empty, spans of all kinds are returned

## How was this change tested?
- Unit and E2E tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
