### PR TITLE
[es] Upgrade integration tests to use v2 factory

### DIFF
--- a/internal/storage/integration/elasticsearch_test.go
+++ b/internal/storage/integration/elasticsearch_test.go
@@ -7,7 +7,6 @@ package integration
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,16 +17,15 @@ import (
 	"github.com/olivere/elastic/v7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
-	"github.com/jaegertracing/jaeger/internal/config"
-	"github.com/jaegertracing/jaeger/internal/metrics"
-	"github.com/jaegertracing/jaeger/internal/storage/v1/api/dependencystore"
+	escfg "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 	es "github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	esv2 "github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
+	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/testutils"
 )
 
@@ -44,8 +42,7 @@ const (
 	spanTemplateName         = "jaeger-span"
 	serviceTemplateName      = "jaeger-service"
 	dependenciesTemplateName = "jaeger-dependencies"
-	primaryNamespace         = "es"
-	archiveNamespace         = "es-archive"
+	archiveAliasSuffix       = "archive"
 )
 
 type ESStorageIntegration struct {
@@ -57,8 +54,8 @@ type ESStorageIntegration struct {
 	ArchiveTraceReader tracestore.Reader
 	ArchiveTraceWriter tracestore.Writer
 
-	factory        *es.Factory
-	archiveFactory *es.Factory
+	factory        *esv2.Factory
+	archiveFactory *esv2.Factory
 }
 
 func (s *ESStorageIntegration) getVersion() (uint, error) {
@@ -109,58 +106,78 @@ func (s *ESStorageIntegration) esCleanUp(t *testing.T) {
 	require.NoError(t, s.archiveFactory.Purge(context.Background()))
 }
 
-func (*ESStorageIntegration) initializeESFactory(t *testing.T, args []string, factoryInit func() *es.Factory) *es.Factory {
-	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
-	f := factoryInit()
-	v, command := config.Viperize(f.AddFlags)
-	require.NoError(t, command.ParseFlags(args))
-	f.InitFromViper(v, logger)
-	require.NoError(t, f.Initialize(metrics.NullFactory, logger))
+func getESIndexOptions() escfg.IndexOptions {
+	replicas := int64(1)
+	return escfg.IndexOptions{
+		Shards:            5,
+		Replicas:          &replicas,
+		DateLayout:        "2006-01-02",
+		RolloverFrequency: "day",
+	}
+}
 
-	t.Cleanup(func() {
-		require.NoError(t, f.Close())
-	})
-	return f
+func getESIndices() escfg.Indices {
+	return escfg.Indices{
+		IndexPrefix:  indexPrefix,
+		Spans:        getESIndexOptions(),
+		Sampling:     getESIndexOptions(),
+		Services:     getESIndexOptions(),
+		Dependencies: getESIndexOptions(),
+	}
 }
 
 func (s *ESStorageIntegration) initSpanstore(t *testing.T, allTagsAsFields bool) {
-	f := s.initializeESFactory(t, []string{
-		fmt.Sprintf("--es.num-shards=%v", 5),
-		fmt.Sprintf("--es.num-replicas=%v", 1),
-		fmt.Sprintf("--es.index-prefix=%v", indexPrefix),
-		fmt.Sprintf("--es.use-ilm=%v", false),
-		fmt.Sprintf("--es.service-cache-ttl=%v", 1*time.Second),
-		fmt.Sprintf("--es.tags-as-fields.all=%v", allTagsAsFields),
-		fmt.Sprintf("--es.bulk.actions=%v", 1),
-		fmt.Sprintf("--es.bulk.flush-interval=%v", time.Nanosecond),
-	}, es.NewFactory)
-	af := s.initializeESFactory(t, []string{
-		"--es-archive.enabled=true",
-		fmt.Sprintf("--es-archive.tags-as-fields.all=%v", allTagsAsFields),
-		fmt.Sprintf("--es-archive.index-prefix=%v", indexPrefix),
-	}, es.NewArchiveFactory)
+	cfg := escfg.Configuration{
+		Servers:         []string{"http://127.0.0.1:9200"},
+		UseILM:          false,
+		ServiceCacheTTL: 1 * time.Second,
+		Tags: escfg.TagsAsFields{
+			AllAsFields: allTagsAsFields,
+		},
+		BulkProcessing: escfg.BulkProcessing{
+			MaxActions:    1,
+			FlushInterval: time.Nanosecond,
+		},
+		Indices:              getESIndices(),
+		CreateIndexTemplates: true,
+	}
+	defaultCfg := es.DefaultConfig()
+	cfg.ApplyDefaults(&defaultCfg)
+	var err error
+	f, err := esv2.NewFactory(context.Background(), cfg, telemetry.NoopSettings())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, f.Close())
+	})
+	acfg := escfg.Configuration{
+		Servers: []string{"http://127.0.0.1:9200"},
+		Tags: escfg.TagsAsFields{
+			AllAsFields: allTagsAsFields,
+		},
+		Indices:             getESIndices(),
+		ReadAliasSuffix:     archiveAliasSuffix,
+		WriteAliasSuffix:    archiveAliasSuffix,
+		UseReadWriteAliases: true,
+	}
+	acfg.ApplyDefaults(&defaultCfg)
+	af, err := esv2.NewFactory(context.Background(), acfg, telemetry.NoopSettings())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, af.Close())
+	})
 	s.factory = f
 	s.archiveFactory = af
-	var err error
-	spanWriter, err := f.CreateSpanWriter()
+	s.TraceWriter, err = f.CreateTraceWriter()
 	require.NoError(t, err)
-	s.TraceWriter = v1adapter.NewTraceWriter(spanWriter)
-	spanReader, err := f.CreateSpanReader()
+	s.TraceReader, err = f.CreateTraceReader()
 	require.NoError(t, err)
-	s.TraceReader = v1adapter.NewTraceReader(spanReader)
-	archiveSpanReader, err := af.CreateSpanReader()
+	s.ArchiveTraceReader, err = af.CreateTraceReader()
 	require.NoError(t, err)
-	s.ArchiveTraceReader = v1adapter.NewTraceReader(archiveSpanReader)
-	archiveSpanWriter, err := af.CreateSpanWriter()
+	s.ArchiveTraceWriter, err = af.CreateTraceWriter()
 	require.NoError(t, err)
-	s.ArchiveTraceWriter = v1adapter.NewTraceWriter(archiveSpanWriter)
-
-	dependencyReader, err := f.CreateDependencyReader()
+	s.DependencyReader, err = f.CreateDependencyReader()
 	require.NoError(t, err)
-	s.DependencyReader = v1adapter.NewDependencyReader(dependencyReader)
-
-	s.DependencyWriter = v1adapter.NewDependencyWriter(dependencyReader.(dependencystore.Writer))
-
+	s.DependencyWriter = s.DependencyReader.(depstore.Writer)
 	s.SamplingStore, err = f.CreateSamplingStore(1)
 	require.NoError(t, err)
 }

--- a/internal/storage/v2/elasticsearch/factory.go
+++ b/internal/storage/v2/elasticsearch/factory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/internal/metrics"
 	escfg "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
@@ -57,6 +58,10 @@ func (f *Factory) CreateTraceWriter() (tracestore.Writer, error) {
 func (f *Factory) CreateDependencyReader() (depstore.Reader, error) {
 	params := f.coreFactory.GetDependencyStoreParams()
 	return v2depstore.NewDependencyStoreV2(params), nil
+}
+
+func (f *Factory) CreateSamplingStore(maxBuckets int) (samplingstore.Store, error) {
+	return f.coreFactory.CreateSamplingStore(maxBuckets)
 }
 
 func (f *Factory) Close() error {

--- a/internal/storage/v2/elasticsearch/factory_test.go
+++ b/internal/storage/v2/elasticsearch/factory_test.go
@@ -36,6 +36,8 @@ func TestNewFactory(t *testing.T) {
 	require.NoError(t, err)
 	_, err = f.CreateDependencyReader()
 	require.NoError(t, err)
+	_, err = f.CreateSamplingStore(1)
+	require.NoError(t, err)
 	err = f.Close()
 	require.NoError(t, err)
 	err = f.Purge(context.Background())


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes a part of: #7050 

## Description of the changes
- Upgrage integration tests for elastic search

## How was this change tested?
- E2E

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
