### PR TITLE
fix(es): remove time-based ordering from trace ID aggregation

### DIFF
--- a/internal/storage/v1/elasticsearch/spanstore/reader.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader.go
@@ -600,17 +600,10 @@ func (s *SpanReader) findTraceIDsFromQuery(ctx context.Context, traceQuery dbmod
 	return bucketToStringArray[dbmodel.TraceID](traceIDBuckets)
 }
 
-func (s *SpanReader) buildTraceIDAggregation(numOfTraces int) elastic.Aggregation {
+func (*SpanReader) buildTraceIDAggregation(numOfTraces int) elastic.Aggregation {
 	return elastic.NewTermsAggregation().
 		Size(numOfTraces).
-		Field(traceIDField).
-		Order(startTimeField, false).
-		SubAggregation(startTimeField, s.buildTraceIDSubAggregation())
-}
-
-func (*SpanReader) buildTraceIDSubAggregation() elastic.Aggregation {
-	return elastic.NewMaxAggregation().
-		Field(startTimeField)
+		Field(traceIDField)
 }
 
 func (s *SpanReader) buildFindTraceIDsQuery(traceQuery dbmodel.TraceQueryParameters) elastic.Query {

--- a/internal/storage/v1/elasticsearch/spanstore/reader_test.go
+++ b/internal/storage/v1/elasticsearch/spanstore/reader_test.go
@@ -1079,25 +1079,17 @@ func TestTraceQueryParameterValidation(t *testing.T) {
 }
 
 func TestSpanReader_buildTraceIDAggregation(t *testing.T) {
-	expectedStr := `{ "terms":{
-            "field":"traceID",
-            "size":123,
-            "order":{
-               "startTime":"desc"
-            }
-         },
-         "aggregations": {
-            "startTime" : { "max": {"field": "startTime"}}
-         }}`
 	withSpanReader(t, func(r *spanReaderTest) {
 		traceIDAggregation := r.reader.buildTraceIDAggregation(123)
 		actual, err := traceIDAggregation.Source()
 		require.NoError(t, err)
 
-		expected := make(map[string]any)
-		json.Unmarshal([]byte(expectedStr), &expected)
-		expected["terms"].(map[string]any)["size"] = 123
-		expected["terms"].(map[string]any)["order"] = []any{map[string]string{"startTime": "desc"}}
+		expected := map[string]any{
+			"terms": map[string]any{
+				"field": "traceID",
+				"size":  123,
+			},
+		}
 		assert.EqualValues(t, expected, actual)
 	})
 }


### PR DESCRIPTION
Fixes #8186

## Problem

When querying traces over large time windows (e.g. 12 hours), the Jaeger UI returns only a few minutes of spans. The root cause is in `buildTraceIDAggregation()` in the ES spanstore reader.

The terms aggregation used `.Order(startTimeField, false)` to sort buckets by `max(startTime)` descending. Combined with the default limit of 100 traces, this causes all returned trace IDs to cluster in the most recent minutes of the time window — effectively ignoring the rest of the range.

## Fix

Remove the time-based ordering (`.Order()` and the `max(startTime)` sub-aggregation) from the terms aggregation. Without explicit ordering, ES returns buckets by `doc_count` descending (the default), which naturally distributes results across the full time range since traces with more spans are not biased toward any particular time window.

This is the minimal change: two lines removed from `buildTraceIDAggregation()` and the now-unused `buildTraceIDSubAggregation()` helper deleted.

## Test

- Updated `TestSpanReader_buildTraceIDAggregation` to match the simplified aggregation structure.
- `go test ./internal/storage/v1/elasticsearch/spanstore/...` passes.