### PR TITLE
Implement timer duration bucket parsing in metrics Init

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // MustInit initializes the passed in metrics and initializes its fields using the passed in factory.
@@ -46,7 +47,8 @@ func Init(m any, factory Factory, globalTags map[string]string) error {
 	for i := 0; i < t.NumField(); i++ {
 		tags := make(map[string]string)
 		maps.Copy(tags, globalTags)
-		var buckets []float64
+		var histogramBuckets []float64
+		var timerBuckets []time.Duration
 		field := t.Field(i)
 		metric := field.Tag.Get("metric")
 		if metric == "" {
@@ -66,10 +68,16 @@ func Init(m any, factory Factory, globalTags map[string]string) error {
 		if bucketString := field.Tag.Get("buckets"); bucketString != "" {
 			switch {
 			case field.Type.AssignableTo(timerPtrType):
-				// TODO: Parse timer duration buckets
-				return fmt.Errorf(
-					"Field [%s]: Buckets are not currently initialized for timer metrics",
-					field.Name)
+				bucketValues := strings.Split(bucketString, ",")
+				for _, bucket := range bucketValues {
+					d, err := time.ParseDuration(strings.TrimSpace(bucket))
+					if err != nil {
+						return fmt.Errorf(
+							"Field [%s]: Bucket [%s] could not be converted to time.Duration in 'buckets' string [%s]",
+							field.Name, bucket, bucketString)
+					}
+					timerBuckets = append(timerBuckets, d)
+				}
 			case field.Type.AssignableTo(histogramPtrType):
 				bucketValues := strings.Split(bucketString, ",")
 				for _, bucket := range bucketValues {
@@ -79,7 +87,7 @@ func Init(m any, factory Factory, globalTags map[string]string) error {
 							"Field [%s]: Bucket [%s] could not be converted to float64 in 'buckets' string [%s]",
 							field.Name, bucket, bucketString)
 					}
-					buckets = append(buckets, b)
+					histogramBuckets = append(histogramBuckets, b)
 				}
 			default:
 				return fmt.Errorf(
@@ -103,18 +111,18 @@ func Init(m any, factory Factory, globalTags map[string]string) error {
 				Help: help,
 			})
 		case field.Type.AssignableTo(timerPtrType):
-			// TODO: Add buckets once parsed (see TODO above)
 			obj = factory.Timer(TimerOptions{
-				Name: metric,
-				Tags: tags,
-				Help: help,
+				Name:    metric,
+				Tags:    tags,
+				Help:    help,
+				Buckets: timerBuckets,
 			})
 		case field.Type.AssignableTo(histogramPtrType):
 			obj = factory.Histogram(HistogramOptions{
 				Name:    metric,
 				Tags:    tags,
 				Help:    help,
-				Buckets: buckets,
+				Buckets: histogramBuckets,
 			})
 		default:
 			return fmt.Errorf(

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -20,7 +20,7 @@ func TestInitMetrics(t *testing.T) {
 	testMetrics := struct {
 		Gauge     metrics.Gauge     `metric:"gauge" tags:"1=one,2=two"`
 		Counter   metrics.Counter   `metric:"counter"`
-		Timer     metrics.Timer     `metric:"timer"`
+		Timer     metrics.Timer     `metric:"timer" buckets:"1ms,5ms,10ms,50ms"`
 		Histogram metrics.Histogram `metric:"histogram" buckets:"20,40,60,80"`
 	}{}
 
@@ -76,7 +76,7 @@ var (
 	}{}
 
 	badTimerBucket = struct {
-		BadTimerBucket metrics.Timer `metric:"timer" buckets:"1"`
+		BadTimerBucket metrics.Timer `metric:"timer" buckets:"invalid"`
 	}{}
 
 	invalidBuckets = struct {
@@ -97,7 +97,7 @@ func TestInitMetricsFailures(t *testing.T) {
 		"Field [BadHistogramBucket]: Bucket [a] could not be converted to float64 in 'buckets' string [1,2,a,4]")
 
 	require.EqualError(t, metrics.Init(&badTimerBucket, nil, nil),
-		"Field [BadTimerBucket]: Buckets are not currently initialized for timer metrics")
+		"Field [BadTimerBucket]: Bucket [invalid] could not be converted to time.Duration in 'buckets' string [invalid]")
 
 	require.EqualError(t, metrics.Init(&invalidBuckets, nil, nil),
 		"Field [InvalidBuckets]: Buckets should only be defined for Timer and Histogram metric types")


### PR DESCRIPTION
This change adds support for parsing duration-based bucket values for Timer metrics via the `buckets` struct tag. Timer buckets now accept duration strings like "1ms,5ms,10ms,50ms" and are parsed using time.ParseDuration, similar to how Histogram buckets parse float64 values.

Changes:
- Parse timer buckets as comma-separated time.Duration values
- Split bucket storage into histogramBuckets and timerBuckets for type safety
- Pass parsed timerBuckets to factory.Timer() via TimerOptions.Buckets
- Update test to verify timer bucket parsing with valid durations
- Update error test to check invalid duration string handling

Resolves #7950

## AI Usage in this PR (choose one)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
