### PR TITLE
chore: fixed port for metrics

### DIFF
--- a/examples/hotrod/README.md
+++ b/examples/hotrod/README.md
@@ -86,8 +86,8 @@ Then open http://127.0.0.1:8080
 ## Metrics
 
 The app exposes metrics in either Go's `expvar` format (by default) or in Prometheus format (enabled via `-m prometheus` flag).
-  * `expvar`: `curl http://127.0.0.1:8083/debug/vars`
-  * Prometheus: `curl http://127.0.0.1:8083/metrics`
+  * `expvar`: `curl http://127.0.0.1:8080/debug/vars`
+  * Prometheus: `curl http://127.0.0.1:8080/metrics`
 
 ## Linking to traces
 


### PR DESCRIPTION
If you curl metrics on port 8083 you get a message "endpoint moved to the frontend service". Since the frontend port is 8080, I changed the metrics port to 8080, too. Now the examples are working again.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
