### PR TITLE
[refactor] Converge v2 API with v2 remote storage API

### DIFF
--- a/cmd/jaeger/internal/integration/trace_reader.go
+++ b/cmd/jaeger/internal/integration/trace_reader.go
@@ -113,7 +113,7 @@ func (r *traceReader) FindTraces(
 	query tracestore.TraceQueryParams,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
-		if query.NumTraces > math.MaxInt32 {
+		if query.SearchDepth > math.MaxInt32 {
 			yield(nil, fmt.Errorf("NumTraces must not be greater than %d", math.MaxInt32))
 			return
 		}
@@ -127,7 +127,7 @@ func (r *traceReader) FindTraces(
 				DurationMin:   query.DurationMin,
 				DurationMax:   query.DurationMax,
 				//nolint: gosec // G115
-				SearchDepth: int32(query.NumTraces),
+				SearchDepth: int32(query.SearchDepth),
 				RawTraces:   true,
 			},
 		})

--- a/cmd/query/app/apiv3/grpc_handler.go
+++ b/cmd/query/app/apiv3/grpc_handler.go
@@ -75,7 +75,7 @@ func (h *Handler) internalFindTraces(
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
 			Attributes:    jptrace.MapToAttributes(query.GetAttributes()),
-			NumTraces:     int(query.GetSearchDepth()),
+			SearchDepth:   int(query.GetSearchDepth()),
 		},
 		RawTraces: query.GetRawTraces(),
 	}

--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -239,7 +239,7 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		if h.tryParamError(w, err, paramNumTraces) {
 			return nil, true
 		}
-		queryParams.NumTraces = numTraces
+		queryParams.SearchDepth = numTraces
 	}
 
 	if d := q.Get(paramDurationMin); d != "" {

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -266,7 +266,7 @@ func mockFindQueries() (url.Values, tracestore.TraceQueryParams) {
 		StartTimeMax:  time2,
 		DurationMin:   1 * time.Second,
 		DurationMax:   2 * time.Second,
-		NumTraces:     10,
+		SearchDepth:   10,
 	}
 }
 

--- a/cmd/query/app/querysvc/v2/querysvc/service_test.go
+++ b/cmd/query/app/querysvc/v2/querysvc/service_test.go
@@ -278,7 +278,7 @@ func TestFindTraces_Success(t *testing.T) {
 		OperationName: "operation",
 		StartTimeMax:  now,
 		DurationMin:   duration,
-		NumTraces:     200,
+		SearchDepth:   200,
 	}
 	tqs.traceReader.On("FindTraces", mock.Anything, queryParams).Return(responseIter).Once()
 
@@ -352,7 +352,7 @@ func TestFindTraces_WithRawTraces_PerformsAdjustment(t *testing.T) {
 				OperationName: "operation",
 				StartTimeMax:  now,
 				DurationMin:   duration,
-				NumTraces:     200,
+				SearchDepth:   200,
 			}).
 				Return(responseIter).Once()
 
@@ -362,7 +362,7 @@ func TestFindTraces_WithRawTraces_PerformsAdjustment(t *testing.T) {
 					OperationName: "operation",
 					StartTimeMax:  now,
 					DurationMin:   duration,
-					NumTraces:     200,
+					SearchDepth:   200,
 				},
 				RawTraces: test.rawTraces,
 			}
@@ -488,7 +488,7 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 				OperationName: "operation",
 				StartTimeMax:  now,
 				DurationMin:   duration,
-				NumTraces:     200,
+				SearchDepth:   200,
 			}).
 				Return(responseIter).Once()
 
@@ -498,7 +498,7 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 					OperationName: "operation",
 					StartTimeMax:  now,
 					DurationMin:   duration,
-					NumTraces:     200,
+					SearchDepth:   200,
 				},
 				RawTraces: test.rawTraces,
 			}

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -101,7 +101,7 @@ func (q *Query) ToTraceQueryParams() *tracestore.TraceQueryParams {
 		StartTimeMax:  q.StartTimeMax,
 		DurationMin:   q.DurationMin,
 		DurationMax:   q.DurationMax,
-		NumTraces:     q.NumTraces,
+		SearchDepth:   q.NumTraces,
 	}
 }
 

--- a/internal/storage/v2/api/tracestore/reader.go
+++ b/internal/storage/v2/api/tracestore/reader.go
@@ -86,7 +86,7 @@ type TraceQueryParams struct {
 	StartTimeMax  time.Time
 	DurationMin   time.Duration
 	DurationMax   time.Duration
-	NumTraces     int
+	SearchDepth   int
 }
 
 // FoundTraceID is a wrapper around trace ID returned from FindTraceIDs
@@ -111,7 +111,7 @@ func (t *TraceQueryParams) ToSpanStoreQueryParameters() *spanstore.TraceQueryPar
 		StartTimeMax:  t.StartTimeMax,
 		DurationMin:   t.DurationMin,
 		DurationMax:   t.DurationMax,
-		NumTraces:     t.NumTraces,
+		NumTraces:     t.SearchDepth,
 	}
 }
 

--- a/internal/storage/v2/api/tracestore/reader.go
+++ b/internal/storage/v2/api/tracestore/reader.go
@@ -77,7 +77,9 @@ type GetTraceParams struct {
 	End time.Time
 }
 
-// TraceQueryParams contains parameters of a trace query.
+// TraceQueryParams contains query parameters to find traces. For a detailed
+// definition of each field in this message, refer to `TraceQueryParameters` in `jaeger.api_v3`
+// (https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto).
 type TraceQueryParams struct {
 	ServiceName   string
 	OperationName string

--- a/internal/storage/v2/api/tracestore/reader_test.go
+++ b/internal/storage/v2/api/tracestore/reader_test.go
@@ -26,7 +26,7 @@ func TestToSpanStoreQueryParameters(t *testing.T) {
 		StartTimeMax:  now.Add(time.Minute),
 		DurationMin:   time.Minute,
 		DurationMax:   time.Hour,
-		NumTraces:     10,
+		SearchDepth:   10,
 	}
 	expected := &spanstore.TraceQueryParameters{
 		ServiceName:   "service",

--- a/internal/storage/v2/v1adapter/spanreader.go
+++ b/internal/storage/v2/v1adapter/spanreader.go
@@ -84,7 +84,7 @@ func (sr *SpanReader) FindTraces(
 		StartTimeMax:  query.StartTimeMax,
 		DurationMin:   query.DurationMin,
 		DurationMax:   query.DurationMax,
-		NumTraces:     query.NumTraces,
+		SearchDepth:   query.NumTraces,
 	})
 	return V1TracesFromSeq2(getTracesIter)
 }
@@ -101,7 +101,7 @@ func (sr *SpanReader) FindTraceIDs(
 		StartTimeMax:  query.StartTimeMax,
 		DurationMin:   query.DurationMin,
 		DurationMax:   query.DurationMax,
-		NumTraces:     query.NumTraces,
+		SearchDepth:   query.NumTraces,
 	})
 	return V1TraceIDsFromSeq2(traceIDsIter)
 }

--- a/internal/storage/v2/v1adapter/tracereader_test.go
+++ b/internal/storage/v2/v1adapter/tracereader_test.go
@@ -307,7 +307,7 @@ func TestTraceReader_FindTracesDelegatesSuccessResponse(t *testing.T) {
 			StartTimeMax:  now.Add(time.Minute),
 			DurationMin:   time.Minute,
 			DurationMax:   time.Hour,
-			NumTraces:     10,
+			SearchDepth:   10,
 		},
 	))
 	require.NoError(t, err)
@@ -480,7 +480,7 @@ func TestTraceReader_FindTraceIDsDelegatesResponse(t *testing.T) {
 					StartTimeMax:  now.Add(time.Minute),
 					DurationMin:   time.Minute,
 					DurationMax:   time.Hour,
-					NumTraces:     10,
+					SearchDepth:   10,
 				},
 			))
 			require.ErrorIs(t, err, test.err)


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6629 and #6765

## Description of the changes
- This PR makes the following changes to converge the v2 storage API with the v2 remote storage API
  - `NumTraces` -> `SearchDepth`
  - Update documentation for `TraceQueryParams`

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
