### PR TITLE
[grpc][v2] Implement v2 gRPC trace writer 

### DIFF
--- a/internal/storage/v2/grpc/tracewriter.go
+++ b/internal/storage/v2/grpc/tracewriter.go
@@ -5,6 +5,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
@@ -32,5 +33,8 @@ func NewTraceWriter(conn *grpc.ClientConn) *TraceWriter {
 func (tw *TraceWriter) WriteTraces(ctx context.Context, td ptrace.Traces) error {
 	req := ptraceotlp.NewExportRequestFromTraces(td)
 	_, err := tw.client.Export(ctx, req)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to export traces: %w", err)
+	}
+	return nil
 }

--- a/internal/storage/v2/grpc/tracewriter.go
+++ b/internal/storage/v2/grpc/tracewriter.go
@@ -1,0 +1,32 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+)
+
+var _ tracestore.Writer = (*TraceWriter)(nil)
+
+type TraceWriter struct {
+	client ptraceotlp.GRPCClient
+}
+
+// NewTraceWriter creates a TraceWriter that exports traces to a remote gRPC storage server.
+//
+// The provided gRPC connection is used exclusively for sending trace data to the backend.
+// To prevent recursive trace generation, this connection should not have instrumentation enabled.
+func NewTraceWriter(conn *grpc.ClientConn) *TraceWriter {
+	return &TraceWriter{
+		client: ptraceotlp.NewGRPCClient(conn),
+	}
+}
+
+func (tw *TraceWriter) WriteTraces(ctx context.Context, td ptrace.Traces) error {
+	req := ptraceotlp.NewExportRequestFromTraces(td)
+	_, err := tw.client.Export(ctx, req)
+	return err
+}

--- a/internal/storage/v2/grpc/tracewriter.go
+++ b/internal/storage/v2/grpc/tracewriter.go
@@ -1,12 +1,16 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package grpc
 
 import (
 	"context"
 
-	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
 var _ tracestore.Writer = (*TraceWriter)(nil)

--- a/internal/storage/v2/grpc/tracewriter_test.go
+++ b/internal/storage/v2/grpc/tracewriter_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type testWriterServer struct {
+	ptraceotlp.UnimplementedGRPCServer
+
+	err error
+}
+
+func (s *testWriterServer) Export(
+	context.Context,
+	ptraceotlp.ExportRequest,
+) (ptraceotlp.ExportResponse, error) {
+	return ptraceotlp.NewExportResponse(), s.err
+}
+
+func startWriterServer(t *testing.T, testServer *testWriterServer) *grpc.ClientConn {
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	ptraceotlp.RegisterGRPCServer(server, testServer)
+
+	go func() {
+		server.Serve(listener)
+	}()
+
+	conn, err := grpc.NewClient(
+		listener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(
+		func() {
+			conn.Close()
+			server.Stop()
+			listener.Close()
+		},
+	)
+
+	return conn
+}
+
+func TestTraceWriter_WriteTraces(t *testing.T) {
+	tests := []struct {
+		name        string
+		serverErr   error
+		expectedErr string
+	}{
+		{
+			name: "no error",
+		},
+		{
+			name:        "server error",
+			serverErr:   assert.AnError,
+			expectedErr: "failed to export traces",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := &testWriterServer{err: test.serverErr}
+			conn := startWriterServer(t, server)
+
+			writer := NewTraceWriter(conn)
+			err := writer.WriteTraces(context.Background(), ptrace.NewTraces())
+			if test.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6789 

## Description of the changes
- This PR implements the v2 gRPC trace writer using OTEL's gRPC exporter client. 

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
