### PR TITLE
Added custom timeout to docker-all-in-one CI job

### DIFF
--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   all-in-one:
     runs-on: ubuntu-latest
+    timeout: 30 # min, max + 3*std over the last 2600 runs
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-docker-all-in-one.yml
+++ b/.github/workflows/ci-docker-all-in-one.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   all-in-one:
     runs-on: ubuntu-latest
-    timeout: 30 # min, max + 3*std over the last 2600 runs
+    timeout-minutes: 30 # max + 3*std over the last 2600 runs
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Which problem is this PR solving?
Added custom timeout for `all-in-one` job of the `Build all-in-one` workflow based on historical data that could lead to resource savings and faster CI for the project.

### More details
Over the last 2643 successful runs, the `all-in-one` job has a maximum runtime of 18 minutes (mean=6, std=4) across all matrix combinations.

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/jaegertracing/jaeger/actions/runs/13909902215/job/38921630813) job run, that failed after 6 hours. More stuck jobs have been observed over the last months, the first one on 21-Sep-2024 and the last one one on 17-Mar-2025, while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of 16 hours would have been saved over the last few months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

## Description of the changes

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail with a timeout at 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 30 minutes` where `max` and `std` (standard deviation) are derived from the history of 2643 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.



## Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

## How was this change tested?
No testing was performed.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
