### PR TITLE
[refactor]: use the built-in max to simplify the code

### DIFF
--- a/internal/storage/metricstore/elasticsearch/processor.go
+++ b/internal/storage/metricstore/elasticsearch/processor.go
@@ -239,10 +239,7 @@ func applySlidingWindow(mf *metrics.MetricFamily, lookback int, processor func(m
 		processedPoints := make([]*metrics.MetricPoint, 0, len(points))
 
 		for i, currentPoint := range points {
-			start := i - lookback + 1
-			if start < 0 {
-				start = 0
-			}
+			start := max(i-lookback+1, 0)
 			window := points[start : i+1]
 			resultValue := processor(metric, window)
 

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -422,10 +422,7 @@ func (r *TraceReader) durationQueries(plan *executionPlan, query *spanstore.Trac
 
 func mergeJoinIds(left, right [][]byte) [][]byte {
 	// len(left) or len(right) is the maximum, whichever is the smallest
-	allocateSize := len(left)
-	if len(right) < allocateSize {
-		allocateSize = len(right)
-	}
+	allocateSize := min(len(right), len(left))
 
 	merged := make([][]byte, 0, allocateSize)
 


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

## How was this change tested?

No need.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
