### PR TITLE
made test faster

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -218,8 +218,8 @@ type BearerTokenAuthentication struct {
 	AllowFromContext bool `mapstructure:"from_context"`
 }
 
-// NewClient creates a new ElasticSearch client
-func NewClient(c *Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
+// NewClient creates a new ElasticSearch client. This is a variable to allow mocking in tests.
+var NewClient = func(c *Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
 	if len(c.Servers) < 1 {
 		return nil, errors.New("no servers specified")
 	}
@@ -274,7 +274,6 @@ func NewClient(c *Configuration, logger *zap.Logger, metricsFactory metrics.Fact
 			}
 		}
 		logger.Info("Elasticsearch detected", zap.Int("version", esVersion))
-		//nolint: gosec // G115
 		c.Version = uint(esVersion)
 	}
 


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/7167 

## Description of the changes


Elasticsearch storage tests were taking ~5 seconds each due to
waiting conditions and network timeouts when attempting to connect to non-existent servers.
 - Reduce the timeout values in the `assert.Eventually` calls in `testPasswordFromFile`
- Modified `escfg.NewClient` to be a variable, allowing it to be
   mocked.
- Mock `escfg.NewClient` in `TestESStorageFactoryWithConfigError`
   and `TestFactoryInitializeErr/server_error` to return an immediate
   error, bypassing network calls and timeouts.




## How was this change tested?
-  ``` GOMAXPROCS=1 go test -parallel 128 -p 16 -v ./internal/storage/v1/elasticsearch/ ```

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
