### PR TITLE
[es] Use single loop for special tag processing in from_dbmodel

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
@@ -102,18 +102,32 @@ func dbSpanToSpan(dbSpan *dbmodel.Span, span ptrace.Span) error {
 	endTime := startTime.Add(duration)
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(endTime))
 
-	// TODO rewrite this to use a single loop over tags
-	// and map special tag names to OTEL Span fields
+	// Process tags in a single loop, mapping special tag names
+	// directly to OTEL Span fields instead of adding then removing.
 	attrs := span.Attributes()
 	attrs.EnsureCapacity(len(dbSpan.Tags))
-	dbTagsToAttributes(dbSpan.Tags, attrs)
-	if spanKindAttr, ok := attrs.Get(model.SpanKindKey); ok {
-		span.SetKind(dbSpanKindToOTELSpanKind(spanKindAttr.Str()))
-		attrs.Remove(model.SpanKindKey)
+	var statusTags collectedStatusTags
+	for i, tag := range dbSpan.Tags {
+		switch tag.Key {
+		case model.SpanKindKey:
+			if v, ok := tag.Value.(string); ok {
+				span.SetKind(dbSpanKindToOTELSpanKind(v))
+			}
+		case tagW3CTraceState:
+			if v, ok := tag.Value.(string); ok {
+				span.TraceState().FromRaw(v)
+			}
+		case tagError:
+			statusTags.errorTag = &dbSpan.Tags[i]
+		case conventions.OtelStatusCode:
+			statusTags.statusCode = &dbSpan.Tags[i]
+		case conventions.OtelStatusDescription:
+			statusTags.statusDesc = &dbSpan.Tags[i]
+		default:
+			dbTagToAttribute(tag, attrs)
+		}
 	}
-	setSpanStatus(attrs, span)
-
-	span.TraceState().FromRaw(getTraceStateFromAttrs(attrs))
+	resolveSpanStatus(attrs, span, statusTags)
 
 	// drop the attributes slice if all of them were replaced during translation
 	if attrs.Len() == 0 {
@@ -133,58 +147,63 @@ func dbSpanToSpan(dbSpan *dbmodel.Span, span ptrace.Span) error {
 
 func dbTagsToAttributes(tags []dbmodel.KeyValue, attributes pcommon.Map) {
 	for _, tag := range tags {
-		tagValue, ok := tag.Value.(string)
-		if !ok {
-			switch tag.Type {
-			case dbmodel.Float64Type, dbmodel.Int64Type:
-				fromDBNumber(tag, attributes)
-			case dbmodel.BoolType:
-				v, ok := tag.Value.(bool)
-				if !ok {
-					recordTagInvalidTypeError(tag, attributes)
-				} else {
-					attributes.PutBool(tag.Key, v)
-				}
-			default:
-				// This means type is string/binary but value is of non string type, hence record the type error
-				recordTagInvalidTypeError(tag, attributes)
-			}
-			continue
-		}
+		dbTagToAttribute(tag, attributes)
+	}
+}
+
+// dbTagToAttribute converts a single DB KeyValue tag to an OTEL attribute.
+func dbTagToAttribute(tag dbmodel.KeyValue, attributes pcommon.Map) {
+	tagValue, ok := tag.Value.(string)
+	if !ok {
 		switch tag.Type {
-		case dbmodel.StringType:
-			attributes.PutStr(tag.Key, tagValue)
+		case dbmodel.Float64Type, dbmodel.Int64Type:
+			fromDBNumber(tag, attributes)
 		case dbmodel.BoolType:
-			convBoolVal, err := strconv.ParseBool(tagValue)
-			if err != nil {
-				recordTagConversionError(tag, err, attributes)
+			v, ok := tag.Value.(bool)
+			if !ok {
+				recordTagInvalidTypeError(tag, attributes)
 			} else {
-				attributes.PutBool(tag.Key, convBoolVal)
-			}
-		case dbmodel.Int64Type:
-			intVal, err := strconv.ParseInt(tagValue, 10, 64)
-			if err != nil {
-				recordTagConversionError(tag, err, attributes)
-			} else {
-				attributes.PutInt(tag.Key, intVal)
-			}
-		case dbmodel.Float64Type:
-			floatVal, err := strconv.ParseFloat(tagValue, 64)
-			if err != nil {
-				recordTagConversionError(tag, err, attributes)
-			} else {
-				attributes.PutDouble(tag.Key, floatVal)
-			}
-		case dbmodel.BinaryType:
-			value, err := hex.DecodeString(tagValue)
-			if err != nil {
-				recordTagConversionError(tag, err, attributes)
-			} else {
-				attributes.PutEmptyBytes(tag.Key).FromRaw(value)
+				attributes.PutBool(tag.Key, v)
 			}
 		default:
-			attributes.PutStr(tag.Key, fmt.Sprintf("<Unknown Jaeger TagType %q>", tag.Type))
+			// This means type is string/binary but value is of non string type, hence record the type error
+			recordTagInvalidTypeError(tag, attributes)
 		}
+		return
+	}
+	switch tag.Type {
+	case dbmodel.StringType:
+		attributes.PutStr(tag.Key, tagValue)
+	case dbmodel.BoolType:
+		convBoolVal, err := strconv.ParseBool(tagValue)
+		if err != nil {
+			recordTagConversionError(tag, err, attributes)
+		} else {
+			attributes.PutBool(tag.Key, convBoolVal)
+		}
+	case dbmodel.Int64Type:
+		intVal, err := strconv.ParseInt(tagValue, 10, 64)
+		if err != nil {
+			recordTagConversionError(tag, err, attributes)
+		} else {
+			attributes.PutInt(tag.Key, intVal)
+		}
+	case dbmodel.Float64Type:
+		floatVal, err := strconv.ParseFloat(tagValue, 64)
+		if err != nil {
+			recordTagConversionError(tag, err, attributes)
+		} else {
+			attributes.PutDouble(tag.Key, floatVal)
+		}
+	case dbmodel.BinaryType:
+		value, err := hex.DecodeString(tagValue)
+		if err != nil {
+			recordTagConversionError(tag, err, attributes)
+		} else {
+			attributes.PutEmptyBytes(tag.Key).FromRaw(value)
+		}
+	default:
+		attributes.PutStr(tag.Key, fmt.Sprintf("<Unknown Jaeger TagType %q>", tag.Type))
 	}
 }
 
@@ -229,81 +248,113 @@ func recordTagConversionError(kv dbmodel.KeyValue, err error, dest pcommon.Map) 
 	dest.PutStr(kv.Key, fmt.Sprintf("Can't convert the type %s for the key %s: %v", string(kv.Type), kv.Key, err))
 }
 
-func setSpanStatus(attrs pcommon.Map, span ptrace.Span) {
+// collectedStatusTags holds special tags collected during the single-pass loop
+// that are needed for span status resolution.
+type collectedStatusTags struct {
+	errorTag   *dbmodel.KeyValue
+	statusCode *dbmodel.KeyValue
+	statusDesc *dbmodel.KeyValue
+}
+
+// errorTagAsBool checks if an error tag would convert to a boolean attribute.
+// Returns the boolean value and whether the tag represents a valid boolean.
+func errorTagAsBool(tag dbmodel.KeyValue) (value bool, isBool bool) {
+	if tag.Type != dbmodel.BoolType {
+		return false, false
+	}
+	switch v := tag.Value.(type) {
+	case bool:
+		return v, true
+	case string:
+		parsed, err := strconv.ParseBool(v)
+		return parsed, err == nil
+	default:
+		return false, false
+	}
+}
+
+// resolveSpanStatus determines the span status from collected special tags.
+// Priority: error tag > otel.status_code > HTTP status code (from attrs).
+// Tags not consumed by status resolution are added back to attrs.
+func resolveSpanStatus(attrs pcommon.Map, span ptrace.Span, tags collectedStatusTags) {
 	dest := span.Status()
 	statusCode := ptrace.StatusCodeUnset
 	statusMessage := ""
 	statusExists := false
+	statusDescConsumed := false
 
-	if errorVal, ok := attrs.Get(tagError); ok && errorVal.Type() == pcommon.ValueTypeBool {
-		if errorVal.Bool() {
-			statusCode = ptrace.StatusCodeError
-			attrs.Remove(tagError)
-			statusExists = true
-			if desc, ok := extractStatusDescFromAttr(attrs); ok {
-				statusMessage = desc
-			} else if descAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
-				statusMessage = descAttr.Str()
+	// 1. Error tag has highest priority
+	if tags.errorTag != nil {
+		if errVal, isBool := errorTagAsBool(*tags.errorTag); isBool {
+			if errVal {
+				statusCode = ptrace.StatusCodeError
+				statusExists = true
+				statusDescConsumed = true
+				if tags.statusDesc != nil {
+					if v, ok := tags.statusDesc.Value.(string); ok {
+						statusMessage = v
+					}
+				} else if descAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
+					statusMessage = descAttr.Str()
+				}
+			} else {
+				// error=false: add back to attrs as bool
+				attrs.PutBool(tags.errorTag.Key, false)
 			}
+		} else {
+			// Not a valid bool: add back to attrs as regular attribute
+			dbTagToAttribute(*tags.errorTag, attrs)
 		}
 	}
 
-	if codeAttr, ok := attrs.Get(conventions.OtelStatusCode); ok {
+	// 2. otel.status_code (never added back to attrs)
+	if tags.statusCode != nil {
 		if !statusExists {
 			// The error tag is the ultimate truth for a Jaeger spans' error
 			// status. Only parse the otel.status_code tag if the error tag is
 			// not set to true.
 			statusExists = true
-			switch strings.ToUpper(codeAttr.Str()) {
-			case statusOk:
-				statusCode = ptrace.StatusCodeOk
-			case statusError:
-				statusCode = ptrace.StatusCodeError
-			default:
-				statusCode = ptrace.StatusCodeUnset
+			statusDescConsumed = true
+			if v, ok := tags.statusCode.Value.(string); ok {
+				switch strings.ToUpper(v) {
+				case statusOk:
+					statusCode = ptrace.StatusCodeOk
+				case statusError:
+					statusCode = ptrace.StatusCodeError
+				default:
+					statusCode = ptrace.StatusCodeUnset
+				}
 			}
-
-			if desc, ok := extractStatusDescFromAttr(attrs); ok {
-				statusMessage = desc
-			}
-		}
-		// Regardless of error tag inputValue, remove the otel.status_code tag. The
-		// otel.status_message tag will have already been removed if
-		// statusExists is true.
-		attrs.Remove(conventions.OtelStatusCode)
-	} else if httpCodeAttr, ok := attrs.Get(string(conventions.HTTPResponseStatusCodeKey)); !statusExists && ok {
-		// Fallback to introspecting if this span represents a failed HTTP
-		// request or response, but again, only do so if the `error` tag was
-		// not set to true and no explicit status was sent.
-		if code, err := getStatusCodeFromHTTPStatusAttr(httpCodeAttr, span.Kind()); err == nil {
-			if code != ptrace.StatusCodeUnset {
-				statusExists = true
-				statusCode = code
-			}
-
-			if msgAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
-				statusMessage = msgAttr.Str()
+			if tags.statusDesc != nil {
+				if v, ok := tags.statusDesc.Value.(string); ok {
+					statusMessage = v
+				}
 			}
 		}
+	} else if !statusExists {
+		// 3. Fallback to HTTP status code (reads from attrs, never removes)
+		if httpCodeAttr, ok := attrs.Get(string(conventions.HTTPResponseStatusCodeKey)); ok {
+			if code, err := getStatusCodeFromHTTPStatusAttr(httpCodeAttr, span.Kind()); err == nil {
+				if code != ptrace.StatusCodeUnset {
+					statusExists = true
+					statusCode = code
+				}
+				if msgAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
+					statusMessage = msgAttr.Str()
+				}
+			}
+		}
+	}
+
+	// Add back otel.status_description if it wasn't consumed by status resolution
+	if tags.statusDesc != nil && !statusDescConsumed {
+		dbTagToAttribute(*tags.statusDesc, attrs)
 	}
 
 	if statusExists {
 		dest.SetCode(statusCode)
 		dest.SetMessage(statusMessage)
 	}
-}
-
-// extractStatusDescFromAttr returns the OTel status description from attrs
-// along with true if it is set. Otherwise, an empty string and false are
-// returned. The OTel status description attribute is deleted from attrs in
-// the process.
-func extractStatusDescFromAttr(attrs pcommon.Map) (string, bool) {
-	if msgAttr, ok := attrs.Get(conventions.OtelStatusDescription); ok {
-		msg := msgAttr.Str()
-		attrs.Remove(conventions.OtelStatusDescription)
-		return msg, true
-	}
-	return "", false
 }
 
 // codeFromAttr returns the integer code inputValue from attrVal. An error is
@@ -430,16 +481,6 @@ func dbSpanRefsToSpanEvents(refs []dbmodel.Reference, excludeParentID dbmodel.Sp
 		link.Attributes().PutStr(conventions.AttributeOpentracingRefType, dbRefTypeToAttribute(ref.RefType))
 	}
 	return nil
-}
-
-func getTraceStateFromAttrs(attrs pcommon.Map) string {
-	traceState := ""
-	// TODO Bring this inline with solution for jaegertracing/jaeger-client-java #702 once available
-	if attr, ok := attrs.Get(tagW3CTraceState); ok {
-		traceState = attr.Str()
-		attrs.Remove(tagW3CTraceState)
-	}
-	return traceState
 }
 
 func dbSpanToScope(span *dbmodel.Span, scopeSpan ptrace.ScopeSpans) {

--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
@@ -625,47 +625,51 @@ func TestDbProcessToResource(t *testing.T) {
 	}
 }
 
-func TestGetTraceStateFromAttrs(t *testing.T) {
+func TestGetTraceStateFromSpanTags(t *testing.T) {
 	tests := []struct {
 		name               string
-		attrs              map[string]any
+		tags               []dbmodel.KeyValue
 		expectedTraceState string
-		expectedAttrCount  int
 		description        string
 	}{
 		{
-			name: "attrs with w3c trace state",
-			attrs: map[string]any{
-				tagW3CTraceState: "vendor1=value1,vendor2=value2",
-				"other-attr":     "other-value",
+			name: "span with w3c trace state tag",
+			tags: []dbmodel.KeyValue{
+				{Key: tagW3CTraceState, Value: "vendor1=value1,vendor2=value2", Type: dbmodel.StringType},
+				{Key: "other-attr", Value: "other-value", Type: dbmodel.StringType},
 			},
 			expectedTraceState: "vendor1=value1,vendor2=value2",
-			expectedAttrCount:  1,
-			description:        "Should extract and remove W3C trace state",
+			description:        "Should extract W3C trace state from tags and set on span",
 		},
 		{
-			name: "attrs without w3c trace state",
-			attrs: map[string]any{
-				"other-attr": "other-value",
+			name: "span without w3c trace state tag",
+			tags: []dbmodel.KeyValue{
+				{Key: "other-attr", Value: "other-value", Type: dbmodel.StringType},
 			},
 			expectedTraceState: "",
-			expectedAttrCount:  1,
-			description:        "Should return empty string when no trace state",
+			description:        "Should have empty trace state when no w3c tag present",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attrs := pcommon.NewMap()
-			require.NoError(t, attrs.FromRaw(tt.attrs))
-			traceState := getTraceStateFromAttrs(attrs)
-			assert.Equal(t, tt.expectedTraceState, traceState, tt.description)
-			assert.Equal(t, tt.expectedAttrCount, attrs.Len(), "Attribute count should match expected")
+			dbSpan := &dbmodel.Span{
+				TraceID: dbmodel.TraceID("0123456789abcdef0123456789abcdef"),
+				SpanID:  dbmodel.SpanID("0123456789abcdef"),
+				Tags:    tt.tags,
+			}
+			span := ptrace.NewSpan()
+			err := dbSpanToSpan(dbSpan, span)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTraceState, span.TraceState().AsRaw(), tt.description)
+			// Verify w3c.tracestate was NOT added to attributes
+			_, exists := span.Attributes().Get(tagW3CTraceState)
+			assert.False(t, exists, "w3c.tracestate should not appear in attributes")
 		})
 	}
 }
 
-func TestSetInternalSpanStatus(t *testing.T) {
+func TestResolveSpanStatus(t *testing.T) {
 	okStatus := ptrace.NewStatus()
 	okStatus.SetCode(ptrace.StatusCodeOk)
 	errorStatus := ptrace.NewStatus()
@@ -679,88 +683,87 @@ func TestSetInternalSpanStatus(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		attrs            map[string]any
+		tags             []dbmodel.KeyValue
 		status           ptrace.Status
-		kind             ptrace.SpanKind
-		attrsModifiedLen int // Length of attributes map after dropping converted fields
+		attrsModifiedLen int
 	}{
 		{
 			name: "status.code is set as string",
-			attrs: map[string]any{
-				conventions.OtelStatusCode: statusOk,
+			tags: []dbmodel.KeyValue{
+				{Key: conventions.OtelStatusCode, Value: statusOk, Type: dbmodel.StringType},
 			},
 			status:           okStatus,
 			attrsModifiedLen: 0,
 		},
 		{
 			name: "status.code, status.message and error tags are set",
-			attrs: map[string]any{
-				conventions.OtelStatusCode:        statusError,
-				conventions.OtelStatusDescription: "Error: Invalid argument",
+			tags: []dbmodel.KeyValue{
+				{Key: conventions.OtelStatusCode, Value: statusError, Type: dbmodel.StringType},
+				{Key: conventions.OtelStatusDescription, Value: "Error: Invalid argument", Type: dbmodel.StringType},
 			},
 			status:           errorStatusWithMessage,
 			attrsModifiedLen: 0,
 		},
 		{
 			name: "http.status_code tag is set as string",
-			attrs: map[string]any{
-				conventions.HTTPResponseStatusCodeKey: "404",
+			tags: []dbmodel.KeyValue{
+				{Key: string(conventions.HTTPResponseStatusCodeKey), Value: "404", Type: dbmodel.StringType},
 			},
 			status:           errorStatus,
 			attrsModifiedLen: 1,
 		},
 		{
 			name: "http.status_code, http.status_message and error tags are set",
-			attrs: map[string]any{
-				conventions.HTTPResponseStatusCodeKey: 404,
-				tagHTTPStatusMsg:                      "HTTP 404: Not Found",
+			tags: []dbmodel.KeyValue{
+				{Key: string(conventions.HTTPResponseStatusCodeKey), Value: int64(404), Type: dbmodel.Int64Type},
+				{Key: tagHTTPStatusMsg, Value: "HTTP 404: Not Found", Type: dbmodel.StringType},
 			},
 			status:           errorStatusWith404Message,
 			attrsModifiedLen: 2,
 		},
 		{
-			name: "status.code has precedence over http.status_code.",
-			attrs: map[string]any{
-				conventions.OtelStatusCode:            statusOk,
-				conventions.HTTPResponseStatusCodeKey: 500,
-				tagHTTPStatusMsg:                      "Server Error",
+			name: "status.code has precedence over http.status_code",
+			tags: []dbmodel.KeyValue{
+				{Key: conventions.OtelStatusCode, Value: statusOk, Type: dbmodel.StringType},
+				{Key: string(conventions.HTTPResponseStatusCodeKey), Value: int64(500), Type: dbmodel.Int64Type},
+				{Key: tagHTTPStatusMsg, Value: "Server Error", Type: dbmodel.StringType},
 			},
 			status:           okStatus,
 			attrsModifiedLen: 2,
 		},
 		{
-			name: "status.error has precedence over http.status_error.",
-			attrs: map[string]any{
-				conventions.OtelStatusCode:            statusError,
-				conventions.HTTPResponseStatusCodeKey: 500,
-				tagHTTPStatusMsg:                      "Server Error",
+			name: "status.error has precedence over http.status_error",
+			tags: []dbmodel.KeyValue{
+				{Key: conventions.OtelStatusCode, Value: statusError, Type: dbmodel.StringType},
+				{Key: string(conventions.HTTPResponseStatusCodeKey), Value: int64(500), Type: dbmodel.Int64Type},
+				{Key: tagHTTPStatusMsg, Value: "Server Error", Type: dbmodel.StringType},
 			},
 			status:           errorStatus,
 			attrsModifiedLen: 2,
 		},
 		{
 			name: "whether tagHttpStatusMsg is set as string",
-			attrs: map[string]any{
-				conventions.HTTPResponseStatusCodeKey: 404,
-				tagHTTPStatusMsg:                      "HTTP 404: Not Found",
+			tags: []dbmodel.KeyValue{
+				{Key: string(conventions.HTTPResponseStatusCodeKey), Value: int64(404), Type: dbmodel.Int64Type},
+				{Key: tagHTTPStatusMsg, Value: "HTTP 404: Not Found", Type: dbmodel.StringType},
 			},
 			status:           errorStatusWith404Message,
 			attrsModifiedLen: 2,
 		},
 		{
 			name: "error tag set and message present",
-			attrs: map[string]any{
-				tagError:                          true,
-				conventions.OtelStatusDescription: "Error: Invalid argument",
+			tags: []dbmodel.KeyValue{
+				{Key: tagError, Value: true, Type: dbmodel.BoolType},
+				{Key: conventions.OtelStatusDescription, Value: "Error: Invalid argument", Type: dbmodel.StringType},
 			},
 			status:           errorStatusWithMessage,
 			attrsModifiedLen: 0,
 		},
 		{
 			name: "error tag set and http tag message present",
-			attrs: map[string]any{
-				tagError:         true,
-				tagHTTPStatusMsg: "HTTP 404: Not Found",
+			tags: []dbmodel.KeyValue{
+				{Key: tagError, Value: true, Type: dbmodel.BoolType},
+				{Key: tagHTTPStatusMsg, Value: "HTTP 404: Not Found", Type: dbmodel.StringType},
 			},
 			status:           errorStatusWith404Message,
 			attrsModifiedLen: 1,
@@ -769,14 +772,16 @@ func TestSetInternalSpanStatus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			dbSpan := &dbmodel.Span{
+				TraceID: dbmodel.TraceID("0123456789abcdef0123456789abcdef"),
+				SpanID:  dbmodel.SpanID("0123456789abcdef"),
+				Tags:    test.tags,
+			}
 			span := ptrace.NewSpan()
-			span.SetKind(test.kind)
-			status := span.Status()
-			attrs := pcommon.NewMap()
-			require.NoError(t, attrs.FromRaw(test.attrs))
-			setSpanStatus(attrs, span)
-			assert.Equal(t, test.status, status)
-			assert.Equal(t, test.attrsModifiedLen, attrs.Len())
+			err := dbSpanToSpan(dbSpan, span)
+			require.NoError(t, err)
+			assert.Equal(t, test.status, span.Status())
+			assert.Equal(t, test.attrsModifiedLen, span.Attributes().Len())
 		})
 	}
 }
@@ -830,17 +835,19 @@ func TestDbSpanKindToOTELSpanKind_DefaultCase(t *testing.T) {
 	assert.Equal(t, ptrace.SpanKindUnspecified, result)
 }
 
-func TestSetInternalSpanStatus_DefaultCase(t *testing.T) {
+func TestResolveSpanStatus_DefaultCase(t *testing.T) {
+	dbSpan := &dbmodel.Span{
+		TraceID: dbmodel.TraceID("0123456789abcdef0123456789abcdef"),
+		SpanID:  dbmodel.SpanID("0123456789abcdef"),
+		Tags: []dbmodel.KeyValue{
+			{Key: conventions.OtelStatusCode, Value: "UNKNOWN_STATUS", Type: dbmodel.StringType},
+		},
+	}
 	span := ptrace.NewSpan()
-	status := span.Status()
-	attrs := pcommon.NewMap()
-
-	attrs.PutStr(conventions.OtelStatusCode, "UNKNOWN_STATUS")
-
-	setSpanStatus(attrs, span)
-
-	assert.Equal(t, ptrace.StatusCodeUnset, status.Code())
-	assert.Empty(t, status.Message())
+	err := dbSpanToSpan(dbSpan, span)
+	require.NoError(t, err)
+	assert.Equal(t, ptrace.StatusCodeUnset, span.Status().Code())
+	assert.Empty(t, span.Status().Message())
 }
 
 func TestFromDbModel_Fixtures(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves the TODO in `from_dbmodel.go`:
```go
// TODO rewrite this to use a single loop over tags
// and map special tag names to OTEL Span fields
```

The previous implementation processed tags in multiple passes, first adding all tags to attributes via `dbTagsToAttributes`, then looking up and removing special tags (`span.kind`, `w3c.tracestate`, `error`, `otel.status_code`, `otel.status_description`) from the attributes map in separate functions (`setSpanStatus`, `extractStatusDescFromAttr`, `getTraceStateFromAttrs`).

## Description of the changes

- Expand the single-pass loop in `dbSpanToSpan` to intercept all 5 special tags during iteration, instead of only `span.kind` and `w3c.tracestate`
- Add `collectedStatusTags` struct to hold status-related tags collected during the loop
- Add `errorTagAsBool` helper for safe boolean type checking without modifying attributes
- Replace `setSpanStatus` and `extractStatusDescFromAttr` with `resolveSpanStatus`, which accepts collected tag values directly instead of reading/removing from attributes
- Delete the now-unused `getTraceStateFromAttrs` function
- Rewrite status tests to validate end-to-end through `dbSpanToSpan`

## How was this change tested?

- Rewrote `TestSetInternalSpanStatus` -> `TestResolveSpanStatus` (9 test cases covering otel.status_code, error tag, HTTP fallback, status description, precedence rules)
- Rewrote `TestSetInternalSpanStatus_DefaultCase` -> `TestResolveSpanStatus_DefaultCase`
- Existing tests for span kind, trace state, tag conversion, and fixtures continue to pass
- Ran `gofmt` and `go vet` with no issues

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes