### PR TITLE
[feat] Use v2 ES/OS storage in Jaeger-v2

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -17,9 +17,9 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra"
-	es "github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/memory"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	es "github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/grpc"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
@@ -183,16 +183,20 @@ func (s *storageExt) Start(ctx context.Context, host component.Host) error {
 				s.telset.Logger,
 			)
 		case cfg.Elasticsearch != nil:
-			v1Factory, err = es.NewFactoryWithConfig(
+			esTelset := telset
+			esTelset.Metrics = scopedMetricsFactory(storageName, "elasticsearch", "tracestore")
+			factory, err = es.NewFactory(
+				ctx,
 				*cfg.Elasticsearch,
-				scopedMetricsFactory(storageName, "elasticsearch", "tracestore"),
-				s.telset.Logger,
+				esTelset,
 			)
 		case cfg.Opensearch != nil:
-			v1Factory, err = es.NewFactoryWithConfig(
+			osTelset := telset
+			osTelset.Metrics = scopedMetricsFactory(storageName, "opensearch", "tracestore")
+			factory, err = es.NewFactory(
+				ctx,
 				*cfg.Opensearch,
-				scopedMetricsFactory(storageName, "opensearch", "tracestore"),
-				s.telset.Logger,
+				osTelset,
 			)
 		}
 		if err != nil {

--- a/internal/storage/v1/elasticsearch/factory_v1.go
+++ b/internal/storage/v1/elasticsearch/factory_v1.go
@@ -49,21 +49,6 @@ func NewArchiveFactory() *Factory {
 	}
 }
 
-//nolint:nolintlint
-//nolint:contextcheck
-func NewFactoryWithConfig(
-	cfg config.Configuration,
-	metricsFactory metrics.Factory,
-	logger *zap.Logger,
-) (*Factory, error) {
-	f := &Factory{Options: &Options{Config: namespaceConfig{Configuration: cfg}}}
-	err := f.Initialize(metricsFactory, logger)
-	if err != nil {
-		return nil, err
-	}
-	return f, nil
-}
-
 func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
 	f.Options.AddFlags(flagSet)
 }

--- a/internal/storage/v1/elasticsearch/factoryv1_test.go
+++ b/internal/storage/v1/elasticsearch/factoryv1_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -38,27 +37,6 @@ func TestElasticsearchFactory(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, f.Close())
-}
-
-func TestNewFactoryWithConfig(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(mockEsServerResponse)
-	}))
-	t.Cleanup(server.Close)
-	cfg := escfg.Configuration{
-		Servers: []string{server.URL},
-	}
-	f, err := NewFactoryWithConfig(cfg, metrics.NullFactory, zap.NewNop())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, f.Close())
-	})
-}
-
-func TestNewFactoryWithConfig_Error(t *testing.T) {
-	f, err := NewFactoryWithConfig(escfg.Configuration{}, metrics.NullFactory, zap.NewNop())
-	assert.Nil(t, f)
-	require.ErrorContains(t, err, "Servers: non zero value required")
 }
 
 func TestInheritSettingsFrom(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes a part of: #7034 

## Description of the changes
- Upgrade jaeger to use v2 APIs for ES/OS storage

## How was this change tested?
- Unit and e2e

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
