### PR TITLE
[v1][adjuster] Change v1 adjuster interface to not return error and modify trace in place

### DIFF
--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -254,10 +254,7 @@ func (aH *APIHandler) search(w http.ResponseWriter, r *http.Request) {
 func (aH *APIHandler) tracesToResponse(traces []*model.Trace, adjust bool, uiErrors []structuredError) *structuredResponse {
 	uiTraces := make([]*ui.Trace, len(traces))
 	for i, v := range traces {
-		uiTrace, uiErr := aH.convertModelToUI(v, adjust)
-		if uiErr != nil {
-			uiErrors = append(uiErrors, *uiErr)
-		}
+		uiTrace := aH.convertModelToUI(v, adjust)
 		uiTraces[i] = uiTrace
 	}
 
@@ -364,24 +361,12 @@ func (aH *APIHandler) metrics(w http.ResponseWriter, r *http.Request, getMetrics
 	aH.writeJSON(w, r, m)
 }
 
-func (aH *APIHandler) convertModelToUI(trc *model.Trace, adjust bool) (*ui.Trace, *structuredError) {
-	var errs []error
+func (aH *APIHandler) convertModelToUI(trc *model.Trace, adjust bool) *ui.Trace {
 	if adjust {
-		var err error
-		trc, err = aH.queryService.Adjust(trc)
-		if err != nil {
-			errs = append(errs, err)
-		}
+		trc = aH.queryService.Adjust(trc)
 	}
 	uiTrace := uiconv.FromDomain(trc)
-	var uiError *structuredError
-	if err := errors.Join(errs...); err != nil {
-		uiError = &structuredError{
-			Msg:     err.Error(),
-			TraceID: uiTrace.TraceID,
-		}
-	}
-	return uiTrace, uiError
+	return uiTrace
 }
 
 func (*APIHandler) deduplicateDependencies(dependencies []model.DependencyLink) []ui.DependencyLink {

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -363,7 +363,7 @@ func (aH *APIHandler) metrics(w http.ResponseWriter, r *http.Request, getMetrics
 
 func (aH *APIHandler) convertModelToUI(trc *model.Trace, adjust bool) *ui.Trace {
 	if adjust {
-		trc = aH.queryService.Adjust(trc)
+		aH.queryService.Adjust(trc)
 	}
 	uiTrace := uiconv.FromDomain(trc)
 	return uiTrace

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
-	"github.com/jaegertracing/jaeger/model/adjuster"
 	ui "github.com/jaegertracing/jaeger/model/json"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
@@ -59,7 +58,6 @@ func (m *IoReaderMock) Read(b []byte) (int, error) {
 var (
 	errStorageMsg = "storage error"
 	errStorage    = errors.New(errStorageMsg)
-	errAdjustment = errors.New("adjustment error")
 
 	httpClient = &http.Client{
 		Timeout: 2 * time.Second,
@@ -375,25 +373,6 @@ func TestGetTraceNotFound(t *testing.T) {
 	require.EqualError(t, err, parsedError(404, "trace not found"))
 }
 
-func TestGetTraceAdjustmentFailure(t *testing.T) {
-	ts := initializeTestServerWithHandler(
-		t,
-		querysvc.QueryServiceOptions{
-			Adjuster: adjuster.Func(func(trace *model.Trace) (*model.Trace, error) {
-				return trace, errAdjustment
-			}),
-		},
-	)
-	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("spanstore.GetTraceParameters")).
-		Return(mockTrace, nil).Once()
-
-	var response structuredResponse
-	err := getJSON(ts.server.URL+`/api/traces/123456`, &response)
-	require.NoError(t, err)
-	assert.Len(t, response.Errors, 1)
-	assert.EqualValues(t, errAdjustment.Error(), response.Errors[0].Msg)
-}
-
 func TestGetTraceBadTraceID(t *testing.T) {
 	ts := initializeTestServer(t)
 
@@ -562,25 +541,6 @@ func TestSearchByTraceIDFailure(t *testing.T) {
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces?traceID=1`, &response)
 	require.EqualError(t, err, parsedError(500, whatsamattayou))
-}
-
-func TestSearchModelConversionFailure(t *testing.T) {
-	ts := initializeTestServerWithOptions(
-		t,
-		&tenancy.Manager{},
-		querysvc.QueryServiceOptions{
-			Adjuster: adjuster.Func(func(trace *model.Trace) (*model.Trace, error) {
-				return trace, errAdjustment
-			}),
-		},
-	)
-	ts.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).
-		Return([]*model.Trace{mockTrace}, nil).Once()
-	var response structuredResponse
-	err := getJSON(ts.server.URL+`/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms`, &response)
-	require.NoError(t, err)
-	assert.Len(t, response.Errors, 1)
-	assert.EqualValues(t, errAdjustment.Error(), response.Errors[0].Msg)
 }
 
 func TestSearchDBFailure(t *testing.T) {

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -128,8 +128,8 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query spanstore.GetTrac
 }
 
 // Adjust applies adjusters to the trace.
-func (qs QueryService) Adjust(trace *model.Trace) *model.Trace {
-	return qs.options.Adjuster.Adjust(trace)
+func (qs QueryService) Adjust(trace *model.Trace) {
+	qs.options.Adjuster.Adjust(trace)
 }
 
 // GetDependencies implements dependencystore.Reader.GetDependencies

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -128,7 +128,7 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query spanstore.GetTrac
 }
 
 // Adjust applies adjusters to the trace.
-func (qs QueryService) Adjust(trace *model.Trace) (*model.Trace, error) {
+func (qs QueryService) Adjust(trace *model.Trace) *model.Trace {
 	return qs.options.Adjuster.Adjust(trace)
 }
 

--- a/model/adjuster/adjuster.go
+++ b/model/adjuster/adjuster.go
@@ -5,57 +5,38 @@
 package adjuster
 
 import (
-	"errors"
-
 	"github.com/jaegertracing/jaeger/model"
 )
 
 // Adjuster applies certain modifications to a Trace object.
 // It returns adjusted Trace, which can be the same Trace updated in place.
 // If it detects a problem with the trace that prevents it from applying
-// adjustments, it must still return the original trace, and the error.
+// adjustments, it must still return the original trace.
 type Adjuster interface {
-	Adjust(trace *model.Trace) (*model.Trace, error)
+	Adjust(trace *model.Trace) *model.Trace
 }
 
 // Func wraps a function of appropriate signature and makes an Adjuster from it.
-type Func func(trace *model.Trace) (*model.Trace, error)
+type Func func(trace *model.Trace) *model.Trace
 
 // Adjust implements Adjuster interface.
-func (f Func) Adjust(trace *model.Trace) (*model.Trace, error) {
+func (f Func) Adjust(trace *model.Trace) *model.Trace {
 	return f(trace)
 }
 
 // Sequence creates an adjuster that combines a series of adjusters
-// applied in order. Errors from each step are accumulated and returned
-// in the end as a single wrapper error. Errors do not interrupt the
-// sequence of adapters.
+// applied in order.
 func Sequence(adjusters ...Adjuster) Adjuster {
 	return sequence{adjusters: adjusters}
 }
 
-// FailFastSequence is similar to Sequence() but returns immediately
-// if any adjuster returns an error.
-func FailFastSequence(adjusters ...Adjuster) Adjuster {
-	return sequence{adjusters: adjusters, failFast: true}
-}
-
 type sequence struct {
 	adjusters []Adjuster
-	failFast  bool
 }
 
-func (c sequence) Adjust(trace *model.Trace) (*model.Trace, error) {
-	var errs []error
+func (c sequence) Adjust(trace *model.Trace) *model.Trace {
 	for _, adjuster := range c.adjusters {
-		var err error
-		trace, err = adjuster.Adjust(trace)
-		if err != nil {
-			if c.failFast {
-				return trace, err
-			}
-			errs = append(errs, err)
-		}
+		trace = adjuster.Adjust(trace)
 	}
-	return trace, errors.Join(errs...)
+	return trace
 }

--- a/model/adjuster/adjuster.go
+++ b/model/adjuster/adjuster.go
@@ -8,20 +8,17 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 )
 
-// Adjuster applies certain modifications to a Trace object.
-// It returns adjusted Trace, which can be the same Trace updated in place.
-// If it detects a problem with the trace that prevents it from applying
-// adjustments, it must still return the original trace.
+// Adjuster is an interface for modifying a trace object in place.
 type Adjuster interface {
-	Adjust(trace *model.Trace) *model.Trace
+	Adjust(trace *model.Trace)
 }
 
 // Func wraps a function of appropriate signature and makes an Adjuster from it.
-type Func func(trace *model.Trace) *model.Trace
+type Func func(trace *model.Trace)
 
 // Adjust implements Adjuster interface.
-func (f Func) Adjust(trace *model.Trace) *model.Trace {
-	return f(trace)
+func (f Func) Adjust(trace *model.Trace) {
+	f(trace)
 }
 
 // Sequence creates an adjuster that combines a series of adjusters
@@ -34,9 +31,8 @@ type sequence struct {
 	adjusters []Adjuster
 }
 
-func (c sequence) Adjust(trace *model.Trace) *model.Trace {
+func (c sequence) Adjust(trace *model.Trace) {
 	for _, adjuster := range c.adjusters {
-		trace = adjuster.Adjust(trace)
+		adjuster.Adjust(trace)
 	}
-	return trace
 }

--- a/model/adjuster/adjuster_test.go
+++ b/model/adjuster/adjuster_test.go
@@ -5,12 +5,9 @@
 package adjuster_test
 
 import (
-	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/model/adjuster"
@@ -18,41 +15,18 @@ import (
 
 func TestSequences(t *testing.T) {
 	// mock adjuster that increments span ID
-	adj := adjuster.Func(func(trace *model.Trace) (*model.Trace, error) {
+	adj := adjuster.Func(func(trace *model.Trace) *model.Trace {
 		trace.Spans[0].SpanID++
-		return trace, nil
+		return trace
 	})
 
-	adjErr := errors.New("mock adjuster error")
-	failingAdj := adjuster.Func(func(trace *model.Trace) (*model.Trace, error) {
-		return trace, adjErr
-	})
+	seqAdjuster := adjuster.Sequence(adj, adj)
 
-	testCases := []struct {
-		adjuster   adjuster.Adjuster
-		err        string
-		lastSpanID int
-	}{
-		{
-			adjuster:   adjuster.Sequence(adj, failingAdj, adj, failingAdj),
-			err:        fmt.Sprintf("%s\n%s", adjErr, adjErr),
-			lastSpanID: 2,
-		},
-		{
-			adjuster:   adjuster.FailFastSequence(adj, failingAdj, adj, failingAdj),
-			err:        adjErr.Error(),
-			lastSpanID: 1,
-		},
-	}
+	span := &model.Span{}
+	trace := model.Trace{Spans: []*model.Span{span}}
 
-	for _, testCase := range testCases {
-		span := &model.Span{}
-		trace := model.Trace{Spans: []*model.Span{span}}
+	adjTrace := seqAdjuster.Adjust(&trace)
 
-		adjTrace, err := testCase.adjuster.Adjust(&trace)
-
-		assert.Equal(t, span, adjTrace.Spans[0], "same trace & span returned")
-		assert.EqualValues(t, testCase.lastSpanID, span.SpanID, "expect span ID to be incremented")
-		require.EqualError(t, err, testCase.err)
-	}
+	assert.Equal(t, span, adjTrace.Spans[0], "same trace & span returned")
+	assert.EqualValues(t, 2, span.SpanID, "expect span ID to be incremented")
 }

--- a/model/adjuster/adjuster_test.go
+++ b/model/adjuster/adjuster_test.go
@@ -15,9 +15,8 @@ import (
 
 func TestSequences(t *testing.T) {
 	// mock adjuster that increments span ID
-	adj := adjuster.Func(func(trace *model.Trace) *model.Trace {
+	adj := adjuster.Func(func(trace *model.Trace) {
 		trace.Spans[0].SpanID++
-		return trace
 	})
 
 	seqAdjuster := adjuster.Sequence(adj, adj)
@@ -25,8 +24,8 @@ func TestSequences(t *testing.T) {
 	span := &model.Span{}
 	trace := model.Trace{Spans: []*model.Span{span}}
 
-	adjTrace := seqAdjuster.Adjust(&trace)
+	seqAdjuster.Adjust(&trace)
 
-	assert.Equal(t, span, adjTrace.Spans[0], "same trace & span returned")
+	assert.Equal(t, span, trace.Spans[0], "same trace & span returned")
 	assert.EqualValues(t, 2, span.SpanID, "expect span ID to be incremented")
 }

--- a/model/adjuster/bad_span_references.go
+++ b/model/adjuster/bad_span_references.go
@@ -12,12 +12,11 @@ import (
 
 // SpanReferences creates an adjuster that removes invalid span references, e.g. with traceID==0
 func SpanReferences() Adjuster {
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		adjuster := spanReferenceAdjuster{}
 		for _, span := range trace.Spans {
 			adjuster.adjust(span)
 		}
-		return trace
 	})
 }
 

--- a/model/adjuster/bad_span_references.go
+++ b/model/adjuster/bad_span_references.go
@@ -12,12 +12,12 @@ import (
 
 // SpanReferences creates an adjuster that removes invalid span references, e.g. with traceID==0
 func SpanReferences() Adjuster {
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		adjuster := spanReferenceAdjuster{}
 		for _, span := range trace.Spans {
 			adjuster.adjust(span)
 		}
-		return trace, nil
+		return trace
 	})
 }
 

--- a/model/adjuster/bad_span_references_test.go
+++ b/model/adjuster/bad_span_references_test.go
@@ -28,7 +28,7 @@ func TestSpanReferencesAdjuster(t *testing.T) {
 			},
 		},
 	}
-	trace = SpanReferences().Adjust(trace)
+	SpanReferences().Adjust(trace)
 	assert.Empty(t, trace.Spans[0].References)
 	assert.Empty(t, trace.Spans[1].References)
 	assert.Len(t, trace.Spans[2].References, 2)

--- a/model/adjuster/bad_span_references_test.go
+++ b/model/adjuster/bad_span_references_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -29,8 +28,7 @@ func TestSpanReferencesAdjuster(t *testing.T) {
 			},
 		},
 	}
-	trace, err := SpanReferences().Adjust(trace)
-	require.NoError(t, err)
+	trace = SpanReferences().Adjust(trace)
 	assert.Empty(t, trace.Spans[0].References)
 	assert.Empty(t, trace.Spans[1].References)
 	assert.Len(t, trace.Spans[2].References, 2)

--- a/model/adjuster/clockskew.go
+++ b/model/adjuster/clockskew.go
@@ -23,7 +23,7 @@ import (
 //
 // Any issues encountered by the adjuster are recorded in Span.Warnings.
 func ClockSkew(maxDelta time.Duration) Adjuster {
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		adjuster := &clockSkewAdjuster{
 			trace:    trace,
 			maxDelta: maxDelta,
@@ -34,7 +34,6 @@ func ClockSkew(maxDelta time.Duration) Adjuster {
 			skew := clockSkew{hostKey: n.hostKey}
 			adjuster.adjustNode(n, nil, skew)
 		}
-		return adjuster.trace
 	})
 }
 

--- a/model/adjuster/clockskew.go
+++ b/model/adjuster/clockskew.go
@@ -21,10 +21,9 @@ import (
 // The algorithm assumes that all spans have unique IDs, so the trace may need
 // to go through another adjuster first, such as ZipkinSpanIDUniquifier.
 //
-// This adjuster never returns any errors. Instead it records any issues
-// it encounters in Span.Warnings.
+// Any issues encountered by the adjuster are recorded in Span.Warnings.
 func ClockSkew(maxDelta time.Duration) Adjuster {
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		adjuster := &clockSkewAdjuster{
 			trace:    trace,
 			maxDelta: maxDelta,
@@ -35,7 +34,7 @@ func ClockSkew(maxDelta time.Duration) Adjuster {
 			skew := clockSkew{hostKey: n.hostKey}
 			adjuster.adjustNode(n, nil, skew)
 		}
-		return adjuster.trace, nil
+		return adjuster.trace
 	})
 }
 

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -187,8 +187,7 @@ func TestClockSkewAdjuster(t *testing.T) {
 		testCase := tt // capture loop var
 		t.Run(testCase.description, func(t *testing.T) {
 			adjuster := ClockSkew(tt.maxAdjust)
-			trace, err := adjuster.Adjust(makeTrace(testCase.trace))
-			require.NoError(t, err)
+			trace := adjuster.Adjust(makeTrace(testCase.trace))
 			if testCase.err != "" {
 				var err string
 				for _, span := range trace.Spans {

--- a/model/adjuster/clockskew_test.go
+++ b/model/adjuster/clockskew_test.go
@@ -187,7 +187,8 @@ func TestClockSkewAdjuster(t *testing.T) {
 		testCase := tt // capture loop var
 		t.Run(testCase.description, func(t *testing.T) {
 			adjuster := ClockSkew(tt.maxAdjust)
-			trace := adjuster.Adjust(makeTrace(testCase.trace))
+			trace := makeTrace(testCase.trace)
+			adjuster.Adjust(trace)
 			if testCase.err != "" {
 				var err string
 				for _, span := range trace.Spans {

--- a/model/adjuster/ip_tag.go
+++ b/model/adjuster/ip_tag.go
@@ -49,12 +49,11 @@ func IPTagAdjuster() Adjuster {
 		}
 	}
 
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		for _, span := range trace.Spans {
 			adjustTags(span.Tags)
 			adjustTags(span.Process.Tags)
 			model.KeyValues(span.Process.Tags).Sort()
 		}
-		return trace
 	})
 }

--- a/model/adjuster/ip_tag.go
+++ b/model/adjuster/ip_tag.go
@@ -49,12 +49,12 @@ func IPTagAdjuster() Adjuster {
 		}
 	}
 
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		for _, span := range trace.Spans {
 			adjustTags(span.Tags)
 			adjustTags(span.Process.Tags)
 			model.KeyValues(span.Process.Tags).Sort()
 		}
-		return trace, nil
+		return trace
 	})
 }

--- a/model/adjuster/ip_tag_test.go
+++ b/model/adjuster/ip_tag_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -36,8 +35,7 @@ func TestIPTagAdjuster(t *testing.T) {
 			},
 		},
 	}
-	trace, err := IPTagAdjuster().Adjust(trace)
-	require.NoError(t, err)
+	trace = IPTagAdjuster().Adjust(trace)
 
 	expectedSpanTags := model.KeyValues{
 		model.Int64("a", 42),

--- a/model/adjuster/ip_tag_test.go
+++ b/model/adjuster/ip_tag_test.go
@@ -35,7 +35,7 @@ func TestIPTagAdjuster(t *testing.T) {
 			},
 		},
 	}
-	trace = IPTagAdjuster().Adjust(trace)
+	IPTagAdjuster().Adjust(trace)
 
 	expectedSpanTags := model.KeyValues{
 		model.Int64("a", 42),

--- a/model/adjuster/otel_tag.go
+++ b/model/adjuster/otel_tag.go
@@ -32,11 +32,10 @@ func OTelTagAdjuster() Adjuster {
 		span.Tags = span.Tags[:newI]
 	}
 
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		for _, span := range trace.Spans {
 			adjustSpanTags(span)
 			model.KeyValues(span.Process.Tags).Sort()
 		}
-		return trace
 	})
 }

--- a/model/adjuster/otel_tag.go
+++ b/model/adjuster/otel_tag.go
@@ -32,11 +32,11 @@ func OTelTagAdjuster() Adjuster {
 		span.Tags = span.Tags[:newI]
 	}
 
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		for _, span := range trace.Spans {
 			adjustSpanTags(span)
 			model.KeyValues(span.Process.Tags).Sort()
 		}
-		return trace, nil
+		return trace
 	})
 }

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/otelsemconv"
@@ -79,8 +78,7 @@ func TestOTelTagAdjuster(t *testing.T) {
 			trace := &model.Trace{
 				Spans: []*model.Span{testCase.span},
 			}
-			trace, err := OTelTagAdjuster().Adjust(trace)
-			require.NoError(t, err)
+			trace = OTelTagAdjuster().Adjust(trace)
 			assert.Equal(t, testCase.expected.Tags, trace.Spans[0].Tags)
 			assert.Equal(t, testCase.expected.Process.Tags, trace.Spans[0].Process.Tags)
 

--- a/model/adjuster/otel_tag_test.go
+++ b/model/adjuster/otel_tag_test.go
@@ -78,7 +78,7 @@ func TestOTelTagAdjuster(t *testing.T) {
 			trace := &model.Trace{
 				Spans: []*model.Span{testCase.span},
 			}
-			trace = OTelTagAdjuster().Adjust(trace)
+			OTelTagAdjuster().Adjust(trace)
 			assert.Equal(t, testCase.expected.Tags, trace.Spans[0].Tags)
 			assert.Equal(t, testCase.expected.Process.Tags, trace.Spans[0].Process.Tags)
 

--- a/model/adjuster/parent_reference.go
+++ b/model/adjuster/parent_reference.go
@@ -11,7 +11,7 @@ import (
 // This is necessary to match jaeger-ui expectations:
 // * https://github.com/jaegertracing/jaeger-ui/issues/966
 func ParentReference() Adjuster {
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		for _, span := range trace.Spans {
 			firstChildOfRef := -1
 			firstOtherRef := -1
@@ -33,7 +33,5 @@ func ParentReference() Adjuster {
 				span.References[swap], span.References[0] = span.References[0], span.References[swap]
 			}
 		}
-
-		return trace
 	})
 }

--- a/model/adjuster/parent_reference.go
+++ b/model/adjuster/parent_reference.go
@@ -11,7 +11,7 @@ import (
 // This is necessary to match jaeger-ui expectations:
 // * https://github.com/jaegertracing/jaeger-ui/issues/966
 func ParentReference() Adjuster {
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		for _, span := range trace.Spans {
 			firstChildOfRef := -1
 			firstOtherRef := -1
@@ -34,6 +34,6 @@ func ParentReference() Adjuster {
 			}
 		}
 
-		return trace, nil
+		return trace
 	})
 }

--- a/model/adjuster/parent_reference_test.go
+++ b/model/adjuster/parent_reference_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -96,8 +95,7 @@ func TestParentReference(t *testing.T) {
 					},
 				},
 			}
-			trace, err := ParentReference().Adjust(trace)
-			require.NoError(t, err)
+			trace = ParentReference().Adjust(trace)
 			assert.Equal(t, testCase.expected, trace.Spans[0].References)
 		})
 	}

--- a/model/adjuster/parent_reference_test.go
+++ b/model/adjuster/parent_reference_test.go
@@ -95,7 +95,7 @@ func TestParentReference(t *testing.T) {
 					},
 				},
 			}
-			trace = ParentReference().Adjust(trace)
+			ParentReference().Adjust(trace)
 			assert.Equal(t, testCase.expected, trace.Spans[0].References)
 		})
 	}

--- a/model/adjuster/sort_tags_and_log_fields.go
+++ b/model/adjuster/sort_tags_and_log_fields.go
@@ -20,7 +20,7 @@ import (
 // place in the list. This adjuster needs some sort of config describing predefined
 // field names/types and their relative order.
 func SortTagsAndLogFields() Adjuster {
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		for _, span := range trace.Spans {
 			model.KeyValues(span.Tags).Sort()
 			if span.Process != nil {
@@ -45,6 +45,5 @@ func SortTagsAndLogFields() Adjuster {
 				}
 			}
 		}
-		return trace
 	})
 }

--- a/model/adjuster/sort_tags_and_log_fields.go
+++ b/model/adjuster/sort_tags_and_log_fields.go
@@ -20,7 +20,7 @@ import (
 // place in the list. This adjuster needs some sort of config describing predefined
 // field names/types and their relative order.
 func SortTagsAndLogFields() Adjuster {
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		for _, span := range trace.Spans {
 			model.KeyValues(span.Tags).Sort()
 			if span.Process != nil {
@@ -45,6 +45,6 @@ func SortTagsAndLogFields() Adjuster {
 				}
 			}
 		}
-		return trace, nil
+		return trace
 	})
 }

--- a/model/adjuster/sort_tags_and_log_fields_test.go
+++ b/model/adjuster/sort_tags_and_log_fields_test.go
@@ -80,8 +80,7 @@ func TestSortTagsAndLogFieldsDoesSortFields(t *testing.T) {
 				},
 			},
 		}
-		trace, err := SortTagsAndLogFields().Adjust(trace)
-		require.NoError(t, err)
+		trace = SortTagsAndLogFields().Adjust(trace)
 		assert.Equal(t, testCase.expected, model.KeyValues(trace.Spans[0].Logs[0].Fields))
 	}
 }
@@ -109,8 +108,7 @@ func TestSortTagsAndLogFieldsDoesSortTags(t *testing.T) {
 				},
 			},
 		}
-		sorted, err := SortTagsAndLogFields().Adjust(trace)
-		require.NoError(t, err)
+		sorted := SortTagsAndLogFields().Adjust(trace)
 		assert.ElementsMatch(t, tags, sorted.Spans[0].Tags)
 		adjustedKeys := make([]string, len(sorted.Spans[0].Tags))
 		for i, kv := range sorted.Spans[0].Tags {
@@ -135,8 +133,7 @@ func TestSortTagsAndLogFieldsDoesSortProcessTags(t *testing.T) {
 			},
 		},
 	}
-	sorted, err := SortTagsAndLogFields().Adjust(trace)
-	require.NoError(t, err)
+	sorted := SortTagsAndLogFields().Adjust(trace)
 	assert.ElementsMatch(t, trace.Spans[0].Process.Tags, sorted.Spans[0].Process.Tags)
 	adjustedKeys := make([]string, len(sorted.Spans[0].Process.Tags))
 	for i, kv := range sorted.Spans[0].Process.Tags {
@@ -151,6 +148,6 @@ func TestSortTagsAndLogFieldsHandlesNilProcessTags(t *testing.T) {
 			{},
 		},
 	}
-	_, err := SortTagsAndLogFields().Adjust(trace)
-	require.NoError(t, err)
+	gotTrace := SortTagsAndLogFields().Adjust(trace)
+	require.Equal(t, trace, gotTrace)
 }

--- a/model/adjuster/sort_tags_and_log_fields_test.go
+++ b/model/adjuster/sort_tags_and_log_fields_test.go
@@ -80,7 +80,7 @@ func TestSortTagsAndLogFieldsDoesSortFields(t *testing.T) {
 				},
 			},
 		}
-		trace = SortTagsAndLogFields().Adjust(trace)
+		SortTagsAndLogFields().Adjust(trace)
 		assert.Equal(t, testCase.expected, model.KeyValues(trace.Spans[0].Logs[0].Fields))
 	}
 }
@@ -108,10 +108,10 @@ func TestSortTagsAndLogFieldsDoesSortTags(t *testing.T) {
 				},
 			},
 		}
-		sorted := SortTagsAndLogFields().Adjust(trace)
-		assert.ElementsMatch(t, tags, sorted.Spans[0].Tags)
-		adjustedKeys := make([]string, len(sorted.Spans[0].Tags))
-		for i, kv := range sorted.Spans[0].Tags {
+		SortTagsAndLogFields().Adjust(trace)
+		assert.ElementsMatch(t, tags, trace.Spans[0].Tags)
+		adjustedKeys := make([]string, len(trace.Spans[0].Tags))
+		for i, kv := range trace.Spans[0].Tags {
 			adjustedKeys[i] = kv.Key
 		}
 		assert.IsIncreasing(t, adjustedKeys)
@@ -133,10 +133,9 @@ func TestSortTagsAndLogFieldsDoesSortProcessTags(t *testing.T) {
 			},
 		},
 	}
-	sorted := SortTagsAndLogFields().Adjust(trace)
-	assert.ElementsMatch(t, trace.Spans[0].Process.Tags, sorted.Spans[0].Process.Tags)
-	adjustedKeys := make([]string, len(sorted.Spans[0].Process.Tags))
-	for i, kv := range sorted.Spans[0].Process.Tags {
+	SortTagsAndLogFields().Adjust(trace)
+	adjustedKeys := make([]string, len(trace.Spans[0].Process.Tags))
+	for i, kv := range trace.Spans[0].Process.Tags {
 		adjustedKeys[i] = kv.Key
 	}
 	assert.IsIncreasing(t, adjustedKeys)
@@ -148,6 +147,10 @@ func TestSortTagsAndLogFieldsHandlesNilProcessTags(t *testing.T) {
 			{},
 		},
 	}
-	gotTrace := SortTagsAndLogFields().Adjust(trace)
-	require.Equal(t, trace, gotTrace)
+	SortTagsAndLogFields().Adjust(trace)
+	require.Equal(t, &model.Trace{
+		Spans: []*model.Span{
+			{},
+		},
+	}, trace)
 }

--- a/model/adjuster/span_hash_deduper.go
+++ b/model/adjuster/span_hash_deduper.go
@@ -11,10 +11,10 @@ import (
 // This is useful for when spans are duplicated in archival storage, as happens with
 // ElasticSearch archival.
 func DedupeBySpanHash() Adjuster {
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		deduper := &spanHashDeduper{trace: trace}
 		deduper.groupSpansByHash()
-		return deduper.trace, nil
+		return deduper.trace
 	})
 }
 

--- a/model/adjuster/span_hash_deduper.go
+++ b/model/adjuster/span_hash_deduper.go
@@ -11,10 +11,9 @@ import (
 // This is useful for when spans are duplicated in archival storage, as happens with
 // ElasticSearch archival.
 func DedupeBySpanHash() Adjuster {
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		deduper := &spanHashDeduper{trace: trace}
 		deduper.groupSpansByHash()
-		return deduper.trace
 	})
 }
 

--- a/model/adjuster/span_hash_deduper_test.go
+++ b/model/adjuster/span_hash_deduper_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -74,8 +73,7 @@ func getSpanIDs(spans []*model.Span) []int {
 func TestDedupeBySpanHashTriggers(t *testing.T) {
 	trc := newDuplicatedSpansTrace()
 	deduper := DedupeBySpanHash()
-	trc, err := deduper.Adjust(trc)
-	require.NoError(t, err)
+	trc = deduper.Adjust(trc)
 
 	assert.Len(t, trc.Spans, 2, "should dedupe spans")
 
@@ -86,8 +84,7 @@ func TestDedupeBySpanHashTriggers(t *testing.T) {
 func TestDedupeBySpanHashNotTriggered(t *testing.T) {
 	trc := newUniqueSpansTrace()
 	deduper := DedupeBySpanHash()
-	trc, err := deduper.Adjust(trc)
-	require.NoError(t, err)
+	trc = deduper.Adjust(trc)
 
 	assert.Len(t, trc.Spans, 2, "should not dedupe spans")
 
@@ -99,8 +96,7 @@ func TestDedupeBySpanHashNotTriggered(t *testing.T) {
 func TestDedupeBySpanHashEmpty(t *testing.T) {
 	trc := &model.Trace{}
 	deduper := DedupeBySpanHash()
-	trc, err := deduper.Adjust(trc)
-	require.NoError(t, err)
+	trc = deduper.Adjust(trc)
 
 	assert.Empty(t, trc.Spans, "should be empty")
 }
@@ -117,8 +113,7 @@ func TestDedupeBySpanHashManyManySpans(t *testing.T) {
 	}
 	trc := &model.Trace{Spans: spans}
 	deduper := DedupeBySpanHash()
-	trc, err := deduper.Adjust(trc)
-	require.NoError(t, err)
+	trc = deduper.Adjust(trc)
 
 	assert.Len(t, trc.Spans, distinctSpanIDs, "should dedupe spans")
 

--- a/model/adjuster/span_hash_deduper_test.go
+++ b/model/adjuster/span_hash_deduper_test.go
@@ -73,7 +73,7 @@ func getSpanIDs(spans []*model.Span) []int {
 func TestDedupeBySpanHashTriggers(t *testing.T) {
 	trc := newDuplicatedSpansTrace()
 	deduper := DedupeBySpanHash()
-	trc = deduper.Adjust(trc)
+	deduper.Adjust(trc)
 
 	assert.Len(t, trc.Spans, 2, "should dedupe spans")
 
@@ -84,7 +84,7 @@ func TestDedupeBySpanHashTriggers(t *testing.T) {
 func TestDedupeBySpanHashNotTriggered(t *testing.T) {
 	trc := newUniqueSpansTrace()
 	deduper := DedupeBySpanHash()
-	trc = deduper.Adjust(trc)
+	deduper.Adjust(trc)
 
 	assert.Len(t, trc.Spans, 2, "should not dedupe spans")
 
@@ -96,7 +96,7 @@ func TestDedupeBySpanHashNotTriggered(t *testing.T) {
 func TestDedupeBySpanHashEmpty(t *testing.T) {
 	trc := &model.Trace{}
 	deduper := DedupeBySpanHash()
-	trc = deduper.Adjust(trc)
+	deduper.Adjust(trc)
 
 	assert.Empty(t, trc.Spans, "should be empty")
 }
@@ -113,7 +113,7 @@ func TestDedupeBySpanHashManyManySpans(t *testing.T) {
 	}
 	trc := &model.Trace{Spans: spans}
 	deduper := DedupeBySpanHash()
-	trc = deduper.Adjust(trc)
+	deduper.Adjust(trc)
 
 	assert.Len(t, trc.Spans, distinctSpanIDs, "should dedupe spans")
 

--- a/model/adjuster/zipkin_span_id_uniquify.go
+++ b/model/adjuster/zipkin_span_id_uniquify.go
@@ -20,11 +20,11 @@ import (
 // This adjuster never returns any errors. Instead it records any issues
 // it encounters in Span.Warnings.
 func ZipkinSpanIDUniquifier() Adjuster {
-	return Func(func(trace *model.Trace) (*model.Trace, error) {
+	return Func(func(trace *model.Trace) *model.Trace {
 		deduper := &spanIDDeduper{trace: trace}
 		deduper.groupSpansByID()
 		deduper.uniquifyServerSpanIDs()
-		return deduper.trace, nil
+		return deduper.trace
 	})
 }
 

--- a/model/adjuster/zipkin_span_id_uniquify.go
+++ b/model/adjuster/zipkin_span_id_uniquify.go
@@ -20,11 +20,10 @@ import (
 // This adjuster never returns any errors. Instead it records any issues
 // it encounters in Span.Warnings.
 func ZipkinSpanIDUniquifier() Adjuster {
-	return Func(func(trace *model.Trace) *model.Trace {
+	return Func(func(trace *model.Trace) {
 		deduper := &spanIDDeduper{trace: trace}
 		deduper.groupSpansByID()
 		deduper.uniquifyServerSpanIDs()
-		return deduper.trace
 	})
 }
 

--- a/model/adjuster/zipkin_span_id_uniquify_test.go
+++ b/model/adjuster/zipkin_span_id_uniquify_test.go
@@ -52,7 +52,7 @@ func newZipkinTrace() *model.Trace {
 func TestZipkinSpanIDUniquifierTriggered(t *testing.T) {
 	trc := newZipkinTrace()
 	deduper := ZipkinSpanIDUniquifier()
-	trc = deduper.Adjust(trc)
+	deduper.Adjust(trc)
 
 	clientSpan := trc.Spans[0]
 	assert.Equal(t, clientSpanID, clientSpan.SpanID, "client span ID should not change")
@@ -71,7 +71,7 @@ func TestZipkinSpanIDUniquifierNotTriggered(t *testing.T) {
 	trc.Spans = trc.Spans[1:] // remove client span
 
 	deduper := ZipkinSpanIDUniquifier()
-	trc = deduper.Adjust(trc)
+	deduper.Adjust(trc)
 
 	serverSpanID := clientSpanID // for better readability
 	serverSpan := trc.Spans[0]

--- a/model/adjuster/zipkin_span_id_uniquify_test.go
+++ b/model/adjuster/zipkin_span_id_uniquify_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/model"
 )
@@ -53,8 +52,7 @@ func newZipkinTrace() *model.Trace {
 func TestZipkinSpanIDUniquifierTriggered(t *testing.T) {
 	trc := newZipkinTrace()
 	deduper := ZipkinSpanIDUniquifier()
-	trc, err := deduper.Adjust(trc)
-	require.NoError(t, err)
+	trc = deduper.Adjust(trc)
 
 	clientSpan := trc.Spans[0]
 	assert.Equal(t, clientSpanID, clientSpan.SpanID, "client span ID should not change")
@@ -73,8 +71,7 @@ func TestZipkinSpanIDUniquifierNotTriggered(t *testing.T) {
 	trc.Spans = trc.Spans[1:] // remove client span
 
 	deduper := ZipkinSpanIDUniquifier()
-	trc, err := deduper.Adjust(trc)
-	require.NoError(t, err)
+	trc = deduper.Adjust(trc)
 
 	serverSpanID := clientSpanID // for better readability
 	serverSpan := trc.Spans[0]

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -90,8 +90,7 @@ func (st *Store) GetDependencies(ctx context.Context, endTs time.Time, lookback 
 	deps := map[string]*model.DependencyLink{}
 	startTs := endTs.Add(-1 * lookback)
 	for _, orig := range m.traces {
-		// ZipkinSpanIDUniquifier never returns an err
-		trace, _ := m.deduper.Adjust(orig)
+		trace := m.deduper.Adjust(orig)
 		if traceIsBetweenStartAndEnd(startTs, endTs, trace) {
 			for _, s := range trace.Spans {
 				parentSpan := findSpan(trace, s.ParentSpanID())

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -89,8 +89,8 @@ func (st *Store) GetDependencies(ctx context.Context, endTs time.Time, lookback 
 	defer m.Unlock()
 	deps := map[string]*model.DependencyLink{}
 	startTs := endTs.Add(-1 * lookback)
-	for _, orig := range m.traces {
-		trace := m.deduper.Adjust(orig)
+	for _, trace := range m.traces {
+		m.deduper.Adjust(trace)
 		if traceIsBetweenStartAndEnd(startTs, endTs, trace) {
 			for _, s := range trace.Spans {
 				parentSpan := findSpan(trace, s.ParentSpanID())


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6417

## Description of the changes
- The v1 adjuster interface returns an error even though none of the adjusters ever return an error. This was leading to handling errors that would never be thrown. This PR simplifies the interface by removing the error return. 
- The v1 adjuster interface was also returning the trace that it modified. However, all the adjusters currently just take the trace in as a pointer and modify it in place so this return was not necessary. 

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
