### PR TITLE
#5608 Improve SPM e2e test with test for error rate

### DIFF
--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -124,7 +124,7 @@ validate_service_metrics() {
 
     non_zero_count=$(count_non_zero_metrics_point "$response")
     local services_with_error="driver frontend ui redis"
-    if [[ "$services_with_error" =~ "$service" ]]; then # the service is in the list
+    if [[ "$services_with_error" =~ $service ]]; then # the service is in the list
       if [[ $non_zero_count == "0" ]]; then
         echo "❌ ERROR: expect service $service to have positive errors rate"
         return 1
@@ -161,14 +161,15 @@ assert_labels_set_equals() {
     echo "❌ ERROR: Obtained labels: '$labels' are not same as expected labels: '$expected'"
     return 1
   fi
+  return 0
 }
 
 count_zero_metrics_point() {
-  echo "$(echo "$1" | jq -r '[.metrics[0].metricPoints[].gaugeValue.doubleValue | select(. == 0)] | length')"
+  echo "$1" | jq -r '[.metrics[0].metricPoints[].gaugeValue.doubleValue | select(. == 0)] | length'
 }
 
 count_non_zero_metrics_point() {
-  echo "$(echo "$1" | jq -r '[.metrics[0].metricPoints[].gaugeValue.doubleValue | select(. != 0)] | length')"
+  echo "$1" | jq -r '[.metrics[0].metricPoints[].gaugeValue.doubleValue | select(. != 0)] | length'
 }
 
 check_spm() {

--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -76,51 +76,76 @@ validate_service_metrics() {
     local fiveMinutes=300000
     local oneMinute=60000
     local fifteenSec=15000 # Prometheus is also configured to scrape every 15sec.
+
     # When endTs=(blank) the server will default it to now().
     local url="http://localhost:16686/api/metrics/calls?service=${service}&endTs=&lookback=${fiveMinutes}&step=${fifteenSec}&ratePer=${oneMinute}"
     response=$(curl -s "$url")
-    service_name=$(echo "$response" | jq -r 'if .metrics and .metrics[0] then .metrics[0].labels[] | select(.name=="service_name") | .value else empty end')
-    if [ "$service_name" != "$service" ]; then
-      echo "⏳ No metrics found for service '$service'"
+    if ! assert_service_name_equals "$response" "$service" ; then
       return 1
     fi
-    # Store the values in an array
-    mapfile -t metric_points < <(echo "$response" | jq -r '.metrics[0].metricPoints[].gaugeValue.doubleValue')
-    echo "Metric datapoints found for service '$service': " "${metric_points[@]}"
-    # Check that atleast some values are non-zero after the threshold
-    local non_zero_count=0
-    local expected_non_zero_count=4
-    local zero_count=0
-    local expected_max_zero_count=4
-    for value in "${metric_points[@]}"; do
-      if [[ $(echo "$value > 0.0" | bc) == "1" ]]; then
-        non_zero_count=$((non_zero_count + 1))
-      else
-        zero_count=$((zero_count + 1))
-      fi
 
-      if [[ $zero_count -gt $expected_max_zero_count ]]; then
-        echo "❌ ERROR: Zero values crossing threshold limit not expected (Threshold limit - '$expected_max_zero_count')"
-        return 1
-      fi
-    done
-    if [ $non_zero_count -lt $expected_non_zero_count ]; then
+    # Check that at least some values are non-zero after the threshold
+    local non_zero_count
+    non_zero_count=$(echo "$response" | jq -r '[.metrics[0].metricPoints[].gaugeValue.doubleValue | select(. != 0)] | length')
+    local expected_non_zero_count=4
+    local zero_count
+    zero_count=$(echo "$response" | jq -r '[.metrics[0].metricPoints[].gaugeValue.doubleValue | select(. == 0)] | length')
+    local expected_max_zero_count=4
+    echo "⏳ Metrics data points found: ${zero_count} zero, ${non_zero_count} non-zero"
+
+    if [[ $zero_count -gt $expected_max_zero_count ]]; then
+      echo "❌ ERROR: Zero values crossing threshold limit not expected (Threshold limit - '$expected_max_zero_count')"
+      return 1
+    fi
+    if [[ $non_zero_count -lt $expected_non_zero_count ]]; then
       echo "⏳ Expecting at least 4 non-zero data points"
       return 1
     fi
 
      # Validate if labels are correct
     local url="http://localhost:16686/api/metrics/calls?service=${service}&groupByOperation=true&endTs=&lookback=${fiveMinutes}&step=${fifteenSec}&ratePer=${oneMinute}"
-
-    local labels
-    labels=$(curl -s "$url" | jq -r '.metrics[0].labels[].name' | sort | tr '\n' ' ')
-    local exp_labels="operation service_name "
-
-    if [[ "$labels" != "$exp_labels" ]]; then
-      echo "❌ ERROR: Obtained labels: '$labels' are not same as expected labels: '$exp_labels'"
+    response=$(curl -s "$url")
+    if ! assert_labels_set_equals "$response" "operation service_name" ; then
       return 1
     fi
+
+    ### Validate Errors Rate metrics
+    local url="http://localhost:16686/api/metrics/errors?service=${service}&endTs=&lookback=${fiveMinutes}&step=${fifteenSec}&ratePer=${oneMinute}"
+    response=$(curl -s "$url")
+    if ! assert_service_name_equals "$response" "$service" ; then
+      return 1
+    fi
+
+    local url="http://localhost:16686/api/metrics/calls?service=${service}&groupByOperation=true&endTs=&lookback=${fiveMinutes}&step=${fifteenSec}&ratePer=${oneMinute}"
+    response=$(curl -s "$url")
+    if ! assert_labels_set_equals "$response" "operation service_name" ; then
+      return 1
+    fi
+
     return 0
+}
+
+assert_service_name_equals() {
+  local response=$1
+  local expected=$2
+  service_name=$(echo "$response" | jq -r 'if .metrics and .metrics[0] then .metrics[0].labels[] | select(.name=="service_name") | .value else empty end')
+  if [[ "$service_name" != "$expected" ]]; then
+    echo "❌ ERROR: Obtained service_name: '$service_name' are not same as expected: '$expected'"
+    return 1
+  fi
+  return 0
+}
+
+assert_labels_set_equals() {
+  local response=$1
+  local expected="$2 " # need one extra space due to how labels is computed
+
+  labels=$(echo "$response" | jq -r '.metrics[0].labels[].name' | sort | tr '\n' ' ')
+
+  if [[ "$labels" != "$expected" ]]; then
+    echo "❌ ERROR: Obtained labels: '$labels' are not same as expected labels: '$expected'"
+    return 1
+  fi
 }
 
 check_spm() {


### PR DESCRIPTION
## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger/issues/5608

## Description of the changes
- Add smoke test for /metrics/errors
  - validate correct service name
  - validate correct labels (case groupByOperation=true)

## How was this change tested?
- run `scripts/e2e/spm.sh` locally

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
