### PR TITLE
Increase test coverage for startAdaptiveStrategyProvider

### DIFF
--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -76,7 +76,7 @@ func makeStorageExtension(t *testing.T, memstoreName string) component.Host {
 	return host
 }
 
-func makeStorageExtensionWithBadSamplingStore(_ *testing.T, storageName string) component.Host {
+func makeStorageExtensionWithBadSamplingStore(storageName string) component.Host {
 	ext := &fakeStorageExtensionForTest{
 		storageName: storageName,
 		failOn:      "CreateSamplingStore",
@@ -86,7 +86,7 @@ func makeStorageExtensionWithBadSamplingStore(_ *testing.T, storageName string) 
 	return host
 }
 
-func makeStorageExtensionWithBadLock(_ *testing.T, storageName string) component.Host {
+func makeStorageExtensionWithBadLock(storageName string) component.Host {
 	ext := &fakeStorageExtensionForTest{
 		storageName: storageName,
 		failOn:      "CreateLock",
@@ -244,7 +244,8 @@ func TestStartAdaptiveStrategyProviderErrors(t *testing.T) {
 }
 
 func TestStartAdaptiveStrategyProviderCreateStoreError(t *testing.T) {
-	storageHost := makeStorageExtensionWithBadSamplingStore(t, "failstore")
+	// storage extension has the requested store name but its factory fails on CreateSamplingStore
+	storageHost := makeStorageExtensionWithBadSamplingStore("failstore")
 
 	ext := &rsExtension{
 		cfg: &Config{
@@ -263,7 +264,7 @@ func TestStartAdaptiveStrategyProviderCreateStoreError(t *testing.T) {
 }
 
 func TestStartAdaptiveStrategyProviderCreateLockError(t *testing.T) {
-	storageHost := makeStorageExtensionWithBadLock(t, "lockerror")
+	storageHost := makeStorageExtensionWithBadLock("lockerror")
 
 	ext := &rsExtension{
 		cfg: &Config{


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7432 

## Description of the changes
- Added 2 tests for `startAdaptiveStrategyProvider`:
  - `TestStartAdaptiveStrategyProviderCreateStoreError` - tests error when `CreateSamplingStore()` fails
  - `TestStartAdaptiveStrategyProviderCreateLockError` - tests error when `CreateLock()` fails

## How was this change tested?
- Unit tests

- Before:
<img width="945" height="14" alt="Screenshot 2025-12-16 094507" src="https://github.com/user-attachments/assets/b1d71648-ac39-4d03-a5b2-2d3e9f267444" />

- After:
<img width="941" height="14" alt="Screenshot 2025-12-16 094611" src="https://github.com/user-attachments/assets/810405c8-cd9d-419e-abd1-0b310c342527" />


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
