### PR TITLE
Extract loadStrategies into reusable generic utility

### DIFF
--- a/internal/jio/load.go
+++ b/internal/jio/load.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package jio provides generic I/O utility functions.
+package jio
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// JSONLoad calls the provided loader function to fetch raw bytes,
+// then unmarshals the JSON data into a value of type T.
+func JSONLoad[T any](loader func() ([]byte, error)) (*T, error) {
+	data, err := loader()
+	if err != nil {
+		return nil, err
+	}
+
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+	return &v, nil
+}

--- a/internal/jio/load_test.go
+++ b/internal/jio/load_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jio
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testConfig struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func TestJSONLoad_Success(t *testing.T) {
+	loader := func() ([]byte, error) {
+		return []byte(`{"name":"test","value":42}`), nil
+	}
+
+	result, err := JSONLoad[testConfig](loader)
+	require.NoError(t, err)
+	assert.Equal(t, "test", result.Name)
+	assert.Equal(t, 42, result.Value)
+}
+
+func TestJSONLoad_NullJSON(t *testing.T) {
+	loader := func() ([]byte, error) {
+		return []byte("null"), nil
+	}
+
+	result, err := JSONLoad[testConfig](loader)
+	require.NoError(t, err)
+	assert.Zero(t, result.Name)
+	assert.Zero(t, result.Value)
+}
+
+func TestJSONLoad_LoaderError(t *testing.T) {
+	loader := func() ([]byte, error) {
+		return nil, errors.New("load failed")
+	}
+
+	result, err := JSONLoad[testConfig](loader)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, "load failed", err.Error())
+}
+
+func TestJSONLoad_InvalidJSON(t *testing.T) {
+	loader := func() ([]byte, error) {
+		return []byte(`{invalid}`), nil
+	}
+
+	result, err := JSONLoad[testConfig](loader)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to unmarshal JSON")
+}
+
+func TestJSONLoad_PointerType(t *testing.T) {
+	loader := func() ([]byte, error) {
+		return []byte(`{"name":"ptr","value":99}`), nil
+	}
+
+	result, err := JSONLoad[*testConfig](loader)
+	require.NoError(t, err)
+	require.NotNil(t, *result)
+	assert.Equal(t, "ptr", (*result).Name)
+	assert.Equal(t, 99, (*result).Value)
+}
+
+func TestJSONLoad_NullPointerType(t *testing.T) {
+	loader := func() ([]byte, error) {
+		return []byte("null"), nil
+	}
+
+	result, err := JSONLoad[*testConfig](loader)
+	require.NoError(t, err)
+	assert.Nil(t, *result)
+}

--- a/internal/jio/package_test.go
+++ b/internal/jio/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jio
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/sampling/samplingstrategy/file/provider.go
+++ b/internal/sampling/samplingstrategy/file/provider.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
+	"github.com/jaegertracing/jaeger/internal/jio"
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy"
 )
 
@@ -184,18 +185,12 @@ func (h *samplingProvider) updateSamplingStrategy(dataBytes []byte) error {
 	return nil
 }
 
-// TODO good candidate for a global util function
 func loadStrategies(loadFn strategyLoader) (*strategies, error) {
-	strategyBytes, err := loadFn()
+	s, err := jio.JSONLoad[*strategies](loadFn)
 	if err != nil {
 		return nil, err
 	}
-
-	var strategies *strategies
-	if err := json.Unmarshal(strategyBytes, &strategies); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal strategies: %w", err)
-	}
-	return strategies, nil
+	return *s, nil
 }
 
 func (h *samplingProvider) parseStrategies(strategies *strategies) {

--- a/internal/sampling/samplingstrategy/file/provider_test.go
+++ b/internal/sampling/samplingstrategy/file/provider_test.go
@@ -98,8 +98,8 @@ func TestStrategyStoreWithFile(t *testing.T) {
 	require.ErrorContains(t, err, "failed to read strategies file fileNotFound.json")
 
 	_, err = NewProvider(Options{StrategiesFile: "fixtures/bad_strategies.json", DefaultSamplingProbability: DefaultSamplingProbability}, zap.NewNop())
-	require.EqualError(t, err,
-		"failed to unmarshal strategies: json: cannot unmarshal string into Go value of type file.strategies")
+	require.ErrorContains(t, err,
+		"json: cannot unmarshal string into Go value of type file.strategies")
 
 	// Test default strategy
 	logger, buf := testutils.NewLogger()


### PR DESCRIPTION
Introduces a new `internal/jio` package with a generic `JSONLoad[T]` function that abstracts the common pattern of loading bytes from a source and unmarshaling into a typed struct. This addresses the TODO comment in the sampling provider and makes the pattern reusable across the codebase.

Changes:
- Create internal/jio package with JSONLoad[T any] generic function
- Refactor loadStrategies to use jio.JSONLoad[*strategies]
- Add comprehensive tests covering success, null JSON, errors, and pointer types
- Update provider_test to use ErrorContains for flexible error matching

The JSONLoad utility handles both regular and pointer types correctly, properly unmarshaling JSON null values according to Go semantics.

Resolves #8021

- [ ] **Moderate**: AI helped with code generation or debugging specific parts
