### PR TITLE
Add support for ES health-check timeout at startup

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -108,7 +108,7 @@ type Configuration struct {
 	// Disable the Elasticsearch health check
 	DisableHealthCheck bool `mapstructure:"disable_health_check"`
 	// Set the Elasticsearch health check timeout startup
-	HealthCheckTimeOutStartup time.Duration `mapstructure:"health_check_timeout_startup"`
+	HealthCheckTimeoutStartup time.Duration `mapstructure:"health_check_timeout_startup"`
 	// SendGetBodyAs is the HTTP verb to use for requests that contain a body.
 	SendGetBodyAs string `mapstructure:"send_get_body_as"`
 	// QueryTimeout contains the timeout used for queries. A timeout of zero means no timeout.
@@ -583,8 +583,8 @@ func (c *Configuration) getESOptions(disableHealthCheck bool) []elastic.ClientOp
 	options := []elastic.ClientOptionFunc{
 		elastic.SetURL(c.Servers...), elastic.SetSniff(c.Sniffing.Enabled), elastic.SetHealthcheck(!disableHealthCheck),
 	}
-	if c.HealthCheckTimeOutStartup > 0 {
-		options = append(options, elastic.SetHealthcheckTimeoutStartup(c.HealthCheckTimeOutStartup))
+	if c.HealthCheckTimeoutStartup > 0 {
+		options = append(options, elastic.SetHealthcheckTimeoutStartup(c.HealthCheckTimeoutStartup))
 	}
 	if c.Sniffing.UseHTTPS {
 		options = append(options, elastic.SetScheme("https"))

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -1435,7 +1435,7 @@ func TestGetESOptions(t *testing.T) {
 					"http://localhost:9201",
 					"http://localhost:9202",
 				},
-				HealthCheckTimeOutStartup: 10 * time.Millisecond,
+				HealthCheckTimeoutStartup: 10 * time.Millisecond,
 				Sniffing: Sniffing{
 					Enabled:  true,
 					UseHTTPS: false,

--- a/internal/storage/metricstore/elasticsearch/factory_test.go
+++ b/internal/storage/metricstore/elasticsearch/factory_test.go
@@ -103,7 +103,7 @@ func TestNewFactory(t *testing.T) {
 			if tt.response != nil && tt.statusCode != 0 {
 				server := setupMockServer(t, tt.response, tt.statusCode)
 				tt.cfg.Servers = []string{server.URL}
-				tt.cfg.HealthCheckTimeOutStartup = 100 * time.Millisecond
+				tt.cfg.HealthCheckTimeoutStartup = 100 * time.Millisecond
 			}
 			f, err := NewFactory(context.Background(), tt.cfg, telemetry.NoopSettings(), nil)
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6111 

## Description of the changes
- In unit testing, if we expect the ES to fail when trying to create a Client on a failed server, we wouldn't want to wait for a default of 5 seconds every time. **Reduce down to 100ms.**

BEFORE:
<img width="1708" height="267" alt="screenshot-2026-02-25_17-38-14" src="https://github.com/user-attachments/assets/4fbf51c2-ac0f-4386-b7b1-0d86b33d4824" />

AFTER:
<img width="1678" height="376" alt="screenshot-2026-02-25_17-38-31" src="https://github.com/user-attachments/assets/c268b14d-421c-4300-96ae-6922178c3770" />


## How was this change tested?
- `GOMAXPROCS=1 go test -parallel 128 -p 16 -count=1 -json ./... | go run github.com/roblaszczak/vgt@latest`

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
