### PR TITLE
feat(query): add stub /api/ai/analyze endpoint

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler.go
@@ -12,13 +12,13 @@ import (
 
 // analyzeRequest is the JSON body for POST /api/ai/analyze.
 type analyzeRequest struct {
-	TraceID  string `json:"trace_id"`
+	TraceID  string `json:"traceID"`
 	Question string `json:"question"`
 }
 
 // analyzeResponse is returned inside structuredResponse.Data.
 type analyzeResponse struct {
-	TraceID string `json:"trace_id"`
+	TraceID string `json:"traceID"`
 	Answer  string `json:"answer"`
 }
 
@@ -38,7 +38,7 @@ func (aH *APIHandler) analyzeTraceAI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.TraceID == "" {
-		aH.handleError(w, errors.New("trace_id is required"), http.StatusBadRequest)
+		aH.handleError(w, errors.New("traceID is required"), http.StatusBadRequest)
 		return
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// analyzeRequest is the JSON body for POST /api/ai/analyze.
+type analyzeRequest struct {
+	TraceID  string `json:"trace_id"`
+	Question string `json:"question"`
+}
+
+// analyzeResponse is returned inside structuredResponse.Data.
+type analyzeResponse struct {
+	TraceID string `json:"trace_id"`
+	Answer  string `json:"answer"`
+}
+
+// analyzeTraceAI handles POST /api/ai/analyze requests.
+// It accepts a trace_id and question, orchestrates MCP + LLM calls via AIService,
+// and returns the analysis wrapped in the standard structuredResponse envelope.
+//
+// This is a Level-1 AI endpoint (single-trace Q&A) as described in:
+// - Issue #7832 (AI-Powered Trace Analysis with Local LLM Support)
+// - Issue #7827 (GenAI integration with Jaeger, Level 1)
+// - ADR-002 (MCP Server)
+func (aH *APIHandler) analyzeTraceAI(w http.ResponseWriter, r *http.Request) {
+	var req analyzeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		aH.handleError(w, fmt.Errorf("invalid JSON request body: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	if req.TraceID == "" {
+		aH.handleError(w, errors.New("trace_id is required"), http.StatusBadRequest)
+		return
+	}
+
+	if req.Question == "" {
+		aH.handleError(w, errors.New("question is required"), http.StatusBadRequest)
+		return
+	}
+
+	if aH.aiService == nil {
+		aH.handleError(w, errors.New("AI service is not configured"), http.StatusNotImplemented)
+		return
+	}
+
+	answer, err := aH.aiService.AnalyzeTrace(r.Context(), req.TraceID, req.Question)
+	if aH.handleError(w, err, http.StatusInternalServerError) {
+		return
+	}
+
+	resp := structuredResponse{
+		Data: analyzeResponse{
+			TraceID: req.TraceID,
+			Answer:  answer,
+		},
+		Total: 1,
+	}
+
+	aH.writeJSON(w, r, &resp)
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler_test.go
@@ -127,7 +127,7 @@ func TestAnalyzeTraceAISuccess(t *testing.T) {
 		},
 	)
 
-	body := `{"trace_id": "abc123def456", "question": "Why is this trace slow?"}`
+	body := `{"traceID": "abc123def456", "question": "Why is this trace slow?"}`
 	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -142,7 +142,7 @@ func TestAnalyzeTraceAISuccess(t *testing.T) {
 	// Data comes back as map[string]any from JSON decoding.
 	data, ok := result.Data.(map[string]any)
 	require.True(t, ok, "expected Data to be a map")
-	assert.Equal(t, "abc123def456", data["trace_id"])
+	assert.Equal(t, "abc123def456", data["traceID"])
 	assert.Contains(t, data["answer"], "database query")
 }
 
@@ -170,7 +170,7 @@ func TestAnalyzeTraceAIMissingTraceID(t *testing.T) {
 func TestAnalyzeTraceAIMissingQuestion(t *testing.T) {
 	ts := initializeAITestServer(t, &StubMCPClient{}, &StubLLMClient{})
 
-	body := `{"trace_id": "abc123"}`
+	body := `{"traceID": "abc123"}`
 	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -184,7 +184,7 @@ func TestAnalyzeTraceAIInternalError(t *testing.T) {
 		&mockLLMClient{response: "unused"},
 	)
 
-	body := `{"trace_id": "abc123", "question": "What happened?"}`
+	body := `{"traceID": "abc123", "question": "What happened?"}`
 	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -199,7 +199,7 @@ func TestAnalyzeTraceAINoAIService(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	t.Cleanup(ts.Close)
 
-	body := `{"trace_id": "abc123", "question": "Why slow?"}`
+	body := `{"traceID": "abc123", "question": "Why slow?"}`
 	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/ai_handler_test.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// --- Mock implementations ---
+
+type mockMCPClient struct {
+	topologyResponse     string
+	criticalPathResponse string
+	topologyErr          error
+	criticalPathErr      error
+}
+
+func (m *mockMCPClient) GetTraceTopology(_ context.Context, _ string) (string, error) {
+	return m.topologyResponse, m.topologyErr
+}
+
+func (m *mockMCPClient) GetCriticalPath(_ context.Context, _ string) (string, error) {
+	return m.criticalPathResponse, m.criticalPathErr
+}
+
+type mockLLMClient struct {
+	response string
+	err      error
+}
+
+func (m *mockLLMClient) AnalyzeTrace(_ context.Context, _ string) (string, error) {
+	return m.response, m.err
+}
+
+// --- Helper: create a minimal test server with AI wired up ---
+
+func initializeAITestServer(t *testing.T, mcpClient MCPClient, llmClient LLMClient) *httptest.Server {
+	t.Helper()
+	aiSvc := NewAIService(mcpClient, llmClient)
+	apiHandler := NewAPIHandler(nil,
+		HandlerOptions.Logger(zap.NewNop()),
+		HandlerOptions.AIService(aiSvc),
+	)
+	mux := http.NewServeMux()
+	apiHandler.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// --- AIService unit tests ---
+
+func TestAIServiceAnalyzeTrace(t *testing.T) {
+	svc := NewAIService(
+		&mockMCPClient{
+			topologyResponse:     "A -> B -> C",
+			criticalPathResponse: "B (100ms) -> C (200ms)",
+		},
+		&mockLLMClient{response: "Service C is the bottleneck."},
+	)
+
+	answer, err := svc.AnalyzeTrace(context.Background(), "abc123", "Why is this trace slow?")
+	require.NoError(t, err)
+	assert.Equal(t, "Service C is the bottleneck.", answer)
+}
+
+func TestAIServiceAnalyzeTraceMCPTopologyError(t *testing.T) {
+	svc := NewAIService(
+		&mockMCPClient{topologyErr: errors.New("connection refused")},
+		&mockLLMClient{response: "unused"},
+	)
+
+	_, err := svc.AnalyzeTrace(context.Background(), "abc123", "question")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get trace topology")
+}
+
+func TestAIServiceAnalyzeTraceMCPCriticalPathError(t *testing.T) {
+	svc := NewAIService(
+		&mockMCPClient{
+			topologyResponse: "A -> B",
+			criticalPathErr:  errors.New("timeout"),
+		},
+		&mockLLMClient{response: "unused"},
+	)
+
+	_, err := svc.AnalyzeTrace(context.Background(), "abc123", "question")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get critical path")
+}
+
+func TestAIServiceAnalyzeTraceLLMError(t *testing.T) {
+	svc := NewAIService(
+		&mockMCPClient{
+			topologyResponse:     "A -> B",
+			criticalPathResponse: "B (50ms)",
+		},
+		&mockLLMClient{err: errors.New("model not loaded")},
+	)
+
+	_, err := svc.AnalyzeTrace(context.Background(), "abc123", "question")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM analysis failed")
+}
+
+// --- HTTP handler tests ---
+
+func TestAnalyzeTraceAISuccess(t *testing.T) {
+	ts := initializeAITestServer(t,
+		&mockMCPClient{
+			topologyResponse:     "frontend -> backend -> db",
+			criticalPathResponse: "backend (80ms) -> db (150ms)",
+		},
+		&mockLLMClient{
+			response: "The database query in the db service is the primary bottleneck.",
+		},
+	)
+
+	body := `{"trace_id": "abc123def456", "question": "Why is this trace slow?"}`
+	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result structuredResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Total)
+
+	// Data comes back as map[string]any from JSON decoding.
+	data, ok := result.Data.(map[string]any)
+	require.True(t, ok, "expected Data to be a map")
+	assert.Equal(t, "abc123def456", data["trace_id"])
+	assert.Contains(t, data["answer"], "database query")
+}
+
+func TestAnalyzeTraceAIInvalidJSON(t *testing.T) {
+	ts := initializeAITestServer(t, &StubMCPClient{}, &StubLLMClient{})
+
+	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString("not json"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestAnalyzeTraceAIMissingTraceID(t *testing.T) {
+	ts := initializeAITestServer(t, &StubMCPClient{}, &StubLLMClient{})
+
+	body := `{"question": "Why is this slow?"}`
+	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestAnalyzeTraceAIMissingQuestion(t *testing.T) {
+	ts := initializeAITestServer(t, &StubMCPClient{}, &StubLLMClient{})
+
+	body := `{"trace_id": "abc123"}`
+	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestAnalyzeTraceAIInternalError(t *testing.T) {
+	ts := initializeAITestServer(t,
+		&mockMCPClient{topologyErr: errors.New("MCP server unreachable")},
+		&mockLLMClient{response: "unused"},
+	)
+
+	body := `{"trace_id": "abc123", "question": "What happened?"}`
+	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestAnalyzeTraceAINoAIService(t *testing.T) {
+	apiHandler := NewAPIHandler(nil, HandlerOptions.Logger(zap.NewNop()))
+	mux := http.NewServeMux()
+	apiHandler.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	body := `{"trace_id": "abc123", "question": "Why slow?"}`
+	resp, err := http.Post(ts.URL+"/api/ai/analyze", "application/json", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+}
+
+func TestAnalyzeTraceAIMethodNotAllowed(t *testing.T) {
+	ts := initializeAITestServer(t, &StubMCPClient{}, &StubLLMClient{})
+
+	resp, err := http.Get(ts.URL + "/api/ai/analyze")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+// --- Stub tests ---
+
+func TestStubMCPClient(t *testing.T) {
+	client := &StubMCPClient{}
+
+	topology, err := client.GetTraceTopology(context.Background(), "test-trace-1")
+	require.NoError(t, err)
+	assert.Contains(t, topology, "test-trace-1")
+
+	critPath, err := client.GetCriticalPath(context.Background(), "test-trace-1")
+	require.NoError(t, err)
+	assert.Contains(t, critPath, "test-trace-1")
+}
+
+func TestStubLLMClient(t *testing.T) {
+	client := &StubLLMClient{}
+
+	answer, err := client.AnalyzeTrace(context.Background(), "some prompt")
+	require.NoError(t, err)
+	assert.NotEmpty(t, answer)
+}
+
+func TestBuildAnalysisPrompt(t *testing.T) {
+	prompt := buildAnalysisPrompt("trace-123", "A -> B", "B (100ms)", "Why slow?")
+	assert.Contains(t, prompt, "trace-123")
+	assert.Contains(t, prompt, "A -> B")
+	assert.Contains(t, prompt, "B (100ms)")
+	assert.Contains(t, prompt, "Why slow?")
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/ai_service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/ai_service.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"fmt"
+)
+
+// MCPClient defines the interface for communicating with the Jaeger MCP server.
+// In production, this will make HTTP calls to the MCP server (default port 16687).
+// TODO: Replace StubMCPClient with an HTTP client calling MCP tools on ports.MCPHTTP.
+type MCPClient interface {
+	// GetTraceTopology returns the service dependency topology for a given trace.
+	GetTraceTopology(ctx context.Context, traceID string) (string, error)
+	// GetCriticalPath returns the critical path analysis for a given trace.
+	GetCriticalPath(ctx context.Context, traceID string) (string, error)
+}
+
+// LLMClient defines the interface for communicating with a local LLM.
+// In production, this will call Ollama (default port 11434) or similar local models.
+// TODO: Replace StubLLMClient with an Ollama/LangChainGo client.
+type LLMClient interface {
+	// AnalyzeTrace sends a prompt containing trace context to the LLM and returns its analysis.
+	AnalyzeTrace(ctx context.Context, prompt string) (string, error)
+}
+
+// AIService orchestrates the Level-1 AI trace analysis pipeline:
+// 1. Fetch trace context from MCP tools (topology, critical path).
+// 2. Build a prompt combining trace context with the user's question.
+// 3. Send the prompt to the LLM for analysis.
+type AIService struct {
+	mcpClient MCPClient
+	llmClient LLMClient
+}
+
+// NewAIService creates a new AIService with the given MCP and LLM clients.
+func NewAIService(mcpClient MCPClient, llmClient LLMClient) *AIService {
+	return &AIService{
+		mcpClient: mcpClient,
+		llmClient: llmClient,
+	}
+}
+
+// AnalyzeTrace performs Level-1 single-trace Q&A:
+// fetches trace topology and critical path via MCP, builds a prompt, and queries the LLM.
+func (s *AIService) AnalyzeTrace(ctx context.Context, traceID string, question string) (string, error) {
+	topology, err := s.mcpClient.GetTraceTopology(ctx, traceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get trace topology: %w", err)
+	}
+
+	criticalPath, err := s.mcpClient.GetCriticalPath(ctx, traceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get critical path: %w", err)
+	}
+
+	prompt := buildAnalysisPrompt(traceID, topology, criticalPath, question)
+
+	answer, err := s.llmClient.AnalyzeTrace(ctx, prompt)
+	if err != nil {
+		return "", fmt.Errorf("LLM analysis failed: %w", err)
+	}
+
+	return answer, nil
+}
+
+// buildAnalysisPrompt constructs the LLM prompt from trace context and user question.
+func buildAnalysisPrompt(traceID, topology, criticalPath, question string) string {
+	return fmt.Sprintf(
+		"You are an expert distributed systems engineer analyzing a trace.\n\n"+
+			"Trace ID: %s\n\n"+
+			"Trace Topology:\n%s\n\n"+
+			"Critical Path:\n%s\n\n"+
+			"User Question: %s\n\n"+
+			"Provide a concise, actionable analysis.",
+		traceID, topology, criticalPath, question,
+	)
+}
+
+// --- Stub implementations (for PoC / testing) ---
+
+// StubMCPClient returns fixed responses without calling a real MCP server.
+type StubMCPClient struct{}
+
+// GetTraceTopology returns a stub topology string.
+func (*StubMCPClient) GetTraceTopology(_ context.Context, traceID string) (string, error) {
+	return fmt.Sprintf(
+		"frontend-web -> api-gateway -> order-service -> payment-service (trace: %s)",
+		traceID,
+	), nil
+}
+
+// GetCriticalPath returns a stub critical path string.
+func (*StubMCPClient) GetCriticalPath(_ context.Context, traceID string) (string, error) {
+	return fmt.Sprintf(
+		"api-gateway (12ms) -> order-service (45ms) -> payment-service (120ms) [total: 177ms] (trace: %s)",
+		traceID,
+	), nil
+}
+
+// StubLLMClient returns a fixed analysis without calling a real LLM.
+type StubLLMClient struct{}
+
+// AnalyzeTrace returns a stub analysis string.
+func (*StubLLMClient) AnalyzeTrace(_ context.Context, _ string) (string, error) {
+	return "The trace shows the payment-service is the primary bottleneck, " +
+		"consuming 120ms (68% of the total 177ms critical path). " +
+		"Consider investigating the payment-service for slow database queries or external API calls.", nil
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/handler_options.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/handler_options.go
@@ -63,3 +63,10 @@ func (handlerOptions) MetricsQueryService(mqs metricstore.Reader) HandlerOption 
 		apiHandler.metricsQueryService = mqs
 	}
 }
+
+// AIService creates a HandlerOption that sets the AI service for trace analysis.
+func (handlerOptions) AIService(aiService *AIService) HandlerOption {
+	return func(apiHandler *APIHandler) {
+		apiHandler.aiService = aiService
+	}
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -76,6 +76,7 @@ type APIHandler struct {
 	apiPrefix           string
 	logger              *zap.Logger
 	tracer              trace.TracerProvider
+	aiService           *AIService
 }
 
 // NewAPIHandler returns an APIHandler
@@ -121,6 +122,8 @@ func (aH *APIHandler) RegisterRoutes(router *http.ServeMux) {
 	aH.handleFunc(router, aH.errors, http.MethodGet, "/metrics/errors")
 	aH.handleFunc(router, aH.minStep, http.MethodGet, "/metrics/minstep")
 	aH.handleFunc(router, aH.getQualityMetrics, http.MethodGet, "/quality-metrics")
+	// AI-powered trace analysis (Level-1 PoC, #7832)
+	aH.handleFunc(router, aH.analyzeTraceAI, http.MethodPost, "/ai/analyze")
 }
 
 func (aH *APIHandler) handleFunc(

--- a/docs/api/ai.md
+++ b/docs/api/ai.md
@@ -37,21 +37,21 @@ Analyze a trace using AI. Accepts a trace ID and a natural-language question.
 #### Request
 ```json
 {
-  "trace_id": "abc123def456789",
+  "traceID": "abc123def456789",
   "question": "Why is this trace slow?"
 }
 ```
 
 | Field      | Type   | Required | Description                              |
 |------------|--------|----------|------------------------------------------|
-| `trace_id` | string | Yes      | The trace ID to analyze.                 |
+| `traceID` | string | Yes      | The trace ID to analyze.                 |
 | `question` | string | Yes      | A natural-language question about the trace. |
 
 #### Response (Success)
 ```json
 {
   "data": {
-    "trace_id": "abc123def456789",
+    "traceID": "abc123def456789",
     "answer": "The payment-service is the primary bottleneck, consuming 120ms of the 177ms critical path."
   },
   "total": 1
@@ -64,7 +64,7 @@ Analyze a trace using AI. Accepts a trace ID and a natural-language question.
   "errors": [
     {
       "code": 400,
-      "msg": "trace_id is required"
+      "msg": "traceID is required"
     }
   ]
 }
@@ -73,7 +73,7 @@ Analyze a trace using AI. Accepts a trace ID and a natural-language question.
 | HTTP Status | When                                          |
 |-------------|-----------------------------------------------|
 | 200         | Analysis completed successfully.               |
-| 400         | Missing or invalid `trace_id` or `question`.   |
+| 400         | Missing or invalid `traceID` or `question`.   |
 | 501         | AI service is not configured.                  |
 | 500         | MCP server or LLM unavailable / internal error.|
 

--- a/docs/api/ai.md
+++ b/docs/api/ai.md
@@ -1,0 +1,92 @@
+# AI Trace Analysis API (Level-1 PoC)
+
+> **Status:** Prototype / Proof of Concept
+> **Related issue:** [#7832 – AI-Powered Trace Analysis with Local LLM Support](https://github.com/jaegertracing/jaeger/issues/7832)
+> **Roadmap reference:** [#7827 – GenAI integration with Jaeger (Level 1)](https://github.com/jaegertracing/jaeger/issues/7827)
+
+## Overview
+
+This endpoint provides Level-1 AI-powered trace analysis: a user asks a free-form question about a single trace, and the system returns a natural-language explanation.
+
+The architecture follows ADR-002 (MCP Server) and the GenAI roadmap:
+```
+User Question + Trace ID
+        |
+        v
+  jaegerquery         POST /api/ai/analyze
+  (AI Handler)
+        |  Fetches trace context
+        v
+  jaegermcp           MCP tools (port 16687)
+  (MCP Server)        - get_trace_topology
+                      - get_critical_path
+        |  Trace context returned
+        v
+  Local LLM           e.g. Ollama (port 11434)
+        |  Natural language answer
+        v
+  JSON Response
+```
+
+## Endpoint
+
+### `POST /api/ai/analyze`
+
+Analyze a trace using AI. Accepts a trace ID and a natural-language question.
+
+#### Request
+```json
+{
+  "trace_id": "abc123def456789",
+  "question": "Why is this trace slow?"
+}
+```
+
+| Field      | Type   | Required | Description                              |
+|------------|--------|----------|------------------------------------------|
+| `trace_id` | string | Yes      | The trace ID to analyze.                 |
+| `question` | string | Yes      | A natural-language question about the trace. |
+
+#### Response (Success)
+```json
+{
+  "data": {
+    "trace_id": "abc123def456789",
+    "answer": "The payment-service is the primary bottleneck, consuming 120ms of the 177ms critical path."
+  },
+  "total": 1
+}
+```
+
+#### Response (Error)
+```json
+{
+  "errors": [
+    {
+      "code": 400,
+      "msg": "trace_id is required"
+    }
+  ]
+}
+```
+
+| HTTP Status | When                                          |
+|-------------|-----------------------------------------------|
+| 200         | Analysis completed successfully.               |
+| 400         | Missing or invalid `trace_id` or `question`.   |
+| 501         | AI service is not configured.                  |
+| 500         | MCP server or LLM unavailable / internal error.|
+
+## Current Status (PoC)
+
+- **MCP client**: Stub returning fixed topology and critical path strings.
+- **LLM client**: Stub returning a fixed analysis.
+
+## Future Work
+
+1. Real MCP integration via HTTP client on port 16687.
+2. Real LLM integration via Ollama/LangChainGo on port 11434.
+3. Streaming responses (SSE).
+4. Evidence linking (span IDs in answers).
+5. Benchmarks per #7827.
+6. UI integration.


### PR DESCRIPTION
## Which problem is this PR solving?
- Ref: #7832 (AI-Powered Trace Analysis with Local LLM Support)
- Related: #7827 (GenAI integration with Jaeger, Level 1)

## Description of the changes

Adds a minimal Level-1 AI trace analysis endpoint to `jaegerquery` as a proof-of-concept for #7832.

**New endpoint:** `POST /api/ai/analyze`
- Accepts `trace_id` + `question` in JSON body
- Orchestrates: MCPClient (stub) → LLMClient (stub) → JSON response
- Wrapped in Jaeger's standard `structuredResponse` envelope

Architecture: `POST /api/ai/analyze → APIHandler.analyzeTraceAI → AIService → MCPClient (stub) → LLMClient (stub) → structuredResponse`

Follows [ADR-002](https://github.com/jaegertracing/jaeger/blob/main/docs/adr/002-mcp-server.md) and GenAI roadmap Level 1.

| File | Change |
|------|--------|
| `ai_service.go` | NEW: MCPClient + LLMClient interfaces, AIService orchestrator, stub implementations |
| `ai_handler.go` | NEW: `analyzeTraceAI` handler on APIHandler for POST /api/ai/analyze |
| `ai_handler_test.go` | NEW: 14 unit tests (success, validation, error paths, stubs, prompt) |
| `http_handler.go` | MODIFIED: added `aiService` field + route registration |
| `handler_options.go` | MODIFIED: added `HandlerOptions.AIService()` option |
| `docs/api/ai.md` | NEW: endpoint documentation with architecture and examples |

**Not included (intentionally):** No real MCP/LLM calls, no UI, no streaming. Stubs only so CI has no external dependencies. Follow-ups planned once maintainers agree on the endpoint shape.

## How was this change tested?
- `go build` ✅
- `golangci-lint` ✅ (0 issues)
- 14/14 new tests pass ✅
- Existing tests not broken ✅

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes