### PR TITLE
[chore] Upgrade grpc_handler_test to v2 storage api

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
-	// "github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	spanstoremocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	depsmocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #7852 

## Description of the changes
- This PR refactors `cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler_test.go`  to use v2 storage interfaces.

## How was this change tested?
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
