### PR TITLE
ci: Exclude HTTP 5xx metrics from comparisons

### DIFF
--- a/scripts/e2e/compare_metrics.py
+++ b/scripts/e2e/compare_metrics.py
@@ -93,9 +93,8 @@ def parse_metrics(content):
     for family in text_string_to_metric_families(content):
         for sample in family.samples:
             labels = dict(sample.labels)
-            
-            should_exclude= should_exclude_metric(sample.name, labels)
-            if should_exclude:
+
+            if should_exclude_metric(sample.name, labels):
                 continue
 
             labels.pop('service_instance_id', None)


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7617 

## Description of the changes
- This PR introduces the changes to filter out 503 calls to reduce the flakiness in the metrics comparision.

## How was this change tested?
- I used the artifacts form https://github.com/jaegertracing/jaeger/actions/runs/19589467818/job/56105108460 and https://github.com/jaegertracing/jaeger/actions/runs/19596403385/job/56121587792?pr=7666 to manually test the script. Before changes the 503 calls were listed as metrics added/deleted but after changes they are being filtered correctly.

Before changes
<img width="1885" height="299" alt="image" src="https://github.com/user-attachments/assets/0bac1ceb-f8a9-47f3-b841-41639c4841c8" />

After changes
<img width="1805" height="77" alt="image" src="https://github.com/user-attachments/assets/96e6d79c-352a-43a9-9da6-868791634277" />



## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
