### PR TITLE
Simplify backend release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,26 +1,12 @@
 name: Publish release
 
 on:
-  # Disable auto-run, once we sunset 1.x components we might go back to auto-release.
-  #
-  # release:
-  #   types:
-  #     - published
+  release:
+    types:
+      - published
 
   workflow_dispatch:
     inputs:
-      # Disable version inputs for now, the build always uses the latest tags.
-      #
-      # version_v1:
-      #   required: true
-      #   type: string
-      #   description: Version number for 1.x components. Don't include a leading `v`.
-
-      # version_v2:
-      #   required: true
-      #   type: string
-      #   description: Version number for 2.x components. Don't include a leading `v`.
-
       dry_run:
         required: true
         type: boolean

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,27 +35,18 @@ Follow the checklist in the created tracking issue. The high level steps are:
 <!-- BEGIN_CHECKLIST -->
 
 1. Create a PR "Prepare release vX.Y.Z" against main or maintenance branch ([example](https://github.com/jaegertracing/jaeger/pull/6826)).
-    * **Automated**: `make prepare-release VERSION=X.Y.Z`
-      * Updates CHANGELOG.md (generates content via `make changelog`)
-      * Upgrades jaeger-ui submodule to the corresponding version
-      * Rotates release managers table
-      * Creates PR with label `changelog:skip`
-    * Manual: See [Manual release pull request](https://github.com/jaegertracing/jaeger/blob/main/RELEASE.md#manual-release-pull-request).
-2. After the PR is merged, create new release tag (command is in the PR description if using automation):
-    ```
-    git checkout main
-    git pull
-    git tag vX.Y.Z -s -m "Release vX.Y.Z" # use the new version
-    git push upstream vX.Y.Z
-    ```
-3. Create a release on Github:
-    * **Automated**:  `make draft-release`
-    * Manual: See [Manual release](https://github.com/jaegertracing/jaeger/blob/main/RELEASE.md#manual-release).
-4. Go to [Publish Release workflow](https://github.com/jaegertracing/jaeger/actions/workflows/ci-release.yml) on GitHub
-   and run it manually using Run Workflow button on the right.
-   1. For monitoring and troubleshooting, open the logs of the workflow run from above URL.
-   2. Check the images are available on [Docker Hub](https://hub.docker.com/r/jaegertracing/)
-      and binaries are uploaded [to the release](https://github.com/jaegertracing/jaeger/releases)
+  * **Automated**: `make prepare-release VERSION=X.Y.Z`
+    * Updates CHANGELOG.md (generates content via `make changelog`)
+    * Upgrades jaeger-ui submodule to the corresponding version
+    * Rotates release managers table
+    * Creates PR with label `changelog:skip`
+  * Manual: See [Manual release pull request](https://github.com/jaegertracing/jaeger/blob/main/RELEASE.md#manual-release-pull-request).
+2. After the PR is merged, create a release on Github:
+  * **Automated**:  `make draft-release`
+  * Manual: See [Manual release](https://github.com/jaegertracing/jaeger/blob/main/RELEASE.md#manual-release).
+3. Once the release is created, the [Publish Release workflow](https://github.com/jaegertracing/jaeger/actions/workflows/ci-release.yml) will run to build artifacts.
+  * Wait for the workflow to finish. For monitoring and troubleshooting, open the logs of the workflow run from above URL.
+  * Check the images are available on [Docker Hub](https://hub.docker.com/r/jaegertracing/) and binaries are uploaded [to the release](https://github.com/jaegertracing/jaeger/releases).
 
 <!-- END_CHECKLIST -->
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Simplify release process. Now that we're back to a single release number we can run the publish workflow automatically upon creating a GitHub release, just like we do in the UI repo.

## Description of the changes
- Enable publish workflow to run on release.
- Remove manual tagging instructions, it will happen via GH release.
- Update release instructions checklist.

## How was this change tested?
- yolo
