### PR TITLE
test: remove redundant TestGetTraceWithRawTracesParameter

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -446,30 +446,6 @@ func TestGetTraceBadTimeWindow(t *testing.T) {
 	}
 }
 
-func TestGetTraceWithRawTracesParameter(t *testing.T) {
-	// TODO: extend the test cases to ensure raw traces are obtained
-	// when the flag is set once the differentiating logic has been implemented
-	tests := []struct {
-		rawTraces bool
-	}{
-		{rawTraces: true},
-		{rawTraces: false},
-	}
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("rawTraces=%v", test.rawTraces), func(t *testing.T) {
-			ts := initializeTestServer(t)
-			ts.traceReader.On("GetTraces", mock.Anything, mock.MatchedBy(func(params []tracestore.GetTraceParams) bool {
-				return len(params) == 1 && params[0].TraceID == v1adapter.FromV1TraceID(mockTraceID)
-			})).Return(tracesIter(makeMockPTrace())).Once()
-
-			var response structuredResponse
-			err := getJSON(fmt.Sprintf("%s/api/traces/%s?raw=%v", ts.server.URL, mockTraceID.String(), test.rawTraces), &response)
-			require.NoError(t, err)
-			assert.Empty(t, response.Errors)
-		})
-	}
-}
-
 func TestGetTraceBadRawTracesFlag(t *testing.T) {
 	ts := initializeTestServer(t)
 	var response structuredResponse


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves a stale `// TODO` in `http_handler_test.go`. The test logic for the `raw` parameter was already implemented in `TestGetTrace`, making `TestGetTraceWithRawTracesParameter` redundant.

## Description of the changes
- Removed `TestGetTraceWithRawTracesParameter` entirely.
- The `raw` query parameter behavior (asserting that `raw=true` yields 3 spans and `raw=false` yields 2 spans via deduplication) is already adequately covered by the existing `TestGetTrace` test earlier in the same file. Removing this function eliminates code duplication and reduces maintenance cost.

## How was this change tested?
- Verified that `make test` and `make lint` still pass successfully without the redundant test.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality (Not applicable, removed redundant test)
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See[AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes