### PR TITLE
[jaegermcp] Add MCP SDK client integration tests (ADR-002 §4.12)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -57,7 +57,9 @@ func (s *mcpSession) callTool(t *testing.T, name string, args map[string]any) st
 
 // connectMCPSession starts a test server backed by the given mock reader,
 // connects an MCP SDK client, and returns the session with a 5s context.
-// If mockReader is nil, a default no-op reader is used.
+// Pass nil for tests that only exercise protocol-level operations (initialize,
+// tools/list, health) which do not hit storage. Passing nil creates a
+// QueryService backed by empty mocks that will panic on unexpected storage calls.
 func connectMCPSession(t *testing.T, mockReader *tracestoremocks.Reader) *mcpSession {
 	t.Helper()
 	var svc *querysvc.QueryService
@@ -379,13 +381,12 @@ func TestMCPClientInvalidToolCall(t *testing.T) {
 
 func TestMCPClientSearchTracesMissingRequiredField(t *testing.T) {
 	s := connectMCPSession(t, nil)
-	result, err := s.CallTool(s.ctx, &mcp.CallToolParams{
+	_, err := s.CallTool(s.ctx, &mcp.CallToolParams{
 		Name:      "search_traces",
 		Arguments: map[string]any{"start_time_min": "-1h"},
 	})
-	if err == nil {
-		assert.True(t, result.IsError, "search_traces without service_name should return error")
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service_name")
 }
 
 func TestMCPClientSearchTracesEmptyResults(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

ADR-002 Phase 4 Item 12 calls for integration tests that verify MCP protocol compliance using the SDK client. The existing `server_test.go` tests use raw HTTP `POST` with hand-rolled JSON-RPC payloads, which doesn't exercise the SDK's session management, protocol negotiation, or typed tool invocation.

## Description of the changes

Adds `integration_test.go` with 15 tests that use the official MCP Go SDK client (`mcp.NewClient` + `StreamableClientTransport`) against a test server backed by mock storage:

**Protocol compliance:**
- `TestMCPClientInitialize` — connect, initialize, verify server info
- `TestMCPClientToolsListDiscovery` — `tools/list` returns all 8 registered tools
- `TestMCPClientMultipleSessionsIndependent` — concurrent sessions don't interfere

**Tool invocation (all 7 data tools + health):**
- `TestMCPClientHealthTool`
- `TestMCPClientGetServices`
- `TestMCPClientGetSpanNames`
- `TestMCPClientSearchTraces`
- `TestMCPClientGetTraceTopology`
- `TestMCPClientGetSpanDetails`
- `TestMCPClientGetTraceErrors`
- `TestMCPClientGetCriticalPath`

**End-to-end workflow:**
- `TestMCPClientProgressiveDisclosure` — services → search → topology → critical path → details (the intended LLM interaction pattern)

**Error handling:**
- `TestMCPClientInvalidToolCall` — non-existent tool
- `TestMCPClientSearchTracesMissingRequiredField` — missing required input
- `TestMCPClientSearchTracesEmptyResults` — empty results don't produce null

Reuses existing test helpers (`startTestServerWithQueryService`, `connectMCPClient`) and v2 storage mocks. No new dependencies.

## How was this change tested?

```
go test ./cmd/jaeger/internal/extension/jaegermcp/... -run TestMCPClient -count=1 -v
make fmt && make lint && make test  # all pass, 0 lint issues
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I ran `make lint` and `make test` successfully