### PR TITLE
Add standard tags for internal warnings and span format

### DIFF
--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/queue"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 )
 
 const (
@@ -237,7 +238,7 @@ func (sp *spanProcessor) enqueueSpan(span *model.Span, originalFormat processor.
 	}
 
 	// add format tag
-	span.Tags = append(span.Tags, model.String("@jaeger@format", string(originalFormat)))
+	span.Tags = append(span.Tags, model.String(jptrace.FormatAttribute, string(originalFormat)))
 
 	item := queueItem{
 		queuedTime: time.Now(),

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer"
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/queue"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
-	"github.com/jaegertracing/jaeger/internal/jptrace"
 )
 
 const (

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -237,7 +237,7 @@ func (sp *spanProcessor) enqueueSpan(span *model.Span, originalFormat processor.
 	}
 
 	// add format tag
-	span.Tags = append(span.Tags, model.String("internal.span.format", string(originalFormat)))
+	span.Tags = append(span.Tags, model.String("@jaeger@format", string(originalFormat)))
 
 	item := queueItem{
 		queuedTime: time.Now(),

--- a/internal/jptrace/attributes.go
+++ b/internal/jptrace/attributes.go
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package jptrace
 
-const(
+const (
 	// WarningsAttribute is the name of the span attribute where we can
 	// store various warnings produced from transformations,
 	// such as inbound sanitizers and outbound adjusters.
 	// The value type of the attribute is a string slice.
 	WarningsAttribute = "@jaeger@warnings"
 	// FormatAttribute is a key for span attribute that records the original
-	// wire format in which the span was received by Jaeger, 
+	// wire format in which the span was received by Jaeger,
 	// e.g. proto, thrift, json.
 	FormatAttribute = "@jaeger@format"
 )

--- a/internal/jptrace/attributes.go
+++ b/internal/jptrace/attributes.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
 package jptrace
 
 const(

--- a/internal/jptrace/attributes.go
+++ b/internal/jptrace/attributes.go
@@ -1,0 +1,7 @@
+package jptrace
+
+const(
+
+	WarningsAttribute = "@jaeger@warnings"
+	FormatAttribute = "@jaeger@format"
+)

--- a/internal/jptrace/attributes.go
+++ b/internal/jptrace/attributes.go
@@ -1,7 +1,13 @@
 package jptrace
 
 const(
-
+	// WarningsAttribute is the name of the span attribute where we can
+	// store various warnings produced from transformations,
+	// such as inbound sanitizers and outbound adjusters.
+	// The value type of the attribute is a string slice.
 	WarningsAttribute = "@jaeger@warnings"
+	// FormatAttribute is a key for span attribute that records the original
+	// wire format in which the span was received by Jaeger, 
+	// e.g. proto, thrift, json.
 	FormatAttribute = "@jaeger@format"
 )

--- a/internal/jptrace/warning.go
+++ b/internal/jptrace/warning.go
@@ -13,7 +13,7 @@ const (
 	// store various warnings produced from transformations,
 	// such as inbound sanitizers and outbound adjusters.
 	// The value type of the attribute is a string slice.
-	WarningsAttribute = "jaeger.internal.warnings"
+	WarningsAttribute = "@jaeger@warnings"
 )
 
 func AddWarnings(span ptrace.Span, warnings ...string) {

--- a/internal/jptrace/warning.go
+++ b/internal/jptrace/warning.go
@@ -8,13 +8,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-const (
-	// WarningsAttribute is the name of the span attribute where we can
-	// store various warnings produced from transformations,
-	// such as inbound sanitizers and outbound adjusters.
-	// The value type of the attribute is a string slice.
-	WarningsAttribute = "@jaeger@warnings"
-)
 
 func AddWarnings(span ptrace.Span, warnings ...string) {
 	var w pcommon.Slice

--- a/internal/jptrace/warning.go
+++ b/internal/jptrace/warning.go
@@ -8,7 +8,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-
 func AddWarnings(span ptrace.Span, warnings ...string) {
 	var w pcommon.Slice
 	if currWarnings, ok := span.Attributes().Get(WarningsAttribute); ok {

--- a/internal/jptrace/warning_test.go
+++ b/internal/jptrace/warning_test.go
@@ -42,13 +42,13 @@ func TestAddWarning(t *testing.T) {
 			span := ptrace.NewSpan()
 			attrs := span.Attributes()
 			if test.existing != nil {
-				warnings := attrs.PutEmptySlice("@jaeger@warnings")
+				warnings := attrs.PutEmptySlice(WarningsAttribute)
 				for _, warn := range test.existing {
 					warnings.AppendEmpty().SetStr(warn)
 				}
 			}
 			AddWarnings(span, test.newWarn)
-			warnings, ok := attrs.Get("@jaeger@warnings")
+			warnings, ok := attrs.Get(WarningsAttribute)
 			assert.True(t, ok)
 			assert.Equal(t, len(test.expected), warnings.Slice().Len())
 			for i, expectedWarn := range test.expected {
@@ -61,7 +61,7 @@ func TestAddWarning(t *testing.T) {
 func TestAddWarning_MultipleWarnings(t *testing.T) {
 	span := ptrace.NewSpan()
 	AddWarnings(span, "warning-1", "warning-2")
-	warnings, ok := span.Attributes().Get("@jaeger@warnings")
+	warnings, ok := span.Attributes().Get(WarningsAttribute)
 	require.True(t, ok)
 	require.Equal(t, "warning-1", warnings.Slice().At(0).Str())
 	require.Equal(t, "warning-2", warnings.Slice().At(1).Str())
@@ -94,7 +94,7 @@ func TestGetWarnings(t *testing.T) {
 			span := ptrace.NewSpan()
 			attrs := span.Attributes()
 			if test.existing != nil {
-				warnings := attrs.PutEmptySlice("@jaeger@warnings")
+				warnings := attrs.PutEmptySlice(WarningsAttribute)
 				for _, warn := range test.existing {
 					warnings.AppendEmpty().SetStr(warn)
 				}

--- a/internal/jptrace/warning_test.go
+++ b/internal/jptrace/warning_test.go
@@ -42,13 +42,13 @@ func TestAddWarning(t *testing.T) {
 			span := ptrace.NewSpan()
 			attrs := span.Attributes()
 			if test.existing != nil {
-				warnings := attrs.PutEmptySlice("jaeger.internal.warnings")
+				warnings := attrs.PutEmptySlice("@jaeger@warnings")
 				for _, warn := range test.existing {
 					warnings.AppendEmpty().SetStr(warn)
 				}
 			}
 			AddWarnings(span, test.newWarn)
-			warnings, ok := attrs.Get("jaeger.internal.warnings")
+			warnings, ok := attrs.Get("@jaeger@warnings")
 			assert.True(t, ok)
 			assert.Equal(t, len(test.expected), warnings.Slice().Len())
 			for i, expectedWarn := range test.expected {
@@ -61,7 +61,7 @@ func TestAddWarning(t *testing.T) {
 func TestAddWarning_MultipleWarnings(t *testing.T) {
 	span := ptrace.NewSpan()
 	AddWarnings(span, "warning-1", "warning-2")
-	warnings, ok := span.Attributes().Get("jaeger.internal.warnings")
+	warnings, ok := span.Attributes().Get("@jaeger@warnings")
 	require.True(t, ok)
 	require.Equal(t, "warning-1", warnings.Slice().At(0).Str())
 	require.Equal(t, "warning-2", warnings.Slice().At(1).Str())
@@ -94,7 +94,7 @@ func TestGetWarnings(t *testing.T) {
 			span := ptrace.NewSpan()
 			attrs := span.Attributes()
 			if test.existing != nil {
-				warnings := attrs.PutEmptySlice("jaeger.internal.warnings")
+				warnings := attrs.PutEmptySlice("@jaeger@warnings")
 				for _, warn := range test.existing {
 					warnings.AppendEmpty().SetStr(warn)
 				}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6522 

## Description of the changes
- Replaced the names of non-standard tags with standard tags

## How was this change tested?
- make test returned pass for all the test cases

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make test`
