### PR TITLE
moved pkg/metrics to internal/metrics/api

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -29,6 +29,7 @@ import (
 	queryApp "github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	v2querysvc "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	ss "github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/metafactory"
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore"
 	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
@@ -37,7 +38,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
@@ -84,10 +84,10 @@ by default uses only in-memory database.`,
 				return err
 			}
 			logger := svc.Logger // shortcut
-			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
+			baseFactory := svc.MetricsFactory.Namespace(api.NSOptions{Name: "jaeger"})
 			version.NewInfoMetrics(baseFactory)
-			collectorMetricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "collector"})
-			queryMetricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "query"})
+			collectorMetricsFactory := baseFactory.Namespace(api.NSOptions{Name: "collector"})
+			queryMetricsFactory := baseFactory.Namespace(api.NSOptions{Name: "query"})
 
 			tracer, err := jtracer.New("jaeger-all-in-one")
 			if err != nil {

--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -18,11 +18,11 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/server"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/safeexpvar"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 )
 
@@ -36,7 +36,7 @@ type Collector struct {
 	// required to start a new collector
 	serviceName        string
 	logger             *zap.Logger
-	metricsFactory     metrics.Factory
+	metricsFactory     api.Factory
 	traceWriter        tracestore.Writer
 	samplingProvider   samplingstrategy.Provider
 	samplingAggregator samplingstrategy.Aggregator
@@ -56,7 +56,7 @@ type Collector struct {
 type CollectorParams struct {
 	ServiceName        string
 	Logger             *zap.Logger
-	MetricsFactory     metrics.Factory
+	MetricsFactory     api.Factory
 	TraceWriter        tracestore.Writer
 	SamplingProvider   samplingstrategy.Provider
 	SamplingAggregator samplingstrategy.Aggregator

--- a/cmd/collector/app/metrics_test.go
+++ b/cmd/collector/app/metrics_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
+	jaegerM "github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
-	jaegerM "github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestProcessorMetrics(t *testing.T) {

--- a/cmd/collector/app/options.go
+++ b/cmd/collector/app/options.go
@@ -11,13 +11,13 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/collector/app/flags"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 type options struct {
 	logger                 *zap.Logger
-	serviceMetrics         metrics.Factory
-	hostMetrics            metrics.Factory
+	serviceMetrics         api.Factory
+	hostMetrics            api.Factory
 	preProcessSpans        ProcessSpans // see docs in PreProcessSpans option.
 	sanitizer              sanitizer.SanitizeSpan
 	preSave                ProcessSpan
@@ -48,14 +48,14 @@ func (options) Logger(logger *zap.Logger) Option {
 }
 
 // ServiceMetrics creates an Option that initializes the serviceMetrics metrics factory
-func (options) ServiceMetrics(serviceMetrics metrics.Factory) Option {
+func (options) ServiceMetrics(serviceMetrics api.Factory) Option {
 	return func(b *options) {
 		b.serviceMetrics = serviceMetrics
 	}
 }
 
 // HostMetrics creates an Option that initializes the hostMetrics metrics factory
-func (options) HostMetrics(hostMetrics metrics.Factory) Option {
+func (options) HostMetrics(hostMetrics api.Factory) Option {
 	return func(b *options) {
 		b.hostMetrics = hostMetrics
 	}
@@ -170,10 +170,10 @@ func (options) apply(opts ...Option) options {
 		ret.logger = zap.NewNop()
 	}
 	if ret.serviceMetrics == nil {
-		ret.serviceMetrics = metrics.NullFactory
+		ret.serviceMetrics = api.NullFactory
 	}
 	if ret.hostMetrics == nil {
-		ret.hostMetrics = metrics.NullFactory
+		ret.hostMetrics = api.NullFactory
 	}
 	if ret.preProcessSpans == nil {
 		ret.preProcessSpans = func(_ processor.Batch) {}

--- a/cmd/collector/app/options_test.go
+++ b/cmd/collector/app/options_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/flags"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 func TestAllOptionSet(t *testing.T) {
@@ -23,8 +23,8 @@ func TestAllOptionSet(t *testing.T) {
 		Options.BlockingSubmit(true),
 		Options.ExtraFormatTypes(types),
 		Options.SpanFilter(func(_ *model.Span) bool { return true }),
-		Options.HostMetrics(metrics.NullFactory),
-		Options.ServiceMetrics(metrics.NullFactory),
+		Options.HostMetrics(api.NullFactory),
+		Options.ServiceMetrics(api.NullFactory),
 		Options.Logger(zap.NewNop()),
 		Options.NumWorkers(5),
 		Options.PreProcessSpans(func(_ processor.Batch) {}),

--- a/cmd/collector/app/server/http.go
+++ b/cmd/collector/app/server/http.go
@@ -13,11 +13,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	samplinghttp "github.com/jaegertracing/jaeger/internal/sampling/http"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"github.com/jaegertracing/jaeger/pkg/httpmetrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/recoveryhandler"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 )
@@ -27,7 +27,7 @@ type HTTPServerParams struct {
 	confighttp.ServerConfig
 	Handler          handler.JaegerBatchesHandler
 	SamplingProvider samplingstrategy.Provider
-	MetricsFactory   metrics.Factory
+	MetricsFactory   api.Factory
 	HealthCheck      *healthcheck.HealthCheck
 	Logger           *zap.Logger
 }

--- a/cmd/collector/app/span_handler_builder.go
+++ b/cmd/collector/app/span_handler_builder.go
@@ -14,8 +14,8 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	zs "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 )
 
@@ -24,7 +24,7 @@ type SpanHandlerBuilder struct {
 	TraceWriter    tracestore.Writer
 	CollectorOpts  *flags.CollectorOptions
 	Logger         *zap.Logger
-	MetricsFactory metrics.Factory
+	MetricsFactory api.Factory
 	TenancyMgr     *tenancy.Manager
 }
 
@@ -39,7 +39,7 @@ type SpanHandlers struct {
 func (b *SpanHandlerBuilder) BuildSpanProcessor(additional ...ProcessSpan) (processor.SpanProcessor, error) {
 	hostname, _ := os.Hostname()
 	svcMetrics := b.metricsFactory()
-	hostMetrics := svcMetrics.Namespace(metrics.NSOptions{Tags: map[string]string{"host": hostname}})
+	hostMetrics := svcMetrics.Namespace(api.NSOptions{Tags: map[string]string{"host": hostname}})
 
 	return NewSpanProcessor(
 		b.TraceWriter,
@@ -82,9 +82,9 @@ func (b *SpanHandlerBuilder) logger() *zap.Logger {
 	return b.Logger
 }
 
-func (b *SpanHandlerBuilder) metricsFactory() metrics.Factory {
+func (b *SpanHandlerBuilder) metricsFactory() api.Factory {
 	if b.MetricsFactory == nil {
-		return metrics.NullFactory
+		return api.NullFactory
 	}
 	return b.MetricsFactory
 }

--- a/cmd/collector/app/span_handler_builder_test.go
+++ b/cmd/collector/app/span_handler_builder_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/collector/app/flags"
 	cmdFlags "github.com/jaegertracing/jaeger/cmd/internal/flags"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/memory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 )
 
@@ -41,7 +41,7 @@ func TestNewSpanHandlerBuilder(t *testing.T) {
 		TraceWriter:    v1adapter.NewTraceWriter(spanWriter),
 		CollectorOpts:  cOpts,
 		Logger:         zap.NewNop(),
-		MetricsFactory: metrics.NullFactory,
+		MetricsFactory: api.NullFactory,
 		TenancyMgr:     &tenancy.Manager{},
 	}
 

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -42,11 +42,11 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/collector/app/handler"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
 	zipkinsanitizer "github.com/jaegertracing/jaeger/cmd/collector/app/sanitizer/zipkin"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 )
 
@@ -94,8 +94,8 @@ func TestBySvcMetrics(t *testing.T) {
 		mb := metricstest.NewFactory(time.Hour)
 		defer mb.Backend.Stop()
 		logger := zap.NewNop()
-		serviceMetrics := mb.Namespace(metrics.NSOptions{Name: "service", Tags: nil})
-		hostMetrics := mb.Namespace(metrics.NSOptions{Name: "host", Tags: nil})
+		serviceMetrics := mb.Namespace(api.NSOptions{Name: "service", Tags: nil})
+		hostMetrics := mb.Namespace(api.NSOptions{Name: "host", Tags: nil})
 		sp, err := newSpanProcessor(
 			v1adapter.NewTraceWriter(&fakeSpanWriter{}),
 			nil,
@@ -285,7 +285,7 @@ func TestSpanProcessorErrors(t *testing.T) {
 	}
 	mb := metricstest.NewFactory(time.Hour)
 	defer mb.Backend.Stop()
-	serviceMetrics := mb.Namespace(metrics.NSOptions{Name: "service", Tags: nil})
+	serviceMetrics := mb.Namespace(api.NSOptions{Name: "service", Tags: nil})
 	pp, err := NewSpanProcessor(
 		v1adapter.NewTraceWriter(w),
 		nil,
@@ -386,7 +386,7 @@ func TestSpanProcessorBusy(t *testing.T) {
 func TestSpanProcessorWithNilProcess(t *testing.T) {
 	mb := metricstest.NewFactory(time.Hour)
 	defer mb.Backend.Stop()
-	serviceMetrics := mb.Namespace(metrics.NSOptions{Name: "service", Tags: nil})
+	serviceMetrics := mb.Namespace(api.NSOptions{Name: "service", Tags: nil})
 
 	w := &fakeSpanWriter{}
 	pp, err := NewSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.ServiceMetrics(serviceMetrics))
@@ -520,7 +520,7 @@ func TestSpanProcessorCountSpan(t *testing.T) {
 		t.Run(tt.name, func(_ *testing.T) {
 			mb := metricstest.NewFactory(time.Hour)
 			defer mb.Backend.Stop()
-			m := mb.Namespace(metrics.NSOptions{})
+			m := mb.Namespace(api.NSOptions{})
 
 			w := &fakeSpanWriter{}
 			opts := []Option{

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -23,11 +23,11 @@ import (
 	cmdFlags "github.com/jaegertracing/jaeger/cmd/internal/flags"
 	"github.com/jaegertracing/jaeger/cmd/internal/printconfig"
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	ss "github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/metafactory"
 	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
@@ -63,8 +63,8 @@ func main() {
 				return err
 			}
 			logger := svc.Logger // shortcut
-			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
-			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "collector"})
+			baseFactory := svc.MetricsFactory.Namespace(api.NSOptions{Name: "jaeger"})
+			metricsFactory := baseFactory.Namespace(api.NSOptions{Name: "collector"})
 			version.NewInfoMetrics(metricsFactory)
 
 			baseTelset := telemetry.NoopSettings()

--- a/cmd/ingester/app/builder/builder.go
+++ b/cmd/ingester/app/builder/builder.go
@@ -12,14 +12,14 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/ingester/app"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/consumer"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/kafka"
 	kafkaConsumer "github.com/jaegertracing/jaeger/pkg/kafka/consumer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // CreateConsumer creates a new span consumer for the ingester
-func CreateConsumer(logger *zap.Logger, metricsFactory metrics.Factory, spanWriter spanstore.Writer, options app.Options) (*consumer.Consumer, error) {
+func CreateConsumer(logger *zap.Logger, metricsFactory api.Factory, spanWriter spanstore.Writer, options app.Options) (*consumer.Consumer, error) {
 	var unmarshaller kafka.Unmarshaller
 	switch options.Encoding {
 	case kafka.EncodingJSON:

--- a/cmd/ingester/app/consumer/consumer.go
+++ b/cmd/ingester/app/consumer/consumer.go
@@ -12,14 +12,14 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/kafka/consumer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // Params are the parameters of a Consumer
 type Params struct {
 	ProcessorFactory      ProcessorFactory
-	MetricsFactory        metrics.Factory
+	MetricsFactory        api.Factory
 	Logger                *zap.Logger
 	InternalConsumer      consumer.Consumer
 	DeadlockCheckInterval time.Duration
@@ -27,7 +27,7 @@ type Params struct {
 
 // Consumer uses sarama to consume and handle messages from kafka
 type Consumer struct {
-	metricsFactory metrics.Factory
+	metricsFactory api.Factory
 	logger         *zap.Logger
 
 	internalConsumer consumer.Consumer
@@ -38,7 +38,7 @@ type Consumer struct {
 	partitionIDToState  map[int32]*consumerState
 	partitionMapLock    sync.Mutex
 	partitionsHeld      int64
-	partitionsHeldGauge metrics.Gauge
+	partitionsHeldGauge api.Gauge
 
 	doneWg sync.WaitGroup
 }

--- a/cmd/ingester/app/consumer/consumer_metrics.go
+++ b/cmd/ingester/app/consumer/consumer_metrics.go
@@ -6,29 +6,29 @@ package consumer
 import (
 	"strconv"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 const consumerNamespace = "sarama-consumer"
 
 type msgMetrics struct {
-	counter     metrics.Counter
-	offsetGauge metrics.Gauge
-	lagGauge    metrics.Gauge
+	counter     api.Counter
+	offsetGauge api.Gauge
+	lagGauge    api.Gauge
 }
 
 type errMetrics struct {
-	errCounter metrics.Counter
+	errCounter api.Counter
 }
 
 type partitionMetrics struct {
-	startCounter metrics.Counter
-	closeCounter metrics.Counter
+	startCounter api.Counter
+	closeCounter api.Counter
 }
 
-func (c *Consumer) namespace(topic string, partition int32) metrics.Factory {
+func (c *Consumer) namespace(topic string, partition int32) api.Factory {
 	return c.metricsFactory.Namespace(
-		metrics.NSOptions{
+		api.NSOptions{
 			Name: consumerNamespace,
 			Tags: map[string]string{
 				"topic":     topic,
@@ -40,24 +40,24 @@ func (c *Consumer) namespace(topic string, partition int32) metrics.Factory {
 func (c *Consumer) newMsgMetrics(topic string, partition int32) msgMetrics {
 	f := c.namespace(topic, partition)
 	return msgMetrics{
-		counter:     f.Counter(metrics.Options{Name: "messages", Tags: nil}),
-		offsetGauge: f.Gauge(metrics.Options{Name: "current-offset", Tags: nil}),
-		lagGauge:    f.Gauge(metrics.Options{Name: "offset-lag", Tags: nil}),
+		counter:     f.Counter(api.Options{Name: "messages", Tags: nil}),
+		offsetGauge: f.Gauge(api.Options{Name: "current-offset", Tags: nil}),
+		lagGauge:    f.Gauge(api.Options{Name: "offset-lag", Tags: nil}),
 	}
 }
 
 func (c *Consumer) newErrMetrics(topic string, partition int32) errMetrics {
-	return errMetrics{errCounter: c.namespace(topic, partition).Counter(metrics.Options{Name: "errors", Tags: nil})}
+	return errMetrics{errCounter: c.namespace(topic, partition).Counter(api.Options{Name: "errors", Tags: nil})}
 }
 
 func (c *Consumer) partitionMetrics(topic string, partition int32) partitionMetrics {
 	f := c.namespace(topic, partition)
 	return partitionMetrics{
-		closeCounter: f.Counter(metrics.Options{Name: "partition-close", Tags: nil}),
-		startCounter: f.Counter(metrics.Options{Name: "partition-start", Tags: nil}),
+		closeCounter: f.Counter(api.Options{Name: "partition-close", Tags: nil}),
+		startCounter: f.Counter(api.Options{Name: "partition-start", Tags: nil}),
 	}
 }
 
-func partitionsHeldGauge(metricsFactory metrics.Factory) metrics.Gauge {
-	return metricsFactory.Namespace(metrics.NSOptions{Name: consumerNamespace, Tags: nil}).Gauge(metrics.Options{Name: "partitions-held", Tags: nil})
+func partitionsHeldGauge(metricsFactory api.Factory) api.Gauge {
+	return metricsFactory.Namespace(api.NSOptions{Name: consumerNamespace, Tags: nil}).Gauge(api.Options{Name: "partitions-held", Tags: nil})
 }

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
 	pmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/pkg/kafka/consumer"
 	kmocks "github.com/jaegertracing/jaeger/pkg/kafka/consumer/mocks"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 //go:generate mockery -dir ../../../../pkg/kafka/config/ -name Consumer
@@ -36,7 +36,7 @@ const (
 )
 
 func TestConstructor(t *testing.T) {
-	newConsumer, err := New(Params{MetricsFactory: metrics.NullFactory})
+	newConsumer, err := New(Params{MetricsFactory: api.NullFactory})
 	require.NoError(t, err)
 	assert.NotNil(t, newConsumer)
 }
@@ -76,7 +76,7 @@ func newSaramaClusterConsumer(saramaPartitionConsumer sarama.PartitionConsumer, 
 
 func newConsumer(
 	t *testing.T,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	_ string, /* topic */
 	proc processor.SpanProcessor,
 	cons consumer.Consumer,

--- a/cmd/ingester/app/consumer/offset/manager.go
+++ b/cmd/ingester/app/consumer/offset/manager.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 const (
@@ -28,8 +28,8 @@ const (
 // [1] https://kafka.apache.org/0100/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html
 type Manager struct {
 	markOffsetFunction  MarkOffset
-	offsetCommitCount   metrics.Counter
-	lastCommittedOffset metrics.Gauge
+	offsetCommitCount   api.Counter
+	lastCommittedOffset api.Gauge
 	minOffset           int64
 	list                *ConcurrentList
 	close               chan struct{}
@@ -45,7 +45,7 @@ func NewManager(
 	markOffset MarkOffset,
 	topic string,
 	partition int32,
-	factory metrics.Factory,
+	factory api.Factory,
 ) *Manager {
 	tags := map[string]string{
 		"topic":     topic,
@@ -54,8 +54,8 @@ func NewManager(
 	return &Manager{
 		markOffsetFunction:  markOffset,
 		close:               make(chan struct{}),
-		offsetCommitCount:   factory.Counter(metrics.Options{Name: "offset-commits-total", Tags: tags}),
-		lastCommittedOffset: factory.Gauge(metrics.Options{Name: "last-committed-offset", Tags: tags}),
+		offsetCommitCount:   factory.Counter(api.Options{Name: "offset-commits-total", Tags: tags}),
+		lastCommittedOffset: factory.Gauge(api.Options{Name: "last-committed-offset", Tags: tags}),
 		list:                newConcurrentList(minOffset),
 		minOffset:           minOffset,
 	}

--- a/cmd/ingester/app/consumer/offset/manager_test.go
+++ b/cmd/ingester/app/consumer/offset/manager_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestHandleReset(t *testing.T) {
@@ -46,7 +46,7 @@ func TestCache(t *testing.T) {
 	fakeMarker := func(_ /* offset */ int64) {
 		assert.Fail(t, "Shouldn't mark cached offset")
 	}
-	manager := NewManager(offset, fakeMarker, "test_topic", 1, metrics.NullFactory)
+	manager := NewManager(offset, fakeMarker, "test_topic", 1, api.NullFactory)
 	manager.Start()
 	time.Sleep(resetInterval + 50)
 	manager.MarkOffset(offset)

--- a/cmd/ingester/app/consumer/processor_factory.go
+++ b/cmd/ingester/app/consumer/processor_factory.go
@@ -11,8 +11,8 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/offset"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/decorator"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/kafka/consumer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // ProcessorFactoryParams are the parameters of a ProcessorFactory
@@ -20,7 +20,7 @@ type ProcessorFactoryParams struct {
 	Parallelism    int
 	BaseProcessor  processor.SpanProcessor
 	SaramaConsumer consumer.Consumer
-	Factory        metrics.Factory
+	Factory        api.Factory
 	Logger         *zap.Logger
 	RetryOptions   []decorator.RetryOption
 }
@@ -28,7 +28,7 @@ type ProcessorFactoryParams struct {
 // ProcessorFactory is a factory for creating startedProcessors
 type ProcessorFactory struct {
 	consumer       consumer.Consumer
-	metricsFactory metrics.Factory
+	metricsFactory api.Factory
 	logger         *zap.Logger
 	baseProcessor  processor.SpanProcessor
 	parallelism    int

--- a/cmd/ingester/app/consumer/processor_factory_test.go
+++ b/cmd/ingester/app/consumer/processor_factory_test.go
@@ -14,8 +14,8 @@ import (
 
 	cmocks "github.com/jaegertracing/jaeger/cmd/ingester/app/consumer/mocks"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	kmocks "github.com/jaegertracing/jaeger/pkg/kafka/consumer/mocks"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func Test_NewFactory(t *testing.T) {
@@ -38,7 +38,7 @@ func Test_new(t *testing.T) {
 
 	pf := ProcessorFactory{
 		consumer:       mockConsumer,
-		metricsFactory: metrics.NullFactory,
+		metricsFactory: api.NullFactory,
 		logger:         zap.NewNop(),
 		baseProcessor:  sp,
 		parallelism:    1,

--- a/cmd/ingester/app/processor/decorator/retry.go
+++ b/cmd/ingester/app/processor/decorator/retry.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 type retryDecorator struct {
 	processor     processor.SpanProcessor
-	retryAttempts metrics.Counter
-	exhausted     metrics.Counter
+	retryAttempts api.Counter
+	exhausted     api.Counter
 	options       retryOptions
 	io.Closer
 }
@@ -79,16 +79,16 @@ func PropagateError(b bool) RetryOption {
 
 // NewRetryingProcessor returns a processor that retries failures using an exponential backoff
 // with jitter.
-func NewRetryingProcessor(f metrics.Factory, proc processor.SpanProcessor, opts ...RetryOption) processor.SpanProcessor {
+func NewRetryingProcessor(f api.Factory, proc processor.SpanProcessor, opts ...RetryOption) processor.SpanProcessor {
 	options := defaultOpts
 	for _, opt := range opts {
 		opt(&options)
 	}
 
-	m := f.Namespace(metrics.NSOptions{Name: "span-processor", Tags: nil})
+	m := f.Namespace(api.NSOptions{Name: "span-processor", Tags: nil})
 	return &retryDecorator{
-		retryAttempts: m.Counter(metrics.Options{Name: "retry-attempts", Tags: nil}),
-		exhausted:     m.Counter(metrics.Options{Name: "retry-exhausted", Tags: nil}),
+		retryAttempts: m.Counter(api.Options{Name: "retry-attempts", Tags: nil}),
+		exhausted:     m.Counter(api.Options{Name: "retry-exhausted", Tags: nil}),
 		processor:     proc,
 		options:       options,
 	}

--- a/cmd/ingester/app/processor/decorator/retry_test.go
+++ b/cmd/ingester/app/processor/decorator/retry_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/processor/mocks"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 type fakeMsg struct{}
@@ -125,7 +125,7 @@ func Test_ProcessBackoff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(_ *testing.T) {
 			rd := &retryDecorator{
-				retryAttempts: metrics.NullCounter,
+				retryAttempts: api.NullCounter,
 				options: retryOptions{
 					minInterval: minBackoff,
 					maxInterval: maxBackoff,

--- a/cmd/ingester/app/processor/metrics_decorator.go
+++ b/cmd/ingester/app/processor/metrics_decorator.go
@@ -7,22 +7,22 @@ import (
 	"io"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 type metricsDecorator struct {
-	errors    metrics.Counter
-	latency   metrics.Timer
+	errors    api.Counter
+	latency   api.Timer
 	processor SpanProcessor
 	io.Closer
 }
 
 // NewDecoratedProcessor returns a processor with metrics
-func NewDecoratedProcessor(f metrics.Factory, processor SpanProcessor) SpanProcessor {
-	m := f.Namespace(metrics.NSOptions{Name: "span-processor", Tags: nil})
+func NewDecoratedProcessor(f api.Factory, processor SpanProcessor) SpanProcessor {
+	m := f.Namespace(api.NSOptions{Name: "span-processor", Tags: nil})
 	return &metricsDecorator{
-		errors:    m.Counter(metrics.Options{Name: "errors", Tags: nil}),
-		latency:   m.Timer(metrics.TimerOptions{Name: "latency", Tags: nil}),
+		errors:    m.Counter(api.Options{Name: "errors", Tags: nil}),
+		latency:   m.Timer(api.TimerOptions{Name: "latency", Tags: nil}),
 		processor: processor,
 	}
 }

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -22,9 +22,9 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/internal/flags"
 	"github.com/jaegertracing/jaeger/cmd/internal/printconfig"
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/version"
 	"github.com/jaegertracing/jaeger/ports"
@@ -49,8 +49,8 @@ func main() {
 				return err
 			}
 			logger := svc.Logger // shortcut
-			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
-			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "ingester"})
+			baseFactory := svc.MetricsFactory.Namespace(api.NSOptions{Name: "jaeger"})
+			metricsFactory := baseFactory.Namespace(api.NSOptions{Name: "ingester"})
 			version.NewInfoMetrics(metricsFactory)
 
 			baseTelset := telemetry.NoopSettings()

--- a/cmd/internal/flags/service.go
+++ b/cmd/internal/flags/service.go
@@ -17,9 +17,9 @@ import (
 	"go.uber.org/zap/zapgrpc"
 	"google.golang.org/grpc/grpclog"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metrics/metricsbuilder"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -38,7 +38,7 @@ type Service struct {
 	Logger *zap.Logger
 
 	// MetricsFactory is the root factory without a namespace.
-	MetricsFactory metrics.Factory
+	MetricsFactory api.Factory
 
 	signalsChannel chan os.Signal
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -17,6 +17,7 @@ import (
 	queryApp "github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	v2querysvc "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore/disabled"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
@@ -24,7 +25,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 )
@@ -75,8 +75,8 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 	telset := telemetry.FromOtelComponent(s.telset, host)
 	telset.TracerProvider = tracerProvider.OTEL
 	telset.Metrics = telset.Metrics.
-		Namespace(metrics.NSOptions{Name: "jaeger"}).
-		Namespace(metrics.NSOptions{Name: "query"})
+		Namespace(api.NSOptions{Name: "jaeger"}).
+		Namespace(api.NSOptions{Name: "query"})
 	tf, err := jaegerstorage.GetTraceStoreFactory(s.config.Storage.TracesPrimary, host)
 	if err != nil {
 		return fmt.Errorf("cannot find factory for trace storage %s: %w", s.config.Storage.TracesPrimary, err)

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore/prometheus"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
@@ -21,7 +22,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/memory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 )
 
@@ -144,9 +144,9 @@ func newStorageExt(config *Config, telset component.TelemetrySettings) *storageE
 
 func (s *storageExt) Start(_ context.Context, host component.Host) error {
 	telset := telemetry.FromOtelComponent(s.telset, host)
-	telset.Metrics = telset.Metrics.Namespace(metrics.NSOptions{Name: "jaeger"})
-	scopedMetricsFactory := func(name, kind, role string) metrics.Factory {
-		return telset.Metrics.Namespace(metrics.NSOptions{
+	telset.Metrics = telset.Metrics.Namespace(api.NSOptions{Name: "jaeger"})
+	scopedMetricsFactory := func(name, kind, role string) api.Factory {
+		return telset.Metrics.Namespace(api.NSOptions{
 			Name: "storage",
 			Tags: map[string]string{
 				"name": name,

--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerstorage"
 	"github.com/jaegertracing/jaeger/internal/leaderelection"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	samplinggrpc "github.com/jaegertracing/jaeger/internal/sampling/grpc"
 	samplinghttp "github.com/jaegertracing/jaeger/internal/sampling/http"
@@ -29,7 +30,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/adaptive"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/file"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var _ extension.Extension = (*rsExtension)(nil)
@@ -223,7 +223,7 @@ func (ext *rsExtension) startAdaptiveStrategyProvider(host component.Host) error
 
 func (ext *rsExtension) startHTTPServer(ctx context.Context, host component.Host) error {
 	mf := otelmetrics.NewFactory(ext.telemetry.MeterProvider)
-	mf = mf.Namespace(metrics.NSOptions{Name: "jaeger_remote_sampling"})
+	mf = mf.Namespace(api.NSOptions{Name: "jaeger_remote_sampling"})
 	handler := samplinghttp.NewHandler(samplinghttp.HandlerParams{
 		ConfigManager: &samplinghttp.ConfigManager{
 			SamplingProvider: ext.strategyProvider,

--- a/cmd/query/app/querysvc/query_service_test.go
+++ b/cmd/query/app/querysvc/query_service_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
@@ -26,7 +27,6 @@ import (
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const millisToNanosMultiplier = int64(time.Millisecond / time.Nanosecond)
@@ -451,7 +451,7 @@ func TestGetCapabilitiesWithSupportsArchive(t *testing.T) {
 
 type fakeStorageFactory1 struct{}
 
-func (*fakeStorageFactory1) Initialize(metrics.Factory, *zap.Logger) error {
+func (*fakeStorageFactory1) Initialize(api.Factory, *zap.Logger) error {
 	return nil
 }
 func (*fakeStorageFactory1) CreateSpanReader() (spanstore.Reader, error)             { return nil, nil }

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/query/app"
 	"github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 	querysvcv2 "github.com/jaegertracing/jaeger/cmd/query/app/querysvc/v2/querysvc"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	metricsPlugin "github.com/jaegertracing/jaeger/internal/storage/metricstore"
 	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
@@ -31,7 +32,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
@@ -63,8 +63,8 @@ func main() {
 				return err
 			}
 			logger := svc.Logger // shortcut
-			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
-			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "query"})
+			baseFactory := svc.MetricsFactory.Namespace(api.NSOptions{Name: "jaeger"})
+			metricsFactory := baseFactory.Namespace(api.NSOptions{Name: "query"})
 			version.NewInfoMetrics(metricsFactory)
 
 			defaultOpts := app.DefaultQueryOptions()

--- a/cmd/remote-storage/main.go
+++ b/cmd/remote-storage/main.go
@@ -21,9 +21,9 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/internal/printconfig"
 	"github.com/jaegertracing/jaeger/cmd/internal/status"
 	"github.com/jaegertracing/jaeger/cmd/remote-storage/app"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/pkg/version"
@@ -54,8 +54,8 @@ func main() {
 				return err
 			}
 			logger := svc.Logger // shortcut
-			baseFactory := svc.MetricsFactory.Namespace(metrics.NSOptions{Name: "jaeger"})
-			metricsFactory := baseFactory.Namespace(metrics.NSOptions{Name: "remote-storage"})
+			baseFactory := svc.MetricsFactory.Namespace(api.NSOptions{Name: "jaeger"})
+			metricsFactory := baseFactory.Namespace(api.NSOptions{Name: "remote-storage"})
 			version.NewInfoMetrics(metricsFactory)
 
 			opts, err := new(app.Options).InitFromViper(v)

--- a/examples/hotrod/cmd/root.go
+++ b/examples/hotrod/cmd/root.go
@@ -13,13 +13,13 @@ import (
 
 	"github.com/jaegertracing/jaeger/examples/hotrod/services/config"
 	"github.com/jaegertracing/jaeger/internal/jaegerclientenv2otel"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metrics/prometheus"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var (
 	logger         *zap.Logger
-	metricsFactory metrics.Factory
+	metricsFactory api.Factory
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -58,7 +58,7 @@ func onInitialize() {
 
 	jaegerclientenv2otel.MapJaegerToOtelEnvVars(logger)
 
-	metricsFactory = prometheus.New().Namespace(metrics.NSOptions{Name: "hotrod", Tags: nil})
+	metricsFactory = prometheus.New().Namespace(api.NSOptions{Name: "hotrod", Tags: nil})
 
 	if config.MySQLGetDelay != fixDBConnDelay {
 		logger.Info("fix: overriding MySQL query delay", zap.Duration("old", config.MySQLGetDelay), zap.Duration("new", fixDBConnDelay))

--- a/examples/hotrod/pkg/tracing/init.go
+++ b/examples/hotrod/pkg/tracing/init.go
@@ -25,14 +25,14 @@ import (
 
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/log"
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/tracing/rpcmetrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/otelsemconv"
 )
 
 var once sync.Once
 
 // InitOTEL initializes OpenTelemetry SDK.
-func InitOTEL(serviceName string, exporterType string, metricsFactory metrics.Factory, logger log.Factory) trace.TracerProvider {
+func InitOTEL(serviceName string, exporterType string, metricsFactory api.Factory, logger log.Factory) trace.TracerProvider {
 	once.Do(func() {
 		otel.SetTextMapPropagator(
 			propagation.NewCompositeTextMapPropagator(

--- a/examples/hotrod/pkg/tracing/rpcmetrics/metrics.go
+++ b/examples/hotrod/pkg/tracing/rpcmetrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 const (
@@ -20,28 +20,28 @@ const (
 // throughput, success, errors, and performance.
 type Metrics struct {
 	// RequestCountSuccess is a counter of the total number of successes.
-	RequestCountSuccess metrics.Counter `metric:"requests" tags:"error=false"`
+	RequestCountSuccess api.Counter `metric:"requests" tags:"error=false"`
 
 	// RequestCountFailures is a counter of the number of times any failure has been observed.
-	RequestCountFailures metrics.Counter `metric:"requests" tags:"error=true"`
+	RequestCountFailures api.Counter `metric:"requests" tags:"error=true"`
 
 	// RequestLatencySuccess is a latency histogram of successful requests.
-	RequestLatencySuccess metrics.Timer `metric:"request_latency" tags:"error=false"`
+	RequestLatencySuccess api.Timer `metric:"request_latency" tags:"error=false"`
 
 	// RequestLatencyFailures is a latency histogram of failed requests.
-	RequestLatencyFailures metrics.Timer `metric:"request_latency" tags:"error=true"`
+	RequestLatencyFailures api.Timer `metric:"request_latency" tags:"error=true"`
 
 	// HTTPStatusCode2xx is a counter of the total number of requests with HTTP status code 200-299
-	HTTPStatusCode2xx metrics.Counter `metric:"http_requests" tags:"status_code=2xx"`
+	HTTPStatusCode2xx api.Counter `metric:"http_requests" tags:"status_code=2xx"`
 
 	// HTTPStatusCode3xx is a counter of the total number of requests with HTTP status code 300-399
-	HTTPStatusCode3xx metrics.Counter `metric:"http_requests" tags:"status_code=3xx"`
+	HTTPStatusCode3xx api.Counter `metric:"http_requests" tags:"status_code=3xx"`
 
 	// HTTPStatusCode4xx is a counter of the total number of requests with HTTP status code 400-499
-	HTTPStatusCode4xx metrics.Counter `metric:"http_requests" tags:"status_code=4xx"`
+	HTTPStatusCode4xx api.Counter `metric:"http_requests" tags:"status_code=4xx"`
 
 	// HTTPStatusCode5xx is a counter of the total number of requests with HTTP status code 500-599
-	HTTPStatusCode5xx metrics.Counter `metric:"http_requests" tags:"status_code=5xx"`
+	HTTPStatusCode5xx api.Counter `metric:"http_requests" tags:"status_code=5xx"`
 }
 
 func (m *Metrics) recordHTTPStatusCode(statusCode int64) {
@@ -61,14 +61,14 @@ func (m *Metrics) recordHTTPStatusCode(statusCode int64) {
 // Only maxNumberOfEndpoints Metrics are stored, all other endpoint names are mapped
 // to a generic endpoint name "other".
 type MetricsByEndpoint struct {
-	metricsFactory    metrics.Factory
+	metricsFactory    api.Factory
 	endpoints         *normalizedEndpoints
 	metricsByEndpoint map[string]*Metrics
 	mux               sync.RWMutex
 }
 
 func newMetricsByEndpoint(
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	normalizer NameNormalizer,
 	maxNumberOfEndpoints int,
 ) *MetricsByEndpoint {
@@ -109,7 +109,7 @@ func (m *MetricsByEndpoint) getWithWriteLock(safeName string) *Metrics {
 	// expensive, however some metrics backends (e.g. expvar) may not like duplicate metrics.
 	met := &Metrics{}
 	tags := map[string]string{endpointNameMetricTag: safeName}
-	metrics.Init(met, m.metricsFactory, tags)
+	api.Init(met, m.metricsFactory, tags)
 
 	m.metricsByEndpoint[safeName] = met
 	return met

--- a/examples/hotrod/pkg/tracing/rpcmetrics/observer.go
+++ b/examples/hotrod/pkg/tracing/rpcmetrics/observer.go
@@ -13,7 +13,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/otelsemconv"
 )
 
@@ -27,7 +27,7 @@ type Observer struct {
 }
 
 // NewObserver creates a new observer that can emit RPC metrics.
-func NewObserver(metricsFactory metrics.Factory, normalizer NameNormalizer) *Observer {
+func NewObserver(metricsFactory api.Factory, normalizer NameNormalizer) *Observer {
 	return &Observer{
 		metricsByEndpoint: newMetricsByEndpoint(
 			metricsFactory,

--- a/examples/hotrod/services/customer/server.go
+++ b/examples/hotrod/services/customer/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/httperr"
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/log"
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/tracing"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 // Server implements Customer service
@@ -28,7 +28,7 @@ type Server struct {
 }
 
 // NewServer creates a new customer.Server
-func NewServer(hostPort string, otelExporter string, metricsFactory metrics.Factory, logger log.Factory) *Server {
+func NewServer(hostPort string, otelExporter string, metricsFactory api.Factory, logger log.Factory) *Server {
 	return &Server{
 		hostPort: hostPort,
 		tracer:   tracing.InitOTEL("customer", otelExporter, metricsFactory, logger),

--- a/examples/hotrod/services/driver/redis.go
+++ b/examples/hotrod/services/driver/redis.go
@@ -20,7 +20,7 @@ import (
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/log"
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/tracing"
 	"github.com/jaegertracing/jaeger/examples/hotrod/services/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 // Redis is a simulator of remote Redis cache
@@ -30,7 +30,7 @@ type Redis struct {
 	errorSimulator
 }
 
-func newRedis(otelExporter string, metricsFactory metrics.Factory, logger log.Factory) *Redis {
+func newRedis(otelExporter string, metricsFactory api.Factory, logger log.Factory) *Redis {
 	tp := tracing.InitOTEL("redis-manual", otelExporter, metricsFactory, logger)
 	return &Redis{
 		tracer: tp.Tracer("redis-manual"),

--- a/examples/hotrod/services/driver/server.go
+++ b/examples/hotrod/services/driver/server.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/log"
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/tracing"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 // Server implements jaeger-demo-frontend service
@@ -29,7 +29,7 @@ type Server struct {
 var _ DriverServiceServer = (*Server)(nil)
 
 // NewServer creates a new driver.Server
-func NewServer(hostPort string, otelExporter string, metricsFactory metrics.Factory, logger log.Factory) *Server {
+func NewServer(hostPort string, otelExporter string, metricsFactory api.Factory, logger log.Factory) *Server {
 	tracerProvider := tracing.InitOTEL("driver", otelExporter, metricsFactory, logger)
 	server := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler(otelgrpc.WithTracerProvider(tracerProvider))),

--- a/internal/metrics/api/counter.go
+++ b/internal/metrics/api/counter.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+// Counter tracks the number of times an event has occurred
+type Counter interface {
+	// Inc adds the given value to the counter.
+	Inc(int64)
+}
+
+// NullCounter counter that does nothing
+var NullCounter Counter = nullCounter{}
+
+type nullCounter struct{}
+
+func (nullCounter) Inc(int64) {}

--- a/internal/metrics/api/factory.go
+++ b/internal/metrics/api/factory.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2022 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"time"
+)
+
+// NSOptions defines the name and tags map associated with a factory namespace
+type NSOptions struct {
+	Name string
+	Tags map[string]string
+}
+
+// Options defines the information associated with a metric
+type Options struct {
+	Name string
+	Tags map[string]string
+	Help string
+}
+
+// TimerOptions defines the information associated with a metric
+type TimerOptions struct {
+	Name    string
+	Tags    map[string]string
+	Help    string
+	Buckets []time.Duration
+}
+
+// HistogramOptions defines the information associated with a metric
+type HistogramOptions struct {
+	Name    string
+	Tags    map[string]string
+	Help    string
+	Buckets []float64
+}
+
+// Factory creates new metrics
+type Factory interface {
+	Counter(metric Options) Counter
+	Timer(metric TimerOptions) Timer
+	Gauge(metric Options) Gauge
+	Histogram(metric HistogramOptions) Histogram
+
+	// Namespace returns a nested metrics factory.
+	Namespace(scope NSOptions) Factory
+}
+
+// NullFactory is a metrics factory that returns NullCounter, NullTimer, and NullGauge.
+var NullFactory Factory = nullFactory{}
+
+type nullFactory struct{}
+
+func (nullFactory) Counter(Options) Counter {
+	return NullCounter
+}
+
+func (nullFactory) Timer(TimerOptions) Timer {
+	return NullTimer
+}
+
+func (nullFactory) Gauge(Options) Gauge {
+	return NullGauge
+}
+
+func (nullFactory) Histogram(HistogramOptions) Histogram {
+	return NullHistogram
+}
+func (nullFactory) Namespace(NSOptions /* scope */) Factory { return NullFactory }

--- a/internal/metrics/api/gauge.go
+++ b/internal/metrics/api/gauge.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+// Gauge returns instantaneous measurements of something as an int64 value
+type Gauge interface {
+	// Update the gauge to the value passed in.
+	Update(int64)
+}
+
+// NullGauge gauge that does nothing
+var NullGauge Gauge = nullGauge{}
+
+type nullGauge struct{}
+
+func (nullGauge) Update(int64) {}

--- a/internal/metrics/api/histogram.go
+++ b/internal/metrics/api/histogram.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 The Jaeger Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+// Histogram that keeps track of a distribution of values.
+type Histogram interface {
+	// Records the value passed in.
+	Record(float64)
+}
+
+// NullHistogram that does nothing
+var NullHistogram Histogram = nullHistogram{}
+
+type nullHistogram struct{}
+
+func (nullHistogram) Record(float64) {}

--- a/internal/metrics/api/metrics.go
+++ b/internal/metrics/api/metrics.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2022 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// MustInit initializes the passed in metrics and initializes its fields using the passed in factory.
+//
+// It uses reflection to initialize a struct containing metrics fields
+// by assigning new Counter/Gauge/Timer values with the metric name retrieved
+// from the `metric` tag and stats tags retrieved from the `tags` tag.
+//
+// Note: all fields of the struct must be exported, have a `metric` tag, and be
+// of type Counter or Gauge or Timer.
+//
+// Errors during Init lead to a panic.
+func MustInit(metrics any, factory Factory, globalTags map[string]string) {
+	if err := Init(metrics, factory, globalTags); err != nil {
+		panic(err.Error())
+	}
+}
+
+// Init does the same as MustInit, but returns an error instead of
+// panicking.
+func Init(m any, factory Factory, globalTags map[string]string) error {
+	// Allow user to opt out of reporting metrics by passing in nil.
+	if factory == nil {
+		factory = NullFactory
+	}
+
+	counterPtrType := reflect.TypeOf((*Counter)(nil)).Elem()
+	gaugePtrType := reflect.TypeOf((*Gauge)(nil)).Elem()
+	timerPtrType := reflect.TypeOf((*Timer)(nil)).Elem()
+	histogramPtrType := reflect.TypeOf((*Histogram)(nil)).Elem()
+
+	v := reflect.ValueOf(m).Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		tags := make(map[string]string)
+		for k, v := range globalTags {
+			tags[k] = v
+		}
+		var buckets []float64
+		field := t.Field(i)
+		metric := field.Tag.Get("metric")
+		if metric == "" {
+			return fmt.Errorf("Field %s is missing a tag 'metric'", field.Name)
+		}
+		if tagString := field.Tag.Get("tags"); tagString != "" {
+			tagPairs := strings.Split(tagString, ",")
+			for _, tagPair := range tagPairs {
+				tag := strings.Split(tagPair, "=")
+				if len(tag) != 2 {
+					return fmt.Errorf(
+						"Field [%s]: Tag [%s] is not of the form key=value in 'tags' string [%s]",
+						field.Name, tagPair, tagString)
+				}
+				tags[tag[0]] = tag[1]
+			}
+		}
+		if bucketString := field.Tag.Get("buckets"); bucketString != "" {
+			switch {
+			case field.Type.AssignableTo(timerPtrType):
+				// TODO: Parse timer duration buckets
+				return fmt.Errorf(
+					"Field [%s]: Buckets are not currently initialized for timer metrics",
+					field.Name)
+			case field.Type.AssignableTo(histogramPtrType):
+				bucketValues := strings.Split(bucketString, ",")
+				if len(bucketValues) == 1 && bucketValues[0] == "" {
+					return fmt.Errorf(
+						"Field [%s]: Buckets string is empty in 'buckets' string [%s]",
+						field.Name, bucketString)
+				}
+				for _, bucket := range bucketValues {
+					if bucket == "" {
+						continue
+					}
+					b, err := strconv.ParseFloat(bucket, 64)
+					if err != nil {
+						return fmt.Errorf(
+							"Field [%s]: Bucket [%s] could not be converted to float64 in 'buckets' string [%s]",
+							field.Name, bucket, bucketString)
+					}
+					buckets = append(buckets, b)
+				}
+			default:
+				return fmt.Errorf(
+					"Field [%s]: Buckets should only be defined for Timer and Histogram metric types",
+					field.Name)
+			}
+		}
+		help := field.Tag.Get("help")
+		var obj any
+		switch {
+		case field.Type.AssignableTo(counterPtrType):
+			obj = factory.Counter(Options{
+				Name: metric,
+				Tags: tags,
+				Help: help,
+			})
+		case field.Type.AssignableTo(gaugePtrType):
+			obj = factory.Gauge(Options{
+				Name: metric,
+				Tags: tags,
+				Help: help,
+			})
+		case field.Type.AssignableTo(timerPtrType):
+			// TODO: Add buckets once parsed (see TODO above)
+			obj = factory.Timer(TimerOptions{
+				Name: metric,
+				Tags: tags,
+				Help: help,
+			})
+		case field.Type.AssignableTo(histogramPtrType):
+			obj = factory.Histogram(HistogramOptions{
+				Name:    metric,
+				Tags:    tags,
+				Help:    help,
+				Buckets: buckets,
+			})
+		default:
+			return fmt.Errorf(
+				"Field %s is not a pointer to timer, gauge, or counter",
+				field.Name)
+		}
+		v.Field(i).Set(reflect.ValueOf(obj))
+	}
+	return nil
+}

--- a/internal/metrics/api/metrics_test.go
+++ b/internal/metrics/api/metrics_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2022 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Must use separate test package to break import cycle.
+package api_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
+	"github.com/jaegertracing/jaeger/internal/metricstest"
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestInitMetrics(t *testing.T) {
+	testMetrics := struct {
+		Gauge     api.Gauge     `metric:"gauge" tags:"1=one,2=two"`
+		Counter   api.Counter   `metric:"counter"`
+		Timer     api.Timer     `metric:"timer"`
+		Histogram api.Histogram `metric:"histogram" buckets:"20,40,60,80"`
+	}{}
+
+	f := metricstest.NewFactory(0)
+	defer f.Stop()
+
+	globalTags := map[string]string{"key": "value"}
+
+	err := api.Init(&testMetrics, f, globalTags)
+	require.NoError(t, err)
+
+	testMetrics.Gauge.Update(10)
+	testMetrics.Counter.Inc(5)
+	testMetrics.Timer.Record(time.Duration(time.Second * 35))
+	testMetrics.Histogram.Record(42)
+
+	// wait for metrics
+	for i := 0; i < 1000; i++ {
+		c, _ := f.Snapshot()
+		if _, ok := c["counter"]; ok {
+			break
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	c, g := f.Snapshot()
+
+	assert.EqualValues(t, 5, c["counter|key=value"])
+	assert.EqualValues(t, 10, g["gauge|1=one|2=two|key=value"])
+	assert.EqualValues(t, 36863, g["timer|key=value.P50"])
+	assert.EqualValues(t, 43, g["histogram|key=value.P50"])
+
+	stopwatch := api.StartStopwatch(testMetrics.Timer)
+	stopwatch.Stop()
+	assert.Positive(t, stopwatch.ElapsedTime())
+}
+
+var (
+	noMetricTag = struct {
+		NoMetricTag api.Counter
+	}{}
+
+	badTags = struct {
+		BadTags api.Counter `metric:"bad_tags" tags:"1=one,no_value,2=two"`
+	}{}
+
+	badMetricType = struct {
+		BadMetricType int64 `metric:"bad_metric_type"`
+	}{}
+
+	badBucketsValue = struct {
+		BadBucketsValue api.Histogram `metric:"bad_histogram_value" buckets:"1,b,3"`
+	}{}
+
+	badBucketFormat = struct {
+		BadBucketFormat api.Histogram `metric:"bad_histogram_value" buckets:"[1,2,3]"`
+	}{}
+)
+
+func TestInitMetricsFailures(t *testing.T) {
+	require.EqualError(t, api.Init(&noMetricTag, nil, nil), "Field NoMetricTag is missing a tag 'metric'")
+
+	require.EqualError(t, api.Init(&badTags, nil, nil),
+		"Field [BadTags]: Tag [no_value] is not of the form key=value in 'tags' string [1=one,no_value,2=two]")
+
+	require.EqualError(t, api.Init(&badMetricType, nil, nil),
+		"Field BadMetricType is not a pointer to timer, gauge, or counter")
+
+	require.EqualError(t, api.Init(&badBucketsValue, nil, nil),
+		"Field [BadBucketsValue]: Bucket [b] could not be converted to float64 in 'buckets' string [1,b,3]")
+
+	// No need to test empty buckets since it's handled by a nil factory check earlier
+	// require.EqualError(t, api.Init(&emptyBucketsValue, nil, nil),
+	//	"Field [EmptyBucketsValue]: Buckets string is empty in 'buckets' string []")
+
+	require.EqualError(t, api.Init(&badBucketFormat, nil, nil),
+		"Field [BadBucketFormat]: Bucket [[1] could not be converted to float64 in 'buckets' string [[1,2,3]]")
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("The code did not panic")
+		}
+	}()
+
+	api.MustInit(&noMetricTag, api.NullFactory, nil)
+}
+
+func TestNullMetrics(*testing.T) {
+	// This test is just for cover
+	api.NullFactory.Timer(api.TimerOptions{
+		Name: "name",
+	}).Record(0)
+	api.NullFactory.Counter(api.Options{
+		Name: "name",
+	}).Inc(0)
+	api.NullFactory.Gauge(api.Options{
+		Name: "name",
+	}).Update(0)
+	api.NullFactory.Histogram(api.HistogramOptions{
+		Name: "name",
+	}).Record(0)
+	api.NullFactory.Namespace(api.NSOptions{
+		Name: "name",
+	}).Gauge(api.Options{
+		Name: "name2",
+	}).Update(0)
+}
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/metrics/api/package.go
+++ b/internal/metrics/api/package.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package metrics provides an internal abstraction for metrics API,
+// and command line flags for configuring the metrics backend.
+package api

--- a/internal/metrics/api/stopwatch.go
+++ b/internal/metrics/api/stopwatch.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"time"
+)
+
+// StartStopwatch begins recording the executing time of an event, returning
+// a Stopwatch that should be used to stop the recording the time for
+// that event.  Multiple events can be occurring simultaneously each
+// represented by different active Stopwatches
+func StartStopwatch(timer Timer) Stopwatch {
+	return Stopwatch{t: timer, start: time.Now()}
+}
+
+// A Stopwatch tracks the execution time of a specific event
+type Stopwatch struct {
+	t     Timer
+	start time.Time
+}
+
+// Stop stops executing of the stopwatch and records the amount of elapsed time
+func (s Stopwatch) Stop() {
+	s.t.Record(s.ElapsedTime())
+}
+
+// ElapsedTime returns the amount of elapsed time (in time.Duration)
+func (s Stopwatch) ElapsedTime() time.Duration {
+	return time.Since(s.start)
+}

--- a/internal/metrics/api/timer.go
+++ b/internal/metrics/api/timer.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"time"
+)
+
+// Timer accumulates observations about how long some operation took,
+// and also maintains a historgam of percentiles.
+type Timer interface {
+	// Records the time passed in.
+	Record(time.Duration)
+}
+
+// NullTimer timer that does nothing
+var NullTimer Timer = nullTimer{}
+
+type nullTimer struct{}
+
+func (nullTimer) Record(time.Duration) {}

--- a/internal/metrics/benchmark_test.go
+++ b/internal/metrics/benchmark_test.go
@@ -11,22 +11,22 @@ import (
 	promExporter "go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	prom "github.com/jaegertracing/jaeger/internal/metrics/prometheus"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestMain(m *testing.M) {
 	testutils.VerifyGoLeaks(m)
 }
 
-func setupPrometheusFactory() metrics.Factory {
+func setupPrometheusFactory() api.Factory {
 	reg := prometheus.NewRegistry()
 	return prom.New(prom.WithRegisterer(reg))
 }
 
-func setupOTELFactory(b *testing.B) metrics.Factory {
+func setupOTELFactory(b *testing.B) api.Factory {
 	registry := prometheus.NewRegistry()
 	exporter, err := promExporter.New(promExporter.WithRegisterer(registry))
 	require.NoError(b, err)
@@ -36,8 +36,8 @@ func setupOTELFactory(b *testing.B) metrics.Factory {
 	return otelmetrics.NewFactory(meterProvider)
 }
 
-func benchmarkCounter(b *testing.B, factory metrics.Factory) {
-	counter := factory.Counter(metrics.Options{
+func benchmarkCounter(b *testing.B, factory api.Factory) {
+	counter := factory.Counter(api.Options{
 		Name: "test_counter",
 		Tags: map[string]string{"tag1": "value1"},
 	})
@@ -47,8 +47,8 @@ func benchmarkCounter(b *testing.B, factory metrics.Factory) {
 	}
 }
 
-func benchmarkGauge(b *testing.B, factory metrics.Factory) {
-	gauge := factory.Gauge(metrics.Options{
+func benchmarkGauge(b *testing.B, factory api.Factory) {
+	gauge := factory.Gauge(api.Options{
 		Name: "test_gauge",
 		Tags: map[string]string{"tag1": "value1"},
 	})
@@ -58,8 +58,8 @@ func benchmarkGauge(b *testing.B, factory metrics.Factory) {
 	}
 }
 
-func benchmarkTimer(b *testing.B, factory metrics.Factory) {
-	timer := factory.Timer(metrics.TimerOptions{
+func benchmarkTimer(b *testing.B, factory api.Factory) {
+	timer := factory.Timer(api.TimerOptions{
 		Name: "test_timer",
 		Tags: map[string]string{"tag1": "value1"},
 	})
@@ -69,8 +69,8 @@ func benchmarkTimer(b *testing.B, factory metrics.Factory) {
 	}
 }
 
-func benchmarkHistogram(b *testing.B, factory metrics.Factory) {
-	histogram := factory.Histogram(metrics.HistogramOptions{
+func benchmarkHistogram(b *testing.B, factory api.Factory) {
+	histogram := factory.Histogram(api.HistogramOptions{
 		Name: "test_histogram",
 		Tags: map[string]string{"tag1": "value1"},
 	})

--- a/internal/metrics/metricsbuilder/builder.go
+++ b/internal/metrics/metricsbuilder/builder.go
@@ -13,8 +13,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	jprom "github.com/jaegertracing/jaeger/internal/metrics/prometheus"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -55,14 +55,14 @@ func (b *Builder) InitFromViper(v *viper.Viper) *Builder {
 // CreateMetricsFactory creates a metrics factory based on the configured type of the backend.
 // If the metrics backend supports HTTP endpoint for scraping, it is stored in the builder and
 // can be later added by RegisterHandler function.
-func (b *Builder) CreateMetricsFactory(namespace string) (metrics.Factory, error) {
+func (b *Builder) CreateMetricsFactory(namespace string) (api.Factory, error) {
 	if b.Backend == "prometheus" {
-		metricsFactory := jprom.New().Namespace(metrics.NSOptions{Name: namespace, Tags: nil})
+		metricsFactory := jprom.New().Namespace(api.NSOptions{Name: namespace, Tags: nil})
 		b.handler = promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{DisableCompression: true})
 		return metricsFactory, nil
 	}
 	if b.Backend == "none" || b.Backend == "" {
-		return metrics.NullFactory, nil
+		return api.NullFactory, nil
 	}
 	return nil, errUnknownBackend
 }

--- a/internal/metrics/metricsbuilder/builder_test.go
+++ b/internal/metrics/metricsbuilder/builder_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestAddFlags(t *testing.T) {
@@ -88,7 +88,7 @@ func TestBuilder(t *testing.T) {
 			continue
 		}
 		require.NotNil(t, mf)
-		mf.Counter(metrics.Options{Name: "counter", Tags: nil}).Inc(1)
+		mf.Counter(api.Options{Name: "counter", Tags: nil}).Inc(1)
 		if testCase.assert != nil {
 			testCase.assert()
 		}

--- a/internal/metrics/otelmetrics/factory.go
+++ b/internal/metrics/otelmetrics/factory.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 type otelFactory struct {
@@ -22,7 +22,7 @@ type otelFactory struct {
 	tags       map[string]string
 }
 
-func NewFactory(meterProvider metric.MeterProvider) metrics.Factory {
+func NewFactory(meterProvider metric.MeterProvider) api.Factory {
 	return &otelFactory{
 		meter:      meterProvider.Meter("jaeger-v2"),
 		separator:  ".",
@@ -31,12 +31,12 @@ func NewFactory(meterProvider metric.MeterProvider) metrics.Factory {
 	}
 }
 
-func (f *otelFactory) Counter(opts metrics.Options) metrics.Counter {
+func (f *otelFactory) Counter(opts api.Options) api.Counter {
 	name := CounterNamingConvention(f.subScope(opts.Name))
 	counter, err := f.meter.Int64Counter(name)
 	if err != nil {
 		log.Printf("Error creating OTEL counter: %v", err)
-		return metrics.NullCounter
+		return api.NullCounter
 	}
 	return &otelCounter{
 		counter:  counter,
@@ -45,12 +45,12 @@ func (f *otelFactory) Counter(opts metrics.Options) metrics.Counter {
 	}
 }
 
-func (f *otelFactory) Gauge(opts metrics.Options) metrics.Gauge {
+func (f *otelFactory) Gauge(opts api.Options) api.Gauge {
 	name := f.subScope(opts.Name)
 	gauge, err := f.meter.Int64Gauge(name)
 	if err != nil {
 		log.Printf("Error creating OTEL gauge: %v", err)
-		return metrics.NullGauge
+		return api.NullGauge
 	}
 
 	return &otelGauge{
@@ -60,12 +60,12 @@ func (f *otelFactory) Gauge(opts metrics.Options) metrics.Gauge {
 	}
 }
 
-func (f *otelFactory) Histogram(opts metrics.HistogramOptions) metrics.Histogram {
+func (f *otelFactory) Histogram(opts api.HistogramOptions) api.Histogram {
 	name := f.subScope(opts.Name)
 	histogram, err := f.meter.Float64Histogram(name)
 	if err != nil {
 		log.Printf("Error creating OTEL histogram: %v", err)
-		return metrics.NullHistogram
+		return api.NullHistogram
 	}
 
 	return &otelHistogram{
@@ -75,12 +75,12 @@ func (f *otelFactory) Histogram(opts metrics.HistogramOptions) metrics.Histogram
 	}
 }
 
-func (f *otelFactory) Timer(opts metrics.TimerOptions) metrics.Timer {
+func (f *otelFactory) Timer(opts api.TimerOptions) api.Timer {
 	name := f.subScope(opts.Name)
 	timer, err := f.meter.Float64Histogram(name, metric.WithUnit("s"))
 	if err != nil {
 		log.Printf("Error creating OTEL timer: %v", err)
-		return metrics.NullTimer
+		return api.NullTimer
 	}
 	return &otelTimer{
 		histogram: timer,
@@ -89,7 +89,7 @@ func (f *otelFactory) Timer(opts metrics.TimerOptions) metrics.Timer {
 	}
 }
 
-func (f *otelFactory) Namespace(opts metrics.NSOptions) metrics.Factory {
+func (f *otelFactory) Namespace(opts api.NSOptions) api.Factory {
 	return &otelFactory{
 		meter:      f.meter,
 		scope:      f.subScope(opts.Name),

--- a/internal/metrics/prometheus/factory.go
+++ b/internal/metrics/prometheus/factory.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
-// Factory implements metrics.Factory backed by Prometheus registry.
+// Factory implements api.Factory backed by Prometheus registry.
 type Factory struct {
 	scope      string
 	tags       map[string]string
@@ -23,7 +23,7 @@ type Factory struct {
 	separator  Separator
 }
 
-var _ metrics.Factory = (*Factory)(nil)
+var _ api.Factory = (*Factory)(nil)
 
 type options struct {
 	registerer prometheus.Registerer
@@ -115,8 +115,8 @@ func newFactory(parent *Factory, scope string, tags map[string]string) *Factory 
 	}
 }
 
-// Counter implements Counter of metrics.Factory.
-func (f *Factory) Counter(options metrics.Options) metrics.Counter {
+// Counter implements Counter of api.Factory.
+func (f *Factory) Counter(options api.Options) api.Counter {
 	help := strings.TrimSpace(options.Help)
 	if len(help) == 0 {
 		help = options.Name
@@ -134,8 +134,8 @@ func (f *Factory) Counter(options metrics.Options) metrics.Counter {
 	}
 }
 
-// Gauge implements Gauge of metrics.Factory.
-func (f *Factory) Gauge(options metrics.Options) metrics.Gauge {
+// Gauge implements Gauge of api.Factory.
+func (f *Factory) Gauge(options api.Options) api.Gauge {
 	help := strings.TrimSpace(options.Help)
 	if len(help) == 0 {
 		help = options.Name
@@ -153,8 +153,8 @@ func (f *Factory) Gauge(options metrics.Options) metrics.Gauge {
 	}
 }
 
-// Timer implements Timer of metrics.Factory.
-func (f *Factory) Timer(options metrics.TimerOptions) metrics.Timer {
+// Timer implements Timer of api.Factory.
+func (f *Factory) Timer(options api.TimerOptions) api.Timer {
 	help := strings.TrimSpace(options.Help)
 	if len(help) == 0 {
 		help = options.Name
@@ -182,8 +182,8 @@ func asFloatBuckets(buckets []time.Duration) []float64 {
 	return data
 }
 
-// Histogram implements Histogram of metrics.Factory.
-func (f *Factory) Histogram(options metrics.HistogramOptions) metrics.Histogram {
+// Histogram implements Histogram of api.Factory.
+func (f *Factory) Histogram(options api.HistogramOptions) api.Histogram {
 	help := strings.TrimSpace(options.Help)
 	if len(help) == 0 {
 		help = options.Name
@@ -203,8 +203,8 @@ func (f *Factory) Histogram(options metrics.HistogramOptions) metrics.Histogram 
 	}
 }
 
-// Namespace implements Namespace of metrics.Factory.
-func (f *Factory) Namespace(scope metrics.NSOptions) metrics.Factory {
+// Namespace implements Namespace of api.Factory.
+func (f *Factory) Namespace(scope api.NSOptions) api.Factory {
 	return newFactory(f, f.subScope(scope.Name), f.mergeTags(scope.Tags))
 }
 

--- a/internal/metrics/prometheus/factory_test.go
+++ b/internal/metrics/prometheus/factory_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	promMetrics "github.com/jaegertracing/jaeger/internal/metrics/prometheus"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestOptions(t *testing.T) {
@@ -25,41 +25,56 @@ func TestOptions(t *testing.T) {
 func TestSeparator(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry), promMetrics.WithSeparator(promMetrics.SeparatorColon))
-	c1 := f1.Namespace(metrics.NSOptions{
+	c1 := f1.Namespace(api.NSOptions{
 		Name: "bender",
-	}).Counter(metrics.Options{
+	}).Counter(api.Options{
 		Name: "rodriguez",
-		Tags: map[string]string{"a": "b"},
+		Tags: map[string]string{
+			"a": "b",
+		},
 		Help: "Help message",
 	})
 	c1.Inc(1)
+	c2 := f1.Namespace(api.NSOptions{
+		Name: "bender",
+		Tags: map[string]string{
+			"a": "b",
+		},
+	}).Counter(api.Options{
+		Name: "rodriguez",
+		Help: "Help message",
+	})
+	c2.Inc(1)
+
 	snapshot, err := registry.Gather()
 	require.NoError(t, err)
-	m1 := findMetric(t, snapshot, "bender:rodriguez_total", map[string]string{"a": "b"})
-	assert.InDelta(t, 1.0, m1.GetCounter().GetValue(), 0.01, "%+v", m1)
+	m1 := findMetric(t, snapshot, "bender:rodriguez_total", map[string]string{
+		"a": "b",
+	})
+	assert.InDelta(t, 2, m1.GetCounter().GetValue(), 0.001, "%+v", m1)
 }
 
 func TestCounter(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	fDummy := f1.Namespace(metrics.NSOptions{})
-	f2 := fDummy.Namespace(metrics.NSOptions{
+	fDummy := f1.Namespace(api.NSOptions{})
+	f2 := fDummy.Namespace(api.NSOptions{
 		Name: "bender",
 		Tags: map[string]string{"a": "b"},
 	})
-	f3 := f2.Namespace(metrics.NSOptions{})
+	f3 := f2.Namespace(api.NSOptions{})
 
-	c1 := f2.Counter(metrics.Options{
+	c1 := f2.Counter(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 		Help: "Help message",
 	})
-	c2 := f2.Counter(metrics.Options{
+	c2 := f2.Counter(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
 	})
-	c3 := f3.Counter(metrics.Options{
+	c3 := f3.Counter(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
@@ -84,7 +99,7 @@ func TestCounter(t *testing.T) {
 func TestCounterDefaultHelp(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	c1 := f1.Counter(metrics.Options{
+	c1 := f1.Counter(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 	})
@@ -99,24 +114,24 @@ func TestCounterDefaultHelp(t *testing.T) {
 func TestGauge(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	f2 := f1.Namespace(metrics.NSOptions{
+	f2 := f1.Namespace(api.NSOptions{
 		Name: "bender",
 		Tags: map[string]string{"a": "b"},
 	})
-	f3 := f2.Namespace(metrics.NSOptions{
+	f3 := f2.Namespace(api.NSOptions{
 		Tags: map[string]string{"a": "b"},
 	}) // essentially same as f2
-	g1 := f2.Gauge(metrics.Options{
+	g1 := f2.Gauge(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 		Help: "Help message",
 	})
-	g2 := f2.Gauge(metrics.Options{
+	g2 := f2.Gauge(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
 	})
-	g3 := f3.Gauge(metrics.Options{
+	g3 := f3.Gauge(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
@@ -141,7 +156,7 @@ func TestGauge(t *testing.T) {
 func TestGaugeDefaultHelp(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	g1 := f1.Gauge(metrics.Options{
+	g1 := f1.Gauge(api.Options{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 	})
@@ -156,24 +171,24 @@ func TestGaugeDefaultHelp(t *testing.T) {
 func TestTimer(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	f2 := f1.Namespace(metrics.NSOptions{
+	f2 := f1.Namespace(api.NSOptions{
 		Name: "bender",
 		Tags: map[string]string{"a": "b"},
 	})
-	f3 := f2.Namespace(metrics.NSOptions{
+	f3 := f2.Namespace(api.NSOptions{
 		Tags: map[string]string{"a": "b"},
 	}) // essentially same as f2
-	t1 := f2.Timer(metrics.TimerOptions{
+	t1 := f2.Timer(api.TimerOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 		Help: "Help message",
 	})
-	t2 := f2.Timer(metrics.TimerOptions{
+	t2 := f2.Timer(api.TimerOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
 	})
-	t3 := f3.Timer(metrics.TimerOptions{
+	t3 := f3.Timer(api.TimerOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
@@ -220,7 +235,7 @@ func TestTimer(t *testing.T) {
 func TestTimerDefaultHelp(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	t1 := f1.Timer(metrics.TimerOptions{
+	t1 := f1.Timer(api.TimerOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 	})
@@ -236,7 +251,7 @@ func TestTimerCustomBuckets(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry), promMetrics.WithBuckets([]float64{1.5}))
 	// dot and dash in the metric name will be replaced with underscore
-	t1 := f1.Timer(metrics.TimerOptions{
+	t1 := f1.Timer(api.TimerOptions{
 		Name:    "bender.bending-rodriguez",
 		Tags:    map[string]string{"x": "y"},
 		Buckets: []time.Duration{time.Nanosecond, 5 * time.Nanosecond},
@@ -257,7 +272,7 @@ func TestTimerDefaultBuckets(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry), promMetrics.WithBuckets([]float64{1.5, 2}))
 	// dot and dash in the metric name will be replaced with underscore
-	t1 := f1.Timer(metrics.TimerOptions{
+	t1 := f1.Timer(api.TimerOptions{
 		Name:    "bender.bending-rodriguez",
 		Tags:    map[string]string{"x": "y"},
 		Buckets: nil,
@@ -277,24 +292,24 @@ func TestTimerDefaultBuckets(t *testing.T) {
 func TestHistogram(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	f2 := f1.Namespace(metrics.NSOptions{
+	f2 := f1.Namespace(api.NSOptions{
 		Name: "bender",
 		Tags: map[string]string{"a": "b"},
 	})
-	f3 := f2.Namespace(metrics.NSOptions{
+	f3 := f2.Namespace(api.NSOptions{
 		Tags: map[string]string{"a": "b"},
 	}) // essentially same as f2
-	t1 := f2.Histogram(metrics.HistogramOptions{
+	t1 := f2.Histogram(api.HistogramOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 		Help: "Help message",
 	})
-	t2 := f2.Histogram(metrics.HistogramOptions{
+	t2 := f2.Histogram(api.HistogramOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
 	})
-	t3 := f3.Histogram(metrics.HistogramOptions{
+	t3 := f3.Histogram(api.HistogramOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "z"},
 		Help: "Help message",
@@ -341,7 +356,7 @@ func TestHistogram(t *testing.T) {
 func TestHistogramDefaultHelp(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
-	t1 := f1.Histogram(metrics.HistogramOptions{
+	t1 := f1.Histogram(api.HistogramOptions{
 		Name: "rodriguez",
 		Tags: map[string]string{"x": "y"},
 	})
@@ -357,7 +372,7 @@ func TestHistogramCustomBuckets(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry))
 	// dot and dash in the metric name will be replaced with underscore
-	t1 := f1.Histogram(metrics.HistogramOptions{
+	t1 := f1.Histogram(api.HistogramOptions{
 		Name:    "bender.bending-rodriguez",
 		Tags:    map[string]string{"x": "y"},
 		Buckets: []float64{1.5},
@@ -378,7 +393,7 @@ func TestHistogramDefaultBuckets(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := promMetrics.New(promMetrics.WithRegisterer(registry), promMetrics.WithBuckets([]float64{1.5}))
 	// dot and dash in the metric name will be replaced with underscore
-	t1 := f1.Histogram(metrics.HistogramOptions{
+	t1 := f1.Histogram(api.HistogramOptions{
 		Name:    "bender.bending-rodriguez",
 		Tags:    map[string]string{"x": "y"},
 		Buckets: nil,

--- a/internal/metricstest/local.go
+++ b/internal/metricstest/local.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/HdrHistogram/hdrhistogram-go"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 // This is intentionally very similar to github.com/codahale/metrics, the
@@ -328,7 +328,7 @@ func (l *Factory) newNamespace(name string) string {
 }
 
 // Counter returns a local stats counter
-func (l *Factory) Counter(options metrics.Options) metrics.Counter {
+func (l *Factory) Counter(options api.Options) api.Counter {
 	return &localCounter{
 		stats{
 			name:         l.newNamespace(options.Name),
@@ -339,7 +339,7 @@ func (l *Factory) Counter(options metrics.Options) metrics.Counter {
 }
 
 // Timer returns a local stats timer.
-func (l *Factory) Timer(options metrics.TimerOptions) metrics.Timer {
+func (l *Factory) Timer(options api.TimerOptions) api.Timer {
 	return &localTimer{
 		stats{
 			name:            l.newNamespace(options.Name),
@@ -351,7 +351,7 @@ func (l *Factory) Timer(options metrics.TimerOptions) metrics.Timer {
 }
 
 // Gauge returns a local stats gauge.
-func (l *Factory) Gauge(options metrics.Options) metrics.Gauge {
+func (l *Factory) Gauge(options api.Options) api.Gauge {
 	return &localGauge{
 		stats{
 			name:         l.newNamespace(options.Name),
@@ -362,7 +362,7 @@ func (l *Factory) Gauge(options metrics.Options) metrics.Gauge {
 }
 
 // Histogram returns a local stats histogram.
-func (l *Factory) Histogram(options metrics.HistogramOptions) metrics.Histogram {
+func (l *Factory) Histogram(options api.HistogramOptions) api.Histogram {
 	return &localHistogram{
 		stats{
 			name:         l.newNamespace(options.Name),
@@ -374,7 +374,7 @@ func (l *Factory) Histogram(options metrics.HistogramOptions) metrics.Histogram 
 }
 
 // Namespace returns a new namespace.
-func (l *Factory) Namespace(scope metrics.NSOptions) metrics.Factory {
+func (l *Factory) Namespace(scope api.NSOptions) api.Factory {
 	return &Factory{
 		namespace: l.newNamespace(scope.Name),
 		tags:      l.appendTags(scope.Tags),

--- a/internal/metricstest/local_test.go
+++ b/internal/metricstest/local_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 func TestLocalMetrics(t *testing.T) {
@@ -20,38 +20,38 @@ func TestLocalMetrics(t *testing.T) {
 
 	f := NewFactory(0)
 	defer f.Stop()
-	f.Counter(metrics.Options{
+	f.Counter(api.Options{
 		Name: "my-counter",
 		Tags: tags,
 	}).Inc(4)
-	f.Counter(metrics.Options{
+	f.Counter(api.Options{
 		Name: "my-counter",
 		Tags: tags,
 	}).Inc(6)
-	f.Counter(metrics.Options{
+	f.Counter(api.Options{
 		Name: "my-counter",
 	}).Inc(6)
-	f.Counter(metrics.Options{
+	f.Counter(api.Options{
 		Name: "other-counter",
 	}).Inc(8)
-	f.Gauge(metrics.Options{
+	f.Gauge(api.Options{
 		Name: "my-gauge",
 	}).Update(25)
-	f.Gauge(metrics.Options{
+	f.Gauge(api.Options{
 		Name: "my-gauge",
 	}).Update(43)
-	f.Gauge(metrics.Options{
+	f.Gauge(api.Options{
 		Name: "other-gauge",
 	}).Update(74)
-	f.Namespace(metrics.NSOptions{
+	f.Namespace(api.NSOptions{
 		Name: "namespace",
 		Tags: tags,
-	}).Counter(metrics.Options{
+	}).Counter(api.Options{
 		Name: "my-counter",
 	}).Inc(7)
-	f.Namespace(metrics.NSOptions{
+	f.Namespace(api.NSOptions{
 		Name: "ns.subns",
-	}).Counter(metrics.Options{
+	}).Counter(api.Options{
 		Tags: map[string]string{"service": "a-service"},
 	}).Inc(9)
 
@@ -72,13 +72,13 @@ func TestLocalMetrics(t *testing.T) {
 
 	for metric, timing := range timings {
 		for _, d := range timing {
-			f.Timer(metrics.TimerOptions{
+			f.Timer(api.TimerOptions{
 				Name: metric,
 			}).Record(d)
 		}
 	}
 
-	histogram := f.Histogram(metrics.HistogramOptions{
+	histogram := f.Histogram(api.HistogramOptions{
 		Name: "my-histo",
 	})
 	histogram.Record(321)
@@ -134,7 +134,7 @@ func TestLocalMetricsInterval(t *testing.T) {
 	f := NewFactory(refreshInterval)
 	defer f.Stop()
 
-	f.Timer(metrics.TimerOptions{
+	f.Timer(api.TimerOptions{
 		Name: "timer",
 	}).Record(1)
 

--- a/internal/sampling/http/handler.go
+++ b/internal/sampling/http/handler.go
@@ -15,9 +15,9 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	p2json "github.com/jaegertracing/jaeger/model/converter/json"
 	t2p "github.com/jaegertracing/jaeger/model/converter/thrift/jaeger"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const mimeTypeApplicationJSON = "application/json"
@@ -31,7 +31,7 @@ type ClientConfigManager interface {
 // HandlerParams contains parameters that must be passed to NewHTTPHandler.
 type HandlerParams struct {
 	ConfigManager  ClientConfigManager // required
-	MetricsFactory metrics.Factory     // required
+	MetricsFactory api.Factory         // required
 
 	// BasePath will be used as a prefix for the endpoints, e.g. "/api"
 	BasePath string
@@ -47,32 +47,32 @@ type Handler struct {
 	params  HandlerParams
 	metrics struct {
 		// Number of good sampling requests
-		SamplingRequestSuccess metrics.Counter `metric:"http-server.requests" tags:"type=sampling"`
+		SamplingRequestSuccess api.Counter `metric:"http-server.requests" tags:"type=sampling"`
 
 		// Number of good sampling requests against the old endpoint / using Thrift 0.9.2 enum codes
-		LegacySamplingRequestSuccess metrics.Counter `metric:"http-server.requests" tags:"type=sampling-legacy"`
+		LegacySamplingRequestSuccess api.Counter `metric:"http-server.requests" tags:"type=sampling-legacy"`
 
 		// Number of bad requests (400s)
-		BadRequest metrics.Counter `metric:"http-server.errors" tags:"status=4xx,source=all"`
+		BadRequest api.Counter `metric:"http-server.errors" tags:"status=4xx,source=all"`
 
 		// Number of collector proxy failures
-		CollectorProxyFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=collector-proxy"`
+		CollectorProxyFailures api.Counter `metric:"http-server.errors" tags:"status=5xx,source=collector-proxy"`
 
 		// Number of bad responses due to malformed thrift
-		BadThriftFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=thrift"`
+		BadThriftFailures api.Counter `metric:"http-server.errors" tags:"status=5xx,source=thrift"`
 
 		// Number of bad responses due to proto conversion
-		BadProtoFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=proto"`
+		BadProtoFailures api.Counter `metric:"http-server.errors" tags:"status=5xx,source=proto"`
 
 		// Number of failed response writes from http server
-		WriteFailures metrics.Counter `metric:"http-server.errors" tags:"status=5xx,source=write"`
+		WriteFailures api.Counter `metric:"http-server.errors" tags:"status=5xx,source=write"`
 	}
 }
 
 // NewHandler creates new HTTPHandler.
 func NewHandler(params HandlerParams) *Handler {
 	handler := &Handler{params: params}
-	metrics.MustInit(&handler.metrics, params.MetricsFactory, nil)
+	api.MustInit(&handler.metrics, params.MetricsFactory, nil)
 	return handler
 }
 

--- a/internal/sampling/samplingstrategy/adaptive/aggregator.go
+++ b/internal/sampling/samplingstrategy/adaptive/aggregator.go
@@ -12,11 +12,11 @@ import (
 
 	span_model "github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/leaderelection"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore/model"
 	"github.com/jaegertracing/jaeger/pkg/hostname"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -32,8 +32,8 @@ const (
 type aggregator struct {
 	sync.Mutex
 
-	operationsCounter   metrics.Counter
-	servicesCounter     metrics.Counter
+	operationsCounter   api.Counter
+	servicesCounter     api.Counter
 	currentThroughput   serviceOperationThroughput
 	postAggregator      *PostAggregator
 	aggregationInterval time.Duration
@@ -44,7 +44,7 @@ type aggregator struct {
 
 // NewAggregator creates a throughput aggregator that simply emits metrics
 // about the number of operations seen over the aggregationInterval.
-func NewAggregator(options Options, logger *zap.Logger, metricsFactory metrics.Factory, participant leaderelection.ElectionParticipant, store samplingstore.Store) (samplingstrategy.Aggregator, error) {
+func NewAggregator(options Options, logger *zap.Logger, metricsFactory api.Factory, participant leaderelection.ElectionParticipant, store samplingstore.Store) (samplingstrategy.Aggregator, error) {
 	hostId, err := hostname.AsIdentifier()
 	if err != nil {
 		return nil, err
@@ -57,8 +57,8 @@ func NewAggregator(options Options, logger *zap.Logger, metricsFactory metrics.F
 	}
 
 	return &aggregator{
-		operationsCounter:   metricsFactory.Counter(metrics.Options{Name: "sampling_operations"}),
-		servicesCounter:     metricsFactory.Counter(metrics.Options{Name: "sampling_services"}),
+		operationsCounter:   metricsFactory.Counter(api.Options{Name: "sampling_operations"}),
+		servicesCounter:     metricsFactory.Counter(api.Options{Name: "sampling_services"}),
 		currentThroughput:   make(serviceOperationThroughput),
 		aggregationInterval: options.CalculationInterval,
 		postAggregator:      postAggregator,

--- a/internal/sampling/samplingstrategy/adaptive/factory.go
+++ b/internal/sampling/samplingstrategy/adaptive/factory.go
@@ -11,11 +11,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/leaderelection"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var (
@@ -27,7 +27,7 @@ var (
 type Factory struct {
 	options        *Options
 	logger         *zap.Logger
-	metricsFactory metrics.Factory
+	metricsFactory api.Factory
 	lock           distributedlock.Lock
 	store          samplingstore.Store
 	participant    *leaderelection.DistributedElectionParticipant
@@ -54,7 +54,7 @@ func (f *Factory) InitFromViper(v *viper.Viper, _ *zap.Logger) {
 }
 
 // Initialize implements samplingstrategy.Factory
-func (f *Factory) Initialize(metricsFactory metrics.Factory, ssFactory storage.SamplingStoreFactory, logger *zap.Logger) error {
+func (f *Factory) Initialize(metricsFactory api.Factory, ssFactory storage.SamplingStoreFactory, logger *zap.Logger) error {
 	if ssFactory == nil {
 		return errors.New("sampling store factory is nil. Please configure a backend that supports adaptive sampling")
 	}

--- a/internal/sampling/samplingstrategy/adaptive/factory_test.go
+++ b/internal/sampling/samplingstrategy/adaptive/factory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
@@ -21,7 +22,6 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
 	lmocks "github.com/jaegertracing/jaeger/pkg/distributedlock/mocks"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var (
@@ -60,7 +60,7 @@ func TestFactory(t *testing.T) {
 	assert.Equal(t, time.Second, f.options.LeaderLeaseRefreshInterval)
 	assert.Equal(t, time.Second*2, f.options.FollowerLeaseRefreshInterval)
 
-	require.NoError(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
+	require.NoError(t, f.Initialize(api.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
 	provider, aggregator, err := f.CreateStrategyProvider()
 	require.NoError(t, err)
 	require.NoError(t, provider.Close())
@@ -84,7 +84,7 @@ func TestBadConfigFail(t *testing.T) {
 
 		f.InitFromViper(v, zap.NewNop())
 
-		require.NoError(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
+		require.NoError(t, f.Initialize(api.NullFactory, &mockSamplingStoreFactory{}, zap.NewNop()))
 		_, _, err := f.CreateStrategyProvider()
 		require.Error(t, err)
 		require.NoError(t, f.Close())
@@ -95,13 +95,13 @@ func TestSamplingStoreFactoryFails(t *testing.T) {
 	f := NewFactory()
 
 	// nil fails
-	require.Error(t, f.Initialize(metrics.NullFactory, nil, zap.NewNop()))
+	require.Error(t, f.Initialize(api.NullFactory, nil, zap.NewNop()))
 
 	// fail if lock fails
-	require.Error(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{lockFailsWith: errors.New("fail")}, zap.NewNop()))
+	require.Error(t, f.Initialize(api.NullFactory, &mockSamplingStoreFactory{lockFailsWith: errors.New("fail")}, zap.NewNop()))
 
 	// fail if store fails
-	require.Error(t, f.Initialize(metrics.NullFactory, &mockSamplingStoreFactory{storeFailsWith: errors.New("fail")}, zap.NewNop()))
+	require.Error(t, f.Initialize(api.NullFactory, &mockSamplingStoreFactory{storeFailsWith: errors.New("fail")}, zap.NewNop()))
 }
 
 type mockSamplingStoreFactory struct {

--- a/internal/sampling/samplingstrategy/adaptive/post_aggregator.go
+++ b/internal/sampling/samplingstrategy/adaptive/post_aggregator.go
@@ -13,10 +13,10 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/leaderelection"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/adaptive/calculationstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore/model"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -88,8 +88,8 @@ type PostAggregator struct {
 
 	shutdown chan struct{}
 
-	operationsCalculatedGauge     metrics.Gauge
-	calculateProbabilitiesLatency metrics.Timer
+	operationsCalculatedGauge     api.Gauge
+	calculateProbabilitiesLatency api.Timer
 	lastCheckedTime               time.Time
 }
 
@@ -99,7 +99,7 @@ func newPostAggregator(
 	hostname string,
 	storage samplingstore.Store,
 	electionParticipant leaderelection.ElectionParticipant,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	logger *zap.Logger,
 ) (*PostAggregator, error) {
 	if opts.CalculationInterval == 0 || opts.AggregationBuckets == 0 {
@@ -108,7 +108,7 @@ func newPostAggregator(
 	if opts.BucketsForCalculation < 1 {
 		return nil, errBucketsForCalculation
 	}
-	metricsFactory = metricsFactory.Namespace(metrics.NSOptions{Name: "adaptive_sampling_processor"})
+	metricsFactory = metricsFactory.Namespace(api.NSOptions{Name: "adaptive_sampling_processor"})
 	return &PostAggregator{
 		Options:             opts,
 		storage:             storage,
@@ -121,8 +121,8 @@ func newPostAggregator(
 		weightVectorCache:             NewWeightVectorCache(),
 		probabilityCalculator:         calculationstrategy.NewPercentageIncreaseCappedCalculator(1.0),
 		serviceCache:                  []SamplingCache{},
-		operationsCalculatedGauge:     metricsFactory.Gauge(metrics.Options{Name: "operations_calculated"}),
-		calculateProbabilitiesLatency: metricsFactory.Timer(metrics.TimerOptions{Name: "calculate_probabilities"}),
+		operationsCalculatedGauge:     metricsFactory.Gauge(api.Options{Name: "operations_calculated"}),
+		calculateProbabilitiesLatency: metricsFactory.Timer(api.TimerOptions{Name: "calculate_probabilities"}),
 		shutdown:                      make(chan struct{}),
 	}, nil
 }

--- a/internal/sampling/samplingstrategy/factory.go
+++ b/internal/sampling/samplingstrategy/factory.go
@@ -6,8 +6,8 @@ package samplingstrategy
 import (
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // Factory defines an interface for a factory that can create implementations of different sampling strategy components.
@@ -18,7 +18,7 @@ import (
 // storage.Configurable
 type Factory interface {
 	// Initialize performs internal initialization of the factory.
-	Initialize(metricsFactory metrics.Factory, ssFactory storage.SamplingStoreFactory, logger *zap.Logger) error
+	Initialize(metricsFactory api.Factory, ssFactory storage.SamplingStoreFactory, logger *zap.Logger) error
 
 	// CreateStrategyProvider initializes and returns Provider and optionallty Aggregator.
 	CreateStrategyProvider() (Provider, Aggregator, error)

--- a/internal/sampling/samplingstrategy/file/factory.go
+++ b/internal/sampling/samplingstrategy/file/factory.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var _ storage.Configurable = (*Factory)(nil)
@@ -41,7 +41,7 @@ func (f *Factory) InitFromViper(v *viper.Viper, _ *zap.Logger) {
 }
 
 // Initialize implements samplingstrategy.Factory
-func (f *Factory) Initialize(_ metrics.Factory, _ storage.SamplingStoreFactory, logger *zap.Logger) error {
+func (f *Factory) Initialize(_ api.Factory, _ storage.SamplingStoreFactory, logger *zap.Logger) error {
 	f.logger = logger
 	return nil
 }

--- a/internal/sampling/samplingstrategy/file/factory_test.go
+++ b/internal/sampling/samplingstrategy/file/factory_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var (
@@ -26,7 +26,7 @@ func TestFactory(t *testing.T) {
 	command.ParseFlags([]string{"--sampling.strategies-file=fixtures/strategies.json"})
 	f.InitFromViper(v, zap.NewNop())
 
-	require.NoError(t, f.Initialize(metrics.NullFactory, nil, zap.NewNop()))
+	require.NoError(t, f.Initialize(api.NullFactory, nil, zap.NewNop()))
 	_, _, err := f.CreateStrategyProvider()
 	require.NoError(t, err)
 	require.NoError(t, f.Close())

--- a/internal/sampling/samplingstrategy/metafactory/factory.go
+++ b/internal/sampling/samplingstrategy/metafactory/factory.go
@@ -11,11 +11,11 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/adaptive"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/file"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // Kind is a datatype holding the type of strategy store.
@@ -88,7 +88,7 @@ func (f *Factory) InitFromViper(v *viper.Viper, logger *zap.Logger) {
 }
 
 // Initialize implements samplingstrategy.Factory
-func (f *Factory) Initialize(metricsFactory metrics.Factory, ssFactory storage.SamplingStoreFactory, logger *zap.Logger) error {
+func (f *Factory) Initialize(metricsFactory api.Factory, ssFactory storage.SamplingStoreFactory, logger *zap.Logger) error {
 	for _, factory := range f.factories {
 		if err := factory.Initialize(metricsFactory, ssFactory, logger); err != nil {
 			return err

--- a/internal/sampling/samplingstrategy/metafactory/factory_test.go
+++ b/internal/sampling/samplingstrategy/metafactory/factory_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var (
@@ -64,14 +64,14 @@ func TestNewFactory(t *testing.T) {
 		mock := new(mockFactory)
 		f.factories[Kind(tc.strategyStoreType)] = mock
 
-		require.NoError(t, f.Initialize(metrics.NullFactory, mockSSFactory, zap.NewNop()))
+		require.NoError(t, f.Initialize(api.NullFactory, mockSSFactory, zap.NewNop()))
 		_, _, err = f.CreateStrategyProvider()
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
 		// force the mock to return errors
 		mock.retError = true
-		require.EqualError(t, f.Initialize(metrics.NullFactory, mockSSFactory, zap.NewNop()), "error initializing store")
+		require.EqualError(t, f.Initialize(api.NullFactory, mockSSFactory, zap.NewNop()), "error initializing store")
 		_, _, err = f.CreateStrategyProvider()
 		require.EqualError(t, err, "error creating store")
 		require.EqualError(t, f.Close(), "error closing store")
@@ -127,7 +127,7 @@ func (f *mockFactory) CreateStrategyProvider() (samplingstrategy.Provider, sampl
 	return nil, nil, nil
 }
 
-func (f *mockFactory) Initialize(metrics.Factory, storage.SamplingStoreFactory, *zap.Logger) error {
+func (f *mockFactory) Initialize(api.Factory, storage.SamplingStoreFactory, *zap.Logger) error {
 	if f.retError {
 		return errors.New("error initializing store")
 	}

--- a/internal/storage/integration/badgerstore_test.go
+++ b/internal/storage/integration/badgerstore_test.go
@@ -11,10 +11,10 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 type BadgerIntegrationStorage struct {
@@ -27,7 +27,7 @@ func (s *BadgerIntegrationStorage) initialize(t *testing.T) {
 	s.factory.Config.Ephemeral = false
 
 	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
-	err := s.factory.Initialize(metrics.NullFactory, logger)
+	err := s.factory.Initialize(api.NullFactory, logger)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		s.factory.Close()

--- a/internal/storage/integration/cassandra_test.go
+++ b/internal/storage/integration/cassandra_test.go
@@ -14,12 +14,12 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/testutils"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 type CassandraStorageIntegration struct {
@@ -49,7 +49,7 @@ func (*CassandraStorageIntegration) initializeCassandraFactory(t *testing.T, fla
 	v, command := config.Viperize(f.AddFlags)
 	require.NoError(t, command.ParseFlags(flags))
 	f.InitFromViper(v, logger)
-	require.NoError(t, f.Initialize(metrics.NullFactory, logger))
+	require.NoError(t, f.Initialize(api.NullFactory, logger))
 	t.Cleanup(func() {
 		assert.NoError(t, f.Close())
 	})

--- a/internal/storage/integration/elasticsearch_test.go
+++ b/internal/storage/integration/elasticsearch_test.go
@@ -22,13 +22,13 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	es "github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/testutils"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -115,7 +115,7 @@ func (*ESStorageIntegration) initializeESFactory(t *testing.T, args []string, fa
 	v, command := config.Viperize(f.AddFlags)
 	require.NoError(t, command.ParseFlags(args))
 	f.InitFromViper(v, logger)
-	require.NoError(t, f.Initialize(metrics.NullFactory, logger))
+	require.NoError(t, f.Initialize(api.NullFactory, logger))
 
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())

--- a/internal/storage/integration/grpc_test.go
+++ b/internal/storage/integration/grpc_test.go
@@ -11,11 +11,11 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/grpc"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/testutils"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/ports"
 )
 
@@ -34,7 +34,7 @@ func (s *GRPCStorageIntegrationTestSuite) initialize(t *testing.T) {
 		v, command := config.Viperize(f.AddFlags)
 		require.NoError(t, command.ParseFlags(flags))
 		f.InitFromViper(v, logger)
-		require.NoError(t, f.Initialize(metrics.NullFactory, logger))
+		require.NoError(t, f.Initialize(api.NullFactory, logger))
 	}
 	f := grpc.NewFactory()
 	initFactory(f, s.flags)

--- a/internal/storage/integration/kafka_test.go
+++ b/internal/storage/integration/kafka_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app"
 	"github.com/jaegertracing/jaeger/cmd/ingester/app/builder"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/kafka"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/memory"
@@ -25,7 +26,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/testutils"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/kafka/consumer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const defaultLocalKafkaBroker = "127.0.0.1:9092"
@@ -54,7 +54,7 @@ func (s *KafkaIntegrationTestSuite) initialize(t *testing.T) {
 	})
 	require.NoError(t, err)
 	f.InitFromViper(v, logger)
-	err = f.Initialize(metrics.NullFactory, logger)
+	err = f.Initialize(api.NullFactory, logger)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, f.Close())
@@ -84,7 +84,7 @@ func (s *KafkaIntegrationTestSuite) initialize(t *testing.T) {
 	}
 	options.InitFromViper(v)
 	traceStore := memory.NewStore()
-	spanConsumer, err := builder.CreateConsumer(logger, metrics.NullFactory, traceStore, options)
+	spanConsumer, err := builder.CreateConsumer(logger, api.NullFactory, traceStore, options)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, spanConsumer.Close())

--- a/internal/storage/integration/remote_memory_storage.go
+++ b/internal/storage/integration/remote_memory_storage.go
@@ -19,10 +19,10 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/jaegertracing/jaeger/cmd/remote-storage/app"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	storage "github.com/jaegertracing/jaeger/internal/storage/v1/factory"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/ports"
@@ -51,7 +51,7 @@ func StartNewRemoteMemoryStorage(t *testing.T, port int) *RemoteMemoryStorage {
 
 	v, _ := config.Viperize(storageFactory.AddFlags)
 	storageFactory.InitFromViper(v, logger)
-	require.NoError(t, storageFactory.Initialize(metrics.NullFactory, logger))
+	require.NoError(t, storageFactory.Initialize(api.NullFactory, logger))
 
 	t.Logf("Starting in-process remote storage server on %s", opts.NetAddr.Endpoint)
 	telset := telemetry.NoopSettings()

--- a/internal/storage/metricstore/factory.go
+++ b/internal/storage/metricstore/factory.go
@@ -10,11 +10,11 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore/disabled"
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore/prometheus"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 )
 
@@ -67,7 +67,7 @@ func (*Factory) getFactoryOfType(factoryType string) (storage.MetricStoreFactory
 func (f *Factory) Initialize(telset telemetry.Settings) error {
 	for kind, factory := range f.factories {
 		scopedTelset := telset
-		scopedTelset.Metrics = telset.Metrics.Namespace(metrics.NSOptions{
+		scopedTelset.Metrics = telset.Metrics.Namespace(api.NSOptions{
 			Name: "storage",
 			Tags: map[string]string{
 				"kind": kind,

--- a/internal/storage/v1/api/metricstore/metricstoremetrics/decorator.go
+++ b/internal/storage/v1/api/metricstore/metricstoremetrics/decorator.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	protometrics "github.com/jaegertracing/jaeger/proto-gen/api_v2/metrics"
 )
 
@@ -22,10 +22,10 @@ type ReadMetricsDecorator struct {
 }
 
 type queryMetrics struct {
-	Errors     metrics.Counter `metric:"requests" tags:"result=err"`
-	Successes  metrics.Counter `metric:"requests" tags:"result=ok"`
-	ErrLatency metrics.Timer   `metric:"latency" tags:"result=err"`
-	OKLatency  metrics.Timer   `metric:"latency" tags:"result=ok"`
+	Errors     api.Counter `metric:"requests" tags:"result=err"`
+	Successes  api.Counter `metric:"requests" tags:"result=ok"`
+	ErrLatency api.Timer   `metric:"latency" tags:"result=err"`
+	OKLatency  api.Timer   `metric:"latency" tags:"result=ok"`
 }
 
 func (q *queryMetrics) emit(err error, latency time.Duration) {
@@ -39,7 +39,7 @@ func (q *queryMetrics) emit(err error, latency time.Duration) {
 }
 
 // NewReadMetricsDecorator returns a new ReadMetricsDecorator.
-func NewReaderDecorator(reader metricstore.Reader, metricsFactory metrics.Factory) *ReadMetricsDecorator {
+func NewReaderDecorator(reader metricstore.Reader, metricsFactory api.Factory) *ReadMetricsDecorator {
 	return &ReadMetricsDecorator{
 		reader:                    reader,
 		getLatenciesMetrics:       buildQueryMetrics("get_latencies", metricsFactory),
@@ -49,10 +49,10 @@ func NewReaderDecorator(reader metricstore.Reader, metricsFactory metrics.Factor
 	}
 }
 
-func buildQueryMetrics(operation string, metricsFactory metrics.Factory) *queryMetrics {
+func buildQueryMetrics(operation string, metricsFactory api.Factory) *queryMetrics {
 	qMetrics := &queryMetrics{}
-	scoped := metricsFactory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"operation": operation}})
-	metrics.Init(qMetrics, scoped, nil)
+	scoped := metricsFactory.Namespace(api.NSOptions{Name: "", Tags: map[string]string{"operation": operation}})
+	api.Init(qMetrics, scoped, nil)
 	return qMetrics
 }
 

--- a/internal/storage/v1/api/spanstore/downsampling_writer_benchmark_test.go
+++ b/internal/storage/v1/api/spanstore/downsampling_writer_benchmark_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 // Benchmark result:
@@ -46,6 +46,7 @@ func BenchmarkDownSamplingWriter_HashBytes(b *testing.B) {
 	for i := 0; i < 16; i++ {
 		ba[i] = byte(i)
 	}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 	h := c.sampler.hasherPool.Get().(*hasher)
@@ -62,7 +63,7 @@ func BenchmarkDownsamplingWriter_RandomHash(b *testing.B) {
 	downsamplingOptions := DownsamplingOptions{
 		Ratio:          1,
 		HashSalt:       "jaeger-test",
-		MetricsFactory: metrics.NullFactory,
+		MetricsFactory: api.NullFactory,
 	}
 	c := NewDownsamplingWriter(&noopWriteSpanStore{}, downsamplingOptions)
 	h := c.sampler.hasherPool.Get().(*hasher)

--- a/internal/storage/v1/api/spanstore/downsampling_writer_test.go
+++ b/internal/storage/v1/api/spanstore/downsampling_writer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 type noopWriteSpanStore struct{}
@@ -55,7 +56,7 @@ func TestDownSamplingWriter_hashBytes(t *testing.T) {
 	downsamplingOptions := DownsamplingOptions{
 		Ratio:          1,
 		HashSalt:       "",
-		MetricsFactory: nil,
+		MetricsFactory: api.NullFactory,
 	}
 	c := NewDownsamplingWriter(&noopWriteSpanStore{}, downsamplingOptions)
 	h := c.sampler.hasherPool.Get().(*hasher)

--- a/internal/storage/v1/api/spanstore/spanstoremetrics/write_metrics.go
+++ b/internal/storage/v1/api/spanstore/spanstoremetrics/write_metrics.go
@@ -7,22 +7,22 @@ package spanstoremetrics
 import (
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 // WriteMetrics is a collection of metrics for write operations.
 type WriteMetrics struct {
-	Attempts   metrics.Counter `metric:"attempts"`
-	Inserts    metrics.Counter `metric:"inserts"`
-	Errors     metrics.Counter `metric:"errors"`
-	LatencyOk  metrics.Timer   `metric:"latency-ok"`
-	LatencyErr metrics.Timer   `metric:"latency-err"`
+	Attempts   api.Counter `metric:"attempts"`
+	Inserts    api.Counter `metric:"inserts"`
+	Errors     api.Counter `metric:"errors"`
+	LatencyOk  api.Timer   `metric:"latency-ok"`
+	LatencyErr api.Timer   `metric:"latency-err"`
 }
 
 // NewWriter takes a metrics scope and creates a metrics struct
-func NewWriter(factory metrics.Factory, tableName string) *WriteMetrics {
+func NewWriter(factory api.Factory, tableName string) *WriteMetrics {
 	t := &WriteMetrics{}
-	metrics.Init(t, factory.Namespace(metrics.NSOptions{Name: tableName, Tags: nil}), nil)
+	api.Init(t, factory.Namespace(api.NSOptions{Name: tableName, Tags: nil}), nil)
 	return t
 }
 

--- a/internal/storage/v1/api/spanstore/spanstoremetrics/write_metrics_test.go
+++ b/internal/storage/v1/api/spanstore/spanstoremetrics/write_metrics_test.go
@@ -51,6 +51,7 @@ func TestTableEmit(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tc := range testCases {
 		mf := metricstest.NewFactory(time.Second)
 		tm := NewWriter(mf, "a_table")

--- a/internal/storage/v1/badger/dependencystore/storage_test.go
+++ b/internal/storage/v1/badger/dependencystore/storage_test.go
@@ -14,11 +14,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // Opens a badger db and runs a test on it.
@@ -36,7 +36,7 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 	})
 	f.InitFromViper(v, zap.NewNop())
 
-	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	err := f.Initialize(api.NullFactory, zap.NewNop())
 	require.NoError(tb, err)
 
 	sw, err := f.CreateSpanWriter()

--- a/internal/storage/v1/badger/factory_test.go
+++ b/internal/storage/v1/badger/factory_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestInitializationErrors(t *testing.T) {
@@ -34,7 +34,7 @@ func TestInitializationErrors(t *testing.T) {
 	})
 	f.InitFromViper(v, zap.NewNop())
 
-	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	err := f.Initialize(api.NullFactory, zap.NewNop())
 	require.Error(t, err)
 }
 
@@ -44,7 +44,7 @@ func TestForCodecov(t *testing.T) {
 	v, _ := config.Viperize(f.AddFlags)
 	f.InitFromViper(v, zap.NewNop())
 
-	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	err := f.Initialize(api.NullFactory, zap.NewNop())
 	require.NoError(t, err)
 
 	// Get all the writers, readers, etc
@@ -193,7 +193,7 @@ func TestConfigure(t *testing.T) {
 
 func TestBadgerStorageFactoryWithConfig(t *testing.T) {
 	cfg := Config{}
-	_, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
+	_, err := NewFactoryWithConfig(cfg, api.NullFactory, zap.NewNop())
 	require.ErrorContains(t, err, "Error Creating Dir")
 
 	tmp := os.TempDir()
@@ -207,7 +207,7 @@ func TestBadgerStorageFactoryWithConfig(t *testing.T) {
 		MaintenanceInterval:   5,
 		MetricsUpdateInterval: 10,
 	}
-	factory, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
+	factory, err := NewFactoryWithConfig(cfg, api.NullFactory, zap.NewNop())
 	require.NoError(t, err)
 	defer factory.Close()
 }

--- a/internal/storage/v1/badger/spanstore/read_write_test.go
+++ b/internal/storage/v1/badger/spanstore/read_write_test.go
@@ -19,10 +19,10 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestWriteReadBack(t *testing.T) {
@@ -387,7 +387,7 @@ func TestPersist(t *testing.T) {
 		})
 		f.InitFromViper(v, zap.NewNop())
 
-		err := f.Initialize(metrics.NullFactory, zap.NewNop())
+		err := f.Initialize(api.NullFactory, zap.NewNop())
 		require.NoError(t, err)
 
 		sw, err := f.CreateSpanWriter()
@@ -446,7 +446,7 @@ func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer,
 	})
 	f.InitFromViper(v, zap.NewNop())
 
-	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	err := f.Initialize(api.NullFactory, zap.NewNop())
 	require.NoError(tb, err)
 
 	sw, err := f.CreateSpanWriter()
@@ -616,7 +616,7 @@ func runLargeFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Wr
 
 	f.InitFromViper(v, zap.NewNop())
 
-	err = f.Initialize(metrics.NullFactory, zap.NewNop())
+	err = f.Initialize(api.NullFactory, zap.NewNop())
 	assertion.NoError(err)
 
 	sw, err := f.CreateSpanWriter()

--- a/internal/storage/v1/badger/stats_test.go
+++ b/internal/storage/v1/badger/stats_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestDiskStatisticsUpdate(t *testing.T) {
@@ -24,7 +24,7 @@ func TestDiskStatisticsUpdate(t *testing.T) {
 		"--badger.consistency=false",
 	})
 	f.InitFromViper(v, zap.NewNop())
-	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	err := f.Initialize(api.NullFactory, zap.NewNop())
 	require.NoError(t, err)
 	defer f.Close()
 

--- a/internal/storage/v1/blackhole/factory.go
+++ b/internal/storage/v1/blackhole/factory.go
@@ -7,10 +7,10 @@ package blackhole
 import (
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // interface comformance checks
@@ -18,7 +18,7 @@ var _ storage.Factory = (*Factory)(nil)
 
 // Factory implements storage.Factory and creates blackhole storage components.
 type Factory struct {
-	metricsFactory metrics.Factory
+	metricsFactory api.Factory
 	logger         *zap.Logger
 	store          *Store
 }
@@ -29,7 +29,7 @@ func NewFactory() *Factory {
 }
 
 // Initialize implements storage.Factory
-func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
+func (f *Factory) Initialize(metricsFactory api.Factory, logger *zap.Logger) error {
 	f.metricsFactory, f.logger = metricsFactory, logger
 	f.store = NewStore()
 	logger.Info("Blackhole storage initialized")

--- a/internal/storage/v1/blackhole/factory_test.go
+++ b/internal/storage/v1/blackhole/factory_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var _ storage.Factory = new(Factory)
 
 func TestStorageFactory(t *testing.T) {
 	f := NewFactory()
-	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(api.NullFactory, zap.NewNop()))
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateSpanReader()
 	require.NoError(t, err)

--- a/internal/storage/v1/cassandra/dependencystore/storage.go
+++ b/internal/storage/v1/cassandra/dependencystore/storage.go
@@ -13,9 +13,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	casMetrics "github.com/jaegertracing/jaeger/pkg/cassandra/metrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // Version determines which version of the dependencies table to use.
@@ -56,7 +56,7 @@ type DependencyStore struct {
 // NewDependencyStore returns a DependencyStore
 func NewDependencyStore(
 	session cassandra.Session,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	logger *zap.Logger,
 	version Version,
 ) (*DependencyStore, error) {

--- a/internal/storage/v1/cassandra/dependencystore/storage_test.go
+++ b/internal/storage/v1/cassandra/dependencystore/storage_test.go
@@ -16,12 +16,12 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/testutils"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	"github.com/jaegertracing/jaeger/pkg/cassandra/mocks"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 type depStorageTest struct {
@@ -58,7 +58,7 @@ func TestVersionIsValid(t *testing.T) {
 }
 
 func TestInvalidVersion(t *testing.T) {
-	_, err := NewDependencyStore(&mocks.Session{}, metrics.NullFactory, zap.NewNop(), versionEnumEnd)
+	_, err := NewDependencyStore(&mocks.Session{}, api.NullFactory, zap.NewNop(), versionEnumEnd)
 	require.Error(t, err)
 }
 

--- a/internal/storage/v1/cassandra/samplingstore/storage.go
+++ b/internal/storage/v1/cassandra/samplingstore/storage.go
@@ -17,10 +17,10 @@ import (
 	"github.com/gocql/gocql"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore/model"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	casMetrics "github.com/jaegertracing/jaeger/pkg/cassandra/metrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -57,7 +57,7 @@ type SamplingStore struct {
 }
 
 // New creates a new cassandra sampling store.
-func New(session cassandra.Session, factory metrics.Factory, logger *zap.Logger) *SamplingStore {
+func New(session cassandra.Session, factory api.Factory, logger *zap.Logger) *SamplingStore {
 	return &SamplingStore{
 		session: session,
 		metrics: samplingStoreMetrics{

--- a/internal/storage/v1/cassandra/savetracetest/main.go
+++ b/internal/storage/v1/cassandra/savetracetest/main.go
@@ -11,19 +11,19 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra"
 	cSpanStore "github.com/jaegertracing/jaeger/internal/storage/v1/cassandra/spanstore"
 	cascfg "github.com/jaegertracing/jaeger/pkg/cassandra/config"
 	"github.com/jaegertracing/jaeger/pkg/jtracer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var logger, _ = zap.NewDevelopment()
 
 // TODO: this is going morph into a load testing framework for cassandra 3.7
 func main() {
-	noScope := metrics.NullFactory
+	noScope := api.NullFactory
 	cConfig := &cascfg.Configuration{
 		Schema: cascfg.Schema{
 			Keyspace: "jaeger_v1_test",

--- a/internal/storage/v1/cassandra/spanstore/operation_names.go
+++ b/internal/storage/v1/cassandra/spanstore/operation_names.go
@@ -11,11 +11,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/cache"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	casMetrics "github.com/jaegertracing/jaeger/pkg/cassandra/metrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -90,7 +90,7 @@ type OperationNamesStorage struct {
 func NewOperationNamesStorage(
 	session cassandra.Session,
 	writeCacheTTL time.Duration,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	logger *zap.Logger,
 ) (*OperationNamesStorage, error) {
 	schemaVersion := latestVersion

--- a/internal/storage/v1/cassandra/spanstore/reader.go
+++ b/internal/storage/v1/cassandra/spanstore/reader.go
@@ -16,11 +16,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	casMetrics "github.com/jaegertracing/jaeger/pkg/cassandra/metrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/otelsemconv"
 )
 
@@ -106,11 +106,11 @@ type SpanReader struct {
 // NewSpanReader returns a new SpanReader.
 func NewSpanReader(
 	session cassandra.Session,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	logger *zap.Logger,
 	tracer trace.Tracer,
 ) (*SpanReader, error) {
-	readFactory := metricsFactory.Namespace(metrics.NSOptions{Name: "read", Tags: nil})
+	readFactory := metricsFactory.Namespace(api.NSOptions{Name: "read", Tags: nil})
 	serviceNamesStorage := NewServiceNamesStorage(session, 0, metricsFactory, logger)
 	operationNamesStorage, err := NewOperationNamesStorage(session, 0, metricsFactory, logger)
 	if err != nil {

--- a/internal/storage/v1/cassandra/spanstore/service_names.go
+++ b/internal/storage/v1/cassandra/spanstore/service_names.go
@@ -11,9 +11,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/cache"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	casMetrics "github.com/jaegertracing/jaeger/pkg/cassandra/metrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -36,7 +36,7 @@ type ServiceNamesStorage struct {
 func NewServiceNamesStorage(
 	session cassandra.Session,
 	writeCacheTTL time.Duration,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	logger *zap.Logger,
 ) *ServiceNamesStorage {
 	return &ServiceNamesStorage{

--- a/internal/storage/v1/cassandra/spanstore/writer.go
+++ b/internal/storage/v1/cassandra/spanstore/writer.go
@@ -15,10 +15,10 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
 	casMetrics "github.com/jaegertracing/jaeger/pkg/cassandra/metrics"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -83,7 +83,7 @@ type SpanWriter struct {
 	operationNamesWriter operationNamesWriter
 	writerMetrics        spanWriterMetrics
 	logger               *zap.Logger
-	tagIndexSkipped      metrics.Counter
+	tagIndexSkipped      api.Counter
 	tagFilter            dbmodel.TagFilter
 	storageMode          storageMode
 	indexFilter          dbmodel.IndexFilter
@@ -93,7 +93,7 @@ type SpanWriter struct {
 func NewSpanWriter(
 	session cassandra.Session,
 	writeCacheTTL time.Duration,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	logger *zap.Logger,
 	options ...Option,
 ) (*SpanWriter, error) {
@@ -102,7 +102,7 @@ func NewSpanWriter(
 	if err != nil {
 		return nil, err
 	}
-	tagIndexSkipped := metricsFactory.Counter(metrics.Options{Name: "tag_index_skipped", Tags: nil})
+	tagIndexSkipped := metricsFactory.Counter(api.Options{Name: "tag_index_skipped", Tags: nil})
 	opts := applyOptions(options...)
 	return &SpanWriter{
 		session:              session,

--- a/internal/storage/v1/elasticsearch/spanstore/writer.go
+++ b/internal/storage/v1/elasticsearch/spanstore/writer.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/cache"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/spanstoremetrics"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch/spanstore/internal/dbmodel"
 	"github.com/jaegertracing/jaeger/pkg/es"
 	cfg "github.com/jaegertracing/jaeger/pkg/es/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -52,7 +52,7 @@ type SpanWriterV1 struct {
 type SpanWriterParams struct {
 	Client              func() es.Client
 	Logger              *zap.Logger
-	MetricsFactory      metrics.Factory
+	MetricsFactory      api.Factory
 	SpanIndex           cfg.IndexOptions
 	ServiceIndex        cfg.IndexOptions
 	IndexPrefix         cfg.IndexPrefix

--- a/internal/storage/v1/factory.go
+++ b/internal/storage/v1/factory.go
@@ -9,12 +9,12 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 )
 
@@ -41,7 +41,7 @@ type Factory interface {
 	BaseFactory
 	// Initialize performs internal initialization of the factory, such as opening connections to the backend store.
 	// It is called after all configuration of the factory itself has been done.
-	Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error
+	Initialize(metricsFactory api.Factory, logger *zap.Logger) error
 }
 
 // Purger defines an interface that is capable of purging the storage.

--- a/internal/storage/v1/factory/factory_test.go
+++ b/internal/storage/v1/factory/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	depStoreMocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore/mocks"
@@ -25,7 +26,6 @@ import (
 	spanStoreMocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/mocks"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func defaultCfg() Config {
@@ -92,7 +92,7 @@ func TestInitialize(t *testing.T) {
 	f.factories[cassandraStorageType] = mock
 	f.archiveFactories[cassandraStorageType] = mock
 
-	m := metrics.NullFactory
+	m := api.NullFactory
 	l := zap.NewNop()
 	mock.On("Initialize", m, l).Return(nil)
 	require.NoError(t, f.Initialize(m, l))
@@ -133,7 +133,7 @@ func TestCreate(t *testing.T) {
 	require.EqualError(t, err, "dep-reader-error")
 
 	mock.On("CreateSpanWriter").Return(spanWriter, nil)
-	m := metrics.NullFactory
+	m := api.NullFactory
 	l := zap.NewNop()
 	mock.On("Initialize", m, l).Return(nil)
 	f.Initialize(m, l)
@@ -151,7 +151,7 @@ func TestCreateDownsamplingWriter(t *testing.T) {
 	spanWriter := new(spanStoreMocks.Writer)
 	mock.On("CreateSpanWriter").Return(spanWriter, nil)
 
-	m := metrics.NullFactory
+	m := api.NullFactory
 	l := zap.NewNop()
 	mock.On("Initialize", m, l).Return(nil)
 
@@ -200,7 +200,7 @@ func TestCreateMulti(t *testing.T) {
 
 	mock.On("CreateSpanWriter").Return(spanWriter, nil)
 	mock2.On("CreateSpanWriter").Return(spanWriter2, nil)
-	m := metrics.NullFactory
+	m := api.NullFactory
 	l := zap.NewNop()
 	mock.On("Initialize", m, l).Return(nil)
 	mock2.On("Initialize", m, l).Return(nil)
@@ -398,7 +398,7 @@ func TestArchiveConfigurable(t *testing.T) {
 			f.factories[cassandraStorageType] = primaryFactory
 			f.archiveFactories[cassandraStorageType] = archiveConfigurable
 
-			m := metrics.NullFactory
+			m := api.NullFactory
 			l := zap.NewNop()
 			primaryFactory.On("Initialize", m, l).Return(nil).Once()
 			archiveFactory.On("Initialize", m, l).Return(test.archiveInitError).Once()
@@ -561,7 +561,7 @@ var (
 	_ io.Closer       = (*errorFactory)(nil)
 )
 
-func (errorFactory) Initialize(metrics.Factory, *zap.Logger) error {
+func (errorFactory) Initialize(api.Factory, *zap.Logger) error {
 	panic("implement me")
 }
 

--- a/internal/storage/v1/grpc/factory.go
+++ b/internal/storage/v1/grpc/factory.go
@@ -21,13 +21,13 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/spanstoremetrics"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/grpc/shared"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 )
@@ -90,7 +90,7 @@ func (f *Factory) InitFromViper(v *viper.Viper, logger *zap.Logger) {
 }
 
 // Initialize implements storage.Factory
-func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
+func (f *Factory) Initialize(metricsFactory api.Factory, logger *zap.Logger) error {
 	f.telset.Metrics = metricsFactory
 	f.telset.Logger = logger
 	f.telset.TracerProvider = otel.GetTracerProvider()

--- a/internal/storage/v1/grpc/factory_test.go
+++ b/internal/storage/v1/grpc/factory_test.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	dependencyStoreMocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
@@ -29,7 +30,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/grpc/shared"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/grpc/shared/mocks"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 	"github.com/jaegertracing/jaeger/pkg/telemetry"
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 )
@@ -84,7 +84,7 @@ func makeFactory(t *testing.T) *Factory {
 	f := NewFactory()
 	f.InitFromViper(viper.New(), zap.NewNop())
 	f.options.ClientConfig.Endpoint = ":0"
-	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(api.NullFactory, zap.NewNop()))
 
 	t.Cleanup(func() {
 		f.Close()
@@ -111,7 +111,7 @@ func TestNewFactoryError(t *testing.T) {
 		f := NewFactory()
 		f.InitFromViper(viper.New(), zap.NewNop())
 		f.options.Config = *cfg
-		err := f.Initialize(metrics.NullFactory, zap.NewNop())
+		err := f.Initialize(api.NullFactory, zap.NewNop())
 		assert.ErrorContains(t, err, "authenticator")
 	})
 

--- a/internal/storage/v1/kafka/factory.go
+++ b/internal/storage/v1/kafka/factory.go
@@ -12,11 +12,11 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/pkg/kafka/producer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var ( // interface comformance checks
@@ -29,7 +29,7 @@ var ( // interface comformance checks
 type Factory struct {
 	options Options
 
-	metricsFactory metrics.Factory
+	metricsFactory api.Factory
 	logger         *zap.Logger
 
 	producer   sarama.AsyncProducer
@@ -60,7 +60,7 @@ func (f *Factory) configureFromOptions(o Options) {
 }
 
 // Initialize implements storage.Factory
-func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
+func (f *Factory) Initialize(metricsFactory api.Factory, logger *zap.Logger) error {
 	f.metricsFactory, f.logger = metricsFactory, logger
 	logger.Info("Kafka factory",
 		zap.Any("producer builder", f.Builder),

--- a/internal/storage/v1/kafka/factory_test.go
+++ b/internal/storage/v1/kafka/factory_test.go
@@ -15,9 +15,9 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/pkg/config"
 	kafkaConfig "github.com/jaegertracing/jaeger/pkg/kafka/producer"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 type mockProducerBuilder struct {
@@ -43,10 +43,10 @@ func TestKafkaFactory(t *testing.T) {
 		err: errors.New("made-up error"),
 		t:   t,
 	}
-	require.EqualError(t, f.Initialize(metrics.NullFactory, zap.NewNop()), "made-up error")
+	require.EqualError(t, f.Initialize(api.NullFactory, zap.NewNop()), "made-up error")
 
 	f.Builder = &mockProducerBuilder{t: t}
-	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(api.NullFactory, zap.NewNop()))
 	assert.IsType(t, &protobufMarshaller{}, f.marshaller)
 
 	_, err := f.CreateSpanWriter()
@@ -78,7 +78,7 @@ func TestKafkaFactoryEncoding(t *testing.T) {
 			f.InitFromViper(v, zap.NewNop())
 
 			f.Builder = &mockProducerBuilder{t: t}
-			require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+			require.NoError(t, f.Initialize(api.NullFactory, zap.NewNop()))
 			assert.IsType(t, test.marshaller, f.marshaller)
 			require.NoError(t, f.Close())
 		})
@@ -92,7 +92,7 @@ func TestKafkaFactoryMarshallerErr(t *testing.T) {
 	f.InitFromViper(v, zap.NewNop())
 
 	f.Builder = &mockProducerBuilder{t: t}
-	require.Error(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.Error(t, f.Initialize(api.NullFactory, zap.NewNop()))
 }
 
 func TestKafkaFactoryDoesNotLogPassword(t *testing.T) {
@@ -137,7 +137,7 @@ func TestKafkaFactoryDoesNotLogPassword(t *testing.T) {
 				zapcore.AddSync(logbuf),
 				zap.NewAtomicLevel(),
 			))
-			err = f.Initialize(metrics.NullFactory, logger)
+			err = f.Initialize(api.NullFactory, logger)
 			require.NoError(t, err)
 			logger.Sync()
 

--- a/internal/storage/v1/kafka/writer.go
+++ b/internal/storage/v1/kafka/writer.go
@@ -10,12 +10,12 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 type spanWriterMetrics struct {
-	SpansWrittenSuccess metrics.Counter
-	SpansWrittenFailure metrics.Counter
+	SpansWrittenSuccess api.Counter
+	SpansWrittenFailure api.Counter
 }
 
 // SpanWriter writes spans to kafka. Implements spanstore.Writer
@@ -31,12 +31,12 @@ func NewSpanWriter(
 	producer sarama.AsyncProducer,
 	marshaller Marshaller,
 	topic string,
-	factory metrics.Factory,
+	factory api.Factory,
 	logger *zap.Logger,
 ) *SpanWriter {
 	writeMetrics := spanWriterMetrics{
-		SpansWrittenSuccess: factory.Counter(metrics.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "success"}}),
-		SpansWrittenFailure: factory.Counter(metrics.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "failure"}}),
+		SpansWrittenSuccess: factory.Counter(api.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "success"}}),
+		SpansWrittenFailure: factory.Counter(api.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "failure"}}),
 	}
 
 	go func() {

--- a/internal/storage/v1/memory/factory.go
+++ b/internal/storage/v1/memory/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/safeexpvar"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
@@ -18,7 +19,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/spanstoremetrics"
 	"github.com/jaegertracing/jaeger/pkg/distributedlock"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var ( // interface comformance checks
@@ -31,7 +31,7 @@ var ( // interface comformance checks
 // Factory implements storage.Factory and creates storage components backed by memory store.
 type Factory struct {
 	options        Options
-	metricsFactory metrics.Factory
+	metricsFactory api.Factory
 	logger         *zap.Logger
 	store          *Store
 }
@@ -44,7 +44,7 @@ func NewFactory() *Factory {
 // NewFactoryWithConfig is used from jaeger(v2).
 func NewFactoryWithConfig(
 	cfg Configuration,
-	metricsFactory metrics.Factory,
+	metricsFactory api.Factory,
 	logger *zap.Logger,
 ) *Factory {
 	f := NewFactory()
@@ -69,7 +69,7 @@ func (f *Factory) configureFromOptions(opts Options) {
 }
 
 // Initialize implements storage.Factory
-func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger) error {
+func (f *Factory) Initialize(metricsFactory api.Factory, logger *zap.Logger) error {
 	f.metricsFactory, f.logger = metricsFactory, logger
 	f.store = WithConfiguration(f.options.Configuration)
 	logger.Info("Memory storage initialized", zap.Any("configuration", f.store.defaultConfig))

--- a/internal/storage/v1/memory/factory_test.go
+++ b/internal/storage/v1/memory/factory_test.go
@@ -12,16 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/pkg/config"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var _ storage.Factory = new(Factory)
 
 func TestMemoryStorageFactory(t *testing.T) {
 	f := NewFactory()
-	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(api.NullFactory, zap.NewNop()))
 	assert.NotNil(t, f.store)
 	reader, err := f.CreateSpanReader()
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestNewFactoryWithConfig(t *testing.T) {
 	cfg := Configuration{
 		MaxTraces: 42,
 	}
-	f := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
+	f := NewFactoryWithConfig(cfg, api.NullFactory, zap.NewNop())
 	assert.Equal(t, cfg, f.options.Configuration)
 }
 
@@ -62,6 +62,6 @@ func TestPublishOpts(t *testing.T) {
 	command.ParseFlags([]string{"--memory.max-traces=100"})
 	f.InitFromViper(v, zap.NewNop())
 
-	require.NoError(t, f.Initialize(metrics.NullFactory, zap.NewNop()))
+	require.NoError(t, f.Initialize(api.NullFactory, zap.NewNop()))
 	assert.EqualValues(t, 100, expvar.Get("jaeger_storage_memory_max_traces").(*expvar.Int).Value())
 }

--- a/internal/storage/v1/mocks/Factory.go
+++ b/internal/storage/v1/mocks/Factory.go
@@ -9,7 +9,7 @@ package mocks
 
 import (
 	dependencystore "github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
-	metrics "github.com/jaegertracing/jaeger/pkg/metrics"
+	metrics "github.com/jaegertracing/jaeger/internal/metrics/api"
 
 	mock "github.com/stretchr/testify/mock"
 

--- a/pkg/cassandra/metrics/table.go
+++ b/pkg/cassandra/metrics/table.go
@@ -10,9 +10,9 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/spanstoremetrics"
 	"github.com/jaegertracing/jaeger/pkg/cassandra"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // Table is a collection of metrics about Cassandra write operations.
@@ -21,9 +21,9 @@ type Table struct {
 }
 
 // NewTable takes a metrics scope and creates a table metrics struct
-func NewTable(factory metrics.Factory, tableName string) *Table {
+func NewTable(factory api.Factory, tableName string) *Table {
 	t := spanstoremetrics.WriteMetrics{}
-	metrics.Init(&t, factory.Namespace(metrics.NSOptions{Name: "", Tags: map[string]string{"table": tableName}}), nil)
+	api.Init(&t, factory.Namespace(api.NSOptions{Name: "", Tags: map[string]string{"table": tableName}}), nil)
 	return &Table{t}
 }
 

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -26,11 +26,11 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zapgrpc"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/spanstoremetrics"
 	"github.com/jaegertracing/jaeger/pkg/bearertoken"
 	"github.com/jaegertracing/jaeger/pkg/es"
 	eswrapper "github.com/jaegertracing/jaeger/pkg/es/wrapper"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 const (
@@ -211,7 +211,7 @@ type BearerTokenAuthentication struct {
 }
 
 // NewClient creates a new ElasticSearch client
-func NewClient(c *Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
+func NewClient(c *Configuration, logger *zap.Logger, metricsFactory api.Factory) (es.Client, error) {
 	if len(c.Servers) < 1 {
 		return nil, errors.New("no servers specified")
 	}

--- a/pkg/es/config/config_test.go
+++ b/pkg/es/config/config_test.go
@@ -16,8 +16,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 var mockEsServerResponseWithVersion0 = []byte(`
@@ -406,7 +406,7 @@ func TestNewClient(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			logger := zap.NewNop()
-			metricsFactory := metrics.NullFactory
+			metricsFactory := api.NullFactory
 			config := test.config
 			client, err := NewClient(config, logger, metricsFactory)
 			if test.expectedError {

--- a/pkg/httpmetrics/metrics_test.go
+++ b/pkg/httpmetrics/metrics_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metrics/prometheus"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 func TestNewMetricsHandler(t *testing.T) {
@@ -69,7 +69,7 @@ func TestIllegalPrometheusLabel(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot) // any subsequent statuses should be ignored
 	})
 
-	mf := prometheus.New().Namespace(metrics.NSOptions{})
+	mf := prometheus.New().Namespace(api.NSOptions{})
 	handler := Wrap(dummyHandlerFunc, mf, zap.NewNop())
 
 	invalidUtf8 := []byte{0xC0, 0xAE, 0xC0, 0xAE}

--- a/pkg/queue/bounded_queue.go
+++ b/pkg/queue/bounded_queue.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 // Consumer consumes data from a bounded queue
@@ -151,7 +151,7 @@ func (q *BoundedQueue[T]) Capacity() int {
 
 // StartLengthReporting starts a timer-based goroutine that periodically reports
 // current queue length to a given metrics gauge.
-func (q *BoundedQueue[T]) StartLengthReporting(reportPeriod time.Duration, gauge metrics.Gauge) {
+func (q *BoundedQueue[T]) StartLengthReporting(reportPeriod time.Duration, gauge api.Gauge) {
 	ticker := time.NewTicker(reportPeriod)
 	go func() {
 		defer ticker.Stop()

--- a/pkg/queue/bounded_queue_test.go
+++ b/pkg/queue/bounded_queue_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metricstest"
 	"github.com/jaegertracing/jaeger/internal/testutils"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 // In this test we run a queue with capacity 1 and a single consumer.
@@ -25,8 +25,8 @@ import (
 // by holding a startLock before submitting items to the queue.
 func helper(t *testing.T, startConsumers func(q *BoundedQueue[string], consumerFn func(item string))) {
 	mFact := metricstest.NewFactory(0)
-	counter := mFact.Counter(metrics.Options{Name: "dropped", Tags: nil})
-	gauge := mFact.Gauge(metrics.Options{Name: "size", Tags: nil})
+	counter := mFact.Counter(api.Options{Name: "dropped", Tags: nil})
+	gauge := mFact.Gauge(api.Options{Name: "size", Tags: nil})
 
 	q := NewBoundedQueue[string](1, func( /* item */ string) {
 		counter.Inc(1)

--- a/pkg/telemetry/settings.go
+++ b/pkg/telemetry/settings.go
@@ -13,14 +13,14 @@ import (
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
-	"github.com/jaegertracing/jaeger/pkg/metrics"
 )
 
 type Settings struct {
 	Logger         *zap.Logger
-	Metrics        metrics.Factory
+	Metrics        api.Factory
 	MeterProvider  metric.MeterProvider
 	TracerProvider trace.TracerProvider
 	ReportStatus   func(*componentstatus.Event) // TODO remove this
@@ -50,7 +50,7 @@ func HCAdapter(hc *healthcheck.HealthCheck) func(*componentstatus.Event) {
 func NoopSettings() Settings {
 	return Settings{
 		Logger:         zap.NewNop(),
-		Metrics:        metrics.NullFactory,
+		Metrics:        api.NullFactory,
 		MeterProvider:  noopmetric.NewMeterProvider(),
 		TracerProvider: nooptrace.NewTracerProvider(),
 		ReportStatus:   func(*componentstatus.Event) {},

--- a/pkg/version/build.go
+++ b/pkg/version/build.go
@@ -6,7 +6,7 @@ package version
 import (
 	"fmt"
 
-	"github.com/jaegertracing/jaeger/pkg/metrics"
+	"github.com/jaegertracing/jaeger/internal/metrics/api"
 )
 
 var (
@@ -29,7 +29,7 @@ type Info struct {
 
 // InfoMetrics hold a gauge whose tags include build information.
 type InfoMetrics struct {
-	BuildInfo metrics.Gauge `metric:"build_info"`
+	BuildInfo api.Gauge `metric:"build_info"`
 }
 
 // Get creates and initialized Info object
@@ -42,7 +42,7 @@ func Get() Info {
 }
 
 // NewInfoMetrics returns a InfoMetrics
-func NewInfoMetrics(metricsFactory metrics.Factory) *InfoMetrics {
+func NewInfoMetrics(metricsFactory api.Factory) *InfoMetrics {
 	var info InfoMetrics
 
 	buildTags := map[string]string{
@@ -50,7 +50,7 @@ func NewInfoMetrics(metricsFactory metrics.Factory) *InfoMetrics {
 		"version":    latestVersion,
 		"build_date": date,
 	}
-	metrics.Init(&info, metricsFactory, buildTags)
+	api.Init(&info, metricsFactory, buildTags)
 	info.BuildInfo.Update(1)
 
 	return &info


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger/issues/6869

## Description of the changes
- moved `pkg/metrics` to` internal/metrics/api`  to hold the metrics interfaces and utility functions
- The `/pkg/metrics` package provided an abstraction layer for metrics in Jaeger , it defines Interface definitions for metrics types (Counter, Gauge, Timer, Histogram) ,factory interface for creating metrics,Utility functions for initializing metrics in structs
- There was already implementations of the metrics interfaces in `/internal/metrics/prometheus` - Prometheus implementation ,`/internal/metrics/otelmetrics` - OpenTelemetry metrics implementation,`/internal/metrics/metricsbuilder` - Builder for metrics factories ,These implementations depended on the interfaces defined in `/pkg/metrics`.


## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
