### PR TITLE
[grpc][v2] Implement OTLP exporter API in gRPC v2 handler

### DIFF
--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
 
 	"github.com/jaegertracing/jaeger/internal/jptrace"
@@ -391,6 +392,39 @@ func TestHandler_FindTraceIDs(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, test.expectedTraceIDs, response.TraceIds)
 		}
+	}
+}
+
+func TestHandler_Export(t *testing.T) {
+	tests := []struct {
+		name           string
+		writeTracesErr error
+		expectedErr    error
+	}{
+		{
+			name: "success",
+		},
+		{
+			name:           "write error",
+			expectedErr:    assert.AnError,
+			writeTracesErr: assert.AnError,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := new(tracestoremocks.Reader)
+			writer := new(tracestoremocks.Writer)
+			writer.On("WriteTraces", mock.Anything, makeTestTrace()).Return(test.writeTracesErr).Once()
+			server := NewHandler(reader, writer)
+
+			response, err := server.Export(context.Background(), ptraceotlp.NewExportRequestFromTraces(makeTestTrace()))
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, ptraceotlp.NewExportResponse(), response)
+		})
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6979

## Description of the changes
- Implement the `Export` (from OTEL's Exporter API) call in the gRPC v2 handler

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
