### PR TITLE
Do not run binary size check on push to main

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -168,8 +168,8 @@ jobs:
         restore-keys: |
           jaeger_binary_size
 
-    - name: Compare jaeger binary sizes
-      if: steps.cache-binary-size.outputs.cache-matched-key != ''
+    - name: Compare `jaeger` binary sizes
+      if: ${{ (steps.cache-binary-size.outputs.cache-matched-key != '') && ((github.event_name != 'push') || (github.ref != 'refs/heads/main')) }}
       run: |
         set -euf -o pipefail
         OLD_BINARY_SIZE=$(cat ./jaeger_binary_size.txt)


### PR DESCRIPTION
## Which problem is this PR solving?
- When previous PR #7094 was force-merged with binary size check failing (there's no way to override that check to succeed), the same check [failed](https://github.com/jaegertracing/jaeger/actions/runs/14816241094/job/41597074760) on `main` AND the steps to update the binary size cache did not run

## Description of the changes
- Change the check for size to not run when on the main branch

## Testing
- The check is expected to still fail for this PR and will have to be force-merged
- But then the same check on main should succeed and update the cached value