### PR TITLE
[refactor]: use reflect.TypeFor

### DIFF
--- a/internal/gogocodec/codec_test.go
+++ b/internal/gogocodec/codec_test.go
@@ -72,8 +72,7 @@ func TestWireCompatibility(t *testing.T) {
 func TestUseGogo(t *testing.T) {
 	assert.False(t, useGogo(nil))
 
-	var span model.Span
-	assert.True(t, useGogo(reflect.TypeOf(span)))
+	assert.True(t, useGogo(reflect.TypeFor[model.Span]()))
 }
 
 func BenchmarkCodecUnmarshal25Spans(b *testing.B) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,10 +36,10 @@ func Init(m any, factory Factory, globalTags map[string]string) error {
 		factory = NullFactory
 	}
 
-	counterPtrType := reflect.TypeOf((*Counter)(nil)).Elem()
-	gaugePtrType := reflect.TypeOf((*Gauge)(nil)).Elem()
-	timerPtrType := reflect.TypeOf((*Timer)(nil)).Elem()
-	histogramPtrType := reflect.TypeOf((*Histogram)(nil)).Elem()
+	counterPtrType := reflect.TypeFor[Counter]()
+	gaugePtrType := reflect.TypeFor[Gauge]()
+	timerPtrType := reflect.TypeFor[Timer]()
+	histogramPtrType := reflect.TypeFor[Histogram]()
 
 	v := reflect.ValueOf(m).Elem()
 	t := v.Type()


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes


Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.
More info https://github.com/golang/go/issues/60088



## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
