### PR TITLE
[clickhouse] Implement GetOperations for trace reader in ClickHouse storage

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/dbmodel.go
@@ -55,3 +55,8 @@ type Event struct {
 type Service struct {
 	Name string `ch:"name"`
 }
+
+type Operation struct {
+	Name     string `ch:"name"`
+	SpanKind string `ch:"span_kind"`
+}

--- a/internal/storage/v2/clickhouse/tracestore/reader_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader_test.go
@@ -23,7 +23,7 @@ type testDriver struct {
 	err  error
 }
 
-func (t *testDriver) Query(_ context.Context, query string, _ ...any) (driver.Rows, error) {
+func (t *testDriver) Query(_ context.Context, _ string, _ ...any) (driver.Rows, error) {
 	return t.rows, t.err
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #7134

## Description of the changes
- Implemented a function to get operations from ClickHouse storage. 

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
