### PR TITLE
clickhouse(depstore): return error instead of panic in GetDependencies

### DIFF
--- a/internal/storage/v2/clickhouse/depstore/reader.go
+++ b/internal/storage/v2/clickhouse/depstore/reader.go
@@ -5,6 +5,7 @@ package depstore
 
 import (
 	"context"
+	"errors"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
@@ -19,5 +20,5 @@ func NewDependencyReader() *Reader {
 }
 
 func (*Reader) GetDependencies(context.Context, depstore.QueryParameters) ([]model.DependencyLink, error) {
-	panic("not implemented")
+	return nil, errors.New("clickhouse dependency reader is not implemented")
 }

--- a/internal/storage/v2/clickhouse/depstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/depstore/reader_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
@@ -17,7 +18,8 @@ func TestReader_GetDependencies(t *testing.T) {
 	ctx := context.Background()
 	query := depstore.QueryParameters{}
 
-	require.Panics(t, func() {
-		reader.GetDependencies(ctx, query)
-	})
+	dependencies, err := reader.GetDependencies(ctx, query)
+
+	require.Nil(t, dependencies)
+	assert.EqualError(t, err, "clickhouse dependency reader is not implemented")
 }


### PR DESCRIPTION
### Motivation
- The ClickHouse storage backend is selectable and its dependency reader previously used `panic("not implemented")`, which can crash the query service when invoked and cause a DoS. This change prevents process termination by returning an error.

### Description
- Replace the panic in `(*Reader).GetDependencies` with a returned error.
- Update the unit test in `internal/storage/v2/clickhouse/depstore/reader_test.go` to assert a `nil` result and the expected error instead of expecting a panic.

### Testing
- `make fmt`
- `make lint`
- `make test`
