### PR TITLE
fix(uiconv): truncate output files before writing to prevent stale data

### DIFF
--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -24,7 +24,7 @@ type extractor struct {
 
 // newExtractor creates extractor.
 func newExtractor(uiFile string, traceID string, reader *spanReader, logger *zap.Logger) (*extractor, error) {
-	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}

--- a/cmd/anonymizer/app/writer/writer.go
+++ b/cmd/anonymizer/app/writer/writer.go
@@ -48,13 +48,13 @@ func New(config Config, logger *zap.Logger) (*Writer, error) {
 	}
 	logger.Sugar().Infof("Current working dir is %s", wd)
 
-	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}
 	logger.Sugar().Infof("Writing captured spans to file %s", config.CapturedFile)
 
-	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}

--- a/cmd/anonymizer/app/writer/writer_test.go
+++ b/cmd/anonymizer/app/writer/writer_test.go
@@ -4,7 +4,10 @@
 package writer
 
 import (
+	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -116,4 +119,50 @@ func TestWriter_WriteSpan(t *testing.T) {
 		err = writer.WriteSpan(span)
 		require.ErrorIs(t, err, ErrMaxSpansCountReached)
 	})
+}
+
+// TestWriter_TruncatesExistingFile verifies that writer.New() truncates
+// existing output files via O_TRUNC, preventing stale data.
+func TestWriter_TruncatesExistingFile(t *testing.T) {
+	tempDir := t.TempDir()
+	capturedFile := filepath.Join(tempDir, "captured.json")
+	anonymizedFile := filepath.Join(tempDir, "anonymized.json")
+	mappingFile := filepath.Join(tempDir, "mapping.json")
+
+	// Create files with old content that is clearly longer than what writer.New() will write
+	oldContent := `{"old":"data","stale":true,"extra":"this_should_be_removed_completely"}`
+	err := os.WriteFile(capturedFile, []byte(oldContent), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(anonymizedFile, []byte(oldContent), 0o644)
+	require.NoError(t, err)
+
+	// Create writer with existing files - should truncate them
+	config := Config{
+		MaxSpansCount:  10,
+		CapturedFile:   capturedFile,
+		AnonymizedFile: anonymizedFile,
+		MappingFile:    mappingFile,
+	}
+	writer, err := New(config, zap.NewNop())
+	require.NoError(t, err)
+	writer.Close()
+
+	// Verify old content is gone from captured file
+	capturedData, err := os.ReadFile(capturedFile)
+	require.NoError(t, err)
+	require.NotContains(t, string(capturedData), "old")
+	require.NotContains(t, string(capturedData), "stale")
+	require.NotContains(t, string(capturedData), "extra") // proves no leftover tail
+	// Ensure no partial/corrupted JSON remains
+	var v any
+	require.NoError(t, json.Unmarshal(capturedData, &v))
+
+	// Verify old content is gone from anonymized file
+	anonymizedData, err := os.ReadFile(anonymizedFile)
+	require.NoError(t, err)
+	require.NotContains(t, string(anonymizedData), "old")
+	require.NotContains(t, string(anonymizedData), "stale")
+	require.NotContains(t, string(anonymizedData), "extra") // proves no leftover tail
+	// Ensure no partial/corrupted JSON remains
+	require.NoError(t, json.Unmarshal(anonymizedData, &v))
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #8231

## Description of the changes
- Adds os.O_TRUNC when opening output files in uiconv and anonymizer writer. Without truncation, running the tool multiple times on the same file can leave old data at the end if the new output is smaller, resulting in invalid JSON.

## How was this change tested?
- Reproduced the issue by writing to the same file twice and observing stale data without O_TRUNC, and correct output with O_TRUNC. Also ran go build ./cmd/... and go test ./cmd/... successfully.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes