### PR TITLE
feat: Change v1 Kafka storage and jaeger-ingester to use OTEL exporter/receiver

### DIFF
--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -50,6 +50,7 @@ type Collector struct {
 	grpcServer     *grpc.Server
 	otlpReceiver   receiver.Traces
 	zipkinReceiver receiver.Traces
+	kafkaReceiver  receiver.Traces
 }
 
 // CollectorParams to construct a new Jaeger Collector.
@@ -133,7 +134,7 @@ func (c *Collector) Start(options *flags.CollectorOptions) error {
 		}
 		c.zipkinReceiver = zipkinReceiver
 	}
-
+	// TODO: Handle Kafka receiver, Kafka broker by default should be localhost:9092, Should we do the check for this?
 	if options.OTLP.Enabled {
 		otlpReceiver, err := handler.StartOTLPReceiver(options, c.logger, c.spanProcessor, c.tenancyMgr)
 		if err != nil {

--- a/cmd/collector/app/flags/flags.go
+++ b/cmd/collector/app/flags/flags.go
@@ -125,6 +125,7 @@ type CollectorOptions struct {
 		confighttp.ServerConfig
 		KeepAlive bool
 	}
+	// TODO:Do we need to define a section for Kafka?
 	// CollectorTags is the string representing collector tags to append to each and every span
 	CollectorTags map[string]string
 	// SpanSizeMetricsEnabled determines whether to enable metrics based on processed span size

--- a/cmd/collector/app/handler/kafka_receiver.go
+++ b/cmd/collector/app/handler/kafka_receiver.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/collector/app/flags"
+	"github.com/jaegertracing/jaeger/cmd/collector/app/processor"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
+)
+
+var (
+	kafkaComponentType = component.MustNewType("kafka")
+	kafkaID            = component.NewID(kafkaComponentType)
+)
+
+// StartKafkaReceiver starts Kafka receiver from OTEL Collector.
+func StartKafkaReceiver(
+	options *flags.CollectorOptions,
+	logger *zap.Logger,
+	spanProcessor processor.SpanProcessor,
+	tm *tenancy.Manager,
+) (receiver.Traces, error) {
+	kafkaFactory := kafkareceiver.NewFactory()
+	return startKafkaReceiver(
+		options,
+		logger,
+		spanProcessor,
+		tm,
+		kafkaFactory,
+		consumer.NewTraces,
+		kafkaFactory.CreateTraces,
+	)
+}
+
+// Some of OTELCOL constructor functions return errors when passed nil arguments,
+// which is a situation we cannot reproduce. To test our own error handling, this
+// function allows to mock those constructors.
+func startKafkaReceiver(
+	options *flags.CollectorOptions,
+	logger *zap.Logger,
+	spanProcessor processor.SpanProcessor,
+	tm *tenancy.Manager,
+	// from here: params that can be mocked in tests
+	kafkaFactory receiver.Factory,
+	newTraces func(consume consumer.ConsumeTracesFunc, options ...consumer.Option) (consumer.Traces, error),
+	createTracesReceiver func(ctx context.Context, set receiver.Settings,
+		cfg component.Config, nextConsumer consumer.Traces) (receiver.Traces, error),
+) (receiver.Traces, error) {
+	receiverConfig := kafkaFactory.CreateDefaultConfig().(*kafkareceiver.Config)
+	// ClientConfig, ConsumerConfig declarations?
+	receiverSettings := receiver.Settings{
+		ID: kafkaID,
+		TelemetrySettings: component.TelemetrySettings{
+			Logger:         logger,
+			TracerProvider: nooptrace.NewTracerProvider(),
+			MeterProvider:  noopmetric.NewMeterProvider(),
+		},
+	}
+
+	consumerHelper := &consumerHelper{
+		batchConsumer: newBatchConsumer(logger,
+			spanProcessor,
+			processor.HTTPTransport,
+			processor.KafkaSpanFormat,
+			tm),
+	}
+
+	nextConsumer, err := newTraces(consumerHelper.consume)
+	if err != nil {
+		return nil, fmt.Errorf("could not create Kafka consumer: %w", err)
+	}
+	rcvr, err := createTracesReceiver(
+		context.Background(),
+		receiverSettings,
+		receiverConfig,
+		nextConsumer,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not create Kafka receiver: %w", err)
+	}
+	if err := rcvr.Start(context.Background(), &otelHost{logger: logger}); err != nil {
+		return nil, fmt.Errorf("could not start Kafka receiver: %w", err)
+	}
+	return rcvr, nil
+}

--- a/cmd/collector/app/processor/constants.go
+++ b/cmd/collector/app/processor/constants.go
@@ -30,6 +30,8 @@ const (
 	JaegerSpanFormat SpanFormat = "jaeger"
 	// ZipkinSpanFormat is for Zipkin Thrift spans.
 	ZipkinSpanFormat SpanFormat = "zipkin"
+	// KafkaSpanFormat is for kafka spans.
+	KafkaSpanFormat SpanFormat = "kafka"
 	// ProtoSpanFormat is for Jaeger protobuf Spans.
 	ProtoSpanFormat SpanFormat = "proto"
 	// OTLPSpanFormat is for OpenTelemetry OTLP format.


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #6922 

## Description of the changes
- Set up `kafka_receiver.go`
- TODO: Add kafka to collectors.go
- TODO: Kafka receiver ClientConfig, ConsumerConfig in `kafka_receiver.go`
- TODO: `kafka_receiver_test.go`
## How was this change tested?
- Not tested, As it's not a complete PR.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
