### PR TITLE
[grpc][v2] Implement v2 gRPC dependency reader 

### DIFF
--- a/internal/storage/v2/grpc/depreader.go
+++ b/internal/storage/v2/grpc/depreader.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpc
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/proto-gen/storage/v2"
+)
+
+var _ depstore.Reader = (*DependencyReader)(nil)
+
+type DependencyReader struct {
+	client storage.DependencyReaderClient
+}
+
+// NewDependencyReader creates a DependencyReader that communicates with a remote gRPC storage server.
+// The provided gRPC connection is used exclusively for reading dependencies, meaning it is safe
+// to enable instrumentation on the connection.
+func NewDependencyReader(conn *grpc.ClientConn) *DependencyReader {
+	return &DependencyReader{
+		client: storage.NewDependencyReaderClient(conn),
+	}
+}
+
+func (dr *DependencyReader) GetDependencies(
+	ctx context.Context,
+	query depstore.QueryParameters,
+) ([]model.DependencyLink, error) {
+	resp, err := dr.client.GetDependencies(ctx, &storage.GetDependenciesRequest{
+		StartTime: query.StartTime,
+		EndTime:   query.EndTime,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dependencies: %w", err)
+	}
+	dependencies := make([]model.DependencyLink, len(resp.Dependencies))
+	for i, dep := range resp.Dependencies {
+		dependencies[i] = model.DependencyLink{
+			Parent:    dep.Parent,
+			Child:     dep.Child,
+			CallCount: dep.CallCount,
+			Source:    dep.Source,
+		}
+	}
+	return dependencies, nil
+}

--- a/internal/storage/v2/grpc/depreader_test.go
+++ b/internal/storage/v2/grpc/depreader_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/proto-gen/storage/v2"
+)
+
+// testDependenciesServer implements the storage.DependencyReaderServer interface
+// to simulate responses for testing.
+type testDependenciesServer struct {
+	storage.UnimplementedDependencyReaderServer
+
+	dependencies []*storage.Dependency
+	err          error
+}
+
+func (t *testDependenciesServer) GetDependencies(
+	context.Context,
+	*storage.GetDependenciesRequest,
+) (*storage.GetDependenciesResponse, error) {
+	return &storage.GetDependenciesResponse{
+		Dependencies: t.dependencies,
+	}, t.err
+}
+
+func startTestDependenciesServer(t *testing.T, testServer *testDependenciesServer) *grpc.ClientConn {
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	storage.RegisterDependencyReaderServer(server, testServer)
+
+	return startServer(t, server, listener)
+}
+
+func TestDependencyReader_GetDependencies(t *testing.T) {
+	tests := []struct {
+		name                 string
+		testServer           *testDependenciesServer
+		expectedDependencies []model.DependencyLink
+		expectedError        string
+	}{
+		{
+			name: "success",
+			testServer: &testDependenciesServer{
+				dependencies: []*storage.Dependency{
+					{
+						Parent:    "service-a",
+						Child:     "service-b",
+						CallCount: 42,
+						Source:    "source",
+					},
+					{
+						Parent:    "service-c",
+						Child:     "service-d",
+						CallCount: 24,
+						Source:    "source",
+					},
+				},
+			},
+			expectedDependencies: []model.DependencyLink{
+				{
+					Parent:    "service-a",
+					Child:     "service-b",
+					CallCount: 42,
+					Source:    "source",
+				},
+				{
+					Parent:    "service-c",
+					Child:     "service-d",
+					CallCount: 24,
+					Source:    "source",
+				},
+			},
+		},
+		{
+			name: "empty",
+			testServer: &testDependenciesServer{
+				dependencies: []*storage.Dependency{},
+			},
+			expectedDependencies: []model.DependencyLink{},
+		},
+		{
+			name: "error",
+			testServer: &testDependenciesServer{
+				err: assert.AnError,
+			},
+			expectedError: "failed to get dependencies",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conn := startTestDependenciesServer(t, test.testServer)
+
+			reader := NewDependencyReader(conn)
+			dependencies, err := reader.GetDependencies(context.Background(), depstore.QueryParameters{})
+
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+			} else {
+				require.Equal(t, test.expectedDependencies, dependencies)
+			}
+		})
+	}
+}

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -65,6 +65,10 @@ func startTestServer(t *testing.T, testServer *testServer) *grpc.ClientConn {
 	server := grpc.NewServer()
 	storage.RegisterTraceReaderServer(server, testServer)
 
+	return startServer(t, server, listener)
+}
+
+func startServer(t *testing.T, server *grpc.Server, listener net.Listener) *grpc.ClientConn {
 	go func() {
 		server.Serve(listener)
 	}()


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6789 

## Description of the changes
- This PR implements the v2 gRPC dependency reader

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
