### PR TITLE
Add tests for resource-prefixed attribute filtering in memory store

### DIFF
--- a/cmd/tracegen/docker-compose.yml
+++ b/cmd/tracegen/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         - '4318:4318'
 
     tracegen:
-      image: cr.jaegertracing.io/jaegertracing/jaeger-tracegen:latest@sha256:ae42768cddedf514585fe19ddf8a422eb46a54d77f2481604c99397dd6b0c458
+      image: cr.jaegertracing.io/jaegertracing/jaeger-tracegen:2.14.1@sha256:ae42768cddedf514585fe19ddf8a422eb46a54d77f2481604c99397dd6b0c458
       environment:
         - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
       command: ["-duration", "10s", "-workers", "3", "-pause", "250ms"]

--- a/docker-compose/kafka/docker-compose.yml
+++ b/docker-compose/kafka/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       retries: 3
 
   jaeger-collector:
-    image: cr.jaegertracing.io/jaegertracing/jaeger:latest@sha256:d5e5fe1c2b2f663b07c28c6f7cc5a6e61aef076752dab8df8eeb6b0f5494c94b
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.14.1@sha256:d5e5fe1c2b2f663b07c28c6f7cc5a6e61aef076752dab8df8eeb6b0f5494c94b
     volumes:
       - ../../cmd/jaeger/config-kafka-collector.yaml:/etc/jaeger/config.yaml
     command:
@@ -39,7 +39,7 @@ services:
       - kafka
 
   jaeger-ingester:
-    image: cr.jaegertracing.io/jaegertracing/jaeger:latest@sha256:d5e5fe1c2b2f663b07c28c6f7cc5a6e61aef076752dab8df8eeb6b0f5494c94b
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.14.1@sha256:d5e5fe1c2b2f663b07c28c6f7cc5a6e61aef076752dab8df8eeb6b0f5494c94b
     volumes:
       - ./jaeger-ingester-remote-storage.yaml:/etc/jaeger/config.yaml
     command:
@@ -65,7 +65,7 @@ services:
       - jaeger-remote-storage
 
   jaeger-query:
-    image: cr.jaegertracing.io/jaegertracing/jaeger:latest@sha256:d5e5fe1c2b2f663b07c28c6f7cc5a6e61aef076752dab8df8eeb6b0f5494c94b
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.14.1@sha256:d5e5fe1c2b2f663b07c28c6f7cc5a6e61aef076752dab8df8eeb6b0f5494c94b
     volumes:
       - ../../cmd/jaeger/config-query.yaml:/etc/jaeger/config.yaml
       - ../../cmd/jaeger/config-ui.json:/cmd/jaeger/config-ui.json:ro

--- a/docker-compose/tail-sampling/docker-compose.yml
+++ b/docker-compose/tail-sampling/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   tracegen:
     networks:
       - backend
-    image: cr.jaegertracing.io/jaegertracing/jaeger-tracegen:latest@sha256:bb5ed9592a5963b783cd47e3623b47a24957ebf51b35e8fc4ef07ec635309d43
+    image: cr.jaegertracing.io/jaegertracing/jaeger-tracegen:2.14.1@sha256:bb5ed9592a5963b783cd47e3623b47a24957ebf51b35e8fc4ef07ec635309d43
     environment:
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://otel_collector:4318/v1/traces
     command: ["-workers", "3", "-pause", "250ms", "-services", "5", "-duration", "10s"]

--- a/internal/storage/v2/memory/tenant_test.go
+++ b/internal/storage/v2/memory/tenant_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+func TestResourcePrefixedAttributeFiltering(t *testing.T) {
+	tenant := newTenant(&Configuration{MaxTraces: 10})
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+
+	// resource attribute
+	rs.Resource().Attributes().PutStr("host", "server-1")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("test-scope")
+
+	span := ss.Spans().AppendEmpty()
+	span.SetName("op-1")
+	span.Attributes().PutStr("host", "span-host")
+
+	start := time.Now()
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(start.Add(time.Second)))
+
+	traceID := pcommon.TraceID([16]byte{1})
+	span.SetTraceID(traceID)
+
+	tenant.storeTraces(map[pcommon.TraceID]ptrace.ResourceSpansSlice{
+		traceID: traces.ResourceSpans(),
+	})
+
+	// case 1: no prefix (should match resource)
+	q1 := tracestore.TraceQueryParams{SearchDepth: 10}
+	q1.Attributes = pcommon.NewMap()
+	q1.Attributes.PutStr("host", "server-1")
+
+	res, err := tenant.findTraceAndIds(q1)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	// case 2: resource prefix (correct)
+	q2 := tracestore.TraceQueryParams{SearchDepth: 10}
+	q2.Attributes = pcommon.NewMap()
+	q2.Attributes.PutStr("resource.host", "server-1")
+
+	res, err = tenant.findTraceAndIds(q2)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	// case 3: resource prefix but only on span
+	q3 := tracestore.TraceQueryParams{SearchDepth: 10}
+	q3.Attributes = pcommon.NewMap()
+	q3.Attributes.PutStr("resource.host", "span-host")
+
+	res, err = tenant.findTraceAndIds(q3)
+	require.NoError(t, err)
+	require.Empty(t, res)
+}


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
When searching for traces in the backend, our current contract treats all attributes specified in TraceQueryParameters.attributes as matching against both resource attributes and span attributes. This implicit behaviour makes it unclear which attribute namespace is being queried and can lead to ambiguous or unintended results.
#7791

## Description of the changes
This PR adds focused tests to the v2 memory storage backend to document and lock in the existing behavior around resource-prefixed attribute filters.

The memory backend already supports queries like `resource.foo=bar` to explicitly match resource attributes. However, this behavior was previously untested. The new test verifies that:

• resource-prefixed keys only match resource attributes  
• non-prefixed keys continue to match across span/scope/resource (backward compatibility)  
• resource-prefixed queries do not accidentally match span attributes  

This change does not modify production behavior. It establishes a reference behavior and a safety net for future work related to attribute namespace disambiguation (see #7791).

