### PR TITLE
Add Jaeger Demo Monitoring Setup with Deployment Script

### DIFF
--- a/examples/oci/README.md
+++ b/examples/oci/README.md
@@ -25,7 +25,7 @@ The following components are deployed as part of the Jaeger demo setup:
 To deploy the entire infrastructure with a single command, run:
 
 ```bash
-bash ./examples/oci/deploy-all.sh
+bash ./deploy-all.sh
 ```
 This script will automatically install and configure all components on your Kubernetes , To deal with individual components refer to deploy-all.sh script . 
 

--- a/examples/oci/README.md
+++ b/examples/oci/README.md
@@ -13,78 +13,25 @@ Ensure the following tools are installed and configured:
 
 ---
 
-## 1. Clone Jaeger Helm Charts (v2 Branch)
+## Deploy the Jaeger Demo Setup
+
+The following components are deployed as part of the Jaeger demo setup:
+
+- **Jaeger All-in-One**: Tracing backend (collector, query, UI, agent in one pod)
+- **HotROD Demo App**: Sample microservices application for tracing demonstration
+- **Prometheus Monitoring Stack**: Includes Prometheus, Grafana, and Alertmanager for metrics and dashboards
+- **Load Generator**: Continuously generates traces from the HotROD app
+
+To deploy the entire infrastructure with a single command, run:
 
 ```bash
-git clone https://github.com/jaegertracing/helm-charts.git
-cd helm-charts
-git checkout v2
+bash ./examples/oci/deploy-all.sh
 ```
-After cloning, you must install chart dependencies to avoid the depedency missing error using this command :
-``` bash
-helm dependency build ./charts/jaeger
-```
----
+This script will automatically install and configure all components on your Kubernetes , To deal with individual components refer to deploy-all.sh script . 
 
-## 2. Prepare Your Values and Config Files
+## Access the Deployment
 
-* `config.yaml`: Configuration file for the Jaeger Collector (in Jaeger binary mode).
-
-  * Currently configured to:
-
-    * Store **traces** in **memory**
-    * Export **metrics** to **Prometheus**
-
-* `prometheus.yml`: Configuration for Prometheus scrape targets.
-
----
-
-## 3. Create ConfigMap for Prometheus
-
-Create a ConfigMap to mount the Prometheus configuration:
-
-```bash
-kubectl create configmap prometheus-config --from-file=prometheus.yml=./prometheus.yml
-```
-
----
-
-## 4. Deploy Jaeger (All-in-One Mode with Memory Storage)
-
-Ensure you're in the correct directory 
-```bash
-cd ./examples/oci/
-```
-Install the Jaeger Helm chart with memory storage and a custom config:
-
-```bash
-helm install jaeger /path/to/charts/jaeger \
-  --set provisionDataStore.cassandra=false \
-  --set allInOne.enabled=true \
-  --set storage.type=memory \
-  --set-file userconfig="./config.yaml" \
-  -f ./jaeger-values.yaml
-```
-
-> 🔁 Adjust the path to match your local directory structure.
-
----
-
-## 5. Deploy Prometheus (for SPM Metrics)
-
-Apply the Prometheus deployment and service:
-
-```bash
-kubectl apply -f ./prometheus-deploy.yaml
-```
-
-This enables **Span Metrics Processor (SPM)** functionality in Jaeger.
-
----
-
-## 6. Port Forward Services for Local Access
-
-Use the following port-forward commands to access the UIs locally:
+After deploying, you can access each component locally using the following port-forward commands in separate terminals:
 
 ```bash
 # Jaeger UI
@@ -93,32 +40,19 @@ kubectl port-forward svc/jaeger-query 16686:16686
 # Prometheus UI
 kubectl port-forward svc/prometheus 9090:9090
 
+# Grafana Dashboard
+kubectl port-forward svc/prometheus-grafana 9091:80
+
 # HotROD UI
 kubectl port-forward svc/jaeger-hotrod 8080:80
 ```
 
-Then open in browser:
+Then, open the following URLs in your browser:
 
-* 🔍 Jaeger: [http://localhost:16686](http://localhost:16686)
-* 📈 Prometheus: [http://localhost:9090](http://localhost:9090)
-* 🚕 HotROD: [http://localhost:8080](http://localhost:8080)
-
-## 7. Deploy Load Generator (Trace Generator Pod)
-
-Run the following commands to deploy the load generator that continuously sends trace traffic to the HotROD service:
-
-Create ConfigMap from the Python trace generator script
-```bash
-kubectl create configmap trace-script --from-file=./load-generator/generate_traces.py
-```
-Apply the Deployment YAML
-```bash
-kubectl apply -f ./load-generator/load-generator.yaml
-```
-(Optional) View Logs to Confirm Trace Generation
-```bash
-kubectl logs -f deployment/trace-generator
-```
+- **Jaeger UI:** [http://localhost:16686](http://localhost:16686)
+- **Prometheus:** [http://localhost:9090](http://localhost:9090)
+- **Grafana:** [http://localhost:9091](http://localhost:9091)
+- **HotROD Demo App:** [http://localhost:8080](http://localhost:8080)
 
 🔧 Remarks
 
@@ -129,3 +63,9 @@ Helm --namespace flags
 Kubernetes manifests (metadata.namespace)
 Prometheus scrape configs and service selectors if targeting Jaeger in a different namespace
 ```
+📌 The default credentials for Grafana dashboards are:
+
+- **Username:** `admin`
+- **Password:** `prom-operator`
+
+Once logged in, you can explore the pre-built dashboards or add your own tracing and metrics visualizations.

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -28,7 +28,7 @@ fi
 
 # Deploy Jaeger (All-in-One with memory storage)
 echo "🟣 Step 1: Installing Jaeger..."
-helm install jaeger ./helm-charts/charts/jaeger \
+helm upgrade --install jaeger ./helm-charts/charts/jaeger \
   --set provisionDataStore.cassandra=false \
   --set allInOne.enabled=true \
   --set storage.type=memory \
@@ -37,7 +37,9 @@ helm install jaeger ./helm-charts/charts/jaeger \
 
 # Deploy Prometheus Monitoring Stack
 echo "🟢 Step 2: Deploying Prometheus Monitoring stack..."
-helm install prometheus -f monitoring-values.yaml prometheus-community/kube-prometheus-stack
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm upgrade --install prometheus -f monitoring-values.yaml prometheus-community/kube-prometheus-stack
 
 # Create ConfigMap for Trace Generator
 echo "🔵 Step 3: Creating ConfigMap for Trace Generator..."

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -3,6 +3,8 @@
 # Copyright (c) 2025 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+set -euo pipefail
+
 # Clone Jaeger Helm Charts (v2 branch) if not already present
 if [ ! -d "helm-charts" ]; then
   echo "📥 Cloning Jaeger Helm Charts..."

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -28,7 +28,7 @@ fi
 
 # Deploy Jaeger (All-in-One with memory storage)
 echo "🟣 Step 1: Installing Jaeger..."
-helm install jaeger ../../helm-charts/charts/jaeger \
+helm install jaeger ./helm-charts/charts/jaeger \
   --set provisionDataStore.cassandra=false \
   --set allInOne.enabled=true \
   --set storage.type=memory \
@@ -37,7 +37,7 @@ helm install jaeger ../../helm-charts/charts/jaeger \
 
 # Deploy Prometheus Monitoring Stack
 echo "🟢 Step 2: Deploying Prometheus Monitoring stack..."
-helm upgrade --install prometheus -f monitoring-values.yaml prometheus-community/kube-prometheus-stack
+helm install prometheus -f monitoring-values.yaml prometheus-community/kube-prometheus-stack
 
 # Create ConfigMap for Trace Generator
 echo "🔵 Step 3: Creating ConfigMap for Trace Generator..."

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright (c) 2025 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+# Clone Jaeger Helm Charts (v2 branch) if not already present
+if [ ! -d "helm-charts" ]; then
+  echo "📥 Cloning Jaeger Helm Charts..."
+  git clone https://github.com/jaegertracing/helm-charts.git
+  cd helm-charts
+  git checkout v2
+  helm dependency build ./charts/jaeger
+  cd ..
+else
+  echo "📁 Jaeger Helm Charts already exist. Skipping clone."
+fi
+
+# Navigate into examples/oci if not already in it
+if [[ "$(basename $PWD)" != "oci" ]]; then
+  if [ -d "./examples/oci" ]; then
+    echo "📂 Changing to ./examples/oci directory..."
+    cd ./examples/oci
+  else
+    echo "❌ Cannot find ./examples/oci directory. Exiting."
+    exit 1
+  fi
+fi
+
+# Deploy Jaeger (All-in-One with memory storage)
+echo "🟣 Step 1: Installing Jaeger..."
+helm install jaeger ../../helm-charts/charts/jaeger \
+  --set provisionDataStore.cassandra=false \
+  --set allInOne.enabled=true \
+  --set storage.type=memory \
+  --set-file userconfig="./config.yaml" \
+  -f ./jaeger-values.yaml
+
+# Deploy Prometheus Monitoring Stack
+echo "🟢 Step 2: Deploying Prometheus Monitoring stack..."
+helm upgrade --install prometheus -f monitoring-values.yaml prometheus-community/kube-prometheus-stack
+
+# Create ConfigMap for Trace Generator
+echo "🔵 Step 3: Creating ConfigMap for Trace Generator..."
+kubectl create configmap trace-script --from-file=./load-generator/generate_traces.py --dry-run=client -o yaml | kubectl apply -f -
+
+# Deploy Trace Generator Pod
+echo "🟡 Step 4: Deploying Trace Generator Pod..."
+kubectl apply -f ./load-generator/load-generator.yaml
+
+# Output Port-forward Instructions
+echo "✅ Deployment Complete!"
+echo ""
+echo "📡 Port-forward the following to access UIs locally:"
+echo ""
+echo "kubectl port-forward svc/jaeger-query 16686:16686      # Jaeger UI"
+echo "kubectl port-forward svc/prometheus 9090:9090          # Prometheus UI"
+echo "kubectl port-forward svc/prometheus-grafana 9091:80    # Grafana UI"
+echo "kubectl port-forward svc/jaeger-hotrod 8080:80         # HotROD UI"
+echo ""
+echo "Then open:"
+echo "🔍 Jaeger: http://localhost:16686"
+echo "📈 Prometheus: http://localhost:9090"
+echo "📊 Grafana: http://localhost:9091"
+echo "🚕 HotROD: http://localhost:8080"

--- a/examples/oci/monitoring-values.yaml
+++ b/examples/oci/monitoring-values.yaml
@@ -1,3 +1,5 @@
+# Configuration for Prometheus , Grafana , Alertmanager can be set from this configuration 
+
 fullnameOverride: ""
 prometheus:
   prometheusSpec:

--- a/examples/oci/monitoring-values.yaml
+++ b/examples/oci/monitoring-values.yaml
@@ -1,0 +1,11 @@
+fullnameOverride: ""
+prometheus:
+  prometheusSpec:
+    enableAdminAPI: true
+    additionalScrapeConfigs: |
+      - job_name: aggregated-trace-metrics
+        static_configs:
+          - targets: ['jaeger-collector-prometheus.default.svc.cluster.local:8889']
+        scrape_interval:     15s
+
+

--- a/examples/oci/prometheus-deploy.yaml
+++ b/examples/oci/prometheus-deploy.yaml
@@ -1,43 +1,20 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: prometheus
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: prometheus
-  template:
-    metadata:
-      labels:
-        app: prometheus
-    spec:
-      containers:
-        - name: prometheus
-          image: prom/prometheus:v2.52.0
-          args: ["--config.file=/etc/prometheus/prometheus.yml"]
-          ports:
-            - containerPort: 9090
-          volumeMounts:
-            - name: prometheus-config
-              mountPath: /etc/prometheus/prometheus.yml
-              subPath: prometheus.yml
-      volumes:
-        - name: prometheus-config
-          configMap:
-            name: prometheus-config
----
+# Services to expose ports 
+
 apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
 spec:
   selector:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus-kube-prometheus-prometheus
   ports:
     - name: http
       port: 9090
       targetPort: 9090
+
 ---
 apiVersion: v1
 kind: Service

--- a/examples/oci/prometheus-deploy.yaml
+++ b/examples/oci/prometheus-deploy.yaml
@@ -1,4 +1,4 @@
-# Services to expose ports 
+# Services to expose ports for Prometheus
 
 apiVersion: v1
 kind: Service

--- a/examples/oci/prometheus.yml
+++ b/examples/oci/prometheus.yml
@@ -1,8 +1,0 @@
-global:
-  scrape_interval:     15s
-  evaluation_interval: 15s
-
-scrape_configs:
-  - job_name: aggregated-trace-metrics
-    static_configs:
-      - targets: ['jaeger-collector-prometheus.default.svc.cluster.local:8889']


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7115 
- Added Deployment script to deploy the whole setup with bash command (Jaeger demos + Monitoring stack + load-generator )
- Added helm chart deployment for prometheus + grafana + alert manager 
- All of the setup configured directly from their respective values.yaml 

Screentshots ( forced dark mode enabled due to chrome extension) : 
![Screenshot_20250708_122947](https://github.com/user-attachments/assets/e55d03b0-5465-45e5-be1a-52212661d34d)
![Screenshot_20250708_122937](https://github.com/user-attachments/assets/dc2ba7a6-307c-41fb-acef-a6d44486ee66)
250708_122947.png…]()
![Screenshot_20250708_122929](https://github.com/user-attachments/assets/dff8f1ca-7438-4932-90d3-f4405e294762)
![Screenshot_20250708_122855](https://github.com/user-attachments/assets/81a0268c-b881-4f9d-9349-4030267352ad)
![Screenshot_20250708_123243](https://github.com/user-attachments/assets/77922ab7-7df5-4dbb-86f7-0f7dc5a47900)

## Checklist
- [ *] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ *] I have signed all commits
- [ *] I have added unit tests for the new functionality
- [ *] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
