### PR TITLE
[clickhouse]: deprecated the dbmodel base on `ch-go` library

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/dbmodel.go
@@ -5,6 +5,7 @@ package dbmodel
 
 import "time"
 
+// Deprecated: Use internal.Trace instead.
 // Trace Domain model in Clickhouse.
 // This struct represents the schema for storing OTel pipeline Traces in Clickhouse.
 type Trace struct {
@@ -15,16 +16,19 @@ type Trace struct {
 	Events   []Event
 }
 
+// Deprecated: Use internal.Resource instead.
 type Resource struct {
 	Attributes AttributesGroup
 }
 
+// Deprecated: Use internal.Scope instead.
 type Scope struct {
 	Name       string
 	Version    string
 	Attributes AttributesGroup
 }
 
+// Deprecated: Use internal.Trace instead.
 type Span struct {
 	Timestamp     time.Time
 	TraceId       string
@@ -39,6 +43,7 @@ type Span struct {
 	Attributes    AttributesGroup
 }
 
+// Deprecated: Use internal.Link instead.
 type Link struct {
 	TraceId    string
 	SpanId     string
@@ -46,6 +51,7 @@ type Link struct {
 	Attributes AttributesGroup
 }
 
+// Deprecated: Use internal.Event instead.
 type Event struct {
 	Name       string
 	Timestamp  time.Time

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/jptrace"
 )
 
+// Deprecated: Use internal.FromDBModel instead.
 func FromDBModel(dbTrace Trace) ptrace.Traces {
 	trace := ptrace.NewTraces()
 	resourceSpans := trace.ResourceSpans().AppendEmpty()

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/dbmodel.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// Trace Domain model in Clickhouse.
+// This struct represents the schema for storing ptrace.Traces in Clickhouse.
+type Trace struct {
+	Resource Resource
+	Scope    Scope
+	Span     Span
+	Events   []Event
+	Links    []Link
+}
+
+// Resource Domain model in Clickhouse.
+// This struct represents the schema for storing pcommon.Resource in Clickhouse.
+type Resource struct {
+	Attributes AttributesGroup
+}
+
+// Scope Domain model in Clickhouse.
+// This struct represents the schema for storing pcommon.InstrumentationScope in Clickhouse.
+type Scope struct {
+	Name       string
+	Version    string
+	Attributes AttributesGroup
+}
+
+// Span Domain model in Clickhouse.
+// This struct represents the schema for storing ptrace.Span in Clickhouse.
+type Span struct {
+	StartTime     time.Time
+	TraceId       []byte
+	SpanId        []byte
+	ParentSpanId  []byte
+	TraceState    string
+	ServiceName   string
+	Name          string
+	Kind          string
+	Duration      int64
+	StatusCode    string
+	StatusMessage string
+	Attributes    AttributesGroup
+}
+
+// Link Domain model in Clickhouse.
+// This struct represents the schema for storing ptrace.SpanLink in Clickhouse.
+type Link struct {
+	ptrace.SpanEvent
+	TraceId    []byte
+	SpanId     []byte
+	TraceState string
+	Attributes AttributesGroup
+}
+
+// Event Domain model in Clickhouse.
+// This struct represents the schema for storing ptrace.SpanLink in Clickhouse.
+type Event struct {
+	Name       string
+	Timestamp  time.Time
+	Attributes AttributesGroup
+}
+
+// AttributesGroup captures all data from a single pcommon.Map, except
+// complex attributes (like slice or map) which are currently not supported.
+// AttributesGroup consists of pairs of vectors for each of the supported primitive
+// types, e.g. (BoolKeys, BoolValues). Every attribute in the pcommon.Map is mapped
+// to one of the pairs depending on its type. The slices in each pair have identical
+// length, which may be different from length in another pair. For example, if the
+// pcommon.Map has no Boolean attributes then (BoolKeys=[], BoolValues=[]).
+type AttributesGroup struct {
+	BoolKeys     []string
+	BoolValues   []bool
+	DoubleKeys   []string
+	DoubleValues []float64
+	IntKeys      []string
+	IntValues    []int64
+	StrKeys      []string
+	StrValues    []string
+	BytesKeys    []string
+	BytesValues  [][]byte
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/fixtures/dbmodel.json
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/fixtures/dbmodel.json
@@ -1,0 +1,214 @@
+{
+  "Resource": {
+    "Attributes": {
+      "BoolKeys": [
+        "browser.mobile"
+      ],
+      "BoolValues": [
+        true
+      ],
+      "DoubleKeys": [
+        "host.memory.swap"
+      ],
+      "DoubleValues": [
+        2048
+      ],
+      "IntKeys": [
+        "process.parent.pid",
+        "process.pid",
+        "faas.max_memory"
+      ],
+      "IntValues": [
+        111,
+        1234,
+        134217728
+      ],
+      "StrKeys": [
+        "service.name",
+        "service.instance.id"
+      ],
+      "StrValues": [
+        "clickhouse",
+        "627cc493-f310-47de-96bd-71410b7dec09"
+      ],
+      "BytesKeys": [
+        "oci.manifest.digest"
+      ],
+      "BytesValues": [
+        "c2hhMjU2OmU0Y2E2MmMwZDYyZjNlODg2ZTY4NDgwNmRmZTlkNGUwY2RhNjBkNTQ5ODY4OTgxNzNjMTA4Mzg1NmNmZGEwZjQ="
+      ]
+    }
+  },
+  "Scope": {
+    "Name": "io.opentelemetry.contrib.clickhouse",
+    "Version": "1.0.0",
+    "Attributes": {
+      "BoolKeys": [
+        "library.feature.async_processing_enabled",
+        "library.security.data_masking_active"
+      ],
+      "BoolValues": [
+        true,
+        false
+      ],
+      "DoubleKeys": [
+        "component.config.sampling.ratio"
+      ],
+      "DoubleValues": [
+        0.75
+      ],
+      "IntKeys": [
+        "component.max_workers",
+        "component.min_workers"
+      ],
+      "IntValues": [
+        10,
+        2
+      ],
+      "StrKeys": [
+        "library.language",
+        "library.version"
+      ],
+      "StrValues": [
+        "go",
+        "v2.2.2"
+      ],
+      "BytesKeys": [
+        "scope.test.bytes.value"
+      ],
+      "BytesValues": [
+        "AQIDBA=="
+      ]
+    }
+  },
+  "Span": {
+    "StartTime": "2023-12-25T09:53:49Z",
+    "TraceId": "AQIDAAAAAAAAAAAAAAAAAA==",
+    "SpanId": "AQIDAAAAAAA=",
+    "ParentSpanId": "AQIEAAAAAAA=",
+    "TraceState": "trace state",
+    "ServiceName": "clickhouse",
+    "Name": "call db",
+    "Kind": "Internal",
+    "Duration": 60000000000,
+    "StatusCode": "Error",
+    "StatusMessage": "error",
+    "Attributes": {
+      "BoolKeys": [
+        "app.payment.card_valid",
+        "app.payment.charged"
+      ],
+      "BoolValues": [
+        true,
+        true
+      ],
+      "DoubleKeys": [
+        "app.payment.amount"
+      ],
+      "DoubleValues": [
+        99.99
+      ],
+      "IntKeys": [
+        "app.payment.count"
+      ],
+      "IntValues": [
+        5
+      ],
+      "StrKeys": [
+        "app.payment.id"
+      ],
+      "StrValues": [
+        "123456789"
+      ],
+      "BytesKeys": [
+        "span.test.bytes.value"
+      ],
+      "BytesValues": [
+        "AQIDBAUG"
+      ]
+    }
+  },
+  "Events": [
+    {
+      "Name": "event1",
+      "Timestamp": "2023-12-25T09:53:49Z",
+      "Attributes": {
+        "BoolKeys": [
+          "inventory.available",
+          "payment.successful"
+        ],
+        "BoolValues": [
+          true,
+          true
+        ],
+        "DoubleKeys": [
+          "product.price",
+          "order.discount.rate"
+        ],
+        "DoubleValues": [
+          6.04,
+          0.04
+        ],
+        "IntKeys": [
+          "order.quantity"
+        ],
+        "IntValues": [
+          2
+        ],
+        "StrKeys": [
+          "product.id",
+          "order.id"
+        ],
+        "StrValues": [
+          "987654321",
+          "123456789"
+        ],
+        "BytesKeys": [
+          "event.test.bytes.value"
+        ],
+        "BytesValues": [
+          "AQIDBAUG"
+        ]
+      }
+    }
+  ],
+  "Links": [
+    {
+      "TraceId": "AQIFAAAAAAAAAAAAAAAAAA==",
+      "SpanId": "AQIFAAAAAAA=",
+      "TraceState": "test",
+      "Attributes": {
+        "BoolKeys": [
+          "is.retry"
+        ],
+        "BoolValues": [
+          true
+        ],
+        "DoubleKeys": [
+          "similarity.score"
+        ],
+        "DoubleValues": [
+          0.85
+        ],
+        "IntKeys": [
+          "correlation.id"
+        ],
+        "IntValues": [
+          1324141
+        ],
+        "StrKeys": [
+          "related.resource.id"
+        ],
+        "StrValues": [
+          "resource-123"
+        ],
+        "BytesKeys": [
+          "link.test.bytes.value"
+        ],
+        "BytesValues": [
+          "AQIDBAUG"
+        ]
+      }
+    }
+  ]
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/fixtures/ptrace.json
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/fixtures/ptrace.json
@@ -1,0 +1,265 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "clickhouse"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "627cc493-f310-47de-96bd-71410b7dec09"
+            }
+          },
+          {
+            "key": "process.parent.pid",
+            "value": {
+              "intValue": "111"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": "1234"
+            }
+          },
+          {
+            "key": "faas.max_memory",
+            "value": {
+              "intValue": "134217728"
+            }
+          },
+          {
+            "key": "host.memory.swap",
+            "value": {
+              "doubleValue": 2048
+            }
+          },
+          {
+            "key": "browser.mobile",
+            "value": {
+              "boolValue": true
+            }
+          },
+          {
+            "key": "oci.manifest.digest",
+            "value": {
+              "bytesValue": "c2hhMjU2OmU0Y2E2MmMwZDYyZjNlODg2ZTY4NDgwNmRmZTlkNGUwY2RhNjBkNTQ5ODY4OTgxNzNjMTA4Mzg1NmNmZGEwZjQ="
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "io.opentelemetry.contrib.clickhouse",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "library.language",
+                "value": {
+                  "stringValue": "go"
+                }
+              },
+              {
+                "key": "library.version",
+                "value": {
+                  "stringValue": "v2.2.2"
+                }
+              },
+              {
+                "key": "library.feature.async_processing_enabled",
+                "value": {
+                  "boolValue": true
+                }
+              },
+              {
+                "key": "library.security.data_masking_active",
+                "value": {
+                  "boolValue": false
+                }
+              },
+              {
+                "key": "component.config.sampling.ratio",
+                "value": {
+                  "doubleValue": 0.75
+                }
+              },
+              {
+                "key": "component.max_workers",
+                "value": {
+                  "intValue": "10"
+                }
+              },
+              {
+                "key": "component.min_workers",
+                "value": {
+                  "intValue": "2"
+                }
+              },
+              {
+                "key": "scope.test.bytes.value",
+                "value": {
+                  "bytesValue": "AQIDBA=="
+                }
+              }
+            ]
+          },
+          "spans": [
+            {
+              "traceId": "01020300000000000000000000000000",
+              "spanId": "0102030000000000",
+              "traceState": "trace state",
+              "parentSpanId": "0102040000000000",
+              "name": "call db",
+              "kind": 1,
+              "startTimeUnixNano": "1703498029000000000",
+              "endTimeUnixNano": "1703498089000000000",
+              "attributes": [
+                {
+                  "key": "app.payment.card_valid",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "app.payment.charged",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "app.payment.amount",
+                  "value": {
+                    "doubleValue": 99.99
+                  }
+                },
+                {
+                  "key": "app.payment.count",
+                  "value": {
+                    "intValue": "5"
+                  }
+                },
+                {
+                  "key": "app.payment.id",
+                  "value": {
+                    "stringValue": "123456789"
+                  }
+                },
+                {
+                  "key": "span.test.bytes.value",
+                  "value": {
+                    "bytesValue": "AQIDBAUG"
+                  }
+                }
+              ],
+              "events": [
+                {
+                  "timeUnixNano": "1703498029000000000",
+                  "name": "event1",
+                  "attributes": [
+                    {
+                      "key": "inventory.available",
+                      "value": {
+                        "boolValue": true
+                      }
+                    },
+                    {
+                      "key": "payment.successful",
+                      "value": {
+                        "boolValue": true
+                      }
+                    },
+                    {
+                      "key": "product.price",
+                      "value": {
+                        "doubleValue": 6.04
+                      }
+                    },
+                    {
+                      "key": "order.discount.rate",
+                      "value": {
+                        "doubleValue": 0.04
+                      }
+                    },
+                    {
+                      "key": "order.quantity",
+                      "value": {
+                        "intValue": "2"
+                      }
+                    },
+                    {
+                      "key": "order.id",
+                      "value": {
+                        "stringValue": "123456789"
+                      }
+                    },
+                    {
+                      "key": "product.id",
+                      "value": {
+                        "stringValue": "987654321"
+                      }
+                    },
+                    {
+                      "key": "event.test.bytes.value",
+                      "value": {
+                        "bytesValue": "AQIDBAUG"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "links": [
+                {
+                  "traceId": "01020500000000000000000000000000",
+                  "spanId": "0102050000000000",
+                  "traceState": "test",
+                  "attributes": [
+                    {
+                      "key": "is.retry",
+                      "value": {
+                        "boolValue": true
+                      }
+                    },
+                    {
+                      "key": "similarity.score",
+                      "value": {
+                        "doubleValue": 0.85
+                      }
+                    },
+                    {
+                      "key": "correlation.id",
+                      "value": {
+                        "intValue": "1324141"
+                      }
+                    },
+                    {
+                      "key": "related.resource.id",
+                      "value": {
+                        "stringValue": "resource-123"
+                      }
+                    },
+                    {
+                      "key": "link.test.bytes.value",
+                      "value": {
+                        "bytesValue": "AQIDBAUG"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "status": {
+                "message": "error",
+                "code": 2
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/from_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/from_dbmodel.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// FromDBModel convert the Trace to ptrace.Traces
+func FromDBModel(dbTrace Trace) ptrace.Traces {
+	trace := ptrace.NewTraces()
+	resourceSpans := trace.ResourceSpans().AppendEmpty()
+
+	resourceAttributes := attributesGroupToMap(dbTrace.Resource.Attributes)
+	resourceAttributes.CopyTo(resourceSpans.Resource().Attributes())
+
+	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+	scope := scopeSpans.Scope()
+	FromDBScope(dbTrace.Scope).CopyTo(scope)
+
+	span := scopeSpans.Spans().AppendEmpty()
+	FromDBSpan(dbTrace.Span).CopyTo(span)
+	for i := range dbTrace.Events {
+		event := span.Events().AppendEmpty()
+		fromDBEvent(dbTrace.Events[i]).CopyTo(event)
+	}
+
+	for i := range dbTrace.Links {
+		link := span.Links().AppendEmpty()
+		fromDBLink(dbTrace.Links[i]).CopyTo(link)
+	}
+	return trace
+}
+
+func FromDBScope(s Scope) pcommon.InstrumentationScope {
+	scope := ptrace.NewScopeSpans().Scope()
+	scope.SetName(s.Name)
+	scope.SetVersion(s.Version)
+	attributes := attributesGroupToMap(s.Attributes)
+	attributes.CopyTo(scope.Attributes())
+
+	return scope
+}
+
+func FromDBSpan(s Span) ptrace.Span {
+	span := ptrace.NewSpan()
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(s.StartTime))
+	span.SetTraceID(pcommon.TraceID(s.TraceId))
+	span.SetSpanID(pcommon.SpanID(s.SpanId))
+	span.SetParentSpanID(pcommon.SpanID(s.ParentSpanId))
+	span.TraceState().FromRaw(s.TraceState)
+	span.SetName(s.Name)
+	span.SetKind(fromDBSpanKind(s.Kind))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(s.StartTime.Add(time.Duration(s.Duration))))
+	span.Status().SetCode(fromDBStatusCode(s.StatusCode))
+	span.Status().SetMessage(s.StatusMessage)
+	spanAttributes := attributesGroupToMap(s.Attributes)
+	spanAttributes.CopyTo(span.Attributes())
+
+	return span
+}
+
+func fromDBEvent(e Event) ptrace.SpanEvent {
+	event := ptrace.NewSpanEvent()
+	event.SetName(e.Name)
+	event.SetTimestamp(pcommon.NewTimestampFromTime(e.Timestamp))
+
+	attributes := attributesGroupToMap(e.Attributes)
+	attributes.CopyTo(event.Attributes())
+	return event
+}
+
+func fromDBLink(l Link) ptrace.SpanLink {
+	link := ptrace.NewSpanLink()
+
+	link.SetTraceID(pcommon.TraceID(l.TraceId))
+	link.SetSpanID(pcommon.SpanID(l.SpanId))
+	link.TraceState().FromRaw(l.TraceState)
+	attributes := attributesGroupToMap(l.Attributes)
+	attributes.CopyTo(link.Attributes())
+	return link
+}
+
+func fromDBSpanKind(sk string) ptrace.SpanKind {
+	switch sk {
+	case "Unspecified":
+		return ptrace.SpanKindUnspecified
+	case "Internal":
+		return ptrace.SpanKindInternal
+	case "Server":
+		return ptrace.SpanKindServer
+	case "Client":
+		return ptrace.SpanKindClient
+	case "Producer":
+		return ptrace.SpanKindProducer
+	case "Consumer":
+		return ptrace.SpanKindConsumer
+	}
+	return ptrace.SpanKindUnspecified
+}
+
+func fromDBStatusCode(sc string) ptrace.StatusCode {
+	switch sc {
+	case "OK":
+		return ptrace.StatusCodeOk
+	case "Unset":
+		return ptrace.StatusCodeUnset
+	case "Error":
+		return ptrace.StatusCodeError
+	}
+	return ptrace.StatusCodeUnset
+}
+
+func attributesGroupToMap(group AttributesGroup) pcommon.Map {
+	result := pcommon.NewMap()
+	for i := range group.BoolKeys {
+		key := group.BoolKeys[i]
+		value := group.BoolValues[i]
+		result.PutBool(key, value)
+	}
+	for i := range group.IntKeys {
+		key := group.IntKeys[i]
+		value := group.IntValues[i]
+		result.PutInt(key, value)
+	}
+	for i := range group.DoubleKeys {
+		key := group.DoubleKeys[i]
+		value := group.DoubleValues[i]
+		result.PutDouble(key, value)
+	}
+	for i := range group.StrKeys {
+		key := group.StrKeys[i]
+		value := group.StrValues[i]
+		result.PutStr(key, value)
+	}
+	for i := range group.BytesKeys {
+		key := group.BytesKeys[i]
+		value := group.BytesValues[i]
+		result.PutEmptyBytes(key).FromRaw(value)
+	}
+	return result
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/from_dbmodel_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/from_dbmodel_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestFromDBModel_Fixtures(t *testing.T) {
+	dbTrace := jsonToDBModel(t, "./fixtures/dbmodel.json")
+	expected := jsonToPtrace(t, "./fixtures/ptrace.json")
+	actual := FromDBModel(dbTrace)
+
+	require.Equal(t, expected.ResourceSpans().Len(), actual.ResourceSpans().Len())
+	if actual.ResourceSpans().Len() == 0 {
+		t.Fatal("Actual trace contains no ResourceSpans")
+	}
+	expectedResourceSpans := expected.ResourceSpans().At(0)
+	actualResourceSpans := actual.ResourceSpans().At(0)
+	comparePCommonResource(t, expectedResourceSpans.Resource(), actualResourceSpans.Resource())
+
+	require.Equal(t, expectedResourceSpans.ScopeSpans().Len(), actualResourceSpans.ScopeSpans().Len())
+	if actualResourceSpans.ScopeSpans().Len() == 0 {
+		t.Fatal("Actual ResourceSpans contains no ScopeSpans")
+	}
+	exceptedScopeSpans := expectedResourceSpans.ScopeSpans().At(0)
+	actualScopeSpans := actualResourceSpans.ScopeSpans().At(0)
+	comparePCommonScope(t, exceptedScopeSpans.Scope(), actualScopeSpans.Scope())
+
+	require.Equal(t, exceptedScopeSpans.Spans().Len(), actualScopeSpans.Spans().Len())
+	if actualScopeSpans.Spans().Len() == 0 {
+		t.Fatal("Actual ScopeSpans contains no Spans")
+	}
+	exceptedSpan := exceptedScopeSpans.Spans().At(0)
+	actualSpan := actualScopeSpans.Spans().At(0)
+	comparePTraceSpan(t, exceptedSpan, actualSpan)
+
+	exceptedEvents := exceptedSpan.Events()
+	actualEvents := actualSpan.Events()
+	require.Equal(t, exceptedEvents.Len(), actualEvents.Len())
+	for i := 0; i < exceptedEvents.Len(); i++ {
+		exceptedEvent := exceptedEvents.At(i)
+		actualEvent := actualEvents.At(i)
+		compareSpanEvent(t, exceptedEvent, actualEvent)
+	}
+
+	exceptedLinks := exceptedSpan.Links()
+	actualLinks := actualSpan.Links()
+	require.Equal(t, exceptedLinks.Len(), actualLinks.Len())
+	for i := 0; i < exceptedLinks.Len(); i++ {
+		exceptedLink := exceptedLinks.At(i)
+		actualLink := actualLinks.At(i)
+		compareSpanLink(t, exceptedLink, actualLink)
+	}
+}
+
+func TestFromDBSpanKind(t *testing.T) {
+	type args struct {
+		sk string
+	}
+	tests := []struct {
+		name string
+		args args
+		want ptrace.SpanKind
+	}{
+		{
+			name: "Unspecified",
+			args: args{
+				sk: "Unspecified",
+			},
+			want: ptrace.SpanKindUnspecified,
+		},
+		{
+			name: "Internal",
+			args: args{
+				sk: "Internal",
+			},
+			want: ptrace.SpanKindInternal,
+		},
+		{
+			name: "Server",
+			args: args{
+				sk: "Server",
+			},
+			want: ptrace.SpanKindServer,
+		},
+		{
+			name: "Client",
+			args: args{
+				sk: "Client",
+			},
+			want: ptrace.SpanKindClient,
+		},
+		{
+			name: "Producer",
+			args: args{
+				sk: "Producer",
+			},
+			want: ptrace.SpanKindProducer,
+		},
+		{
+			name: "Consumer",
+			args: args{
+				sk: "Consumer",
+			},
+			want: ptrace.SpanKindConsumer,
+		},
+		{
+			name: "Unknown",
+			args: args{
+				sk: "Unknown",
+			},
+			want: ptrace.SpanKindUnspecified,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, fromDBSpanKind(tt.args.sk))
+		})
+	}
+}
+
+func TestFromDBStatusCode(t *testing.T) {
+	type args struct {
+		sc string
+	}
+	tests := []struct {
+		name string
+		args args
+		want ptrace.StatusCode
+	}{
+		{
+			name: "OK status code",
+			args: args{
+				sc: "OK",
+			},
+			want: ptrace.StatusCodeOk,
+		},
+		{
+			name: "Unset status code",
+			args: args{
+				sc: "Unset",
+			},
+			want: ptrace.StatusCodeUnset,
+		},
+		{
+			name: "Error status code",
+			args: args{
+				sc: "Error",
+			},
+			want: ptrace.StatusCodeError,
+		},
+		{
+			name: "Unknown status code",
+			args: args{
+				sc: "Unknown",
+			},
+			want: ptrace.StatusCodeUnset,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, fromDBStatusCode(tt.args.sc))
+		})
+	}
+}
+
+func comparePCommonResource(t *testing.T, expected pcommon.Resource, resource pcommon.Resource) {
+	require.Equal(t, expected.Attributes().AsRaw(), resource.Attributes().AsRaw())
+}
+
+func comparePCommonScope(t *testing.T, excepted pcommon.InstrumentationScope, actual pcommon.InstrumentationScope) {
+	require.Equal(t, excepted.Name(), actual.Name())
+	require.Equal(t, excepted.Version(), actual.Version())
+	require.Equal(t, excepted.Attributes().AsRaw(), actual.Attributes().AsRaw())
+}
+
+func comparePTraceSpan(t *testing.T, excepted ptrace.Span, actual ptrace.Span) {
+	require.Equal(t, excepted.StartTimestamp(), actual.StartTimestamp())
+	require.Equal(t, excepted.TraceID(), actual.TraceID())
+	require.Equal(t, excepted.SpanID(), actual.SpanID())
+	require.Equal(t, excepted.ParentSpanID(), actual.ParentSpanID())
+	require.Equal(t, excepted.TraceState(), actual.TraceState())
+	require.Equal(t, excepted.Name(), actual.Name())
+	require.Equal(t, excepted.Kind(), actual.Kind())
+	require.Equal(t, excepted.EndTimestamp(), actual.EndTimestamp())
+	require.Equal(t, excepted.Status().Code(), actual.Status().Code())
+	require.Equal(t, excepted.Status().Message(), actual.Status().Message())
+	require.Equal(t, excepted.Attributes().AsRaw(), actual.Attributes().AsRaw())
+}
+
+func compareSpanEvent(t *testing.T, excepted ptrace.SpanEvent, actual ptrace.SpanEvent) {
+	require.Equal(t, excepted.Name(), actual.Name())
+	require.Equal(t, excepted.Timestamp(), actual.Timestamp())
+	require.Equal(t, excepted.Attributes().AsRaw(), actual.Attributes().AsRaw())
+}
+
+func compareSpanLink(t *testing.T, excepted ptrace.SpanLink, actual ptrace.SpanLink) {
+	require.Equal(t, excepted.SpanID(), actual.SpanID())
+	require.Equal(t, excepted.TraceID(), actual.TraceID())
+	require.Equal(t, excepted.TraceState(), actual.TraceState())
+	require.Equal(t, excepted.Attributes().AsRaw(), actual.Attributes().AsRaw())
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/package_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/package_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}
+
+func readJSONBytes(t *testing.T, filename string) []byte {
+	t.Helper()
+	path := filepath.Join(".", filename)
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err, "Failed to read file %s", filename)
+	return bytes
+}
+
+func jsonToPtrace(t *testing.T, filename string) (trace ptrace.Traces) {
+	unMarshaler := ptrace.JSONUnmarshaler{}
+	trace, err := unMarshaler.UnmarshalTraces(readJSONBytes(t, filename))
+	require.NoError(t, err, "Failed to unmarshal trace with %s", filename)
+	return trace
+}
+
+func jsonToDBModel(t *testing.T, filename string) (trace Trace) {
+	traceBytes := readJSONBytes(t, filename)
+	err := json.Unmarshal(traceBytes, &trace)
+	require.NoError(t, err, "Failed to read file %s", filename)
+	return trace
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/to_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/to_dbmodel.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"encoding/hex"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+const (
+	ValueTypeBool   = pcommon.ValueTypeBool
+	ValueTypeDouble = pcommon.ValueTypeDouble
+	ValueTypeInt    = pcommon.ValueTypeInt
+	ValueTypeStr    = pcommon.ValueTypeStr
+	ValueTypeBytes  = pcommon.ValueTypeBytes
+)
+
+// ToDBModel Converts the ptrace.Traces into a slice of Clickhouse domain model for batch insertion.
+func ToDBModel(td ptrace.Traces) []Trace {
+	var traces []Trace
+	for _, resourceSpan := range td.ResourceSpans().All() {
+		rs := resourceSpan.Resource()
+		resource := Resource{
+			Attributes: attributesToGroup(rs.Attributes()),
+		}
+		for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
+			sc := scopeSpan.Scope()
+			scope := Scope{
+				Name:       sc.Name(),
+				Version:    sc.Version(),
+				Attributes: attributesToGroup(sc.Attributes()),
+			}
+			for _, sp := range scopeSpan.Spans().All() {
+				span := Span{
+					StartTime:     sp.StartTimestamp().AsTime(),
+					TraceId:       encodeTraceID(sp.TraceID()),
+					SpanId:        encodeSpanID(sp.SpanID()),
+					ParentSpanId:  encodeSpanID(sp.ParentSpanID()),
+					TraceState:    sp.TraceState().AsRaw(),
+					ServiceName:   getServiceName(rs.Attributes()),
+					Name:          sp.Name(),
+					Kind:          sp.Kind().String(),
+					Duration:      duration(sp.StartTimestamp(), sp.EndTimestamp()),
+					StatusCode:    sp.Status().Code().String(),
+					StatusMessage: sp.Status().Message(),
+					Attributes:    attributesToGroup(sp.Attributes()),
+				}
+				trace := Trace{
+					Resource: resource,
+					Scope:    scope,
+					Span:     span,
+				}
+				if sp.Events().Len() > 0 {
+					trace.Events = make([]Event, sp.Events().Len())
+				}
+				if sp.Links().Len() > 0 {
+					trace.Links = make([]Link, sp.Links().Len())
+				}
+
+				for i, e := range sp.Events().All() {
+					event := Event{
+						Name:       e.Name(),
+						Timestamp:  e.Timestamp().AsTime(),
+						Attributes: attributesToGroup(e.Attributes()),
+					}
+					trace.Events[i] = event
+				}
+				for i, l := range sp.Links().All() {
+					link := Link{
+						TraceId:    encodeTraceID(l.TraceID()),
+						SpanId:     encodeSpanID(l.SpanID()),
+						TraceState: l.TraceState().AsRaw(),
+						Attributes: attributesToGroup(l.Attributes()),
+					}
+					trace.Links[i] = link
+				}
+				traces = append(traces, trace)
+			}
+		}
+	}
+
+	return traces
+}
+
+// attributesToGroup Categorizes and aggregates Attributes based on the data type of their values, and writes them in batches.
+func attributesToGroup(attributes pcommon.Map) AttributesGroup {
+	attributesMap := attributesToMap(attributes)
+	var group AttributesGroup
+	for valueType := range attributesMap {
+		kvPairs := attributesMap[valueType]
+		switch valueType {
+		case ValueTypeBool:
+			for k, v := range kvPairs {
+				group.BoolKeys = append(group.BoolKeys, k)
+				group.BoolValues = append(group.BoolValues, v.Bool())
+			}
+		case ValueTypeDouble:
+			for k, v := range kvPairs {
+				group.DoubleKeys = append(group.DoubleKeys, k)
+				group.DoubleValues = append(group.DoubleValues, v.Double())
+			}
+		case ValueTypeInt:
+			for k, v := range kvPairs {
+				group.IntKeys = append(group.IntKeys, k)
+				group.IntValues = append(group.IntValues, v.Int())
+			}
+		case ValueTypeStr:
+			for k, v := range kvPairs {
+				group.StrKeys = append(group.StrKeys, k)
+				group.StrValues = append(group.StrValues, v.Str())
+			}
+		case ValueTypeBytes:
+			for k, v := range kvPairs {
+				group.BytesKeys = append(group.BytesKeys, k)
+				group.BytesValues = append(group.BytesValues, v.Bytes().AsRaw())
+			}
+		default:
+		}
+	}
+	return group
+}
+
+// attributesToMap Groups a pcommon.Map by data type and splits the key-value pairs into arrays for storage.
+// The values in the key-value pairs of a pcommon.Map instance may not all be of the same data type.
+// For example, a pcommon.Map can contain key-value pairs such as:
+// string-string, string-bool, string-int64, string-float64. Clearly, the key-value pairs need to be classified based on the data type.
+func attributesToMap(attrs pcommon.Map) map[pcommon.ValueType]map[string]pcommon.Value {
+	result := make(map[pcommon.ValueType]map[string]pcommon.Value)
+	for _, valueType := range []pcommon.ValueType{
+		ValueTypeBool, ValueTypeDouble, ValueTypeInt, ValueTypeStr, ValueTypeBytes,
+	} {
+		result[valueType] = make(map[string]pcommon.Value)
+	}
+	// Fill according to the data type of the value
+	for k, v := range attrs.All() {
+		typ := v.Type()
+		// For basic data types (such as bool, uint64, and float64) we can make sure type safe.
+		// TODO: For non-basic types (such as Map, Slice), they should be serialized and stored as OTLP/JSON strings
+		result[typ][k] = v
+	}
+	return result
+}
+
+// encodeTraceID convert pcommon.TraceID to [16]byte.
+func encodeTraceID(id pcommon.TraceID) []byte {
+	if id.IsEmpty() {
+		return nil
+	}
+	bytes, _ := hex.DecodeString(id.String())
+	return bytes
+}
+
+// encodeSpanID convert pcommon.SpanID to [8]byte.
+func encodeSpanID(id pcommon.SpanID) []byte {
+	if id.IsEmpty() {
+		return nil
+	}
+	bytes, _ := hex.DecodeString(id.String())
+	return bytes
+}
+
+// duration calculate duration using span start and end time.
+func duration(startTime pcommon.Timestamp, endTime pcommon.Timestamp) int64 {
+	return endTime.AsTime().Sub(startTime.AsTime()).Nanoseconds()
+}
+
+// getServiceName find service name in resource attributes if existed.
+func getServiceName(attributes pcommon.Map) string {
+	serviceName, exists := attributes.Get("service.name")
+	if !exists {
+		return ""
+	}
+
+	return serviceName.Str()
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/to_dbmodel_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/internal/to_dbmodel_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestTODBModel_Fixtures(t *testing.T) {
+	trace := jsonToPtrace(t, "./fixtures/ptrace.json")
+	actual := ToDBModel(trace)[0]
+	expected := jsonToDBModel(t, "./fixtures/dbmodel.json")
+
+	compareResource(t, expected.Resource, actual.Resource)
+	compareScope(t, expected.Scope, actual.Scope)
+	compareSpan(t, expected.Span, actual.Span)
+
+	require.Len(t, expected.Events, len(actual.Events))
+	for i := range expected.Events {
+		compareEvent(t, expected.Events[i], actual.Events[i])
+	}
+
+	require.Len(t, expected.Links, len(actual.Links))
+	for i := range expected.Links {
+		compareLink(t, expected.Links[i], actual.Links[i])
+	}
+}
+
+func Test_encodeTraceID(t *testing.T) {
+	type args struct {
+		id pcommon.TraceID
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "empty",
+			args: args{
+				pcommon.NewTraceIDEmpty(),
+			},
+			want: nil,
+		},
+		{
+			name: "successful",
+			args: args{
+				pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
+			},
+			want: []byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, encodeTraceID(tt.args.id), "encodeTraceID(%v)", tt.args.id)
+		})
+	}
+}
+
+func Test_encodeSpanID(t *testing.T) {
+	type args struct {
+		id pcommon.SpanID
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "empty",
+			args: args{
+				pcommon.NewSpanIDEmpty(),
+			},
+			want: nil,
+		},
+		{
+			name: "successful",
+			args: args{
+				pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+			},
+			want: []byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, encodeSpanID(tt.args.id), "encodeSpanID(%v)", tt.args.id)
+		})
+	}
+}
+
+func compareResource(t *testing.T, expected Resource, actual Resource) {
+	t.Helper()
+	compareAttributes(t, expected.Attributes, actual.Attributes)
+}
+
+func compareScope(t *testing.T, expected Scope, actual Scope) {
+	t.Helper()
+	require.Equal(t, expected.Name, actual.Name)
+	require.Equal(t, expected.Version, actual.Version)
+	compareAttributes(t, expected.Attributes, actual.Attributes)
+}
+
+func compareSpan(t *testing.T, expected Span, actual Span) {
+	t.Helper()
+	require.Equal(t, expected.StartTime, actual.StartTime)
+	require.Equal(t, expected.TraceId, actual.TraceId)
+	require.Equal(t, expected.SpanId, actual.SpanId)
+	require.Equal(t, expected.ParentSpanId, actual.ParentSpanId)
+	require.Equal(t, expected.Name, actual.Name)
+	require.Equal(t, expected.Kind, actual.Kind)
+	require.Equal(t, expected.Duration, actual.Duration)
+	require.Equal(t, expected.StatusCode, actual.StatusCode)
+	require.Equal(t, expected.ServiceName, actual.ServiceName)
+	require.Equal(t, expected.StatusMessage, actual.StatusMessage)
+	compareAttributes(t, expected.Attributes, actual.Attributes)
+}
+
+func compareEvent(t *testing.T, expected Event, actual Event) {
+	t.Helper()
+	require.Equal(t, expected.Name, actual.Name)
+	require.Equal(t, expected.Timestamp, actual.Timestamp)
+	compareAttributes(t, expected.Attributes, actual.Attributes)
+}
+
+func compareLink(t *testing.T, expected Link, actual Link) {
+	t.Helper()
+	require.Equal(t, expected.TraceId, actual.TraceId)
+	require.Equal(t, expected.SpanId, actual.SpanId)
+	require.Equal(t, expected.TraceState, actual.TraceState)
+	compareAttributes(t, expected.Attributes, actual.Attributes)
+}
+
+func compareAttributes(t *testing.T, excepted AttributesGroup, actual AttributesGroup) {
+	t.Helper()
+	assert.ElementsMatch(t, excepted.BoolKeys, actual.BoolKeys)
+	assert.ElementsMatch(t, excepted.BoolValues, actual.BoolValues)
+	assert.ElementsMatch(t, excepted.DoubleKeys, actual.DoubleKeys)
+	assert.ElementsMatch(t, excepted.DoubleValues, actual.DoubleValues)
+	assert.ElementsMatch(t, excepted.IntKeys, actual.IntKeys)
+	assert.ElementsMatch(t, excepted.IntValues, actual.IntValues)
+	assert.ElementsMatch(t, excepted.StrKeys, actual.StrKeys)
+	assert.ElementsMatch(t, excepted.StrValues, actual.StrValues)
+	assert.ElementsMatch(t, excepted.BytesKeys, actual.BytesKeys)
+	assert.ElementsMatch(t, excepted.BytesValues, actual.BytesValues)
+}

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+// Deprecated: Use internal.ToDBModel instead.
 // ToDBModel Converts the OTel pipeline Traces into a ClickHouse-compatible format for batch insertion.
 // It maps the trace attributes, spans, links and events from the OTel model to the appropriate ClickHouse column types
 func ToDBModel(td ptrace.Traces) proto.Input {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7148

## Description of the changes
- Deprecated exist db model base on `ch-go` and functions:`to_dbmodel` `from_dbmodel`.
- Introduce new db model and base on the clickhouse-go only.

## How was this change tested?
- unit tests.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
