### PR TITLE
[clickhouse] Add types for ClickHouse dependency store reader

### DIFF
--- a/internal/storage/v2/clickhouse/depstore/link.go
+++ b/internal/storage/v2/clickhouse/depstore/link.go
@@ -37,6 +37,9 @@ func (l dependencyLink) toModel() model.DependencyLink {
 type dependencyLinks []dependencyLink
 
 func dependencyLinksFromModel(deps []model.DependencyLink) dependencyLinks {
+	if deps == nil {
+		return nil
+	}
 	links := make(dependencyLinks, len(deps))
 	for i, d := range deps {
 		links[i] = dependencyLinkFromModel(d)
@@ -45,6 +48,9 @@ func dependencyLinksFromModel(deps []model.DependencyLink) dependencyLinks {
 }
 
 func (links dependencyLinks) toModel() []model.DependencyLink {
+	if links == nil {
+		return nil
+	}
 	result := make([]model.DependencyLink, len(links))
 	for i, l := range links {
 		result[i] = l.toModel()

--- a/internal/storage/v2/clickhouse/depstore/link.go
+++ b/internal/storage/v2/clickhouse/depstore/link.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package depstore
+
+import "github.com/jaegertracing/jaeger-idl/model/v1"
+
+// dependencyLink is the JSON representation of a single dependency link
+// as stored in ClickHouse.
+type dependencyLink struct {
+	Parent    string `json:"parent"`
+	Child     string `json:"child"`
+	CallCount uint64 `json:"callCount"`
+}
+
+func dependencyLinkFromModel(d model.DependencyLink) dependencyLink {
+	return dependencyLink{
+		Parent:    d.Parent,
+		Child:     d.Child,
+		CallCount: d.CallCount,
+	}
+}
+
+func (l dependencyLink) toModel() model.DependencyLink {
+	return model.DependencyLink{
+		Parent:    l.Parent,
+		Child:     l.Child,
+		CallCount: l.CallCount,
+	}
+}
+
+// dependencyLinks represents the JSON value stored in the `dependencies_json`
+// column of the ClickHouse dependencies table. All dependency links computed
+// in a single aggregation interval are stored as one JSON blob per row rather
+// than one row per link. This keeps the table compact and allows an entire
+// snapshot to be read or written in a single operation.
+type dependencyLinks []dependencyLink
+
+func dependencyLinksFromModel(deps []model.DependencyLink) dependencyLinks {
+	links := make(dependencyLinks, len(deps))
+	for i, d := range deps {
+		links[i] = dependencyLinkFromModel(d)
+	}
+	return links
+}
+
+func (links dependencyLinks) toModel() []model.DependencyLink {
+	result := make([]model.DependencyLink, len(links))
+	for i, l := range links {
+		result[i] = l.toModel()
+	}
+	return result
+}

--- a/internal/storage/v2/clickhouse/depstore/link.go
+++ b/internal/storage/v2/clickhouse/depstore/link.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package depstore

--- a/internal/storage/v2/clickhouse/depstore/link_test.go
+++ b/internal/storage/v2/clickhouse/depstore/link_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package depstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+)
+
+var testModelDeps = []model.DependencyLink{
+	{Parent: "serviceA", Child: "serviceB", CallCount: 10},
+	{Parent: "serviceB", Child: "serviceC", CallCount: 5},
+}
+
+var testDBLinks = dependencyLinks{
+	{Parent: "serviceA", Child: "serviceB", CallCount: 10},
+	{Parent: "serviceB", Child: "serviceC", CallCount: 5},
+}
+
+func TestDependencyLink(t *testing.T) {
+	t.Run("fromModel", func(t *testing.T) {
+		got := dependencyLinkFromModel(testModelDeps[0])
+		assert.Equal(t, testDBLinks[0], got)
+	})
+	t.Run("toModel", func(t *testing.T) {
+		got := testDBLinks[0].toModel()
+		assert.Equal(t, testModelDeps[0], got)
+	})
+	t.Run("roundTrip", func(t *testing.T) {
+		got := dependencyLinkFromModel(testModelDeps[0]).toModel()
+		assert.Equal(t, testModelDeps[0], got)
+	})
+}
+
+func TestDependencyLinks(t *testing.T) {
+	t.Run("fromModel", func(t *testing.T) {
+		got := dependencyLinksFromModel(testModelDeps)
+		assert.Equal(t, testDBLinks, got)
+	})
+	t.Run("toModel", func(t *testing.T) {
+		got := testDBLinks.toModel()
+		assert.Equal(t, testModelDeps, got)
+	})
+	t.Run("roundTrip", func(t *testing.T) {
+		got := dependencyLinksFromModel(testModelDeps).toModel()
+		assert.Equal(t, testModelDeps, got)
+	})
+}

--- a/internal/storage/v2/clickhouse/depstore/link_test.go
+++ b/internal/storage/v2/clickhouse/depstore/link_test.go
@@ -41,9 +41,18 @@ func TestDependencyLinks(t *testing.T) {
 		got := dependencyLinksFromModel(testModelDeps)
 		assert.Equal(t, testDBLinks, got)
 	})
+	t.Run("fromModel_nil", func(t *testing.T) {
+		got := dependencyLinksFromModel(nil)
+		assert.Nil(t, got)
+	})
 	t.Run("toModel", func(t *testing.T) {
 		got := testDBLinks.toModel()
 		assert.Equal(t, testModelDeps, got)
+	})
+	t.Run("toModel_nil", func(t *testing.T) {
+		var links dependencyLinks
+		got := links.toModel()
+		assert.Nil(t, got)
 	})
 	t.Run("roundTrip", func(t *testing.T) {
 		got := dependencyLinksFromModel(testModelDeps).toModel()

--- a/internal/storage/v2/clickhouse/depstore/link_test.go
+++ b/internal/storage/v2/clickhouse/depstore/link_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package depstore


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #7136 

## Description of the changes
- Adds two new types to the ClickHouse depstore package
  1. `dependencyLink` which represents a single dependency
  2. `dependencyLinks` is a list of dependencies which is what will be stored in the `dependencies_json` column 
- Adds convenience helpers for converting from/to the API return type `model.DependecyLink`

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
