### PR TITLE
[grpc][v2] Implement `FindTraces` in gRPC v2 handler

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -98,3 +98,78 @@ func (h *Handler) GetOperations(
 		Operations: grpcOperations,
 	}, nil
 }
+
+func convertKeyValueListToMap(kvList []*storage.KeyValue) pcommon.Map {
+	m := pcommon.NewMap()
+	for _, kv := range kvList {
+		if kv == nil || kv.Value == nil {
+			continue
+		}
+		setValueToMap(m, kv.Key, kv.Value)
+	}
+	return m
+}
+
+func setValueToMap(m pcommon.Map, key string, av *storage.AnyValue) {
+	switch v := av.Value.(type) {
+	case *storage.AnyValue_StringValue:
+		m.PutStr(key, v.StringValue)
+	case *storage.AnyValue_BoolValue:
+		m.PutBool(key, v.BoolValue)
+	case *storage.AnyValue_IntValue:
+		m.PutInt(key, v.IntValue)
+	case *storage.AnyValue_DoubleValue:
+		m.PutDouble(key, v.DoubleValue)
+	case *storage.AnyValue_BytesValue:
+		m.PutEmptyBytes(key).FromRaw(v.BytesValue)
+	case *storage.AnyValue_ArrayValue:
+		sliceVal := m.PutEmptySlice(key)
+		for _, elem := range v.ArrayValue.Values {
+			if elem == nil {
+				sliceVal.AppendEmpty()
+				continue
+			}
+			setValueToSlice(sliceVal, elem)
+		}
+	case *storage.AnyValue_KvlistValue:
+		mapVal := m.PutEmptyMap(key)
+		for _, kv := range v.KvlistValue.Values {
+			if kv == nil || kv.Value == nil {
+				continue
+			}
+			setValueToMap(mapVal, kv.Key, kv.Value)
+		}
+	}
+}
+
+func setValueToSlice(slice pcommon.Slice, av *storage.AnyValue) {
+	switch v := av.Value.(type) {
+	case *storage.AnyValue_StringValue:
+		slice.AppendEmpty().SetStr(v.StringValue)
+	case *storage.AnyValue_BoolValue:
+		slice.AppendEmpty().SetBool(v.BoolValue)
+	case *storage.AnyValue_IntValue:
+		slice.AppendEmpty().SetInt(v.IntValue)
+	case *storage.AnyValue_DoubleValue:
+		slice.AppendEmpty().SetDouble(v.DoubleValue)
+	case *storage.AnyValue_BytesValue:
+		slice.AppendEmpty().SetEmptyBytes().FromRaw(v.BytesValue)
+	case *storage.AnyValue_ArrayValue:
+		newSlice := slice.AppendEmpty().SetEmptySlice()
+		for _, subElem := range v.ArrayValue.Values {
+			if subElem == nil {
+				newSlice.AppendEmpty()
+				continue
+			}
+			setValueToSlice(newSlice, subElem)
+		}
+	case *storage.AnyValue_KvlistValue:
+		newMap := slice.AppendEmpty().SetEmptyMap()
+		for _, kv := range v.KvlistValue.Values {
+			if kv == nil || kv.Value == nil {
+				continue
+			}
+			setValueToMap(newMap, kv.Key, kv.Value)
+		}
+	}
+}

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -494,6 +494,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 													{
 														Value: &storage.AnyValue_StringValue{StringValue: "inner1"},
 													},
+													nil,
 												},
 											},
 										},
@@ -510,7 +511,8 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				slice := m.PutEmptySlice("key1")
 				nestedSlice := slice.AppendEmpty().SetEmptySlice()
 				nestedSlice.AppendEmpty().SetStr("inner1")
-				slice.AppendEmpty() // for the nil entry
+				nestedSlice.AppendEmpty() // for the nil entry
+				slice.AppendEmpty()       // for the nil entry
 				return m
 			}(),
 		},

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -251,10 +251,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 					Value: nil,
 				},
 			},
-			expected: func() pcommon.Map {
-				m := pcommon.NewMap()
-				return m
-			}(),
+			expected: pcommon.NewMap(),
 		},
 		{
 			name: "primitive types",

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -315,6 +315,10 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 											Value: &storage.AnyValue_StringValue{StringValue: "nestedValue"},
 										},
 									},
+									{
+										Key:   "nilValueKey",
+										Value: nil, // should be skipped
+									},
 								},
 							},
 						},
@@ -343,6 +347,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 									{
 										Value: &storage.AnyValue_IntValue{IntValue: 42},
 									},
+									nil,
 								},
 							},
 						},
@@ -354,6 +359,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				slice := m.PutEmptySlice("key1")
 				slice.AppendEmpty().SetStr("value1")
 				slice.AppendEmpty().SetInt(42)
+				slice.AppendEmpty() // for the nil entry
 				return m
 			}(),
 		},

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"google.golang.org/grpc"
 
 	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
@@ -22,7 +23,7 @@ import (
 )
 
 type testStream struct {
-	storage.TraceReader_GetTracesServer
+	grpc.ServerStream
 	sent    []*jptrace.TracesData
 	sendErr error
 }

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -430,6 +430,9 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 										Value: &storage.AnyValue_IntValue{IntValue: 42},
 									},
 									{
+										Value: &storage.AnyValue_DoubleValue{DoubleValue: 3.14},
+									},
+									{
 										Value: &storage.AnyValue_BoolValue{BoolValue: true},
 									},
 									{
@@ -466,6 +469,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				slice := m.PutEmptySlice("key1")
 				slice.AppendEmpty().SetStr("value1")
 				slice.AppendEmpty().SetInt(42)
+				slice.AppendEmpty().SetDouble(3.14)
 				slice.AppendEmpty().SetBool(true)
 				slice.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2})
 				nested := slice.AppendEmpty().SetEmptyMap()

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -414,7 +414,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 			}(),
 		},
 		{
-			name: "array attribute",
+			name: "array",
 			input: []*storage.KeyValue{
 				{
 					Key: "key1",
@@ -428,6 +428,23 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 									{
 										Value: &storage.AnyValue_IntValue{IntValue: 42},
 									},
+									{
+										Value: &storage.AnyValue_BoolValue{BoolValue: true},
+									},
+									{
+										Value: &storage.AnyValue_KvlistValue{
+											KvlistValue: &storage.KeyValueList{
+												Values: []*storage.KeyValue{
+													{
+														Key: "nestedKey",
+														Value: &storage.AnyValue{
+															Value: &storage.AnyValue_StringValue{StringValue: "nestedValue"},
+														},
+													},
+												},
+											},
+										},
+									},
 									nil,
 								},
 							},
@@ -440,6 +457,9 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				slice := m.PutEmptySlice("key1")
 				slice.AppendEmpty().SetStr("value1")
 				slice.AppendEmpty().SetInt(42)
+				slice.AppendEmpty().SetBool(true)
+				nested := slice.AppendEmpty().SetEmptyMap()
+				nested.PutStr("nestedKey", "nestedValue")
 				slice.AppendEmpty() // for the nil entry
 				return m
 			}(),

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -441,6 +441,11 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 															Value: &storage.AnyValue_StringValue{StringValue: "nestedValue"},
 														},
 													},
+													{
+														Key:   "nilValueKey",
+														Value: nil, // should be skipped
+													},
+													nil, // should be skipped
 												},
 											},
 										},
@@ -461,6 +466,40 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				nested := slice.AppendEmpty().SetEmptyMap()
 				nested.PutStr("nestedKey", "nestedValue")
 				slice.AppendEmpty() // for the nil entry
+				return m
+			}(),
+		},
+		{
+			name: "nested array",
+			input: []*storage.KeyValue{
+				{
+					Key: "key1",
+					Value: &storage.AnyValue{
+						Value: &storage.AnyValue_ArrayValue{
+							ArrayValue: &storage.ArrayValue{
+								Values: []*storage.AnyValue{
+									{
+										Value: &storage.AnyValue_ArrayValue{
+											ArrayValue: &storage.ArrayValue{
+												Values: []*storage.AnyValue{
+													{
+														Value: &storage.AnyValue_StringValue{StringValue: "inner1"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: func() pcommon.Map {
+				m := pcommon.NewMap()
+				slice := m.PutEmptySlice("key1")
+				nestedSlice := slice.AppendEmpty().SetEmptySlice()
+				nestedSlice.AppendEmpty().SetStr("inner1")
 				return m
 			}(),
 		},

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -433,6 +433,9 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 										Value: &storage.AnyValue_BoolValue{BoolValue: true},
 									},
 									{
+										Value: &storage.AnyValue_BytesValue{BytesValue: []byte{1, 2}},
+									},
+									{
 										Value: &storage.AnyValue_KvlistValue{
 											KvlistValue: &storage.KeyValueList{
 												Values: []*storage.KeyValue{
@@ -464,6 +467,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				slice.AppendEmpty().SetStr("value1")
 				slice.AppendEmpty().SetInt(42)
 				slice.AppendEmpty().SetBool(true)
+				slice.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2})
 				nested := slice.AppendEmpty().SetEmptyMap()
 				nested.PutStr("nestedKey", "nestedValue")
 				slice.AppendEmpty() // for the nil entry
@@ -490,6 +494,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 											},
 										},
 									},
+									nil,
 								},
 							},
 						},
@@ -501,6 +506,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				slice := m.PutEmptySlice("key1")
 				nestedSlice := slice.AppendEmpty().SetEmptySlice()
 				nestedSlice.AppendEmpty().SetStr("inner1")
+				nestedSlice.AppendEmpty() // for the nil entry
 				return m
 			}(),
 		},

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -405,6 +405,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 						},
 					},
 				},
+				nil, // should be skipped
 			},
 			expected: func() pcommon.Map {
 				m := pcommon.NewMap()

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -506,7 +506,7 @@ func TestConvertKeyValueListToMap(t *testing.T) {
 				slice := m.PutEmptySlice("key1")
 				nestedSlice := slice.AppendEmpty().SetEmptySlice()
 				nestedSlice.AppendEmpty().SetStr("inner1")
-				nestedSlice.AppendEmpty() // for the nil entry
+				slice.AppendEmpty() // for the nil entry
 				return m
 			}(),
 		},


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6979

## Description of the changes
- Implement the `FindTraces` call in the gRPC v2 handler

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
