### PR TITLE
[all-in-one] Avoid multi-arch builds in merge queue (#6880)

### DIFF
--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -48,10 +48,10 @@ jobs:
 
     - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
-    - name: Define BUILD_FLAGS var if running on a Pull Request
+    - name: Define BUILD_FLAGS var if running on a Pull Request or Merge Queue
       run: |
         case ${GITHUB_EVENT_NAME} in
-          pull_request)
+          pull_request|merge_group)
             echo "BUILD_FLAGS=-l -D -p linux/$(go env GOARCH)" >> ${GITHUB_ENV}
             ;;
           *)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6880: Optimizes the all-in-one CI workflow by preventing unnecessary multi-architecture builds in the merge queue, reducing build times.

## Description of the changes
- Updated `.github/workflows/ci-docker-all-in-one.yml` to exclude multi-arch builds for merge queue events, similar to PR handling.
- This prevents sequential multi-arch builds, significantly improving CI efficiency.

## How was this change tested?


## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
