### PR TITLE
Implemented  WriteTraces  for Badger storage v2 API

### DIFF
--- a/internal/storage/v2/badger/tracestore/package_test.go
+++ b/internal/storage/v2/badger/tracestore/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/storage/v2/badger/tracestore/writer.go
+++ b/internal/storage/v2/badger/tracestore/writer.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"context"
+	"encoding/binary"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	conventions "github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+)
+
+/*
+Key schema for native v2 Badger storage:
+
+Span keys: spanKeyPrefix<trace-id><startTime><span-id>
+  - Value: protobuf-encoded ptrace.Traces containing the span with its resource/scope
+
+Index keys (empty values, using \x00 separator between variable-length fields):
+  - Service: serviceNameIndexKey<serviceName><startTime><traceId>
+  - Operation: operationNameIndexKey<serviceName>\x00<operationName><startTime><traceId>
+  - Tag: tagIndexKey<serviceName>\x00<tagKey>\x00<tagValue><startTime><traceId>
+  - Duration: durationIndexKey<duration><startTime><traceId>
+*/
+
+const (
+	spanKeyPrefix         byte = 0x80
+	indexKeyRange         byte = 0x0F
+	serviceNameIndexKey   byte = 0x81
+	operationNameIndexKey byte = 0x82
+	tagIndexKey           byte = 0x83
+	durationIndexKey      byte = 0x84
+
+	sizeOfTraceID = 16
+	sizeOfSpanID  = 8
+
+	// separator is used between variable-length fields in index keys
+	// to prevent key collisions (e.g., "foo"+"bar" vs "foob"+"ar")
+	separator = "\x00"
+)
+
+var _ tracestore.Writer = (*TraceWriter)(nil)
+
+// TraceWriter writes traces to badger storage in native OTLP format.
+type TraceWriter struct {
+	store *badger.DB
+	ttl   time.Duration
+}
+
+// NewTraceWriter creates a new TraceWriter.
+func NewTraceWriter(db *badger.DB, ttl time.Duration) *TraceWriter {
+	return &TraceWriter{
+		store: db,
+		ttl:   ttl,
+	}
+}
+
+// WriteTraces writes a batch of traces to storage in OTLP format.
+func (w *TraceWriter) WriteTraces(_ context.Context, td ptrace.Traces) error {
+	//nolint:gosec // G115
+	expireTime := uint64(time.Now().Add(w.ttl).Unix())
+
+	return w.store.Update(func(txn *badger.Txn) error {
+		for _, rs := range td.ResourceSpans().All() {
+			serviceName := getServiceName(rs.Resource())
+			for _, ss := range rs.ScopeSpans().All() {
+				for _, span := range ss.Spans().All() {
+					if err := w.writeSpan(txn, rs, ss, span, serviceName, expireTime); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func (*TraceWriter) writeSpan(
+	txn *badger.Txn,
+	rs ptrace.ResourceSpans,
+	ss ptrace.ScopeSpans,
+	span ptrace.Span,
+	serviceName string,
+	expireTime uint64,
+) error {
+	traceID := span.TraceID()
+	spanID := span.SpanID()
+	startTime := uint64(span.StartTimestamp())
+
+	// Serialize span with its resource and scope context
+	spanBytes, err := marshalSpan(rs, ss, span)
+	if err != nil {
+		return err
+	}
+
+	// Write primary span entry
+	spanKey := createSpanKey(traceID, startTime, spanID)
+	if err := setEntry(txn, spanKey, spanBytes, expireTime); err != nil {
+		return err
+	}
+
+	// Write service index
+	if serviceName != "" {
+		serviceKey := createIndexKey(serviceNameIndexKey, []byte(serviceName), startTime, traceID)
+		if err := setEntry(txn, serviceKey, nil, expireTime); err != nil {
+			return err
+		}
+
+		// Write operation index
+		operationName := span.Name()
+		if operationName != "" {
+			opKey := createIndexKey(operationNameIndexKey, []byte(serviceName+separator+operationName), startTime, traceID)
+			if err := setEntry(txn, opKey, nil, expireTime); err != nil {
+				return err
+			}
+		}
+
+		// Write tag indexes from span attributes
+		for key, val := range span.Attributes().All() {
+			tagKey := createIndexKey(tagIndexKey, []byte(serviceName+separator+key+separator+val.AsString()), startTime, traceID)
+			if err := setEntry(txn, tagKey, nil, expireTime); err != nil {
+				return err
+			}
+		}
+
+		// Write tag indexes from resource attributes (excluding service name)
+		for key, val := range rs.Resource().Attributes().All() {
+			if key == conventions.ServiceNameKey {
+				continue
+			}
+			tagKey := createIndexKey(tagIndexKey, []byte(serviceName+separator+key+separator+val.AsString()), startTime, traceID)
+			if err := setEntry(txn, tagKey, nil, expireTime); err != nil {
+				return err
+			}
+		}
+
+		// Write tag indexes from events
+		for _, event := range span.Events().All() {
+			for key, val := range event.Attributes().All() {
+				tagKey := createIndexKey(tagIndexKey, []byte(serviceName+separator+key+separator+val.AsString()), startTime, traceID)
+				if err := setEntry(txn, tagKey, nil, expireTime); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Write duration index (always written, independent of serviceName,
+	// to support duration-based queries without service filter)
+	startTS := span.StartTimestamp()
+	endTS := span.EndTimestamp()
+	var duration uint64
+	if endTS >= startTS {
+		duration = uint64(endTS - startTS)
+	} else {
+		duration = 0
+	}
+	durationBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(durationBytes, duration)
+	durationKey := createIndexKey(durationIndexKey, durationBytes, startTime, traceID)
+	return setEntry(txn, durationKey, nil, expireTime)
+}
+
+func setEntry(txn *badger.Txn, key, value []byte, expireTime uint64) error {
+	return txn.SetEntry(&badger.Entry{
+		Key:       key,
+		Value:     value,
+		ExpiresAt: expireTime,
+	})
+}
+
+func createSpanKey(traceID pcommon.TraceID, startTime uint64, spanID pcommon.SpanID) []byte {
+	key := make([]byte, 1+sizeOfTraceID+8+sizeOfSpanID)
+	key[0] = spanKeyPrefix
+	pos := 1
+	copy(key[pos:], traceID[:])
+	pos += sizeOfTraceID
+	binary.BigEndian.PutUint64(key[pos:], startTime)
+	pos += 8
+	copy(key[pos:], spanID[:])
+	return key
+}
+
+func createIndexKey(indexPrefix byte, value []byte, startTime uint64, traceID pcommon.TraceID) []byte {
+	key := make([]byte, 1+len(value)+8+sizeOfTraceID)
+	key[0] = (indexPrefix & indexKeyRange) | spanKeyPrefix
+	pos := 1
+	copy(key[pos:], value)
+	pos += len(value)
+	binary.BigEndian.PutUint64(key[pos:], startTime)
+	pos += 8
+	copy(key[pos:], traceID[:])
+	return key
+}
+
+func marshalSpan(rs ptrace.ResourceSpans, ss ptrace.ScopeSpans, span ptrace.Span) ([]byte, error) {
+	td := ptrace.NewTraces()
+	newRS := td.ResourceSpans().AppendEmpty()
+	rs.Resource().CopyTo(newRS.Resource())
+	newRS.SetSchemaUrl(rs.SchemaUrl())
+
+	newSS := newRS.ScopeSpans().AppendEmpty()
+	ss.Scope().CopyTo(newSS.Scope())
+	newSS.SetSchemaUrl(ss.SchemaUrl())
+
+	span.CopyTo(newSS.Spans().AppendEmpty())
+
+	marshaler := &ptrace.ProtoMarshaler{}
+	return marshaler.MarshalTraces(td)
+}
+
+func getServiceName(resource pcommon.Resource) string {
+	if val, ok := resource.Attributes().Get(conventions.ServiceNameKey); ok {
+		return val.Str()
+	}
+	return ""
+}

--- a/internal/storage/v2/badger/tracestore/writer_test.go
+++ b/internal/storage/v2/badger/tracestore/writer_test.go
@@ -1,0 +1,617 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	conventions "github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+)
+
+func setupBadger(t *testing.T) *badger.DB {
+	opts := badger.DefaultOptions(t.TempDir())
+	opts.SyncWrites = false
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestTraceWriter_WriteTraces(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := makeTraces()
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Verify span was written
+	var spanCount int
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{spanKeyPrefix}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			spanCount++
+
+			// Verify we can unmarshal the value
+			item := it.Item()
+			val, err := item.ValueCopy(nil)
+			require.NoError(t, err)
+
+			unmarshaler := &ptrace.ProtoUnmarshaler{}
+			traces, err := unmarshaler.UnmarshalTraces(val)
+			require.NoError(t, err)
+			assert.Equal(t, 1, traces.ResourceSpans().Len())
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, spanCount)
+}
+
+func TestTraceWriter_WriteTraces_ServiceIndex(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := makeTraces()
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Verify service index was created
+	var indexFound bool
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{serviceNameIndexKey}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			indexFound = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, indexFound)
+}
+
+func TestTraceWriter_WriteTraces_OperationIndex(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := makeTraces()
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Verify operation index was created
+	var indexFound bool
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{operationNameIndexKey}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			indexFound = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, indexFound)
+}
+
+func TestTraceWriter_WriteTraces_MultipleSpans(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := makeTracesWithMultipleSpans(3)
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Count spans
+	var spanCount int
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{spanKeyPrefix}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			spanCount++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, spanCount)
+}
+
+func TestTraceWriter_WriteTraces_EmptyTraces(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := ptrace.NewTraces()
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+}
+
+func TestTraceWriter_WriteTraces_NoServiceName(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+
+	// Create traces without service name
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("test-op")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Span should be written
+	var spanFound bool
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{spanKeyPrefix}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			spanFound = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, spanFound)
+
+	// But service index should NOT be created
+	var serviceIndexFound bool
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{serviceNameIndexKey}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			serviceIndexFound = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.False(t, serviceIndexFound)
+}
+
+func TestTraceWriter_WriteTraces_TagIndexes(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := makeTracesWithAttributes()
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Verify tag indexes were created
+	var tagIndexCount int
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{tagIndexKey}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			tagIndexCount++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Positive(t, tagIndexCount)
+}
+
+func TestTraceWriter_WriteTraces_DurationIndex(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := makeTraces()
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Verify duration index was created
+	var durationIndexFound bool
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{durationIndexKey}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			durationIndexFound = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, durationIndexFound)
+}
+
+func TestNewTraceWriter(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	assert.NotNil(t, writer)
+	assert.Equal(t, db, writer.store)
+	assert.Equal(t, time.Hour, writer.ttl)
+}
+
+func TestCreateSpanKey(t *testing.T) {
+	traceID := traceIDFromInts(0x0102030405060708, 0x090a0b0c0d0e0f10)
+	spanID := spanIDFromInt(0x1112131415161718)
+	startTime := uint64(1234567890)
+
+	key := createSpanKey(traceID, startTime, spanID)
+
+	assert.Equal(t, spanKeyPrefix, key[0])
+	assert.Len(t, key, 1+sizeOfTraceID+8+sizeOfSpanID)
+	assert.Equal(t, traceID[:], key[1:1+sizeOfTraceID])
+	gotTime := binary.BigEndian.Uint64(key[1+sizeOfTraceID : 1+sizeOfTraceID+8])
+	assert.Equal(t, startTime, gotTime)
+	assert.Equal(t, spanID[:], key[1+sizeOfTraceID+8:])
+}
+
+func TestCreateIndexKey(t *testing.T) {
+	traceID := traceIDFromInts(0x0102030405060708, 0x090a0b0c0d0e0f10)
+	startTime := uint64(1234567890)
+	value := []byte("test-value")
+
+	key := createIndexKey(serviceNameIndexKey, value, startTime, traceID)
+
+	assert.Equal(t, (serviceNameIndexKey&indexKeyRange)|spanKeyPrefix, key[0])
+	assert.Len(t, key, 1+len(value)+8+sizeOfTraceID)
+	assert.Equal(t, value, key[1:1+len(value)])
+	gotTime := binary.BigEndian.Uint64(key[1+len(value) : 1+len(value)+8])
+	assert.Equal(t, startTime, gotTime)
+	assert.Equal(t, traceID[:], key[1+len(value)+8:])
+}
+
+func TestSeparatorPreventsKeyCollision(t *testing.T) {
+	// This test verifies that the separator prevents key collisions
+	// e.g., service="foo" + op="bar" should differ from service="foob" + op="ar"
+	traceID := traceIDFromInts(0, 1)
+	startTime := uint64(1234567890)
+
+	// Without separator, "foo"+"bar" == "foob"+"ar" == "foobar"
+	// With separator, "foo\x00bar" != "foob\x00ar"
+	key1 := createIndexKey(operationNameIndexKey, []byte("foo"+separator+"bar"), startTime, traceID)
+	key2 := createIndexKey(operationNameIndexKey, []byte("foob"+separator+"ar"), startTime, traceID)
+
+	assert.NotEqual(t, key1, key2, "keys should differ due to separator")
+
+	// Also verify tag keys with multiple separators
+	tagKey1 := createIndexKey(tagIndexKey, []byte("svc"+separator+"key"+separator+"val"), startTime, traceID)
+	tagKey2 := createIndexKey(tagIndexKey, []byte("svck"+separator+"ey"+separator+"val"), startTime, traceID)
+
+	assert.NotEqual(t, tagKey1, tagKey2, "tag keys should differ due to separators")
+}
+
+func TestMarshalSpan(t *testing.T) {
+	td := makeTraces()
+	rs := td.ResourceSpans().At(0)
+	ss := rs.ScopeSpans().At(0)
+	span := ss.Spans().At(0)
+
+	data, err := marshalSpan(rs, ss, span)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+
+	// Unmarshal and verify
+	unmarshaler := &ptrace.ProtoUnmarshaler{}
+	traces, err := unmarshaler.UnmarshalTraces(data)
+	require.NoError(t, err)
+	assert.Equal(t, 1, traces.ResourceSpans().Len())
+
+	gotRS := traces.ResourceSpans().At(0)
+	svcName, ok := gotRS.Resource().Attributes().Get(conventions.ServiceNameKey)
+	assert.True(t, ok)
+	assert.Equal(t, "test-service", svcName.Str())
+}
+
+func TestGetServiceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() pcommon.Resource
+		expected string
+	}{
+		{
+			name: "service name present",
+			setup: func() pcommon.Resource {
+				td := ptrace.NewTraces()
+				rs := td.ResourceSpans().AppendEmpty()
+				rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "my-service")
+				return rs.Resource()
+			},
+			expected: "my-service",
+		},
+		{
+			name: "service name missing",
+			setup: func() pcommon.Resource {
+				td := ptrace.NewTraces()
+				rs := td.ResourceSpans().AppendEmpty()
+				return rs.Resource()
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := tt.setup()
+			result := getServiceName(resource)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper functions
+
+func traceIDFromInts(high, low uint64) pcommon.TraceID {
+	var id pcommon.TraceID
+	binary.BigEndian.PutUint64(id[:8], high)
+	binary.BigEndian.PutUint64(id[8:], low)
+	return id
+}
+
+func spanIDFromInt(val uint64) pcommon.SpanID {
+	var id pcommon.SpanID
+	binary.BigEndian.PutUint64(id[:], val)
+	return id
+}
+
+func makeTraces() ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "test-service")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("test-operation")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+
+	return td
+}
+
+func makeTracesWithMultipleSpans(count int) ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "test-service")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	for i := 0; i < count; i++ {
+		span := ss.Spans().AppendEmpty()
+		span.SetName("test-operation")
+		span.SetTraceID(traceIDFromInts(0, 1))
+		span.SetSpanID(spanIDFromInt(uint64(i + 1)))
+		span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+	}
+
+	return td
+}
+
+func makeTracesWithAttributes() ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "test-service")
+	rs.Resource().Attributes().PutStr("deployment.environment", "test")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("test-operation")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+	span.Attributes().PutStr("http.method", "GET")
+	span.Attributes().PutInt("http.status_code", 200)
+
+	return td
+}
+
+func TestTraceWriter_WriteTraces_Error_ClosedDB(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := makeTraces()
+
+	// Close the DB to force an error
+	require.NoError(t, db.Close())
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DB Closed")
+}
+
+func TestTraceWriter_WriteTraces_Error_KeyTooLarge(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	// Create a huge service name > 65KB (Badger's key limit)
+	hugeService := string(make([]byte, 70000))
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, hugeService)
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("test-operation")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.Error(t, err)
+	// Badger error for key too large
+	assert.Contains(t, err.Error(), "Key with size")
+	assert.Contains(t, err.Error(), "exceeded")
+}
+
+func TestTraceWriter_WriteTraces_Error_OperationKeyTooLarge(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "normal-service")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	// Huge operation name to fail operation index write
+	hugeOp := string(make([]byte, 70000))
+	span.SetName(hugeOp)
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Key with size")
+}
+
+func TestTraceWriter_WriteTraces_Error_TagKeyTooLarge(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "normal-service")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("normal-operation")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+
+	// Huge attribute value to fail tag index write
+	hugeVal := string(make([]byte, 70000))
+	span.Attributes().PutStr("regular-key", hugeVal)
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Key with size")
+}
+
+func TestTraceWriter_WriteTraces_Error_ResourceTagKeyTooLarge(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	// Huge resource attribute
+	hugeVal := string(make([]byte, 70000))
+	rs.Resource().Attributes().PutStr("huge-resource-attr", hugeVal)
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "normal-service")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("normal-operation")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Key with size")
+}
+
+func TestTraceWriter_WriteTraces_Error_EventTagKeyTooLarge(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "normal-service")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("normal-operation")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(100 * time.Millisecond)))
+
+	// Huge event attribute
+	event := span.Events().AppendEmpty()
+	event.SetName("test-event")
+	hugeVal := string(make([]byte, 70000))
+	event.Attributes().PutStr("huge-event-attr", hugeVal)
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Key with size")
+}
+
+func TestTraceWriter_WriteTraces_DurationUnderflow(t *testing.T) {
+	db := setupBadger(t)
+	writer := NewTraceWriter(db, time.Hour)
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "test-service")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("test-operation")
+	span.SetTraceID(traceIDFromInts(0, 1))
+	span.SetSpanID(spanIDFromInt(1))
+
+	// Start time is AFTER end time, which should cause underflow if not handled
+	now := time.Now()
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(time.Hour)))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(now))
+
+	err := writer.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+
+	// Verify duration index
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		// Decode the key to check duration
+		// durationIndexKey format: <prefix><duration><startTime><traceId>
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		prefix := []byte{durationIndexKey}
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			key := it.Item().Key()
+			// Prefix (1) + Duration (8)
+			if len(key) < 9 {
+				continue
+			}
+			durationBytes := key[1:9]
+			duration := binary.BigEndian.Uint64(durationBytes)
+
+			// If underflow occurred, duration will be huge (near max uint64)
+			// If fixed, it should be 0
+			assert.Equal(t, uint64(0), duration, "Duration should be 0 for invalid span timestamps")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
--> 

## Which problem is this PR solving?
-  part of #7937 
## Description of the changes
  - Add `internal/storage/v2/badger/tracestore/writer.go`                                                                                                                                          
  - Add `internal/storage/v2/badger/tracestore/writer_test.go`                                                                                                                                    
  - Add `internal/storage/v2/badger/tracestore/package_test.go`    

## How was this change tested?
- unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
