### PR TITLE
Feat: Add Deep Dependencies endpoint

### DIFF
--- a/cmd/jaeger/internal/all_in_one_test.go
+++ b/cmd/jaeger/internal/all_in_one_test.go
@@ -62,6 +62,7 @@ func TestAllInOne(t *testing.T) {
 	t.Run("verifyGetTraceAPI", verifyGetTraceAPI)
 	t.Run("verifyGetSamplingStrategyAPI", verifyGetSamplingStrategyAPI)
 	t.Run("verifyGetServicesAPIV3", verifyGetServicesAPIV3)
+	t.Run("checkDeepDependencies", checkDeepDependencies)
 }
 
 func healthCheck(t *testing.T) {
@@ -189,4 +190,13 @@ func verifyGetServicesAPIV3(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &servicesResponse))
 	require.Len(t, servicesResponse.Services, 1)
 	assert.Contains(t, servicesResponse.Services[0], "jaeger")
+}
+
+func checkDeepDependencies(t *testing.T) {
+	_, body := httpGet(t, queryAddr+"/analytics/v1/dependencies?service=test")
+	var response struct {
+		Dependencies []any `json:"dependencies"`
+	}
+	require.NoError(t, json.Unmarshal(body, &response))
+	assert.NotEmpty(t, response.Dependencies)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -123,6 +123,13 @@ func (aH *APIHandler) RegisterRoutes(router *mux.Router) {
 	aH.handleFunc(router, aH.transformOTLP, "/transform").Methods(http.MethodPost)
 	aH.handleFunc(router, aH.dependencies, "/dependencies").Methods(http.MethodGet)
 	aH.handleFunc(router, aH.deepDependencies, "/deep-dependencies").Methods(http.MethodGet)
+
+	// Register /analytics/v1/dependencies to match UI expectations
+	analyticsRoute := "/analytics/v1/dependencies"
+	var analyticsHandler http.Handler = http.HandlerFunc(aH.deepDependencies)
+	analyticsHandler = otelhttp.WithRouteTag(analyticsRoute, analyticsHandler)
+	analyticsHandler = spanNameHandler(analyticsRoute, analyticsHandler)
+	router.HandleFunc(analyticsRoute, analyticsHandler.ServeHTTP).Methods(http.MethodGet)
 	aH.handleFunc(router, aH.latencies, "/metrics/latencies").Methods(http.MethodGet)
 	aH.handleFunc(router, aH.calls, "/metrics/calls").Methods(http.MethodGet)
 	aH.handleFunc(router, aH.errors, "/metrics/errors").Methods(http.MethodGet)


### PR DESCRIPTION


## Which problem is this PR solving?
- Fixes #6606


## Description of the changes
- Adds the missing backend endpoint to support the Deep Dependencies graph in the UI.

## How was this change tested?
- Ran the server: `go run ./cmd/jaeger`
- Ran Jaeger UI: `npm start`
- Opened `http://localhost:5173/deep-dependencies?service=test` and confirmed the graph renders.

<img width="1804" height="999" alt="image" src="https://github.com/user-attachments/assets/3bd32909-4b85-4b7c-9565-55fb38f13664" />


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
