### PR TITLE
[clickhouse] Add indexes for spans table in ClickHouse storage

### DIFF
--- a/internal/storage/v2/clickhouse/sql/create_spans_table.sql
+++ b/internal/storage/v2/clickhouse/sql/create_spans_table.sql
@@ -53,6 +53,8 @@ CREATE TABLE
         INDEX idx_duration duration TYPE minmax GRANULARITY 1,
         INDEX idx_attributes_keys str_attributes.key TYPE bloom_filter GRANULARITY 1,
         INDEX idx_attributes_values str_attributes.value TYPE bloom_filter GRANULARITY 1,
+        INDEX idx_resource_attributes_keys resource_str_attributes.key TYPE bloom_filter GRANULARITY 1,
+        INDEX idx_resource_attributes_values resource_str_attributes.value TYPE bloom_filter GRANULARITY 1,
     ) ENGINE = MergeTree
 PARTITION BY toDate(start_time)
 ORDER BY (trace_id)


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #7134 

## Description of the changes
- This PR updates the schema for the `spans` table in ClickHouse to add data skipping indexes  

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
