### PR TITLE
Add readiness and liveness probe paths to Demo deployment for improved health checks

### DIFF
--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -7,6 +7,10 @@ hotrod:
   extraArgs:
     - --otel-exporter=otlp
     - --basepath=/hotrod
+  livenessProbe:
+    path: /hotrod
+  readinessProbe: 
+    path: /hotrod
   extraEnv:
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://jaeger-collector:4318

--- a/examples/oci/monitoring-values.yaml
+++ b/examples/oci/monitoring-values.yaml
@@ -15,5 +15,5 @@ grafana:
   grafana.ini:
     server:
       domain: demo.jaegertracing.io
-      root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
+      root_url: "%(protocol)s://%(domain)s/grafana/"
       serve_from_sub_path: true


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7115 
- Add probe path for deployment 
- Removed http_port from grafana configuration 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
