### PR TITLE
[grpc][v2] Implement gRPC v2 factory

### DIFF
--- a/internal/storage/v2/grpc/config.go
+++ b/internal/storage/v2/grpc/config.go
@@ -1,0 +1,28 @@
+package grpc
+
+import (
+	"time"
+
+	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+const (
+	defaultConnectionTimeout = time.Duration(5 * time.Second)
+)
+
+type Config struct {
+	Tenancy                      tenancy.Options `mapstructure:"multi_tenancy"`
+	configgrpc.ClientConfig      `mapstructure:",squash"`
+	exporterhelper.TimeoutConfig `mapstructure:",squash"`
+	enabled                      bool
+}
+
+func DefaultConfig() Config {
+	return Config{
+		TimeoutConfig: exporterhelper.TimeoutConfig{
+			Timeout: defaultConnectionTimeout,
+		},
+	}
+}

--- a/internal/storage/v2/grpc/config.go
+++ b/internal/storage/v2/grpc/config.go
@@ -12,10 +12,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
-const (
-	defaultConnectionTimeout = time.Duration(5 * time.Second)
-)
-
 type Config struct {
 	Tenancy                      tenancy.Options `mapstructure:"multi_tenancy"`
 	configgrpc.ClientConfig      `mapstructure:",squash"`
@@ -25,7 +21,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		TimeoutConfig: exporterhelper.TimeoutConfig{
-			Timeout: defaultConnectionTimeout,
+			Timeout: time.Duration(5 * time.Second),
 		},
 	}
 }

--- a/internal/storage/v2/grpc/config.go
+++ b/internal/storage/v2/grpc/config.go
@@ -1,11 +1,15 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package grpc
 
 import (
 	"time"
 
-	"github.com/jaegertracing/jaeger/internal/tenancy"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 const (
@@ -16,7 +20,6 @@ type Config struct {
 	Tenancy                      tenancy.Options `mapstructure:"multi_tenancy"`
 	configgrpc.ClientConfig      `mapstructure:",squash"`
 	exporterhelper.TimeoutConfig `mapstructure:",squash"`
-	enabled                      bool
 }
 
 func DefaultConfig() Config {

--- a/internal/storage/v2/grpc/config_test.go
+++ b/internal/storage/v2/grpc/config_test.go
@@ -11,5 +11,5 @@ import (
 
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
-	require.Equal(t, defaultConnectionTimeout, cfg.Timeout)
+	require.NotEmpty(t, cfg.Timeout)
 }

--- a/internal/storage/v2/grpc/config_test.go
+++ b/internal/storage/v2/grpc/config_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	require.Equal(t, defaultConnectionTimeout, cfg.Timeout)
+}

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -1,0 +1,110 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jaegertracing/jaeger/internal/bearertoken"
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+)
+
+type Factory struct {
+	telset telemetry.Settings
+	config Config
+
+	traceReader *TraceReader
+	traceWriter *TraceWriter
+
+	readerConn *grpc.ClientConn
+	writerConn *grpc.ClientConn
+}
+
+func NewFactory(
+	cfg Config,
+	telset telemetry.Settings,
+) (*Factory, error) {
+	f := &Factory{
+		telset: telset,
+		config: cfg,
+	}
+	f.telset.TracerProvider = otel.GetTracerProvider()
+
+	readerTelset := getTelset(f.telset, f.telset.TracerProvider)
+	writerTelset := getTelset(f.telset, noop.NewTracerProvider())
+	newClientFn := func(telset component.TelemetrySettings, opts ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
+		clientOpts := make([]configgrpc.ToClientConnOption, 0)
+		for _, opt := range opts {
+			clientOpts = append(clientOpts, configgrpc.WithGrpcDialOption(opt))
+		}
+		return f.config.ToClientConn(context.Background(), f.telset.Host, telset, clientOpts...)
+	}
+
+	f.initializeClients(readerTelset, writerTelset, newClientFn)
+
+	return f, nil
+}
+
+func getTelset(
+	telset telemetry.Settings,
+	tracerProvider trace.TracerProvider,
+) component.TelemetrySettings {
+	return component.TelemetrySettings{
+		Logger:         telset.Logger,
+		TracerProvider: tracerProvider,
+		MeterProvider:  telset.MeterProvider,
+	}
+}
+
+type newClientFn func(telset component.TelemetrySettings, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+
+func (f *Factory) initializeClients(
+	readerTelset, writerTelset component.TelemetrySettings,
+	newClient newClientFn,
+) error {
+	if f.config.Auth != nil {
+		return errors.New("authenticator is not supported")
+	}
+
+	unaryInterceptors := []grpc.UnaryClientInterceptor{bearertoken.NewUnaryClientInterceptor()}
+	streamInterceptors := []grpc.StreamClientInterceptor{bearertoken.NewStreamClientInterceptor()}
+
+	if tenancyMgr := tenancy.NewManager(&f.config.Tenancy); tenancyMgr.Enabled {
+		unaryInterceptors = append(unaryInterceptors, tenancy.NewClientUnaryInterceptor(tenancyMgr))
+		streamInterceptors = append(streamInterceptors, tenancy.NewClientStreamInterceptor(tenancyMgr))
+	}
+
+	baseOpts := []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
+		grpc.WithChainStreamInterceptor(streamInterceptors...),
+	}
+
+	createConn := func(telset component.TelemetrySettings) (*grpc.ClientConn, error) {
+		opts := append(baseOpts, grpc.WithStatsHandler(
+			otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(telset.TracerProvider)),
+		))
+		return newClient(telset, opts...)
+	}
+
+	readerConn, err := createConn(readerTelset)
+	if err != nil {
+		return fmt.Errorf("error creating reader client connection: %w", err)
+	}
+	writerConn, err := createConn(writerTelset)
+	if err != nil {
+		return fmt.Errorf("error creating writer client connection: %w", err)
+	}
+
+	f.readerConn, f.writerConn = readerConn, writerConn
+	f.traceReader, f.traceWriter = NewTraceReader(readerConn), NewTraceWriter(writerConn)
+
+	return nil
+}

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -33,11 +33,16 @@ var (
 type Factory struct {
 	telset telemetry.Settings
 	config Config
-
+	// readerConn is the gRPC connection used for reading data from the remote storage backend.
+	// It is safe for this connection to have instrumentation enabled without
+	// the risk of recursively generating traces.
 	readerConn *grpc.ClientConn
+	// writerConn is the gRPC connection used for writing data to the remote storage backend.
+	// This connection should not have instrumentation enabled to avoid recursively generating traces.
 	writerConn *grpc.ClientConn
 }
 
+// NewFactory initializes a new gRPC (remote) storage backend.
 func NewFactory(
 	cfg Config,
 	telset telemetry.Settings,

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
@@ -51,7 +50,6 @@ func NewFactory(
 		telset: telset,
 		config: cfg,
 	}
-	f.telset.TracerProvider = otel.GetTracerProvider()
 
 	readerTelset := getTelset(f.telset, f.telset.TracerProvider)
 	writerTelset := getTelset(f.telset, noop.NewTracerProvider())

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -58,7 +58,9 @@ func NewFactory(
 		return f.config.ToClientConn(context.Background(), f.telset.Host, telset, clientOpts...)
 	}
 
-	f.initializeConnections(readerTelset, writerTelset, newClientFn)
+	if err := f.initializeConnections(readerTelset, writerTelset, newClientFn); err != nil {
+		return nil, err
+	}
 
 	return f, nil
 }

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -35,7 +35,7 @@ func TestNewFactory(t *testing.T) {
 			log.Fatalf("Server exited with error: %v", err)
 		}
 	}()
-	defer s.Stop()
+	t.Cleanup(s.Stop)
 
 	cfg := Config{
 		ClientConfig: configgrpc.ClientConfig{

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -1,0 +1,55 @@
+package grpc
+
+import (
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configauth"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"google.golang.org/grpc"
+)
+
+func TestNewFactory_NonEmptyAuthenticator(t *testing.T) {
+	cfg := &Config{
+		ClientConfig: configgrpc.ClientConfig{
+			Auth: &configauth.Authentication{},
+		},
+	}
+	_, err := NewFactory(*cfg, telemetry.NoopSettings())
+	require.ErrorContains(t, err, "authenticator is not supported")
+}
+
+func TestNewFactory(t *testing.T) {
+	lis, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "failed to listen")
+
+	s := grpc.NewServer()
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+	defer s.Stop()
+
+	cfg := Config{
+		ClientConfig: configgrpc.ClientConfig{
+			Endpoint: lis.Addr().String(),
+		},
+		TimeoutConfig: exporterhelper.TimeoutConfig{
+			Timeout: 1 * time.Second,
+		},
+		Tenancy: tenancy.Options{
+			Enabled: true,
+		},
+	}
+	telset := telemetry.NoopSettings()
+	f, err := NewFactory(cfg, telset)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+}

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -1,18 +1,21 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package grpc
 
 import (
-	"log"
 	"net"
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger/internal/telemetry"
-	"github.com/jaegertracing/jaeger/internal/tenancy"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/grpc"
+
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 func TestNewFactory_NonEmptyAuthenticator(t *testing.T) {
@@ -30,12 +33,8 @@ func TestNewFactory(t *testing.T) {
 	require.NoError(t, err, "failed to listen")
 
 	s := grpc.NewServer()
-	go func() {
-		if err := s.Serve(lis); err != nil {
-			log.Fatalf("Server exited with error: %v", err)
-		}
-	}()
-	t.Cleanup(s.Stop)
+
+	startServer(t, s, lis)
 
 	cfg := Config{
 		ClientConfig: configgrpc.ClientConfig{

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -53,3 +53,33 @@ func TestNewFactory(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 }
+
+func TestFactory(t *testing.T) {
+	lis, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "failed to listen")
+
+	s := grpc.NewServer()
+
+	conn := startServer(t, s, lis)
+	f := &Factory{
+		readerConn: conn,
+	}
+
+	t.Run("CreateTraceReader", func(t *testing.T) {
+		tr, err := f.CreateTraceReader()
+		require.NoError(t, err)
+		require.NotNil(t, tr)
+	})
+
+	t.Run("CreateTraceWriter", func(t *testing.T) {
+		tr, err := f.CreateTraceWriter()
+		require.NoError(t, err)
+		require.NotNil(t, tr)
+	})
+
+	t.Run("CreateDependencyReader", func(t *testing.T) {
+		tr, err := f.CreateDependencyReader()
+		require.NoError(t, err)
+		require.NotNil(t, tr)
+	})
+}


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #6965

## Description of the changes
- This PR implements the following factories for gRPC storage
  - `io.Closer`
  - `tracestore.Factory`
  - `depstore.Factory`
## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
