### PR TITLE
docs: add Quick Start section with Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@
 
 💥💥💥 Jaeger v2 is out! Read the [blog post](https://medium.com/jaegertracing/jaeger-v2-released-09a6033d1b10) and [try it out](https://www.jaegertracing.io/docs/latest/getting-started/).
 
+## Quick Start
+
+Get Jaeger running in seconds with Docker:
+
+```bash
+# Run Jaeger all-in-one (includes UI, collector, query, and in-memory storage)
+docker run --rm --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  jaegertracing/jaeger:latest
+
+# Access the UI at http://localhost:16686
+# Send traces via OTLP: gRPC on port 4317, HTTP on port 4318
+```
+
+For production deployments and more options, see the [Getting Started Guide](https://www.jaegertracing.io/docs/latest/getting-started/).
+
+## Architecture
+
 ```mermaid
 graph TD
     SDK["OpenTelemetry SDK"] --> |HTTP or gRPC| COLLECTOR


### PR DESCRIPTION
## What

Adds a Quick Start section to the README with a Docker one-liner command.

## Why

The current README directs users to external documentation for getting started. Adding a Quick Start section directly in the README allows new users to:

1. Try Jaeger immediately without leaving GitHub
2. Understand the basic setup at a glance
3. Know which ports to use for sending traces

This follows the pattern used by many popular CNCF projects (like Prometheus, Grafana) that include quick start commands in their READMEs.

## Changes

- Added "Quick Start" section after the Jaeger v2 announcement
- Included Docker command for running Jaeger all-in-one
- Documented common ports (16686 for UI, 4317/4318 for OTLP)
- Added "Architecture" header before the existing mermaid diagram for better structure
- Linked to the full Getting Started guide for production deployments

## Testing

Verified the Docker command works:
```bash
docker run --rm jaegertracing/jaeger:latest
```