### PR TITLE
Exclude idl/ as a source of Go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ ALL_SRC = $(shell find . -name '*.go' \
 				   -not -name 'mocks*' \
 				   -not -name '*.pb.go' \
 				   -not -path './vendor/*' \
+				   -not -path './idl/*' \
 				   -not -path './internal/tools/*' \
 				   -not -path './docker/debug/*' \
 				   -not -path '*/mocks/*' \


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6494
- Since `jaeger-idl` repo now includes Go code, as soon as we update the submodule here it's treated as a real source of Go code, including by tools like `go fmt`, etc.

## Description of the changes
- Exclude `idl/` from ALL_SOURCES, so that `make fmt` does not apply to it
- Bump `idl` submodule to latest

## How was this change tested?
- CI
