### PR TITLE
[clickhouse] Implement dependency reader for ClickHouse

### DIFF
--- a/internal/storage/v2/clickhouse/depstore/reader.go
+++ b/internal/storage/v2/clickhouse/depstore/reader.go
@@ -5,20 +5,70 @@ package depstore
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 )
 
 var _ depstore.Reader = (*Reader)(nil)
 
-type Reader struct{}
-
-func NewDependencyReader() *Reader {
-	return &Reader{}
+type Reader struct {
+	conn driver.Conn
 }
 
-func (*Reader) GetDependencies(context.Context, depstore.QueryParameters) ([]model.DependencyLink, error) {
-	return nil, errors.New("clickhouse dependency reader is not implemented")
+func NewDependencyReader(conn driver.Conn) *Reader {
+	return &Reader{conn: conn}
+}
+
+// dependencyLink is the JSON representation of a single dependency link.
+type dependencyLink struct {
+	Parent    string `json:"parent"`
+	Child     string `json:"child"`
+	CallCount uint64 `json:"callCount"`
+}
+
+func (r *Reader) GetDependencies(ctx context.Context, query depstore.QueryParameters) ([]model.DependencyLink, error) {
+	rows, err := r.conn.Query(ctx, sql.SelectDependencies, query.StartTime, query.EndTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query dependencies: %w", err)
+	}
+	defer rows.Close()
+
+	// Merge dependencies from all snapshots in the time range.
+	// Use a map keyed by (parent, child) to aggregate call counts.
+	type key struct{ parent, child string }
+	merged := make(map[key]uint64)
+
+	for rows.Next() {
+		var blob string
+		if err := rows.Scan(&blob); err != nil {
+			return nil, fmt.Errorf("failed to scan dependency row: %w", err)
+		}
+		var links []dependencyLink
+		if err := json.Unmarshal([]byte(blob), &links); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal dependencies JSON: %w", err)
+		}
+		for _, link := range links {
+			merged[key{link.Parent, link.Child}] += link.CallCount
+		}
+	}
+
+	if len(merged) == 0 {
+		return nil, nil
+	}
+
+	dependencies := make([]model.DependencyLink, 0, len(merged))
+	for k, callCount := range merged {
+		dependencies = append(dependencies, model.DependencyLink{
+			Parent:    k.parent,
+			Child:     k.child,
+			CallCount: callCount,
+		})
+	}
+	return dependencies, nil
 }

--- a/internal/storage/v2/clickhouse/depstore/reader.go
+++ b/internal/storage/v2/clickhouse/depstore/reader.go
@@ -32,6 +32,12 @@ type dependencyLink struct {
 	CallCount uint64 `json:"callCount"`
 }
 
+// dependencyKey groups dependency links by (parent, child) for merging.
+type dependencyKey struct {
+	parent string
+	child  string
+}
+
 func (r *Reader) GetDependencies(ctx context.Context, query depstore.QueryParameters) ([]model.DependencyLink, error) {
 	rows, err := r.conn.Query(ctx, sql.SelectDependencies, query.StartTime, query.EndTime)
 	if err != nil {
@@ -40,9 +46,7 @@ func (r *Reader) GetDependencies(ctx context.Context, query depstore.QueryParame
 	defer rows.Close()
 
 	// Merge dependencies from all snapshots in the time range.
-	// Use a map keyed by (parent, child) to aggregate call counts.
-	type key struct{ parent, child string }
-	merged := make(map[key]uint64)
+	merged := make(map[dependencyKey]uint64)
 
 	for rows.Next() {
 		var blob string
@@ -54,7 +58,7 @@ func (r *Reader) GetDependencies(ctx context.Context, query depstore.QueryParame
 			return nil, fmt.Errorf("failed to unmarshal dependencies JSON: %w", err)
 		}
 		for _, link := range links {
-			merged[key{link.Parent, link.Child}] += link.CallCount
+			merged[dependencyKey{link.Parent, link.Child}] += link.CallCount
 		}
 	}
 

--- a/internal/storage/v2/clickhouse/depstore/reader.go
+++ b/internal/storage/v2/clickhouse/depstore/reader.go
@@ -25,13 +25,6 @@ func NewDependencyReader(conn driver.Conn) *Reader {
 	return &Reader{conn: conn}
 }
 
-// dependencyLink is the JSON representation of a single dependency link.
-type dependencyLink struct {
-	Parent    string `json:"parent"`
-	Child     string `json:"child"`
-	CallCount uint64 `json:"callCount"`
-}
-
 // dependencyKey groups dependency links by (parent, child) for merging.
 type dependencyKey struct {
 	parent string

--- a/internal/storage/v2/clickhouse/depstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/depstore/reader_test.go
@@ -6,20 +6,161 @@ package depstore
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 )
 
-func TestReader_GetDependencies(t *testing.T) {
-	reader := NewDependencyReader()
-	ctx := context.Background()
-	query := depstore.QueryParameters{}
+func scanString(dest any, src string) error {
+	dests := dest.([]any)
+	*dests[0].(*string) = src
+	return nil
+}
 
-	dependencies, err := reader.GetDependencies(ctx, query)
+func TestGetDependencies(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name        string
+		conn        *clickhousetest.Driver
+		query       depstore.QueryParameters
+		expected    []model.DependencyLink
+		expectError string
+	}{
+		{
+			name: "successfully returns dependencies from single snapshot",
+			conn: &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectDependencies: {
+						Rows: &clickhousetest.Rows[string]{
+							Data: []string{
+								`[{"parent":"serviceA","child":"serviceB","callCount":42},{"parent":"serviceB","child":"serviceC","callCount":7}]`,
+							},
+							ScanFn: scanString,
+						},
+					},
+				},
+			},
+			query: depstore.QueryParameters{
+				StartTime: now.Add(-1 * time.Hour),
+				EndTime:   now,
+			},
+			expected: []model.DependencyLink{
+				{Parent: "serviceA", Child: "serviceB", CallCount: 42},
+				{Parent: "serviceB", Child: "serviceC", CallCount: 7},
+			},
+		},
+		{
+			name: "merges dependencies across multiple snapshots",
+			conn: &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectDependencies: {
+						Rows: &clickhousetest.Rows[string]{
+							Data: []string{
+								`[{"parent":"serviceA","child":"serviceB","callCount":10}]`,
+								`[{"parent":"serviceA","child":"serviceB","callCount":5},{"parent":"serviceC","child":"serviceD","callCount":3}]`,
+							},
+							ScanFn: scanString,
+						},
+					},
+				},
+			},
+			query: depstore.QueryParameters{
+				StartTime: now.Add(-2 * time.Hour),
+				EndTime:   now,
+			},
+			expected: []model.DependencyLink{
+				{Parent: "serviceA", Child: "serviceB", CallCount: 15},
+				{Parent: "serviceC", Child: "serviceD", CallCount: 3},
+			},
+		},
+		{
+			name: "returns nil when no dependencies",
+			conn: &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectDependencies: {
+						Rows: &clickhousetest.Rows[string]{},
+					},
+				},
+			},
+			query: depstore.QueryParameters{
+				StartTime: now.Add(-1 * time.Hour),
+				EndTime:   now,
+			},
+			expected: nil,
+		},
+		{
+			name: "query error",
+			conn: &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectDependencies: {
+						Err: assert.AnError,
+					},
+				},
+			},
+			query: depstore.QueryParameters{
+				StartTime: now.Add(-1 * time.Hour),
+				EndTime:   now,
+			},
+			expectError: "failed to query dependencies",
+		},
+		{
+			name: "scan error",
+			conn: &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectDependencies: {
+						Rows: &clickhousetest.Rows[string]{
+							Data: []string{
+								`[{"parent":"a","child":"b","callCount":1}]`,
+							},
+							ScanErr: assert.AnError,
+						},
+					},
+				},
+			},
+			query: depstore.QueryParameters{
+				StartTime: now.Add(-1 * time.Hour),
+				EndTime:   now,
+			},
+			expectError: "failed to scan dependency row",
+		},
+		{
+			name: "invalid JSON blob",
+			conn: &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectDependencies: {
+						Rows: &clickhousetest.Rows[string]{
+							Data: []string{
+								`not valid json`,
+							},
+							ScanFn: scanString,
+						},
+					},
+				},
+			},
+			query: depstore.QueryParameters{
+				StartTime: now.Add(-1 * time.Hour),
+				EndTime:   now,
+			},
+			expectError: "failed to unmarshal dependencies JSON",
+		},
+	}
 
-	require.Nil(t, dependencies)
-	assert.EqualError(t, err, "clickhouse dependency reader is not implemented")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := NewDependencyReader(test.conn)
+			result, err := reader.GetDependencies(context.Background(), test.query)
+			if test.expectError != "" {
+				require.ErrorContains(t, err, test.expectError)
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, test.expected, result)
+			}
+		})
+	}
 }

--- a/internal/storage/v2/clickhouse/factory.go
+++ b/internal/storage/v2/clickhouse/factory.go
@@ -135,8 +135,8 @@ func (f *Factory) CreateTraceWriter() (tracestore.Writer, error) {
 	return chtracestore.NewWriter(f.conn), nil
 }
 
-func (*Factory) CreateDependencyReader() (depstore.Reader, error) {
-	return chdepstore.NewDependencyReader(), nil
+func (f *Factory) CreateDependencyReader() (depstore.Reader, error) {
+	return chdepstore.NewDependencyReader(f.conn), nil
 }
 
 func (f *Factory) Close() error {


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #7136 

## Description of the changes
- Implements the dependency reader for ClickHouse

## How was this change tested?
Start ClickHouse in docker
```
docker compose -f docker-compose/clickhouse/docker-compose.yml up
```

Start jaeger (to automatically create schema)
```
go run ./cmd/jaeger --config cmd/jaeger/config-clickhouse.yaml --feature-gates=storage.clickhouse
```

Seed dependencies table
```
docker exec clickhouse clickhouse-client --database=jaeger --query="                             
INSERT INTO dependencies (timestamp, dependencies_json) VALUES
  (now() - INTERVAL 30 MINUTE, '[{\"parent\":\"frontend\",\"child\":\"api-gateway\",\"callCount\":100},{\"parent\":\"api-gateway\",\"child\":\"user-service\",\"callCount\":50}]'),
  (now() - INTERVAL 10 MINUTE, '[{\"parent\":\"frontend\",\"child\":\"api-gateway\",\"callCount\":200},{\"parent\":\"api-gateway\",\"child\":\"order-service\",\"callCount\":30}]')
"
```

Verify entries were inserted
```
docker exec clickhouse clickhouse-client --database=jaeger --query="select * from dependencies"  
2026-04-11 14:02:08.000000000   [{"parent":"frontend","child":"api-gateway","callCount":100},{"parent":"api-gateway","child":"user-service","callCount":50}]
2026-04-11 14:22:08.000000000   [{"parent":"frontend","child":"api-gateway","callCount":200},{"parent":"api-gateway","child":"order-service","callCount":30}]
```

Write the following test to call the new function
```
func TestGetDependenciesIntegration(t *testing.T) {
	ctx := context.Background()

	conn, err := clickhouse.Open(&clickhouse.Options{
		Addr: []string{"127.0.0.1:9000"},
		Auth: clickhouse.Auth{
			Database: "jaeger",
			Username: "default",
			Password: "password",
		},
		DialTimeout: 5 * time.Second,
	})
	require.NoError(t, err)
	defer conn.Close()

	reader := NewDependencyReader(conn)
	deps, err := reader.GetDependencies(ctx, depstore.QueryParameters{
		StartTime: time.Now().Add(-1 * time.Hour),
		EndTime:   time.Now(),
	})
	t.Log(deps)
	require.NoError(t, err)
	require.NotNil(t, deps)
}
```

And see the following in the logs
```
[{frontend api-gateway 300  {} [] 0} {api-gateway user-service 50  {} [] 0} {api-gateway order-service 30  {} [] 0}
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
