### PR TITLE
[spm] And esclient to es/reader.go and refactor test

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -227,6 +227,7 @@ func (s *storageExt) Start(ctx context.Context, host component.Host) error {
 			esTelset := telset
 			esTelset.Metrics = scopedMetricsFactory(metricStorageName, "elasticsearch", "metricstore")
 			metricStoreFactory, err = esmetrics.NewFactory(
+				ctx,
 				*cfg.Elasticsearch,
 				esTelset,
 			)

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -251,6 +251,14 @@ func (s *storageExt) Shutdown(context.Context) error {
 			}
 		}
 	}
+	for _, metricfactory := range s.metricsFactories {
+		if closer, ok := metricfactory.(io.Closer); ok {
+			err := closer.Close()
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
 	return errors.Join(errs...)
 }
 

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -253,8 +253,7 @@ func (s *storageExt) Shutdown(context.Context) error {
 	}
 	for _, metricfactory := range s.metricsFactories {
 		if closer, ok := metricfactory.(io.Closer); ok {
-			err := closer.Close()
-			if err != nil {
+			if err := closer.Close(); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -367,7 +367,7 @@ func TestStartError(t *testing.T) {
 	require.ErrorContains(t, err, "empty configuration")
 }
 
-func TestMetricsMetricBackendStorageStartError(t *testing.T) {
+func TestMetricStorageStartError(t *testing.T) {
 	expectedError := "failed to initialize metrics storage 'foo'"
 	tests := []struct {
 		name   string

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -301,11 +301,25 @@ func TestPrometheus(t *testing.T) {
 }
 
 func TestElasticsearchAsMetricsBackend(t *testing.T) {
+	versionResponse, e := json.Marshal(map[string]any{
+		"Version": map[string]any{
+			"Number": "7",
+		},
+	})
+	require.NoError(t, e)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(versionResponse)
+	}))
+	defer server.Close()
+
 	ext := makeStorageExtension(t, &Config{
 		MetricBackends: map[string]MetricBackend{
 			"foo": {
 				Elasticsearch: &esCfg.Configuration{
-					Servers: []string{"localhost:9200"},
+					Servers:  []string{server.URL},
+					LogLevel: "info",
 				},
 			},
 		},

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -23,6 +23,8 @@ import (
 
 	promCfg "github.com/jaegertracing/jaeger/internal/config/promcfg"
 	esCfg "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/memory"
@@ -42,8 +44,32 @@ func (errorFactory) CreateTraceWriter() (tracestore.Writer, error) {
 	panic("not implemented")
 }
 
+func (errorFactory) CreateMetricsReader() (metricstore.Reader, error) { panic("not implemented") }
+
 func (e errorFactory) Close() error {
 	return e.closeErr
+}
+
+func setupMockServer(t *testing.T, response []byte, statusCode int) *httptest.Server {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		w.Write(response)
+	}))
+	require.NotNil(t, mockServer)
+	t.Cleanup(mockServer.Close)
+
+	return mockServer
+}
+
+func getVersionResponse(t *testing.T) []byte {
+	versionResponse, e := json.Marshal(map[string]any{
+		"Version": map[string]any{
+			"Number": "7",
+		},
+	})
+	require.NoError(t, e)
+	return versionResponse
 }
 
 func TestStorageFactoryBadHostError(t *testing.T) {
@@ -301,18 +327,7 @@ func TestPrometheus(t *testing.T) {
 }
 
 func TestElasticsearchAsMetricsBackend(t *testing.T) {
-	versionResponse, e := json.Marshal(map[string]any{
-		"Version": map[string]any{
-			"Number": "7",
-		},
-	})
-	require.NoError(t, e)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(versionResponse)
-	}))
-	defer server.Close()
+	server := setupMockServer(t, getVersionResponse(t), http.StatusOK)
 
 	ext := makeStorageExtension(t, &Config{
 		MetricBackends: map[string]MetricBackend{
@@ -330,6 +345,17 @@ func TestElasticsearchAsMetricsBackend(t *testing.T) {
 	require.NoError(t, ext.Shutdown(ctx))
 }
 
+func TestMetricsBackendCloseError(t *testing.T) {
+	shutdownError := errors.New("shutdown error")
+	ext := storageExt{
+		metricsFactories: map[string]storage.MetricStoreFactory{
+			"foo": errorFactory{closeErr: shutdownError},
+		},
+	}
+	err := ext.Shutdown(context.Background())
+	require.ErrorIs(t, err, shutdownError)
+}
+
 func TestStartError(t *testing.T) {
 	ext := makeStorageExtension(t, &Config{
 		TraceBackends: map[string]TraceBackend{
@@ -341,16 +367,41 @@ func TestStartError(t *testing.T) {
 	require.ErrorContains(t, err, "empty configuration")
 }
 
-func TestMetricsStorageStartError(t *testing.T) {
-	ext := makeStorageExtension(t, &Config{
-		MetricBackends: map[string]MetricBackend{
-			"foo": {
-				Prometheus: &promCfg.Configuration{},
+func TestMetricsMetricBackendStorageStartError(t *testing.T) {
+	expectedError := "failed to initialize metrics storage 'foo'"
+	tests := []struct {
+		name   string
+		config *Config
+	}{
+		{
+			name: "Prometheus backend initialization error",
+			config: &Config{
+				MetricBackends: map[string]MetricBackend{
+					"foo": {
+						Prometheus: &promCfg.Configuration{},
+					},
+				},
 			},
 		},
-	})
-	err := ext.Start(context.Background(), componenttest.NewNopHost())
-	require.ErrorContains(t, err, "failed to initialize metrics storage 'foo'")
+		{
+			name: "Elasticsearch backend initialization error",
+			config: &Config{
+				MetricBackends: map[string]MetricBackend{
+					"foo": {
+						Elasticsearch: &esCfg.Configuration{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ext := makeStorageExtension(t, tt.config)
+			err := ext.Start(context.Background(), componenttest.NewNopHost())
+			require.ErrorContains(t, err, expectedError)
+		})
+	}
 }
 
 func testElasticsearchOrOpensearch(t *testing.T, cfg TraceBackend) {
@@ -366,16 +417,7 @@ func testElasticsearchOrOpensearch(t *testing.T, cfg TraceBackend) {
 }
 
 func TestXYZsearch(t *testing.T) {
-	versionResponse, err := json.Marshal(map[string]any{
-		"Version": map[string]any{
-			"Number": "7",
-		},
-	})
-	require.NoError(t, err)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(versionResponse)
-	}))
-	defer server.Close()
+	server := setupMockServer(t, getVersionResponse(t), http.StatusOK)
 	t.Run("Elasticsearch", func(t *testing.T) {
 		testElasticsearchOrOpensearch(t, TraceBackend{
 			Elasticsearch: &esCfg.Configuration{

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -221,7 +221,7 @@ type BearerTokenAuthentication struct {
 }
 
 // NewClient creates a new ElasticSearch client
-func NewClient(c *Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
+func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error) {
 	if len(c.Servers) < 1 {
 		return nil, errors.New("no servers specified")
 	}
@@ -249,14 +249,14 @@ func NewClient(c *Configuration, logger *zap.Logger, metricsFactory metrics.Fact
 		Workers(c.BulkProcessing.Workers).
 		BulkActions(c.BulkProcessing.MaxActions).
 		FlushInterval(c.BulkProcessing.FlushInterval).
-		Do(context.Background())
+		Do(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if c.Version == 0 {
 		// Determine ElasticSearch Version
-		pingResult, _, err := rawClient.Ping(c.Servers[0]).Do(context.Background())
+		pingResult, _, err := rawClient.Ping(c.Servers[0]).Do(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -225,7 +225,7 @@ func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metric
 	if len(c.Servers) < 1 {
 		return nil, errors.New("no servers specified")
 	}
-	options, err := c.getConfigOptions(logger)
+	options, err := c.getConfigOptions(ctx, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metric
 
 	var rawClientV8 *esV8.Client
 	if c.Version >= 8 {
-		rawClientV8, err = newElasticsearchV8(c, logger)
+		rawClientV8, err = newElasticsearchV8(ctx, c, logger)
 		if err != nil {
 			return nil, fmt.Errorf("error creating v8 client: %w", err)
 		}
@@ -337,14 +337,14 @@ func (bcb *bulkCallback) invoke(id int64, requests []elastic.BulkableRequest, re
 	}
 }
 
-func newElasticsearchV8(c *Configuration, logger *zap.Logger) (*esV8.Client, error) {
+func newElasticsearchV8(ctx context.Context, c *Configuration, logger *zap.Logger) (*esV8.Client, error) {
 	var options esV8.Config
 	options.Addresses = c.Servers
 	options.Username = c.Authentication.BasicAuthentication.Username
 	options.Password = c.Authentication.BasicAuthentication.Password
 	options.DiscoverNodesOnStart = c.Sniffing.Enabled
 	options.CompressRequestBody = c.HTTPCompression
-	transport, err := GetHTTPRoundTripper(c, logger)
+	transport, err := GetHTTPRoundTripper(ctx, c, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (c *Configuration) TagKeysAsFields() ([]string, error) {
 }
 
 // getConfigOptions wraps the configs to feed to the ElasticSearch client init
-func (c *Configuration) getConfigOptions(logger *zap.Logger) ([]elastic.ClientOptionFunc, error) {
+func (c *Configuration) getConfigOptions(ctx context.Context, logger *zap.Logger) ([]elastic.ClientOptionFunc, error) {
 	// Disable health check when token from context is allowed, this is because at this time
 	// we don'r have a valid token to do the check ad if we don't disable the check the service that
 	// uses this won't start.
@@ -523,7 +523,7 @@ func (c *Configuration) getConfigOptions(logger *zap.Logger) ([]elastic.ClientOp
 		return options, err
 	}
 
-	transport, err := GetHTTPRoundTripper(c, logger)
+	transport, err := GetHTTPRoundTripper(ctx, c, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -565,9 +565,9 @@ func addLoggerOptions(options []elastic.ClientOptionFunc, logLevel string, logge
 }
 
 // GetHTTPRoundTripper returns configured http.RoundTripper
-func GetHTTPRoundTripper(c *Configuration, logger *zap.Logger) (http.RoundTripper, error) {
+func GetHTTPRoundTripper(ctx context.Context, c *Configuration, logger *zap.Logger) (http.RoundTripper, error) {
 	if !c.TLS.Insecure {
-		ctlsConfig, err := c.TLS.LoadTLSConfig(context.Background())
+		ctlsConfig, err := c.TLS.LoadTLSConfig(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -583,7 +583,7 @@ func GetHTTPRoundTripper(c *Configuration, logger *zap.Logger) (http.RoundTrippe
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: c.TLS.InsecureSkipVerify},
 	}
 	if c.TLS.CAFile != "" {
-		ctlsConfig, err := c.TLS.LoadTLSConfig(context.Background())
+		ctlsConfig, err := c.TLS.LoadTLSConfig(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -416,7 +417,7 @@ func TestNewClient(t *testing.T) {
 			logger := zap.NewNop()
 			metricsFactory := metrics.NullFactory
 			config := test.config
-			client, err := NewClient(config, logger, metricsFactory)
+			client, err := NewClient(context.Background(), config, logger, metricsFactory)
 			if test.expectedError {
 				require.Error(t, err)
 				require.Nil(t, client)

--- a/internal/storage/metricstore/elasticsearch/factory.go
+++ b/internal/storage/metricstore/elasticsearch/factory.go
@@ -36,11 +36,7 @@ func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
 	}
 	f.client = client
 
-	mr, _ := NewMetricsReader(f.config, f.telset.Logger, f.telset.TracerProvider, f.client)
-	// Currently, the NewMetricsReader function does not return an error.
-	// if err != nil {
-	//	 return nil, err
-	// }
+	mr := NewMetricsReader(f.config, f.telset.Logger, f.telset.TracerProvider, f.client)
 	return metricstoremetrics.NewReaderDecorator(mr, f.telset.Metrics), nil
 }
 

--- a/internal/storage/metricstore/elasticsearch/factory.go
+++ b/internal/storage/metricstore/elasticsearch/factory.go
@@ -4,6 +4,8 @@
 package elasticsearch
 
 import (
+	"context"
+
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
@@ -18,12 +20,12 @@ type Factory struct {
 }
 
 // NewFactory creates a new Factory with the given configuration and telemetry settings.
-func NewFactory(cfg config.Configuration, telset telemetry.Settings) (*Factory, error) {
+func NewFactory(ctx context.Context, cfg config.Configuration, telset telemetry.Settings) (*Factory, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
-	client, err := config.NewClient(&cfg, telset.Logger, telset.Metrics)
+	client, err := config.NewClient(ctx, &cfg, telset.Logger, telset.Metrics)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/metricstore/elasticsearch/factory.go
+++ b/internal/storage/metricstore/elasticsearch/factory.go
@@ -22,21 +22,22 @@ func NewFactory(cfg config.Configuration, telset telemetry.Settings) (*Factory, 
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
+
+	client, err := config.NewClient(&cfg, telset.Logger, telset.Metrics)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Factory{
 		config: cfg,
 		telset: telset,
+		client: client,
 	}, nil
 }
 
 // CreateMetricsReader implements storage.MetricStoreFactory.
 func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
-	client, err := config.NewClient(&f.config, f.telset.Logger, f.telset.Metrics)
-	if err != nil {
-		return nil, err
-	}
-	f.client = client
-
-	mr := NewMetricsReader(f.config, f.telset.Logger, f.telset.TracerProvider, f.client)
+	mr := NewMetricsReader(f.client, f.telset.Logger, f.telset.TracerProvider)
 	return metricstoremetrics.NewReaderDecorator(mr, f.telset.Metrics), nil
 }
 

--- a/internal/storage/metricstore/elasticsearch/factory.go
+++ b/internal/storage/metricstore/elasticsearch/factory.go
@@ -44,8 +44,5 @@ func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
 }
 
 func (f *Factory) Close() error {
-	if f.client != nil {
-		return f.client.Close()
-	}
-	return nil
+	return f.client.Close()
 }

--- a/internal/storage/metricstore/elasticsearch/factory_test.go
+++ b/internal/storage/metricstore/elasticsearch/factory_test.go
@@ -55,10 +55,9 @@ func TestCreateMetricsReader(t *testing.T) {
 	f, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
 	require.NoError(t, err)
 	require.NotNil(t, f)
-
-	reader, err := f.CreateMetricsReader()
 	defer require.NoError(t, f.Close())
 
+	reader, err := f.CreateMetricsReader()
 	require.NoError(t, err)
 	assert.NotNil(t, reader)
 }

--- a/internal/storage/metricstore/elasticsearch/factory_test.go
+++ b/internal/storage/metricstore/elasticsearch/factory_test.go
@@ -110,8 +110,10 @@ func TestNewFactory(t *testing.T) {
 
 			if tt.expectedErr {
 				require.Error(t, err)
+				require.Nil(t, f)
 			} else {
 				require.NoError(t, err)
+				require.NotNil(t, f)
 				require.NoError(t, f.Close())
 			}
 		})

--- a/internal/storage/metricstore/elasticsearch/factory_test.go
+++ b/internal/storage/metricstore/elasticsearch/factory_test.go
@@ -4,7 +4,8 @@
 package elasticsearch
 
 import (
-	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,26 +18,62 @@ import (
 
 var _ storage.MetricStoreFactory = new(Factory)
 
-func TestCreateMetricsReader(t *testing.T) {
-	listener, err := net.Listen("tcp", "localhost:")
-	require.NoError(t, err)
-	assert.NotNil(t, listener)
-	defer listener.Close()
+// mockESServerResponse simulates a basic Elasticsearch version response.
+var mockESServerResponse = []byte(`
+{
+    "version": {
+       "number": "6.8.0"
+    }
+}
+`)
 
+func setupMockServer(t *testing.T) (*httptest.Server, func()) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mockESServerResponse)
+	}))
+	require.NotNil(t, mockServer)
+
+	return mockServer, mockServer.Close
+}
+
+func TestCreateMetricsReader(t *testing.T) {
+	mockServer, closeServer := setupMockServer(t)
+	defer closeServer()
 	cfg := config.Configuration{
-		Servers: []string{"http://" + listener.Addr().String()},
+		Servers:  []string{mockServer.URL},
+		LogLevel: "debug",
 	}
 	f, err := NewFactory(cfg, telemetry.NoopSettings())
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
 	reader, err := f.CreateMetricsReader()
-
 	require.NoError(t, err)
 	assert.NotNil(t, reader)
+	require.NoError(t, f.Close())
+}
+
+func TestCreateMetricsReaderError(t *testing.T) {
+	cfg := config.Configuration{
+		Servers: []string{""},
+	}
+	f := Factory{
+		config: cfg,
+		telset: telemetry.NoopSettings(),
+	}
+	require.NotNil(t, f)
+
+	reader, err := f.CreateMetricsReader()
+
+	require.Error(t, err)
+	assert.Nil(t, reader)
+	require.NoError(t, f.Close())
 }
 
 func TestNewFactory(t *testing.T) {
+	mockServer, closeServer := setupMockServer(t)
+	defer closeServer()
 	tests := []struct {
 		name        string
 		cfg         config.Configuration
@@ -45,7 +82,8 @@ func TestNewFactory(t *testing.T) {
 		{
 			name: "valid config",
 			cfg: config.Configuration{
-				Servers: []string{"http://localhost:9200"},
+				Servers:  []string{mockServer.URL},
+				LogLevel: "debug",
 			},
 			expectedErr: false,
 		},
@@ -56,17 +94,25 @@ func TestNewFactory(t *testing.T) {
 			},
 			expectedErr: true,
 		},
+		{
+			name: "invalid config - malformed server URL",
+			cfg: config.Configuration{
+				Servers: []string{"://malformed-url"}, // Malformed URL
+			},
+			expectedErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			telset := telemetry.NoopSettings()
-			_, err := NewFactory(tt.cfg, telset)
+			f, err := NewFactory(tt.cfg, telset)
 
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+				require.NoError(t, f.Close())
 			}
 		})
 	}

--- a/internal/storage/metricstore/elasticsearch/factory_test.go
+++ b/internal/storage/metricstore/elasticsearch/factory_test.go
@@ -4,6 +4,7 @@
 package elasticsearch
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -51,7 +52,7 @@ func newTestFactoryConfig(serverURL string) config.Configuration {
 func TestCreateMetricsReader(t *testing.T) {
 	server := setupMockServer(t, mockESServerResponse, http.StatusOK)
 	cfg := newTestFactoryConfig(server.URL)
-	f, err := NewFactory(cfg, telemetry.NoopSettings())
+	f, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
 	require.NoError(t, err)
 	require.NotNil(t, f)
 
@@ -103,7 +104,7 @@ func TestNewFactory(t *testing.T) {
 				server := setupMockServer(t, tt.response, tt.statusCode)
 				tt.cfg.Servers = []string{server.URL}
 			}
-			f, err := NewFactory(tt.cfg, telemetry.NoopSettings())
+			f, err := NewFactory(context.Background(), tt.cfg, telemetry.NoopSettings())
 
 			if tt.expectedErr {
 				require.Error(t, err)

--- a/internal/storage/metricstore/elasticsearch/reader.go
+++ b/internal/storage/metricstore/elasticsearch/reader.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
+	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
@@ -22,12 +23,14 @@ const minStep = time.Millisecond
 
 // MetricsReader is a Elasticsearch metrics reader.
 type MetricsReader struct {
+	client es.Client
 	logger *zap.Logger
 	tracer trace.Tracer
 }
 
-func NewMetricsReader(_ config.Configuration, logger *zap.Logger, tracer trace.TracerProvider) (*MetricsReader, error) {
+func NewMetricsReader(_ config.Configuration, logger *zap.Logger, tracer trace.TracerProvider, client es.Client) (*MetricsReader, error) {
 	return &MetricsReader{
+		client: client,
 		logger: logger,
 		tracer: tracer.Tracer("elasticsearch-metricstore"),
 	}, nil

--- a/internal/storage/metricstore/elasticsearch/reader.go
+++ b/internal/storage/metricstore/elasticsearch/reader.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
-	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
 
@@ -28,7 +27,7 @@ type MetricsReader struct {
 	tracer trace.Tracer
 }
 
-func NewMetricsReader(_ config.Configuration, logger *zap.Logger, tracer trace.TracerProvider, client es.Client) *MetricsReader {
+func NewMetricsReader(client es.Client, logger *zap.Logger, tracer trace.TracerProvider) *MetricsReader {
 	return &MetricsReader{
 		client: client,
 		logger: logger,

--- a/internal/storage/metricstore/elasticsearch/reader.go
+++ b/internal/storage/metricstore/elasticsearch/reader.go
@@ -28,12 +28,12 @@ type MetricsReader struct {
 	tracer trace.Tracer
 }
 
-func NewMetricsReader(_ config.Configuration, logger *zap.Logger, tracer trace.TracerProvider, client es.Client) (*MetricsReader, error) {
+func NewMetricsReader(_ config.Configuration, logger *zap.Logger, tracer trace.TracerProvider, client es.Client) *MetricsReader {
 	return &MetricsReader{
 		client: client,
 		logger: logger,
 		tracer: tracer.Tracer("elasticsearch-metricstore"),
-	}, nil
+	}
 }
 
 func (MetricsReader) GetLatencies(_ context.Context, _ *metricstore.LatenciesQueryParameters) (*metrics.MetricFamily, error) {

--- a/internal/storage/metricstore/elasticsearch/reader_test.go
+++ b/internal/storage/metricstore/elasticsearch/reader_test.go
@@ -74,9 +74,8 @@ func setupMetricsReader(t *testing.T) (*MetricsReader, func()) {
 	}
 
 	client, clientCloser := clientProvider(t, &cfg, logger, telemetry.NoopSettings().Metrics)
-	reader, err := NewMetricsReader(cfg, logger, tracer, client)
+	reader := NewMetricsReader(cfg, logger, tracer, client)
 
-	require.NoError(t, err)
 	require.NotNil(t, reader)
 
 	// Return a cleanup function that combines the tracer shutdown and any other necessary cleanup.

--- a/internal/storage/metricstore/elasticsearch/reader_test.go
+++ b/internal/storage/metricstore/elasticsearch/reader_test.go
@@ -47,7 +47,7 @@ func tracerProvider(t *testing.T) trace.TracerProvider {
 }
 
 func clientProvider(t *testing.T, c *config.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) es.Client {
-	client, err := config.NewClient(c, logger, metricsFactory)
+	client, err := config.NewClient(context.Background(), c, logger, metricsFactory)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -42,7 +42,7 @@ type FactoryBase struct {
 	logger         *zap.Logger
 	tracer         trace.TracerProvider
 
-	newClientFn func(c *config.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error)
+	newClientFn func(ctx context.Context, c *config.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) (es.Client, error)
 
 	config *config.Configuration
 
@@ -75,7 +75,7 @@ func NewFactoryBase(
 	}
 	f.tags = tags
 
-	client, err := f.newClientFn(f.config, logger, metricsFactory)
+	client, err := f.newClientFn(ctx, f.config, logger, metricsFactory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Elasticsearch client: %w", err)
 	}
@@ -213,7 +213,7 @@ func (f *FactoryBase) onClientPasswordChange(cfg *config.Configuration, client *
 	newCfg.Authentication.BasicAuthentication.Password = newPassword
 	newCfg.Authentication.BasicAuthentication.PasswordFilePath = "" // avoid error that both are set
 
-	newClient, err := f.newClientFn(&newCfg, f.logger, mf)
+	newClient, err := f.newClientFn(context.Background(), &newCfg, f.logger, mf)
 	if err != nil {
 		f.logger.Error("failed to recreate Elasticsearch client with new password", zap.Error(err))
 		return

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -209,7 +209,7 @@ func TestCreateTemplates(t *testing.T) {
 	for _, test := range tests {
 		f := FactoryBase{}
 		mockClient := &mocks.Client{}
-		f.newClientFn = func(_ *escfg.Configuration, _ *zap.Logger, _ metrics.Factory) (es.Client, error) {
+		f.newClientFn = func(_ context.Context, _ *escfg.Configuration, _ *zap.Logger, _ metrics.Factory) (es.Client, error) {
 			return mockClient, nil
 		}
 		f.logger = zaptest.NewLogger(t)
@@ -228,7 +228,7 @@ func TestCreateTemplates(t *testing.T) {
 			},
 		}}
 		f.tracer = otel.GetTracerProvider()
-		client, err := f.newClientFn(&escfg.Configuration{}, zaptest.NewLogger(t), metrics.NullFactory)
+		client, err := f.newClientFn(context.Background(), &escfg.Configuration{}, zaptest.NewLogger(t), metrics.NullFactory)
 		require.NoError(t, err)
 		f.client.Store(&client)
 		f.templateBuilder = es.TextTemplateBuilder{}

--- a/internal/storage/v1/elasticsearch/helper.go
+++ b/internal/storage/v1/elasticsearch/helper.go
@@ -21,7 +21,7 @@ type mockClientBuilder struct {
 	createTemplateError error
 }
 
-func (m *mockClientBuilder) NewClient(*escfg.Configuration, *zap.Logger, metrics.Factory) (es.Client, error) {
+func (m *mockClientBuilder) NewClient(context.Context, *escfg.Configuration, *zap.Logger, metrics.Factory) (es.Client, error) {
 	if m.err == nil {
 		c := &mocks.Client{}
 		tService := &mocks.TemplateCreateService{}
@@ -48,7 +48,7 @@ func SetFactoryForTestWithCreateTemplateErr(f *FactoryBase, logger *zap.Logger, 
 	f.metricsFactory = metricsFactory
 	f.config = cfg
 	f.tracer = otel.GetTracerProvider()
-	client, err := f.newClientFn(cfg, logger, metricsFactory)
+	client, err := f.newClientFn(context.Background(), cfg, logger, metricsFactory)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Partly solve https://github.com/jaegertracing/jaeger/issues/7208

## Description of the changes
- Add es.client to metricstore/elasticsearch/reader.go
- Use mockServer for factory_test and reader_test and refactor it

## How was this change tested?
- make lint test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
