### PR TITLE
Do not run label check from merge queue

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -24,7 +24,7 @@ jobs:
           egress-policy: audit
 
       - name: Check PR label
-        if: github.event.pull_request.user.login != 'dependabot'
+        if: ${{ github.event.pull_request.user.login != 'dependabot' && github.event_name != 'merge_group' }}
         run: |
           LABEL_NAME="changelog:"
           if [[ $(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq -r '.labels[].name' | grep -c "^$LABEL_NAME") -eq 0 ]]; then


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/6712#issuecomment-2657267408

## Description of the changes
- Do not run label check step from merge queue, let workflow succeed

## How was this change tested?
- CI
