### PR TITLE
feat(ci): add metrics snapshot to SPM E2E workflow

### DIFF
--- a/.github/workflows/ci-e2e-spm.yml
+++ b/.github/workflows/ci-e2e-spm.yml
@@ -45,3 +45,8 @@ jobs:
     - name: Run SPM Test
       run:  bash scripts/e2e/spm.sh -m ${{ matrix.mode.metricstore }}
 
+    - uses: ./.github/actions/verify-metrics-snapshot
+      with:
+        snapshot: metrics_snapshot_spm_${{ matrix.mode.metricstore }}
+        artifact_key: metrics_snapshot_spm_${{ matrix.mode.metricstore }}
+

--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -370,6 +370,31 @@ dump_logs() {
   log "::endgroup::"
 }
 
+scrape_metrics() {
+  local metrics_url="http://localhost:8888/metrics"
+  local output_dir=".metrics"
+  mkdir -p "${output_dir}"
+  local snapshot_file="${output_dir}/metrics_snapshot_spm_${METRICSTORE}.txt"
+  local max_retries=3
+  local retry_delay_seconds=5
+
+  log "Scraping Jaeger metrics from ${metrics_url} into ${snapshot_file}"
+  for attempt in $(seq 1 "${max_retries}"); do
+    if curl -sf "${metrics_url}" -o "${snapshot_file}"; then
+      log "✅ Metrics snapshot saved to ${snapshot_file} (attempt ${attempt}/${max_retries})"
+      return 0
+    fi
+
+    if [ "${attempt}" -lt "${max_retries}" ]; then
+      log "⚠️  Could not scrape metrics from ${metrics_url} (attempt ${attempt}/${max_retries}). Retrying in ${retry_delay_seconds}s..."
+      sleep "${retry_delay_seconds}"
+    fi
+  done
+
+  log "❌ ERROR: Failed to scrape metrics from ${metrics_url} after ${max_retries} attempts"
+  return 1
+}
+
 teardown_services() {
   if [[ "$success" == "false" ]]; then
     dump_logs
@@ -382,6 +407,7 @@ main() {
 
   wait_for_services_to_be_healthy
   check_spm
+  scrape_metrics || log "⚠️  Metrics scraping failed; snapshot will be skipped but test result is unaffected"
   success="true"
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves part of jaegertracing/jaeger#6278

## Description of the changes
- Add a `scrape_metrics()` function to `scripts/e2e/spm.sh` that
  curls the Jaeger metrics endpoint (`http://localhost:8888/metrics`)
  after the SPM test assertions pass and saves the output to
  `.metrics/metrics_snapshot_spm_${METRICSTORE}.txt`
- The snapshot name embeds the metricstore name (`prometheus`,
  `elasticsearch`, `opensearch`) so each matrix variant produces
  a distinct, non-conflicting file
- Add `verify-metrics-snapshot` action step to `ci-e2e-spm.yml`
  for each matrix variant using the matching snapshot/artifact key
- Unlike the storage E2E tests, SPM runs Jaeger via docker-compose
  and does not use `e2e_integration.go`, so the scraping is done
  explicitly in the shell script

## How was this change tested?
- Verified that the SPM docker-compose setup starts Jaeger on the
  standard metrics port `8888` (same as all other E2E setups)
- Confirmed the script pattern matches how other standalone tests
  handle metrics (curl to :8888/metrics, save to .metrics/)
- The `scrape_metrics()` is called after `check_spm()` succeeds
  and is non-fatal (warns but does not fail) if the endpoint is
  temporarily unavailable

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
