### PR TITLE
Add timeout to helm commands in Jaeger Demo deployment

### DIFF
--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -70,7 +70,7 @@ fi
 if [[ "$MODE" == "local" ]]; then
 
   echo "🟣 Deploying Jaeger with local registry images..."
-  helm $HELM_JAEGER_CMD jaeger ./helm-charts/charts/jaeger \
+  helm $HELM_JAEGER_CMD --timeout 10m0s jaeger ./helm-charts/charts/jaeger \
     --set provisionDataStore.cassandra=false \
     --set allInOne.enabled=true \
     --set storage.type=memory \
@@ -86,7 +86,7 @@ if [[ "$MODE" == "local" ]]; then
     -f ./jaeger-values.yaml
 else
   echo "🟣 Deploying Jaeger..."
-  helm $HELM_JAEGER_CMD jaeger ./helm-charts/charts/jaeger \
+  helm $HELM_JAEGER_CMD --timeout 10m0s jaeger ./helm-charts/charts/jaeger \
     --set provisionDataStore.cassandra=false \
     --set allInOne.enabled=true \
     --set storage.type=memory \


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7115 
- Frequently saw issue of "timeout waiting for resource completion" during scheduled runs , According to answers online increasing timeout fixes this issue in cases the script involves downloading resources 

## Description of the changes
- added a 10 minute timeout 

## How was this change tested?
- locallly 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
