### PR TITLE
Reduce CI duration by modifying e2e test execution strategy

### DIFF
--- a/.github/workflows/ci-e2e-cassandra.yml
+++ b/.github/workflows/ci-e2e-cassandra.yml
@@ -2,7 +2,8 @@ name: CIT Cassandra
 
 on:
   workflow_call:
-
+  schedule:
+    - cron "0 0 * * *"
 concurrency:
   group: cit-cassandra-${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
   cancel-in-progress: true
@@ -19,18 +20,17 @@ jobs:
       matrix:
         jaeger-version: [v1, v2]
         create-schema: [manual, auto]
+        cassandra-version: ${{ fromJSON(env.cassandra-version) }}
         version:
         - distribution: cassandra
-          major: 4.x
-          schema: v004
-        - distribution: cassandra
-          major: 5.x
           schema: v004
         exclude:
         # Exclude v1 as create schema on fly is available for v2 only
         - jaeger-version: v1
           create-schema: auto
-    name: ${{ matrix.version.distribution }}-${{ matrix.version.major }} ${{ matrix.jaeger-version }} schema=${{ matrix.create-schema }}
+    env:
+      cassandra-version: ${{ github.event_name == 'schedule' && '[4.x, 5.x]' || '[5.x]' }}
+    name: ${{ matrix.version.distribution }}-${{ matrix.cassandra-version }} ${{ matrix.jaeger-version }} schema=${{ matrix.create-schema }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -45,7 +45,7 @@ jobs:
 
     - name: Run cassandra integration tests
       id: test-execution
-      run: bash scripts/cassandra-integration-test.sh ${{ matrix.version.major }} ${{ matrix.version.schema }} ${{ matrix.jaeger-version }}
+      run: bash scripts/cassandra-integration-test.sh ${{ matrix.cassandra-version }} ${{ matrix.version.schema }} ${{ matrix.jaeger-version }}
       env:
         SKIP_APPLY_SCHEMA: ${{ matrix.create-schema == 'auto' && true || false }}
 
@@ -53,4 +53,4 @@ jobs:
       uses: ./.github/actions/upload-codecov
       with:
         files: cover.out
-        flags: cassandra-${{ matrix.version.major }}-${{ matrix.jaeger-version }}-${{ matrix.create-schema }}
+        flags: cassandra-${{ matrix.cassandra-version }}-${{ matrix.jaeger-version }}-${{ matrix.create-schema }}

--- a/.github/workflows/ci-e2e-elasticsearch.yml
+++ b/.github/workflows/ci-e2e-elasticsearch.yml
@@ -2,6 +2,8 @@ name: CIT Elasticsearch
 
 on:
   workflow_call:
+  schedule:
+    - cron "0 0 * * *"
 
 concurrency:
   group: cit-elasticsearch-${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
@@ -17,20 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        jaeger-version: [ v1, v2 ]
+        es-version: ${{ fromJSON(env.es-version) }}
         version:
-        - major: 6.x
-          distribution: elasticsearch
-          jaeger: v1
-        - major: 7.x
-          distribution: elasticsearch
-          jaeger: v1
-        - major: 8.x
-          distribution: elasticsearch
-          jaeger: v1
-        - major: 8.x
-          distribution: elasticsearch
-          jaeger: v2
-    name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
+          - distribution: elasticsearch
+    env:
+      es-version: ${{ github.event_name == 'schedule' && '["8.x", "7.x", "6.x"]' || '["8.x"]' }}
+    name: ${{ matrix.version.distribution }} ${{ matrix.es-version }} ${{ matrix.jaeger-version }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -57,11 +52,11 @@ jobs:
     - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Run ${{ matrix.version.distribution }} integration tests
       id: test-execution
-      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
+      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.es-version }} ${{ matrix.jaeger-version }}
 
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:
         files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
-        flags: ${{ matrix.version.distribution }}-${{ matrix.version.major }}-${{ matrix.version.jaeger }}
+        flags: ${{ matrix.version.distribution }}-${{ matrix.es-version }}-${{ matrix.jaeger-version }}
 

--- a/.github/workflows/ci-e2e-kafka.yml
+++ b/.github/workflows/ci-e2e-kafka.yml
@@ -18,8 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         jaeger-version: [v1, v2]
-        kafka-version: ["3.x", "2.x"]
+        kafka-version: ${{ fromJSON(env.kafka-version) }}
     name: kafka ${{matrix.kafka-version }} ${{ matrix.jaeger-version }}
+    env:
+      kafka-version: ${{ github.event_name == 'schedule' && '[3.x, 2.x]' || '[3.x]' }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/ci-e2e-opensearch.yml
+++ b/.github/workflows/ci-e2e-opensearch.yml
@@ -2,6 +2,8 @@ name: CIT OpenSearch
 
 on:
   workflow_call:
+  schedule:
+    - cron "0 0 * * *"
 
 concurrency:
   group: cit-opensearch-${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
@@ -17,17 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        jaeger-version: [ v1, v2 ]
+        opensearch-version: ${{ fromJSON(env.opensearch-version) }}
         version:
-        - major: 1.x
-          distribution: opensearch
-          jaeger: v1
-        - major: 2.x
-          distribution: opensearch
-          jaeger: v1
-        - major: 2.x
-          distribution: opensearch
-          jaeger: v2
-    name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
+        - distribution: opensearch
+    env:
+      opensearch-version: ${{ github.event_name == 'schedule' && '[1.x, 2.x]' || '[2.x]' }}
+    name: ${{ matrix.version.distribution }} ${{ matrix.opensearch-version }} ${{ matrix.jaeger-version }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -50,10 +48,10 @@ jobs:
 
     - name: Run ${{ matrix.version.distribution }} integration tests
       id: test-execution
-      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
+      run: bash scripts/es-integration-test.sh ${{ matrix.version.distribution }} ${{ matrix.opensearch-version }} ${{ matrix.jaeger-version }}
 
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:
         files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
-        flags: ${{ matrix.version.distribution }}-${{ matrix.version.major }}-${{ matrix.version.jaeger }}
+        flags: ${{ matrix.version.distribution }}-${{ matrix.opensearch-version }}-${{ matrix.jaeger-version }}

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,8 @@
       ],
       "groupName": "github-actions deps",
       "schedule": [
-        "on the first day of the month"
+        "on the first day of the month",
+        "at midnight"
       ]
     },
     {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3068 

## Description of the changes
- old version of the backend storage integration tests runs once daily.
## How was this change tested?
- integration tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
