### PR TITLE
[refactor] Change `TraceQueryParameters` to accept typed attributes

### DIFF
--- a/cmd/jaeger/internal/integration/trace_reader.go
+++ b/cmd/jaeger/internal/integration/trace_reader.go
@@ -110,7 +110,7 @@ func (r *traceReader) GetOperations(ctx context.Context, query tracestore.Operat
 
 func (r *traceReader) FindTraces(
 	ctx context.Context,
-	query tracestore.TraceQueryParams,
+	query tracestore.TraceQueryParameters,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
 		if query.NumTraces > math.MaxInt32 {
@@ -137,7 +137,7 @@ func (r *traceReader) FindTraces(
 
 func (*traceReader) FindTraceIDs(
 	_ context.Context,
-	_ tracestore.TraceQueryParams,
+	_ tracestore.TraceQueryParameters,
 ) iter.Seq2[[]pcommon.TraceID, error] {
 	panic("not implemented")
 }

--- a/cmd/jaeger/internal/integration/trace_reader.go
+++ b/cmd/jaeger/internal/integration/trace_reader.go
@@ -113,7 +113,7 @@ func (r *traceReader) FindTraces(
 	query tracestore.TraceQueryParameters,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
-		if query.NumTraces > math.MaxInt32 {
+		if query.SearchDepth > math.MaxInt32 {
 			yield(nil, fmt.Errorf("NumTraces must not be greater than %d", math.MaxInt32))
 			return
 		}
@@ -127,7 +127,7 @@ func (r *traceReader) FindTraces(
 				DurationMin:   query.DurationMin,
 				DurationMax:   query.DurationMax,
 				//nolint: gosec // G115
-				SearchDepth: int32(query.NumTraces),
+				SearchDepth: int32(query.SearchDepth),
 				RawTraces:   true,
 			},
 		})

--- a/cmd/jaeger/internal/integration/trace_reader.go
+++ b/cmd/jaeger/internal/integration/trace_reader.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
@@ -121,7 +122,7 @@ func (r *traceReader) FindTraces(
 			Query: &api_v3.TraceQueryParameters{
 				ServiceName:   query.ServiceName,
 				OperationName: query.OperationName,
-				Attributes:    query.Tags,
+				Attributes:    jptrace.AttributesToMap(query.Attributes),
 				StartTimeMin:  query.StartTimeMin,
 				StartTimeMax:  query.StartTimeMax,
 				DurationMin:   query.DurationMin,

--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -70,7 +70,7 @@ func (h *Handler) internalFindTraces(
 	}
 
 	queryParams := querysvc.TraceQueryParams{
-		TraceQueryParams: tracestore.TraceQueryParams{
+		TraceQueryParameters: tracestore.TraceQueryParameters{
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
 			Tags:          query.GetAttributes(),

--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
@@ -73,7 +74,7 @@ func (h *Handler) internalFindTraces(
 		TraceQueryParameters: tracestore.TraceQueryParameters{
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
-			Tags:          query.GetAttributes(),
+			Attributes:    jptrace.MapToAttributes(query.GetAttributes()),
 			SearchDepth:   int(query.GetSearchDepth()),
 		},
 		RawTraces: query.GetRawTraces(),

--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -74,7 +74,7 @@ func (h *Handler) internalFindTraces(
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
 			Tags:          query.GetAttributes(),
-			NumTraces:     int(query.GetSearchDepth()),
+			SearchDepth:   int(query.GetSearchDepth()),
 		},
 		RawTraces: query.GetRawTraces(),
 	}

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -238,7 +238,7 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		if h.tryParamError(w, err, paramNumTraces) {
 			return nil, true
 		}
-		queryParams.NumTraces = numTraces
+		queryParams.SearchDepth = numTraces
 	}
 
 	if d := q.Get(paramDurationMin); d != "" {

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -208,7 +208,7 @@ func (h *HTTPGateway) findTraces(w http.ResponseWriter, r *http.Request) {
 
 func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*querysvc.TraceQueryParams, bool) {
 	queryParams := &querysvc.TraceQueryParams{
-		TraceQueryParams: tracestore.TraceQueryParams{
+		TraceQueryParameters: tracestore.TraceQueryParameters{
 			ServiceName:   q.Get(paramServiceName),
 			OperationName: q.Get(paramOperationName),
 			Tags:          nil, // most curiously not supported by grpc-gateway

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gorilla/mux"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
@@ -211,7 +212,7 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		TraceQueryParameters: tracestore.TraceQueryParameters{
 			ServiceName:   q.Get(paramServiceName),
 			OperationName: q.Get(paramOperationName),
-			Tags:          nil, // most curiously not supported by grpc-gateway
+			Attributes:    pcommon.NewMap(), // most curiously not supported by grpc-gateway
 		},
 	}
 

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -242,7 +242,7 @@ func TestHTTPGatewayGetTraceInternalErrors(t *testing.T) {
 	assert.Contains(t, w.Body.String(), assert.AnError.Error())
 }
 
-func mockFindQueries() (url.Values, tracestore.TraceQueryParams) {
+func mockFindQueries() (url.Values, tracestore.TraceQueryParameters) {
 	// mock performs deep comparison of the timestamps and can fail
 	// if they are different in the timezone or the monotonic clocks.
 	// To void that we truncate monotonic clock and force UTC timezone.
@@ -257,7 +257,7 @@ func mockFindQueries() (url.Values, tracestore.TraceQueryParams) {
 	q.Set(paramDurationMax, "2s")
 	q.Set(paramNumTraces, "10")
 
-	return q, tracestore.TraceQueryParams{
+	return q, tracestore.TraceQueryParameters{
 		ServiceName:   "foo",
 		OperationName: "bar",
 		StartTimeMin:  time1,

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -264,7 +264,7 @@ func mockFindQueries() (url.Values, tracestore.TraceQueryParameters) {
 		StartTimeMax:  time2,
 		DurationMin:   1 * time.Second,
 		DurationMax:   2 * time.Second,
-		NumTraces:     10,
+		SearchDepth:   10,
 	}
 }
 

--- a/cmd/query/app/querysvc/v2/querysvc/service.go
+++ b/cmd/query/app/querysvc/v2/querysvc/service.go
@@ -58,7 +58,7 @@ type GetTraceParams struct {
 
 // TraceQueryParams represents the parameters for querying a batch of traces.
 type TraceQueryParams struct {
-	tracestore.TraceQueryParams
+	tracestore.TraceQueryParameters
 	// RawTraces indicates whether to retrieve raw traces.
 	// If set to false, the traces will be adjusted using QueryServiceOptions.Adjuster.
 	RawTraces bool
@@ -122,7 +122,7 @@ func (qs QueryService) FindTraces(
 	query TraceQueryParams,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
-		tracesIter := qs.traceReader.FindTraces(ctx, query.TraceQueryParams)
+		tracesIter := qs.traceReader.FindTraces(ctx, query.TraceQueryParameters)
 		qs.receiveTraces(tracesIter, yield, query.RawTraces)
 	}
 }

--- a/cmd/query/app/querysvc/v2/querysvc/service_test.go
+++ b/cmd/query/app/querysvc/v2/querysvc/service_test.go
@@ -278,7 +278,7 @@ func TestFindTraces_Success(t *testing.T) {
 		OperationName: "operation",
 		StartTimeMax:  now,
 		DurationMin:   duration,
-		NumTraces:     200,
+		SearchDepth:   200,
 	}
 	tqs.traceReader.On("FindTraces", mock.Anything, queryParams).Return(responseIter).Once()
 
@@ -352,7 +352,7 @@ func TestFindTraces_WithRawTraces_PerformsAdjustment(t *testing.T) {
 				OperationName: "operation",
 				StartTimeMax:  now,
 				DurationMin:   duration,
-				NumTraces:     200,
+				SearchDepth:   200,
 			}).
 				Return(responseIter).Once()
 
@@ -362,7 +362,7 @@ func TestFindTraces_WithRawTraces_PerformsAdjustment(t *testing.T) {
 					OperationName: "operation",
 					StartTimeMax:  now,
 					DurationMin:   duration,
-					NumTraces:     200,
+					SearchDepth:   200,
 				},
 				RawTraces: test.rawTraces,
 			}
@@ -488,7 +488,7 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 				OperationName: "operation",
 				StartTimeMax:  now,
 				DurationMin:   duration,
-				NumTraces:     200,
+				SearchDepth:   200,
 			}).
 				Return(responseIter).Once()
 
@@ -498,7 +498,7 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 					OperationName: "operation",
 					StartTimeMax:  now,
 					DurationMin:   duration,
-					NumTraces:     200,
+					SearchDepth:   200,
 				},
 				RawTraces: test.rawTraces,
 			}

--- a/cmd/query/app/querysvc/v2/querysvc/service_test.go
+++ b/cmd/query/app/querysvc/v2/querysvc/service_test.go
@@ -273,7 +273,7 @@ func TestFindTraces_Success(t *testing.T) {
 
 	duration := 20 * time.Millisecond
 	now := time.Now()
-	queryParams := tracestore.TraceQueryParams{
+	queryParams := tracestore.TraceQueryParameters{
 		ServiceName:   "service",
 		OperationName: "operation",
 		StartTimeMax:  now,
@@ -282,7 +282,7 @@ func TestFindTraces_Success(t *testing.T) {
 	}
 	tqs.traceReader.On("FindTraces", mock.Anything, queryParams).Return(responseIter).Once()
 
-	query := TraceQueryParams{TraceQueryParams: queryParams}
+	query := TraceQueryParams{TraceQueryParameters: queryParams}
 	getTracesIter := tqs.queryService.FindTraces(context.Background(), query)
 	gotTraces, err := jiter.FlattenWithErrors(getTracesIter)
 	require.NoError(t, err)
@@ -347,7 +347,7 @@ func TestFindTraces_WithRawTraces_PerformsAdjustment(t *testing.T) {
 			duration, err := time.ParseDuration("20ms")
 			require.NoError(t, err)
 			now := time.Now()
-			tqs.traceReader.On("FindTraces", mock.Anything, tracestore.TraceQueryParams{
+			tqs.traceReader.On("FindTraces", mock.Anything, tracestore.TraceQueryParameters{
 				ServiceName:   "service",
 				OperationName: "operation",
 				StartTimeMax:  now,
@@ -357,7 +357,7 @@ func TestFindTraces_WithRawTraces_PerformsAdjustment(t *testing.T) {
 				Return(responseIter).Once()
 
 			query := TraceQueryParams{
-				TraceQueryParams: tracestore.TraceQueryParams{
+				TraceQueryParameters: tracestore.TraceQueryParameters{
 					ServiceName:   "service",
 					OperationName: "operation",
 					StartTimeMax:  now,
@@ -483,7 +483,7 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 			duration, err := time.ParseDuration("20ms")
 			require.NoError(t, err)
 			now := time.Now()
-			tqs.traceReader.On("FindTraces", mock.Anything, tracestore.TraceQueryParams{
+			tqs.traceReader.On("FindTraces", mock.Anything, tracestore.TraceQueryParameters{
 				ServiceName:   "service",
 				OperationName: "operation",
 				StartTimeMax:  now,
@@ -493,7 +493,7 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 				Return(responseIter).Once()
 
 			query := TraceQueryParams{
-				TraceQueryParams: tracestore.TraceQueryParams{
+				TraceQueryParameters: tracestore.TraceQueryParameters{
 					ServiceName:   "service",
 					OperationName: "operation",
 					StartTimeMax:  now,

--- a/internal/jptrace/attributes.go
+++ b/internal/jptrace/attributes.go
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package jptrace
 
-import "go.opentelemetry.io/collector/pdata/pcommon"
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
 
 const (
 	// WarningsAttribute is the name of the span attribute where we can

--- a/internal/jptrace/attributes.go
+++ b/internal/jptrace/attributes.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package jptrace
 
+import "go.opentelemetry.io/collector/pdata/pcommon"
+
 const (
 	// WarningsAttribute is the name of the span attribute where we can
 	// store various warnings produced from transformations,
@@ -13,3 +15,20 @@ const (
 	// e.g. proto, thrift, json.
 	FormatAttribute = "@jaeger@format"
 )
+
+func AttributesToMap(attributes pcommon.Map) map[string]string {
+	tags := make(map[string]string)
+	attributes.Range(func(k string, v pcommon.Value) bool {
+		tags[k] = v.AsString()
+		return true
+	})
+	return tags
+}
+
+func MapToAttributes(tags map[string]string) pcommon.Map {
+	attributes := pcommon.NewMap()
+	for k, v := range tags {
+		attributes.PutStr(k, v)
+	}
+	return attributes
+}

--- a/internal/jptrace/attributes_test.go
+++ b/internal/jptrace/attributes_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jptrace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestAttributesToMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes pcommon.Map
+		expected   map[string]string
+	}{
+		{
+			name:       "empty attributes",
+			attributes: pcommon.NewMap(),
+			expected:   map[string]string{},
+		},
+		{
+			name: "single attribute",
+			attributes: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key1", "value1")
+				return m
+			}(),
+			expected: map[string]string{"key1": "value1"},
+		},
+		{
+			name: "multiple attributes",
+			attributes: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key1", "value1")
+				m.PutStr("key2", "value2")
+				return m
+			}(),
+			expected: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name: "non-string attributes",
+			attributes: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutInt("key1", 1)
+				m.PutDouble("key2", 3.14)
+				return m
+			}(),
+			expected: map[string]string{"key1": "1", "key2": "3.14"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := AttributesToMap(test.attributes)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestMapToAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     map[string]string
+		expected pcommon.Map
+	}{
+		{
+			name:     "empty map",
+			tags:     map[string]string{},
+			expected: pcommon.NewMap(),
+		},
+		{
+			name: "single tag",
+			tags: map[string]string{"key1": "value1"},
+			expected: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key1", "value1")
+				return m
+			}(),
+		},
+		{
+			name: "multiple tags",
+			tags: map[string]string{"key1": "value1", "key2": "value2"},
+			expected: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key1", "value1")
+				m.PutStr("key2", "value2")
+				return m
+			}(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := MapToAttributes(test.tags)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/internal/storage/integration/fixtures/queries.json
+++ b/internal/storage/integration/fixtures/queries.json
@@ -4,12 +4,12 @@
     "Query": {
       "ServiceName": "query01-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -23,12 +23,12 @@
     "Query": {
       "ServiceName": "query02-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -42,12 +42,12 @@
     "Query": {
       "ServiceName": "query03-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -61,12 +61,12 @@
     "Query": {
       "ServiceName": "query04-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -80,7 +80,7 @@
     "Query": {
       "ServiceName": "query05-service",
       "OperationName": "",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T00:00:31.639875Z",
       "StartTimeMax": "2017-01-26T00:07:31.639875Z",
       "DurationMin": 0,
@@ -94,7 +94,7 @@
     "Query": {
       "ServiceName": "query06-service",
       "OperationName": "query06-operation",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -108,7 +108,7 @@
     "Query": {
       "ServiceName": "query07-service",
       "OperationName": "query07-operation",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -122,7 +122,7 @@
     "Query": {
       "ServiceName": "query08-service",
       "OperationName": "query08-operation",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -136,7 +136,7 @@
     "Query": {
       "ServiceName": "query09-service",
       "OperationName": "",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -150,7 +150,7 @@
     "Query": {
       "ServiceName": "query10-service",
       "OperationName": "",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -164,7 +164,7 @@
     "Query": {
       "ServiceName": "query11-service",
       "OperationName": "",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -178,12 +178,12 @@
     "Query": {
       "ServiceName": "query12-service",
       "OperationName": "query12-operation",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -197,12 +197,12 @@
     "Query": {
       "ServiceName": "query13-service",
       "OperationName": "query13-operation",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -216,12 +216,12 @@
     "Query": {
       "ServiceName": "query14-service",
       "OperationName": "query14-operation",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -235,12 +235,12 @@
     "Query": {
       "ServiceName": "query15-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -254,12 +254,12 @@
     "Query": {
       "ServiceName": "query16-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -273,12 +273,12 @@
     "Query": {
       "ServiceName": "query17-service",
       "OperationName": "query17-operation",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -292,12 +292,12 @@
     "Query": {
       "ServiceName": "query18-service",
       "OperationName": "query18-operation",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -311,12 +311,12 @@
     "Query": {
       "ServiceName": "query19-service",
       "OperationName": "query19-operation",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -330,12 +330,12 @@
     "Query": {
       "ServiceName": "query20-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -349,12 +349,12 @@
     "Query": {
       "ServiceName": "query21-service",
       "OperationName": "",
-      "Attributes": [
-        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
-        { "key": "sameplacetag2", "value": { "int_value": 123 } },
-        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
-        { "key": "sameplacetag4", "value": { "bool_value": true } }
-      ],
+      "Attributes": {
+        "sameplacetag1": { "string_value": "sameplacevalue" },
+        "sameplacetag2": { "int_value": 123 },
+        "sameplacetag3": { "double_value": 72.5 },
+        "sameplacetag4": { "bool_value": true }
+      },
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -368,7 +368,7 @@
     "Query": {
       "ServiceName": "query22-service",
       "OperationName": "",
-      "Attributes": [],
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,

--- a/internal/storage/integration/fixtures/queries.json
+++ b/internal/storage/integration/fixtures/queries.json
@@ -4,7 +4,7 @@
     "Query": {
       "ServiceName": "query01-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -14,7 +14,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["span_tags_trace"]
   },
@@ -23,7 +23,7 @@
     "Query": {
       "ServiceName": "query02-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -33,7 +33,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["log_tags_trace"]
   },
@@ -42,7 +42,7 @@
     "Query": {
       "ServiceName": "query03-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -52,7 +52,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["process_tags_trace"]
   },
@@ -61,7 +61,7 @@
     "Query": {
       "ServiceName": "query04-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -71,7 +71,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multi_spot_tags_trace"]
   },
@@ -80,12 +80,12 @@
     "Query": {
       "ServiceName": "query05-service",
       "OperationName": "",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T00:00:31.639875Z",
       "StartTimeMax": "2017-01-26T00:07:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multi_index_trace"]
   },
@@ -94,12 +94,12 @@
     "Query": {
       "ServiceName": "query06-service",
       "OperationName": "query06-operation",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["opname_trace"]
   },
@@ -108,12 +108,12 @@
     "Query": {
       "ServiceName": "query07-service",
       "OperationName": "query07-operation",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 2000,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["opname_maxdur_trace"]
   },
@@ -122,12 +122,12 @@
     "Query": {
       "ServiceName": "query08-service",
       "OperationName": "query08-operation",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
       "DurationMax": 5500,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["opname_dur_trace"]
   },
@@ -136,12 +136,12 @@
     "Query": {
       "ServiceName": "query09-service",
       "OperationName": "",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
       "DurationMax": 5500,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["dur_trace"]
   },
@@ -150,12 +150,12 @@
     "Query": {
       "ServiceName": "query10-service",
       "OperationName": "",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 1000,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["max_dur_trace"]
   },
@@ -164,12 +164,12 @@
     "Query": {
       "ServiceName": "query11-service",
       "OperationName": "",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["default"]
   },
@@ -178,7 +178,7 @@
     "Query": {
       "ServiceName": "query12-service",
       "OperationName": "query12-operation",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -188,7 +188,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["tags_opname_trace"]
   },
@@ -197,7 +197,7 @@
     "Query": {
       "ServiceName": "query13-service",
       "OperationName": "query13-operation",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -207,7 +207,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 2000,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["tags_opname_maxdur_trace"]
   },
@@ -216,7 +216,7 @@
     "Query": {
       "ServiceName": "query14-service",
       "OperationName": "query14-operation",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -226,7 +226,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
       "DurationMax": 5500,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["tags_opname_dur_trace"]
   },
@@ -235,7 +235,7 @@
     "Query": {
       "ServiceName": "query15-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -245,7 +245,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
       "DurationMax": 5500,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["tags_dur_trace"]
   },
@@ -254,7 +254,7 @@
     "Query": {
       "ServiceName": "query16-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -264,7 +264,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 1000,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["tags_maxdur_trace"]
   },
@@ -273,7 +273,7 @@
     "Query": {
       "ServiceName": "query17-service",
       "OperationName": "query17-operation",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -283,7 +283,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multispottag_opname_trace"]
   },
@@ -292,7 +292,7 @@
     "Query": {
       "ServiceName": "query18-service",
       "OperationName": "query18-operation",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -302,7 +302,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 2000,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multispottag_opname_maxdur_trace"]
   },
@@ -311,7 +311,7 @@
     "Query": {
       "ServiceName": "query19-service",
       "OperationName": "query19-operation",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -321,7 +321,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
       "DurationMax": 5500,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multispottag_opname_dur_trace"]
   },
@@ -330,7 +330,7 @@
     "Query": {
       "ServiceName": "query20-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -340,7 +340,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
       "DurationMax": 5500,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multispottag_dur_trace"]
   },
@@ -349,7 +349,7 @@
     "Query": {
       "ServiceName": "query21-service",
       "OperationName": "",
-      "Tags": {
+      "Attributes": {
         "sameplacetag1":"sameplacevalue",
         "sameplacetag2":"123",
         "sameplacetag3":"72.5",
@@ -359,7 +359,7 @@
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 1000,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multispottag_maxdur_trace"]
   },
@@ -368,12 +368,12 @@
     "Query": {
       "ServiceName": "query22-service",
       "OperationName": "",
-      "Tags": null,
+      "Attributes": {},
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
       "DurationMax": 0,
-      "NumTraces": 1000
+      "SearchDepth": 1000
     },
     "ExpectedFixtures": ["multiple1_trace", "multiple2_trace", "multiple3_trace"]
   }

--- a/internal/storage/integration/fixtures/queries.json
+++ b/internal/storage/integration/fixtures/queries.json
@@ -4,12 +4,12 @@
     "Query": {
       "ServiceName": "query01-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -23,12 +23,12 @@
     "Query": {
       "ServiceName": "query02-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -42,12 +42,12 @@
     "Query": {
       "ServiceName": "query03-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -61,12 +61,12 @@
     "Query": {
       "ServiceName": "query04-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -80,7 +80,7 @@
     "Query": {
       "ServiceName": "query05-service",
       "OperationName": "",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T00:00:31.639875Z",
       "StartTimeMax": "2017-01-26T00:07:31.639875Z",
       "DurationMin": 0,
@@ -94,7 +94,7 @@
     "Query": {
       "ServiceName": "query06-service",
       "OperationName": "query06-operation",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -108,7 +108,7 @@
     "Query": {
       "ServiceName": "query07-service",
       "OperationName": "query07-operation",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -122,7 +122,7 @@
     "Query": {
       "ServiceName": "query08-service",
       "OperationName": "query08-operation",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -136,7 +136,7 @@
     "Query": {
       "ServiceName": "query09-service",
       "OperationName": "",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -150,7 +150,7 @@
     "Query": {
       "ServiceName": "query10-service",
       "OperationName": "",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -164,7 +164,7 @@
     "Query": {
       "ServiceName": "query11-service",
       "OperationName": "",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -178,12 +178,12 @@
     "Query": {
       "ServiceName": "query12-service",
       "OperationName": "query12-operation",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -197,12 +197,12 @@
     "Query": {
       "ServiceName": "query13-service",
       "OperationName": "query13-operation",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -216,12 +216,12 @@
     "Query": {
       "ServiceName": "query14-service",
       "OperationName": "query14-operation",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -235,12 +235,12 @@
     "Query": {
       "ServiceName": "query15-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -254,12 +254,12 @@
     "Query": {
       "ServiceName": "query16-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -273,12 +273,12 @@
     "Query": {
       "ServiceName": "query17-service",
       "OperationName": "query17-operation",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -292,12 +292,12 @@
     "Query": {
       "ServiceName": "query18-service",
       "OperationName": "query18-operation",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -311,12 +311,12 @@
     "Query": {
       "ServiceName": "query19-service",
       "OperationName": "query19-operation",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -330,12 +330,12 @@
     "Query": {
       "ServiceName": "query20-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 4500,
@@ -349,12 +349,12 @@
     "Query": {
       "ServiceName": "query21-service",
       "OperationName": "",
-      "Attributes": {
-        "sameplacetag1":"sameplacevalue",
-        "sameplacetag2":"123",
-        "sameplacetag3":"72.5",
-        "sameplacetag4":"true"
-      },
+      "Attributes": [
+        { "key": "sameplacetag1", "value": { "string_value": "sameplacevalue" } },
+        { "key": "sameplacetag2", "value": { "int_value": 123 } },
+        { "key": "sameplacetag3", "value": { "double_value": 72.5 } },
+        { "key": "sameplacetag4", "value": { "bool_value": true } }
+      ],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,
@@ -368,7 +368,7 @@
     "Query": {
       "ServiceName": "query22-service",
       "OperationName": "",
-      "Attributes": {},
+      "Attributes": [],
       "StartTimeMin": "2017-01-26T15:46:31.639875Z",
       "StartTimeMax": "2017-01-26T17:46:31.639875Z",
       "DurationMin": 0,

--- a/internal/storage/integration/fixtures/queries_es.json
+++ b/internal/storage/integration/fixtures/queries_es.json
@@ -4,9 +4,9 @@
         "Query": {
         "ServiceName": "query23-service",
         "OperationName": "query23-operation",
-        "Attributes": [
-            { "key": "sameplacetag1", "value": { "string_value": "same\\*" } }
-        ],
+        "Attributes": {
+            "sameplacetag1": { "string_value": "same\\*" }
+        },
         "StartTimeMin": "2017-01-26T15:46:31.639875Z",
         "StartTimeMax": "2017-01-26T17:46:31.639875Z",
         "DurationMin": 0,
@@ -20,9 +20,9 @@
         "Query": {
         "ServiceName": "query24-service",
         "OperationName": "",
-        "Attributes": [
-            { "key": "sameplacetag1", "value": { "string_value": "same.*" } }
-        ],
+        "Attributes": {
+            "sameplacetag1": { "string_value": "same.*" }
+        },
         "StartTimeMin": "2017-01-26T15:46:31.639875Z",
         "StartTimeMax": "2017-01-26T17:46:31.639875Z",
         "DurationMin": 0,

--- a/internal/storage/integration/fixtures/queries_es.json
+++ b/internal/storage/integration/fixtures/queries_es.json
@@ -4,14 +4,14 @@
         "Query": {
         "ServiceName": "query23-service",
         "OperationName": "query23-operation",
-        "Tags": {
+        "Attributes": {
             "sameplacetag1":"same\\*"
         },
         "StartTimeMin": "2017-01-26T15:46:31.639875Z",
         "StartTimeMax": "2017-01-26T17:46:31.639875Z",
         "DurationMin": 0,
         "DurationMax": 1000,
-        "NumTraces": 1000
+        "SearchDepth": 1000
         },
         "ExpectedFixtures": ["tags_escaped_operator_trace_1"]
     },
@@ -20,14 +20,14 @@
         "Query": {
         "ServiceName": "query24-service",
         "OperationName": "",
-        "Tags": {
+        "Attributes": {
             "sameplacetag1":"same.*"
         },
         "StartTimeMin": "2017-01-26T15:46:31.639875Z",
         "StartTimeMax": "2017-01-26T17:46:31.639875Z",
         "DurationMin": 0,
         "DurationMax": 0,
-        "NumTraces": 1000
+        "SearchDepth": 1000
         },
         "ExpectedFixtures": ["tags_wildcard_regex_1", "tags_wildcard_regex_2"]
     }

--- a/internal/storage/integration/fixtures/queries_es.json
+++ b/internal/storage/integration/fixtures/queries_es.json
@@ -4,9 +4,9 @@
         "Query": {
         "ServiceName": "query23-service",
         "OperationName": "query23-operation",
-        "Attributes": {
-            "sameplacetag1":"same\\*"
-        },
+        "Attributes": [
+            { "key": "sameplacetag1", "value": { "string_value": "same\\*" } }
+        ],
         "StartTimeMin": "2017-01-26T15:46:31.639875Z",
         "StartTimeMax": "2017-01-26T17:46:31.639875Z",
         "DurationMin": 0,
@@ -20,9 +20,9 @@
         "Query": {
         "ServiceName": "query24-service",
         "OperationName": "",
-        "Attributes": {
-            "sameplacetag1":"same.*"
-        },
+        "Attributes": [
+            { "key": "sameplacetag1", "value": { "string_value": "same.*" } }
+        ],
         "StartTimeMin": "2017-01-26T15:46:31.639875Z",
         "StartTimeMax": "2017-01-26T17:46:31.639875Z",
         "DurationMin": 0,

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -75,7 +75,7 @@ type StorageIntegration struct {
 // the service name is formatted "query##-service".
 type QueryFixtures struct {
 	Caption          string
-	Query            *tracestore.TraceQueryParams
+	Query            *tracestore.TraceQueryParameters
 	ExpectedFixtures []string
 }
 
@@ -150,7 +150,7 @@ func (s *StorageIntegration) testGetServices(t *testing.T) {
 			// If the storage backend returns more services than expected, let's log traces for those
 			t.Log("🛑 Found unexpected services!")
 			for _, service := range actual {
-				iterTraces := s.TraceReader.FindTraces(context.Background(), tracestore.TraceQueryParams{
+				iterTraces := s.TraceReader.FindTraces(context.Background(), tracestore.TraceQueryParameters{
 					ServiceName:  service,
 					StartTimeMin: time.Now().Add(-2 * time.Hour),
 					StartTimeMax: time.Now(),
@@ -323,7 +323,7 @@ func (s *StorageIntegration) testFindTraces(t *testing.T) {
 	}
 }
 
-func (s *StorageIntegration) findTracesByQuery(t *testing.T, query *tracestore.TraceQueryParams, expected []*model.Trace) []*model.Trace {
+func (s *StorageIntegration) findTracesByQuery(t *testing.T, query *tracestore.TraceQueryParameters, expected []*model.Trace) []*model.Trace {
 	var traces []*model.Trace
 	found := s.waitForCondition(t, func(t *testing.T) bool {
 		var err error

--- a/internal/storage/v2/api/tracestore/mocks/Reader.go
+++ b/internal/storage/v2/api/tracestore/mocks/Reader.go
@@ -26,7 +26,7 @@ type Reader struct {
 }
 
 // FindTraceIDs provides a mock function with given fields: ctx, query
-func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]pcommon.TraceID, error] {
+func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error] {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
@@ -34,7 +34,7 @@ func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryP
 	}
 
 	var r0 iter.Seq2[[]pcommon.TraceID, error]
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParams) iter.Seq2[[]pcommon.TraceID, error]); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error]); ok {
 		r0 = rf(ctx, query)
 	} else {
 		if ret.Get(0) != nil {
@@ -46,7 +46,7 @@ func (_m *Reader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryP
 }
 
 // FindTraces provides a mock function with given fields: ctx, query
-func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error] {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
@@ -54,7 +54,7 @@ func (_m *Reader) FindTraces(ctx context.Context, query tracestore.TraceQueryPar
 	}
 
 	var r0 iter.Seq2[[]ptrace.Traces, error]
-	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error]); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, tracestore.TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error]); ok {
 		r0 = rf(ctx, query)
 	} else {
 		if ret.Get(0) != nil {

--- a/internal/storage/v2/api/tracestore/reader.go
+++ b/internal/storage/v2/api/tracestore/reader.go
@@ -87,7 +87,7 @@ type TraceQueryParameters struct {
 	StartTimeMax  time.Time
 	DurationMin   time.Duration
 	DurationMax   time.Duration
-	NumTraces     int
+	SearchDepth   int
 }
 
 func (t *TraceQueryParameters) ToSpanStoreQueryParameters() *spanstore.TraceQueryParameters {
@@ -99,7 +99,7 @@ func (t *TraceQueryParameters) ToSpanStoreQueryParameters() *spanstore.TraceQuer
 		StartTimeMax:  t.StartTimeMax,
 		DurationMin:   t.DurationMin,
 		DurationMax:   t.DurationMax,
-		NumTraces:     t.NumTraces,
+		NumTraces:     t.SearchDepth,
 	}
 }
 

--- a/internal/storage/v2/api/tracestore/reader.go
+++ b/internal/storage/v2/api/tracestore/reader.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 )
 
@@ -76,13 +77,13 @@ type GetTraceParams struct {
 	End time.Time
 }
 
-// TraceQueryParameters contains query paramters to find traces. For a detailed
+// TraceQueryParameters contains query parameters to find traces. For a detailed
 // definition of each field in this message, refer to `TraceQueryParameters` in `jaeger.api_v3`
 // (https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto).
 type TraceQueryParameters struct {
 	ServiceName   string
 	OperationName string
-	Tags          map[string]string
+	Attributes    pcommon.Map
 	StartTimeMin  time.Time
 	StartTimeMax  time.Time
 	DurationMin   time.Duration
@@ -94,7 +95,7 @@ func (t *TraceQueryParameters) ToSpanStoreQueryParameters() *spanstore.TraceQuer
 	return &spanstore.TraceQueryParameters{
 		ServiceName:   t.ServiceName,
 		OperationName: t.OperationName,
-		Tags:          t.Tags,
+		Tags:          jptrace.AttributesToMap(t.Attributes),
 		StartTimeMin:  t.StartTimeMin,
 		StartTimeMax:  t.StartTimeMax,
 		DurationMin:   t.DurationMin,

--- a/internal/storage/v2/api/tracestore/reader.go
+++ b/internal/storage/v2/api/tracestore/reader.go
@@ -49,7 +49,7 @@ type Reader interface {
 	// There's currently an implementation-dependent ambiguity whether all query filters
 	// (such as multiple tags) must apply to the same span within a trace, or can be satisfied
 	// by different spans.
-	FindTraces(ctx context.Context, query TraceQueryParams) iter.Seq2[[]ptrace.Traces, error]
+	FindTraces(ctx context.Context, query TraceQueryParameters) iter.Seq2[[]ptrace.Traces, error]
 
 	// FindTraceIDs returns an iterator that retrieves IDs of traces matching query parameters.
 	// The iterator is single-use: once consumed, it cannot be used again.
@@ -61,7 +61,7 @@ type Reader interface {
 	// of matching trace IDs. This is useful in some contexts, such as batch jobs, where a
 	// large list of trace IDs may be queried first and then the full traces are loaded
 	// in batches.
-	FindTraceIDs(ctx context.Context, query TraceQueryParams) iter.Seq2[[]pcommon.TraceID, error]
+	FindTraceIDs(ctx context.Context, query TraceQueryParameters) iter.Seq2[[]pcommon.TraceID, error]
 }
 
 // GetTraceParams contains single-trace parameters for a GetTraces request.
@@ -76,8 +76,10 @@ type GetTraceParams struct {
 	End time.Time
 }
 
-// TraceQueryParams contains parameters of a trace query.
-type TraceQueryParams struct {
+// TraceQueryParameters contains query paramters to find traces. For a detailed
+// definition of each field in this message, refer to `TraceQueryParameters` in `jaeger.api_v3`
+// (https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto).
+type TraceQueryParameters struct {
 	ServiceName   string
 	OperationName string
 	Tags          map[string]string
@@ -88,7 +90,7 @@ type TraceQueryParams struct {
 	NumTraces     int
 }
 
-func (t *TraceQueryParams) ToSpanStoreQueryParameters() *spanstore.TraceQueryParameters {
+func (t *TraceQueryParameters) ToSpanStoreQueryParameters() *spanstore.TraceQueryParameters {
 	return &spanstore.TraceQueryParameters{
 		ServiceName:   t.ServiceName,
 		OperationName: t.OperationName,

--- a/internal/storage/v2/api/tracestore/reader_test.go
+++ b/internal/storage/v2/api/tracestore/reader_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestToSpanStoreQueryParameters(t *testing.T) {
 	now := time.Now()
-	query := &TraceQueryParams{
+	query := &TraceQueryParameters{
 		ServiceName:   "service",
 		OperationName: "operation",
 		Tags:          map[string]string{"tag-a": "val-a"},

--- a/internal/storage/v2/api/tracestore/reader_test.go
+++ b/internal/storage/v2/api/tracestore/reader_test.go
@@ -8,16 +8,20 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 )
 
 func TestToSpanStoreQueryParameters(t *testing.T) {
 	now := time.Now()
+	attributes := pcommon.NewMap()
+	attributes.PutStr("tag-a", "val-a")
+
 	query := &TraceQueryParameters{
 		ServiceName:   "service",
 		OperationName: "operation",
-		Tags:          map[string]string{"tag-a": "val-a"},
+		Attributes:    attributes,
 		StartTimeMin:  now,
 		StartTimeMax:  now.Add(time.Minute),
 		DurationMin:   time.Minute,

--- a/internal/storage/v2/api/tracestore/reader_test.go
+++ b/internal/storage/v2/api/tracestore/reader_test.go
@@ -22,7 +22,7 @@ func TestToSpanStoreQueryParameters(t *testing.T) {
 		StartTimeMax:  now.Add(time.Minute),
 		DurationMin:   time.Minute,
 		DurationMax:   time.Hour,
-		NumTraces:     10,
+		SearchDepth:   10,
 	}
 	expected := &spanstore.TraceQueryParameters{
 		ServiceName:   "service",

--- a/internal/storage/v2/grpc/trace_storage.proto
+++ b/internal/storage/v2/grpc/trace_storage.proto
@@ -64,7 +64,7 @@ message GetOperationsResponse {
   repeated Operation operations = 1;
 }
 
-// TraceQueryParameters contains query paramters to find traces. For a detailed
+// TraceQueryParameters contains query parameters to find traces. For a detailed
 // definition of each field in this message, refer to `TraceQueryParameters` in `jaeger.api_v3`
 // (https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto).
 message TraceQueryParameters {

--- a/internal/storage/v2/v1adapter/spanreader.go
+++ b/internal/storage/v2/v1adapter/spanreader.go
@@ -75,7 +75,7 @@ func (sr *SpanReader) FindTraces(
 	ctx context.Context,
 	query *spanstore.TraceQueryParameters,
 ) ([]*model.Trace, error) {
-	getTracesIter := sr.traceReader.FindTraces(ctx, tracestore.TraceQueryParams{
+	getTracesIter := sr.traceReader.FindTraces(ctx, tracestore.TraceQueryParameters{
 		ServiceName:   query.ServiceName,
 		OperationName: query.OperationName,
 		Tags:          query.Tags,
@@ -92,7 +92,7 @@ func (sr *SpanReader) FindTraceIDs(
 	ctx context.Context,
 	query *spanstore.TraceQueryParameters,
 ) ([]model.TraceID, error) {
-	traceIDsIter := sr.traceReader.FindTraceIDs(ctx, tracestore.TraceQueryParams{
+	traceIDsIter := sr.traceReader.FindTraceIDs(ctx, tracestore.TraceQueryParameters{
 		ServiceName:   query.ServiceName,
 		OperationName: query.OperationName,
 		Tags:          query.Tags,

--- a/internal/storage/v2/v1adapter/spanreader.go
+++ b/internal/storage/v2/v1adapter/spanreader.go
@@ -83,7 +83,7 @@ func (sr *SpanReader) FindTraces(
 		StartTimeMax:  query.StartTimeMax,
 		DurationMin:   query.DurationMin,
 		DurationMax:   query.DurationMax,
-		NumTraces:     query.NumTraces,
+		SearchDepth:   query.NumTraces,
 	})
 	return V1TracesFromSeq2(getTracesIter)
 }
@@ -100,7 +100,7 @@ func (sr *SpanReader) FindTraceIDs(
 		StartTimeMax:  query.StartTimeMax,
 		DurationMin:   query.DurationMin,
 		DurationMax:   query.DurationMax,
-		NumTraces:     query.NumTraces,
+		SearchDepth:   query.NumTraces,
 	})
 	return V1TraceIDsFromSeq2(traceIDsIter)
 }

--- a/internal/storage/v2/v1adapter/spanreader.go
+++ b/internal/storage/v2/v1adapter/spanreader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
@@ -78,7 +79,7 @@ func (sr *SpanReader) FindTraces(
 	getTracesIter := sr.traceReader.FindTraces(ctx, tracestore.TraceQueryParameters{
 		ServiceName:   query.ServiceName,
 		OperationName: query.OperationName,
-		Tags:          query.Tags,
+		Attributes:    jptrace.MapToAttributes(query.Tags),
 		StartTimeMin:  query.StartTimeMin,
 		StartTimeMax:  query.StartTimeMax,
 		DurationMin:   query.DurationMin,
@@ -95,7 +96,7 @@ func (sr *SpanReader) FindTraceIDs(
 	traceIDsIter := sr.traceReader.FindTraceIDs(ctx, tracestore.TraceQueryParameters{
 		ServiceName:   query.ServiceName,
 		OperationName: query.OperationName,
-		Tags:          query.Tags,
+		Attributes:    jptrace.MapToAttributes(query.Tags),
 		StartTimeMin:  query.StartTimeMin,
 		StartTimeMax:  query.StartTimeMax,
 		DurationMin:   query.DurationMin,

--- a/internal/storage/v2/v1adapter/spanreader_test.go
+++ b/internal/storage/v2/v1adapter/spanreader_test.go
@@ -231,7 +231,7 @@ func TestSpanReader_FindTraces(t *testing.T) {
 	tests := []struct {
 		name           string
 		query          *spanstore.TraceQueryParameters
-		expectedQuery  tracestore.TraceQueryParams
+		expectedQuery  tracestore.TraceQueryParameters
 		traces         []ptrace.Traces
 		expectedTraces []*model.Trace
 		err            error
@@ -242,7 +242,7 @@ func TestSpanReader_FindTraces(t *testing.T) {
 			query: &spanstore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
-			expectedQuery: tracestore.TraceQueryParams{
+			expectedQuery: tracestore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
 			err:         assert.AnError,
@@ -253,7 +253,7 @@ func TestSpanReader_FindTraces(t *testing.T) {
 			query: &spanstore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
-			expectedQuery: tracestore.TraceQueryParams{
+			expectedQuery: tracestore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
 			traces:         []ptrace.Traces{},
@@ -264,7 +264,7 @@ func TestSpanReader_FindTraces(t *testing.T) {
 			query: &spanstore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
-			expectedQuery: tracestore.TraceQueryParams{
+			expectedQuery: tracestore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
 			traces: func() []ptrace.Traces {
@@ -335,7 +335,7 @@ func TestSpanReader_FindTraceIDs(t *testing.T) {
 	tests := []struct {
 		name             string
 		query            *spanstore.TraceQueryParameters
-		expectedQuery    tracestore.TraceQueryParams
+		expectedQuery    tracestore.TraceQueryParameters
 		traceIDs         []pcommon.TraceID
 		expectedTraceIDs []model.TraceID
 		err              error
@@ -346,7 +346,7 @@ func TestSpanReader_FindTraceIDs(t *testing.T) {
 			query: &spanstore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
-			expectedQuery: tracestore.TraceQueryParams{
+			expectedQuery: tracestore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
 			err:         assert.AnError,
@@ -357,7 +357,7 @@ func TestSpanReader_FindTraceIDs(t *testing.T) {
 			query: &spanstore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
-			expectedQuery: tracestore.TraceQueryParams{
+			expectedQuery: tracestore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
 			traceIDs:         []pcommon.TraceID{},
@@ -368,7 +368,7 @@ func TestSpanReader_FindTraceIDs(t *testing.T) {
 			query: &spanstore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
-			expectedQuery: tracestore.TraceQueryParams{
+			expectedQuery: tracestore.TraceQueryParameters{
 				ServiceName: "service1",
 			},
 			traceIDs: []pcommon.TraceID{

--- a/internal/storage/v2/v1adapter/tracereader.go
+++ b/internal/storage/v2/v1adapter/tracereader.go
@@ -92,7 +92,7 @@ func (tr *TraceReader) GetOperations(
 
 func (tr *TraceReader) FindTraces(
 	ctx context.Context,
-	query tracestore.TraceQueryParams,
+	query tracestore.TraceQueryParameters,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
 		traces, err := tr.spanReader.FindTraces(ctx, query.ToSpanStoreQueryParameters())
@@ -112,7 +112,7 @@ func (tr *TraceReader) FindTraces(
 
 func (tr *TraceReader) FindTraceIDs(
 	ctx context.Context,
-	query tracestore.TraceQueryParams,
+	query tracestore.TraceQueryParameters,
 ) iter.Seq2[[]pcommon.TraceID, error] {
 	return func(yield func([]pcommon.TraceID, error) bool) {
 		traceIDs, err := tr.spanReader.FindTraceIDs(ctx, query.ToSpanStoreQueryParameters())

--- a/internal/storage/v2/v1adapter/tracereader_test.go
+++ b/internal/storage/v2/v1adapter/tracereader_test.go
@@ -295,12 +295,14 @@ func TestTraceReader_FindTracesDelegatesSuccessResponse(t *testing.T) {
 	traceReader := &TraceReader{
 		spanReader: sr,
 	}
+	attributes := pcommon.NewMap()
+	attributes.PutStr("tag-a", "val-a")
 	traces, err := jiter.FlattenWithErrors(traceReader.FindTraces(
 		context.Background(),
 		tracestore.TraceQueryParameters{
 			ServiceName:   "service",
 			OperationName: "operation",
-			Tags:          map[string]string{"tag-a": "val-a"},
+			Attributes:    attributes,
 			StartTimeMin:  now,
 			StartTimeMax:  now.Add(time.Minute),
 			DurationMin:   time.Minute,
@@ -456,12 +458,14 @@ func TestTraceReader_FindTraceIDsDelegatesResponse(t *testing.T) {
 			traceReader := &TraceReader{
 				spanReader: sr,
 			}
+			attributes := pcommon.NewMap()
+			attributes.PutStr("tag-a", "val-a")
 			traceIDs, err := jiter.FlattenWithErrors(traceReader.FindTraceIDs(
 				context.Background(),
 				tracestore.TraceQueryParameters{
 					ServiceName:   "service",
 					OperationName: "operation",
-					Tags:          map[string]string{"tag-a": "val-a"},
+					Attributes:    attributes,
 					StartTimeMin:  now,
 					StartTimeMax:  now.Add(time.Minute),
 					DurationMin:   time.Minute,

--- a/internal/storage/v2/v1adapter/tracereader_test.go
+++ b/internal/storage/v2/v1adapter/tracereader_test.go
@@ -305,7 +305,7 @@ func TestTraceReader_FindTracesDelegatesSuccessResponse(t *testing.T) {
 			StartTimeMax:  now.Add(time.Minute),
 			DurationMin:   time.Minute,
 			DurationMax:   time.Hour,
-			NumTraces:     10,
+			SearchDepth:   10,
 		},
 	))
 	require.NoError(t, err)
@@ -466,7 +466,7 @@ func TestTraceReader_FindTraceIDsDelegatesResponse(t *testing.T) {
 					StartTimeMax:  now.Add(time.Minute),
 					DurationMin:   time.Minute,
 					DurationMax:   time.Hour,
-					NumTraces:     10,
+					SearchDepth:   10,
 				},
 			))
 			require.ErrorIs(t, err, test.err)

--- a/internal/storage/v2/v1adapter/tracereader_test.go
+++ b/internal/storage/v2/v1adapter/tracereader_test.go
@@ -297,7 +297,7 @@ func TestTraceReader_FindTracesDelegatesSuccessResponse(t *testing.T) {
 	}
 	traces, err := jiter.FlattenWithErrors(traceReader.FindTraces(
 		context.Background(),
-		tracestore.TraceQueryParams{
+		tracestore.TraceQueryParameters{
 			ServiceName:   "service",
 			OperationName: "operation",
 			Tags:          map[string]string{"tag-a": "val-a"},
@@ -360,7 +360,7 @@ func TestTraceReader_FindTracesEdgeCases(t *testing.T) {
 			}
 			traces, err := jiter.FlattenWithErrors(traceReader.FindTraces(
 				context.Background(),
-				tracestore.TraceQueryParams{},
+				tracestore.TraceQueryParameters{},
 			))
 			require.ErrorIs(t, err, test.err)
 			require.Equal(t, test.expectedTraces, traces)
@@ -380,7 +380,7 @@ func TestTraceReader_FindTracesEarlyStop(t *testing.T) {
 	}
 	called := 0
 	traceReader.FindTraces(
-		context.Background(), tracestore.TraceQueryParams{},
+		context.Background(), tracestore.TraceQueryParameters{},
 	)(func(tr []ptrace.Traces, err error) bool {
 		require.NoError(t, err)
 		require.Len(t, tr, 1)
@@ -390,7 +390,7 @@ func TestTraceReader_FindTracesEarlyStop(t *testing.T) {
 	assert.Equal(t, 3, called)
 	called = 0
 	traceReader.FindTraces(
-		context.Background(), tracestore.TraceQueryParams{},
+		context.Background(), tracestore.TraceQueryParameters{},
 	)(func(tr []ptrace.Traces, err error) bool {
 		require.NoError(t, err)
 		require.Len(t, tr, 1)
@@ -458,7 +458,7 @@ func TestTraceReader_FindTraceIDsDelegatesResponse(t *testing.T) {
 			}
 			traceIDs, err := jiter.FlattenWithErrors(traceReader.FindTraceIDs(
 				context.Background(),
-				tracestore.TraceQueryParams{
+				tracestore.TraceQueryParameters{
 					ServiceName:   "service",
 					OperationName: "operation",
 					Tags:          map[string]string{"tag-a": "val-a"},

--- a/proto-gen/storage/v2/trace_storage.pb.go
+++ b/proto-gen/storage/v2/trace_storage.pb.go
@@ -341,7 +341,7 @@ func (m *GetOperationsResponse) GetOperations() []*Operation {
 	return nil
 }
 
-// TraceQueryParameters contains query paramters to find traces. For a detailed
+// TraceQueryParameters contains query parameters to find traces. For a detailed
 // definition of each field in this message, refer to `TraceQueryParameters` in `jaeger.api_v3`
 // (https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto).
 type TraceQueryParameters struct {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6765

## Description of the changes
- Updates `TraceQueryParams` with the following changes to match the Remote Storage API v2 being developed as part of https://github.com/jaegertracing/jaeger/issues/6629
  - `TraceQueryParams` was renamed `TraceQueryParameters`
  - `NumTraces` was renamed to `SearchDepth`
  - `Tags` was renamed to `Attributes`
  - `Attributes` was changed from `map[string]string` to `pcommon.Map` to accept typed attributes 

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
