### PR TITLE
Enable range-val-address linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -142,9 +142,6 @@ linters:
         # maybe enable, needs invesitgation of the impact
         - name: get-return
           disabled: true
-        # investigate, could be real bugs. But didn't recent Go version changed loop variables semantics?
-        - name: range-val-address
-          disabled: true
         # this is idiocy, promotes less readable code. Don't enable.
         - name: var-declaration
           disabled: true


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #5506 

## Description of the changes
- Enabled the `range-val-address` rule with required changes to the files.

## How was this change tested?
- make test
- make lint

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
