### PR TITLE
fix: return deep copies from memory store to prevent in-place mutation of stored traces

### DIFF
--- a/internal/storage/v2/memory/memory.go
+++ b/internal/storage/v2/memory/memory.go
@@ -106,7 +106,9 @@ func (st *Store) FindTraces(ctx context.Context, query tracestore.TraceQueryPara
 			return
 		}
 		for i := range traceAndIds {
-			if !yield([]ptrace.Traces{traceAndIds[i].trace}, nil) {
+			cp := ptrace.NewTraces()
+			traceAndIds[i].trace.CopyTo(cp)
+			if !yield([]ptrace.Traces{cp}, nil) {
 				return
 			}
 		}

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -150,7 +150,9 @@ func (t *Tenant) getTraces(traceIds ...tracestore.GetTraceParams) []ptrace.Trace
 	for i := range traceIds {
 		index, ok := t.ids[traceIds[i].TraceID]
 		if ok {
-			traces = append(traces, t.traces[index].trace)
+			cp := ptrace.NewTraces()
+			t.traces[index].trace.CopyTo(cp)
+			traces = append(traces, cp)
 		}
 	}
 	return traces


### PR DESCRIPTION
## Which problem is this PR solving?
- When using the memory storage backend, querying a trace could change the stored trace data.
- This happened because the memory store returned shared trace objects and query-time adjusters modified them in place.
- Querying the same trace multiple times could lead to incorrect timestamps, span data, or missing spans.


## Description of the changes
- The memory store now returns copies of trace data instead of shared references.
- This ensures query-time adjustments do not affect the stored traces.


## How was this change tested?
- Ran `make test` locally on Ubuntu (WSL), including the Go race detector.
- Ran `make lint` and verified there were no linting issues.


## Checklist
- [✔️] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [✔️] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [✔️] I have run lint and test steps successfully

### **make test output**
<img width="1019" height="269" alt="image" src="https://github.com/user-attachments/assets/9ad693df-73af-4bdd-91a7-8ea79069a1f0" />