### PR TITLE
fix(anonymizer): truncate output files before writing to prevent stale data

### DIFF
--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -24,7 +24,7 @@ type extractor struct {
 
 // newExtractor creates extractor.
 func newExtractor(uiFile string, traceID string, reader *spanReader, logger *zap.Logger) (*extractor, error) {
-	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}

--- a/cmd/anonymizer/app/uiconv/extractor_test.go
+++ b/cmd/anonymizer/app/uiconv/extractor_test.go
@@ -89,6 +89,39 @@ func TestExtractorTraceScanError(t *testing.T) {
 	require.ErrorContains(t, err, "failed when scanning the file")
 }
 
+func TestExtractorTruncatesOutputOnRerun(t *testing.T) {
+	// Regression test for https://github.com/jaegertracing/jaeger/issues/8231:
+	// a second run on the same output file must not leave stale bytes from the first run.
+	inputFile := "fixtures/trace_success.json"
+	outputFile := t.TempDir() + "/out.json"
+
+	runExtractor := func() {
+		reader, err := newSpanReader(inputFile, zap.NewNop())
+		require.NoError(t, err)
+		extractor, err := newExtractor(outputFile, "2be38093ead7a083", reader, zap.NewNop())
+		require.NoError(t, err)
+		require.NoError(t, extractor.Run())
+	}
+
+	// First run — writes normally.
+	runExtractor()
+	first, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	// Overwrite the file with longer content to simulate a "large previous run".
+	require.NoError(t, os.WriteFile(outputFile, append(first, []byte("STALE_GARBAGE")...), 0o600))
+
+	// Second run — must truncate, leaving only fresh output.
+	runExtractor()
+	second, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second, "second run left stale bytes from the first run")
+
+	var trace UITrace
+	loadJSON(t, outputFile, &trace)
+}
+
 func loadJSON(t *testing.T, fileName string, i any) {
 	b, err := os.ReadFile(fileName)
 	require.NoError(t, err)

--- a/cmd/anonymizer/app/writer/writer.go
+++ b/cmd/anonymizer/app/writer/writer.go
@@ -48,25 +48,30 @@ func New(config Config, logger *zap.Logger) (*Writer, error) {
 	}
 	logger.Sugar().Infof("Current working dir is %s", wd)
 
-	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}
 	logger.Sugar().Infof("Writing captured spans to file %s", config.CapturedFile)
 
-	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
+		cf.Close()
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}
 	logger.Sugar().Infof("Writing anonymized spans to file %s", config.AnonymizedFile)
 
 	_, err = cf.WriteString("[")
 	if err != nil {
-		return nil, fmt.Errorf("cannot write tp output file: %w", err)
+		cf.Close()
+		af.Close()
+		return nil, fmt.Errorf("cannot write to output file: %w", err)
 	}
 	_, err = af.WriteString("[")
 	if err != nil {
-		return nil, fmt.Errorf("cannot write tp output file: %w", err)
+		cf.Close()
+		af.Close()
+		return nil, fmt.Errorf("cannot write to output file: %w", err)
 	}
 
 	options := anonymizer.Options{

--- a/cmd/anonymizer/app/writer/writer_test.go
+++ b/cmd/anonymizer/app/writer/writer_test.go
@@ -4,7 +4,9 @@
 package writer
 
 import (
+	"encoding/json"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -78,6 +80,53 @@ func TestNew(t *testing.T) {
 		_, err := New(config, nopLogger)
 		require.ErrorContains(t, err, "cannot create output file")
 	})
+}
+
+func TestWriterTruncatesOutputOnRerun(t *testing.T) {
+	// Regression test for https://github.com/jaegertracing/jaeger/issues/8231:
+	// a second Writer run on the same files must not leave stale bytes from the first run.
+	nopLogger := zap.NewNop()
+	tempDir := t.TempDir()
+	config := Config{
+		MaxSpansCount:  10,
+		CapturedFile:   tempDir + "/captured.json",
+		AnonymizedFile: tempDir + "/anonymized.json",
+		MappingFile:    tempDir + "/mapping.json",
+	}
+
+	// First run — write multiple spans.
+	w1, err := New(config, nopLogger)
+	require.NoError(t, err)
+	for range 5 {
+		require.NoError(t, w1.WriteSpan(span))
+	}
+	w1.Close()
+
+	firstCaptured, err := os.ReadFile(config.CapturedFile)
+	require.NoError(t, err)
+	firstAnonymized, err := os.ReadFile(config.AnonymizedFile)
+	require.NoError(t, err)
+
+	// Second run — write fewer spans; stale bytes must not remain.
+	w2, err := New(config, nopLogger)
+	require.NoError(t, err)
+	require.NoError(t, w2.WriteSpan(span))
+	w2.Close()
+
+	secondCaptured, err := os.ReadFile(config.CapturedFile)
+	require.NoError(t, err)
+	secondAnonymized, err := os.ReadFile(config.AnonymizedFile)
+	require.NoError(t, err)
+
+	require.Less(t, len(secondCaptured), len(firstCaptured),
+		"second run should produce fewer bytes (fewer spans)")
+	require.Less(t, len(secondAnonymized), len(firstAnonymized),
+		"second run should produce fewer bytes (fewer spans)")
+
+	// Both outputs must be valid JSON arrays.
+	var capArr, anonArr []any
+	require.NoError(t, json.Unmarshal(secondCaptured, &capArr), "captured file is not valid JSON")
+	require.NoError(t, json.Unmarshal(secondAnonymized, &anonArr), "anonymized file is not valid JSON")
 }
 
 func TestWriter_WriteSpan(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #8231

When `uiconv` or the anonymizer writer ran multiple times on the same output file, old data from a previous (larger) run was not cleared. If the new output was smaller, leftover bytes from the previous write remained at the end of the file, producing broken/invalid JSON.

## Description of the changes

`os.OpenFile` was called with `os.O_CREATE|os.O_WRONLY` but without `os.O_TRUNC`, so the file cursor starts at position 0 but the file is not truncated. Adding `os.O_TRUNC` ensures the file is cleared before each write.

Changed files:
- `cmd/anonymizer/app/uiconv/extractor.go` — add `O_TRUNC` to output UI file open flags
- `cmd/anonymizer/app/writer/writer.go` — add `O_TRUNC` to both captured and anonymized file open flags

## How was this change tested?

- All existing `cmd/anonymizer/...` tests pass: `go test ./cmd/anonymizer/...`
- The same root cause existed in `writer.go` (captured and anonymized files) — fixed there too for consistency

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully: `go test ./cmd/anonymizer/...`

