### PR TITLE
[jaegermcp] Add MCP prompts for common investigation workflows

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -406,6 +406,74 @@ func TestMCPClientSearchTracesEmptyResults(t *testing.T) {
 	assert.NotContains(t, text, `"traces": null`)
 }
 
+// --- Prompt discovery and retrieval tests ---
+
+func TestMCPClientPromptsListDiscovery(t *testing.T) {
+	s := connectMCPSession(t, nil)
+
+	result, err := s.ListPrompts(s.ctx, nil)
+	require.NoError(t, err)
+
+	expected := []string{
+		"investigate_service",
+		"investigate_errors",
+		"investigate_latency",
+	}
+	got := make(map[string]bool, len(result.Prompts))
+	for _, p := range result.Prompts {
+		got[p.Name] = true
+	}
+	for _, name := range expected {
+		assert.True(t, got[name], "prompt %q should be discovered via prompts/list", name)
+	}
+	assert.Len(t, result.Prompts, len(expected))
+}
+
+func TestMCPClientGetPromptWithArguments(t *testing.T) {
+	s := connectMCPSession(t, nil)
+
+	result, err := s.GetPrompt(s.ctx, &mcp.GetPromptParams{
+		Name:      "investigate_service",
+		Arguments: map[string]string{"service_name": "frontend"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Messages)
+	assert.Equal(t, mcp.Role("user"), result.Messages[0].Role)
+
+	tc, ok := result.Messages[0].Content.(*mcp.TextContent)
+	require.True(t, ok, "prompt message content should be TextContent")
+	assert.Contains(t, tc.Text, "frontend")
+	assert.Contains(t, tc.Text, "search_traces")
+	assert.Contains(t, tc.Text, "get_trace_topology")
+}
+
+func TestMCPClientGetPromptMissingRequired(t *testing.T) {
+	s := connectMCPSession(t, nil)
+
+	_, err := s.GetPrompt(s.ctx, &mcp.GetPromptParams{
+		Name:      "investigate_service",
+		Arguments: map[string]string{},
+	})
+	require.Error(t, err)
+}
+
+func TestMCPClientGetPromptLatencyWithDuration(t *testing.T) {
+	s := connectMCPSession(t, nil)
+
+	result, err := s.GetPrompt(s.ctx, &mcp.GetPromptParams{
+		Name:      "investigate_latency",
+		Arguments: map[string]string{"service_name": "backend", "duration_min": "500ms"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Messages)
+
+	tc, ok := result.Messages[0].Content.(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "backend")
+	assert.Contains(t, tc.Text, "500ms")
+	assert.Contains(t, tc.Text, "get_critical_path")
+}
+
 // --- Session isolation test ---
 
 func TestMCPClientMultipleSessionsIndependent(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/prompts.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/prompts.go
@@ -124,8 +124,8 @@ func investigateLatencyPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mc
 2. Pick the slowest trace.
 3. Call get_trace_topology with that trace_id to see the service call graph.
 4. Call get_critical_path with that trace_id to find the blocking execution path.
-5. The critical path shows which spans contributed most to total latency (highest self_time).
-6. Call get_span_details for the top self_time spans on the critical path.
+5. The critical path shows which spans contributed most to total latency (highest self_time_us).
+6. Call get_span_details for the top self_time_us spans on the critical path.
 7. Summarize where time is spent and which service/operation is the bottleneck.`,
 						service, service, durationFilter),
 				},

--- a/cmd/jaeger/internal/extension/jaegermcp/prompts.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/prompts.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegermcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerPrompts registers MCP prompts that encode common investigation
+// workflows. MCP prompts are user-controlled conversation starters (unlike
+// tools which are model-controlled). Clients surface them as slash commands
+// or menu items, letting users select a workflow and fill in parameters
+// before the LLM begins reasoning.
+func (s *server) registerPrompts() {
+	s.mcpServer.AddPrompt(&mcp.Prompt{
+		Name:        "investigate_service",
+		Description: "Step-by-step workflow for investigating a service using progressive disclosure.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "service_name", Description: "Service name to investigate", Required: true},
+		},
+	}, investigateServicePrompt)
+
+	s.mcpServer.AddPrompt(&mcp.Prompt{
+		Name:        "investigate_errors",
+		Description: "Diagnose error patterns for a service by finding error traces and drilling into root causes.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "service_name", Description: "Service name to investigate", Required: true},
+		},
+	}, investigateErrorsPrompt)
+
+	s.mcpServer.AddPrompt(&mcp.Prompt{
+		Name:        "investigate_latency",
+		Description: "Identify latency bottlenecks for a service using critical path analysis.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "service_name", Description: "Service name to investigate", Required: true},
+			{Name: "duration_min", Description: "Minimum trace duration to filter for (e.g. 500ms, 2s)", Required: false},
+		},
+	}, investigateLatencyPrompt)
+}
+
+func investigateServicePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	service := req.Params.Arguments["service_name"]
+	if service == "" {
+		return nil, errors.New("service_name is required")
+	}
+
+	return &mcp.GetPromptResult{
+		Description: "Investigate service: " + service,
+		Messages: []*mcp.PromptMessage{
+			{
+				Role: "user",
+				Content: &mcp.TextContent{
+					Text: fmt.Sprintf(
+						`Investigate the service "%s" in Jaeger. Follow this workflow:
+
+1. Call search_traces with service_name="%s" and start_time_min="-1h" to find recent traces.
+2. Pick the trace with the highest span count or longest duration.
+3. Call get_trace_topology with that trace_id to see the structural overview.
+4. Identify which spans look suspicious (errors, high duration).
+5. Call get_span_details for those specific spans to see full attributes.
+6. Summarize what this service is doing, which downstream services it calls, and any issues found.`,
+						service, service),
+				},
+			},
+		},
+	}, nil
+}
+
+func investigateErrorsPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	service := req.Params.Arguments["service_name"]
+	if service == "" {
+		return nil, errors.New("service_name is required")
+	}
+
+	return &mcp.GetPromptResult{
+		Description: "Investigate errors for service: " + service,
+		Messages: []*mcp.PromptMessage{
+			{
+				Role: "user",
+				Content: &mcp.TextContent{
+					Text: fmt.Sprintf(
+						`Diagnose error patterns for the service "%s" in Jaeger. Follow this workflow:
+
+1. Call search_traces with service_name="%s", with_errors=true, and start_time_min="-1h".
+2. Pick a trace that has errors.
+3. Call get_trace_errors with that trace_id to see all error spans.
+4. Identify whether errors originate in "%s" or propagate from a downstream service.
+5. Call get_span_details for the earliest error span to see the root cause attributes and events.
+6. Summarize the error pattern: where it originates, how it propagates, and what the error message says.`,
+						service, service, service),
+				},
+			},
+		},
+	}, nil
+}
+
+func investigateLatencyPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	service := req.Params.Arguments["service_name"]
+	if service == "" {
+		return nil, errors.New("service_name is required")
+	}
+
+	durationMin := req.Params.Arguments["duration_min"]
+	durationFilter := ""
+	if durationMin != "" {
+		durationFilter = fmt.Sprintf(", duration_min=%q", durationMin)
+	}
+
+	return &mcp.GetPromptResult{
+		Description: "Investigate latency for service: " + service,
+		Messages: []*mcp.PromptMessage{
+			{
+				Role: "user",
+				Content: &mcp.TextContent{
+					Text: fmt.Sprintf(
+						`Identify latency bottlenecks for the service "%s" in Jaeger. Follow this workflow:
+
+1. Call search_traces with service_name="%s", start_time_min="-1h"%s to find slow traces.
+2. Pick the slowest trace.
+3. Call get_trace_topology with that trace_id to see the service call graph.
+4. Call get_critical_path with that trace_id to find the blocking execution path.
+5. The critical path shows which spans contributed most to total latency (highest self_time).
+6. Call get_span_details for the top self_time spans on the critical path.
+7. Summarize where time is spent and which service/operation is the bottleneck.`,
+						service, service, durationFilter),
+				},
+			},
+		},
+	}, nil
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -77,6 +77,7 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		},
 	)
 	s.registerTools()
+	s.registerPrompts()
 	s.mcpServer.AddReceivingMiddleware(createLoggingMiddleware(s.telset.Logger))
 
 	mcpHandler := mcp.NewStreamableHTTPHandler(


### PR DESCRIPTION
## Which problem is this PR solving?

- Part of #7827

The MCP server currently exposes only tools (model-controlled primitives). The MCP spec also defines **prompts** (user-controlled primitives) for pre-built conversation starters that clients surface as slash commands or menu items. Jaeger has no prompt support today.

## Use case

MCP clients like Claude Desktop show prompts as selectable actions in the UI. A user picks "investigate_latency", fills in a service name, and the LLM receives a structured message telling it exactly which tools to call and in what order. This is different from the system prompt in INSTRUCTIONS.md:

- **INSTRUCTIONS.md** is a static blob sent during initialization. It teaches the LLM what tools exist.
- **Prompts** are interactive, parameterized, and user-triggered. They tell the LLM how to solve a specific problem with specific inputs.

The investigation patterns encoded in these prompts come directly from the progressive disclosure workflow described in the ADR and INSTRUCTIONS.md.

## Description of the changes

Registers three MCP prompts via `Server.AddPrompt()`:

| Prompt | Arguments | Workflow |
|---|---|---|
| `investigate_service` | `service_name` (required) | search_traces -> get_trace_topology -> get_span_details |
| `investigate_errors` | `service_name` (required) | search_traces(with_errors) -> get_trace_errors -> get_span_details |
| `investigate_latency` | `service_name` (required), `duration_min` (optional) | search_traces -> get_trace_topology -> get_critical_path -> get_span_details |

The SDK auto-advertises the `prompts` capability when prompts are registered. No config changes needed.

**Files changed:**
- `prompts.go` (new): prompt handlers and registration
- `server.go`: +1 line calling `registerPrompts()` after `registerTools()`
- `integration_test.go`: 4 tests for prompts/list discovery, prompts/get with arguments, missing required arguments, and optional argument handling

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegermcp/...` - all passing
- `make lint` - 0 issues
- `make fmt` - clean
- Integration tests use the MCP SDK client's `ListPrompts()` and `GetPrompt()` methods

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)