### PR TITLE
Enable linter rule: confusing-naming

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,9 +113,6 @@ linters:
         # often looks like a red herring, needs investigation
         - name: flag-parameter
           disabled: true
-        # looks like a good linter, needs cleanup
-        - name: confusing-naming
-          disabled: true
         # too pendantic
         - name: function-length
           disabled: true

--- a/cmd/collector/app/handler/otlp_receiver.go
+++ b/cmd/collector/app/handler/otlp_receiver.go
@@ -35,7 +35,7 @@ var _ component.Host = (*otelHost)(nil) // API check
 // StartOTLPReceiver starts OpenTelemetry OTLP receiver listening on gRPC and HTTP ports.
 func StartOTLPReceiver(options *flags.CollectorOptions, logger *zap.Logger, spanProcessor processor.SpanProcessor, tm *tenancy.Manager) (receiver.Traces, error) {
 	otlpFactory := otlpreceiver.NewFactory()
-	return createOTLPReceiver(
+	return initiateOTLPReceiver(
 		options,
 		logger,
 		spanProcessor,
@@ -49,7 +49,7 @@ func StartOTLPReceiver(options *flags.CollectorOptions, logger *zap.Logger, span
 // Some of OTELCOL constructor functions return errors when passed nil arguments,
 // which is a situation we cannot reproduce. To test our own error handling, this
 // function allows to mock those constructors.
-func createOTLPReceiver(
+func initiateOTLPReceiver(
 	options *flags.CollectorOptions,
 	logger *zap.Logger,
 	spanProcessor processor.SpanProcessor,

--- a/cmd/collector/app/handler/otlp_receiver.go
+++ b/cmd/collector/app/handler/otlp_receiver.go
@@ -35,7 +35,7 @@ var _ component.Host = (*otelHost)(nil) // API check
 // StartOTLPReceiver starts OpenTelemetry OTLP receiver listening on gRPC and HTTP ports.
 func StartOTLPReceiver(options *flags.CollectorOptions, logger *zap.Logger, spanProcessor processor.SpanProcessor, tm *tenancy.Manager) (receiver.Traces, error) {
 	otlpFactory := otlpreceiver.NewFactory()
-	return startOTLPReceiver(
+	return createOTLPReceiver(
 		options,
 		logger,
 		spanProcessor,
@@ -49,7 +49,7 @@ func StartOTLPReceiver(options *flags.CollectorOptions, logger *zap.Logger, span
 // Some of OTELCOL constructor functions return errors when passed nil arguments,
 // which is a situation we cannot reproduce. To test our own error handling, this
 // function allows to mock those constructors.
-func startOTLPReceiver(
+func createOTLPReceiver(
 	options *flags.CollectorOptions,
 	logger *zap.Logger,
 	spanProcessor processor.SpanProcessor,

--- a/cmd/collector/app/handler/otlp_receiver_test.go
+++ b/cmd/collector/app/handler/otlp_receiver_test.go
@@ -85,7 +85,7 @@ func TestStartOtlpReceiver_Error(t *testing.T) {
 		return nil, errors.New("mock error")
 	}
 	f := otlpreceiver.NewFactory()
-	_, err = startOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, newTraces, f.CreateTraces)
+	_, err = createOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, newTraces, f.CreateTraces)
 	require.ErrorContains(t, err, "could not create the OTLP consumer")
 
 	createTracesReceiver := func(
@@ -93,7 +93,7 @@ func TestStartOtlpReceiver_Error(t *testing.T) {
 	) (receiver.Traces, error) {
 		return nil, errors.New("mock error")
 	}
-	_, err = startOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, consumer.NewTraces, createTracesReceiver)
+	_, err = createOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, consumer.NewTraces, createTracesReceiver)
 	assert.ErrorContains(t, err, "could not create the OTLP receiver")
 }
 

--- a/cmd/collector/app/handler/otlp_receiver_test.go
+++ b/cmd/collector/app/handler/otlp_receiver_test.go
@@ -85,7 +85,7 @@ func TestStartOtlpReceiver_Error(t *testing.T) {
 		return nil, errors.New("mock error")
 	}
 	f := otlpreceiver.NewFactory()
-	_, err = createOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, newTraces, f.CreateTraces)
+	_, err = initiateOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, newTraces, f.CreateTraces)
 	require.ErrorContains(t, err, "could not create the OTLP consumer")
 
 	createTracesReceiver := func(
@@ -93,7 +93,7 @@ func TestStartOtlpReceiver_Error(t *testing.T) {
 	) (receiver.Traces, error) {
 		return nil, errors.New("mock error")
 	}
-	_, err = createOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, consumer.NewTraces, createTracesReceiver)
+	_, err = initiateOTLPReceiver(opts, logger, spanProcessor, &tenancy.Manager{}, f, consumer.NewTraces, createTracesReceiver)
 	assert.ErrorContains(t, err, "could not create the OTLP receiver")
 }
 

--- a/cmd/collector/app/handler/zipkin_receiver.go
+++ b/cmd/collector/app/handler/zipkin_receiver.go
@@ -33,7 +33,7 @@ func StartZipkinReceiver(
 	tm *tenancy.Manager,
 ) (receiver.Traces, error) {
 	zipkinFactory := zipkinreceiver.NewFactory()
-	return createZipkinReceiver(
+	return initiateZipkinReceiver(
 		options,
 		logger,
 		spanProcessor,
@@ -47,7 +47,7 @@ func StartZipkinReceiver(
 // Some of OTELCOL constructor functions return errors when passed nil arguments,
 // which is a situation we cannot reproduce. To test our own error handling, this
 // function allows to mock those constructors.
-func createZipkinReceiver(
+func initiateZipkinReceiver(
 	options *flags.CollectorOptions,
 	logger *zap.Logger,
 	spanProcessor processor.SpanProcessor,

--- a/cmd/collector/app/handler/zipkin_receiver.go
+++ b/cmd/collector/app/handler/zipkin_receiver.go
@@ -33,7 +33,7 @@ func StartZipkinReceiver(
 	tm *tenancy.Manager,
 ) (receiver.Traces, error) {
 	zipkinFactory := zipkinreceiver.NewFactory()
-	return startZipkinReceiver(
+	return createZipkinReceiver(
 		options,
 		logger,
 		spanProcessor,
@@ -47,7 +47,7 @@ func StartZipkinReceiver(
 // Some of OTELCOL constructor functions return errors when passed nil arguments,
 // which is a situation we cannot reproduce. To test our own error handling, this
 // function allows to mock those constructors.
-func startZipkinReceiver(
+func createZipkinReceiver(
 	options *flags.CollectorOptions,
 	logger *zap.Logger,
 	spanProcessor processor.SpanProcessor,

--- a/cmd/collector/app/handler/zipkin_receiver_test.go
+++ b/cmd/collector/app/handler/zipkin_receiver_test.go
@@ -149,7 +149,7 @@ func TestStartZipkinReceiver_Error(t *testing.T) {
 		return nil, errors.New("mock error")
 	}
 	f := zipkinreceiver.NewFactory()
-	_, err = createZipkinReceiver(opts, logger, spanProcessor, tm, f, newTraces, f.CreateTraces)
+	_, err = initiateZipkinReceiver(opts, logger, spanProcessor, tm, f, newTraces, f.CreateTraces)
 	require.ErrorContains(t, err, "could not create Zipkin consumer")
 
 	createTracesReceiver := func(
@@ -157,6 +157,6 @@ func TestStartZipkinReceiver_Error(t *testing.T) {
 	) (receiver.Traces, error) {
 		return nil, errors.New("mock error")
 	}
-	_, err = createZipkinReceiver(opts, logger, spanProcessor, tm, f, consumer.NewTraces, createTracesReceiver)
+	_, err = initiateZipkinReceiver(opts, logger, spanProcessor, tm, f, consumer.NewTraces, createTracesReceiver)
 	assert.ErrorContains(t, err, "could not create Zipkin receiver")
 }

--- a/cmd/collector/app/handler/zipkin_receiver_test.go
+++ b/cmd/collector/app/handler/zipkin_receiver_test.go
@@ -149,7 +149,7 @@ func TestStartZipkinReceiver_Error(t *testing.T) {
 		return nil, errors.New("mock error")
 	}
 	f := zipkinreceiver.NewFactory()
-	_, err = startZipkinReceiver(opts, logger, spanProcessor, tm, f, newTraces, f.CreateTraces)
+	_, err = createZipkinReceiver(opts, logger, spanProcessor, tm, f, newTraces, f.CreateTraces)
 	require.ErrorContains(t, err, "could not create Zipkin consumer")
 
 	createTracesReceiver := func(
@@ -157,6 +157,6 @@ func TestStartZipkinReceiver_Error(t *testing.T) {
 	) (receiver.Traces, error) {
 		return nil, errors.New("mock error")
 	}
-	_, err = startZipkinReceiver(opts, logger, spanProcessor, tm, f, consumer.NewTraces, createTracesReceiver)
+	_, err = createZipkinReceiver(opts, logger, spanProcessor, tm, f, consumer.NewTraces, createTracesReceiver)
 	assert.ErrorContains(t, err, "could not create Zipkin receiver")
 }

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -72,7 +72,7 @@ func NewSpanProcessor(
 	additional []ProcessSpan,
 	opts ...Option,
 ) (processor.SpanProcessor, error) {
-	sp, err := createSpanProcessor(traceWriter, additional, opts...)
+	sp, err := freshSpanProcessor(traceWriter, additional, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("could not create span processor: %w", err)
 	}
@@ -95,7 +95,7 @@ func NewSpanProcessor(
 	return sp, nil
 }
 
-func createSpanProcessor(traceWriter tracestore.Writer, additional []ProcessSpan, opts ...Option) (*spanProcessor, error) {
+func freshSpanProcessor(traceWriter tracestore.Writer, additional []ProcessSpan, opts ...Option) (*spanProcessor, error) {
 	options := Options.apply(opts...)
 	handlerMetrics := NewSpanProcessorMetrics(
 		options.serviceMetrics,

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -96,7 +96,7 @@ func TestBySvcMetrics(t *testing.T) {
 		logger := zap.NewNop()
 		serviceMetrics := mb.Namespace(metrics.NSOptions{Name: "service", Tags: nil})
 		hostMetrics := mb.Namespace(metrics.NSOptions{Name: "host", Tags: nil})
-		sp, err := createSpanProcessor(
+		sp, err := freshSpanProcessor(
 			v1adapter.NewTraceWriter(&fakeSpanWriter{}),
 			nil,
 			Options.ServiceMetrics(serviceMetrics),
@@ -647,7 +647,7 @@ func TestUpdateDynQueueSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &fakeSpanWriter{}
-			p, err := createSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(tt.initialCapacity), Options.DynQueueSizeWarmup(tt.warmup), Options.DynQueueSizeMemory(tt.sizeInBytes))
+			p, err := freshSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(tt.initialCapacity), Options.DynQueueSizeWarmup(tt.warmup), Options.DynQueueSizeMemory(tt.sizeInBytes))
 			require.NoError(t, err)
 			assert.Equal(t, tt.initialCapacity, p.queue.Capacity())
 
@@ -662,7 +662,7 @@ func TestUpdateDynQueueSize(t *testing.T) {
 
 func TestUpdateQueueSizeNoActivityYet(t *testing.T) {
 	w := &fakeSpanWriter{}
-	p, err := createSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(1), Options.DynQueueSizeWarmup(1), Options.DynQueueSizeMemory(1))
+	p, err := freshSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(1), Options.DynQueueSizeWarmup(1), Options.DynQueueSizeMemory(1))
 	require.NoError(t, err)
 	assert.NotPanics(t, p.updateQueueSize)
 }
@@ -671,7 +671,7 @@ func TestStartDynQueueSizeUpdater(t *testing.T) {
 	w := &fakeSpanWriter{}
 	oneGiB := uint(1024 * 1024 * 1024)
 
-	p, err := createSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(100), Options.DynQueueSizeWarmup(1000), Options.DynQueueSizeMemory(oneGiB))
+	p, err := freshSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(100), Options.DynQueueSizeWarmup(1000), Options.DynQueueSizeMemory(oneGiB))
 	require.NoError(t, err)
 	assert.Equal(t, 100, p.queue.Capacity())
 

--- a/cmd/collector/app/span_processor_test.go
+++ b/cmd/collector/app/span_processor_test.go
@@ -96,7 +96,7 @@ func TestBySvcMetrics(t *testing.T) {
 		logger := zap.NewNop()
 		serviceMetrics := mb.Namespace(metrics.NSOptions{Name: "service", Tags: nil})
 		hostMetrics := mb.Namespace(metrics.NSOptions{Name: "host", Tags: nil})
-		sp, err := newSpanProcessor(
+		sp, err := createSpanProcessor(
 			v1adapter.NewTraceWriter(&fakeSpanWriter{}),
 			nil,
 			Options.ServiceMetrics(serviceMetrics),
@@ -647,7 +647,7 @@ func TestUpdateDynQueueSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &fakeSpanWriter{}
-			p, err := newSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(tt.initialCapacity), Options.DynQueueSizeWarmup(tt.warmup), Options.DynQueueSizeMemory(tt.sizeInBytes))
+			p, err := createSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(tt.initialCapacity), Options.DynQueueSizeWarmup(tt.warmup), Options.DynQueueSizeMemory(tt.sizeInBytes))
 			require.NoError(t, err)
 			assert.Equal(t, tt.initialCapacity, p.queue.Capacity())
 
@@ -662,7 +662,7 @@ func TestUpdateDynQueueSize(t *testing.T) {
 
 func TestUpdateQueueSizeNoActivityYet(t *testing.T) {
 	w := &fakeSpanWriter{}
-	p, err := newSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(1), Options.DynQueueSizeWarmup(1), Options.DynQueueSizeMemory(1))
+	p, err := createSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(1), Options.DynQueueSizeWarmup(1), Options.DynQueueSizeMemory(1))
 	require.NoError(t, err)
 	assert.NotPanics(t, p.updateQueueSize)
 }
@@ -671,7 +671,7 @@ func TestStartDynQueueSizeUpdater(t *testing.T) {
 	w := &fakeSpanWriter{}
 	oneGiB := uint(1024 * 1024 * 1024)
 
-	p, err := newSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(100), Options.DynQueueSizeWarmup(1000), Options.DynQueueSizeMemory(oneGiB))
+	p, err := createSpanProcessor(v1adapter.NewTraceWriter(w), nil, Options.QueueSize(100), Options.DynQueueSizeWarmup(1000), Options.DynQueueSizeMemory(oneGiB))
 	require.NoError(t, err)
 	assert.Equal(t, 100, p.queue.Capacity())
 

--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -28,11 +28,11 @@ type IndexFilter struct {
 
 // Filter filters indices.
 func (i *IndexFilter) Filter(indices []client.Index) []client.Index {
-	indices = i.filterByPattern(indices)
+	indices = i.filterIndices(indices)
 	return filter.ByDate(indices, i.DeleteBeforeThisDate)
 }
 
-func (i *IndexFilter) filterByPattern(indices []client.Index) []client.Index {
+func (i *IndexFilter) filterIndices(indices []client.Index) []client.Index {
 	var reg *regexp.Regexp
 	switch {
 	case i.Archive:

--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -28,11 +28,11 @@ type IndexFilter struct {
 
 // Filter filters indices.
 func (i *IndexFilter) Filter(indices []client.Index) []client.Index {
-	indices = i.filter(indices)
+	indices = i.filterByPattern(indices)
 	return filter.ByDate(indices, i.DeleteBeforeThisDate)
 }
 
-func (i *IndexFilter) filter(indices []client.Index) []client.Index {
+func (i *IndexFilter) filterByPattern(indices []client.Index) []client.Index {
 	var reg *regexp.Regexp
 	switch {
 	case i.Archive:

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 func TestIndexFilter(t *testing.T) {
-	testIndexFilter(t, "")
+	runIndexFilterTest(t, "")
 }
 
 func TestIndexFilter_prefix(t *testing.T) {
-	testIndexFilter(t, "tenant1-")
+	runIndexFilterTest(t, "tenant1-")
 }
 
-func testIndexFilter(t *testing.T, prefix string) {
+func runIndexFilterTest(t *testing.T, prefix string) {
 	time20200807 := time.Date(2020, time.August, 6, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
 	indices := []client.Index{
 		{

--- a/cmd/internal/featuregate/command.go
+++ b/cmd/internal/featuregate/command.go
@@ -9,13 +9,13 @@ import (
 )
 
 func Command() *cobra.Command {
-	return command(func() *cobra.Command {
+	return extractFeatureGateCommand(func() *cobra.Command {
 		settings := otelcol.CollectorSettings{}
 		return otelcol.NewCommand(settings)
 	})
 }
 
-func command(otelCmdFn func() *cobra.Command) *cobra.Command {
+func extractFeatureGateCommand(otelCmdFn func() *cobra.Command) *cobra.Command {
 	otelCmd := otelCmdFn()
 	for _, cmd := range otelCmd.Commands() {
 		if cmd.Name() == "featuregate" {

--- a/cmd/internal/featuregate/command_test.go
+++ b/cmd/internal/featuregate/command_test.go
@@ -17,7 +17,7 @@ func TestCommand(t *testing.T) {
 
 func TestCommand_Panic(t *testing.T) {
 	assert.PanicsWithValue(t, "could not find 'featuregate' command", func() {
-		command(func() *cobra.Command {
+		extractFeatureGateCommand(func() *cobra.Command {
 			return &cobra.Command{}
 		})
 	})

--- a/cmd/query/app/querysvc/v2/adjuster/spanlinks.go
+++ b/cmd/query/app/querysvc/v2/adjuster/spanlinks.go
@@ -32,14 +32,14 @@ func (la LinksAdjuster) Adjust(traces ptrace.Traces) {
 			spans := ss.Spans()
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
-				la.adjust(span)
+				la.adjustSpan(span)
 			}
 		}
 	}
 }
 
-// adjust removes invalid links from a span.
-func (la LinksAdjuster) adjust(span ptrace.Span) {
+// adjustSpan removes invalid links from a span.
+func (la LinksAdjuster) adjustSpan(span ptrace.Span) {
 	links := span.Links()
 	validLinks := ptrace.NewSpanLinkSlice()
 	for i := 0; i < links.Len(); i++ {

--- a/crossdock/services/tracehandler.go
+++ b/crossdock/services/tracehandler.go
@@ -104,7 +104,7 @@ func (h *TraceHandler) AdaptiveSamplingTest(t crossdock.T) {
 	service := t.Param(servicesParam)
 	h.logger.Info("Starting AdaptiveSampling test", zap.String("service", service))
 
-	if err := h.runTest(service, request, h.adaptiveSamplingTest, validateAdaptiveSamplingTraces); err != nil {
+	if err := h.runTest(service, request, h.runAdaptiveSamplingTest, validateAdaptiveSamplingTraces); err != nil {
 		h.logger.Error(err.Error())
 		t.Errorf("Fail: %s", err.Error())
 	} else {
@@ -120,7 +120,7 @@ func (*TraceHandler) runTest(service string, request *traceRequest, tFunc testFu
 	return vFunc(request, traces)
 }
 
-func (h *TraceHandler) adaptiveSamplingTest(service string, request *traceRequest) ([]*ui.Trace, error) {
+func (h *TraceHandler) runAdaptiveSamplingTest(service string, request *traceRequest) ([]*ui.Trace, error) {
 	stop := make(chan struct{})
 	go h.createTracesLoop(service, *request, stop)
 	defer close(stop)

--- a/crossdock/services/tracehandler_test.go
+++ b/crossdock/services/tracehandler_test.go
@@ -438,7 +438,7 @@ func TestAdaptiveSamplingTestInternal(t *testing.T) {
 				query.On("GetTraces", "crossdock-svc", "op", mock.Anything).Return([]*ui.Trace{&testTrace}, nil)
 			}
 
-			_, err := handler.adaptiveSamplingTest("svc", &traceRequest{Operation: "op"})
+			_, err := handler.runAdaptiveSamplingTest("svc", &traceRequest{Operation: "op"})
 			if test.errMsg != "" {
 				require.EqualError(t, err, test.errMsg)
 			} else {

--- a/internal/sampling/http/handler_test.go
+++ b/internal/sampling/http/handler_test.go
@@ -70,12 +70,12 @@ func withServer(
 
 func TestHTTPHandler(t *testing.T) {
 	testGorillaHTTPHandler(t, "")
-	testHTTPHandler(t, "")
+	runHTTPHandlerTest(t, "")
 }
 
 func TestHTTPHandlerWithBasePath(t *testing.T) {
 	testGorillaHTTPHandler(t, "/foo")
-	testHTTPHandler(t, "/foo")
+	runHTTPHandlerTest(t, "/foo")
 }
 
 func testGorillaHTTPHandler(t *testing.T, basePath string) {
@@ -127,7 +127,7 @@ func testGorillaHTTPHandler(t *testing.T, basePath string) {
 	})
 }
 
-func testHTTPHandler(t *testing.T, basePath string) {
+func runHTTPHandlerTest(t *testing.T, basePath string) {
 	withServer(basePath, rateLimiting(42), false, func(ts *testServer) {
 		tests := []struct {
 			endpoint  string

--- a/internal/storage/integration/elasticsearch_test.go
+++ b/internal/storage/integration/elasticsearch_test.go
@@ -160,7 +160,7 @@ func healthCheck(c *http.Client) error {
 	return errors.New("elastic search is not ready")
 }
 
-func testElasticsearchStorage(t *testing.T, allTagsAsFields bool) {
+func runElasticsearchStorageTest(t *testing.T, allTagsAsFields bool) {
 	SkipUnlessEnv(t, "elasticsearch", "opensearch")
 	c := getESHttpClient(t)
 	require.NoError(t, healthCheck(c))
@@ -181,14 +181,14 @@ func TestElasticsearchStorage(t *testing.T) {
 	t.Cleanup(func() {
 		testutils.VerifyGoLeaksOnceForES(t)
 	})
-	testElasticsearchStorage(t, false)
+	runElasticsearchStorageTest(t, false)
 }
 
 func TestElasticsearchStorage_AllTagsAsObjectFields(t *testing.T) {
 	t.Cleanup(func() {
 		testutils.VerifyGoLeaksOnceForES(t)
 	})
-	testElasticsearchStorage(t, true)
+	runElasticsearchStorageTest(t, true)
 }
 
 func TestElasticsearchStorage_IndexTemplates(t *testing.T) {

--- a/internal/storage/kafka/auth/config_test.go
+++ b/internal/storage/kafka/auth/config_test.go
@@ -18,14 +18,14 @@ import (
 	"github.com/jaegertracing/jaeger/internal/config"
 )
 
-func addFlags(flags *flag.FlagSet) {
+func addTestFlags(flags *flag.FlagSet) {
 	configPrefix := "kafka.auth"
 	AddFlags(configPrefix, flags)
 }
 
 func Test_InitFromViper(t *testing.T) {
 	configPrefix := "kafka.auth"
-	v, command := config.Viperize(addFlags)
+	v, command := config.Viperize(addTestFlags)
 	command.ParseFlags([]string{
 		"--kafka.auth.authentication=tls",
 		"--kafka.auth.kerberos.service-name=kafka",
@@ -92,7 +92,7 @@ func TestSetConfiguration(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	saramaConfig := sarama.NewConfig()
 	configPrefix := "kafka.auth"
-	v, command := config.Viperize(addFlags)
+	v, command := config.Viperize(addTestFlags)
 
 	// Table-driven test cases
 	tests := []struct {

--- a/internal/storage/v1/cassandra/spanstore/reader.go
+++ b/internal/storage/v1/cassandra/spanstore/reader.go
@@ -257,7 +257,7 @@ func (s *SpanReader) FindTraceIDs(ctx context.Context, traceQuery *spanstore.Tra
 		traceQuery.NumTraces = defaultNumTraces
 	}
 
-	dbTraceIDs, err := s.findTraceIDs(ctx, traceQuery)
+	dbTraceIDs, err := s.queryTraceIDs(ctx, traceQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (s *SpanReader) FindTraceIDs(ctx context.Context, traceQuery *spanstore.Tra
 	return traceIDs, nil
 }
 
-func (s *SpanReader) findTraceIDs(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) (dbmodel.UniqueTraceIDs, error) {
+func (s *SpanReader) queryTraceIDs(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) (dbmodel.UniqueTraceIDs, error) {
 	if traceQuery.DurationMin != 0 || traceQuery.DurationMax != 0 {
 		return s.queryByDuration(ctx, traceQuery)
 	}

--- a/internal/storage/v1/cassandra/spanstore/reader.go
+++ b/internal/storage/v1/cassandra/spanstore/reader.go
@@ -257,7 +257,7 @@ func (s *SpanReader) FindTraceIDs(ctx context.Context, traceQuery *spanstore.Tra
 		traceQuery.NumTraces = defaultNumTraces
 	}
 
-	dbTraceIDs, err := s.queryTraceIDs(ctx, traceQuery)
+	dbTraceIDs, err := s.locateTraceIDs(ctx, traceQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (s *SpanReader) FindTraceIDs(ctx context.Context, traceQuery *spanstore.Tra
 	return traceIDs, nil
 }
 
-func (s *SpanReader) queryTraceIDs(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) (dbmodel.UniqueTraceIDs, error) {
+func (s *SpanReader) locateTraceIDs(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) (dbmodel.UniqueTraceIDs, error) {
 	if traceQuery.DurationMin != 0 || traceQuery.DurationMax != 0 {
 		return s.queryByDuration(ctx, traceQuery)
 	}

--- a/internal/storage/v1/cassandra/spanstore/writer.go
+++ b/internal/storage/v1/cassandra/spanstore/writer.go
@@ -133,7 +133,7 @@ func (s *SpanWriter) Close() error {
 func (s *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	ds := dbmodel.FromDomain(span)
 	if s.storageMode&storeFlag == storeFlag {
-		if err := s.writeSpan(span, ds); err != nil {
+		if err := s.insertSpan(span, ds); err != nil {
 			return err
 		}
 	}
@@ -145,7 +145,7 @@ func (s *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	return nil
 }
 
-func (s *SpanWriter) writeSpan(_ *model.Span, ds *dbmodel.Span) error {
+func (s *SpanWriter) insertSpan(_ *model.Span, ds *dbmodel.Span) error {
 	mainQuery := s.session.Query(
 		insertSpan,
 		ds.TraceID,

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -331,7 +331,7 @@ func TestPasswordFromFile(t *testing.T) {
 		testutils.VerifyGoLeaksOnce(t)
 	})
 	t.Run("primary client", func(t *testing.T) {
-		testPasswordFromFile(t)
+		runPasswordFromFileTest(t)
 	})
 
 	t.Run("load token error", func(t *testing.T) {
@@ -342,7 +342,7 @@ func TestPasswordFromFile(t *testing.T) {
 	})
 }
 
-func testPasswordFromFile(t *testing.T) {
+func runPasswordFromFileTest(t *testing.T) {
 	const (
 		pwd1 = "first password"
 		pwd2 = "second password"

--- a/internal/storage/v1/elasticsearch/spanstore/reader.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader.go
@@ -360,7 +360,7 @@ func (s *SpanReader) FindTraceIDs(ctx context.Context, traceQuery dbmodel.TraceQ
 		traceQuery.NumTraces = defaultNumTraces
 	}
 
-	esTraceIDs, err := s.findTraceIDs(ctx, traceQuery)
+	esTraceIDs, err := s.queryTraceIDs(ctx, traceQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -494,8 +494,8 @@ func validateQuery(p dbmodel.TraceQueryParameters) error {
 	return nil
 }
 
-func (s *SpanReader) findTraceIDs(ctx context.Context, traceQuery dbmodel.TraceQueryParameters) ([]dbmodel.TraceID, error) {
-	ctx, childSpan := s.tracer.Start(ctx, "findTraceIDs")
+func (s *SpanReader) queryTraceIDs(ctx context.Context, traceQuery dbmodel.TraceQueryParameters) ([]dbmodel.TraceID, error) {
+	ctx, childSpan := s.tracer.Start(ctx, "queryTraceIDs")
 	defer childSpan.End()
 	//  Below is the JSON body to our HTTP GET request to ElasticSearch. This function creates this.
 	// {
@@ -551,7 +551,7 @@ func (s *SpanReader) findTraceIDs(ctx context.Context, traceQuery dbmodel.TraceQ
 	//      "aggs": { "traceIDs" : { "terms" : {"size": 100,"field": "traceID" }}}
 	//  }
 	aggregation := s.buildTraceIDAggregation(traceQuery.NumTraces)
-	boolQuery := s.buildFindTraceIDsQuery(traceQuery)
+	boolQuery := s.buildTraceIDsQuery(traceQuery)
 	jaegerIndices := s.timeRangeIndices(
 		s.spanIndexPrefix,
 		s.spanIndex.DateLayout,
@@ -597,7 +597,7 @@ func (*SpanReader) buildTraceIDSubAggregation() elastic.Aggregation {
 		Field(startTimeField)
 }
 
-func (s *SpanReader) buildFindTraceIDsQuery(traceQuery dbmodel.TraceQueryParameters) elastic.Query {
+func (s *SpanReader) buildTraceIDsQuery(traceQuery dbmodel.TraceQueryParameters) elastic.Query {
 	boolQuery := elastic.NewBoolQuery()
 
 	// add duration query

--- a/internal/storage/v1/elasticsearch/spanstore/reader.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader.go
@@ -360,7 +360,7 @@ func (s *SpanReader) FindTraceIDs(ctx context.Context, traceQuery dbmodel.TraceQ
 		traceQuery.NumTraces = defaultNumTraces
 	}
 
-	esTraceIDs, err := s.queryTraceIDs(ctx, traceQuery)
+	esTraceIDs, err := s.locateTraceIDs(ctx, traceQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -494,8 +494,8 @@ func validateQuery(p dbmodel.TraceQueryParameters) error {
 	return nil
 }
 
-func (s *SpanReader) queryTraceIDs(ctx context.Context, traceQuery dbmodel.TraceQueryParameters) ([]dbmodel.TraceID, error) {
-	ctx, childSpan := s.tracer.Start(ctx, "queryTraceIDs")
+func (s *SpanReader) locateTraceIDs(ctx context.Context, traceQuery dbmodel.TraceQueryParameters) ([]dbmodel.TraceID, error) {
+	ctx, childSpan := s.tracer.Start(ctx, "locateTraceIDs")
 	defer childSpan.End()
 	//  Below is the JSON body to our HTTP GET request to ElasticSearch. This function creates this.
 	// {

--- a/internal/storage/v1/elasticsearch/spanstore/reader_test.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader_test.go
@@ -692,7 +692,7 @@ func returnSearchFunc(typ string, r *spanReaderTest) (any, error) {
 			dbmodel.OperationQueryParameters{ServiceName: "someService"},
 		)
 	case traceIDAggregation:
-		return r.reader.findTraceIDs(context.Background(), dbmodel.TraceQueryParameters{})
+		return r.reader.queryTraceIDs(context.Background(), dbmodel.TraceQueryParameters{})
 	}
 	return nil, errors.New("Specify services, operations, traceIDs only")
 }
@@ -1060,7 +1060,7 @@ func TestSpanReader_buildTraceIDAggregation(t *testing.T) {
 	})
 }
 
-func TestSpanReader_buildFindTraceIDsQuery(t *testing.T) {
+func TestSpanReader_buildTraceIDsQuery(t *testing.T) {
 	withSpanReader(t, func(r *spanReaderTest) {
 		traceQuery := dbmodel.TraceQueryParameters{
 			DurationMin:   time.Second,
@@ -1074,7 +1074,7 @@ func TestSpanReader_buildFindTraceIDsQuery(t *testing.T) {
 			},
 		}
 
-		actualQuery := r.reader.buildFindTraceIDsQuery(traceQuery)
+		actualQuery := r.reader.buildTraceIDsQuery(traceQuery)
 		actual, err := actualQuery.Source()
 		require.NoError(t, err)
 		expectedQuery := elastic.NewBoolQuery().

--- a/internal/storage/v1/elasticsearch/spanstore/reader_test.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader_test.go
@@ -692,7 +692,7 @@ func returnSearchFunc(typ string, r *spanReaderTest) (any, error) {
 			dbmodel.OperationQueryParameters{ServiceName: "someService"},
 		)
 	case traceIDAggregation:
-		return r.reader.queryTraceIDs(context.Background(), dbmodel.TraceQueryParameters{})
+		return r.reader.locateTraceIDs(context.Background(), dbmodel.TraceQueryParameters{})
 	}
 	return nil, errors.New("Specify services, operations, traceIDs only")
 }

--- a/internal/storage/v1/elasticsearch/spanstore/to_domain_test.go
+++ b/internal/storage/v1/elasticsearch/spanstore/to_domain_test.go
@@ -22,13 +22,13 @@ import (
 )
 
 func TestToDomain(t *testing.T) {
-	testToDomain(t, false)
-	testToDomain(t, true)
+	runToDomainTest(t, false)
+	runToDomainTest(t, true)
 	// this is just to confirm the uint64 representation of float64(72.5) used as a "temperature" tag
 	assert.Equal(t, int64(4634802150889750528), int64(math.Float64bits(72.5)))
 }
 
-func testToDomain(t *testing.T, testParentSpanID bool) {
+func runToDomainTest(t *testing.T, testParentSpanID bool) {
 	for i := 1; i <= NumberOfFixtures; i++ {
 		span, err := loadESSpanFixture(i)
 		require.NoError(t, err)

--- a/internal/storage/v1/elasticsearch/spanstore/writer.go
+++ b/internal/storage/v1/elasticsearch/spanstore/writer.go
@@ -122,7 +122,7 @@ func (s *SpanWriter) WriteSpan(spanStartTime time.Time, span *dbmodel.Span) {
 	if serviceIndexName != "" {
 		s.writeService(serviceIndexName, span)
 	}
-	s.writeSpan(spanIndexName, span)
+	s.indexSpan(spanIndexName, span)
 	s.logger.Debug("Wrote span to ES index", zap.String("index", spanIndexName))
 }
 
@@ -152,7 +152,7 @@ func (s *SpanWriter) writeService(indexName string, jsonSpan *dbmodel.Span) {
 	s.serviceWriter(indexName, jsonSpan)
 }
 
-func (s *SpanWriter) writeSpan(indexName string, jsonSpan *dbmodel.Span) {
+func (s *SpanWriter) indexSpan(indexName string, jsonSpan *dbmodel.Span) {
 	s.client().Index().Index(indexName).Type(spanType).BodyJson(&jsonSpan).Add()
 }
 

--- a/internal/storage/v1/elasticsearch/spanstore/writer_test.go
+++ b/internal/storage/v1/elasticsearch/spanstore/writer_test.go
@@ -239,7 +239,7 @@ func TestWriteSpanInternal(t *testing.T) {
 
 		jsonSpan := &dbmodel.Span{}
 
-		w.writer.writeSpan(indexName, jsonSpan)
+		w.writer.indexSpan(indexName, jsonSpan)
 		indexService.AssertNumberOfCalls(t, "Add", 1)
 		assert.Empty(t, w.logBuffer.String())
 	})
@@ -262,7 +262,7 @@ func TestWriteSpanInternalError(t *testing.T) {
 			SpanID:  dbmodel.SpanID("0"),
 		}
 
-		w.writer.writeSpan(indexName, jsonSpan)
+		w.writer.indexSpan(indexName, jsonSpan)
 		indexService.AssertNumberOfCalls(t, "Add", 1)
 	})
 }

--- a/internal/storage/v2/elasticsearch/depstore/storage.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage.go
@@ -69,7 +69,7 @@ func NewDependencyStore(p Params) *DependencyStore {
 // WriteDependencies write dependencies to Elasticsearch
 func (s *DependencyStore) WriteDependencies(ts time.Time, dependencies []dbmodel.DependencyLink) error {
 	writeIndexName := s.getWriteIndex(ts)
-	s.writeDependencies(writeIndexName, ts, dependencies)
+	s.indexDependencies(writeIndexName, ts, dependencies)
 	return nil
 }
 
@@ -82,7 +82,7 @@ func (s *DependencyStore) CreateTemplates(dependenciesTemplate string) error {
 	return nil
 }
 
-func (s *DependencyStore) writeDependencies(indexName string, ts time.Time, dependencies []dbmodel.DependencyLink) {
+func (s *DependencyStore) indexDependencies(indexName string, ts time.Time, dependencies []dbmodel.DependencyLink) {
 	s.client().Index().Index(indexName).Type(dependencyType).
 		BodyJson(&dbmodel.TimeDependencies{
 			Timestamp:    ts,

--- a/internal/storage/v2/elasticsearch/tracestore/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/reader_test.go
@@ -180,7 +180,7 @@ func TestTraceReader_FindTraceIDs(t *testing.T) {
 	}
 	expected := make([]tracestore.FoundTraceID, 0, len(dbTraceIDs))
 	for _, dbTraceID := range dbTraceIDs {
-		expected = append(expected, fromDBTraceId(t, dbTraceID))
+		expected = append(expected, convertDBTraceId(t, dbTraceID))
 	}
 	coreReader.On("FindTraceIDs", mock.Anything, mock.Anything).Return(dbTraceIDs, nil)
 	for traceIds, err := range reader.FindTraceIDs(context.Background(), tracestore.TraceQueryParams{
@@ -252,7 +252,7 @@ func Test_NewTraceReader(t *testing.T) {
 	assert.IsType(t, &spanstore.SpanReader{}, reader.spanReader)
 }
 
-func fromDBTraceId(t *testing.T, traceID dbmodel.TraceID) tracestore.FoundTraceID {
+func convertDBTraceId(t *testing.T, traceID dbmodel.TraceID) tracestore.FoundTraceID {
 	traceId, err := fromDbTraceId(traceID)
 	require.NoError(t, err)
 	return tracestore.FoundTraceID{


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves part of #5506 
- Linter rule enabled: confusing-naming

## How was this change tested?
- `make lint`, `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
