### PR TITLE
[grpc][v2] Register gRPC v2 handler in remote-storage server

### DIFF
--- a/cmd/remote-storage/app/server.go
+++ b/cmd/remote-storage/app/server.go
@@ -100,7 +100,8 @@ func createGRPCServer(
 	tm *tenancy.Manager,
 	handler *shared.GRPCHandler,
 	v2Handler *grpcstorage.Handler,
-	telset telemetry.Settings) (*grpc.Server, error) {
+	telset telemetry.Settings,
+) (*grpc.Server, error) {
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		bearertoken.NewUnaryServerInterceptor(),
 	}

--- a/cmd/remote-storage/app/server.go
+++ b/cmd/remote-storage/app/server.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	"github.com/jaegertracing/jaeger/internal/bearertoken"
-	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/grpc/shared"
@@ -125,10 +124,9 @@ func createGRPCServer(
 	}
 	healthServer := health.NewServer()
 	reflection.Register(server)
-	handler.Register(server, healthServer)
 
-	storage.RegisterTraceReaderServer(server, v2Handler)
-	storage.RegisterDependencyReaderServer(server, v2Handler)
+	handler.Register(server, healthServer)
+	v2Handler.Register(server, healthServer)
 
 	return server, nil
 }

--- a/cmd/remote-storage/app/server_test.go
+++ b/cmd/remote-storage/app/server_test.go
@@ -158,13 +158,7 @@ func TestCreateGRPCHandler(t *testing.T) {
 	writer := new(tracestoremocks.Writer)
 	depReader := new(depstoremocks.Reader)
 
-	f := &fakeFactory{
-		reader:    reader,
-		writer:    writer,
-		depReader: depReader,
-	}
-
-	h, err := createGRPCHandler(f, f)
+	h, err := createGRPCHandler(reader, writer, depReader)
 	require.NoError(t, err)
 
 	writer.On("WriteTraces", mock.Anything, mock.Anything).Return(errors.New("writer error"))

--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -195,8 +195,6 @@ func (h *Handler) Register(ss *grpc.Server, hs *health.Server) {
 	hs.SetServingStatus("jaeger.storage.v2.TraceReader", grpc_health_v1.HealthCheckResponse_SERVING)
 	hs.SetServingStatus("jaeger.storage.v2.DependencyReader", grpc_health_v1.HealthCheckResponse_SERVING)
 	hs.SetServingStatus("jaeger.storage.v2.TraceWriter", grpc_health_v1.HealthCheckResponse_SERVING)
-
-	grpc_health_v1.RegisterHealthServer(ss, hs)
 }
 
 func toTraceQueryParams(t *storage.TraceQueryParameters) tracestore.TraceQueryParams {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #6979

## Description of the changes
- Registers the v2 gRPC handler in the remote-storage server

## How was this change tested?
- CI 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
