### PR TITLE
[fix] Ensure Badger maintenance is stopped before existing Close()

### DIFF
--- a/internal/storage/v1/badger/factory.go
+++ b/internal/storage/v1/badger/factory.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/badger/v4"
@@ -50,6 +51,7 @@ type Factory struct {
 
 	tmpDir          string
 	maintenanceDone chan bool
+	bgWg            sync.WaitGroup
 
 	// TODO initialize via reflection; convert comments to tag 'description'.
 	metrics struct {
@@ -120,8 +122,15 @@ func (f *Factory) Initialize(metricsFactory metrics.Factory, logger *zap.Logger)
 
 	f.registerBadgerExpvarMetrics(metricsFactory)
 
-	go f.maintenance()
-	go f.metricsCopier()
+	f.bgWg.Add(2)
+	go func() {
+		defer f.bgWg.Done()
+		f.maintenance()
+	}()
+	go func() {
+		defer f.bgWg.Done()
+		f.metricsCopier()
+	}()
 
 	logger.Info("Badger storage configuration", zap.Any("configuration", opts))
 
@@ -165,6 +174,7 @@ func (*Factory) CreateLock() (distributedlock.Lock, error) {
 // Close Implements io.Closer and closes the underlying storage
 func (f *Factory) Close() error {
 	close(f.maintenanceDone)
+	f.bgWg.Wait() // Wait for background goroutines to finish before closing store
 	if f.store == nil {
 		return nil
 	}


### PR DESCRIPTION
This PR adds synchronization between the Badger storage factory’s background goroutines and store shutdown.

During shutdown (for example, pod termination or process restart), the maintenance or metrics goroutines may still be running while the Badger store is being closed. This change ensures the goroutines are allowed to exit cleanly after shutdown is signaled and before the store is closed.

The behavior and APIs remain unchanged; the update only makes the shutdown sequence safer and more predictable.

Thanks for taking a look, and please let me know if any adjustments are needed.