### PR TITLE
Remove last mockery/with-expecter=false

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -29,7 +29,6 @@ packages:
   github.com/jaegertracing/jaeger/internal/storage/cassandra:
     config:
       unroll-variadic: false
-      with-expecter: false
     interfaces:
       Iterator:
       Query:

--- a/internal/storage/cassandra/mocks/Iterator.go
+++ b/internal/storage/cassandra/mocks/Iterator.go
@@ -14,6 +14,14 @@ type Iterator struct {
 	mock.Mock
 }
 
+type Iterator_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Iterator) EXPECT() *Iterator_Expecter {
+	return &Iterator_Expecter{mock: &_m.Mock}
+}
+
 // Close provides a mock function with no fields
 func (_m *Iterator) Close() error {
 	ret := _m.Called()
@@ -32,9 +40,42 @@ func (_m *Iterator) Close() error {
 	return r0
 }
 
+// Iterator_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type Iterator_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *Iterator_Expecter) Close() *Iterator_Close_Call {
+	return &Iterator_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *Iterator_Close_Call) Run(run func()) *Iterator_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Iterator_Close_Call) Return(_a0 error) *Iterator_Close_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Iterator_Close_Call) RunAndReturn(run func() error) *Iterator_Close_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Scan provides a mock function with given fields: dest
 func (_m *Iterator) Scan(dest ...any) bool {
-	ret := _m.Called(dest)
+	var tmpRet mock.Arguments
+	if len(dest) > 0 {
+		tmpRet = _m.Called(dest)
+	} else {
+		tmpRet = _m.Called()
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for Scan")
@@ -48,6 +89,41 @@ func (_m *Iterator) Scan(dest ...any) bool {
 	}
 
 	return r0
+}
+
+// Iterator_Scan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Scan'
+type Iterator_Scan_Call struct {
+	*mock.Call
+}
+
+// Scan is a helper method to define mock.On call
+//   - dest ...any
+func (_e *Iterator_Expecter) Scan(dest ...interface{}) *Iterator_Scan_Call {
+	return &Iterator_Scan_Call{Call: _e.mock.On("Scan",
+		append([]interface{}{}, dest...)...)}
+}
+
+func (_c *Iterator_Scan_Call) Run(run func(dest ...any)) *Iterator_Scan_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]any, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		run(variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Iterator_Scan_Call) Return(_a0 bool) *Iterator_Scan_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Iterator_Scan_Call) RunAndReturn(run func(...any) bool) *Iterator_Scan_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewIterator creates a new instance of Iterator. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/storage/cassandra/mocks/Query.go
+++ b/internal/storage/cassandra/mocks/Query.go
@@ -17,9 +17,23 @@ type Query struct {
 	mock.Mock
 }
 
+type Query_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Query) EXPECT() *Query_Expecter {
+	return &Query_Expecter{mock: &_m.Mock}
+}
+
 // Bind provides a mock function with given fields: v
 func (_m *Query) Bind(v ...any) cassandra.Query {
-	ret := _m.Called(v)
+	var tmpRet mock.Arguments
+	if len(v) > 0 {
+		tmpRet = _m.Called(v)
+	} else {
+		tmpRet = _m.Called()
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for Bind")
@@ -35,6 +49,41 @@ func (_m *Query) Bind(v ...any) cassandra.Query {
 	}
 
 	return r0
+}
+
+// Query_Bind_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Bind'
+type Query_Bind_Call struct {
+	*mock.Call
+}
+
+// Bind is a helper method to define mock.On call
+//   - v ...any
+func (_e *Query_Expecter) Bind(v ...interface{}) *Query_Bind_Call {
+	return &Query_Bind_Call{Call: _e.mock.On("Bind",
+		append([]interface{}{}, v...)...)}
+}
+
+func (_c *Query_Bind_Call) Run(run func(v ...any)) *Query_Bind_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]any, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		run(variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Query_Bind_Call) Return(_a0 cassandra.Query) *Query_Bind_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Query_Bind_Call) RunAndReturn(run func(...any) cassandra.Query) *Query_Bind_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Consistency provides a mock function with given fields: level
@@ -57,6 +106,34 @@ func (_m *Query) Consistency(level cassandra.Consistency) cassandra.Query {
 	return r0
 }
 
+// Query_Consistency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Consistency'
+type Query_Consistency_Call struct {
+	*mock.Call
+}
+
+// Consistency is a helper method to define mock.On call
+//   - level cassandra.Consistency
+func (_e *Query_Expecter) Consistency(level interface{}) *Query_Consistency_Call {
+	return &Query_Consistency_Call{Call: _e.mock.On("Consistency", level)}
+}
+
+func (_c *Query_Consistency_Call) Run(run func(level cassandra.Consistency)) *Query_Consistency_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(cassandra.Consistency))
+	})
+	return _c
+}
+
+func (_c *Query_Consistency_Call) Return(_a0 cassandra.Query) *Query_Consistency_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Query_Consistency_Call) RunAndReturn(run func(cassandra.Consistency) cassandra.Query) *Query_Consistency_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Exec provides a mock function with no fields
 func (_m *Query) Exec() error {
 	ret := _m.Called()
@@ -73,6 +150,33 @@ func (_m *Query) Exec() error {
 	}
 
 	return r0
+}
+
+// Query_Exec_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Exec'
+type Query_Exec_Call struct {
+	*mock.Call
+}
+
+// Exec is a helper method to define mock.On call
+func (_e *Query_Expecter) Exec() *Query_Exec_Call {
+	return &Query_Exec_Call{Call: _e.mock.On("Exec")}
+}
+
+func (_c *Query_Exec_Call) Run(run func()) *Query_Exec_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Query_Exec_Call) Return(_a0 error) *Query_Exec_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Query_Exec_Call) RunAndReturn(run func() error) *Query_Exec_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Iter provides a mock function with no fields
@@ -95,6 +199,33 @@ func (_m *Query) Iter() cassandra.Iterator {
 	return r0
 }
 
+// Query_Iter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Iter'
+type Query_Iter_Call struct {
+	*mock.Call
+}
+
+// Iter is a helper method to define mock.On call
+func (_e *Query_Expecter) Iter() *Query_Iter_Call {
+	return &Query_Iter_Call{Call: _e.mock.On("Iter")}
+}
+
+func (_c *Query_Iter_Call) Run(run func()) *Query_Iter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Query_Iter_Call) Return(_a0 cassandra.Iterator) *Query_Iter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Query_Iter_Call) RunAndReturn(run func() cassandra.Iterator) *Query_Iter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PageSize provides a mock function with given fields: _a0
 func (_m *Query) PageSize(_a0 int) cassandra.Query {
 	ret := _m.Called(_a0)
@@ -115,9 +246,43 @@ func (_m *Query) PageSize(_a0 int) cassandra.Query {
 	return r0
 }
 
+// Query_PageSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PageSize'
+type Query_PageSize_Call struct {
+	*mock.Call
+}
+
+// PageSize is a helper method to define mock.On call
+//   - _a0 int
+func (_e *Query_Expecter) PageSize(_a0 interface{}) *Query_PageSize_Call {
+	return &Query_PageSize_Call{Call: _e.mock.On("PageSize", _a0)}
+}
+
+func (_c *Query_PageSize_Call) Run(run func(_a0 int)) *Query_PageSize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int))
+	})
+	return _c
+}
+
+func (_c *Query_PageSize_Call) Return(_a0 cassandra.Query) *Query_PageSize_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Query_PageSize_Call) RunAndReturn(run func(int) cassandra.Query) *Query_PageSize_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ScanCAS provides a mock function with given fields: dest
 func (_m *Query) ScanCAS(dest ...any) (bool, error) {
-	ret := _m.Called(dest)
+	var tmpRet mock.Arguments
+	if len(dest) > 0 {
+		tmpRet = _m.Called(dest)
+	} else {
+		tmpRet = _m.Called()
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for ScanCAS")
@@ -143,6 +308,41 @@ func (_m *Query) ScanCAS(dest ...any) (bool, error) {
 	return r0, r1
 }
 
+// Query_ScanCAS_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ScanCAS'
+type Query_ScanCAS_Call struct {
+	*mock.Call
+}
+
+// ScanCAS is a helper method to define mock.On call
+//   - dest ...any
+func (_e *Query_Expecter) ScanCAS(dest ...interface{}) *Query_ScanCAS_Call {
+	return &Query_ScanCAS_Call{Call: _e.mock.On("ScanCAS",
+		append([]interface{}{}, dest...)...)}
+}
+
+func (_c *Query_ScanCAS_Call) Run(run func(dest ...any)) *Query_ScanCAS_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]any, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		run(variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Query_ScanCAS_Call) Return(_a0 bool, _a1 error) *Query_ScanCAS_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Query_ScanCAS_Call) RunAndReturn(run func(...any) (bool, error)) *Query_ScanCAS_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // String provides a mock function with no fields
 func (_m *Query) String() string {
 	ret := _m.Called()
@@ -159,6 +359,33 @@ func (_m *Query) String() string {
 	}
 
 	return r0
+}
+
+// Query_String_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'String'
+type Query_String_Call struct {
+	*mock.Call
+}
+
+// String is a helper method to define mock.On call
+func (_e *Query_Expecter) String() *Query_String_Call {
+	return &Query_String_Call{Call: _e.mock.On("String")}
+}
+
+func (_c *Query_String_Call) Run(run func()) *Query_String_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Query_String_Call) Return(_a0 string) *Query_String_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Query_String_Call) RunAndReturn(run func() string) *Query_String_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewQuery creates a new instance of Query. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/storage/cassandra/mocks/Session.go
+++ b/internal/storage/cassandra/mocks/Session.go
@@ -17,14 +17,55 @@ type Session struct {
 	mock.Mock
 }
 
+type Session_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Session) EXPECT() *Session_Expecter {
+	return &Session_Expecter{mock: &_m.Mock}
+}
+
 // Close provides a mock function with no fields
 func (_m *Session) Close() {
 	_m.Called()
 }
 
+// Session_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type Session_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *Session_Expecter) Close() *Session_Close_Call {
+	return &Session_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *Session_Close_Call) Run(run func()) *Session_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Session_Close_Call) Return() *Session_Close_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Session_Close_Call) RunAndReturn(run func()) *Session_Close_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Query provides a mock function with given fields: stmt, values
 func (_m *Session) Query(stmt string, values ...any) cassandra.Query {
-	ret := _m.Called(stmt, values)
+	var tmpRet mock.Arguments
+	if len(values) > 0 {
+		tmpRet = _m.Called(stmt, values)
+	} else {
+		tmpRet = _m.Called(stmt)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for Query")
@@ -40,6 +81,42 @@ func (_m *Session) Query(stmt string, values ...any) cassandra.Query {
 	}
 
 	return r0
+}
+
+// Session_Query_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Query'
+type Session_Query_Call struct {
+	*mock.Call
+}
+
+// Query is a helper method to define mock.On call
+//   - stmt string
+//   - values ...any
+func (_e *Session_Expecter) Query(stmt interface{}, values ...interface{}) *Session_Query_Call {
+	return &Session_Query_Call{Call: _e.mock.On("Query",
+		append([]interface{}{stmt}, values...)...)}
+}
+
+func (_c *Session_Query_Call) Run(run func(stmt string, values ...any)) *Session_Query_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]any, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Session_Query_Call) Return(_a0 cassandra.Query) *Session_Query_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Session_Query_Call) RunAndReturn(run func(string, ...any) cassandra.Query) *Session_Query_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewSession creates a new instance of Session. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/storage/v1/cassandra/samplingstore/storage_test.go
+++ b/internal/storage/v1/cassandra/samplingstore/storage_test.go
@@ -263,7 +263,7 @@ func TestGetLatestProbabilities(t *testing.T) {
 				query := &mocks.Query{}
 				query.On("Iter").Return(iter)
 
-				s.session.On("Query", mock.AnythingOfType("string"), matchEverything()).Return(query)
+				s.session.On("Query", mock.AnythingOfType("string")).Return(query)
 
 				probabilities, err := s.store.GetLatestProbabilities()
 

--- a/internal/storage/v1/cassandra/spanstore/matchers_test.go
+++ b/internal/storage/v1/cassandra/spanstore/matchers_test.go
@@ -28,10 +28,6 @@ func matchOnceWithSideEffect(fn func(v []any)) any {
 	})
 }
 
-func matchEverything() any {
-	return mock.MatchedBy(func(_ []any) bool { return true })
-}
-
 // stringMatcher can match a string argument when it contains a specific substring q
 func stringMatcher(q string) any {
 	matchFunc := func(s string) bool {

--- a/internal/storage/v1/cassandra/spanstore/reader_test.go
+++ b/internal/storage/v1/cassandra/spanstore/reader_test.go
@@ -162,14 +162,14 @@ func TestSpanReaderGetTrace(t *testing.T) {
 			withSpanReader(t, func(r *spanReaderTest) {
 				iter := &mocks.Iterator{}
 				iter.On("Scan", testCase.scanner).Return(true)
-				iter.On("Scan", matchEverything()).Return(false)
+				iter.On("Scan", mock.Anything).Return(false)
 				iter.On("Close").Return(testCase.closeErr)
 
 				query := &mocks.Query{}
 				query.On("Consistency", cassandra.One).Return(query)
 				query.On("Iter").Return(iter)
 
-				r.session.On("Query", mock.AnythingOfType("string"), matchEverything()).Return(query)
+				r.session.On("Query", mock.AnythingOfType("string"), mock.Anything).Return(query)
 
 				trace, err := r.reader.GetTrace(context.Background(), spanstore.GetTraceParameters{})
 				if testCase.expectedErr == "" {
@@ -188,14 +188,14 @@ func TestSpanReaderGetTrace(t *testing.T) {
 func TestSpanReaderGetTrace_TraceNotFound(t *testing.T) {
 	withSpanReader(t, func(r *spanReaderTest) {
 		iter := &mocks.Iterator{}
-		iter.On("Scan", matchEverything()).Return(false)
+		iter.On("Scan", mock.Anything).Return(false)
 		iter.On("Close").Return(nil)
 
 		query := &mocks.Query{}
 		query.On("Consistency", cassandra.One).Return(query)
 		query.On("Iter").Return(iter)
 
-		r.session.On("Query", mock.AnythingOfType("string"), matchEverything()).Return(query)
+		r.session.On("Query", mock.AnythingOfType("string"), mock.Anything).Return(query)
 
 		trace, err := r.reader.GetTrace(context.Background(), spanstore.GetTraceParameters{})
 		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
@@ -352,11 +352,11 @@ func TestSpanReaderFindTraces(t *testing.T) {
 				mockQuery := func(queryErr error) *mocks.Query {
 					iter := &mocks.Iterator{}
 					iter.On("Scan", scanMatcher("queryIter")).Return(true)
-					iter.On("Scan", matchEverything()).Return(false)
+					iter.On("Scan", mock.Anything).Return(false)
 					iter.On("Close").Return(queryErr)
 
 					query := &mocks.Query{}
-					query.On("Bind", matchEverything()).Return(query)
+					query.On("Bind", mock.Anything).Return(query)
 					query.On("Consistency", cassandra.One).Return(query)
 					query.On("PageSize", 0).Return(query)
 					query.On("Iter").Return(iter)
@@ -373,34 +373,34 @@ func TestSpanReaderFindTraces(t *testing.T) {
 				makeLoadQuery := func() *mocks.Query {
 					loadQueryIter := &mocks.Iterator{}
 					loadQueryIter.On("Scan", scanMatcher("loadIter")).Return(true)
-					loadQueryIter.On("Scan", matchEverything()).Return(false)
+					loadQueryIter.On("Scan", mock.Anything).Return(false)
 					loadQueryIter.On("Close").Return(testCase.loadQueryError)
 
 					loadQuery := &mocks.Query{}
 					loadQuery.On("Consistency", cassandra.One).Return(loadQuery)
 					loadQuery.On("Iter").Return(loadQueryIter)
-					loadQuery.On("PageSize", matchEverything()).Return(loadQuery)
+					loadQuery.On("PageSize", mock.Anything).Return(loadQuery)
 					return loadQuery
 				}
 
 				r.session.On("Query",
-					stringMatcher(queryByServiceName),
-					matchEverything()).Return(mainQuery)
+					queryByServiceName,
+					mock.Anything).Return(mainQuery)
 				r.session.On("Query",
-					stringMatcher(queryByTag),
-					matchEverything()).Return(tagsQuery)
+					queryByTag,
+					mock.Anything).Return(tagsQuery)
 				r.session.On("Query",
-					stringMatcher(queryByServiceAndOperationName),
-					matchEverything()).Return(operationQuery)
+					queryByServiceAndOperationName,
+					mock.Anything).Return(operationQuery)
 				r.session.On("Query",
-					stringMatcher(queryByDuration),
-					matchEverything()).Return(durationQuery)
+					queryByDuration,
+					mock.Anything).Return(durationQuery)
 				r.session.On("Query",
 					stringMatcher("SELECT trace_id"),
 					matchOnce()).Return(makeLoadQuery())
 				r.session.On("Query",
 					stringMatcher("SELECT trace_id"),
-					matchEverything()).Return(makeLoadQuery())
+					mock.Anything).Return(makeLoadQuery())
 
 				queryParams := &spanstore.TraceQueryParameters{
 					ServiceName:  "service-a",

--- a/internal/storage/v1/cassandra/spanstore/service_names_test.go
+++ b/internal/storage/v1/cassandra/spanstore/service_names_test.go
@@ -60,8 +60,7 @@ func TestServiceNamesStorageWrite(t *testing.T) {
 				query2.On("Exec").Return(execError)
 				query2.On("String").Return("select from service_names")
 
-				var emptyArgs []any
-				s.session.On("Query", mock.AnythingOfType("string"), emptyArgs).Return(query)
+				s.session.On("Query", mock.AnythingOfType("string")).Return(query)
 
 				err := s.storage.Write("service-a")
 				require.NoError(t, err)
@@ -118,8 +117,7 @@ func TestServiceNamesStorageGetServices(t *testing.T) {
 			query := &mocks.Query{}
 			query.On("Iter").Return(iter)
 
-			var emptyArgs []any
-			s.session.On("Query", mock.AnythingOfType("string"), emptyArgs).Return(query)
+			s.session.On("Query", mock.AnythingOfType("string")).Return(query)
 
 			services, err := s.storage.GetServices()
 			if expErr == nil {

--- a/internal/storage/v1/cassandra/spanstore/writer_test.go
+++ b/internal/storage/v1/cassandra/spanstore/writer_test.go
@@ -195,17 +195,17 @@ func TestSpanWriter(t *testing.T) {
 				}
 
 				spanQuery := &mocks.Query{}
-				spanQuery.On("Bind", matchEverything()).Return(spanQuery)
+				spanQuery.On("Bind", mock.Anything).Return(spanQuery)
 				spanQuery.On("Exec").Return(testCase.mainQueryError)
 				spanQuery.On("String").Return("select from traces")
 
 				serviceNameQuery := &mocks.Query{}
-				serviceNameQuery.On("Bind", matchEverything()).Return(serviceNameQuery)
+				serviceNameQuery.On("Bind", mock.Anything).Return(serviceNameQuery)
 				serviceNameQuery.On("Exec").Return(testCase.serviceNameQueryError)
 				serviceNameQuery.On("String").Return("select from service_name_index")
 
 				serviceOperationNameQuery := &mocks.Query{}
-				serviceOperationNameQuery.On("Bind", matchEverything()).Return(serviceOperationNameQuery)
+				serviceOperationNameQuery.On("Bind", mock.Anything).Return(serviceOperationNameQuery)
 				serviceOperationNameQuery.On("Exec").Return(testCase.serviceOperationNameQueryError)
 				serviceOperationNameQuery.On("String").Return("select from service_operation_index")
 
@@ -214,17 +214,17 @@ func TestSpanWriter(t *testing.T) {
 				tagsQuery.On("String").Return("select from tags")
 
 				durationNoOperationQuery := &mocks.Query{}
-				durationNoOperationQuery.On("Bind", matchEverything()).Return(durationNoOperationQuery)
+				durationNoOperationQuery.On("Bind", mock.Anything).Return(durationNoOperationQuery)
 				durationNoOperationQuery.On("Exec").Return(testCase.durationNoOperationQueryError)
 				durationNoOperationQuery.On("String").Return("select from duration_index")
 
 				// Define expected queries
-				w.session.On("Query", stringMatcher(insertSpan), matchEverything()).Return(spanQuery)
-				w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
-				w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
-				// note: using matchOnce below because we only want one tag to be inserted
-				w.session.On("Query", stringMatcher(tagIndex), matchOnce()).Return(tagsQuery)
-				w.session.On("Query", stringMatcher(durationIndex), matchOnce()).Return(durationNoOperationQuery)
+				w.session.On("Query", insertSpan, mock.Anything).Return(spanQuery)
+				w.session.On("Query", serviceNameIndex).Return(serviceNameQuery)
+				w.session.On("Query", serviceOperationIndex, mock.Anything).Return(serviceOperationNameQuery)
+				// note: using Once() below because we only want one tag to be inserted
+				w.session.On("Query", tagIndex, mock.Anything).Return(tagsQuery).Once()
+				w.session.On("Query", durationIndex).Return(durationNoOperationQuery).Once()
 
 				w.writer.serviceNamesWriter = func(_ /* serviceName */ string) error { return testCase.serviceNameError }
 				w.writer.operationNamesWriter = func(_ dbmodel.Operation) error { return testCase.serviceNameError }
@@ -326,20 +326,20 @@ func TestStorageMode_IndexOnly(t *testing.T) {
 		}
 
 		serviceNameQuery := &mocks.Query{}
-		serviceNameQuery.On("Bind", matchEverything()).Return(serviceNameQuery)
+		serviceNameQuery.On("Bind", mock.Anything).Return(serviceNameQuery)
 		serviceNameQuery.On("Exec").Return(nil)
 
 		serviceOperationNameQuery := &mocks.Query{}
-		serviceOperationNameQuery.On("Bind", matchEverything()).Return(serviceOperationNameQuery)
+		serviceOperationNameQuery.On("Bind", mock.Anything).Return(serviceOperationNameQuery)
 		serviceOperationNameQuery.On("Exec").Return(nil)
 
 		durationNoOperationQuery := &mocks.Query{}
-		durationNoOperationQuery.On("Bind", matchEverything()).Return(durationNoOperationQuery)
+		durationNoOperationQuery.On("Bind", mock.Anything).Return(durationNoOperationQuery)
 		durationNoOperationQuery.On("Exec").Return(nil)
 
-		w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
-		w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
-		w.session.On("Query", stringMatcher(durationIndex), matchOnce()).Return(durationNoOperationQuery)
+		w.session.On("Query", serviceNameIndex).Return(serviceNameQuery)
+		w.session.On("Query", serviceOperationIndex).Return(serviceOperationNameQuery)
+		w.session.On("Query", durationIndex).Return(durationNoOperationQuery).Once()
 
 		err := w.writer.WriteSpan(context.Background(), span)
 
@@ -348,7 +348,7 @@ func TestStorageMode_IndexOnly(t *testing.T) {
 		serviceOperationNameQuery.AssertExpectations(t)
 		durationNoOperationQuery.AssertExpectations(t)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(insertSpan), matchEverything())
+		w.session.AssertNotCalled(t, "Query", insertSpan, mock.Anything)
 	}, StoreIndexesOnly())
 }
 
@@ -370,9 +370,9 @@ func TestStorageMode_IndexOnly_WithFilter(t *testing.T) {
 		err := w.writer.WriteSpan(context.Background(), span)
 		require.NoError(t, err)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceOperationIndex), matchEverything())
-		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex), matchEverything())
-		w.session.AssertNotCalled(t, "Query", stringMatcher(durationIndex), matchEverything())
+		w.session.AssertNotCalled(t, "Query", serviceOperationIndex, mock.Anything)
+		w.session.AssertNotCalled(t, "Query", serviceNameIndex, mock.Anything)
+		w.session.AssertNotCalled(t, "Query", durationIndex, mock.Anything)
 	}, StoreIndexesOnly())
 }
 
@@ -401,24 +401,24 @@ func TestStorageMode_IndexOnly_FirehoseSpan(t *testing.T) {
 		}
 
 		serviceNameQuery := &mocks.Query{}
-		serviceNameQuery.On("Bind", matchEverything()).Return(serviceNameQuery)
+		serviceNameQuery.On("Bind", mock.Anything).Return(serviceNameQuery)
 		serviceNameQuery.On("Exec").Return(nil)
 		serviceNameQuery.On("String").Return("select from service_name_index")
 
 		serviceOperationNameQuery := &mocks.Query{}
-		serviceOperationNameQuery.On("Bind", matchEverything()).Return(serviceOperationNameQuery)
+		serviceOperationNameQuery.On("Bind", mock.Anything).Return(serviceOperationNameQuery)
 		serviceOperationNameQuery.On("Exec").Return(nil)
 		serviceOperationNameQuery.On("String").Return("select from service_operation_index")
 
 		// Define expected queries
-		w.session.On("Query", stringMatcher(serviceNameIndex), matchEverything()).Return(serviceNameQuery)
-		w.session.On("Query", stringMatcher(serviceOperationIndex), matchEverything()).Return(serviceOperationNameQuery)
+		w.session.On("Query", serviceNameIndex).Return(serviceNameQuery)
+		w.session.On("Query", serviceOperationIndex).Return(serviceOperationNameQuery)
 
 		err := w.writer.WriteSpan(context.Background(), span)
 		require.NoError(t, err)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(tagIndex), matchEverything())
-		w.session.AssertNotCalled(t, "Query", stringMatcher(durationIndex), matchEverything())
+		w.session.AssertNotCalled(t, "Query", tagIndex, mock.Anything)
+		w.session.AssertNotCalled(t, "Query", durationIndex, mock.Anything)
 		assert.Equal(t, "planet-express", *serviceWritten.Load())
 		assert.Equal(t, dbmodel.Operation{
 			ServiceName:   "planet-express",
@@ -442,13 +442,13 @@ func TestStorageMode_StoreWithoutIndexing(t *testing.T) {
 		}
 		spanQuery := &mocks.Query{}
 		spanQuery.On("Exec").Return(nil)
-		w.session.On("Query", stringMatcher(insertSpan), matchEverything()).Return(spanQuery)
+		w.session.On("Query", insertSpan, mock.Anything).Return(spanQuery)
 
 		err := w.writer.WriteSpan(context.Background(), span)
 
 		require.NoError(t, err)
 		spanQuery.AssertExpectations(t)
 		w.session.AssertExpectations(t)
-		w.session.AssertNotCalled(t, "Query", stringMatcher(serviceNameIndex), matchEverything())
+		w.session.AssertNotCalled(t, "Query", serviceNameIndex, mock.Anything)
 	}, StoreWithoutIndexing())
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Final cleanup to accompany #7046

## Description of the changes
- Remove `with-expecter=true` for Cassandra and fix the tests

## How was this change tested?
- CI
