### PR TITLE
clickhouse: Refactor `to_dbmodel` function

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/fixtures/input_dbmodel.json
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/fixtures/input_dbmodel.json
@@ -1,0 +1,30 @@
+[
+  {
+    "ID": "0102030000000000",
+    "TraceID": "01020300000000000000000000000000",
+    "TraceState": "trace state",
+    "ParentSpanID": "0102040000000000",
+    "Name": "call db",
+    "Kind": "Internal",
+    "StartTime": "2023-12-25T09:53:49Z",
+    "StatusCode": "Error",
+    "StatusMessage": "error",
+    "Duration": 60000000000,
+    "Events": [
+      {
+        "Name": "event1",
+        "Timestamp": "2023-12-25T09:53:49Z"
+      }
+    ],
+    "Links": [
+      {
+        "TraceID": "01020500000000000000000000000000",
+        "SpanID": "0102050000000000",
+        "TraceState": "test"
+      }
+    ],
+    "ServiceName": "",
+    "ScopeName": "io.opentelemetry.contrib.clickhouse",
+    "ScopeVersion": "1.0.0"
+  }
+]

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel_test.go
@@ -15,7 +15,7 @@ func TestToDBModel(t *testing.T) {
 	trace := jsonToPtrace(t, "./fixtures/ptrace.json")
 	input := ToDBModel(trace)
 
-	expected := readJSONBytes(t, "./fixtures/input.json")
+	expected := readJSONBytes(t, "./fixtures/input_dbmodel.json")
 	actual, err := json.MarshalIndent(input, "", "  ")
 	require.NoError(t, err)
 	require.ElementsMatch(t, expected, actual)


### PR DESCRIPTION
Resolves #7148.


## Description of the changes
This PR updates `to_dbmodel` function, so that
`to_dbmodel` returns array of `Span` struct.

This change will also unblock https://github.com/jaegertracing/jaeger/issues/7135.

from now on `to_dbmodel` will return clickhouse-go
compatible array of`Span` structs.

## How was this change tested?
Unit test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
