### PR TITLE
[refactor] Conditionally implement interfaces in v1adapter factory

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -116,7 +116,11 @@ by default uses only in-memory database.`,
 			if err != nil {
 				logger.Fatal("Failed to create span writer", zap.Error(err))
 			}
-			dependencyReader, err := v2Factory.CreateDependencyReader()
+			depstoreFactory, ok := v2Factory.(depstore.Factory)
+			if !ok {
+				logger.Fatal("Failed to create dependency reader", zap.Error(err))
+			}
+			dependencyReader, err := depstoreFactory.CreateDependencyReader()
 			if err != nil {
 				logger.Fatal("Failed to create dependency reader", zap.Error(err))
 			}

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -25,6 +25,7 @@ import (
 	querysvcv2 "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
 	metricsPlugin "github.com/jaegertracing/jaeger/internal/storage/metricstore"
 	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config"
@@ -98,7 +99,11 @@ func main() {
 			if err != nil {
 				logger.Fatal("Failed to create trace reader", zap.Error(err))
 			}
-			dependencyReader, err := v2Factory.CreateDependencyReader()
+			depstoreFactory, ok := v2Factory.(depstore.Factory)
+			if !ok {
+				logger.Fatal("Failed to create dependency reader", zap.Error(err))
+			}
+			dependencyReader, err := depstoreFactory.CreateDependencyReader()
 			if err != nil {
 				logger.Fatal("Failed to create dependency reader", zap.Error(err))
 			}

--- a/internal/storage/v2/v1adapter/factory.go
+++ b/internal/storage/v2/v1adapter/factory.go
@@ -29,42 +29,42 @@ func NewFactory(ss storage_v1.Factory) tracestore.Factory {
 	switch {
 	case isPurger && isSampler && isCloser:
 		return struct {
-			tracestore.Factory
+			*Factory
 			storage_v1.Purger
 			storage_v1.SamplingStoreFactory
 			io.Closer
 		}{factory, purger, sampler, closer}
 	case isPurger && isCloser:
 		return struct {
-			tracestore.Factory
+			*Factory
 			storage_v1.Purger
 			io.Closer
 		}{factory, purger, closer}
 	case isSampler && isCloser:
 		return struct {
-			tracestore.Factory
+			*Factory
 			storage_v1.SamplingStoreFactory
 			io.Closer
 		}{factory, sampler, closer}
 	case isSampler && isPurger:
 		return struct {
-			tracestore.Factory
+			*Factory
 			storage_v1.Purger
 			storage_v1.SamplingStoreFactory
 		}{factory, purger, sampler}
 	case isCloser:
 		return struct {
-			tracestore.Factory
+			*Factory
 			io.Closer
 		}{factory, closer}
 	case isPurger:
 		return struct {
-			tracestore.Factory
+			*Factory
 			storage_v1.Purger
 		}{factory, purger}
 	case isSampler:
 		return struct {
-			tracestore.Factory
+			*Factory
 			storage_v1.SamplingStoreFactory
 		}{factory, sampler}
 	default:

--- a/internal/storage/v2/v1adapter/factory.go
+++ b/internal/storage/v2/v1adapter/factory.go
@@ -27,12 +27,6 @@ func NewFactory(ss storage_v1.Factory) tracestore.Factory {
 	)
 
 	switch {
-	case isPurger && isSampler:
-		return struct {
-			*Factory
-			storage_v1.Purger
-			storage_v1.SamplingStoreFactory
-		}{factory, purger, sampler}
 	case isSampler && isPurger:
 		return struct {
 			*Factory

--- a/internal/storage/v2/v1adapter/factory_test.go
+++ b/internal/storage/v2/v1adapter/factory_test.go
@@ -4,7 +4,6 @@
 package v1adapter
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -12,30 +11,8 @@ import (
 
 	dependencyStoreMocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore/mocks"
 	spanstoreMocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/mocks"
-	"github.com/jaegertracing/jaeger/internal/storage/v1/grpc"
 	factoryMocks "github.com/jaegertracing/jaeger/internal/storage/v1/mocks"
 )
-
-func TestAdapterInitialize(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("initialize did not panic")
-		}
-	}()
-
-	f := &Factory{}
-	_ = f.Initialize(context.Background())
-}
-
-func TestAdapterCloseNotOk(t *testing.T) {
-	f := NewFactory(&factoryMocks.Factory{})
-	require.NoError(t, f.Close(context.Background()))
-}
-
-func TestAdapterClose(t *testing.T) {
-	f := NewFactory(grpc.NewFactory())
-	require.NoError(t, f.Close(context.Background()))
-}
 
 func TestAdapterCreateTraceReader(t *testing.T) {
 	f1 := new(factoryMocks.Factory)
@@ -77,7 +54,7 @@ func TestAdapterCreateDependencyReader(t *testing.T) {
 	f1 := new(factoryMocks.Factory)
 	f1.On("CreateDependencyReader").Return(new(dependencyStoreMocks.Reader), nil)
 
-	f := NewFactory(f1)
+	f := &Factory{ss: f1}
 	r, err := f.CreateDependencyReader()
 	require.NoError(t, err)
 	require.NotNil(t, r)
@@ -88,7 +65,7 @@ func TestAdapterCreateDependencyReaderError(t *testing.T) {
 	testErr := errors.New("test error")
 	f1.On("CreateDependencyReader").Return(nil, testErr)
 
-	f := NewFactory(f1)
+	f := &Factory{ss: f1}
 	r, err := f.CreateDependencyReader()
 	require.ErrorIs(t, err, testErr)
 	require.Nil(t, r)


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6697

## Description of the changes
- This is a prequel to https://github.com/jaegertracing/jaeger/pull/6699. This PR refactors `v1adapter.Factory` to conditionally propagate the implementations of `storage.Purger` and `storage.SamplingStoreFactory`. Without this change, the implementation of the aforementioned interfaces get lost when we wrap a v1 `storage.Factory` into the adapter.. 

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
