### PR TITLE
Handle ES ping failures more gracefully

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -265,7 +265,7 @@ func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metric
 
 		// The deserialization in the ping implementation may succeed even if the response
 		// contains no relevant properties and we may get empty values in that case.
-		if len(pingResult.Version.Number) == 0 {
+		if pingResult.Version.Number == "" {
 			return nil, fmt.Errorf("ElasticSearch server %s returned invalid ping response", c.Servers[0])
 		}
 

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -506,6 +506,7 @@ func TestNewClient(t *testing.T) {
 		})
 	}
 }
+
 func TestNewClientPingErrorHandling(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -537,7 +538,7 @@ func TestNewClientPingErrorHandling(t *testing.T) {
 			statusCode:     200,
 			expectedError:  "invalid ping response",
 		},
-		
+
 		{
 			name:           "ping returns valid 200 status with version",
 			serverResponse: mockEsServerResponseWithVersion0,
@@ -556,8 +557,8 @@ func TestNewClientPingErrorHandling(t *testing.T) {
 			defer testServer.Close()
 
 			config := &Configuration{
-				Servers: []string{testServer.URL},
-				LogLevel: "error",
+				Servers:            []string{testServer.URL},
+				LogLevel:           "error",
 				DisableHealthCheck: true,
 			}
 
@@ -579,7 +580,6 @@ func TestNewClientPingErrorHandling(t *testing.T) {
 	}
 }
 
-
 func TestNewClientVersionDetection(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -594,7 +594,7 @@ func TestNewClientVersionDetection(t *testing.T) {
                     "Number": "7.x.1"
                 }
             }`),
-			expectedVersion: 7, 
+			expectedVersion: 7,
 			expectedError:   "",
 		},
 		{
@@ -619,15 +619,15 @@ func TestNewClientVersionDetection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-				res.WriteHeader(200)
+			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+				res.WriteHeader(http.StatusOK)
 				res.Write(test.serverResponse)
 			}))
 			defer testServer.Close()
 
 			config := &Configuration{
-				Servers: []string{testServer.URL},
-				LogLevel: "error",
+				Servers:            []string{testServer.URL},
+				LogLevel:           "error",
 				DisableHealthCheck: true,
 			}
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7625 

## Description of the changes
- Added test cases for the changes done in the #7422 

## How was this change tested?
- `/usr/bin/go test -timeout 30s -coverprofile=/tmp/vscode-gokdhNQo/go-code-cover github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
