### PR TITLE
Change example hotrod version in Jaeger Demo version 

### DIFF
--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -1,7 +1,7 @@
 hotrod:
   enabled: true
   image:
-    tag: "latest"
+    tag: "1.72.0"
   args:
     - all
   extraArgs:


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7115 
- There was a issue where assets wont load for hotrod if we changed the basepath , even after merging the PR changes wont reflect on "latest" tag docker image . 
- Shifted to docker image to latest hotrod image version 

## How was this change tested?
- tested it locally on kind cluster 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
