### PR TITLE
fix(elasticsearch): respect explicitly configured replicas=0 in index…

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -49,7 +49,7 @@ type IndexOptions struct {
 	// Shards is the number of shards per index in Elasticsearch.
 	Shards int64 `mapstructure:"shards"`
 	// Replicas is the number of replicas per index in Elasticsearch.
-	Replicas int64 `mapstructure:"replicas"`
+	Replicas *int64 `mapstructure:"replicas"`
 	// RolloverFrequency contains the rollover frequency setting used to fetch
 	// indices from elasticsearch.
 	// Valid configuration options are: [hour, day].
@@ -355,7 +355,7 @@ func setDefaultIndexOptions(target, source *IndexOptions) {
 		target.Shards = source.Shards
 	}
 
-	if target.Replicas == 0 {
+	if target.Replicas == nil {
 		target.Replicas = source.Replicas
 	}
 


### PR DESCRIPTION

Previously, replicas set to 0 in the OpenTelemetryCollector config
would be overwritten by default values.

This commit updates the IndexOptions struct to use a pointer type for
`Replicas` and adjusts the defaulting logic to only apply defaults when
`Replicas` is nil. This allows users to explicitly configure
`replicas: 0` without being ignored.

Relates to: #7123 