### PR TITLE
[jaegermcp] Fix searchDepth clamped to zero when maxResults is unlimited

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -147,7 +147,7 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	if searchDepth <= 0 {
 		searchDepth = defaultSearchDepth
 	}
-	if searchDepth > h.maxResults {
+	if h.maxResults > 0 && searchDepth > h.maxResults {
 		searchDepth = h.maxResults
 	}
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -513,3 +513,28 @@ func TestSearchTracesHandler_Handle_LimitEnforced(t *testing.T) {
 	// Returned traces are capped at exactly the limit (5 traces, limit=3 → exactly 3 traces)
 	assert.Len(t, output.Traces, 3)
 }
+
+func TestSearchTracesHandler_Handle_SearchDepthNotClampedWhenUnlimited(t *testing.T) {
+	testTrace := createTestTrace("trace001", "svc", "/a", false)
+
+	mock := &mockQueryService{
+		findTracesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+			// When maxResults=0 (unlimited), searchDepth must not be clamped to 0
+			assert.Equal(t, 50, query.SearchDepth)
+			return func(yield func([]ptrace.Traces, error) bool) {
+				yield([]ptrace.Traces{testTrace}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 0}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "svc",
+		SearchDepth:  50,
+	}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Follow-up to #8242. When `MaxSearchResults` is `0` (unlimited), the `searchDepth` clamp incorrectly evaluates `10 > 0` as true and sets `searchDepth` to `0`. This causes the storage query to request zero results even though the config intends no limit.

## Description of the changes

One-line guard: `if h.maxResults > 0 && searchDepth > h.maxResults`

Without the guard, the default `searchDepth` of 10 is always clamped to 0 when `maxResults` is 0 (unlimited), making `search_traces` return empty results.

## How was this change tested?

- `TestSearchTracesHandler_Handle_SearchDepthNotClampedWhenUnlimited` — sets `maxResults=0` with `searchDepth=50`, asserts the query receives `searchDepth=50` unchanged
- All existing tests pass
- `make fmt && make lint && make test` — all green

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run `make lint` and `make test` successfully