### PR TITLE
Add riscv64 binary support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 JAEGER_IMPORT_PATH = github.com/jaegertracing/jaeger
 
 # PLATFORMS is a list of all supported platforms
-PLATFORMS="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,darwin/amd64,darwin/arm64,windows/amd64"
+PLATFORMS="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64,darwin/amd64,darwin/arm64,windows/amd64"
 LINUX_PLATFORMS=$(shell echo "$(PLATFORMS)" | tr ',' '\n' | grep linux | tr '\n' ',' | sed 's/,$$/\n/')
 
 # SRC_ROOT is the top of the source tree.
@@ -52,8 +52,10 @@ GO=go
 GOOS ?= $(shell $(GO) env GOOS)
 GOARCH ?= $(shell $(GO) env GOARCH)
 
-# go test does not support -race flag on s390x architecture
+# go test does not support -race flag on s390x and riscv64 architectures
 ifeq ($(GOARCH), s390x)
+	RACE=
+else ifeq ($(GOARCH), riscv64)
 	RACE=
 else
 	RACE=-race

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -144,6 +144,10 @@ build-binaries-linux-arm64:
 build-binaries-linux-ppc64le:
 	GOOS=linux GOARCH=ppc64le $(MAKE) _build-platform-binaries
 
+.PHONY: build-binaries-linux-riscv64
+build-binaries-linux-riscv64:
+	GOOS=linux GOARCH=riscv64 $(MAKE) _build-platform-binaries
+
 # build all binaries for one specific platform GOOS/GOARCH
 .PHONY: _build-platform-binaries
 _build-platform-binaries: \


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves: #7528 

## Description of the changes
This PR adds full riscv64 support to the Jaeger build system by:
- Adding `linux/riscv64` to the supported platforms list
- Creating the appropriate build targets for riscv64
- Disabling the race detector for riscv64 (as Go's race detector doesn't support this architecture)

## How was this change tested?
- Verified platform detection: `make echo-platforms` includes riscv64
- Successfully built riscv64 binary: `make build-binaries-linux-riscv64`
- Confirmed generated binary is valid RISC-V 64-bit ELF executable

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
