### PR TITLE
[test] Change api_v3 unit tests to use `tracestore` natively

### DIFF
--- a/cmd/query/app/apiv3/gateway_test.go
+++ b/cmd/query/app/apiv3/gateway_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
 	"github.com/jaegertracing/jaeger/model"
@@ -35,7 +37,10 @@ const (
 // Snapshots can be regenerated via:
 //
 //	REGENERATE_SNAPSHOTS=true go test -v ./cmd/query/app/apiv3/...
-var regenerateSnapshots = os.Getenv("REGENERATE_SNAPSHOTS") == "true"
+var (
+	regenerateSnapshots = os.Getenv("REGENERATE_SNAPSHOTS") == "true"
+	traceID             = pcommon.TraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+)
 
 type testGateway struct {
 	reader *spanstoremocks.Reader
@@ -97,6 +102,21 @@ func makeTestTrace() (*model.Trace, spanstore.GetTraceParameters) {
 			},
 		},
 	}, query
+}
+
+func makeTestTraceV2() ptrace.Traces {
+	trace := ptrace.NewTraces()
+	resources := trace.ResourceSpans().AppendEmpty()
+	scopes := resources.ScopeSpans().AppendEmpty()
+
+	spanA := scopes.Spans().AppendEmpty()
+	spanA.SetName("foobar")
+	spanA.SetTraceID(traceID)
+	spanA.SetSpanID(pcommon.SpanID([8]byte{180}))
+	spanA.SetKind(ptrace.SpanKindServer)
+	spanA.Attributes().PutBool("error", true)
+
+	return trace
 }
 
 func runGatewayTests(


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6460

## Description of the changes
- The unit tests for the `api_v3` grpc handler were still using `package spanstore` wrapped in a v1 adapter. Now that the API has been migrated to use the v2 query service, the tests were changed to pass in the native reader instead.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
