### PR TITLE
linter for jaeger-idl depndency #6743

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -25,6 +25,8 @@ jobs:
         egress-policy: audit # TODO: change to 'egress-policy: block' after a couple of runs
 
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      with:
+        submodules: recursive
 
     - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
@@ -117,6 +119,9 @@ jobs:
       run: |
         SHUNIT2=.tools/shunit2 bash scripts/utils/run-tests.sh
 
+    - name: Check jaeger-idl versions
+      run: make lint-jaeger-idl-version
+      
   binary-size-check:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,12 @@ lint-goleak:
 lint-go: $(LINT)
 	$(LINT) -v run
 
+.PHONY: lint-jaeger-idl-version
+lint-jaeger-idl-version:
+	@echo Checking jaeger-idl version consistency between go.mod and submodule...
+	./scripts/lint/check-jaeger-idl-version.sh
+
+
 .PHONY: run-all-in-one
 run-all-in-one: build-ui
 	go run ./cmd/all-in-one --log-level debug

--- a/scripts/lint/check-jaeger-idl-version.sh
+++ b/scripts/lint/check-jaeger-idl-version.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch the version from go.mod, stripping any '+incompatible' suffix
+GO_MOD_VERSION=$(grep 'github.com/jaegertracing/jaeger-idl' go.mod | awk '{print $2}' | sed 's/+incompatible//')
+
+if [ -z "$GO_MOD_VERSION" ]; then
+    echo "Error: jaeger-idl version not found in go.mod"
+    exit 1
+fi
+
+# Check submodule directory exists
+if [ ! -d "idl" ]; then
+    echo "Error: 'idl' submodule directory not found. Initialize submodules first."
+    exit 1
+fi
+
+cd idl
+
+# Ensure tags are fetched to find the latest semver tag
+git fetch --tags --quiet
+
+# Get the latest semver tag at the current submodule commit
+SUBMODULE_TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort --version-sort | tail -n1)
+
+if [ -z "$SUBMODULE_TAG" ]; then
+    echo "No semver tag found at HEAD. Attempting to find the latest tag..."
+
+    # Find the latest tag and check it out
+    LATEST_TAG=$(git tag | sort --version-sort | tail -n1)
+
+    if [ -n "$LATEST_TAG" ]; then
+        echo "Checking out latest tag: $LATEST_TAG"
+        git checkout "$LATEST_TAG"
+        SUBMODULE_TAG="$LATEST_TAG"
+    else
+        echo "Error: No valid semver tag found for jaeger-idl submodule"
+        exit 1
+    fi
+fi
+
+cd ..
+
+# Compare versions
+if [ "$GO_MOD_VERSION" != "$SUBMODULE_TAG" ]; then
+    echo "Error: Version mismatch between go.mod ($GO_MOD_VERSION) and jaeger-idl submodule ($SUBMODULE_TAG)"
+    exit 1
+fi
+
+echo "Versions are in sync: go.mod ($GO_MOD_VERSION) and submodule ($SUBMODULE_TAG)"
+exit 0


### PR DESCRIPTION
##  linter for jaeger-idl version check
Resolves  #6743 

## Description of the changes
- created a new bash script file for checking semantic versions git.mod and git submodule

## How was this change tested?
- 
![Screenshot 2025-02-19 233516](https://github.com/user-attachments/assets/aefd9907-1d09-40fe-abea-6e2c464148fe)
![Screenshot 2025-02-19 234236](https://github.com/user-attachments/assets/eff97501-a195-4935-887f-08577d1815c9)


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
