### PR TITLE
chore: Bump hotrod Dockerfile to Alpine 3.23 for security fix

### DIFF
--- a/examples/hotrod/Dockerfile
+++ b/examples/hotrod/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.21.3 AS cert
+FROM alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375 AS cert
 RUN apk add --update --no-cache ca-certificates
 
 FROM scratch


### PR DESCRIPTION
## Summary

This PR updates the hotrod example Dockerfile from Alpine 3.21.3 to Alpine 3.23.0 with a pinned SHA256 digest to address security vulnerabilities that are fixed natively in Alpine 3.23.

## Changes

- Updated `examples/hotrod/Dockerfile` from `alpine:3.21.3` to `alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375`

## Context

The base Dockerfile (`scripts/build/docker/base/Dockerfile`) was already updated to Alpine 3.23.0. This change aligns the hotrod example with the same security baseline.

## Testing

- [x] All unit tests pass (`make test`)
- [x] All linters pass (`make lint`)

## Related

This addresses the security issues fixed in Alpine 3.23 base image.