### PR TITLE
fix(hotrod): include CA certificates for HOTRod Dockerfile

### DIFF
--- a/examples/hotrod/Dockerfile
+++ b/examples/hotrod/Dockerfile
@@ -1,9 +1,13 @@
 # Copyright (c) 2024 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+FROM alpine:latest AS prep
+RUN apk --update add ca-certificates
+
 FROM scratch
 ARG TARGETARCH
 EXPOSE 8080 8081 8082 8083
+COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY hotrod-linux-$TARGETARCH /go/bin/hotrod-linux
 ENTRYPOINT ["/go/bin/hotrod-linux"]
 CMD ["all"]

--- a/examples/hotrod/Dockerfile
+++ b/examples/hotrod/Dockerfile
@@ -1,13 +1,14 @@
 # Copyright (c) 2024 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:latest AS prep
-RUN apk --update add ca-certificates
+FROM alpine:3.21.2 AS cert
+RUN apk add --update --no-cache ca-certificates
 
 FROM scratch
 ARG TARGETARCH
 EXPOSE 8080 8081 8082 8083
-COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY hotrod-linux-$TARGETARCH /go/bin/hotrod-linux
 ENTRYPOINT ["/go/bin/hotrod-linux"]
 CMD ["all"]
+


### PR DESCRIPTION
## Which problem is this PR solving?
- resolves #6626

## Description of the changes
- includes CA Certificates to the HOTRod image

## How was this change tested?
- Tested with secured endpoint of upstream collector

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
