### PR TITLE
[clickhouse] Remove unused data skipping indexes on spans table

### DIFF
--- a/internal/storage/v2/clickhouse/sql/create_spans_table.sql
+++ b/internal/storage/v2/clickhouse/sql/create_spans_table.sql
@@ -48,11 +48,7 @@ CREATE TABLE
         scope_str_attributes Nested (key String, value String),
         scope_complex_attributes Nested (key String, value String),
         INDEX idx_trace_id trace_id TYPE bloom_filter GRANULARITY 1,
-        INDEX idx_duration duration TYPE minmax GRANULARITY 1,
-        INDEX idx_attributes_keys str_attributes.key TYPE bloom_filter GRANULARITY 1,
-        INDEX idx_attributes_values str_attributes.value TYPE bloom_filter GRANULARITY 1,
-        INDEX idx_resource_attributes_keys resource_str_attributes.key TYPE bloom_filter GRANULARITY 1,
-        INDEX idx_resource_attributes_values resource_str_attributes.value TYPE bloom_filter GRANULARITY 1,
+        INDEX idx_duration duration TYPE minmax GRANULARITY 1
     ) ENGINE = MergeTree
 PARTITION BY toDate(start_time)
 ORDER BY (service_name, name, toDateTime(start_time))


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #7814

## Description of the changes
- During a benchmark run, I realized that the bloom filter for attribute searching was not being leveraged since we use the `arrayExists` function with a lambda which cannot leverage index lookup.  

## How was this change tested?
- Benchmarking showed the 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
