### PR TITLE
Add RISC-V 64-bit support and fix version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 JAEGER_IMPORT_PATH = github.com/jaegertracing/jaeger
 
 # PLATFORMS is a list of all supported platforms
-PLATFORMS="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,darwin/amd64,darwin/arm64,windows/amd64"
+PLATFORMS="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64,darwin/amd64,darwin/arm64,windows/amd64"
 LINUX_PLATFORMS=$(shell echo "$(PLATFORMS)" | tr ',' '\n' | grep linux | tr '\n' ',' | sed 's/,$$/\n/')
 
 # SRC_ROOT is the top of the source tree.
@@ -98,6 +98,11 @@ echo-v1:
 
 .PHONY: echo-v2
 echo-v2:
+
+.PHONY: build-riscv64
+build-riscv64:
+	@echo "Building for RISC-V 64-bit..."
+	@bash scripts/build-riscv64.sh
 	@echo "$(GIT_CLOSEST_TAG_V2)"
 
 .PHONY: echo-platforms

--- a/scripts/build-riscv64.sh
+++ b/scripts/build-riscv64.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Build script for RISC-V 64-bit architecture
+
+# Set environment variables
+export GOOS=linux
+export GOARCH=riscv64
+export CGO_ENABLED=0
+
+# Get version information
+GIT_SHA=$(git rev-parse HEAD)
+GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Build flags
+GO_BUILD_ARGS="-ldflags=-X github.com/jaegertracing/jaeger/internal/version.commitSHA=${GIT_SHA} \
+                       -X github.com/jaegertracing/jaeger/internal/version.latestVersion=${GIT_TAG} \
+                       -X github.com/jaegertracing/jaeger/internal/version.date=${BUILD_DATE}"
+
+# Create build directory
+mkdir -p build/riscv64
+
+# Build all-in-one binary
+go build ${GO_BUILD_ARGS} -o build/riscv64/jaeger-all-in-one ./cmd/all-in-one


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
