### PR TITLE
feat: Add generic solution for optional config fields #5828 

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,11 +5,15 @@
 package config
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/confmap"
 )
 
 // Viperize creates new Viper and command add passes flags to command
@@ -35,4 +39,135 @@ func AddFlags(v *viper.Viper, command *cobra.Command, inits ...func(*flag.FlagSe
 func configureViper(v *viper.Viper) {
 	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+}
+
+// ProcessOptionalPointers processes a configuration struct using reflection to properly
+// handle optional pointer fields based on whether they were set in the configuration map.
+//
+// This is a generic solution for the OpenTelemetry Collector optional fields issue:
+// https://github.com/open-telemetry/opentelemetry-collector/issues/10266
+//
+// The function modifies the config struct in-place, setting pointer fields to nil
+// if they were not explicitly set in the configuration, even if they have default values.
+//
+// Parameters:
+//   - config: Pointer to the configuration struct to process
+//   - conf: The confmap.Conf containing the raw configuration data
+//   - fieldPath: Optional prefix for nested field paths (used in recursive calls)
+//
+// Example usage:
+//
+//	type Config struct {
+//		Required    string      `mapstructure:"required"`
+//		Optional    *SubConfig  `mapstructure:"optional"`
+//		AnotherOpt  *OtherConf  `mapstructure:"another_opt"`
+//	}
+//
+//	// After normal unmarshal:
+//	err := conf.Unmarshal(&config)
+//	if err != nil {
+//		return err
+//	}
+//
+//	// Process optional fields:
+//	err = config.ProcessOptionalPointers(&config, conf, "")
+//	if err != nil {
+//		return err
+//	}
+//
+//	// Now config.Optional will be nil if "optional" was not in the YAML/config
+func ProcessOptionalPointers(config interface{}, conf *confmap.Conf, fieldPath string) error {
+	if config == nil {
+		return errors.New("config cannot be nil")
+	}
+
+	v := reflect.ValueOf(config)
+	if v.Kind() != reflect.Ptr {
+		return errors.New("config must be a pointer to struct")
+	}
+
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return errors.New("config must be a pointer to struct")
+	}
+
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+
+		// Skip unexported fields
+		if !field.CanSet() {
+			continue
+		}
+
+		// Get the mapstructure tag for the field name
+		tag := fieldType.Tag.Get("mapstructure")
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		// Handle squash tag (embedded structs)
+		if strings.Contains(tag, "squash") {
+			if field.Kind() == reflect.Struct {
+				// Recursively process embedded struct
+				err := ProcessOptionalPointers(field.Addr().Interface(), conf, fieldPath)
+				if err != nil {
+					return fmt.Errorf("failed to process embedded struct %s: %w", fieldType.Name, err)
+				}
+			}
+			continue
+		}
+
+		// Extract field name from tag (handle omitempty, etc.)
+		fieldName := strings.Split(tag, ",")[0]
+		if fieldName == "" {
+			fieldName = fieldType.Name
+		}
+
+		// Process pointer fields that could be optional
+		if field.Kind() == reflect.Ptr {
+			// Check if the field was explicitly set in config
+			if !conf.IsSet(fieldName) {
+				// Field was not set in config, set to nil regardless of current value
+				field.Set(reflect.Zero(field.Type()))
+			} else {
+				// Field was explicitly set, check if it was set to null explicitly
+				rawValue := conf.Get(fieldName)
+				if rawValue == nil {
+					// Field was explicitly set to null, keep it as nil
+					field.Set(reflect.Zero(field.Type()))
+				} else if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+					// Field was set to a value and is a struct, recursively process
+					if subConf, err := conf.Sub(fieldName); err == nil {
+						err := ProcessOptionalPointers(field.Interface(), subConf, "")
+						if err != nil {
+							return fmt.Errorf("failed to process nested struct %s: %w", fieldName, err)
+						}
+					}
+				}
+				// If field is nil but was not explicitly set to null, it means
+				// unmarshal failed for some reason, keep current state
+			}
+		} else if field.Kind() == reflect.Struct {
+			// For non-pointer structs, recursively process nested fields if the section exists
+			if conf.IsSet(fieldName) {
+				if subConf, err := conf.Sub(fieldName); err == nil {
+					err := ProcessOptionalPointers(field.Addr().Interface(), subConf, "")
+					if err != nil {
+						return fmt.Errorf("failed to process nested struct %s: %w", fieldName, err)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// IsOptionalFieldSet checks if a specific optional field was explicitly set in the configuration.
+// This is a utility function for manual checking when automatic processing is not suitable.
+func IsOptionalFieldSet(conf *confmap.Conf, fieldPath string) bool {
+	return conf.IsSet(fieldPath)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
 )
 
 func TestViperize(t *testing.T) {
@@ -52,4 +54,255 @@ func TestEnv(t *testing.T) {
 
 	v, _ := Viperize(addFlags)
 	assert.Equal(t, expectedString, v.GetString(envFlag))
+}
+
+// Tests for optional fields functionality
+
+func TestProcessOptionalPointers(t *testing.T) {
+	type SubConfig struct {
+		Name string `mapstructure:"name"`
+		Port int    `mapstructure:"port"`
+	}
+
+	type NestedConfig struct {
+		OptionalSub *SubConfig `mapstructure:"optional_sub"`
+		RequiredStr string     `mapstructure:"required_str"`
+	}
+
+	type Config struct {
+		Required  string       `mapstructure:"required"`
+		Optional1 *SubConfig   `mapstructure:"optional1"`
+		Optional2 *SubConfig   `mapstructure:"optional2"`
+		Nested    NestedConfig `mapstructure:"nested"`
+	}
+
+	tests := []struct {
+		name               string
+		input              map[string]interface{}
+		expectOpt1Nil      bool
+		expectOpt2Nil      bool
+		expectNestedSubNil bool
+	}{
+		{
+			name: "all fields set",
+			input: map[string]interface{}{
+				"required": "test",
+				"optional1": map[string]interface{}{
+					"name": "service1",
+					"port": 8080,
+				},
+				"optional2": map[string]interface{}{
+					"name": "service2",
+					"port": 9090,
+				},
+				"nested": map[string]interface{}{
+					"optional_sub": map[string]interface{}{
+						"name": "nested-service",
+						"port": 3000,
+					},
+					"required_str": "nested-test",
+				},
+			},
+			expectOpt1Nil:      false,
+			expectOpt2Nil:      false,
+			expectNestedSubNil: false,
+		},
+		{
+			name: "only required fields set",
+			input: map[string]interface{}{
+				"required": "test",
+				"nested": map[string]interface{}{
+					"required_str": "nested-test",
+				},
+			},
+			expectOpt1Nil:      true,
+			expectOpt2Nil:      true,
+			expectNestedSubNil: true,
+		},
+		{
+			name: "partial optional fields set",
+			input: map[string]interface{}{
+				"required": "test",
+				"optional1": map[string]interface{}{
+					"name": "service1",
+					"port": 8080,
+				},
+				"nested": map[string]interface{}{
+					"optional_sub": map[string]interface{}{
+						"name": "nested-service",
+						"port": 3000,
+					},
+					"required_str": "nested-test",
+				},
+			},
+			expectOpt1Nil:      false,
+			expectOpt2Nil:      true,
+			expectNestedSubNil: false,
+		},
+		{
+			name: "explicit null values",
+			input: map[string]interface{}{
+				"required":  "test",
+				"optional1": nil,
+				"optional2": nil,
+				"nested": map[string]interface{}{
+					"optional_sub": nil,
+					"required_str": "nested-test",
+				},
+			},
+			expectOpt1Nil:      true,
+			expectOpt2Nil:      true,
+			expectNestedSubNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := confmap.NewFromStringMap(tt.input)
+
+			// Create config with default values (simulating factory default)
+			config := &Config{
+				Optional1: &SubConfig{Name: "default1", Port: 1111},
+				Optional2: &SubConfig{Name: "default2", Port: 2222},
+				Nested: NestedConfig{
+					OptionalSub: &SubConfig{Name: "default-nested", Port: 3333},
+				},
+			}
+
+			// First unmarshal normally
+			err := conf.Unmarshal(config)
+			require.NoError(t, err)
+
+			// Then process optional pointers
+			err = ProcessOptionalPointers(config, conf, "")
+			require.NoError(t, err)
+
+			// Verify results
+			if tt.expectOpt1Nil {
+				assert.Nil(t, config.Optional1, "Optional1 should be nil")
+			} else {
+				assert.NotNil(t, config.Optional1, "Optional1 should not be nil")
+			}
+
+			if tt.expectOpt2Nil {
+				assert.Nil(t, config.Optional2, "Optional2 should be nil")
+			} else {
+				assert.NotNil(t, config.Optional2, "Optional2 should not be nil")
+			}
+
+			if tt.expectNestedSubNil {
+				assert.Nil(t, config.Nested.OptionalSub, "Nested.OptionalSub should be nil")
+			} else {
+				assert.NotNil(t, config.Nested.OptionalSub, "Nested.OptionalSub should not be nil")
+			}
+		})
+	}
+}
+
+func TestProcessOptionalPointers_Squash(t *testing.T) {
+	type EmbeddedConfig struct {
+		OptionalField *string `mapstructure:"optional_field"`
+		RequiredField string  `mapstructure:"required_field"`
+	}
+
+	type Config struct {
+		EmbeddedConfig `mapstructure:",squash"`
+		TopLevel       *string `mapstructure:"top_level"`
+	}
+
+	input := map[string]interface{}{
+		"required_field": "test",
+		// optional_field and top_level are not set
+	}
+
+	conf := confmap.NewFromStringMap(input)
+
+	// Create config with defaults
+	config := &Config{
+		EmbeddedConfig: EmbeddedConfig{
+			OptionalField: stringPtr("default"),
+		},
+		TopLevel: stringPtr("default-top"),
+	}
+
+	// Unmarshal normally
+	err := conf.Unmarshal(config)
+	require.NoError(t, err)
+
+	// Process optional pointers
+	err = ProcessOptionalPointers(config, conf, "")
+	require.NoError(t, err)
+
+	// Verify that optional fields were set to nil
+	assert.Nil(t, config.OptionalField, "EmbeddedConfig.OptionalField should be nil")
+	assert.Nil(t, config.TopLevel, "TopLevel should be nil")
+	assert.Equal(t, "test", config.RequiredField, "RequiredField should keep its value")
+}
+
+func TestProcessOptionalPointers_ErrorCases(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]interface{}{})
+
+	tests := []struct {
+		name        string
+		config      interface{}
+		expectError string
+	}{
+		{
+			name:        "nil config",
+			config:      nil,
+			expectError: "config cannot be nil",
+		},
+		{
+			name:        "non-pointer config",
+			config:      struct{}{},
+			expectError: "config must be a pointer to struct",
+		},
+		{
+			name:        "pointer to non-struct",
+			config:      stringPtr("test"),
+			expectError: "config must be a pointer to struct",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ProcessOptionalPointers(tt.config, conf, "")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestIsOptionalFieldSet(t *testing.T) {
+	input := map[string]interface{}{
+		"set_field": "value",
+		"nested": map[string]interface{}{
+			"set_nested": "nested_value",
+		},
+	}
+
+	conf := confmap.NewFromStringMap(input)
+
+	tests := []struct {
+		fieldPath string
+		expected  bool
+	}{
+		{"set_field", true},
+		{"unset_field", false},
+		{"nested", true},             // nested object exists
+		{"nested.set_nested", false}, // confmap.IsSet doesn't support dot notation for nested fields
+		{"nonexistent.nested.field", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldPath, func(t *testing.T) {
+			result := IsOptionalFieldSet(conf, tt.fieldPath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
This commit addresses the OpenTelemetry Collector issue where confmap cannot distinguish between unset fields and zero values for pointer fields in configuration structs.

* Add ProcessOptionalPointers() function in internal/config
* Provides reflection-based solution for any config struct
* Handles nested structs and embedded structs with squash tags
* Properly handles explicit null values vs unset fields
* Includes comprehensive test suite with edge cases
* Replace manual field checking in remotesampling config

Resolves OpenTelemetry Collector issue: #5828

This generic solution can be used across all Jaeger V2 configurations that need optional pointer field support.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
