### PR TITLE
Remove TODO comment in returnTraces error handling

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -122,7 +122,6 @@ func (h *HTTPGateway) returnTrace(td ptrace.Traces, w http.ResponseWriter) {
 }
 
 func (h *HTTPGateway) returnTraces(traces []ptrace.Traces, err error, w http.ResponseWriter) {
-	// TODO how do we distinguish internal error from bad parameters?
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {
 		return
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7960

## Description of the changes
The TODO questioned how to distinguish
internal errors from bad parameters.
This distinction is already handled correctly:
- Parameter validation occurs in HTTP handlers before QueryService calls
- Only storage layer errors reach `returnTraces`, which are legitimately 500 errors.

All parameter validation happens before QueryService calls in `getTrace()` and `parseFindTracesQuery()` using tryParamError()
## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
