### PR TITLE
[refactor] Remove archive storage from gRPC config

### DIFF
--- a/cmd/jaeger/config-remote-storage-backend.yaml
+++ b/cmd/jaeger/config-remote-storage-backend.yaml
@@ -1,5 +1,5 @@
 service:
-  extensions: [jaeger_storage, remote_storage, remote_storage/archive, healthcheckv2]
+  extensions: [jaeger_storage, remote_storage, healthcheckv2]
   pipelines:
     traces:
       receivers: [otlp]
@@ -33,15 +33,9 @@ extensions:
       memory-storage:
         memory:
           max_traces: 100000
-      memory-storage-archive:
-        memory:
-          max_traces: 100000
   remote_storage:
     endpoint: localhost:17271
     storage: memory-storage
-  remote_storage/archive:
-    endpoint: localhost:17272
-    storage: memory-storage-archive
 
 receivers:
   otlp:

--- a/cmd/jaeger/config-remote-storage.yaml
+++ b/cmd/jaeger/config-remote-storage.yaml
@@ -29,7 +29,6 @@ extensions:
   jaeger_query:
     storage:
       traces: some-storage
-      traces_archive: another-storage
     ui:
       config_file: ./cmd/jaeger/config-ui.json
   jaeger_storage:
@@ -43,11 +42,6 @@ extensions:
             endpoint: ${env:REMOTE_STORAGE_WRITER_ENDPOINT:-0.0.0.0:4316}
             tls:
               insecure: true
-      another-storage:
-        grpc:
-          endpoint: "${env:ARCHIVE_REMOTE_STORAGE_ENDPOINT:-localhost:17272}"
-          tls:
-            insecure: true  
 
 receivers:
   otlp:

--- a/cmd/jaeger/internal/integration/grpc_test.go
+++ b/cmd/jaeger/internal/integration/grpc_test.go
@@ -37,7 +37,6 @@ func TestGRPCStorage(t *testing.T) {
 		PropagateEnvVars: []string{
 			"REMOTE_STORAGE_ENDPOINT",
 			"REMOTE_STORAGE_WRITER_ENDPOINT",
-			"ARCHIVE_REMOTE_STORAGE_ENDPOINT",
 		},
 	}
 	collector.e2eInitialize(t, "grpc")

--- a/internal/storage/v2/grpc/README.md
+++ b/internal/storage/v2/grpc/README.md
@@ -37,7 +37,6 @@ Run the integration tests for the gRPC storage backend using the following comma
 STORAGE=grpc \
 CUSTOM_STORAGE=true \
 REMOTE_STORAGE_ENDPOINT=${MY_REMOTE_STORAGE_ENDPOINT} \
-ARCHIVE_REMOTE_STORAGE_ENDPOINT=${MY_ARCHIVE_REMOTE_STORAGE_ENDPOINT} \
 REMOTE_STORAGE_WRITER_ENDPOINT=${MY_REMOTE_STORAGE_WRITER_ENDPOINT} \
 make jaeger-v2-storage-integration-test
 ```


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #7055

## Description of the changes
- Removes the archive storage from the gRPC config as it is not being used in the integration test setup

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
