### PR TITLE
ci: fix excessive GitHub workflow token permissions

### DIFF
--- a/.github/workflows/ci-orchestrator-stage1.yml
+++ b/.github/workflows/ci-orchestrator-stage1.yml
@@ -3,6 +3,9 @@ name: "CI Orchestrator: Stage 1 (Linters)"
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint-checks:
     uses: ./.github/workflows/ci-lint-checks.yaml

--- a/.github/workflows/ci-orchestrator-stage2.yml
+++ b/.github/workflows/ci-orchestrator-stage2.yml
@@ -3,6 +3,10 @@ name: "CI Orchestrator: Stage 2 (Unit Tests)"
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   unit-tests:
     uses: ./.github/workflows/ci-unit-tests.yml

--- a/.github/workflows/ci-orchestrator-stage3.yml
+++ b/.github/workflows/ci-orchestrator-stage3.yml
@@ -3,6 +3,12 @@ name: "CI Orchestrator: Stage 3 (Docker, E2E, Binaries, Static Analysis)"
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+  actions: read
+
 jobs:
   build-binaries:
     uses: ./.github/workflows/ci-build-binaries.yml

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -11,9 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Grant all permissions to allow child workflows to request what they need
-# Child workflows can downgrade permissions as needed (principle of least privilege)
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   # ============================================================================
@@ -117,12 +116,20 @@ jobs:
   stage2-seq:
     needs: [setup, stage1-seq]
     if: ${{ needs.setup.outputs.parallel == 'false' }}
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/ci-orchestrator-stage2.yml
     secrets: inherit
 
   stage3-seq:
     needs: [setup, stage2-seq]
     if: ${{ needs.setup.outputs.parallel == 'false' }}
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+      actions: read
     uses: ./.github/workflows/ci-orchestrator-stage3.yml
     secrets: inherit
 
@@ -140,12 +147,20 @@ jobs:
   stage2-fast:
     needs: [setup]
     if: ${{ needs.setup.outputs.parallel == 'true' }}
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/ci-orchestrator-stage2.yml
     secrets: inherit
 
   stage3-fast:
     needs: [setup]
     if: ${{ needs.setup.outputs.parallel == 'true' }}
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+      actions: read
     uses: ./.github/workflows/ci-orchestrator-stage3.yml
     secrets: inherit
 


### PR DESCRIPTION
## Motivation

The OpenSSF Scorecard reports token-permissions warnings for the CI orchestrator workflows:
- `ci-orchestrator.yml` uses `permissions: write-all`, granting the GITHUB_TOKEN maximum privileges
- `ci-orchestrator-stage1.yml`, `stage2.yml`, `stage3.yml` have no top-level `permissions` defined

This violates the principle of least privilege and lowers the Scorecard Token-Permissions score.

## Modifications

- **ci-orchestrator.yml**: Replace `permissions: write-all` with `permissions: contents: read`. Add job-level permissions for stage2 jobs (`checks: write`) and stage3 jobs (`packages: read`, `security-events: write`, `actions: read`) to pass through only the scopes required by child workflows.
- **ci-orchestrator-stage1.yml**: Add `permissions: contents: read`.
- **ci-orchestrator-stage2.yml**: Add `permissions: contents: read, checks: write` (needed by `ci-unit-tests.yml`).
- **ci-orchestrator-stage3.yml**: Add `permissions: contents: read, packages: read, security-events: write, actions: read` (needed by `ci-docker-all-in-one.yml` and `codeql.yml`).

## Verification

Permissions are set following the least-privilege principle while ensuring each child workflow in the call chain receives the scopes it declares at job level. No functional behavior changes.