### PR TITLE
[docs] Fix ADR-002 hyperlink path in jaegermcp README

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/README.md
+++ b/cmd/jaeger/internal/extension/jaegermcp/README.md
@@ -14,7 +14,7 @@ This approach prevents context-window exhaustion in LLMs and enables more effici
 
 **Note:** The current implementation uses Streamable HTTP transport only. MCP `stdio` transport is not supported.
 
-See [ADR-002](../../../../docs/adr/002-mcp-server.md) for full design details.
+See [ADR-002](/docs/adr/002-mcp-server.md) for full design details.
 
 ## Available Endpoints
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Fix broken relative path for ADR-002 hyperlink in jaegermcp README.

## Description of the changes
-  Replace fragile relative path (../../../../../docs/adr/002-mcp-server.md) with absolute path from repo root (/docs/adr/002-mcp-server.md) for the ADR-002 link in cmd/jaeger/internal/extension/jaegermcp/README.md.

## How was this change tested?
- Verified the hyperlink renders correctly in GitHub's markdown preview.

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality  — N/A, markdown-only change
- [ ] I have run lint and test steps successfully: `make lint test`  — N/A, markdown-only change

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
