### PR TITLE
Enable argument-limit linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,8 +135,8 @@ linters:
         - name: function-length
           disabled: true
         # definitely a good one, needs cleanup first
-        - name: argument-limit
-          disabled: true
+        # - name: argument-limit
+        #   disabled: true
         # this is idiocy, promotes less readable code. Don't enable.
         - name: var-declaration
           disabled: true


### PR DESCRIPTION
## Which problem is this PR solving?
- Partial fix for #5506

## Description of the changes
- Enabled the `argument-limit` revive linter rule
- No code changes required - the codebase already complies with this rule
- The `argument-limit` rule enforces a maximum number of function parameters, promoting cleaner function signatures and better code design

## How was this change tested?
- `make fmt`
- `make lint` (0 issues)
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`