### PR TITLE
feat(cassandra): implement V2 storage interfaces and V1 hooks

### DIFF
--- a/internal/storage/v1/cassandra/schema/v004-go-tmpl.cql.tmpl
+++ b/internal/storage/v1/cassandra/schema/v004-go-tmpl.cql.tmpl
@@ -18,7 +18,9 @@ CREATE TYPE IF NOT EXISTS {{.Keyspace}}.log (
 CREATE TYPE IF NOT EXISTS {{.Keyspace}}.span_ref (
     ref_type        text,
     trace_id        blob,
-    span_id         bigint
+    span_id         bigint,
+    trace_state     text,
+    tags            frozen<list<frozen<{{.Keyspace}}.keyvalue>>>
 );
 
 CREATE TYPE IF NOT EXISTS {{.Keyspace}}.process (
@@ -35,6 +37,8 @@ CREATE TABLE IF NOT EXISTS {{.Keyspace}}.traces (
     span_hash       bigint,
     parent_id       bigint,
     operation_name  text,
+    scope_name      text,
+    scope_version   text,
     flags           int,
     start_time      bigint, -- microseconds since epoch
     duration        bigint, -- microseconds

--- a/internal/storage/v1/cassandra/schema/v004-go-tmpl.cql.tmpl
+++ b/internal/storage/v1/cassandra/schema/v004-go-tmpl.cql.tmpl
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS {{.Keyspace}}.traces (
     operation_name  text,
     scope_name      text,
     scope_version   text,
+    trace_state     text,
     flags           int,
     start_time      bigint, -- microseconds since epoch
     duration        bigint, -- microseconds

--- a/internal/storage/v1/cassandra/schema/v004.cql.tmpl
+++ b/internal/storage/v1/cassandra/schema/v004.cql.tmpl
@@ -40,7 +40,9 @@ CREATE TYPE IF NOT EXISTS ${keyspace}.log (
 CREATE TYPE IF NOT EXISTS ${keyspace}.span_ref (
     ref_type        text,
     trace_id        blob,
-    span_id         bigint
+    span_id         bigint,
+    trace_state     text,
+    tags            frozen<list<frozen<${keyspace}.keyvalue>>>
 );
 
 CREATE TYPE IF NOT EXISTS ${keyspace}.process (
@@ -57,6 +59,8 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.traces (
     span_hash       bigint,
     parent_id       bigint,
     operation_name  text,
+    scope_name      text,
+    scope_version   text,
     flags           int,
     start_time      bigint, -- microseconds since epoch
     duration        bigint, -- microseconds

--- a/internal/storage/v1/cassandra/schema/v004.cql.tmpl
+++ b/internal/storage/v1/cassandra/schema/v004.cql.tmpl
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS ${keyspace}.traces (
     operation_name  text,
     scope_name      text,
     scope_version   text,
+    trace_state     text,
     flags           int,
     start_time      bigint, -- microseconds since epoch
     duration        bigint, -- microseconds

--- a/internal/storage/v1/cassandra/spanstore/dbmodel/model.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/model.go
@@ -41,6 +41,8 @@ type Span struct {
 	Process       Process
 	ServiceName   string
 	SpanHash      int64
+	ScopeName     string
+	ScopeVersion  string
 }
 
 // KeyValue is the UDT representation of a Jaeger KeyValue.
@@ -152,9 +154,11 @@ type Log struct {
 
 // SpanRef is the UDT representation of a Jaeger Span Reference.
 type SpanRef struct {
-	RefType string  `cql:"ref_type"`
-	TraceID TraceID `cql:"trace_id"`
-	SpanID  int64   `cql:"span_id"`
+	RefType    string     `cql:"ref_type"`
+	TraceID    TraceID    `cql:"trace_id"`
+	SpanID     int64      `cql:"span_id"`
+	TraceState string     `cql:"trace_state"`
+	Tags       []KeyValue `cql:"tags"`
 }
 
 // Process is the UDT representation of a Jaeger Process.

--- a/internal/storage/v1/cassandra/spanstore/dbmodel/model.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/model.go
@@ -43,6 +43,7 @@ type Span struct {
 	SpanHash      int64
 	ScopeName     string
 	ScopeVersion  string
+	TraceState    string
 }
 
 // KeyValue is the UDT representation of a Jaeger KeyValue.

--- a/internal/storage/v1/cassandra/spanstore/mocks/mocks.go
+++ b/internal/storage/v1/cassandra/spanstore/mocks/mocks.go
@@ -378,3 +378,70 @@ func (_c *CoreSpanReader_GetTrace_Call) RunAndReturn(run func(ctx context.Contex
 	_c.Call.Return(run)
 	return _c
 }
+// ReadTraceDB provides a mock function for the type CoreSpanReader
+func (_mock *CoreSpanReader) ReadTraceDB(ctx context.Context, traceID dbmodel.TraceID) ([]dbmodel.Span, error) {
+	ret := _mock.Called(ctx, traceID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReadTraceDB")
+	}
+
+	var r0 []dbmodel.Span
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, dbmodel.TraceID) ([]dbmodel.Span, error)); ok {
+		return returnFunc(ctx, traceID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, dbmodel.TraceID) []dbmodel.Span); ok {
+		r0 = returnFunc(ctx, traceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]dbmodel.Span)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, dbmodel.TraceID) error); ok {
+		r1 = returnFunc(ctx, traceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// CoreSpanReader_ReadTraceDB_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReadTraceDB'
+type CoreSpanReader_ReadTraceDB_Call struct {
+	*mock.Call
+}
+
+// ReadTraceDB is a helper method to define mock.On call
+//   - ctx context.Context
+//   - traceID dbmodel.TraceID
+func (_e *CoreSpanReader_Expecter) ReadTraceDB(ctx interface{}, traceID interface{}) *CoreSpanReader_ReadTraceDB_Call {
+	return &CoreSpanReader_ReadTraceDB_Call{Call: _e.mock.On("ReadTraceDB", ctx, traceID)}
+}
+
+func (_c *CoreSpanReader_ReadTraceDB_Call) Run(run func(ctx context.Context, traceID dbmodel.TraceID)) *CoreSpanReader_ReadTraceDB_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 dbmodel.TraceID
+		if args[1] != nil {
+			arg1 = args[1].(dbmodel.TraceID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *CoreSpanReader_ReadTraceDB_Call) Return(spans []dbmodel.Span, err error) *CoreSpanReader_ReadTraceDB_Call {
+	_c.Call.Return(spans, err)
+	return _c
+}
+
+func (_c *CoreSpanReader_ReadTraceDB_Call) RunAndReturn(run func(ctx context.Context, traceID dbmodel.TraceID) ([]dbmodel.Span, error)) *CoreSpanReader_ReadTraceDB_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/storage/v1/cassandra/spanstore/reader.go
+++ b/internal/storage/v1/cassandra/spanstore/reader.go
@@ -28,7 +28,7 @@ import (
 const (
 	bucketRange        = `(0,1,2,3,4,5,6,7,8,9)`
 	querySpanByTraceID = `
-		SELECT trace_id, span_id, parent_id, operation_name, flags, start_time, duration, tags, logs, refs, process
+		SELECT trace_id, span_id, parent_id, operation_name, flags, start_time, duration, tags, logs, refs, process, scope_name, scope_version, trace_state
 		FROM traces
 		WHERE trace_id = ?`
 	queryByTag = `
@@ -104,6 +104,7 @@ type CoreSpanReader interface {
 	GetServices(ctx context.Context) ([]string, error)
 	GetOperations(ctx context.Context, query tracestore.OperationQueryParams) ([]tracestore.Operation, error)
 	GetTrace(ctx context.Context, traceID dbmodel.TraceID) ([]dbmodel.Span, error)
+	ReadTraceDB(ctx context.Context, traceID dbmodel.TraceID) ([]dbmodel.Span, error)
 	FindTraces(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) ([]dbmodel.Trace, error)
 	FindTraceIDs(ctx context.Context, traceQuery *spanstore.TraceQueryParameters) ([]dbmodel.TraceID, error)
 }
@@ -184,7 +185,8 @@ func (s *SpanReader) readTraceInSpan(_ context.Context, traceID dbmodel.TraceID)
 	var tags []dbmodel.KeyValue
 	var logs []dbmodel.Log
 	var spans []dbmodel.Span
-	for i.Scan(&traceIDFromSpan, &spanID, &parentID, &operationName, &flags, &startTime, &duration, &tags, &logs, &refs, &dbProcess) {
+	var scopeName, scopeVersion, traceState string
+	for i.Scan(&traceIDFromSpan, &spanID, &parentID, &operationName, &flags, &startTime, &duration, &tags, &logs, &refs, &dbProcess, &scopeName, &scopeVersion, &traceState) {
 		spans = append(spans, dbmodel.Span{
 			TraceID:       traceIDFromSpan,
 			SpanID:        spanID,
@@ -198,6 +200,9 @@ func (s *SpanReader) readTraceInSpan(_ context.Context, traceID dbmodel.TraceID)
 			Refs:          refs,
 			Process:       dbProcess,
 			ServiceName:   dbProcess.ServiceName,
+			ScopeName:     scopeName,
+			ScopeVersion:  scopeVersion,
+			TraceState:    traceState,
 		})
 	}
 
@@ -211,6 +216,12 @@ func (s *SpanReader) readTraceInSpan(_ context.Context, traceID dbmodel.TraceID)
 
 // GetTrace takes a traceID and returns the spans associated with that traceID
 func (s *SpanReader) GetTrace(ctx context.Context, traceID dbmodel.TraceID) ([]dbmodel.Span, error) {
+	return s.readTrace(ctx, traceID)
+}
+
+// ReadTraceDB takes a traceID and returns the spans associated with that traceID.
+// This is a hook for V2 storage.
+func (s *SpanReader) ReadTraceDB(ctx context.Context, traceID dbmodel.TraceID) ([]dbmodel.Span, error) {
 	return s.readTrace(ctx, traceID)
 }
 

--- a/internal/storage/v1/cassandra/spanstore/reader.go
+++ b/internal/storage/v1/cassandra/spanstore/reader.go
@@ -219,8 +219,8 @@ func (s *SpanReader) GetTrace(ctx context.Context, traceID dbmodel.TraceID) ([]d
 	return s.readTrace(ctx, traceID)
 }
 
-// ReadTraceDB takes a traceID and returns the spans associated with that traceID.
-// This is a hook for V2 storage.
+// ReadTraceDB takes a traceID and returns the spans associated with that traceID in database model format.
+// This is a high-performance hook for the V2 storage engine to bypass the model.Trace layer.
 func (s *SpanReader) ReadTraceDB(ctx context.Context, traceID dbmodel.TraceID) ([]dbmodel.Span, error) {
 	return s.readTrace(ctx, traceID)
 }

--- a/internal/storage/v1/cassandra/spanstore/writer.go
+++ b/internal/storage/v1/cassandra/spanstore/writer.go
@@ -25,8 +25,8 @@ const (
 	insertSpan = `
 		INSERT
 		INTO traces(trace_id, span_id, span_hash, parent_id, operation_name, flags,
-				    start_time, duration, tags, logs, refs, process)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				    start_time, duration, tags, logs, refs, process, scope_name, scope_version, trace_state)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	serviceNameIndex = `
 		INSERT
@@ -130,22 +130,29 @@ func (s *SpanWriter) Close() error {
 }
 
 // WriteSpan saves the span into Cassandra
-func (s *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
+func (s *SpanWriter) WriteSpan(ctx context.Context, span *model.Span) error {
 	ds := dbmodel.FromDomain(span)
+	return s.WriteDBSpan(ctx, ds)
+}
+
+// WriteDBSpan saves the dbmodel.Span into Cassandra. This is a hook for V2 storage.
+func (s *SpanWriter) WriteDBSpan(_ context.Context, ds *dbmodel.Span) error {
 	if s.storageMode&storeFlag == storeFlag {
-		if err := s.writeSpanToDB(span, ds); err != nil {
+		if err := s.writeDBSpanToDB(ds); err != nil {
 			return err
 		}
 	}
 	if s.storageMode&indexFlag == indexFlag {
-		if err := s.writeIndexes(span, ds); err != nil {
+		// Attempt to index based on the DB model. Note: This assumes some fields are already populated in ds
+		// like ServiceName which is used in indexing.
+		if err := s.writeIndexesFromDB(ds); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *SpanWriter) writeSpanToDB(_ *model.Span, ds *dbmodel.Span) error {
+func (s *SpanWriter) writeDBSpanToDB(ds *dbmodel.Span) error {
 	mainQuery := s.session.Query(
 		insertSpan,
 		ds.TraceID,
@@ -160,11 +167,65 @@ func (s *SpanWriter) writeSpanToDB(_ *model.Span, ds *dbmodel.Span) error {
 		ds.Logs,
 		ds.Refs,
 		ds.Process,
+		ds.ScopeName,
+		ds.ScopeVersion,
+		ds.TraceState,
 	)
 	if err := s.writerMetrics.traces.Exec(mainQuery, s.logger); err != nil {
 		return s.logError(ds, err, "Failed to insert span", s.logger)
 	}
 	return nil
+}
+
+func (s *SpanWriter) writeIndexesFromDB(ds *dbmodel.Span) error {
+	spanKind := ""
+	for _, tag := range ds.Tags {
+		if tag.Key == model.SpanKindKey {
+			spanKind = tag.ValueString
+			break
+		}
+	}
+
+	if err := s.saveServiceNameAndOperationName(dbmodel.Operation{
+		ServiceName:   ds.ServiceName,
+		SpanKind:      spanKind,
+		OperationName: ds.OperationName,
+	}); err != nil {
+		return s.logError(ds, err, "Failed to insert service name and operation name", s.logger)
+	}
+
+	if s.indexFilter(ds, dbmodel.ServiceIndex) {
+		if err := s.indexByService(ds); err != nil {
+			return s.logError(ds, err, "Failed to index service name", s.logger)
+		}
+	}
+
+	if s.indexFilter(ds, dbmodel.OperationIndex) {
+		if err := s.indexByOperation(ds); err != nil {
+			return s.logError(ds, err, "Failed to index operation name", s.logger)
+		}
+	}
+
+	if ds.Flags&int32(model.FirehoseFlag) != 0 {
+		return nil // skipping expensive indexing
+	}
+
+	if err := s.indexByTags(ds); err != nil {
+		return s.logError(ds, err, "Failed to index tags", s.logger)
+	}
+
+	if s.indexFilter(ds, dbmodel.DurationIndex) {
+		// Convert StartTime (microseconds) back to time.Time for duration indexing
+		startTime := time.Unix(0, ds.StartTime*1000)
+		if err := s.indexByDuration(ds, startTime); err != nil {
+			return s.logError(ds, err, "Failed to index duration", s.logger)
+		}
+	}
+	return nil
+}
+
+func (s *SpanWriter) writeSpanToDB(_ *model.Span, ds *dbmodel.Span) error {
+	return s.writeDBSpanToDB(ds)
 }
 
 func (s *SpanWriter) writeIndexes(span *model.Span, ds *dbmodel.Span) error {

--- a/internal/storage/v1/cassandra/spanstore/writer.go
+++ b/internal/storage/v1/cassandra/spanstore/writer.go
@@ -135,8 +135,9 @@ func (s *SpanWriter) WriteSpan(ctx context.Context, span *model.Span) error {
 	return s.WriteDBSpan(ctx, ds)
 }
 
-// WriteDBSpan saves the dbmodel.Span into Cassandra. This is a hook for V2 storage.
-func (s *SpanWriter) WriteDBSpan(_ context.Context, ds *dbmodel.Span) error {
+// WriteDBSpan saves a pre-converted dbmodel.Span into Cassandra.
+// This is a high-performance hook for the V2 storage engine to bypass the model.Trace layer.
+func (s *SpanWriter) WriteDBSpan(ctx context.Context, ds *dbmodel.Span) error {
 	if s.storageMode&storeFlag == storeFlag {
 		if err := s.writeDBSpanToDB(ds); err != nil {
 			return err

--- a/internal/storage/v2/cassandra/tracestore/fixtures/cas_01.json
+++ b/internal/storage/v2/cassandra/tracestore/fixtures/cas_01.json
@@ -8,16 +8,6 @@
   "Duration": 5,
   "Tags": [
     {
-      "Key": "otel.scope.name",
-      "ValueType": "string",
-      "value_string": "testing-library"
-    },
-    {
-      "Key": "otel.scope.version",
-      "ValueType": "string",
-      "value_string": "1.1.1"
-    },
-    {
       "Key": "peer.service",
       "ValueType": "string",
       "value_string": "service-y"
@@ -46,11 +36,6 @@
       "Key": "otel.status_description",
       "ValueType": "string",
       "value_string": "random-message"
-    },
-    {
-      "Key": "w3c.tracestate",
-      "ValueType": "string",
-      "value_string": "some-state"
     }
   ],
   "Logs": [
@@ -84,17 +69,35 @@
     {
       "RefType": "child-of",
       "TraceID": "AAAAAAAAAAEAAAAAAAAAAA==",
-      "SpanID": 3
+      "SpanID": 3,
+      "TraceState": "",
+      "Tags": null
     },
     {
       "RefType": "follows-from",
       "TraceID": "AAAAAAAAAAEAAAAAAAAAAA==",
-      "SpanID": 4
+      "SpanID": 4,
+      "TraceState": "",
+      "Tags": [
+        {
+          "Key": "opentracing.ref_type",
+          "ValueType": "string",
+          "value_string": "follows_from"
+        }
+      ]
     },
     {
       "RefType": "child-of",
       "TraceID": "AAAAAAAAAP8AAAAAAAAAAA==",
-      "SpanID": 255
+      "SpanID": 255,
+      "TraceState": "",
+      "Tags": [
+        {
+          "Key": "opentracing.ref_type",
+          "ValueType": "string",
+          "value_string": "child_of"
+        }
+      ]
     }
   ],
   "Process": {
@@ -108,5 +111,8 @@
     ]
   },
   "ServiceName": "service-x",
-  "SpanHash": 0
+  "SpanHash": 0,
+  "ScopeName": "testing-library",
+  "ScopeVersion": "1.1.1",
+  "TraceState": "some-state"
 }

--- a/internal/storage/v2/cassandra/tracestore/from_dbmodel.go
+++ b/internal/storage/v2/cassandra/tracestore/from_dbmodel.go
@@ -90,7 +90,7 @@ func dbSpanToSpan(dbspan *dbmodel.Span, span ptrace.Span) {
 	}
 	setSpanStatus(attrs, span)
 
-	span.TraceState().FromRaw(getTraceStateFromAttrs(attrs))
+	span.TraceState().FromRaw(dbspan.TraceState)
 
 	// drop the attributes slice if all of them were replaced during translation
 	if attrs.Len() == 0 {
@@ -307,38 +307,19 @@ func dbReferencesToSpanLinks(refs []dbmodel.SpanRef, excludeParentID int64, span
 		link.SetTraceID(pcommon.TraceID(ref.TraceID))
 		//nolint:gosec // G115 // bit-preserving uint64<->int64 conversion for opaque IDs
 		link.SetSpanID(idutils.UInt64ToSpanID(uint64(ref.SpanID)))
-		link.Attributes().PutStr(otelsemconv.AttributeOpentracingRefType, dbRefTypeToAttribute(ref.RefType))
+		link.TraceState().FromRaw(ref.TraceState)
+		dbTagsToAttributes(ref.Tags, link.Attributes())
+		if refType, ok := link.Attributes().Get(otelsemconv.AttributeOpentracingRefType); !ok {
+			link.Attributes().PutStr(otelsemconv.AttributeOpentracingRefType, dbRefTypeToAttribute(ref.RefType))
+		} else if refType.Str() == "" {
+			link.Attributes().PutStr(otelsemconv.AttributeOpentracingRefType, dbRefTypeToAttribute(ref.RefType))
+		}
 	}
-}
-
-func getTraceStateFromAttrs(attrs pcommon.Map) string {
-	traceState := ""
-	// TODO Bring this inline with solution for jaegertracing/jaeger-client-java #702 once available
-	if attr, ok := attrs.Get(tagW3CTraceState); ok {
-		traceState = attr.Str()
-		attrs.Remove(tagW3CTraceState)
-	}
-	return traceState
 }
 
 func dbSpanToScope(span *dbmodel.Span, scopeSpan ptrace.ScopeSpans) {
-	if libraryName, ok := getAndDeleteTag(span, otelsemconv.AttributeOtelScopeName); ok {
-		scopeSpan.Scope().SetName(libraryName)
-		if libraryVersion, ok := getAndDeleteTag(span, otelsemconv.AttributeOtelScopeVersion); ok {
-			scopeSpan.Scope().SetVersion(libraryVersion)
-		}
-	}
-}
-
-func getAndDeleteTag(span *dbmodel.Span, key string) (string, bool) {
-	for i, tag := range span.Tags {
-		if tag.Key == key {
-			val := tag.ValueString
-			span.Tags = append(span.Tags[:i], span.Tags[i+1:]...)
-			return val, true
-		}
-	}
-	return "", false
+	scopeSpan.Scope().SetName(span.ScopeName)
+	scopeSpan.Scope().SetVersion(span.ScopeVersion)
 }
 
 func dbRefTypeToAttribute(ref string) string {

--- a/internal/storage/v2/cassandra/tracestore/reader.go
+++ b/internal/storage/v2/cassandra/tracestore/reader.go
@@ -16,6 +16,9 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 )
 
+// TraceReader is a V2 storage reader for Cassandra.
+// It wraps a V1 CoreSpanReader and performs direct conversion from database models
+// to OTLP ptrace.Traces.
 type TraceReader struct {
 	reader spanstore.CoreSpanReader
 }
@@ -32,6 +35,7 @@ func (r *TraceReader) GetOperations(ctx context.Context, query tracestore.Operat
 	return r.reader.GetOperations(ctx, query)
 }
 
+// GetTraces retrieves batches of traces by their IDs.
 func (r *TraceReader) GetTraces(ctx context.Context, traceIDs ...tracestore.GetTraceParams) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
 		for _, id := range traceIDs {
@@ -52,6 +56,7 @@ func (r *TraceReader) GetTraces(ctx context.Context, traceIDs ...tracestore.GetT
 	}
 }
 
+// FindTraces retrieves traces that match the given query parameters.
 func (r *TraceReader) FindTraces(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
 		traces, err := r.reader.FindTraces(ctx, v1adapter.GetV1QueryParameters(query))
@@ -68,6 +73,7 @@ func (r *TraceReader) FindTraces(ctx context.Context, query tracestore.TraceQuer
 	}
 }
 
+// FindTraceIDs retrieves trace IDs that match the given query parameters.
 func (r *TraceReader) FindTraceIDs(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]tracestore.FoundTraceID, error] {
 	return func(yield func([]tracestore.FoundTraceID, error) bool) {
 		dbIDs, err := r.reader.FindTraceIDs(ctx, v1adapter.GetV1QueryParameters(query))

--- a/internal/storage/v2/cassandra/tracestore/reader.go
+++ b/internal/storage/v2/cassandra/tracestore/reader.go
@@ -36,7 +36,7 @@ func (r *TraceReader) GetTraces(ctx context.Context, traceIDs ...tracestore.GetT
 	return func(yield func([]ptrace.Traces, error) bool) {
 		for _, id := range traceIDs {
 			// pcommon.TraceID and cassdbmodel.TraceID are both [16]byte with same byte layout
-			spans, err := r.reader.GetTrace(ctx, cassdbmodel.TraceID(id.TraceID))
+			spans, err := r.reader.ReadTraceDB(ctx, cassdbmodel.TraceID(id.TraceID))
 			if err != nil {
 				yield(nil, err)
 				return

--- a/internal/storage/v2/cassandra/tracestore/reader_test.go
+++ b/internal/storage/v2/cassandra/tracestore/reader_test.go
@@ -74,7 +74,7 @@ func TestGetTraces(t *testing.T) {
 	traceID := cassdbmodel.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	spans := []cassdbmodel.Span{{TraceID: traceID, OperationName: "op"}}
 	reader := mocks.CoreSpanReader{}
-	reader.On("GetTrace", mock.Anything, traceID).Return(spans, nil)
+	reader.On("ReadTraceDB", mock.Anything, traceID).Return(spans, nil)
 	tracereader := &TraceReader{reader: &reader}
 	var results []ptrace.Traces
 	for batch, err := range tracereader.GetTraces(context.Background(), tracestore.GetTraceParams{
@@ -89,7 +89,7 @@ func TestGetTraces(t *testing.T) {
 func TestGetTraces_NotFound(t *testing.T) {
 	traceID := cassdbmodel.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	reader := mocks.CoreSpanReader{}
-	reader.On("GetTrace", mock.Anything, traceID).Return([]cassdbmodel.Span(nil), nil)
+	reader.On("ReadTraceDB", mock.Anything, traceID).Return([]cassdbmodel.Span(nil), nil)
 	tracereader := &TraceReader{reader: &reader}
 	var count int
 	for _, err := range tracereader.GetTraces(context.Background(), tracestore.GetTraceParams{
@@ -104,7 +104,7 @@ func TestGetTraces_NotFound(t *testing.T) {
 func TestGetTraces_Error(t *testing.T) {
 	traceID := cassdbmodel.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	reader := mocks.CoreSpanReader{}
-	reader.On("GetTrace", mock.Anything, traceID).Return([]cassdbmodel.Span(nil), errors.New("storage error"))
+	reader.On("ReadTraceDB", mock.Anything, traceID).Return([]cassdbmodel.Span(nil), errors.New("storage error"))
 	tracereader := &TraceReader{reader: &reader}
 	for _, err := range tracereader.GetTraces(context.Background(), tracestore.GetTraceParams{
 		TraceID: pcommon.TraceID(traceID),
@@ -129,7 +129,7 @@ func TestGetTraces_StopIteration(t *testing.T) {
 	traceID2 := cassdbmodel.TraceID{1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	spans := []cassdbmodel.Span{{TraceID: traceID1, OperationName: "op"}}
 	reader := mocks.CoreSpanReader{}
-	reader.On("GetTrace", mock.Anything, traceID1).Return(spans, nil)
+	reader.On("ReadTraceDB", mock.Anything, traceID1).Return(spans, nil)
 	tracereader := &TraceReader{reader: &reader}
 	var count int
 	for range tracereader.GetTraces(context.Background(),

--- a/internal/storage/v2/cassandra/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/cassandra/tracestore/to_dbmodel.go
@@ -138,23 +138,24 @@ func spanToDbSpan(span ptrace.Span, scope pcommon.InstrumentationScope, process 
 		StartTime: int64(model.TimeAsEpochMicroseconds(startTime)),
 		//nolint:gosec // G115 // span.EndTime - span.StartTime is guaranteed non-negative by schema constraints
 		Duration: int64(model.DurationAsMicroseconds(span.EndTimestamp().AsTime().Sub(startTime))),
-		Tags:     getDbTags(span, scope),
+		Tags:     getDbTags(span),
 		Logs:     spanEventsToDbLogs(span.Events()),
 		Process:  process,
 		//nolint:gosec // G115 // span.Flags is uint32, converting to int32 for DB storage (semantically non-negative, fits in int32)
-		Flags:       int32(span.Flags()),
-		ServiceName: process.ServiceName,
-		ParentID:    spanIDToDbSpanId(span.ParentSpanID()),
+		Flags:        int32(span.Flags()),
+		ServiceName:  process.ServiceName,
+		ParentID:     spanIDToDbSpanId(span.ParentSpanID()),
+		ScopeName:    scope.Name(),
+		ScopeVersion: scope.Version(),
+		TraceState:   span.TraceState().AsRaw(),
 	}
 }
 
-func getDbTags(span ptrace.Span, scope pcommon.InstrumentationScope) []dbmodel.KeyValue {
+func getDbTags(span ptrace.Span) []dbmodel.KeyValue {
 	var spanKindTag, statusCodeTag, statusMsgTag dbmodel.KeyValue
 	var spanKindTagFound, statusCodeTagFound, statusMsgTagFound bool
 
-	libraryTags, libraryTagsFound := getTagsFromInstrumentationLibrary(scope)
-
-	tagsCount := span.Attributes().Len() + len(libraryTags)
+	tagsCount := span.Attributes().Len()
 
 	spanKindTag, spanKindTagFound = getTagFromSpanKind(span.Kind())
 	if spanKindTagFound {
@@ -171,19 +172,11 @@ func getDbTags(span ptrace.Span, scope pcommon.InstrumentationScope) []dbmodel.K
 		tagsCount++
 	}
 
-	traceStateTags, traceStateTagsFound := getTagsFromTraceState(span.TraceState().AsRaw())
-	if traceStateTagsFound {
-		tagsCount += len(traceStateTags)
-	}
-
 	if tagsCount == 0 {
 		return nil
 	}
 
 	tags := make([]dbmodel.KeyValue, 0, tagsCount)
-	if libraryTagsFound {
-		tags = append(tags, libraryTags...)
-	}
 	tags = appendTagsFromAttributes(tags, span.Attributes())
 	if spanKindTagFound {
 		tags = append(tags, spanKindTag)
@@ -193,9 +186,6 @@ func getDbTags(span ptrace.Span, scope pcommon.InstrumentationScope) []dbmodel.K
 	}
 	if statusMsgTagFound {
 		tags = append(tags, statusMsgTag)
-	}
-	if traceStateTagsFound {
-		tags = append(tags, traceStateTags...)
 	}
 	return tags
 }
@@ -240,9 +230,11 @@ func linksToDbSpanRefs(links ptrace.SpanLinkSlice, parentSpanID int64, traceID d
 			continue
 		}
 		refs = append(refs, dbmodel.SpanRef{
-			TraceID: linkTraceID,
-			SpanID:  linkSpanID,
-			RefType: linkRefType,
+			TraceID:    linkTraceID,
+			SpanID:     linkSpanID,
+			RefType:    linkRefType,
+			TraceState: link.TraceState().AsRaw(),
+			Tags:       appendTagsFromAttributes(nil, link.Attributes()),
 		})
 	}
 
@@ -330,43 +322,6 @@ func getTagFromStatusMsg(statusMsg string) (dbmodel.KeyValue, bool) {
 		ValueString: statusMsg,
 		ValueType:   dbmodel.StringType,
 	}, true
-}
-
-func getTagsFromTraceState(traceState string) ([]dbmodel.KeyValue, bool) {
-	var keyValues []dbmodel.KeyValue
-	exists := traceState != ""
-	if exists {
-		// TODO Bring this inline with solution for jaegertracing/jaeger-client-java #702 once available
-		kv := dbmodel.KeyValue{
-			Key:         tagW3CTraceState,
-			ValueString: traceState,
-			ValueType:   dbmodel.StringType,
-		}
-		keyValues = append(keyValues, kv)
-	}
-	return keyValues, exists
-}
-
-func getTagsFromInstrumentationLibrary(scope pcommon.InstrumentationScope) ([]dbmodel.KeyValue, bool) {
-	var keyValues []dbmodel.KeyValue
-	if ilName := scope.Name(); ilName != "" {
-		kv := dbmodel.KeyValue{
-			Key:         otelsemconv.AttributeOtelScopeName,
-			ValueString: ilName,
-			ValueType:   dbmodel.StringType,
-		}
-		keyValues = append(keyValues, kv)
-	}
-	if ilVersion := scope.Version(); ilVersion != "" {
-		kv := dbmodel.KeyValue{
-			Key:         otelsemconv.AttributeOtelScopeVersion,
-			ValueString: ilVersion,
-			ValueType:   dbmodel.StringType,
-		}
-		keyValues = append(keyValues, kv)
-	}
-
-	return keyValues, len(keyValues) > 0
 }
 
 func dbRefTypeFromLink(link ptrace.SpanLink) string {

--- a/internal/storage/v2/cassandra/tracestore/writer.go
+++ b/internal/storage/v2/cassandra/tracestore/writer.go
@@ -12,6 +12,9 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra/spanstore"
 )
 
+// TraceWriter is a V2 storage writer for Cassandra.
+// It wraps a V1 SpanWriter and performs direct conversion from OTLP ptrace.Traces
+// to database models before calling the V1 storage hook.
 type TraceWriter struct {
 	writer *spanstore.SpanWriter
 }
@@ -20,6 +23,7 @@ func NewTraceWriter(writer *spanstore.SpanWriter) *TraceWriter {
 	return &TraceWriter{writer: writer}
 }
 
+// WriteTraces writes a batch of OTLP traces to Cassandra.
 func (w *TraceWriter) WriteTraces(ctx context.Context, td ptrace.Traces) error {
 	var errs error
 	for _, ds := range ToDBModel(td) {

--- a/internal/storage/v2/cassandra/tracestore/writer.go
+++ b/internal/storage/v2/cassandra/tracestore/writer.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracestore
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/multierr"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra/spanstore"
+)
+
+type TraceWriter struct {
+	writer *spanstore.SpanWriter
+}
+
+func NewTraceWriter(writer *spanstore.SpanWriter) *TraceWriter {
+	return &TraceWriter{writer: writer}
+}
+
+func (w *TraceWriter) WriteTraces(ctx context.Context, td ptrace.Traces) error {
+	var errs error
+	for _, ds := range ToDBModel(td) {
+		if err := w.writer.WriteDBSpan(ctx, &ds); err != nil {
+			errs = multierr.Append(errs, err)
+		}
+	}
+	return errs
+}


### PR DESCRIPTION
This PR implements the actual storage logic for the Cassandra V2 backend.

V1 Hooks: Added a WriteDBSpan hook to the V1 SpanWriter and a ReadTraceDB hook to the CoreSpanReader. This allows direct database access without the model.Trace middle layer.
V2 TraceWriter: Implemented a new TraceWriter in the V2 package that routes OTLP traces directly to the new WriteDBSpan hook.
V2 TraceReader: Updated the V2 reader to use the native ReadTraceDB hook, enabling direct reconstruction of OTLP traces from the expanded schema.
Regressions Fixed: Aligned V1 indexing logic (service/operation indexing for Firehose spans) to ensure full backward compatibility with the existing V1 testing suite.