### PR TITLE
feat(release): make release process v2-centric while preserving v1 support

### DIFF
--- a/scripts/build/package-deploy.sh
+++ b/scripts/build/package-deploy.sh
@@ -41,11 +41,9 @@ function stage-platform-files-v1 {
     local -r PACKAGE_STAGING_DIR=$2
     local -r FILE_EXTENSION=${3:-}
 
-    cp "./cmd/all-in-one/all-in-one-${PLATFORM}"  "${PACKAGE_STAGING_DIR}/jaeger-all-in-one${FILE_EXTENSION}"
     cp "./cmd/query/query-${PLATFORM}"            "${PACKAGE_STAGING_DIR}/jaeger-query${FILE_EXTENSION}"
     cp "./cmd/collector/collector-${PLATFORM}"    "${PACKAGE_STAGING_DIR}/jaeger-collector${FILE_EXTENSION}"
     cp "./cmd/ingester/ingester-${PLATFORM}"      "${PACKAGE_STAGING_DIR}/jaeger-ingester${FILE_EXTENSION}"
-    cp "./examples/hotrod/hotrod-${PLATFORM}"     "${PACKAGE_STAGING_DIR}/example-hotrod${FILE_EXTENSION}"
 }
 
 function stage-platform-files-v2 {


### PR DESCRIPTION
# Summary

This PR implements the first step of issue #7497 by reclassifying release artifacts:
- **v1 packages**: now contain only `collector`, `query`, and `ingester` 
- **v2 packages**: contain `jaeger` binary (including hotrod and ES utilities)

## Changes

- Modified `scripts/build/package-deploy.sh` to exclude `all-in-one` and `hotrod` binaries from v1 package staging
- No workflow changes, no build process modifications
- All other files match upstream/main

## Impact

- v1 releases will be smaller and focused on core tracing components
- All-in-one binary and hotrod demo remain available in v2 releases
- Prepares for eventual v2-centric release process

## Related

- Closes #7497 (first step)
- Addresses maintainer feedback to minimize changes and focus solely on packaging requirements

---

**Testing**: Packaging logic can be verified by running `scripts/build/package-deploy.sh` - v1 packages will no longer contain `jaeger-all-in-one` or `example-hotrod` binaries.