### PR TITLE
Sanitize Cassandra version before use it

### DIFF
--- a/plugin/storage/cassandra/schema/create.sh
+++ b/plugin/storage/cassandra/schema/create.sh
@@ -26,7 +26,7 @@ function usage {
 trace_ttl=${TRACE_TTL:-172800}
 dependencies_ttl=${DEPENDENCIES_TTL:-0}
 cas_version=${VERSION:-4}
-
+cas_version=$(echo "$cas_version" | tr -cd '0-9')
 template=$1
 if [[ "$template" == "" ]]; then
     case "$cas_version" in


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Fixes https://github.com/jaegertracing/jaeger/issues/6597

## Description of the changes
-  This issue arises when I was trying to release the operator, for some reason (may be the cassandra version) the returned version contains spaces. This result in trying to fallback to /`cassandra-schema/v004-go-tmpl.cql.tmpl` which is a golang template. This produced the following error

This migh be happen only with 3.x and I know we dropped support for it. but it could also happens with others. 

```
Using template file /cassandra-schema/v004-go-tmpl.cql.tmpl with parameters:
    mode = test
    datacenter = datacenter3
    keyspace = jaeger_v1_datacenter3
    replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
    trace_ttl = 172800
    dependencies_ttl = 0
    compaction_window_size = 96
    compaction_window_unit = MINUTES
<stdin>:5:SyntaxException: line 1:0 no viable alternative at input 'HOLA' ([HOLA]...)
<stdin>:15:SyntaxException: line 1:26 no viable alternative at input '{' (CREATE TYPE IF NOT EXISTS [{]...)
<stdin>:20:SyntaxException: line 1:26 no viable alternative at input '{' (CREATE TYPE IF NOT EXISTS [{]...)
<stdin>:26:SyntaxException: line 1:26 no viable alternative at input '{' (CREATE TYPE IF NOT EXISTS [{]...)
<stdin>:31:SyntaxException: line 1:26 no viable alternative at input '{' (CREATE TYPE IF NOT EXISTS [{]...
```


## How was this change tested?
-  I build a new image with the change and tested with the jaeger-operator unit tests. Now I see the migration applied.


## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
