### PR TITLE
[grpc][v2] Implement `GetTraces` in gRPC v2 handler

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -40,8 +40,11 @@ func (h *Handler) GetTraces(
 ) error {
 	traceIDs := make([]tracestore.GetTraceParams, len(req.Query))
 	for i, query := range req.Query {
+		var sizedTraceID [16]byte
+		copy(sizedTraceID[:], query.TraceId)
+
 		traceIDs[i] = tracestore.GetTraceParams{
-			TraceID: pcommon.TraceID(query.TraceId),
+			TraceID: pcommon.TraceID(sizedTraceID),
 			Start:   query.StartTime,
 			End:     query.EndTime,
 		}

--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -6,8 +6,10 @@ package grpc
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
@@ -30,6 +32,32 @@ func NewHandler(traceReader tracestore.Reader) *Handler {
 	return &Handler{
 		traceReader: traceReader,
 	}
+}
+
+func (h *Handler) GetTraces(
+	req *storage.GetTracesRequest,
+	srv storage.TraceReader_GetTracesServer,
+) error {
+	traceIDs := make([]tracestore.GetTraceParams, len(req.Query))
+	for i, query := range req.Query {
+		traceIDs[i] = tracestore.GetTraceParams{
+			TraceID: pcommon.TraceID(query.TraceId),
+			Start:   query.StartTime,
+			End:     query.EndTime,
+		}
+	}
+	for traces, err := range h.traceReader.GetTraces(srv.Context(), traceIDs...) {
+		if err != nil {
+			return err
+		}
+		for _, trace := range traces {
+			td := jptrace.TracesData(trace)
+			if err = srv.Send(&td); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (h *Handler) GetServices(

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -5,18 +5,129 @@ package grpc
 
 import (
 	"context"
+	"iter"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 )
 
-func TestServer_GetServices(t *testing.T) {
+type testStream struct {
+	storage.TraceReader_GetTracesServer
+	sent    []*jptrace.TracesData
+	sendErr error
+}
+
+func (*testStream) Context() context.Context {
+	return context.Background()
+}
+
+func (f *testStream) Send(td *jptrace.TracesData) error {
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	f.sent = append(f.sent, td)
+	return nil
+}
+
+func TestHandler_GetTraces(t *testing.T) {
+	reader := new(tracestoremocks.Reader)
+	start := time.Now()
+	end := start.Add(time.Minute)
+	query := tracestore.GetTraceParams{
+		TraceID: pcommon.TraceID([16]byte{1}),
+		Start:   start,
+		End:     end,
+	}
+	trace := makeTestTrace()
+	td := jptrace.TracesData(trace)
+
+	tests := []struct {
+		name         string
+		traces       [][]ptrace.Traces
+		expectedSent []*jptrace.TracesData
+		sendErr      error
+		getTraceErr  error
+		expectedErr  error
+	}{
+		{
+			name:   "single trace",
+			traces: [][]ptrace.Traces{{trace}},
+			expectedSent: []*jptrace.TracesData{
+				&td,
+			},
+		},
+		{
+			name:         "multiple traces",
+			traces:       [][]ptrace.Traces{{trace, trace}},
+			expectedSent: []*jptrace.TracesData{&td, &td},
+		},
+		{
+			name:         "multiple chunks",
+			traces:       [][]ptrace.Traces{{trace, trace}, {trace, trace}},
+			expectedSent: []*jptrace.TracesData{&td, &td, &td, &td},
+		},
+		{
+			name:        "storage error",
+			getTraceErr: assert.AnError,
+			expectedErr: assert.AnError,
+		},
+		{
+			name:        "send error",
+			traces:      [][]ptrace.Traces{{trace, trace}},
+			sendErr:     assert.AnError,
+			expectedErr: assert.AnError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader.On("GetTraces", mock.Anything, query).
+				Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+					if test.getTraceErr != nil {
+						yield(nil, test.getTraceErr)
+						return
+					}
+					for _, traces := range test.traces {
+						if !yield(traces, nil) {
+							return
+						}
+					}
+				})).Once()
+
+			server := NewHandler(reader)
+			stream := &testStream{
+				sendErr: test.sendErr,
+			}
+			err := server.GetTraces(&storage.GetTracesRequest{
+				Query: []*storage.GetTraceParams{
+					{
+						TraceId:   []byte{1},
+						StartTime: start,
+						EndTime:   end,
+					},
+				},
+			}, stream)
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedSent, stream.sent)
+			}
+		})
+	}
+}
+
+func TestHandler_GetServices(t *testing.T) {
 	tests := []struct {
 		name             string
 		services         []string
@@ -50,6 +161,7 @@ func TestServer_GetServices(t *testing.T) {
 			server := NewHandler(reader)
 			resp, err := server.GetServices(context.Background(), &storage.GetServicesRequest{})
 			if test.expectedErr == nil {
+				require.NoError(t, err)
 				require.Equal(t, test.expectedServices, resp.Services)
 			} else {
 				require.ErrorIs(t, err, test.expectedErr)
@@ -58,7 +170,7 @@ func TestServer_GetServices(t *testing.T) {
 	}
 }
 
-func TestServer_GetOperations(t *testing.T) {
+func TestHandler_GetOperations(t *testing.T) {
 	params := tracestore.OperationQueryParams{
 		ServiceName: "service",
 		SpanKind:    "kind",
@@ -106,6 +218,7 @@ func TestServer_GetOperations(t *testing.T) {
 			server := NewHandler(reader)
 			resp, err := server.GetOperations(context.Background(), req)
 			if test.expectedErr == nil {
+				require.NoError(t, err)
 				require.Equal(t, test.expectedOperations, resp.Operations)
 			} else {
 				require.ErrorIs(t, err, test.expectedErr)


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6979

## Description of the changes
- Implement the `Traces` call in the gRPC v2 handler

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
