### PR TITLE
[bug] Fix the version module path in ldflags

### DIFF
--- a/scripts/makefiles/BuildInfo.mk
+++ b/scripts/makefiles/BuildInfo.mk
@@ -10,7 +10,7 @@ GIT_CLOSEST_TAG_V2 = $(eval GIT_CLOSEST_TAG_V2 := $(shell scripts/utils/compute-
 
 # args: (1) - name, (2) - value
 define buildinfo
-  $(JAEGER_IMPORT_PATH)/pkg/version.$(1)=$(2)
+  $(JAEGER_IMPORT_PATH)/internal/version.$(1)=$(2)
 endef
 # args (1) - V1|V2
 define buildinfoflags


### PR DESCRIPTION
I noticed that you have changed the version module path so we have to update the path in the ldflags too: https://github.com/jaegertracing/jaeger/blob/06840acda4e6ea5cec5afaa19356125595904231/CHANGELOG.md?plain=1#L86