### PR TITLE
Redirect to demo documentation in Jaeger demo deployment 

### DIFF
--- a/examples/oci/README.md
+++ b/examples/oci/README.md
@@ -49,7 +49,7 @@ kubectl port-forward svc/jaeger-hotrod 8080:80
 
 Then, open the following URLs in your browser:
 
-- **Jaeger UI:** [http://localhost:16686](http://localhost:16686)
+- **Jaeger UI:** [http://localhost:16686/jaeger](http://localhost:16686)
 - **Prometheus:** [http://localhost:9090](http://localhost:9090)
 - **Grafana:** [http://localhost:9091](http://localhost:9091)
 - **HotROD Demo App:** [http://localhost:8080](http://localhost:8080)

--- a/examples/oci/README.md
+++ b/examples/oci/README.md
@@ -49,7 +49,7 @@ kubectl port-forward svc/jaeger-hotrod 8080:80
 
 Then, open the following URLs in your browser:
 
-- **Jaeger UI:** [http://localhost:16686/jaeger](http://localhost:16686)
+- **Jaeger UI:** [http://localhost:16686/jaeger](http://localhost:16686/jaeger)
 - **Prometheus:** [http://localhost:9090](http://localhost:9090)
 - **Grafana:** [http://localhost:9091](http://localhost:9091)
 - **HotROD Demo App:** [http://localhost:8080](http://localhost:8080)

--- a/examples/oci/config.yaml
+++ b/examples/oci/config.yaml
@@ -23,6 +23,7 @@ extensions:
       http:
         endpoint: 0.0.0.0:13133
   jaeger_query:
+    base_path: /jaeger
     storage:
       traces: some_storage
       metrics: some_metrics_storage

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -55,6 +55,10 @@ kubectl create configmap trace-script --from-file=./load-generator/generate_trac
 echo "🟡 Step 4: Deploying Trace Generator Pod..."
 kubectl apply -f ./load-generator/load-generator.yaml
 
+#Deploy ingress changes 
+echo "🟡 Step 4: Deploying Ingress Resource..."
+kubectl apply -f ingress.yaml
+
 # Output Port-forward Instructions
 echo "✅ Deployment Complete!"
 echo ""
@@ -66,7 +70,7 @@ echo "kubectl port-forward svc/prometheus-grafana 9091:80    # Grafana UI"
 echo "kubectl port-forward svc/jaeger-hotrod 8080:80         # HotROD UI"
 echo ""
 echo "Then open:"
-echo "🔍 Jaeger: http://localhost:16686"
+echo "🔍 Jaeger: http://localhost:16686/jaeger"
 echo "📈 Prometheus: http://localhost:9090"
 echo "📊 Grafana: http://localhost:9091"
 echo "🚕 HotROD: http://localhost:8080"

--- a/examples/oci/ingress.yaml
+++ b/examples/oci/ingress.yaml
@@ -14,7 +14,7 @@ spec:
     - host: demo.jaegertracing.io
       http:
         paths:
-          - path: /
+          - path: /jaeger
             pathType: Prefix
             backend:
               service:
@@ -35,3 +35,31 @@ spec:
                 name: jaeger-hotrod
                 port:
                   number: 80
+
+---
+# Separate Ingress to redirect / -> external site
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jaeger-root-redirect
+  annotations:
+    cert-manager.io/issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/permanent-redirect: https://www.jaegertracing.io/demo/
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - demo.jaegertracing.io
+      secretName: demo-jaeger-tls
+  rules:
+    - host: demo.jaegertracing.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              # Backend is ignored due to redirect annotation; must be valid
+              service:
+                name: jaeger-query
+                port:
+                  number: 16686

--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -7,7 +7,7 @@ hotrod:
   extraArgs:
     - --otel-exporter=otlp
     - --basepath=/hotrod
-    - --jaeger-ui=https://demo.jaegertracing.io
+    - --jaeger-ui=https://demo.jaegertracing.io/jaeger
   livenessProbe:
     path: /hotrod
   readinessProbe: 


### PR DESCRIPTION
## Description of the changes
- Part of #7115
- Changed base path for jaeger deployment 
- Changed redirect path on jaeger hotrod 
- add a dummy ingress to redirect 
- made changes to deployment script 

## How was this change tested?
- locally on kind cluster 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
