### PR TITLE
Return errors from span processor creation

### DIFF
--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -95,7 +95,11 @@ func (c *Collector) Start(options *flags.CollectorOptions) error {
 		})
 	}
 
-	c.spanProcessor = handlerBuilder.BuildSpanProcessor(additionalProcessors...)
+	spanProcessor, err := handlerBuilder.BuildSpanProcessor(additionalProcessors...)
+	if err != nil {
+		return fmt.Errorf("could not create span processor: %w", err)
+	}
+	c.spanProcessor = spanProcessor
 	c.spanHandlers = handlerBuilder.BuildHandlers(c.spanProcessor)
 	grpcServer, err := server.StartGRPCServer(&server.GRPCServerParams{
 		Handler:          c.spanHandlers.GRPCHandler,

--- a/cmd/collector/app/span_handler_builder.go
+++ b/cmd/collector/app/span_handler_builder.go
@@ -36,7 +36,7 @@ type SpanHandlers struct {
 }
 
 // BuildSpanProcessor builds the span processor to be used with the handlers
-func (b *SpanHandlerBuilder) BuildSpanProcessor(additional ...ProcessSpan) processor.SpanProcessor {
+func (b *SpanHandlerBuilder) BuildSpanProcessor(additional ...ProcessSpan) (processor.SpanProcessor, error) {
 	hostname, _ := os.Hostname()
 	svcMetrics := b.metricsFactory()
 	hostMetrics := svcMetrics.Namespace(metrics.NSOptions{Tags: map[string]string{"host": hostname}})

--- a/cmd/collector/app/span_handler_builder_test.go
+++ b/cmd/collector/app/span_handler_builder_test.go
@@ -44,7 +44,8 @@ func TestNewSpanHandlerBuilder(t *testing.T) {
 		TenancyMgr:     &tenancy.Manager{},
 	}
 
-	spanProcessor := builder.BuildSpanProcessor()
+	spanProcessor, err := builder.BuildSpanProcessor()
+	require.NoError(t, err)
 	spanHandlers := builder.BuildHandlers(spanProcessor)
 	assert.NotNil(t, spanHandlers.ZipkinSpansHandler)
 	assert.NotNil(t, spanHandlers.JaegerBatchesHandler)


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6487

## Description of the changes
- Creation of exporterhelper may result in an error, so extend the processor construction signature to return the error.

## How was this change tested?
- CI
