### PR TITLE
Do not run dco-check from merge queue

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -67,6 +67,7 @@ jobs:
         python-version: '3.x'
 
     - name: Run DCO check
+      if: ${{ github.event.pull_request.user.login != 'dependabot' && github.event_name != 'merge_group' }}
       run: python3 scripts/lint/dco_check.py -b main -v --exclude-pattern '@users\.noreply\.github\.com'
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +122,7 @@ jobs:
     steps:
     - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
       with:
-        egress-policy: audit 
+        egress-policy: audit
 
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       with:
@@ -142,7 +143,7 @@ jobs:
         TOTAL_SIZE=$(du -sb ./cmd/jaeger/jaeger-linux-amd64 | cut -f1)
         echo "$TOTAL_SIZE" > ./new_jaeger_binary_size.txt
         echo "Total binary size: $TOTAL_SIZE bytes"
-        
+
     - name: Restore previous binary size
       id: cache-binary-size
       uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57      #v4.2.0
@@ -159,7 +160,7 @@ jobs:
         NEW_BINARY_SIZE=$(cat ./new_jaeger_binary_size.txt)
         echo "Previous binary size: $OLD_BINARY_SIZE bytes"
         echo "New binary size: $NEW_BINARY_SIZE bytes"
-        
+
         SIZE_CHANGE=$(( $NEW_BINARY_SIZE - $OLD_BINARY_SIZE ))
         PERCENTAGE_CHANGE=$(( SIZE_CHANGE * 100 / $OLD_BINARY_SIZE ))
         echo "Size change: $PERCENTAGE_CHANGE%"
@@ -169,13 +170,13 @@ jobs:
         else
           echo "✅ binary size change is within acceptable range ($PERCENTAGE_CHANGE%)"
         fi
- 
+
 
     - name: Remove previous *_binary_*.txt
       run: |
         rm -rf ./jaeger_binary_size.txt
         mv ./new_jaeger_binary_size.txt ./jaeger_binary_size.txt
-      
+
     - name: Save new jaeger binary size
       if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
       uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57     #v4.2.0


### PR DESCRIPTION
## Which problem is this PR solving?
It fails in merge queue
```
Detected: GitHub CI
Unknown workflow event: merge_group
Error: Process completed with exit code 1.
```

## Description of the changes
- Skip this check in merge queue

## How was this change tested?
- CI
