### PR TITLE
feat: add option to disable Elasticsearch health check

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -101,6 +101,8 @@ type Configuration struct {
 	// TLS contains the TLS configuration for the connection to the ElasticSearch clusters.
 	TLS      configtls.ClientConfig `mapstructure:"tls"`
 	Sniffing Sniffing               `mapstructure:"sniffing"`
+	// Disable the Elasticsearch health check
+	DisableHealthCheck bool `mapstructure:"disable_health_check"`
 	// SendGetBodyAs is the HTTP verb to use for requests that contain a body.
 	SendGetBodyAs string `mapstructure:"send_get_body_as"`
 	// QueryTimeout contains the timeout used for queries. A timeout of zero means no timeout.
@@ -482,12 +484,14 @@ func (c *Configuration) TagKeysAsFields() ([]string, error) {
 
 // getConfigOptions wraps the configs to feed to the ElasticSearch client init
 func (c *Configuration) getConfigOptions(logger *zap.Logger) ([]elastic.ClientOptionFunc, error) {
+	// Disable health check when token from context is allowed, this is because at this time
+	// we don'r have a valid token to do the check ad if we don't disable the check the service that
+	// uses this won't start.
+	// Also disable health check when it was requested (health check has problems on AWS OpenSearch)
+	disableHealthCheck := c.Authentication.BearerTokenAuthentication.AllowFromContext || c.DisableHealthCheck
 	options := []elastic.ClientOptionFunc{
 		elastic.SetURL(c.Servers...), elastic.SetSniff(c.Sniffing.Enabled),
-		// Disable health check when token from context is allowed, this is because at this time
-		// we don'r have a valid token to do the check ad if we don't disable the check the service that
-		// uses this won't start.
-		elastic.SetHealthcheck(!c.Authentication.BearerTokenAuthentication.AllowFromContext),
+		elastic.SetHealthcheck(!disableHealthCheck),
 	}
 	if c.Sniffing.UseHTTPS {
 		options = append(options, elastic.SetScheme("https"))

--- a/internal/storage/v1/elasticsearch/options.go
+++ b/internal/storage/v1/elasticsearch/options.go
@@ -21,6 +21,7 @@ const (
 	suffixUsername                       = ".username"
 	suffixPassword                       = ".password"
 	suffixSniffer                        = ".sniffer"
+	suffixDisableHealthCheck             = ".disable-health-check"
 	suffixSnifferTLSEnabled              = ".sniffer-tls-enabled"
 	suffixTokenPath                      = ".token-file"
 	suffixPasswordPath                   = ".password-file"
@@ -154,6 +155,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixSniffer,
 		nsConfig.Sniffing.Enabled,
 		"The sniffer config for Elasticsearch; client uses sniffing process to find all nodes automatically, disable if not required")
+	flagSet.Bool(
+		nsConfig.namespace+suffixDisableHealthCheck,
+		nsConfig.DisableHealthCheck,
+		"Disable the Elasticsearch health check.")
 	flagSet.String(
 		nsConfig.namespace+suffixServerURLs,
 		defaultServerURL,
@@ -319,6 +324,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.Authentication.BasicAuthentication.PasswordFilePath = v.GetString(cfg.namespace + suffixPasswordPath)
 	cfg.Sniffing.Enabled = v.GetBool(cfg.namespace + suffixSniffer)
 	cfg.Sniffing.UseHTTPS = v.GetBool(cfg.namespace + suffixSnifferTLSEnabled)
+	cfg.DisableHealthCheck = v.GetBool(cfg.namespace + suffixDisableHealthCheck)
 	cfg.Servers = strings.Split(stripWhiteSpace(v.GetString(cfg.namespace+suffixServerURLs)), ",")
 	cfg.MaxSpanAge = v.GetDuration(cfg.namespace + suffixMaxSpanAge)
 	cfg.AdaptiveSamplingLookback = v.GetDuration(cfg.namespace + suffixAdaptiveSamplingLookback)
@@ -423,6 +429,7 @@ func DefaultConfig() config.Configuration {
 		Sniffing: config.Sniffing{
 			Enabled: false,
 		},
+		DisableHealthCheck:       false,
 		MaxSpanAge:               72 * time.Hour,
 		AdaptiveSamplingLookback: 72 * time.Hour,
 		BulkProcessing: config.BulkProcessing{

--- a/internal/storage/v1/elasticsearch/options_test.go
+++ b/internal/storage/v1/elasticsearch/options_test.go
@@ -38,6 +38,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, 72*time.Hour, primary.MaxSpanAge)
 	assert.False(t, primary.Sniffing.Enabled)
 	assert.False(t, primary.Sniffing.UseHTTPS)
+	assert.False(t, primary.DisableHealthCheck)
 }
 
 func TestOptionsWithFlags(t *testing.T) {
@@ -51,6 +52,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.password-file=/foo/bar/baz",
 		"--es.sniffer=true",
 		"--es.sniffer-tls-enabled=true",
+		"--es.disable-health-check=true",
 		"--es.max-span-age=48h",
 		"--es.num-shards=20",
 		"--es.num-replicas=10",
@@ -82,6 +84,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
 	assert.True(t, primary.Sniffing.Enabled)
 	assert.True(t, primary.Sniffing.UseHTTPS)
+	assert.True(t, primary.DisableHealthCheck)
 	assert.False(t, primary.TLS.Insecure)
 	assert.True(t, primary.TLS.InsecureSkipVerify)
 	assert.True(t, primary.Tags.AllAsFields)


### PR DESCRIPTION
## Which problem is this PR solving?
On AWS OpenSearch, I am experiencing an issue with the ElasticSearch storage where Jaeger fails to initialize the storage on the first try. 

The corresponding error message is
```
2025-06-03T13:53:19.517Z        info    jaegerstorage/extension.go:159  Initializing storage 'aws_opensearch'   {"otelcol.component.id": "jaeger_storage", "otelcol.component.kind": "extension"}
2025-06-03T13:53:25.518Z        error   extensions/extensions.go:58     Failed to start extension       {"otelcol.component.id": "jaeger_storage", "otelcol.component.kind": "extension", "error": "failed to initialize storage 'aws_opensearch': failed to create Elasticsearch client: Head \"https://my-opensearch-domain.es.amazonaws.com:443\": context deadline exceeded"}
```

## Description of the changes
The problem was already reported in the olivere/elastic library that Jaeger uses: https://github.com/olivere/elastic/issues/880. The proposed fix is to disable the health check. Currently, this is possible in Jaeger by setting `auth.bearer_token.from_context = true` as a workaround.
The change in this PR adds a configuration option, `disable_health_check`, that can be used to disable the health check directly.

## How was this change tested?
I tested the change locally with Jaeger v1 and v2, logging the value that is used in `elastic.SetHealthcheck`. I tested the workaround mentioned above in our test environment, where it solved the problem.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
