### PR TITLE
[clickhouse][refactor] Move test implementations to common `clickhousetest` package

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,7 @@ ignore:
   - "**/main.go"
   - "examples/hotrod"
   - "internal/storage/integration"
+  - "internal/storage/v2/clickhouse/clickhousetest"
   - "cmd/jaeger/internal/integration"
   - "internal/tools"
   - "monitoring/jaeger-mixin/generate"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,7 +12,6 @@ ignore:
   - "**/main.go"
   - "examples/hotrod"
   - "internal/storage/integration"
-  - "internal/storage/v2/clickhouse/clickhousetest"
   - "cmd/jaeger/internal/integration"
   - "internal/tools"
   - "monitoring/jaeger-mixin/generate"

--- a/internal/storage/v2/clickhouse/clickhousetest/driver.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhousetest
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+type QueryResponse struct {
+	Rows driver.Rows
+	Err  error
+}
+
+type BatchResponse struct {
+	Batch *Batch
+	Err   error
+}
+
+// Driver is a test double for driver.Conn, which is an interface to manage connections to a ClickHouse database.
+// It returns pre-configured response entries matched by query substring.
+type Driver struct {
+	driver.Conn
+
+	T               *testing.T
+	QueryResponses  map[string]*QueryResponse
+	BatchResponses  map[string]*BatchResponse
+	RecordedQueries []string
+}
+
+func (d *Driver) Query(_ context.Context, query string, _ ...any) (driver.Rows, error) {
+	d.RecordedQueries = append(d.RecordedQueries, query)
+
+	// Normalize whitespace so substring matching works regardless of indentation.
+	normalized := strings.Join(strings.Fields(query), " ")
+	for querySubstring, response := range d.QueryResponses {
+		normalizedSubstring := strings.Join(strings.Fields(querySubstring), " ")
+		if strings.Contains(normalized, normalizedSubstring) {
+			return response.Rows, response.Err
+		}
+	}
+
+	return nil, nil
+}
+
+func (d *Driver) PrepareBatch(
+	_ context.Context,
+	query string,
+	_ ...driver.PrepareBatchOption,
+) (driver.Batch, error) {
+	d.RecordedQueries = append(d.RecordedQueries, query)
+
+	for querySubstring, response := range d.BatchResponses {
+		if strings.Contains(query, querySubstring) {
+			return response.Batch, response.Err
+		}
+	}
+
+	return nil, nil
+}
+
+// Batch is a test double for driver.Batch, which is an interface
+// to allow inserting multiple rows in a single operation.
+type Batch struct {
+	driver.Batch
+	T          *testing.T
+	Appended   [][]any
+	AppendErr  error
+	SendCalled bool
+	SendErr    error
+}
+
+func (b *Batch) Append(v ...any) error {
+	if b.AppendErr != nil {
+		return b.AppendErr
+	}
+	b.Appended = append(b.Appended, v)
+	return nil
+}
+
+func (b *Batch) Send() error {
+	if b.SendErr != nil {
+		return b.SendErr
+	}
+	b.SendCalled = true
+	return nil
+}
+
+func (*Batch) Close() error {
+	return nil
+}
+
+// Rows is a generic test double for driver.Rows, which is an interface representing a query response.
+type Rows[T any] struct {
+	driver.Rows
+
+	Data     []T
+	Index    int
+	ScanErr  error
+	ScanFn   func(dest any, src T) error
+	CloseErr error
+	RowsErr  error
+}
+
+func (r *Rows[T]) Close() error {
+	return r.CloseErr
+}
+
+func (r *Rows[T]) Err() error {
+	return r.RowsErr
+}
+
+func (r *Rows[T]) Next() bool {
+	return r.Index < len(r.Data)
+}
+
+func (r *Rows[T]) ScanStruct(dest any) error {
+	if r.ScanErr != nil {
+		return r.ScanErr
+	}
+	if r.Index >= len(r.Data) {
+		return errors.New("no more rows")
+	}
+	if r.ScanFn == nil {
+		return errors.New("ScanFn is not provided")
+	}
+	err := r.ScanFn(dest, r.Data[r.Index])
+	r.Index++
+	return err
+}
+
+func (r *Rows[T]) Scan(dest ...any) error {
+	if r.ScanErr != nil {
+		return r.ScanErr
+	}
+	if r.Index >= len(r.Data) {
+		return errors.New("no more rows")
+	}
+	if r.ScanFn == nil {
+		return errors.New("ScanFn is not provided")
+	}
+	err := r.ScanFn(dest, r.Data[r.Index])
+	r.Index++
+	return err
+}

--- a/internal/storage/v2/clickhouse/clickhousetest/driver.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver.go
@@ -127,7 +127,7 @@ func (r *Rows[T]) ScanStruct(dest any) error {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
-		return errors.New("ScanFn is not provided")
+		return errors.New("scanFn is not provided")
 	}
 	err := r.ScanFn(dest, r.Data[r.Index])
 	r.Index++
@@ -142,7 +142,7 @@ func (r *Rows[T]) Scan(dest ...any) error {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
-		return errors.New("ScanFn is not provided")
+		return errors.New("scanFn is not provided")
 	}
 	err := r.ScanFn(dest, r.Data[r.Index])
 	r.Index++

--- a/internal/storage/v2/clickhouse/clickhousetest/driver.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
@@ -27,7 +26,6 @@ type BatchResponse struct {
 type Driver struct {
 	driver.Conn
 
-	T               *testing.T
 	QueryResponses  map[string]*QueryResponse
 	BatchResponses  map[string]*BatchResponse
 	RecordedQueries []string
@@ -55,8 +53,11 @@ func (d *Driver) PrepareBatch(
 ) (driver.Batch, error) {
 	d.RecordedQueries = append(d.RecordedQueries, query)
 
+	// Normalize whitespace so substring matching works regardless of indentation.
+	normalized := strings.Join(strings.Fields(query), " ")
 	for querySubstring, response := range d.BatchResponses {
-		if strings.Contains(query, querySubstring) {
+		normalizedSubstring := strings.Join(strings.Fields(querySubstring), " ")
+		if strings.Contains(normalized, normalizedSubstring) {
 			return response.Batch, response.Err
 		}
 	}
@@ -68,7 +69,6 @@ func (d *Driver) PrepareBatch(
 // to allow inserting multiple rows in a single operation.
 type Batch struct {
 	driver.Batch
-	T          *testing.T
 	Appended   [][]any
 	AppendErr  error
 	SendCalled bool
@@ -116,35 +116,35 @@ func (r *Rows[T]) Err() error {
 }
 
 func (r *Rows[T]) Next() bool {
-	return r.Index < len(r.Data)
+	if r.Index >= len(r.Data) {
+		return false
+	}
+	r.Index++
+	return true
 }
 
 func (r *Rows[T]) ScanStruct(dest any) error {
 	if r.ScanErr != nil {
 		return r.ScanErr
 	}
-	if r.Index >= len(r.Data) {
+	if r.Index <= 0 || r.Index > len(r.Data) {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
 		return errors.New("scanFn is not provided")
 	}
-	err := r.ScanFn(dest, r.Data[r.Index])
-	r.Index++
-	return err
+	return r.ScanFn(dest, r.Data[r.Index-1])
 }
 
 func (r *Rows[T]) Scan(dest ...any) error {
 	if r.ScanErr != nil {
 		return r.ScanErr
 	}
-	if r.Index >= len(r.Data) {
+	if r.Index <= 0 || r.Index > len(r.Data) {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
 		return errors.New("scanFn is not provided")
 	}
-	err := r.ScanFn(dest, r.Data[r.Index])
-	r.Index++
-	return err
+	return r.ScanFn(dest, r.Data[r.Index-1])
 }

--- a/internal/storage/v2/clickhouse/clickhousetest/driver_test.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver_test.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhousetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriver_Query_Match(t *testing.T) {
+	rows := &Rows[string]{Data: []string{"a"}}
+	d := &Driver{
+		QueryResponses: map[string]*QueryResponse{
+			"SELECT foo": {Rows: rows, Err: nil},
+		},
+	}
+	got, err := d.Query(context.Background(), "SELECT foo FROM bar")
+	require.NoError(t, err)
+	assert.Equal(t, rows, got)
+	assert.Equal(t, []string{"SELECT foo FROM bar"}, d.RecordedQueries)
+}
+
+func TestDriver_Query_MatchError(t *testing.T) {
+	wantErr := errors.New("query error")
+	d := &Driver{
+		QueryResponses: map[string]*QueryResponse{
+			"SELECT foo": {Rows: nil, Err: wantErr},
+		},
+	}
+	got, err := d.Query(context.Background(), "SELECT foo FROM bar")
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, got)
+}
+
+func TestDriver_Query_NoMatch(t *testing.T) {
+	d := &Driver{
+		QueryResponses: map[string]*QueryResponse{
+			"SELECT foo": {Rows: &Rows[string]{}, Err: nil},
+		},
+	}
+	got, err := d.Query(context.Background(), "SELECT baz FROM bar")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestDriver_Query_WhitespaceNormalization(t *testing.T) {
+	rows := &Rows[string]{Data: []string{"a"}}
+	d := &Driver{
+		QueryResponses: map[string]*QueryResponse{
+			"SELECT   foo": {Rows: rows},
+		},
+	}
+	got, err := d.Query(context.Background(), "SELECT foo FROM bar")
+	require.NoError(t, err)
+	assert.Equal(t, rows, got)
+}
+
+func TestDriver_PrepareBatch_Match(t *testing.T) {
+	batch := &Batch{}
+	d := &Driver{
+		BatchResponses: map[string]*BatchResponse{
+			"INSERT INTO spans": {Batch: batch, Err: nil},
+		},
+	}
+	got, err := d.PrepareBatch(context.Background(), "INSERT INTO spans VALUES (?)")
+	require.NoError(t, err)
+	assert.Equal(t, batch, got)
+	assert.Equal(t, []string{"INSERT INTO spans VALUES (?)"}, d.RecordedQueries)
+}
+
+func TestDriver_PrepareBatch_MatchError(t *testing.T) {
+	wantErr := errors.New("batch error")
+	d := &Driver{
+		BatchResponses: map[string]*BatchResponse{
+			"INSERT INTO spans": {Batch: nil, Err: wantErr},
+		},
+	}
+	got, err := d.PrepareBatch(context.Background(), "INSERT INTO spans VALUES (?)")
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, got)
+}
+
+func TestDriver_PrepareBatch_NoMatch(t *testing.T) {
+	d := &Driver{
+		BatchResponses: map[string]*BatchResponse{
+			"INSERT INTO spans": {Batch: &Batch{}},
+		},
+	}
+	got, err := d.PrepareBatch(context.Background(), "INSERT INTO other VALUES (?)")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestBatch_Append(t *testing.T) {
+	b := &Batch{}
+	require.NoError(t, b.Append("row1", 42))
+	assert.Equal(t, [][]any{{"row1", 42}}, b.Appended)
+}
+
+func TestBatch_Append_Error(t *testing.T) {
+	wantErr := errors.New("append error")
+	b := &Batch{AppendErr: wantErr}
+	require.ErrorIs(t, b.Append("row1"), wantErr)
+	assert.Empty(t, b.Appended)
+}
+
+func TestBatch_Send(t *testing.T) {
+	b := &Batch{}
+	require.NoError(t, b.Send())
+	assert.True(t, b.SendCalled)
+}
+
+func TestBatch_Send_Error(t *testing.T) {
+	wantErr := errors.New("send error")
+	b := &Batch{SendErr: wantErr}
+	require.ErrorIs(t, b.Send(), wantErr)
+	assert.False(t, b.SendCalled)
+}
+
+func TestBatch_Close(t *testing.T) {
+	b := &Batch{}
+	require.NoError(t, b.Close())
+}
+
+func TestRows_Next(t *testing.T) {
+	r := &Rows[string]{Data: []string{"a", "b"}}
+	assert.True(t, r.Next())
+	assert.True(t, r.Next())
+	assert.False(t, r.Next())
+}
+
+func TestRows_Close(t *testing.T) {
+	r := &Rows[string]{}
+	require.NoError(t, r.Close())
+
+	r2 := &Rows[string]{CloseErr: errors.New("close error")}
+	require.Error(t, r2.Close())
+}
+
+func TestRows_Err(t *testing.T) {
+	r := &Rows[string]{}
+	require.NoError(t, r.Err())
+
+	wantErr := errors.New("rows error")
+	r2 := &Rows[string]{RowsErr: wantErr}
+	require.ErrorIs(t, r2.Err(), wantErr)
+}
+
+func TestRows_ScanStruct(t *testing.T) {
+	r := &Rows[string]{
+		Data:   []string{"hello"},
+		ScanFn: func(dest any, src string) error { *(dest.(*string)) = src; return nil },
+	}
+	r.Next()
+	var out string
+	require.NoError(t, r.ScanStruct(&out))
+	assert.Equal(t, "hello", out)
+}
+
+func TestRows_ScanStruct_ScanErr(t *testing.T) {
+	wantErr := errors.New("scan error")
+	r := &Rows[string]{Data: []string{"x"}, ScanErr: wantErr}
+	r.Next()
+	require.ErrorIs(t, r.ScanStruct(nil), wantErr)
+}
+
+func TestRows_ScanStruct_OutOfBounds(t *testing.T) {
+	r := &Rows[string]{Data: []string{"x"}}
+	// Index is 0 (Next not called), so out-of-bounds
+	require.Error(t, r.ScanStruct(nil))
+}
+
+func TestRows_ScanStruct_NilScanFn(t *testing.T) {
+	r := &Rows[string]{Data: []string{"x"}}
+	r.Next()
+	require.Error(t, r.ScanStruct(nil))
+}
+
+func TestRows_Scan(t *testing.T) {
+	r := &Rows[string]{
+		Data:   []string{"hello"},
+		ScanFn: func(dest any, src string) error { dest.([]any)[0] = src; return nil },
+	}
+	r.Next()
+	var out any
+	require.NoError(t, r.Scan(&out))
+}
+
+func TestRows_Scan_ScanErr(t *testing.T) {
+	wantErr := errors.New("scan error")
+	r := &Rows[string]{Data: []string{"x"}, ScanErr: wantErr}
+	r.Next()
+	require.ErrorIs(t, r.Scan(nil), wantErr)
+}
+
+func TestRows_Scan_OutOfBounds(t *testing.T) {
+	r := &Rows[string]{Data: []string{"x"}}
+	require.Error(t, r.Scan(nil))
+}
+
+func TestRows_Scan_NilScanFn(t *testing.T) {
+	r := &Rows[string]{Data: []string{"x"}}
+	r.Next()
+	require.Error(t, r.Scan(nil))
+}

--- a/internal/storage/v2/clickhouse/clickhousetest/driver_test.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package clickhousetest

--- a/internal/storage/v2/clickhouse/clickhousetest/server_test.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package clickhousetest

--- a/internal/storage/v2/clickhouse/clickhousetest/server_test.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/server_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhousetest
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func postQuery(t *testing.T, url, query string) (int, string) {
+	t.Helper()
+	resp, err := http.Post(url, "text/plain", strings.NewReader(query))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+func TestNewServer_PingQuery(t *testing.T) {
+	srv := NewServer(FailureConfig{})
+	defer srv.Close()
+	status, _ := postQuery(t, srv.URL, PingQuery)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+func TestNewServer_HandshakeQuery(t *testing.T) {
+	srv := NewServer(FailureConfig{})
+	defer srv.Close()
+	status, _ := postQuery(t, srv.URL, HandshakeQuery)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+func TestNewServer_DefaultQuery(t *testing.T) {
+	srv := NewServer(FailureConfig{})
+	defer srv.Close()
+	status, _ := postQuery(t, srv.URL, "SELECT * FROM some_table")
+	assert.Equal(t, http.StatusOK, status)
+}
+
+func TestNewServer_FailureConfig(t *testing.T) {
+	wantErr := errors.New("simulated failure")
+	srv := NewServer(FailureConfig{PingQuery: wantErr})
+	defer srv.Close()
+	status, body := postQuery(t, srv.URL, PingQuery)
+	assert.Equal(t, http.StatusInternalServerError, status)
+	assert.Contains(t, body, wantErr.Error())
+}

--- a/internal/storage/v2/clickhouse/tracestore/attribute_metadata_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/attribute_metadata_test.go
@@ -137,7 +137,7 @@ func TestGetAttributeMetadata_NoStringAttributes(t *testing.T) {
 	assert.Empty(t, driver.RecordedQueries)
 }
 
-func makeTestDriverWithMetadata(t *testing.T) *clickhousetest.Driver {
+func makeTestDriverWithMetadata() *clickhousetest.Driver {
 	return &clickhousetest.Driver{
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
@@ -160,7 +160,7 @@ func makeTestDriverWithMetadata(t *testing.T) *clickhousetest.Driver {
 }
 
 func TestGetAttributeMetadata_CacheMiss(t *testing.T) {
-	d := makeTestDriverWithMetadata(t)
+	d := makeTestDriverWithMetadata()
 	reader := NewReader(d, ReaderConfig{
 		AttributeMetadataCacheTTL:     time.Minute,
 		AttributeMetadataCacheMaxSize: 1000,
@@ -178,7 +178,7 @@ func TestGetAttributeMetadata_CacheMiss(t *testing.T) {
 }
 
 func TestGetAttributeMetadata_CacheHit(t *testing.T) {
-	d := makeTestDriverWithMetadata(t)
+	d := makeTestDriverWithMetadata()
 	reader := NewReader(d, ReaderConfig{
 		AttributeMetadataCacheTTL:     time.Minute,
 		AttributeMetadataCacheMaxSize: 1000,
@@ -202,7 +202,7 @@ func TestGetAttributeMetadata_CacheHit(t *testing.T) {
 
 func TestGetAttributeMetadata_CacheTTLExpiration(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		d := makeTestDriverWithMetadata(t)
+		d := makeTestDriverWithMetadata()
 		cacheTTL := 5 * time.Minute
 		reader := NewReader(d, ReaderConfig{
 			AttributeMetadataCacheTTL:     cacheTTL,
@@ -273,7 +273,7 @@ func TestGetAttributeMetadata_DoesNotCacheEmptyResult(t *testing.T) {
 }
 
 func TestGetAttributeMetadata_NonStringAttributesSkipped(t *testing.T) {
-	d := makeTestDriverWithMetadata(t)
+	d := makeTestDriverWithMetadata()
 	reader := NewReader(d, ReaderConfig{
 		AttributeMetadataCacheTTL:     time.Minute,
 		AttributeMetadataCacheMaxSize: 1000,

--- a/internal/storage/v2/clickhouse/tracestore/attribute_metadata_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/attribute_metadata_test.go
@@ -29,7 +29,6 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 		{
 			name: "QueryError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
 						Rows: nil,
@@ -42,7 +41,6 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 		{
 			name: "ScanStructError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
 						Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
@@ -62,7 +60,6 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 		{
 			name: "RowsIterationError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
 						Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
@@ -90,7 +87,6 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 		{
 			name: "UnknownLevelError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
 						Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
@@ -132,9 +128,7 @@ func TestGetAttributeMetadata_NoStringAttributes(t *testing.T) {
 	attrs.PutInt("some.int", 42)
 	attrs.PutDouble("some.double", 3.14)
 
-	driver := &clickhousetest.Driver{
-		T: t,
-	}
+	driver := &clickhousetest.Driver{}
 
 	reader := NewReader(driver, ReaderConfig{AttributeMetadataCacheMaxSize: 1000})
 	metadata, err := reader.getAttributeMetadata(t.Context(), attrs)
@@ -145,7 +139,6 @@ func TestGetAttributeMetadata_NoStringAttributes(t *testing.T) {
 
 func makeTestDriverWithMetadata(t *testing.T) *clickhousetest.Driver {
 	return &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
 				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
@@ -250,7 +243,6 @@ func TestGetAttributeMetadata_CacheTTLExpiration(t *testing.T) {
 func TestGetAttributeMetadata_DoesNotCacheEmptyResult(t *testing.T) {
 	// When metadata returns no rows for a key, the empty result should NOT be cached.
 	d := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
 				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{

--- a/internal/storage/v2/clickhouse/tracestore/attribute_metadata_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/attribute_metadata_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/tracestore/dbmodel"
 )
@@ -22,17 +23,17 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		driver      *testDriver
+		driver      *clickhousetest.Driver
 		expectedErr string
 	}{
 		{
 			name: "QueryError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
-						rows: nil,
-						err:  assert.AnError,
+						Rows: nil,
+						Err:  assert.AnError,
 					},
 				},
 			},
@@ -40,19 +41,19 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "ScanStructError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
-						rows: &testRows[dbmodel.AttributeMetadata]{
-							data: []dbmodel.AttributeMetadata{{
+						Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+							Data: []dbmodel.AttributeMetadata{{
 								AttributeKey: "http.method",
 								Type:         "str",
 								Level:        "span",
 							}},
-							scanErr: assert.AnError,
+							ScanErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -60,17 +61,17 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "RowsIterationError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
-						rows: &testRows[dbmodel.AttributeMetadata]{
-							data: []dbmodel.AttributeMetadata{{
+						Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+							Data: []dbmodel.AttributeMetadata{{
 								AttributeKey: "http.method",
 								Type:         "str",
 								Level:        "span",
 							}},
-							scanFn: func(dest any, src dbmodel.AttributeMetadata) error {
+							ScanFn: func(dest any, src dbmodel.AttributeMetadata) error {
 								ptr, ok := dest.(*dbmodel.AttributeMetadata)
 								if !ok {
 									return assert.AnError
@@ -78,9 +79,9 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 								*ptr = src
 								return nil
 							},
-							rowsErr: assert.AnError,
+							RowsErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -88,17 +89,17 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "UnknownLevelError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectAttributeMetadata: {
-						rows: &testRows[dbmodel.AttributeMetadata]{
-							data: []dbmodel.AttributeMetadata{{
+						Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+							Data: []dbmodel.AttributeMetadata{{
 								AttributeKey: "http.method",
 								Type:         "str",
 								Level:        "unknown",
 							}},
-							scanFn: func(dest any, src dbmodel.AttributeMetadata) error {
+							ScanFn: func(dest any, src dbmodel.AttributeMetadata) error {
 								ptr, ok := dest.(*dbmodel.AttributeMetadata)
 								if !ok {
 									return assert.AnError
@@ -107,7 +108,7 @@ func TestGetAttributeMetadata_ErrorCases(t *testing.T) {
 								return nil
 							},
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -131,27 +132,27 @@ func TestGetAttributeMetadata_NoStringAttributes(t *testing.T) {
 	attrs.PutInt("some.int", 42)
 	attrs.PutDouble("some.double", 3.14)
 
-	driver := &testDriver{
-		t: t,
+	driver := &clickhousetest.Driver{
+		T: t,
 	}
 
 	reader := NewReader(driver, ReaderConfig{AttributeMetadataCacheMaxSize: 1000})
 	metadata, err := reader.getAttributeMetadata(t.Context(), attrs)
 	require.NoError(t, err)
 	assert.Empty(t, metadata)
-	assert.Empty(t, driver.recordedQueries)
+	assert.Empty(t, driver.RecordedQueries)
 }
 
-func makeTestDriverWithMetadata(t *testing.T) *testDriver {
-	return &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+func makeTestDriverWithMetadata(t *testing.T) *clickhousetest.Driver {
+	return &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
-				rows: &testRows[dbmodel.AttributeMetadata]{
-					data: []dbmodel.AttributeMetadata{
+				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+					Data: []dbmodel.AttributeMetadata{
 						{AttributeKey: "http.method", Type: "str", Level: "span"},
 					},
-					scanFn: func(dest any, src dbmodel.AttributeMetadata) error {
+					ScanFn: func(dest any, src dbmodel.AttributeMetadata) error {
 						ptr, ok := dest.(*dbmodel.AttributeMetadata)
 						if !ok {
 							return assert.AnError
@@ -179,7 +180,7 @@ func TestGetAttributeMetadata_CacheMiss(t *testing.T) {
 	metadata, err := reader.getAttributeMetadata(t.Context(), attrs)
 	require.NoError(t, err)
 	assert.Len(t, metadata, 1)
-	assert.Len(t, d.recordedQueries, 1, "expected query to ClickHouse on cache miss")
+	assert.Len(t, d.RecordedQueries, 1, "expected query to ClickHouse on cache miss")
 	assert.Equal(t, 1, reader.attrMetaCache.Size(), "result should be cached after miss")
 }
 
@@ -197,13 +198,13 @@ func TestGetAttributeMetadata_CacheHit(t *testing.T) {
 	metadata, err := reader.getAttributeMetadata(t.Context(), attrs)
 	require.NoError(t, err)
 	assert.Len(t, metadata, 1)
-	assert.Len(t, d.recordedQueries, 1)
+	assert.Len(t, d.RecordedQueries, 1)
 
 	// Second call should use cache — no additional queries
 	metadata, err = reader.getAttributeMetadata(t.Context(), attrs)
 	require.NoError(t, err)
 	assert.Len(t, metadata, 1)
-	assert.Len(t, d.recordedQueries, 1, "expected no additional queries due to cache hit")
+	assert.Len(t, d.RecordedQueries, 1, "expected no additional queries due to cache hit")
 }
 
 func TestGetAttributeMetadata_CacheTTLExpiration(t *testing.T) {
@@ -222,38 +223,38 @@ func TestGetAttributeMetadata_CacheTTLExpiration(t *testing.T) {
 		metadata, err := reader.getAttributeMetadata(t.Context(), attrs)
 		require.NoError(t, err)
 		assert.Len(t, metadata, 1)
-		assert.Len(t, d.recordedQueries, 1)
+		assert.Len(t, d.RecordedQueries, 1)
 
 		// Second call within TTL should use cache
 		metadata, err = reader.getAttributeMetadata(t.Context(), attrs)
 		require.NoError(t, err)
 		assert.Len(t, metadata, 1)
-		assert.Len(t, d.recordedQueries, 1)
+		assert.Len(t, d.RecordedQueries, 1)
 
 		// Advance time past TTL
 		time.Sleep(cacheTTL + time.Second)
 
 		// Reset row iterator so the re-query can scan rows again
-		resp := d.queryResponses[sql.SelectAttributeMetadata]
-		rows := resp.rows.(*testRows[dbmodel.AttributeMetadata])
-		rows.index = 0
+		resp := d.QueryResponses[sql.SelectAttributeMetadata]
+		rows := resp.Rows.(*clickhousetest.Rows[dbmodel.AttributeMetadata])
+		rows.Index = 0
 
 		// Call after TTL expiration should query ClickHouse again
 		metadata, err = reader.getAttributeMetadata(t.Context(), attrs)
 		require.NoError(t, err)
 		assert.Len(t, metadata, 1)
-		assert.Len(t, d.recordedQueries, 2, "expected re-query after cache TTL expired")
+		assert.Len(t, d.RecordedQueries, 2, "expected re-query after cache TTL expired")
 	})
 }
 
 func TestGetAttributeMetadata_DoesNotCacheEmptyResult(t *testing.T) {
 	// When metadata returns no rows for a key, the empty result should NOT be cached.
-	d := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	d := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
-				rows: &testRows[dbmodel.AttributeMetadata]{
-					data: []dbmodel.AttributeMetadata{}, // no results
+				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+					Data: []dbmodel.AttributeMetadata{}, // no results
 				},
 			},
 		},
@@ -270,13 +271,13 @@ func TestGetAttributeMetadata_DoesNotCacheEmptyResult(t *testing.T) {
 	metadata, err := reader.getAttributeMetadata(t.Context(), attrs)
 	require.NoError(t, err)
 	assert.Empty(t, metadata["nonexistent.key"].span)
-	assert.Len(t, d.recordedQueries, 1)
+	assert.Len(t, d.RecordedQueries, 1)
 
 	// Second call should query ClickHouse again since empty results are not cached
 	metadata, err = reader.getAttributeMetadata(t.Context(), attrs)
 	require.NoError(t, err)
 	assert.Empty(t, metadata["nonexistent.key"].span)
-	assert.Len(t, d.recordedQueries, 2, "expected another query since empty results are not cached")
+	assert.Len(t, d.RecordedQueries, 2, "expected another query since empty results are not cached")
 }
 
 func TestGetAttributeMetadata_NonStringAttributesSkipped(t *testing.T) {

--- a/internal/storage/v2/clickhouse/tracestore/driver_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/driver_test.go
@@ -4,15 +4,12 @@
 package tracestore
 
 import (
-	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,136 +51,4 @@ func verifyQuerySnapshot(t *testing.T, queries ...string) {
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(string(snapshot)), query, "comparing against stored snapshot. Use REGENERATE_SNAPSHOTS=true to rebuild snapshots.")
 	}
-}
-
-type testBatch struct {
-	driver.Batch
-	t          *testing.T
-	appended   [][]any
-	appendErr  error
-	sendCalled bool
-	sendErr    error
-}
-
-func (tb *testBatch) Append(v ...any) error {
-	if tb.appendErr != nil {
-		return tb.appendErr
-	}
-	tb.appended = append(tb.appended, v)
-	return nil
-}
-
-func (tb *testBatch) Send() error {
-	if tb.sendErr != nil {
-		return tb.sendErr
-	}
-	tb.sendCalled = true
-	return nil
-}
-
-func (*testBatch) Close() error {
-	return nil
-}
-
-type testQueryResponse struct {
-	rows driver.Rows
-	err  error
-}
-
-type testBatchResponse struct {
-	batch *testBatch
-	err   error
-}
-
-type testDriver struct {
-	driver.Conn
-
-	t               *testing.T
-	queryResponses  map[string]*testQueryResponse
-	batchResponses  map[string]*testBatchResponse
-	recordedQueries []string
-}
-
-func (t *testDriver) Query(_ context.Context, query string, _ ...any) (driver.Rows, error) {
-	t.recordedQueries = append(t.recordedQueries, query)
-
-	// Normalize whitespace so substring matching works regardless of indentation.
-	normalized := strings.Join(strings.Fields(query), " ")
-	for querySubstring, response := range t.queryResponses {
-		normalizedQuerySubstring := strings.Join(strings.Fields(querySubstring), " ")
-		if strings.Contains(normalized, normalizedQuerySubstring) {
-			return response.rows, response.err
-		}
-	}
-
-	return nil, nil
-}
-
-type testRows[T any] struct {
-	driver.Rows
-
-	data     []T
-	index    int
-	scanErr  error
-	scanFn   func(dest any, src T) error
-	closeErr error
-	rowsErr  error
-}
-
-func (tr *testRows[T]) Close() error {
-	return tr.closeErr
-}
-
-func (tr *testRows[T]) Err() error {
-	return tr.rowsErr
-}
-
-func (tr *testRows[T]) Next() bool {
-	return tr.index < len(tr.data)
-}
-
-func (tr *testRows[T]) ScanStruct(dest any) error {
-	if tr.scanErr != nil {
-		return tr.scanErr
-	}
-	if tr.index >= len(tr.data) {
-		return errors.New("no more rows")
-	}
-	if tr.scanFn == nil {
-		return errors.New("scanFn is not provided")
-	}
-	err := tr.scanFn(dest, tr.data[tr.index])
-	tr.index++
-	return err
-}
-
-func (tr *testRows[T]) Scan(dest ...any) error {
-	if tr.scanErr != nil {
-		return tr.scanErr
-	}
-	if tr.index >= len(tr.data) {
-		return errors.New("no more rows")
-	}
-	if tr.scanFn == nil {
-		return errors.New("scanFn is not provided")
-	}
-	err := tr.scanFn(dest, tr.data[tr.index])
-	tr.index++
-	return err
-}
-
-func (t *testDriver) PrepareBatch(
-	_ context.Context,
-	query string,
-	_ ...driver.PrepareBatchOption,
-) (driver.Batch, error) {
-	t.recordedQueries = append(t.recordedQueries, query)
-
-	for querySubstring, response := range t.batchResponses {
-		if strings.Contains(query, querySubstring) {
-			return response.batch, response.err
-		}
-	}
-
-	return nil, nil
 }

--- a/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
@@ -29,7 +29,7 @@ func TestBuildFindTraceIDsQuery_MarshalErrors(t *testing.T) {
 		s := attrs.PutEmptySlice("bad_slice")
 		s.AppendEmpty()
 
-		reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
+		reader := NewReader(&clickhousetest.Driver{}, testReaderConfig)
 		_, _, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{Attributes: attrs})
 
 		require.Error(t, err)
@@ -41,7 +41,7 @@ func TestBuildFindTraceIDsQuery_MarshalErrors(t *testing.T) {
 		m := attrs.PutEmptyMap("bad_map")
 		m.PutEmpty("key")
 
-		reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
+		reader := NewReader(&clickhousetest.Driver{}, testReaderConfig)
 		_, _, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{Attributes: attrs})
 
 		require.Error(t, err)
@@ -51,7 +51,6 @@ func TestBuildFindTraceIDsQuery_MarshalErrors(t *testing.T) {
 
 func TestBuildFindTraceIDsQuery_AttributeMetadataError(t *testing.T) {
 	td := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
 				Rows: nil,

--- a/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 )
 
@@ -28,7 +29,7 @@ func TestBuildFindTraceIDsQuery_MarshalErrors(t *testing.T) {
 		s := attrs.PutEmptySlice("bad_slice")
 		s.AppendEmpty()
 
-		reader := NewReader(&testDriver{t: t}, testReaderConfig)
+		reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
 		_, _, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{Attributes: attrs})
 
 		require.Error(t, err)
@@ -40,7 +41,7 @@ func TestBuildFindTraceIDsQuery_MarshalErrors(t *testing.T) {
 		m := attrs.PutEmptyMap("bad_map")
 		m.PutEmpty("key")
 
-		reader := NewReader(&testDriver{t: t}, testReaderConfig)
+		reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
 		_, _, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{Attributes: attrs})
 
 		require.Error(t, err)
@@ -49,12 +50,12 @@ func TestBuildFindTraceIDsQuery_MarshalErrors(t *testing.T) {
 }
 
 func TestBuildFindTraceIDsQuery_AttributeMetadataError(t *testing.T) {
-	td := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	td := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
-				rows: nil,
-				err:  assert.AnError,
+				Rows: nil,
+				Err:  assert.AnError,
 			},
 		},
 	}

--- a/internal/storage/v2/clickhouse/tracestore/reader_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader_test.go
@@ -247,7 +247,6 @@ func TestGetTraces_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conn := &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
 						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -280,7 +279,6 @@ func TestGetTraces_ErrorCases(t *testing.T) {
 		{
 			name: "QueryError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
 						Rows: nil,
@@ -293,7 +291,6 @@ func TestGetTraces_ErrorCases(t *testing.T) {
 		{
 			name: "ScanError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
 						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -309,7 +306,6 @@ func TestGetTraces_ErrorCases(t *testing.T) {
 		{
 			name: "CloseError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
 						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -349,7 +345,6 @@ func TestGetTraces_ScanErrorContinues(t *testing.T) {
 	}
 
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansByTraceID: {
 				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -378,7 +373,6 @@ func TestGetTraces_ScanErrorContinues(t *testing.T) {
 
 func TestGetTraces_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansByTraceID: {
 				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -416,7 +410,6 @@ func TestGetServices(t *testing.T) {
 		{
 			name: "successfully returns services",
 			conn: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectServices: {
 						Rows: &clickhousetest.Rows[dbmodel.Service]{
@@ -443,7 +436,6 @@ func TestGetServices(t *testing.T) {
 		{
 			name: "query error",
 			conn: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectServices: {
 						Rows: nil,
@@ -456,7 +448,6 @@ func TestGetServices(t *testing.T) {
 		{
 			name: "scan error",
 			conn: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectServices: {
 						Rows: &clickhousetest.Rows[dbmodel.Service]{
@@ -504,7 +495,6 @@ func TestGetOperations(t *testing.T) {
 		{
 			name: "successfully returns operations for all kinds",
 			conn: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsAllKinds: {
 						Rows: &clickhousetest.Rows[dbmodel.Operation]{
@@ -544,7 +534,6 @@ func TestGetOperations(t *testing.T) {
 		{
 			name: "successfully returns operations by kind",
 			conn: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsByKind: {
 						Rows: &clickhousetest.Rows[dbmodel.Operation]{
@@ -588,7 +577,6 @@ func TestGetOperations(t *testing.T) {
 		{
 			name: "query error",
 			conn: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsAllKinds: {
 						Rows: nil,
@@ -601,7 +589,6 @@ func TestGetOperations(t *testing.T) {
 		{
 			name: "scan error",
 			conn: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsAllKinds: {
 						Rows: &clickhousetest.Rows[dbmodel.Operation]{
@@ -656,7 +643,6 @@ func TestFindTraces_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conn := &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansQuery: {
 						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -684,7 +670,6 @@ func TestFindTraces_Success(t *testing.T) {
 
 func TestFindTraces_WithFilters(t *testing.T) {
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
 				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
@@ -723,9 +708,7 @@ func TestFindTraces_WithFilters(t *testing.T) {
 }
 
 func TestFindTraces_SearchDepthExceedsMax(t *testing.T) {
-	driver := &clickhousetest.Driver{
-		T: t,
-	}
+	driver := &clickhousetest.Driver{}
 	reader := NewReader(driver, testReaderConfig)
 	iter := reader.FindTraces(context.Background(), tracestore.TraceQueryParams{
 		SearchDepth: 10000,
@@ -737,7 +720,6 @@ func TestFindTraces_SearchDepthExceedsMax(t *testing.T) {
 
 func TestFindTraces_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansQuery: {
 				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -777,7 +759,6 @@ func TestFindTraces_ScanErrorContinues(t *testing.T) {
 	}
 
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansQuery: {
 				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -813,7 +794,6 @@ func TestFindTraces_ErrorCases(t *testing.T) {
 		{
 			name: "QueryError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansQuery: {
 						Rows: nil,
@@ -826,7 +806,6 @@ func TestFindTraces_ErrorCases(t *testing.T) {
 		{
 			name: "ScanError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansQuery: {
 						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
@@ -864,7 +843,7 @@ func TestFindTraces_BuildQueryError(t *testing.T) {
 	attrs := pcommon.NewMap()
 	attrs.PutEmptySlice("bad_slice").AppendEmpty()
 
-	reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
+	reader := NewReader(&clickhousetest.Driver{}, testReaderConfig)
 	iter := reader.FindTraces(context.Background(), tracestore.TraceQueryParams{
 		Attributes:  attrs,
 		SearchDepth: 1,
@@ -875,7 +854,6 @@ func TestFindTraces_BuildQueryError(t *testing.T) {
 
 func TestFindTraceIDs(t *testing.T) {
 	driver := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
 				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
@@ -923,7 +901,6 @@ func TestFindTraceIDs(t *testing.T) {
 
 func TestFindTraceIDs_SearchDepthExceedsMax(t *testing.T) {
 	driver := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
 				Rows: &clickhousetest.Rows[[]any]{
@@ -955,7 +932,6 @@ func TestFindTraceIDs_SearchDepthExceedsMax(t *testing.T) {
 
 func TestFindTraceIDs_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
 				Rows: &clickhousetest.Rows[[]any]{
@@ -1001,7 +977,6 @@ func TestFindTraceIDs_ScanErrorContinues(t *testing.T) {
 	}
 
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
 				Rows: &clickhousetest.Rows[[]any]{
@@ -1035,7 +1010,6 @@ func TestFindTraceIDs_ScanErrorContinues(t *testing.T) {
 
 func TestFindTraceIDs_DecodeErrorContinues(t *testing.T) {
 	conn := &clickhousetest.Driver{
-		T: t,
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
 				Rows: &clickhousetest.Rows[[]any]{
@@ -1101,7 +1075,6 @@ func TestFindTraceIDs_ErrorCases(t *testing.T) {
 		{
 			name: "QueryError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SearchTraceIDsBase: {
 						Rows: nil,
@@ -1114,7 +1087,6 @@ func TestFindTraceIDs_ErrorCases(t *testing.T) {
 		{
 			name: "ScanError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SearchTraceIDsBase: {
 						Rows: &clickhousetest.Rows[[]any]{
@@ -1130,7 +1102,6 @@ func TestFindTraceIDs_ErrorCases(t *testing.T) {
 		{
 			name: "DecodeError",
 			driver: &clickhousetest.Driver{
-				T: t,
 				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SearchTraceIDsBase: {
 						Rows: &clickhousetest.Rows[[]any]{
@@ -1174,7 +1145,7 @@ func TestFindTraceIDs_BuildQueryError(t *testing.T) {
 	attrs := pcommon.NewMap()
 	attrs.PutEmptyMap("bad_map").PutEmpty("key")
 
-	reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
+	reader := NewReader(&clickhousetest.Driver{}, testReaderConfig)
 	iter := reader.FindTraceIDs(context.Background(), tracestore.TraceQueryParams{
 		Attributes:  attrs,
 		SearchDepth: 1,

--- a/internal/storage/v2/clickhouse/tracestore/reader_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/internal/jiter"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/tracestore/dbmodel"
 )
@@ -245,15 +246,15 @@ func TestGetTraces_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conn := &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn := &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
-						rows: &testRows[*dbmodel.SpanRow]{
-							data:   tt.data,
-							scanFn: scanSpanRowFn(),
+						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+							Data:   tt.data,
+							ScanFn: scanSpanRowFn(),
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			}
@@ -263,8 +264,8 @@ func TestGetTraces_Success(t *testing.T) {
 			traces, err := jiter.FlattenWithErrors(getTracesIter)
 
 			require.NoError(t, err)
-			require.Len(t, conn.recordedQueries, 1)
-			verifyQuerySnapshot(t, conn.recordedQueries...)
+			require.Len(t, conn.RecordedQueries, 1)
+			verifyQuerySnapshot(t, conn.RecordedQueries...)
 			requireTracesEqual(t, tt.data, traces)
 		})
 	}
@@ -273,17 +274,17 @@ func TestGetTraces_Success(t *testing.T) {
 func TestGetTraces_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name        string
-		driver      *testDriver
+		driver      *clickhousetest.Driver
 		expectedErr string
 	}{
 		{
 			name: "QueryError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
-						rows: nil,
-						err:  assert.AnError,
+						Rows: nil,
+						Err:  assert.AnError,
 					},
 				},
 			},
@@ -291,15 +292,15 @@ func TestGetTraces_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "ScanError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
-						rows: &testRows[*dbmodel.SpanRow]{
-							data:    singleSpan,
-							scanErr: assert.AnError,
+						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+							Data:    singleSpan,
+							ScanErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -307,16 +308,16 @@ func TestGetTraces_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "CloseError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansByTraceID: {
-						rows: &testRows[*dbmodel.SpanRow]{
-							data:     singleSpan,
-							scanFn:   scanSpanRowFn(),
-							closeErr: assert.AnError,
+						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+							Data:     singleSpan,
+							ScanFn:   scanSpanRowFn(),
+							CloseErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -339,7 +340,7 @@ func TestGetTraces_ErrorCases(t *testing.T) {
 func TestGetTraces_ScanErrorContinues(t *testing.T) {
 	scanCalled := 0
 
-	scanFn := func(dest any, src *dbmodel.SpanRow) error {
+	ScanFn := func(dest any, src *dbmodel.SpanRow) error {
 		scanCalled++
 		if scanCalled == 1 {
 			return assert.AnError // simulate scan error on the first row
@@ -347,15 +348,15 @@ func TestGetTraces_ScanErrorContinues(t *testing.T) {
 		return scanSpanRowFn()(dest, src)
 	}
 
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansByTraceID: {
-				rows: &testRows[*dbmodel.SpanRow]{
-					data:   multipleSpans,
-					scanFn: scanFn,
+				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+					Data:   multipleSpans,
+					ScanFn: ScanFn,
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -376,15 +377,15 @@ func TestGetTraces_ScanErrorContinues(t *testing.T) {
 }
 
 func TestGetTraces_YieldFalseOnSuccessStopsIteration(t *testing.T) {
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansByTraceID: {
-				rows: &testRows[*dbmodel.SpanRow]{
-					data:   multipleSpans,
-					scanFn: scanSpanRowFn(),
+				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+					Data:   multipleSpans,
+					ScanFn: scanSpanRowFn(),
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -408,23 +409,23 @@ func TestGetTraces_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 func TestGetServices(t *testing.T) {
 	tests := []struct {
 		name        string
-		conn        *testDriver
+		conn        *clickhousetest.Driver
 		expected    []string
 		expectError string
 	}{
 		{
 			name: "successfully returns services",
-			conn: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectServices: {
-						rows: &testRows[dbmodel.Service]{
-							data: []dbmodel.Service{
+						Rows: &clickhousetest.Rows[dbmodel.Service]{
+							Data: []dbmodel.Service{
 								{Name: "serviceA"},
 								{Name: "serviceB"},
 								{Name: "serviceC"},
 							},
-							scanFn: func(dest any, src dbmodel.Service) error {
+							ScanFn: func(dest any, src dbmodel.Service) error {
 								svc, ok := dest.(*dbmodel.Service)
 								if !ok {
 									return errors.New("dest is not *dbmodel.Service")
@@ -433,7 +434,7 @@ func TestGetServices(t *testing.T) {
 								return nil
 							},
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -441,12 +442,12 @@ func TestGetServices(t *testing.T) {
 		},
 		{
 			name: "query error",
-			conn: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectServices: {
-						rows: nil,
-						err:  assert.AnError,
+						Rows: nil,
+						Err:  assert.AnError,
 					},
 				},
 			},
@@ -454,19 +455,19 @@ func TestGetServices(t *testing.T) {
 		},
 		{
 			name: "scan error",
-			conn: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectServices: {
-						rows: &testRows[dbmodel.Service]{
-							data: []dbmodel.Service{
+						Rows: &clickhousetest.Rows[dbmodel.Service]{
+							Data: []dbmodel.Service{
 								{Name: "serviceA"},
 								{Name: "serviceB"},
 								{Name: "serviceC"},
 							},
-							scanErr: assert.AnError,
+							ScanErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -484,8 +485,8 @@ func TestGetServices(t *testing.T) {
 				require.ErrorContains(t, err, test.expectError)
 			} else {
 				require.NoError(t, err)
-				require.Len(t, test.conn.recordedQueries, 1)
-				verifyQuerySnapshot(t, test.conn.recordedQueries...)
+				require.Len(t, test.conn.RecordedQueries, 1)
+				verifyQuerySnapshot(t, test.conn.RecordedQueries...)
 				require.Equal(t, test.expected, result)
 			}
 		})
@@ -495,24 +496,24 @@ func TestGetServices(t *testing.T) {
 func TestGetOperations(t *testing.T) {
 	tests := []struct {
 		name        string
-		conn        *testDriver
+		conn        *clickhousetest.Driver
 		query       tracestore.OperationQueryParams
 		expected    []tracestore.Operation
 		expectError string
 	}{
 		{
 			name: "successfully returns operations for all kinds",
-			conn: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsAllKinds: {
-						rows: &testRows[dbmodel.Operation]{
-							data: []dbmodel.Operation{
+						Rows: &clickhousetest.Rows[dbmodel.Operation]{
+							Data: []dbmodel.Operation{
 								{Name: "operationA"},
 								{Name: "operationB"},
 								{Name: "operationC"},
 							},
-							scanFn: func(dest any, src dbmodel.Operation) error {
+							ScanFn: func(dest any, src dbmodel.Operation) error {
 								svc, ok := dest.(*dbmodel.Operation)
 								if !ok {
 									return errors.New("dest is not *dbmodel.Operation")
@@ -521,7 +522,7 @@ func TestGetOperations(t *testing.T) {
 								return nil
 							},
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -542,17 +543,17 @@ func TestGetOperations(t *testing.T) {
 		},
 		{
 			name: "successfully returns operations by kind",
-			conn: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsByKind: {
-						rows: &testRows[dbmodel.Operation]{
-							data: []dbmodel.Operation{
+						Rows: &clickhousetest.Rows[dbmodel.Operation]{
+							Data: []dbmodel.Operation{
 								{Name: "operationA", SpanKind: "server"},
 								{Name: "operationB", SpanKind: "server"},
 								{Name: "operationC", SpanKind: "server"},
 							},
-							scanFn: func(dest any, src dbmodel.Operation) error {
+							ScanFn: func(dest any, src dbmodel.Operation) error {
 								svc, ok := dest.(*dbmodel.Operation)
 								if !ok {
 									return errors.New("dest is not *dbmodel.Operation")
@@ -561,7 +562,7 @@ func TestGetOperations(t *testing.T) {
 								return nil
 							},
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -586,12 +587,12 @@ func TestGetOperations(t *testing.T) {
 		},
 		{
 			name: "query error",
-			conn: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsAllKinds: {
-						rows: nil,
-						err:  assert.AnError,
+						Rows: nil,
+						Err:  assert.AnError,
 					},
 				},
 			},
@@ -599,19 +600,19 @@ func TestGetOperations(t *testing.T) {
 		},
 		{
 			name: "scan error",
-			conn: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectOperationsAllKinds: {
-						rows: &testRows[dbmodel.Operation]{
-							data: []dbmodel.Operation{
+						Rows: &clickhousetest.Rows[dbmodel.Operation]{
+							Data: []dbmodel.Operation{
 								{Name: "operationA"},
 								{Name: "operationB"},
 								{Name: "operationC"},
 							},
-							scanErr: assert.AnError,
+							ScanErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -629,8 +630,8 @@ func TestGetOperations(t *testing.T) {
 				require.ErrorContains(t, err, test.expectError)
 			} else {
 				require.NoError(t, err)
-				require.Len(t, test.conn.recordedQueries, 1)
-				verifyQuerySnapshot(t, test.conn.recordedQueries...)
+				require.Len(t, test.conn.RecordedQueries, 1)
+				verifyQuerySnapshot(t, test.conn.RecordedQueries...)
 				require.Equal(t, test.expected, result)
 			}
 		})
@@ -654,15 +655,15 @@ func TestFindTraces_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conn := &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			conn := &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansQuery: {
-						rows: &testRows[*dbmodel.SpanRow]{
-							data:   tt.data,
-							scanFn: scanSpanRowFn(),
+						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+							Data:   tt.data,
+							ScanFn: scanSpanRowFn(),
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			}
@@ -674,29 +675,29 @@ func TestFindTraces_Success(t *testing.T) {
 			traces, err := jiter.FlattenWithErrors(findTracesIter)
 
 			require.NoError(t, err)
-			require.Len(t, conn.recordedQueries, 1)
-			verifyQuerySnapshot(t, conn.recordedQueries...)
+			require.Len(t, conn.RecordedQueries, 1)
+			verifyQuerySnapshot(t, conn.RecordedQueries...)
 			requireTracesEqual(t, tt.data, traces)
 		})
 	}
 }
 
 func TestFindTraces_WithFilters(t *testing.T) {
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
-				rows: &testRows[dbmodel.AttributeMetadata]{
-					data:   testAttributeMetadata,
-					scanFn: scanAttributeMetadataFn(),
+				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+					Data:   testAttributeMetadata,
+					ScanFn: scanAttributeMetadataFn(),
 				},
 			},
 			sql.SelectSpansQuery: {
-				rows: &testRows[*dbmodel.SpanRow]{
-					data:   multipleSpans,
-					scanFn: scanSpanRowFn(),
+				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+					Data:   multipleSpans,
+					ScanFn: scanSpanRowFn(),
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -716,14 +717,14 @@ func TestFindTraces_WithFilters(t *testing.T) {
 	})
 	traces, err := jiter.FlattenWithErrors(iter)
 	require.NoError(t, err)
-	require.Len(t, conn.recordedQueries, 2)
-	verifyQuerySnapshot(t, conn.recordedQueries...)
+	require.Len(t, conn.RecordedQueries, 2)
+	verifyQuerySnapshot(t, conn.RecordedQueries...)
 	requireTracesEqual(t, multipleSpans, traces)
 }
 
 func TestFindTraces_SearchDepthExceedsMax(t *testing.T) {
-	driver := &testDriver{
-		t: t,
+	driver := &clickhousetest.Driver{
+		T: t,
 	}
 	reader := NewReader(driver, testReaderConfig)
 	iter := reader.FindTraces(context.Background(), tracestore.TraceQueryParams{
@@ -735,15 +736,15 @@ func TestFindTraces_SearchDepthExceedsMax(t *testing.T) {
 }
 
 func TestFindTraces_YieldFalseOnSuccessStopsIteration(t *testing.T) {
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansQuery: {
-				rows: &testRows[*dbmodel.SpanRow]{
-					data:   multipleSpans,
-					scanFn: scanSpanRowFn(),
+				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+					Data:   multipleSpans,
+					ScanFn: scanSpanRowFn(),
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -767,7 +768,7 @@ func TestFindTraces_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 func TestFindTraces_ScanErrorContinues(t *testing.T) {
 	scanCalled := 0
 
-	scanFn := func(dest any, src *dbmodel.SpanRow) error {
+	ScanFn := func(dest any, src *dbmodel.SpanRow) error {
 		scanCalled++
 		if scanCalled == 1 {
 			return assert.AnError // simulate scan error on the first row
@@ -775,15 +776,15 @@ func TestFindTraces_ScanErrorContinues(t *testing.T) {
 		return scanSpanRowFn()(dest, src)
 	}
 
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectSpansQuery: {
-				rows: &testRows[*dbmodel.SpanRow]{
-					data:   multipleSpans,
-					scanFn: scanFn,
+				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+					Data:   multipleSpans,
+					ScanFn: ScanFn,
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -806,17 +807,17 @@ func TestFindTraces_ScanErrorContinues(t *testing.T) {
 func TestFindTraces_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name        string
-		driver      *testDriver
+		driver      *clickhousetest.Driver
 		expectedErr string
 	}{
 		{
 			name: "QueryError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansQuery: {
-						rows: nil,
-						err:  assert.AnError,
+						Rows: nil,
+						Err:  assert.AnError,
 					},
 				},
 			},
@@ -824,15 +825,15 @@ func TestFindTraces_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "ScanError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SelectSpansQuery: {
-						rows: &testRows[*dbmodel.SpanRow]{
-							data:    singleSpan,
-							scanErr: assert.AnError,
+						Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
+							Data:    singleSpan,
+							ScanErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -863,7 +864,7 @@ func TestFindTraces_BuildQueryError(t *testing.T) {
 	attrs := pcommon.NewMap()
 	attrs.PutEmptySlice("bad_slice").AppendEmpty()
 
-	reader := NewReader(&testDriver{t: t}, testReaderConfig)
+	reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
 	iter := reader.FindTraces(context.Background(), tracestore.TraceQueryParams{
 		Attributes:  attrs,
 		SearchDepth: 1,
@@ -873,21 +874,21 @@ func TestFindTraces_BuildQueryError(t *testing.T) {
 }
 
 func TestFindTraceIDs(t *testing.T) {
-	driver := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	driver := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectAttributeMetadata: {
-				rows: &testRows[dbmodel.AttributeMetadata]{
-					data:   testAttributeMetadata,
-					scanFn: scanAttributeMetadataFn(),
+				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+					Data:   testAttributeMetadata,
+					ScanFn: scanAttributeMetadataFn(),
 				},
 			},
 			sql.SearchTraceIDsBase: {
-				rows: &testRows[[]any]{
-					data:   testTraceIDsData,
-					scanFn: scanTraceIDFn(),
+				Rows: &clickhousetest.Rows[[]any]{
+					Data:   testTraceIDsData,
+					ScanFn: scanTraceIDFn(),
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -906,8 +907,8 @@ func TestFindTraceIDs(t *testing.T) {
 	})
 	ids, err := jiter.FlattenWithErrors(iter)
 	require.NoError(t, err)
-	require.Len(t, driver.recordedQueries, 2)
-	verifyQuerySnapshot(t, driver.recordedQueries...)
+	require.Len(t, driver.RecordedQueries, 2)
+	verifyQuerySnapshot(t, driver.RecordedQueries...)
 	require.Equal(t, []tracestore.FoundTraceID{
 		{
 			TraceID: pcommon.TraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
@@ -921,12 +922,12 @@ func TestFindTraceIDs(t *testing.T) {
 }
 
 func TestFindTraceIDs_SearchDepthExceedsMax(t *testing.T) {
-	driver := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	driver := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
-				rows: &testRows[[]any]{
-					data: [][]any{
+				Rows: &clickhousetest.Rows[[]any]{
+					Data: [][]any{
 						{
 							"00000000000000000000000000000001",
 							time.Now().Add(-1 * time.Hour),
@@ -938,9 +939,9 @@ func TestFindTraceIDs_SearchDepthExceedsMax(t *testing.T) {
 							time.Now().Add(-2 * time.Minute),
 						},
 					},
-					scanFn: scanTraceIDFn(),
+					ScanFn: scanTraceIDFn(),
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -953,15 +954,15 @@ func TestFindTraceIDs_SearchDepthExceedsMax(t *testing.T) {
 }
 
 func TestFindTraceIDs_YieldFalseOnSuccessStopsIteration(t *testing.T) {
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
-				rows: &testRows[[]any]{
-					data:   testTraceIDsData,
-					scanFn: scanTraceIDFn(),
+				Rows: &clickhousetest.Rows[[]any]{
+					Data:   testTraceIDsData,
+					ScanFn: scanTraceIDFn(),
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -991,7 +992,7 @@ func TestFindTraceIDs_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 func TestFindTraceIDs_ScanErrorContinues(t *testing.T) {
 	scanCalled := 0
 
-	scanFn := func(dest any, src []any) error {
+	ScanFn := func(dest any, src []any) error {
 		scanCalled++
 		if scanCalled == 1 {
 			return assert.AnError // simulate scan error on the first row
@@ -999,15 +1000,15 @@ func TestFindTraceIDs_ScanErrorContinues(t *testing.T) {
 		return scanTraceIDFn()(dest, src)
 	}
 
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
-				rows: &testRows[[]any]{
-					data:   testTraceIDsData,
-					scanFn: scanFn,
+				Rows: &clickhousetest.Rows[[]any]{
+					Data:   testTraceIDsData,
+					ScanFn: ScanFn,
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -1033,12 +1034,12 @@ func TestFindTraceIDs_ScanErrorContinues(t *testing.T) {
 }
 
 func TestFindTraceIDs_DecodeErrorContinues(t *testing.T) {
-	conn := &testDriver{
-		t: t,
-		queryResponses: map[string]*testQueryResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SearchTraceIDsBase: {
-				rows: &testRows[[]any]{
-					data: [][]any{
+				Rows: &clickhousetest.Rows[[]any]{
+					Data: [][]any{
 						testTraceIDsData[0],
 						{
 							"0x",
@@ -1052,9 +1053,9 @@ func TestFindTraceIDs_DecodeErrorContinues(t *testing.T) {
 						},
 						testTraceIDsData[1],
 					},
-					scanFn: scanTraceIDFn(),
+					ScanFn: scanTraceIDFn(),
 				},
-				err: nil,
+				Err: nil,
 			},
 		},
 	}
@@ -1094,17 +1095,17 @@ func TestFindTraceIDs_DecodeErrorContinues(t *testing.T) {
 func TestFindTraceIDs_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name        string
-		driver      *testDriver
+		driver      *clickhousetest.Driver
 		expectedErr string
 	}{
 		{
 			name: "QueryError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SearchTraceIDsBase: {
-						rows: nil,
-						err:  assert.AnError,
+						Rows: nil,
+						Err:  assert.AnError,
 					},
 				},
 			},
@@ -1112,15 +1113,15 @@ func TestFindTraceIDs_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "ScanError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SearchTraceIDsBase: {
-						rows: &testRows[[]any]{
-							data:    testTraceIDsData,
-							scanErr: assert.AnError,
+						Rows: &clickhousetest.Rows[[]any]{
+							Data:    testTraceIDsData,
+							ScanErr: assert.AnError,
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -1128,21 +1129,21 @@ func TestFindTraceIDs_ErrorCases(t *testing.T) {
 		},
 		{
 			name: "DecodeError",
-			driver: &testDriver{
-				t: t,
-				queryResponses: map[string]*testQueryResponse{
+			driver: &clickhousetest.Driver{
+				T: t,
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
 					sql.SearchTraceIDsBase: {
-						rows: &testRows[[]any]{
-							data: [][]any{
+						Rows: &clickhousetest.Rows[[]any]{
+							Data: [][]any{
 								{
 									"0x",
 									time.Now().Add(-1 * time.Hour),
 									time.Now().Add(-1 * time.Minute),
 								},
 							},
-							scanFn: scanTraceIDFn(),
+							ScanFn: scanTraceIDFn(),
 						},
-						err: nil,
+						Err: nil,
 					},
 				},
 			},
@@ -1173,7 +1174,7 @@ func TestFindTraceIDs_BuildQueryError(t *testing.T) {
 	attrs := pcommon.NewMap()
 	attrs.PutEmptyMap("bad_map").PutEmpty("key")
 
-	reader := NewReader(&testDriver{t: t}, testReaderConfig)
+	reader := NewReader(&clickhousetest.Driver{T: t}, testReaderConfig)
 	iter := reader.FindTraceIDs(context.Background(), tracestore.TraceQueryParams{
 		Attributes:  attrs,
 		SearchDepth: 1,

--- a/internal/storage/v2/clickhouse/tracestore/reader_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader_test.go
@@ -340,7 +340,7 @@ func TestGetTraces_ErrorCases(t *testing.T) {
 func TestGetTraces_ScanErrorContinues(t *testing.T) {
 	scanCalled := 0
 
-	ScanFn := func(dest any, src *dbmodel.SpanRow) error {
+	scanFn := func(dest any, src *dbmodel.SpanRow) error {
 		scanCalled++
 		if scanCalled == 1 {
 			return assert.AnError // simulate scan error on the first row
@@ -354,7 +354,7 @@ func TestGetTraces_ScanErrorContinues(t *testing.T) {
 			sql.SelectSpansByTraceID: {
 				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
 					Data:   multipleSpans,
-					ScanFn: ScanFn,
+					ScanFn: scanFn,
 				},
 				Err: nil,
 			},
@@ -768,7 +768,7 @@ func TestFindTraces_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 func TestFindTraces_ScanErrorContinues(t *testing.T) {
 	scanCalled := 0
 
-	ScanFn := func(dest any, src *dbmodel.SpanRow) error {
+	scanFn := func(dest any, src *dbmodel.SpanRow) error {
 		scanCalled++
 		if scanCalled == 1 {
 			return assert.AnError // simulate scan error on the first row
@@ -782,7 +782,7 @@ func TestFindTraces_ScanErrorContinues(t *testing.T) {
 			sql.SelectSpansQuery: {
 				Rows: &clickhousetest.Rows[*dbmodel.SpanRow]{
 					Data:   multipleSpans,
-					ScanFn: ScanFn,
+					ScanFn: scanFn,
 				},
 				Err: nil,
 			},
@@ -992,7 +992,7 @@ func TestFindTraceIDs_YieldFalseOnSuccessStopsIteration(t *testing.T) {
 func TestFindTraceIDs_ScanErrorContinues(t *testing.T) {
 	scanCalled := 0
 
-	ScanFn := func(dest any, src []any) error {
+	scanFn := func(dest any, src []any) error {
 		scanCalled++
 		if scanCalled == 1 {
 			return assert.AnError // simulate scan error on the first row
@@ -1006,7 +1006,7 @@ func TestFindTraceIDs_ScanErrorContinues(t *testing.T) {
 			sql.SearchTraceIDsBase: {
 				Rows: &clickhousetest.Rows[[]any]{
 					Data:   testTraceIDsData,
-					ScanFn: ScanFn,
+					ScanFn: scanFn,
 				},
 				Err: nil,
 			},

--- a/internal/storage/v2/clickhouse/tracestore/writer_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/writer_test.go
@@ -31,9 +31,8 @@ func tracesFromSpanRows(rows []*dbmodel.SpanRow) ptrace.Traces {
 }
 
 func TestWriter_Success(t *testing.T) {
-	b := &clickhousetest.Batch{T: t}
+	b := &clickhousetest.Batch{}
 	conn := &clickhousetest.Driver{
-		T: t,
 		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
 				Batch: b,
@@ -148,7 +147,6 @@ func TestWriter_Success(t *testing.T) {
 
 func TestWriter_PrepareBatchError(t *testing.T) {
 	conn := &clickhousetest.Driver{
-		T: t,
 		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
 				Batch: nil,
@@ -163,9 +161,8 @@ func TestWriter_PrepareBatchError(t *testing.T) {
 }
 
 func TestWriter_AppendBatchError(t *testing.T) {
-	b := &clickhousetest.Batch{T: t, AppendErr: assert.AnError}
+	b := &clickhousetest.Batch{AppendErr: assert.AnError}
 	conn := &clickhousetest.Driver{
-		T: t,
 		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
 				Batch: b,
@@ -180,9 +177,8 @@ func TestWriter_AppendBatchError(t *testing.T) {
 }
 
 func TestWriter_SendError(t *testing.T) {
-	b := &clickhousetest.Batch{T: t, SendErr: assert.AnError}
+	b := &clickhousetest.Batch{SendErr: assert.AnError}
 	conn := &clickhousetest.Driver{
-		T: t,
 		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
 				Batch: b,

--- a/internal/storage/v2/clickhouse/tracestore/writer_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/writer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/tracestore/dbmodel"
 )
@@ -30,12 +31,12 @@ func tracesFromSpanRows(rows []*dbmodel.SpanRow) ptrace.Traces {
 }
 
 func TestWriter_Success(t *testing.T) {
-	b := &testBatch{t: t}
-	conn := &testDriver{
-		t: t,
-		batchResponses: map[string]*testBatchResponse{
+	b := &clickhousetest.Batch{T: t}
+	conn := &clickhousetest.Driver{
+		T: t,
+		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
-				batch: b,
+				Batch: b,
 			},
 		},
 	}
@@ -46,13 +47,13 @@ func TestWriter_Success(t *testing.T) {
 	err := w.WriteTraces(context.Background(), td)
 	require.NoError(t, err)
 
-	require.Len(t, conn.recordedQueries, 1)
-	verifyQuerySnapshot(t, conn.recordedQueries[0])
-	require.True(t, b.sendCalled)
-	require.Len(t, b.appended, len(multipleSpans))
+	require.Len(t, conn.RecordedQueries, 1)
+	verifyQuerySnapshot(t, conn.RecordedQueries[0])
+	require.True(t, b.SendCalled)
+	require.Len(t, b.Appended, len(multipleSpans))
 
 	for i, expected := range multipleSpans {
-		row := b.appended[i]
+		row := b.Appended[i]
 
 		require.Equal(t, expected.ID, row[0])                        // SpanID
 		require.Equal(t, expected.TraceID, row[1])                   // TraceID
@@ -146,12 +147,12 @@ func TestWriter_Success(t *testing.T) {
 }
 
 func TestWriter_PrepareBatchError(t *testing.T) {
-	conn := &testDriver{
-		t: t,
-		batchResponses: map[string]*testBatchResponse{
+	conn := &clickhousetest.Driver{
+		T: t,
+		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
-				batch: nil,
-				err:   assert.AnError,
+				Batch: nil,
+				Err:   assert.AnError,
 			},
 		},
 	}
@@ -162,12 +163,12 @@ func TestWriter_PrepareBatchError(t *testing.T) {
 }
 
 func TestWriter_AppendBatchError(t *testing.T) {
-	b := &testBatch{t: t, appendErr: assert.AnError}
-	conn := &testDriver{
-		t: t,
-		batchResponses: map[string]*testBatchResponse{
+	b := &clickhousetest.Batch{T: t, AppendErr: assert.AnError}
+	conn := &clickhousetest.Driver{
+		T: t,
+		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
-				batch: b,
+				Batch: b,
 			},
 		},
 	}
@@ -175,16 +176,16 @@ func TestWriter_AppendBatchError(t *testing.T) {
 	err := w.WriteTraces(context.Background(), tracesFromSpanRows(multipleSpans))
 	require.ErrorContains(t, err, "failed to append span to batch")
 	require.ErrorIs(t, err, assert.AnError)
-	require.False(t, b.sendCalled)
+	require.False(t, b.SendCalled)
 }
 
 func TestWriter_SendError(t *testing.T) {
-	b := &testBatch{t: t, sendErr: assert.AnError}
-	conn := &testDriver{
-		t: t,
-		batchResponses: map[string]*testBatchResponse{
+	b := &clickhousetest.Batch{T: t, SendErr: assert.AnError}
+	conn := &clickhousetest.Driver{
+		T: t,
+		BatchResponses: map[string]*clickhousetest.BatchResponse{
 			sql.InsertSpan: {
-				batch: b,
+				Batch: b,
 			},
 		},
 	}
@@ -192,7 +193,7 @@ func TestWriter_SendError(t *testing.T) {
 	err := w.WriteTraces(context.Background(), tracesFromSpanRows(multipleSpans))
 	require.ErrorContains(t, err, "failed to send batch")
 	require.ErrorIs(t, err, assert.AnError)
-	require.False(t, b.sendCalled)
+	require.False(t, b.SendCalled)
 }
 
 func TestToTuple(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #7136 

## Description of the changes
- The test implementations of ClickHouse interfaces used for `tracestore` can also be used for `depstore` now (in #8356). This PR simply moves those implementations to the top-level `clickhousetest` package and updates the callsites with the new usage.

## How was this change tested?
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
