### PR TITLE
Implement GetOperations for Badger v2

### DIFF
--- a/internal/storage/v2/badger/tracestore/package_test.go
+++ b/internal/storage/v2/badger/tracestore/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/storage/v2/badger/tracestore/reader.go
+++ b/internal/storage/v2/badger/tracestore/reader.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/dgraph-io/badger/v4"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+var _ tracestore.Reader = (*Reader)(nil)
+
+const (
+	// operationNameIndexKey (0x82) is the prefix for the operations index.
+	operationNameIndexKey byte = 0x82
+
+	// sizeOfTraceID is 16 bytes for a TraceID.
+	sizeOfTraceID = 16
+)
+
+// Reader implements the tracestore.Reader interface for Badger.
+type Reader struct {
+	db *badger.DB
+}
+
+// NewReader creates a new Reader instance.
+func NewReader(db *badger.DB) *Reader {
+	return &Reader{
+		db: db,
+	}
+}
+
+// GetOperations returns all operation names for a given service.
+func (r *Reader) GetOperations(_ context.Context, query tracestore.OperationQueryParams) ([]tracestore.Operation, error) {
+	var operations []tracestore.Operation
+
+	err := r.db.View(func(txn *badger.Txn) error {
+		// Create the search prefix: [0x82][ServiceName]
+		prefix := make([]byte, len(query.ServiceName)+1)
+		prefix[0] = operationNameIndexKey
+		copy(prefix[1:], query.ServiceName)
+
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+
+		uniqueOps := make(map[string]struct{})
+		for it.Seek(prefix); it.ValidForPrefix((prefix)); it.Next() {
+			key := it.Item().Key()
+
+			// Key layout: [Prefix(1)][Service(N)][Operation(M)][Time(8)][TraceID(16)]
+			opNameStart := 1 + len(query.ServiceName)
+			opNameEnd := len(key) - (8 + sizeOfTraceID)
+
+			if opNameEnd > opNameStart {
+				opName := string(key[opNameStart:opNameEnd])
+				if _, exists := uniqueOps[opName]; !exists {
+					uniqueOps[opName] = struct{}{}
+					operations = append(operations, tracestore.Operation{
+						Name: opName,
+					})
+				}
+			}
+		}
+		return nil
+	})
+	return operations, err
+}
+
+// Stubs
+func (*Reader) GetServices(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (*Reader) GetTraces(context.Context, ...tracestore.GetTraceParams) iter.Seq2[[]ptrace.Traces, error] {
+	return func(_ func([]ptrace.Traces, error) bool) {}
+}
+
+func (*Reader) FindTraces(context.Context, tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+	return func(_ func([]ptrace.Traces, error) bool) {}
+}
+
+func (*Reader) FindTraceIDs(context.Context, tracestore.TraceQueryParams) iter.Seq2[[]tracestore.FoundTraceID, error] {
+	return func(_ func([]tracestore.FoundTraceID, error) bool) {}
+}

--- a/internal/storage/v2/badger/tracestore/reader.go
+++ b/internal/storage/v2/badger/tracestore/reader.go
@@ -37,9 +37,13 @@ func NewReader(db *badger.DB) *Reader {
 }
 
 // GetOperations returns all operation names for a given service.
+
 func (r *Reader) GetOperations(_ context.Context, query tracestore.OperationQueryParams) ([]tracestore.Operation, error) {
 	if query.SpanKind != "" {
 		return nil, errors.New("badger storage does not support SpanKind filtering")
+	}
+	if query.ServiceName == "" {
+		return nil, errors.New("service name is required")
 	}
 
 	var operations []tracestore.Operation

--- a/internal/storage/v2/badger/tracestore/reader_test.go
+++ b/internal/storage/v2/badger/tracestore/reader_test.go
@@ -31,7 +31,7 @@ func TestGetOperations(t *testing.T) {
 	// 2. Insert Dummy data
 	err = db.Update(func(txn *badger.Txn) error {
 		// Helper to create a key in the exact format:
-		// [0x82][ServiceName][Timestamp(8)][TraceID(16)]
+		// [0x82][ServiceName][OperationName][Timestamp(8)][TraceID(16)]
 		createKey := func(service, operation string, id uint64) []byte {
 			key := make([]byte, 1+len(service)+len(operation)+8+16)
 			key[0] = operationNameIndexKey
@@ -59,7 +59,7 @@ func TestGetOperations(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify GetOperations for "service-a"
+	// 3. Verify GetOperations for "service-a"
 	ops, err := reader.GetOperations(context.Background(),
 		tracestore.OperationQueryParams{
 			ServiceName: "service-a",
@@ -79,4 +79,12 @@ func TestGetOperations(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, ops, 1)
 	assert.Equal(t, "op-3", ops[0].Name)
+
+	// 5. Verify GetOperations for non-existent service
+	ops, err = reader.GetOperations(context.Background(),
+		tracestore.OperationQueryParams{
+			ServiceName: "service-c",
+		})
+	require.NoError(t, err)
+	assert.Empty(t, ops)
 }

--- a/internal/storage/v2/badger/tracestore/reader_test.go
+++ b/internal/storage/v2/badger/tracestore/reader_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+func TestGetOperations(t *testing.T) {
+	// 1. Setup Badger with a temporary directory (standard pattern)
+	opts := badger.DefaultOptions(t.TempDir()).WithLoggingLevel(badger.ERROR)
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	// Ensure DB is closed after test
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	reader := NewReader(db)
+
+	// 2. Insert Dummy data
+	err = db.Update(func(txn *badger.Txn) error {
+		// Helper to create a key in the exact format:
+		// [0x82][ServiceName][Timestamp(8)][TraceID(16)]
+		createKey := func(service, operation string, id uint64) []byte {
+			key := make([]byte, 1+len(service)+len(operation)+8+16)
+			key[0] = operationNameIndexKey
+			n := 1
+			n += copy(key[n:], service)
+			n += copy(key[n:], operation)
+
+			// Add dummy timestamp (8 bytes)
+			binary.BigEndian.PutUint64(key[n:], 123456)
+			n += 8
+
+			// Add dummy trace ID (16 bytes)
+			binary.BigEndian.PutUint64(key[n:], 0)    // High
+			binary.BigEndian.PutUint64(key[n+8:], id) // Low
+			return key
+		}
+
+		// Add two operations for "service-a" and one for "service-b"
+		require.NoError(t, txn.Set(createKey("service-a", "op-1", 1), []byte{}))
+		require.NoError(t, txn.Set(createKey("service-a", "op-1", 2), []byte{})) // Duplicate op name, different trace
+		require.NoError(t, txn.Set(createKey("service-a", "op-2", 3), []byte{}))
+		require.NoError(t, txn.Set(createKey("service-b", "op-3", 4), []byte{}))
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	// Verify GetOperations for "service-a"
+	ops, err := reader.GetOperations(context.Background(),
+		tracestore.OperationQueryParams{
+			ServiceName: "service-a",
+		})
+	require.NoError(t, err)
+
+	// We expect 2 unique operations: "op-1" and "op-2"
+	assert.Len(t, ops, 2)
+	assert.Contains(t, []string{ops[0].Name, ops[1].Name}, "op-1")
+	assert.Contains(t, []string{ops[0].Name, ops[1].Name}, "op-2")
+
+	// 4. Verify GetOperations for "service-b"
+	ops, err = reader.GetOperations(context.Background(),
+		tracestore.OperationQueryParams{
+			ServiceName: "service-b",
+		})
+	require.NoError(t, err)
+	assert.Len(t, ops, 1)
+	assert.Equal(t, "op-3", ops[0].Name)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7937
- Implements the [GetOperations](cci:1://file:///home/Sudhanshu/dev/open-source/jaeger/internal/storage/v1/badger/spanstore/reader.go:244:0-250:1) method for the Badger v2 trace reader.
## Description of the changes
- Implemented [GetOperations](cci:1://file:///home/Sudhanshu/dev/open-source/jaeger/internal/storage/v1/badger/spanstore/reader.go:244:0-250:1) using efficient prefix scanning (0x82) to retrieve operation names.
- Added [reader_test.go](cci:7://file:///home/Sudhanshu/dev/open-source/jaeger/internal/storage/v2/api/tracestore/reader_test.go:0:0-0:0) with unit tests covering duplicates, multiple services, and empty results.
- Added [package_test.go](cci:7://file:///home/Sudhanshu/dev/open-source/jaeger/internal/storage/v2/api/package_test.go:0:0-0:0) to ensure goroutine leak compliance (`testutils.VerifyGoLeaks`).
- Ensured full compliance with project naming conventions, error wrapping strings, and import grouping.
## How was this change tested?
- **Unit Tests**: Added [TestGetOperations](cci:1://file:///home/Sudhanshu/dev/open-source/jaeger/internal/storage/v2/badger/tracestore/reader_test.go:17:0-81:1) in [reader_test.go](cci:7://file:///home/Sudhanshu/dev/open-source/jaeger/internal/storage/v2/api/tracestore/reader_test.go:0:0-0:0) which verifies correct data retrieval and de-duplication against a temporary Badger DB (`t.TempDir()`).
- **Linting**: Verified with `make lint` (passed with 0 issues).
- **Compliance**: Verified imports and formatting with `make fmt`.
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`