### PR TITLE
chore: enable rangeValCopy from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,6 @@ linters:
         - hugeParam
         - importShadow
         - paramTypeCombine # WON'T FIX
-        - rangeValCopy
         - returnAfterHttpError
         - todoCommentWithoutDetail
         - unnamedResult

--- a/cmd/anonymizer/main.go
+++ b/cmd/anonymizer/main.go
@@ -66,8 +66,9 @@ func main() {
 				logger.Error("Failed to close grpc client connection", zap.Error(err))
 			}
 
-			for _, span := range spans {
-				if err := w.WriteSpan(&span); err != nil {
+			for i := range spans {
+				span := &spans[i]
+				if err := w.WriteSpan(span); err != nil {
 					if errors.Is(err, writer.ErrMaxSpansCountReached) {
 						logger.Info("max spans count reached")
 						os.Exit(0)

--- a/internal/storage/v1/grpc/shared/grpc_client.go
+++ b/internal/storage/v1/grpc/shared/grpc_client.go
@@ -152,13 +152,14 @@ func (c *GRPCClient) FindTraces(ctx context.Context, query *spanstore.TraceQuery
 			return nil, fmt.Errorf("stream error: %w", err)
 		}
 
-		for i, span := range received.Spans {
+		for i := range received.Spans {
+			span := &received.Spans[i]
 			if trace == nil || span.TraceID != traceID {
 				trace = &model.Trace{}
 				traceID = span.TraceID
 				traces = append(traces, trace)
 			}
-			trace.Spans = append(trace.Spans, &received.Spans[i])
+			trace.Spans = append(trace.Spans, span)
 		}
 	}
 	return traces, nil

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/to_dbmodel.go
@@ -441,7 +441,7 @@ func (link *LinkColumnSet) linkInput() proto.Input {
 func (acm attributeColumnsMap) attributesInput() proto.Input {
 	var result []proto.InputColumn
 	for _, pair := range acm {
-		result = append(result, 
+		result = append(result,
 			input(pair.keyColName, pair.keyCol),
 			input(pair.valueColName, pair.valueCol),
 		)
@@ -476,7 +476,8 @@ func (acm attributeColumnsMap) appendNestedAttributeGroup(nestedGroup NestedAttr
 	var strValues [][]string
 	var bytesKeys [][]string
 	var bytesValues [][]string
-	for _, group := range nestedGroup.AttributesGroups {
+	for i := range nestedGroup.AttributesGroups {
+		group := &nestedGroup.AttributesGroups[i]
 		boolKeys = append(boolKeys, group.BoolKeys)
 		boolValues = append(boolValues, group.BoolValues)
 		doubleKeys = append(doubleKeys, group.DoubleKeys)


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- enable rangeValCopy from go-critic

## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
