### PR TITLE
Pass Context through span processors

### DIFF
--- a/cmd/collector/app/collector_test.go
+++ b/cmd/collector/app/collector_test.go
@@ -263,7 +263,7 @@ func TestAggregator(t *testing.T) {
 			},
 		},
 	}
-	_, err := c.spanProcessor.ProcessSpans(processor.SpansV1{
+	_, err := c.spanProcessor.ProcessSpans(context.Background(), processor.SpansV1{
 		Spans: spans,
 		Details: processor.Details{
 			SpanFormat: processor.JaegerSpanFormat,

--- a/cmd/collector/app/handler/grpc_handler.go
+++ b/cmd/collector/app/handler/grpc_handler.go
@@ -75,7 +75,7 @@ func (c *batchConsumer) consume(ctx context.Context, batch *model.Batch) error {
 			span.Process = batch.Process
 		}
 	}
-	_, err = c.spanProcessor.ProcessSpans(processor.SpansV1{
+	_, err = c.spanProcessor.ProcessSpans(ctx, processor.SpansV1{
 		Spans: batch.Spans,
 		Details: processor.Details{
 			InboundTransport: c.spanOptions.InboundTransport,

--- a/cmd/collector/app/handler/grpc_handler_test.go
+++ b/cmd/collector/app/handler/grpc_handler_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
+var _ processor.SpanProcessor = (*mockSpanProcessor)(nil)
+
 type mockSpanProcessor struct {
 	expectedError error
 	mux           sync.Mutex
@@ -34,7 +36,7 @@ type mockSpanProcessor struct {
 	spanFormat    processor.SpanFormat
 }
 
-func (p *mockSpanProcessor) ProcessSpans(batch processor.Batch) ([]bool, error) {
+func (p *mockSpanProcessor) ProcessSpans(_ context.Context, batch processor.Batch) ([]bool, error) {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	batch.GetSpans(func(spans []*model.Span) {

--- a/cmd/collector/app/handler/http_thrift_handler.go
+++ b/cmd/collector/app/handler/http_thrift_handler.go
@@ -75,7 +75,7 @@ func (aH *APIHandler) SaveSpan(w http.ResponseWriter, r *http.Request) {
 	}
 	batches := []*tJaeger.Batch{batch}
 	opts := SubmitBatchOptions{InboundTransport: processor.HTTPTransport}
-	if _, err = aH.jaegerBatchesHandler.SubmitBatches(batches, opts); err != nil {
+	if _, err = aH.jaegerBatchesHandler.SubmitBatches(r.Context(), batches, opts); err != nil {
 		http.Error(w, fmt.Sprintf("Cannot submit Jaeger batch: %v", err), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/collector/app/handler/http_thrift_handler_test.go
+++ b/cmd/collector/app/handler/http_thrift_handler_test.go
@@ -25,7 +25,10 @@ import (
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
 )
 
-var httpClient = &http.Client{Timeout: 2 * time.Second}
+var (
+	httpClient                      = &http.Client{Timeout: 2 * time.Second}
+	_          JaegerBatchesHandler = (*mockJaegerHandler)(nil)
+)
 
 type mockJaegerHandler struct {
 	err     error
@@ -33,7 +36,7 @@ type mockJaegerHandler struct {
 	batches []*jaeger.Batch
 }
 
-func (p *mockJaegerHandler) SubmitBatches(batches []*jaeger.Batch, _ SubmitBatchOptions) ([]*jaeger.BatchSubmitResponse, error) {
+func (p *mockJaegerHandler) SubmitBatches(_ context.Context, batches []*jaeger.Batch, _ SubmitBatchOptions) ([]*jaeger.BatchSubmitResponse, error) {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 	p.batches = append(p.batches, batches...)

--- a/cmd/collector/app/processor/processor.go
+++ b/cmd/collector/app/processor/processor.go
@@ -4,6 +4,7 @@
 package processor
 
 import (
+	"context"
 	"io"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -29,7 +30,7 @@ type Batch interface {
 // SpanProcessor handles spans
 type SpanProcessor interface {
 	// ProcessSpans processes spans and return with either a list of true/false success or an error
-	ProcessSpans(spans Batch) ([]bool, error)
+	ProcessSpans(ctx context.Context, spans Batch) ([]bool, error)
 	io.Closer
 }
 

--- a/cmd/collector/app/server/test.go
+++ b/cmd/collector/app/server/test.go
@@ -26,6 +26,6 @@ func (*mockSpanProcessor) Close() error {
 	return nil
 }
 
-func (*mockSpanProcessor) ProcessSpans(_ processor.Batch) ([]bool, error) {
+func (*mockSpanProcessor) ProcessSpans(_ context.Context, _ processor.Batch) ([]bool, error) {
 	return []bool{}, nil
 }

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -241,7 +241,6 @@ func (sp *spanProcessor) countSpansInQueue(span *model.Span, _ string /* tenant 
 	sp.spansProcessed.Add(1)
 }
 
-// TODO pass Context
 func (sp *spanProcessor) ProcessSpans(ctx context.Context, batch processor.Batch) ([]bool, error) {
 	// We call preProcessSpans on a batch, it's responsibility of implementation
 	// to understand v1/v2 distinction. Jaeger itself does not use pre-processors.


### PR DESCRIPTION
## Which problem is this PR solving?
- Context is lost in the process, see https://github.com/jaegertracing/jaeger/pull/6491#discussion_r1912529658

## Description of the changes
- Add Context argument to handler and span processor methods

## How was this change tested?
- CI
