### PR TITLE
Add example of ES/OS server_urls to configs

### DIFF
--- a/cmd/jaeger/config-elasticsearch.yaml
+++ b/cmd/jaeger/config-elasticsearch.yaml
@@ -32,6 +32,8 @@ extensions:
     backends:
       some_storage:
         elasticsearch:
+          server_urls:
+            - http://localhost:9200
           indices:
             index_prefix: "jaeger-main"
             spans:
@@ -56,6 +58,8 @@ extensions:
               replicas: 1
       another_storage:
         elasticsearch:
+          server_urls:
+            - http://localhost:9200
           indices:
             index_prefix: "jaeger-archive"
 

--- a/cmd/jaeger/config-opensearch.yaml
+++ b/cmd/jaeger/config-opensearch.yaml
@@ -32,6 +32,8 @@ extensions:
     backends:
       some_storage:
         opensearch:
+          server_urls:
+            - http://localhost:9200
           indices:
             index_prefix: "jaeger-main"
             spans:
@@ -56,6 +58,8 @@ extensions:
               replicas: 1
       another_storage:
         opensearch:
+          server_urls:
+            - http://localhost:9200
           indices:
             index_prefix: "jaeger-archive"
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Example configs do not show how to configure server addresses
- https://github.com/orgs/jaegertracing/discussions/6548#discussioncomment-11925175

## Description of the changes
- Add server address

## How was this change tested?
- CI
