### PR TITLE
chore(jaeger-tracegen): upgrade tracegen docker compose to jaeger-v2

### DIFF
--- a/cmd/tracegen/docker-compose.yml
+++ b/cmd/tracegen/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
     jaeger:
-      image: cr.jaegertracing.io/jaegertracing/all-in-one:latest@sha256:144b7028db6045b28b50c4728dd3bea14fa76ab024b64afeccec51c8cb1edd63
-      environment:
-        - COLLECTOR_OTLP_ENABLED=true
+      image: cr.jaegertracing.io/jaegertracing/jaeger:latest@sha256:e128b9adbb29c7146ac0b43e26be9dec794fee3478f2f05c4ef7a5b14ddba9a4
       ports:
         - '16686:16686'
         - '4318:4318'
@@ -10,8 +8,7 @@ services:
     tracegen:
       image: cr.jaegertracing.io/jaegertracing/jaeger-tracegen:latest@sha256:be1e8e3d9d41ace4aeb3568af9e5ffaedd8dd907555bc467a0725ac051e246da
       environment:
-        - OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger:14268/api/traces
-        - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=jaeger:4318
+        - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
       command: ["-duration", "10s", "-workers", "3", "-pause", "250ms"]
       depends_on:
         - jaeger


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Fix #7480 <!-- Example: Resolves #123 -->


## Description of the changes
- Use jaeger v2 instead of v1

## How was this change tested?
Running docker compose I was able to see tracegen service

<img width="2533" height="975" alt="image" src="https://github.com/user-attachments/assets/5b90056f-af20-495f-8796-ea2c067dcd1a" />


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
