### PR TITLE
Serve Hotrod UI and Grafana from Separate Basepaths in Jaeger Demo

### DIFF
--- a/examples/oci/ingress.yaml
+++ b/examples/oci/ingress.yaml
@@ -15,7 +15,7 @@ spec:
                 name: jaeger-query
                 port:
                   number: 16686
-          - path: /grafana(/|$)(.*)
+          - path: /grafana(/.*)?
             pathType: ImplementationSpecific
             backend:
               service:

--- a/examples/oci/ingress.yaml
+++ b/examples/oci/ingress.yaml
@@ -15,8 +15,8 @@ spec:
                 name: jaeger-query
                 port:
                   number: 16686
-          - path: /grafana
-            pathType: Prefix
+          - path: /grafana(/|$)(.*)
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: prometheus-grafana

--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -6,6 +6,7 @@ hotrod:
     - all
   extraArgs:
     - --otel-exporter=otlp
+    - --basepath=hotrod
   extraEnv:
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://jaeger-collector:4318

--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -6,7 +6,7 @@ hotrod:
     - all
   extraArgs:
     - --otel-exporter=otlp
-    - --basepath=hotrod
+    - --basepath=/hotrod
   extraEnv:
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://jaeger-collector:4318

--- a/examples/oci/monitoring-values.yaml
+++ b/examples/oci/monitoring-values.yaml
@@ -11,3 +11,9 @@ prometheus:
         scrape_interval:     15s
 
 
+grafana:
+  grafana.ini:
+    server:
+      domain: demo.jaegertracing.io
+      root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
+      serve_from_sub_path: true


### PR DESCRIPTION
## Which problem is this PR solving?
 - Part of #7115 
- Solve the issue of base path for hotrod ui and grafana ui 

## Description of the changes
- Changed ingress , helm values of jaeger and monitoring stack


## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
