### PR TITLE
[clickhouse] Implement dependency writer for ClickHouse storage

### DIFF
--- a/internal/storage/v2/clickhouse/depstore/writer.go
+++ b/internal/storage/v2/clickhouse/depstore/writer.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/jaegertracing/jaeger-idl/model/v1"
 
+	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 )

--- a/internal/storage/v2/clickhouse/depstore/writer.go
+++ b/internal/storage/v2/clickhouse/depstore/writer.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package depstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
+)
+
+var _ depstore.Writer = (*Writer)(nil)
+
+type Writer struct {
+	conn driver.Conn
+}
+
+func NewDependencyWriter(conn driver.Conn) *Writer {
+	return &Writer{conn: conn}
+}
+
+func (w *Writer) WriteDependencies(ts time.Time, dependencies []model.DependencyLink) error {
+	jsonBytes, err := json.Marshal(dependencyLinksFromModel(dependencies))
+	if err != nil {
+		return fmt.Errorf("failed to marshal dependencies: %w", err)
+	}
+	ctx := context.TODO()
+	batch, err := w.conn.PrepareBatch(ctx, sql.InsertDependencies)
+	if err != nil {
+		return fmt.Errorf("failed to prepare batch: %w", err)
+	}
+	defer batch.Close()
+	if err := batch.Append(ts, string(jsonBytes)); err != nil {
+		return fmt.Errorf("failed to append to batch: %w", err)
+	}
+	if err := batch.Send(); err != nil {
+		return fmt.Errorf("failed to send batch: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/v2/clickhouse/depstore/writer.go
+++ b/internal/storage/v2/clickhouse/depstore/writer.go
@@ -26,12 +26,11 @@ func NewDependencyWriter(conn driver.Conn) *Writer {
 	return &Writer{conn: conn}
 }
 
-func (w *Writer) WriteDependencies(ts time.Time, dependencies []model.DependencyLink) error {
+func (w *Writer) WriteDependencies(ctx context.Context, ts time.Time, dependencies []model.DependencyLink) error {
 	jsonBytes, err := json.Marshal(dependencyLinksFromModel(dependencies))
 	if err != nil {
 		return fmt.Errorf("failed to marshal dependencies: %w", err)
 	}
-	ctx := context.TODO()
 	batch, err := w.conn.PrepareBatch(ctx, sql.InsertDependencies)
 	if err != nil {
 		return fmt.Errorf("failed to prepare batch: %w", err)

--- a/internal/storage/v2/clickhouse/depstore/writer_test.go
+++ b/internal/storage/v2/clickhouse/depstore/writer_test.go
@@ -72,7 +72,7 @@ func TestWriteDependencies_Errors(t *testing.T) {
 				},
 			}
 			w := NewDependencyWriter(conn)
-			err := w.WriteDependencies(time.Now(), testDeps)
+			err := w.WriteDependencies(t.Context(), time.Now(), testDeps)
 			require.ErrorContains(t, err, test.expectError)
 			require.ErrorIs(t, err, assert.AnError)
 		})

--- a/internal/storage/v2/clickhouse/depstore/writer_test.go
+++ b/internal/storage/v2/clickhouse/depstore/writer_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package depstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
+)
+
+var testDeps = []model.DependencyLink{
+	{Parent: "serviceA", Child: "serviceB", CallCount: 10},
+	{Parent: "serviceB", Child: "serviceC", CallCount: 5},
+}
+
+func TestWriteDependencies(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	b := &clickhousetest.Batch{}
+	conn := &clickhousetest.Driver{
+		BatchResponses: map[string]*clickhousetest.BatchResponse{
+			sql.InsertDependencies: {Batch: b},
+		},
+	}
+	w := NewDependencyWriter(conn)
+	err := w.WriteDependencies(ts, testDeps)
+	require.NoError(t, err)
+
+	require.True(t, b.SendCalled)
+	require.Len(t, b.Appended, 1)
+	row := b.Appended[0]
+	assert.Equal(t, ts, row[0])
+	expectedJSON := `[{"parent":"serviceA","child":"serviceB","callCount":10},{"parent":"serviceB","child":"serviceC","callCount":5}]`
+	assert.Equal(t, expectedJSON, row[1])
+}
+
+func TestWriteDependencies_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		batch       *clickhousetest.Batch
+		batchErr    error
+		expectError string
+	}{
+		{
+			name:        "prepare batch error",
+			batchErr:    assert.AnError,
+			expectError: "failed to prepare batch",
+		},
+		{
+			name:        "append error",
+			batch:       &clickhousetest.Batch{AppendErr: assert.AnError},
+			expectError: "failed to append to batch",
+		},
+		{
+			name:        "send error",
+			batch:       &clickhousetest.Batch{SendErr: assert.AnError},
+			expectError: "failed to send batch",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conn := &clickhousetest.Driver{
+				BatchResponses: map[string]*clickhousetest.BatchResponse{
+					sql.InsertDependencies: {Batch: test.batch, Err: test.batchErr},
+				},
+			}
+			w := NewDependencyWriter(conn)
+			err := w.WriteDependencies(time.Now(), testDeps)
+			require.ErrorContains(t, err, test.expectError)
+			require.ErrorIs(t, err, assert.AnError)
+		})
+	}
+}

--- a/internal/storage/v2/clickhouse/depstore/writer_test.go
+++ b/internal/storage/v2/clickhouse/depstore/writer_test.go
@@ -29,7 +29,7 @@ func TestWriteDependencies(t *testing.T) {
 		},
 	}
 	w := NewDependencyWriter(conn)
-	err := w.WriteDependencies(ts, testDeps)
+	err := w.WriteDependencies(t.Context(), ts, testDeps)
 	require.NoError(t, err)
 
 	require.True(t, b.SendCalled)

--- a/internal/storage/v2/clickhouse/depstore/writer_test.go
+++ b/internal/storage/v2/clickhouse/depstore/writer_test.go
@@ -37,7 +37,7 @@ func TestWriteDependencies(t *testing.T) {
 	row := b.Appended[0]
 	assert.Equal(t, ts, row[0])
 	expectedJSON := `[{"parent":"serviceA","child":"serviceB","callCount":10},{"parent":"serviceB","child":"serviceC","callCount":5}]`
-	assert.Equal(t, expectedJSON, row[1])
+	assert.JSONEq(t, expectedJSON, row[1].(string))
 }
 
 func TestWriteDependencies_Errors(t *testing.T) {

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -288,6 +288,12 @@ WHERE
     timestamp >= ?
     AND timestamp < ?`
 
+const InsertDependencies = `
+INSERT INTO
+    dependencies (timestamp, dependencies_json)
+VALUES
+    (?, ?)`
+
 //go:embed create_dependencies_table.sql
 var CreateDependenciesTable string
 


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #8359

## Description of the changes
- Implement a dependency writer for ClickHouse

## How was this change tested?
Start ClickHouse in docker
```
docker compose -f docker-compose/clickhouse/docker-compose.yml up
```

Start jaeger (to automatically create schema)
```
go run ./cmd/jaeger --config cmd/jaeger/config-clickhouse.yaml --feature-gates=storage.clickhouse
```

Write the following test to call the new function
```
func TestWriteDependenciesIntegration(t *testing.T) {
	conn, err := clickhouse.Open(&clickhouse.Options{
		Addr: []string{"127.0.0.1:9000"},
		Auth: clickhouse.Auth{
			Database: "jaeger",
			Username: "default",
			Password: "password",
		},
		DialTimeout: 5 * time.Second,
	})
	require.NoError(t, err)
	defer conn.Close()

	ts := time.Now().Truncate(time.Second)
	deps := []model.DependencyLink{
		{Parent: "test-frontend", Child: "test-api", CallCount: 42},
		{Parent: "test-api", Child: "test-db", CallCount: 7},
	}

	writer := NewDependencyWriter(conn)
	err = writer.WriteDependencies(ts, deps)
	require.NoError(t, err)
}
```

Verify the entries were inserted
```
docker exec clickhouse clickhouse-client --database=jaeger --query="select * from dependencies" 
2026-04-13 01:25:38.000000000   [{"parent":"test-frontend","child":"test-api","callCount":42},{"parent":"test-api","child":"test-db","callCount":7}]
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
