### PR TITLE
Fix Kafka TLS configuration with plaintext authentication

### DIFF
--- a/cmd/ingester/app/flags_test.go
+++ b/cmd/ingester/app/flags_test.go
@@ -55,16 +55,39 @@ func TestTLSFlags(t *testing.T) {
 		expected auth.AuthenticationConfig
 	}{
 		{
-			flags:    []string{},
-			expected: auth.AuthenticationConfig{Authentication: "none", Kerberos: kerb, PlainText: plain},
+			flags: []string{},
+			expected: auth.AuthenticationConfig{
+				Authentication: "none",
+				Kerberos:       kerb,
+				TLS: configtls.ClientConfig{
+					Insecure: true, // TLS disabled by default
+				},
+				PlainText: plain,
+			},
 		},
 		{
-			flags:    []string{"--kafka.consumer.authentication=foo"},
-			expected: auth.AuthenticationConfig{Authentication: "foo", Kerberos: kerb, PlainText: plain},
+			flags: []string{"--kafka.consumer.authentication=foo"},
+			expected: auth.AuthenticationConfig{
+				Authentication: "foo",
+				Kerberos:       kerb,
+				TLS: configtls.ClientConfig{
+					Insecure: true, // TLS disabled by default
+				},
+				PlainText: plain,
+			},
 		},
 		{
-			flags:    []string{"--kafka.consumer.authentication=kerberos", "--kafka.consumer.tls.enabled=true"},
-			expected: auth.AuthenticationConfig{Authentication: "kerberos", Kerberos: kerb, PlainText: plain},
+			flags: []string{"--kafka.consumer.authentication=kerberos", "--kafka.consumer.tls.enabled=true"},
+			expected: auth.AuthenticationConfig{
+				Authentication: "kerberos",
+				Kerberos:       kerb,
+				TLS: configtls.ClientConfig{
+					Config: configtls.Config{
+						IncludeSystemCACertsPool: true,
+					},
+				},
+				PlainText: plain,
+			},
 		},
 		{
 			flags: []string{"--kafka.consumer.authentication=tls"},

--- a/internal/storage/v1/kafka/options_test.go
+++ b/internal/storage/v1/kafka/options_test.go
@@ -172,16 +172,39 @@ func TestTLSFlags(t *testing.T) {
 		expected auth.AuthenticationConfig
 	}{
 		{
-			flags:    []string{},
-			expected: auth.AuthenticationConfig{Authentication: "none", Kerberos: kerb, PlainText: plain},
+			flags: []string{},
+			expected: auth.AuthenticationConfig{
+				Authentication: "none",
+				Kerberos:       kerb,
+				TLS: configtls.ClientConfig{
+					Insecure: true, // TLS disabled by default
+				},
+				PlainText: plain,
+			},
 		},
 		{
-			flags:    []string{"--kafka.producer.authentication=foo"},
-			expected: auth.AuthenticationConfig{Authentication: "foo", Kerberos: kerb, PlainText: plain},
+			flags: []string{"--kafka.producer.authentication=foo"},
+			expected: auth.AuthenticationConfig{
+				Authentication: "foo",
+				Kerberos:       kerb,
+				TLS: configtls.ClientConfig{
+					Insecure: true, // TLS disabled by default
+				},
+				PlainText: plain,
+			},
 		},
 		{
-			flags:    []string{"--kafka.producer.authentication=kerberos", "--kafka.producer.tls.enabled=true"},
-			expected: auth.AuthenticationConfig{Authentication: "kerberos", Kerberos: kerb, TLS: configtls.ClientConfig{}, PlainText: plain},
+			flags: []string{"--kafka.producer.authentication=kerberos", "--kafka.producer.tls.enabled=true"},
+			expected: auth.AuthenticationConfig{
+				Authentication: "kerberos",
+				Kerberos:       kerb,
+				TLS: configtls.ClientConfig{
+					Config: configtls.Config{
+						IncludeSystemCACertsPool: true,
+					},
+				},
+				PlainText: plain,
+			},
 		},
 		{
 			flags: []string{"--kafka.producer.authentication=tls"},


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6764

## Description of the changes
- PR #6270 introduced a regression in Kafka TLS configuration. The original code allowed TLS to be used with any authentication method (plaintext, kerberos, tls) by checking `config.Authentication == tls || config.TLS.Enabled`. However, the pr changed this to only `config.Authentication == tls`, breaking SASL_SSL configurations where users need `authentication=plaintext` with `tls.enabled=true`.

## Solution
- I fixed the issue in two parts:
  - In `InitFromViper` method: always load TLS configuration from viper instead of only when `authentication=tls`, ensuring TLS settings are available for all authentication methods.
  - In `SetConfiguration` method: restored the original logic to apply TLS when either authentication=tls or when TLS is explicitly enabled, but using the correct OTEL pattern `!config.TLS.Insecure` instead of the old `config.TLS.Enabled`

## How was this change tested?
- added comprehensive tests for SASL_SSL scenarios:
  - TestPlaintextWithTLS
  - TestKerberosWithTLS
- updated test expectations in both `internal/storage/v1/kafka/options_test.go` and `cmd/ingester/app/flags_test.go` to show the new behavior where TLS configuration is always loaded.
- the configuration `--kafka.producer.authentication=plaintext --kafka.producer.tls.enabled=true` now correctly enables both TLS and SASL in the sarama configuration, allowing SASL_SSL with PLAIN authentication to work as expected.
- ran full test suite

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
