### PR TITLE
[fix] Fix test expectations for translator to avoid depending on order

### DIFF
--- a/internal/jptrace/translator_test.go
+++ b/internal/jptrace/translator_test.go
@@ -88,28 +88,28 @@ func TestProtoToTraces_AddsWarnings(t *testing.T) {
 
 	assert.Equal(t, 2, traces.ResourceSpans().Len())
 
-	rs1 := traces.ResourceSpans().At(0)
-	assert.Equal(t, 1, rs1.ScopeSpans().Len())
-	ss1 := rs1.ScopeSpans().At(0)
-	assert.Equal(t, 2, ss1.Spans().Len())
+	spanMap := make(map[string]ptrace.Span)
 
-	span1 := ss1.Spans().At(0)
-	assert.Equal(t, "test-span-1", span1.Name())
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		resource := traces.ResourceSpans().At(i)
+		for j := 0; j < resource.ScopeSpans().Len(); j++ {
+			scope := resource.ScopeSpans().At(j)
+			for k := 0; k < scope.Spans().Len(); k++ {
+				span := scope.Spans().At(k)
+				spanMap[span.Name()] = span
+			}
+		}
+	}
+
+	span1 := spanMap["test-span-1"]
 	assert.Equal(t, pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}), span1.SpanID())
 	assert.Equal(t, []string{"test-warning-1", "test-warning-2"}, GetWarnings(span1))
 
-	span2 := ss1.Spans().At(1)
-	assert.Equal(t, "test-span-2", span2.Name())
+	span2 := spanMap["test-span-2"]
 	assert.Equal(t, pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2}), span2.SpanID())
 	assert.Empty(t, GetWarnings(span2))
 
-	rs2 := traces.ResourceSpans().At(1)
-	assert.Equal(t, 1, rs2.ScopeSpans().Len())
-	ss3 := rs2.ScopeSpans().At(0)
-	assert.Equal(t, 1, ss3.Spans().Len())
-
-	span3 := ss3.Spans().At(0)
-	assert.Equal(t, "test-span-3", span3.Name())
+	span3 := spanMap["test-span-3"]
 	assert.Equal(t, pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 3}), span3.SpanID())
 	assert.Equal(t, []string{"test-warning-3"}, GetWarnings(span3))
 }


### PR DESCRIPTION
## Description of the changes
- The output of `ProtoToTraces` is not guaranteed to be in order which was causing flaky test failures in `translator_test.go`. This PR changes the test expectations to not depend on the return order of `ProtoToTraces`. 

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
