### PR TITLE
skip delve for riscv64 arch

### DIFF
--- a/scripts/build/docker/debug/Dockerfile
+++ b/scripts/build/docker/debug/Dockerfile
@@ -10,7 +10,8 @@ COPY go.mod go.sum /go/src/debug-delve/
 
 # TODO: Remove s390x once go-delve adds support for it (https://github.com/go-delve/delve/issues/2883)
 # TODO: Remove ppc64le once support is released (https://github.com/go-delve/delve/issues/1564) - not yet as of delve@v1.22.1
-RUN if [[ "$TARGETARCH" == "s390x" ||  "$TARGETARCH" == "ppc64le" ]] ; then \
+# TODO: Remove riscv64 once its supported
+RUN if [[ "$TARGETARCH" == "s390x" ||  "$TARGETARCH" == "ppc64le" ||  "$TARGETARCH" == "riscv64" ]] ; then \
 	touch /go/bin/dlv; \
     else \
         cd /go/src/debug-delve && go mod download && go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv; \


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #7528 

## Description of the changes
-  Skip delve debugger in the Dockerfile when the architecture is riscv64, as its still experimental and not yet supported

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
