### PR TITLE
Fix data race in ESv1 WriteSpan by using distinct inputs

### DIFF
--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -323,10 +323,10 @@ func testPasswordFromFile(t *testing.T) {
 	})
 
 	writer := spanstore.NewSpanWriter(f.GetSpanWriterParams())
-	span := &dbmodel.Span{
+	span1 := &dbmodel.Span{
 		Process: dbmodel.Process{ServiceName: "foo"},
 	}
-	writer.WriteSpan(time.Now(), span)
+	writer.WriteSpan(time.Now(), span1)
 	assert.Eventually(t,
 		func() bool {
 			pwd, ok := authReceived.Load(upwd1)
@@ -351,7 +351,10 @@ func testPasswordFromFile(t *testing.T) {
 		"expecting es.Client to change for the new password",
 	)
 
-	writer.WriteSpan(time.Now(), span)
+	span2 := &dbmodel.Span{
+		Process: dbmodel.Process{ServiceName: "foo"},
+	}
+	writer.WriteSpan(time.Now(), span2)
 	assert.Eventually(t,
 		func() bool {
 			pwd, ok := authReceived.Load(upwd2)

--- a/internal/storage/v1/elasticsearch/spanstore/writer.go
+++ b/internal/storage/v1/elasticsearch/spanstore/writer.go
@@ -125,7 +125,6 @@ func (s *SpanWriter) deepCopySpan(span *dbmodel.Span) (*dbmodel.Span, error) {
 	if err := json.Unmarshal(data, &spanCopy); err != nil {
 		return nil, err
 	}
-
 	return &spanCopy, nil
 }
 

--- a/internal/storage/v1/elasticsearch/spanstore/writer.go
+++ b/internal/storage/v1/elasticsearch/spanstore/writer.go
@@ -131,6 +131,7 @@ func (s *SpanWriter) deepCopySpan(span *dbmodel.Span) (*dbmodel.Span, error) {
 // WriteSpan writes a span and its corresponding service:operation in ElasticSearch
 func (s *SpanWriter) WriteSpan(spanStartTime time.Time, span *dbmodel.Span) {
 	s.writerMetrics.Attempts.Inc(1)
+
 	spanCopy, err := s.deepCopySpan(span)
 	if err != nil {
 		s.logger.Error("Failed to copy span", zap.Error(err))
@@ -138,7 +139,9 @@ func (s *SpanWriter) WriteSpan(spanStartTime time.Time, span *dbmodel.Span) {
 		return
 	}
 
+	// modify the copy
 	s.convertNestedTagsToFieldTags(spanCopy)
+
 	spanIndexName, serviceIndexName := s.spanServiceIndex(spanStartTime)
 	if serviceIndexName != "" {
 		s.writeService(serviceIndexName, spanCopy)

--- a/internal/storage/v1/elasticsearch/spanstore/writer.go
+++ b/internal/storage/v1/elasticsearch/spanstore/writer.go
@@ -133,7 +133,9 @@ func (s *SpanWriter) WriteSpan(spanStartTime time.Time, span *dbmodel.Span) {
 	s.writerMetrics.Attempts.Inc(1)
 	spanCopy, err := s.deepCopySpan(span)
 	if err != nil {
-		spanCopy = span
+		s.logger.Error("Failed to copy span", zap.Error(err))
+		s.writerMetrics.Errors.Inc(1)
+		return
 	}
 
 	s.convertNestedTagsToFieldTags(spanCopy)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7168 

## Description of the changes
- Sent different spans to both functions to stop data race

## How was this change tested?
![image](https://github.com/user-attachments/assets/1a13fe04-27fa-448c-b00e-160118e48fa4)


## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
