### PR TITLE
[ES] Add `Scope` field to DB Span

### DIFF
--- a/internal/storage/elasticsearch/dbmodel/model.go
+++ b/internal/storage/elasticsearch/dbmodel/model.go
@@ -60,6 +60,7 @@ type Span struct {
 	Tag     map[string]any `json:"tag,omitempty"`
 	Logs    []Log          `json:"logs"`
 	Process Process        `json:"process,omitempty"`
+	Scope   Scope          `json:"scope,omitempty"`
 }
 
 // Reference is a reference from one span to another
@@ -119,4 +120,11 @@ type TraceQueryParameters struct {
 	DurationMax   time.Duration
 	// TODO: Rename NumTraces to SearchDepth
 	NumTraces int
+}
+
+type Scope struct {
+	Name    string         `json:"name,omitempty"`
+	Version string         `json:"version,omitempty"`
+	Tags    []KeyValue     `json:"tags,omitempty"`
+	Tag     map[string]any `json:"tag,omitempty"`
 }

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-6.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-6.json
@@ -120,6 +120,39 @@
             }
           }
         },
+        "scope": {
+          "properties": {
+            "name": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "version": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "tag": {
+              "type": "object"
+            },
+            "tags": {
+              "type": "nested",
+              "dynamic": false,
+              "properties": {
+                "key": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                },
+                "value": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                },
+                "type": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        },
         "references":{
           "type":"nested",
           "dynamic":false,

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-7.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-7.json
@@ -120,6 +120,39 @@
           }
         }
       },
+      "scope": {
+        "properties": {
+          "name": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "version": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "tag": {
+            "type": "object"
+          },
+          "tags": {
+            "type": "nested",
+            "dynamic": false,
+            "properties": {
+              "key": {
+                "type": "keyword",
+                "ignore_above": 256
+              },
+              "value": {
+                "type": "keyword",
+                "ignore_above": 256
+              },
+              "type": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
       "references":{
         "type":"nested",
         "dynamic":false,

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-8.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-8.json
@@ -122,6 +122,39 @@
             }
           }
         },
+        "scope":{
+          "properties":{
+            "name":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "version":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "tag":{
+              "type":"object"
+            },
+            "tags":{
+              "type":"nested",
+              "dynamic":false,
+              "properties":{
+                "key":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "value":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "type":{
+                  "type":"keyword",
+                  "ignore_above":256
+                }
+              }
+            }
+          }
+        },
         "references": {
           "type": "nested",
           "dynamic": false,

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-6.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-6.json
@@ -120,6 +120,39 @@
             }
           }
         },
+        "scope":{
+          "properties":{
+            "name":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "version":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "tag":{
+              "type":"object"
+            },
+            "tags":{
+              "type":"nested",
+              "dynamic":false,
+              "properties":{
+                "key":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "value":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "type":{
+                  "type":"keyword",
+                  "ignore_above":256
+                }
+              }
+            }
+          }
+        },
         "references":{
           "type":"nested",
           "dynamic":false,

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-7.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-7.json
@@ -124,6 +124,39 @@
           }
         }
       },
+      "scope":{
+          "properties":{
+            "name":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "version":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "tag":{
+              "type":"object"
+            },
+            "tags":{
+              "type":"nested",
+              "dynamic":false,
+              "properties":{
+                "key":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "value":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "type":{
+                  "type":"keyword",
+                  "ignore_above":256
+                }
+              }
+            }
+          }
+        },
       "references":{
         "type":"nested",
         "dynamic":false,

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-8.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-8.json
@@ -127,6 +127,39 @@
             }
           }
         },
+        "scope":{
+          "properties":{
+            "name":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "version":{
+              "type":"keyword",
+              "ignore_above":256
+            },
+            "tag":{
+              "type":"object"
+            },
+            "tags":{
+              "type":"nested",
+              "dynamic":false,
+              "properties":{
+                "key":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "value":{
+                  "type":"keyword",
+                  "ignore_above":256
+                },
+                "type":{
+                  "type":"keyword",
+                  "ignore_above":256
+                }
+              }
+            }
+          }
+        },
         "references": {
           "type": "nested",
           "dynamic": false,

--- a/internal/storage/v1/elasticsearch/mappings/mapping_test.go
+++ b/internal/storage/v1/elasticsearch/mappings/mapping_test.go
@@ -5,10 +5,12 @@ package mappings
 
 import (
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"testing"
 	"text/template"
 
@@ -68,14 +70,16 @@ func TestMappingBuilderGetMapping(t *testing.T) {
 				UseILM:        true,
 				ILMPolicyName: "jaeger-test-policy",
 			}
+			var wantObj, gotObj map[string]any
 			got, err := mb.GetMapping(tt.mapping)
 			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal([]byte(got), &gotObj))
 			var wantbytes []byte
 			fileSuffix := fmt.Sprintf("-%d", tt.esVersion)
 			wantbytes, err = FIXTURES.ReadFile("fixtures/" + templateName + fileSuffix + ".json")
 			require.NoError(t, err)
-			want := string(wantbytes)
-			assert.Equal(t, want, got)
+			require.NoError(t, json.Unmarshal(wantbytes, &wantObj))
+			assert.True(t, reflect.DeepEqual(wantObj, gotObj))
 		})
 	}
 }

--- a/internal/storage/v1/elasticsearch/spanstore/fixtures/es_01.json
+++ b/internal/storage/v1/elasticsearch/spanstore/fixtures/es_01.json
@@ -86,5 +86,6 @@
         "value": true
       }
     ]
-  }
+  },
+  "scope": {}
 }

--- a/internal/storage/v1/elasticsearch/spanstore/fixtures/query_01.json
+++ b/internal/storage/v1/elasticsearch/spanstore/fixtures/query_01.json
@@ -24,6 +24,17 @@
         }
       },
       {
+        "bool":{
+          "must":{
+            "regexp":{
+              "scope.tag.bat@foo":{
+                "value":"spook"
+              }
+            }
+          }
+        }
+      },
+      {
         "nested":{
           "path":"tags",
           "query":{
@@ -89,6 +100,31 @@
                 {
                   "regexp":{
                     "logs.fields.value":{
+                      "value":"spook"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested":{
+          "path":"scope.tags",
+          "query":{
+            "bool":{
+              "must":[
+                {
+                  "match":{
+                    "scope.tags.key":{
+                      "query":"bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp":{
+                    "scope.tags.value":{
                       "value":"spook"
                     }
                   }

--- a/internal/storage/v1/elasticsearch/spanstore/fixtures/query_02.json
+++ b/internal/storage/v1/elasticsearch/spanstore/fixtures/query_02.json
@@ -24,6 +24,17 @@
         }
       },
       {
+        "bool":{
+          "must":{
+            "regexp":{
+              "scope.tag.bat@foo":{
+                "value":"spo.*"
+              }
+            }
+          }
+        }
+      },
+      {
         "nested":{
           "path":"tags",
           "query":{
@@ -89,6 +100,31 @@
                 {
                   "regexp":{
                     "logs.fields.value":{
+                      "value":"spo.*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested":{
+          "path":"scope.tags",
+          "query":{
+            "bool":{
+              "must":[
+                {
+                  "match":{
+                    "scope.tags.key":{
+                      "query":"bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp":{
+                    "scope.tags.value":{
                       "value":"spo.*"
                     }
                   }

--- a/internal/storage/v1/elasticsearch/spanstore/fixtures/query_03.json
+++ b/internal/storage/v1/elasticsearch/spanstore/fixtures/query_03.json
@@ -24,6 +24,17 @@
         }
       },
       {
+        "bool":{
+          "must":{
+            "regexp":{
+              "scope.tag.bat@foo":{
+                "value":"spo\\*"
+              }
+            }
+          }
+        }
+      },
+      {
         "nested":{
           "path":"tags",
           "query":{
@@ -89,6 +100,31 @@
                 {
                   "regexp":{
                     "logs.fields.value":{
+                      "value":"spo\\*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested":{
+          "path":"scope.tags",
+          "query":{
+            "bool":{
+              "must":[
+                {
+                  "match":{
+                    "scope.tags.key":{
+                      "query":"bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp":{
+                    "scope.tags.value":{
                       "value":"spo\\*"
                     }
                   }

--- a/internal/storage/v1/elasticsearch/spanstore/reader.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader.go
@@ -40,9 +40,11 @@ const (
 	operationNameField     = "operationName"
 	objectTagsField        = "tag"
 	objectProcessTagsField = "process.tag"
+	objectScopeTagsField   = "scope.tag"
 	nestedTagsField        = "tags"
 	nestedProcessTagsField = "process.tags"
 	nestedLogFieldsField   = "logs.fields"
+	nestedScopeTagsField   = "scope.tags"
 	tagKeyField            = "key"
 	tagValueField          = "value"
 
@@ -72,9 +74,9 @@ var (
 
 	defaultMaxDuration = model.DurationAsMicroseconds(time.Hour * 24)
 
-	objectTagFieldList = []string{objectTagsField, objectProcessTagsField}
+	objectTagFieldList = []string{objectTagsField, objectProcessTagsField, objectScopeTagsField}
 
-	nestedTagFieldList = []string{nestedTagsField, nestedProcessTagsField, nestedLogFieldsField}
+	nestedTagFieldList = []string{nestedTagsField, nestedProcessTagsField, nestedLogFieldsField, nestedScopeTagsField}
 
 	_ CoreSpanReader = (*SpanReader)(nil) // check API conformance
 

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
@@ -25,16 +25,6 @@
   "duration": 5,
   "tags": [
     {
-      "key": "otel.scope.name",
-      "type": "string",
-      "value": "testing-library"
-    },
-    {
-      "key": "otel.scope.version",
-      "type": "string",
-      "value": "1.1.1"
-    },
-    {
       "key": "peer.service",
       "type": "string",
       "value": "service-y"
@@ -94,6 +84,17 @@
         "key": "sdk.version",
         "type": "string",
         "value": "1.2.1"
+      }
+    ]
+  },
+  "scope": {
+    "name": "testing-library",
+    "version": "1.1.1",
+    "tags": [
+      {
+        "key": "testing-attribute",
+        "type": "string",
+        "value": "scope-x"
       }
     ]
   }

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
@@ -25,16 +25,6 @@
   "duration": 5,
   "tags": [
     {
-      "key": "otel.scope.name",
-      "type": "string",
-      "value": "testing-library"
-    },
-    {
-      "key": "otel.scope.version",
-      "type": "string",
-      "value": "1.1.1"
-    },
-    {
       "key": "peer.service",
       "type": "string",
       "value": "service-y"
@@ -94,6 +84,17 @@
         "key": "sdk.version",
         "type": "string",
         "value": "1.2.1"
+      }
+    ]
+  },
+  "scope": {
+    "name": "testing-library",
+    "version": "1.1.1",
+    "tags": [
+      {
+        "key": "testing-attribute",
+        "type": "string",
+        "value": "scope-x"
       }
     ]
   }

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/otel_traces_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/otel_traces_01.json
@@ -21,7 +21,15 @@
         {
           "scope": {
             "name": "testing-library",
-            "version": "1.1.1"
+            "version": "1.1.1",
+            "attributes": [
+              {
+                "key": "testing-attribute",
+                "value": {
+                  "stringValue": "scope-x"
+                }
+              }
+            ]
           },
           "spans": [
             {

--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
@@ -650,6 +650,32 @@ func TestToDbModel_Fixtures_StringTags(t *testing.T) {
 	testTraces(t, expectedTraces, td)
 }
 
+func TestDBScopeToScope(t *testing.T) {
+	scopeTags := []dbmodel.KeyValue{
+		{
+			Key:   conventions.AttributeOtelScopeName,
+			Type:  dbmodel.StringType,
+			Value: "testing-name",
+		},
+		{
+			Key:   conventions.AttributeOtelScopeVersion,
+			Type:  dbmodel.StringType,
+			Value: "1.1.1",
+		},
+	}
+	// This is a hypothetical case! It can't be possible to a db span having both
+	// scope and scope tags. This test is to ensure that even if such case rises, it
+	// should give precedence to tags
+	dbScope := dbmodel.Scope{
+		Name:    "testing-name-1",
+		Version: "1.1.2",
+	}
+	scope := pcommon.NewInstrumentationScope()
+	dbScopeToScope(dbScope, scopeTags, scope)
+	assert.Equal(t, "testing-name", scope.Name())
+	assert.Equal(t, "1.1.1", scope.Version())
+}
+
 func getDbTraceIdFromByteArray(arr [16]byte) dbmodel.TraceID {
 	return dbmodel.TraceID(hex.EncodeToString(arr[:]))
 }

--- a/internal/storage/v2/elasticsearch/tracestore/ids.go
+++ b/internal/storage/v2/elasticsearch/tracestore/ids.go
@@ -32,7 +32,7 @@ func fromDbSpanId(dbSpanId dbmodel.SpanID) (pcommon.SpanID, error) {
 }
 
 // TODO extend DB model to support parent span ID directly
-func getParentSpanId(dbSpan *dbmodel.Span) dbmodel.SpanID {
+func getParentSpanId(dbSpan dbmodel.Span) dbmodel.SpanID {
 	var followsFromRef *dbmodel.Reference
 	for i := range dbSpan.References {
 		ref := dbSpan.References[i]


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes a part of: #7034 

## Description of the changes
- Currently it is impossible to record scope information completely as there is no way to store scope attributes in ES DB Span. Therefore it is necessary to add a scope field in db span.

## How was this change tested?
- Unit And integration tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
