### PR TITLE
Add clean,deploy and port-forward scripts and values for Jaeger + OpenSearch + OTel Demo

### DIFF
--- a/examples/otel-demo/README.md
+++ b/examples/otel-demo/README.md
@@ -1,0 +1,100 @@
+# OpenTelemetry Demo app + HotRODapp + Jaeger + OpenSearch 
+
+This example provides a one-command deployment of a complete observability stack on Kubernetes:
+- Jaeger (all-in-one) for tracing
+- OpenSearch and OpenSearch Dashboards
+- OpenTelemetry Demo application (multi-service web store)
+- HotRod application
+
+It is driven by `deploy-all.sh`, which supports both clean installs and upgrades.
+
+## Prerequisites
+- Kubernetes cluster reachable via `kubectl`
+- Installed CLIs: `bash`, `git`, `curl`, `kubectl`, `helm`
+- Network access to Helm repositories
+
+## Quick start
+- Clean install (removes previous releases/namespaces, then installs everything):
+```bash path=null start=null
+./deploy-all.sh clean
+```
+- Upgrade (default) — installs if missing, upgrades if present:
+```bash path=null start=null
+./deploy-all.sh
+# or explicitly
+./deploy-all.sh upgrade
+```
+- Specify Jaeger all-in-one image tag:
+```bash path=null start=null
+./deploy-all.sh upgrade <image-tag>
+# Example
+./deploy-all.sh upgrade latest
+```
+
+Environment variables:
+- ROLLOUT_TIMEOUT: rollout wait timeout in seconds (default 600)
+
+```bash path=null start=null
+ROLLOUT_TIMEOUT=900 ./deploy-all.sh clean
+```
+
+## What gets deployed
+- Namespace `opensearch`:
+  - OpenSearch (single node) StatefulSet
+  - OpenSearch Dashboards Deployment
+- Namespace `jaeger`:
+  - Jaeger all-in-one Deployment (storage=none)
+  - HOTROD application 
+  - Jaeger Query ClusterIP service (jaeger-query-clusterip)
+- Namespace `otel-demo`:
+  - OpenTelemetry Demo (frontend, load-generator, and supporting services)
+  
+
+## Verifying the deployment
+- Pods status:
+```bash path=null start=null
+kubectl get pods -n opensearch
+kubectl get pods -n jaeger
+kubectl get pods -n otel-demo
+```
+- Services:
+```bash path=null start=null
+kubectl get svc -n opensearch
+kubectl get svc -n jaeger
+kubectl get svc -n otel-demo
+```
+
+
+## Automatic port-forward using scrpit
+ - OpenSearch Dashboards:
+```bash path=null start=null
+./start-port-forward.sh
+
+
+## Customization
+- Helm values provided in this directory:
+  - `opensearch-values.yaml`
+  - `opensearch-dashboard-values.yaml`
+  - `jaeger-values.yaml`
+  - `jaeger-config.yaml`
+  - `otel-demo-values.yaml`
+  - `jaeger-query-service.yaml`
+
+You can adjust these files and re-run `./deploy-all.sh upgrade` to apply changes.
+
+## Clean-up
+- Clean uninstall using cleanup.sh :
+```bash path=null start=null
+./cleanup.sh
+```
+- Manual teardown:
+```bash path=null start=null
+helm uninstall opensearch -n opensearch || true
+helm uninstall opensearch-dashboards -n opensearch || true
+helm uninstall jaeger -n jaeger || true
+helm uninstall otel-demo -n otel-demo || true
+kubectl delete namespace opensearch jaeger otel-demo --ignore-not-found=true
+```
+
+
+

--- a/examples/otel-demo/cleanup.sh
+++ b/examples/otel-demo/cleanup.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# OpenSearch Observability Stack Cleanup Script
+# This script removes all components deployed by the deployment script
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging function
+log() {
+    echo -e "${BLUE}[$(date +'%Y-%m-%d %H:%M:%S')] $1${NC}"
+}
+
+success() {
+    echo -e "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')] $1${NC}"
+}
+
+warning() {
+    echo -e "${YELLOW}[$(date +'%Y-%m-%d %H:%M:%S')]  $1${NC}"
+}
+
+error() {
+    echo -e "${RED}[$(date +'%Y-%m-%d %H:%M:%S')]  $1${NC}"
+}
+
+# Main cleanup function
+main() {
+    log "Starting OpenSearch Observability Stack Cleanup"
+    
+    # Stop any existing port forwards
+    log "Stopping any existing port-forward processes..."
+    pkill -f "kubectl port-forward" 2>/dev/null || true
+    success "Port-forward processes stopped"
+    
+    
+    # Uninstall OTEL Demo
+    log "Uninstalling OTEL Demo..."
+    if helm list -n otel-demo | grep -q otel-demo; then
+        helm uninstall otel-demo -n otel-demo
+        success "OTEL Demo uninstalled"
+    else
+        warning "OTEL Demo not found or already uninstalled"
+    fi
+    
+    # Uninstall Jaeger
+    log "Uninstalling Jaeger..."
+    if helm list -n jaeger | grep -q jaeger; then
+        helm uninstall jaeger -n jaeger
+        success "Jaeger uninstalled"
+    else
+        warning "Jaeger not found or already uninstalled"
+    fi
+    
+    # Uninstall OpenSearch Dashboards
+    log "Uninstalling OpenSearch Dashboards..."
+    if helm list -n opensearch | grep -q opensearch-dashboards; then
+        helm uninstall opensearch-dashboards -n opensearch
+        success "OpenSearch Dashboards uninstalled"
+    else
+        warning "OpenSearch Dashboards not found or already uninstalled"
+    fi
+    
+    # Uninstall OpenSearch
+    log "Uninstalling OpenSearch..."
+    if helm list -n opensearch | grep -q opensearch; then
+        helm uninstall opensearch -n opensearch
+        success "OpenSearch uninstalled"
+    else
+        warning "OpenSearch not found or already uninstalled"
+    fi
+    
+    # Wait for pods to terminate
+    log "Waiting for pods to terminate..."
+    sleep 10
+    
+    # Delete namespaces
+    log "Deleting namespaces..."
+    for ns in otel-demo jaeger opensearch; do
+        if kubectl get namespace $ns > /dev/null 2>&1; then
+            kubectl delete namespace $ns --force --grace-period=0 2>/dev/null || true
+            success "Namespace $ns deleted"
+        else
+            warning "Namespace $ns not found or already deleted"
+        fi
+    done
+    
+    # Clean up any remaining resources (PVCs, etc.)
+    log "Cleaning up any remaining PVCs..."
+    kubectl get pvc -A | grep -E "(opensearch|jaeger|otel-demo)" || warning "No remaining PVCs found"
+    
+    # Final verification
+    log "Performing final verification..."
+    remaining_pods=$(kubectl get pods -A | grep -E "(opensearch|jaeger|otel-demo)" || true)
+    if [ -z "$remaining_pods" ]; then
+        success "All components cleaned up successfully!"
+    else
+        warning "Some pods may still be terminating:"
+        echo "$remaining_pods"
+        log "This is normal and they should disappear shortly"
+    fi
+    
+    echo ""
+    success "Cleanup Complete! "
+    echo ""
+    log "All OpenSearch observability stack components have been removed"
+    echo ""
+}
+
+
+main "$@"

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-600}"
+
+MODE="${1:-upgrade}"
+IMAGE_TAG="${2:-latest}"
+
+case "$MODE" in
+  upgrade|clean)
+    echo " Running in '$MODE' mode..."
+    ;;
+  *)
+    echo "Error: Invalid mode '$MODE'"
+    echo "Usage: $0 [upgrade|clean] [image-tag]"
+    echo ""
+    echo "Modes:"
+    echo "  upgrade  - Upgrade existing deployment or install if not present (default)"
+    echo "  clean    - Clean install (removes existing deployment first)"
+    echo ""
+    echo "Examples:"
+    echo "  $0                    # Upgrade mode with latest tag"
+    echo "  $0 clean              # Clean install"
+    exit 1
+    ;;
+ esac
+
+if [[ "$MODE" == "upgrade" ]]; then
+  HELM_JAEGER_CMD="upgrade --install --force"
+else
+  # For clean mode, use install after cleanup
+  HELM_JAEGER_CMD="install"
+fi
+
+log() { echo "[$(date +"%F %T")] $*"; }
+err() { echo "[$(date +"%F %T")] ERROR: $*" >&2; exit 1; }
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "$1 is required but not installed"
+  fi
+}
+
+check_cluster() {
+  if ! kubectl cluster-info >/dev/null 2>&1; then
+    err "Cannot reach a Kubernetes cluster with kubectl"
+  fi
+}
+
+check_required_files() {
+  local files=(
+    "$SCRIPT_DIR/opensearch-values.yaml"
+    "$SCRIPT_DIR/opensearch-dashboard-values.yaml"
+    "$SCRIPT_DIR/jaeger-values.yaml"
+    "$SCRIPT_DIR/jaeger-config.yaml"
+    "$SCRIPT_DIR/otel-demo-values.yaml"
+    "$SCRIPT_DIR/jaeger-query-service.yaml"
+  )
+  for f in "${files[@]}"; do
+    [[ -f "$f" ]] || err "Missing required file: $f"
+  done
+}
+
+wait_for_deployment() {
+  local namespace="$1"
+  local deployment="$2"
+  local timeout="${3:-${ROLLOUT_TIMEOUT}s}"
+  log "Waiting for deployment $deployment in $namespace..."
+  if ! kubectl rollout status "deployment/$deployment" -n "$namespace" --timeout="$timeout"; then
+    kubectl -n "$namespace" get deploy "$deployment" -o wide || true
+    kubectl -n "$namespace" describe deploy "$deployment" || true
+    kubectl -n "$namespace" get pods -l app.kubernetes.io/name="$deployment" -o wide || true
+    err "Deployment $deployment failed to become ready in $namespace"
+  fi
+  log "Deployment $deployment is ready"
+}
+
+wait_for_statefulset() {
+  local namespace="$1"
+  local sts="$2"
+  local timeout="${3:-${ROLLOUT_TIMEOUT}s}"
+  log "Waiting for statefulset $sts in $namespace..."
+  if ! kubectl rollout status "statefulset/$sts" -n "$namespace" --timeout="$timeout"; then
+    kubectl -n "$namespace" get statefulset "$sts" -o wide || true
+    kubectl -n "$namespace" describe statefulset "$sts" || true
+    kubectl -n "$namespace" get pods -l statefulset.kubernetes.io/pod-name -o wide || true
+    err "StatefulSet $sts failed to become ready in $namespace"
+  fi
+  log "StatefulSet $sts is ready"
+}
+
+cleanup() {
+  log "Cleanup: uninstalling existing releases if present"
+  helm uninstall opensearch -n opensearch >/dev/null 2>&1 || true
+  helm uninstall opensearch-dashboards -n opensearch >/dev/null 2>&1 || true
+  helm uninstall jaeger -n jaeger >/dev/null 2>&1 || true
+  helm uninstall otel-demo -n otel-demo >/dev/null 2>&1 || true
+
+  log "Cleanup: deleting namespaces (may take time)"
+  for ns in jaeger otel-demo opensearch; do
+    kubectl delete namespace "$ns" --ignore-not-found=true >/dev/null 2>&1 || true
+  done
+
+  # Wait for namespaces to disappear
+  for ns in jaeger otel-demo opensearch; do
+    for i in {1..120}; do
+      if ! kubectl get namespace "$ns" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 2
+    done
+    done
+  log "Cleanup complete"
+}
+
+# Clone Jaeger Helm chart and prepare dependencies
+clone_jaeger_v2() {
+  local dest="$SCRIPT_DIR/helm-charts"
+  if [[ ! -d "$dest" ]]; then
+    log "Cloning Jaeger Helm Charts..."
+    git clone https://github.com/jaegertracing/helm-charts.git "$dest"
+    (
+      cd "$dest"
+      log "Using v2 branch for Jaeger v2..."
+      git checkout v2
+      log "Adding required Helm repositories..."
+      helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1 || true
+      helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
+      helm repo add incubator https://charts.helm.sh/incubator >/dev/null 2>&1 || true
+      helm repo update >/dev/null
+      helm dependency build ./charts/jaeger
+    )
+  else
+    log "Jaeger Helm Charts already exist. Skipping clone."
+    # Ensure required repos exist even if charts folder already exists
+    helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1 || true
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
+    helm repo add incubator https://charts.helm.sh/incubator >/dev/null 2>&1 || true
+    helm repo update >/dev/null
+  fi
+}
+
+
+
+main() {
+  log "Starting CI deploy (weekly refresh)"
+  need bash
+  need git
+  need curl
+  need kubectl
+  need helm
+  check_required_files
+  check_cluster
+
+
+  if [[ "$MODE" == "clean" ]]; then
+    cleanup
+  fi
+
+  log "Adding/updating Helm repos"
+  helm repo add opensearch https://opensearch-project.github.io/helm-charts >/dev/null 2>&1 || true
+  helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts >/dev/null 2>&1 || true
+  helm repo add jaegertracing https://jaegertracing.github.io/helm-charts >/dev/null 2>&1 || true
+  helm repo update >/dev/null
+  clone_jaeger_v2
+
+  log "Deploying OpenSearch"
+  helm upgrade --install opensearch opensearch/opensearch \
+    --namespace opensearch --create-namespace \
+    --version 2.19.0 \
+    --set image.tag=2.11.0 \
+    -f "$SCRIPT_DIR/opensearch-values.yaml" \
+    --wait --timeout 10m
+  wait_for_statefulset opensearch opensearch-cluster-single "${ROLLOUT_TIMEOUT}s"
+
+  log "Deploying OpenSearch Dashboards"
+  helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards \
+    --namespace opensearch \
+    -f "$SCRIPT_DIR/opensearch-dashboard-values.yaml" \
+    --wait --timeout 10m
+  wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
+
+  
+  log "Deploying Jaeger (all-in-one, no storage)"
+  helm $HELM_JAEGER_CMD jaeger "$SCRIPT_DIR/helm-charts/charts/jaeger" \
+    --namespace jaeger --create-namespace \
+    --set allInOne.enabled=true \
+    --set storage.type=none \
+    --set allInOne.image.repository=jaegertracing/jaeger \
+    --set allInOne.image.tag="${IMAGE_TAG}" \
+    --set-file userconfig="$SCRIPT_DIR/jaeger-config.yaml" \
+    -f "$SCRIPT_DIR/jaeger-values.yaml" \
+    --wait --timeout 10m
+  wait_for_deployment jaeger jaeger "${ROLLOUT_TIMEOUT}s"
+
+  
+  log "Creating Jaeger query ClusterIP service..."
+  kubectl apply -n jaeger -f "$SCRIPT_DIR/jaeger-query-service.yaml"
+  log "Jaeger query ClusterIP service created"
+
+  log "Deploying OpenTelemetry Demo"
+  helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
+    -f "$SCRIPT_DIR/otel-demo-values.yaml" \
+    --namespace otel-demo --create-namespace \
+    --wait --timeout 15m
+  wait_for_deployment otel-demo frontend "${ROLLOUT_TIMEOUT}s"
+  wait_for_deployment otel-demo load-generator "${ROLLOUT_TIMEOUT}s"
+
+  log "All components deployed successfully"
+
+}
+
+main

--- a/examples/otel-demo/jaeger-config.yaml
+++ b/examples/otel-demo/jaeger-config.yaml
@@ -1,0 +1,80 @@
+service:
+  extensions: [jaeger_storage, jaeger_query, healthcheckv2]
+  
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter]
+
+extensions:
+  healthcheckv2:
+    use_v2: true
+    http:
+      endpoint: 0.0.0.0:13133
+  
+  jaeger_query:
+    storage:
+      traces: some_storage
+      traces_archive: another_storage
+      metrics: some_storage  # For SPM metrics
+  
+  jaeger_storage:
+    backends:
+      some_storage: &opensearch_config
+        opensearch:
+          server_urls:
+            - http://opensearch-cluster-single.opensearch.svc.cluster.local:9200
+          indices:
+            index_prefix: "jaeger-main"
+            spans:
+              date_layout: "2006-01-02"
+              rollover_frequency: "day"
+              shards: 1
+              replicas: 0
+            services:
+              date_layout: "2006-01-02"
+              rollover_frequency: "day"
+              shards: 1
+              replicas: 0
+            dependencies:
+              date_layout: "2006-01-02"
+              rollover_frequency: "day"
+              shards: 1
+              replicas: 0
+            sampling:
+              date_layout: "2006-01-02"
+              rollover_frequency: "day"
+              shards: 1
+              replicas: 0
+      
+      another_storage:
+        opensearch:
+          server_urls:
+            - http://opensearch-cluster-single.opensearch.svc.cluster.local:9200
+          indices:
+            index_prefix: "jaeger-archive"
+            spans:
+              date_layout: "2006-01-02"
+              rollover_frequency: "day"
+              shards: 1
+              replicas: 0
+    
+    metric_backends:
+      some_storage: *opensearch_config
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+
+processors:
+  batch:
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: some_storage
+

--- a/examples/otel-demo/jaeger-query-service.yaml
+++ b/examples/otel-demo/jaeger-query-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-query-clusterip
+  namespace: jaeger
+  labels:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: query
+    app.kubernetes.io/instance: jaeger
+spec:
+  type: ClusterIP
+  ports:
+    - name: jaeger-query
+      port: 16686
+      targetPort: 16686
+      protocol: TCP
+    - name: jaeger-admin
+      port: 16685
+      targetPort: 16685
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: all-in-one
+    app.kubernetes.io/instance: jaeger

--- a/examples/otel-demo/jaeger-values.yaml
+++ b/examples/otel-demo/jaeger-values.yaml
@@ -1,0 +1,34 @@
+allInOne:
+  enabled: true
+  extraEnv: []
+  
+
+# Enable HotROD demo application
+hotrod:
+  enabled: true
+  image:
+    tag: "1.72.0"
+  args:
+    - all
+  extraArgs:
+    - --otel-exporter=otlp
+  livenessProbe:
+    path: /
+  readinessProbe:
+    path: /
+  extraEnv:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://jaeger-collector:4318
+    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      value: http://jaeger-collector:4318/v1/traces
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+    - name: OTEL_SERVICE_NAME
+      value: hotrod
+    - name: OTEL_LOG_LEVEL
+      value: debug
+  
+
+query:
+  service:
+    type: ClusterIP

--- a/examples/otel-demo/opensearch-dashboard-values.yaml
+++ b/examples/otel-demo/opensearch-dashboard-values.yaml
@@ -1,0 +1,19 @@
+
+image:
+  tag: "2.11.0"
+
+opensearchHosts: "http://opensearch-cluster-single:9200"
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+
+config:
+  opensearch_dashboards.yml: |
+    server.host: 0.0.0.0
+    opensearch.hosts: ["http://opensearch-cluster-single:9200"]
+    opensearch.username: "admin"
+    opensearch.password: "admin123"
+    opensearch.ssl.verificationMode: none
+    opensearch_security.enabled: false
+

--- a/examples/otel-demo/opensearch-values.yaml
+++ b/examples/otel-demo/opensearch-values.yaml
@@ -1,0 +1,34 @@
+clusterName: "opensearch-cluster"
+nodeGroup: "single"
+
+replicas: 1
+
+persistence:
+  enabled: true
+  size: "10Gi"  
+  storageClass: "oci-bv" # Using Oracle Cloud Block Volume storage class
+
+opensearchJavaOpts: "-Xmx1g -Xms1g"
+
+securityConfig:
+  enabled: false
+
+extraEnvs:
+  - name: DISABLE_INSTALL_DEMO_CONFIG
+    value: "true"
+  - name: DISABLE_SECURITY_PLUGIN
+    value: "true"
+
+
+
+config:
+  opensearch.yml: |
+    cluster.name: opensearch-cluster
+    network.host: 0.0.0.0
+    bootstrap.memory_lock: false
+    plugins.security.disabled: true
+
+service:
+  type: ClusterIP
+  port: 9200
+

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -1,0 +1,322 @@
+# official schema for otel demo is at https://raw.githubusercontent.com/open-telemetry/opentelemetry-helm-charts/main/charts/opentelemetry-demo/values.yaml
+
+# Disable all bundled infrastructure components
+opentelemetry-collector:
+  enabled: false
+
+jaeger:
+  enabled: false
+
+prometheus:
+  enabled: false
+
+grafana:
+  enabled: false
+
+opensearch:
+  enabled: false
+
+# Global configuration pointing to Jaeger
+default:
+  env:
+    - name: OTEL_SERVICE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: "metadata.labels['app.kubernetes.io/component']"
+    # Override default collector to point to Jaeger
+    - name: OTEL_COLLECTOR_NAME
+      value: jaeger-collector.jaeger.svc.cluster.local
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      value: http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: service.namespace=otel-demo,deployment.environment=minikube-demo
+    # Disable logs and metrics export to Jaeger (only traces)
+    - name: OTEL_LOGS_EXPORTER
+      value: none
+    - name: OTEL_METRICS_EXPORTER
+      value: none
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+
+# Component-specific configurations using correct schema names
+components:
+  # Enable Kafka for services that require it
+  kafka:
+    enabled: true
+
+  # Frontend configuration
+  frontend:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      # Frontend service addresses
+      - name: FRONTEND_PORT
+        value: "8080"
+      - name: FRONTEND_ADDR
+        value: ":8080"
+      - name: AD_ADDR
+        value: ad:8080
+      - name: CART_ADDR
+        value: cart:8080
+      - name: CHECKOUT_ADDR
+        value: checkout:8080
+      - name: CURRENCY_ADDR
+        value: currency:8080
+      - name: PRODUCT_CATALOG_ADDR
+        value: product-catalog:8080
+      - name: RECOMMENDATION_ADDR
+        value: recommendation:8080
+      - name: SHIPPING_ADDR
+        value: shipping:8080
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      # Override the problematic variable substitution
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+    
+
+  # Load generator 
+  load-generator:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: LOCUST_USERS
+        value: "5"
+      - name: LOCUST_SPAWN_RATE
+        value: "2"
+      - name: LOCUST_HOST
+        value: http://frontend-proxy:8080
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+    
+  # Fraud detection 
+  fraud-detection:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: KAFKA_ADDR
+        value: kafka:9092
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+
+  # Product catalog 
+  product-catalog:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: PRODUCT_CATALOG_PORT
+        value: "8080"
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+
+  # All other services with consistent configuration
+  checkout:
+    enabled: true
+    useDefault:
+      env: false
+    env:
+      - name: OTEL_SERVICE_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: "metadata.labels['app.kubernetes.io/component']"
+      - name: CHECKOUT_PORT
+        value: "8080"
+      - name: KAFKA_ADDR
+        value: kafka:9092
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      # Go service with gRPC
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4317
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: grpc
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        value: service.namespace=otel-demo,deployment.environment=minikube-demo
+      - name: OTEL_LOGS_EXPORTER
+        value: none
+      - name: OTEL_METRICS_EXPORTER
+        value: none
+      - name: OTEL_TRACES_EXPORTER
+        value: otlp
+      # Additional required addresses
+      - name: CART_ADDR
+        value: cart:8080
+      - name: CURRENCY_ADDR
+        value: currency:8080
+      - name: EMAIL_ADDR
+        value: email:8080
+      - name: PAYMENT_ADDR
+        value: payment:8080
+      - name: PRODUCT_CATALOG_ADDR
+        value: product-catalog:8080
+      - name: SHIPPING_ADDR
+        value: shipping:8080
+
+  currency:
+    enabled: true
+    useDefault:
+      env: false
+    env:
+      - name: OTEL_SERVICE_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: "metadata.labels['app.kubernetes.io/component']"
+      - name: CURRENCY_PORT
+        value: "8080"
+      - name: VERSION
+        value: "2.0.2"
+      # Currency service (C++) with gRPC endpoint
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: jaeger-collector.jaeger.svc.cluster.local:4317
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: grpc
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        value: service.namespace=otel-demo,deployment.environment=minikube-demo
+      - name: OTEL_LOGS_EXPORTER
+        value: none
+      - name: OTEL_METRICS_EXPORTER
+        value: none
+      - name: OTEL_TRACES_EXPORTER
+        value: otlp
+
+  payment:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: PAYMENT_PORT
+        value: "8080"
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+
+  shipping:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: SHIPPING_PORT
+        value: "8080"
+      - name: QUOTE_ADDR
+        value: http://quote:8080
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+
+  recommendation:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: RECOMMENDATION_PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_ADDR
+        value: product-catalog:8080
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+
+  cart:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: CART_PORT
+        value: "8080"
+      - name: ASPNETCORE_URLS
+        value: http://*:8080
+      - name: VALKEY_ADDR
+        value: valkey-cart:6379
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+
+  accounting:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: KAFKA_ADDR
+        value: kafka:9092
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+
+  # Keep other components that don't require configuration changes
+  ad:
+    enabled: true
+    useDefault:
+      env: true
+    env:
+      - name: AD_PORT
+        value: "8080"
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://jaeger-collector.jaeger.svc.cluster.local:4318
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+  
+  email:
+    enabled: true
+    
+  frontend-proxy:
+    enabled: true
+    
+  image-provider:
+    enabled: true
+    
+  quote:
+    enabled: true
+    
+  flagd:
+    enabled: true
+    
+  valkey-cart:
+    enabled: true

--- a/examples/otel-demo/start-port-forward.sh
+++ b/examples/otel-demo/start-port-forward.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# OpenSearch Observability Stack Port Forwarding Script
+# This script sets up port forwarding for all services
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging function
+log() {
+    echo -e "${BLUE}[$(date +'%Y-%m-%d %H:%M:%S')] $1${NC}"
+}
+
+success() {
+    echo -e "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')] $1${NC}"
+}
+
+warning() {
+    echo -e "${YELLOW}[$(date +'%Y-%m-%d %H:%M:%S')]  $1${NC}"
+}
+
+error() {
+    echo -e "${RED}[$(date +'%Y-%m-%d %H:%M:%S')] $1${NC}"
+    exit 1
+}
+
+# Function to check if service exists
+check_service() {
+    local service=$1
+    local namespace=$2
+    
+    if kubectl get svc $service -n $namespace > /dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Main function
+main() {
+    log "Starting Port Forwarding for OpenSearch Observability Stack"
+    
+    # Check if kubectl is available
+    if ! command -v kubectl &> /dev/null; then
+        error "kubectl is required but not installed."
+    fi
+    
+    # Check if cluster is accessible
+    if ! kubectl cluster-info > /dev/null 2>&1; then
+        error "Cannot connect to Kubernetes cluster. Please ensure minikube is running."
+    fi
+    
+    # Stop any existing port forwards first
+    log "Stopping any existing port-forward processes..."
+    pkill -f "kubectl port-forward" 2>/dev/null || true
+    sleep 2
+    
+    # Array to track started services
+    started_services=()
+    failed_services=()
+    
+    # Start port forwarding for each service
+    log "Starting port forwarding services..."
+    
+    # Jaeger Query UI
+    if check_service "jaeger-query-clusterip" "jaeger"; then
+        kubectl port-forward -n jaeger svc/jaeger-query-clusterip 16686:16686 &
+        started_services+=("Jaeger UI (http://localhost:16686)")
+        log "Started: Jaeger UI on port 16686"
+    else
+        failed_services+=("Jaeger (service not found)")
+        warning "Jaeger service not found"
+    fi
+    
+    # OpenSearch Dashboards
+    if check_service "opensearch-dashboards" "opensearch"; then
+        kubectl port-forward -n opensearch svc/opensearch-dashboards 5601:5601 &
+        started_services+=("OpenSearch Dashboards (http://localhost:5601)")
+        log "Started: OpenSearch Dashboards on port 5601"
+    else
+        failed_services+=("OpenSearch Dashboards (service not found)")
+        warning "OpenSearch Dashboards service not found"
+    fi
+    
+    # OpenSearch API
+    if check_service "opensearch-cluster-single" "opensearch"; then
+        kubectl port-forward -n opensearch svc/opensearch-cluster-single 9200:9200 &
+        started_services+=("OpenSearch API (http://localhost:9200)")
+        log "Started: OpenSearch API on port 9200"
+    else
+        failed_services+=("OpenSearch API (service not found)")
+        warning "OpenSearch API service not found"
+    fi
+    
+    # OTEL Demo Frontend
+    if check_service "frontend-proxy" "otel-demo"; then
+        kubectl port-forward -n otel-demo svc/frontend-proxy 8080:8080 &
+        started_services+=("OTEL Demo Frontend (http://localhost:8080)")
+        log "Started: OTEL Demo Frontend on port 8080"
+    else
+        failed_services+=("OTEL Demo Frontend (service not found)")
+        warning "OTEL Demo Frontend service not found"
+    fi
+    
+    # Load Generator
+    if check_service "load-generator" "otel-demo"; then
+        kubectl port-forward -n otel-demo svc/load-generator 8089:8089 &
+        started_services+=("Load Generator (http://localhost:8089)")
+        log "Started: Load Generator on port 8089"
+    else
+        failed_services+=("Load Generator (service not found)")
+        warning "Load Generator service not found"
+    fi
+    
+    # HotROD Demo App (from Jaeger Helm chart v2)
+    if check_service "jaeger-hotrod" "jaeger"; then
+        kubectl port-forward -n jaeger svc/jaeger-hotrod 8088:80 &
+        started_services+=("HotROD Demo App (http://localhost:8088)")
+        log "Started: HotROD Demo App on port 8088"
+    else
+        failed_services+=("HotROD Demo App (service not found)")
+        warning "HotROD Demo App service not found"
+    fi
+    
+    # Wait for services to start
+    sleep 3
+    
+    # Display summary
+    echo ""
+    success "Port Forwarding Setup Complete!"
+    echo ""
+    
+    if [ ${#started_services[@]} -gt 0 ]; then
+        echo -e "${GREEN}Successfully started services:${NC}"
+        for service in "${started_services[@]}"; do
+            echo "  • $service"
+        done
+        echo ""
+    fi
+    
+    if [ ${#failed_services[@]} -gt 0 ]; then
+        echo -e "${YELLOW}Failed to start services:${NC}"
+        for service in "${failed_services[@]}"; do
+            echo "  • $service"
+        done
+        echo ""
+        warning "Some services may not be deployed yet. Run the deployment script first."
+        echo ""
+    fi
+    
+    if [ ${#started_services[@]} -gt 0 ]; then
+        echo -e "${BLUE} Management Commands:${NC}"
+        echo "  • View all port-forwards: jobs"
+        echo "  • Stop all port-forwards: pkill -f 'kubectl port-forward'"
+        echo "  • Stop this script: Ctrl+C"
+        echo ""
+        
+        # Keep the script running
+        log "Port forwarding is active. Press Ctrl+C to stop all port-forwards."
+        
+        # Wait for interrupt
+        trap 'log "Stopping all port-forwards..."; pkill -f "kubectl port-forward"; success "All port-forwards stopped."; exit 0' INT
+        
+        # Keep script alive
+        while true; do
+            sleep 10
+        done
+    else
+        error "No services were successfully started. Please check your deployment."
+    fi
+}
+
+
+main "$@"


### PR DESCRIPTION




## Which problem is this PR solving?
part of mentorship work 
- https://github.com/jaegertracing/jaeger/issues/7326

## Description of the changes
Summary
This PR introduces a complete, repeatable deployment for the OpenTelemetry Demo with Jaeger , HotROD app and OpenSearch (including Dashboards) under examples/otel-demo. It provides a single entrypoint script that supports both upgrade and clean install modes, plus the necessary Helm values and a ClusterIP service for Jaeger Query.

Deployment script 

•  Added deploy-all.sh  with modes: upgrade (default) and clean (uninstall + fresh install)
◦  Pre-flight checks for required CLIs (bash, git, curl, kubectl, helm) and cluster availability
◦  Validates presence of required values files
◦  Clones jaegertracing/helm-charts v2 and builds dependencies
◦  Deploys in order: OpenSearch -> OpenSearch Dashboards -> Jaeger (all-in-one) -> OTel Demo
◦  Waits for StatefulSets/Deployments to be ready with rollout status and timeouts
◦  Creates a dedicated ClusterIP service for Jaeger Query


Added values files:

◦  opensearch-values.yaml
◦  opensearch-dashboard-values.yaml
◦  jaeger-values.yaml
◦  jaeger-config.yaml (userconfig for Jaeger)
◦  otel-demo-values.yaml
•  Added Jaeger Query service:
◦  jaeger-query-service.yaml (ClusterIP service in jaeger namespace)


## How was this change tested?
- Tested in Local Minikube Cluster as well as production Oracle Cluster 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
