### PR TITLE
Switch to go.yaml.in/yaml/v3

### DIFF
--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/integration/storagecleaner"
 	"github.com/jaegertracing/jaeger/internal/storage/integration"


### PR DESCRIPTION
- The original [gopkg.in/yaml.v3](http://gopkg.in/yaml.v3) was marked unmaintained (April 2025)
- [go.yaml.in/yaml/v3](http://go.yaml.in/yaml/v3) is now maintained by the official YAML organization
- It's a drop-in replacement - just change the import path