### PR TITLE
[ES][v2] Change the DB Tag value from `string` to `any` type

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
@@ -42,7 +42,7 @@
     {
       "key": "peer.ipv4",
       "type": "int64",
-      "value": 23456
+      "value": "23456"
     },
     {
       "key": "blob",
@@ -52,12 +52,12 @@
     {
       "key": "temperature",
       "type": "float64",
-      "value": 72.5
+      "value": "72.5"
     },
     {
       "key": "error",
       "type": "bool",
-      "value": true
+      "value": "true"
     }
   ],
   "logs": [

--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
@@ -216,6 +216,17 @@ func TestSetAttributesFromDbTags(t *testing.T) {
 			},
 		},
 		{
+			name: "wrong non string int input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "bool-val",
+				Type:  dbmodel.BoolType,
+				Value: 12,
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutStr("bool-val", "invalid bool type in 12")
+			},
+		},
+		{
 			name: "wrong int input value",
 			keyModel: dbmodel.KeyValue{
 				Key:   "int-val",
@@ -235,6 +246,50 @@ func TestSetAttributesFromDbTags(t *testing.T) {
 			},
 			expectedValueFn: func(p pcommon.Map) {
 				p.PutInt("int-val", 123)
+			},
+		},
+		{
+			name: "right non string int input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "int-val",
+				Type:  dbmodel.Int64Type,
+				Value: int64(123),
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutInt("int-val", 123)
+			},
+		},
+		{
+			name: "right non string int float input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "int-val",
+				Type:  dbmodel.Int64Type,
+				Value: float64(123),
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutInt("int-val", 123)
+			},
+		},
+		{
+			name: "right non string json number int input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "int-val",
+				Type:  dbmodel.Int64Type,
+				Value: json.Number("123"),
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutInt("int-val", 123)
+			},
+		},
+		{
+			name: "wrong non string int input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "int-val",
+				Type:  dbmodel.Int64Type,
+				Value: true,
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutStr("int-val", "invalid int64 type in true")
 			},
 		},
 		{
@@ -260,6 +315,39 @@ func TestSetAttributesFromDbTags(t *testing.T) {
 			},
 		},
 		{
+			name: "right non string double input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "double-val",
+				Type:  dbmodel.Float64Type,
+				Value: 25.6,
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutDouble("double-val", 25.6)
+			},
+		},
+		{
+			name: "right non string json number double input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "double-val",
+				Type:  dbmodel.Float64Type,
+				Value: json.Number("123.56"),
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutDouble("double-val", 123.56)
+			},
+		},
+		{
+			name: "wrong non string float input value",
+			keyModel: dbmodel.KeyValue{
+				Key:   "double-val",
+				Type:  dbmodel.Float64Type,
+				Value: true,
+			},
+			expectedValueFn: func(p pcommon.Map) {
+				p.PutStr("double-val", "invalid float64 type in true")
+			},
+		},
+		{
 			name: "wrong binary input value",
 			keyModel: dbmodel.KeyValue{
 				Key:   "binary-val",
@@ -282,14 +370,14 @@ func TestSetAttributesFromDbTags(t *testing.T) {
 			},
 		},
 		{
-			name: "non-string input value",
+			name: "non-string input value with string type",
 			keyModel: dbmodel.KeyValue{
 				Key:   "bool-val",
-				Type:  dbmodel.Int64Type,
+				Type:  dbmodel.StringType,
 				Value: 123,
 			},
 			expectedValueFn: func(p pcommon.Map) {
-				p.PutStr("bool-val", "Got non string inputValue for the key bool-val")
+				p.PutStr("bool-val", "invalid string type in 123")
 			},
 		},
 		{
@@ -549,6 +637,17 @@ func TestFromDbModel_Fixtures(t *testing.T) {
 	actualTd, err := FromDBModel(spans)
 	require.NoError(t, err)
 	testTraces(t, tracesData, actualTd)
+}
+
+func TestToDbModel_Fixtures_StringTags(t *testing.T) {
+	spanData, err := os.ReadFile("fixtures/es_01_string_tags.json")
+	require.NoError(t, err)
+	var dbSpan dbmodel.Span
+	require.NoError(t, json.Unmarshal(spanData, &dbSpan))
+	td, err := FromDBModel([]dbmodel.Span{dbSpan})
+	require.NoError(t, err)
+	expectedTraces := loadTraces(t, 1)
+	testTraces(t, expectedTraces, td)
 }
 
 func getDbTraceIdFromByteArray(arr [16]byte) dbmodel.TraceID {

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -100,11 +100,13 @@ func appendTagsFromAttributes(dest []dbmodel.KeyValue, attrs pcommon.Map) []dbmo
 
 func attributeToDbTag(key string, attr pcommon.Value) dbmodel.KeyValue {
 	var tag dbmodel.KeyValue
-	if attr.Type() == pcommon.ValueTypeBytes {
+	switch attr.Type() {
+	case pcommon.ValueTypeBytes:
 		tag = dbmodel.KeyValue{Key: key, Value: hex.EncodeToString(attr.Bytes().AsRaw())}
-	} else {
-		// TODO why are all values being converted to strings?
+	case pcommon.ValueTypeMap:
 		tag = dbmodel.KeyValue{Key: key, Value: attr.AsString()}
+	default:
+		tag = dbmodel.KeyValue{Key: key, Value: attr.AsRaw()}
 	}
 	switch attr.Type() {
 	case pcommon.ValueTypeStr:
@@ -294,7 +296,7 @@ func getTagFromStatusCode(statusCode ptrace.StatusCode) (dbmodel.KeyValue, bool)
 		return dbmodel.KeyValue{
 			Key:   tagError,
 			Type:  dbmodel.BoolType,
-			Value: "true",
+			Value: true,
 		}, true
 	} else if statusCode == ptrace.StatusCodeOk {
 		return dbmodel.KeyValue{

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel_test.go
@@ -45,7 +45,7 @@ func TestGetTagFromStatusCode(t *testing.T) {
 			tag: dbmodel.KeyValue{
 				Key:   tagError,
 				Type:  dbmodel.BoolType,
-				Value: "true",
+				Value: true,
 			},
 		},
 	}
@@ -220,12 +220,12 @@ func TestAttributesToDbSpanTags(t *testing.T) {
 		{
 			Key:   "bool-val",
 			Type:  dbmodel.BoolType,
-			Value: "true",
+			Value: true,
 		},
 		{
 			Key:   "int-val",
 			Type:  dbmodel.Int64Type,
-			Value: "123",
+			Value: int64(123),
 		},
 		{
 			Key:   "string-val",
@@ -235,7 +235,7 @@ func TestAttributesToDbSpanTags(t *testing.T) {
 		{
 			Key:   "double-val",
 			Type:  dbmodel.Float64Type,
-			Value: "1.23",
+			Value: 1.23,
 		},
 		{
 			Key:   "bytes-val",
@@ -292,14 +292,23 @@ func writeActualData(t *testing.T, name string, data []byte) {
 
 // Loads and returns domain model and JSON model fixtures with given number i.
 func loadFixtures(t *testing.T, i int) (tracesData []byte, spansData []byte) {
-	var err error
-	inTraces := fmt.Sprintf("fixtures/otel_traces_%02d.json", i)
-	tracesData, err = os.ReadFile(inTraces)
-	require.NoError(t, err)
-	inSpans := fmt.Sprintf("fixtures/es_%02d.json", i)
-	spansData, err = os.ReadFile(inSpans)
-	require.NoError(t, err)
+	tracesData = loadTraces(t, i)
+	spansData = loadSpans(t, i)
 	return tracesData, spansData
+}
+
+func loadTraces(t *testing.T, i int) []byte {
+	inTraces := fmt.Sprintf("fixtures/otel_traces_%02d.json", i)
+	tracesData, err := os.ReadFile(inTraces)
+	require.NoError(t, err)
+	return tracesData
+}
+
+func loadSpans(t *testing.T, i int) []byte {
+	inSpans := fmt.Sprintf("fixtures/es_%02d.json", i)
+	spansData, err := os.ReadFile(inSpans)
+	require.NoError(t, err)
+	return spansData
 }
 
 func testTraces(t *testing.T, expectedTraces []byte, actualTraces ptrace.Traces) {


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a part of: #6458 

## Description of the changes
- As discussed in #6946 we need to change the value which was saved as string in v1 to a raw value in v2

## How was this change tested?
- Unit Tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
