### PR TITLE
Fixed invalid string type issue for array-valued tags

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -103,7 +103,7 @@ func attributeToDbTag(key string, attr pcommon.Value) dbmodel.KeyValue {
 	switch attr.Type() {
 	case pcommon.ValueTypeBytes:
 		tag = dbmodel.KeyValue{Key: key, Value: hex.EncodeToString(attr.Bytes().AsRaw())}
-	case pcommon.ValueTypeMap:
+	case pcommon.ValueTypeMap, pcommon.ValueTypeSlice:
 		tag = dbmodel.KeyValue{Key: key, Value: attr.AsString()}
 	default:
 		tag = dbmodel.KeyValue{Key: key, Value: attr.AsRaw()}

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel_test.go
@@ -415,6 +415,23 @@ func TestAttributeConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "slice type attributes",
+			setupAttr: func() pcommon.Map {
+				attributes := pcommon.NewMap()
+				slice := attributes.PutEmptySlice("blockers")
+				slice.AppendEmpty().SetStr("2804-5")
+				slice.AppendEmpty().SetStr("1234-6")
+				return attributes
+			},
+			expected: []dbmodel.KeyValue{
+				{
+					Key:   "blockers",
+					Type:  dbmodel.StringType,
+					Value: `["2804-5","1234-6"]`,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7346 

## Description of the changes
- Problem:
  - when traces contained array valued tags like `[value1, value2]`, the ui showed `invalid string type` error
  - this happened because collection type attributes were not properly handled during elasticsearch storage
- Root Cause:
  - In `internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go`, the `attributeToDbTag` function only handled `ValueTypeMap` for JSON serialization
  - `ValueTypeSlice` (arrays) were falling through to the default case, this causing the type mismatching
- solution:
  - added `pcommon.ValueTypeSlice` to the existing case that handles JSON serialization

## How was this change tested?
- Created a test scenario in HotRod that generates array-valued tags `(blockers: ["7510-2"])`
- added unit tests to prevent regression
Screenshot:
<img width="1121" height="509" alt="Screenshot 2025-07-20 025600" src="https://github.com/user-attachments/assets/d69986da-3b82-4be9-9b8d-0e5583e0b4ec" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
