### PR TITLE
Add retry configuration to storage exporter

### DIFF
--- a/cmd/jaeger/internal/exporters/storageexporter/README.md
+++ b/cmd/jaeger/internal/exporters/storageexporter/README.md
@@ -20,32 +20,23 @@ extensions:
 
 ### Retry Configuration
 
-The exporter supports configurable retry behavior for failed exports. By default, retry is enabled with the following settings:
+The exporter supports configurable retry behavior for failed exports. By default, retry is disabled. When enabled, the following default settings are used:
 
-- `enabled`: true
+- `enabled`: false (disabled by default)
 - `initial_interval`: 5s
 - `randomization_factor`: 0.5
 - `multiplier`: 1.5
 - `max_interval`: 30s
 - `max_elapsed_time`: 5m
 
-#### Explanation of Retry Parameters
-
-- `enabled`: Controls whether retry is enabled or disabled
-- `initial_interval`: The initial time to wait before the first retry
-- `randomization_factor`: Randomization factor to apply to the backoff interval (0.0 to 1.0)
-- `multiplier`: Factor to multiply the interval by for each subsequent retry
-- `max_interval`: The maximum interval between retries
-- `max_elapsed_time`: The maximum total time spent retrying before giving up
-
-You can customize the retry behavior like this:
+To enable and customize the retry behavior:
 
 ```yaml
 exporters:
   jaeger_storage_exporter:
     trace_storage: memstore
     retry_on_failure:
-      enabled: true
+      enabled: true  # Explicitly enable retries
       initial_interval: 10s
       max_interval: 1m
       max_elapsed_time: 10m
@@ -53,14 +44,4 @@ exporters:
       enabled: true
       num_consumers: 10
       queue_size: 1000
-```
-
-To disable retry:
-
-```yaml
-exporters:
-  jaeger_storage_exporter:
-    trace_storage: memstore
-    retry_on_failure:
-      enabled: false
 ```

--- a/cmd/jaeger/internal/exporters/storageexporter/README.md
+++ b/cmd/jaeger/internal/exporters/storageexporter/README.md
@@ -4,6 +4,8 @@ This module implements `exporter.Traces` and writes spans into Jaeger native `sp
 
 ## Configuration
 
+### Basic Configuration
+
 ```yaml
 exporters:
   jaeger_storage_exporter:
@@ -14,4 +16,51 @@ extensions:
     memory:
       memstore:
         max_traces: 100000
+```
+
+### Retry Configuration
+
+The exporter supports configurable retry behavior for failed exports. By default, retry is enabled with the following settings:
+
+- `enabled`: true
+- `initial_interval`: 5s
+- `randomization_factor`: 0.5
+- `multiplier`: 1.5
+- `max_interval`: 30s
+- `max_elapsed_time`: 5m
+
+#### Explanation of Retry Parameters
+
+- `enabled`: Controls whether retry is enabled or disabled
+- `initial_interval`: The initial time to wait before the first retry
+- `randomization_factor`: Randomization factor to apply to the backoff interval (0.0 to 1.0)
+- `multiplier`: Factor to multiply the interval by for each subsequent retry
+- `max_interval`: The maximum interval between retries
+- `max_elapsed_time`: The maximum total time spent retrying before giving up
+
+You can customize the retry behavior like this:
+
+```yaml
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: memstore
+    retry_on_failure:
+      enabled: true
+      initial_interval: 10s
+      max_interval: 1m
+      max_elapsed_time: 10m
+    queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 1000
+```
+
+To disable retry:
+
+```yaml
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: memstore
+    retry_on_failure:
+      enabled: false
 ```

--- a/cmd/jaeger/internal/exporters/storageexporter/config.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/config.go
@@ -20,7 +20,7 @@ var (
 type Config struct {
 	TraceStorage string                          `mapstructure:"trace_storage" valid:"required"`
 	QueueConfig  exporterhelper.QueueBatchConfig `mapstructure:"queue" valid:"optional"`
-	RetryConfig  configretry.BackOffConfig       `mapstructure:"retry_on_failure" valid:"optional"`
+	RetryConfig  configretry.BackOffConfig       `mapstructure:"retry_on_failure"`
 }
 
 func (cfg *Config) Validate() error {

--- a/cmd/jaeger/internal/exporters/storageexporter/config.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/config.go
@@ -6,6 +6,7 @@ package storageexporter
 import (
 	"github.com/asaskevich/govalidator"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
@@ -19,6 +20,7 @@ var (
 type Config struct {
 	TraceStorage string                          `mapstructure:"trace_storage" valid:"required"`
 	QueueConfig  exporterhelper.QueueBatchConfig `mapstructure:"queue" valid:"optional"`
+	RetryConfig  configretry.BackOffConfig       `mapstructure:"retry_on_failure" valid:"optional"`
 }
 
 func (cfg *Config) Validate() error {

--- a/cmd/jaeger/internal/exporters/storageexporter/factory.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/factory.go
@@ -5,7 +5,6 @@ package storageexporter
 
 import (
 	"context"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
@@ -30,56 +29,17 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	cfg := configretry.NewDefaultBackOffConfig()
+	cfg.Enabled = false
 	return &Config{
-		RetryConfig: configretry.BackOffConfig{
-			Enabled:             true,
-			InitialInterval:     5 * time.Second,
-			RandomizationFactor: 0.5,
-			Multiplier:          1.5,
-			MaxInterval:         30 * time.Second,
-			MaxElapsedTime:      5 * time.Minute,
-		},
+		RetryConfig: cfg,
 	}
 }
 
-func createTracesExporter(
-	ctx context.Context,
-	set exporter.Settings,
-	config component.Config,
-) (exporter.Traces, error) {
+func createTracesExporter(ctx context.Context, set exporter.Settings, config component.Config) (exporter.Traces, error) {
 	cfg := config.(*Config)
-
-	defaultCfg := createDefaultConfig().(*Config)
-
-	if !cfg.RetryConfig.Enabled {
-		cfg.RetryConfig = configretry.BackOffConfig{
-			Enabled: false,
-		}
-	} else {
-		if cfg.RetryConfig.InitialInterval == 0 {
-			cfg.RetryConfig.InitialInterval = defaultCfg.RetryConfig.InitialInterval
-		}
-		if cfg.RetryConfig.MaxInterval == 0 {
-			cfg.RetryConfig.MaxInterval = defaultCfg.RetryConfig.MaxInterval
-		}
-		if cfg.RetryConfig.MaxElapsedTime == 0 {
-			cfg.RetryConfig.MaxElapsedTime = defaultCfg.RetryConfig.MaxElapsedTime
-		}
-		if cfg.RetryConfig.RandomizationFactor == 0 {
-			cfg.RetryConfig.RandomizationFactor = defaultCfg.RetryConfig.RandomizationFactor
-		}
-		if cfg.RetryConfig.Multiplier == 0 {
-			cfg.RetryConfig.Multiplier = defaultCfg.RetryConfig.Multiplier
-		}
-		cfg.RetryConfig.Enabled = true
-	}
-
 	ex := newExporter(cfg, set.TelemetrySettings)
-
-	return exporterhelper.NewTraces(
-		ctx,
-		set,
-		cfg,
+	return exporterhelper.NewTraces(ctx, set, cfg,
 		ex.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// Disable Timeout

--- a/cmd/jaeger/internal/exporters/storageexporter/factory.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/factory.go
@@ -5,6 +5,7 @@ package storageexporter
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
@@ -29,18 +30,61 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		RetryConfig: configretry.BackOffConfig{
+			Enabled:             true,
+			InitialInterval:     5 * time.Second,
+			RandomizationFactor: 0.5,
+			Multiplier:          1.5,
+			MaxInterval:         30 * time.Second,
+			MaxElapsedTime:      5 * time.Minute,
+		},
+	}
 }
 
-func createTracesExporter(ctx context.Context, set exporter.Settings, config component.Config) (exporter.Traces, error) {
+func createTracesExporter(
+	ctx context.Context,
+	set exporter.Settings,
+	config component.Config,
+) (exporter.Traces, error) {
 	cfg := config.(*Config)
+
+	defaultCfg := createDefaultConfig().(*Config)
+
+	if !cfg.RetryConfig.Enabled {
+		cfg.RetryConfig = configretry.BackOffConfig{
+			Enabled: false,
+		}
+	} else {
+		if cfg.RetryConfig.InitialInterval == 0 {
+			cfg.RetryConfig.InitialInterval = defaultCfg.RetryConfig.InitialInterval
+		}
+		if cfg.RetryConfig.MaxInterval == 0 {
+			cfg.RetryConfig.MaxInterval = defaultCfg.RetryConfig.MaxInterval
+		}
+		if cfg.RetryConfig.MaxElapsedTime == 0 {
+			cfg.RetryConfig.MaxElapsedTime = defaultCfg.RetryConfig.MaxElapsedTime
+		}
+		if cfg.RetryConfig.RandomizationFactor == 0 {
+			cfg.RetryConfig.RandomizationFactor = defaultCfg.RetryConfig.RandomizationFactor
+		}
+		if cfg.RetryConfig.Multiplier == 0 {
+			cfg.RetryConfig.Multiplier = defaultCfg.RetryConfig.Multiplier
+		}
+		cfg.RetryConfig.Enabled = true
+	}
+
 	ex := newExporter(cfg, set.TelemetrySettings)
-	return exporterhelper.NewTraces(ctx, set, cfg,
+
+	return exporterhelper.NewTraces(
+		ctx,
+		set,
+		cfg,
 		ex.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		// Disable Timeout/RetryOnFailure
+		// Disable Timeout
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
-		exporterhelper.WithRetry(configretry.BackOffConfig{Enabled: false}),
+		exporterhelper.WithRetry(cfg.RetryConfig),
 		exporterhelper.WithQueue(cfg.QueueConfig),
 		exporterhelper.WithStart(ex.start),
 		exporterhelper.WithShutdown(ex.close),

--- a/cmd/jaeger/internal/exporters/storageexporter/factory_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/factory_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package storageexporter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/exporter"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				TraceStorage: "test",
+				RetryConfig: configretry.BackOffConfig{
+					Enabled:         true,
+					InitialInterval: 5 * time.Second,
+					MaxInterval:     30 * time.Second,
+					MaxElapsedTime:  5 * time.Minute,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing trace storage",
+			config: &Config{
+				TraceStorage: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func createTestExporterSettings() exporter.Settings {
+	return exporter.Settings{
+		ID:                component.MustNewIDWithName("jaeger_storage", "test"),
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+}
+
+func TestCreateTracesExporter(t *testing.T) {
+	t.Run("with default config", func(t *testing.T) {
+		defaultCfg := createDefaultConfig().(*Config)
+		defaultCfg.TraceStorage = "test"
+
+		exp, err := createTracesExporter(
+			context.Background(),
+			createTestExporterSettings(),
+			defaultCfg,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+
+		assert.True(t, defaultCfg.RetryConfig.Enabled, "Retry should be enabled by default")
+		assert.Equal(t, 5*time.Second, defaultCfg.RetryConfig.InitialInterval, "InitialInterval should be 5s")
+		assert.InDelta(t, 0.5, defaultCfg.RetryConfig.RandomizationFactor, 1e-6, "RandomizationFactor should be 0.5")
+		assert.InDelta(t, 1.5, defaultCfg.RetryConfig.Multiplier, 1e-6, "Multiplier should be 1.5")
+		assert.Equal(t, 30*time.Second, defaultCfg.RetryConfig.MaxInterval, "MaxInterval should be 30s")
+		assert.Equal(t, 5*time.Minute, defaultCfg.RetryConfig.MaxElapsedTime, "MaxElapsedTime should be 5m")
+	})
+
+	t.Run("with custom retry config", func(t *testing.T) {
+		cfg := &Config{
+			TraceStorage: "test",
+			RetryConfig: configretry.BackOffConfig{
+				Enabled:             true,
+				InitialInterval:     10 * time.Second,
+				RandomizationFactor: 0.7,
+				Multiplier:          2.0,
+				MaxInterval:         60 * time.Second,
+				MaxElapsedTime:      10 * time.Minute,
+			},
+		}
+
+		exp, err := createTracesExporter(
+			context.Background(),
+			createTestExporterSettings(),
+			cfg,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+
+		assert.True(t, cfg.RetryConfig.Enabled, "Retry should be enabled")
+		assert.Equal(t, 10*time.Second, cfg.RetryConfig.InitialInterval, "InitialInterval should be 10s")
+		assert.InDelta(t, 0.7, cfg.RetryConfig.RandomizationFactor, 1e-6, "RandomizationFactor should be 0.7")
+		assert.InDelta(t, 2.0, cfg.RetryConfig.Multiplier, 1e-6, "Multiplier should be 2.0")
+		assert.Equal(t, 60*time.Second, cfg.RetryConfig.MaxInterval, "MaxInterval should be 60s")
+		assert.Equal(t, 10*time.Minute, cfg.RetryConfig.MaxElapsedTime, "MaxElapsedTime should be 10m")
+	})
+
+	t.Run("with disabled retry", func(t *testing.T) {
+		cfg := &Config{
+			TraceStorage: "test",
+			RetryConfig: configretry.BackOffConfig{
+				Enabled: false,
+			},
+		}
+
+		exp, err := createTracesExporter(
+			context.Background(),
+			createTestExporterSettings(),
+			cfg,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+
+		assert.False(t, cfg.RetryConfig.Enabled)
+	})
+}
+
+func TestCreateTracesExporter_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				TraceStorage: "test",
+				RetryConfig: configretry.BackOffConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing trace storage",
+			config: &Config{
+				RetryConfig: configretry.BackOffConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/jaeger/internal/exporters/storageexporter/factory_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/factory_test.go
@@ -76,13 +76,7 @@ func TestCreateTracesExporter(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, exp)
-
-		assert.True(t, defaultCfg.RetryConfig.Enabled, "Retry should be enabled by default")
-		assert.Equal(t, 5*time.Second, defaultCfg.RetryConfig.InitialInterval, "InitialInterval should be 5s")
-		assert.InDelta(t, 0.5, defaultCfg.RetryConfig.RandomizationFactor, 1e-6, "RandomizationFactor should be 0.5")
-		assert.InDelta(t, 1.5, defaultCfg.RetryConfig.Multiplier, 1e-6, "Multiplier should be 1.5")
-		assert.Equal(t, 30*time.Second, defaultCfg.RetryConfig.MaxInterval, "MaxInterval should be 30s")
-		assert.Equal(t, 5*time.Minute, defaultCfg.RetryConfig.MaxElapsedTime, "MaxElapsedTime should be 5m")
+		assert.False(t, defaultCfg.RetryConfig.Enabled, "Retry should be disabled by default")
 	})
 
 	t.Run("with custom retry config", func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7110

## Description of the changes
- Added retry configuration with all available parameters
- Updated documentation to reflect all configurable retry parameters

## How was this change tested?
- Added tests in `storageexporter` package.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
