### PR TITLE
Clean Go cache after installing gotip as suggested. 

### DIFF
--- a/.github/workflows/ci-unit-tests-go-tip.yml
+++ b/.github/workflows/ci-unit-tests-go-tip.yml
@@ -40,6 +40,11 @@ jobs:
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Clean Go cache for gotip
+      run: |
+        go clean -cache
+        go clean -modcache
+
     - name: Run unit tests
       run: make test-ci
 


### PR DESCRIPTION
Fixes #7664

## Problem
After the initial fix, cached modules built with stable Go (1.25.x) were causing version mismatch errors when gotip tried to use them.

## Solution
Added cache cleanup after installing gotip to clear build cache and module cache. This ensures gotip builds modules from scratch instead of reusing cached artifacts from stable Go.

## Changes
- Runs `go clean -cache` and `go clean -modcache` after gotip installation.
- Prevents version conflicts between stable Go and gotip cached modules.