### PR TITLE
[fix] Fix mermaid diagram for gRPC integration test setup

### DIFF
--- a/cmd/jaeger/internal/integration/README.md
+++ b/cmd/jaeger/internal/integration/README.md
@@ -124,6 +124,8 @@ RemoteStorageAPI --> |read| Storage
 PurgeEndpoint --> |purge| Storage
 subgraph Integration Test Executable
     Test
+end
+subgraph Collector
     SpanWriter
     SpanReader
 end

--- a/cmd/jaeger/internal/integration/README.md
+++ b/cmd/jaeger/internal/integration/README.md
@@ -116,18 +116,25 @@ flowchart LR
 
 Test --> |writeSpan| SpanWriter
 Test --> |HTTP/purge| PurgeEndpoint
-SpanWriter --> |0.0.0.0:4316| OTLP_Receiver
+SpanWriter --> |0.0.0.0:4317| OTLP_Receiver1
+OTLP_Receiver1 --> GRPCStorage
+GRPCStorage --> |0.0.0.0:4316| OTLP_Receiver
 OTLP_Receiver --> |write| Storage
 Test --> |readSpan| SpanReader
-SpanReader --> |0.0.0.0:17271| RemoteStorageAPI
+SpanReader --> |0.0.0.0:16685| QueryExtension
+QueryExtension --> GRPCStorage
+GRPCStorage --> |0.0.0.0:17271| RemoteStorageAPI
 RemoteStorageAPI --> |read| Storage
 PurgeEndpoint --> |purge| Storage
 subgraph Integration Test Executable
     Test
-end
-subgraph Collector
     SpanWriter
     SpanReader
+end
+subgraph Collector
+    OTLP_Receiver1[OTLP Receiver]
+    QueryExtension[Query Extension]
+    GRPCStorage[gRPC Storage]
 end
 subgraph Remote Storage Backend
     OTLP_Receiver[OTLP Receiver]


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #7055

## Description of the changes
- The original Mermaid diagram for the gRPC integration test setup only showed two binaries, but there are actually three involved. This PR updates the diagram to accurately reflect all three.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
