### PR TITLE
Do not run dependency-review on push to main

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,10 @@ permissions:
 
 jobs:
   dependency-review:
+    if: |
+      ${{ github.event_name == 'pull_request' ||
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
The dep review action is only meant for pull requests.