### PR TITLE
Integrate Slack bot alerts for Jaeger demo run failures

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -60,3 +60,4 @@ jobs:
           
           <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|🔗 View Failed Run>
         SLACK_FOOTER: 'Jaeger CI/CD Pipeline'
+        

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -40,3 +40,23 @@ jobs:
           echo "🔄 Manual run - using deploy-all.sh with clean mode (uninstall/install)"
           bash ./examples/oci/deploy-all.sh clean
         fi         
+
+    - name: Send detailed Slack notification on failure
+      if: failure()
+      uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907 # v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_CHANNEL: '#jaeger-operations'
+        SLACK_COLOR: danger
+        SLACK_USERNAME: 'Jaeger CI Bot'
+        SLACK_ICON_EMOJI: ':warning:'
+        SLACK_TITLE: '🚨 Jaeger OKE Deployment Failed'
+        SLACK_MESSAGE: |
+          *Repository:* ${{ github.repository }}
+          *Workflow:* ${{ github.workflow }}
+          *Run ID:* ${{ github.run_id }}
+          *Trigger:* ${{ github.event_name }}
+          *Actor:* ${{ github.actor }}
+          
+          <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|🔗 View Failed Run>
+        SLACK_FOOTER: 'Jaeger CI/CD Pipeline'


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7115 
- The scheduled runs for jaeger demo fail silently , we require a solution to notify the maintainers if a upgrade / install fails . 

## Description of the changes
- Added an extra step in the deployment workflow to notify in slack channel in runs fail

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
