### PR TITLE
[memory] Include link attributes when searching by tags

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -229,6 +229,12 @@ func TestFindTracesAttributesMatching(t *testing.T) {
 				return td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Events().AppendEmpty().Attributes()
 			},
 		},
+		{
+			name: "link-attributes",
+			attributes: func(td ptrace.Traces) pcommon.Map {
+				return td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Links().AppendEmpty().Attributes()
+			},
+		},
 	}
 	store, err := NewStore(Configuration{
 		MaxTraces: 10,

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -332,6 +332,11 @@ func findKeyValInTrace(key string, val pcommon.Value, resourceAttributes pcommon
 			return true
 		}
 	}
+	for _, link := range span.Links().All() {
+		if matchAttributes(key, val, link.Attributes()) {
+			return true
+		}
+	}
 	return tagsMatched
 }
 


### PR DESCRIPTION
## Description of the changes
- Memory storage was ignoring link attributes, which needs to be matched with query

## How was this change tested?
- Unit Test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
