### PR TITLE
[clickhouse] Implement GetTraces for ClickHouse Storage

### DIFF
--- a/internal/storage/v2/clickhouse/schema/schema.sql
+++ b/internal/storage/v2/clickhouse/schema/schema.sql
@@ -29,3 +29,16 @@ CREATE TABLE IF NOT EXISTS spans (
 )
 ENGINE = MergeTree
 ORDER BY (start_time, trace_id, id);
+
+
+CREATE TABLE IF NOT EXISTS services (
+    name String
+) ENGINE = AggregatingMergeTree
+ORDER BY name;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS services_mv
+TO services
+AS
+SELECT service_name AS name
+FROM spans
+GROUP BY service_name;

--- a/internal/storage/v2/clickhouse/schema/schema.sql
+++ b/internal/storage/v2/clickhouse/schema/schema.sql
@@ -28,11 +28,12 @@ CREATE TABLE IF NOT EXISTS spans (
     scope_version String
 )
 ENGINE = MergeTree
-
+PRIMARY KEY(trace_id);
 
 CREATE TABLE IF NOT EXISTS services (
     name String
 ) ENGINE = AggregatingMergeTree
+PRIMARY KEY(name);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS services_mv
 TO services
@@ -45,6 +46,7 @@ CREATE TABLE IF NOT EXISTS operations (
     name String,
     span_kind String
 ) ENGINE = AggregatingMergeTree
+PRIMARY KEY(name, span_kind);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS operations_mv
 TO operations

--- a/internal/storage/v2/clickhouse/schema/schema.sql
+++ b/internal/storage/v2/clickhouse/schema/schema.sql
@@ -42,3 +42,20 @@ AS
 SELECT service_name AS name
 FROM spans
 GROUP BY service_name;
+
+CREATE TABLE IF NOT EXISTS operations (
+    name String,
+    span_kind String
+) ENGINE = AggregatingMergeTree
+ORDER BY (name, span_kind);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS operations_mv
+TO operations
+AS
+SELECT
+    name,
+    kind AS span_kind
+FROM spans
+GROUP BY
+    name,
+    span_kind;

--- a/internal/storage/v2/clickhouse/schema/schema.sql
+++ b/internal/storage/v2/clickhouse/schema/schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS spans (
     start_time DateTime64(9),
     status_code String,
     status_message String,
-    duration UInt64,
+    duration Int64,
 
     events Nested (
         name String,

--- a/internal/storage/v2/clickhouse/schema/schema.sql
+++ b/internal/storage/v2/clickhouse/schema/schema.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS spans (
+    id String,
+    trace_id String,
+    trace_state String,
+    parent_span_id String,
+    name String,
+    kind String,
+    start_time DateTime64(9),
+    status_code String,
+    status_message String,
+    duration UInt64,
+
+    events Nested (
+        name String,
+        timestamp DateTime64(9)
+    ),
+
+    
+    links Nested (
+        trace_id String,
+        span_id String,
+        trace_state String
+    ),
+
+    service_name String,
+
+    scope_name String,
+    scope_version String
+)
+ENGINE = MergeTree
+ORDER BY (start_time, trace_id, id);

--- a/internal/storage/v2/clickhouse/schema/schema.sql
+++ b/internal/storage/v2/clickhouse/schema/schema.sql
@@ -28,13 +28,11 @@ CREATE TABLE IF NOT EXISTS spans (
     scope_version String
 )
 ENGINE = MergeTree
-ORDER BY (start_time, trace_id, id);
 
 
 CREATE TABLE IF NOT EXISTS services (
     name String
 ) ENGINE = AggregatingMergeTree
-ORDER BY name;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS services_mv
 TO services
@@ -47,7 +45,6 @@ CREATE TABLE IF NOT EXISTS operations (
     name String,
     span_kind String
 ) ENGINE = AggregatingMergeTree
-ORDER BY (name, span_kind);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS operations_mv
 TO operations

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/dbmodel.go
@@ -11,15 +11,15 @@ import (
 type Span struct {
 	// --- Span ---
 	// TODO: add attributes
-	ID            string    `ch:"id"`
-	TraceID       string    `ch:"trace_id"`
-	TraceState    string    `ch:"trace_state"`
-	ParentSpanID  string    `ch:"parent_span_id"`
-	Name          string    `ch:"name"`
-	Kind          string    `ch:"kind"`
-	StartTime     time.Time `ch:"start_time"`
-	StatusCode    string    `ch:"status_code"`
-	StatusMessage string    `ch:"status_message"`
+	ID            string
+	TraceID       string
+	TraceState    string
+	ParentSpanID  string
+	Name          string
+	Kind          string
+	StartTime     time.Time
+	StatusCode    string
+	StatusMessage string
 
 	// Duration is stored in ClickHouse as a UInt64 representing the number of nanoseconds.
 	// In Go, it is manually converted to and from time.Duration for convenience.
@@ -39,12 +39,12 @@ type Span struct {
 
 	// --- Resource ---
 	// TODO: add attributes
-	ServiceName string `ch:"service_name"`
+	ServiceName string
 
 	// --- Scope ---
 	// TODO: add attributes
-	ScopeName    string `ch:"scope_name"`
-	ScopeVersion string `ch:"scope_version"`
+	ScopeName    string
+	ScopeVersion string
 }
 
 type Link struct {

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel.go
@@ -152,7 +152,7 @@ func convertSpanKind(sk string) ptrace.SpanKind {
 
 func convertStatusCode(sc string) ptrace.StatusCode {
 	switch sc {
-	case "OK":
+	case "Ok":
 		return ptrace.StatusCodeOk
 	case "Unset":
 		return ptrace.StatusCodeUnset

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel.go
@@ -92,7 +92,9 @@ func convertSpan(s Span) (ptrace.Span, error) {
 	if err != nil {
 		return span, fmt.Errorf("failed to decode parent span ID: %w", err)
 	}
-	span.SetParentSpanID(pcommon.SpanID(parentSpanId))
+	if len(parentSpanId) != 0 {
+		span.SetParentSpanID(pcommon.SpanID(parentSpanId))
+	}
 	span.TraceState().FromRaw(s.TraceState)
 	span.SetName(s.Name)
 	span.SetKind(convertSpanKind(s.Kind))

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/from_dbmodel_test.go
@@ -244,7 +244,7 @@ func TestConvertStatusCode(t *testing.T) {
 		{
 			name: "OK status code",
 			args: args{
-				sc: "OK",
+				sc: "Ok",
 			},
 			want: ptrace.StatusCodeOk,
 		},

--- a/internal/storage/v2/clickhouse/tracestore/reader.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	sqlSelectSpansByTraceID = `SELECT id, trace_id, trace_state, parent_span_id, 
+	sqlSelectSpansByTraceID = `SELECT id, trace_id, trace_state, parent_span_id,
 	name, kind, start_time, status_code, status_message,
 	duration, events.name, events.timestamp,
     links.trace_id, links.span_id, links.trace_state,

--- a/internal/storage/v2/clickhouse/tracestore/reader.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader.go
@@ -74,7 +74,6 @@ func (r *Reader) GetTraces(
 				return
 			}
 
-			var traces []ptrace.Traces
 			done := false
 			for rows.Next() {
 				span, err := scanSpanRow(rows)
@@ -86,8 +85,8 @@ func (r *Reader) GetTraces(
 					continue
 				}
 
-				traces = append(traces, dbmodel.FromDBModel(span))
-				if !yield(traces, nil) {
+				trace := dbmodel.FromDBModel(span)
+				if !yield([]ptrace.Traces{trace}, nil) {
 					done = true
 					break
 				}

--- a/internal/storage/v2/clickhouse/tracestore/reader.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader.go
@@ -17,13 +17,29 @@ import (
 )
 
 const (
-	sqlSelectSpansByTraceID = `SELECT id, trace_id, trace_state, parent_span_id,
-	name, kind, start_time, status_code, status_message,
-	duration, events.name, events.timestamp,
-    links.trace_id, links.span_id, links.trace_state,
-	service_name, scope_name, scope_version
+	sqlSelectSpansByTraceID = `
+	SELECT
+		id,
+		trace_id,
+		trace_state,
+		parent_span_id,
+		name,
+		kind,
+		start_time,
+		status_code,
+		status_message,
+		duration,
+		events.name,
+		events.timestamp,
+		links.trace_id,
+		links.span_id,
+		links.trace_state,
+		service_name,
+		scope_name,
+		scope_version
 	FROM spans
-	WHERE trace_id = ?`
+	WHERE
+		trace_id = ?`
 	sqlSelectAllServices        = `SELECT DISTINCT name FROM services`
 	sqlSelectOperationsAllKinds = `SELECT name, span_kind
 	FROM operations

--- a/internal/storage/v2/clickhouse/tracestore/reader.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	sqlSelectSpansByTraceID = `SELECT *
+	sqlSelectSpansByTraceID = `SELECT id, trace_id, trace_state, parent_span_id, name, kind, start_time, status_code, status_message,
+	duration, service_name, scope_name, scope_version
 	FROM spans
 	WHERE trace_id = ?`
 	sqlSelectAllServices        = `SELECT DISTINCT name FROM services`
@@ -61,13 +62,22 @@ func (r *Reader) GetTraces(
 					rawDuration uint64
 				)
 
-				if err := rows.ScanStruct(&span); err != nil {
+				if err := rows.Scan(
+					&span.ID,
+					&span.TraceID,
+					&span.TraceState,
+					&span.ParentSpanID,
+					&span.Name,
+					&span.Kind,
+					&span.StartTime,
+					&span.StatusCode,
+					&span.StatusMessage,
+					&rawDuration,
+					&span.ServiceName,
+					&span.ScopeName,
+					&span.ScopeVersion,
+				); err != nil {
 					yield(nil, fmt.Errorf("failed to scan row: %w", err))
-					continue
-				}
-
-				if err := rows.Scan(&rawDuration); err != nil {
-					yield(nil, fmt.Errorf("failed to scan duration: %w", err))
 					continue
 				}
 

--- a/internal/storage/v2/clickhouse/tracestore/reader.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader.go
@@ -81,7 +81,7 @@ func (r *Reader) GetTraces(
 func scanSpanRow(rows driver.Rows) (dbmodel.Span, error) {
 	var (
 		span            dbmodel.Span
-		rawDuration     uint64
+		rawDuration     int64
 		eventNames      []string
 		eventTimestamps []time.Time
 		linkTraceIDs    []string

--- a/internal/storage/v2/clickhouse/tracestore/reader_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader_test.go
@@ -160,6 +160,7 @@ func TestGetTraces_ScanError(t *testing.T) {
 }
 
 func TestGetTraces_SingleTrace(t *testing.T) {
+	//TODO: move data to fixture?
 	now := time.Now()
 	conn := &testDriver{
 		t:             t,

--- a/internal/storage/v2/clickhouse/tracestore/testdata/assert.go
+++ b/internal/storage/v2/clickhouse/tracestore/testdata/assert.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func RequireScopeEqual(t *testing.T, expected SpanRow, actual pcommon.InstrumentationScope) {
+	t.Helper()
+
+	require.Equal(t, expected.ScopeName, actual.Name())
+	require.Equal(t, expected.ScopeVersion, actual.Version())
+}
+
+func RequireSpanEqual(t *testing.T, expected SpanRow, actual ptrace.Span) {
+	t.Helper()
+
+	require.Equal(t, expected.ID, actual.SpanID().String())
+	require.Equal(t, expected.TraceID, actual.TraceID().String())
+	require.Equal(t, expected.TraceState, actual.TraceState().AsRaw())
+	require.Equal(t, expected.ParentSpanID, actual.ParentSpanID().String())
+	require.Equal(t, expected.Name, actual.Name())
+	require.Equal(t, expected.Kind, actual.Kind().String())
+	require.Equal(t, expected.StartTime.UnixNano(), actual.StartTimestamp().AsTime().UnixNano())
+	require.Equal(t, expected.StatusCode, actual.Status().Code().String(), "status code mismatch")
+	require.Equal(t, expected.StatusMessage, actual.Status().Message(), "status message mismatch")
+	require.Equal(t, time.Duration(expected.RawDuration), actual.EndTimestamp().AsTime().Sub(actual.StartTimestamp().AsTime()))
+
+	require.Equal(t, actual.Events().Len(), len(expected.EventNames))
+	for i, e := range actual.Events().All() {
+		require.Equal(t, expected.EventNames[i], e.Name())
+		require.Equal(t, expected.EventTimestamps[i].UnixNano(), e.Timestamp().AsTime().UnixNano())
+	}
+
+	require.Equal(t, actual.Links().Len(), len(expected.LinkSpanIDs))
+	for i, l := range actual.Links().All() {
+		require.Equal(t, expected.LinkTraceIDs[i], l.TraceID().String())
+		require.Equal(t, expected.LinkSpanIDs[i], l.SpanID().String())
+		require.Equal(t, expected.LinkTraceStates[i], l.TraceState().AsRaw())
+	}
+}

--- a/internal/storage/v2/clickhouse/tracestore/testdata/assert.go
+++ b/internal/storage/v2/clickhouse/tracestore/testdata/assert.go
@@ -29,8 +29,8 @@ func RequireSpanEqual(t *testing.T, expected SpanRow, actual ptrace.Span) {
 	require.Equal(t, expected.Name, actual.Name())
 	require.Equal(t, expected.Kind, actual.Kind().String())
 	require.Equal(t, expected.StartTime.UnixNano(), actual.StartTimestamp().AsTime().UnixNano())
-	require.Equal(t, expected.StatusCode, actual.Status().Code().String(), "status code mismatch")
-	require.Equal(t, expected.StatusMessage, actual.Status().Message(), "status message mismatch")
+	require.Equal(t, expected.StatusCode, actual.Status().Code().String())
+	require.Equal(t, expected.StatusMessage, actual.Status().Message())
 	require.Equal(t, time.Duration(expected.RawDuration), actual.EndTimestamp().AsTime().Sub(actual.StartTimestamp().AsTime()))
 
 	require.Equal(t, actual.Events().Len(), len(expected.EventNames))
@@ -44,5 +44,25 @@ func RequireSpanEqual(t *testing.T, expected SpanRow, actual ptrace.Span) {
 		require.Equal(t, expected.LinkTraceIDs[i], l.TraceID().String())
 		require.Equal(t, expected.LinkSpanIDs[i], l.SpanID().String())
 		require.Equal(t, expected.LinkTraceStates[i], l.TraceState().AsRaw())
+	}
+}
+
+func RequireTracesEqual(t *testing.T, expected []SpanRow, actual []ptrace.Traces) {
+	t.Helper()
+
+	require.Len(t, actual, len(expected))
+
+	for i, e := range expected {
+		resources := actual[i].ResourceSpans()
+		require.Equal(t, 1, resources.Len())
+
+		scopes := resources.At(0).ScopeSpans()
+		require.Equal(t, 1, scopes.Len())
+		RequireScopeEqual(t, e, scopes.At(0).Scope())
+
+		spans := scopes.At(0).Spans()
+		require.Equal(t, 1, spans.Len())
+
+		RequireSpanEqual(t, e, spans.At(0))
 	}
 }

--- a/internal/storage/v2/clickhouse/tracestore/testdata/package_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/testdata/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/storage/v2/clickhouse/tracestore/testdata/spans.go
+++ b/internal/storage/v2/clickhouse/tracestore/testdata/spans.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import "time"
+
+type SpanRow struct {
+	ID              string
+	TraceID         string
+	TraceState      string
+	ParentSpanID    string
+	Name            string
+	Kind            string
+	StartTime       time.Time
+	StatusCode      string
+	StatusMessage   string
+	RawDuration     int64
+	EventNames      []string
+	EventTimestamps []time.Time
+	LinkTraceIDs    []string
+	LinkSpanIDs     []string
+	LinkTraceStates []string
+	ServiceName     string
+	ScopeName       string
+	ScopeVersion    string
+}
+
+var now = time.Date(2025, 6, 14, 10, 0, 0, 0, time.UTC)
+
+var SingleSpan = SpanRow{
+	ID:              "0000000000000001",
+	TraceID:         "00000000000000000000000000000001",
+	TraceState:      "state1",
+	Name:            "GET /api/user",
+	Kind:            "Server",
+	StartTime:       now,
+	StatusCode:      "Ok",
+	StatusMessage:   "success",
+	RawDuration:     1_000_000_000,
+	EventNames:      []string{"login"},
+	EventTimestamps: []time.Time{now},
+	LinkTraceIDs:    []string{"00000000000000000000000000000002"},
+	LinkSpanIDs:     []string{"0000000000000002"},
+	LinkTraceStates: []string{"state2"},
+	ServiceName:     "user-service",
+	ScopeName:       "auth-scope",
+	ScopeVersion:    "v1.0.0",
+}

--- a/internal/storage/v2/clickhouse/tracestore/testdata/spans.go
+++ b/internal/storage/v2/clickhouse/tracestore/testdata/spans.go
@@ -3,7 +3,11 @@
 
 package testdata
 
-import "time"
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
 
 type SpanRow struct {
 	ID              string
@@ -26,24 +30,70 @@ type SpanRow struct {
 	ScopeVersion    string
 }
 
+var TraceID = pcommon.TraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+
 var now = time.Date(2025, 6, 14, 10, 0, 0, 0, time.UTC)
 
-var SingleSpan = SpanRow{
-	ID:              "0000000000000001",
-	TraceID:         "00000000000000000000000000000001",
-	TraceState:      "state1",
-	Name:            "GET /api/user",
-	Kind:            "Server",
-	StartTime:       now,
-	StatusCode:      "Ok",
-	StatusMessage:   "success",
-	RawDuration:     1_000_000_000,
-	EventNames:      []string{"login"},
-	EventTimestamps: []time.Time{now},
-	LinkTraceIDs:    []string{"00000000000000000000000000000002"},
-	LinkSpanIDs:     []string{"0000000000000002"},
-	LinkTraceStates: []string{"state2"},
-	ServiceName:     "user-service",
-	ScopeName:       "auth-scope",
-	ScopeVersion:    "v1.0.0",
+var SingleSpan = []SpanRow{
+	{
+		ID:              "0000000000000001",
+		TraceID:         TraceID.String(),
+		TraceState:      "state1",
+		Name:            "GET /api/user",
+		Kind:            "Server",
+		StartTime:       now,
+		StatusCode:      "Ok",
+		StatusMessage:   "success",
+		RawDuration:     1_000_000_000,
+		EventNames:      []string{"login"},
+		EventTimestamps: []time.Time{now},
+		LinkTraceIDs:    []string{"00000000000000000000000000000002"},
+		LinkSpanIDs:     []string{"0000000000000002"},
+		LinkTraceStates: []string{"state2"},
+		ServiceName:     "user-service",
+		ScopeName:       "auth-scope",
+		ScopeVersion:    "v1.0.0",
+	},
+}
+
+var MultipleSpans = []SpanRow{
+	{
+		ID:              "0000000000000001",
+		TraceID:         TraceID.String(),
+		TraceState:      "state1",
+		Name:            "GET /api/user",
+		Kind:            "Server",
+		StartTime:       now,
+		StatusCode:      "Ok",
+		StatusMessage:   "success",
+		RawDuration:     1_000_000_000,
+		EventNames:      []string{"login"},
+		EventTimestamps: []time.Time{now},
+		LinkTraceIDs:    []string{"00000000000000000000000000000002"},
+		LinkSpanIDs:     []string{"0000000000000002"},
+		LinkTraceStates: []string{"state2"},
+		ServiceName:     "user-service",
+		ScopeName:       "auth-scope",
+		ScopeVersion:    "v1.0.0",
+	},
+	{
+		ID:              "0000000000000003",
+		TraceID:         TraceID.String(),
+		TraceState:      "state1",
+		ParentSpanID:    "0000000000000001",
+		Name:            "SELECT /db/query",
+		Kind:            "Client",
+		StartTime:       now.Add(10 * time.Millisecond),
+		StatusCode:      "Ok",
+		StatusMessage:   "success",
+		RawDuration:     500_000_000,
+		EventNames:      []string{"query-start", "query-end"},
+		EventTimestamps: []time.Time{now.Add(10 * time.Millisecond), now.Add(510 * time.Millisecond)},
+		LinkTraceIDs:    []string{},
+		LinkSpanIDs:     []string{},
+		LinkTraceStates: []string{},
+		ServiceName:     "db-service",
+		ScopeName:       "db-scope",
+		ScopeVersion:    "v1.0.0",
+	},
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #7134

## Description of the changes
- This PR implements the `GetTraces` function for ClickHouse storage. 
- This PR also introduces a schema that will later be used to auto-create the required tables upon instantiation of the ClickHouse factory. 

## How was this change tested?

Started the ClickHouse server on my local machine using 
```
./clickhouse server
```

Initialized the tables using
```
/Users/mzaryab/clickhouse client --multiquery < schema.sql
```

Seeded the database using [test.sql](https://gist.github.com/mahadzaryab1/9b7243f637804e10b972647f82374bef#file-test-sql)
```
/Users/mzaryab/clickhouse client --multiquery < test.sql
```

Wrote a [Go unit test](https://gist.github.com/mahadzaryab1/9b7243f637804e10b972647f82374bef#file-reader_test-go) to run `GetTraces` and got the following output
```
Span: POST /api/order, Start: 2025-06-08 00:58:05 +0000 UTC, Duration: 2.5s
Event: checkout, Timestamp: 2025-06-08 00:58:03 +0000 UTC
Event: payment, Timestamp: 2025-06-08 00:58:04 +0000 UTC
Link: TraceID: 00000000000000000000000000000001, SpanID: 0000000000000001, TraceState: state1
Link: TraceID: 00000000000000000000000000000003, SpanID: 0000000000000003, TraceState: state1
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
