### PR TITLE
fix(cassandra): preserve gocql timeouts when unset in config

### DIFF
--- a/cmd/jaeger/config-cassandra.yaml
+++ b/cmd/jaeger/config-cassandra.yaml
@@ -46,6 +46,8 @@ extensions:
                 password: "cassandra"
             tls:
               insecure: true
+          query:
+            timeout: 30s
       another_storage:
         cassandra:
           schema: 
@@ -59,6 +61,8 @@ extensions:
                 password: "cassandra"
             tls:
               insecure: true
+          query:
+            timeout: 30s
 
   remote_sampling:
     adaptive:

--- a/internal/storage/cassandra/config/config.go
+++ b/internal/storage/cassandra/config/config.go
@@ -175,10 +175,14 @@ func (c *Configuration) NewCluster() (*gocql.ClusterConfig, error) {
 	cluster := gocql.NewCluster(c.Connection.Servers...)
 	cluster.Keyspace = c.Schema.Keyspace
 	cluster.NumConns = c.Connection.ConnectionsPerHost
-	cluster.ConnectTimeout = c.Connection.Timeout
+	if c.Connection.Timeout > 0 {
+		cluster.ConnectTimeout = c.Connection.Timeout
+	}
 	cluster.ReconnectInterval = c.Connection.ReconnectInterval
 	cluster.SocketKeepalive = c.Connection.SocketKeepAlive
-	cluster.Timeout = c.Query.Timeout
+	if c.Query.Timeout > 0 {
+		cluster.Timeout = c.Query.Timeout
+	}
 	if c.Connection.ProtoVersion > 0 {
 		cluster.ProtoVersion = c.Connection.ProtoVersion
 	}

--- a/internal/storage/cassandra/config/config_test.go
+++ b/internal/storage/cassandra/config/config_test.go
@@ -60,6 +60,44 @@ func TestNewClusterWithDefaults(t *testing.T) {
 	assert.NotEmpty(t, cl.Keyspace)
 }
 
+func TestNewCluster_PreservesDriverTimeoutDefaultsWhenUnset(t *testing.T) {
+	cfg := Configuration{
+		Connection: Connection{
+			Servers: []string{"127.0.0.1:9042"},
+			// Timeout left at zero as when connection.timeout is omitted from YAML.
+		},
+		Schema: Schema{
+			CompactionWindow: time.Minute,
+		},
+		// Query.Timeout left at zero as when query.timeout is omitted from YAML.
+	}
+	require.NoError(t, cfg.Validate())
+	cl, err := cfg.NewCluster()
+	require.NoError(t, err)
+	assert.Equal(t, 11*time.Second, cl.Timeout, "gocql NewCluster default query timeout")
+	assert.Equal(t, 11*time.Second, cl.ConnectTimeout, "gocql NewCluster default connect timeout")
+}
+
+func TestNewCluster_AppliesTimeoutsWhenSet(t *testing.T) {
+	cfg := Configuration{
+		Connection: Connection{
+			Servers: []string{"127.0.0.1:9042"},
+			Timeout: 60 * time.Second,
+		},
+		Schema: Schema{
+			CompactionWindow: time.Minute,
+		},
+		Query: Query{
+			Timeout: 45 * time.Second,
+		},
+	}
+	require.NoError(t, cfg.Validate())
+	cl, err := cfg.NewCluster()
+	require.NoError(t, err)
+	assert.Equal(t, 45*time.Second, cl.Timeout)
+	assert.Equal(t, 60*time.Second, cl.ConnectTimeout)
+}
+
 func TestNewClusterWithOverrides(t *testing.T) {
 	cfg := DefaultConfiguration()
 	cfg.Query.Consistency = "LOCAL_QUORUM"


### PR DESCRIPTION
## Description of the changes

“Replaces #8367 — same commit, from a named branch for maintainer request.”

Set ConnectTimeout and cluster.Timeout when YAML provides a positive duration. Zero values from unmarshalling must not overwrite gocql.NewCluster() default, which broke operators who set only connection.timeout and omitted query.timeout.

Also add query.timeout to config-cassandra.yaml example.


## How was this change tested?
- `make lint test` 


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`


## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
