### PR TITLE
[ES][v2] Implement `GetOperations` and `GetServices` for v2

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/reader.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"context"
+	"iter"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/dbmodel"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch/spanstore"
+	v2api "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+// TraceReader is a wrapper around spanstore.CoreSpanReader which return the output parallel to OTLP Models
+type TraceReader struct {
+	spanReader spanstore.CoreSpanReader
+}
+
+// NewTraceReader returns an instance of TraceReader
+func NewTraceReader(p spanstore.SpanReaderParams) *TraceReader {
+	return &TraceReader{
+		spanReader: spanstore.NewSpanReader(p),
+	}
+}
+
+func (*TraceReader) GetTraces(_ context.Context, _ ...v2api.GetTraceParams) iter.Seq2[[]ptrace.Traces, error] {
+	panic("not implemented")
+}
+
+func (t *TraceReader) GetServices(ctx context.Context) ([]string, error) {
+	return t.spanReader.GetServices(ctx)
+}
+
+func (t *TraceReader) GetOperations(ctx context.Context, query v2api.OperationQueryParams) ([]v2api.Operation, error) {
+	dbOperations, err := t.spanReader.GetOperations(ctx, dbmodel.OperationQueryParameters{
+		ServiceName: query.ServiceName,
+		SpanKind:    query.SpanKind,
+	})
+	if err != nil {
+		return nil, err
+	}
+	operations := make([]v2api.Operation, 0, len(dbOperations))
+	for _, op := range dbOperations {
+		operations = append(operations, v2api.Operation{
+			Name:     op.Name,
+			SpanKind: op.SpanKind,
+		})
+	}
+	return operations, nil
+}
+
+func (*TraceReader) FindTraces(_ context.Context, _ v2api.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+	panic("not implemented")
+}
+
+func (*TraceReader) FindTraceIDs(_ context.Context, _ v2api.TraceQueryParams) iter.Seq2[[]v2api.FoundTraceID, error] {
+	panic("not implemented")
+}

--- a/internal/storage/v2/elasticsearch/tracestore/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/reader_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/dbmodel"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch/spanstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch/spanstore/mocks"
+	v2api "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+func TestTraceReader_GetServices(t *testing.T) {
+	coreReader := &mocks.CoreSpanReader{}
+	reader := TraceReader{spanReader: coreReader}
+	services := []string{"service1", "service2"}
+	coreReader.On("GetServices", mock.Anything).Return(services, nil)
+	actual, err := reader.GetServices(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, services, actual)
+}
+
+func TestTraceReader_GetOperations(t *testing.T) {
+	coreReader := &mocks.CoreSpanReader{}
+	reader := TraceReader{spanReader: coreReader}
+	operations := []dbmodel.Operation{
+		{
+			Name:     "op-1",
+			SpanKind: "kind--1",
+		},
+		{
+			Name:     "op-2",
+			SpanKind: "kind--2",
+		},
+	}
+	coreReader.On("GetOperations", mock.Anything, mock.Anything).Return(operations, nil)
+	expected := []v2api.Operation{
+		{
+			Name:     "op-1",
+			SpanKind: "kind--1",
+		},
+		{
+			Name:     "op-2",
+			SpanKind: "kind--2",
+		},
+	}
+	actual, err := reader.GetOperations(context.Background(), v2api.OperationQueryParams{})
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestTraceReader_GetOperations_Error(t *testing.T) {
+	coreReader := &mocks.CoreSpanReader{}
+	reader := TraceReader{spanReader: coreReader}
+	coreReader.On("GetOperations", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+	operations, err := reader.GetOperations(context.Background(), v2api.OperationQueryParams{})
+	require.EqualError(t, err, "error")
+	require.Nil(t, operations)
+}
+
+func TestTraceReader_GetTraces(t *testing.T) {
+	reader := NewTraceReader(spanstore.SpanReaderParams{
+		Logger: zap.NewNop(),
+	})
+	assert.Panics(t, func() {
+		reader.GetTraces(context.Background(), v2api.GetTraceParams{})
+	})
+}
+
+func TestTraceReader_FindTraces(t *testing.T) {
+	reader := NewTraceReader(spanstore.SpanReaderParams{
+		Logger: zap.NewNop(),
+	})
+	assert.Panics(t, func() {
+		reader.FindTraces(context.Background(), v2api.TraceQueryParams{})
+	})
+}
+
+func TestTraceReader_FindTraceIDs(t *testing.T) {
+	reader := NewTraceReader(spanstore.SpanReaderParams{
+		Logger: zap.NewNop(),
+	})
+	assert.Panics(t, func() {
+		reader.FindTraceIDs(context.Background(), v2api.TraceQueryParams{})
+	})
+}


### PR DESCRIPTION
## Which problem is this PR solving?
-  Fixes a part of: #6458 

## Description of the changes
- Implement `GetOperations` and `GetServices` for v2 for ES/OS

## How was this change tested?
- Unit Tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
