### PR TITLE
Multiple minor changes in Jaeger demo deployment in OKE 

### DIFF
--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -35,7 +35,7 @@ fi
 
 # Deploy Jaeger (All-in-One with memory storage)
 echo "🟣 Step 1: Installing Jaeger..."
-helm upgrade --install jaeger ./helm-charts/charts/jaeger \
+helm upgrade --install --force jaeger ./helm-charts/charts/jaeger \
   --set provisionDataStore.cassandra=false \
   --set allInOne.enabled=true \
   --set storage.type=memory \
@@ -44,9 +44,8 @@ helm upgrade --install jaeger ./helm-charts/charts/jaeger \
 
 # Deploy Prometheus Monitoring Stack
 echo "🟢 Step 2: Deploying Prometheus Monitoring stack..."
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-helm upgrade --install prometheus -f monitoring-values.yaml prometheus-community/kube-prometheus-stack
+kubectl apply -f prometheus-svc.yaml
+helm upgrade --install --force prometheus -f monitoring-values.yaml prometheus-community/kube-prometheus-stack
 
 # Create ConfigMap for Trace Generator
 echo "🔵 Step 3: Creating ConfigMap for Trace Generator..."

--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -1,7 +1,7 @@
 hotrod:
   enabled: true
   image:
-    tag: "latest"
+    tag: "1.72.0"
   args:
     - all
   extraArgs:

--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -7,6 +7,7 @@ hotrod:
   extraArgs:
     - --otel-exporter=otlp
     - --basepath=/hotrod
+    - --jaeger-ui=https://demo.jaegertracing.io
   livenessProbe:
     path: /hotrod
   readinessProbe: 

--- a/examples/oci/prometheus-svc.yaml
+++ b/examples/oci/prometheus-svc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus-kube-prometheus-prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-collector-prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/instance: jaeger
+  ports:
+    - name: prometheus
+      port: 8889
+      targetPort: 8889
+    - name: metrics
+      port: 8888
+      targetPort: 8888


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7115 
- Fix the issue where hotrod redirected to jaeger-ui to localhost 
- Deleted unused YAML in one of the previous PRs but that was indeed needed to help jaeger access the prometheus database when created with helm . 
- add --force flag to ensure upgrade are not done inplace but by recreating the pods 

## How was this change tested?
- locally on a kind cluster 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
