### PR TITLE
Untangle logger from HandleRootSpan

### DIFF
--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -91,7 +91,7 @@ func (c *Collector) Start(options *flags.CollectorOptions) error {
 	var additionalProcessors []ProcessSpan
 	if c.samplingAggregator != nil {
 		additionalProcessors = append(additionalProcessors, func(span *model.Span, _ /* tenant */ string) {
-			c.samplingAggregator.HandleRootSpan(span, c.logger)
+			c.samplingAggregator.HandleRootSpan(span)
 		})
 	}
 

--- a/cmd/collector/app/collector_test.go
+++ b/cmd/collector/app/collector_test.go
@@ -92,7 +92,7 @@ func (t *mockAggregator) RecordThroughput(string /* service */, string /* operat
 	t.callCount.Add(1)
 }
 
-func (t *mockAggregator) HandleRootSpan(*model.Span, *zap.Logger) {
+func (t *mockAggregator) HandleRootSpan(*model.Span) {
 	t.callCount.Add(1)
 }
 

--- a/cmd/jaeger/internal/processors/adaptivesampling/processor.go
+++ b/cmd/jaeger/internal/processors/adaptivesampling/processor.go
@@ -71,7 +71,7 @@ func (tp *traceProcessor) processTraces(_ context.Context, td ptrace.Traces) (pt
 			if span.Process == nil {
 				span.Process = batch.Process
 			}
-			tp.aggregator.HandleRootSpan(span, tp.telset.Logger)
+			tp.aggregator.HandleRootSpan(span)
 		}
 	}
 	return td, nil

--- a/cmd/jaeger/internal/processors/adaptivesampling/processor_test.go
+++ b/cmd/jaeger/internal/processors/adaptivesampling/processor_test.go
@@ -140,7 +140,7 @@ type notClosingAgg struct{}
 
 func (*notClosingAgg) Close() error { return errors.New("not closing") }
 
-func (*notClosingAgg) HandleRootSpan(*model.Span, *zap.Logger)                     {}
+func (*notClosingAgg) HandleRootSpan(*model.Span)                                  {}
 func (*notClosingAgg) RecordThroughput(string, string, model.SamplerType, float64) {}
 func (*notClosingAgg) Start()                                                      {}
 

--- a/internal/sampling/samplingstrategy/adaptive/aggregator.go
+++ b/internal/sampling/samplingstrategy/adaptive/aggregator.go
@@ -140,7 +140,7 @@ func (a *aggregator) Close() error {
 	return nil
 }
 
-func (a *aggregator) HandleRootSpan(span *span_model.Span, logger *zap.Logger) {
+func (a *aggregator) HandleRootSpan(span *span_model.Span) {
 	// simply checking parentId to determine if a span is a root span is not sufficient. However,
 	// we can be sure that only a root span will have sampler tags.
 	if span.ParentSpanID() != span_model.NewSpanID(0) {
@@ -150,7 +150,7 @@ func (a *aggregator) HandleRootSpan(span *span_model.Span, logger *zap.Logger) {
 	if service == "" || span.OperationName == "" {
 		return
 	}
-	samplerType, samplerParam := span.GetSamplerParams(logger)
+	samplerType, samplerParam := span.GetSamplerParams(a.postAggregator.logger)
 	if samplerType == span_model.SamplerTypeUnrecognized {
 		return
 	}

--- a/internal/sampling/samplingstrategy/adaptive/aggregator_test.go
+++ b/internal/sampling/samplingstrategy/adaptive/aggregator_test.go
@@ -121,7 +121,7 @@ func TestRecordThroughput(t *testing.T) {
 
 	// Testing non-root span
 	span := &model.Span{References: []model.SpanRef{{SpanID: model.NewSpanID(1), RefType: model.ChildOf}}}
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name but no operation
@@ -129,12 +129,12 @@ func TestRecordThroughput(t *testing.T) {
 	span.Process = &model.Process{
 		ServiceName: "A",
 	}
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name and operation but no probabilistic sampling tags
 	span.OperationName = http.MethodGet
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name, operation, and probabilistic sampling tags
@@ -142,7 +142,7 @@ func TestRecordThroughput(t *testing.T) {
 		model.String("sampler.type", "probabilistic"),
 		model.String("sampler.param", "0.001"),
 	}
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	assert.EqualValues(t, 1, a.(*aggregator).currentThroughput["A"][http.MethodGet].Count)
 }
 
@@ -162,7 +162,7 @@ func TestRecordThroughputFunc(t *testing.T) {
 
 	// Testing non-root span
 	span := &model.Span{References: []model.SpanRef{{SpanID: model.NewSpanID(1), RefType: model.ChildOf}}}
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name but no operation
@@ -170,12 +170,12 @@ func TestRecordThroughputFunc(t *testing.T) {
 	span.Process = &model.Process{
 		ServiceName: "A",
 	}
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name and operation but no probabilistic sampling tags
 	span.OperationName = http.MethodGet
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	require.Empty(t, a.(*aggregator).currentThroughput)
 
 	// Testing span with service name, operation, and probabilistic sampling tags
@@ -183,6 +183,6 @@ func TestRecordThroughputFunc(t *testing.T) {
 		model.String("sampler.type", "probabilistic"),
 		model.String("sampler.param", "0.001"),
 	}
-	a.HandleRootSpan(span, logger)
+	a.HandleRootSpan(span)
 	assert.EqualValues(t, 1, a.(*aggregator).currentThroughput["A"][http.MethodGet].Count)
 }

--- a/internal/sampling/samplingstrategy/aggregator.go
+++ b/internal/sampling/samplingstrategy/aggregator.go
@@ -6,8 +6,6 @@ package samplingstrategy
 import (
 	"io"
 
-	"go.uber.org/zap"
-
 	"github.com/jaegertracing/jaeger/model"
 )
 
@@ -18,7 +16,7 @@ type Aggregator interface {
 
 	// The HandleRootSpan function processes a span, checking if it's a root span.
 	// If it is, it extracts sampler parameters, then calls RecordThroughput.
-	HandleRootSpan(span *model.Span, logger *zap.Logger)
+	HandleRootSpan(span *model.Span)
 
 	// RecordThroughput records throughput for an operation for aggregation.
 	RecordThroughput(service, operation string, samplerType model.SamplerType, probability float64)


### PR DESCRIPTION


## Which problem is this PR solving?
- Resolves #6584 

## Description of the changes
- Removed logger and its use cases

## How was this change tested?
- make test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
