### PR TITLE
[api_v3][query] Change api_v3 grpc handler to use query service v2 

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
 	queryApp "github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	v2querysvc "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -171,6 +172,7 @@ by default uses only in-memory database.`,
 			queryTelset.Metrics = queryMetricsFactory
 			querySrv := startQuery(
 				svc, qOpts, qOpts.BuildQueryServiceOptions(storageFactory, logger),
+				qOpts.BuildV2QueryServiceOptions(storageFactory, logger),
 				traceReader, dependencyReader, metricsQueryService,
 				tm, queryTelset,
 			)
@@ -218,6 +220,7 @@ func startQuery(
 	svc *flags.Service,
 	qOpts *queryApp.QueryOptions,
 	queryOpts *querysvc.QueryServiceOptions,
+	v2QueryOpts *v2querysvc.QueryServiceOptions,
 	traceReader tracestore.Reader,
 	depReader depstore.Reader,
 	metricsQueryService querysvc.MetricsQueryService,
@@ -225,8 +228,9 @@ func startQuery(
 	telset telemetry.Settings,
 ) *queryApp.Server {
 	qs := querysvc.NewQueryService(traceReader, depReader, *queryOpts)
+	v2qs := v2querysvc.NewQueryService(traceReader, depReader, *v2QueryOpts)
 
-	server, err := queryApp.NewServer(context.Background(), qs, metricsQueryService, qOpts, tm, telset)
+	server, err := queryApp.NewServer(context.Background(), qs, v2qs, metricsQueryService, qOpts, tm, telset)
 	if err != nil {
 		svc.Logger.Fatal("Could not create jaeger-query", zap.Error(err))
 	}

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -172,7 +172,7 @@ by default uses only in-memory database.`,
 			queryTelset.Metrics = queryMetricsFactory
 			querySrv := startQuery(
 				svc, qOpts, qOpts.BuildQueryServiceOptions(storageFactory, logger),
-				qOpts.BuildV2QueryServiceOptions(storageFactory, logger),
+				qOpts.BuildQueryServiceOptionsV2(storageFactory, logger),
 				traceReader, dependencyReader, metricsQueryService,
 				tm, queryTelset,
 			)

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -172,7 +172,8 @@ func (s *server) addV2ArchiveStorage(opts *v2querysvc.QueryServiceOptions, host 
 
 func (s *server) initializeV2ArchiveStorage(
 	storageFactory storage.Factory,
-	opts *v2querysvc.QueryServiceOptions) bool {
+	opts *v2querysvc.QueryServiceOptions,
+) bool {
 	archiveFactory, ok := storageFactory.(storage.ArchiveFactory)
 	if !ok {
 		s.telset.Logger.Info("Archive storage not supported by the factory")

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -133,7 +133,8 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 func (s *server) addArchiveStorage(
 	opts *querysvc.QueryServiceOptions,
 	v2opts *v2querysvc.QueryServiceOptions,
-	host component.Host) error {
+	host component.Host,
+) error {
 	if s.config.Storage.TracesArchive == "" {
 		s.telset.Logger.Info("Archive storage not configured")
 		return nil

--- a/cmd/jaeger/internal/extension/jaegerquery/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	v2querysvc "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
 	"github.com/jaegertracing/jaeger/internal/grpctest"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
@@ -257,6 +258,7 @@ func TestServerAddArchiveStorage(t *testing.T) {
 	tests := []struct {
 		name           string
 		qSvcOpts       *querysvc.QueryServiceOptions
+		v2qSvcOpts     *v2querysvc.QueryServiceOptions
 		config         *Config
 		extension      component.Component
 		expectedOutput string
@@ -266,6 +268,7 @@ func TestServerAddArchiveStorage(t *testing.T) {
 			name:           "Archive storage unset",
 			config:         &Config{},
 			qSvcOpts:       &querysvc.QueryServiceOptions{},
+			v2qSvcOpts:     &v2querysvc.QueryServiceOptions{},
 			expectedOutput: `{"level":"info","msg":"Archive storage not configured"}` + "\n",
 			expectedErr:    "",
 		},
@@ -277,6 +280,7 @@ func TestServerAddArchiveStorage(t *testing.T) {
 				},
 			},
 			qSvcOpts:       &querysvc.QueryServiceOptions{},
+			v2qSvcOpts:     &v2querysvc.QueryServiceOptions{},
 			expectedOutput: "",
 			expectedErr:    "cannot find archive storage factory: cannot find extension",
 		},
@@ -288,6 +292,7 @@ func TestServerAddArchiveStorage(t *testing.T) {
 				},
 			},
 			qSvcOpts:       &querysvc.QueryServiceOptions{},
+			v2qSvcOpts:     &v2querysvc.QueryServiceOptions{},
 			extension:      fakeStorageExt{},
 			expectedOutput: "Archive storage not supported by the factory",
 			expectedErr:    "",
@@ -306,7 +311,7 @@ func TestServerAddArchiveStorage(t *testing.T) {
 			if tt.extension != nil {
 				host = storagetest.NewStorageHost().WithExtension(jaegerstorage.ID, tt.extension)
 			}
-			err := server.addArchiveStorage(tt.qSvcOpts, host)
+			err := server.addArchiveStorage(tt.qSvcOpts, tt.v2qSvcOpts, host)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -45,8 +45,7 @@ func (h *Handler) GetTrace(request *api_v3.GetTraceRequest, stream api_v3.QueryS
 		RawTraces: request.GetRawTraces(),
 	}
 	getTracesIter := h.QueryService.GetTraces(stream.Context(), query)
-	err = h.recieveTraces(getTracesIter, stream.Send)
-	return err
+	return receiveTraces(getTracesIter, stream.Send)
 }
 
 // FindTraces implements api_v3.QueryServiceServer's FindTraces
@@ -92,8 +91,7 @@ func (h *Handler) internalFindTraces(
 	}
 
 	findTracesIter := h.QueryService.FindTraces(ctx, queryParams)
-	err := h.recieveTraces(findTracesIter, streamSend)
-	return err
+	return receiveTraces(findTracesIter, streamSend)
 }
 
 // GetServices implements api_v3.QueryServiceServer's GetServices
@@ -128,9 +126,10 @@ func (h *Handler) GetOperations(ctx context.Context, request *api_v3.GetOperatio
 	}, nil
 }
 
-func (h *Handler) recieveTraces(
+func receiveTraces(
 	seq iter.Seq2[[]ptrace.Traces, error],
-	sendFn func(*api_v3.TracesData) error) error {
+	sendFn func(*api_v3.TracesData) error,
+) error {
 	var capturedErr error
 	seq(func(traces []ptrace.Traces, err error) bool {
 		if err != nil {

--- a/cmd/query/app/apiv3/grpc_handler_test.go
+++ b/cmd/query/app/apiv3/grpc_handler_test.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
 	"github.com/jaegertracing/jaeger/model"
 	_ "github.com/jaegertracing/jaeger/pkg/gogocodec" // force gogo codec registration

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -164,7 +164,8 @@ func (qOpts *QueryOptions) BuildV2QueryServiceOptions(storageFactory storage.Bas
 func initializeV2ArchiveStorage(
 	storageFactory storage.BaseFactory,
 	opts *v2querysvc.QueryServiceOptions,
-	logger *zap.Logger) bool {
+	logger *zap.Logger,
+) bool {
 	archiveFactory, ok := storageFactory.(storage.ArchiveFactory)
 	if !ok {
 		logger.Info("Archive storage not supported by the factory")

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -150,7 +150,7 @@ func (qOpts *QueryOptions) BuildQueryServiceOptions(storageFactory storage.BaseF
 	return opts
 }
 
-func (qOpts *QueryOptions) BuildV2QueryServiceOptions(storageFactory storage.BaseFactory, logger *zap.Logger) *v2querysvc.QueryServiceOptions {
+func (qOpts *QueryOptions) BuildQueryServiceOptionsV2(storageFactory storage.BaseFactory, logger *zap.Logger) *v2querysvc.QueryServiceOptions {
 	opts := &v2querysvc.QueryServiceOptions{}
 	if !initializeV2ArchiveStorage(storageFactory, opts, logger) {
 		logger.Info("Archive storage not initialized")

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -152,7 +152,12 @@ func (qOpts *QueryOptions) BuildQueryServiceOptions(storageFactory storage.BaseF
 
 func (qOpts *QueryOptions) BuildQueryServiceOptionsV2(storageFactory storage.BaseFactory, logger *zap.Logger) *v2querysvc.QueryServiceOptions {
 	opts := &v2querysvc.QueryServiceOptions{}
-	if !initializeV2ArchiveStorage(storageFactory, opts, logger) {
+
+	ar, aw := v1adapter.InitializeArchiveStorage(storageFactory, logger)
+	if ar != nil && aw != nil {
+		opts.ArchiveTraceReader = ar
+		opts.ArchiveTraceWriter = aw
+	} else {
 		logger.Info("Archive storage not initialized")
 	}
 

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -166,39 +166,6 @@ func (qOpts *QueryOptions) BuildQueryServiceOptionsV2(storageFactory storage.Bas
 	return opts
 }
 
-func initializeV2ArchiveStorage(
-	storageFactory storage.BaseFactory,
-	opts *v2querysvc.QueryServiceOptions,
-	logger *zap.Logger,
-) bool {
-	archiveFactory, ok := storageFactory.(storage.ArchiveFactory)
-	if !ok {
-		logger.Info("Archive storage not supported by the factory")
-		return false
-	}
-	reader, err := archiveFactory.CreateArchiveSpanReader()
-	if errors.Is(err, storage.ErrArchiveStorageNotConfigured) || errors.Is(err, storage.ErrArchiveStorageNotSupported) {
-		logger.Info("Archive storage not created", zap.String("reason", err.Error()))
-		return false
-	}
-	if err != nil {
-		logger.Error("Cannot init archive storage reader", zap.Error(err))
-		return false
-	}
-	writer, err := archiveFactory.CreateArchiveSpanWriter()
-	if errors.Is(err, storage.ErrArchiveStorageNotConfigured) || errors.Is(err, storage.ErrArchiveStorageNotSupported) {
-		logger.Info("Archive storage not created", zap.String("reason", err.Error()))
-		return false
-	}
-	if err != nil {
-		logger.Error("Cannot init archive storage writer", zap.Error(err))
-		return false
-	}
-	opts.ArchiveTraceReader = v1adapter.NewTraceReader(reader)
-	opts.ArchiveTraceWriter = v1adapter.NewTraceWriter(writer)
-	return true
-}
-
 // stringSliceAsHeader parses a slice of strings and returns a http.Header.
 // Each string in the slice is expected to be in the format "key: value"
 func stringSliceAsHeader(slice []string) (http.Header, error) {

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -116,6 +116,36 @@ func TestBuildQueryServiceOptions(t *testing.T) {
 	assert.NotNil(t, qSvcOpts.ArchiveSpanWriter)
 }
 
+func TestBuildQueryServiceOptionsV2(t *testing.T) {
+	v, _ := config.Viperize(AddFlags)
+	qOpts, err := new(QueryOptions).InitFromViper(v, zap.NewNop())
+	require.NoError(t, err)
+	assert.NotNil(t, qOpts)
+
+	qSvcOpts := qOpts.BuildQueryServiceOptionsV2(&mocks.Factory{}, zap.NewNop())
+	assert.NotNil(t, qSvcOpts)
+	assert.NotNil(t, qSvcOpts.Adjuster)
+	assert.Nil(t, qSvcOpts.ArchiveTraceReader)
+	assert.Nil(t, qSvcOpts.ArchiveTraceWriter)
+
+	comboFactory := struct {
+		*mocks.Factory
+		*mocks.ArchiveFactory
+	}{
+		&mocks.Factory{},
+		&mocks.ArchiveFactory{},
+	}
+
+	comboFactory.ArchiveFactory.On("CreateArchiveSpanReader").Return(&spanstore_mocks.Reader{}, nil)
+	comboFactory.ArchiveFactory.On("CreateArchiveSpanWriter").Return(&spanstore_mocks.Writer{}, nil)
+
+	qSvcOpts = qOpts.BuildQueryServiceOptionsV2(comboFactory, zap.NewNop())
+	assert.NotNil(t, qSvcOpts)
+	assert.NotNil(t, qSvcOpts.Adjuster)
+	assert.NotNil(t, qSvcOpts.ArchiveTraceReader)
+	assert.NotNil(t, qSvcOpts.ArchiveTraceWriter)
+}
+
 func TestQueryOptionsPortAllocationFromFlags(t *testing.T) {
 	flagPortCases := []struct {
 		name                 string

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -146,6 +146,20 @@ func TestBuildQueryServiceOptionsV2(t *testing.T) {
 	assert.NotNil(t, qSvcOpts.ArchiveTraceWriter)
 }
 
+func TestBuildQueryServiceOptionsV2_NoArchiveStorage(t *testing.T) {
+	v, _ := config.Viperize(AddFlags)
+	qOpts, err := new(QueryOptions).InitFromViper(v, zap.NewNop())
+	require.NoError(t, err)
+	assert.NotNil(t, qOpts)
+
+	logger, logBuf := testutils.NewLogger()
+	qSvcOpts := qOpts.BuildQueryServiceOptionsV2(&mocks.Factory{}, logger)
+	assert.Nil(t, qSvcOpts.ArchiveTraceReader)
+	assert.Nil(t, qSvcOpts.ArchiveTraceWriter)
+
+	require.Contains(t, logBuf.String(), "Archive storage not initialized")
+}
+
 func TestQueryOptionsPortAllocationFromFlags(t *testing.T) {
 	flagPortCases := []struct {
 		name                 string

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/internal/flags"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	v2querysvc "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
@@ -89,7 +90,8 @@ func runQueryService(t *testing.T, esURL string) *Server {
 	traceReader := v1adapter.NewTraceReader(spanReader)
 
 	querySvc := querysvc.NewQueryService(traceReader, nil, querysvc.QueryServiceOptions{})
-	server, err := NewServer(context.Background(), querySvc, nil,
+	v2QuerySvc := v2querysvc.NewQueryService(traceReader, nil, v2querysvc.QueryServiceOptions{})
+	server, err := NewServer(context.Background(), querySvc, v2QuerySvc, nil,
 		&QueryOptions{
 			BearerTokenPropagation: true,
 			HTTP: confighttp.ServerConfig{

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -113,7 +113,7 @@ func main() {
 				dependencyReader,
 				*queryServiceOptions)
 
-			queryServiceOptionsV2 := queryOpts.BuildV2QueryServiceOptions(storageFactory, logger)
+			queryServiceOptionsV2 := queryOpts.BuildQueryServiceOptionsV2(storageFactory, logger)
 			queryServiceV2 := querysvcv2.NewQueryService(
 				traceReader,
 				dependencyReader,

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
 	"github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
+	querysvcv2 "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
@@ -111,12 +112,20 @@ func main() {
 				traceReader,
 				dependencyReader,
 				*queryServiceOptions)
+
+			queryServiceOptionsV2 := queryOpts.BuildV2QueryServiceOptions(storageFactory, logger)
+			queryServiceV2 := querysvcv2.NewQueryService(
+				traceReader,
+				dependencyReader,
+				*queryServiceOptionsV2)
+
 			tm := tenancy.NewManager(&queryOpts.Tenancy)
 			telset := baseTelset // copy
 			telset.Metrics = metricsFactory
 			server, err := app.NewServer(
 				context.Background(),
 				queryService,
+				queryServiceV2,
 				metricsQueryService,
 				queryOpts,
 				tm,

--- a/storage_v2/v1adapter/archive.go
+++ b/storage_v2/v1adapter/archive.go
@@ -1,0 +1,39 @@
+package v1adapter
+
+import (
+	"errors"
+
+	"github.com/jaegertracing/jaeger/storage"
+	"go.uber.org/zap"
+)
+
+func InitializeArchiveStorage(
+	storageFactory storage.BaseFactory,
+	logger *zap.Logger,
+) (*TraceReader, *TraceWriter) {
+	archiveFactory, ok := storageFactory.(storage.ArchiveFactory)
+	if !ok {
+		logger.Info("Archive storage not supported by the factory")
+		return nil, nil
+	}
+	reader, err := archiveFactory.CreateArchiveSpanReader()
+	if errors.Is(err, storage.ErrArchiveStorageNotConfigured) || errors.Is(err, storage.ErrArchiveStorageNotSupported) {
+		logger.Info("Archive storage not created", zap.String("reason", err.Error()))
+		return nil, nil
+	}
+	if err != nil {
+		logger.Error("Cannot init archive storage reader", zap.Error(err))
+		return nil, nil
+	}
+	writer, err := archiveFactory.CreateArchiveSpanWriter()
+	if errors.Is(err, storage.ErrArchiveStorageNotConfigured) || errors.Is(err, storage.ErrArchiveStorageNotSupported) {
+		logger.Info("Archive storage not created", zap.String("reason", err.Error()))
+		return nil, nil
+	}
+	if err != nil {
+		logger.Error("Cannot init archive storage writer", zap.Error(err))
+		return nil, nil
+	}
+
+	return NewTraceReader(reader), NewTraceWriter(writer)
+}

--- a/storage_v2/v1adapter/archive.go
+++ b/storage_v2/v1adapter/archive.go
@@ -1,10 +1,14 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1adapter
 
 import (
 	"errors"
 
-	"github.com/jaegertracing/jaeger/storage"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/storage"
 )
 
 func InitializeArchiveStorage(

--- a/storage_v2/v1adapter/archive_test.go
+++ b/storage_v2/v1adapter/archive_test.go
@@ -1,15 +1,20 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1adapter
 
 import (
 	"testing"
 
-	"github.com/crossdock/crossdock-go/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/storage"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	spanstoremocks "github.com/jaegertracing/jaeger/storage/spanstore/mocks"
-	"go.uber.org/zap"
 )
 
 type fakeStorageFactory1 struct{}
@@ -42,8 +47,8 @@ func TestInitializeArchiveStorage(t *testing.T) {
 
 	t.Run("Archive storage not supported by the factory", func(t *testing.T) {
 		reader, writer := InitializeArchiveStorage(new(fakeStorageFactory1), logger)
-		assert.Nil(t, reader)
-		assert.Nil(t, writer)
+		require.Nil(t, reader)
+		require.Nil(t, writer)
 	})
 
 	t.Run("Archive storage not configured", func(t *testing.T) {
@@ -51,8 +56,8 @@ func TestInitializeArchiveStorage(t *testing.T) {
 			&fakeStorageFactory2{rErr: storage.ErrArchiveStorageNotConfigured},
 			logger,
 		)
-		assert.Nil(t, reader)
-		assert.Nil(t, writer)
+		require.Nil(t, reader)
+		require.Nil(t, writer)
 	})
 
 	t.Run("Archive storage not supported", func(t *testing.T) {
@@ -60,8 +65,8 @@ func TestInitializeArchiveStorage(t *testing.T) {
 			&fakeStorageFactory2{rErr: storage.ErrArchiveStorageNotSupported},
 			logger,
 		)
-		assert.Nil(t, reader)
-		assert.Nil(t, writer)
+		require.Nil(t, reader)
+		require.Nil(t, writer)
 	})
 
 	t.Run("Error initializing archive span reader", func(t *testing.T) {
@@ -69,8 +74,8 @@ func TestInitializeArchiveStorage(t *testing.T) {
 			&fakeStorageFactory2{rErr: assert.AnError},
 			logger,
 		)
-		assert.Nil(t, reader)
-		assert.Nil(t, writer)
+		require.Nil(t, reader)
+		require.Nil(t, writer)
 	})
 
 	t.Run("Error initializing archive span writer", func(t *testing.T) {
@@ -78,8 +83,8 @@ func TestInitializeArchiveStorage(t *testing.T) {
 			&fakeStorageFactory2{wErr: assert.AnError},
 			logger,
 		)
-		assert.Nil(t, reader)
-		assert.Nil(t, writer)
+		require.Nil(t, reader)
+		require.Nil(t, writer)
 	})
 
 	t.Run("Successfully initialize archive storage", func(t *testing.T) {
@@ -89,9 +94,7 @@ func TestInitializeArchiveStorage(t *testing.T) {
 			&fakeStorageFactory2{r: reader, w: writer},
 			logger,
 		)
-		assert.NotNil(t, traceReader)
-		assert.NotNil(t, traceWriter)
-		assert.Equal(t, reader, traceReader.spanReader)
-		assert.Equal(t, writer, traceWriter.spanWriter)
+		require.Equal(t, reader, traceReader.spanReader)
+		require.Equal(t, writer, traceWriter.spanWriter)
 	})
 }

--- a/storage_v2/v1adapter/archive_test.go
+++ b/storage_v2/v1adapter/archive_test.go
@@ -60,7 +60,7 @@ func TestInitializeArchiveStorage(t *testing.T) {
 		require.Nil(t, writer)
 	})
 
-	t.Run("Archive storage not supported", func(t *testing.T) {
+	t.Run("Archive storage not supported for reader", func(t *testing.T) {
 		reader, writer := InitializeArchiveStorage(
 			&fakeStorageFactory2{rErr: storage.ErrArchiveStorageNotSupported},
 			logger,
@@ -72,6 +72,15 @@ func TestInitializeArchiveStorage(t *testing.T) {
 	t.Run("Error initializing archive span reader", func(t *testing.T) {
 		reader, writer := InitializeArchiveStorage(
 			&fakeStorageFactory2{rErr: assert.AnError},
+			logger,
+		)
+		require.Nil(t, reader)
+		require.Nil(t, writer)
+	})
+
+	t.Run("Archive storage not supported for writer", func(t *testing.T) {
+		reader, writer := InitializeArchiveStorage(
+			&fakeStorageFactory2{wErr: storage.ErrArchiveStorageNotSupported},
 			logger,
 		)
 		require.Nil(t, reader)

--- a/storage_v2/v1adapter/archive_test.go
+++ b/storage_v2/v1adapter/archive_test.go
@@ -1,0 +1,97 @@
+package v1adapter
+
+import (
+	"testing"
+
+	"github.com/crossdock/crossdock-go/assert"
+	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/storage"
+	"github.com/jaegertracing/jaeger/storage/dependencystore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+	spanstoremocks "github.com/jaegertracing/jaeger/storage/spanstore/mocks"
+	"go.uber.org/zap"
+)
+
+type fakeStorageFactory1 struct{}
+
+type fakeStorageFactory2 struct {
+	fakeStorageFactory1
+	r    spanstore.Reader
+	w    spanstore.Writer
+	rErr error
+	wErr error
+}
+
+func (*fakeStorageFactory1) Initialize(metrics.Factory, *zap.Logger) error {
+	return nil
+}
+func (*fakeStorageFactory1) CreateSpanReader() (spanstore.Reader, error)             { return nil, nil }
+func (*fakeStorageFactory1) CreateSpanWriter() (spanstore.Writer, error)             { return nil, nil }
+func (*fakeStorageFactory1) CreateDependencyReader() (dependencystore.Reader, error) { return nil, nil }
+
+func (f *fakeStorageFactory2) CreateArchiveSpanReader() (spanstore.Reader, error) { return f.r, f.rErr }
+func (f *fakeStorageFactory2) CreateArchiveSpanWriter() (spanstore.Writer, error) { return f.w, f.wErr }
+
+var (
+	_ storage.Factory        = new(fakeStorageFactory1)
+	_ storage.ArchiveFactory = new(fakeStorageFactory2)
+)
+
+func TestInitializeArchiveStorage(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("Archive storage not supported by the factory", func(t *testing.T) {
+		reader, writer := InitializeArchiveStorage(new(fakeStorageFactory1), logger)
+		assert.Nil(t, reader)
+		assert.Nil(t, writer)
+	})
+
+	t.Run("Archive storage not configured", func(t *testing.T) {
+		reader, writer := InitializeArchiveStorage(
+			&fakeStorageFactory2{rErr: storage.ErrArchiveStorageNotConfigured},
+			logger,
+		)
+		assert.Nil(t, reader)
+		assert.Nil(t, writer)
+	})
+
+	t.Run("Archive storage not supported", func(t *testing.T) {
+		reader, writer := InitializeArchiveStorage(
+			&fakeStorageFactory2{rErr: storage.ErrArchiveStorageNotSupported},
+			logger,
+		)
+		assert.Nil(t, reader)
+		assert.Nil(t, writer)
+	})
+
+	t.Run("Error initializing archive span reader", func(t *testing.T) {
+		reader, writer := InitializeArchiveStorage(
+			&fakeStorageFactory2{rErr: assert.AnError},
+			logger,
+		)
+		assert.Nil(t, reader)
+		assert.Nil(t, writer)
+	})
+
+	t.Run("Error initializing archive span writer", func(t *testing.T) {
+		reader, writer := InitializeArchiveStorage(
+			&fakeStorageFactory2{wErr: assert.AnError},
+			logger,
+		)
+		assert.Nil(t, reader)
+		assert.Nil(t, writer)
+	})
+
+	t.Run("Successfully initialize archive storage", func(t *testing.T) {
+		reader := &spanstoremocks.Reader{}
+		writer := &spanstoremocks.Writer{}
+		traceReader, traceWriter := InitializeArchiveStorage(
+			&fakeStorageFactory2{r: reader, w: writer},
+			logger,
+		)
+		assert.NotNil(t, traceReader)
+		assert.NotNil(t, traceWriter)
+		assert.Equal(t, reader, traceReader.spanReader)
+		assert.Equal(t, writer, traceWriter.spanWriter)
+	})
+}

--- a/storage_v2/v1adapter/writer.go
+++ b/storage_v2/v1adapter/writer.go
@@ -10,14 +10,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger/storage/spanstore"
-	"github.com/jaegertracing/jaeger/storage_v2/tracestore"
 )
 
 type TraceWriter struct {
 	spanWriter spanstore.Writer
 }
 
-func NewTraceWriter(spanWriter spanstore.Writer) tracestore.Writer {
+func NewTraceWriter(spanWriter spanstore.Writer) *TraceWriter {
 	return &TraceWriter{
 		spanWriter: spanWriter,
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6337

## Description of the changes
- This PR migrates the v3_api GRPC handler to use the new v2 query service.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
