### PR TITLE
ci: Always update summary report comment if present

### DIFF
--- a/.github/scripts/ci-summary-report-publish.js
+++ b/.github/scripts/ci-summary-report-publish.js
@@ -143,15 +143,18 @@ async function postCheckRun(github, owner, repo, headSha, name, conclusion, outp
 
 /**
  * Post or update the CI summary comment on a PR.
- * Finds an existing comment by COMMENT_TAG and updates it, or creates a new one.
+ * Always updates an existing comment (clears stale failure messages on green runs).
+ * Only creates a new comment when createNew is true.
  * @param {object} github - Octokit client
  * @param {string} owner
  * @param {string} repo
  * @param {number} prNumber
  * @param {string} body
  * @param {object} core - GitHub Actions core logger
+ * @param {object} [opts]
+ * @param {boolean} [opts.createNew=true] - create a comment if none exists
  */
-async function postOrUpdateComment(github, owner, repo, prNumber, body, core) {
+async function postOrUpdateComment(github, owner, repo, prNumber, body, core, { createNew = true } = {}) {
   core.info(`Searching for existing CI summary comment on PR #${prNumber}`);
   const existing = await github.paginate(github.rest.issues.listComments, {
     owner, repo, issue_number: prNumber,
@@ -163,12 +166,14 @@ async function postOrUpdateComment(github, owner, repo, prNumber, body, core) {
       owner, repo, comment_id: existing.id, body,
     });
     core.info(`Comment updated: url=${updated.html_url}`);
-  } else {
+  } else if (createNew) {
     core.info(`Creating new comment on PR #${prNumber}`);
     const { data: created } = await github.rest.issues.createComment({
       owner, repo, issue_number: prNumber, body,
     });
     core.info(`Comment created: id=${created.id} url=${created.html_url}`);
+  } else {
+    core.info('No existing comment and no issues to report; skipping PR comment.');
   }
 }
 
@@ -229,16 +234,17 @@ async function handler({ github, core, fs, inputs }) {
     text:    footer,
   }, core);
 
-  // ── PR comment (only when there is something to report) ──────────────────
-  const hasIssues = metrics.conclusion === 'failure' || coverage.conclusion === 'failure'
-                    || metrics.totalChanges > 0;
-  if (!prNumber || !hasIssues) {
-    core.info('No issues to report; skipping PR comment.');
-    return;
+  // ── PR comment ──
+  if (prNumber) {
+    // Always update an existing comment so stale failure messages don't linger
+    // after a green run.  Only create a new comment when there is something to report.
+    const hasIssues = metrics.conclusion === 'failure' || coverage.conclusion === 'failure'
+                      || metrics.totalChanges > 0;
+    const body = buildCommentBody(metrics.text, coverage.text, footer);
+    await postOrUpdateComment(github, owner, repo, prNumber, body, core, { createNew: hasIssues });
+  } else {
+    core.info('No PR number; skipping PR comment.');
   }
-
-  const body = buildCommentBody(metrics.text, coverage.text, footer);
-  await postOrUpdateComment(github, owner, repo, prNumber, body, core);
 }
 
 module.exports = handler;

--- a/.github/scripts/ci-summary-report-publish.test.js
+++ b/.github/scripts/ci-summary-report-publish.test.js
@@ -248,4 +248,39 @@ describe('postOrUpdateComment', () => {
     );
     expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining('Updating existing comment id=100'));
   });
+
+  test('skips creating a new comment when createNew is false and no existing comment', async () => {
+    const mockGithub = {
+      paginate: jest.fn().mockResolvedValue([{ id: 1, body: 'unrelated' }]),
+      rest: { issues: {
+        listComments: jest.fn(),
+        createComment: jest.fn(),
+      }},
+    };
+    const mockCore = { info: jest.fn() };
+
+    await postOrUpdateComment(mockGithub, owner, repo, prNumber, body, mockCore, { createNew: false });
+
+    expect(mockGithub.rest.issues.createComment).not.toHaveBeenCalled();
+    expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining('No existing comment'));
+  });
+
+  test('still updates existing comment when createNew is false', async () => {
+    const existingComment = { id: 100, body: `${COMMENT_TAG}\nold failure` };
+    const mockGithub = {
+      paginate: jest.fn().mockResolvedValue([existingComment]),
+      rest: { issues: {
+        listComments: jest.fn(),
+        updateComment: jest.fn().mockResolvedValue({ data: { html_url: 'https://example.com/comment/100' } }),
+      }},
+    };
+    const mockCore = { info: jest.fn() };
+
+    await postOrUpdateComment(mockGithub, owner, repo, prNumber, body, mockCore, { createNew: false });
+
+    expect(mockGithub.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({ owner, repo, comment_id: 100, body })
+    );
+    expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining('Updating existing comment id=100'));
+  });
 });


### PR DESCRIPTION
## Problem

After a PR's CI run goes green following a previous failure, the existing
failure comment was never updated — it stayed stale because the publish script
skipped the comment step entirely when `hasIssues` was false.

## Fix

`postOrUpdateComment` now accepts a `{ createNew }` option:
- Always updates an existing comment (clears stale failure messages on green runs)
- Skips creating a **new** comment when `createNew` is false

`handler` now calls it with `{ createNew: hasIssues }`:

| State | Existing comment | Result |
|-------|-----------------|--------|
| Issues | yes | update |
| Issues | no | create |
| No issues | yes | **update** ← fix |
| No issues | no | skip (no noise) |

## Files changed

| File | Change |
|------|--------|
| `.github/scripts/ci-summary-report-publish.js` | Add `{ createNew }` option to `postOrUpdateComment`; restructure handler comment block |
| `.github/scripts/ci-summary-report-publish.test.js` | Add 2 tests: skip-create-when-absent and update-when-`createNew`-false |

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
