### PR TITLE
Fix: Migrate to OTEL Kafka exporter and clean up sarama usage

### DIFF
--- a/internal/storage/v1/kafka/writer.go
+++ b/internal/storage/v1/kafka/writer.go
@@ -1,16 +1,20 @@
 // Copyright (c) 2018 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
-
 package kafka
 
 import (
 	"context"
+	"errors"
 
-	"github.com/Shopify/sarama"
+	kafkaexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 )
 
 type spanWriterMetrics struct {
@@ -21,65 +25,79 @@ type spanWriterMetrics struct {
 // SpanWriter writes spans to kafka. Implements spanstore.Writer
 type SpanWriter struct {
 	metrics    spanWriterMetrics
-	producer   sarama.AsyncProducer
+	exporter   component.Component
 	marshaller Marshaller
-	topic      string
+	pushFunc   func(ctx context.Context, td ptrace.Traces) error
 }
 
 // NewSpanWriter initiates and returns a new kafka spanwriter
 func NewSpanWriter(
-	producer sarama.AsyncProducer,
-	marshaller Marshaller,
+
 	topic string,
 	factory metrics.Factory,
+	brokers []string,
+	marshaller Marshaller,
 	logger *zap.Logger,
-) *SpanWriter {
+	telemetry component.TelemetrySettings,
+) (*SpanWriter, error) {
 	writeMetrics := spanWriterMetrics{
 		SpansWrittenSuccess: factory.Counter(metrics.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "success"}}),
 		SpansWrittenFailure: factory.Counter(metrics.Options{Name: "kafka_spans_written", Tags: map[string]string{"status": "failure"}}),
 	}
 
-	go func() {
-		for range producer.Successes() {
-			writeMetrics.SpansWrittenSuccess.Inc(1)
-		}
-	}()
-	go func() {
-		for e := range producer.Errors() {
-			if e != nil && e.Err != nil {
-				logger.Error(e.Err.Error())
-			}
-			writeMetrics.SpansWrittenFailure.Inc(1)
-		}
-	}()
+	exportercfg := kafkaexporter.NewFactory().CreateDefaultConfig().(*kafkaexporter.Config)
+	exportercfg.Topic = topic
+	exportercfg.Brokers = brokers
+
+	settings := exporter.Settings{
+		ID: component.MustNewID("kafka"),
+		TelemetrySettings: component.TelemetrySettings{
+			Logger:         logger,
+			TracerProvider: telemetry.TracerProvider,
+			MeterProvider:  telemetry.MeterProvider,
+		},
+		BuildInfo: component.NewDefaultBuildInfo(),
+	}
+
+	exp, err := kafkaexporter.NewFactory().CreateTraces(context.Background(), settings, exportercfg)
+	if err != nil {
+		return nil, err
+	}
 
 	return &SpanWriter{
-		producer:   producer,
-		marshaller: marshaller,
-		topic:      topic,
+		
 		metrics:    writeMetrics,
-	}
+		exporter:   exp,
+		marshaller: marshaller,
+		pushFunc:   exp.ConsumeTraces,
+	}, nil
 }
 
 // WriteSpan writes the span to kafka.
-func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
-	spanBytes, err := w.marshaller.Marshal(span)
+func (w *SpanWriter) WriteSpan(ctx context.Context, span *model.Span) error {
+	batch := &model.Batch{Spans: []*model.Span{span}}
+	traces := v1adapter.V1BatchesToTraces([]*model.Batch{batch})
+	if traces.SpanCount() == 0 {
+		w.metrics.SpansWrittenFailure.Inc(1)
+		return errors.New("trace data conversion resulted in empty trace")
+	}
+
+	err := w.pushFunc(ctx, traces)
 	if err != nil {
 		w.metrics.SpansWrittenFailure.Inc(1)
 		return err
 	}
-
+	w.metrics.SpansWrittenSuccess.Inc(1)
 	// The AsyncProducer accepts messages on a channel and produces them asynchronously
 	// in the background as efficiently as possible
-	w.producer.Input() <- &sarama.ProducerMessage{
-		Topic: w.topic,
-		Key:   sarama.StringEncoder(span.TraceID.String()),
-		Value: sarama.ByteEncoder(spanBytes),
-	}
+
 	return nil
 }
 
 // Close closes SpanWriter by closing producer
 func (w *SpanWriter) Close() error {
-	return w.producer.Close()
+	if w.exporter != nil {
+		return w.exporter.Shutdown(context.Background())
+	}
+	return nil
 }


### PR DESCRIPTION

<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
 Resolves #6922


## What has changed?
- Changed the Kafka consumer to use the OTEL Kafka exporter.
- Removed the old Kafka library (`sarama`).
- Cleaned up some unnecessary code and updated the dependencies.

## How was this tested?
- I tested it by running the existing tests to make sure everything still works.
- I checked that the OTEL exporter is working properly and sending data.

## Checklist
- [x] I have read the contribution guide: https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all my commits
- [x] I have added tests if needed
- [x] I ran the tests and everything passed
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
