### PR TITLE
[test] Always log the size of large trace

### DIFF
--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -413,7 +413,7 @@ func (s *StorageIntegration) writeLargeTraceWithDuplicateSpanIds(
 ) *model.Trace {
 	trace := s.getTraceFixture(t, "example_trace")
 	repeatedSpan := trace.Spans[0]
-	trace.Spans = make([]*model.Span, 0, totalCount)
+	trace.Spans = make([]*model.Span, totalCount)
 	for i := range totalCount {
 		newSpan := new(model.Span)
 		*newSpan = *repeatedSpan


### PR DESCRIPTION
Logs now always show the size of loaded trace
```
    integration.go:393: 2025-06-24 13:57:54.188 Writing trace with 10008 spans
    integration.go:400: 2025-06-24 13:57:56.547 Finished writing trace with 10008 spans
...
    integration.go:240: 2025-06-24 13:57:58.426 Loaded large trace, expected=10008, actual=10008
```