### PR TITLE
[fix] Return empty array instead of nil from api/v3/services

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -272,6 +272,9 @@ func (h *HTTPGateway) getServices(w http.ResponseWriter, r *http.Request) {
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {
 		return
 	}
+	if services == nil {
+		services = []string{}
+	}
 	h.marshalResponse(&api_v3.GetServicesResponse{
 		Services: services,
 	}, w)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -390,3 +390,18 @@ func TestHTTPGatewayGetOperationsErrors(t *testing.T) {
 	gw.router.ServeHTTP(w, r)
 	assert.Contains(t, w.Body.String(), assert.AnError.Error())
 }
+
+func TestHTTPGatewayGetServicesEmptyResponse(t *testing.T) {
+	gw := setupHTTPGatewayNoServer(t, "")
+	gw.reader.
+		On("GetServices", matchContext).
+		Return(nil, nil).Once()
+
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/services", http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	gw.router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{"services":[]}`, w.Body.String())
+	gw.reader.AssertExpectations(t)
+}


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #7921 

## Description of the changes
- Added a handler check to return `{ "services": [] }` when no services are found instead of `{}`.
- Added unit test 

## How was this change tested?
- While removing the fix, the unit test is failing with a clear fail message

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
