### PR TITLE
Remove pool.go/pool.stop method (deadcode)

### DIFF
--- a/examples/hotrod/pkg/pool/pool.go
+++ b/examples/hotrod/pkg/pool/pool.go
@@ -36,10 +36,3 @@ func New(workers int) *Pool {
 func (p *Pool) Execute(job func()) {
 	p.jobs <- job
 }
-
-// Stop halts all the workers
-func (p *Pool) Stop() {
-	if p.stop != nil {
-		close(p.stop)
-	}
-}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves part of #7261

## Description of the changes
- Working on: `examples/hotrod/pkg/pool/pool.go` (`Pool.Stop` Method)
- Files identified by deadcode tool: `examples/hotrod/pkg/pool/pool.go`: - `Pool.Stop` method unreachable
- When introduced: PR #40
- When fixed: PR #1454
- current state: Pool.Stop() method is never called anywhere in the codebase. Only Pool.New() and Pool.Execute() are used in production
- Files to modify: `examples/hotrod/pkg/pool/pool.go` - remove Stop() method

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
