### PR TITLE
[chore][tests] Clean up integration tests to remove archive reader / writer

### DIFF
--- a/cmd/jaeger/internal/integration/badger_test.go
+++ b/cmd/jaeger/internal/integration/badger_test.go
@@ -15,8 +15,7 @@ func TestBadgerStorage(t *testing.T) {
 	s := &E2EStorageIntegration{
 		ConfigFile: "../../config-badger.yaml",
 		StorageIntegration: integration.StorageIntegration{
-			SkipArchiveTest: true,
-			CleanUp:         purge,
+			CleanUp: purge,
 
 			// TODO: remove this once badger supports returning spanKind from GetOperations
 			// Cf https://github.com/jaegertracing/jaeger/issues/1922

--- a/cmd/jaeger/internal/integration/cassandra_test.go
+++ b/cmd/jaeger/internal/integration/cassandra_test.go
@@ -16,7 +16,6 @@ func TestCassandraStorage(t *testing.T) {
 		StorageIntegration: integration.StorageIntegration{
 			CleanUp:                      purge,
 			GetDependenciesReturnsSource: true,
-			SkipArchiveTest:              true,
 
 			SkipList: integration.CassandraSkippedTests,
 		},

--- a/cmd/jaeger/internal/integration/kafka_test.go
+++ b/cmd/jaeger/internal/integration/kafka_test.go
@@ -58,7 +58,6 @@ func TestKafkaStorage(t *testing.T) {
 				StorageIntegration: integration.StorageIntegration{
 					CleanUp:                      purge,
 					GetDependenciesReturnsSource: true,
-					SkipArchiveTest:              true,
 				},
 				EnvVarOverrides: envVarOverrides,
 			}

--- a/cmd/jaeger/internal/integration/memory_test.go
+++ b/cmd/jaeger/internal/integration/memory_test.go
@@ -15,8 +15,7 @@ func TestMemoryStorage(t *testing.T) {
 	s := &E2EStorageIntegration{
 		ConfigFile: "../../config.yaml",
 		StorageIntegration: integration.StorageIntegration{
-			SkipArchiveTest: true,
-			CleanUp:         purge,
+			CleanUp: purge,
 		},
 	}
 	s.e2eInitialize(t, "memory")

--- a/plugin/storage/integration/badgerstore_test.go
+++ b/plugin/storage/integration/badgerstore_test.go
@@ -56,8 +56,6 @@ func TestBadgerStorage(t *testing.T) {
 	})
 	s := &BadgerIntegrationStorage{
 		StorageIntegration: StorageIntegration{
-			SkipArchiveTest: true,
-
 			// TODO: remove this badger supports returning spanKind from GetOperations
 			GetOperationsMissingSpanKind: true,
 		},

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/testutils"

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -255,13 +255,17 @@ func (s *ESStorageIntegration) cleanESIndexTemplates(t *testing.T, prefix string
 	return nil
 }
 
+// testArchiveTrace validates that a trace with a start time older than maxSpanAge
+// can still be retrieved via the archive storage. This ensures archived traces are
+// accessible even when their age exceeds the retention period for primary storage.
+// This test applies only to Elasticsearch (ES) storage.
 func (s *ESStorageIntegration) testArchiveTrace(t *testing.T) {
 	s.skipIfNeeded(t)
 	defer s.cleanUp(t)
 	tID := model.NewTraceID(uint64(11), uint64(22))
 	expected := &model.Span{
 		OperationName: "archive_span",
-		StartTime:     time.Now().Add(-time.Hour * 72 * 5).Truncate(time.Microsecond),
+		StartTime:     time.Now().Add(-maxSpanAge * 5).Truncate(time.Microsecond),
 		TraceID:       tID,
 		SpanID:        model.NewSpanID(55),
 		References:    []model.SpanRef{},

--- a/plugin/storage/integration/elasticsearch_test.go
+++ b/plugin/storage/integration/elasticsearch_test.go
@@ -21,11 +21,13 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/jaegertracing/jaeger/storage_v2/v1adapter"
 )
 
@@ -51,6 +53,9 @@ type ESStorageIntegration struct {
 
 	client   *elastic.Client
 	v8Client *elasticsearch8.Client
+
+	ArchiveSpanReader spanstore.Reader
+	ArchiveSpanWriter spanstore.Writer
 
 	factory        *es.Factory
 	archiveFactory *es.Factory
@@ -174,8 +179,7 @@ func testElasticsearchStorage(t *testing.T, allTagsAsFields bool) {
 	require.NoError(t, healthCheck(c))
 	s := &ESStorageIntegration{
 		StorageIntegration: StorageIntegration{
-			Fixtures:        LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
-			SkipArchiveTest: false,
+			Fixtures: LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
 			// TODO: remove this flag after ES supports returning spanKind
 			//  Issue https://github.com/jaegertracing/jaeger/issues/1923
 			GetOperationsMissingSpanKind: true,
@@ -183,6 +187,7 @@ func testElasticsearchStorage(t *testing.T, allTagsAsFields bool) {
 	}
 	s.initializeES(t, c, allTagsAsFields)
 	s.RunAll(t)
+	t.Run("ArchiveTrace", s.testArchiveTrace)
 }
 
 func TestElasticsearchStorage(t *testing.T) {
@@ -248,4 +253,29 @@ func (s *ESStorageIntegration) cleanESIndexTemplates(t *testing.T, prefix string
 		require.NoError(t, err)
 	}
 	return nil
+}
+
+func (s *ESStorageIntegration) testArchiveTrace(t *testing.T) {
+	s.skipIfNeeded(t)
+	defer s.cleanUp(t)
+	tID := model.NewTraceID(uint64(11), uint64(22))
+	expected := &model.Span{
+		OperationName: "archive_span",
+		StartTime:     time.Now().Add(-time.Hour * 72 * 5).Truncate(time.Microsecond),
+		TraceID:       tID,
+		SpanID:        model.NewSpanID(55),
+		References:    []model.SpanRef{},
+		Process:       model.NewProcess("archived_service", model.KeyValues{}),
+	}
+
+	require.NoError(t, s.ArchiveSpanWriter.WriteSpan(context.Background(), expected))
+
+	var actual *model.Trace
+	found := s.waitForCondition(t, func(_ *testing.T) bool {
+		var err error
+		actual, err = s.ArchiveSpanReader.GetTrace(context.Background(), spanstore.GetTraceParameters{TraceID: tID})
+		return err == nil && len(actual.Spans) == 1
+	})
+	require.True(t, found)
+	CompareTraces(t, &model.Trace{Spans: []*model.Span{expected}}, actual)
 }

--- a/plugin/storage/integration/grpc_test.go
+++ b/plugin/storage/integration/grpc_test.go
@@ -53,10 +53,6 @@ func (s *GRPCStorageIntegrationTestSuite) initialize(t *testing.T) {
 	spanReader, err := f.CreateSpanReader()
 	require.NoError(t, err)
 	s.TraceReader = v1adapter.NewTraceReader(spanReader)
-	s.ArchiveSpanReader, err = af.CreateSpanReader()
-	require.NoError(t, err)
-	s.ArchiveSpanWriter, err = af.CreateSpanWriter()
-	require.NoError(t, err)
 
 	// TODO DependencyWriter is not implemented in grpc store
 

--- a/plugin/storage/integration/kafka_test.go
+++ b/plugin/storage/integration/kafka_test.go
@@ -95,7 +95,6 @@ func (s *KafkaIntegrationTestSuite) initialize(t *testing.T) {
 	s.TraceReader = v1adapter.NewTraceReader(spanReader)
 	s.TraceWriter = v1adapter.NewTraceWriter(spanWriter)
 	s.CleanUp = func(_ *testing.T) {}
-	s.SkipArchiveTest = true
 }
 
 // The ingester consumes spans from kafka and writes them to an in-memory traceStore

--- a/plugin/storage/integration/memstore_test.go
+++ b/plugin/storage/integration/memstore_test.go
@@ -23,12 +23,9 @@ func (s *MemStorageIntegrationTestSuite) initialize(_ *testing.T) {
 	s.logger, _ = testutils.NewLogger()
 
 	store := memory.NewStore()
-	archiveStore := memory.NewStore()
 	s.SamplingStore = memory.NewSamplingStore(2)
 	s.TraceReader = v1adapter.NewTraceReader(store)
 	s.TraceWriter = v1adapter.NewTraceWriter(store)
-	s.ArchiveSpanReader = archiveStore
-	s.ArchiveSpanWriter = archiveStore
 
 	// TODO DependencyWriter is not implemented in memory store
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6065

## Description of the changes
- This PR cleans up the integration test suite for jaeger-v1 by removing the archive related fields for all tests since they were being skipped anyway, with the exception of elasticsearch.
- Since the only storage that has a difference between primary and archive storage is ElasticSearch, this PR moves the archive trace test to `elasticsearch_test.go`.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
