### PR TITLE
fix(anonymizer): truncate output files on open to prevent stale JSON

### DIFF
--- a/cmd/anonymizer/app/uiconv/extractor.go
+++ b/cmd/anonymizer/app/uiconv/extractor.go
@@ -24,9 +24,9 @@ type extractor struct {
 
 // newExtractor creates extractor.
 func newExtractor(uiFile string, traceID string, reader *spanReader, logger *zap.Logger) (*extractor, error) {
-	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(uiFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create output file: %w", err)
+		return nil, fmt.Errorf("cannot create output file %q: %w", uiFile, err)
 	}
 	logger.Sugar().Infof("Writing spans to UI file %s", uiFile)
 

--- a/cmd/anonymizer/app/writer/writer.go
+++ b/cmd/anonymizer/app/writer/writer.go
@@ -48,15 +48,15 @@ func New(config Config, logger *zap.Logger) (*Writer, error) {
 	}
 	logger.Sugar().Infof("Current working dir is %s", wd)
 
-	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	cf, err := os.OpenFile(config.CapturedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create output file: %w", err)
+		return nil, fmt.Errorf("cannot create output file %q: %w", config.CapturedFile, err)
 	}
 	logger.Sugar().Infof("Writing captured spans to file %s", config.CapturedFile)
 
-	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	af, err := os.OpenFile(config.AnonymizedFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create output file: %w", err)
+		return nil, fmt.Errorf("cannot create output file %q: %w", config.AnonymizedFile, err)
 	}
 	logger.Sugar().Infof("Writing anonymized spans to file %s", config.AnonymizedFile)
 


### PR DESCRIPTION
## What does this PR do?

When you run the anonymizer tool more than once and point it to the same output files, the old content isn't cleared before writing starts. The files are opened with `O_CREATE|O_WRONLY` but without `O_TRUNC`, so if a previous run wrote more data than the current one, the leftover bytes stick around at the end and produce invalid JSON.

This adds `os.O_TRUNC` to all three `os.OpenFile` calls — two in `writer.go` (for the captured and anonymized output files) and one in `extractor.go` (for the UI converter output). That ensures the file is always empty when we start writing.

## Which issue(s) does this PR fix?

Fixes #8231

## Checklist

- [x] Code follows the project style guidelines
- [x] Existing tests pass (uses `t.TempDir()` which always starts with an empty dir, so no test assertions are affected)
- [x] Change is minimal and focused

Signed-off-by: Sakthi Harish <sakthi.harish@edgeverve.com>