### PR TITLE
chore: enable several rules from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,7 +76,6 @@ linters:
         - importShadow
         - nestingReduce
         - paramTypeCombine
-        - preferFilepathJoin
         - preferStringWriter
         - rangeValCopy
         - redundantSprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
     gocritic:
       disabled-checks:
         - appendAssign
-        - appendCombine
         - badLock
         - commentedOutCode
         - deferInLoop

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,6 @@ linters:
         - rangeValCopy
         - regexpSimplify
         - returnAfterHttpError
-        - sloppyReassign
         - sprintfQuotedString
         - stringsCompare
         - todoCommentWithoutDetail

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,6 @@ linters:
         - rangeValCopy
         - regexpSimplify
         - returnAfterHttpError
-        - stringsCompare
         - todoCommentWithoutDetail
         - typeAssertChain
         - typeUnparen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,6 @@ linters:
         - rangeValCopy
         - regexpSimplify
         - returnAfterHttpError
-        - sprintfQuotedString
         - stringsCompare
         - todoCommentWithoutDetail
         - typeAssertChain

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,7 +77,6 @@ linters:
         - nestingReduce
         - paramTypeCombine
         - rangeValCopy
-        - redundantSprint
         - regexpSimplify
         - returnAfterHttpError
         - sloppyReassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,6 @@ linters:
         - commentedOutCode
         - deferInLoop
         - dupArg
-        - emptyStringTest
         - exitAfterDefer
         - exposedSyncMutex
         - httpNoBody

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,6 @@ linters:
         - typeAssertChain
         - unnamedResult
         - whyNoLint
-        - yodaStyleExpr
       enable-all: true
     gosec:
       excludes:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,6 @@ linters:
         - returnAfterHttpError
         - todoCommentWithoutDetail
         - typeAssertChain
-        - typeUnparen
         - unnamedResult
         - unnecessaryDefer
         - whyNoLint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,6 @@ linters:
         - dupArg
         - exitAfterDefer
         - exposedSyncMutex
-        - httpNoBody
         - hugeParam
         - importShadow
         - nestingReduce

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,7 +82,6 @@ linters:
         - todoCommentWithoutDetail
         - typeAssertChain
         - unnamedResult
-        - unnecessaryDefer
         - whyNoLint
         - yodaStyleExpr
       enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,39 @@ linters:
               desc: Use github.com/jaegertracing/jaeger-idl/model/v1
             - pkg: github.com/jaegertracing/jaeger/internal/proto-gen/api_v2$
               desc: Use github.com/jaegertracing/jaeger-idl/proto-gen/api_v2
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - appendCombine
+        - badLock
+        - commentedOutCode
+        - deferInLoop
+        - dupArg
+        - emptyStringTest
+        - exitAfterDefer
+        - exposedSyncMutex
+        - httpNoBody
+        - hugeParam
+        - importShadow
+        - nestingReduce
+        - paramTypeCombine
+        - preferFilepathJoin
+        - preferStringWriter
+        - rangeValCopy
+        - redundantSprint
+        - regexpSimplify
+        - returnAfterHttpError
+        - sloppyReassign
+        - sprintfQuotedString
+        - stringsCompare
+        - todoCommentWithoutDetail
+        - typeAssertChain
+        - typeUnparen
+        - unnamedResult
+        - unnecessaryDefer
+        - whyNoLint
+        - yodaStyleExpr
+      enable-all: true
     gosec:
       excludes:
         - G104
@@ -164,15 +197,6 @@ linters:
       - linters:
           - staticcheck
         path: internal/grpctest/
-      - linters:
-          - gocritic
-        text: dupArg
-      - linters:
-          - gocritic
-        text: exitAfterDefer
-      - linters:
-          - gocritic
-        text: appendAssign
     paths:
       - .*.pb.go$
       - mocks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,7 +76,6 @@ linters:
         - importShadow
         - nestingReduce
         - paramTypeCombine
-        - preferStringWriter
         - rangeValCopy
         - redundantSprint
         - regexpSimplify

--- a/cmd/all-in-one/all_in_one_test.go
+++ b/cmd/all-in-one/all_in_one_test.go
@@ -101,7 +101,7 @@ func healthCheckV2(t *testing.T) {
 
 func httpGet(t *testing.T, url string) (*http.Response, []byte) {
 	t.Logf("Executing HTTP GET %s", url)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	require.NoError(t, err)
 	req.Close = true // avoid persistent connections which leak goroutines
 

--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -181,13 +181,17 @@ by default uses only in-memory database.`,
 
 			svc.RunAndThen(func() {
 				var errs []error
-				errs = append(errs, c.Close())
-				errs = append(errs, querySrv.Close())
+				errs = append(errs,
+					c.Close(),
+					querySrv.Close(),
+				)
 				if closer, ok := spanWriter.(io.Closer); ok {
 					errs = append(errs, closer.Close())
 				}
-				errs = append(errs, storageFactory.Close())
-				errs = append(errs, tracer.Close(context.Background()))
+				errs = append(errs,
+					storageFactory.Close(),
+					tracer.Close(context.Background()),
+				)
 				if err := errors.Join(errs...); err != nil {
 					logger.Error("Failed to close services", zap.Error(err))
 				}

--- a/cmd/anonymizer/app/anonymizer/anonymizer_test.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer_test.go
@@ -75,7 +75,7 @@ func TestNew(t *testing.T) {
 	require.NoError(t, err)
 	defer file.Close()
 
-	_, err = file.Write([]byte(`
+	_, err = file.WriteString(`
 {
     "services": {
 		"api": "hashed_api"
@@ -84,7 +84,7 @@ func TestNew(t *testing.T) {
 		"[api]:delete": "hashed_api_delete"
 	}
 }
-`))
+`)
 	require.NoError(t, err)
 
 	anonymizer := New(file.Name(), Options{}, nopLogger)

--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -73,9 +73,9 @@ func (e *extractor) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal UI trace: %w", err)
 	}
-	e.uiFile.Write([]byte(`{"data": [`))
+	e.uiFile.WriteString(`{"data": [`)
 	e.uiFile.Write(jsonBytes)
-	e.uiFile.Write([]byte(`]}`))
+	e.uiFile.WriteString(`]}`)
 	e.uiFile.Sync()
 	e.uiFile.Close()
 	e.logger.Sugar().Infof("Wrote spans to UI file %s", e.uiFile.Name())

--- a/cmd/collector/app/collector_test.go
+++ b/cmd/collector/app/collector_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
-var _ (io.Closer) = (*Collector)(nil)
+var _ io.Closer = (*Collector)(nil)
 
 func optionsForEphemeralPorts() *flags.CollectorOptions {
 	collectorOpts := &flags.CollectorOptions{

--- a/cmd/collector/app/handler/otlp_receiver_test.go
+++ b/cmd/collector/app/handler/otlp_receiver_test.go
@@ -56,9 +56,7 @@ func TestStartOtlpReceiver(t *testing.T) {
 	tm := &tenancy.Manager{}
 	rec, err := StartOTLPReceiver(optionsWithPorts(":0"), logger, spanProcessor, tm)
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, rec.Shutdown(context.Background()))
-	}()
+	require.NoError(t, rec.Shutdown(context.Background()))
 
 	// Ideally, we want to test with a real gRPC client, but OTEL repos only have those as internal packages.
 	// So we will rely on otlpreceiver being tested in the OTEL repos, and we only test the consumer function.

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -231,7 +231,7 @@ func (m *SpanProcessorMetrics) GetCountsForFormat(spanFormat processor.SpanForma
 // the span and reports a counter stat.
 func (m metricsBySvc) ForSpanV1(span *model.Span) {
 	var serviceName string
-	if nil == span.Process || len(span.Process.ServiceName) == 0 {
+	if nil == span.Process || span.Process.ServiceName == "" {
 		serviceName = unknownServiceName
 	} else {
 		serviceName = span.Process.ServiceName

--- a/cmd/collector/app/metrics.go
+++ b/cmd/collector/app/metrics.go
@@ -231,7 +231,7 @@ func (m *SpanProcessorMetrics) GetCountsForFormat(spanFormat processor.SpanForma
 // the span and reports a counter stat.
 func (m metricsBySvc) ForSpanV1(span *model.Span) {
 	var serviceName string
-	if nil == span.Process || span.Process.ServiceName == "" {
+	if span.Process == nil || span.Process.ServiceName == "" {
 		serviceName = unknownServiceName
 	} else {
 		serviceName = span.Process.ServiceName

--- a/cmd/collector/app/server/grpc_test.go
+++ b/cmd/collector/app/server/grpc_test.go
@@ -120,7 +120,7 @@ func TestCollectorStartWithTLS(t *testing.T) {
 	}
 	server, err := StartGRPCServer(params)
 	require.NoError(t, err)
-	defer server.Stop()
+	server.Stop()
 }
 
 func TestCollectorReflection(t *testing.T) {

--- a/cmd/collector/app/server/http_test.go
+++ b/cmd/collector/app/server/http_test.go
@@ -89,7 +89,7 @@ func TestSpanCollectorHTTP(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, response)
 	defer response.Body.Close()
-	defer server.Close()
+	server.Close()
 }
 
 func optionalFromPtr[T any](ptr *T) configoptional.Optional[T] {

--- a/cmd/collector/app/server/httpmetrics/metrics_test.go
+++ b/cmd/collector/app/server/httpmetrics/metrics_test.go
@@ -30,7 +30,7 @@ func TestNewMetricsHandler(t *testing.T) {
 	defer mb.Stop()
 	handler := Wrap(dummyHandlerFunc, mb, zap.NewNop())
 
-	req, err := http.NewRequest(http.MethodGet, "/subdir/qwerty", nil)
+	req, err := http.NewRequest(http.MethodGet, "/subdir/qwerty", http.NoBody)
 	require.NoError(t, err)
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
@@ -73,7 +73,7 @@ func TestIllegalPrometheusLabel(t *testing.T) {
 	handler := Wrap(dummyHandlerFunc, mf, zap.NewNop())
 
 	invalidUtf8 := []byte{0xC0, 0xAE, 0xC0, 0xAE}
-	req, err := http.NewRequest(http.MethodGet, string(invalidUtf8), nil)
+	req, err := http.NewRequest(http.MethodGet, string(invalidUtf8), http.NoBody)
 	require.NoError(t, err)
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 }

--- a/cmd/es-rollover/app/rollover/action.go
+++ b/cmd/es-rollover/app/rollover/action.go
@@ -30,7 +30,7 @@ func (a *Action) Do() error {
 
 func (a *Action) rollover(indexSet app.IndexOption) error {
 	conditionsMap := map[string]any{}
-	if len(a.Conditions) > 0 {
+	if a.Conditions != "" {
 		err := json.Unmarshal([]byte(a.Config.Conditions), &conditionsMap)
 		if err != nil {
 			return err

--- a/cmd/ingester/app/consumer/consumer_test.go
+++ b/cmd/ingester/app/consumer/consumer_test.go
@@ -65,7 +65,7 @@ func newSaramaClusterConsumer(saramaPartitionConsumer sarama.PartitionConsumer, 
 		PartitionConsumer: saramaPartitionConsumer,
 	}
 	saramaClusterConsumer := &kmocks.Consumer{}
-	saramaClusterConsumer.On("Partitions").Return((<-chan cluster.PartitionConsumer)(pcha))
+	saramaClusterConsumer.On("Partitions").Return((<-chan cluster.PartitionConsumer)(pcha)) //nolint:gocritic // typeUnparen is failing
 	saramaClusterConsumer.On("Close").Return(nil).Run(func(_ mock.Arguments) {
 		mc.Close()
 		close(pcha)

--- a/cmd/ingester/app/flags.go
+++ b/cmd/ingester/app/flags.go
@@ -105,7 +105,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(
 		KafkaConsumerConfigPrefix+SuffixEncoding,
 		DefaultEncoding,
-		fmt.Sprintf(`The encoding of spans ("%s") consumed from kafka`, strings.Join(kafka.AllEncodings, "\", \"")))
+		fmt.Sprintf(`The encoding of spans (%q) consumed from kafka`, strings.Join(kafka.AllEncodings, "\", \"")))
 	flagSet.String(
 		KafkaConsumerConfigPrefix+SuffixRackID,
 		"",

--- a/cmd/internal/flags/admin_test.go
+++ b/cmd/internal/flags/admin_test.go
@@ -149,7 +149,7 @@ func TestAdminServerTLS(t *testing.T) {
 				},
 			}
 			url := fmt.Sprintf("https://localhost:%d", ports.CollectorAdminHTTP)
-			req, err := http.NewRequest(http.MethodGet, url, nil)
+			req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 			require.NoError(t, err)
 			req.Close = true // avoid persistent connections which leak goroutines
 			response, requestError := client.Do(req)

--- a/cmd/internal/status/command.go
+++ b/cmd/internal/status/command.go
@@ -30,7 +30,7 @@ func Command(v *viper.Viper, adminPort int) *cobra.Command {
 			url := convert(v.GetString(statusHTTPHostPort))
 			ctx, cx := context.WithTimeout(context.Background(), time.Second)
 			defer cx()
-			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return err

--- a/cmd/jaeger/internal/extension/expvar/extension_test.go
+++ b/cmd/jaeger/internal/extension/expvar/extension_test.go
@@ -46,7 +46,7 @@ func TestExpvarExtension(t *testing.T) {
 			addr := fmt.Sprintf("http://0.0.0.0:%d/", Port)
 			client := &http.Client{}
 			require.Eventually(t, func() bool {
-				r, err := http.NewRequest(http.MethodPost, addr, nil)
+				r, err := http.NewRequest(http.MethodPost, addr, http.NoBody)
 				require.NoError(t, err)
 				resp, err := client.Do(r)
 				require.NoError(t, err)

--- a/cmd/jaeger/internal/integration/binary.go
+++ b/cmd/jaeger/internal/integration/binary.go
@@ -78,7 +78,7 @@ func (b *Binary) doHealthCheck(t *testing.T) bool {
 	t.Logf("Checking if %s is available on %s", b.Name, healthCheckEndpoint)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthCheckEndpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthCheckEndpoint, http.NoBody)
 	if err != nil {
 		t.Logf("HTTP request creation failed: %v", err)
 		return false

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -122,7 +122,7 @@ func (s *E2EStorageIntegration) scrapeMetrics(t *testing.T, storage string) {
 	}
 	metricsUrl := fmt.Sprintf("http://localhost:%d/metrics", metricsPort)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, metricsUrl, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, metricsUrl, http.NoBody)
 	require.NoError(t, err)
 
 	client := &http.Client{}
@@ -219,7 +219,7 @@ func purge(t *testing.T) {
 		addr = purgerAddr
 	}
 	t.Logf("Purging storage via %s", addr)
-	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, addr, nil)
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, addr, http.NoBody)
 	require.NoError(t, err)
 
 	client := &http.Client{}

--- a/cmd/jaeger/internal/integration/storagecleaner/extension_test.go
+++ b/cmd/jaeger/internal/integration/storagecleaner/extension_test.go
@@ -106,7 +106,7 @@ func TestStorageCleanerExtension(t *testing.T) {
 			addr := fmt.Sprintf("http://0.0.0.0:%s%s", Port, URL)
 			client := &http.Client{}
 			require.Eventually(t, func() bool {
-				r, err := http.NewRequest(http.MethodPost, addr, nil)
+				r, err := http.NewRequest(http.MethodPost, addr, http.NoBody)
 				require.NoError(t, err)
 				resp, err := client.Do(r)
 				require.NoError(t, err)

--- a/cmd/query/app/additional_headers_test.go
+++ b/cmd/query/app/additional_headers_test.go
@@ -28,7 +28,7 @@ func TestResponseHeadersHandler(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
 	require.NoError(t, err)
 
 	resp, err := server.Client().Do(req)

--- a/cmd/query/app/apiv3/gateway_test.go
+++ b/cmd/query/app/apiv3/gateway_test.go
@@ -51,7 +51,7 @@ type testGateway struct {
 }
 
 func (gw *testGateway) execRequest(t *testing.T, url string) ([]byte, int) {
-	req, err := http.NewRequest(http.MethodGet, gw.url+url, nil)
+	req, err := http.NewRequest(http.MethodGet, gw.url+url, http.NoBody)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	gw.setupRequest(req)

--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -141,7 +141,7 @@ func TestHTTPGatewayGetTrace(t *testing.T) {
 				testUrl += "?" + q.Encode()
 			}
 
-			r, err := http.NewRequest(http.MethodGet, testUrl, nil)
+			r, err := http.NewRequest(http.MethodGet, testUrl, http.NoBody)
 			require.NoError(t, err)
 			w := httptest.NewRecorder()
 			gw.router.ServeHTTP(w, r)
@@ -157,7 +157,7 @@ func TestHTTPGatewayGetTraceEmptyResponse(t *testing.T) {
 			yield([]ptrace.Traces{}, nil)
 		})).Once()
 
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces/1", nil)
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces/1", http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
@@ -167,7 +167,7 @@ func TestHTTPGatewayGetTraceEmptyResponse(t *testing.T) {
 
 func TestHTTPGatewayFindTracesEmptyResponse(t *testing.T) {
 	q, qp := mockFindQueries()
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), nil)
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 
@@ -219,7 +219,7 @@ func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 					yield([]ptrace.Traces{}, nil)
 				})).Once()
 
-			r, err := http.NewRequest(http.MethodGet, tc.requestUrl, nil)
+			r, err := http.NewRequest(http.MethodGet, tc.requestUrl, http.NoBody)
 			require.NoError(t, err)
 			w := httptest.NewRecorder()
 			gw.router.ServeHTTP(w, r)
@@ -235,7 +235,7 @@ func TestHTTPGatewayGetTraceInternalErrors(t *testing.T) {
 			yield([]ptrace.Traces{}, assert.AnError)
 		})).Once()
 
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces/1", nil)
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces/1", http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
@@ -335,7 +335,7 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 			for k, v := range tc.params {
 				q.Set(k, v)
 			}
-			r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), nil)
+			r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
 			require.NoError(t, err)
 			w := httptest.NewRecorder()
 
@@ -346,7 +346,7 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 	}
 	t.Run("span reader error", func(t *testing.T) {
 		q, qp := mockFindQueries()
-		r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), nil)
+		r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
 		require.NoError(t, err)
 		w := httptest.NewRecorder()
 
@@ -369,7 +369,7 @@ func TestHTTPGatewayGetServicesErrors(t *testing.T) {
 		On("GetServices", matchContext).
 		Return(nil, assert.AnError).Once()
 
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/services", nil)
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/services", http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
@@ -384,7 +384,7 @@ func TestHTTPGatewayGetOperationsErrors(t *testing.T) {
 		On("GetOperations", matchContext, qp).
 		Return(nil, assert.AnError).Once()
 
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&span_kind=server", nil)
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&span_kind=server", http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)

--- a/cmd/query/app/http_handler.go
+++ b/cmd/query/app/http_handler.go
@@ -395,7 +395,7 @@ func (*APIHandler) filterDependenciesByService(
 	dependencies []model.DependencyLink,
 	service string,
 ) []model.DependencyLink {
-	if len(service) == 0 {
+	if service == "" {
 		return dependencies
 	}
 

--- a/cmd/query/app/http_handler_test.go
+++ b/cmd/query/app/http_handler_test.go
@@ -867,7 +867,7 @@ func TestGetMetricsSuccess(t *testing.T) {
 
 func TestGetQualityMetrics(t *testing.T) {
 	handler := &APIHandler{}
-	req := httptest.NewRequest(http.MethodGet, "/quality-metrics", nil)
+	req := httptest.NewRequest(http.MethodGet, "/quality-metrics", http.NoBody)
 	rr := httptest.NewRecorder()
 	handler.getQualityMetrics(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
@@ -879,7 +879,7 @@ func TestGetQualityMetrics(t *testing.T) {
 
 func TestGetDeepDependenciesData(t *testing.T) {
 	handler := &APIHandler{}
-	req := httptest.NewRequest(http.MethodGet, "/deep-dependencies?service=customer", nil)
+	req := httptest.NewRequest(http.MethodGet, "/deep-dependencies?service=customer", http.NoBody)
 	rr := httptest.NewRecorder()
 
 	handler.deepDependencies(rr, req)
@@ -997,7 +997,7 @@ func getJSON(url string, out any) error {
 }
 
 func getJSONCustomHeaders(url string, additionalHeaders map[string]string, out any) error {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -1104,7 +1104,7 @@ func TestSearchTenancyRejectionHTTP(t *testing.T) {
 	ts.spanReader.On("GetTrace", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("spanstore.GetTraceParameters")).
 		Return(mockTrace, nil).Twice()
 
-	req, err := http.NewRequest(http.MethodGet, ts.server.URL+`/api/traces?traceID=1&traceID=2`, nil)
+	req, err := http.NewRequest(http.MethodGet, ts.server.URL+`/api/traces?traceID=1&traceID=2`, http.NoBody)
 	require.NoError(t, err)
 	req.Header.Add("Accept", "application/json")
 	// We don't set tenant header

--- a/cmd/query/app/query_parser_test.go
+++ b/cmd/query/app/query_parser_test.go
@@ -205,7 +205,7 @@ func TestParseTraceQuery(t *testing.T) {
 	for _, tc := range tests {
 		test := tc // capture loop var
 		t.Run(test.urlStr, func(t *testing.T) {
-			request, err := http.NewRequest(http.MethodGet, test.urlStr, nil)
+			request, err := http.NewRequest(http.MethodGet, test.urlStr, http.NoBody)
 			require.NoError(t, err)
 			parser := &queryParser{
 				timeNow: func() time.Time {
@@ -248,7 +248,7 @@ func TestParseBool(t *testing.T) {
 		{"0", false},
 	} {
 		t.Run(tc.input, func(t *testing.T) {
-			request, err := http.NewRequest(http.MethodGet, "x?service=foo&groupByOperation="+tc.input, nil)
+			request, err := http.NewRequest(http.MethodGet, "x?service=foo&groupByOperation="+tc.input, http.NoBody)
 			require.NoError(t, err)
 			timeNow := time.Now()
 			parser := &queryParser{
@@ -264,7 +264,7 @@ func TestParseBool(t *testing.T) {
 }
 
 func TestParseDuration(t *testing.T) {
-	request, err := http.NewRequest(http.MethodGet, "x?service=foo&step=1000", nil)
+	request, err := http.NewRequest(http.MethodGet, "x?service=foo&step=1000", http.NoBody)
 	require.NoError(t, err)
 	parser := &queryParser{
 		timeNow: time.Now,
@@ -275,7 +275,7 @@ func TestParseDuration(t *testing.T) {
 }
 
 func TestParseRepeatedServices(t *testing.T) {
-	request, err := http.NewRequest(http.MethodGet, "x?service=foo&service=bar", nil)
+	request, err := http.NewRequest(http.MethodGet, "x?service=foo&service=bar", http.NoBody)
 	require.NoError(t, err)
 	parser := &queryParser{
 		timeNow: time.Now,
@@ -287,7 +287,7 @@ func TestParseRepeatedServices(t *testing.T) {
 
 func TestParseRepeatedSpanKinds(t *testing.T) {
 	q := "x?service=foo&spanKind=unspecified&spanKind=internal&spanKind=server&spanKind=client&spanKind=producer&spanKind=consumer"
-	request, err := http.NewRequest(http.MethodGet, q, nil)
+	request, err := http.NewRequest(http.MethodGet, q, http.NoBody)
 	require.NoError(t, err)
 	parser := &queryParser{
 		timeNow: time.Now,

--- a/cmd/query/app/server.go
+++ b/cmd/query/app/server.go
@@ -236,8 +236,10 @@ func createHTTPServer(
 
 func (hS httpServer) Close() error {
 	var errs []error
-	errs = append(errs, hS.Server.Close())
-	errs = append(errs, hS.staticHandlerCloser.Close())
+	errs = append(errs,
+		hS.Server.Close(),
+		hS.staticHandlerCloser.Close(),
+	)
 	return errors.Join(errs...)
 }
 

--- a/cmd/query/app/server_test.go
+++ b/cmd/query/app/server_test.go
@@ -416,7 +416,7 @@ func TestServerHTTPTLS(t *testing.T) {
 				}
 				querySvc.spanReader.On("FindTraces", mock.Anything, mock.Anything).Return([]*model.Trace{mockTrace}, nil).Once()
 				queryString := "/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms"
-				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/%s", server.HTTPAddr(), queryString), nil)
+				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/%s", server.HTTPAddr(), queryString), http.NoBody)
 				require.NoError(t, err)
 				req.Header.Add("Accept", "application/json")
 
@@ -764,7 +764,7 @@ func TestServerHTTPTenancy(t *testing.T) {
 			require.NoError(t, clientError)
 
 			queryString := "/api/traces?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20ms"
-			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080"+queryString, nil)
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080"+queryString, http.NoBody)
 			if test.tenant != "" {
 				req.Header.Add(tenancyMgr.Header, test.tenant)
 			}
@@ -863,7 +863,7 @@ func TestServerHTTP_TracesRequest(t *testing.T) {
 				require.NoError(t, server.Close())
 			})
 
-			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080"+test.queryString, nil)
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080"+test.queryString, http.NoBody)
 			require.NoError(t, err)
 
 			client := &http.Client{}

--- a/cmd/query/app/token_propagation_test.go
+++ b/cmd/query/app/token_propagation_test.go
@@ -147,7 +147,7 @@ func TestBearerTokenPropagation(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, url, nil)
+			req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 			require.NoError(t, err)
 			req.Header.Add(testCase.headerName, testCase.headerValue)
 

--- a/cmd/query/app/trace_response_handler_test.go
+++ b/cmd/query/app/trace_response_handler_test.go
@@ -30,7 +30,7 @@ func TestTraceResponseHandler(t *testing.T) {
 	ctx, span := tracer.Start(context.Background(), "test-span")
 	defer span.End()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8080", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8080", http.NoBody)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()

--- a/crossdock/services/query.go
+++ b/crossdock/services/query.go
@@ -67,7 +67,8 @@ func (s *queryService) GetTraces(serviceName, operation string, tags map[string]
 	s.logger.Info("GetTraces: received response from query", zap.String("body", string(body)), zap.String("url", fmtURL))
 
 	var queryResponse response
-	if err = json.Unmarshal(body, &queryResponse); err != nil {
+	err = json.Unmarshal(body, &queryResponse)
+	if err != nil {
 		return nil, err
 	}
 	return queryResponse.Data, nil

--- a/examples/hotrod/pkg/log/spanlogger.go
+++ b/examples/hotrod/pkg/log/spanlogger.go
@@ -99,7 +99,7 @@ func (e *bridgeFieldEncoder) AddComplex64(key string, value complex64) {
 }
 
 func (e *bridgeFieldEncoder) AddDuration(key string, value time.Duration) {
-	e.pairs = append(e.pairs, attribute.String(key, fmt.Sprint(value)))
+	e.pairs = append(e.pairs, attribute.String(key, value.String()))
 }
 
 func (e *bridgeFieldEncoder) AddFloat64(key string, value float64) {
@@ -135,7 +135,7 @@ func (e *bridgeFieldEncoder) AddString(key, value string) {
 }
 
 func (e *bridgeFieldEncoder) AddTime(key string, value time.Time) {
-	e.pairs = append(e.pairs, attribute.String(key, fmt.Sprint(value)))
+	e.pairs = append(e.pairs, attribute.String(key, value.String()))
 }
 
 func (e *bridgeFieldEncoder) AddUint(key string, value uint) {

--- a/examples/hotrod/pkg/tracing/http.go
+++ b/examples/hotrod/pkg/tracing/http.go
@@ -36,7 +36,7 @@ func NewHTTPClient(tp trace.TracerProvider) *HTTPClient {
 // GetJSON executes HTTP GET against specified url and tried to parse
 // the response into out object.
 func (c *HTTPClient) GetJSON(ctx context.Context, _ string /* endpoint */, url string, out any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return err
 	}

--- a/internal/auth/bearertoken/http_test.go
+++ b/internal/auth/bearertoken/http_test.go
@@ -64,7 +64,7 @@ func Test_PropagationHandler(t *testing.T) {
 			r := PropagationHandler(logger, testCase.handler(&stop))
 			server := httptest.NewServer(r)
 			defer server.Close()
-			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
 			require.NoError(t, err)
 			if testCase.sendHeader {
 				req.Header.Add(testCase.headerName, testCase.headerValue)

--- a/internal/auth/transport_test.go
+++ b/internal/auth/transport_test.go
@@ -133,7 +133,7 @@ func TestRoundTripper(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})
 
-			req, err := http.NewRequestWithContext(tc.requestContext, http.MethodGet, "http://fake.example.com/api", nil)
+			req, err := http.NewRequestWithContext(tc.requestContext, http.MethodGet, "http://fake.example.com/api", http.NoBody)
 			require.NoError(t, err)
 
 			var transport http.RoundTripper = wrappedTransport

--- a/internal/config/tlscfg/options.go
+++ b/internal/config/tlscfg/options.go
@@ -41,7 +41,7 @@ func (o *options) ToOtelClientConfig() configtls.ClientConfig {
 
 			// when no truststore given, use SystemCertPool
 			// https://github.com/jaegertracing/jaeger/issues/6334
-			IncludeSystemCACertsPool: o.Enabled && (len(o.CAPath) == 0),
+			IncludeSystemCACertsPool: o.Enabled && (o.CAPath == ""),
 		},
 	}
 }

--- a/internal/gzipfs/gzip_test.go
+++ b/internal/gzipfs/gzip_test.go
@@ -134,7 +134,7 @@ func TestFileStatError(t *testing.T) {
 }
 
 func TestFileRead(t *testing.T) {
-	f := &file{content: ([]byte)("long content")}
+	f := &file{content: []byte("long content")}
 	buf := make([]byte, 5) // shorter buffer
 	n, err := f.Read(buf)
 	require.NoError(t, err)

--- a/internal/healthcheck/handler.go
+++ b/internal/healthcheck/handler.go
@@ -6,7 +6,6 @@ package healthcheck
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -99,7 +98,7 @@ func (*HealthCheck) createRespBody(state state, template healthCheckResponse) []
 	resp := template // clone
 	if state.status == Ready {
 		resp.UpSince = state.upSince
-		resp.Uptime = fmt.Sprintf("%v", time.Since(state.upSince))
+		resp.Uptime = time.Since(state.upSince).String()
 	}
 	healthCheckStatus, _ := json.Marshal(resp)
 	return healthCheckStatus

--- a/internal/healthcheck/handler_test.go
+++ b/internal/healthcheck/handler_test.go
@@ -43,7 +43,7 @@ func TestStatusSetGet(t *testing.T) {
 
 func TestHealthCheck_Handler_ContentType(t *testing.T) {
 	rec := httptest.NewRecorder()
-	healthcheck.New().Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	healthcheck.New().Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 	resp := rec.Result()
 
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))

--- a/internal/metrics/prometheus/factory.go
+++ b/internal/metrics/prometheus/factory.go
@@ -118,7 +118,7 @@ func newFactory(parent *Factory, scope string, tags map[string]string) *Factory 
 // Counter implements Counter of metrics.Factory.
 func (f *Factory) Counter(options metrics.Options) metrics.Counter {
 	help := strings.TrimSpace(options.Help)
-	if len(help) == 0 {
+	if help == "" {
 		help = options.Name
 	}
 	name := counterNamingConvention(f.subScope(options.Name))
@@ -143,7 +143,7 @@ func (f *Factory) Counter(options metrics.Options) metrics.Counter {
 // Gauge implements Gauge of metrics.Factory.
 func (f *Factory) Gauge(options metrics.Options) metrics.Gauge {
 	help := strings.TrimSpace(options.Help)
-	if len(help) == 0 {
+	if help == "" {
 		help = options.Name
 	}
 	name := f.subScope(options.Name)
@@ -167,7 +167,7 @@ func (f *Factory) Gauge(options metrics.Options) metrics.Gauge {
 // Timer implements Timer of metrics.Factory.
 func (f *Factory) Timer(options metrics.TimerOptions) metrics.Timer {
 	help := strings.TrimSpace(options.Help)
-	if len(help) == 0 {
+	if help == "" {
 		help = options.Name
 	}
 	name := f.subScope(options.Name)
@@ -201,7 +201,7 @@ func asFloatBuckets(buckets []time.Duration) []float64 {
 // Histogram implements Histogram of metrics.Factory.
 func (f *Factory) Histogram(options metrics.HistogramOptions) metrics.Histogram {
 	help := strings.TrimSpace(options.Help)
-	if len(help) == 0 {
+	if help == "" {
 		help = options.Name
 	}
 	name := f.subScope(options.Name)

--- a/internal/recoveryhandler/zap_test.go
+++ b/internal/recoveryhandler/zap_test.go
@@ -23,7 +23,7 @@ func TestNewRecoveryHandler(t *testing.T) {
 	})
 
 	recovery := NewRecoveryHandler(logger, false)(handlerFunc)
-	req, err := http.NewRequest(http.MethodGet, "/subdir/asdf", nil)
+	req, err := http.NewRequest(http.MethodGet, "/subdir/asdf", http.NoBody)
 	require.NoError(t, err)
 
 	res := httptest.NewRecorder()

--- a/internal/sampling/http/handler.go
+++ b/internal/sampling/http/handler.go
@@ -196,7 +196,7 @@ func (*Handler) encodeThriftEnums092(jsonData []byte) []byte {
 	for _, strategyType := range samplingStrategyTypes {
 		str = strings.Replace(
 			str,
-			fmt.Sprintf(`"strategyType":"%s"`, strategyType.String()),
+			fmt.Sprintf(`"strategyType":%q`, strategyType.String()),
 			fmt.Sprintf(`"strategyType":%d`, strategyType),
 			1,
 		)

--- a/internal/sampling/http/handler_test.go
+++ b/internal/sampling/http/handler_test.go
@@ -244,7 +244,7 @@ func TestHTTPHandlerErrors(t *testing.T) {
 			withServer("", probabilistic(0.001), withGorilla, func(ts *testServer) {
 				handler := ts.handler
 
-				req := httptest.NewRequest(http.MethodGet, "http://localhost:80/?service=X", nil)
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:80/?service=X", http.NoBody)
 				w := &mockWriter{header: make(http.Header)}
 				handler.serveSamplingHTTP(w, req, handler.encodeThriftLegacy)
 

--- a/internal/sampling/samplingstrategy/file/provider.go
+++ b/internal/sampling/samplingstrategy/file/provider.go
@@ -95,7 +95,7 @@ func (h *samplingProvider) downloadSamplingStrategies(samplingURL string) ([]byt
 
 	ctx, cx := context.WithTimeout(context.Background(), time.Second)
 	defer cx()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, samplingURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, samplingURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("cannot construct HTTP request: %w", err)
 	}

--- a/internal/storage/elasticsearch/client/client.go
+++ b/internal/storage/elasticsearch/client/client.go
@@ -67,7 +67,7 @@ func (c *Client) request(esRequest elasticRequest) ([]byte, error) {
 		reader = bytes.NewBuffer(esRequest.body)
 		r, err = http.NewRequestWithContext(context.Background(), esRequest.method, fmt.Sprintf("%s/%s", c.Endpoint, esRequest.endpoint), reader)
 	} else {
-		r, err = http.NewRequestWithContext(context.Background(), esRequest.method, fmt.Sprintf("%s/%s", c.Endpoint, esRequest.endpoint), nil)
+		r, err = http.NewRequestWithContext(context.Background(), esRequest.method, fmt.Sprintf("%s/%s", c.Endpoint, esRequest.endpoint), http.NoBody)
 	}
 	if err != nil {
 		return []byte{}, err

--- a/internal/storage/elasticsearch/client/cluster_client.go
+++ b/internal/storage/elasticsearch/client/cluster_client.go
@@ -32,7 +32,8 @@ func (c *ClusterClient) Version() (uint, error) {
 		return 0, err
 	}
 	var info clusterInfo
-	if err = json.Unmarshal(body, &info); err != nil {
+	err = json.Unmarshal(body, &info)
+	if err != nil {
 		return 0, err
 	}
 

--- a/internal/storage/elasticsearch/client/index_client_test.go
+++ b/internal/storage/elasticsearch/client/index_client_test.go
@@ -167,8 +167,10 @@ func TestClientGetIndices(t *testing.T) {
 func getIndicesList(size int) []Index {
 	indicesList := []Index{}
 	for count := 1; count <= size/2; count++ {
-		indicesList = append(indicesList, Index{Index: fmt.Sprintf("jaeger-span-%06d", count)})
-		indicesList = append(indicesList, Index{Index: fmt.Sprintf("jaeger-service-%06d", count)})
+		indicesList = append(indicesList,
+			Index{Index: fmt.Sprintf("jaeger-span-%06d", count)},
+			Index{Index: fmt.Sprintf("jaeger-service-%06d", count)},
+		)
 	}
 	return indicesList
 }

--- a/internal/storage/elasticsearch/client/index_client_test.go
+++ b/internal/storage/elasticsearch/client/index_client_test.go
@@ -156,7 +156,7 @@ func TestClientGetIndices(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				sort.Slice(indices, func(i, j int) bool {
-					return strings.Compare(indices[i].Index, indices[j].Index) < 0
+					return indices[i].Index < indices[j].Index
 				})
 				assert.Equal(t, test.indices, indices)
 			}

--- a/internal/storage/kafka/consumer/config.go
+++ b/internal/storage/kafka/consumer/config.go
@@ -48,7 +48,7 @@ func (c *Configuration) NewConsumer(logger *zap.Logger) (Consumer, error) {
 	saramaConfig.ClientID = c.ClientID
 	saramaConfig.RackID = c.RackID
 	saramaConfig.Consumer.Fetch.Default = c.FetchMaxMessageBytes
-	if len(c.ProtocolVersion) > 0 {
+	if c.ProtocolVersion != "" {
 		ver, err := sarama.ParseKafkaVersion(c.ProtocolVersion)
 		if err != nil {
 			return nil, err

--- a/internal/storage/kafka/producer/config.go
+++ b/internal/storage/kafka/producer/config.go
@@ -44,7 +44,7 @@ func (c *Configuration) NewProducer(logger *zap.Logger) (sarama.AsyncProducer, e
 	saramaConfig.Producer.Flush.Messages = c.BatchMinMessages
 	saramaConfig.Producer.Flush.MaxMessages = c.BatchMaxMessages
 	saramaConfig.Producer.MaxMessageBytes = c.MaxMessageBytes
-	if len(c.ProtocolVersion) > 0 {
+	if c.ProtocolVersion != "" {
 		ver, err := sarama.ParseKafkaVersion(c.ProtocolVersion)
 		if err != nil {
 			return nil, err

--- a/internal/storage/metricstore/prometheus/metricstore/reader.go
+++ b/internal/storage/metricstore/prometheus/metricstore/reader.go
@@ -136,7 +136,7 @@ func (m MetricsReader) GetLatencies(ctx context.Context, requestParams *metricst
 		buildPromQuery: func(p promQueryParams) string {
 			return fmt.Sprintf(
 				// Note: p.spanKindFilter can be ""; trailing commas are okay within a timeseries selection.
-				`histogram_quantile(%.2f, sum(rate(%s_bucket{service_name =~ "%s", %s}[%s])) by (%s))`,
+				`histogram_quantile(%.2f, sum(rate(%s_bucket{service_name =~ %q, %s}[%s])) by (%s))`,
 				requestParams.Quantile,
 				m.latencyMetricName,
 				p.serviceFilter,
@@ -179,7 +179,7 @@ func (m MetricsReader) GetCallRates(ctx context.Context, requestParams *metricst
 		buildPromQuery: func(p promQueryParams) string {
 			return fmt.Sprintf(
 				// Note: p.spanKindFilter can be ""; trailing commas are okay within a timeseries selection.
-				`sum(rate(%s{service_name =~ "%s", %s}[%s])) by (%s)`,
+				`sum(rate(%s{service_name =~ %q, %s}[%s])) by (%s)`,
 				m.callsMetricName,
 				p.serviceFilter,
 				p.spanKindFilter,
@@ -213,7 +213,7 @@ func (m MetricsReader) GetErrorRates(ctx context.Context, requestParams *metrics
 		buildPromQuery: func(p promQueryParams) string {
 			return fmt.Sprintf(
 				// Note: p.spanKindFilter can be ""; trailing commas are okay within a timeseries selection.
-				`sum(rate(%s{service_name =~ "%s", status_code = "STATUS_CODE_ERROR", %s}[%s])) by (%s) / sum(rate(%s{service_name =~ "%s", %s}[%s])) by (%s)`,
+				`sum(rate(%s{service_name =~ %q, status_code = "STATUS_CODE_ERROR", %s}[%s])) by (%s) / sum(rate(%s{service_name =~ %q, %s}[%s])) by (%s)`,
 				m.callsMetricName, p.serviceFilter, p.spanKindFilter, p.rate, p.groupBy,
 				m.callsMetricName, p.serviceFilter, p.spanKindFilter, p.rate, p.groupBy,
 			)
@@ -306,7 +306,7 @@ func (m MetricsReader) buildPromQuery(metricsParams metricsQueryParams) string {
 
 	spanKindFilter := ""
 	if len(metricsParams.SpanKinds) > 0 {
-		spanKindFilter = fmt.Sprintf(`span_kind =~ "%s"`, strings.Join(metricsParams.SpanKinds, "|"))
+		spanKindFilter = fmt.Sprintf(`span_kind =~ %q`, strings.Join(metricsParams.SpanKinds, "|"))
 	}
 	promParams := promQueryParams{
 		serviceFilter:  strings.Join(metricsParams.ServiceNames, "|"),

--- a/internal/storage/metricstore/prometheus/metricstore/reader_test.go
+++ b/internal/storage/metricstore/prometheus/metricstore/reader_test.go
@@ -779,7 +779,7 @@ func TestGetRoundTripperTLSConfig(t *testing.T) {
 				bearertoken.ContextWithBearerToken(context.Background(), "foo"),
 				http.MethodGet,
 				server.URL,
-				nil,
+				http.NoBody,
 			)
 			require.NoError(t, err)
 
@@ -817,7 +817,7 @@ func TestGetRoundTripperTokenFile(t *testing.T) {
 		ctx,
 		http.MethodGet,
 		server.URL,
-		nil,
+		http.NoBody,
 	)
 	require.NoError(t, err)
 
@@ -851,7 +851,7 @@ func TestGetRoundTripperTokenFromContext(t *testing.T) {
 		ctx,
 		http.MethodGet,
 		server.URL,
-		nil,
+		http.NoBody,
 	)
 	require.NoError(t, err)
 

--- a/internal/storage/metricstore/prometheus/metricstore/reader_test.go
+++ b/internal/storage/metricstore/prometheus/metricstore/reader_test.go
@@ -798,7 +798,7 @@ func TestGetRoundTripperTokenFile(t *testing.T) {
 	file, err := os.Create(t.TempDir() + "token_")
 	require.NoError(t, err)
 
-	_, err = file.Write([]byte(wantBearer))
+	_, err = file.WriteString(wantBearer)
 	require.NoError(t, err)
 	require.NoError(t, file.Close())
 
@@ -832,7 +832,7 @@ func TestGetRoundTripperTokenFromContext(t *testing.T) {
 	file, err := os.Create(t.TempDir() + "token_")
 	require.NoError(t, err)
 
-	_, err = file.Write([]byte("token from file"))
+	_, err = file.WriteString("token from file")
 	require.NoError(t, err)
 	require.NoError(t, file.Close())
 

--- a/internal/storage/v1/badger/config.go
+++ b/internal/storage/v1/badger/config.go
@@ -16,8 +16,11 @@ const (
 	defaultMetricsUpdateInterval time.Duration = 10 * time.Second
 	defaultTTL                   time.Duration = time.Hour * 72
 	defaultDataDir               string        = string(os.PathSeparator) + "data"
-	defaultValueDir              string        = defaultDataDir + string(os.PathSeparator) + "values"
-	defaultKeysDir               string        = defaultDataDir + string(os.PathSeparator) + "keys"
+)
+
+var (
+	defaultValueDir string = filepath.Join(defaultDataDir, "values")
+	defaultKeysDir  string = filepath.Join(defaultDataDir, "keys")
 )
 
 // Config is badger's internal configuration data.

--- a/internal/storage/v1/badger/factory.go
+++ b/internal/storage/v1/badger/factory.go
@@ -238,12 +238,13 @@ func (f *Factory) metricsCopier() {
 		case <-metricsTicker.C:
 			expvar.Do(func(kv expvar.KeyValue) {
 				if strings.HasPrefix(kv.Key, "badger") {
-					if intVal, ok := kv.Value.(*expvar.Int); ok {
+					switch val := kv.Value.(type) {
+					case *expvar.Int:
 						if g, found := f.metrics.badgerMetrics[kv.Key]; found {
-							g.Update(intVal.Value())
+							g.Update(val.Value())
 						}
-					} else if mapVal, ok := kv.Value.(*expvar.Map); ok {
-						mapVal.Do(func(innerKv expvar.KeyValue) {
+					case *expvar.Map:
+						val.Do(func(innerKv expvar.KeyValue) {
 							// The metrics we're interested in have only a single inner key (dynamic name)
 							// and we're only interested in its value
 							if intVal, ok := innerKv.Value.(*expvar.Int); ok {
@@ -264,14 +265,15 @@ func (f *Factory) registerBadgerExpvarMetrics(metricsFactory metrics.Factory) {
 
 	expvar.Do(func(kv expvar.KeyValue) {
 		if strings.HasPrefix(kv.Key, "badger") {
-			if _, ok := kv.Value.(*expvar.Int); ok {
+			switch val := kv.Value.(type) {
+			case *expvar.Int:
 				g := metricsFactory.Gauge(metrics.Options{Name: kv.Key})
 				f.metrics.badgerMetrics[kv.Key] = g
-			} else if mapVal, ok := kv.Value.(*expvar.Map); ok {
-				mapVal.Do(func(innerKv expvar.KeyValue) {
+			case *expvar.Map:
+				val.Do(func(innerKv expvar.KeyValue) {
 					// The metrics we're interested in have only a single inner key (dynamic name)
 					// and we're only interested in its value
-					if _, ok = innerKv.Value.(*expvar.Int); ok {
+					if _, ok := innerKv.Value.(*expvar.Int); ok {
 						g := metricsFactory.Gauge(metrics.Options{Name: kv.Key})
 						f.metrics.badgerMetrics[kv.Key] = g
 					}

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -67,9 +67,11 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 		return err
 	}
 
-	entriesToStore = append(entriesToStore, trace)
-	entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(serviceNameIndexKey, []byte(span.Process.ServiceName), startTime, span.TraceID), nil, expireTime))
-	entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), nil, expireTime))
+	entriesToStore = append(entriesToStore,
+		trace,
+		w.createBadgerEntry(createIndexKey(serviceNameIndexKey, []byte(span.Process.ServiceName), startTime, span.TraceID), nil, expireTime),
+		w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), nil, expireTime),
+	)
 
 	// It doesn't matter if we overwrite Duration index keys, everything is read at Trace level in any case
 	durationValue := make([]byte, 8)

--- a/internal/storage/v1/cassandra/options.go
+++ b/internal/storage/v1/cassandra/options.go
@@ -249,7 +249,7 @@ func (opt *Options) GetConfig() config.Configuration {
 
 // TagIndexBlacklist returns the list of blacklisted tags
 func (opt *Options) TagIndexBlacklist() []string {
-	if len(opt.Index.TagBlackList) > 0 {
+	if opt.Index.TagBlackList != "" {
 		return strings.Split(opt.Index.TagBlackList, ",")
 	}
 
@@ -258,7 +258,7 @@ func (opt *Options) TagIndexBlacklist() []string {
 
 // TagIndexWhitelist returns the list of whitelisted tags
 func (opt *Options) TagIndexWhitelist() []string {
-	if len(opt.Index.TagWhiteList) > 0 {
+	if opt.Index.TagWhiteList != "" {
 		return strings.Split(opt.Index.TagWhiteList, ",")
 	}
 

--- a/internal/storage/v1/cassandra/schema/schema.go
+++ b/internal/storage/v1/cassandra/schema/schema.go
@@ -103,7 +103,7 @@ func (*Creator) getQueriesFromBytes(queryFile []byte) ([]string, error) {
 		}
 	}
 
-	if len(queryString) > 0 {
+	if queryString != "" {
 		return nil, errors.New(`query exists in template without ";"`)
 	}
 

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -92,7 +92,8 @@ func NewFactoryBase(
 		}
 	}
 
-	if err = f.createTemplates(ctx); err != nil {
+	err = f.createTemplates(ctx)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -312,7 +312,7 @@ func TestESStorageFactoryWithConfig(t *testing.T) {
 	}
 	factory, err := NewFactoryBase(context.Background(), cfg, metrics.NullFactory, zap.NewNop())
 	require.NoError(t, err)
-	defer factory.Close()
+	factory.Close()
 }
 
 func TestESStorageFactoryWithConfigError(t *testing.T) {

--- a/internal/storage/v1/elasticsearch/options.go
+++ b/internal/storage/v1/elasticsearch/options.go
@@ -477,7 +477,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.UseILM = v.GetBool(cfg.namespace + suffixUseILM)
 
 	remoteReadClusters := stripWhiteSpace(v.GetString(cfg.namespace + suffixRemoteReadClusters))
-	if len(remoteReadClusters) > 0 {
+	if remoteReadClusters != "" {
 		cfg.RemoteReadClusters = strings.Split(remoteReadClusters, ",")
 	}
 

--- a/internal/storage/v1/kafka/options.go
+++ b/internal/storage/v1/kafka/options.go
@@ -163,7 +163,7 @@ func (*Options) AddFlags(flagSet *flag.FlagSet) {
 	flagSet.String(
 		configPrefix+suffixEncoding,
 		defaultEncoding,
-		fmt.Sprintf(`Encoding of spans ("%s" or "%s") sent to kafka.`, EncodingJSON, EncodingProto),
+		fmt.Sprintf(`Encoding of spans (%q or %q) sent to kafka.`, EncodingJSON, EncodingProto),
 	)
 
 	auth.AddFlags(configPrefix, flagSet)

--- a/internal/storage/v2/badger/factory_test.go
+++ b/internal/storage/v2/badger/factory_test.go
@@ -61,5 +61,5 @@ func TestBadgerStorageFactoryWithConfig(t *testing.T) {
 	}
 	factory, err := NewFactory(cfg, metrics.NullFactory, zaptest.NewLogger(t))
 	require.NoError(t, err)
-	defer factory.Close()
+	factory.Close()
 }

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel.go
@@ -441,8 +441,10 @@ func (link *LinkColumnSet) linkInput() proto.Input {
 func (acm attributeColumnsMap) attributesInput() proto.Input {
 	var result []proto.InputColumn
 	for _, pair := range acm {
-		result = append(result, input(pair.keyColName, pair.keyCol))
-		result = append(result, input(pair.valueColName, pair.valueCol))
+		result = append(result, 
+			input(pair.keyColName, pair.keyCol),
+			input(pair.valueColName, pair.valueCol),
+		)
 	}
 	return result
 }

--- a/internal/storage/v2/elasticsearch/factory_test.go
+++ b/internal/storage/v2/elasticsearch/factory_test.go
@@ -56,7 +56,7 @@ func TestESStorageFactoryWithConfig(t *testing.T) {
 	}
 	factory, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
 	require.NoError(t, err)
-	defer factory.Close()
+	factory.Close()
 }
 
 func TestESStorageFactoryErr(t *testing.T) {

--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -67,7 +67,8 @@ func (h *Handler) GetTraces(
 		}
 		for _, trace := range traces {
 			td := jptrace.TracesData(trace)
-			if err = srv.Send(&td); err != nil {
+			err = srv.Send(&td)
+			if err != nil {
 				return err
 			}
 		}
@@ -121,7 +122,8 @@ func (h *Handler) FindTraces(
 		}
 		for _, trace := range traces {
 			td := jptrace.TracesData(trace)
-			if err = srv.Send(&td); err != nil {
+			err = srv.Send(&td)
+			if err != nil {
 				return err
 			}
 		}

--- a/internal/tenancy/flags.go
+++ b/internal/tenancy/flags.go
@@ -33,7 +33,7 @@ func InitFromViper(v *viper.Viper) Options {
 	p.Enabled = v.GetBool(flagTenancyEnabled)
 	p.Header = v.GetString(flagTenancyHeader)
 	tenants := v.GetString(flagValidTenants)
-	if len(tenants) != 0 {
+	if tenants != "" {
 		p.Tenants = strings.Split(tenants, ",")
 	} else {
 		p.Tenants = []string{}

--- a/internal/testutils/leakcheck_test.go
+++ b/internal/testutils/leakcheck_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestVerifyGoLeaksOnce(t *testing.T) {
-	defer testutils.VerifyGoLeaksOnce(t)
+	testutils.VerifyGoLeaksOnce(t)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Which problem is this PR solving?
- 

## Description of the changes
- Enable all rules by default and disable the rules not yet applied

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
