### PR TITLE
[v2][query] Apply "Max Clock Skew Adjust" setting

### DIFF
--- a/cmd/jaeger/config.yaml
+++ b/cmd/jaeger/config.yaml
@@ -32,6 +32,9 @@ extensions:
       traces_archive: another_store
     ui:
       config_file: ./cmd/jaeger/config-ui.json
+    # The maximum duration that is considered for clock skew adjustments.
+    # Defaults to 0 seconds, which means it's disabled.
+    max_clock_skew_adjust: 0s
 
   jaeger_storage:
     backends:

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -95,8 +95,12 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("cannot create dependencies reader: %w", err)
 	}
 
-	var opts querysvc.QueryServiceOptions
-	var v2opts v2querysvc.QueryServiceOptions
+	opts := querysvc.QueryServiceOptions{
+		MaxClockSkewAdjust: s.config.MaxClockSkewAdjust,
+	}
+	v2opts := v2querysvc.QueryServiceOptions{
+		MaxClockSkewAdjust: s.config.MaxClockSkewAdjust,
+	}
 	if err := s.addArchiveStorage(&opts, &v2opts, host); err != nil {
 		return err
 	}

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -102,9 +102,9 @@ func TestBuildQueryServiceOptions(t *testing.T) {
 
 	qSvcOpts := qOpts.BuildQueryServiceOptions(initializedFn, zap.NewNop())
 	assert.NotNil(t, qSvcOpts)
-	assert.NotNil(t, qSvcOpts.Adjuster)
 	assert.NotNil(t, qSvcOpts.ArchiveSpanReader)
 	assert.NotNil(t, qSvcOpts.ArchiveSpanWriter)
+	assert.Equal(t, defaultMaxClockSkewAdjust, qSvcOpts.MaxClockSkewAdjust)
 }
 
 func TestBuildQueryServiceOptions_NoArchiveStorage(t *testing.T) {
@@ -116,9 +116,9 @@ func TestBuildQueryServiceOptions_NoArchiveStorage(t *testing.T) {
 	logger, logBuf := testutils.NewLogger()
 	qSvcOpts := qOpts.BuildQueryServiceOptions(uninitializedFn, logger)
 	assert.NotNil(t, qSvcOpts)
-	assert.NotNil(t, qSvcOpts.Adjuster)
 	assert.Nil(t, qSvcOpts.ArchiveSpanReader)
 	assert.Nil(t, qSvcOpts.ArchiveSpanWriter)
+	assert.Equal(t, defaultMaxClockSkewAdjust, qSvcOpts.MaxClockSkewAdjust)
 
 	require.Contains(t, logBuf.String(), "Archive storage not initialized")
 }
@@ -132,9 +132,9 @@ func TestBuildQueryServiceOptionsV2(t *testing.T) {
 	qSvcOpts := qOpts.BuildQueryServiceOptionsV2(initializedFn, zap.NewNop())
 
 	assert.NotNil(t, qSvcOpts)
-	assert.NotNil(t, qSvcOpts.Adjuster)
 	assert.NotNil(t, qSvcOpts.ArchiveTraceReader)
 	assert.NotNil(t, qSvcOpts.ArchiveTraceWriter)
+	assert.Equal(t, defaultMaxClockSkewAdjust, qSvcOpts.MaxClockSkewAdjust)
 }
 
 func TestBuildQueryServiceOptionsV2_NoArchiveStorage(t *testing.T) {

--- a/cmd/query/app/querysvc/v2/querysvc/service.go
+++ b/cmd/query/app/querysvc/v2/querysvc/service.go
@@ -21,19 +21,14 @@ import (
 
 var errNoArchiveSpanStorage = errors.New("archive span storage was not configured")
 
-const (
-	defaultMaxClockSkewAdjust = time.Second
-)
-
 // QueryServiceOptions holds the configuration options for the query service.
 type QueryServiceOptions struct {
 	// ArchiveTraceReader is used to read archived traces from the storage.
 	ArchiveTraceReader tracestore.Reader
 	// ArchiveTraceWriter is used to write traces to the archive storage.
 	ArchiveTraceWriter tracestore.Writer
-	// Adjuster is used to adjust traces before they are returned to the client.
-	// If not set, the default adjuster will be used.
-	Adjuster adjuster.Adjuster
+	// MaxClockSkewAdjust is the maximum duration by which to adjust a span.
+	MaxClockSkewAdjust time.Duration
 }
 
 // StorageCapabilities is a feature flag for query service
@@ -48,6 +43,7 @@ type StorageCapabilities struct {
 type QueryService struct {
 	traceReader      tracestore.Reader
 	dependencyReader depstore.Reader
+	adjuster         adjuster.Adjuster
 	options          QueryServiceOptions
 }
 
@@ -76,13 +72,12 @@ func NewQueryService(
 	qsvc := &QueryService{
 		traceReader:      traceReader,
 		dependencyReader: dependencyReader,
-		options:          options,
+		adjuster: adjuster.Sequence(
+			adjuster.StandardAdjusters(options.MaxClockSkewAdjust)...,
+		),
+		options: options,
 	}
 
-	if qsvc.options.Adjuster == nil {
-		qsvc.options.Adjuster = adjuster.Sequence(
-			adjuster.StandardAdjusters(defaultMaxClockSkewAdjust)...)
-	}
 	return qsvc
 }
 
@@ -191,7 +186,7 @@ func (qs QueryService) receiveTraces(
 		}
 		for _, trace := range traces {
 			if !rawTraces {
-				qs.options.Adjuster.Adjust(trace)
+				qs.adjuster.Adjust(trace)
 			}
 			jptrace.SpanIter(trace)(func(_ jptrace.SpanIterPos, span ptrace.Span) bool {
 				foundTraceIDs[span.TraceID()] = struct{}{}

--- a/cmd/query/app/querysvc/v2/querysvc/service_test.go
+++ b/cmd/query/app/querysvc/v2/querysvc/service_test.go
@@ -59,12 +59,6 @@ func withArchiveTraceWriter() testOption {
 	}
 }
 
-func withAdjuster(adj adjuster.Adjuster) testOption {
-	return func(_ *testQueryService, options *QueryServiceOptions) {
-		options.Adjuster = adj
-	}
-}
-
 func initializeTestService(opts ...testOption) *testQueryService {
 	traceReader := &tracestoremocks.Reader{}
 	dependencyStorage := &depstoremocks.Reader{}
@@ -483,7 +477,8 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 				adjustCalls++
 			})
 
-			tqs := initializeTestService(withAdjuster(adj))
+			tqs := initializeTestService()
+			tqs.queryService.adjuster = adj
 			duration, err := time.ParseDuration("20ms")
 			require.NoError(t, err)
 			now := time.Now()


### PR DESCRIPTION
Apply the `max_clock_skew_adjust` setting to the query service during initialization.

The maximum clock skew adjustment setting for the query component is properly read during initialization, but not applied in the v2 server in the end. This causes it to always default to 1 second, regardless of the configuration value.

## Which problem is this PR solving?

- Resolves #6565 

## Description of the changes

- Initialize and set the `Adjuster` on both the v1 and v2 query options.
- The config defaults to `0` so applying this unconditionally would now disable the clock skew adjustment instead of defaulting to `1s`? However, the same _seems to be done_ in the older services from v1.
  - Having a default of `1s` instead of `0` (which disables adjustments completely) might have been an accident?

## How was this change tested?

- Not testing so far.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
