### PR TITLE
Enable argument-limit revive linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,9 +134,9 @@ linters:
         # too pendantic
         - name: function-length
           disabled: true
-        # definitely a good one, needs cleanup first
         - name: argument-limit
-          disabled: true
+          arguments:
+            - 7
         # this is idiocy, promotes less readable code. Don't enable.
         - name: var-declaration
           disabled: true


### PR DESCRIPTION
## Summary

Enables the `argument-limit` revive linter rule with a threshold of 7 parameters per function. This is part of the incremental effort in #5506 to enable additional revive rules to improve code quality.

## Changes

**`.golangci.yml`:**
- Enable `argument-limit` rule with threshold of 7
- Fix malformed `flag-parameter` entry (restore proper `disabled: true`)

**`internal/storage/v1/badger/spanstore/read_write_test.go`:**
- Refactor `writeSpans` function (8 params → 2 params)
- Introduce `writeSpansParams` struct to group benchmark configuration
- Update 2 call sites to use struct initialization

## Test Plan

- [x] Zero violations reported by revive for `argument-limit`
- [x] Badger storage tests pass
- [x] Full codebase builds successfully

The refactoring improves code readability by making the benchmark parameters explicit with named struct fields.

Resolves #5506