### PR TITLE
chore: enable badLock from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
     gocritic:
       disabled-checks:
         - appendAssign
-        - badLock
         - commentedOutCode
         - deferInLoop
         - dupArg

--- a/cmd/collector/app/queue/bounded_queue_test.go
+++ b/cmd/collector/app/queue/bounded_queue_test.go
@@ -43,7 +43,7 @@ func helper(t *testing.T, startConsumers func(q *BoundedQueue[string], consumerF
 
 		// block further processing until startLock is released
 		startLock.Lock()
-		//nolint:staticcheck // empty section is ok
+		//nolint:gocritic,staticcheck // empty section is ok
 		startLock.Unlock()
 	})
 


### PR DESCRIPTION

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes
- enable badLock from go-critic

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
