### PR TITLE
[grpc][v2] Implement `GetOperations` Call in gRPC reader for remote storage api v2

### DIFF
--- a/internal/storage/v2/grpc/tracereader.go
+++ b/internal/storage/v2/grpc/tracereader.go
@@ -5,7 +5,6 @@ package grpc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"iter"
 
@@ -17,11 +16,6 @@ import (
 )
 
 var _ tracestore.Reader = (*TraceReader)(nil)
-
-var (
-	errFailedToGetServices   = errors.New("failed to get services")
-	errFailedToGetOperations = errors.New("failed to get operations")
-)
 
 type TraceReader struct {
 	client storage.TraceReaderClient
@@ -46,7 +40,7 @@ func (*TraceReader) GetTraces(
 func (tr *TraceReader) GetServices(ctx context.Context) ([]string, error) {
 	resp, err := tr.client.GetServices(ctx, &storage.GetServicesRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errFailedToGetServices, err)
+		return nil, fmt.Errorf("failed to get services: %w", err)
 	}
 	return resp.Services, nil
 }
@@ -60,7 +54,7 @@ func (tr *TraceReader) GetOperations(
 		SpanKind: params.SpanKind,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errFailedToGetOperations, err)
+		return nil, fmt.Errorf("failed to get operations: %w", err)
 	}
 	operations := make([]tracestore.Operation, len(resp.Operations))
 	for i, op := range resp.Operations {

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -22,16 +22,15 @@ import (
 type testServer struct {
 	storage.UnimplementedTraceReaderServer
 
-	getServicesError   error
-	getOperationsError error
+	err error
 }
 
 func (s *testServer) GetServices(
 	context.Context,
 	*storage.GetServicesRequest,
 ) (*storage.GetServicesResponse, error) {
-	if s.getServicesError != nil {
-		return nil, s.getServicesError
+	if s.err != nil {
+		return nil, s.err
 	}
 	return &storage.GetServicesResponse{
 		Services: []string{"service-a", "service-b"},
@@ -42,8 +41,8 @@ func (s *testServer) GetOperations(
 	context.Context,
 	*storage.GetOperationsRequest,
 ) (*storage.GetOperationsResponse, error) {
-	if s.getOperationsError != nil {
-		return nil, s.getOperationsError
+	if s.err != nil {
+		return nil, s.err
 	}
 	return &storage.GetOperationsResponse{
 		Operations: []*storage.Operation{
@@ -104,7 +103,7 @@ func TestTraceReader_GetServices(t *testing.T) {
 		{
 			name: "error",
 			testServer: &testServer{
-				getServicesError: assert.AnError,
+				err: assert.AnError,
 			},
 			expectedError: errFailedToGetServices,
 		},
@@ -141,7 +140,7 @@ func TestTraceReader_GetOperations(t *testing.T) {
 		{
 			name: "error",
 			testServer: &testServer{
-				getOperationsError: assert.AnError,
+				err: assert.AnError,
 			},
 			expectedError: errFailedToGetOperations,
 		},

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -95,7 +95,7 @@ func TestTraceReader_GetServices(t *testing.T) {
 		name             string
 		testServer       *testServer
 		expectedServices []string
-		expectedError    error
+		expectedError    string
 	}{
 		{
 			name: "success",
@@ -113,7 +113,7 @@ func TestTraceReader_GetServices(t *testing.T) {
 					err: assert.AnError,
 				},
 			},
-			expectedError: errFailedToGetServices,
+			expectedError: "failed to get services",
 		},
 	}
 
@@ -124,8 +124,11 @@ func TestTraceReader_GetServices(t *testing.T) {
 			reader := NewTraceReader(conn)
 			services, err := reader.GetServices(context.Background())
 
-			require.ErrorIs(t, err, test.expectedError)
-			require.Equal(t, test.expectedServices, services)
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+			} else {
+				require.Equal(t, test.expectedServices, services)
+			}
 		})
 	}
 }
@@ -135,7 +138,7 @@ func TestTraceReader_GetOperations(t *testing.T) {
 		name          string
 		testServer    *testServer
 		expectedOps   []tracestore.Operation
-		expectedError error
+		expectedError string
 	}{
 		{
 			name: "success",
@@ -159,7 +162,7 @@ func TestTraceReader_GetOperations(t *testing.T) {
 					err: assert.AnError,
 				},
 			},
-			expectedError: errFailedToGetOperations,
+			expectedError: "failed to get operations",
 		},
 	}
 
@@ -173,8 +176,11 @@ func TestTraceReader_GetOperations(t *testing.T) {
 				SpanKind:    "kind",
 			})
 
-			require.ErrorIs(t, err, test.expectedError)
-			require.Equal(t, test.expectedOps, ops)
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+			} else {
+				require.Equal(t, test.expectedOps, ops)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #6789

## Description of the changes
- This PR implements the `GetOperations` call in the gRPC tracereader

## How was this change tested?
- Added a unit test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
