### PR TITLE
[tracegen] Add tracegen repeatable generation

### DIFF
--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -101,7 +101,7 @@ func createTracers(cfg *tracegen.Config, logger *zap.Logger) ([]trace.Tracer, fu
 			sdktrace.WithBatcher(exp, sdktrace.WithBlocking()),
 			sdktrace.WithResource(res),
 		}
-		if cfg.Static {
+		if cfg.Repeatable {
 			opts = append(opts, sdktrace.WithIDGenerator(tracegen.NewPseudoRandomIDGenerator(s+1)))
 		}
 		if flagAdaptiveSamplingEndpoint != "" {

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	err = tracegen.Run(cfg, tracers, logger)
 	if err != nil {
-		panic(err)
+		logger.Sugar().Fatalf("Failed to run tracegen: %v", err)
 	}
 }
 

--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -54,7 +54,7 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.IntVar(&c.Services, "services", 1, "Number of unique suffixes to add to service name when generating traces, e.g. tracegen-01 (but only one service per trace)")
 	fs.StringVar(&c.TraceExporter, "trace-exporter", "otlp-http", "Trace exporter (otlp/otlp-http|otlp-grpc|stdout). Exporters can be additionally configured via environment variables, see https://github.com/jaegertracing/jaeger/blob/main/cmd/tracegen/README.md")
 	fs.BoolVar(&c.Static, "static", false, "For generated static data to suit some Trace Bench, default: false")
-	fs.StringVar(&c.StaticTimeStart, "static-timestart", "2025-01-01T00:00:00.000000+0000", "For support generated static data from this time point. default&eg. 2025-01-01T00:00:00.000000+0000")
+	fs.StringVar(&c.StaticTimeStart, "static-timestart", "2025-01-01T00:00:00.000000000+00:00", "For support generated static data from this time point. default&eg. 2025-01-01T00:00:00.000000000+00:00")
 }
 
 // Run executes the test scenario.
@@ -91,11 +91,11 @@ func Run(c *Config, tracers []trace.Tracer, logger *zap.Logger) error {
 				wg:      &wg,
 				logger:  logger.With(zap.Int("worker", i)),
 			}
-			// 使用标准 layout 解析
-			layout := "2006-01-02T15:04:05.000000000+0000"
+
+			layout := "2006-01-02T15:04:05.000000000+00:00"
 			t, err := time.Parse(layout, c.StaticTimeStart)
 			if err != nil {
-				panic("Static time start is not valid: " + err.Error() + "  check this flag format, default&eg.: 2025-01-01T00:00:00.000000+00:00")
+				panic("Static time start is not valid: " + err.Error() + "  check this flag format, default&eg.: 2025-01-01T00:00:00.000000000+00:00")
 			}
 			// mark
 			startTime := t.Add(time.Microsecond)
@@ -139,18 +139,12 @@ func (g *PseudoRandomIDGenerator) NewIDs(ctx context.Context) (trace.TraceID, tr
 			break
 		}
 	}
-	if !tid.IsValid() {
-		tid[0] = 1
-	}
 
 	for {
 		binary.NativeEndian.PutUint64(sid[:], g.rng.Uint64())
 		if sid.IsValid() {
 			break
 		}
-	}
-	if !sid.IsValid() {
-		sid[0] = 1
 	}
 
 	return tid, sid
@@ -166,9 +160,6 @@ func (g *PseudoRandomIDGenerator) NewSpanID(ctx context.Context, traceID trace.T
 		if sid.IsValid() {
 			break
 		}
-	}
-	if !sid.IsValid() {
-		sid[0] = 1
 	}
 	return sid
 }

--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -4,32 +4,38 @@
 package tracegen
 
 import (
+	"context"
+	"encoding/binary"
 	"errors"
 	"flag"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
 // Config describes the test scenario.
 type Config struct {
-	Workers       int
-	Services      int
-	Traces        int
-	ChildSpans    int
-	Attributes    int
-	AttrKeys      int
-	AttrValues    int
-	Marshal       bool
-	Debug         bool
-	Firehose      bool
-	Pause         time.Duration
-	Duration      time.Duration
-	Service       string
-	TraceExporter string
+	Workers         int
+	Services        int
+	Traces          int
+	ChildSpans      int
+	Attributes      int
+	AttrKeys        int
+	AttrValues      int
+	Marshal         bool
+	Debug           bool
+	Firehose        bool
+	Pause           time.Duration
+	Duration        time.Duration
+	Service         string
+	TraceExporter   string
+	Static          bool
+	StaticTimeStart string
 }
 
 // Flags registers config flags.
@@ -47,6 +53,8 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Service, "service", "tracegen", "Service name prefix to use")
 	fs.IntVar(&c.Services, "services", 1, "Number of unique suffixes to add to service name when generating traces, e.g. tracegen-01 (but only one service per trace)")
 	fs.StringVar(&c.TraceExporter, "trace-exporter", "otlp-http", "Trace exporter (otlp/otlp-http|otlp-grpc|stdout). Exporters can be additionally configured via environment variables, see https://github.com/jaegertracing/jaeger/blob/main/cmd/tracegen/README.md")
+	fs.BoolVar(&c.Static, "static", false, "For generated static data to suit some Trace Bench, default: false")
+	fs.StringVar(&c.StaticTimeStart, "static-timestart", "2025-01-01T00:00:00.000000+0000", "For support generated static data from this time point. default&eg. 2025-01-01T00:00:00.000000+0000")
 }
 
 // Run executes the test scenario.
@@ -59,23 +67,108 @@ func Run(c *Config, tracers []trace.Tracer, logger *zap.Logger) error {
 
 	wg := sync.WaitGroup{}
 	var running uint32 = 1
-	for i := 0; i < c.Workers; i++ {
-		wg.Add(1)
-		w := worker{
-			id:      i,
-			tracers: tracers,
-			Config:  *c,
-			running: &running,
-			wg:      &wg,
-			logger:  logger.With(zap.Int("worker", i)),
+	if !c.Static {
+		for i := 0; i < c.Workers; i++ {
+			wg.Add(1)
+			w := worker{
+				id:      i,
+				tracers: tracers,
+				Config:  *c,
+				running: &running,
+				wg:      &wg,
+				logger:  logger.With(zap.Int("worker", i)),
+			}
+			go w.simulateTraces()
 		}
-
-		go w.simulateTraces()
+	} else {
+		for i := 0; i < c.Workers; i++ {
+			wg.Add(1)
+			w := worker{
+				id:      i,
+				tracers: tracers,
+				Config:  *c,
+				running: &running,
+				wg:      &wg,
+				logger:  logger.With(zap.Int("worker", i)),
+			}
+			// 使用标准 layout 解析
+			layout := "2006-01-02T15:04:05.000000000+0000"
+			t, err := time.Parse(layout, c.StaticTimeStart)
+			if err != nil {
+				panic("Static time start is not valid: " + err.Error() + "  check this flag format, default&eg.: 2025-01-01T00:00:00.000000+00:00")
+			}
+			// mark
+			startTime := t.Add(time.Microsecond)
+			go w.simulateStaticTraces(startTime)
+		}
 	}
+
 	if c.Duration > 0 {
 		time.Sleep(c.Duration)
 		atomic.StoreUint32(&running, 0)
 	}
 	wg.Wait()
 	return nil
+}
+
+// PseudoRandomIDGenerator For static data generation
+type PseudoRandomIDGenerator struct {
+	mu  sync.Mutex
+	rng *rand.Rand
+}
+
+// NewPseudoRandomIDGenerator  The Nth TracerProvider has a pseudo seed of N. / 应该改成可指定
+func NewPseudoRandomIDGenerator(seed int) sdktrace.IDGenerator {
+	src := rand.NewSource(int64(seed))
+	return &PseudoRandomIDGenerator{
+		rng: rand.New(src),
+	}
+}
+
+func (g *PseudoRandomIDGenerator) NewIDs(ctx context.Context) (trace.TraceID, trace.SpanID) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	tid := trace.TraceID{}
+	sid := trace.SpanID{}
+
+	for {
+		binary.NativeEndian.PutUint64(tid[:8], g.rng.Uint64())
+		binary.NativeEndian.PutUint64(tid[8:], g.rng.Uint64())
+		if tid.IsValid() {
+			break
+		}
+	}
+	if !tid.IsValid() {
+		tid[0] = 1
+	}
+
+	for {
+		binary.NativeEndian.PutUint64(sid[:], g.rng.Uint64())
+		if sid.IsValid() {
+			break
+		}
+	}
+	if !sid.IsValid() {
+		sid[0] = 1
+	}
+
+	return tid, sid
+}
+
+func (g *PseudoRandomIDGenerator) NewSpanID(ctx context.Context, traceID trace.TraceID) trace.SpanID {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	sid := trace.SpanID{}
+	for {
+		binary.NativeEndian.PutUint64(sid[:], g.rng.Uint64())
+		if sid.IsValid() {
+			break
+		}
+	}
+	if !sid.IsValid() {
+		sid[0] = 1
+	}
+	return sid
 }

--- a/internal/tracegen/config_test.go
+++ b/internal/tracegen/config_test.go
@@ -77,7 +77,7 @@ func Test_Flags(t *testing.T) {
 		Services:        1,
 		TraceExporter:   "otlp-http",
 		Static:          false,
-		StaticTimeStart: "2025-01-01T00:00:00.000000000+0000",
+		StaticTimeStart: "2025-01-01T00:00:00.000000000+00:00",
 	}
 
 	config.Flags(fs)

--- a/internal/tracegen/config_test.go
+++ b/internal/tracegen/config_test.go
@@ -63,19 +63,21 @@ func Test_Flags(t *testing.T) {
 	fs := &flag.FlagSet{}
 	config := &Config{}
 	expectedConfig := &Config{
-		Workers:       1,
-		Traces:        1,
-		ChildSpans:    1,
-		Attributes:    11,
-		AttrKeys:      97,
-		AttrValues:    1000,
-		Debug:         false,
-		Firehose:      false,
-		Pause:         1000,
-		Duration:      0,
-		Service:       "tracegen",
-		Services:      1,
-		TraceExporter: "otlp-http",
+		Workers:         1,
+		Traces:          1,
+		ChildSpans:      1,
+		Attributes:      11,
+		AttrKeys:        97,
+		AttrValues:      1000,
+		Debug:           false,
+		Firehose:        false,
+		Pause:           1000,
+		Duration:        0,
+		Service:         "tracegen",
+		Services:        1,
+		TraceExporter:   "otlp-http",
+		Static:          false,
+		StaticTimeStart: "2025-01-01T00:00:00.000000000+0000",
 	}
 
 	config.Flags(fs)

--- a/internal/tracegen/config_test.go
+++ b/internal/tracegen/config_test.go
@@ -63,21 +63,21 @@ func Test_Flags(t *testing.T) {
 	fs := &flag.FlagSet{}
 	config := &Config{}
 	expectedConfig := &Config{
-		Workers:         1,
-		Traces:          1,
-		ChildSpans:      1,
-		Attributes:      11,
-		AttrKeys:        97,
-		AttrValues:      1000,
-		Debug:           false,
-		Firehose:        false,
-		Pause:           1000,
-		Duration:        0,
-		Service:         "tracegen",
-		Services:        1,
-		TraceExporter:   "otlp-http",
-		Static:          false,
-		StaticTimeStart: "2025-01-01T00:00:00.000000000+00:00",
+		Workers:             1,
+		Traces:              1,
+		ChildSpans:          1,
+		Attributes:          11,
+		AttrKeys:            97,
+		AttrValues:          1000,
+		Debug:               false,
+		Firehose:            false,
+		Pause:               1000,
+		Duration:            0,
+		Service:             "tracegen",
+		Services:            1,
+		TraceExporter:       "otlp-http",
+		Repeatable:          false,
+		RepeatableTimeStart: "2025-01-01T00:00:00.000000000+00:00",
 	}
 
 	config.Flags(fs)

--- a/internal/tracegen/worker.go
+++ b/internal/tracegen/worker.go
@@ -27,6 +27,9 @@ type worker struct {
 	traceNo   int
 	attrKeyNo int
 	attrValNo int
+
+	// for trace&span static time
+	spanInterval int
 }
 
 const (
@@ -112,4 +115,91 @@ func (w *worker) simulateChildSpans(ctx context.Context, start time.Time, tracer
 			)
 		}
 	}
+}
+
+// For static simulate
+func (w *worker) simulateStaticTraces(startTime time.Time) {
+	// reset
+	w.spanInterval = 1
+	w.traceNo = 0
+
+	for atomic.LoadUint32(w.running) == 1 {
+		svcNo := w.traceNo % len(w.tracers)
+		w.simulateStaticOneTrace(w.tracers[svcNo], startTime)
+		w.traceNo++
+		if w.Traces != 0 && w.traceNo >= w.Traces {
+			break
+		}
+	}
+	w.logger.Info(fmt.Sprintf("Worker %d generated %d traces", w.id, w.traceNo))
+	w.wg.Done()
+}
+
+func (w *worker) simulateStaticOneTrace(tracer trace.Tracer, baseStartTime time.Time) {
+	ctx := context.Background()
+	attrs := []attribute.KeyValue{
+		attribute.String("peer.service", "tracegen-server"),
+		attribute.String("peer.host.ipv4", "1.1.1.1"),
+	}
+	if w.Debug {
+		attrs = append(attrs, attribute.Bool("jaeger.debug", true))
+	}
+	if w.Firehose {
+		attrs = append(attrs, attribute.Bool("jaeger.firehose", true))
+	}
+
+	start := baseStartTime
+	ctx, parent := tracer.Start(
+		ctx,
+		"lets-go",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(attrs...),
+		trace.WithTimestamp(start),
+	)
+
+	lastEnd := w.simulateStaticChildSpans(ctx, start, tracer)
+
+	parent.End(trace.WithTimestamp(lastEnd))
+}
+
+func (w *worker) simulateStaticChildSpans(ctx context.Context, baseStart time.Time, tracer trace.Tracer) time.Time {
+	lastEnd := baseStart
+
+	for c := 0; c < w.ChildSpans; c++ {
+		spanStart := lastEnd
+
+		if w.Pause != 0 {
+			spanStart = spanStart.Add(w.Pause)
+		}
+
+		var attrs []attribute.KeyValue
+		for a := 0; a < w.Attributes; a++ {
+			key := fmt.Sprintf("attr_%02d", w.attrKeyNo)
+			val := fmt.Sprintf("val_%02d", w.attrValNo)
+			attrs = append(attrs, attribute.String(key, val))
+			w.attrKeyNo = (w.attrKeyNo + 1) % w.AttrKeys
+			w.attrValNo = (w.attrValNo + 1) % w.AttrValues
+		}
+
+		_, child := tracer.Start(
+			ctx,
+			fmt.Sprintf("child-span-%02d", c),
+			trace.WithSpanKind(trace.SpanKindClient),
+			trace.WithAttributes(attrs...),
+			trace.WithTimestamp(spanStart),
+		)
+
+		spanEnd := spanStart.Add(time.Duration(c)*time.Microsecond + time.Duration(w.spanInterval)*time.Microsecond)
+		child.End(trace.WithTimestamp(spanEnd))
+
+		lastEnd = spanEnd.Add(w.Pause)
+
+		w.spanInterval++
+		// Can be controlled,When will it be reset
+		if w.spanInterval > 123 {
+			w.spanInterval = 1
+		}
+	}
+
+	return lastEnd
 }

--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -60,3 +60,55 @@ func Test_SimulateTraces(t *testing.T) {
 		})
 	}
 }
+
+func Test_SimulateStaticTraces(t *testing.T) {
+	tests := []struct {
+		name  string
+		pause time.Duration
+	}{
+		{
+			name:  "no pause",
+			pause: 0,
+		},
+		{
+			name:  "with pause",
+			pause: time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, buf := testutils.NewLogger()
+			var tracers []trace.Tracer
+			opts := []sdktrace.TracerProviderOption{
+				sdktrace.WithIDGenerator(NewPseudoRandomIDGenerator(1)),
+			}
+			tp := sdktrace.NewTracerProvider(opts...)
+			tracers = append(tracers, tp.Tracer("stdout"))
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			var running uint32 = 1
+			worker := &worker{
+				logger:  logger,
+				tracers: tracers,
+				wg:      &wg,
+				id:      7,
+				running: &running,
+				Config: Config{
+					Traces:     7,
+					Duration:   time.Second,
+					Pause:      tt.pause,
+					Service:    "stdout",
+					Debug:      true,
+					Firehose:   true,
+					ChildSpans: 1,
+				},
+			}
+			expectedOutput := `{"level":"info","msg":"Worker 7 generated 7 traces"}` + "\n"
+			layout := "2006-01-02T15:04:05.000000000+0000"
+			start, _ := time.Parse(layout, "2025-01-01T00:00:00.000000000+0000")
+			worker.simulateStaticTraces(start)
+			assert.Equal(t, expectedOutput, buf.String())
+		})
+	}
+}

--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -88,7 +88,7 @@ func Test_SimulateRepeatableTraces(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			var running uint32 = 1
-			worker := &worker{
+			w := &worker{
 				logger:  logger,
 				tracers: tracers,
 				wg:      &wg,
@@ -102,12 +102,13 @@ func Test_SimulateRepeatableTraces(t *testing.T) {
 					Debug:      true,
 					Firehose:   true,
 					ChildSpans: 1,
+					Repeatable: true,
 				},
 			}
+			s, _ := newRepeatableStrategy("2025-01-01T00:00:00.000000000+00:00")
+			w.setStrategy(s)
 			expectedOutput := `{"level":"info","msg":"Worker 7 generated 7 traces"}` + "\n"
-			layout := "2006-01-02T15:04:05.000000000+00:00"
-			start, _ := time.Parse(layout, "2025-01-01T00:00:00.000000000+00:00")
-			worker.simulateRepeatableTraces(start)
+			w.simulateTraces()
 			assert.Equal(t, expectedOutput, buf.String())
 		})
 	}

--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -61,7 +61,7 @@ func Test_SimulateTraces(t *testing.T) {
 	}
 }
 
-func Test_SimulateStaticTraces(t *testing.T) {
+func Test_SimulateRepeatableTraces(t *testing.T) {
 	tests := []struct {
 		name  string
 		pause time.Duration
@@ -107,7 +107,7 @@ func Test_SimulateStaticTraces(t *testing.T) {
 			expectedOutput := `{"level":"info","msg":"Worker 7 generated 7 traces"}` + "\n"
 			layout := "2006-01-02T15:04:05.000000000+00:00"
 			start, _ := time.Parse(layout, "2025-01-01T00:00:00.000000000+00:00")
-			worker.simulateStaticTraces(start)
+			worker.simulateRepeatableTraces(start)
 			assert.Equal(t, expectedOutput, buf.String())
 		})
 	}

--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -105,8 +105,8 @@ func Test_SimulateStaticTraces(t *testing.T) {
 				},
 			}
 			expectedOutput := `{"level":"info","msg":"Worker 7 generated 7 traces"}` + "\n"
-			layout := "2006-01-02T15:04:05.000000000+0000"
-			start, _ := time.Parse(layout, "2025-01-01T00:00:00.000000000+0000")
+			layout := "2006-01-02T15:04:05.000000000+00:00"
+			start, _ := time.Parse(layout, "2025-01-01T00:00:00.000000000+00:00")
 			worker.simulateStaticTraces(start)
 			assert.Equal(t, expectedOutput, buf.String())
 		})


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/7202

## Description of the changes
- Support -repeatable parameter to generate repeatable data
- Support -repeatable-timestart to generate repeatable data from this time point
- Other instructions https://github.com/jaegertracing/jaeger/blob/main/cmd/tracegen/README.md


## How was this change tested?
- ./tracegen -spans=10 -traces=10 -services=3 -workers=10 -repeatable=true -trace-exporter=stdout -repeatable-timestart="2025-01-01T00:00:00.000000000+00:00"
- unit test.
> The TraceID,SpanID and span time interval is repeatable. Every time execute a command it will produce the same data.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
