### PR TITLE
Enable UDP ports in all-in-one

### DIFF
--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -62,6 +62,10 @@ receivers:
         endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:14250"
       thrift_http:
         endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:14268"
+      thrift_binary:
+        endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:6832"
+      thrift_compact:
+        endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:6831"
 
   zipkin:
     endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:9411"


### PR DESCRIPTION
## Which problem is this PR solving?
- Recently there was a thread in `#jaeger` slack room with a user who is still using legacy SDKs that emit traces via UDP. The all-in-one configuration in Jaeger v2 currently has them disabled, which breaks backwards compatibility.

## Description of the changes
- Enable UDP ports

## How was this change tested?
- Ran `go run ./cmd/jaeger` to ensure configuration is accepted. The user on slack also confirmed that it worked for them.
- Unfortunately, we do not have e2e tests for this.
