### PR TITLE
[refactor] Move sampling grpc handler to internal/sampling/grpc

### DIFF
--- a/cmd/collector/app/server/grpc.go
+++ b/cmd/collector/app/server/grpc.go
@@ -17,8 +17,8 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
-	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/samplingstrategy"
+	samplinggrpc "github.com/jaegertracing/jaeger/internal/sampling/grpc"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
@@ -65,7 +65,7 @@ func serveGRPC(server *grpc.Server, listener net.Listener, params *GRPCServerPar
 	healthServer := health.NewServer()
 
 	api_v2.RegisterCollectorServiceServer(server, params.Handler)
-	api_v2.RegisterSamplingManagerServer(server, sampling.NewGRPCHandler(params.SamplingProvider))
+	api_v2.RegisterSamplingManagerServer(server, samplinggrpc.NewHandler(params.SamplingProvider))
 
 	healthServer.SetServingStatus("jaeger.api_v2.CollectorService", grpc_health_v1.HealthCheckResponse_SERVING)
 	healthServer.SetServingStatus("jaeger.api_v2.SamplingManager", grpc_health_v1.HealthCheckResponse_SERVING)

--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -19,10 +19,10 @@ import (
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage"
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
+	samplinggrpc "github.com/jaegertracing/jaeger/internal/sampling/grpc"
 	"github.com/jaegertracing/jaeger/pkg/clientcfg/clientcfghttp"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/plugin/sampling/leaderelection"
@@ -276,7 +276,7 @@ func (ext *rsExtension) startGRPCServer(ctx context.Context, host component.Host
 		return err
 	}
 
-	api_v2.RegisterSamplingManagerServer(ext.grpcServer, sampling.NewGRPCHandler(ext.strategyProvider))
+	api_v2.RegisterSamplingManagerServer(ext.grpcServer, samplinggrpc.NewHandler(ext.strategyProvider))
 
 	healthServer := health.NewServer() // support health checks on the gRPC server
 	healthServer.SetServingStatus("jaeger.api_v2.SamplingManager", grpc_health_v1.HealthCheckResponse_SERVING)

--- a/internal/sampling/grpc/grpc_handler.go
+++ b/internal/sampling/grpc/grpc_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package sampling
+package grpc
 
 import (
 	"context"
@@ -10,19 +10,19 @@ import (
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 )
 
-// GRPCHandler is sampling strategy handler for gRPC.
-type GRPCHandler struct {
+// Handler is sampling strategy handler for gRPC.
+type Handler struct {
 	samplingProvider samplingstrategy.Provider
 }
 
-// NewGRPCHandler creates a handler that controls sampling strategies for services.
-func NewGRPCHandler(provider samplingstrategy.Provider) GRPCHandler {
-	return GRPCHandler{
+// NewHandler creates a handler that controls sampling strategies for services.
+func NewHandler(provider samplingstrategy.Provider) Handler {
+	return Handler{
 		samplingProvider: provider,
 	}
 }
 
 // GetSamplingStrategy returns sampling decision from store.
-func (s GRPCHandler) GetSamplingStrategy(ctx context.Context, param *api_v2.SamplingStrategyParameters) (*api_v2.SamplingStrategyResponse, error) {
+func (s Handler) GetSamplingStrategy(ctx context.Context, param *api_v2.SamplingStrategyParameters) (*api_v2.SamplingStrategyResponse, error) {
 	return s.samplingProvider.GetSamplingStrategy(ctx, param.GetServiceName())
 }

--- a/internal/sampling/grpc/grpc_handler_test.go
+++ b/internal/sampling/grpc/grpc_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package sampling
+package grpc
 
 import (
 	"errors"
@@ -40,7 +40,7 @@ func TestNewGRPCHandler(t *testing.T) {
 		{req: &api_v2.SamplingStrategyParameters{ServiceName: "nil"}, resp: nil},
 		{req: &api_v2.SamplingStrategyParameters{ServiceName: "foo"}, resp: &api_v2.SamplingStrategyResponse{StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC}},
 	}
-	h := NewGRPCHandler(mockSamplingStore{})
+	h := NewHandler(mockSamplingStore{})
 	for _, test := range tests {
 		resp, err := h.GetSamplingStrategy(context.Background(), test.req)
 		if test.err != "" {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6411 

## Description of the changes
- Move sampling grpc handler from cmd/collector/app/sampling to internal/sampling/grpc

## How was this change tested?
- Covered by existing

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
