### PR TITLE
Add SSE endpoint to MCP server

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -93,9 +93,15 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		},
 	)
 
-	// Create HTTP server with MCP handler and health endpoint
+	sseHandler := mcp.NewSSEHandler(
+		func(_ *http.Request) *mcp.Server { return s.mcpServer },
+		&mcp.SSEOptions{},
+	)
+
+	// Create HTTP server with MCP handlers and health endpoint
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", mcpHandler)
+	mux.Handle("/sse", sseHandler)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("MCP server is running"))


### PR DESCRIPTION
## Which problem is this PR solving?
- Claude Code does not seem to work with StreamableHTTP

## Description of the changes
- Add SSE handler

## How was this change tested?
terminal 1
```
$ curl -v http://localhost:16687/sse
...
< Content-Type: text/event-stream
< Date: Tue, 17 Mar 2026 20:54:07 GMT
< Transfer-Encoding: chunked
<
event: endpoint
data: /sse?sessionid=H3UB6EG3JVBPMKWWD5GU2L64YZ
```
terminal 2
```
$ curl -X POST "http://localhost:16687/sse?sessionid=H3UB6EG3JVBPMKWWD5GU2L64YZ" \
     -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
```
terminal 1
```
event: message
data: {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{},"tools":{"listChanged":true}},"protocolVersion":"2024-11-05","serverInfo":{"name":"jaeger","version":"dev"}}}
```
