### PR TITLE
[Fix] es mapping in jaeger-span.json the duration type is long, does …

### DIFF
--- a/cmd/collector/app/span_handler_builder_test.go
+++ b/cmd/collector/app/span_handler_builder_test.go
@@ -6,11 +6,13 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/collector/app/flags"
 	cmdFlags "github.com/jaegertracing/jaeger/cmd/internal/flags"
 	"github.com/jaegertracing/jaeger/internal/config"
@@ -57,4 +59,66 @@ func TestNewSpanHandlerBuilder(t *testing.T) {
 
 func TestDefaultSpanFilter(t *testing.T) {
 	assert.True(t, defaultSpanFilter(nil))
+}
+
+func TestNegativeDurationSpanSanitizer(t *testing.T) {
+	builder := &SpanHandlerBuilder{
+		Logger: zap.NewNop(),
+	}
+
+	spans := []*model.Span{
+		{
+			TraceID:  model.NewTraceID(0, 1),
+			SpanID:   model.NewSpanID(1),
+			Duration: time.Duration(0),
+			Tags:     []model.KeyValue{},
+		},
+		{
+			TraceID:  model.NewTraceID(0, 2),
+			SpanID:   model.NewSpanID(2),
+			Duration: time.Duration(10000),
+			Tags:     []model.KeyValue{},
+		},
+		{
+			TraceID:  model.NewTraceID(0, 3),
+			SpanID:   model.NewSpanID(3),
+			Duration: time.Duration(-5000),
+			Tags:     []model.KeyValue{},
+		},
+		{
+			TraceID:  model.NewTraceID(0, 4),
+			SpanID:   model.NewSpanID(4),
+			Duration: time.Duration(-1),
+			Tags:     []model.KeyValue{},
+		},
+	}
+
+	for i, span := range spans {
+		result := builder.NegativeDurationSpanSanitizer(span)
+
+		switch i {
+		case 0:
+			assert.Equal(t, time.Duration(0), result.Duration)
+			assert.Empty(t, result.Warnings)
+			assert.Empty(t, result.Tags)
+		case 1:
+			assert.Equal(t, time.Duration(10000), result.Duration)
+			assert.Empty(t, result.Warnings)
+			assert.Empty(t, result.Tags)
+		case 2:
+			assert.Equal(t, time.Duration(1), result.Duration)
+			assert.Len(t, result.Warnings, 1)
+			assert.Contains(t, result.Warnings[0], "Negative duration")
+			assert.Len(t, result.Tags, 1)
+			assert.Equal(t, "duration-adjusted", result.Tags[0].Key)
+			assert.Equal(t, int64(1), result.Tags[0].VInt64)
+		case 3:
+			assert.Equal(t, time.Duration(1), result.Duration)
+			assert.Len(t, result.Warnings, 1)
+			assert.Contains(t, result.Warnings[0], "Negative duration")
+			assert.Len(t, result.Tags, 1)
+			assert.Equal(t, "duration-adjusted", result.Tags[0].Key)
+			assert.Equal(t, int64(1), result.Tags[0].VInt64)
+		}
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2517

## Description of the changes
- A new sanitizer check has been introduced to replace negative durations with a default value of 1.
- When a negative duration is corrected, additional metadata(warning, tag and) is added to the span to capture the adjustment + the event is logged.

## How was this change tested?
- A unit test has been added to verify that negative durations are correctly converted to 1, while positive durations remain unchanged.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
