### PR TITLE
fix(ci): update upload-artifact to v6 in metrics comparison workflow

### DIFF
--- a/.github/workflows/ci-compare-metrics.yml
+++ b/.github/workflows/ci-compare-metrics.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload metrics comparison report as artifact
         if: success() && steps.download-artifacts.outputs.pr_number
-        uses: actions/upload-artifact@ea165844305e4b11d771d9cf5d8d1b1a5d991f5a # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: metrics-comparison-report
           path: ./.metrics/combined_summary.md


### PR DESCRIPTION
## Problem

The **Metrics Comparison and Post Comment** workflow is failing during "Set up job" because the `actions/upload-artifact` action is pinned to a commit SHA that no longer exists on GitHub.

**Error:**
```
Error: An action could not be found at the URI 'https://api.github.com/repos/actions/upload-artifact/tarball/ea165844305e4b11d771d9cf5d8d1b1a5d991f5a'
```

**Failed run:** https://github.com/jaegertracing/jaeger/actions/runs/21814695605/job/62933823781

## Root Cause

The workflow file `ci-compare-metrics.yml` was using:
```yaml
uses: actions/upload-artifact@ea165844305e4b11d771d9cf5d8d1b1a5d991f5a # v4
```

This v4 SHA (`ea165844305e...`) has been removed or is no longer available from GitHub.

## Fix

Update to the same v6 version used by other workflows in this repository (`ci-e2e-all.yml`, `scorecard.yml`):
```yaml
uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
```

## Testing

This change only updates the action version. The workflow should now be able to download the action during job setup.