### PR TITLE
Add OpenSearch 3.x support

### DIFF
--- a/.github/workflows/ci-e2e-opensearch.yml
+++ b/.github/workflows/ci-e2e-opensearch.yml
@@ -27,6 +27,9 @@ jobs:
         - major: 2.x
           distribution: opensearch
           jaeger: v2
+        - major: 3.x
+          distribution: opensearch
+          jaeger: v2
     name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.jaeger }}
     steps:
     - name: Harden Runner

--- a/docker-compose/opensearch/v3/docker-compose.yml
+++ b/docker-compose/opensearch/v3/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:3.0.0
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=passRT%^#234
+    ports:
+      - "9200:9200"

--- a/internal/storage/elasticsearch/client/cluster_client.go
+++ b/internal/storage/elasticsearch/client/cluster_client.go
@@ -46,7 +46,7 @@ func (c *ClusterClient) Version() (uint, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid version format: %s", version[0])
 	}
-	if strings.Contains(info.TagLine, "OpenSearch") && (major == 1 || major == 2) {
+	if strings.Contains(info.TagLine, "OpenSearch") && (major == 1 || major == 2 || major == 3) {
 		return 7, nil
 	}
 	return uint(major), nil

--- a/internal/storage/elasticsearch/client/cluster_client_test.go
+++ b/internal/storage/elasticsearch/client/cluster_client_test.go
@@ -92,6 +92,26 @@ const opensearch2 = `
   }
 `
 
+const opensearch3 = `
+{
+	"name" : "opensearch-node1",
+	"cluster_name" : "opensearch-cluster",
+	"cluster_uuid" : "1StaUGrGSx61r41d-1nDiw",
+	"version" : {
+	  "distribution" : "opensearch",
+	  "number" : "3.0.0",
+	  "build_type" : "tar",
+	  "build_hash" : "34550c5b17124ddc59458ef774f6b43a086522e3",
+	  "build_date" : "2025-05-06T23:22:21.383695Z",
+	  "build_snapshot" : false,
+	  "lucene_version" : "10.0.0",
+	  "minimum_wire_compatibility_version" : "6.8.0",
+	  "minimum_index_compatibility_version" : "6.0.0-beta1"
+	},
+	"tagline" : "The OpenSearch Project: https://opensearch.org/"
+  }
+`
+
 const elasticsearch7 = `
 {
 	"name" : "elasticsearch-0",
@@ -178,6 +198,12 @@ func TestVersion(t *testing.T) {
 			name:           "success with opensearch 2",
 			responseCode:   http.StatusOK,
 			response:       opensearch2,
+			expectedResult: 7,
+		},
+		{
+			name:           "success with opensearch 3",
+			responseCode:   http.StatusOK,
+			response:       opensearch3,
 			expectedResult: 7,
 		},
 		{

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -275,6 +275,10 @@ func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metric
 				logger.Info("OpenSearch 2.x detected, using ES 7.x index mappings")
 				esVersion = 7
 			}
+			if pingResult.Version.Number[0] == '3' {
+				logger.Info("OpenSearch 3.x detected, using ES 7.x index mappings")
+				esVersion = 7
+			}
 		}
 		logger.Info("Elasticsearch detected", zap.Int("version", esVersion))
 		//nolint: gosec // G115

--- a/internal/storage/integration/elasticsearch_test.go
+++ b/internal/storage/integration/elasticsearch_test.go
@@ -69,7 +69,7 @@ func (s *ESStorageIntegration) getVersion() (uint, error) {
 	}
 	// OpenSearch is based on ES 7.x
 	if strings.Contains(pingResult.TagLine, "OpenSearch") {
-		if pingResult.Version.Number[0] == '1' || pingResult.Version.Number[0] == '2' {
+		if pingResult.Version.Number[0] == '1' || pingResult.Version.Number[0] == '2' || pingResult.Version.Number[0] == '3' {
 			esVersion = 7
 		}
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7133 

## Description of the changes
- Updated version detection in `internal/storage/elasticsearch/config/config.go`
- updated version detection in  `internal/storage/elasticsearch/client/cluster_client.go`
- updated intgration test logic in `internal/storage/integration/elasticsearch_test.go`
- added OpenSearch 3.x mock response in `cluster_client_test.go`
- added test case "success with opensearch 3" that expects version 7
- added OpenSearch 3.x mock response and test case in `config_test.go`
- Created `docker-compose/opensearch/v3/docker-compose.yml` for testing with OpenSearch 3.x

## How was this change tested?
- All tests passed successfully (cluster client version detection tests (including new openSearch 3.x test), configuration tests (including new OpenSearch 3.x test))

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
