### PR TITLE
feat(ci): add metrics snapshot to tailsampling E2E workflow

### DIFF
--- a/.github/workflows/ci-e2e-tailsampling.yml
+++ b/.github/workflows/ci-e2e-tailsampling.yml
@@ -26,8 +26,14 @@ jobs:
       run: |
         make tail-sampling-integration-test
 
+    - uses: ./.github/actions/verify-metrics-snapshot
+      with:
+        snapshot: metrics_snapshot_tailsampling
+        artifact_key: metrics_snapshot_tailsampling
+
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:
         files: cover.out
         flag: tailsampling-processor
+

--- a/cmd/jaeger/internal/integration/tailsampling_test.go
+++ b/cmd/jaeger/internal/integration/tailsampling_test.go
@@ -70,7 +70,7 @@ func TestTailSamplingProcessor_EnforcesPolicies(t *testing.T) {
 //  3. Read the stored services from the memory store
 //  4. Check that the sampled services match what is expected
 func (ts *TailSamplingIntegration) testTailSamplingProccessor(t *testing.T) {
-	ts.e2eInitialize(t, "memory")
+	ts.e2eInitialize(t, "tailsampling")
 	ts.generateTraces(t)
 
 	var actual []string


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves part of jaegertracing/jaeger#6278

## Description of the changes
- Add `verify-metrics-snapshot` action step to `ci-e2e-tailsampling.yml`
- Update `tailsampling_test.go` to pass `"tailsampling"` as the storage
  label to `e2eInitialize()` instead of `"memory"`, so the snapshot is
  written to `.metrics/metrics_snapshot_tailsampling.txt` with a unique
  name that does not conflict with the memory workflow's snapshot
- The metrics scraping itself is already handled automatically by
  `E2EStorageIntegration.scrapeMetrics()` in `e2e_integration.go`  the
  test just needed the correct label and the workflow step wiring

## How was this change tested?
- Verified that `testTailSamplingProccessor` uses `e2eInitialize()` from
  `E2EStorageIntegration`, which already calls `scrapeMetrics()` at cleanup
- Confirmed the pattern matches existing workflows (badger, memory, grpc, etc.)
  that call `verify-metrics-snapshot` after the same test framework
- `gofmt` passes on all modified Go files

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
