### PR TITLE
[grpc] Allow remote storage endpoint to be set via environment variable

### DIFF
--- a/cmd/jaeger/config-remote-storage.yaml
+++ b/cmd/jaeger/config-remote-storage.yaml
@@ -45,7 +45,7 @@ extensions:
               insecure: true
       another-storage:
         grpc:
-          endpoint: localhost:17272
+          endpoint:  "${env:ARCHIVE_REMOTE_STORAGE_ENDPOINT:-localhost:17272}"
           tls:
             insecure: true  
 

--- a/cmd/jaeger/config-remote-storage.yaml
+++ b/cmd/jaeger/config-remote-storage.yaml
@@ -36,7 +36,7 @@ extensions:
     backends:
       some-storage:
         grpc:
-          endpoint: localhost:17271
+          endpoint: "${env:REMOTE_STORAGE_ENDPOINT:-localhost:17271}"
           tls:
             insecure: true
           writer:


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #7055

## Description of the changes
- This PR allows the remote storage endpoint in `config-remote-storage.yml` to be set via an environment variable. The instructions for setting this PR will be added to https://github.com/jaegertracing/jaeger/pull/7097

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
