### PR TITLE
Fix Jaeger v2 panics when exporting a span without "service.name" to multiple exporters

### DIFF
--- a/cmd/jaeger/internal/exporters/storageexporter/exporter.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter.go
@@ -50,5 +50,10 @@ func (*storageExporter) close(_ context.Context) error {
 }
 
 func (exp *storageExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
-	return exp.traceWriter.WriteTraces(ctx, exp.sanitizer(td))
+	// Make sure exp.sanitizer func work when multiple exporters are defined in pipeline
+	// More info see: https://github.com/open-telemetry/opentelemetry-collector/blob/main/internal/fanoutconsumer/traces.go#L66-L75
+	newTraces := ptrace.NewTraces()
+	td.CopyTo(newTraces)
+
+	return exp.traceWriter.WriteTraces(ctx, exp.sanitizer(newTraces))
 }

--- a/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
+++ b/cmd/jaeger/internal/exporters/storageexporter/exporter_test.go
@@ -141,6 +141,7 @@ func TestExporter(t *testing.T) {
 	traceID[15] = 1 // 00000000000000000000000000000001
 	span.SetTraceID(traceID)
 
+	traces.MarkReadOnly()
 	err = tracesExporter.ConsumeTraces(ctx, traces)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7221

## Description of the changes
- Use `CopyTo` to generate a new ptrace.Traces var: `newTraces` to make it editable

## How was this change tested?
-  Add a line `traces.MarkReadOnly()` to mock the  ptrace.Traces is ready only

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
