### PR TITLE
jaegermcp: validate start_time_max is not before start_time_min

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -122,6 +122,11 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 		return querysvc.TraceQueryParams{}, errors.New("service_name is required")
 	}
 
+	// Validate time range
+	if maxStartTime.Before(minStartTime) {
+		return querysvc.TraceQueryParams{}, errors.New("start_time_max must not be before start_time_min")
+	}
+
 	// Parse duration parameters
 	var durationMin, durationMax time.Duration
 	if input.DurationMin != "" {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -588,3 +588,19 @@ func TestSearchTracesHandler_Handle_LimitEnforced(t *testing.T) {
 	// Returned traces are capped at exactly the limit (5 traces, limit=3 → exactly 3 traces)
 	assert.Len(t, output.Traces, 3)
 }
+
+func TestSearchTracesHandler_Handle_ReversedTimeRange(t *testing.T) {
+	handler := NewSearchTracesHandler(nil, 100)
+
+	input := types.SearchTracesInput{
+		// start_time_max is before start_time_min — should be rejected
+		StartTimeMin: "-1h",
+		StartTimeMax: "-2h",
+		ServiceName:  "test",
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start_time_max must not be before start_time_min")
+}


### PR DESCRIPTION
## Summary

Fixes #8289

When `search_traces` is called with `start_time_max` earlier than `start_time_min`, the handler passes the reversed range to the storage backend, which returns empty results with no explanation. This is confusing for users.

## Change

Add a validation check in `buildQuery` after both times are parsed:

```go
if maxStartTime.Before(minStartTime) {
    return querysvc.TraceQueryParams{}, errors.New("start_time_max must not be before start_time_min")
}
```

This is consistent with the existing `duration_max < duration_min` check already present in the same function.

## Test

Added `TestSearchTracesHandler_Handle_ReversedTimeRange` which passes `start_time_min: "-1h"` and `start_time_max: "-2h"` and asserts a clear error is returned.