### PR TITLE
[mcp] Validate start_time_max is after start_time_min Ensure search_t…

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -118,8 +118,7 @@ func (*searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysvc.
 	// Ensure the requested time window is valid.
 	// Reject queries where start_time_max is earlier than start_time_min.
 	if maxStartTime.Before(minStartTime) {
-		return querysvc.TraceQueryParams{},
-			errors.New("start_time_max must be after start_time_min")
+		return querysvc.TraceQueryParams{}, errors.New("start_time_max must not be before start_time_min")
 	}
 
 	if input.ServiceName == "" {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -332,7 +332,7 @@ func TestSearchTracesHandler_Handle_StartTimeMaxBeforeMin(t *testing.T) {
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, input)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "start_time_max must be after start_time_min")
+	assert.Contains(t, err.Error(), "start_time_max must not be before start_time_min")
 }
 
 func TestSearchTracesHandler_Handle_InvalidTimeFormat(t *testing.T) {

--- a/internal/storage/v1/elasticsearch/spanstore/fixtures/es_01-actual.json
+++ b/internal/storage/v1/elasticsearch/spanstore/fixtures/es_01-actual.json
@@ -1,0 +1,90 @@
+{
+  "traceID": "0000000000000001",
+  "spanID": "0000000000000002",
+  "flags": 1,
+  "operationName": "test-general-conversion",
+  "references": [
+    {
+      "refType": "CHILD_OF",
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000003"
+    },
+    {
+      "refType": "FOLLOWS_FROM",
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000004"
+    },
+    {
+      "refType": "CHILD_OF",
+      "traceID": "00000000000000ff",
+      "spanID": "00000000000000ff"
+    }
+  ],
+  "startTime": 1485467191639875,
+  "startTimeMillis": 1485467191639,
+  "duration": 5,
+  "tags": [
+    {
+      "key": "peer.service",
+      "type": "string",
+      "value": "service-y"
+    },
+    {
+      "key": "peer.ipv4",
+      "type": "int64",
+      "value": 23456
+    },
+    {
+      "key": "error",
+      "type": "bool",
+      "value": true
+    },
+    {
+      "key": "temperature",
+      "type": "float64",
+      "value": 72.5
+    },
+    {
+      "key": "blob",
+      "type": "binary",
+      "value": "00003039"
+    }
+  ],
+  "logs": [
+    {
+      "timestamp": 1485467191639875,
+      "fields": [
+        {
+          "key": "event",
+          "type": "int64",
+          "value": 123415
+        }
+      ]
+    },
+    {
+      "timestamp": 1485467191639875,
+      "fields": [
+        {
+          "key": "x",
+          "type": "string",
+          "value": "y"
+        }
+      ]
+    }
+  ],
+  "process": {
+    "serviceName": "service-x",
+    "tags": [
+      {
+        "key": "peer.ipv4",
+        "type": "int64",
+        "value": 23456
+      },
+      {
+        "key": "error",
+        "type": "bool",
+        "value": true
+      }
+    ]
+  }
+}

--- a/internal/uimodel/converter/v1/json/fixtures/es_01-actual.json
+++ b/internal/uimodel/converter/v1/json/fixtures/es_01-actual.json
@@ -1,0 +1,90 @@
+{
+  "traceID": "0000000000000001",
+  "spanID": "0000000000000002",
+  "flags": 1,
+  "operationName": "test-general-conversion",
+  "references": [
+    {
+      "refType": "CHILD_OF",
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000003"
+    },
+    {
+      "refType": "FOLLOWS_FROM",
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000004"
+    },
+    {
+      "refType": "CHILD_OF",
+      "traceID": "00000000000000ff",
+      "spanID": "00000000000000ff"
+    }
+  ],
+  "startTime": 1485467191639875,
+  "duration": 5,
+  "tags": [
+    {
+      "key": "peer.service",
+      "type": "string",
+      "value": "service-y"
+    },
+    {
+      "key": "peer.ipv4",
+      "type": "int64",
+      "value": "23456"
+    },
+    {
+      "key": "error",
+      "type": "bool",
+      "value": "true"
+    },
+    {
+      "key": "temperature",
+      "type": "float64",
+      "value": "72.5"
+    },
+    {
+      "key": "blob",
+      "type": "binary",
+      "value": "00003039"
+    }
+  ],
+  "logs": [
+    {
+      "timestamp": 1485467191639875,
+      "fields": [
+        {
+          "key": "event",
+          "type": "int64",
+          "value": "123415"
+        }
+      ]
+    },
+    {
+      "timestamp": 1485467191639875,
+      "fields": [
+        {
+          "key": "x",
+          "type": "string",
+          "value": "y"
+        }
+      ]
+    }
+  ],
+  "process": {
+    "serviceName": "service-x",
+    "tags": [
+      {
+        "key": "peer.ipv4",
+        "type": "int64",
+        "value": "23456"
+      },
+      {
+        "key": "error",
+        "type": "bool",
+        "value": "true"
+      }
+    ]
+  },
+  "warnings": null
+}

--- a/internal/uimodel/converter/v1/json/fixtures/ui_01-actual.json
+++ b/internal/uimodel/converter/v1/json/fixtures/ui_01-actual.json
@@ -1,0 +1,162 @@
+{
+  "traceID": "0000000000000001",
+  "spans": [
+    {
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000002",
+      "operationName": "test-general-conversion",
+      "references": [],
+      "startTime": 1485467191639875,
+      "duration": 5,
+      "tags": [],
+      "logs": [
+        {
+          "timestamp": 1485467191639875,
+          "fields": [
+            {
+              "key": "event",
+              "type": "string",
+              "value": "some-event"
+            }
+          ]
+        },
+        {
+          "timestamp": 1485467191639875,
+          "fields": [
+            {
+              "key": "x",
+              "type": "string",
+              "value": "y"
+            }
+          ]
+        }
+      ],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000002",
+      "operationName": "some-operation",
+      "references": [],
+      "startTime": 1485467191639875,
+      "duration": 5,
+      "tags": [
+        {
+          "key": "peer.service",
+          "type": "string",
+          "value": "service-y"
+        },
+        {
+          "key": "peer.ipv4",
+          "type": "int64",
+          "value": 23456
+        },
+        {
+          "key": "error",
+          "type": "bool",
+          "value": true
+        },
+        {
+          "key": "temperature",
+          "type": "float64",
+          "value": 72.5
+        },
+        {
+          "key": "javascript_limit",
+          "type": "int64",
+          "value": "9223372036854775222"
+        },
+        {
+          "key": "blob",
+          "type": "binary",
+          "value": "AAAwOQ=="
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000003",
+      "operationName": "some-operation",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "0000000000000001",
+          "spanID": "0000000000000002"
+        }
+      ],
+      "startTime": 1485467191639875,
+      "duration": 5,
+      "tags": [],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000004",
+      "operationName": "reference-test",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "00000000000000ff",
+          "spanID": "00000000000000ff"
+        },
+        {
+          "refType": "CHILD_OF",
+          "traceID": "0000000000000001",
+          "spanID": "0000000000000002"
+        },
+        {
+          "refType": "FOLLOWS_FROM",
+          "traceID": "0000000000000001",
+          "spanID": "0000000000000002"
+        }
+      ],
+      "startTime": 1485467191639875,
+      "duration": 5,
+      "tags": [],
+      "logs": [],
+      "processID": "p2",
+      "warnings": [
+        "some span warning"
+      ]
+    },
+    {
+      "traceID": "0000000000000001",
+      "spanID": "0000000000000005",
+      "operationName": "preserveParentID-test",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "0000000000000001",
+          "spanID": "0000000000000004"
+        }
+      ],
+      "startTime": 1485467191639875,
+      "duration": 4,
+      "tags": [],
+      "logs": [],
+      "processID": "p2",
+      "warnings": [
+        "some span warning"
+      ]
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-x",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-y",
+      "tags": []
+    }
+  },
+  "warnings": [
+    "some trace warning"
+  ]
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Improves validation in the `search_traces` MCP tool by ensuring that
`start_time_max` is not earlier than `start_time_min`.

Part of #7827

## Description of the changes
- Added validation in `buildQuery` to reject invalid time ranges.
- Returns a clear error when `start_time_max` precedes `start_time_min`.
- Added unit test covering this validation scenario.

## How was this change tested?
- Added a new unit test: `TestSearchTracesHandler_Handle_StartTimeMaxBeforeMin`
- Ran `make fmt`, `make lint`, and `make test` successfully.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR 
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
