### PR TITLE
[jaegermcp] Add end-to-end tracing integration tests

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server_test.go
@@ -112,17 +112,24 @@ func waitForServer(t *testing.T, addr string) {
 // Pass a nil logger to use the no-op logger from componenttest.
 func startTestServerWithQueryService(t *testing.T, svc *querysvc.QueryService, logger *zap.Logger) (*server, string) {
 	t.Helper()
-
-	host := newMockHostWithQueryService(svc)
 	telset := componenttest.NewNopTelemetrySettings()
 	if logger != nil {
 		telset.Logger = logger
 	}
+	return startTestServerWithTelemetry(t, svc, telset)
+}
+
+// startTestServerWithTelemetry creates and starts a test server with the given
+// telemetry settings. Use this when you need a real TracerProvider for tracing tests.
+func startTestServerWithTelemetry(t *testing.T, svc *querysvc.QueryService, telset component.TelemetrySettings) (*server, string) {
+	t.Helper()
+
+	host := newMockHostWithQueryService(svc)
 
 	config := &Config{
 		HTTP: confighttp.ServerConfig{
 			NetAddr: confignet.AddrConfig{
-				Endpoint:  "localhost:0", // OS will assign a free port
+				Endpoint:  "localhost:0",
 				Transport: confignet.TransportTypeTCP,
 			},
 		},

--- a/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegermcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+)
+
+// TODO: Add trace propagation test once #8361 (_meta extraction) lands.
+// HTTP-level traceparent doesn't reach MCP middleware spans because the SDK's
+// StreamableClientTransport dispatches handlers in the session context, not the
+// per-request context. _meta propagation via CallToolParams.Meta bridges this gap.
+
+func TestTracingE2E_NonToolMethod(t *testing.T) {
+	capture := newTraceCapture(t)
+	_, addr := startTestServerWithTelemetry(t, nil, telsetFromCapture(capture))
+	connectTracedMCPClient(t, addr)
+
+	span := findSpanByName(t, capture, "initialize")
+	assertHasStringAttribute(t, span.Attributes,
+		string(otelsemconv.McpMethodName("").Key), "initialize")
+}
+
+func TestTracingE2E_ToolErrorPath(t *testing.T) {
+	capture := newTraceCapture(t)
+	_, addr := startTestServerWithTelemetry(t, nil, telsetFromCapture(capture))
+	session := connectTracedMCPClient(t, addr)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search_traces",
+		Arguments: map[string]any{"start_time_min": "-1h"},
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+
+	span := findSpanByName(t, capture, "tools/call search_traces")
+	assertHasStringAttribute(t, span.Attributes,
+		string(otelsemconv.ErrorType("").Key), errorTypeTool)
+}
+
+func telsetFromCapture(capture *traceCapture) component.TelemetrySettings {
+	telset := componenttest.NewNopTelemetrySettings()
+	telset.TracerProvider = capture.provider
+	return telset
+}
+
+func connectTracedMCPClient(t *testing.T, addr string) *mcp.ClientSession {
+	t.Helper()
+
+	client := mcp.NewClient(
+		&mcp.Implementation{Name: "tracing-test", Version: "1.0.0"},
+		nil,
+	)
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   fmt.Sprintf("http://%s/mcp", addr),
+		HTTPClient: http.DefaultClient,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { session.Close() })
+
+	return session
+}
+
+func findSpanByName(t *testing.T, capture *traceCapture, name string) tracetest.SpanStub {
+	t.Helper()
+	var found tracetest.SpanStub
+	require.Eventually(t, func() bool {
+		spans := capture.exporter.GetSpans()
+		for i := range spans {
+			if spans[i].Name == name {
+				found = spans[i]
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "span %q not found", name)
+	return found
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Part of #8343

The MCP tracing middleware (#8160) has unit-level tests but no automated tests that exercise it through a real MCP SDK client connection. This PR adds that coverage.

## Description of the changes

Adds `tracing_integration_test.go` with two E2E test cases using the MCP SDK client:

- **Non-tool method**: verifies that `initialize` produces a span with `mcp.method.name=initialize`.
- **Tool error path**: triggers a validation error on `search_traces` (missing `service_name`) and asserts the span carries `error.type=tool_error`.

A trace propagation test is deferred until #8361 (`_meta` extraction) lands. The SDK's `StreamableClientTransport` dispatches method handlers in the session context, not the per-request HTTP context, so HTTP-level `traceparent` doesn't reach MCP middleware spans. `_meta` propagation via `CallToolParams.Meta` bridges this gap.

Also refactors `startTestServerWithQueryService` to delegate to a new `startTestServerWithTelemetry` helper so tests can inject a real `TracerProvider` without duplicating server setup.

**2 files changed. Test-only — no production code modifications.**

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegermcp/...` — all passing
- `make lint` — 0 issues
- `make fmt` — clean

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)