### PR TITLE
Remove outdated info related to jaeger exporter

### DIFF
--- a/cmd/tracegen/README.md
+++ b/cmd/tracegen/README.md
@@ -11,10 +11,9 @@ $ docker run jaegertracing/jaeger-tracegen -service abcd -traces 10
 
 The generator can be configured to export traces in different formats, via `-exporter` flag.
 By default, the exporters send data to `localhost`. If running in a container, this refers
-to the networking namespace of the container itself, so to export to another container
-(like Jaeger Collector), the exporters need to be provided with appropriate location.
-Exporters accept configuration via environment variables:
-  * Jaeger exporter: see https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/jaeger/README.md
-  * OTLP exporter: see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
+to the networking namespace of the container itself, so to export to another container,
+the exporters need to be provided with appropriate location.
+OTLP exporter accepts configuration via environment variables.
+For more information about configuring OTLP exporter, see [OpenTelemetry Protocol Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md).
 
 See example in the included [docker-compose](./docker-compose.yml) file.


### PR DESCRIPTION
Remove outdated info related to jaeger exporter from the tracegen readme

jaeger exporter is no longer supported, see https://github.com/jaegertracing/jaeger/pull/4717
