### PR TITLE
Fix - TODO remove redundant sanitize call from queue

### DIFF
--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -277,7 +277,7 @@ func (sp *spanProcessor) processSpans(_ context.Context, batch processor.Batch, 
 	}
 
 	for i, mSpan := range spans {
-		if (batch.GetSpanFormat() == processor.JaegerSpanFormat){
+		if batch.GetSpanFormat() == processor.JaegerSpanFormat {
 			sp.sanitizer(mSpan)
 		}
 		ok := sp.enqueueSpan(mSpan, batch.GetSpanFormat(), batch.GetInboundTransport(), batch.GetTenant())
@@ -290,7 +290,7 @@ func (sp *spanProcessor) processSpans(_ context.Context, batch processor.Batch, 
 }
 
 func (sp *spanProcessor) processItemFromQueue(item queueItem) {
-    sp.processSpan(item.span, item.tenant)
+	sp.processSpan(item.span, item.tenant)
 	sp.metrics.InQueueLatency.Record(time.Since(item.queuedTime))
 }
 

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -287,8 +287,7 @@ func (sp *spanProcessor) processSpans(_ context.Context, batch processor.Batch, 
 }
 
 func (sp *spanProcessor) processItemFromQueue(item queueItem) {
-	// TODO calling sanitizer here contradicts the comment in enqueueSpan about immutable Process.
-	sp.processSpan(sp.sanitizer(item.span), item.tenant)
+	sp.processSpan(item.span, item.tenant)
 	sp.metrics.InQueueLatency.Record(time.Since(item.queuedTime))
 }
 

--- a/cmd/collector/app/span_processor.go
+++ b/cmd/collector/app/span_processor.go
@@ -277,6 +277,9 @@ func (sp *spanProcessor) processSpans(_ context.Context, batch processor.Batch, 
 	}
 
 	for i, mSpan := range spans {
+		if (batch.GetSpanFormat() == processor.JaegerSpanFormat){
+			sp.sanitizer(mSpan)
+		}
 		ok := sp.enqueueSpan(mSpan, batch.GetSpanFormat(), batch.GetInboundTransport(), batch.GetTenant())
 		if !ok && sp.reportBusy {
 			return nil, processor.ErrBusy
@@ -287,7 +290,7 @@ func (sp *spanProcessor) processSpans(_ context.Context, batch processor.Batch, 
 }
 
 func (sp *spanProcessor) processItemFromQueue(item queueItem) {
-	sp.processSpan(item.span, item.tenant)
+    sp.processSpan(item.span, item.tenant)
 	sp.metrics.InQueueLatency.Record(time.Since(item.queuedTime))
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves a TODO

## Description of the changes
- removed sanitize func being called while the spans were in queue


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
