### PR TITLE
[sampling] Inherit default per-operation strategies

### DIFF
--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -1,5 +1,5 @@
 service:
-  extensions: [jaeger_storage, jaeger_query, remote_sampling, healthcheckv2, expvar]
+  extensions: [jaeger_storage, jaeger_query, remote_sampling, healthcheckv2, expvar, zpages]
   pipelines:
     traces:
       receivers: [otlp, jaeger, zipkin]
@@ -48,6 +48,11 @@ extensions:
 
   expvar:
     endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:27777"
+
+  zpages:
+    # for some reason the official extension listens on ephemeral port 55679
+    # so we override it with a normal port
+    endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:27778"
 
 receivers:
   otlp:

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -32,10 +32,9 @@ var (
 		"jaeger.sampling.includeDefaultOpStrategies",
 		featuregate.StageBeta, // enabed by default
 		featuregate.WithRegisterFromVersion("v2.2.0"),
+		featuregate.WithRegisterToVersion("v2.5.0"),
 		featuregate.WithRegisterDescription("Forces service strategy to be merged with default strategy, including per-operation overrides."),
 		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/5270"),
-		// TODO set ToVersion after going to Beta stage
-		// featuregate.WithRegisterToVersion("v0.70.0"),
 	)
 )
 

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/jaegertracing/jaeger/plugin/sampling/strategyprovider/adaptive"
 )
@@ -26,6 +27,16 @@ var (
 	_ component.Config          = (*Config)(nil)
 	_ component.ConfigValidator = (*Config)(nil)
 	_ confmap.Unmarshaler       = (*Config)(nil)
+
+	includeDefaultOpStrategies = featuregate.GlobalRegistry().MustRegister(
+		"jaeger.sampling.includeDefaultOpStrategies",
+		featuregate.StageBeta, // enabed by default
+		featuregate.WithRegisterFromVersion("v2.2.0"),
+		featuregate.WithRegisterDescription("Forces service strategy to be merged with default strategy, including per-operation overrides."),
+		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/5270"),
+		// TODO set ToVersion after going to Beta stage
+		// featuregate.WithRegisterToVersion("v0.70.0"),
+	)
 )
 
 type Config struct {

--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -165,8 +165,9 @@ func (ext *rsExtension) Shutdown(ctx context.Context) error {
 
 func (ext *rsExtension) startFileBasedStrategyProvider(_ context.Context) error {
 	opts := static.Options{
-		StrategiesFile: ext.cfg.File.Path,
-		ReloadInterval: ext.cfg.File.ReloadInterval,
+		StrategiesFile:             ext.cfg.File.Path,
+		ReloadInterval:             ext.cfg.File.ReloadInterval,
+		IncludeDefaultOpStrategies: includeDefaultOpStrategies.IsEnabled(),
 	}
 
 	// contextcheck linter complains about next line that context is not passed.

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	go.opentelemetry.io/collector/extension v0.116.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.116.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.116.0
+	go.opentelemetry.io/collector/featuregate v1.22.0
 	go.opentelemetry.io/collector/otelcol v0.116.0
 	go.opentelemetry.io/collector/pdata v1.22.0
 	go.opentelemetry.io/collector/pipeline v0.116.0
@@ -248,7 +249,6 @@ require (
 	go.opentelemetry.io/collector/extension/auth v0.116.0 // indirect
 	go.opentelemetry.io/collector/extension/experimental/storage v0.116.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.116.0
-	go.opentelemetry.io/collector/featuregate v1.22.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.116.0 // indirect
 	go.opentelemetry.io/collector/internal/memorylimiter v0.116.0 // indirect
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.116.0 // indirect

--- a/plugin/sampling/strategyprovider/static/options.go
+++ b/plugin/sampling/strategyprovider/static/options.go
@@ -33,7 +33,7 @@ type Options struct {
 func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
 	flagSet.String(samplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
-	flagSet.Bool(samplingStrategiesBugfix5270, false, "Include default operation level strategies for Ratesampling type service level strategy. Cf. https://github.com/jaegertracing/jaeger/issues/5270")
+	flagSet.Bool(samplingStrategiesBugfix5270, true, "Include default operation level strategies for Ratesampling type service level strategy. Cf. https://github.com/jaegertracing/jaeger/issues/5270")
 }
 
 // InitFromViper initializes Options with properties from viper


### PR DESCRIPTION
## Which problem is this PR solving?
- Part 2 of #5270

## Description of the changes
- 🛑 Make the new behavior to inherit from default strategy to be ON by default.
- In v1 it can still be disabled via a flag, which will be deprecated in the future.
- In v2 it can be disabled via a feature gate `jaeger.sampling.includeDefaultOpStrategies`

## How was this change tested?
- CI
