### PR TITLE
[jaegermcp] Enforce response limits in search_traces, get_trace_errors, and get_trace_topology

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_errors.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_errors.go
@@ -21,15 +21,18 @@ import (
 // This tool retrieves all spans with error status from a specific trace, returning full
 // OTLP span details including attributes, events, and links for error analysis.
 type getTraceErrorsHandler struct {
-	queryService queryServiceGetTracesInterface
+	queryService             queryServiceGetTracesInterface
+	maxSpanDetailsPerRequest int
 }
 
 // NewGetTraceErrorsHandler creates a new get_trace_errors handler and returns the handler function.
 func NewGetTraceErrorsHandler(
 	queryService *querysvc.QueryService,
+	maxSpanDetailsPerRequest int,
 ) mcp.ToolHandlerFor[types.GetTraceErrorsInput, types.GetTraceErrorsOutput] {
 	h := &getTraceErrorsHandler{
-		queryService: queryService,
+		queryService:             queryService,
+		maxSpanDetailsPerRequest: maxSpanDetailsPerRequest,
 	}
 	return h.handle
 }
@@ -51,8 +54,11 @@ func (h *getTraceErrorsHandler) handle(
 	// Wrap with AggregateTraces to ensure each ptrace.Traces contains a complete trace
 	aggregatedIter := jptrace.AggregateTraces(tracesIter)
 
-	// Collect spans with error status
+	// Collect spans with error status.
+	// We always count every error span so ErrorCount reflects the true total,
+	// but we only collect full span details up to the configured limit.
 	var errorSpans []types.SpanDetail
+	totalErrors := 0
 	traceFound := false
 
 	for trace, err := range aggregatedIter {
@@ -62,12 +68,14 @@ func (h *getTraceErrorsHandler) handle(
 
 		traceFound = true
 
-		// Iterate through all spans in the trace
 		for pos, span := range jptrace.SpanIter(trace) {
-			// Check if span has error status
 			if span.Status().Code() == ptrace.StatusCodeError {
-				detail := buildSpanDetail(pos, span)
-				errorSpans = append(errorSpans, detail)
+				totalErrors++
+
+				limited := h.maxSpanDetailsPerRequest > 0 && len(errorSpans) >= h.maxSpanDetailsPerRequest
+				if !limited {
+					errorSpans = append(errorSpans, buildSpanDetail(pos, span))
+				}
 			}
 		}
 	}
@@ -78,7 +86,7 @@ func (h *getTraceErrorsHandler) handle(
 
 	output := types.GetTraceErrorsOutput{
 		TraceID:    input.TraceID,
-		ErrorCount: len(errorSpans),
+		ErrorCount: totalErrors,
 		Spans:      errorSpans,
 	}
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_errors_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_errors_test.go
@@ -153,7 +153,7 @@ func TestGetTraceErrorsHandler_Handle_SingleError(t *testing.T) {
 }
 
 func TestGetTraceErrorsHandler_Handle_MissingTraceID(t *testing.T) {
-	handler := NewGetTraceErrorsHandler(nil)
+	handler := NewGetTraceErrorsHandler(nil, 0)
 
 	input := types.GetTraceErrorsInput{
 		TraceID: "",
@@ -166,7 +166,7 @@ func TestGetTraceErrorsHandler_Handle_MissingTraceID(t *testing.T) {
 }
 
 func TestGetTraceErrorsHandler_Handle_InvalidTraceID(t *testing.T) {
-	handler := NewGetTraceErrorsHandler(nil)
+	handler := NewGetTraceErrorsHandler(nil, 0)
 
 	input := types.GetTraceErrorsInput{
 		TraceID: "invalid-trace-id",
@@ -371,4 +371,55 @@ func TestGetTraceErrorsHandler_Handle_ErrorSpanWithEvents(t *testing.T) {
 	assert.Equal(t, "exception", span.Events[0].Name)
 	assert.Equal(t, "RuntimeError", span.Events[0].Attributes["exception.type"])
 	assert.Equal(t, "Something went wrong", span.Events[0].Attributes["exception.message"])
+}
+
+func TestGetTraceErrorsHandler_Handle_MaxSpanDetailsEnforced(t *testing.T) {
+	traceID := testTraceID
+
+	spanConfigs := []spanConfig{
+		{spanID: "span001", operation: "/err1", hasError: true, errorMessage: "Error 1"},
+		{spanID: "span002", operation: "/err2", hasError: true, errorMessage: "Error 2"},
+		{spanID: "span003", operation: "/err3", hasError: true, errorMessage: "Error 3"},
+		{spanID: "span004", operation: "/err4", hasError: true, errorMessage: "Error 4"},
+		{spanID: "span005", operation: "/err5", hasError: true, errorMessage: "Error 5"},
+	}
+
+	testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+	mock := newMockYieldingTraces(testTrace)
+
+	handler := &getTraceErrorsHandler{queryService: mock, maxSpanDetailsPerRequest: 3}
+
+	input := types.GetTraceErrorsInput{TraceID: traceID}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Equal(t, traceID, output.TraceID)
+	// ErrorCount reflects the true total, not the truncated slice length
+	assert.Equal(t, 5, output.ErrorCount)
+	assert.Len(t, output.Spans, 3)
+}
+
+func TestGetTraceErrorsHandler_Handle_UnlimitedWhenZero(t *testing.T) {
+	traceID := testTraceID
+
+	spanConfigs := []spanConfig{
+		{spanID: "span001", operation: "/err1", hasError: true, errorMessage: "Error 1"},
+		{spanID: "span002", operation: "/err2", hasError: true, errorMessage: "Error 2"},
+		{spanID: "span003", operation: "/err3", hasError: true, errorMessage: "Error 3"},
+	}
+
+	testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+	mock := newMockYieldingTraces(testTrace)
+
+	// maxSpanDetailsPerRequest=0 means unlimited
+	handler := &getTraceErrorsHandler{queryService: mock, maxSpanDetailsPerRequest: 0}
+
+	input := types.GetTraceErrorsInput{TraceID: traceID}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, output.ErrorCount)
+	assert.Len(t, output.Spans, 3)
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology.go
@@ -24,15 +24,18 @@ import (
 // This tool returns the structural tree of a trace showing parent-child relationships,
 // timing, and error locations WITHOUT returning attributes or logs to keep the response compact.
 type getTraceTopologyHandler struct {
-	queryService queryServiceGetTracesInterface
+	queryService             queryServiceGetTracesInterface
+	maxSpanDetailsPerRequest int
 }
 
 // NewGetTraceTopologyHandler creates a new get_trace_topology handler and returns the handler function.
 func NewGetTraceTopologyHandler(
 	queryService *querysvc.QueryService,
+	maxSpanDetailsPerRequest int,
 ) mcp.ToolHandlerFor[types.GetTraceTopologyInput, types.GetTraceTopologyOutput] {
 	h := &getTraceTopologyHandler{
-		queryService: queryService,
+		queryService:             queryService,
+		maxSpanDetailsPerRequest: maxSpanDetailsPerRequest,
 	}
 	return h.handle
 }
@@ -80,6 +83,10 @@ func (h *getTraceTopologyHandler) handle(
 		// Iterate through all spans in the trace and collect them
 		for pos, span := range jptrace.SpanIter(trace) {
 			spans = append(spans, extractRawSpan(pos, span))
+
+			if h.maxSpanDetailsPerRequest > 0 && len(spans) >= h.maxSpanDetailsPerRequest {
+				break
+			}
 		}
 	}
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology_test.go
@@ -338,7 +338,7 @@ func TestGetTraceTopologyHandler_Handle_NoAttributes(t *testing.T) {
 }
 
 func TestGetTraceTopologyHandler_Handle_MissingTraceID(t *testing.T) {
-	handler := NewGetTraceTopologyHandler(nil)
+	handler := NewGetTraceTopologyHandler(nil, 0)
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, types.GetTraceTopologyInput{})
 
@@ -347,7 +347,7 @@ func TestGetTraceTopologyHandler_Handle_MissingTraceID(t *testing.T) {
 }
 
 func TestGetTraceTopologyHandler_Handle_InvalidTraceID(t *testing.T) {
-	handler := NewGetTraceTopologyHandler(nil)
+	handler := NewGetTraceTopologyHandler(nil, 0)
 
 	input := types.GetTraceTopologyInput{TraceID: "invalid-trace-id"}
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, input)
@@ -568,4 +568,53 @@ func TestGetTraceTopologyHandler_Handle_DFSOrder(t *testing.T) {
 	// DFS: A and its subtree come before B.
 	assert.Less(t, indexOf["C"], indexOf["B"])
 	assert.Less(t, indexOf["D"], indexOf["B"])
+}
+
+func TestGetTraceTopologyHandler_Handle_MaxSpanDetailsEnforced(t *testing.T) {
+	traceID := testTraceID
+
+	// Create 5 spans, but set limit to 3
+	spanConfigs := []spanConfig{
+		{spanID: "span001", operation: "root"},
+		{spanID: "span002", operation: "child1", parentSpanID: "span001"},
+		{spanID: "span003", operation: "child2", parentSpanID: "span001"},
+		{spanID: "span004", operation: "child3", parentSpanID: "span001"},
+		{spanID: "span005", operation: "child4", parentSpanID: "span001"},
+	}
+
+	testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+	mock := newMockYieldingTraces(testTrace)
+
+	handler := &getTraceTopologyHandler{queryService: mock, maxSpanDetailsPerRequest: 3}
+
+	input := types.GetTraceTopologyInput{TraceID: traceID, Depth: 0}
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	// Topology is built from the collected spans, which should be capped at 3
+	assert.LessOrEqual(t, len(output.Spans), 3)
+}
+
+func TestGetTraceTopologyHandler_Handle_UnlimitedWhenZero(t *testing.T) {
+	traceID := testTraceID
+
+	spanConfigs := []spanConfig{
+		{spanID: "span001", operation: "root"},
+		{spanID: "span002", operation: "child1", parentSpanID: "span001"},
+		{spanID: "span003", operation: "child2", parentSpanID: "span001"},
+		{spanID: "span004", operation: "child3", parentSpanID: "span001"},
+		{spanID: "span005", operation: "child4", parentSpanID: "span001"},
+	}
+
+	testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+	mock := newMockYieldingTraces(testTrace)
+
+	// maxSpanDetailsPerRequest=0 means unlimited
+	handler := &getTraceTopologyHandler{queryService: mock, maxSpanDetailsPerRequest: 0}
+
+	input := types.GetTraceTopologyInput{TraceID: traceID, Depth: 0}
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Len(t, output.Spans, 5)
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -78,6 +78,10 @@ func (h *searchTracesHandler) handle(
 
 		summary := buildTraceSummary(trace)
 		summaries = append(summaries, summary)
+
+		if h.maxResults > 0 && len(summaries) >= h.maxResults {
+			break
+		}
 	}
 
 	output := types.SearchTracesOutput{Traces: summaries}
@@ -144,7 +148,7 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	if searchDepth <= 0 {
 		searchDepth = defaultSearchDepth
 	}
-	if searchDepth > h.maxResults {
+	if h.maxResults > 0 && searchDepth > h.maxResults {
 		searchDepth = h.maxResults
 	}
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -476,3 +476,57 @@ func TestSearchTracesHandler_Handle_DefaultStartTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, output.Traces, 1)
 }
+
+func TestSearchTracesHandler_Handle_MaxResultsEnforced(t *testing.T) {
+	trace1 := createTestTrace("trace001", "svc", "/a", false)
+	trace2 := createTestTrace("trace002", "svc", "/b", false)
+	trace3 := createTestTrace("trace003", "svc", "/c", false)
+
+	mock := &mockQueryService{
+		findTracesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+			return func(yield func([]ptrace.Traces, error) bool) {
+				yield([]ptrace.Traces{trace1}, nil)
+				yield([]ptrace.Traces{trace2}, nil)
+				yield([]ptrace.Traces{trace3}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 2}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "svc",
+	}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Len(t, output.Traces, 2)
+}
+
+func TestSearchTracesHandler_Handle_SearchDepthNotClampedWhenUnlimited(t *testing.T) {
+	testTrace := createTestTrace("trace001", "svc", "/a", false)
+
+	mock := &mockQueryService{
+		findTracesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+			// When maxResults=0 (unlimited), searchDepth should not be clamped to 0
+			assert.Equal(t, 50, query.SearchDepth)
+			return func(yield func([]ptrace.Traces, error) bool) {
+				yield([]ptrace.Traces{testTrace}, nil)
+			}
+		},
+	}
+
+	// maxResults=0 means unlimited — searchDepth must not be clamped
+	handler := &searchTracesHandler{queryService: mock, maxResults: 0}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "svc",
+		SearchDepth:  50,
+	}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -155,12 +155,12 @@ func (s *server) registerTools() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name:        "get_trace_errors",
 		Description: "Get full details for all spans with error status.",
-	}, handlers.NewGetTraceErrorsHandler(s.queryAPI))
+	}, handlers.NewGetTraceErrorsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name:        "get_trace_topology",
 		Description: "Get the structural topology of a trace as a flat, depth-first list of spans. Each span's 'path' field encodes ancestry as slash-delimited span IDs (e.g. rootID/parentID/spanID). Does NOT return attributes or logs.",
-	}, handlers.NewGetTraceTopologyHandler(s.queryAPI))
+	}, handlers.NewGetTraceTopologyHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name:        "get_critical_path",


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #8118

`MaxSpanDetailsPerRequest` and `MaxSearchResults` are defined in the config but not consistently enforced across all MCP handlers. Unbounded responses risk high memory usage, oversized HTTP payloads, and exceeding LLM context windows.

## Description of the changes

| Handler | Before | After |
|---|---|---|
| `search_traces` | `searchDepth` passed to query but aggregation loop uncapped | Breaks once `MaxSearchResults` is reached |
| `get_trace_errors` | Collected all error spans — no cap | Caps `Spans` slice at `MaxSpanDetailsPerRequest` while still counting all errors so `ErrorCount` reflects the **true total** |
| `get_trace_topology` | Collected all spans — no cap | Breaks once `MaxSpanDetailsPerRequest` is reached |
| `server.go` | `NewGetTraceErrorsHandler` / `NewGetTraceTopologyHandler` called without limit | Now pass `MaxSpanDetailsPerRequest` |

Additionally fixes a bug in `search_traces` where `searchDepth` was incorrectly clamped to `0` when `maxResults == 0` (unlimited).

### Design choice: `ErrorCount` reflects true total

`get_trace_errors` continues iterating **all** spans even after the detail limit is reached. This lets `ErrorCount` report the true number of errors in the trace, giving the LLM full context about error scope even when span details are truncated. For example, `ErrorCount: 47, Spans: [3 items]` tells the model "this trace is very unhealthy" — information lost if we stopped counting at the limit.

The guard uses `> 0` so a zero-value limit (e.g. in test struct literals) means unlimited, avoiding any test breakage.

## How was this change tested?

- `TestSearchTracesHandler_Handle_MaxResultsEnforced` — 3 traces, limit 2, asserts `len(Traces) == 2`
- `TestSearchTracesHandler_Handle_SearchDepthNotClampedWhenUnlimited` — `maxResults=0`, `searchDepth=50`, asserts depth is preserved
- `TestGetTraceErrorsHandler_Handle_MaxSpanDetailsEnforced` — 5 error spans, limit 3, asserts `ErrorCount == 5` and `len(Spans) == 3`
- `TestGetTraceErrorsHandler_Handle_UnlimitedWhenZero` — `maxSpanDetailsPerRequest=0`, all spans returned
- `TestGetTraceTopologyHandler_Handle_MaxSpanDetailsEnforced` — 5 spans, limit 3, asserts `len(Spans) <= 3`
- `TestGetTraceTopologyHandler_Handle_UnlimitedWhenZero` — `maxSpanDetailsPerRequest=0`, all spans returned
- All existing tests updated and passing
- `make fmt && make lint && make test` — all green

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run `make lint` and `make test` successfully

> **AI disclosure:** Light — used for researching existing patterns and generating test scaffolding.