### PR TITLE
Reduce tracegen test simulation from seconds to miliseconds

### DIFF
--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -26,7 +26,7 @@ func Test_SimulateTraces(t *testing.T) {
 		},
 		{
 			name:  "with pause",
-			pause: time.Second,
+			pause: time.Millisecond,
 		},
 	}
 

--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -4,6 +4,7 @@
 package tracegen
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -38,14 +39,16 @@ func Test_SimulateTraces(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			var running uint32 = 1
+			workerID := 7
+			numTraces := 7
 			worker := &worker{
 				logger:  logger,
 				tracers: tracers,
 				wg:      &wg,
-				id:      7,
+				id:      workerID,
 				running: &running,
 				Config: Config{
-					Traces:     7,
+					Traces:     numTraces,
 					Duration:   time.Second,
 					Pause:      tt.pause,
 					Service:    "stdout",
@@ -54,7 +57,7 @@ func Test_SimulateTraces(t *testing.T) {
 					ChildSpans: 1,
 				},
 			}
-			expectedOutput := `{"level":"info","msg":"Worker 7 generated 7 traces"}` + "\n"
+			expectedOutput := fmt.Sprintf(`{"level":"info","msg":"Worker %d generated %d traces"}`, workerID, numTraces) + "\n"
 			worker.simulateTraces()
 			assert.Equal(t, expectedOutput, buf.String())
 		})


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #6111 

## Description of the changes
- In tracegen unit testing, there is no need for each simulating trace to sleep for a second before finish tracing. Reduce it down to 1ms instead. 
- Side change, I'm not sure why 7 is the number of simulating traces but I put the hard-coded value into a variable for later on calibration. 

BEFORE:
<img width="1689" height="591" alt="image" src="https://github.com/user-attachments/assets/d01cd685-7557-480d-a1d4-299e8a01942f" />

AFTER:
<img width="1462" height="576" alt="image" src="https://github.com/user-attachments/assets/84f55bab-225d-4515-be9c-287e92ec48a7" />


## How was this change tested?
- `GOMAXPROCS=1 go test -parallel 128 -p 16 -count=1 -json ./... | go run github.com/roblaszczak/vgt@latest -duration-cutoff="6ms"`

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes