### PR TITLE
[jaegermcp] Expose service names in search_traces trace summaries

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 	"strings"
 	"time"
 
@@ -235,12 +236,19 @@ func buildTraceSummary(trace ptrace.Traces) types.TraceSummary {
 		summary.RootService = rootServiceName
 	}
 
+	serviceNames := make([]string, 0, len(services))
+	for svc := range services {
+		serviceNames = append(serviceNames, svc)
+	}
+	slices.Sort(serviceNames)
+
 	// Build summary
 	summary.TraceID = traceID.String()
 	summary.StartTime = minStartTime.Format(time.RFC3339)
 	summary.DurationUs = duration.Microseconds()
 	summary.SpanCount = spanCount
 	summary.ServiceCount = len(services)
+	summary.Services = serviceNames
 	summary.HasErrors = hasErrors
 
 	return summary

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
@@ -33,6 +34,7 @@ func TestSearchTracesHandler_Handle_Success(t *testing.T) {
 	assert.Equal(t, "/api/checkout", summary.RootSpanName)
 	assert.Equal(t, 1, summary.SpanCount)
 	assert.Equal(t, 1, summary.ServiceCount)
+	assert.Equal(t, []string{"frontend"}, summary.Services)
 	assert.False(t, summary.HasErrors)
 }
 
@@ -43,7 +45,41 @@ func TestSearchTracesHandler_BuildSummary_WithErrors(t *testing.T) {
 
 	assert.Equal(t, "payment", summary.RootService)
 	assert.Equal(t, "/process", summary.RootSpanName)
+	assert.Equal(t, []string{"payment"}, summary.Services)
 	assert.True(t, summary.HasErrors)
+}
+
+func TestSearchTracesHandler_BuildSummary_MultipleServices(t *testing.T) {
+	traces := ptrace.NewTraces()
+	tid := pcommon.TraceID{}
+	copy(tid[:], "multiservicetrace")
+
+	// Add spans from three different services in non-alphabetical order
+	spanIDs := []pcommon.SpanID{
+		{1, 0, 0, 0, 0, 0, 0, 0},
+		{2, 0, 0, 0, 0, 0, 0, 0},
+		{3, 0, 0, 0, 0, 0, 0, 0},
+	}
+	for i, svc := range []string{"payment", "api-gateway", "user-service"} {
+		rs := traces.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("service.name", svc)
+		span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(tid)
+		span.SetSpanID(spanIDs[i])
+		span.SetName("/op")
+		span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(-5 * time.Second)))
+		span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		span.Status().SetCode(ptrace.StatusCodeOk)
+		if i > 0 {
+			span.SetParentSpanID(spanIDs[0])
+		}
+	}
+
+	summary := buildTraceSummary(traces)
+
+	assert.Equal(t, 3, summary.ServiceCount)
+	// Services must be sorted alphabetically for deterministic output
+	assert.Equal(t, []string{"api-gateway", "payment", "user-service"}, summary.Services)
 }
 
 func TestSearchTracesHandler_Handle_FullWorkflow(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/search_traces.go
@@ -47,12 +47,13 @@ type SearchTracesOutput struct {
 
 // TraceSummary contains lightweight metadata about a single trace.
 type TraceSummary struct {
-	TraceID      string `json:"trace_id" jsonschema:"Unique identifier for the trace"`
-	RootService  string `json:"root_service" jsonschema:"Service name of the root span"`
-	RootSpanName string `json:"root_span_name" jsonschema:"Span name of the root span"`
-	StartTime    string `json:"start_time" jsonschema:"Trace start time in RFC3339 format"`
-	DurationUs   int64  `json:"duration_us" jsonschema:"Total trace duration in microseconds"`
-	SpanCount    int    `json:"span_count" jsonschema:"Total number of spans in the trace"`
-	ServiceCount int    `json:"service_count" jsonschema:"Number of unique services in the trace"`
-	HasErrors    bool   `json:"has_errors" jsonschema:"Whether the trace contains any error spans"`
+	TraceID      string   `json:"trace_id" jsonschema:"Unique identifier for the trace"`
+	RootService  string   `json:"root_service" jsonschema:"Service name of the root span"`
+	RootSpanName string   `json:"root_span_name" jsonschema:"Span name of the root span"`
+	StartTime    string   `json:"start_time" jsonschema:"Trace start time in RFC3339 format"`
+	DurationUs   int64    `json:"duration_us" jsonschema:"Total trace duration in microseconds"`
+	SpanCount    int      `json:"span_count" jsonschema:"Total number of spans in the trace"`
+	ServiceCount int      `json:"service_count" jsonschema:"Number of unique services in the trace"`
+	Services     []string `json:"services" jsonschema:"Sorted list of unique service names participating in the trace"`
+	HasErrors    bool     `json:"has_errors" jsonschema:"Whether the trace contains any error spans"`
 }


### PR DESCRIPTION
## Which problem is this PR solving?

When an agent calls `search_traces`, the response includes `service_count` (an integer) but not the actual service names. The agent knows a trace spans 5 services but has no idea which ones. To find out, it must call `get_trace_topology` or `get_span_details` for every trace individually, which defeats the purpose of a lightweight summary endpoint.

The data is already computed internally. `buildTraceSummary` builds a `services` map to derive `service_count`, then discards the map keys. This has been the case since the function was introduced in #7858, where the map was built but only `len(services)` was surfaced. Subsequent changes (#7859, #7863, #7916, #8194) restructured the types and renamed fields but never revisited the service data gap.

## Short description of the changes

- Added `Services []string` to `TraceSummary`, populated from the existing `services` map
- Sorted alphabetically via `slices.Sort` for deterministic output across calls
- Added multi-service test with three services in non-alphabetical order, unique span IDs, and proper parent-child relationships to verify sort correctness
- Updated existing summary tests to assert on the new field
- `ServiceCount` preserved for backward compatibility

## Use case

An agent investigating a latency spike searches for slow traces. The summary now returns:

```json
{
  "service_count": 3,
  "services": ["api-gateway", "payment", "user-service"]
}
```

The agent can immediately see that the payment service is involved and drill into that trace, instead of blindly fetching topology for every result.

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegermcp/...` - all passing
- `make lint` - 0 issues
- `make fmt` - clean
- `make test` - 3053 tests passing

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)