### PR TITLE
Fix scripts/release/draft.py

### DIFF
--- a/scripts/release/draft.py
+++ b/scripts/release/draft.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 
 version_pattern = re.compile(r"v?(\d+\.\d+\.\d+)")
+header_pattern = re.compile(r"^v?\d+\.\d+\.\d+")
 
 underline_pattern = re.compile(r"^[-]+$", flags=0)
 
@@ -60,7 +61,7 @@ def get_changelog(repo):
         for line in f:
             versions = version_pattern.findall(line)
 
-            if versions:
+            if versions and header_pattern.match(line):
                 # Found the first release headers.
                 if in_changelog_text:
                     # Found the next release.


### PR DESCRIPTION
fixed the issue where draft.py was stopping the changelog extraction too early.

The problem was that the script identified any version-like string (like v0.141.0 in a PR title) as a release header. Updated the script to anchor the release header detection to the start of the line, ensuring it only triggers on actual release dividers.