### PR TITLE
ci: Fix Summary Report to be able to retrieve PR number

### DIFF
--- a/.github/workflows/ci-summary-report.yml
+++ b/.github/workflows/ci-summary-report.yml
@@ -18,8 +18,8 @@ on:
     types: [completed]
   workflow_dispatch:
     inputs:
-      parent_run_id:
-        description: 'The Run ID of the CI workflow to pull artifacts from'
+      pr_number:
+        description: 'PR number to generate summary report for'
         required: true
 permissions:
   contents: read
@@ -39,45 +39,44 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.repository.default_branch }}
 
       # Resolve the source run ID from either trigger, then fetch PR metadata.
-      # The run API includes associated PRs in .pull_requests[].
+      # For workflow_run events, PR metadata comes from the event payload
+      # (the REST API returns empty .pull_requests[] for cross-repo fork PRs).
       - name: Resolve source run
         id: source-run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            RUN_ID="${{ github.event.inputs.parent_run_id }}"
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+
+            # Get the PR's head SHA to find the CI Orchestrator run
+            HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+
+            # Find the latest successful CI Orchestrator run for this commit
+            RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/ci-orchestrator.yml/runs?head_sha=$HEAD_SHA&status=success&per_page=1" \
+              --jq '.workflow_runs[0].id')
+
+            if [ -z "$RUN_ID" ] || [ "$RUN_ID" == "null" ]; then
+              echo "::error::No successful CI Orchestrator run found for PR #$PR_NUMBER (SHA $HEAD_SHA)."
+              exit 1
+            fi
+            echo "Found CI Orchestrator run $RUN_ID for PR #$PR_NUMBER"
           else
             RUN_ID="${{ github.event.workflow_run.id }}"
+            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+            HEAD_SHA="${{ github.event.workflow_run.pull_requests[0].head.sha || github.event.workflow_run.head_sha }}"
           fi
+
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "source_run_url=https://github.com/${{ github.repository }}/actions/runs/$RUN_ID" >> $GITHUB_OUTPUT
           echo "summary_run_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
-
-          RUN_DATA=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID")
-
-          # Validate the parent run succeeded (guards against manual dispatch pointing at a failed run)
-          CONCLUSION=$(echo "$RUN_DATA" | jq -r '.conclusion')
-          if [ "$CONCLUSION" != "success" ]; then
-            echo "::error::Parent run $RUN_ID has conclusion '$CONCLUSION', expected 'success'."
-            exit 1
-          fi
-
-          PR_NUMBER=$(echo "$RUN_DATA" | jq -r '.pull_requests[0].number')
-          HEAD_SHA=$(echo "$RUN_DATA" | jq -r '.pull_requests[0].head.sha')
-
-          # For merge_group runs, .pull_requests[] may be empty; fall back to
-          # the run's own head_sha so check-runs attach to the correct commit.
-          if [ "$HEAD_SHA" == "null" ]; then
-            HEAD_SHA=$(echo "$RUN_DATA" | jq -r '.head_sha')
-          fi
           echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
 
-          if [ "$PR_NUMBER" != "null" ]; then
+          if [ -n "$PR_NUMBER" ]; then
             echo "Found PR #$PR_NUMBER at SHA $HEAD_SHA"
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           else
-            echo "No associated PR found for run $RUN_ID; PR comment and check runs will be skipped."
+            echo "No associated PR found for run $RUN_ID; PR comment will be skipped."
           fi
 
       # Download all artifacts from the source CI run.


### PR DESCRIPTION
## Problem

The [ci-summary-report.yml](file:///Users/ysh/dev/jaegertracing/jaeger/.github/workflows/ci-summary-report.yml) workflow resolves PR metadata by querying the GitHub REST API (`GET /actions/runs/{id}`). However, the API returns **empty `.pull_requests[]` for cross-repo fork PRs**, causing the workflow to log "No associated PR found" and skip posting the PR comment — even though the PR clearly exists (observed on PR #8120).

Additionally, the `workflow_dispatch` input accepted a `parent_run_id` which suffered from the same API limitation for fork PRs.

## Changes

**`workflow_run` path** — PR metadata is now read directly from the `workflow_run` event payload (`github.event.workflow_run.pull_requests`), which is populated even for fork PRs. This eliminates the API call for metadata resolution entirely on this path.

**`workflow_dispatch` path** — Input changed from `parent_run_id` to `pr_number`. The workflow now:
1. Fetches the PR's head SHA via the Pulls API
2. Finds the latest successful CI Orchestrator run for that SHA
3. Uses that run ID to download artifacts

This avoids the `.pull_requests[]` limitation and is more user-friendly — a PR number is easier to find than a run ID.

**`head_sha` fallback** — Uses `github.event.workflow_run.pull_requests[0].head.sha || github.event.workflow_run.head_sha` to handle merge queue / main-push runs where no PR is associated.

## Test plan
- [ ] Fork PR triggers `workflow_run` → PR number and head SHA resolved from event payload, PR comment posted
- [ ] Same-repo PR triggers `workflow_run` → same behavior
- [ ] Main push triggers `workflow_run` → no PR found, PR comment skipped, coverage baseline saved
- [ ] Manual `workflow_dispatch` with a PR number → CI Orchestrator run found, artifacts downloaded, checks posted
- [ ] Manual `workflow_dispatch` with a PR that has no successful CI run → error message

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] None
- [ ] Light
- [x] Moderate: AI helped with code generation or debugging specific parts
- [X] Heavy