### PR TITLE
Improve provider naming consistency

### DIFF
--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -42,14 +42,14 @@ var _ extension.Extension = (*rsExtension)(nil)
 const defaultResourceName = "sampling_store_leader"
 
 type rsExtension struct {
-	cfg              *Config
-	telemetry        component.TelemetrySettings
-	httpServer       *http.Server
-	grpcServer       *grpc.Server
-	strategyProvider samplingstrategy.Provider // TODO we should rename this to Provider, not "store"
-	adaptiveStore    samplingstore.Store
-	distLock         *leaderelection.DistributedElectionParticipant
-	shutdownWG       sync.WaitGroup
+	cfg           *Config
+	telemetry     component.TelemetrySettings
+	httpServer    *http.Server
+	grpcServer    *grpc.Server
+	provider      samplingstrategy.Provider
+	adaptiveStore samplingstore.Store
+	distLock      *leaderelection.DistributedElectionParticipant
+	shutdownWG    sync.WaitGroup
 }
 
 func newExtension(cfg *Config, telemetry component.TelemetrySettings) *rsExtension {
@@ -153,8 +153,8 @@ func (ext *rsExtension) Shutdown(ctx context.Context) error {
 		errs = append(errs, ext.distLock.Close())
 	}
 
-	if ext.strategyProvider != nil {
-		errs = append(errs, ext.strategyProvider.Close())
+	if ext.provider != nil {
+		errs = append(errs, ext.provider.Close())
 	}
 	return errors.Join(errs...)
 }
@@ -173,7 +173,7 @@ func (ext *rsExtension) startFileBasedStrategyProvider(_ context.Context) error 
 		return fmt.Errorf("failed to create the local file strategy store: %w", err)
 	}
 
-	ext.strategyProvider = provider
+	ext.provider = provider
 	return nil
 }
 
@@ -214,7 +214,7 @@ func (ext *rsExtension) startAdaptiveStrategyProvider(host component.Host) error
 	if err := provider.Start(); err != nil {
 		return fmt.Errorf("failed to start the adaptive strategy store: %w", err)
 	}
-	ext.strategyProvider = provider
+	ext.provider = provider
 	return nil
 }
 
@@ -223,7 +223,7 @@ func (ext *rsExtension) startHTTPServer(ctx context.Context, host component.Host
 	mf = mf.Namespace(metrics.NSOptions{Name: "jaeger_remote_sampling"})
 	handler := samplinghttp.NewHandler(samplinghttp.HandlerParams{
 		ConfigManager: &samplinghttp.ConfigManager{
-			SamplingProvider: ext.strategyProvider,
+			SamplingProvider: ext.provider,
 		},
 		MetricsFactory: mf,
 
@@ -270,7 +270,7 @@ func (ext *rsExtension) startGRPCServer(ctx context.Context, host component.Host
 		return err
 	}
 
-	api_v2.RegisterSamplingManagerServer(ext.grpcServer, samplinggrpc.NewHandler(ext.strategyProvider))
+	api_v2.RegisterSamplingManagerServer(ext.grpcServer, samplinggrpc.NewHandler(ext.provider))
 
 	healthServer := health.NewServer() // support health checks on the gRPC server
 	healthServer.SetServingStatus("jaeger.api_v2.SamplingManager", grpc_health_v1.HealthCheckResponse_SERVING)

--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -602,7 +602,7 @@ func TestShutdownWithProviderError(t *testing.T) {
 			telemetry: componenttest.NewNopTelemetrySettings(),
 		}
 
-		ext.strategyProvider = &mockFailingProvider{}
+		ext.provider = &mockFailingProvider{}
 
 		err := ext.Shutdown(context.Background())
 		require.Error(t, err)


### PR DESCRIPTION
## Which problem is this PR solving?
- Addresses a TODO related to naming consistency in the remote sampling extension (internal refactor). ##7977

## Description of the changes
- Renamed the `strategyProvider` field to `provider` to better reflect its type (`samplingstrategy.Provider`)
- Updated all internal references in the implementation and tests
- Improves clarity by clearly distinguishing providers from stores (e.g. `adaptiveStore`)
- No behavioral or API changes — refactor only

## How was this change tested?
- Existing unit tests were run and all passed
- Code builds cleanly with no lint issues

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] No new functionality added (no new tests required)
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
