### PR TITLE
Add condition check for empty array

### DIFF
--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -181,6 +181,11 @@ validate_service_metrics() {
 assert_service_name_equals() {
   local response=$1
   local expected=$2
+  # First check if metrics structure exists at all
+  if ! echo "$response" | jq -e '.metrics and .metrics[0]' >/dev/null; then
+    echo "⏳ Metrics not available yet (no metrics array)"
+    return 1
+  fi
   service_name=$(echo "$response" | jq -r 'if .metrics and .metrics[0] then .metrics[0].labels[] | select(.name=="service_name") | .value else empty end')
   if [[ "$service_name" != "$expected" ]]; then
     echo "❌ ERROR: Obtained service_name: '$service_name' are not same as expected: '$expected'"


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves comment https://github.com/jaegertracing/jaeger/pull/7145#issuecomment-2892141567 
```
+ assert_service_name_equals '{"name":"service_call_rate","type":"GAUGE","help":"calls/sec, grouped by service","metrics":[]}' driver
+ local 'response={"name":"service_call_rate","type":"GAUGE","help":"calls/sec, grouped by service","metrics":[]}'
+ local expected=driver
++ echo '{"name":"service_call_rate","type":"GAUGE","help":"calls/sec, grouped by service","metrics":[]}'
++ jq -r 'if .metrics and .metrics[0] then .metrics[0].labels[] | select(.name=="service_name") | .value else empty end'
+ service_name=
+ [[ '' != \d\r\i\v\e\r ]]
+ echo '❌ ERROR: Obtained service_name: '\'''\'' are not same as expected: '\''driver'\'''
+ return 1
❌ ERROR: Obtained service_name: '' are not same as expected: 'driver'
+ return 1
+ sleep 10
```

## Description of the changes
- Add empty check for result array 

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
