### PR TITLE
feat: Enable configuration of hostnames for hotrod services

### DIFF
--- a/examples/hotrod/cmd/customer.go
+++ b/examples/hotrod/cmd/customer.go
@@ -24,7 +24,7 @@ var customerCmd = &cobra.Command{
 		zapLogger := logger.With(zap.String("service", "customer"))
 		logger := log.NewFactory(zapLogger)
 		server := customer.NewServer(
-			net.JoinHostPort("0.0.0.0", strconv.Itoa(customerPort)),
+			net.JoinHostPort(customerHostname, strconv.Itoa(customerPort)),
 			otelExporter,
 			metricsFactory,
 			logger,

--- a/examples/hotrod/cmd/driver.go
+++ b/examples/hotrod/cmd/driver.go
@@ -24,7 +24,7 @@ var driverCmd = &cobra.Command{
 		zapLogger := logger.With(zap.String("service", "driver"))
 		logger := log.NewFactory(zapLogger)
 		server := driver.NewServer(
-			net.JoinHostPort("0.0.0.0", strconv.Itoa(driverPort)),
+			net.JoinHostPort(driverHostname, strconv.Itoa(driverPort)),
 			otelExporter,
 			metricsFactory,
 			logger,

--- a/examples/hotrod/cmd/flags.go
+++ b/examples/hotrod/cmd/flags.go
@@ -17,6 +17,11 @@ var (
 	fixDBConnDisableMutex  bool
 	fixRouteWorkerPoolSize int
 
+	customerHostname string
+	driverHostname   string
+	frontendHostname string
+	routeHostname    string
+
 	customerPort int
 	driverPort   int
 	frontendPort int
@@ -33,6 +38,12 @@ func addFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().DurationVarP(&fixDBConnDelay, "fix-db-query-delay", "D", 300*time.Millisecond, "Average latency of MySQL DB query")
 	cmd.PersistentFlags().BoolVarP(&fixDBConnDisableMutex, "fix-disable-db-conn-mutex", "M", false, "Disables the mutex guarding db connection")
 	cmd.PersistentFlags().IntVarP(&fixRouteWorkerPoolSize, "fix-route-worker-pool-size", "W", 3, "Default worker pool size")
+
+	// Add flags to choose hostnames for services
+	cmd.PersistentFlags().StringVar(&customerHostname, "customer-service-hostname", "0.0.0.0", "Hostname for customer service")
+	cmd.PersistentFlags().StringVar(&driverHostname, "driver-service-hostname", "0.0.0.0", "Hostname for driver service")
+	cmd.PersistentFlags().StringVar(&frontendHostname, "frontend-service-hostname", "0.0.0.0", "Hostname for frontend service")
+	cmd.PersistentFlags().StringVar(&routeHostname, "route-service-hostname", "0.0.0.0", "Hostname for routing service")
 
 	// Add flags to choose ports for services
 	cmd.PersistentFlags().IntVarP(&customerPort, "customer-service-port", "c", 8081, "Port for customer service")

--- a/examples/hotrod/cmd/frontend.go
+++ b/examples/hotrod/cmd/frontend.go
@@ -22,10 +22,10 @@ var frontendCmd = &cobra.Command{
 	Short: "Starts Frontend service",
 	Long:  `Starts Frontend service.`,
 	RunE: func(_ *cobra.Command, _ /* args */ []string) error {
-		options.FrontendHostPort = net.JoinHostPort("0.0.0.0", strconv.Itoa(frontendPort))
-		options.DriverHostPort = net.JoinHostPort("0.0.0.0", strconv.Itoa(driverPort))
-		options.CustomerHostPort = net.JoinHostPort("0.0.0.0", strconv.Itoa(customerPort))
-		options.RouteHostPort = net.JoinHostPort("0.0.0.0", strconv.Itoa(routePort))
+		options.FrontendHostPort = net.JoinHostPort(frontendHostname, strconv.Itoa(frontendPort))
+		options.DriverHostPort = net.JoinHostPort(driverHostname, strconv.Itoa(driverPort))
+		options.CustomerHostPort = net.JoinHostPort(customerHostname, strconv.Itoa(customerPort))
+		options.RouteHostPort = net.JoinHostPort(routeHostname, strconv.Itoa(routePort))
 		options.Basepath = basepath
 		options.JaegerUI = jaegerUI
 

--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -73,6 +73,22 @@ func onInitialize() {
 		config.RouteWorkerPoolSize = fixRouteWorkerPoolSize
 	}
 
+	if customerHostname != "0.0.0.0" {
+		logger.Info("changing customer service hostname", zap.String("old", "0.0.0.0"), zap.String("new", customerHostname))
+	}
+
+	if driverHostname != "0.0.0.0" {
+		logger.Info("changing driver service hostname", zap.String("old", "0.0.0.0"), zap.String("new", driverHostname))
+	}
+
+	if frontendHostname != "0.0.0.0" {
+		logger.Info("changing frontend service hostname", zap.String("old", "0.0.0.0"), zap.String("new", frontendHostname))
+	}
+
+	if routeHostname != "0.0.0.0" {
+		logger.Info("changing route service hostname", zap.String("old", "0.0.0.0"), zap.String("new", routeHostname))
+	}
+
 	if customerPort != 8081 {
 		logger.Info("changing customer service port", zap.Int("old", 8081), zap.Int("new", customerPort))
 	}

--- a/examples/hotrod/cmd/route.go
+++ b/examples/hotrod/cmd/route.go
@@ -25,7 +25,7 @@ var routeCmd = &cobra.Command{
 		zapLogger := logger.With(zap.String("service", "route"))
 		logger := log.NewFactory(zapLogger)
 		server := route.NewServer(
-			net.JoinHostPort("0.0.0.0", strconv.Itoa(routePort)),
+			net.JoinHostPort(routeHostname, strconv.Itoa(routePort)),
 			tracing.InitOTEL("route", otelExporter, metricsFactory, logger),
 			logger,
 		)


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #6774 

We want to allow users to configure the hostnames of the Hotrod services. This would allow users of the example app to run the services as separate containers.

## Description of the changes

The main change is to add hostname flags for each service. We pass these in as part of the `command` when running the containers. 

## How was this change tested?

Example docker-compose usage:

```
hotrod-frontend:
    container_name: hotrod-frontend
    image: hotrod:0.1.0-alpha.2
    ports:
      - '8080:8080'
    command: ["frontend", "--customer-service-hostname", "hotrod-customer", "-c", "8081", "--driver-service-hostname", "hotrod-driver", "-d", "8082", "--route-service-hostname", "hotrod-route", "-r", "8083"]

hotrod-customer:
  container_name: hotrod-customer
  image: ...
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
