### PR TITLE
fix(v2/grpc): correct 64-bit trace ID padding to be right-aligned

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -53,7 +53,11 @@ func (h *Handler) GetTraces(
 	traceIDs := make([]tracestore.GetTraceParams, len(req.Query))
 	for i, query := range req.Query {
 		var sizedTraceID [16]byte
-		copy(sizedTraceID[:], query.TraceId)
+		if len(query.TraceId) == 8 {
+			copy(sizedTraceID[8:], query.TraceId)
+		} else {
+			copy(sizedTraceID[:], query.TraceId)
+		}
 
 		traceIDs[i] = tracestore.GetTraceParams{
 			TraceID: pcommon.TraceID(sizedTraceID),

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -47,56 +47,86 @@ func (f *testStream) Send(td *jptrace.TracesData) error {
 func TestHandler_GetTraces(t *testing.T) {
 	start := time.Now()
 	end := start.Add(time.Minute)
-	query := []tracestore.GetTraceParams{
-		{
-			TraceID: pcommon.TraceID([16]byte{1}),
-			Start:   start,
-			End:     end,
-		},
-	}
 	trace := makeTestTrace()
 	td := jptrace.TracesData(trace)
 
 	tests := []struct {
-		name         string
-		traces       [][]ptrace.Traces
-		expectedSent []*jptrace.TracesData
-		sendErr      error
-		getTraceErr  error
-		expectedErr  error
+		name                 string
+		traces               [][]ptrace.Traces
+		expectedSent         []*jptrace.TracesData
+		sendErr              error
+		getTraceErr          error
+		expectedErr          error
+		inputTraceID         []byte
+		expectedParamTraceID [16]byte
 	}{
 		{
-			name:   "single trace",
-			traces: [][]ptrace.Traces{{trace}},
+			name:                 "single trace (1-byte trace ID)",
+			traces:               [][]ptrace.Traces{{trace}},
+			inputTraceID:         []byte{1},
+			expectedParamTraceID: [16]byte{1},
 			expectedSent: []*jptrace.TracesData{
 				&td,
 			},
 		},
 		{
-			name:         "multiple traces",
-			traces:       [][]ptrace.Traces{{trace, trace}},
-			expectedSent: []*jptrace.TracesData{&td, &td},
+			name:                 "single trace (8-byte trace ID)",
+			traces:               [][]ptrace.Traces{{trace}},
+			inputTraceID:         []byte{1, 2, 3, 4, 5, 6, 7, 8},
+			expectedParamTraceID: [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8},
+			expectedSent: []*jptrace.TracesData{
+				&td,
+			},
 		},
 		{
-			name:         "multiple chunks",
-			traces:       [][]ptrace.Traces{{trace, trace}, {trace, trace}},
-			expectedSent: []*jptrace.TracesData{&td, &td, &td, &td},
+			name:                 "single trace (16-byte trace ID)",
+			traces:               [][]ptrace.Traces{{trace}},
+			inputTraceID:         []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			expectedParamTraceID: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			expectedSent: []*jptrace.TracesData{
+				&td,
+			},
 		},
 		{
-			name:        "storage error",
-			getTraceErr: assert.AnError,
-			expectedErr: assert.AnError,
+			name:                 "multiple traces",
+			traces:               [][]ptrace.Traces{{trace, trace}},
+			inputTraceID:         []byte{1},
+			expectedParamTraceID: [16]byte{1},
+			expectedSent:         []*jptrace.TracesData{&td, &td},
 		},
 		{
-			name:        "send error",
-			traces:      [][]ptrace.Traces{{trace, trace}},
-			sendErr:     assert.AnError,
-			expectedErr: assert.AnError,
+			name:                 "multiple chunks",
+			traces:               [][]ptrace.Traces{{trace, trace}, {trace, trace}},
+			inputTraceID:         []byte{1},
+			expectedParamTraceID: [16]byte{1},
+			expectedSent:         []*jptrace.TracesData{&td, &td, &td, &td},
+		},
+		{
+			name:                 "storage error",
+			getTraceErr:          assert.AnError,
+			expectedErr:          assert.AnError,
+			inputTraceID:         []byte{1},
+			expectedParamTraceID: [16]byte{1},
+		},
+		{
+			name:                 "send error",
+			traces:               [][]ptrace.Traces{{trace, trace}},
+			sendErr:              assert.AnError,
+			expectedErr:          assert.AnError,
+			inputTraceID:         []byte{1},
+			expectedParamTraceID: [16]byte{1},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			query := []tracestore.GetTraceParams{
+				{
+					TraceID: pcommon.TraceID(test.expectedParamTraceID),
+					Start:   start,
+					End:     end,
+				},
+			}
 			reader := new(tracestoremocks.Reader)
 			writer := new(tracestoremocks.Writer)
 			depReader := new(depstoremocks.Reader)
@@ -120,7 +150,7 @@ func TestHandler_GetTraces(t *testing.T) {
 			err := server.GetTraces(&storage.GetTracesRequest{
 				Query: []*storage.GetTraceParams{
 					{
-						TraceId:   []byte{1},
+						TraceId:   test.inputTraceID,
 						StartTime: start,
 						EndTime:   end,
 					},

--- a/internal/storage/v2/grpc/tracereader.go
+++ b/internal/storage/v2/grpc/tracereader.go
@@ -133,7 +133,11 @@ func (tr *TraceReader) FindTraceIDs(
 		foundTraceIDs := make([]tracestore.FoundTraceID, len(resp.TraceIds))
 		for i, foundTraceID := range resp.TraceIds {
 			var sizedTraceID [16]byte
-			copy(sizedTraceID[:], foundTraceID.TraceId)
+			if len(foundTraceID.TraceId) == 8 {
+				copy(sizedTraceID[8:], foundTraceID.TraceId)
+			} else {
+				copy(sizedTraceID[:], foundTraceID.TraceId)
+			}
 
 			foundTraceIDs[i] = tracestore.FoundTraceID{
 				TraceID: pcommon.TraceID(sizedTraceID),

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -491,7 +491,7 @@ func TestTraceReader_FindTraceIDs(t *testing.T) {
 			queryParams: queryParams,
 			expectedIDs: []tracestore.FoundTraceID{
 				{
-					TraceID: pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+					TraceID: pcommon.TraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8}),
 					Start:   now,
 					End:     now.Add(1 * time.Second),
 				},


### PR DESCRIPTION


## Which problem is this PR solving?
- Resolves a 64-bit trace ID corruption issue in the v2 gRPC storage translation layer. This addresses the exact same padding bug identified in the Elasticsearch backend in #8266, but applied to the `grpc` package.

## Description of the changes
- When converting a 64-bit (8-byte) DB trace ID to an OpenTelemetry `pcommon.TraceID` (16-byte), the `copy(traceId[:], traceBytes)` function left-aligns the bytes. This corrupts the ID by appending zeros to the right instead of prepending them to the left.
- This PR fixes the padding logic in `internal/storage/v2/grpc/handler.go` and `internal/storage/v2/grpc/tracereader.go` by explicitly checking for 8-byte lengths and right-aligning them via `copy(traceId[8:], traceBytes)`. 
- It also updates the hardcoded test fixtures in `tracereader_test.go` that were previously expecting the buggy left-aligned output.
- *Note: If this structural fix looks correct to the team, I can do a full audit of the Cassandra and Badger v2 backends to ensure this padding issue isn't hiding anywhere else.*

## How was this change tested?
- Updated the existing test fixtures in `tracereader_test.go` to assert the correct right-aligned behavior. 
- Ran `go test ./internal/storage/v2/grpc/...` locally to verify all trace ID conversions pass successfully. 

## Checklist
- [x] I have read [https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [[AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy)](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes