### PR TITLE
Store service names in map to compact duplicates

### DIFF
--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 
 	"github.com/dgraph-io/badger/v4"
+	"golang.org/x/exp/maps"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
@@ -622,7 +623,7 @@ func scanRangeFunction(it *badger.Iterator, indexEndValue []byte) bool {
 
 // preloadServices fills the cache with services after extracting from badger
 func (r *TraceReader) preloadServices() []string {
-	var services []string
+	services := map[string]struct{}{}
 	r.store.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
 		it := txn.NewIterator(opts)
@@ -635,12 +636,12 @@ func (r *TraceReader) preloadServices() []string {
 			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
 			serviceName := string(it.Item().Key()[len(serviceKey):timestampStartIndex])
 			keyTTL := it.Item().ExpiresAt()
-			services = append(services, serviceName)
+			services[serviceName] = struct{}{}
 			r.cache.AddService(serviceName, keyTTL)
 		}
 		return nil
 	})
-	return services
+	return maps.Keys(services)
 }
 
 // preloadOperations extract all operations for a specified service


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves: https://github.com/jaegertracing/jaeger/issues/7547

## Description of the changes
De-dup service names

## How was this change tested?
Running a local badger config with many traces, it sometimes took 45+ minutes to load after restart. This restarts instantly

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
