### PR TITLE
Used fully qualified names for images

### DIFF
--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -90,6 +90,7 @@ else
     --set provisionDataStore.cassandra=false \
     --set allInOne.enabled=true \
     --set storage.type=memory \
+    --set allInOne.image.repository="docker.io/jaegertracing/jaeger" \
     --set-file userconfig="./config.yaml" \
     --set-file uiconfig="./ui-config.json" \
     -f ./jaeger-values.yaml

--- a/examples/oci/jaeger-values.yaml
+++ b/examples/oci/jaeger-values.yaml
@@ -1,6 +1,7 @@
 hotrod:
   enabled: true
   image:
+    repository: docker.io/jaegertracing/example-hotrod
     tag: "1.72.0"
   args:
     - all


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
--> 

## Which problem is this PR solving?
- After upgrading the Oracle cluster to Kubernetes v1.34, nodes now use the CRI-O container runtime which enforces stricter security measures requiring fully qualified image names. The previous short-form image names caused pods to fail pulling images, leading to continuous pod evictions that eventually filled up boot disk space and made all pods in the cluster unschedulable. 
<img width="781" height="789" alt="Screenshot from 2025-10-11 19-40-26" src="https://github.com/user-attachments/assets/ff75dccb-2ec8-4959-aa51-9247ff50f7da" />  


<img width="1704" height="163" alt="Screenshot from 2025-10-11 22-56-53" src="https://github.com/user-attachments/assets/584d312d-a5dc-4671-93e2-f1fecf26bf5b" />


## Description of the changes
- Modified container image references to use fully qualified names 

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
