### PR TITLE
[test] Fix goroutine leak detection in TestPasswordFromFile

### DIFF
--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -336,7 +336,7 @@ func TestESStorageFactoryWithConfigError(t *testing.T) {
 
 func TestPasswordFromFile(t *testing.T) {
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnce(t)
+		testutils.VerifyGoLeaksOnceForES(t)
 	})
 	t.Run("primary client", func(t *testing.T) {
 		runPasswordFromFileTest(t)
@@ -447,7 +447,7 @@ func TestFactoryESClientsAreNil(t *testing.T) {
 }
 
 func TestPasswordFromFileErrors(t *testing.T) {
-	defer testutils.VerifyGoLeaksOnce(t)
+	defer testutils.VerifyGoLeaksOnceForES(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write(mockEsServerResponse)
 	}))


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #4743

The `TestPasswordFromFile` and `TestPasswordFromFileErrors` tests were failing intermittently with goroutine leak errors. The tests use the Elasticsearch client from the `olivere/elastic` library, which creates persistent HTTP transport goroutines for connection pooling.

## Description of the changes

- Changed `testutils.VerifyGoLeaksOnce(t)` to `testutils.VerifyGoLeaksOnceForES(t)` in both tests
- This function specifically ignores known goroutines from the Elasticsearch HTTP client that are not actual leaks from Jaeger code

The `VerifyGoLeaksOnceForES` function is already used throughout the codebase for Elasticsearch tests (see `internal/storage/integration/elasticsearch_test.go` and `internal/testutils/leakcheck.go`). The HTTP transport goroutines (`writeLoop`, `readLoop`, `pollRuntime`) are managed by the ES client's connection pool and are expected behavior.

## How was this change tested?

- Ran `go test ./internal/storage/v1/elasticsearch/... -timeout 30s` - all tests pass
- Ran `make fmt` and `make lint` - no new issues
- Tested multiple times to ensure consistent pass

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`