### PR TITLE
[grpc][v2] Implement FindTraceIDs in gRPC v2 handler 

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -131,18 +131,8 @@ func (h *Handler) FindTraceIDs(
 	ctx context.Context,
 	req *storage.FindTracesRequest,
 ) (*storage.FindTraceIDsResponse, error) {
-	query := tracestore.TraceQueryParams{
-		ServiceName:   req.Query.ServiceName,
-		OperationName: req.Query.OperationName,
-		Attributes:    convertKeyValueListToMap(req.Query.Attributes),
-		StartTimeMin:  req.Query.StartTimeMin,
-		StartTimeMax:  req.Query.StartTimeMax,
-		DurationMin:   req.Query.DurationMin,
-		DurationMax:   req.Query.DurationMax,
-		SearchDepth:   int(req.Query.SearchDepth),
-	}
 	foundTraceIDs := []*storage.FoundTraceID{}
-	for traceIDs, err := range h.traceReader.FindTraceIDs(ctx, query) {
+	for traceIDs, err := range h.traceReader.FindTraceIDs(ctx, toTraceQueryParams(req.Query)) {
 		if err != nil {
 			return nil, err
 		}
@@ -157,6 +147,19 @@ func (h *Handler) FindTraceIDs(
 	return &storage.FindTraceIDsResponse{
 		TraceIds: foundTraceIDs,
 	}, nil
+}
+
+func toTraceQueryParams(t *storage.TraceQueryParameters) tracestore.TraceQueryParams {
+	return tracestore.TraceQueryParams{
+		ServiceName:   t.ServiceName,
+		OperationName: t.OperationName,
+		Attributes:    convertKeyValueListToMap(t.Attributes),
+		StartTimeMin:  t.StartTimeMin,
+		StartTimeMax:  t.StartTimeMax,
+		DurationMin:   t.DurationMin,
+		DurationMax:   t.DurationMax,
+		SearchDepth:   int(t.SearchDepth),
+	}
 }
 
 func convertKeyValueListToMap(kvList []*storage.KeyValue) pcommon.Map {

--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -141,7 +141,7 @@ func (h *Handler) FindTraceIDs(
 		DurationMax:   req.Query.DurationMax,
 		SearchDepth:   int(req.Query.SearchDepth),
 	}
-	var foundTraceIDs []*storage.FoundTraceID
+	foundTraceIDs := []*storage.FoundTraceID{}
 	for traceIDs, err := range h.traceReader.FindTraceIDs(ctx, query) {
 		if err != nil {
 			return nil, err

--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -103,17 +103,7 @@ func (h *Handler) FindTraces(
 	req *storage.FindTracesRequest,
 	srv storage.TraceReader_FindTracesServer,
 ) error {
-	query := tracestore.TraceQueryParams{
-		ServiceName:   req.Query.ServiceName,
-		OperationName: req.Query.OperationName,
-		Attributes:    convertKeyValueListToMap(req.Query.Attributes),
-		StartTimeMin:  req.Query.StartTimeMin,
-		StartTimeMax:  req.Query.StartTimeMax,
-		DurationMin:   req.Query.DurationMin,
-		DurationMax:   req.Query.DurationMax,
-		SearchDepth:   int(req.Query.SearchDepth),
-	}
-	for traces, err := range h.traceReader.FindTraces(srv.Context(), query) {
+	for traces, err := range h.traceReader.FindTraces(srv.Context(), toTraceQueryParams(req.Query)) {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6979

## Description of the changes
- Implement the `FindTraceIDs` call in the gRPC v2 handler

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
