### PR TITLE
Add initial scaffold for nl trace query parsing

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/nlquery/parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/nlquery/parser.go
@@ -1,0 +1,27 @@
+package nlquery
+
+import (
+	"strings"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// Parse converts a natural language query into TraceQueryParams.
+// This is a deterministic, rule-based baseline before LLM integration.
+func Parse(input string) (Result, error) {
+	q := strings.ToLower(input)
+
+	params := tracestore.TraceQueryParams{}
+
+	if strings.Contains(q, "error") || strings.Contains(q, "errors") {
+		attrs := pcommon.NewMap()
+		attrs.PutStr("error", "true")
+		params.Attributes = attrs
+	}
+
+	return Result{
+		Params: params,
+		Reason: "rule-based fallback",
+	}, nil
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/nlquery/parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/nlquery/parser_test.go
@@ -1,0 +1,19 @@
+package nlquery
+
+import "testing"
+
+func TestParseErrors(t *testing.T) {
+	r, err := Parse("show me errors")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	val, ok := r.Params.Attributes.Get("error")
+	if !ok {
+		t.Fatalf("expected error attribute to exist")
+	}
+
+	if val.Str() != "true" {
+		t.Fatalf("expected error=true")
+	}
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/nlquery/types.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/nlquery/types.go
@@ -1,0 +1,11 @@
+package nlquery
+
+import "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+
+//Result is the deterministic output of natural language parsing.
+//The LLM is contrained to produce only this structure.
+
+type Result struct {
+	Params tracestore.TraceQueryParams
+	Reason string // optional explaination for debugging/UI
+}


### PR DESCRIPTION
 Which problem is this PR solving?
- Part of #7832 (AI-Powered Trace Analysis with Local LLM Support)

Description of the changes
- Introduces an initial scaffold for a natural language -> trace query
  translation layer.
- Adds a dedicated `nlquery` package collocated with the `jaegerquery`
  extension.
- Defines a constrained result type that reuses existing
  `TraceQueryParams` to ensure deterministic behavior.
- No runtime behavior is changed in this PR.

How was this change tested?
- Not applicable at this stage (structural scaffold only).
- Unit tests and functional behavior will be added in follow-up PRs.

Checklist
- [x] I have read the contributing guidelines
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality (planned next)
- [ ] I have run lint and test steps successfully (not required yet for scaffold)
