### PR TITLE
[spm] Bug fix for metricstore/elasticsearch/processor.go

### DIFF
--- a/internal/storage/metricstore/elasticsearch/processor.go
+++ b/internal/storage/metricstore/elasticsearch/processor.go
@@ -77,13 +77,15 @@ func zeroValue(points []*metrics.MetricPoint) []*metrics.MetricPoint {
 	zeroPoints := make([]*metrics.MetricPoint, 0, len(points))
 
 	for _, point := range points {
+		value := math.NaN()
 		// Only append 0 for call_points value is not NaN
 		if !math.IsNaN(point.GetGaugeValue().GetDoubleValue()) {
-			zeroPoints = append(zeroPoints, &metrics.MetricPoint{
-				Timestamp: point.Timestamp,
-				Value:     toDomainMetricPointValue(0.0),
-			})
+			value = 0.0
 		}
+		zeroPoints = append(zeroPoints, &metrics.MetricPoint{
+			Timestamp: point.Timestamp,
+			Value:     toDomainMetricPointValue(value),
+		})
 	}
 
 	return zeroPoints

--- a/internal/storage/metricstore/elasticsearch/processor_test.go
+++ b/internal/storage/metricstore/elasticsearch/processor_test.go
@@ -242,6 +242,19 @@ func TestTrimMetricPointsBefore(t *testing.T) {
 	assert.Len(t, result.Metrics[0].MetricPoints, 2)
 }
 
+func TestZeroValue(t *testing.T) {
+	// Create test input with one NaN and one non-NaN value
+	input := []*metrics.MetricPoint{
+		{Value: toDomainMetricPointValue(math.NaN())}, // NaN case
+		{Value: toDomainMetricPointValue(42.0)},       // Non-NaN case
+	}
+
+	result := zeroValue(input)
+
+	assert.True(t, math.IsNaN(result[0].GetGaugeValue().GetDoubleValue()))
+	assert.InDelta(t, 0.0, result[1].GetGaugeValue().GetDoubleValue(), 0.1)
+}
+
 // createMetricFamily creates a MetricFamily with the given name and metrics.
 func createMetricFamily(name string, m []*metrics.Metric) *metrics.MetricFamily {
 	return &metrics.MetricFamily{

--- a/internal/storage/metricstore/elasticsearch/reader_test.go
+++ b/internal/storage/metricstore/elasticsearch/reader_test.go
@@ -220,7 +220,7 @@ func assertMetricFamily(t *testing.T, got *metrics.MetricFamily, m metricsTestCa
 
 func TestScaleToMillisAndRound_EmptyWindow(t *testing.T) {
 	var window []*metrics.MetricPoint
-	result := scaleToMillisAndRound(window)
+	result := scaleToMillisAndRound(nil, window)
 	assert.True(t, math.IsNaN(result))
 }
 
@@ -735,18 +735,17 @@ func TestGetErrorRates(t *testing.T) {
 				wantLabels: []map[string]string{
 					{
 						"service_name": "driver",
-						"operation":    "/FindNearest",
+						"operation":    "/FindDriverIDs",
 					},
 					{
 						"service_name": "driver",
-						"operation":    "/FindDriverIDs",
+						"operation":    "/FindNearest",
 					},
 				},
 				wantPoints: [][]struct {
 					TimestampSec int64
 					Value        float64
 				}{
-					expectedPoints[0], // FindNearest Expected Points
 					{ // FindDriverIDS Expected Points
 						{1749894840, math.NaN()},
 						{1749894900, math.NaN()},
@@ -760,6 +759,7 @@ func TestGetErrorRates(t *testing.T) {
 						{1749895380, 0.8},
 						{1749895440, 0.8},
 					},
+					expectedPoints[0], // FindNearest Expected Points
 				},
 			},
 			callRateFile: mockCallRateOperationResponse,

--- a/internal/storage/metricstore/elasticsearch/reader_test.go
+++ b/internal/storage/metricstore/elasticsearch/reader_test.go
@@ -316,6 +316,10 @@ func TestGetCallRates(t *testing.T) {
 			wantLabels: []map[string]string{
 				{
 					"service_name": "driver",
+					"operation":    "/FindCar",
+				},
+				{
+					"service_name": "driver",
 					"operation":    "/FindDriverIDs",
 				},
 				{
@@ -327,6 +331,9 @@ func TestGetCallRates(t *testing.T) {
 				TimestampSec int64
 				Value        float64
 			}{
+				{
+					{1749894840, math.NaN()},
+				},
 				{
 					{1749894840, math.NaN()},
 					{1749894900, math.NaN()},
@@ -735,6 +742,10 @@ func TestGetErrorRates(t *testing.T) {
 				wantLabels: []map[string]string{
 					{
 						"service_name": "driver",
+						"operation":    "/FindCar",
+					},
+					{
+						"service_name": "driver",
 						"operation":    "/FindDriverIDs",
 					},
 					{
@@ -746,6 +757,9 @@ func TestGetErrorRates(t *testing.T) {
 					TimestampSec int64
 					Value        float64
 				}{
+					{ // FindCar Expected Points
+						{1749894840, math.NaN()},
+					},
 					{ // FindDriverIDS Expected Points
 						{1749894840, math.NaN()},
 						{1749894900, math.NaN()},

--- a/internal/storage/metricstore/elasticsearch/testdata/output_call_rate_operation.json
+++ b/internal/storage/metricstore/elasticsearch/testdata/output_call_rate_operation.json
@@ -18,6 +18,15 @@
       "sum_other_doc_count": 0,
       "buckets": [
         {
+          "key": "/FindCar",
+          "doc_count": 10,
+          "date_histogram": {
+            "buckets": [
+              {"key": 1749894840000, "doc_count": 10, "cumulative_requests": {"value": 10}}
+            ]
+          }
+        },
+        {
           "key": "/FindDriverIDs",
           "doc_count": 200,
           "date_histogram": {


### PR DESCRIPTION
## Which problem is this PR solving?
- Fix 2 bugs of the current implementation in https://github.com/jaegertracing/jaeger/issues/7147
Bug 1: The current `calcCallRate` overvalue the call rate when after a long period of having no data, this is caused by setting 
`if math.IsNaN(firstValue) { firstValue = 0 }`

**Reference images:** 

![Screenshot 2025-07-09 at 22 15 38](https://github.com/user-attachments/assets/cc8dc8ad-5f90-4566-84f0-33322217046f)

When compares to the working solution: 
![Screenshot 2025-07-09 at 22 15 32](https://github.com/user-attachments/assets/8150c9ae-58bb-4176-ab6c-c43b5ee3af3f)

Some other timestamp & service:
![Screenshot 2025-07-07 at 22 27 31](https://github.com/user-attachments/assets/54054b52-2740-45fe-9262-28291ca5e540)

**Solution**: Use 	`lastNonNaNMap := make(map[string]float64)` that tracks the lastNonNaN value associates with different labels key. When I rerun with this changes, the problem is now fixed: 

![Screenshot 2025-07-09 at 22 13 38](https://github.com/user-attachments/assets/35a4cb41-a506-4372-bd31-9a3cd1e6da17)

When compares to the working solution: 

![Screenshot 2025-07-09 at 22 13 48](https://github.com/user-attachments/assets/215610e3-23a7-499e-a7f9-154e6d839571)

Bug 2: Add 0 data point for service that don't return any data point for errorRate. This changes is made with `zeroValue`


## Description of the changes
- Add `lastNonNaNmap` to fix bug 1
- Add `zeroValue` to fix bug 2

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
