### PR TITLE
fix(ci): Fix CodeQL workflow to properly analyze Go code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: "CodeQL"
 
 on:
+  merge_group:
   push:
     branches: [main]
 
@@ -20,8 +21,9 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   codeql-analyze:
-    # Run only on pull requests, see https://github.com/github/codeql-action/issues/1537
-    if: ${{ github.event_name == 'pull_request' }}
+    # Skip merge_group to avoid duplicate runs (code already scanned on pull_request)
+    # See https://github.com/github/codeql-action/issues/1537
+    if: ${{ github.event_name != 'merge_group' }}
     name: CodeQL Analyze
     runs-on: ubuntu-latest
 
@@ -33,29 +35,40 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go', 'python' ]
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: audit
 
     - name: Checkout repository
       uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      with:
+        submodules: true
 
-    # Initializes the CodeQL tools for scanning.
+    - name: Setup Go
+      if: matrix.language == 'go'
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      with:
+        go-version: 1.25.x
+
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4
+      uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4
+    # Use Autobuild for Python (it works fine for interpreted languages)
+    - name: Autobuild (Python)
+      if: matrix.language == 'python'
+      uses: github/codeql-action/autobuild@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+
+    # Explicit build for Go - required for CodeQL to analyze compiled code
+    - name: Build Go code
+      if: matrix.language == 'go'
+      run: |
+        # Build all Go binaries to ensure CodeQL can analyze them
+        go build -v ./...
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4
+      uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8


### PR DESCRIPTION
## Which problem is this PR solving?

This PR fixes two CodeQL security scanning issues visible at:
https://github.com/jaegertracing/jaeger/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BOPFWWY

### Issue 1: "Go files were found but not processed"
CodeQL's `Autobuild` step was unable to properly compile the Go codebase, preventing security analysis.

### Issue 2: "Code Scanning results may be out of date"
The last successful scan was Feb 13, 2025. This was caused by PR #6719 which added:
```yaml
if: ${{ github.event_name == 'pull_request' }}
```
This condition was intended to prevent duplicate runs in merge queue, but it also disabled scans for:
- Push events to `main`
- Scheduled weekly runs

## Description of the changes

### Fix for Autobuild failure
- Replace `Autobuild` with explicit `go build ./...` for Go (Autobuild is kept for Python)
- Add `setup-go` action to ensure Go is properly configured
- Add `submodules: true` to checkout for complete codebase

### Fix for stale scan results
- Change condition from `== 'pull_request'` to `!= 'merge_group'`
- This preserves the merge queue optimization while enabling scans on all other triggers

### Updated trigger behavior

| Event | CodeQL Runs? | Reason |
|-------|-------------|--------|
| `pull_request` | ✅ Yes | Primary scan when code is submitted |
| `push` to main | ✅ Yes | Catches direct commits & validates merged code |
| `schedule` (weekly) | ✅ Yes | Catches new vulnerabilities in dependencies |
| `merge_group` | ❌ Skipped | Already scanned on `pull_request` |

## How was this change tested?
- Manual review of workflow syntax
- Verification that the workflow triggers correctly based on GitHub Actions documentation

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully (N/A - workflow file only)

## References
- Original issue: https://github.com/github/codeql-action/issues/1537
- PR that introduced the restriction: #6719