### PR TITLE
Define DOCKERHUB_USERNAME env var

### DIFF
--- a/scripts/build/upload-docker-readme.sh
+++ b/scripts/build/upload-docker-readme.sh
@@ -27,7 +27,7 @@ abs_readme_path=$(realpath "$readme_path")
 repository="jaegertracing/$repo"
 
 DOCKERHUB_TOKEN=${DOCKERHUB_TOKEN:?'missing Docker Hub token'}
-DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:?'missing Docker Hub user name'}
+DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-"jaegertracingbot"}
 QUAY_TOKEN=${QUAY_TOKEN:?'missing Quay token'}
 
 dockerhub_url="https://hub.docker.com/v2/repositories/$repository/"


### PR DESCRIPTION
Previous PR #7536 assumed the user name env var is present, but it's not, so set it with a default