### PR TITLE
Support sampling file reload interval

### DIFF
--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -31,6 +31,7 @@ extensions:
     # We can either use file or adaptive sampling strategy in remote_sampling
     file:
       path: ./cmd/jaeger/sampling-strategies.json
+      reload_interval: 1s
     # adaptive:
     #   sampling_store: some_store
     #   initial_sampling_probability: 0.1

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -5,6 +5,7 @@ package remotesampling
 
 import (
 	"errors"
+	"time"
 
 	"github.com/asaskevich/govalidator"
 	"go.opentelemetry.io/collector/component"
@@ -18,6 +19,7 @@ import (
 var (
 	errNoProvider        = errors.New("no sampling strategy provider specified, expecting 'adaptive' or 'file'")
 	errMultipleProviders = errors.New("only one sampling strategy provider can be specified, 'adaptive' or 'file'")
+	errNegativeInterval  = errors.New("reload interval must be a positive value, or zero to disable automatic reloading")
 )
 
 var (
@@ -36,6 +38,9 @@ type Config struct {
 type FileConfig struct {
 	// File specifies a local file as the source of sampling strategies.
 	Path string `valid:"required" mapstructure:"path"`
+	// ReloadInterval is the time interval to check and reload sampling strategies file
+	ReloadInterval time.Duration `mapstructure:"reload_interval"`
+>>>>>>> Stashed changes
 }
 
 type AdaptiveConfig struct {
@@ -84,6 +89,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.File != nil && cfg.Adaptive != nil {
 		return errMultipleProviders
+	}
+
+	if cfg.File != nil && cfg.File.ReloadInterval < 0 {
+		return errNegativeInterval
 	}
 
 	_, err := govalidator.ValidateStruct(cfg)

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -40,7 +40,6 @@ type FileConfig struct {
 	Path string `valid:"required" mapstructure:"path"`
 	// ReloadInterval is the time interval to check and reload sampling strategies file
 	ReloadInterval time.Duration `mapstructure:"reload_interval"`
->>>>>>> Stashed changes
 }
 
 type AdaptiveConfig struct {

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -52,7 +52,7 @@ func Test_Validate(t *testing.T) {
 			expectedErr: "File.Path: non zero value required",
 		},
 		{
-			name: "File provider can have empty file path",
+			name: "File provider has negative reload interval",
 			config: &Config{
 				File: &FileConfig{Path: "", ReloadInterval: -1},
 			},

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -52,6 +52,13 @@ func Test_Validate(t *testing.T) {
 			expectedErr: "File.Path: non zero value required",
 		},
 		{
+			name: "File provider can have empty file path",
+			config: &Config{
+				File: &FileConfig{Path: "", ReloadInterval: -1},
+			},
+			expectedErr: "must be a positive value",
+		},
+		{
 			name: "Invalid Adaptive provider",
 			config: &Config{
 				Adaptive: &AdaptiveConfig{SamplingStore: ""},
@@ -66,7 +73,7 @@ func Test_Validate(t *testing.T) {
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				assert.Equal(t, tt.expectedErr, err.Error())
+				assert.ErrorContains(t, err, tt.expectedErr)
 			}
 		})
 	}

--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -166,6 +166,7 @@ func (ext *rsExtension) Shutdown(ctx context.Context) error {
 func (ext *rsExtension) startFileBasedStrategyProvider(_ context.Context) error {
 	opts := static.Options{
 		StrategiesFile: ext.cfg.File.Path,
+		ReloadInterval: ext.cfg.File.ReloadInterval,
 	}
 
 	// contextcheck linter complains about next line that context is not passed.

--- a/plugin/sampling/strategyprovider/static/provider.go
+++ b/plugin/sampling/strategyprovider/static/provider.go
@@ -146,7 +146,6 @@ func (h *samplingProvider) samplingStrategyLoader(strategiesFile string) strateg
 	}
 
 	return func() ([]byte, error) {
-		h.logger.Info("Loading sampling strategies", zap.String("filename", strategiesFile))
 		currBytes, err := os.ReadFile(filepath.Clean(strategiesFile))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read strategies file %s: %w", strategiesFile, err)


### PR DESCRIPTION
## Which problem is this PR solving?
- Accidentally stumbled upon this when looking at #6431
- Turns out v2 config did not support all the options from v1

## Description of the changes
- Add support for reload interval

## How was this change tested?
`go run ./cmd/jaeger`

```
$ curl "http://localhost:5778/?service=x"
{"strategyType":0,"probabilisticSampling":{"samplingRate":1}}%
```

Edit cmd/jaeger/sampling-strategies.json to change default to 0.1.

Observe server logs showing new values.

```
$ curl "http://localhost:5778/?service=x"
{"strategyType":0,"probabilisticSampling":{"samplingRate":0.1}}%
```
