### PR TITLE
[cassandra] Give responsibility of creating v2 factory to storage backend

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -17,8 +17,8 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore/prometheus"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
-	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/cassandra"
 	es "github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/grpc"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/memory"
@@ -176,7 +176,7 @@ func (s *storageExt) Start(ctx context.Context, host component.Host) error {
 			grpcTelset.Metrics = scopedMetricsFactory(storageName, "grpc", "tracestore")
 			factory, err = grpc.NewFactory(ctx, *cfg.GRPC, grpcTelset)
 		case cfg.Cassandra != nil:
-			v1Factory, err = cassandra.NewFactoryWithConfig(
+			factory, err = cassandra.NewFactory(
 				*cfg.Cassandra,
 				scopedMetricsFactory(storageName, "cassandra", "tracestore"),
 				s.telset.Logger,

--- a/internal/storage/v1/cassandra/factory.go
+++ b/internal/storage/v1/cassandra/factory.go
@@ -82,44 +82,6 @@ func NewArchiveFactory() *Factory {
 	}
 }
 
-// NewFactoryWithConfig initializes factory with Config.
-func NewFactoryWithConfig(
-	opts Options,
-	metricsFactory metrics.Factory,
-	logger *zap.Logger,
-) (*Factory, error) {
-	f := NewFactory()
-	// use this to help with testing
-	b := &withConfigBuilder{
-		f:              f,
-		opts:           &opts,
-		metricsFactory: metricsFactory,
-		logger:         logger,
-		initializer:    f.Initialize, // this can be mocked in tests
-	}
-	return b.build()
-}
-
-type withConfigBuilder struct {
-	f              *Factory
-	opts           *Options
-	metricsFactory metrics.Factory
-	logger         *zap.Logger
-	initializer    func(metricsFactory metrics.Factory, logger *zap.Logger) error
-}
-
-func (b *withConfigBuilder) build() (*Factory, error) {
-	b.f.configureFromOptions(b.opts)
-	if err := b.opts.NamespaceConfig.Validate(); err != nil {
-		return nil, err
-	}
-	err := b.initializer(b.metricsFactory, b.logger)
-	if err != nil {
-		return nil, err
-	}
-	return b.f, nil
-}
-
 // AddFlags implements storage.Configurable
 func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
 	f.Options.AddFlags(flagSet)
@@ -128,11 +90,11 @@ func (f *Factory) AddFlags(flagSet *flag.FlagSet) {
 // InitFromViper implements storage.Configurable
 func (f *Factory) InitFromViper(v *viper.Viper, _ *zap.Logger) {
 	f.Options.InitFromViper(v)
-	f.configureFromOptions(f.Options)
+	f.ConfigureFromOptions(f.Options)
 }
 
 // InitFromOptions initializes factory from options.
-func (f *Factory) configureFromOptions(o *Options) {
+func (f *Factory) ConfigureFromOptions(o *Options) {
 	f.Options = o
 	f.config = o.GetConfig()
 }

--- a/internal/storage/v1/cassandra/helper.go
+++ b/internal/storage/v1/cassandra/helper.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package cassandra
+
+import (
+	"github.com/jaegertracing/jaeger/internal/storage/cassandra"
+	"github.com/jaegertracing/jaeger/internal/storage/cassandra/config"
+	"github.com/jaegertracing/jaeger/internal/storage/cassandra/mocks"
+)
+
+type mockSessionBuilder struct {
+	index    int
+	sessions []*mocks.Session
+	errors   []error
+}
+
+func (m *mockSessionBuilder) add(session *mocks.Session, err error) *mockSessionBuilder {
+	m.sessions = append(m.sessions, session)
+	m.errors = append(m.errors, err)
+	return m
+}
+
+func (m *mockSessionBuilder) build(*config.Configuration) (cassandra.Session, error) {
+	session := m.sessions[m.index]
+	err := m.errors[m.index]
+	m.index++
+	return session, err
+}
+
+func MockSession(f *Factory, session *mocks.Session, err error) {
+	f.sessionBuilderFn = new(mockSessionBuilder).add(session, err).build
+}

--- a/internal/storage/v2/cassandra/factory.go
+++ b/internal/storage/v2/cassandra/factory.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package cassandra
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/internal/distributedlock"
+	"github.com/jaegertracing/jaeger/internal/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
+)
+
+type Factory struct {
+	v1Factory *cassandra.Factory
+}
+
+// NewFactory creates and initializes the factory
+func NewFactory(opts cassandra.Options, metricsFactory metrics.Factory, logger *zap.Logger) (*Factory, error) {
+	factory, err := newFactoryWithConfig(opts, metricsFactory, logger)
+	if err != nil {
+		return nil, err
+	}
+	return &Factory{v1Factory: factory}, nil
+}
+
+func (f *Factory) CreateTraceReader() (tracestore.Reader, error) {
+	reader, err := f.v1Factory.CreateSpanReader()
+	if err != nil {
+		return nil, err
+	}
+	return v1adapter.NewTraceReader(reader), nil
+}
+
+func (f *Factory) CreateTraceWriter() (tracestore.Writer, error) {
+	writer, err := f.v1Factory.CreateSpanWriter()
+	if err != nil {
+		return nil, err
+	}
+	return v1adapter.NewTraceWriter(writer), nil
+}
+
+func (f *Factory) CreateDependencyReader() (depstore.Reader, error) {
+	reader, err := f.v1Factory.CreateDependencyReader()
+	if err != nil {
+		return nil, err
+	}
+	return v1adapter.NewDependencyReader(reader), nil
+}
+
+func (f *Factory) CreateSamplingStore(maxBuckets int) (samplingstore.Store, error) {
+	return f.v1Factory.CreateSamplingStore(maxBuckets)
+}
+
+func (f *Factory) Close() error {
+	return f.v1Factory.Close()
+}
+
+func (f *Factory) Purge(ctx context.Context) error {
+	return f.v1Factory.Purge(ctx)
+}
+
+func (f *Factory) CreateLock() (distributedlock.Lock, error) {
+	return f.v1Factory.CreateLock()
+}
+
+// newFactoryWithConfig initializes factory with Config.
+func newFactoryWithConfig(
+	opts cassandra.Options,
+	metricsFactory metrics.Factory,
+	logger *zap.Logger,
+) (*cassandra.Factory, error) {
+	f := cassandra.NewFactory()
+	// use this to help with testing
+	b := &withConfigBuilder{
+		f:              f,
+		opts:           &opts,
+		metricsFactory: metricsFactory,
+		logger:         logger,
+		initializer:    f.Initialize, // this can be mocked in tests
+	}
+	return b.build()
+}
+
+type withConfigBuilder struct {
+	f              *cassandra.Factory
+	opts           *cassandra.Options
+	metricsFactory metrics.Factory
+	logger         *zap.Logger
+	initializer    func(metricsFactory metrics.Factory, logger *zap.Logger) error
+}
+
+func (b *withConfigBuilder) build() (*cassandra.Factory, error) {
+	b.f.ConfigureFromOptions(b.opts)
+	if err := b.opts.NamespaceConfig.Validate(); err != nil {
+		return nil, err
+	}
+	err := b.initializer(b.metricsFactory, b.logger)
+	if err != nil {
+		return nil, err
+	}
+	return b.f, nil
+}

--- a/internal/storage/v2/cassandra/factory_test.go
+++ b/internal/storage/v2/cassandra/factory_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package cassandra
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/internal/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/cassandra/config"
+	"github.com/jaegertracing/jaeger/internal/storage/cassandra/mocks"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra"
+)
+
+func TestNewFactoryWithConfig(t *testing.T) {
+	t.Run("valid configuration", func(t *testing.T) {
+		opts := &cassandra.Options{
+			NamespaceConfig: cassandra.NamespaceConfig{
+				Configuration: config.DefaultConfiguration(),
+			},
+		}
+		f := cassandra.NewFactory()
+		b := &withConfigBuilder{
+			f:              f,
+			opts:           opts,
+			metricsFactory: metrics.NullFactory,
+			logger:         zap.NewNop(),
+			initializer:    func(_ metrics.Factory, _ *zap.Logger) error { return nil },
+		}
+		_, err := b.build()
+		require.NoError(t, err)
+	})
+	t.Run("connection error", func(t *testing.T) {
+		expErr := errors.New("made-up error")
+		opts := &cassandra.Options{
+			NamespaceConfig: cassandra.NamespaceConfig{
+				Configuration: config.DefaultConfiguration(),
+			},
+		}
+		f := cassandra.NewFactory()
+		b := &withConfigBuilder{
+			f:              f,
+			opts:           opts,
+			metricsFactory: metrics.NullFactory,
+			logger:         zap.NewNop(),
+			initializer:    func(_ metrics.Factory, _ *zap.Logger) error { return expErr },
+		}
+		_, err := b.build()
+		require.ErrorIs(t, err, expErr)
+	})
+	t.Run("invalid configuration", func(t *testing.T) {
+		cfg := cassandra.Options{}
+		_, err := NewFactory(cfg, metrics.NullFactory, zap.NewNop())
+		require.ErrorContains(t, err, "Servers: non zero value required")
+	})
+}
+
+func TestNewFactory(t *testing.T) {
+	v1Factory := cassandra.NewFactory()
+	v1Factory.Options = cassandra.NewOptions("primary")
+	var (
+		session = &mocks.Session{}
+		query   = &mocks.Query{}
+	)
+	session.On("Query", mock.AnythingOfType("string"), mock.Anything).Return(query)
+	session.On("Close").Return()
+	query.On("Exec").Return(nil)
+	cassandra.MockSession(v1Factory, session, nil)
+	require.NoError(t, v1Factory.Initialize(metrics.NullFactory, zap.NewNop()))
+	f := &Factory{v1Factory: v1Factory}
+	_, err := f.CreateTraceWriter()
+	require.NoError(t, err)
+
+	_, err = f.CreateTraceReader()
+	require.NoError(t, err)
+
+	_, err = f.CreateDependencyReader()
+	require.NoError(t, err)
+
+	_, err = f.CreateLock()
+	require.NoError(t, err)
+
+	_, err = f.CreateSamplingStore(0)
+	require.NoError(t, err)
+
+	require.NoError(t, f.Close())
+}
+
+func TestCreateTraceReaderError(t *testing.T) {
+	session := &mocks.Session{}
+	query := &mocks.Query{}
+	session.On("Query",
+		mock.AnythingOfType("string"),
+		mock.Anything).Return(query)
+	session.On("Query",
+		mock.AnythingOfType("string"),
+		mock.Anything).Return(query)
+	query.On("Exec").Return(errors.New("table does not exist"))
+	v1Factory := cassandra.NewFactory()
+	cassandra.MockSession(v1Factory, session, nil)
+	require.NoError(t, v1Factory.Initialize(metrics.NullFactory, zap.NewNop()))
+	f := &Factory{v1Factory: v1Factory}
+	r, err := f.CreateTraceReader()
+	require.ErrorContains(t, err, "neither table operation_names_v2 nor operation_names exist")
+	require.Nil(t, r)
+}
+
+func TestCreateTraceWriterErr(t *testing.T) {
+	v1Factory := cassandra.NewFactory()
+	v1Factory.Options = &cassandra.Options{
+		NamespaceConfig: cassandra.NamespaceConfig{
+			Configuration: config.DefaultConfiguration(),
+		},
+		Index: cassandra.IndexConfig{
+			TagBlackList: "a,b,c",
+			TagWhiteList: "a,b,c",
+		},
+	}
+	var (
+		session = &mocks.Session{}
+		query   = &mocks.Query{}
+	)
+	session.On("Query", mock.AnythingOfType("string"), mock.Anything).Return(query)
+	query.On("Exec").Return(nil)
+	cassandra.MockSession(v1Factory, session, nil)
+	require.NoError(t, v1Factory.Initialize(metrics.NullFactory, zap.NewNop()))
+	f := &Factory{v1Factory: v1Factory}
+	_, err := f.CreateTraceWriter()
+	require.ErrorContains(t, err, "only one of TagIndexBlacklist and TagIndexWhitelist can be specified")
+}

--- a/internal/storage/v2/cassandra/package_test.go
+++ b/internal/storage/v2/cassandra/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package cassandra
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards: #7050

## Description of the changes
- The responsibility of converting the v1 factory to v2 factory is now given to storage backend for cassandra

## How was this change tested?
- Unit Tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
