### PR TITLE
[chore] Rename strategyProvider field to provider in remotesampling extension

### DIFF
--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -604,7 +604,7 @@ func TestShutdownWithProviderError(t *testing.T) {
 			telemetry: componenttest.NewNopTelemetrySettings(),
 		}
 
-		ext.strategyProvider = &mockFailingProvider{}
+		ext.provider = &mockFailingProvider{}
 
 		err := ext.Shutdown(context.Background())
 		require.Error(t, err)


### PR DESCRIPTION
## Which problem is this PR solving?
- This PR replaces strategyProvider field to provider in remotesampling extension.

## Description of the changes
- It replaces the field name strategyProvider to provider, as strategyProvider is misleading and also the type is already says provider.

## How was this change tested?
- These changes were run against make fmt, make lint and make test.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
