### PR TITLE
Reuse v8 index templates for Elasticsearch v9

### DIFF
--- a/internal/storage/v1/elasticsearch/mappings/mapping.go
+++ b/internal/storage/v1/elasticsearch/mappings/mapping.go
@@ -107,7 +107,8 @@ func MappingTypeFromString(val string) (MappingType, error) {
 // GetMapping returns the rendered mapping based on elasticsearch version
 func (mb *MappingBuilder) GetMapping(mappingType MappingType) (string, error) {
 	templateOpts := mb.getMappingTemplateOptions(mappingType)
-	return mb.renderMapping(fmt.Sprintf("%s-%d.json", mappingType.String(), mb.EsVersion), templateOpts)
+	esVersion := min(mb.EsVersion, 8) // Elasticsearch v9 uses the same template as v8
+	return mb.renderMapping(fmt.Sprintf("%s-%d.json", mappingType.String(), esVersion), templateOpts)
 }
 
 // GetSpanServiceMappings returns span and service mappings


### PR DESCRIPTION
## Which problem is this PR solving?
- Addresses part of #7274 by ensuring proper index template selection for Elasticsearch v9.

## Description of the changes
- Modified mapping logic to treat Elasticsearch v9 the same as v8 for template selection.
- This avoids the need for a separate v9 template file and prevents runtime errors due to missing mappings.

## How was this change tested?
- Verified by running `jaeger-query` and `jaeger-collector` using Elasticsearch v9 as the storage backend.
- Confirmed that the services start successfully and ingest/query traces without template-related errors.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
