### PR TITLE
[grpc][v2] Implement `GetServices` in grpc v2 handler

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -44,3 +44,26 @@ func (h *Handler) GetServices(
 		Services: services,
 	}, nil
 }
+
+func (h *Handler) GetOperations(
+	ctx context.Context,
+	req *storage.GetOperationsRequest,
+) (*storage.GetOperationsResponse, error) {
+	operations, err := h.traceReader.GetOperations(ctx, tracestore.OperationQueryParams{
+		ServiceName: req.Service,
+		SpanKind:    req.SpanKind,
+	})
+	if err != nil {
+		return nil, err
+	}
+	grpcOperations := make([]*storage.Operation, len(operations))
+	for i, operation := range operations {
+		grpcOperations[i] = &storage.Operation{
+			Name:     operation.Name,
+			SpanKind: operation.SpanKind,
+		}
+	}
+	return &storage.GetOperationsResponse{
+		Operations: grpcOperations,
+	}, nil
+}

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -30,6 +30,11 @@ func TestServer_GetServices(t *testing.T) {
 			expectedServices: []string{"service1", "service2"},
 		},
 		{
+			name:             "empty",
+			services:         []string{},
+			expectedServices: []string{},
+		},
+		{
 			name:        "error",
 			err:         assert.AnError,
 			expectedErr: assert.AnError,
@@ -79,6 +84,11 @@ func TestServer_GetOperations(t *testing.T) {
 				{Name: "operation1", SpanKind: "kind"},
 				{Name: "operation2", SpanKind: "kind"},
 			},
+		},
+		{
+			name:               "empty",
+			operations:         []tracestore.Operation{},
+			expectedOperations: []*storage.Operation{},
 		},
 		{
 			name:        "error",

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 )
 
@@ -45,6 +46,57 @@ func TestServer_GetServices(t *testing.T) {
 			resp, err := server.GetServices(context.Background(), &storage.GetServicesRequest{})
 			if test.expectedErr == nil {
 				require.Equal(t, test.expectedServices, resp.Services)
+			} else {
+				require.ErrorIs(t, err, test.expectedErr)
+			}
+		})
+	}
+}
+
+func TestServer_GetOperations(t *testing.T) {
+	params := tracestore.OperationQueryParams{
+		ServiceName: "service",
+		SpanKind:    "kind",
+	}
+	req := &storage.GetOperationsRequest{
+		Service:  "service",
+		SpanKind: "kind",
+	}
+	tests := []struct {
+		name               string
+		operations         []tracestore.Operation
+		err                error
+		expectedOperations []*storage.Operation
+		expectedErr        error
+	}{
+		{
+			name: "success",
+			operations: []tracestore.Operation{
+				{Name: "operation1", SpanKind: "kind"},
+				{Name: "operation2", SpanKind: "kind"},
+			},
+			expectedOperations: []*storage.Operation{
+				{Name: "operation1", SpanKind: "kind"},
+				{Name: "operation2", SpanKind: "kind"},
+			},
+		},
+		{
+			name:        "error",
+			err:         assert.AnError,
+			expectedErr: assert.AnError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := new(tracestoremocks.Reader)
+			reader.On("GetOperations", mock.Anything, params).
+				Return(test.operations, test.err).Once()
+
+			server := NewHandler(reader)
+			resp, err := server.GetOperations(context.Background(), req)
+			if test.expectedErr == nil {
+				require.Equal(t, test.expectedOperations, resp.Operations)
 			} else {
 				require.ErrorIs(t, err, test.expectedErr)
 			}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6979

## Description of the changes
- Implement the `GetOperations` call in the gRPC v2 handler

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
