### PR TITLE
[fix] Fix flaky unit test in `attributes_test.go`

### DIFF
--- a/internal/jptrace/attributes_test.go
+++ b/internal/jptrace/attributes_test.go
@@ -64,38 +64,43 @@ func TestMapToAttributes(t *testing.T) {
 	tests := []struct {
 		name     string
 		tags     map[string]string
-		expected pcommon.Map
+		assertFn func(t *testing.T, result pcommon.Map)
 	}{
 		{
-			name:     "empty map",
-			tags:     map[string]string{},
-			expected: pcommon.NewMap(),
+			name: "empty map",
+			tags: map[string]string{},
+			assertFn: func(t *testing.T, result pcommon.Map) {
+				assert.Equal(t, 0, result.Len(), "Expected map to be empty")
+			},
 		},
 		{
 			name: "single tag",
 			tags: map[string]string{"key1": "value1"},
-			expected: func() pcommon.Map {
-				m := pcommon.NewMap()
-				m.PutStr("key1", "value1")
-				return m
-			}(),
+			assertFn: func(t *testing.T, result pcommon.Map) {
+				val, exists := result.Get("key1")
+				assert.True(t, exists)
+				assert.Equal(t, "value1", val.Str())
+			},
 		},
 		{
 			name: "multiple tags",
 			tags: map[string]string{"key1": "value1", "key2": "value2"},
-			expected: func() pcommon.Map {
-				m := pcommon.NewMap()
-				m.PutStr("key1", "value1")
-				m.PutStr("key2", "value2")
-				return m
-			}(),
+			assertFn: func(t *testing.T, result pcommon.Map) {
+				val, exists := result.Get("key1")
+				assert.True(t, exists)
+				assert.Equal(t, "value1", val.Str())
+
+				val, exists = result.Get("key2")
+				assert.True(t, exists)
+				assert.Equal(t, "value2", val.Str())
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := MapToAttributes(test.tags)
-			assert.Equal(t, test.expected, result)
+			test.assertFn(t, result)
 		})
 	}
 }

--- a/internal/jptrace/attributes_test.go
+++ b/internal/jptrace/attributes_test.go
@@ -6,7 +6,7 @@ package jptrace
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -55,44 +55,44 @@ func TestAttributesToMap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := AttributesToMap(test.attributes)
-			assert.Equal(t, test.expected, result)
+			require.Equal(t, test.expected, result)
 		})
 	}
 }
 
 func TestMapToAttributes(t *testing.T) {
 	tests := []struct {
-		name     string
-		tags     map[string]string
-		assertFn func(t *testing.T, result pcommon.Map)
+		name      string
+		tags      map[string]string
+		requireFn func(t *testing.T, result pcommon.Map)
 	}{
 		{
 			name: "empty map",
 			tags: map[string]string{},
-			assertFn: func(t *testing.T, result pcommon.Map) {
-				assert.Equal(t, 0, result.Len(), "Expected map to be empty")
+			requireFn: func(t *testing.T, result pcommon.Map) {
+				require.Equal(t, 0, result.Len(), "Expected map to be empty")
 			},
 		},
 		{
 			name: "single tag",
 			tags: map[string]string{"key1": "value1"},
-			assertFn: func(t *testing.T, result pcommon.Map) {
+			requireFn: func(t *testing.T, result pcommon.Map) {
 				val, exists := result.Get("key1")
-				assert.True(t, exists)
-				assert.Equal(t, "value1", val.Str())
+				require.True(t, exists)
+				require.Equal(t, "value1", val.Str())
 			},
 		},
 		{
 			name: "multiple tags",
 			tags: map[string]string{"key1": "value1", "key2": "value2"},
-			assertFn: func(t *testing.T, result pcommon.Map) {
+			requireFn: func(t *testing.T, result pcommon.Map) {
 				val, exists := result.Get("key1")
-				assert.True(t, exists)
-				assert.Equal(t, "value1", val.Str())
+				require.True(t, exists)
+				require.Equal(t, "value1", val.Str())
 
 				val, exists = result.Get("key2")
-				assert.True(t, exists)
-				assert.Equal(t, "value2", val.Str())
+				require.True(t, exists)
+				require.Equal(t, "value2", val.Str())
 			},
 		},
 	}
@@ -100,7 +100,7 @@ func TestMapToAttributes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := MapToAttributes(test.tags)
-			test.assertFn(t, result)
+			test.requireFn(t, result)
 		})
 	}
 }


### PR DESCRIPTION
## Description of the changes
- This PR fixes a flaky test that was being caused because a map is not iterated in order and hence the insertion order of elements in a `pcommon.Map` is not guaranteed

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
