### PR TITLE
fix: Register basicauth extension in component factory

### DIFF
--- a/cmd/jaeger/internal/components.go
+++ b/cmd/jaeger/internal/components.go
@@ -7,6 +7,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
@@ -76,6 +77,7 @@ func (b builders) build() (otelcol.Factories, error) {
 		zpagesextension.NewFactory(),
 
 		// add-ons
+		basicauthextension.NewFactory(),
 		sigv4authextension.NewFactory(),
 		jaegerquery.NewFactory(),
 		jaegerstorage.NewFactory(),


### PR DESCRIPTION

## Which problem is this PR solving?
* #7656 

 ## Problem
  The basicauth extension from opentelemetry-collector-contrib was not registered in Jaeger's component factory, causing
  "unknown type: basicauth" errors when users tried to configure it for Prometheus authentication with TLS + basic auth.

## Description of the changes
  - Registered `basicauth` extension from opentelemetry-collector-contrib in the component factory
  - Added import for `basicauthextension` package in `cmd/jaeger/internal/components.go`
  - Added `basicauthextension.NewFactory()` to the extensions list to make it available for authentication configurations

  ## How was this change tested?
  - Built the project successfully with the new extension registered
  - Created a test configuration with `basicauth/prometheus_client` extension
  - Verified Jaeger starts without "unknown type: basicauth" error
  - Confirmed the extension loads and starts successfully in the logs

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
