### PR TITLE
Allow dependency-review workflow to run from merge queue

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,9 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Which problem is this PR solving?
- It was blocking merge queue
- Resolves #6712

## Description of the changes
- Make it run from merge queue

## How was this change tested?
- CI
