### PR TITLE
fix(anonymizer): truncate output files before writing

### DIFF
--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -24,7 +24,7 @@ type extractor struct {
 
 // newExtractor creates extractor.
 func newExtractor(uiFile string, traceID string, reader *spanReader, logger *zap.Logger) (*extractor, error) {
-	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}

--- a/cmd/anonymizer/app/writer/writer.go
+++ b/cmd/anonymizer/app/writer/writer.go
@@ -48,13 +48,13 @@ func New(config Config, logger *zap.Logger) (*Writer, error) {
 	}
 	logger.Sugar().Infof("Current working dir is %s", wd)
 
-	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}
 	logger.Sugar().Infof("Writing captured spans to file %s", config.CapturedFile)
 
-	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create output file: %w", err)
 	}


### PR DESCRIPTION
## What
Adds `os.O_TRUNC` flag to `os.OpenFile` calls in the anonymizer's uiconv extractor and span writer.

## Why
When running uiconv or the anonymizer writer multiple times on the same output file, the file is not cleared before writing. If the new output is shorter than the previous one, leftover bytes remain at the end, producing broken/invalid JSON.

**Root cause:** `os.OpenFile` is called with `os.O_CREATE|os.O_WRONLY` but without `os.O_TRUNC`, so existing file contents are not cleared.

## Fix
Add `os.O_TRUNC` to the open flags in:
- `cmd/anonymizer/app/uiconv/extractor.go` (line 27)
- `cmd/anonymizer/app/writer/writer.go` (lines 51, 57)

This matches the fix suggested in the issue.

## Testing
The fix is a one-flag addition. The existing file open behavior is unchanged except that the file is now truncated on open, which is the correct behavior for write-from-beginning operations.

Fixes #8231

Signed-off-by: Ashutosh0x <ashutoshkumarsingh0x@gmail.com>