### PR TITLE
Fix typos and outdated path in Elasticsearch README files

### DIFF
--- a/cmd/es-index-cleaner/README.md
+++ b/cmd/es-index-cleaner/README.md
@@ -1,9 +1,9 @@
 # jaeger-es-index-cleaner
 
 It is common to only keep observability data for a limited time.
-However, Elasticsearch does no support expiring of old data via TTL.
+However, Elasticsearch does not support expiring of old data via TTL.
 To help with this task, `jaeger-es-index-cleaner` can be used to purge
-old Jaeger indices. For example, to delete indixes older than 14 days:
+old Jaeger indices. For example, to delete indices older than 14 days:
 
 ```
 docker run -it --rm --net=host -e ROLLOVER=true \

--- a/internal/storage/v1/elasticsearch/README.md
+++ b/internal/storage/v1/elasticsearch/README.md
@@ -7,7 +7,7 @@ Indices will be created depending on the spans timestamp. i.e., a span with
 a timestamp on 2017/04/21 will be stored in an index named `jaeger-2017-04-21`.
 
 It is common to only keep observability data for a limited time.
-However, Elasticsearch does no support expiring of old data via TTL.
+However, Elasticsearch does not support expiring of old data via TTL.
 To purge old Jaeger indices, use [jaeger-es-index-cleaner](../../../cmd/es-index-cleaner/).
 
 ### Timestamps
@@ -22,7 +22,7 @@ ElasticSearch creates a new document for every nested field, there is currently 
 
 ### Shards and Replicas
 Number of shards and replicas per index can be specified as parameters to the writer and/or through configs under
-`./pkg/es/config/config.go`. If not specified, it defaults to ElasticSearch defaults: 5 shards and 1 replica.
+`./internal/storage/elasticsearch/config/config.go`. If not specified, it defaults to ElasticSearch defaults: 5 shards and 1 replica.
 [This article](https://www.elastic.co/blog/how-many-shards-should-i-have-in-my-elasticsearch-cluster) goes into more information
 about choosing how many shards should be chosen for optimization.
 


### PR DESCRIPTION
## Summary

This PR fixes documentation issues in two Elasticsearch-related README files.

### Changes

**`cmd/es-index-cleaner/README.md`:**
- Fix typo: `does no support` → `does not support`
- Fix typo: `delete indixes` → `delete indices`

**`internal/storage/v1/elasticsearch/README.md`:**
- Fix typo: `does no support` → `does not support`
- Update outdated code path: `./pkg/es/config/config.go` → `./internal/storage/elasticsearch/config/config.go`
  (the `pkg/` directory no longer exists; the config was moved to `internal/`)

These are purely documentation fixes with no functional impact.