### PR TITLE
fix: clock skew adjuster to also adjust EndTimestamp

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/clockskew.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/clockskew.go
@@ -192,6 +192,7 @@ func (a *clockSkewAdjuster) adjustTimestamps(n *node, skew clockSkew) {
 		return
 	}
 	n.span.SetStartTimestamp(pcommon.NewTimestampFromTime(n.span.StartTimestamp().AsTime().Add(skew.delta)))
+	n.span.SetEndTimestamp(pcommon.NewTimestampFromTime(n.span.EndTimestamp().AsTime().Add(skew.delta)))
 	jptrace.AddWarnings(n.span, fmt.Sprintf("This span's timestamps were adjusted by %v", skew.delta))
 	for i := 0; i < n.span.Events().Len(); i++ {
 		event := n.span.Events().At(i)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/clockskew_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/clockskew_test.go
@@ -208,6 +208,11 @@ func TestClockSkewAdjuster(t *testing.T) {
 				assert.Equal(
 					t, toTime(proto.adjusted).UTC(), span.StartTimestamp().AsTime(),
 					"adjusted start time of span[ID = %d]", id)
+
+				assert.Equal(
+					t, toTime(proto.adjusted+proto.duration).UTC(), span.EndTimestamp().AsTime(),
+					"adjusted end time of span[ID = %d]", id)
+
 				for i, logTs := range proto.adjustedEvents {
 					assert.Equal(
 						t, toTime(logTs).UTC(), span.Events().At(i).Timestamp().AsTime(),


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #8167

## Description of the changes
- Clock skew adjuster adjusts StartTimestamp and events but misses EndTimestamp. 
Since ptrace computes duration from end - start, this can produce wrong durations 
after adjustment.

## How was this change tested?
- Added EndTimestamp assertion to existing TestClockSkewAdjuster. 
Without the fix, 3 test cases fail. With the fix, all pass.

`go test ./cmd/jaeger/internal/extension/jaegerquery/... -v`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
