### PR TITLE
fix(license): exclude dev tools from FOSSA license scan

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,30 @@
+# FOSSA Configuration File
+# https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
+#
+# This configuration excludes development-only tooling from license scanning.
+# The excluded paths contain GPL-3.0 licensed tools (golangci-lint and its plugins)
+# that are used only during development and are NOT compiled into or distributed
+# with the final Jaeger binaries.
+#
+# These tools are in separate Go modules specifically to isolate them from
+# production dependencies. Using GPL-licensed development tools to build
+# Apache 2.0 licensed software does not create any license compliance issues.
+
+version: 3
+
+project:
+  id: git+github.com/jaegertracing/jaeger
+  name: jaeger
+
+paths:
+  exclude:
+    # Development tooling (golangci-lint and plugins) - GPL-3.0 licensed
+    # These are NOT part of the distributed binaries
+    - ./internal/tools
+
+    # Debug build utilities - only used for debugging, not distributed
+    - ./scripts/build/docker/debug
+
+    # Git submodules - scanned separately in their own repositories
+    - ./idl
+    - ./jaeger-ui


### PR DESCRIPTION
The FOSSA license scan is failing because it scans development-only tooling directories that contain GPL-3.0 licensed packages:

- golangci-lint and its plugins (depguard, go-header, grouper, etc.)
- gosmopolitan, nonamedreturns, and other linter plugins

These tools are located in internal/tools/go.mod which is a separate Go module used exclusively for development. They are:
- NOT compiled into the final Jaeger binaries
- NOT distributed with Jaeger releases
- Only used by developers for static analysis during development

Using GPL-licensed development tools to build Apache 2.0 licensed software does not create any license compliance issues (this is the 'aggregation' exception in GPL terms).

This configuration file tells FOSSA to exclude:
- ./internal/tools - development tooling
- ./scripts/build/docker/debug - debug utilities
- ./idl and ./jaeger-ui - git submodules (scanned in their own repos)

Fixes the failing FOSSA badge in the README.