### PR TITLE
[jaegermcp] Add end-to-end tracing integration tests

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/middleware_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/middleware_test.go
@@ -6,7 +6,6 @@ package jaegermcp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -199,12 +198,12 @@ func TestTracingMiddlewareUsesTraceContextFromRequestMeta(t *testing.T) {
 		return &mcp.CallToolResult{}, nil
 	})
 
-	_, parentSpan := capture.provider.Tracer("test-parent").Start(context.Background(), "http.request")
+	parentCtx, parentSpan := capture.provider.Tracer("test-parent").Start(context.Background(), "http.request")
 	parentSC := parentSpan.SpanContext()
 
-	req := newToolCallRequestWithMeta("get_services", mcp.Meta{
-		traceContextMetaTraceParent: fmt.Sprintf("00-%s-%s-01", parentSC.TraceID(), parentSC.SpanID()),
-	})
+	meta := mcp.Meta{}
+	requestMetaPropagator.Inject(parentCtx, &requestMetaCarrier{meta: meta})
+	req := newToolCallRequestWithMeta("get_services", meta)
 	_, err := wrapped(context.Background(), mcpMethodToolsCall, req)
 	require.NoError(t, err)
 

--- a/cmd/jaeger/internal/extension/jaegermcp/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server_test.go
@@ -112,17 +112,24 @@ func waitForServer(t *testing.T, addr string) {
 // Pass a nil logger to use the no-op logger from componenttest.
 func startTestServerWithQueryService(t *testing.T, svc *querysvc.QueryService, logger *zap.Logger) (*server, string) {
 	t.Helper()
-
-	host := newMockHostWithQueryService(svc)
 	telset := componenttest.NewNopTelemetrySettings()
 	if logger != nil {
 		telset.Logger = logger
 	}
+	return startTestServerWithTelemetry(t, svc, telset)
+}
+
+// startTestServerWithTelemetry creates and starts a test server with the given
+// telemetry settings. Use this when you need a real TracerProvider for tracing tests.
+func startTestServerWithTelemetry(t *testing.T, svc *querysvc.QueryService, telset component.TelemetrySettings) (*server, string) {
+	t.Helper()
+
+	host := newMockHostWithQueryService(svc)
 
 	config := &Config{
 		HTTP: confighttp.ServerConfig{
 			NetAddr: confignet.AddrConfig{
-				Endpoint:  "localhost:0", // OS will assign a free port
+				Endpoint:  "localhost:0",
 				Transport: confignet.TransportTypeTCP,
 			},
 		},

--- a/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
@@ -5,7 +5,6 @@ package jaegermcp
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -27,13 +26,15 @@ func TestTracingE2E_MetaPropagation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	_, rootSpan := capture.provider.Tracer("test").Start(ctx, "test-root")
+	rootCtx, rootSpan := capture.provider.Tracer("test").Start(ctx, "test-root")
 	sc := rootSpan.SpanContext()
-	traceparent := fmt.Sprintf("00-%s-%s-01", sc.TraceID(), sc.SpanID())
 	rootSpan.End()
 
+	meta := mcp.Meta{}
+	requestMetaPropagator.Inject(rootCtx, &requestMetaCarrier{meta: meta})
+
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
-		Meta: mcp.Meta{traceContextMetaTraceParent: traceparent},
+		Meta: meta,
 		Name: "health",
 	})
 	require.NoError(t, err)

--- a/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegermcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+)
+
+func TestTracingE2E_MetaPropagation(t *testing.T) {
+	capture := newTraceCapture(t)
+	_, addr := startTestServerWithTelemetry(t, nil, telsetFromCapture(capture))
+	session := connectMCPClient(t, addr)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	_, rootSpan := capture.provider.Tracer("test").Start(ctx, "test-root")
+	sc := rootSpan.SpanContext()
+	traceparent := fmt.Sprintf("00-%s-%s-01", sc.TraceID(), sc.SpanID())
+	rootSpan.End()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Meta: mcp.Meta{traceContextMetaTraceParent: traceparent},
+		Name: "health",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	span := findSpanByName(t, capture, "tools/call health")
+	assert.Equal(t, sc.TraceID(), span.SpanContext.TraceID(),
+		"MCP middleware span should belong to the same trace as the client")
+	assert.Equal(t, sc.SpanID(), span.Parent.SpanID(),
+		"MCP middleware span should be a child of the client span")
+}
+
+func TestTracingE2E_NonToolMethod(t *testing.T) {
+	capture := newTraceCapture(t)
+	_, addr := startTestServerWithTelemetry(t, nil, telsetFromCapture(capture))
+	connectMCPClient(t, addr)
+
+	span := findSpanByName(t, capture, "initialize")
+	assertHasStringAttribute(t, span.Attributes,
+		string(otelsemconv.McpMethodName("").Key), "initialize")
+}
+
+func TestTracingE2E_ToolErrorPath(t *testing.T) {
+	capture := newTraceCapture(t)
+	_, addr := startTestServerWithTelemetry(t, nil, telsetFromCapture(capture))
+	session := connectMCPClient(t, addr)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search_traces",
+		Arguments: map[string]any{"start_time_min": "-1h"},
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+
+	span := findSpanByName(t, capture, "tools/call search_traces")
+	assertHasStringAttribute(t, span.Attributes,
+		string(otelsemconv.ErrorType("").Key), errorTypeTool)
+}
+
+func telsetFromCapture(capture *traceCapture) component.TelemetrySettings {
+	telset := componenttest.NewNopTelemetrySettings()
+	telset.TracerProvider = capture.provider
+	return telset
+}
+
+func findSpanByName(t *testing.T, capture *traceCapture, name string) tracetest.SpanStub {
+	t.Helper()
+	var found tracetest.SpanStub
+	require.Eventually(t, func() bool {
+		spans := capture.exporter.GetSpans()
+		for i := range spans {
+			if spans[i].Name == name {
+				found = spans[i]
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "span %q not found", name)
+	return found
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Part of #8343

The MCP tracing middleware (#8160) and SEP-414 `_meta` trace context extraction (#8361) are tested at the unit level with synthetic `mcp.Request` objects, but there is no automated test that exercises the full MCP SDK client → HTTP → `_meta` extraction → middleware span chain. This PR adds that coverage.

## Description of the changes

Adds `tracing_integration_test.go` with three E2E test cases using the MCP SDK client:

- **`_meta` propagation**: creates a root span, formats it as a W3C traceparent, sends it via `CallToolParams.Meta`, and asserts the middleware span (`tools/call health`) has matching TraceID and parent SpanID — proving SEP-414 trace context flows through the middleware correctly.
- **Non-tool method**: verifies that `initialize` produces a span with `mcp.method.name=initialize`.
- **Tool error path**: triggers a validation error on `search_traces` (missing `service_name`) and asserts the span carries `error.type=tool_error`.

Also refactors `startTestServerWithQueryService` to delegate to a new `startTestServerWithTelemetry` helper so tests can inject a real `TracerProvider` without duplicating server setup.

**2 files changed. Test-only — no production code modifications.**

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegermcp/...` — all passing
- `make lint` — 0 issues
- `make fmt` — clean

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)