### PR TITLE
[ci] Fix binary-size-check workflow

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -155,7 +155,7 @@ jobs:
           jaeger_binary_size
 
     - name: Compare jaeger binary sizes
-      if: steps.cache-binary-size.outputs.cache-hit == 'true'
+      if: steps.cache-binary-size.outputs.cache-matched-key != ''
       run: |
         OLD_BINARY_SIZE=$(cat ./jaeger_binary_size.txt)
         NEW_BINARY_SIZE=$(cat ./new_jaeger_binary_size.txt)


### PR DESCRIPTION
## Which problem is this PR solving?
- Fix for one issue caused in #6527 

## Description of the changes
- cache_output not being set after a cache hit using restore key
- Instead check for cache-matched-key != ''" 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
