### PR TITLE
Add mapstructure for prometheus-tls

### DIFF
--- a/internal/config/promcfg/config.go
+++ b/internal/config/promcfg/config.go
@@ -14,7 +14,8 @@ import (
 type Configuration struct {
 	ServerURL      string        `valid:"required" mapstructure:"endpoint"`
 	ConnectTimeout time.Duration `mapstructure:"connect_timeout"`
-	TLS            configtls.ClientConfig
+	// TLS contains the TLS configuration for the connection to the Prometheus clusters.
+	TLS configtls.ClientConfig `mapstructure:"tls"`
 
 	TokenFilePath            string `mapstructure:"token_file_path"`
 	TokenOverrideFromContext bool   `mapstructure:"token_override_from_context"`

--- a/internal/storage/metricstore/prometheus/metricstore/reader_test.go
+++ b/internal/storage/metricstore/prometheus/metricstore/reader_test.go
@@ -731,19 +731,47 @@ func (s *fakePromServer) getAuth() string {
 
 func TestGetRoundTripperTLSConfig(t *testing.T) {
 	for _, tc := range []struct {
-		name       string
-		tlsEnabled bool
+		name      string
+		tlsConfig configtls.ClientConfig
+		wantErr   bool
 	}{
-		{"tls tlsEnabled", true},
-		{"tls disabled", false},
+		{
+			name: "tls enabled with cert verification",
+			tlsConfig: configtls.ClientConfig{
+				Insecure: false,
+			},
+		},
+		{
+			name: "tls enabled insecure",
+			tlsConfig: configtls.ClientConfig{
+				Insecure: true, // Skip verify
+			},
+		},
+		{
+			name:      "tls disabled",
+			tlsConfig: configtls.ClientConfig{},
+		},
+		{
+			name: "invalid tls config",
+			tlsConfig: configtls.ClientConfig{
+				Config: configtls.Config{
+					CAFile: "foo",
+				},
+			},
+			wantErr: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			config := &config.Configuration{
 				ConnectTimeout:           9 * time.Millisecond,
-				TLS:                      configtls.ClientConfig{},
+				TLS:                      tc.tlsConfig,
 				TokenOverrideFromContext: true,
 			}
 			rt, err := getHTTPRoundTripper(config)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			server := newFakePromServer(t)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/7364

## Description of the changes
- Add "mapstructure:tls" to promcfg
- Add related changes to getHTTPRoundTripper inside metricstore/prometheus/reader.go

## How was this change tested?
- CI

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
