### PR TITLE
[ES][v2] Implement `GetDependenies` and `WriteDependencies`

### DIFF
--- a/internal/storage/v2/elasticsearch/depstore/storagev2.go
+++ b/internal/storage/v2/elasticsearch/depstore/storagev2.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package depstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch/depstore/dbmodel"
+)
+
+type DependencyStoreV2 struct {
+	store CoreDependencyStore
+}
+
+// NewDependencyStoreV2 returns a DependencyStoreV2
+func NewDependencyStoreV2(p Params) *DependencyStoreV2 {
+	return &DependencyStoreV2{
+		store: NewDependencyStore(p),
+	}
+}
+
+func (s *DependencyStoreV2) GetDependencies(ctx context.Context, query depstore.QueryParameters) ([]model.DependencyLink, error) {
+	dbDependencies, err := s.store.GetDependencies(ctx, query.EndTime, query.EndTime.Sub(query.StartTime))
+	if err != nil {
+		return nil, err
+	}
+	dependencies := dbmodel.ToDomainDependencies(dbDependencies)
+	return dependencies, nil
+}
+
+func (s *DependencyStoreV2) WriteDependencies(ts time.Time, dependencies []model.DependencyLink) error {
+	dbDependencies := dbmodel.FromDomainDependencies(dependencies)
+	return s.store.WriteDependencies(ts, dbDependencies)
+}

--- a/internal/storage/v2/elasticsearch/depstore/storagev2_test.go
+++ b/internal/storage/v2/elasticsearch/depstore/storagev2_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package depstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch/depstore/dbmodel"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch/depstore/mocks"
+)
+
+func TestV2GetDependencies(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockOutput     []dbmodel.DependencyLink
+		mockErr        error
+		expectedOutput []model.DependencyLink
+		expectedErr    string
+	}{
+		{
+			name:        "error from core reader",
+			mockErr:     errors.New("error from core reader"),
+			expectedErr: "error from core reader",
+		},
+		{
+			name: "success output",
+			mockOutput: []dbmodel.DependencyLink{
+				{
+					Parent:    "testing-parent",
+					Child:     "testing-child",
+					CallCount: 1,
+				},
+			},
+			expectedOutput: []model.DependencyLink{
+				{
+					Parent:    "testing-parent",
+					Child:     "testing-child",
+					CallCount: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coreReader := &mocks.CoreDependencyStore{}
+			store := DependencyStoreV2{
+				store: coreReader,
+			}
+			query := depstore.QueryParameters{
+				StartTime: time.Now(),
+				EndTime:   time.Now(),
+			}
+			coreReader.On("GetDependencies", mock.Anything, query.EndTime, query.EndTime.Sub(query.StartTime)).Return(tt.mockOutput, tt.mockErr)
+			actual, err := store.GetDependencies(context.Background(), query)
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedOutput, actual)
+			}
+		})
+	}
+}
+
+func TestV2WriteDependencies(t *testing.T) {
+	tests := []struct {
+		name         string
+		returningErr error
+		expectedErr  string
+	}{
+		{
+			name:         "error from core writer",
+			returningErr: errors.New("error from core writer"),
+			expectedErr:  "error from core writer",
+		},
+		{
+			name: "success",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coreReader := &mocks.CoreDependencyStore{}
+			store := DependencyStoreV2{
+				store: coreReader,
+			}
+			coreReader.On("WriteDependencies", mock.Anything, mock.Anything).Return(tt.returningErr)
+			err := store.WriteDependencies(time.Now(), []model.DependencyLink{})
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewDependencyStoreV2(t *testing.T) {
+	store := NewDependencyStoreV2(Params{Logger: zap.NewNop()})
+	assert.IsType(t, &DependencyStore{}, store.store)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes a part of: #7034 

## Description of the changes
- Upgrade DependencyStore for ES

## How was this change tested?
- Unit Tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
