### PR TITLE
Secure MCP endpoint with query tenancy enforcement

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/handlers"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 var (
@@ -61,6 +62,7 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("cannot get %s extension: %w", jaegerquery.ID, err)
 	}
 	s.queryAPI = queryExt.QueryService()
+	tenancyMgr := queryExt.TenancyManager()
 	s.telset.Logger.Info("Successfully retrieved v2 QueryService from jaegerquery extension")
 
 	// Initialize MCP server with implementation details
@@ -95,7 +97,8 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 
 	// Create HTTP server with MCP handler and health endpoint
 	mux := http.NewServeMux()
-	mux.Handle("/mcp", mcpHandler)
+	mcpHTTPHandler := tenancy.ExtractTenantHTTPHandler(tenancyMgr, mcpHandler)
+	mux.Handle("/mcp", mcpHTTPHandler)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("MCP server is running"))

--- a/cmd/jaeger/internal/extension/jaegermcp/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server_test.go
@@ -30,23 +30,29 @@ import (
 	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 // mockQueryExtension implements jaegerquery.Extension for testing
 type mockQueryExtension struct {
 	extension.Extension
 	svc *querysvc.QueryService
+	tm  *tenancy.Manager
 }
 
 func newMockQueryExtension(svc *querysvc.QueryService) *mockQueryExtension {
 	if svc == nil {
 		svc = querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
 	}
-	return &mockQueryExtension{svc: svc}
+	return &mockQueryExtension{svc: svc, tm: &tenancy.Manager{}}
 }
 
 func (m *mockQueryExtension) QueryService() *querysvc.QueryService {
 	return m.svc
+}
+
+func (m *mockQueryExtension) TenancyManager() *tenancy.Manager {
+	return m.tm
 }
 
 // mockHost implements component.Host with a jaegerquery extension
@@ -66,6 +72,16 @@ func newMockHostWithQueryService(svc *querysvc.QueryService) *mockHost {
 	return &mockHost{
 		Host:     componenttest.NewNopHost(),
 		queryExt: newMockQueryExtension(svc),
+	}
+}
+
+func newMockHostWithQueryServiceAndTenancy(svc *querysvc.QueryService, tm *tenancy.Manager) *mockHost {
+	return &mockHost{
+		Host: componenttest.NewNopHost(),
+		queryExt: &mockQueryExtension{
+			svc: svc,
+			tm:  tm,
+		},
 	}
 }
 
@@ -729,4 +745,26 @@ func TestCORSPreflight(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
 	assert.Equal(t, "GET, POST, DELETE, OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
+}
+
+func TestServerMCPEndpointEnforcesTenancy(t *testing.T) {
+	tm := tenancy.NewManager(&tenancy.Options{Enabled: true, Header: "x-tenant", Tenants: []string{"tenant-a"}})
+	host := newMockHostWithQueryServiceAndTenancy(nil, tm)
+	telset := componenttest.NewNopTelemetrySettings()
+	config := &Config{
+		HTTP:                     confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "localhost:0", Transport: confignet.TransportTypeTCP}},
+		ServerVersion:            "1.0.0",
+		MaxSpanDetailsPerRequest: 20,
+		MaxSearchResults:         100,
+	}
+
+	server := newServer(config, telset)
+	require.NoError(t, server.Start(context.Background(), host))
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	addr := server.listener.Addr().String()
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/mcp", addr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/extension.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 // Extension is the interface that the jaegerquery extension implements.
@@ -18,6 +19,8 @@ type Extension interface {
 	extension.Extension
 	// QueryService returns the v2 query service.
 	QueryService() *querysvc.QueryService
+	// TenancyManager returns the tenancy manager used by query endpoints.
+	TenancyManager() *tenancy.Manager
 }
 
 // GetExtension retrieves the jaegerquery extension from the host.

--- a/cmd/jaeger/internal/extension/jaegerquery/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/extension_test.go
@@ -14,22 +14,28 @@ import (
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 // mockExtension implements Extension for testing
 type mockExtension struct {
 	extension.Extension
 	qs *querysvc.QueryService
+	tm *tenancy.Manager
 }
 
 func (m *mockExtension) QueryService() *querysvc.QueryService {
 	return m.qs
 }
 
+func (m *mockExtension) TenancyManager() *tenancy.Manager {
+	return m.tm
+}
+
 func TestGetExtension_Success(t *testing.T) {
 	// Create a mock QueryService
 	mockQS := &querysvc.QueryService{}
-	mockExt := &mockExtension{qs: mockQS}
+	mockExt := &mockExtension{qs: mockQS, tm: &tenancy.Manager{}}
 
 	// Create a mock host with the jaegerquery extension
 	host := &mockHost{

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -35,11 +35,12 @@ var (
 )
 
 type server struct {
-	config      *Config
-	server      *queryapp.Server
-	telset      component.TelemetrySettings
-	closeTracer func(ctx context.Context) error
-	qs          *querysvc.QueryService
+	config         *Config
+	server         *queryapp.Server
+	telset         component.TelemetrySettings
+	closeTracer    func(ctx context.Context) error
+	qs             *querysvc.QueryService
+	tenancyManager *tenancy.Manager
 }
 
 func newServer(config *Config, otel component.TelemetrySettings) *server {
@@ -117,6 +118,7 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 	}
 
 	tm := tenancy.NewManager(&s.config.Tenancy)
+	s.tenancyManager = tm
 
 	caps := querysvc.StorageCapabilities{
 		ArchiveStorage: opts.ArchiveTraceReader != nil && opts.ArchiveTraceWriter != nil,
@@ -217,4 +219,9 @@ func (s *server) Shutdown(ctx context.Context) error {
 // QueryService returns the v2 query service instance.
 func (s *server) QueryService() *querysvc.QueryService {
 	return s.qs
+}
+
+// TenancyManager returns the tenancy manager used by query endpoints.
+func (s *server) TenancyManager() *tenancy.Manager {
+	return s.tenancyManager
 }


### PR DESCRIPTION
### Motivation
- The MCP `/mcp` endpoint exposed tools such as `search_traces` without the query server's tenancy/auth guard, allowing unauthenticated trace metadata enumeration in multi-tenant deployments.

### Description
- Wrap the MCP HTTP handler with `tenancy.ExtractTenantHTTPHandler(...)` so `/mcp` uses the same tenant enforcement as the query server.
- Extend the `jaegerquery.Extension` interface with `TenancyManager()` and wire the query server to store and return its `tenancy.Manager`.
- Update MCP startup to obtain the tenancy manager from the `jaegerquery` extension when registering the `/mcp` route.
- Update tests and mocks, including a regression test that verifies `/mcp` returns `401 Unauthorized` when tenancy is enabled and no tenant header is present.

### Testing
- `make fmt`
- `make lint`
- `make test`