### PR TITLE
Fix CI parallel mode detection for org members without team access

### DIFF
--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -55,18 +55,14 @@ jobs:
             # fails (e.g. insufficient token permissions for fork PRs).
             PR_AUTHOR="${{ github.event.pull_request.user.login }}"
             AUTHOR_ASSOC="${{ github.event.pull_request.author_association }}"
-            HTTP_CODE=$(gh api -i --silent "orgs/jaegertracing/members/$PR_AUTHOR" 2>/dev/null \
-                        | head -1 | awk '{print $2}') || true
-            if [[ "$HTTP_CODE" == "204" ]]; then
+            if gh api --silent "orgs/jaegertracing/members/$PR_AUTHOR" 2>/dev/null; then
               echo "Parallel: org member ($PR_AUTHOR, verified via API)"
               PARALLEL=true
-            elif [[ "$HTTP_CODE" == "404" ]]; then
-              echo "Not an org member ($PR_AUTHOR, verified via API)"
             elif [[ "$AUTHOR_ASSOC" == "MEMBER" || "$AUTHOR_ASSOC" == "OWNER" ]]; then
-              echo "Parallel: org member ($AUTHOR_ASSOC, API unavailable HTTP=$HTTP_CODE, fallback to author_association)"
+              echo "Parallel: org member ($PR_AUTHOR, author_association=$AUTHOR_ASSOC)"
               PARALLEL=true
             else
-              echo "Not an org member (author_association=$AUTHOR_ASSOC, API unavailable HTTP=$HTTP_CODE)"
+              echo "Not an org member ($PR_AUTHOR, author_association=$AUTHOR_ASSOC)"
             fi
 
             # Parallel for known bots (dependency update automation)


### PR DESCRIPTION
### Problem

The CI orchestrator determines whether to run stages in parallel (faster, ~10m) or sequentially (~30m) based on whether the PR author is a trusted contributor. For org members, it relied on `github.event.pull_request.author_association` from the event payload, expecting it to be `MEMBER`.

However, GitHub sets `author_association` based on the user's access to the **repository**, not org membership. Org members who don't belong to any team with repo access (e.g., external contributors added to the org specifically for CI benefits) get `author_association: CONTRIBUTOR` instead of `MEMBER`. This caused their PRs to run in slow sequential mode despite being org members.

Discovered on PR #8138 where user Manik2708 — a verified org member for months — was incorrectly classified as "not an org member" because they had no team assignments.

### Fix

Replace the `author_association` check with a live GitHub API call (`gh api orgs/jaegertracing/members/{user}`) that directly verifies org membership regardless of team/repo access. If the API call fails (e.g., due to reduced token permissions on fork PRs), falls back to the original `author_association` check so behavior is no worse than before.

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
