### PR TITLE
[refactor] Remove `jaeger_query` extension from remote storage backend config

### DIFF
--- a/cmd/jaeger/config-remote-storage-backend.yaml
+++ b/cmd/jaeger/config-remote-storage-backend.yaml
@@ -1,5 +1,5 @@
 service:
-  extensions: [jaeger_storage, jaeger_query, remote_storage, remote_storage/archive, healthcheckv2]
+  extensions: [jaeger_storage, remote_storage, remote_storage/archive, healthcheckv2]
   pipelines:
     traces:
       receivers: [otlp]
@@ -27,17 +27,6 @@ extensions:
     http:
       # use different port to avoid conflict with collector on 13133
       endpoint: 0.0.0.0:12133
-
-  jaeger_query:
-    storage:
-      traces: memory-storage
-      traces_archive: memory-storage-archive
-    ui:
-      config_file: ./cmd/jaeger/config-ui.json
-    grpc:
-      endpoint: "${env:JAEGER_QUERY_GRPC_ENDPOINT:-localhost:16685}"
-    http:
-      endpoint: "${env:JAEGER_QUERY_HTTP_ENDPOINT:-localhost:16686}"
 
   jaeger_storage:
     backends:

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -136,7 +136,6 @@ func (s *E2EStorageIntegration) scrapeMetrics(t *testing.T, storage string) {
 func createStorageCleanerConfig(t *testing.T, configFile string, storage string) string {
 	data, err := os.ReadFile(configFile)
 	require.NoError(t, err)
-
 	var config map[string]any
 	err = yaml.Unmarshal(data, &config)
 	require.NoError(t, err)

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -136,6 +136,7 @@ func (s *E2EStorageIntegration) scrapeMetrics(t *testing.T, storage string) {
 func createStorageCleanerConfig(t *testing.T, configFile string, storage string) string {
 	data, err := os.ReadFile(configFile)
 	require.NoError(t, err)
+
 	var config map[string]any
 	err = yaml.Unmarshal(data, &config)
 	require.NoError(t, err)
@@ -148,13 +149,29 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 	extensionsAny, ok := config["extensions"]
 	require.True(t, ok)
 	extensions := extensionsAny.(map[string]any)
-	queryAny, ok := extensions["jaeger_query"]
-	require.True(t, ok)
-	storageAny, ok := queryAny.(map[string]any)["storage"]
-	require.True(t, ok)
-	traceStorageAny, ok := storageAny.(map[string]any)["traces"]
-	require.True(t, ok)
-	traceStorage := traceStorageAny.(string)
+
+	var traceStorage string
+
+	// Try to get the storage from jaeger_query first
+	if queryAny, found := extensions["jaeger_query"]; found {
+		if storageAny, found := queryAny.(map[string]any)["storage"]; found {
+			if traceStorageAny, found := storageAny.(map[string]any)["traces"]; found {
+				traceStorage = traceStorageAny.(string)
+			}
+		}
+	}
+
+	// If jaeger_query not found or no storage, fallback to remote_storage
+	if traceStorage == "" {
+		if remoteAny, found := extensions["remote_storage"]; found {
+			if storageNameAny, found := remoteAny.(map[string]any)["storage"]; found {
+				traceStorage = storageNameAny.(string)
+			}
+		}
+	}
+
+	require.NotEmpty(t, traceStorage, "traceStorage must be set from either jaeger_query or remote_storage")
+
 	extensions["storage_cleaner"] = map[string]string{"trace_storage": traceStorage}
 
 	jaegerStorageAny, ok := extensions["jaeger_storage"]

--- a/cmd/jaeger/internal/integration/e2e_integration_test.go
+++ b/cmd/jaeger/internal/integration/e2e_integration_test.go
@@ -10,4 +10,5 @@ func TestCreateStorageCleanerConfig(t *testing.T) {
 	// This is faster to run than the full integration test.
 	createStorageCleanerConfig(t, "../../config-elasticsearch.yaml", "elasticsearch")
 	createStorageCleanerConfig(t, "../../config-opensearch.yaml", "opensearch")
+	createStorageCleanerConfig(t, "../../config-remote-storage-backend.yaml", "memory")
 }

--- a/cmd/jaeger/internal/integration/grpc_test.go
+++ b/cmd/jaeger/internal/integration/grpc_test.go
@@ -16,10 +16,6 @@ func TestGRPCStorage(t *testing.T) {
 		ConfigFile:      "../../config-remote-storage-backend.yaml",
 		HealthCheckPort: 12133,
 		MetricsPort:     8887,
-		EnvVarOverrides: map[string]string{
-			"JAEGER_QUERY_GRPC_ENDPOINT": "localhost:0",
-			"JAEGER_QUERY_HTTP_ENDPOINT": "localhost:0",
-		},
 	}
 	remoteBackend.e2eInitialize(t, "memory")
 	t.Log("Remote backend initialized")

--- a/cmd/jaeger/internal/integration/query_test.go
+++ b/cmd/jaeger/internal/integration/query_test.go
@@ -26,10 +26,6 @@ func TestJaegerQueryService(t *testing.T) {
 		ConfigFile:      "../../config-remote-storage-backend.yaml",
 		HealthCheckPort: 12133,
 		MetricsPort:     8887,
-		EnvVarOverrides: map[string]string{
-			"JAEGER_QUERY_GRPC_ENDPOINT": "localhost:0",
-			"JAEGER_QUERY_HTTP_ENDPOINT": "localhost:0",
-		},
 		StorageIntegration: integration.StorageIntegration{
 			CleanUp: purge,
 		},


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7058

## Description of the changes
- The `jaeger_query` extension was previously added to `config-remote-storage-backend.yaml` solely to satisfy a requirement in the storage cleaner setup, even though it was otherwise unnecessary.
- This PR removes that dependency by relaxing the logic that creates the storage cleaner configuration. Instead of requiring `jaeger_query`, the code now first attempts to read the storage from the `jaeger_query` extension if available, and falls back to the `remote_storage` extension if it is not.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
