### PR TITLE
Update import paths for jaeger thrift files to use jaeger-idl

### DIFF
--- a/model/converter/json/sampling_test.go
+++ b/model/converter/json/sampling_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
+	api_v1 "github.com/jaegertracing/jaeger-idl/thrift-gen/sampling"
 	thriftconv "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
-	api_v1 "github.com/jaegertracing/jaeger/thrift-gen/sampling"
 )
 
 func TestSamplingStrategyResponseToJSON_Error(t *testing.T) {

--- a/model/converter/thrift/jaeger/sampling_from_domain.go
+++ b/model/converter/thrift/jaeger/sampling_from_domain.go
@@ -8,7 +8,7 @@ import (
 	"math"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger-idl/thrift-gen/sampling"
 )
 
 // ConvertSamplingResponseFromDomain converts proto sampling response to its thrift representation.

--- a/model/converter/thrift/jaeger/sampling_from_domain_test.go
+++ b/model/converter/thrift/jaeger/sampling_from_domain_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger-idl/thrift-gen/sampling"
 )
 
 func TestConvertStrategyTypeFromDomain(t *testing.T) {

--- a/model/converter/thrift/jaeger/sampling_to_domain.go
+++ b/model/converter/thrift/jaeger/sampling_to_domain.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger-idl/thrift-gen/sampling"
 )
 
 // ConvertSamplingResponseToDomain converts thrift sampling response to its proto representation.

--- a/model/converter/thrift/jaeger/sampling_to_domain_test.go
+++ b/model/converter/thrift/jaeger/sampling_to_domain_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/jaegertracing/jaeger-idl/thrift-gen/sampling"
 )
 
 func TestConvertStrategyTypeToDomain(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/6617#issuecomment-2624759289

## Description of the changes
- replace use of jaeger-idl/thrift-gen/sampling imports

## How was this change tested?
- `make test lint'

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
