### PR TITLE
Remove sampling.strategies.bugfix-5270 flag and mark feature Stable

### DIFF
--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -31,7 +31,7 @@ var (
 
 	includeDefaultOpStrategies = featuregate.GlobalRegistry().MustRegister(
 		"jaeger.sampling.includeDefaultOpStrategies",
-		featuregate.StageBeta, // enabed by default
+		featuregate.StageStable, // can only be ON
 		featuregate.WithRegisterFromVersion("v2.2.0"),
 		featuregate.WithRegisterToVersion("v2.5.0"),
 		featuregate.WithRegisterDescription("Forces service strategy to be merged with default strategy, including per-operation overrides."),

--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -29,7 +29,7 @@ var (
 	_ xconfmap.Validator  = (*Config)(nil)
 	_ confmap.Unmarshaler = (*Config)(nil)
 
-	includeDefaultOpStrategies = featuregate.GlobalRegistry().MustRegister(
+	_ = featuregate.GlobalRegistry().MustRegister(
 		"jaeger.sampling.includeDefaultOpStrategies",
 		featuregate.StageStable, // can only be ON
 		featuregate.WithRegisterFromVersion("v2.2.0"),

--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -166,7 +166,6 @@ func (ext *rsExtension) startFileBasedStrategyProvider(_ context.Context) error 
 	opts := file.Options{
 		StrategiesFile:             ext.cfg.File.Path,
 		ReloadInterval:             ext.cfg.File.ReloadInterval,
-		IncludeDefaultOpStrategies: includeDefaultOpStrategies.IsEnabled(),
 		DefaultSamplingProbability: ext.cfg.File.DefaultSamplingProbability,
 	}
 

--- a/internal/sampling/samplingstrategy/file/options.go
+++ b/internal/sampling/samplingstrategy/file/options.go
@@ -14,7 +14,6 @@ const (
 	// samplingStrategiesFile contains the name of CLI option for config file.
 	samplingStrategiesFile                       = "sampling.strategies-file"
 	samplingStrategiesReloadInterval             = "sampling.strategies-reload-interval"
-	samplingStrategiesBugfix5270                 = "sampling.strategies.bugfix-5270"
 	samplingStrategiesDefaultSamplingProbability = "sampling.default-sampling-probability"
 )
 
@@ -24,10 +23,6 @@ type Options struct {
 	StrategiesFile string
 	// ReloadInterval is the time interval to check and reload sampling strategies file
 	ReloadInterval time.Duration
-	// Flag for enabling possibly breaking change which includes default operations level
-	// strategies when calculating Ratelimiting type service level strategy
-	// more information https://github.com/jaegertracing/jaeger/issues/5270
-	IncludeDefaultOpStrategies bool
 	// DefaultSamplingProbability is the sampling probability used by the Strategy Store for static sampling
 	DefaultSamplingProbability float64
 }
@@ -36,7 +31,6 @@ type Options struct {
 func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Duration(samplingStrategiesReloadInterval, 0, "Reload interval to check and reload sampling strategies file. Zero value means no reloading")
 	flagSet.String(samplingStrategiesFile, "", "The path for the sampling strategies file in JSON format. See sampling documentation to see format of the file")
-	flagSet.Bool(samplingStrategiesBugfix5270, true, "Include default operation level strategies for Ratesampling type service level strategy. Cf. https://github.com/jaegertracing/jaeger/issues/5270")
 	flagSet.Float64(samplingStrategiesDefaultSamplingProbability, DefaultSamplingProbability, "Sampling probability used by the Strategy Store for static sampling. Value must be between 0 and 1.")
 }
 
@@ -44,7 +38,6 @@ func AddFlags(flagSet *flag.FlagSet) {
 func (opts *Options) InitFromViper(v *viper.Viper) *Options {
 	opts.StrategiesFile = v.GetString(samplingStrategiesFile)
 	opts.ReloadInterval = v.GetDuration(samplingStrategiesReloadInterval)
-	opts.IncludeDefaultOpStrategies = v.GetBool(samplingStrategiesBugfix5270)
 	opts.DefaultSamplingProbability = v.GetFloat64(samplingStrategiesDefaultSamplingProbability)
 	return opts
 }

--- a/internal/sampling/samplingstrategy/file/provider_test.go
+++ b/internal/sampling/samplingstrategy/file/provider_test.go
@@ -504,38 +504,6 @@ func TestServiceNoPerOperationStrategies(t *testing.T) {
 	}
 }
 
-func TestServiceNoPerOperationStrategiesDeprecatedBehavior(t *testing.T) {
-	// test case to be removed along with removal of strategy_store.parseStrategies_deprecated,
-	// see https://github.com/jaegertracing/jaeger/issues/5270 for more details
-
-	// given setup of strategy provider with no specific per operation sampling strategies
-	provider, err := NewProvider(Options{
-		StrategiesFile: "fixtures/service_no_per_operation.json",
-	}, zap.NewNop())
-	require.NoError(t, err)
-
-	for _, service := range []string{"ServiceA", "ServiceB"} {
-		t.Run(service, func(t *testing.T) {
-			strategy, err := provider.GetSamplingStrategy(context.Background(), service)
-			require.NoError(t, err)
-			strategyJson, err := json.MarshalIndent(strategy, "", "  ")
-			require.NoError(t, err)
-
-			testName := strings.ReplaceAll(t.Name(), "/", "_")
-			snapshotFile := filepath.Join(snapshotLocation, testName+".json")
-			expectedServiceResponse, err := os.ReadFile(snapshotFile)
-			require.NoError(t, err)
-
-			assert.JSONEq(t, string(expectedServiceResponse), string(strategyJson),
-				"comparing against stored snapshot. Use REGENERATE_SNAPSHOTS=true to rebuild snapshots.")
-
-			if regenerateSnapshots {
-				os.WriteFile(snapshotFile, strategyJson, 0o644)
-			}
-		})
-	}
-}
-
 func TestSamplingStrategyLoader(t *testing.T) {
 	provider := &samplingProvider{logger: zap.NewNop()}
 	// invalid file path

--- a/internal/sampling/samplingstrategy/file/provider_test.go
+++ b/internal/sampling/samplingstrategy/file/provider_test.go
@@ -154,10 +154,8 @@ func TestPerOperationSamplingStrategies(t *testing.T) {
 	tests := []struct {
 		options Options
 	}{
-		{Options{StrategiesFile: "fixtures/operation_strategies.json", DefaultSamplingProbability: DefaultSamplingProbability}},
 		{Options{
 			StrategiesFile:             "fixtures/operation_strategies.json",
-			IncludeDefaultOpStrategies: true,
 			DefaultSamplingProbability: DefaultSamplingProbability,
 		}},
 	}
@@ -480,8 +478,7 @@ func TestServiceNoPerOperationStrategies(t *testing.T) {
 	// given setup of strategy provider with no specific per operation sampling strategies
 	// and option "sampling.strategies.bugfix-5270=true"
 	provider, err := NewProvider(Options{
-		StrategiesFile:             "fixtures/service_no_per_operation.json",
-		IncludeDefaultOpStrategies: true,
+		StrategiesFile: "fixtures/service_no_per_operation.json",
 	}, zap.NewNop())
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #5270

## Description of the changes
- Remove v1 flag `--sampling.strategies.bugfix-5270`
- Make `jaeger.sampling.includeDefaultOpStrategies` feature stable, meaning it cannot be changed from `true` anymore
- Remove deprecated code

## How was this change tested?
- CI