### PR TITLE
[refactor][query] Propagate `RawTraces` flag to  query service

### DIFF
--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -68,11 +68,13 @@ func (h *Handler) internalFindTraces(
 		return errors.New("start time min and max are required parameters")
 	}
 
-	queryParams := &spanstore.TraceQueryParameters{
-		ServiceName:   query.GetServiceName(),
-		OperationName: query.GetOperationName(),
-		Tags:          query.GetAttributes(),
-		NumTraces:     int(query.GetSearchDepth()),
+	queryParams := &querysvc.TraceQueryParameters{
+		TraceQueryParameters: spanstore.TraceQueryParameters{
+			ServiceName:   query.GetServiceName(),
+			OperationName: query.GetOperationName(),
+			Tags:          query.GetAttributes(),
+			NumTraces:     int(query.GetSearchDepth()),
+		},
 	}
 	if ts := query.GetStartTimeMin(); !ts.IsZero() {
 		queryParams.StartTimeMin = ts

--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -38,6 +38,7 @@ func (h *Handler) GetTrace(request *api_v3.GetTraceRequest, stream api_v3.QueryS
 			StartTime: request.GetStartTime(),
 			EndTime:   request.GetEndTime(),
 		},
+		RawTraces: request.GetRawTraces(),
 	}
 	trace, err := h.QueryService.GetTrace(stream.Context(), query)
 	if err != nil {
@@ -75,6 +76,7 @@ func (h *Handler) internalFindTraces(
 			Tags:          query.GetAttributes(),
 			NumTraces:     int(query.GetSearchDepth()),
 		},
+		RawTraces: query.GetRawTraces(),
 	}
 	if ts := query.GetStartTimeMin(); !ts.IsZero() {
 		queryParams.StartTimeMin = ts

--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -32,10 +32,12 @@ func (h *Handler) GetTrace(request *api_v3.GetTraceRequest, stream api_v3.QueryS
 		return fmt.Errorf("malform trace ID: %w", err)
 	}
 
-	query := spanstore.GetTraceParameters{
-		TraceID:   traceID,
-		StartTime: request.GetStartTime(),
-		EndTime:   request.GetEndTime(),
+	query := querysvc.GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID:   traceID,
+			StartTime: request.GetStartTime(),
+			EndTime:   request.GetEndTime(),
+		},
 	}
 	trace, err := h.QueryService.GetTrace(stream.Context(), query)
 	if err != nil {

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -182,11 +182,13 @@ func (h *HTTPGateway) findTraces(w http.ResponseWriter, r *http.Request) {
 	h.returnSpans(spans, w)
 }
 
-func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*spanstore.TraceQueryParameters, bool) {
-	queryParams := &spanstore.TraceQueryParameters{
-		ServiceName:   q.Get(paramServiceName),
-		OperationName: q.Get(paramOperationName),
-		Tags:          nil, // most curiously not supported by grpc-gateway
+func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*querysvc.TraceQueryParameters, bool) {
+	queryParams := &querysvc.TraceQueryParameters{
+		TraceQueryParameters: spanstore.TraceQueryParameters{
+			ServiceName:   q.Get(paramServiceName),
+			OperationName: q.Get(paramOperationName),
+			Tags:          nil, // most curiously not supported by grpc-gateway
+		},
 	}
 
 	timeMin := q.Get(paramTimeMin)

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -135,8 +135,10 @@ func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 	if h.tryParamError(w, err, paramTraceID) {
 		return
 	}
-	request := spanstore.GetTraceParameters{
-		TraceID: traceID,
+	request := querysvc.GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: traceID,
+		},
 	}
 	http_query := r.URL.Query()
 	startTime := http_query.Get(paramStartTime)

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -27,17 +27,18 @@ import (
 )
 
 const (
-	paramTraceID       = "trace_id" // get trace by ID
-	paramStartTime     = "start_time"
-	paramEndTime       = "end_time"
-	paramServiceName   = "query.service_name" // find traces
-	paramOperationName = "query.operation_name"
-	paramTimeMin       = "query.start_time_min"
-	paramTimeMax       = "query.start_time_max"
-	paramNumTraces     = "query.num_traces"
-	paramDurationMin   = "query.duration_min"
-	paramDurationMax   = "query.duration_max"
-	paramRawTraces     = "query.raw_traces"
+	paramTraceID        = "trace_id" // get trace by ID
+	paramStartTime      = "start_time"
+	paramEndTime        = "end_time"
+	paramRawTraces      = "raw_traces"
+	paramServiceName    = "query.service_name" // find traces
+	paramOperationName  = "query.operation_name"
+	paramTimeMin        = "query.start_time_min"
+	paramTimeMax        = "query.start_time_max"
+	paramNumTraces      = "query.num_traces"
+	paramDurationMin    = "query.duration_min"
+	paramDurationMax    = "query.duration_max"
+	paramQueryRawTraces = "query.raw_traces"
 
 	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
 	routeFindTraces    = "/api/v3/traces"
@@ -239,9 +240,9 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		}
 		queryParams.DurationMax = dur
 	}
-	if r := q.Get(paramRawTraces); r != "" {
+	if r := q.Get(paramQueryRawTraces); r != "" {
 		rawTraces, err := strconv.ParseBool(r)
-		if h.tryParamError(w, err, paramRawTraces) {
+		if h.tryParamError(w, err, paramQueryRawTraces) {
 			return nil, true
 		}
 		queryParams.RawTraces = rawTraces

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -37,6 +37,7 @@ const (
 	paramNumTraces     = "query.num_traces"
 	paramDurationMin   = "query.duration_min"
 	paramDurationMax   = "query.duration_max"
+	paramRawTraces     = "query.raw_traces"
 
 	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
 	routeFindTraces    = "/api/v3/traces"
@@ -157,6 +158,13 @@ func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 		}
 		request.EndTime = timeParsed.UTC()
 	}
+	if r := http_query.Get(paramRawTraces); r != "" {
+		rawTraces, err := strconv.ParseBool(r)
+		if h.tryParamError(w, err, paramRawTraces) {
+			return
+		}
+		request.RawTraces = rawTraces
+	}
 	trc, err := h.QueryService.GetTrace(r.Context(), request)
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {
 		return
@@ -230,6 +238,13 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 			return nil, true
 		}
 		queryParams.DurationMax = dur
+	}
+	if r := q.Get(paramRawTraces); r != "" {
+		rawTraces, err := strconv.ParseBool(r)
+		if h.tryParamError(w, err, paramRawTraces) {
+			return nil, true
+		}
+		queryParams.RawTraces = rawTraces
 	}
 	return queryParams, false
 }

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -232,6 +232,7 @@ func mockFindQueries() (url.Values, *spanstore.TraceQueryParameters) {
 func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 	goodTimeV := time.Now()
 	goodTime := goodTimeV.Format(time.RFC3339Nano)
+	goodDuration := "1s"
 	timeRangeErr := fmt.Sprintf("%s and %s are required", paramTimeMin, paramTimeMax)
 	testCases := []struct {
 		name   string
@@ -276,6 +277,16 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 			name:   "bad max duration",
 			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMax: "NaN"},
 			expErr: paramDurationMax,
+		},
+		{
+			name: "bad raw traces",
+			params: map[string]string{
+				paramTimeMin:        goodTime,
+				paramTimeMax:        goodTime,
+				paramDurationMax:    goodDuration,
+				paramQueryRawTraces: "foobar",
+			},
+			expErr: paramQueryRawTraces,
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -169,8 +169,8 @@ func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 		},
 		{
 			name:          "TestGetTraceWithInvalidRawTraces",
-			requestUrl:    "/api/v3/traces/123?query.raw_traces=foobar",
-			expectedError: "malformed parameter query.raw_traces",
+			requestUrl:    "/api/v3/traces/123?raw_traces=foobar",
+			expectedError: "malformed parameter raw_traces",
 		},
 	}
 

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -167,6 +167,11 @@ func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 			requestUrl:    "/api/v3/traces/123?end_time=xyz",
 			expectedError: "malformed parameter end_time",
 		},
+		{
+			name:          "TestGetTraceWithInvalidRawTraces",
+			requestUrl:    "/api/v3/traces/123?query.raw_traces=foobar",
+			expectedError: "malformed parameter query.raw_traces",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -117,13 +117,12 @@ func (g *GRPCHandler) ArchiveTrace(ctx context.Context, r *api_v2.ArchiveTraceRe
 	if r.TraceID == (model.TraceID{}) {
 		return nil, errUninitializedTraceID
 	}
-	query := querysvc.GetTraceParameters{
-		GetTraceParameters: spanstore.GetTraceParameters{
-			TraceID:   r.TraceID,
-			StartTime: r.StartTime,
-			EndTime:   r.EndTime,
-		},
+	query := spanstore.GetTraceParameters{
+		TraceID:   r.TraceID,
+		StartTime: r.StartTime,
+		EndTime:   r.EndTime,
 	}
+
 	err := g.queryService.ArchiveTrace(ctx, query)
 	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		g.logger.Warn(msgTraceNotFound, zap.Stringer("id", r.TraceID), zap.Error(err))

--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -95,6 +95,7 @@ func (g *GRPCHandler) GetTrace(r *api_v2.GetTraceRequest, stream api_v2.QuerySer
 			StartTime: r.StartTime,
 			EndTime:   r.EndTime,
 		},
+		RawTraces: r.RawTraces,
 	}
 	trace, err := g.queryService.GetTrace(stream.Context(), query)
 	if errors.Is(err, spanstore.ErrTraceNotFound) {
@@ -156,6 +157,7 @@ func (g *GRPCHandler) FindTraces(r *api_v2.FindTracesRequest, stream api_v2.Quer
 			DurationMax:   query.DurationMax,
 			NumTraces:     int(query.SearchDepth),
 		},
+		RawTraces: query.RawTraces,
 	}
 	traces, err := g.queryService.FindTraces(stream.Context(), &queryParams)
 	if err != nil {

--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -89,10 +89,12 @@ func (g *GRPCHandler) GetTrace(r *api_v2.GetTraceRequest, stream api_v2.QuerySer
 	if r.TraceID == (model.TraceID{}) {
 		return errUninitializedTraceID
 	}
-	query := spanstore.GetTraceParameters{
-		TraceID:   r.TraceID,
-		StartTime: r.StartTime,
-		EndTime:   r.EndTime,
+	query := querysvc.GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID:   r.TraceID,
+			StartTime: r.StartTime,
+			EndTime:   r.EndTime,
+		},
 	}
 	trace, err := g.queryService.GetTrace(stream.Context(), query)
 	if errors.Is(err, spanstore.ErrTraceNotFound) {
@@ -114,10 +116,12 @@ func (g *GRPCHandler) ArchiveTrace(ctx context.Context, r *api_v2.ArchiveTraceRe
 	if r.TraceID == (model.TraceID{}) {
 		return nil, errUninitializedTraceID
 	}
-	query := spanstore.GetTraceParameters{
-		TraceID:   r.TraceID,
-		StartTime: r.StartTime,
-		EndTime:   r.EndTime,
+	query := querysvc.GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID:   r.TraceID,
+			StartTime: r.StartTime,
+			EndTime:   r.EndTime,
+		},
 	}
 	err := g.queryService.ArchiveTrace(ctx, query)
 	if errors.Is(err, spanstore.ErrTraceNotFound) {

--- a/cmd/query/app/grpc_handler.go
+++ b/cmd/query/app/grpc_handler.go
@@ -145,15 +145,17 @@ func (g *GRPCHandler) FindTraces(r *api_v2.FindTracesRequest, stream api_v2.Quer
 	if query == nil {
 		return status.Errorf(codes.InvalidArgument, "missing query")
 	}
-	queryParams := spanstore.TraceQueryParameters{
-		ServiceName:   query.ServiceName,
-		OperationName: query.OperationName,
-		Tags:          query.Tags,
-		StartTimeMin:  query.StartTimeMin,
-		StartTimeMax:  query.StartTimeMax,
-		DurationMin:   query.DurationMin,
-		DurationMax:   query.DurationMax,
-		NumTraces:     int(query.SearchDepth),
+	queryParams := querysvc.TraceQueryParameters{
+		TraceQueryParameters: spanstore.TraceQueryParameters{
+			ServiceName:   query.ServiceName,
+			OperationName: query.OperationName,
+			Tags:          query.Tags,
+			StartTimeMin:  query.StartTimeMin,
+			StartTimeMax:  query.StartTimeMax,
+			DurationMin:   query.DurationMin,
+			DurationMax:   query.DurationMax,
+			NumTraces:     int(query.SearchDepth),
+		},
 	}
 	traces, err := g.queryService.FindTraces(stream.Context(), &queryParams)
 	if err != nil {

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -502,7 +502,7 @@ func (aH *APIHandler) archiveTrace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// QueryService.ArchiveTrace can now archive this traceID.
-	err := aH.queryService.ArchiveTrace(r.Context(), query)
+	err := aH.queryService.ArchiveTrace(r.Context(), query.GetTraceParameters)
 	if errors.Is(err, spanstore.ErrTraceNotFound) {
 		aH.handleError(w, err, http.StatusNotFound)
 		return

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -268,10 +268,12 @@ func (aH *APIHandler) tracesByIDs(ctx context.Context, traceIDs []model.TraceID,
 	var traceErrors []structuredError
 	retMe := make([]*model.Trace, 0, len(traceIDs))
 	for _, traceID := range traceIDs {
-		query := spanstore.GetTraceParameters{
-			TraceID:   traceID,
-			StartTime: startTime,
-			EndTime:   endTime,
+		query := querysvc.GetTraceParameters{
+			GetTraceParameters: spanstore.GetTraceParameters{
+				TraceID:   traceID,
+				StartTime: startTime,
+				EndTime:   endTime,
+			},
 		}
 		if trc, err := aH.queryService.GetTrace(ctx, query); err != nil {
 			if !errors.Is(err, spanstore.ErrTraceNotFound) {
@@ -428,8 +430,8 @@ func (aH *APIHandler) parseMicroseconds(w http.ResponseWriter, r *http.Request, 
 	return time.Time{}, true
 }
 
-func (aH *APIHandler) parseGetTraceParameters(w http.ResponseWriter, r *http.Request) (spanstore.GetTraceParameters, bool) {
-	query := spanstore.GetTraceParameters{}
+func (aH *APIHandler) parseGetTraceParameters(w http.ResponseWriter, r *http.Request) (querysvc.GetTraceParameters, bool) {
+	query := querysvc.GetTraceParameters{}
 	traceID, ok := aH.parseTraceID(w, r)
 	if !ok {
 		return query, false

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -430,6 +430,17 @@ func (aH *APIHandler) parseMicroseconds(w http.ResponseWriter, r *http.Request, 
 	return time.Time{}, true
 }
 
+func (aH *APIHandler) parseBool(w http.ResponseWriter, r *http.Request, boolKey string) (bool, bool) {
+	if boolString := r.FormValue(boolKey); boolString != "" {
+		b, err := parseBool(r, boolKey)
+		if aH.handleError(w, err, http.StatusBadRequest) {
+			return false, false
+		}
+		return b, true
+	}
+	return false, true
+}
+
 func (aH *APIHandler) parseGetTraceParameters(w http.ResponseWriter, r *http.Request) (querysvc.GetTraceParameters, bool) {
 	query := querysvc.GetTraceParameters{}
 	traceID, ok := aH.parseTraceID(w, r)
@@ -444,9 +455,14 @@ func (aH *APIHandler) parseGetTraceParameters(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return query, false
 	}
+	raw, ok := aH.parseBool(w, r, rawParam)
+	if !ok {
+		return query, false
+	}
 	query.TraceID = traceID
 	query.StartTime = startTime
 	query.EndTime = endTime
+	query.RawTraces = raw
 	return query, true
 }
 

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -430,7 +430,7 @@ func (aH *APIHandler) parseMicroseconds(w http.ResponseWriter, r *http.Request, 
 	return time.Time{}, true
 }
 
-func (aH *APIHandler) parseBool(w http.ResponseWriter, r *http.Request, boolKey string) (bool, bool) {
+func (aH *APIHandler) parseBool(w http.ResponseWriter, r *http.Request, boolKey string) (value bool, isValid bool) {
 	if boolString := r.FormValue(boolKey); boolString != "" {
 		b, err := parseBool(r, boolKey)
 		if aH.handleError(w, err, http.StatusBadRequest) {

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -407,6 +407,27 @@ func TestGetTraceBadTimeWindow(t *testing.T) {
 	}
 }
 
+func TestGetTraceWithRawTracesSuccess(t *testing.T) {
+	ts := initializeTestServer(t)
+	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), spanstore.GetTraceParameters{
+		TraceID: mockTraceID,
+	}).Return(mockTrace, nil).Once()
+
+	var response structuredResponse
+	err := getJSON(ts.server.URL+`/api/traces/`+mockTraceID.String()+`?raw=true`, &response)
+	require.NoError(t, err)
+	assert.Empty(t, response.Errors)
+}
+
+func TestGetTraceBadRawTracesFlag(t *testing.T) {
+	ts := initializeTestServer(t)
+	var response structuredResponse
+	err := getJSON(ts.server.URL+`/api/traces/123456?raw=foobar`, &response)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "400 error from server")
+	require.ErrorContains(t, err, "unable to parse param 'raw'")
+}
+
 func TestSearchSuccess(t *testing.T) {
 	ts := initializeTestServer(t)
 	ts.spanReader.On("FindTraces", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*spanstore.TraceQueryParameters")).

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -407,16 +407,32 @@ func TestGetTraceBadTimeWindow(t *testing.T) {
 	}
 }
 
-func TestGetTraceWithRawTracesSuccess(t *testing.T) {
-	ts := initializeTestServer(t)
-	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), spanstore.GetTraceParameters{
-		TraceID: mockTraceID,
-	}).Return(mockTrace, nil).Once()
+func TestGetTraceWithRawTracesParameter(t *testing.T) {
+	// TODO: extend the test cases to ensure raw traces are obtained
+	// when the flag is set once the differentiating logic has been implemented
+	tests := []struct {
+		rawTraces bool
+	}{
+		{
+			rawTraces: true,
+		},
+		{
+			rawTraces: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("rawTraces=%v", test.rawTraces), func(t *testing.T) {
+			ts := initializeTestServer(t)
+			ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), spanstore.GetTraceParameters{
+				TraceID: mockTraceID,
+			}).Return(mockTrace, nil).Once()
 
-	var response structuredResponse
-	err := getJSON(ts.server.URL+`/api/traces/`+mockTraceID.String()+`?raw=true`, &response)
-	require.NoError(t, err)
-	assert.Empty(t, response.Errors)
+			var response structuredResponse
+			err := getJSON(fmt.Sprintf("%s/api/traces/%s?raw=%v", ts.server.URL, mockTraceID.String(), test.rawTraces), &response)
+			require.NoError(t, err)
+			assert.Empty(t, response.Errors)
+		})
+	}
 }
 
 func TestGetTraceBadRawTracesFlag(t *testing.T) {

--- a/cmd/query/app/query_parser.go
+++ b/cmd/query/app/query_parser.go
@@ -34,6 +34,7 @@ const (
 	spanKindParam    = "spanKind"
 	endTimeParam     = "end"
 	prettyPrintParam = "prettyPrint"
+	rawParam         = "raw"
 )
 
 var (
@@ -162,6 +163,11 @@ func (p *queryParser) parseTraceQueryParams(r *http.Request) (*traceQueryParamet
 		traceIDs = append(traceIDs, traceID)
 	}
 
+	raw, err := parseBool(r, rawParam)
+	if err != nil {
+		return nil, err
+	}
+
 	traceQuery := &traceQueryParameters{
 		TraceQueryParameters: querysvc.TraceQueryParameters{
 			TraceQueryParameters: spanstore.TraceQueryParameters{
@@ -174,6 +180,7 @@ func (p *queryParser) parseTraceQueryParams(r *http.Request) (*traceQueryParamet
 				DurationMin:   minDuration,
 				DurationMax:   maxDuration,
 			},
+			RawTraces: raw,
 		},
 		traceIDs: traceIDs,
 	}

--- a/cmd/query/app/query_parser.go
+++ b/cmd/query/app/query_parser.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 	"github.com/jaegertracing/jaeger/storage/metricstore"
@@ -59,7 +60,7 @@ type (
 	}
 
 	traceQueryParameters struct {
-		spanstore.TraceQueryParameters
+		querysvc.TraceQueryParameters
 		traceIDs []model.TraceID
 	}
 
@@ -162,15 +163,17 @@ func (p *queryParser) parseTraceQueryParams(r *http.Request) (*traceQueryParamet
 	}
 
 	traceQuery := &traceQueryParameters{
-		TraceQueryParameters: spanstore.TraceQueryParameters{
-			ServiceName:   service,
-			OperationName: operation,
-			StartTimeMin:  startTime,
-			StartTimeMax:  endTime,
-			Tags:          tags,
-			NumTraces:     limit,
-			DurationMin:   minDuration,
-			DurationMax:   maxDuration,
+		TraceQueryParameters: querysvc.TraceQueryParameters{
+			TraceQueryParameters: spanstore.TraceQueryParameters{
+				ServiceName:   service,
+				OperationName: operation,
+				StartTimeMin:  startTime,
+				StartTimeMax:  endTime,
+				Tags:          tags,
+				NumTraces:     limit,
+				DurationMin:   minDuration,
+				DurationMax:   maxDuration,
+			},
 		},
 		traceIDs: traceIDs,
 	}

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
@@ -40,13 +41,15 @@ func TestParseTraceQuery(t *testing.T) {
 		{
 			"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
 			&traceQueryParameters{
-				TraceQueryParameters: spanstore.TraceQueryParameters{
-					ServiceName:   "service",
-					OperationName: "operation",
-					StartTimeMin:  time.Unix(0, 0),
-					StartTimeMax:  time.Unix(0, 0),
-					NumTraces:     200,
-					Tags:          map[string]string{"k": "v", "x": "y"},
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:   "service",
+						OperationName: "operation",
+						StartTimeMin:  time.Unix(0, 0),
+						StartTimeMax:  time.Unix(0, 0),
+						NumTraces:     200,
+						Tags:          map[string]string{"k": "v", "x": "y"},
+					},
 				},
 			},
 		},
@@ -56,13 +59,15 @@ func TestParseTraceQuery(t *testing.T) {
 		{
 			`x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tags={"x":"y"}`, noErr,
 			&traceQueryParameters{
-				TraceQueryParameters: spanstore.TraceQueryParameters{
-					ServiceName:   "service",
-					OperationName: "operation",
-					StartTimeMin:  time.Unix(0, 0),
-					StartTimeMax:  time.Unix(0, 0),
-					NumTraces:     200,
-					Tags:          map[string]string{"k": "v", "x": "y"},
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:   "service",
+						OperationName: "operation",
+						StartTimeMin:  time.Unix(0, 0),
+						StartTimeMax:  time.Unix(0, 0),
+						NumTraces:     200,
+						Tags:          map[string]string{"k": "v", "x": "y"},
+					},
 				},
 			},
 		},
@@ -70,42 +75,48 @@ func TestParseTraceQuery(t *testing.T) {
 		{
 			`x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tags=%7B%22x%22%3A%22y%22%7D`, noErr,
 			&traceQueryParameters{
-				TraceQueryParameters: spanstore.TraceQueryParameters{
-					ServiceName:   "service",
-					OperationName: "operation",
-					StartTimeMin:  time.Unix(0, 0),
-					StartTimeMax:  time.Unix(0, 0),
-					NumTraces:     200,
-					Tags:          map[string]string{"k": "v", "x": "y"},
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:   "service",
+						OperationName: "operation",
+						StartTimeMin:  time.Unix(0, 0),
+						StartTimeMax:  time.Unix(0, 0),
+						NumTraces:     200,
+						Tags:          map[string]string{"k": "v", "x": "y"},
+					},
 				},
 			},
 		},
 		{
 			"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=10s&maxDuration=20s", noErr,
 			&traceQueryParameters{
-				TraceQueryParameters: spanstore.TraceQueryParameters{
-					ServiceName:   "service",
-					OperationName: "operation",
-					StartTimeMin:  time.Unix(0, 0),
-					StartTimeMax:  time.Unix(0, 0),
-					NumTraces:     200,
-					DurationMin:   10 * time.Second,
-					DurationMax:   20 * time.Second,
-					Tags:          make(map[string]string),
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:   "service",
+						OperationName: "operation",
+						StartTimeMin:  time.Unix(0, 0),
+						StartTimeMax:  time.Unix(0, 0),
+						NumTraces:     200,
+						DurationMin:   10 * time.Second,
+						DurationMax:   20 * time.Second,
+						Tags:          make(map[string]string),
+					},
 				},
 			},
 		},
 		{
 			"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=10s", noErr,
 			&traceQueryParameters{
-				TraceQueryParameters: spanstore.TraceQueryParameters{
-					ServiceName:   "service",
-					OperationName: "operation",
-					StartTimeMin:  time.Unix(0, 0),
-					StartTimeMax:  time.Unix(0, 0),
-					NumTraces:     200,
-					DurationMin:   10 * time.Second,
-					Tags:          make(map[string]string),
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:   "service",
+						OperationName: "operation",
+						StartTimeMin:  time.Unix(0, 0),
+						StartTimeMax:  time.Unix(0, 0),
+						NumTraces:     200,
+						DurationMin:   10 * time.Second,
+						Tags:          make(map[string]string),
+					},
 				},
 			},
 		},
@@ -113,11 +124,13 @@ func TestParseTraceQuery(t *testing.T) {
 		{
 			"x?traceID=1f00&traceID=1E00", noErr,
 			&traceQueryParameters{
-				TraceQueryParameters: spanstore.TraceQueryParameters{
-					NumTraces:    100,
-					StartTimeMin: timeNow,
-					StartTimeMax: timeNow,
-					Tags:         make(map[string]string),
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						NumTraces:    100,
+						StartTimeMin: timeNow,
+						StartTimeMax: timeNow,
+						Tags:         make(map[string]string),
+					},
 				},
 				traceIDs: []model.TraceID{
 					model.NewTraceID(0, 0x1f00),
@@ -128,11 +141,13 @@ func TestParseTraceQuery(t *testing.T) {
 		{
 			"x?traceID=100&traceID=x200", `cannot parse traceID param: strconv.ParseUint: parsing "x200": invalid syntax`,
 			&traceQueryParameters{
-				TraceQueryParameters: spanstore.TraceQueryParameters{
-					StartTimeMin: time.Unix(0, 0),
-					StartTimeMax: time.Unix(0, 0),
-					NumTraces:    100,
-					Tags:         make(map[string]string),
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						StartTimeMin: time.Unix(0, 0),
+						StartTimeMax: time.Unix(0, 0),
+						NumTraces:    100,
+						Tags:         make(map[string]string),
+					},
 				},
 				traceIDs: []model.TraceID{
 					model.NewTraceID(0, 0x100),

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -155,6 +155,52 @@ func TestParseTraceQuery(t *testing.T) {
 				},
 			},
 		},
+		// raw traces
+		{
+			"x?service=service&start=0&end=0&raw=true", noErr,
+			&traceQueryParameters{
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:  "service",
+						StartTimeMin: time.Unix(0, 0),
+						StartTimeMax: time.Unix(0, 0),
+						NumTraces:    100,
+						Tags:         make(map[string]string),
+					},
+					RawTraces: true,
+				},
+			},
+		},
+		{
+			"x?service=service&start=0&end=0&raw=false", noErr,
+			&traceQueryParameters{
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:  "service",
+						StartTimeMin: time.Unix(0, 0),
+						StartTimeMax: time.Unix(0, 0),
+						NumTraces:    100,
+						Tags:         make(map[string]string),
+					},
+					RawTraces: false,
+				},
+			},
+		},
+		{
+			"x?service=service&start=0&end=0&raw=foobar", "unable to parse param 'raw'",
+			&traceQueryParameters{
+				TraceQueryParameters: querysvc.TraceQueryParameters{
+					TraceQueryParameters: spanstore.TraceQueryParameters{
+						ServiceName:  "service",
+						StartTimeMin: time.Unix(0, 0),
+						StartTimeMax: time.Unix(0, 0),
+						NumTraces:    100,
+						Tags:         make(map[string]string),
+					},
+					RawTraces: false,
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		test := tc // capture loop var

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -61,7 +61,7 @@ func NewQueryService(traceReader tracestore.Reader, dependencyReader depstore.Re
 	return qsvc
 }
 
-// GetTraceParameters defines the parameters for querying traces from the query service.
+// GetTraceParameters defines the parameters for querying a single trace from the query service.
 type GetTraceParameters struct {
 	spanstore.GetTraceParameters
 }
@@ -103,13 +103,18 @@ func (qs QueryService) GetOperations(
 	return spanReader.GetOperations(ctx, query)
 }
 
+// GetTraceParameters defines the parameters for querying a batch of traces from the query service.
+type TraceQueryParameters struct {
+	spanstore.TraceQueryParameters
+}
+
 // FindTraces is the queryService implementation of spanstore.Reader.FindTraces
-func (qs QueryService) FindTraces(ctx context.Context, query *spanstore.TraceQueryParameters) ([]*model.Trace, error) {
+func (qs QueryService) FindTraces(ctx context.Context, query *TraceQueryParameters) ([]*model.Trace, error) {
 	spanReader, err := v1adapter.GetV1Reader(qs.traceReader)
 	if err != nil {
 		return nil, err
 	}
-	return spanReader.FindTraces(ctx, query)
+	return spanReader.FindTraces(ctx, &query.TraceQueryParameters)
 }
 
 // ArchiveTrace is the queryService utility to archive traces.

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -64,6 +64,7 @@ func NewQueryService(traceReader tracestore.Reader, dependencyReader depstore.Re
 // GetTraceParameters defines the parameters for querying a single trace from the query service.
 type GetTraceParameters struct {
 	spanstore.GetTraceParameters
+	RawTraces bool
 }
 
 // GetTrace is the queryService implementation of spanstore.Reader.GetTrace
@@ -106,6 +107,7 @@ func (qs QueryService) GetOperations(
 // TraceQueryParameters defines the parameters for querying a batch of traces from the query service.
 type TraceQueryParameters struct {
 	spanstore.TraceQueryParameters
+	RawTraces bool
 }
 
 // FindTraces is the queryService implementation of spanstore.Reader.FindTraces

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -103,7 +103,7 @@ func (qs QueryService) GetOperations(
 	return spanReader.GetOperations(ctx, query)
 }
 
-// GetTraceParameters defines the parameters for querying a batch of traces from the query service.
+// TraceQueryParameters defines the parameters for querying a batch of traces from the query service.
 type TraceQueryParameters struct {
 	spanstore.TraceQueryParameters
 }

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -120,11 +120,11 @@ func (qs QueryService) FindTraces(ctx context.Context, query *TraceQueryParamete
 }
 
 // ArchiveTrace is the queryService utility to archive traces.
-func (qs QueryService) ArchiveTrace(ctx context.Context, query GetTraceParameters) error {
+func (qs QueryService) ArchiveTrace(ctx context.Context, query spanstore.GetTraceParameters) error {
 	if qs.options.ArchiveSpanWriter == nil {
 		return errNoArchiveSpanStorage
 	}
-	trace, err := qs.GetTrace(ctx, query)
+	trace, err := qs.GetTrace(ctx, GetTraceParameters{GetTraceParameters: query})
 	if err != nil {
 		return err
 	}

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -47,6 +47,18 @@ type QueryService struct {
 	options          QueryServiceOptions
 }
 
+// GetTraceParameters defines the parameters for querying a single trace from the query service.
+type GetTraceParameters struct {
+	spanstore.GetTraceParameters
+	RawTraces bool
+}
+
+// TraceQueryParameters defines the parameters for querying a batch of traces from the query service.
+type TraceQueryParameters struct {
+	spanstore.TraceQueryParameters
+	RawTraces bool
+}
+
 // NewQueryService returns a new QueryService.
 func NewQueryService(traceReader tracestore.Reader, dependencyReader depstore.Reader, options QueryServiceOptions) *QueryService {
 	qsvc := &QueryService{
@@ -59,12 +71,6 @@ func NewQueryService(traceReader tracestore.Reader, dependencyReader depstore.Re
 		qsvc.options.Adjuster = adjuster.Sequence(StandardAdjusters(defaultMaxClockSkewAdjust)...)
 	}
 	return qsvc
-}
-
-// GetTraceParameters defines the parameters for querying a single trace from the query service.
-type GetTraceParameters struct {
-	spanstore.GetTraceParameters
-	RawTraces bool
 }
 
 // GetTrace is the queryService implementation of spanstore.Reader.GetTrace
@@ -102,12 +108,6 @@ func (qs QueryService) GetOperations(
 		return nil, err
 	}
 	return spanReader.GetOperations(ctx, query)
-}
-
-// TraceQueryParameters defines the parameters for querying a batch of traces from the query service.
-type TraceQueryParameters struct {
-	spanstore.TraceQueryParameters
-	RawTraces bool
 }
 
 // FindTraces is the queryService implementation of spanstore.Reader.FindTraces

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -225,12 +225,14 @@ func TestFindTraces(t *testing.T) {
 	type contextKey string
 	ctx := context.Background()
 	duration, _ := time.ParseDuration("20ms")
-	params := &spanstore.TraceQueryParameters{
-		ServiceName:   "service",
-		OperationName: "operation",
-		StartTimeMax:  time.Now(),
-		DurationMin:   duration,
-		NumTraces:     200,
+	params := &TraceQueryParameters{
+		TraceQueryParameters: spanstore.TraceQueryParameters{
+			ServiceName:   "service",
+			OperationName: "operation",
+			StartTimeMax:  time.Now(),
+			DurationMin:   duration,
+			NumTraces:     200,
+		},
 	}
 	traces, err := tqs.queryService.FindTraces(context.WithValue(ctx, contextKey("foo"), "bar"), params)
 	require.NoError(t, err)
@@ -244,12 +246,14 @@ func TestFindTraces_V1ReaderNotFound(t *testing.T) {
 	}
 	duration, err := time.ParseDuration("20ms")
 	require.NoError(t, err)
-	params := &spanstore.TraceQueryParameters{
-		ServiceName:   "service",
-		OperationName: "operation",
-		StartTimeMax:  time.Now(),
-		DurationMin:   duration,
-		NumTraces:     200,
+	params := &TraceQueryParameters{
+		TraceQueryParameters: spanstore.TraceQueryParameters{
+			ServiceName:   "service",
+			OperationName: "operation",
+			StartTimeMax:  time.Now(),
+			DurationMin:   duration,
+			NumTraces:     200,
+		},
 	}
 	_, err = qs.FindTraces(context.Background(), params)
 	require.Error(t, err)

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -265,11 +265,10 @@ func TestArchiveTraceNoOptions(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := GetTraceParameters{
-		GetTraceParameters: spanstore.GetTraceParameters{
-			TraceID: mockTraceID,
-		},
+	query := spanstore.GetTraceParameters{
+		TraceID: mockTraceID,
 	}
+
 	err := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	assert.Equal(t, errNoArchiveSpanStorage, err)
 }
@@ -284,10 +283,8 @@ func TestArchiveTraceWithInvalidTraceID(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := GetTraceParameters{
-		GetTraceParameters: spanstore.GetTraceParameters{
-			TraceID: mockTraceID,
-		},
+	query := spanstore.GetTraceParameters{
+		TraceID: mockTraceID,
 	}
 	err := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	assert.Equal(t, spanstore.ErrTraceNotFound, err)
@@ -303,11 +300,10 @@ func TestArchiveTraceWithArchiveWriterError(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := GetTraceParameters{
-		GetTraceParameters: spanstore.GetTraceParameters{
-			TraceID: mockTraceID,
-		},
+	query := spanstore.GetTraceParameters{
+		TraceID: mockTraceID,
 	}
+
 	joinErr := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	// There are two spans in the mockTrace, ArchiveTrace should return a wrapped error.
 	require.EqualError(t, joinErr, "cannot save\ncannot save")
@@ -323,11 +319,10 @@ func TestArchiveTraceSuccess(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := GetTraceParameters{
-		GetTraceParameters: spanstore.GetTraceParameters{
-			TraceID: mockTraceID,
-		},
+	query := spanstore.GetTraceParameters{
+		TraceID: mockTraceID,
 	}
+
 	err := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	require.NoError(t, err)
 }

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -105,7 +105,11 @@ func TestGetTraceSuccess(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	res, err := tqs.queryService.GetTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	require.NoError(t, err)
 	assert.Equal(t, res, mockTrace)
@@ -119,7 +123,11 @@ func TestGetTraceNotFound(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	_, err := tqs.queryService.GetTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	assert.Equal(t, err, spanstore.ErrTraceNotFound)
 }
@@ -129,7 +137,11 @@ func TestGetTrace_V1ReaderNotFound(t *testing.T) {
 	qs := QueryService{
 		traceReader: fr,
 	}
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	_, err := qs.GetTrace(context.Background(), query)
 	require.Error(t, err)
 }
@@ -144,7 +156,11 @@ func TestGetTraceFromArchiveStorage(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	res, err := tqs.queryService.GetTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	require.NoError(t, err)
 	assert.Equal(t, res, mockTrace)
@@ -245,7 +261,11 @@ func TestArchiveTraceNoOptions(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	err := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	assert.Equal(t, errNoArchiveSpanStorage, err)
 }
@@ -260,7 +280,11 @@ func TestArchiveTraceWithInvalidTraceID(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	err := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	assert.Equal(t, spanstore.ErrTraceNotFound, err)
 }
@@ -275,7 +299,11 @@ func TestArchiveTraceWithArchiveWriterError(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	joinErr := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	// There are two spans in the mockTrace, ArchiveTrace should return a wrapped error.
 	require.EqualError(t, joinErr, "cannot save\ncannot save")
@@ -291,7 +319,11 @@ func TestArchiveTraceSuccess(t *testing.T) {
 
 	type contextKey string
 	ctx := context.Background()
-	query := spanstore.GetTraceParameters{TraceID: mockTraceID}
+	query := GetTraceParameters{
+		GetTraceParameters: spanstore.GetTraceParameters{
+			TraceID: mockTraceID,
+		},
+	}
 	err := tqs.queryService.ArchiveTrace(context.WithValue(ctx, contextKey("foo"), "bar"), query)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6417

## Description of the changes
- This PR defines `GetTraceParamaters` and `TraceQueryParameters` inside `package querysvc` that are currently just wrappers around their `package spanstore` counterparts.
- This is done so that additional parameters can be passed into the query service, like the `RawTraces` flag, without having to extend the parameters that are passed into the storage implementations. 

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
