### PR TITLE
[refactor] Move `plugin/storage` to `internal/storage/v1/factory`

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	v2querysvc "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
 	ss "github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/metafactory"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
@@ -40,7 +41,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/plugin/metricstore"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -54,7 +54,7 @@ func main() {
 	if os.Getenv(storage.SpanStorageTypeEnvVar) == "" {
 		os.Setenv(storage.SpanStorageTypeEnvVar, "memory") // other storage types default to SpanStorage
 	}
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.ConfigFromEnvAndCLI(os.Args, os.Stderr))
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -23,13 +23,13 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/internal/printconfig"
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
 	ss "github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/metafactory"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -39,7 +39,7 @@ func main() {
 	cmdFlags.PrintV1EOL()
 	svc := cmdFlags.NewService(ports.CollectorAdminHTTP)
 
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.ConfigFromEnvAndCLI(os.Args, os.Stderr))
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -21,11 +21,11 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/internal/flags"
 	"github.com/jaegertracing/jaeger/cmd/internal/printconfig"
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/version"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -33,7 +33,7 @@ func main() {
 	flags.PrintV1EOL()
 	svc := flags.NewService(ports.IngesterAdminHTTP)
 
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.ConfigFromEnvAndCLI(os.Args, os.Stderr))
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/internal/env/command.go
+++ b/cmd/internal/env/command.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/pflag"
 
 	ss "github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/metafactory"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/plugin/metricstore"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 )
 
 const (

--- a/cmd/query/app/flags.go
+++ b/cmd/query/app/flags.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	v2querysvc "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/config/tlscfg"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 

--- a/cmd/query/app/flags_test.go
+++ b/cmd/query/app/flags_test.go
@@ -15,9 +15,9 @@ import (
 	"go.uber.org/zap"
 
 	spanstoremocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/mocks"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/testutils"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	querysvcv2 "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config"
@@ -32,7 +33,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	metricsPlugin "github.com/jaegertracing/jaeger/plugin/metricstore"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -40,7 +40,7 @@ func main() {
 	flags.PrintV1EOL()
 	svc := flags.NewService(ports.QueryAdminHTTP)
 
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.ConfigFromEnvAndCLI(os.Args, os.Stderr))
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/cmd/remote-storage/main.go
+++ b/cmd/remote-storage/main.go
@@ -20,12 +20,12 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/internal/printconfig"
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
 	"github.com/jaegertracing/jaeger/cmd/remote-storage/app"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -38,7 +38,7 @@ func main() {
 		os.Setenv(storage.SpanStorageTypeEnvVar, "memory")
 		// other storage types default to the same type as SpanStorage
 	}
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.ConfigFromEnvAndCLI(os.Args, os.Stderr))
 	if err != nil {
 		log.Fatalf("Cannot initialize storage factory: %v", err)
 	}

--- a/internal/storage/integration/remote_memory_storage.go
+++ b/internal/storage/integration/remote_memory_storage.go
@@ -19,12 +19,12 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/jaegertracing/jaeger/cmd/remote-storage/app"
+	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
-	"github.com/jaegertracing/jaeger/plugin/storage"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -46,7 +46,7 @@ func StartNewRemoteMemoryStorage(t *testing.T, port int) *RemoteMemoryStorage {
 		},
 	}
 	tm := tenancy.NewManager(&opts.Tenancy)
-	storageFactory, err := storage.NewFactory(storage.FactoryConfigFromEnvAndCLI(os.Args, os.Stderr))
+	storageFactory, err := storage.NewFactory(storage.ConfigFromEnvAndCLI(os.Args, os.Stderr))
 	require.NoError(t, err)
 
 	v, _ := config.Viperize(storageFactory.AddFlags)

--- a/internal/storage/v1/factory/config.go
+++ b/internal/storage/v1/factory/config.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2018 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package storage
+package factory
 
 import (
 	"fmt"
@@ -24,8 +24,8 @@ const (
 	spanStorageFlag = "--span-storage.type"
 )
 
-// FactoryConfig tells the Factory which types of backends it needs to create for different storage types.
-type FactoryConfig struct {
+// Config tells the Factory which types of backends it needs to create for different storage types.
+type Config struct {
 	SpanWriterTypes         []string
 	SpanReaderType          string
 	SamplingStorageType     string
@@ -34,7 +34,7 @@ type FactoryConfig struct {
 	DownsamplingHashSalt    string
 }
 
-// FactoryConfigFromEnvAndCLI reads the desired types of storage backends from SPAN_STORAGE_TYPE and
+// ConfigFromEnvAndCLI reads the desired types of storage backends from SPAN_STORAGE_TYPE and
 // DEPENDENCY_STORAGE_TYPE environment variables. Allowed values:
 // * `cassandra` - built-in
 // * `opensearch` - built-in
@@ -46,7 +46,7 @@ type FactoryConfig struct {
 //
 // For backwards compatibility it also parses the args looking for deprecated --span-storage.type flag.
 // If found, it writes a deprecation warning to the log.
-func FactoryConfigFromEnvAndCLI(args []string, log io.Writer) FactoryConfig {
+func ConfigFromEnvAndCLI(args []string, log io.Writer) Config {
 	spanStorageType := os.Getenv(SpanStorageTypeEnvVar)
 	if spanStorageType == "" {
 		// for backwards compatibility check command line for --span-storage.type flag
@@ -69,7 +69,7 @@ func FactoryConfigFromEnvAndCLI(args []string, log io.Writer) FactoryConfig {
 	}
 	samplingStorageType := os.Getenv(SamplingStorageTypeEnvVar)
 	// TODO support explicit configuration for readers
-	return FactoryConfig{
+	return Config{
 		SpanWriterTypes:         spanWriterTypes,
 		SpanReaderType:          spanWriterTypes[0],
 		DependenciesStorageType: depStorageType,

--- a/internal/storage/v1/factory/config_test.go
+++ b/internal/storage/v1/factory/config_test.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2018 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package storage
+package factory
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFactoryConfigFromEnv(t *testing.T) {
-	f := FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
+	f := ConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Len(t, f.SpanWriterTypes, 1)
 	assert.Equal(t, cassandraStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, cassandraStorageType, f.SpanReaderType)
@@ -23,7 +23,7 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 	t.Setenv(DependencyStorageTypeEnvVar, memoryStorageType)
 	t.Setenv(SamplingStorageTypeEnvVar, cassandraStorageType)
 
-	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
+	f = ConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Len(t, f.SpanWriterTypes, 1)
 	assert.Equal(t, elasticsearchStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
@@ -32,14 +32,14 @@ func TestFactoryConfigFromEnv(t *testing.T) {
 
 	t.Setenv(SpanStorageTypeEnvVar, elasticsearchStorageType+","+kafkaStorageType)
 
-	f = FactoryConfigFromEnvAndCLI(nil, &bytes.Buffer{})
+	f = ConfigFromEnvAndCLI(nil, &bytes.Buffer{})
 	assert.Len(t, f.SpanWriterTypes, 2)
 	assert.Equal(t, []string{elasticsearchStorageType, kafkaStorageType}, f.SpanWriterTypes)
 	assert.Equal(t, elasticsearchStorageType, f.SpanReaderType)
 
 	t.Setenv(SpanStorageTypeEnvVar, badgerStorageType)
 
-	f = FactoryConfigFromEnvAndCLI(nil, nil)
+	f = ConfigFromEnvAndCLI(nil, nil)
 	assert.Len(t, f.SpanWriterTypes, 1)
 	assert.Equal(t, badgerStorageType, f.SpanWriterTypes[0])
 	assert.Equal(t, badgerStorageType, f.SpanReaderType)
@@ -58,7 +58,7 @@ func TestFactoryConfigFromEnvDeprecated(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		log := new(bytes.Buffer)
-		f := FactoryConfigFromEnvAndCLI(testCase.args, log)
+		f := ConfigFromEnvAndCLI(testCase.args, log)
 		assert.Len(t, f.SpanWriterTypes, 1)
 		assert.Equal(t, testCase.value, f.SpanWriterTypes[0])
 		assert.Equal(t, testCase.value, f.SpanReaderType)

--- a/internal/storage/v1/factory/factory.go
+++ b/internal/storage/v1/factory/factory.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package storage
+package factory
 
 import (
 	"errors"
@@ -81,7 +81,7 @@ var ( // interface comformance checks
 
 // Factory implements storage.Factory interface as a meta-factory for storage components.
 type Factory struct {
-	FactoryConfig
+	Config
 	metricsFactory         metrics.Factory
 	factories              map[string]storage.Factory
 	archiveFactories       map[string]storage.Factory
@@ -89,8 +89,8 @@ type Factory struct {
 }
 
 // NewFactory creates the meta-factory.
-func NewFactory(config FactoryConfig) (*Factory, error) {
-	f := &Factory{FactoryConfig: config}
+func NewFactory(config Config) (*Factory, error) {
+	f := &Factory{Config: config}
 	uniqueTypes := map[string]struct{}{
 		f.SpanReaderType:          {},
 		f.DependenciesStorageType: {},
@@ -325,17 +325,17 @@ func (f *Factory) initDownsamplingFromViper(v *viper.Viper) {
 	// if the downsampling flag isn't set then this component used the standard "AddFlags" method
 	// and has no use for downsampling.  the default settings effectively disable downsampling
 	if !f.downsamplingFlagsAdded {
-		f.FactoryConfig.DownsamplingRatio = defaultDownsamplingRatio
-		f.FactoryConfig.DownsamplingHashSalt = defaultDownsamplingHashSalt
+		f.Config.DownsamplingRatio = defaultDownsamplingRatio
+		f.Config.DownsamplingHashSalt = defaultDownsamplingHashSalt
 		return
 	}
 
-	f.FactoryConfig.DownsamplingRatio = v.GetFloat64(downsamplingRatio)
-	if f.FactoryConfig.DownsamplingRatio < 0 || f.FactoryConfig.DownsamplingRatio > 1 {
+	f.Config.DownsamplingRatio = v.GetFloat64(downsamplingRatio)
+	if f.Config.DownsamplingRatio < 0 || f.Config.DownsamplingRatio > 1 {
 		// Values not in the range of 0 ~ 1.0 will be set to default.
-		f.FactoryConfig.DownsamplingRatio = 1.0
+		f.Config.DownsamplingRatio = 1.0
 	}
-	f.FactoryConfig.DownsamplingHashSalt = v.GetString(downsamplingHashSalt)
+	f.Config.DownsamplingHashSalt = v.GetString(downsamplingHashSalt)
 }
 
 type ArchiveStorage struct {
@@ -392,6 +392,6 @@ func (f *Factory) Close() error {
 }
 
 func (f *Factory) publishOpts() {
-	safeexpvar.SetInt(downsamplingRatio, int64(f.FactoryConfig.DownsamplingRatio))
-	safeexpvar.SetInt(spanStorageType+"-"+f.FactoryConfig.SpanReaderType, 1)
+	safeexpvar.SetInt(downsamplingRatio, int64(f.Config.DownsamplingRatio))
+	safeexpvar.SetInt(spanStorageType+"-"+f.Config.SpanReaderType, 1)
 }

--- a/internal/storage/v1/factory/package_test.go
+++ b/internal/storage/v1/factory/package_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package storage
+package factory
 
 import (
 	"testing"


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6637

## Description of the changes
- This PR moves the meta factory from `plugin/storage` to `internal/storage/v1/factory`

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
