### PR TITLE
perf(clickhouse): batch trace lookups using IN clause

### DIFF
--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -204,7 +204,10 @@ FROM
     spans s
 `
 
-const SelectSpansByTraceID = SelectSpansQuery + " WHERE s.trace_id = ?"
+const (
+	SelectSpansByTraceID  = SelectSpansQuery + " WHERE s.trace_id = ?"
+	SelectSpansByTraceIDs = SelectSpansQuery + " WHERE s.trace_id IN (?)"
+)
 
 // SearchTraceIDsBase is the inner SQL fragment for finding distinct trace IDs.
 //

--- a/internal/storage/v2/clickhouse/tracestore/query_builder.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/xpdata"
@@ -96,18 +97,45 @@ func appendStringAttributeFallback(q *strings.Builder, args []any, key string, a
 	return append(args, key, attr.Str(), key, attr.Str(), key, attr.Str(), key, attr.Str(), key, attr.Str())
 }
 
-func buildGetTracesQuery(params tracestore.GetTraceParams) (string, []any) {
+func buildGetTracesQuery(params ...tracestore.GetTraceParams) (string, []any) {
 	var q strings.Builder
-	q.WriteString(sql.SelectSpansByTraceID)
-	args := []any{params.TraceID}
+	if len(params) == 1 {
+		q.WriteString(sql.SelectSpansByTraceID)
+		args := []any{params[0].TraceID}
 
-	if !params.Start.IsZero() {
-		q.WriteString(" AND s.start_time >= ?")
-		args = append(args, params.Start)
+		if !params[0].Start.IsZero() {
+			q.WriteString(" AND s.start_time >= ?")
+			args = append(args, params[0].Start)
+		}
+		if !params[0].End.IsZero() {
+			q.WriteString(" AND s.start_time <= ?")
+			args = append(args, params[0].End)
+		}
+
+		return q.String(), args
 	}
-	if !params.End.IsZero() {
+
+	q.WriteString(sql.SelectSpansByTraceIDs)
+	ids := make([]pcommon.TraceID, len(params))
+	var minStart, maxEnd time.Time
+	for i, p := range params {
+		ids[i] = p.TraceID
+		if !p.Start.IsZero() && (minStart.IsZero() || p.Start.Before(minStart)) {
+			minStart = p.Start
+		}
+		if !p.End.IsZero() && (maxEnd.IsZero() || p.End.After(maxEnd)) {
+			maxEnd = p.End
+		}
+	}
+	args := []any{ids}
+
+	if !minStart.IsZero() {
+		q.WriteString(" AND s.start_time >= ?")
+		args = append(args, minStart)
+	}
+	if !maxEnd.IsZero() {
 		q.WriteString(" AND s.start_time <= ?")
-		args = append(args, params.End)
+		args = append(args, maxEnd)
 	}
 
 	return q.String(), args

--- a/internal/storage/v2/clickhouse/tracestore/reader.go
+++ b/internal/storage/v2/clickhouse/tracestore/reader.go
@@ -58,40 +58,43 @@ func (r *Reader) GetTraces(
 	traceIDs ...tracestore.GetTraceParams,
 ) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {
-		for _, traceID := range traceIDs {
-			query, args := buildGetTracesQuery(traceID)
-			rows, err := r.conn.Query(ctx, query, args...)
+		if len(traceIDs) == 0 {
+			return
+		}
+
+		query, args := buildGetTracesQuery(traceIDs...)
+		rows, err := r.conn.Query(ctx, query, args...)
+		if err != nil {
+			yield(nil, fmt.Errorf("failed to query traces: %w", err))
+			return
+		}
+
+		for rows.Next() {
+			span, err := dbmodel.ScanRow(rows)
 			if err != nil {
-				yield(nil, fmt.Errorf("failed to query trace: %w", err))
-				return
-			}
-
-			done := false
-			for rows.Next() {
-				span, err := dbmodel.ScanRow(rows)
-				if err != nil {
-					if !yield(nil, fmt.Errorf("failed to scan span row: %w", err)) {
-						done = true
-						break
-					}
-					continue
+				if !yield(nil, fmt.Errorf("failed to scan span row: %w", err)) {
+					rows.Close()
+					return
 				}
-
-				trace := dbmodel.FromRow(span)
-				if !yield([]ptrace.Traces{trace}, nil) {
-					done = true
-					break
-				}
+				continue
 			}
 
-			if err := rows.Close(); err != nil {
-				yield(nil, fmt.Errorf("failed to close rows: %w", err))
+			trace := dbmodel.FromRow(span)
+			if !yield([]ptrace.Traces{trace}, nil) {
+				rows.Close()
 				return
 			}
+		}
 
-			if done {
-				return
-			}
+		if err := rows.Err(); err != nil {
+			yield(nil, fmt.Errorf("rows error: %w", err))
+			rows.Close()
+			return
+		}
+
+		if err := rows.Close(); err != nil {
+			yield(nil, fmt.Errorf("failed to close rows: %w", err))
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixing the N+1 query issue in ClickHouse storage. Right now, it fetches traces one by one in a loop, which is not efficient.

## Description of the changes
- **Batch Querying**: Changed `GetTraces` to use a single SQL `IN (?)` query to get all traces in one shot.
- **Smart Time Range**: Updated the builder to find the start and end time across all traces so the query hits fewer blocks in ClickHouse.
- **Resource Cleanup**: Ensured we close the database rows properly even if the search stops early.

## How was this change tested?
- Tested by running `go test` on the ClickHouse tracestore package.
- Verified that it correctly fetches all spans for multiple trace IDs in one go.
- All lint checks and formatting are done.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
