### PR TITLE
[refactor] Move interface to remove cmd/agent dependency

### DIFF
--- a/internal/sampling/http/handler.go
+++ b/internal/sampling/http/handler.go
@@ -5,6 +5,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +15,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
-	"github.com/jaegertracing/jaeger/cmd/agent/app/configmanager"
 	p2json "github.com/jaegertracing/jaeger/model/converter/json"
 	t2p "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
 	"github.com/jaegertracing/jaeger/pkg/metrics"
@@ -24,10 +24,14 @@ const mimeTypeApplicationJSON = "application/json"
 
 var errBadRequest = errors.New("bad request")
 
+type ClientConfigManager interface {
+	GetSamplingStrategy(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error)
+}
+
 // HandlerParams contains parameters that must be passed to NewHTTPHandler.
 type HandlerParams struct {
-	ConfigManager  configmanager.ClientConfigManager // required
-	MetricsFactory metrics.Factory                   // required
+	ConfigManager  ClientConfigManager // required
+	MetricsFactory metrics.Factory     // required
 
 	// BasePath will be used as a prefix for the endpoints, e.g. "/api"
 	BasePath string


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #4739
- This was the only dependency on cmd/agent from other packages. Once the next release of OTEL Contrib lands we can remove cmd/agent.

## Description of the changes
- Copy the interface into internal/sampling/http/handler.go

## How was this change tested?
- CI
