### PR TITLE
Make all-in-one.yaml file independant of sampling-strategies.json file 

### DIFF
--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -30,7 +30,7 @@ extensions:
   remote_sampling:
     # We can either use file or adaptive sampling strategy in remote_sampling
     file:
-      path: ./cmd/jaeger/sampling-strategies.json
+      path:
       reload_interval: 1s
     # adaptive:
     #   sampling_store: some_store

--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -32,7 +32,7 @@ extensions:
     file:
       path:
       reload_interval: 1s
-      defaultSamplingProbability: 0.001
+      default_sampling_probability: 0.001
     # adaptive:
     #   sampling_store: some_store
     #   initial_sampling_probability: 0.1

--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -31,8 +31,8 @@ extensions:
     # We can either use file or adaptive sampling strategy in remote_sampling
     file:
       path:
+      default_sampling_probability: 1
       reload_interval: 1s
-      default_sampling_probability: 0.001
     # adaptive:
     #   sampling_store: some_store
     #   initial_sampling_probability: 0.1

--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -32,6 +32,7 @@ extensions:
     file:
       path:
       reload_interval: 1s
+      defaultSamplingProbability: 0.001
     # adaptive:
     #   sampling_store: some_store
     #   initial_sampling_probability: 0.1

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -47,7 +47,7 @@ type Config struct {
 
 type FileConfig struct {
 	// File specifies a local file as the source of sampling strategies.
-	Path string `valid:"required" mapstructure:"path"`
+	Path string `mapstructure:"path"`
 	// ReloadInterval is the time interval to check and reload sampling strategies file
 	ReloadInterval time.Duration `mapstructure:"reload_interval"`
 }

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -92,6 +92,10 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 }
 
 func (cfg *Config) Validate() error {
+	if cfg.File == nil && cfg.Adaptive == nil {
+		return errNoProvider
+	}
+
 	if cfg.File != nil && cfg.Adaptive != nil {
 		return errMultipleProviders
 	}

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -18,10 +18,9 @@ import (
 )
 
 var (
-	errNoProvider                = errors.New("no sampling strategy provider specified, expecting 'adaptive' or 'file'")
-	errMultipleProviders         = errors.New("only one sampling strategy provider can be specified, 'adaptive' or 'file'")
-	errNegativeInterval          = errors.New("reload interval must be a positive value, or zero to disable automatic reloading")
-	errInvalidDefaultProbability = errors.New("default sampling probability must be between 0 and 1")
+	errNoProvider        = errors.New("no sampling strategy provider specified, expecting 'adaptive' or 'file'")
+	errMultipleProviders = errors.New("only one sampling strategy provider can be specified, 'adaptive' or 'file'")
+	errNegativeInterval  = errors.New("reload interval must be a positive value, or zero to disable automatic reloading")
 )
 
 var (
@@ -52,7 +51,7 @@ type FileConfig struct {
 	// ReloadInterval is the time interval to check and reload sampling strategies file
 	ReloadInterval time.Duration `mapstructure:"reload_interval"`
 	// DefaultSamplingProbability is the sampling probability used by the Strategy Store for static sampling
-	DefaultSamplingProbability float64 `mapstructure:"default_sampling_probability"`
+	DefaultSamplingProbability float64 `mapstructure:"default_sampling_probability" valid:"range(0|1)"`
 }
 
 type AdaptiveConfig struct {
@@ -105,10 +104,6 @@ func (cfg *Config) Validate() error {
 
 	if cfg.File != nil && cfg.File.ReloadInterval < 0 {
 		return errNegativeInterval
-	}
-
-	if cfg.File != nil && (cfg.File.DefaultSamplingProbability > 1 || cfg.File.DefaultSamplingProbability < 0) {
-		return errInvalidDefaultProbability
 	}
 
 	_, err := govalidator.ValidateStruct(cfg)

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	errNoProvider        = errors.New("no sampling strategy provider specified, expecting 'adaptive' or 'file'")
-	errMultipleProviders = errors.New("only one sampling strategy provider can be specified, 'adaptive' or 'file'")
-	errNegativeInterval  = errors.New("reload interval must be a positive value, or zero to disable automatic reloading")
+	errNoProvider                = errors.New("no sampling strategy provider specified, expecting 'adaptive' or 'file'")
+	errMultipleProviders         = errors.New("only one sampling strategy provider can be specified, 'adaptive' or 'file'")
+	errNegativeInterval          = errors.New("reload interval must be a positive value, or zero to disable automatic reloading")
+	errInvalidDefaultProbability = errors.New("default sampling probability must be between 0 and 1")
 )
 
 var (
@@ -50,6 +51,8 @@ type FileConfig struct {
 	Path string `mapstructure:"path"`
 	// ReloadInterval is the time interval to check and reload sampling strategies file
 	ReloadInterval time.Duration `mapstructure:"reload_interval"`
+	// DefaultSamplingProbability is the sampling probability used by the Strategy Store for static sampling
+	DefaultSamplingProbability float64 `mapstructure:"default_sampling_probability"`
 }
 
 type AdaptiveConfig struct {
@@ -102,6 +105,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.File != nil && cfg.File.ReloadInterval < 0 {
 		return errNegativeInterval
+	}
+
+	if cfg.File != nil && (cfg.File.DefaultSamplingProbability > 1 || cfg.File.DefaultSamplingProbability < 0) {
+		return errInvalidDefaultProbability
 	}
 
 	_, err := govalidator.ValidateStruct(cfg)

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -92,10 +92,6 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 }
 
 func (cfg *Config) Validate() error {
-	if cfg.File == nil && cfg.Adaptive == nil {
-		return errNoProvider
-	}
-
 	if cfg.File != nil && cfg.Adaptive != nil {
 		return errMultipleProviders
 	}

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -18,11 +18,6 @@ func Test_Validate(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name:        "No provider specified",
-			config:      &Config{},
-			expectedErr: "no sampling strategy provider specified, expecting 'adaptive' or 'file'",
-		},
-		{
 			name: "Both providers specified",
 			config: &Config{
 				File:     &FileConfig{Path: "test-path"},

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -59,6 +59,20 @@ func Test_Validate(t *testing.T) {
 			expectedErr: "must be a positive value",
 		},
 		{
+			name: "File provider has negative default sampling probability",
+			config: &Config{
+				File: &FileConfig{Path: "", DefaultSamplingProbability: -0.5},
+			},
+			expectedErr: "default sampling probability must be between 0 and 1",
+		},
+		{
+			name: "File provider has default sampling probability greater than 1",
+			config: &Config{
+				File: &FileConfig{Path: "", DefaultSamplingProbability: 1.5},
+			},
+			expectedErr: "default sampling probability must be between 0 and 1",
+		},
+		{
 			name: "Invalid Adaptive provider",
 			config: &Config{
 				Adaptive: &AdaptiveConfig{SamplingStore: ""},

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -18,6 +18,11 @@ func Test_Validate(t *testing.T) {
 		expectedErr string
 	}{
 		{
+			name:        "No provider specified",
+			config:      &Config{},
+			expectedErr: "no sampling strategy provider specified, expecting 'adaptive' or 'file'",
+		},
+		{
 			name: "Both providers specified",
 			config: &Config{
 				File:     &FileConfig{Path: "test-path"},

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -45,11 +45,11 @@ func Test_Validate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name: "Invalid File provider",
+			name: "File provider can have empty file path",
 			config: &Config{
 				File: &FileConfig{Path: ""},
 			},
-			expectedErr: "File.Path: non zero value required",
+			expectedErr: "",
 		},
 		{
 			name: "File provider has negative reload interval",

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -63,14 +63,14 @@ func Test_Validate(t *testing.T) {
 			config: &Config{
 				File: &FileConfig{Path: "", DefaultSamplingProbability: -0.5},
 			},
-			expectedErr: "default sampling probability must be between 0 and 1",
+			expectedErr: "File.DefaultSamplingProbability: -0.5 does not validate as range(0|1)",
 		},
 		{
 			name: "File provider has default sampling probability greater than 1",
 			config: &Config{
 				File: &FileConfig{Path: "", DefaultSamplingProbability: 1.5},
 			},
-			expectedErr: "default sampling probability must be between 0 and 1",
+			expectedErr: "File.DefaultSamplingProbability: 1.5 does not validate as range(0|1)",
 		},
 		{
 			name: "Invalid Adaptive provider",

--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -168,6 +168,7 @@ func (ext *rsExtension) startFileBasedStrategyProvider(_ context.Context) error 
 		StrategiesFile:             ext.cfg.File.Path,
 		ReloadInterval:             ext.cfg.File.ReloadInterval,
 		IncludeDefaultOpStrategies: includeDefaultOpStrategies.IsEnabled(),
+		DefaultSamplingProbability: ext.cfg.File.DefaultSamplingProbability,
 	}
 
 	// contextcheck linter complains about next line that context is not passed.

--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -84,7 +83,7 @@ func makeRemoteSamplingExtension(t *testing.T, cfg component.Config) component.H
 func TestStartFileBasedProvider(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.File.Path = filepath.Join("..", "..", "..", "sampling-strategies.json")
+	cfg.File = nil
 	cfg.Adaptive = nil
 	cfg.HTTP = nil
 	cfg.GRPC = nil
@@ -102,7 +101,7 @@ func TestStartFileBasedProvider(t *testing.T) {
 func TestStartHTTP(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.File.Path = filepath.Join("..", "..", "..", "sampling-strategies.json")
+	cfg.File = nil
 	cfg.Adaptive = nil
 	cfg.HTTP = &confighttp.ServerConfig{
 		Endpoint: "0.0.0.0:12345",
@@ -114,6 +113,7 @@ func TestStartHTTP(t *testing.T) {
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 	}, cfg)
 	require.NoError(t, err)
+	// here, the file is using a service hardcoded in the sampling-services.json file
 	host := makeStorageExtension(t, "foobar")
 	require.NoError(t, ext.Start(context.Background(), host))
 
@@ -139,7 +139,7 @@ func TestStartHTTP(t *testing.T) {
 func TestStartGRPC(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.File.Path = filepath.Join("..", "..", "..", "sampling-strategies.json")
+	cfg.File = nil
 	cfg.Adaptive = nil
 	cfg.HTTP = nil
 	cfg.GRPC = &configgrpc.ServerConfig{
@@ -154,6 +154,7 @@ func TestStartGRPC(t *testing.T) {
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 	}, cfg)
 	require.NoError(t, err)
+	// here, the file is using a service hardcoded in the sampling-services.json file
 	host := makeStorageExtension(t, "foobar")
 	require.NoError(t, ext.Start(context.Background(), host))
 

--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -83,7 +84,7 @@ func makeRemoteSamplingExtension(t *testing.T, cfg component.Config) component.H
 func TestStartFileBasedProvider(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.File = nil
+	cfg.File.Path = filepath.Join("..", "..", "..", "sampling-strategies.json")
 	cfg.Adaptive = nil
 	cfg.HTTP = nil
 	cfg.GRPC = nil
@@ -101,7 +102,7 @@ func TestStartFileBasedProvider(t *testing.T) {
 func TestStartHTTP(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.File = nil
+	cfg.File.Path = filepath.Join("..", "..", "..", "sampling-strategies.json")
 	cfg.Adaptive = nil
 	cfg.HTTP = &confighttp.ServerConfig{
 		Endpoint: "0.0.0.0:12345",
@@ -139,7 +140,7 @@ func TestStartHTTP(t *testing.T) {
 func TestStartGRPC(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.File = nil
+	cfg.File.Path = filepath.Join("..", "..", "..", "sampling-strategies.json")
 	cfg.Adaptive = nil
 	cfg.HTTP = nil
 	cfg.GRPC = &configgrpc.ServerConfig{

--- a/cmd/jaeger/internal/extension/remotesampling/factory.go
+++ b/cmd/jaeger/internal/extension/remotesampling/factory.go
@@ -45,7 +45,7 @@ func createDefaultConfig() component.Config {
 		},
 		File: &FileConfig{
 			Path:                       "", // path needs to be specified
-			DefaultSamplingProbability: static.DefaultDefaultSamplingProbability,
+			DefaultSamplingProbability: static.DefaultSamplingProbability,
 		},
 		Adaptive: &AdaptiveConfig{
 			SamplingStore: "", // storage name needs to be specified

--- a/cmd/jaeger/internal/extension/remotesampling/factory.go
+++ b/cmd/jaeger/internal/extension/remotesampling/factory.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategyprovider/adaptive"
+	"github.com/jaegertracing/jaeger/plugin/sampling/strategyprovider/static"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -43,7 +44,8 @@ func createDefaultConfig() component.Config {
 			},
 		},
 		File: &FileConfig{
-			Path: "", // path needs to be specified
+			Path:                       "", // path needs to be specified
+			DefaultSamplingProbability: static.DefaultDefaultSamplingProbability,
 		},
 		Adaptive: &AdaptiveConfig{
 			SamplingStore: "", // storage name needs to be specified

--- a/plugin/sampling/strategyprovider/static/constants.go
+++ b/plugin/sampling/strategyprovider/static/constants.go
@@ -16,14 +16,14 @@ const (
 	// only up to a fixed number of traces per second.
 	samplerTypeRateLimiting = "ratelimiting"
 
-	// defaultSamplingProbability is the default sampling probability the
-	// Strategy Store will use if none is provided.
-	defaultSamplingProbability = 0.001
+	// defaultDefaultSamplingProbability is the default "defaultSamplingProbability"
+	// used by the Strategy Store in case no defaultSamplingProbability is defined is given
+	defaultDefaultSamplingProbability = 0.001
 )
 
 // defaultStrategy is the default sampling strategy the Strategy Store will return
 // if none is provided.
-func defaultStrategyResponse() *api_v2.SamplingStrategyResponse {
+func defaultStrategyResponse(defaultSamplingProbability float64) *api_v2.SamplingStrategyResponse {
 	return &api_v2.SamplingStrategyResponse{
 		StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
 		ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
@@ -32,10 +32,10 @@ func defaultStrategyResponse() *api_v2.SamplingStrategyResponse {
 	}
 }
 
-func defaultStrategies() *storedStrategies {
+func defaultStrategies(defaultSamplingProbability float64) *storedStrategies {
 	s := &storedStrategies{
 		serviceStrategies: make(map[string]*api_v2.SamplingStrategyResponse),
 	}
-	s.defaultStrategy = defaultStrategyResponse()
+	s.defaultStrategy = defaultStrategyResponse(defaultSamplingProbability)
 	return s
 }

--- a/plugin/sampling/strategyprovider/static/constants.go
+++ b/plugin/sampling/strategyprovider/static/constants.go
@@ -16,9 +16,9 @@ const (
 	// only up to a fixed number of traces per second.
 	samplerTypeRateLimiting = "ratelimiting"
 
-	// defaultDefaultSamplingProbability is the default "defaultSamplingProbability"
-	// used by the Strategy Store in case no defaultSamplingProbability is defined is given
-	defaultDefaultSamplingProbability = 0.001
+	// DefaultDefaultSamplingProbability is the default value for  "DefaultSamplingProbability"
+	// used by the Strategy Store in case no DefaultSamplingProbability is defined
+	DefaultDefaultSamplingProbability = 0.001
 )
 
 // defaultStrategy is the default sampling strategy the Strategy Store will return

--- a/plugin/sampling/strategyprovider/static/constants.go
+++ b/plugin/sampling/strategyprovider/static/constants.go
@@ -16,9 +16,9 @@ const (
 	// only up to a fixed number of traces per second.
 	samplerTypeRateLimiting = "ratelimiting"
 
-	// DefaultDefaultSamplingProbability is the default value for  "DefaultSamplingProbability"
+	// DefaultSamplingProbability is the default value for  "DefaultSamplingProbability"
 	// used by the Strategy Store in case no DefaultSamplingProbability is defined
-	DefaultDefaultSamplingProbability = 0.001
+	DefaultSamplingProbability = 0.001
 )
 
 // defaultStrategy is the default sampling strategy the Strategy Store will return

--- a/plugin/sampling/strategyprovider/static/options.go
+++ b/plugin/sampling/strategyprovider/static/options.go
@@ -28,7 +28,7 @@ type Options struct {
 	// strategies when calculating Ratelimiting type service level strategy
 	// more information https://github.com/jaegertracing/jaeger/issues/5270
 	IncludeDefaultOpStrategies bool
-	// SamplingProbability is the sampling probability used by the Strategy Store for static sampling
+	// DefaultSamplingProbability is the sampling probability used by the Strategy Store for static sampling
 	DefaultSamplingProbability float64
 }
 

--- a/plugin/sampling/strategyprovider/static/options.go
+++ b/plugin/sampling/strategyprovider/static/options.go
@@ -15,7 +15,7 @@ const (
 	samplingStrategiesFile                       = "sampling.strategies-file"
 	samplingStrategiesReloadInterval             = "sampling.strategies-reload-interval"
 	samplingStrategiesBugfix5270                 = "sampling.strategies.bugfix-5270"
-	samplingStrategiesDefaultSamplingProbability = "sampling.stategies-default-sampling-probability"
+	samplingStrategiesDefaultSamplingProbability = "sampling.default-sampling-probability"
 )
 
 // Options holds configuration for the static sampling strategy store.
@@ -37,7 +37,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
 	flagSet.String(samplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
 	flagSet.Bool(samplingStrategiesBugfix5270, true, "Include default operation level strategies for Ratesampling type service level strategy. Cf. https://github.com/jaegertracing/jaeger/issues/5270")
-	flagSet.Float64(samplingStrategiesDefaultSamplingProbability, defaultDefaultSamplingProbability, "Sampling probability used by the Strategy Store for static sampling. Value must be between 0 and 1.")
+	flagSet.Float64(samplingStrategiesDefaultSamplingProbability, DefaultDefaultSamplingProbability, "Sampling probability used by the Strategy Store for static sampling. Value must be between 0 and 1.")
 }
 
 // InitFromViper initializes Options with properties from viper

--- a/plugin/sampling/strategyprovider/static/options.go
+++ b/plugin/sampling/strategyprovider/static/options.go
@@ -37,7 +37,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
 	flagSet.String(samplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
 	flagSet.Bool(samplingStrategiesBugfix5270, true, "Include default operation level strategies for Ratesampling type service level strategy. Cf. https://github.com/jaegertracing/jaeger/issues/5270")
-	flagSet.Float64(samplingStrategiesDefaultSamplingProbability, DefaultDefaultSamplingProbability, "Sampling probability used by the Strategy Store for static sampling. Value must be between 0 and 1.")
+	flagSet.Float64(samplingStrategiesDefaultSamplingProbability, DefaultSamplingProbability, "Sampling probability used by the Strategy Store for static sampling. Value must be between 0 and 1.")
 }
 
 // InitFromViper initializes Options with properties from viper

--- a/plugin/sampling/strategyprovider/static/options.go
+++ b/plugin/sampling/strategyprovider/static/options.go
@@ -12,9 +12,10 @@ import (
 
 const (
 	// samplingStrategiesFile contains the name of CLI option for config file.
-	samplingStrategiesFile           = "sampling.strategies-file"
-	samplingStrategiesReloadInterval = "sampling.strategies-reload-interval"
-	samplingStrategiesBugfix5270     = "sampling.strategies.bugfix-5270"
+	samplingStrategiesFile                       = "sampling.strategies-file"
+	samplingStrategiesReloadInterval             = "sampling.strategies-reload-interval"
+	samplingStrategiesBugfix5270                 = "sampling.strategies.bugfix-5270"
+	samplingStrategiesDefaultSamplingProbability = "sampling.stategies-default-sampling-probability"
 )
 
 // Options holds configuration for the static sampling strategy store.
@@ -27,6 +28,8 @@ type Options struct {
 	// strategies when calculating Ratelimiting type service level strategy
 	// more information https://github.com/jaegertracing/jaeger/issues/5270
 	IncludeDefaultOpStrategies bool
+	// SamplingProbability is the sampling probability used by the Strategy Store for static sampling
+	DefaultSamplingProbability float64
 }
 
 // AddFlags adds flags for Options
@@ -34,6 +37,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
 	flagSet.String(samplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
 	flagSet.Bool(samplingStrategiesBugfix5270, true, "Include default operation level strategies for Ratesampling type service level strategy. Cf. https://github.com/jaegertracing/jaeger/issues/5270")
+	flagSet.Float64(samplingStrategiesDefaultSamplingProbability, defaultDefaultSamplingProbability, "Sampling probability used by the Strategy Store for static sampling. Value must be between 0 and 1.")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -41,5 +45,6 @@ func (opts *Options) InitFromViper(v *viper.Viper) *Options {
 	opts.StrategiesFile = v.GetString(samplingStrategiesFile)
 	opts.ReloadInterval = v.GetDuration(samplingStrategiesReloadInterval)
 	opts.IncludeDefaultOpStrategies = v.GetBool(samplingStrategiesBugfix5270)
+	opts.DefaultSamplingProbability = v.GetFloat64(samplingStrategiesDefaultSamplingProbability)
 	return opts
 }

--- a/plugin/sampling/strategyprovider/static/provider.go
+++ b/plugin/sampling/strategyprovider/static/provider.go
@@ -71,13 +71,13 @@ func NewProvider(options Options, logger *zap.Logger) (ss.Provider, error) {
 		h.logger.Warn("Default operations level strategies will not be included for Ratelimiting service strategies." +
 			"This behavior will be changed in future releases. " +
 			"Cf. https://github.com/jaegertracing/jaeger/issues/5270")
-		h.parseStrategies_deprecated(options, strategies)
+		h.parseStrategies_deprecated(strategies)
 	} else {
-		h.parseStrategies(options, strategies)
+		h.parseStrategies(strategies)
 	}
 
 	if options.ReloadInterval > 0 {
-		go h.autoUpdateStrategies(ctx, options.ReloadInterval, loadFn, options)
+		go h.autoUpdateStrategies(ctx, loadFn)
 	}
 	return h, nil
 }
@@ -154,21 +154,21 @@ func (h *samplingProvider) samplingStrategyLoader(strategiesFile string) strateg
 	}
 }
 
-func (h *samplingProvider) autoUpdateStrategies(ctx context.Context, interval time.Duration, loader strategyLoader, options Options) {
+func (h *samplingProvider) autoUpdateStrategies(ctx context.Context, loader strategyLoader) {
 	lastValue := string(nullJSON)
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(h.options.ReloadInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			lastValue = h.reloadSamplingStrategy(options, loader, lastValue)
+			lastValue = h.reloadSamplingStrategy(loader, lastValue)
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (h *samplingProvider) reloadSamplingStrategy(options Options, loadFn strategyLoader, lastValue string) string {
+func (h *samplingProvider) reloadSamplingStrategy(loadFn strategyLoader, lastValue string) string {
 	newValue, err := loadFn()
 	if err != nil {
 		h.logger.Error("failed to re-load sampling strategies", zap.Error(err))
@@ -177,19 +177,19 @@ func (h *samplingProvider) reloadSamplingStrategy(options Options, loadFn strate
 	if lastValue == string(newValue) {
 		return lastValue
 	}
-	if err := h.updateSamplingStrategy(options, newValue); err != nil {
+	if err := h.updateSamplingStrategy(newValue); err != nil {
 		h.logger.Error("failed to update sampling strategies", zap.Error(err))
 		return lastValue
 	}
 	return string(newValue)
 }
 
-func (h *samplingProvider) updateSamplingStrategy(options Options, dataBytes []byte) error {
+func (h *samplingProvider) updateSamplingStrategy(dataBytes []byte) error {
 	var strategies strategies
 	if err := json.Unmarshal(dataBytes, &strategies); err != nil {
 		return fmt.Errorf("failed to unmarshal sampling strategies: %w", err)
 	}
-	h.parseStrategies(options, &strategies)
+	h.parseStrategies(&strategies)
 	h.logger.Info("Updated sampling strategies:" + string(dataBytes))
 	return nil
 }
@@ -208,10 +208,10 @@ func loadStrategies(loadFn strategyLoader) (*strategies, error) {
 	return strategies, nil
 }
 
-func (h *samplingProvider) parseStrategies_deprecated(options Options, strategies *strategies) {
-	newStore := defaultStrategies(options.DefaultSamplingProbability)
+func (h *samplingProvider) parseStrategies_deprecated(strategies *strategies) {
+	newStore := defaultStrategies(h.options.DefaultSamplingProbability)
 	if strategies.DefaultStrategy != nil {
-		newStore.defaultStrategy = h.parseServiceStrategies(options, strategies.DefaultStrategy)
+		newStore.defaultStrategy = h.parseServiceStrategies(strategies.DefaultStrategy)
 	}
 
 	merge := true
@@ -221,7 +221,7 @@ func (h *samplingProvider) parseStrategies_deprecated(options Options, strategie
 	}
 
 	for _, s := range strategies.ServiceStrategies {
-		newStore.serviceStrategies[s.Service] = h.parseServiceStrategies(options, s)
+		newStore.serviceStrategies[s.Service] = h.parseServiceStrategies(s)
 
 		// Merge with the default operation strategies, because only merging with
 		// the default strategy has no effect on service strategies (the default strategy
@@ -247,14 +247,14 @@ func (h *samplingProvider) parseStrategies_deprecated(options Options, strategie
 	h.storedStrategies.Store(newStore)
 }
 
-func (h *samplingProvider) parseStrategies(options Options, strategies *strategies) {
-	newStore := defaultStrategies(options.DefaultSamplingProbability)
+func (h *samplingProvider) parseStrategies(strategies *strategies) {
+	newStore := defaultStrategies(h.options.DefaultSamplingProbability)
 	if strategies.DefaultStrategy != nil {
-		newStore.defaultStrategy = h.parseServiceStrategies(options, strategies.DefaultStrategy)
+		newStore.defaultStrategy = h.parseServiceStrategies(strategies.DefaultStrategy)
 	}
 
 	for _, s := range strategies.ServiceStrategies {
-		newStore.serviceStrategies[s.Service] = h.parseServiceStrategies(options, s)
+		newStore.serviceStrategies[s.Service] = h.parseServiceStrategies(s)
 
 		// Config for this service may not have per-operation strategies,
 		// but if the default strategy has them they should still apply.
@@ -302,19 +302,19 @@ func mergePerOperationSamplingStrategies(
 	return a
 }
 
-func (h *samplingProvider) parseServiceStrategies(options Options, strategy *serviceStrategy) *api_v2.SamplingStrategyResponse {
-	resp := h.parseStrategy(options, &strategy.strategy)
+func (h *samplingProvider) parseServiceStrategies(strategy *serviceStrategy) *api_v2.SamplingStrategyResponse {
+	resp := h.parseStrategy(&strategy.strategy)
 	if len(strategy.OperationStrategies) == 0 {
 		return resp
 	}
 	opS := &api_v2.PerOperationSamplingStrategies{
-		DefaultSamplingProbability: options.DefaultSamplingProbability,
+		DefaultSamplingProbability: h.options.DefaultSamplingProbability,
 	}
 	if resp.StrategyType == api_v2.SamplingStrategyType_PROBABILISTIC {
 		opS.DefaultSamplingProbability = resp.ProbabilisticSampling.SamplingRate
 	}
 	for _, operationStrategy := range strategy.OperationStrategies {
-		s, ok := h.parseOperationStrategy(options, operationStrategy, opS)
+		s, ok := h.parseOperationStrategy(operationStrategy, opS)
 		if !ok {
 			continue
 		}
@@ -330,11 +330,10 @@ func (h *samplingProvider) parseServiceStrategies(options Options, strategy *ser
 }
 
 func (h *samplingProvider) parseOperationStrategy(
-	options Options,
 	strategy *operationStrategy,
 	parent *api_v2.PerOperationSamplingStrategies,
 ) (s *api_v2.SamplingStrategyResponse, ok bool) {
-	s = h.parseStrategy(options, &strategy.strategy)
+	s = h.parseStrategy(&strategy.strategy)
 	if s.StrategyType == api_v2.SamplingStrategyType_RATE_LIMITING {
 		// TODO OperationSamplingStrategy only supports probabilistic sampling
 		h.logger.Warn(
@@ -348,7 +347,7 @@ func (h *samplingProvider) parseOperationStrategy(
 	return s, true
 }
 
-func (h *samplingProvider) parseStrategy(options Options, strategy *strategy) *api_v2.SamplingStrategyResponse {
+func (h *samplingProvider) parseStrategy(strategy *strategy) *api_v2.SamplingStrategyResponse {
 	switch strategy.Type {
 	case samplerTypeProbabilistic:
 		return &api_v2.SamplingStrategyResponse{
@@ -366,7 +365,7 @@ func (h *samplingProvider) parseStrategy(options Options, strategy *strategy) *a
 		}
 	default:
 		h.logger.Warn("Failed to parse sampling strategy", zap.Any("strategy", strategy))
-		return defaultStrategyResponse(options.DefaultSamplingProbability)
+		return defaultStrategyResponse(h.options.DefaultSamplingProbability)
 	}
 }
 

--- a/plugin/sampling/strategyprovider/static/provider_test.go
+++ b/plugin/sampling/strategyprovider/static/provider_test.go
@@ -94,16 +94,16 @@ func mockStrategyServer(t *testing.T) (*httptest.Server, *atomic.Pointer[string]
 }
 
 func TestStrategyStoreWithFile(t *testing.T) {
-	_, err := NewProvider(Options{StrategiesFile: "fileNotFound.json", DefaultSamplingProbability: DefaultDefaultSamplingProbability}, zap.NewNop())
+	_, err := NewProvider(Options{StrategiesFile: "fileNotFound.json", DefaultSamplingProbability: DefaultSamplingProbability}, zap.NewNop())
 	require.ErrorContains(t, err, "failed to read strategies file fileNotFound.json")
 
-	_, err = NewProvider(Options{StrategiesFile: "fixtures/bad_strategies.json", DefaultSamplingProbability: DefaultDefaultSamplingProbability}, zap.NewNop())
+	_, err = NewProvider(Options{StrategiesFile: "fixtures/bad_strategies.json", DefaultSamplingProbability: DefaultSamplingProbability}, zap.NewNop())
 	require.EqualError(t, err,
 		"failed to unmarshal strategies: json: cannot unmarshal string into Go value of type static.strategies")
 
 	// Test default strategy
 	logger, buf := testutils.NewLogger()
-	provider, err := NewProvider(Options{DefaultSamplingProbability: DefaultDefaultSamplingProbability}, logger)
+	provider, err := NewProvider(Options{DefaultSamplingProbability: DefaultSamplingProbability}, logger)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No sampling strategies source provided, using defaults")
 	s, err := provider.GetSamplingStrategy(context.Background(), "foo")
@@ -130,7 +130,7 @@ func TestStrategyStoreWithURL(t *testing.T) {
 	// Test default strategy when URL is temporarily unavailable.
 	logger, buf := testutils.NewLogger()
 	mockServer, _ := mockStrategyServer(t)
-	provider, err := NewProvider(Options{StrategiesFile: mockServer.URL + "/service-unavailable", DefaultSamplingProbability: DefaultDefaultSamplingProbability}, logger)
+	provider, err := NewProvider(Options{StrategiesFile: mockServer.URL + "/service-unavailable", DefaultSamplingProbability: DefaultSamplingProbability}, logger)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No sampling strategies found or URL is unavailable, using defaults")
 	s, err := provider.GetSamplingStrategy(context.Background(), "foo")
@@ -154,11 +154,11 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 	tests := []struct {
 		options Options
 	}{
-		{Options{StrategiesFile: "fixtures/operation_strategies.json", DefaultSamplingProbability: DefaultDefaultSamplingProbability}},
+		{Options{StrategiesFile: "fixtures/operation_strategies.json", DefaultSamplingProbability: DefaultSamplingProbability}},
 		{Options{
 			StrategiesFile:             "fixtures/operation_strategies.json",
 			IncludeDefaultOpStrategies: true,
-			DefaultSamplingProbability: DefaultDefaultSamplingProbability,
+			DefaultSamplingProbability: DefaultSamplingProbability,
 		}},
 	}
 
@@ -246,11 +246,11 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 
 func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 	logger, buf := testutils.NewLogger()
-	provider, err := NewProvider(Options{StrategiesFile: "fixtures/missing-service-types.json", DefaultSamplingProbability: DefaultDefaultSamplingProbability}, logger)
+	provider, err := NewProvider(Options{StrategiesFile: "fixtures/missing-service-types.json", DefaultSamplingProbability: DefaultSamplingProbability}, logger)
 	assert.Contains(t, buf.String(), "Failed to parse sampling strategy")
 	require.NoError(t, err)
 
-	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, DefaultDefaultSamplingProbability)
+	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, DefaultSamplingProbability)
 
 	s, err := provider.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
@@ -259,12 +259,12 @@ func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 
 	require.NotNil(t, s.OperationSampling)
 	opSampling := s.OperationSampling
-	assert.InDelta(t, DefaultDefaultSamplingProbability, opSampling.DefaultSamplingProbability, 1e-4)
+	assert.InDelta(t, DefaultSamplingProbability, opSampling.DefaultSamplingProbability, 1e-4)
 	require.Len(t, opSampling.PerOperationStrategies, 1)
 	assert.Equal(t, "op1", opSampling.PerOperationStrategies[0].Operation)
 	assert.InDelta(t, 0.2, opSampling.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate, 0.001)
 
-	expected = makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, DefaultDefaultSamplingProbability)
+	expected = makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, DefaultSamplingProbability)
 
 	s, err = provider.GetSamplingStrategy(context.Background(), "bar")
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestParseStrategy(t *testing.T) {
 		},
 	}
 	logger, buf := testutils.NewLogger()
-	provider := &samplingProvider{options: Options{DefaultSamplingProbability: DefaultDefaultSamplingProbability}, logger: logger}
+	provider := &samplingProvider{options: Options{DefaultSamplingProbability: DefaultSamplingProbability}, logger: logger}
 	for _, test := range tests {
 		tt := test
 		t.Run("", func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 func TestAutoUpdateStrategyWithURL(t *testing.T) {
 	mockServer, mockStrategy := mockStrategyServer(t)
 	ss, err := NewProvider(Options{
-		DefaultSamplingProbability: DefaultDefaultSamplingProbability,
+		DefaultSamplingProbability: DefaultSamplingProbability,
 		StrategiesFile:             mockServer.URL,
 		ReloadInterval:             10 * time.Millisecond,
 	}, zap.NewNop())

--- a/plugin/sampling/strategyprovider/static/provider_test.go
+++ b/plugin/sampling/strategyprovider/static/provider_test.go
@@ -94,16 +94,16 @@ func mockStrategyServer(t *testing.T) (*httptest.Server, *atomic.Pointer[string]
 }
 
 func TestStrategyStoreWithFile(t *testing.T) {
-	_, err := NewProvider(Options{StrategiesFile: "fileNotFound.json"}, zap.NewNop())
+	_, err := NewProvider(Options{StrategiesFile: "fileNotFound.json", DefaultSamplingProbability: defaultDefaultSamplingProbability}, zap.NewNop())
 	require.ErrorContains(t, err, "failed to read strategies file fileNotFound.json")
 
-	_, err = NewProvider(Options{StrategiesFile: "fixtures/bad_strategies.json"}, zap.NewNop())
+	_, err = NewProvider(Options{StrategiesFile: "fixtures/bad_strategies.json", DefaultSamplingProbability: defaultDefaultSamplingProbability}, zap.NewNop())
 	require.EqualError(t, err,
 		"failed to unmarshal strategies: json: cannot unmarshal string into Go value of type static.strategies")
 
 	// Test default strategy
 	logger, buf := testutils.NewLogger()
-	provider, err := NewProvider(Options{}, logger)
+	provider, err := NewProvider(Options{DefaultSamplingProbability: defaultDefaultSamplingProbability}, logger)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No sampling strategies source provided, using defaults")
 	s, err := provider.GetSamplingStrategy(context.Background(), "foo")
@@ -130,7 +130,7 @@ func TestStrategyStoreWithURL(t *testing.T) {
 	// Test default strategy when URL is temporarily unavailable.
 	logger, buf := testutils.NewLogger()
 	mockServer, _ := mockStrategyServer(t)
-	provider, err := NewProvider(Options{StrategiesFile: mockServer.URL + "/service-unavailable"}, logger)
+	provider, err := NewProvider(Options{StrategiesFile: mockServer.URL + "/service-unavailable", DefaultSamplingProbability: defaultDefaultSamplingProbability}, logger)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No sampling strategies found or URL is unavailable, using defaults")
 	s, err := provider.GetSamplingStrategy(context.Background(), "foo")
@@ -154,10 +154,11 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 	tests := []struct {
 		options Options
 	}{
-		{Options{StrategiesFile: "fixtures/operation_strategies.json"}},
+		{Options{StrategiesFile: "fixtures/operation_strategies.json", DefaultSamplingProbability: defaultDefaultSamplingProbability}},
 		{Options{
 			StrategiesFile:             "fixtures/operation_strategies.json",
 			IncludeDefaultOpStrategies: true,
+			DefaultSamplingProbability: defaultDefaultSamplingProbability,
 		}},
 	}
 
@@ -245,11 +246,11 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 
 func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 	logger, buf := testutils.NewLogger()
-	provider, err := NewProvider(Options{StrategiesFile: "fixtures/missing-service-types.json"}, logger)
+	provider, err := NewProvider(Options{StrategiesFile: "fixtures/missing-service-types.json", DefaultSamplingProbability: defaultDefaultSamplingProbability}, logger)
 	assert.Contains(t, buf.String(), "Failed to parse sampling strategy")
 	require.NoError(t, err)
 
-	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultDefaultSamplingProbability)
 
 	s, err := provider.GetSamplingStrategy(context.Background(), "foo")
 	require.NoError(t, err)
@@ -258,12 +259,12 @@ func TestMissingServiceSamplingStrategyTypes(t *testing.T) {
 
 	require.NotNil(t, s.OperationSampling)
 	opSampling := s.OperationSampling
-	assert.InDelta(t, defaultSamplingProbability, opSampling.DefaultSamplingProbability, 1e-4)
+	assert.InDelta(t, defaultDefaultSamplingProbability, opSampling.DefaultSamplingProbability, 1e-4)
 	require.Len(t, opSampling.PerOperationStrategies, 1)
 	assert.Equal(t, "op1", opSampling.PerOperationStrategies[0].Operation)
 	assert.InDelta(t, 0.2, opSampling.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate, 0.001)
 
-	expected = makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+	expected = makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultDefaultSamplingProbability)
 
 	s, err = provider.GetSamplingStrategy(context.Background(), "bar")
 	require.NoError(t, err)
@@ -305,18 +306,18 @@ func TestParseStrategy(t *testing.T) {
 		},
 	}
 	logger, buf := testutils.NewLogger()
-	provider := &samplingProvider{logger: logger}
+	provider := &samplingProvider{options: Options{DefaultSamplingProbability: defaultDefaultSamplingProbability}, logger: logger}
 	for _, test := range tests {
 		tt := test
 		t.Run("", func(t *testing.T) {
-			assert.EqualValues(t, tt.expected, *provider.parseStrategy(&tt.strategy.strategy))
+			assert.EqualValues(t, tt.expected, *provider.parseStrategy(provider.options, &tt.strategy.strategy))
 		})
 	}
 	assert.Empty(t, buf.String())
 
 	// Test nonexistent strategy type
-	actual := *provider.parseStrategy(&strategy{Type: "blah", Param: 3.5})
-	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, defaultSamplingProbability)
+	actual := *provider.parseStrategy(provider.options, &strategy{Type: "blah", Param: 3.5})
+	expected := makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, provider.options.DefaultSamplingProbability)
 	assert.EqualValues(t, expected, actual)
 	assert.Contains(t, buf.String(), "Failed to parse sampling strategy")
 }
@@ -374,7 +375,7 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 	assert.EqualValues(t, makeResponse(api_v2.SamplingStrategyType_PROBABILISTIC, 0.8), *s)
 
 	// verify that reloading is a no-op
-	value := provider.reloadSamplingStrategy(provider.samplingStrategyLoader(dstFile), string(srcBytes))
+	value := provider.reloadSamplingStrategy(provider.options, provider.samplingStrategyLoader(dstFile), string(srcBytes))
 	assert.Equal(t, string(srcBytes), value)
 
 	// update file with new probability of 0.9
@@ -396,8 +397,9 @@ func TestAutoUpdateStrategyWithFile(t *testing.T) {
 func TestAutoUpdateStrategyWithURL(t *testing.T) {
 	mockServer, mockStrategy := mockStrategyServer(t)
 	ss, err := NewProvider(Options{
-		StrategiesFile: mockServer.URL,
-		ReloadInterval: 10 * time.Millisecond,
+		DefaultSamplingProbability: defaultDefaultSamplingProbability,
+		StrategiesFile:             mockServer.URL,
+		ReloadInterval:             10 * time.Millisecond,
 	}, zap.NewNop())
 	require.NoError(t, err)
 	provider := ss.(*samplingProvider)
@@ -410,6 +412,7 @@ func TestAutoUpdateStrategyWithURL(t *testing.T) {
 
 	// verify that reloading in no-op
 	value := provider.reloadSamplingStrategy(
+		provider.options,
 		provider.samplingStrategyLoader(mockServer.URL),
 		*mockStrategy.Load(),
 	)
@@ -452,25 +455,25 @@ func TestAutoUpdateStrategyErrors(t *testing.T) {
 	defer provider.Close()
 
 	// check invalid file path or read failure
-	assert.Equal(t, "blah", provider.reloadSamplingStrategy(provider.samplingStrategyLoader(tempFile.Name()+"bad-path"), "blah"))
+	assert.Equal(t, "blah", provider.reloadSamplingStrategy(provider.options, provider.samplingStrategyLoader(tempFile.Name()+"bad-path"), "blah"))
 	assert.Len(t, logs.FilterMessage("failed to re-load sampling strategies").All(), 1)
 
 	// check bad file content
 	require.NoError(t, os.WriteFile(tempFile.Name(), []byte("bad value"), 0o644))
-	assert.Equal(t, "blah", provider.reloadSamplingStrategy(provider.samplingStrategyLoader(tempFile.Name()), "blah"))
+	assert.Equal(t, "blah", provider.reloadSamplingStrategy(provider.options, provider.samplingStrategyLoader(tempFile.Name()), "blah"))
 	assert.Len(t, logs.FilterMessage("failed to update sampling strategies").All(), 1)
 
 	// check invalid url
-	assert.Equal(t, "duh", provider.reloadSamplingStrategy(provider.samplingStrategyLoader("bad-url"), "duh"))
+	assert.Equal(t, "duh", provider.reloadSamplingStrategy(provider.options, provider.samplingStrategyLoader("bad-url"), "duh"))
 	assert.Len(t, logs.FilterMessage("failed to re-load sampling strategies").All(), 2)
 
 	// check status code other than 200
 	mockServer, _ := mockStrategyServer(t)
-	assert.Equal(t, "duh", provider.reloadSamplingStrategy(provider.samplingStrategyLoader(mockServer.URL+"/bad-status"), "duh"))
+	assert.Equal(t, "duh", provider.reloadSamplingStrategy(provider.options, provider.samplingStrategyLoader(mockServer.URL+"/bad-status"), "duh"))
 	assert.Len(t, logs.FilterMessage("failed to re-load sampling strategies").All(), 3)
 
 	// check bad content from url
-	assert.Equal(t, "duh", provider.reloadSamplingStrategy(provider.samplingStrategyLoader(mockServer.URL+"/bad-content"), "duh"))
+	assert.Equal(t, "duh", provider.reloadSamplingStrategy(provider.options, provider.samplingStrategyLoader(mockServer.URL+"/bad-content"), "duh"))
 	assert.Len(t, logs.FilterMessage("failed to update sampling strategies").All(), 2)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- fix #6338 

## Description of the changes
-  Removed the hardcoded path in the default configuration (all-in-one.yaml).
- updated tests accordingly

## How was this change tested?
- Since some of the tests are using hardcoded services in ```sampling-strategies.json``` (the service "foo").
https://github.com/jaegertracing/jaeger/blob/b02900cd99b38a79f70d9ba14f631307ded84764/cmd/jaeger/internal/extension/remotesampling/extension_test.go#L83
the ```sampling-strategies.json``` file could not be removed
- Also, right now there are some tests, namely:
1.) TestServerHTTP_TracesRequest,
2.) all 3 tests in cmd/query/app
which are not passing even on the main branch itself (according to me, otherwise I have made some mistake), and hence these same tests are not passing after I made my changes (my changes should not affect them anyway). 


## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`