### PR TITLE
[refactor] Consolidate v1/v2 reader factory adapter functionality 

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -185,11 +185,7 @@ func getV1Adapters(
 	reader tracestore.Reader,
 	writer tracestore.Writer,
 ) (spanstore.Reader, spanstore.Writer) {
-	v1Reader, ok := v1adapter.GetV1Reader(reader)
-	if !ok {
-		v1Reader = v1adapter.NewSpanReader(reader)
-	}
-
+	v1Reader := v1adapter.GetV1Reader(reader)
 	v1Writer, ok := v1adapter.GetV1Writer(writer)
 	if !ok {
 		v1Writer = v1adapter.NewSpanWriter(writer)

--- a/cmd/jaeger/internal/extension/jaegerquery/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server_test.go
@@ -356,7 +356,7 @@ func TestGetV1Adapters(t *testing.T) {
 			name:           "native tracestore.Reader and tracestore.Writer",
 			reader:         &tracestoremocks.Reader{},
 			writer:         &tracestoremocks.Writer{},
-			expectedReader: v1adapter.NewSpanReader(&tracestoremocks.Reader{}),
+			expectedReader: &v1adapter.SpanReader{},
 			expectedWriter: v1adapter.NewSpanWriter(&tracestoremocks.Writer{}),
 		},
 		{
@@ -371,7 +371,7 @@ func TestGetV1Adapters(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			gotReader, gotWriter := getV1Adapters(test.reader, test.writer)
-			require.Equal(t, test.expectedReader, gotReader)
+			require.IsType(t, test.expectedReader, gotReader)
 			require.Equal(t, test.expectedWriter, gotWriter)
 		})
 	}

--- a/cmd/query/app/querysvc/query_service.go
+++ b/cmd/query/app/querysvc/query_service.go
@@ -55,12 +55,7 @@ type TraceQueryParameters struct {
 
 // NewQueryService returns a new QueryService.
 func NewQueryService(traceReader tracestore.Reader, dependencyReader depstore.Reader, options QueryServiceOptions) *QueryService {
-	spanReader, ok := v1adapter.GetV1Reader(traceReader)
-	if !ok {
-		// if the spanstore.Reader is not available, downgrade the native tracestore.Reader to
-		// a spanstore.Reader
-		spanReader = v1adapter.NewSpanReader(traceReader)
-	}
+	spanReader := v1adapter.GetV1Reader(traceReader)
 	qsvc := &QueryService{
 		spanReader:       spanReader,
 		dependencyReader: dependencyReader,

--- a/internal/storage/v2/v1adapter/spanreader.go
+++ b/internal/storage/v2/v1adapter/spanreader.go
@@ -23,12 +23,6 @@ type SpanReader struct {
 	traceReader tracestore.Reader
 }
 
-func NewSpanReader(traceReader tracestore.Reader) *SpanReader {
-	return &SpanReader{
-		traceReader: traceReader,
-	}
-}
-
 func (sr *SpanReader) GetTrace(ctx context.Context, query spanstore.GetTraceParameters) (*model.Trace, error) {
 	getTracesIter := sr.traceReader.GetTraces(ctx, tracestore.GetTraceParams{
 		TraceID: FromV1TraceID(query.TraceID),

--- a/internal/storage/v2/v1adapter/spanreader_test.go
+++ b/internal/storage/v2/v1adapter/spanreader_test.go
@@ -122,7 +122,9 @@ func TestSpanReader_GetTrace(t *testing.T) {
 				yield(test.traces, test.err)
 			})).Once()
 
-		sr := NewSpanReader(&tr)
+		sr := SpanReader{
+			traceReader: &tr,
+		}
 		trace, err := sr.GetTrace(context.Background(), test.query)
 		require.ErrorIs(t, err, test.expectedErr)
 		require.Equal(t, test.expectedTrace, trace)
@@ -159,7 +161,9 @@ func TestSpanReader_GetServices(t *testing.T) {
 		tr.On("GetServices", mock.Anything).
 			Return(test.services, test.err).Once()
 
-		sr := NewSpanReader(&tr)
+		sr := SpanReader{
+			traceReader: &tr,
+		}
 		services, err := sr.GetServices(context.Background())
 		require.ErrorIs(t, err, test.expectedErr)
 		require.Equal(t, test.expectedServices, services)
@@ -222,7 +226,9 @@ func TestSpanReader_GetOperations(t *testing.T) {
 		tr.On("GetOperations", mock.Anything, test.expectedQuery).
 			Return(test.operations, test.err).Once()
 
-		sr := NewSpanReader(&tr)
+		sr := SpanReader{
+			traceReader: &tr,
+		}
 		ops, err := sr.GetOperations(context.Background(), test.query)
 		require.ErrorIs(t, err, test.expectedErr)
 		require.Equal(t, test.expectedOperations, ops)
@@ -333,7 +339,9 @@ func TestSpanReader_FindTraces(t *testing.T) {
 				yield(test.traces, test.err)
 			})).Once()
 
-		sr := NewSpanReader(&tr)
+		sr := SpanReader{
+			traceReader: &tr,
+		}
 		traces, err := sr.FindTraces(context.Background(), test.query)
 		require.ErrorIs(t, err, test.expectedErr)
 		require.Equal(t, test.expectedTraces, traces)
@@ -405,7 +413,9 @@ func TestSpanReader_FindTraceIDs(t *testing.T) {
 				yield(test.traceIDs, test.err)
 			})).Once()
 
-		sr := NewSpanReader(&tr)
+		sr := SpanReader{
+			traceReader: &tr,
+		}
 		traceIDs, err := sr.FindTraceIDs(context.Background(), test.query)
 		require.ErrorIs(t, err, test.expectedErr)
 		require.Equal(t, test.expectedTraceIDs, traceIDs)

--- a/internal/storage/v2/v1adapter/tracereader.go
+++ b/internal/storage/v2/v1adapter/tracereader.go
@@ -23,11 +23,13 @@ type TraceReader struct {
 	spanReader spanstore.Reader
 }
 
-func GetV1Reader(reader tracestore.Reader) (spanstore.Reader, bool) {
+func GetV1Reader(reader tracestore.Reader) spanstore.Reader {
 	if tr, ok := reader.(*TraceReader); ok {
-		return tr.spanReader, ok
+		return tr.spanReader
 	}
-	return nil, false
+	return &SpanReader{
+		traceReader: reader,
+	}
 }
 
 func NewTraceReader(spanReader spanstore.Reader) *TraceReader {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6979

## Description of the changes
- This PR consolidates the v1/v2 reader adapter functionality by combining `GetV1Reader` with `NewSpanReader`

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
