### PR TITLE
[clickhouse][benchmarking] Add initial results from benchmarking

### DIFF
--- a/internal/storage/v2/clickhouse/BENCHMARKING.md
+++ b/internal/storage/v2/clickhouse/BENCHMARKING.md
@@ -17,7 +17,7 @@
 | **Total traces** | 1,000,000 |
 | **Spans per trace** | 10 (1 parent + 9 children) |
 | **Total spans** | 10,000,000 |
-| **Services** | 2 (`tracegen-00`, `tracegen-01`) |
+| **Services** | 2 |
 | **Partitions (days)** | 5 |
 | **Attributes per span** | 11 (across 97 distinct keys, 1000 distinct values) |
 


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #7814

## Description of the changes
- This PR adds the initial benchmarking results for the ClickHouse storage backend. These numbers will likely change as we investigate and mitigate bottlenecks, particularly in attribute searching. 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
