### PR TITLE
Kept all-in-one and hotrod binaries in v2 only

### DIFF
--- a/scripts/build/package-deploy.sh
+++ b/scripts/build/package-deploy.sh
@@ -41,11 +41,9 @@ function stage-platform-files-v1 {
     local -r PACKAGE_STAGING_DIR=$2
     local -r FILE_EXTENSION=${3:-}
 
-    cp "./cmd/all-in-one/all-in-one-${PLATFORM}"  "${PACKAGE_STAGING_DIR}/jaeger-all-in-one${FILE_EXTENSION}"
     cp "./cmd/query/query-${PLATFORM}"            "${PACKAGE_STAGING_DIR}/jaeger-query${FILE_EXTENSION}"
     cp "./cmd/collector/collector-${PLATFORM}"    "${PACKAGE_STAGING_DIR}/jaeger-collector${FILE_EXTENSION}"
     cp "./cmd/ingester/ingester-${PLATFORM}"      "${PACKAGE_STAGING_DIR}/jaeger-ingester${FILE_EXTENSION}"
-    cp "./examples/hotrod/hotrod-${PLATFORM}"     "${PACKAGE_STAGING_DIR}/example-hotrod${FILE_EXTENSION}"
 }
 
 function stage-platform-files-v2 {
@@ -54,6 +52,7 @@ function stage-platform-files-v2 {
     local -r FILE_EXTENSION=${3:-}
 
     cp "./cmd/jaeger/jaeger-${PLATFORM}"          "${PACKAGE_STAGING_DIR}/jaeger${FILE_EXTENSION}"
+    cp "./cmd/all-in-one/all-in-one-${PLATFORM}"  "${PACKAGE_STAGING_DIR}/jaeger-all-in-one${FILE_EXTENSION}"
     cp "./examples/hotrod/hotrod-${PLATFORM}"     "${PACKAGE_STAGING_DIR}/example-hotrod${FILE_EXTENSION}"
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
Part 1 of https://github.com/jaegertracing/jaeger/issues/7497

## Description of the changes
Kept hotrod and all-in-one binaries only in v2 

## How was this change tested?
Locally

## Checklist
- [ ✅] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [✅ ] I have signed all commits
- [ ✅] I have added unit tests for the new functionality
- [✅ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
