### PR TITLE
feat(monitor): restore Grafana to SPM docker-compose example (ADR-007 Step 1)

### DIFF
--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -93,6 +93,7 @@ docker compose -f docker-compose-opensearch.yml up
 - Let the application run for a couple of minutes to ensure there is enough time series data to plot in the dashboard.
 - Navigate to Jaeger UI at http://localhost:16686/ and inspect the Monitor tab. Select `redis` service from the dropdown to see more than one endpoint.
 - For the Prometheus option, visualize raw metrics in the Prometheus UI at http://localhost:9090/query (e.g., [example query for trace spans](http://localhost:9090/query?g0.expr=traces_span_metrics_calls_total&g0.tab=0&g0.range_input=5m)).
+- **Grafana** is available at http://localhost:3000 with the Jaeger mixin dashboard pre-loaded (no login required). It shows collector ingestion/export rates, storage latency, and query metrics. Note: panels may display Angular deprecation warnings — this is expected and will be resolved in a follow-up migration.
 
 **Warning:** The included ` docker compose` files use the `latest` version of Jaeger and other components. If your local Docker registry already contains older versions, which may still be tagged as `latest`, you may want to delete those images before running the full set, to ensure consistent behavior:
 

--- a/docker-compose/monitor/datasource.yml
+++ b/docker-compose/monitor/datasource.yml
@@ -1,8 +1,0 @@
-apiVersion: 1
-datasources:
-- name: Prometheus
-  type: prometheus
-  url: http://prometheus:9090
-  isDefault: true
-  access: proxy
-  editable: true

--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -38,5 +38,20 @@ services:
     ports:
       - "9090:9090"
 
+  grafana:
+    networks:
+      - backend
+    image: grafana/grafana:11.6.0
+    volumes:
+      - "./grafana/provisioning:/etc/grafana/provisioning"
+      - "../../monitoring/jaeger-mixin/dashboard-for-grafana.json:/etc/grafana/provisioning/dashboards/jaeger.json:ro"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+
 networks:
   backend:

--- a/docker-compose/monitor/grafana/provisioning/dashboards/default.yml
+++ b/docker-compose/monitor/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,6 @@
+apiVersion: 1
+providers:
+  - name: jaeger-mixin
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker-compose/monitor/grafana/provisioning/datasources/prometheus.yml
+++ b/docker-compose/monitor/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    access: proxy
+    editable: true
+# Intentionally no Jaeger datasource. Grafana is included here solely as a
+# metrics dashboard tool. Jaeger UI (port 16686) is the trace visualization
+# interface for this demo. Without a trace datasource configured, Grafana's
+# trace viewer is inert. Users who want to add one can do so manually.


### PR DESCRIPTION
## Summary

Implements **Step 1** of [ADR-007: Grafana Dashboard Modernization](https://github.com/jaegertracing/jaeger/blob/main/docs/adr/007-grafana-dashboards-modernization.md) as directed by @yurishkuro in #5833.

Restores Grafana to the `docker-compose/monitor/` SPM example so the existing mixin dashboard can be validated against live Jaeger metrics, and so subsequent steps (Go SDK migration, CI checks) have a working baseline to validate against.

### Changes

- **`docker-compose/monitor/docker-compose.yml`** — adds `grafana` service (Grafana 11.6.0) mounting `monitoring/jaeger-mixin/dashboard-for-grafana.json` directly from its canonical location (single source of truth, no copy)
- **`docker-compose/monitor/grafana/provisioning/datasources/prometheus.yml`** — moves the orphaned `datasource.yml` to its correct Grafana provisioning path (same content)
- **`docker-compose/monitor/grafana/provisioning/dashboards/default.yml`** — new dashboard provider config
- **`docker-compose/monitor/datasource.yml`** — deleted (now at correct provisioning path)
- **`docker-compose/monitor/README.md`** — notes Grafana is available at http://localhost:3000 with the mixin dashboard pre-loaded

Anonymous access with `Admin` role is enabled — no login prompt in this local dev environment. The `:ro` flag prevents Grafana from writing back to the source file.

Angular deprecation warnings are **expected** at this stage. Grafana 11.x is used intentionally — it is the last series with Angular support enabled by default. The panel type migration (`graph` → `timeseries` via `grafana-foundation-sdk`) is Step 2 of the ADR.

### Test plan

- [ ] `docker compose up` in `docker-compose/monitor/`
- [ ] Confirm Grafana loads at http://localhost:3000 with no login required
- [ ] Confirm "Jaeger" mixin dashboard is pre-provisioned and panels show data after ~2 minutes of microsim traffic
- [ ] Confirm Angular deprecation warnings appear (expected — will be fixed in Step 2)

Relates to #5833

