### PR TITLE
Fix 'req' not found error

### DIFF
--- a/scripts/release/notes.py
+++ b/scripts/release/notes.py
@@ -43,7 +43,7 @@ def print_token_error():
     sys.exit(1)
 
 
-def github_api_request(url, token, additional_headers=None):
+def github_api_request(url, token, verbose, additional_headers=None):
     """Make a GitHub API request with error handling.
 
     Args:
@@ -60,6 +60,8 @@ def github_api_request(url, token, additional_headers=None):
         if additional_headers:
             for header, value in additional_headers.items():
                 req.add_header(header, value)
+        if verbose:
+            eprint(req.full_url)
         return json.loads(urlopen(req).read())
     except HTTPError as e:
         if e.code == 401:
@@ -69,10 +71,10 @@ def github_api_request(url, token, additional_headers=None):
 
 def num_commits_since_prev_tag(token, base_url, branch, verbose):
     tags_url = f"{base_url}/tags"
-    tags = github_api_request(tags_url, token)
+    tags = github_api_request(tags_url, token, verbose)
     prev_release_tag = tags[0]['name']
     compare_url = f"{base_url}/compare/{branch}...{prev_release_tag}"
-    compare_results = github_api_request(compare_url, token)
+    compare_results = github_api_request(compare_url, token, verbose)
     num_commits = compare_results['behind_by']
 
     if verbose:
@@ -118,10 +120,9 @@ def main(token, repo, branch, num_commits, exclude_dependabot, verbose):
 
     # Load commits
     data = urllib.parse.urlencode({'per_page': num_commits})
-    commits = github_api_request(commits_url + '?' + data, token)
+    commits = github_api_request(commits_url + '?' + data, token, verbose)
 
     if verbose:
-        eprint(req.full_url)
         eprint('Retrieved', len(commits), 'commits')
 
     # Load PR for each commit and print summary
@@ -146,7 +147,7 @@ def main(token, repo, branch, num_commits, exclude_dependabot, verbose):
 
         msg_lines = commit['commit']['message'].split('\n')
         msg = msg_lines[0].capitalize()
-        pulls = github_api_request(f"{commits_url}/{sha}/pulls", token, {'accept': accept_header})
+        pulls = github_api_request(f"{commits_url}/{sha}/pulls", token, verbose, {'accept': accept_header})
         if len(pulls) > 1:
             print(f"WARNING: More than one pull request for commit {sha}")
 
@@ -165,7 +166,7 @@ def main(token, repo, branch, num_commits, exclude_dependabot, verbose):
         msg = msg.replace(f'(#{pull_id})', '').strip()
 
         # Check if the pull request has changelog label
-        pull_labels = get_pull_request_labels(token, repo, pull_id)
+        pull_labels = get_pull_request_labels(token, repo, pull_id, verbose)
         changelog_labels = [label for label in pull_labels if label.startswith('changelog:')]
 
         # Handle multiple changelog labels
@@ -221,9 +222,9 @@ def main(token, repo, branch, num_commits, exclude_dependabot, verbose):
             eprint(f"(Skipped dependabot commits: {skipped_dependabot})")
 
 
-def get_pull_request_labels(token, repo, pull_number):
+def get_pull_request_labels(token, repo, pull_number, verbose):
     labels_url = f"https://api.github.com/repos/jaegertracing/{repo}/issues/{pull_number}/labels"
-    labels = github_api_request(labels_url, token)
+    labels = github_api_request(labels_url, token, verbose)
     return [label['name'] for label in labels]
 
 


### PR DESCRIPTION

## Which problem is this PR solving?
- Fixes a `NameError: name 'req' is not defined` error when running `make prepare-release VERSION=v2.17.0` from jaeger-ui.

## Description of the changes
- Moves the line in question to the request creation function, passing the verbose boolean to the function, along with any transient function calls.

## How was this change tested?
- Able to complete `make prepare-release VERSION=v2.17.0` without error (which exercises `verbose` mode as well).

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
