### PR TITLE
Adding suport for attributes in v3 traces querying

### DIFF
--- a/cmd/query/app/apiv3/http_gateway.go
+++ b/cmd/query/app/apiv3/http_gateway.go
@@ -44,7 +44,7 @@ const (
 	paramDurationMin    = "query.duration_min"
 	paramDurationMax    = "query.duration_max"
 	paramQueryRawTraces = "query.raw_traces"
-	paramAttributes="query.attributes"
+	paramAttributes     = "query.attributes"
 
 	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
 	routeFindTraces    = "/api/v3/traces"
@@ -221,7 +221,7 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 	if attrs := q.Get(paramAttributes); attrs != "" {
 		var kv map[string]string
 		if err := json.Unmarshal([]byte(attrs), &kv); err != nil {
-			h.tryHandleError(w, fmt.Errorf("invalid query.attributes format: must be JSON object of string pairs"), http.StatusBadRequest)
+			h.tryHandleError(w, errors.New("invalid query.attributes format: must be JSON object of string pairs"), http.StatusBadRequest)
 			return nil, true
 		}
 		for k, v := range kv {


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #7594 
## Description of the changes
I added support for filtering the traces based on attributes passed. 
## How was this change tested?
- I checked the response I got from the GET request and it showed the correct filtered data.
`http://localhost:16686/api/v3/traces?query.num_traces=1&query.service_name=frontend&query.start_time_max=2025-10-19T15%3A54%3A58.373570048Z&query.start_time_min=2025-10-16T14%3A54%3A59.373570048Z&query.attributes={%22driver%22%3A%22T704822C%22}`


## Checklist
- [ x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
