### PR TITLE
Fix GetOperations to query full service history

### DIFF
--- a/internal/storage/v1/elasticsearch/spanstore/reader.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader.go
@@ -323,10 +323,11 @@ func (s *SpanReader) GetOperations(
 	jaegerIndices := s.timeRangeIndices(
 		s.serviceIndexPrefix,
 		s.serviceIndex.DateLayout,
-		currentTime.Add(-s.maxSpanAge),
+		currentTime.Add(-dawnOfTimeSpanAge), // ✅ FIX
 		currentTime,
 		cfg.RolloverFrequencyAsNegativeDuration(s.serviceIndex.RolloverFrequency),
 	)
+
 	operations, err := s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query.ServiceName, s.maxDocCount)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What
Fixes an issue where GetOperations queried a limited time window,
causing historical operations to disappear.

## Why
Operations are derived from service indices and should not be limited
by span lookback configuration.

## How
Query service indices from a sufficiently old start time to ensure
all historical operations are returned.

Fixes #2420
