### PR TITLE
[test]: Check for jaeger-idl version mismatch

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -72,6 +72,20 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  idl-version-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      with:
+        submodules: recursive
+
+    - name: check jaeger-idl versions across git submodule and go.mod dependency
+      run: make lint-jaeger-idl-versions
+
   generated-files-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -83,6 +83,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Initialize and update submodule
+      run: git submodule update --init --recursive
+
     - name: check jaeger-idl versions across git submodule and go.mod dependency
       run: make lint-jaeger-idl-versions
 

--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -83,9 +83,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Initialize and update submodule
-      run: git submodule update --init --recursive
-
     - name: check jaeger-idl versions across git submodule and go.mod dependency
       run: make lint-jaeger-idl-versions
 

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,11 @@ lint-goleak:
 lint-go: $(LINT)
 	$(LINT) -v run
 
+.PHONY: lint-jaeger-idl-versions
+lint-jaeger-idl-versions:
+	@echo "checking jaeger-idl version mismatch between git submodule and go.mod dependency"
+	@./scripts/lint/check-jaeger-idl-version.sh
+
 .PHONY: run-all-in-one
 run-all-in-one: build-ui
 	go run ./cmd/all-in-one --log-level debug

--- a/scripts/lint/check-jaeger-idl-version.sh
+++ b/scripts/lint/check-jaeger-idl-version.sh
@@ -20,7 +20,7 @@ get_gomod_version() {
 get_submodule_version() {
   cd idl
   commit_version=$(git rev-parse HEAD)
-  semver=$(git describe --tags --match "v*" --exact-match "$commit_version")
+  semver=$(git describe --tags --exact-match "$commit_version")
   if [ ! "$semver" ]; then
     printf "Error: failed getting version from submodule\n" >&2
     exit 1

--- a/scripts/lint/check-jaeger-idl-version.sh
+++ b/scripts/lint/check-jaeger-idl-version.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+dependency="github.com/jaegertracing/jaeger-idl"
+version_regex="v[0-9]\.[0-9]\+\.[0-9]\+"
+
+get_gomod_version() {
+  gomod_dep=$(grep $dependency <go.mod)
+  if [ ! "$gomod_dep" ]; then
+    printf "Error: jaeger-idl dependency not found in go mod\n" >&2
+    exit 1
+  fi
+  gomod_version=$(echo "$gomod_dep" | awk '{print $2}')
+  echo "$gomod_version"
+}
+
+get_submodule_version() {
+  cd idl
+  commit_version=$(git rev-parse HEAD)
+  tags=$(git describe --tags --exact-match "$commit_version")
+  if [ ! "$tags" ]; then
+    printf "Error: failed getting version from submodule\n" >&2
+    exit 1
+  fi
+  semver=$(echo "$tags" | grep "$version_regex")
+  if [ ! "$semver" ]; then
+    printf "Error: no tag matching semantic version\n" >&2
+    exit 1
+  fi
+  echo "$semver"
+}
+
+gomod_semver=$(get_gomod_version) || exit 1
+submod_semver=$(get_submodule_version) || exit 1
+if [[ "$gomod_semver" != "$submod_semver" ]]; then
+  printf "Error: jaeger-idl version mismatch: go.mod %s != submodule %s\n" "$gomod_semver" "$submod_semver" >&2
+fi
+echo "jaeger-idl version match: OK"

--- a/scripts/lint/check-jaeger-idl-version.sh
+++ b/scripts/lint/check-jaeger-idl-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2023 The Jaeger Authors.
+# Copyright (c) 2025 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6743 

## Description of the changes
- Create a bash script for getting semantic versions of go.mod dependency and git submodule
- Update CI

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
