### PR TITLE
[CI] Add upload pr_number artifacts action to ci-e2e-all.yml

### DIFF
--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -60,18 +60,25 @@ jobs:
               head: `${context.payload.workflow_run.head_repository.full_name}:${context.payload.workflow_run.head_branch}`,
             });
             
-            if (pullRequest.data.length > 0) {
-              prNumber = pullRequest.data[0].number;
+            const prArtifactPath = path.join(process.env.GITHUB_WORKSPACE, '.metrics', 'pr_number', 'pr_number.txt');
+            if (fs.existsSync(prArtifactPath)) {
+              prNumber = fs.readFileSync(prArtifactPath, 'utf8').trim();
+              console.log(`Found PR Number from artifact: ${prNumber}`);
             } else {
-              // Fallback to commit SHA if needed
-              const commitSha = context.payload.workflow_run.head_sha;
-              const prsForCommit = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner,
-                repo,
-                commit_sha: commitSha,
-              });
-              if (prsForCommit.data.length > 0) {
-                prNumber = prsForCommit.data[0].number;
+              if (pullRequest.data.length > 0) {
+                prNumber = pullRequest.data[0].number;
+              } else {
+                // Fallback to commit SHA if needed
+                const commitSha = context.payload.workflow_run.head_sha;
+                const prsForCommit = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner,
+                  repo,
+                  commit_sha: commitSha,
+                });
+                if (prsForCommit.data.length > 0) {
+                  prNumber = prsForCommit.data[0].number;
+                  console.log(`Found PR via commit SHA: #${prNumber}`);
+                }
               }
             }
             

--- a/.github/workflows/ci-e2e-all.yml
+++ b/.github/workflows/ci-e2e-all.yml
@@ -39,3 +39,17 @@ jobs:
 
   query:
     uses: ./.github/workflows/ci-e2e-query.yml
+
+  upload_pr_number:
+    name: Save and Upload PR Number as Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number as artifact
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - name: Upload PR number artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves part of https://github.com/jaegertracing/jaeger/issues/6278
- Supports https://github.com/jaegertracing/jaeger/pull/7414

## Description of the changes
- Add upload pr_number artifacts action
- The ci-comment.yml workflow can now detect pr number by downloading the artifact

## How was this change tested?
- from my repostory pull request: https://github.com/pipiland2612/jaeger/pull/2
- log from the action https://github.com/pipiland2612/jaeger/actions/runs/16997159461/job/48190513998: 

```
Successfully extracted metrics_snapshot_elasticsearch_8.x_v2
Processing artifact: diff_metrics_snapshot_elasticsearch_8.x_v2 (ID: 3776313824)
Extracting to /home/runner/work/jaeger/jaeger/.metrics/diff_metrics_snapshot_elasticsearch_8.x_v2
Successfully extracted diff_metrics_snapshot_elasticsearch_8.x_v2

Starting PR number detection...
Workflow run details:
- Head branch: error_branch
- Head repository: pipiland2612/jaeger
- Commit SHA: 49af2ee184cc536901005ca2af043cb32ad1e493

Attempt 1: Searching PRs for branch pipiland2612/jaeger:error_branch
Found PR Number from artifact: 2

Final PR Number: 2
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
