### PR TITLE
[agent] Further simplify UDPServer

### DIFF
--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -190,7 +190,7 @@ func (c *ServerConfiguration) applyDefaults() {
 }
 
 // getUDPServer gets a TBufferedServer backed server using the server configuration
-func (c *ServerConfiguration) getUDPServer(mFactory metrics.Factory) (*servers.UDPServer, error) {
+func (c *ServerConfiguration) getUDPServer(mFactory metrics.Factory) (*servers.TBufferedServer, error) {
 	c.applyDefaults()
 
 	if c.HostPort == "" {
@@ -206,7 +206,7 @@ func (c *ServerConfiguration) getUDPServer(mFactory metrics.Factory) (*servers.U
 		}
 	}
 
-	return servers.NewUDPServer(transport, c.QueueSize, c.MaxPacketSize, mFactory)
+	return servers.NewTBufferedServer(transport, c.QueueSize, c.MaxPacketSize, mFactory)
 }
 
 func defaultInt(value int, defaultVal int) int {

--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -49,7 +49,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 
 	queueSize := 10
 	maxPacketSize := 65000
-	server, err := servers.NewUDPServer(transport, queueSize, maxPacketSize, mFactory)
+	server, err := servers.NewTBufferedServer(transport, queueSize, maxPacketSize, mFactory)
 	require.NoError(t, err)
 
 	numProcessors := 1

--- a/cmd/agent/app/servers/server.go
+++ b/cmd/agent/app/servers/server.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package servers
+
+import (
+	"io"
+)
+
+// Server is the interface for servers that receive inbound span submissions from client.
+// It is just an alias to TBufferedServer implementation since we don't have any others.
+type Server = *TBufferedServer
+
+// ReadBuf is a structure that holds the bytes to read into as well as the number of bytes
+// that was read. The slice is typically pre-allocated to the max packet size and the buffers
+// themselves are polled to avoid memory allocations for every new inbound message.
+type ReadBuf struct {
+	bytes []byte
+	n     int
+}
+
+// GetBytes returns the contents of the ReadBuf as bytes
+func (r *ReadBuf) GetBytes() []byte {
+	return r.bytes[:r.n]
+}
+
+func (r *ReadBuf) Read(p []byte) (int, error) {
+	if r.n == 0 {
+		return 0, io.EOF
+	}
+	n := r.n
+	copied := copy(p, r.bytes[:n])
+	r.n -= copied
+	return n, nil
+}

--- a/cmd/agent/app/servers/server_test.go
+++ b/cmd/agent/app/servers/server_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package servers
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadBuf_EOF(t *testing.T) {
+	b := ReadBuf{}
+	n, err := b.Read(nil)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestReadBuf_Read(t *testing.T) {
+	b := &ReadBuf{bytes: []byte("hello"), n: 5}
+	r := make([]byte, 5)
+	n, err := b.Read(r)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", string(r))
+}

--- a/cmd/agent/app/servers/tbuffered_server.go
+++ b/cmd/agent/app/servers/tbuffered_server.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package servers
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+
+	"github.com/jaegertracing/jaeger/pkg/metrics"
+)
+
+// ThriftTransport is a subset of thrift.TTransport methods, for easier mocking.
+type ThriftTransport interface {
+	io.Reader
+	io.Closer
+}
+
+// TBufferedServer is a custom thrift server that reads traffic using the transport provided
+// and places messages into a buffered channel to be processed by the processor provided
+type TBufferedServer struct {
+	// NB. queueLength HAS to be at the top of the struct or it will SIGSEV for certain architectures.
+	// See https://github.com/golang/go/issues/13868
+	queueSize     int64
+	dataChan      chan *ReadBuf
+	maxPacketSize int
+	maxQueueSize  int
+	serving       uint32
+	transport     ThriftTransport
+	readBufPool   *sync.Pool
+	metrics       struct {
+		// Size of the current server queue
+		QueueSize metrics.Gauge `metric:"thrift.udp.server.queue_size"`
+
+		// Size (in bytes) of packets received by server
+		PacketSize metrics.Gauge `metric:"thrift.udp.server.packet_size"`
+
+		// Number of packets dropped by server
+		PacketsDropped metrics.Counter `metric:"thrift.udp.server.packets.dropped"`
+
+		// Number of packets processed by server
+		PacketsProcessed metrics.Counter `metric:"thrift.udp.server.packets.processed"`
+
+		// Number of malformed packets the server received
+		ReadError metrics.Counter `metric:"thrift.udp.server.read.errors"`
+	}
+}
+
+// NewTBufferedServer creates a TBufferedServer
+func NewTBufferedServer(
+	transport ThriftTransport,
+	maxQueueSize int,
+	maxPacketSize int,
+	mFactory metrics.Factory,
+) (*TBufferedServer, error) {
+	dataChan := make(chan *ReadBuf, maxQueueSize)
+
+	readBufPool := &sync.Pool{
+		New: func() any {
+			return &ReadBuf{bytes: make([]byte, maxPacketSize)}
+		},
+	}
+
+	res := &TBufferedServer{
+		dataChan:      dataChan,
+		transport:     transport,
+		maxQueueSize:  maxQueueSize,
+		maxPacketSize: maxPacketSize,
+		readBufPool:   readBufPool,
+		serving:       stateInit,
+	}
+
+	metrics.MustInit(&res.metrics, mFactory, nil)
+	return res, nil
+}
+
+// Serve initiates the readers and starts serving traffic
+func (s *TBufferedServer) Serve() {
+	defer close(s.dataChan)
+	if !atomic.CompareAndSwapUint32(&s.serving, stateInit, stateServing) {
+		return // Stop already called
+	}
+
+	for s.IsServing() {
+		readBuf := s.readBufPool.Get().(*ReadBuf)
+		n, err := s.transport.Read(readBuf.bytes)
+		if err == nil {
+			readBuf.n = n
+			s.metrics.PacketSize.Update(int64(n))
+			select {
+			case s.dataChan <- readBuf:
+				s.metrics.PacketsProcessed.Inc(1)
+				s.updateQueueSize(1)
+			default:
+				s.readBufPool.Put(readBuf)
+				s.metrics.PacketsDropped.Inc(1)
+			}
+		} else {
+			s.readBufPool.Put(readBuf)
+			s.metrics.ReadError.Inc(1)
+		}
+	}
+}
+
+func (s *TBufferedServer) updateQueueSize(delta int64) {
+	atomic.AddInt64(&s.queueSize, delta)
+	s.metrics.QueueSize.Update(atomic.LoadInt64(&s.queueSize))
+}
+
+// IsServing indicates whether the server is currently serving traffic
+func (s *TBufferedServer) IsServing() bool {
+	return atomic.LoadUint32(&s.serving) == stateServing
+}
+
+// Stop stops the serving of traffic and waits until the queue is
+// emptied by the readers
+func (s *TBufferedServer) Stop() {
+	atomic.StoreUint32(&s.serving, stateStopped)
+	_ = s.transport.Close()
+}
+
+// DataChan returns the data chan of the buffered server
+func (s *TBufferedServer) DataChan() chan *ReadBuf {
+	return s.dataChan
+}
+
+// DataRecd is called by the consumers every time they read a data item from DataChan
+func (s *TBufferedServer) DataRecd(buf *ReadBuf) {
+	s.updateQueueSize(-1)
+	s.readBufPool.Put(buf)
+}

--- a/cmd/agent/app/servers/tbuffered_server_test.go
+++ b/cmd/agent/app/servers/tbuffered_server_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package servers
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger-idl/thrift-gen/agent"
+	"github.com/jaegertracing/jaeger-idl/thrift-gen/zipkincore"
+	"github.com/jaegertracing/jaeger/cmd/agent/app/customtransport"
+	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
+	"github.com/jaegertracing/jaeger/cmd/agent/app/testutils"
+	"github.com/jaegertracing/jaeger/internal/metricstest"
+)
+
+func TestTBufferedServerSendReceive(t *testing.T) {
+	metricsFactory := metricstest.NewFactory(0)
+
+	transport, err := thriftudp.NewTUDPServerTransport("127.0.0.1:0")
+	require.NoError(t, err)
+
+	maxPacketSize := 65000
+	server, err := NewTBufferedServer(transport, 100, maxPacketSize, metricsFactory)
+	require.NoError(t, err)
+	go server.Serve()
+	defer server.Stop()
+
+	hostPort := transport.Addr().String()
+	client, clientCloser, err := testutils.NewZipkinThriftUDPClient(hostPort)
+	require.NoError(t, err)
+	defer clientCloser.Close()
+
+	span := zipkincore.NewSpan()
+	span.Name = "span1"
+
+	for i := 0; i < 1000; i++ {
+		err := client.EmitZipkinBatch(context.Background(), []*zipkincore.Span{span})
+		require.NoError(t, err)
+
+		select {
+		case readBuf := <-server.DataChan():
+			assert.NotEmpty(t, readBuf.GetBytes())
+
+			inMemReporter := testutils.NewInMemoryReporter()
+			protoFact := thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{})
+			trans := &customtransport.TBufferedReadTransport{}
+			protocol := protoFact.GetProtocol(trans)
+
+			_, err = protocol.Transport().Write(readBuf.GetBytes())
+			require.NoError(t, err)
+
+			server.DataRecd(readBuf) // return to pool
+
+			handler := agent.NewAgentProcessor(inMemReporter)
+			_, err = handler.Process(context.Background(), protocol, protocol)
+			require.NoError(t, err)
+
+			require.Len(t, inMemReporter.ZipkinSpans(), 1)
+			assert.Equal(t, "span1", inMemReporter.ZipkinSpans()[0].Name)
+
+			return // exit test on successful receipt
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	t.Fatal("server did not receive packets")
+}
+
+// The fakeTransport allows the server to read two packets, one filled with 1's, another with 2's,
+// then returns an error, and then blocks on the semaphore. The semaphore is only released when
+// the test is exiting.
+type fakeTransport struct {
+	packet atomic.Int64
+	wg     sync.WaitGroup
+}
+
+// Read simulates three packets received, then blocks until semaphore is released at the end of the test.
+// First packet is returned as normal.
+// Second packet is simulated as error.
+// Third packet is returned as normal, but will be dropped as overflow by the server whose queue size = 1.
+func (t *fakeTransport) Read(p []byte) (n int, err error) {
+	packet := t.packet.Add(1)
+	if packet == 2 {
+		// return some error packet, followed by valid one
+		return 0, io.ErrNoProgress
+	}
+	if packet > 3 {
+		// block after 3 packets until the server is shutdown and semaphore released
+		t.wg.Wait()
+		return 0, io.EOF
+	}
+	for i := range p {
+		p[i] = byte(packet)
+	}
+	return len(p), nil
+}
+
+func (*fakeTransport) Close() error {
+	return nil
+}
+
+func TestTBufferedServerMetrics(t *testing.T) {
+	metricsFactory := metricstest.NewFactory(0)
+
+	transport := new(fakeTransport)
+	transport.wg.Add(1)
+	defer transport.wg.Done()
+
+	maxPacketSize := 65000
+	server, err := NewTBufferedServer(transport, 1, maxPacketSize, metricsFactory)
+	require.NoError(t, err)
+	go server.Serve()
+	defer server.Stop()
+
+	// The fakeTransport will allow the server to read exactly two packets and one error in between.
+	// Since we use the server with queue size == 1, the first packet will be
+	// sent to channel, the error will increment the metric, and the second valid packet dropped.
+
+	packetDropped := false
+	for i := 0; i < 5000; i++ {
+		c, _ := metricsFactory.Snapshot()
+		if c["thrift.udp.server.packets.dropped"] == 1 {
+			packetDropped = true
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.True(t, packetDropped, "packetDropped")
+
+	var readBuf *ReadBuf
+	select {
+	case readBuf = <-server.DataChan():
+		b := readBuf.GetBytes()
+		assert.Len(t, b, 65000)
+		assert.EqualValues(t, 1, b[0], "first packet must be all 0x01's")
+	default:
+		t.Fatal("expecting a packet in the channel")
+	}
+
+	metricsFactory.AssertCounterMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 1},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.read.errors", Value: 1},
+	)
+	metricsFactory.AssertGaugeMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 65000},
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 1},
+	)
+
+	server.DataRecd(readBuf)
+	metricsFactory.AssertGaugeMetrics(t,
+		metricstest.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
+	)
+}

--- a/cmd/agent/app/servers/udpserver.go
+++ b/cmd/agent/app/servers/udpserver.go
@@ -11,12 +11,6 @@ import (
 	"sync/atomic"
 )
 
-// TBufferedServer is an alias for UDPServer, for backwards compatibility.
-type TBufferedServer = UDPServer
-
-// NewTBufferedServer is an alias for NewUDPServer, for backwards compatibility.
-var NewTBufferedServer = NewUDPServer
-
 // UDPConn is a an abstraction of *net.UDPConn, for easier mocking.
 type UDPConn interface {
 	io.Reader

--- a/cmd/agent/app/servers/udpserver_test.go
+++ b/cmd/agent/app/servers/udpserver_test.go
@@ -7,8 +7,6 @@ package servers
 import (
 	"bytes"
 	"context"
-	"io"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,18 +15,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/agent/app/servers/thriftudp"
-	"github.com/jaegertracing/jaeger/internal/metricstest"
 )
 
-func TestTBufferedServerSendReceive(t *testing.T) {
-	metricsFactory := metricstest.NewFactory(0)
-
+func TestUDPServerSendReceive(t *testing.T) {
 	transport, err := thriftudp.NewTUDPServerTransport("127.0.0.1:0")
 	require.NoError(t, err)
 
+	var packerRecieved atomic.Bool
+	packerRecieved.Store(false)
+	handler := func(buf *bytes.Buffer, release func(*bytes.Buffer)) {
+		defer release(buf)
+		assert.Positive(t, buf.Len())
+		assert.Equal(t, "span1", buf.String())
+		packerRecieved.Store(true)
+	}
+
 	const maxPacketSize = 65000
 	const maxQueueSize = 100
-	server, err := NewUDPServer(transport, maxQueueSize, maxPacketSize, metricsFactory)
+	server, err := NewUDPServer(transport, handler, maxPacketSize)
 	require.NoError(t, err)
 	go server.Serve()
 	defer server.Stop()
@@ -44,102 +48,20 @@ func TestTBufferedServerSendReceive(t *testing.T) {
 		require.Equal(t, 5, n)
 		require.NoError(t, client.Flush(context.Background()))
 
-		select {
-		case buf := <-server.DataChan():
-			assert.Positive(t, buf.Len())
-			assert.Equal(t, "span1", buf.String())
+		if packerRecieved.Load() {
 			return // exit test on successful receipt
-		default:
-			time.Sleep(10 * time.Millisecond)
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("server did not receive packets")
 }
 
-// The fakeTransport allows the server to read two packets, one filled with 1's, another with 2's,
-// then returns an error, and then blocks on the semaphore. The semaphore is only released when
-// the test is exiting.
-type fakeTransport struct {
-	packet atomic.Int64
-	wg     sync.WaitGroup
-}
-
-// Read simulates three packets received, then blocks until semaphore is released at the end of the test.
-// First packet is returned as normal.
-// Second packet is simulated as error.
-// Third packet is returned as normal, but will be dropped as overflow by the server whose queue size = 1.
-func (t *fakeTransport) Read(p []byte) (n int, err error) {
-	packet := t.packet.Add(1)
-	if packet == 2 {
-		// return some error packet, followed by valid one
-		return 0, io.ErrNoProgress
-	}
-	if packet > 3 {
-		// block after 3 packets until the server is shutdown and semaphore released
-		t.wg.Wait()
-		return 0, io.EOF
-	}
-	for i := range p {
-		p[i] = byte(packet)
-	}
-	return len(p), nil
-}
-
-func (*fakeTransport) Close() error {
-	return nil
-}
-
-func TestTBufferedServerMetrics(t *testing.T) {
-	metricsFactory := metricstest.NewFactory(0)
-
-	transport := new(fakeTransport)
-	transport.wg.Add(1)
-	defer transport.wg.Done()
-
-	const maxPacketSize = 65000
-	const maxQueueSize = 1
-	server, err := NewUDPServer(transport, maxQueueSize, maxPacketSize, metricsFactory)
+func TestUDPServerStopBeforeServe(t *testing.T) {
+	transport, err := thriftudp.NewTUDPServerTransport("127.0.0.1:0")
 	require.NoError(t, err)
-	go server.Serve()
-	defer server.Stop()
-
-	// The fakeTransport will allow the server to read exactly two packets and one error in between.
-	// Since we use the server with queue size == 1, the first packet will be
-	// sent to channel, the error will increment the metric, and the second valid packet dropped.
-
-	packetDropped := false
-	for i := 0; i < 5000; i++ {
-		c, _ := metricsFactory.Snapshot()
-		if c["thrift.udp.server.packets.dropped"] == 1 {
-			packetDropped = true
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-	require.True(t, packetDropped, "packetDropped")
-
-	var readBuf *bytes.Buffer
-	select {
-	case readBuf = <-server.DataChan():
-		b := readBuf.Bytes()
-		assert.Len(t, b, 65000)
-		assert.EqualValues(t, 1, b[0], "first packet must be all 0x01's")
-	default:
-		t.Fatal("expecting a packet in the channel")
-	}
-
-	metricsFactory.AssertCounterMetrics(t,
-		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.processed", Value: 1},
-		metricstest.ExpectedMetric{Name: "thrift.udp.server.packets.dropped", Value: 1},
-		metricstest.ExpectedMetric{Name: "thrift.udp.server.read.errors", Value: 1},
-	)
-	metricsFactory.AssertGaugeMetrics(t,
-		metricstest.ExpectedMetric{Name: "thrift.udp.server.packet_size", Value: 65000},
-		metricstest.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 1},
-	)
-
-	server.DataRecd(readBuf)
-	metricsFactory.AssertGaugeMetrics(t,
-		metricstest.ExpectedMetric{Name: "thrift.udp.server.queue_size", Value: 0},
-	)
+	server, err := NewUDPServer(transport, nil, 65000)
+	require.NoError(t, err)
+	server.Stop()
+	server.Serve()
+	server.Stop() // stop should be idempotent
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6704
- UDPServer was not only receiving data but also handling an internal queue

## Description of the changes


## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
