### PR TITLE
Fix panic when reading malformed warning attribute

### DIFF
--- a/internal/jptrace/warning.go
+++ b/internal/jptrace/warning.go
@@ -21,13 +21,19 @@ func AddWarnings(span ptrace.Span, warnings ...string) {
 }
 
 func GetWarnings(span ptrace.Span) []string {
-	if w, ok := span.Attributes().Get(WarningsAttribute); ok {
-		warnings := []string{}
-		ws := w.Slice()
-		for i := 0; i < ws.Len(); i++ {
-			warnings = append(warnings, ws.At(i).Str())
+	if wa, ok := span.Attributes().Get(WarningsAttribute); ok {
+		switch wa.Type() {
+		case pcommon.ValueTypeSlice:
+			warnings := []string{}
+			ws := wa.Slice()
+			for i := 0; i < ws.Len(); i++ {
+				warnings = append(warnings, ws.At(i).Str())
+			}
+			return warnings
+		default:
+			// fallback for malformed data
+			return []string{wa.AsString()}
 		}
-		return warnings
 	}
 	return nil
 }

--- a/internal/jptrace/warning_test.go
+++ b/internal/jptrace/warning_test.go
@@ -104,3 +104,10 @@ func TestGetWarnings(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWarnings_EmptySpan(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr(WarningsAttribute, "warning-1")
+	actual := GetWarnings(span)
+	assert.Nil(t, actual)
+}


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
