### PR TITLE
docs: Add prerequisites for running make test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,13 @@ We gratefully welcome improvements to documentation as well as to code.
 
 This library uses Go modules to manage dependencies.
 
+If you are running `make test` or other Makefile targets on macOS, please ensure that you have GNU `sed` installed.
+
+To install GNU `sed`:
+
+```bash
+brew install gnu-sed
+```
 
 ```
 git clone git@github.com:jaegertracing/jaeger.git jaeger
@@ -49,6 +56,7 @@ make fmt  # commit all changes from auto-format
 make lint
 make test
 ```
+
 
 ### Auto-format
 


### PR DESCRIPTION
## Description of the changes
Update documentation to highlight the need for GNU sed when running `make test`, especially on macOS systems where BSD sed is the default. This helps avoid test failures due to sed incompatibilities.

Resolves #7329

## How was this change tested?
Changes are in the docs.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
