### PR TITLE
Instruct Renovate to pin GitHub Action hashes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":gitSignOff"
+    ":gitSignOff",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": [
     "changelog:dependencies"

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigests",
+    "config:best-practices",
     ":gitSignOff"
   ],
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":gitSignOff",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    ":gitSignOff"
   ],
   "labels": [
     "changelog:dependencies"


### PR DESCRIPTION
## Which problem is this PR solving?
- In light of https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/, make sure all actions are pinned

## Description of the changes
- Turns out Renovate has this as a feature https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating

## How was this change tested?
- CI