### PR TITLE
Add e2e test for docker-compose-elasticsearch.yml file

### DIFF
--- a/.github/workflows/ci-e2e-spm.yml
+++ b/.github/workflows/ci-e2e-spm.yml
@@ -27,6 +27,8 @@ jobs:
           binary: all-in-one
         - name: v2
           binary: jaeger
+        - name: es
+          binary: elasticsearch
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/ci-e2e-spm.yml
+++ b/.github/workflows/ci-e2e-spm.yml
@@ -25,10 +25,13 @@ jobs:
         mode:
         - name: v1
           binary: all-in-one
+          database: memory
         - name: v2
           binary: jaeger
-        - name: es
-          binary: elasticsearch
+          database: memory
+        - name: v2 with ES
+          binary: jaeger
+          database: elasticsearch
 
     steps:
     - name: Harden Runner
@@ -52,4 +55,4 @@ jobs:
       uses: ./.github/actions/setup-node.js
       
     - name: Run SPM Test
-      run:  bash scripts/e2e/spm.sh  -b ${{ matrix.mode.binary }}
+      run:  bash scripts/e2e/spm.sh -b ${{ matrix.mode.binary }} -d ${{ matrix.mode.database }}

--- a/docker-compose/monitor/Makefile
+++ b/docker-compose/monitor/Makefile
@@ -28,6 +28,11 @@ dev-v1: export BINARY = all-in-one
 dev-v1: build
 	docker compose -f docker-compose-v1.yml up $(DOCKER_COMPOSE_ARGS)
 
+.PHONY: elasticsearch
+elasticsearch: export JAEGER_VERSION = dev
+elasticsearch:
+	docker compose -f docker-compose-elasticsearch.yml up $(DOCKER_COMPOSE_ARGS)
+
 .PHONY: clean-jaeger
 clean-jaeger:
 	# Also cleans up intermediate cached containers.

--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -16,6 +16,7 @@ print_help() {
 BINARY='jaeger'
 DATABASE='memory'
 compose_file=docker-compose/monitor/docker-compose.yml
+make_target="dev"
 
 while getopts "b:d:h" opt; do
   case "${opt}" in
@@ -58,10 +59,12 @@ esac
 # Set compose file based on binary and database
 if [ "$BINARY" == "all-in-one" ]; then
   compose_file=docker-compose/monitor/docker-compose-v1.yml
+  make_target="dev-v1"
 fi
 
 if [ "$DATABASE" == "elasticsearch" ]; then
   compose_file=docker-compose/monitor/docker-compose-elasticsearch.yml
+  make_target="elasticsearch"
 fi
 
 timeout=600
@@ -244,16 +247,7 @@ teardown_services() {
 }
 
 main() {
-  make_target="dev"
-  if [ "$BINARY" == "all-in-one" ]; then
-      make_target="dev-v1"
-  fi
-
   (cd docker-compose/monitor && make build BINARY="$BINARY" && make $make_target DOCKER_COMPOSE_ARGS="-d")
-
-  if [ "$DATABASE" == "elasticsearch" ]; then
-      (cd docker-compose/monitor && make elasticsearch DOCKER_COMPOSE_ARGS="-d")
-  fi
 
   wait_for_services
   check_spm

--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -8,7 +8,7 @@ set -euf -o pipefail
 print_help() {
   echo "Usage: $0 [-b binary] [-d database]"
   echo "-b: Which binary to build: 'all-in-one' or 'jaeger' (v2, default)"
-  echo "-d: Which database to use: 'none' (default) or 'elasticsearch'"
+  echo "-d: Which database to use: 'memory' (default) or 'elasticsearch'"
   echo "-h: Print help"
   exit 1
 }
@@ -244,17 +244,15 @@ teardown_services() {
 }
 
 main() {
-  case "$BINARY" in
-    "jaeger")
-      (cd docker-compose/monitor && make build BINARY="$BINARY" && make dev DOCKER_COMPOSE_ARGS="-d")
-      ;;
-    "all-in-one")
-      (cd docker-compose/monitor && make build BINARY="$BINARY" && make dev-v1 DOCKER_COMPOSE_ARGS="-d")
-      ;;
-  esac
+  make_target="dev"
+  if [ "$BINARY" == "all-in-one" ]; then
+      make_target="dev-v1"
+  fi
+
+  (cd docker-compose/monitor && make build BINARY="$BINARY" && make $make_target DOCKER_COMPOSE_ARGS="-d")
 
   if [ "$DATABASE" == "elasticsearch" ]; then
-    (cd docker-compose/monitor && make elasticsearch DOCKER_COMPOSE_ARGS="-d")
+      (cd docker-compose/monitor && make elasticsearch DOCKER_COMPOSE_ARGS="-d")
   fi
 
   wait_for_services


### PR DESCRIPTION
## Which problem is this PR solving?
- Partly solve https://github.com/jaegertracing/jaeger/issues/7142

## Description of the changes
- Add e2e test to exercise docker-compose-elasticsearch.yml file

## How was this change tested?
- Through system test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
