### PR TITLE
Fix: clamp negative span duration to 0 to prevent uint64 overflow (fixes #8165)

### DIFF
--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -75,7 +75,7 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 
 	// It doesn't matter if we overwrite Duration index keys, everything is read at Trace level in any case
 	durationValue := make([]byte, 8)
-	binary.BigEndian.PutUint64(durationValue, uint64(model.DurationAsMicroseconds(span.Duration)))
+	binary.BigEndian.PutUint64(durationValue, uint64(model.DurationAsMicroseconds(max(0, span.Duration))))
 	entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(durationIndexKey, durationValue, startTime, span.TraceID), nil, expireTime))
 
 	for _, kv := range span.Tags {

--- a/internal/storage/v1/cassandra/spanstore/dbmodel/converter.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/converter.go
@@ -67,7 +67,7 @@ func (c converter) fromDomain(span *model.Span) *Span {
 		OperationName: span.OperationName,
 		Flags:         int32(span.Flags),
 		StartTime:     int64(model.TimeAsEpochMicroseconds(span.StartTime)),
-		Duration:      int64(model.DurationAsMicroseconds(span.Duration)),
+		Duration:      int64(model.DurationAsMicroseconds(max(0, span.Duration))),
 		Tags:          tags,
 		Logs:          logs,
 		Refs:          refs,

--- a/internal/storage/v1/cassandra/spanstore/dbmodel/converter_test.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/converter_test.go
@@ -6,6 +6,7 @@ package dbmodel
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
@@ -345,4 +346,15 @@ func TestFromDBTag_DefaultCase(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid ValueType")
 	assert.Equal(t, model.KeyValue{}, result)
+}
+
+// TestFromDomain_NegativeDuration verifies that a span with negative duration
+// (clock skew: endTime < startTime) does not overflow when stored.
+// Previously, uint64(negative_int64) wrapped to ~213503982 days (issue #8165).
+func TestFromDomain_NegativeDuration(t *testing.T) {
+	span := getTestJaegerSpan()
+	span.Duration = -time.Second // simulate clock skew
+	dbSpan := FromDomain(span)
+	// Duration must be 0 µs, not a huge wrapped int64.
+	assert.Equal(t, int64(0), dbSpan.Duration)
 }

--- a/internal/storage/v1/elasticsearch/spanstore/from_domain.go
+++ b/internal/storage/v1/elasticsearch/spanstore/from_domain.go
@@ -37,7 +37,7 @@ func (fd FromDomain) convertSpanInternal(span *model.Span) dbmodel.Span {
 		OperationName:   span.OperationName,
 		StartTime:       model.TimeAsEpochMicroseconds(span.StartTime),
 		StartTimeMillis: model.TimeAsEpochMicroseconds(span.StartTime) / 1000,
-		Duration:        model.DurationAsMicroseconds(span.Duration),
+		Duration:        model.DurationAsMicroseconds(max(0, span.Duration)),
 		Tags:            tags,
 		Logs:            fd.convertLogs(span.Logs),
 	}

--- a/internal/storage/v2/cassandra/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/cassandra/tracestore/to_dbmodel.go
@@ -136,8 +136,8 @@ func spanToDbSpan(span ptrace.Span, scope pcommon.InstrumentationScope, process 
 		Refs:          dbReferences,
 		//nolint:gosec // G115 // OTLP timestamp is nanoseconds since epoch (semantically non-negative), safe to convert to int64 microseconds
 		StartTime: int64(model.TimeAsEpochMicroseconds(startTime)),
-		//nolint:gosec // G115 // span.EndTime - span.StartTime is guaranteed non-negative by schema constraints
-		Duration: int64(model.DurationAsMicroseconds(span.EndTimestamp().AsTime().Sub(startTime))),
+		//nolint:gosec // G115 // clamped to ≥0 before conversion; safe to cast uint64→int64
+		Duration: int64(model.DurationAsMicroseconds(max(0, span.EndTimestamp().AsTime().Sub(startTime)))),
 		Tags:     getDbTags(span, scope),
 		Logs:     spanEventsToDbLogs(span.Events()),
 		Process:  process,

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -134,7 +134,7 @@ func spanToDbSpan(span ptrace.Span, libraryTags pcommon.InstrumentationScope, pr
 		References:      linksToDbSpanRefs(span.Links(), parentSpanID, traceID),
 		StartTime:       model.TimeAsEpochMicroseconds(startTime),
 		StartTimeMillis: model.TimeAsEpochMicroseconds(startTime) / 1000,
-		Duration:        model.DurationAsMicroseconds(span.EndTimestamp().AsTime().Sub(startTime)),
+		Duration:        model.DurationAsMicroseconds(max(0, span.EndTimestamp().AsTime().Sub(startTime))),
 		Tags:            getDbSpanTags(span, libraryTags),
 		Logs:            spanEventsToDbSpanLogs(span.Events()),
 		Process:         process,

--- a/internal/uimodel/converter/v1/json/from_domain.go
+++ b/internal/uimodel/converter/v1/json/from_domain.go
@@ -65,7 +65,7 @@ func (fd fromDomain) convertSpanInternal(span *model.Span) uimodel.Span {
 		Flags:         uint32(span.Flags),
 		OperationName: span.OperationName,
 		StartTime:     model.TimeAsEpochMicroseconds(span.StartTime),
-		Duration:      model.DurationAsMicroseconds(span.Duration),
+		Duration:      model.DurationAsMicroseconds(max(0, span.Duration)),
 		Tags:          fd.convertKeyValuesFunc(span.Tags),
 		Logs:          fd.convertLogs(span.Logs),
 	}

--- a/internal/uimodel/converter/v1/json/from_domain_test.go
+++ b/internal/uimodel/converter/v1/json/from_domain_test.go
@@ -188,3 +188,30 @@ func TestConvertKeyValues_DefaultValueType(t *testing.T) {
 	assert.Equal(t, "unknown type 999", result[0].Value)
 	assert.Equal(t, uimodel.ValueType("999"), result[0].Type)
 }
+
+// TestFromDomain_NegativeDuration reproduces the overflow reported in issue #8165:
+// a span with endTime < startTime (clock skew) results in a negative Duration,
+// which must be clamped to 0 rather than wrapped to a huge uint64 (~213503982 days).
+func TestFromDomain_NegativeDuration(t *testing.T) {
+	span := &model.Span{
+		TraceID:       model.TraceID{Low: 1},
+		SpanID:        model.SpanID(2),
+		OperationName: "op",
+		StartTime:     time.Now(),
+		Duration:      -time.Second, // clock-skew: endTime < startTime
+		Process: &model.Process{
+			ServiceName: "svc",
+		},
+	}
+	trace := &model.Trace{
+		Spans: []*model.Span{span},
+		ProcessMap: []model.Trace_ProcessMapping{
+			{ProcessID: "p1", Process: *span.Process},
+		},
+	}
+
+	uiTrace := FromDomain(trace)
+	require.Len(t, uiTrace.Spans, 1)
+	// Duration must be 0, not a massive wrapped uint64.
+	assert.Equal(t, uint64(0), uiTrace.Spans[0].Duration)
+}


### PR DESCRIPTION
## Summary

Fixes #8165.

`model.DurationAsMicroseconds` in `jaeger-idl` performs `uint64(d.Nanoseconds() / 1000)`. When a span has `endTime < startTime` (clock skew or corrupted telemetry data), `d.Nanoseconds()` is negative, and casting a negative `int64` to `uint64` wraps to a value near `math.MaxUint64` — roughly 213503982 days, which matches the screenshot in the issue.

---

## Root Cause

In every storage and UI conversion path, `span.Duration` (a `time.Duration` / `int64` nanoseconds) is passed directly to `model.DurationAsMicroseconds` without a bounds check. The `//nolint:gosec // G115` suppression in `to_dbmodel.go` even asserted "guaranteed non-negative by schema constraints" — but clock skew from real-world OTLP SDKs can violate that assumption.

Affected call sites (all reading `span.Duration` or computing `end - start`):

| File | Role |
|------|------|
| `internal/uimodel/converter/v1/json/from_domain.go` | HTTP JSON response to Jaeger UI |
| `internal/storage/v1/cassandra/spanstore/dbmodel/converter.go` | Cassandra v1 write |
| `internal/storage/v1/elasticsearch/spanstore/from_domain.go` | Elasticsearch v1 write |
| `internal/storage/v1/badger/spanstore/writer.go` | Badger v1 write |
| `internal/storage/v2/cassandra/tracestore/to_dbmodel.go` | Cassandra v2 (OTLP) write |
| `internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go` | Elasticsearch v2 (OTLP) write |

---

## Solution

Apply `max(0, duration)` at every call site before passing to `DurationAsMicroseconds`. `max` is a Go built-in for ordered types since Go 1.21, so no import is needed. The change is one token per line and does not alter any type or function signature.

Also updated the stale `//nolint` comment in `to_dbmodel.go` to reflect the actual invariant.

---

## Testing

- `TestFromDomain_NegativeDuration` added to `internal/uimodel/converter/v1/json/from_domain_test.go` — creates a span with `Duration: -time.Second` and asserts `uiTrace.Spans[0].Duration == 0`.
- `TestFromDomain_NegativeDuration` added to `internal/storage/v1/cassandra/spanstore/dbmodel/converter_test.go` — asserts `dbSpan.Duration == 0` for a negative-duration span.
- All existing tests in every changed package still pass.

```bash
go test \
  ./internal/uimodel/converter/v1/json/... \
  ./internal/storage/v1/cassandra/spanstore/dbmodel/... \
  ./internal/storage/v1/elasticsearch/spanstore/... \
  ./internal/storage/v2/cassandra/tracestore/... \
  ./internal/storage/v2/elasticsearch/tracestore/... \
  ./internal/storage/v1/badger/spanstore/...
# All ok
```

`make fmt && make lint` → 0 issues.

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New tests cover the exact failing scenario from the issue
- [x] All existing tests pass
- [x] `make fmt` and `make lint` pass with 0 issues
- [x] No unrelated changes
- [x] Each commit is signed (`Signed-off-by`)
- [x] Read CONTRIBUTING_GUIDELINES.md