### PR TITLE
Issue #7870: Added TTL support for clickhouse

### DIFF
--- a/cmd/jaeger/config-clickhouse.yaml
+++ b/cmd/jaeger/config-clickhouse.yaml
@@ -43,6 +43,7 @@ extensions:
               username: default
               password: password
           create_schema: true
+          ttl: 168h
 
 receivers:
   otlp:

--- a/internal/storage/v2/clickhouse/sql/create_spans_table.sql
+++ b/internal/storage/v2/clickhouse/sql/create_spans_table.sql
@@ -58,3 +58,6 @@ CREATE TABLE
     ) ENGINE = MergeTree
 PARTITION BY toDate(start_time)
 ORDER BY (trace_id)
+{{- if .TTL }}
+TTL start_time + INTERVAL {{ .TTL }} DAY
+{{- end }}

--- a/internal/storage/v2/clickhouse/sql/create_trace_id_timestamps_table.sql
+++ b/internal/storage/v2/clickhouse/sql/create_trace_id_timestamps_table.sql
@@ -5,4 +5,7 @@ CREATE TABLE IF NOT EXISTS trace_id_timestamps
     end DateTime64(9)
 )
 ENGINE = MergeTree()
-ORDER BY (trace_id);
+ORDER BY (trace_id)
+{{- if .TTL }}
+TTL end + INTERVAL {{ .TTL }} DAY
+{{- end }};


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Adds data retention support (TTL) for ClickHouse storage in Jaeger v2, allowing traces to be automatically expired after a configured duration.

## Description of the changes
- **Configuration**: Added a `ttl` field to the ClickHouse configuration with validation and a [TTLDays](cci:1://file:///home/tomato/projects/jaeger/internal/storage/v2/clickhouse/config.go:76:0-83:1) helper.
- **SQL Templates**: Modified `spans` and `trace_id_timestamps` table creation scripts to use Go template logic for applying [TTL](cci:1://file:///home/tomato/projects/jaeger/internal/storage/v2/clickhouse/config.go:76:0-83:1) based on the configuration.
- **Schema Initialization**: Updated [factory.go](cci:7://file:///home/tomato/projects/jaeger/internal/storage/v2/clickhouse/factory.go:0:0-0:0) to parse SQL templates and render them during schema creation using `text/template`.
- **Auto-Migration**: Implemented logic in [NewFactory](cci:1://file:///home/tomato/projects/jaeger/internal/storage/v2/clickhouse/factory.go:39:0-119:1) to automatically run `ALTER TABLE ... MODIFY TTL` on existing tables when a TTL is configured.
- **Telemetry**: Integrated migration warnings with the standard Jaeger `zap` logger.
- **Documentation**: Updated the ClickHouse demo configuration ([config-clickhouse.yaml](cci:7://file:///home/tomato/projects/jaeger/cmd/jaeger/config-clickhouse.yaml:0:0-0:0)) with a 7-day TTL example.

## How was this change tested?
- **Unit Tests**: Added coverage for configuration validation and TTL-to-day conversion in [config_test.go](cci:7://file:///home/tomato/projects/jaeger/internal/storage/v2/clickhouse/config_test.go:0:0-0:0).
- **Integration Tests**: Updated [factory_test.go](cci:7://file:///home/tomato/projects/jaeger/internal/storage/v2/clickhouse/factory_test.go:0:0-0:0) to verify that the factory correctly handles TTL configuration during schema creation and handles template rendering in failure scenarios.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
