### PR TITLE
[fix] Fix incorrect usage of iter package in aggregator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,7 +146,7 @@ linters-settings:
         files:
           - "!**/jptrace/**"
 
-      # TODO: remove once we have upgraded to Go 1.233
+      # TODO: remove once we have upgraded to Go 1.23
       disallow-iter:
         deny:
          - pkg: iter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,6 +146,14 @@ linters-settings:
         files:
           - "!**/jptrace/**"
 
+      # TODO: remove once we have upgraded to Go 1.233
+      disallow-iter:
+        deny:
+         - pkg: iter
+           desc: "Use github.com/jaegertracing/jaeger/pkg/iter"
+        files:
+          - "**"
+
   goimports:
     local-prefixes: github.com/jaegertracing/jaeger
   gosec:

--- a/internal/jptrace/aggregator.go
+++ b/internal/jptrace/aggregator.go
@@ -4,10 +4,10 @@
 package jptrace
 
 import (
-	"iter"
-
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/pkg/iter"
 )
 
 // AggregateTraces aggregates a sequence of trace batches into individual traces.


### PR DESCRIPTION
## Description of the changes
- https://github.com/jaegertracing/jaeger/pull/6401 was accidentally using the official `iter` package instead of the internal one. This PR fixes that usage.
- Added a linter rule so we don't accidentally use the official package again until we upgrade to Go 1.23

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
