### PR TITLE
[v2] Implement `GetOperations` and `GetServices` for memory backend

### DIFF
--- a/internal/storage/v2/memory/fixtures/db_traces_01.json
+++ b/internal/storage/v2/memory/fixtures/db_traces_01.json
@@ -23,7 +23,7 @@
               "spanId": "0000000000000002",
               "parentSpanId": "0000000000000003",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-2",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [
@@ -120,7 +120,7 @@
               "spanId": "0000000000000004",
               "parentSpanId": "0000000000000011",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-4",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [

--- a/internal/storage/v2/memory/fixtures/db_traces_02.json
+++ b/internal/storage/v2/memory/fixtures/db_traces_02.json
@@ -23,7 +23,7 @@
               "spanId": "0000000000000003",
               "parentSpanId": "0000000000000010",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-3",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [
@@ -120,7 +120,7 @@
               "spanId": "0000000000000005",
               "parentSpanId": "0000000000000010",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-5",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [

--- a/internal/storage/v2/memory/fixtures/otel_traces_01.json
+++ b/internal/storage/v2/memory/fixtures/otel_traces_01.json
@@ -23,7 +23,7 @@
               "spanId": "0000000000000002",
               "parentSpanId": "0000000000000003",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-2",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [
@@ -112,7 +112,7 @@
               "spanId": "0000000000000003",
               "parentSpanId": "0000000000000010",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-3",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [
@@ -209,7 +209,7 @@
               "spanId": "0000000000000004",
               "parentSpanId": "0000000000000011",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-4",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [
@@ -298,7 +298,7 @@
               "spanId": "0000000000000005",
               "parentSpanId": "0000000000000010",
               "flags": 1,
-              "name": "test-general-conversion",
+              "name": "test-general-conversion-5",
               "startTimeUnixNano": "1485467191639875000",
               "endTimeUnixNano": "1485467191639880000",
               "attributes": [


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes a part of: #7052 

## Description of the changes
- Implement GetOperations and GetServices for memory backend

## How was this change tested?
- Unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
