### PR TITLE
[fix][clickhouse] Remove `name` column from ordering key for operations table

### DIFF
--- a/internal/storage/v2/clickhouse/sql/create_operations_table.sql
+++ b/internal/storage/v2/clickhouse/sql/create_operations_table.sql
@@ -5,4 +5,4 @@ CREATE TABLE IF NOT EXISTS
         span_kind String
     ) ENGINE = ReplacingMergeTree
 ORDER BY
-    (service_name, name, span_kind);
+    (service_name, span_kind);


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #7134 

## Description of the changes
- The `name` column isn't required in the ordering key for the `operations` table since we only ever filter by `service_name` and `span_kind`

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
