### PR TITLE
Check that version number is corectly embedded in the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ else
 endif
 # sed on Mac does not support the same syntax for in-place updates as sed on Linux
 # When running on MacOS it's best to install gsed and run Makefile with SED=gsed
-ifeq ($(GOOS),darwin)
+ifeq ($(shell uname -s),Darwin)
 	SED=gsed
 else
 	SED=sed

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,9 @@ else
 	RACE=-race
 endif
 # sed on Mac does not support the same syntax for in-place updates as sed on Linux
-# When running on MacOS it's best to install gsed and run Makefile with SED=gsed
-ifeq ($(shell uname -s),Darwin)
+# When running on MacOS it's best to install gsed and run Makefile with SED=gsed.
+# We want the actual OS here, not what GOOS may have been set to by recursive make calls.
+ifeq ($(shell GOOS= $(GO) env GOOS),darwin)
 	SED=gsed
 else
 	SED=sed

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -74,8 +74,8 @@ build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
 	@ set -euf -o pipefail ; \
 	echo "Checking version of built binary" ; \
-	REAL_GOOS=$(shell GOOS= go env GOOS) ; \
-	REAL_GOARCH=$(shell GOARCH= go env GOARCH) ; \
+	REAL_GOOS=$(shell GOOS= $(GO) env GOOS) ; \
+	REAL_GOARCH=$(shell GOARCH= $(GO) env GOARCH) ; \
 	if [ "$(GOOS)" == "$$REAL_GOOS" ] && [ "$(GOARCH)" == "$$REAL_GOARCH" ]; then \
 		./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null ; \
 		echo "" ; \

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -72,14 +72,17 @@ _build-a-binary-%:
 build-jaeger: BIN_NAME = jaeger
 build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
-	./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version
-	@ echo GIT_CLOSEST_TAG_V2 = $(GIT_CLOSEST_TAG_V2); \
-	want=$(GIT_CLOSEST_TAG_V2) ; \
-	have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
-	echo want = $$want have = $$have; \
-	if [ "$$want" != "$$have" ]; then \
-	  echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \
-	  false; \
+	# perform version check when not cross-compiling for a different platform
+	@ if [ "$(GOOS)" = "$(shell go env GOOS)" ] && [ "$(GOARCH)" = "$(shell go env GOARCH)" ]; then \
+		./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version ; \
+		echo GIT_CLOSEST_TAG_V2 = $(GIT_CLOSEST_TAG_V2); \
+		want=$(GIT_CLOSEST_TAG_V2) ; \
+		have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
+		echo want = $$want have = $$have; \
+		if [ "$$want" != "$$have" ]; then \
+		echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \
+		false; \
+		fi ; \
 	fi
 
 .PHONY: build-all-in-one

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -72,6 +72,12 @@ _build-a-binary-%:
 build-jaeger: BIN_NAME = jaeger
 build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
+	want=$$($(MAKE) echo-v2) ; \
+	have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
+	if [ "$$want" != "$$have" ]; then \
+	  echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \
+	  false; \
+	fi
 
 .PHONY: build-all-in-one
 build-all-in-one: BIN_NAME = all-in-one

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -72,7 +72,7 @@ _build-a-binary-%:
 build-jaeger: BIN_NAME = jaeger
 build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
-	@ want=$$($(MAKE) echo-v2) ; \
+	@ want=$$($(MAKE) -s echo-v2) ; \
 	have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
 	if [ "$$want" != "$$have" ]; then \
 	  echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -135,11 +135,11 @@ build-binaries-linux-ppc64le:
 # build all binaries for one specific platform GOOS/GOARCH
 .PHONY: _build-platform-binaries
 _build-platform-binaries: \
+		build-jaeger \
 		build-all-in-one \
 		build-collector \
 		build-query \
 		build-ingester \
-		build-jaeger \
 		build-remote-storage \
 		build-examples \
 		build-tracegen \
@@ -154,12 +154,12 @@ _build-platform-binaries: \
 .PHONY: _build-platform-binaries-debug
 _build-platform-binaries-debug:
 _build-platform-binaries-debug: \
+	build-jaeger \
 	build-collector \
 	build-query \
 	build-ingester \
 	build-remote-storage \
-	build-all-in-one \
-	build-jaeger
+	build-all-in-one
 
 .PHONY: build-all-platforms
 build-all-platforms:

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -72,7 +72,7 @@ _build-a-binary-%:
 build-jaeger: BIN_NAME = jaeger
 build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
-	@ want=$$($(MAKE) -s echo-v2) ; \
+	@ want=$(GIT_CLOSEST_TAG_V2) ; \
 	have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
 	if [ "$$want" != "$$have" ]; then \
 	  echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -72,10 +72,11 @@ _build-a-binary-%:
 build-jaeger: BIN_NAME = jaeger
 build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
+	./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version
 	@ echo GIT_CLOSEST_TAG_V2 = $(GIT_CLOSEST_TAG_V2); \
 	want=$(GIT_CLOSEST_TAG_V2) ; \
-	echo want = $$want; \
 	have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
+	echo want = $$want have = $$have; \
 	if [ "$$want" != "$$have" ]; then \
 	  echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \
 	  false; \

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -72,7 +72,7 @@ _build-a-binary-%:
 build-jaeger: BIN_NAME = jaeger
 build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
-	want=$$($(MAKE) echo-v2) ; \
+	@ want=$$($(MAKE) echo-v2) ; \
 	have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
 	if [ "$$want" != "$$have" ]; then \
 	  echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -72,7 +72,9 @@ _build-a-binary-%:
 build-jaeger: BIN_NAME = jaeger
 build-jaeger: BUILD_INFO = $(BUILD_INFO_V2)
 build-jaeger: build-ui _build-a-binary-jaeger$(SUFFIX)-$(GOOS)-$(GOARCH)
-	@ want=$(GIT_CLOSEST_TAG_V2) ; \
+	@ echo GIT_CLOSEST_TAG_V2 = $(GIT_CLOSEST_TAG_V2); \
+	want=$(GIT_CLOSEST_TAG_V2) ; \
+	echo want = $$want; \
 	have=$$(./cmd/jaeger/jaeger-$(GOOS)-$(GOARCH) version 2>/dev/null | jq -r .gitVersion) ; \
 	if [ "$$want" != "$$have" ]; then \
 	  echo "❌ ERROR: version mismatch: want=$$want, have=$$have" ; \


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7090

## Description of the changes
- Add validation to the build step that the version number is correctly embedded in the binary

## How was this change tested?
- When reverting the fix done in #6990 the build fails:
```
$ make build-jaeger
echo "building binary for $(go env GOOS)-$(go env GOARCH)"; CGO_ENABLED=0 installsuffix=cgo go build -trimpath   -o ./cmd/jaeger/jaeger-darwin-arm64   -ldflags "-X   github.com/jaegertracing/jaeger/pkg/version.commitSHA=687207be86edb688436f8ef6c4383968a0ec1855 -X   github.com/jaegertracing/jaeger/pkg/version.latestVersion=v2.5.0 -X   github.com/jaegertracing/jaeger/pkg/version.date=2025-05-02T18:47:48Z" ./cmd/jaeger
building binary for darwin-arm64
❌ ERROR: version mismatch: want=v2.5.0, have=
make: *** [build-jaeger] Error 1
```
