### PR TITLE
[jaegermcp] Log tool name in MCP middleware for tools/call requests

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/logging_middleware.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/logging_middleware.go
@@ -12,6 +12,7 @@ import (
 )
 
 // createLoggingMiddleware creates an MCP middleware that logs method calls.
+// For tools/call requests it also logs the tool name.
 func createLoggingMiddleware(logger *zap.Logger) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(
@@ -22,31 +23,40 @@ func createLoggingMiddleware(logger *zap.Logger) mcp.Middleware {
 			start := time.Now()
 			sessionID := req.GetSession().ID()
 
-			// Log request details.
-			logger.Info("MCP request",
+			fields := []zap.Field{
 				zap.String("session_id", sessionID),
-				zap.String("method", method))
+				zap.String("method", method),
+			}
+			if toolName := extractToolName(method, req); toolName != "" {
+				fields = append(fields, zap.String("tool", toolName))
+			}
+
+			logger.Info("MCP request", fields...)
 
 			// Call the actual handler.
 			result, err := next(ctx, method, req)
 
 			// Log response details.
-			duration := time.Since(start)
-
+			fields = append(fields, zap.Duration("duration", time.Since(start)))
 			if err != nil {
-				logger.Error("MCP response",
-					zap.String("session_id", sessionID),
-					zap.String("method", method),
-					zap.Duration("duration", duration),
-					zap.Error(err))
+				fields = append(fields, zap.Error(err))
+				logger.Error("MCP response", fields...)
 			} else {
-				logger.Info("MCP response",
-					zap.String("session_id", sessionID),
-					zap.String("method", method),
-					zap.Duration("duration", duration))
+				logger.Info("MCP response", fields...)
 			}
 
 			return result, err
 		}
 	}
+}
+
+// extractToolName returns the tool name from a tools/call request, or empty string otherwise.
+func extractToolName(method string, req mcp.Request) string {
+	if method != "tools/call" {
+		return ""
+	}
+	if params, ok := req.GetParams().(*mcp.CallToolParamsRaw); ok {
+		return params.Name
+	}
+	return ""
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/logging_middleware_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/logging_middleware_test.go
@@ -17,20 +17,21 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestLoggingMiddleware(t *testing.T) {
-	zapCore, logs := observer.New(zapcore.DebugLevel)
-	_, addr := startTestServerWithQueryService(t, nil, zap.New(zapCore))
-
-	// Send an MCP initialize request, which passes through the logging middleware.
-	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+// sendMCPRequest sends a JSON-RPC request to the MCP endpoint and returns
+// the session ID from the response.
+func sendMCPRequest(t *testing.T, addr, sessionID, body string) string {
+	t.Helper()
 	httpReq, err := http.NewRequest(
 		http.MethodPost,
 		fmt.Sprintf("http://%s/mcp", addr),
-		bytes.NewReader([]byte(initReq)),
+		bytes.NewReader([]byte(body)),
 	)
 	require.NoError(t, err)
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		httpReq.Header.Set("Mcp-Session-Id", sessionID)
+	}
 
 	resp, err := http.DefaultClient.Do(httpReq)
 	require.NoError(t, err)
@@ -38,23 +39,40 @@ func TestLoggingMiddleware(t *testing.T) {
 	_, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// Clean up the MCP session to avoid goroutine leaks.
-	sessionID := resp.Header.Get("Mcp-Session-Id")
-	if sessionID != "" {
-		delReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("http://%s/mcp", addr), http.NoBody)
-		require.NoError(t, err)
-		delReq.Header.Set("Mcp-Session-Id", sessionID)
-		resp2, err := http.DefaultClient.Do(delReq)
-		require.NoError(t, err)
-		resp2.Body.Close()
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		return sid
 	}
+	return sessionID
+}
 
-	// The middleware should have emitted one "MCP request" and one "MCP response" entry.
+// deleteMCPSession cleans up an MCP session to avoid goroutine leaks.
+func deleteMCPSession(t *testing.T, addr, sessionID string) {
+	t.Helper()
+	if sessionID == "" {
+		return
+	}
+	delReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("http://%s/mcp", addr), http.NoBody)
+	require.NoError(t, err)
+	delReq.Header.Set("Mcp-Session-Id", sessionID)
+	resp, err := http.DefaultClient.Do(delReq)
+	require.NoError(t, err)
+	resp.Body.Close()
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+	zapCore, logs := observer.New(zapcore.DebugLevel)
+	_, addr := startTestServerWithQueryService(t, nil, zap.New(zapCore))
+
+	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	sessionID := sendMCPRequest(t, addr, "", initReq)
+	t.Cleanup(func() { deleteMCPSession(t, addr, sessionID) })
+
 	requestLogs := logs.FilterMessage("MCP request").All()
 	require.Len(t, requestLogs, 1)
 	reqFields := requestLogs[0].ContextMap()
 	assert.Equal(t, "initialize", reqFields["method"])
 	assert.NotEmpty(t, reqFields["session_id"])
+	assert.NotContains(t, reqFields, "tool", "initialize should not have a tool field")
 
 	responseLogs := logs.FilterMessage("MCP response").All()
 	require.Len(t, responseLogs, 1)
@@ -62,4 +80,33 @@ func TestLoggingMiddleware(t *testing.T) {
 	assert.Equal(t, "initialize", respFields["method"])
 	assert.NotEmpty(t, respFields["session_id"])
 	assert.Contains(t, respFields, "duration")
+	assert.NotContains(t, respFields, "tool", "initialize should not have a tool field")
+}
+
+func TestLoggingMiddlewareToolName(t *testing.T) {
+	zapCore, logs := observer.New(zapcore.DebugLevel)
+	_, addr := startTestServerWithQueryService(t, nil, zap.New(zapCore))
+
+	// Initialize session first
+	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	sessionID := sendMCPRequest(t, addr, "", initReq)
+	require.NotEmpty(t, sessionID)
+	t.Cleanup(func() { deleteMCPSession(t, addr, sessionID) })
+
+	// Call the health tool
+	toolReq := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"health","arguments":{}}}`
+	sendMCPRequest(t, addr, sessionID, toolReq)
+
+	// Filter to tools/call request log and verify tool name
+	toolCallLogs := logs.FilterMessage("MCP request").
+		FilterField(zap.String("method", "tools/call")).All()
+	require.Len(t, toolCallLogs, 1)
+	assert.Equal(t, "health", toolCallLogs[0].ContextMap()["tool"])
+
+	// Filter to tools/call response log and verify tool name
+	toolRespLogs := logs.FilterMessage("MCP response").
+		FilterField(zap.String("method", "tools/call")).All()
+	require.Len(t, toolRespLogs, 1)
+	assert.Equal(t, "health", toolRespLogs[0].ContextMap()["tool"])
+	assert.Contains(t, toolRespLogs[0].ContextMap(), "duration")
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The logging middleware logs the MCP method (e.g. `tools/call`) but not which specific tool was invoked. Operators cannot distinguish between `search_traces`, `get_services`, or `health` calls in logs, making it difficult to debug issues or understand tool-level usage patterns.

Before:
```
MCP request  session_id=abc  method=tools/call
MCP response session_id=abc  method=tools/call  duration=5ms
```

After:
```
MCP request  session_id=abc  method=tools/call  tool=search_traces
MCP response session_id=abc  method=tools/call  tool=search_traces  duration=5ms
```

This aligns with ADR-002 Phase 4 Item 10 (structured logging for debugging).

## Description of the changes

- Extract tool name from `CallToolParamsRaw` when the method is `tools/call`
- Include `tool` field in both request and response log entries
- Add `extractToolName` helper that returns empty string for non-tool methods
- Refactor log field construction to build fields once and reuse for request/response
- Add `TestLoggingMiddlewareToolName` test that verifies tool name appears in logs
- Refactor test helpers (`sendMCPRequest`, `deleteMCPSession`) to reduce duplication

## How was this change tested?

```
go test ./cmd/jaeger/internal/extension/jaegermcp/ -run TestLogging -v -count=1
make fmt && make lint && make test
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I ran `make lint` and `make test` successfully