### PR TITLE
Add Load Generator for Jaeger demo to generate trace data from hotrod service

### DIFF
--- a/examples/oci/README.md
+++ b/examples/oci/README.md
@@ -103,6 +103,23 @@ Then open in browser:
 * 📈 Prometheus: [http://localhost:9090](http://localhost:9090)
 * 🚕 HotROD: [http://localhost:8080](http://localhost:8080)
 
+## 7. Deploy Load Generator (Trace Generator Pod)
+
+Run the following commands to deploy the load generator that continuously sends trace traffic to the HotROD service:
+
+Create ConfigMap from the Python trace generator script
+```bash
+kubectl create configmap trace-script --from-file=generate_traces.py
+```
+Apply the Deployment YAML
+```bash
+kubectl apply -f trace-generator.yaml
+```
+(Optional) View Logs to Confirm Trace Generation
+```bash
+kubectl logs -f deployment/trace-generator
+```
+
 🔧 Remarks
 
 📌 The current configuration is set to run in the default namespace.

--- a/examples/oci/load-generator/generate_traces.py
+++ b/examples/oci/load-generator/generate_traces.py
@@ -1,0 +1,24 @@
+import requests
+import random
+import time
+
+url = "http://jaeger-hotrod.default.svc.cluster.local:80/dispatch" 
+
+customer_ids = [123, 392, 731, 567]
+i = 0
+print("Starting load generator script")
+while True:  #Keep sending requests
+    customer = random.choice(customer_ids)
+    nonse = random.random()
+    params = {
+        "customer": customer,
+        "nonse": nonse
+    }
+
+    try:
+        res = requests.get(url, params=params, timeout=5)
+        print(f"[{i}]th request Sent to {res.url} → Status: {res.status_code}")
+    except Exception as e:
+        print(f"[{i}]th request Error: {e}")
+    i = i + 1
+    time.sleep(10)  # Pause between requests to avoid overload

--- a/examples/oci/load-generator/load-generator.yaml
+++ b/examples/oci/load-generator/load-generator.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trace-generator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: trace-generator
+  template:
+    metadata:
+      labels:
+        app: trace-generator
+    spec:
+      containers:
+      - name: trace-generator
+        image: python:3.11
+        command: 
+          - /bin/sh
+          - -c
+          - |
+            pip install requests && python /app/generate_traces.py
+        volumeMounts:
+        - name: script-volume
+          mountPath: /app
+      restartPolicy: Always
+      volumes:
+      - name: script-volume
+        configMap:
+          name: trace-script


### PR DESCRIPTION
## Which problem is this PR solving?
- This PR adds a python script that will send API request to hotrod service to generate trace data 
- Deployment of a pod with the script to ping the hotrod service 
- Updated the README.md for manual deployment 


## Checklist
- [ *] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ *] I have signed all commits
- [ *] I have added unit tests for the new functionality
- [ *] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
