### PR TITLE
[fix] Return empty array instead of nil from QueryService.getServices

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -119,7 +119,11 @@ func (qs QueryService) GetTraces(
 }
 
 func (qs QueryService) GetServices(ctx context.Context) ([]string, error) {
-	return qs.traceReader.GetServices(ctx)
+	services, err := qs.traceReader.GetServices(ctx)
+	if services == nil {
+		services = []string{}
+	}
+	return services, err
 }
 
 func (qs QueryService) GetOperations(

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
@@ -749,3 +749,18 @@ func TestGetCapabilities(t *testing.T) {
 		})
 	}
 }
+
+func TestQueryServiceGetServicesReturnsEmptySlice(t *testing.T) {
+	reader := new(tracestoremocks.Reader)
+	reader.
+		On("GetServices", mock.Anything).
+		Return(nil, nil).Once()
+
+	qs := NewQueryService(reader, nil, QueryServiceOptions{})
+
+	services, err := qs.GetServices(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, services)
+	require.Empty(t, services)
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #7921.

## Description of the changes
When the backend has no traces, the getServices endpoint returned a nil services field, which is serialized as null in JSON.
This caused the UI to fail validation, since it expects an array.
This change ensures the services field is always returned as an empty array.

## How was this change tested?
wrote a test `TestQueryServiceGetServicesReturnsEmptySlice` in `service_test.go`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
