### PR TITLE
6744 - Fix Kafka TLS configuration with plaintext authentication

### DIFF
--- a/pkg/kafka/auth/config.go
+++ b/pkg/kafka/auth/config.go
@@ -43,11 +43,12 @@ func (config *AuthenticationConfig) SetConfiguration(saramaConfig *sarama.Config
 	if strings.Trim(authentication, " ") == "" {
 		authentication = none
 	}
-	if config.Authentication == tls {
-		if err := setTLSConfiguration(&config.TLS, saramaConfig, logger); err != nil {
-			return err
-		}
-	}
+   if config.Authentication == tls || !config.TLS.Insecure {
+        if err := setTLSConfiguration(&config.TLS, saramaConfig, logger); err != nil {
+            return err
+        }
+    }
+
 	switch authentication {
 	case none:
 		return nil
@@ -57,7 +58,7 @@ func (config *AuthenticationConfig) SetConfiguration(saramaConfig *sarama.Config
 		setKerberosConfiguration(&config.Kerberos, saramaConfig)
 		return nil
 	case plaintext:
-		return setPlainTextConfiguration(&config.PlainText, saramaConfig)
+        return setPlainTextConfiguration(&config.PlainText, saramaConfig)
 	default:
 		return fmt.Errorf("Unknown/Unsupported authentication method %s to kafka cluster", config.Authentication)
 	}
@@ -75,19 +76,22 @@ func (config *AuthenticationConfig) InitFromViper(configPrefix string, v *viper.
 	config.Kerberos.KeyTabPath = v.GetString(configPrefix + kerberosPrefix + suffixKerberosKeyTab)
 	config.Kerberos.DisablePAFXFast = v.GetBool(configPrefix + kerberosPrefix + suffixKerberosDisablePAFXFAST)
 
-	if config.Authentication == tls {
-		if !v.IsSet(configPrefix + ".tls.enabled") {
-			v.Set(configPrefix+".tls.enabled", "true")
-		}
-		tlsClientConfig := tlscfg.ClientFlagsConfig{
-			Prefix: configPrefix,
-		}
-		tlsCfg, err := tlsClientConfig.InitFromViper(v)
-		if err != nil {
-			return fmt.Errorf("failed to process Kafka TLS options: %w", err)
-		}
-		config.TLS = tlsCfg
-	}
+	if config.Authentication == tls || v.GetBool(configPrefix+".tls.enabled"){
+        tlsClientConfig := tlscfg.ClientFlagsConfig{
+            Prefix: configPrefix,
+        }
+        tlsCfg, err := tlsClientConfig.InitFromViper(v)
+        if err != nil {
+            return fmt.Errorf("failed to process Kafka TLS options: %w", err)
+        }
+        config.TLS = tlsCfg
+	} else {
+        // Explicitly set TLS to insecure when disabled
+        config.TLS = configtls.ClientConfig{
+            Insecure: true,
+        }
+    }
+
 
 	config.PlainText.Username = v.GetString(configPrefix + plainTextPrefix + suffixPlainTextUsername)
 	config.PlainText.Password = v.GetString(configPrefix + plainTextPrefix + suffixPlainTextPassword)

--- a/pkg/kafka/auth/tls.go
+++ b/pkg/kafka/auth/tls.go
@@ -12,14 +12,17 @@ import (
 	"go.uber.org/zap"
 )
 
-func setTLSConfiguration(config *configtls.ClientConfig, saramaConfig *sarama.Config, _ *zap.Logger) error {
-	if !config.Insecure {
-		tlsConfig, err := config.LoadTLSConfig(context.Background())
-		if err != nil {
-			return fmt.Errorf("error loading tls config: %w", err)
-		}
-		saramaConfig.Net.TLS.Enable = true
-		saramaConfig.Net.TLS.Config = tlsConfig
-	}
-	return nil
+func setTLSConfiguration(config *configtls.ClientConfig, saramaConfig *sarama.Config, logger *zap.Logger) error {
+    tlsConfig, err := config.LoadTLSConfig(context.Background())
+    if err != nil {
+        return fmt.Errorf("error loading tls config: %w", err)
+    }
+    
+    saramaConfig.Net.TLS.Enable = true
+    saramaConfig.Net.TLS.Config = tlsConfig
+    logger.Info("TLS configuration enabled for Kafka client", 
+        zap.Bool("skip_verify", config.InsecureSkipVerify),
+        zap.String("ca_file", config.CAFile),
+        zap.Bool("system_ca_enabled", config.Config.IncludeSystemCACertsPool))
+    return nil
 }

--- a/pkg/kafka/auth/tls.go
+++ b/pkg/kafka/auth/tls.go
@@ -20,9 +20,5 @@ func setTLSConfiguration(config *configtls.ClientConfig, saramaConfig *sarama.Co
     
     saramaConfig.Net.TLS.Enable = true
     saramaConfig.Net.TLS.Config = tlsConfig
-    logger.Info("TLS configuration enabled for Kafka client", 
-        zap.Bool("skip_verify", config.InsecureSkipVerify),
-        zap.String("ca_file", config.CAFile),
-        zap.Bool("system_ca_enabled", config.Config.IncludeSystemCACertsPool))
     return nil
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6744 - Cannot connect to TLS Kafka with TLS + plaintext authentication

## Description of the changes
- Fixed TLS configuration to work with plaintext authentication when TLS is enabled
- Modified TLS configuration logic in Kafka authentication to support SASL-SSL with PLAIN
- Restored behavior to enable TLS regardless of authentication method when TLS is configured
- Fixed regression introduced in PR #6270

## How was this change tested?
- Verified connectivity with TLS-enabled Kafka cluster using plaintext authentication
- Tested both collector and ingester components
- Validated SASL-SSL with PLAIN authentication works as expected
- Ran `make lint test` successfully

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [] I have added unit tests for the new functionality
- [] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`