### PR TITLE
feat: add schemagen for internal extensions (#6186)

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/golangci/golangci-lint/v2 v2.9.0
 	github.com/josephspurrier/goversioninfo v1.5.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/cmd/schemagen v0.146.0
 	github.com/vektra/mockery/v3 v3.6.1
 	golang.org/x/vuln v1.1.4
 	mvdan.cc/gofumpt v0.9.2
@@ -109,6 +110,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.6.7 // indirect
 	github.com/jgautheron/goconst v1.8.2 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -352,6 +352,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -485,6 +487,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
+github.com/open-telemetry/opentelemetry-collector-contrib/cmd/schemagen v0.146.0 h1:QClmTrp3MQhlqEXXk2FRSwlEA3bQKKDLuCeiu+3ZktE=
+github.com/open-telemetry/opentelemetry-collector-contrib/cmd/schemagen v0.146.0/go.mod h1:OINT7fivIXPsH4oMYFjnkreLeHimo7uayD3NZn+SwY8=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -15,6 +15,7 @@ import (
 
 	_ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 	_ "github.com/josephspurrier/goversioninfo/cmd/goversioninfo"
+	_ "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/schemagen"
 	_ "github.com/vektra/mockery/v3"
 	_ "golang.org/x/vuln/cmd/govulncheck"
 )

--- a/scripts/makefiles/Tools.mk
+++ b/scripts/makefiles/Tools.mk
@@ -13,6 +13,7 @@ GOVERSIONINFO := $(TOOLS_BIN_DIR)/goversioninfo
 GOVULNCHECK   := $(TOOLS_BIN_DIR)/govulncheck
 LINT          := $(TOOLS_BIN_DIR)/golangci-lint
 MOCKERY       := $(TOOLS_BIN_DIR)/mockery
+SCHEMAGEN     := $(TOOLS_BIN_DIR)/schemagen
 
 # this target is useful for setting up local workspace, but from CI we want to call more specific ones
 .PHONY: install-tools


### PR DESCRIPTION
Add the OpenTelemetry schemagen tool to the Jaeger build infrastructure. This is a prerequisite for #6186, making the tool available for future schema generation work.
## Which problem is this PR solving?
Prerequisite for #6186 (Task 1: Generate sensible schemas from existing Go structs)
This PR only adds the build tooling. Actual schema generation and configuration will be handled in a follow-up PR 

## Description of the changes

- Added schemagen to `internal/tools/tools.go` to pin the dependency version.
- Added SCHEMAGEN variable to `scripts/makefiles/Tools.mk` to enable building the tool locally in .tools/.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
