### PR TITLE
anonymizer/uiconv: make tests deterministic for output file errors

### DIFF
--- a/cmd/anonymizer/app/uiconv/extractor_test.go
+++ b/cmd/anonymizer/app/uiconv/extractor_test.go
@@ -6,6 +6,7 @@ package uiconv
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,16 +50,12 @@ func TestExtractorTraceSuccess(t *testing.T) {
 }
 
 func TestExtractorTraceOutputFileError(t *testing.T) {
+	tempDir := t.TempDir()
 	inputFile := "fixtures/trace_success.json"
-	outputFile := "fixtures/trace_success_ui_anonymized.json"
-	defer os.Remove(outputFile)
+	outputFile := filepath.Join(tempDir, "nonexistent", "output.json")
 
 	reader, err := newSpanReader(inputFile, zap.NewNop())
 	require.NoError(t, err)
-
-	err = os.Chmod("fixtures", 0o000)
-	require.NoError(t, err)
-	defer os.Chmod("fixtures", 0o755)
 
 	_, err = newExtractor(
 		outputFile,

--- a/cmd/anonymizer/app/uiconv/module_test.go
+++ b/cmd/anonymizer/app/uiconv/module_test.go
@@ -5,6 +5,7 @@ package uiconv
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,9 +53,9 @@ func TestModule_TraceNonExistent(t *testing.T) {
 }
 
 func TestModule_TraceOutputFileError(t *testing.T) {
+	tempDir := t.TempDir()
 	inputFile := "fixtures/trace_success.json"
-	outputFile := "fixtures/trace_success_ui_anonymized.json"
-	defer os.Remove(outputFile)
+	outputFile := filepath.Join(tempDir, "nonexistent", "output.json")
 
 	config := Config{
 		CapturedFile: inputFile,
@@ -62,10 +63,6 @@ func TestModule_TraceOutputFileError(t *testing.T) {
 		TraceID:      "2be38093ead7a083",
 	}
 
-	err := os.Chmod("fixtures", 0o550)
-	require.NoError(t, err)
-	defer os.Chmod("fixtures", 0o755)
-
-	err = Extract(config, zap.NewNop())
+	err := Extract(config, zap.NewNop())
 	require.ErrorContains(t, err, "cannot create output file")
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes flaky tests in `cmd/anonymizer/app/uiconv` caused by non-portable file permission handling

## Description of the changes
- Replace `os.Chmod`-based failure simulation with a deterministic approach using `t.TempDir()` and a non-existent subdirectory
- Remove reliance on filesystem permissions for triggering file creation errors
- Remove unnecessary cleanup (`os.Remove`) in tests using `t.TempDir()`
- Keep existing error assertions unchanged

## How was this change tested?
- Ran `go test ./cmd/anonymizer/app/uiconv -count=1`
- Ran `go test ./cmd/anonymizer/... -count=1`
- Verified all tests pass, including previously flaky error tests
- Ran `make lint` and `make fmt` with no new issues introduced

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes