### PR TITLE
Fix histogram buckets for storage latency metrics

### DIFF
--- a/internal/storage/v1/api/spanstore/spanstoremetrics/write_metrics.go
+++ b/internal/storage/v1/api/spanstore/spanstoremetrics/write_metrics.go
@@ -15,8 +15,8 @@ type WriteMetrics struct {
 	Attempts   metrics.Counter `metric:"attempts"`
 	Inserts    metrics.Counter `metric:"inserts"`
 	Errors     metrics.Counter `metric:"errors"`
-	LatencyOk  metrics.Timer   `metric:"latency-ok"`
-	LatencyErr metrics.Timer   `metric:"latency-err"`
+	LatencyOk  metrics.Timer   `metric:"latency-ok" buckets:"5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,2s,5s,10s"`
+	LatencyErr metrics.Timer   `metric:"latency-err" buckets:"5ms,10ms,25ms,50ms,100ms,250ms,500ms,1s,2s,5s,10s"`
 }
 
 // NewWriter takes a metrics scope and creates a metrics struct


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7217  
- Storage latency metrics (`jaeger_storage_bulk_index_latency_ok_seconds`) were recorded in seconds but histogram buckets were defined as if they were milliseconds. This caused all realistic latencies (e.g., 20–30ms = 0.02s) to fall into the first bucket (`le="5"`), making the histogram unusable.

## Description of the changes
- Enabled bucket parsing for `metrics.Timer` in `internal/metrics/metrics.go`, allowing timers to accept `buckets:"..."` struct tags.
- Updated `internal/metrics/otelmetrics/factory.go` to convert `[]time.Duration` buckets into float64 seconds and pass them to OpenTelemetry histograms via `metric.WithExplicitBucketBoundaries`.
- Annotated `LatencyOk` and `LatencyErr` timers in `internal/storage/v1/api/spanstore/spanstoremetrics/write_metrics.go` with ms‑scale buckets (`5ms`–`10s`).
- This ensures storage latency histograms now distribute values across realistic ranges instead of piling into `le="5"`.

## How was this change tested?
- Ran `make lint test` locally; all lint checks passed.
- Verified with `make test` that unit tests succeed (no regressions).
- Observed `/metrics` output before and after the change:
  - **Before:** all values fell into `le="5"` despite sums around `0.02`.
  - **After:** values distributed across `.005–.05` buckets, matching ms‑scale latencies.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
