### PR TITLE
changelog: Support attributes filtering in /api/v3/traces endpoint

### DIFF
--- a/cmd/query/app/apiv3/http_gateway_test.go
+++ b/cmd/query/app/apiv3/http_gateway_test.go
@@ -231,7 +231,6 @@ func TestHTTPGatewayFindTracesWithAttributes(t *testing.T) {
 	gw.reader.AssertExpectations(t)
 }
 
-
 func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -259,7 +258,6 @@ func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 			expectedError: "malformed parameter raw_traces",
 		},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			gw := setupHTTPGatewayNoServer(t, "")


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves jaegertracing/jaeger#7594

## Description of the changes
This PR adds support for filtering by `query.attributes` in the `/api/v3/traces` HTTP endpoint. Previously, the `query.attributes` parameter was ignored by the handler.

- **`cmd/query/app/apiv3/http_gateway.go`:**
    - Updated `parseFindTracesQuery` to read the `query.attributes` parameter.
    - Added logic to unmarshal the attributes JSON string and populate the `TraceQueryParams` struct.

## How was this change tested?
- Added new unit tests in **`cmd/query/app/apiv3/http_gateway_test.go`**:
    - `TestHTTPGatewayFindTracesWithAttributes`: Verifies that the `query.attributes` are correctly parsed and passed to the query service.
    - Added a new test case to `TestHTTPGatewayFindTracesErrors` to check for malformed `query.attributes` JSON.
- All tests were run successfully.

### Screenshot
<img width="1492" height="311" alt="image" src="https://github.com/user-attachments/assets/0222c58e-6257-4231-9c70-c4803d8607b6" />

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`

cc @yurishkuro 