### PR TITLE
[test] Block until server starts

### DIFF
--- a/cmd/anonymizer/app/query/query_test.go
+++ b/cmd/anonymizer/app/query/query_test.go
@@ -71,12 +71,15 @@ func newTestServer(t *testing.T) *testServer {
 	lis, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 
-	var exited sync.WaitGroup
+	var started, exited sync.WaitGroup
+	started.Add(1)
 	exited.Add(1)
 	go func() {
+		started.Done()
 		assert.NoError(t, server.Serve(lis))
 		exited.Done()
 	}()
+	started.Wait()
 	t.Cleanup(func() {
 		server.Stop()
 		exited.Wait() // don't allow test to finish before server exits


### PR DESCRIPTION
## Which problem is this PR solving?
- Test failed sporadically https://github.com/jaegertracing/jaeger/actions/runs/14538973210/job/40793017264#step:8:16

## Description of the changes
- Block until test server starts

## How was this change tested?
```
$ go test ./cmd/anonymizer/app/query
ok  	github.com/jaegertracing/jaeger/cmd/anonymizer/app/query	0.409s
```