### PR TITLE
Issue #7870: Added TTL support for clickhouse

### DIFF
--- a/cmd/jaeger/config-clickhouse.yaml
+++ b/cmd/jaeger/config-clickhouse.yaml
@@ -42,7 +42,9 @@ extensions:
             basic:
               username: default
               password: password
-          create_schema: true
+          schema:
+            create: true
+            trace_ttl: 168h  # 7 days, set to 0 to disable
 
 receivers:
   otlp:

--- a/internal/storage/v2/clickhouse/config.go
+++ b/internal/storage/v2/clickhouse/config.go
@@ -30,8 +30,8 @@ type Configuration struct {
 	Auth Authentication `mapstructure:"auth"`
 	// DialTimeout is the timeout for establishing a connection to ClickHouse.
 	DialTimeout time.Duration `mapstructure:"dial_timeout"`
-	// CreateSchema, if set to true, will create the ClickHouse schema if it does not exist.
-	CreateSchema bool `mapstructure:"create_schema"`
+	// Schema contains schema-related configuration options.
+	Schema Schema `mapstructure:"schema"`
 	// DefaultSearchDepth is the default search depth for queries.
 	// This is the maximum number of trace IDs that will be returned when searching for traces
 	// if a limit is not specified in the query.
@@ -42,14 +42,26 @@ type Configuration struct {
 	// TODO: add more settings
 }
 
+// Schema contains schema-related configuration options.
+type Schema struct {
+	// Create, if set to true, will create the ClickHouse schema if it does not exist.
+	Create bool `mapstructure:"create"`
+	// TraceTTL is the TTL for trace data in ClickHouse.
+	// When set to a positive duration, trace data will be automatically deleted after this period.
+	// Set to 0 to disable TTL (default).
+	TraceTTL time.Duration `mapstructure:"trace_ttl"`
+}
+
 type Authentication struct {
 	Basic configoptional.Optional[basicauthextension.ClientAuthSettings] `mapstructure:"basic"`
 	// TODO: add JWT
 }
 
 func (cfg *Configuration) Validate() error {
-	_, err := govalidator.ValidateStruct(cfg)
-	return err
+	if _, err := govalidator.ValidateStruct(cfg); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (cfg *Configuration) applyDefaults() {

--- a/internal/storage/v2/clickhouse/config_test.go
+++ b/internal/storage/v2/clickhouse/config_test.go
@@ -5,6 +5,7 @@ package clickhouse
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +69,36 @@ func TestValidate(t *testing.T) {
 				Protocol: "native",
 			},
 			wantErr: true,
+		},
+		{
+			name: "valid config with TTL disabled (zero)",
+			cfg: Configuration{
+				Addresses: []string{"localhost:9000"},
+				Schema: Schema{
+					TraceTTL: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with TTL of 1 second",
+			cfg: Configuration{
+				Addresses: []string{"localhost:9000"},
+				Schema: Schema{
+					TraceTTL: time.Second,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with TTL of 7 days",
+			cfg: Configuration{
+				Addresses: []string{"localhost:9000"},
+				Schema: Schema{
+					TraceTTL: 168 * time.Hour,
+				},
+			},
+			wantErr: false,
 		},
 	}
 

--- a/internal/storage/v2/clickhouse/sql/create_spans_table.sql
+++ b/internal/storage/v2/clickhouse/sql/create_spans_table.sql
@@ -58,3 +58,6 @@ CREATE TABLE
     ) ENGINE = MergeTree
 PARTITION BY toDate(start_time)
 ORDER BY (trace_id)
+{{- if .TTLSeconds }}
+TTL start_time + INTERVAL {{ .TTLSeconds }} SECOND
+{{- end }}

--- a/internal/storage/v2/clickhouse/sql/create_trace_id_timestamps_table.sql
+++ b/internal/storage/v2/clickhouse/sql/create_trace_id_timestamps_table.sql
@@ -5,4 +5,7 @@ CREATE TABLE IF NOT EXISTS trace_id_timestamps
     end DateTime64(9)
 )
 ENGINE = MergeTree()
-ORDER BY (trace_id);
+ORDER BY (trace_id)
+{{- if .TTLSeconds }}
+TTL start + INTERVAL {{ .TTLSeconds }} SECOND
+{{- end }}

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -298,3 +298,11 @@ var CreateAttributeMetadataTable string
 
 //go:embed create_attribute_metadata_mv.sql
 var CreateAttributeMetadataMaterializedView string
+
+// AlterSpansTTLTemplate is the template for setting TTL on the spans table.
+// Use fmt.Sprintf to substitute the TTL seconds value.
+const AlterSpansTTLTemplate = `ALTER TABLE spans MODIFY TTL start_time + INTERVAL %d SECOND`
+
+// AlterTraceIDTimestampsTTLTemplate is the template for setting TTL on the trace_id_timestamps table.
+// Use fmt.Sprintf to substitute the TTL seconds value.
+const AlterTraceIDTimestampsTTLTemplate = `ALTER TABLE trace_id_timestamps MODIFY TTL start + INTERVAL %d SECOND`


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
-  #7870 

## Description of the changes
                                                                                                                                                                                                                      
  - Added Schema.TraceTTL field to ClickHouse configuration (default: 0/disabled)                                                                                                                                                   
  - TTL is applied via ALTER TABLE statements after schema creation                                                                                                                                                                 
  - Affects spans and trace_id_timestamps tables only (not metadata tables)                                                                                                                                                         
  - Idempotent - can apply/remove TTL on restart                                                                                                                                                                                    
                                                                                                                                                                                                                                      

## How was this change tested?
- Unit tests added for configuration validation and TTL application/removal, including error cases.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
