### PR TITLE
Do not ignore root "jaeger" file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,3 @@ test-results.json
 .mockery.log
 build.log
 sidecar.py.orig
-jaeger


### PR DESCRIPTION
This was added because the binary was being built in the root sometimes but it prevents ringrep from descending into cmd/jaeger/