### PR TITLE
tests: add empty_test.go to packages for coverage compliance

### DIFF
--- a/internal/storage/v2/elasticsearch/depstore/mocks/empty_test.go
+++ b/internal/storage/v2/elasticsearch/depstore/mocks/empty_test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+// This file is added to satisfy the requirement of having at least one test file in each package.

--- a/internal/tools/empty_test.go
+++ b/internal/tools/empty_test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+// This file is added to satisfy the requirement of having at least one test file in each package.

--- a/scripts/build/docker/debug/empty_test.go
+++ b/scripts/build/docker/debug/empty_test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+// This file is added to satisfy the requirement of having at least one test file in each package.


### PR DESCRIPTION
## Which problem is this PR solving?
This PR addresses the coverage compliance requirement enforced by `scripts/lint/check-test-files.sh`. Several packages were missing `*_test.go` files, causing the lint check to fail for code coverage reporting.

## Description of the changes
- Added `empty_test.go` to the following packages:
  - `internal/storage/v2/elasticsearch/depstore/mocks/`
  - `internal/tools/`
  - `scripts/build/docker/debug/`
- These files ensure that Go's test coverage reporting includes these package directories without requiring functional logic in the test files themselves.

## How was this change tested?
- Verified with `bash scripts/lint/check-test-files.sh .`
- Ran `go test ./...` to ensure no impact on the existing test suite.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality (N/A - fixing CI requirement)
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR
- [x] **Moderate**: AI helped identify the failing packages and generated the standard boilerplate test files.
