### PR TITLE
[refactor] Add helpers for converting span kind to/from proto enums

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
-	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
@@ -42,15 +42,6 @@ var (
 
 	// errServiceParameterRequired occurs when no service name is defined.
 	errServiceParameterRequired = fmt.Errorf("parameter '%s' is required", serviceParam)
-
-	jaegerToOtelSpanKind = map[string]string{
-		"unspecified": metrics.SpanKind_SPAN_KIND_UNSPECIFIED.String(),
-		"internal":    metrics.SpanKind_SPAN_KIND_INTERNAL.String(),
-		"server":      metrics.SpanKind_SPAN_KIND_SERVER.String(),
-		"client":      metrics.SpanKind_SPAN_KIND_CLIENT.String(),
-		"producer":    metrics.SpanKind_SPAN_KIND_PRODUCER.String(),
-		"consumer":    metrics.SpanKind_SPAN_KIND_CONSUMER.String(),
-	}
 )
 
 type (
@@ -358,8 +349,8 @@ func parseSpanKinds(r *http.Request, paramName string, defaultSpanKinds []string
 func mapSpanKindsToOpenTelemetry(spanKinds []string) ([]string, error) {
 	otelSpanKinds := make([]string, len(spanKinds))
 	for i, spanKind := range spanKinds {
-		v, ok := jaegerToOtelSpanKind[spanKind]
-		if !ok {
+		v := jptrace.StringToProtoSpanKind(spanKind)
+		if v == "" {
 			return otelSpanKinds, fmt.Errorf("unsupported span kind: '%s'", spanKind)
 		}
 		otelSpanKinds[i] = v

--- a/internal/jptrace/spankind.go
+++ b/internal/jptrace/spankind.go
@@ -11,6 +11,8 @@ import (
 
 func StringToSpanKind(sk string) ptrace.SpanKind {
 	switch strings.ToLower(sk) {
+	case "unspecified":
+		return ptrace.SpanKindUnspecified
 	case "internal":
 		return ptrace.SpanKindInternal
 	case "server":
@@ -27,14 +29,13 @@ func StringToSpanKind(sk string) ptrace.SpanKind {
 }
 
 func SpanKindToString(sk ptrace.SpanKind) string {
-	if sk == ptrace.SpanKindUnspecified {
-		return ""
-	}
 	return strings.ToLower(sk.String())
 }
 
 func ProtoSpanKindToString(s string) string {
-	switch s {
+	switch strings.ToUpper(s) {
+	case "SPAN_KIND_UNSPECIFIED":
+		return "unspecified"
 	case "SPAN_KIND_INTERNAL":
 		return "internal"
 	case "SPAN_KIND_SERVER":
@@ -51,7 +52,7 @@ func ProtoSpanKindToString(s string) string {
 }
 
 func StringToProtoSpanKind(s string) string {
-	switch s {
+	switch strings.ToLower(s) {
 	case "unspecified":
 		return "SPAN_KIND_UNSPECIFIED"
 	case "internal":

--- a/internal/jptrace/spankind.go
+++ b/internal/jptrace/spankind.go
@@ -32,3 +32,44 @@ func SpanKindToString(sk ptrace.SpanKind) string {
 	}
 	return strings.ToLower(sk.String())
 }
+
+// ProtoSpanKindToString converts a proto-style span kind string
+// (e.g. "SPAN_KIND_SERVER") to the lowercase form (e.g. "server").
+func ProtoSpanKindToString(s string) string {
+	switch s {
+	case "SPAN_KIND_INTERNAL":
+		return "internal"
+	case "SPAN_KIND_SERVER":
+		return "server"
+	case "SPAN_KIND_CLIENT":
+		return "client"
+	case "SPAN_KIND_PRODUCER":
+		return "producer"
+	case "SPAN_KIND_CONSUMER":
+		return "consumer"
+	default:
+		return ""
+	}
+}
+
+// StringToProtoSpanKind converts a lowercase span kind string
+// (e.g. "server") to the proto-style form (e.g. "SPAN_KIND_SERVER").
+// Returns empty string for unknown inputs.
+func StringToProtoSpanKind(s string) string {
+	switch s {
+	case "unspecified":
+		return "SPAN_KIND_UNSPECIFIED"
+	case "internal":
+		return "SPAN_KIND_INTERNAL"
+	case "server":
+		return "SPAN_KIND_SERVER"
+	case "client":
+		return "SPAN_KIND_CLIENT"
+	case "producer":
+		return "SPAN_KIND_PRODUCER"
+	case "consumer":
+		return "SPAN_KIND_CONSUMER"
+	default:
+		return ""
+	}
+}

--- a/internal/jptrace/spankind.go
+++ b/internal/jptrace/spankind.go
@@ -11,8 +11,6 @@ import (
 
 func StringToSpanKind(sk string) ptrace.SpanKind {
 	switch strings.ToLower(sk) {
-	case "unspecified":
-		return ptrace.SpanKindUnspecified
 	case "internal":
 		return ptrace.SpanKindInternal
 	case "server":
@@ -29,6 +27,9 @@ func StringToSpanKind(sk string) ptrace.SpanKind {
 }
 
 func SpanKindToString(sk ptrace.SpanKind) string {
+	if sk == ptrace.SpanKindUnspecified {
+		return ""
+	}
 	return strings.ToLower(sk.String())
 }
 

--- a/internal/jptrace/spankind.go
+++ b/internal/jptrace/spankind.go
@@ -33,8 +33,6 @@ func SpanKindToString(sk ptrace.SpanKind) string {
 	return strings.ToLower(sk.String())
 }
 
-// ProtoSpanKindToString converts a proto-style span kind string
-// (e.g. "SPAN_KIND_SERVER") to the lowercase form (e.g. "server").
 func ProtoSpanKindToString(s string) string {
 	switch s {
 	case "SPAN_KIND_INTERNAL":
@@ -52,9 +50,6 @@ func ProtoSpanKindToString(s string) string {
 	}
 }
 
-// StringToProtoSpanKind converts a lowercase span kind string
-// (e.g. "server") to the proto-style form (e.g. "SPAN_KIND_SERVER").
-// Returns empty string for unknown inputs.
 func StringToProtoSpanKind(s string) string {
 	switch s {
 	case "unspecified":

--- a/internal/jptrace/spankind_test.go
+++ b/internal/jptrace/spankind_test.go
@@ -68,7 +68,7 @@ func TestSpanKindToString(t *testing.T) {
 	}{
 		{
 			kind: ptrace.SpanKindUnspecified,
-			want: "unspecified",
+			want: "",
 		},
 		{
 			kind: ptrace.SpanKindInternal,
@@ -164,7 +164,6 @@ func TestProtoSpanKindRoundTrip(t *testing.T) {
 
 func TestSpanKindRoundTrip(t *testing.T) {
 	kinds := []string{
-		"unspecified",
 		"internal",
 		"server",
 		"client",

--- a/internal/jptrace/spankind_test.go
+++ b/internal/jptrace/spankind_test.go
@@ -68,7 +68,7 @@ func TestSpanKindToString(t *testing.T) {
 	}{
 		{
 			kind: ptrace.SpanKindUnspecified,
-			want: "",
+			want: "unspecified",
 		},
 		{
 			kind: ptrace.SpanKindInternal,
@@ -103,12 +103,16 @@ func TestProtoSpanKindToString(t *testing.T) {
 		proto string
 		want  string
 	}{
-		{proto: metrics.SpanKind_SPAN_KIND_UNSPECIFIED.String(), want: ""},
+		{proto: metrics.SpanKind_SPAN_KIND_UNSPECIFIED.String(), want: "unspecified"},
 		{proto: metrics.SpanKind_SPAN_KIND_INTERNAL.String(), want: "internal"},
 		{proto: metrics.SpanKind_SPAN_KIND_SERVER.String(), want: "server"},
 		{proto: metrics.SpanKind_SPAN_KIND_CLIENT.String(), want: "client"},
 		{proto: metrics.SpanKind_SPAN_KIND_PRODUCER.String(), want: "producer"},
 		{proto: metrics.SpanKind_SPAN_KIND_CONSUMER.String(), want: "consumer"},
+		{proto: "span_kind_server", want: "server"},
+		{proto: "Span_Kind_Client", want: "client"},
+		{proto: "", want: ""},
+		{proto: "invalid", want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.proto, func(t *testing.T) {
@@ -128,12 +132,49 @@ func TestStringToProtoSpanKind(t *testing.T) {
 		{input: "client", want: metrics.SpanKind_SPAN_KIND_CLIENT.String()},
 		{input: "producer", want: metrics.SpanKind_SPAN_KIND_PRODUCER.String()},
 		{input: "consumer", want: metrics.SpanKind_SPAN_KIND_CONSUMER.String()},
+		{input: "Server", want: metrics.SpanKind_SPAN_KIND_SERVER.String()},
+		{input: "CLIENT", want: metrics.SpanKind_SPAN_KIND_CLIENT.String()},
 		{input: "unknown", want: ""},
 		{input: "", want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			require.Equal(t, tt.want, StringToProtoSpanKind(tt.input))
+		})
+	}
+}
+
+func TestProtoSpanKindRoundTrip(t *testing.T) {
+	kinds := []string{
+		"unspecified",
+		"internal",
+		"server",
+		"client",
+		"producer",
+		"consumer",
+	}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			proto := StringToProtoSpanKind(kind)
+			require.NotEmpty(t, proto)
+			require.Equal(t, kind, ProtoSpanKindToString(proto))
+		})
+	}
+}
+
+func TestSpanKindRoundTrip(t *testing.T) {
+	kinds := []string{
+		"unspecified",
+		"internal",
+		"server",
+		"client",
+		"producer",
+		"consumer",
+	}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			spanKind := StringToSpanKind(kind)
+			require.Equal(t, kind, SpanKindToString(spanKind))
 		})
 	}
 }

--- a/internal/jptrace/spankind_test.go
+++ b/internal/jptrace/spankind_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
 )
 
 func TestStringToSpanKind(t *testing.T) {
@@ -92,6 +94,46 @@ func TestSpanKindToString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
 			require.Equal(t, tt.want, SpanKindToString(tt.kind))
+		})
+	}
+}
+
+func TestProtoSpanKindToString(t *testing.T) {
+	tests := []struct {
+		proto string
+		want  string
+	}{
+		{proto: metrics.SpanKind_SPAN_KIND_UNSPECIFIED.String(), want: ""},
+		{proto: metrics.SpanKind_SPAN_KIND_INTERNAL.String(), want: "internal"},
+		{proto: metrics.SpanKind_SPAN_KIND_SERVER.String(), want: "server"},
+		{proto: metrics.SpanKind_SPAN_KIND_CLIENT.String(), want: "client"},
+		{proto: metrics.SpanKind_SPAN_KIND_PRODUCER.String(), want: "producer"},
+		{proto: metrics.SpanKind_SPAN_KIND_CONSUMER.String(), want: "consumer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.proto, func(t *testing.T) {
+			require.Equal(t, tt.want, ProtoSpanKindToString(tt.proto))
+		})
+	}
+}
+
+func TestStringToProtoSpanKind(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "unspecified", want: metrics.SpanKind_SPAN_KIND_UNSPECIFIED.String()},
+		{input: "internal", want: metrics.SpanKind_SPAN_KIND_INTERNAL.String()},
+		{input: "server", want: metrics.SpanKind_SPAN_KIND_SERVER.String()},
+		{input: "client", want: metrics.SpanKind_SPAN_KIND_CLIENT.String()},
+		{input: "producer", want: metrics.SpanKind_SPAN_KIND_PRODUCER.String()},
+		{input: "consumer", want: metrics.SpanKind_SPAN_KIND_CONSUMER.String()},
+		{input: "unknown", want: ""},
+		{input: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.want, StringToProtoSpanKind(tt.input))
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #8313

## Description of the changes
- The SpanKind proto enum is used in the metricstore. This PR moves the string<->enum conversion to `jptrace` so that it can be reused

## How was this change tested?
- Added unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
