### PR TITLE
feat: add metrics YAML export for documentation website

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Run Python unit tests for e2e scripts
       run: |
-        pip install prometheus-client
+        pip install prometheus-client pyyaml
         python3 -m unittest discover -s scripts/e2e -p '*_test.py' -v
 
   binary-size-check:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -164,26 +164,55 @@ jobs:
         tag: ${{ env.BRANCH }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Download metrics YAML from latest CI run
+    - name: Download metrics YAML for release commit
       # Download the metrics YAML artifact produced by ci-summary-report.yml
-      # on the main branch. This file documents all Prometheus metrics emitted
-      # by Jaeger and is consumed by the documentation website.
+      # for the *release commit specifically* (not "latest on main"), so the
+      # documentation published alongside the release matches the code shipped
+      # in that release. Falls back to latest main if no run is found for the
+      # release commit (e.g. dry-run from a branch that hasn't hit main yet).
       continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        HEAD_SHA: ${{ github.sha }}
       run: |
-        echo "Downloading jaeger-metrics-yaml artifact from latest CI Orchestrator run on main"
+        if [ "$EVENT_NAME" = "release" ]; then
+          echo "Resolving release tag ${RELEASE_TAG} to a commit SHA"
+          TARGET_SHA=$(gh api \
+            --repo "${GH_REPO}" \
+            "/repos/${GH_REPO}/commits/${RELEASE_TAG}" \
+            --jq '.sha')
+        else
+          TARGET_SHA="${HEAD_SHA}"
+        fi
+        echo "Target commit: ${TARGET_SHA}"
+
         LATEST_RUN=$(gh run list \
           --repo "${GH_REPO}" \
           --workflow "CI Orchestrator" \
-          --branch main \
+          --commit "${TARGET_SHA}" \
           --status success \
           --limit 1 \
           --json databaseId \
-          --jq '.[0].databaseId')
+          --jq '.[0].databaseId // ""')
+
         if [ -z "$LATEST_RUN" ] || [ "$LATEST_RUN" = "null" ]; then
-          echo "::warning::No successful CI Orchestrator run found on main; skipping metrics YAML upload"
+          echo "::warning::No successful CI Orchestrator run found for commit ${TARGET_SHA}; \
+falling back to latest successful run on main"
+          LATEST_RUN=$(gh run list \
+            --repo "${GH_REPO}" \
+            --workflow "CI Orchestrator" \
+            --branch main \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId // ""')
+        fi
+
+        if [ -z "$LATEST_RUN" ] || [ "$LATEST_RUN" = "null" ]; then
+          echo "::warning::No successful CI Orchestrator run found; skipping metrics YAML upload"
           exit 0
         fi
         echo "Using CI Orchestrator run: $LATEST_RUN"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -182,7 +182,7 @@ jobs:
           --limit 1 \
           --json databaseId \
           --jq '.[0].databaseId')
-        if [ -z "$LATEST_RUN" ]; then
+        if [ -z "$LATEST_RUN" ] || [ "$LATEST_RUN" = "null" ]; then
           echo "::warning::No successful CI Orchestrator run found on main; skipping metrics YAML upload"
           exit 0
         fi

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -163,3 +163,45 @@ jobs:
         overwrite: ${{ inputs.overwrite }}
         tag: ${{ env.BRANCH }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Download metrics YAML from latest CI run
+      # Download the metrics YAML artifact produced by ci-summary-report.yml
+      # on the main branch. This file documents all Prometheus metrics emitted
+      # by Jaeger and is consumed by the documentation website.
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        echo "Downloading jaeger-metrics-yaml artifact from latest CI Orchestrator run on main"
+        LATEST_RUN=$(gh run list \
+          --repo "${GH_REPO}" \
+          --workflow "CI Orchestrator" \
+          --branch main \
+          --status success \
+          --limit 1 \
+          --json databaseId \
+          --jq '.[0].databaseId')
+        if [ -z "$LATEST_RUN" ]; then
+          echo "::warning::No successful CI Orchestrator run found on main; skipping metrics YAML upload"
+          exit 0
+        fi
+        echo "Using CI Orchestrator run: $LATEST_RUN"
+        gh run download "$LATEST_RUN" \
+          --repo "${GH_REPO}" \
+          --name jaeger-metrics-yaml \
+          --dir .metrics-export || {
+            echo "::warning::jaeger-metrics-yaml artifact not found in run $LATEST_RUN; skipping"
+            exit 0
+          }
+        ls -la .metrics-export/
+
+    - name: Upload metrics YAML as release asset
+      if: ${{ inputs.dry_run != true }}
+      uses: svenstaro/upload-release-action@5e35e583720436a2cc5f9682b6f55657101c1ea1 # 2.11.1
+      continue-on-error: true
+      with:
+        file: .metrics-export/jaeger-metrics.yaml
+        overwrite: ${{ inputs.overwrite }}
+        tag: ${{ env.BRANCH }}
+        repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-summary-report.yml
+++ b/.github/workflows/ci-summary-report.yml
@@ -36,7 +36,7 @@ jobs:
             --repo "${{ github.repository }}" --dir .artifacts
 
       - name: Install dependencies
-        run: python3 -m pip install prometheus-client
+        run: python3 -m pip install prometheus-client pyyaml
 
       - name: Compare metrics and generate summary
         id: compare-metrics
@@ -44,6 +44,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: bash ./scripts/e2e/metrics_summary.sh
+
+      - name: Export metrics to YAML for documentation
+        if: github.ref == 'refs/heads/main'
+        run: |
+          python3 ./scripts/e2e/export_metrics_to_yaml.py \
+            --snapshot-dir .artifacts \
+            --output .artifacts/jaeger-metrics.yaml || \
+          echo "::warning::Metrics YAML export failed (non-fatal)"
+
+      - name: Upload metrics YAML artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: jaeger-metrics-yaml
+          path: .artifacts/jaeger-metrics.yaml
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: Set up Go for coverage tools
         uses: ./.github/actions/setup-go

--- a/scripts/e2e/export_metrics_to_yaml.py
+++ b/scripts/e2e/export_metrics_to_yaml.py
@@ -1,0 +1,303 @@
+# Copyright (c) 2025 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export Prometheus metrics snapshots to a structured YAML data file.
+
+This script reads raw Prometheus text-format snapshot files (as scraped from
+Jaeger's /metrics endpoint by the integration tests) and produces a single
+YAML file suitable for consumption by the documentation website.
+
+The output follows a similar pattern to the CLI flags YAML files stored in
+``data/cli/{version}/`` in the jaegertracing/documentation repository.  The
+documentation site can place this output in ``data/metrics/{version}/`` and
+render it with a Hugo template, keeping all styling and layout decisions in
+the template layer rather than generating HTML or Markdown directly.
+
+Usage::
+
+    python3 scripts/e2e/export_metrics_to_yaml.py \\
+        --snapshot-dir .metrics \\
+        --output metrics.yaml
+
+The ``--snapshot-dir`` should contain one or more ``metrics_snapshot_*.txt``
+files produced by the E2E integration tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from typing import Any
+
+# PyYAML is preferred for output (human-readable, block style).
+# prometheus_client is used for parsing the Prometheus text format.
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+try:
+    from prometheus_client.parser import text_string_to_metric_families
+except ImportError:
+    text_string_to_metric_families = None  # type: ignore[assignment]
+
+
+# Labels that carry per-instance identity and should be stripped from the
+# documentation output (they add noise without informational value).
+_EXCLUDED_LABELS: frozenset[str] = frozenset({
+    "service_instance_id",
+    "otel_scope_version",
+    "otel_scope_schema_url",
+})
+
+
+def parse_snapshot(content: str) -> list[dict[str, Any]]:
+    """Parse a Prometheus text-format snapshot into a list of metric dicts.
+
+    Each dict has the following structure::
+
+        {
+            "name": "http_server_duration_milliseconds_bucket",
+            "type": "histogram",     # counter | gauge | histogram | summary | untyped
+            "help": "Duration of HTTP server requests.",
+            "labels": ["le", "http_method", "http_route"],
+        }
+
+    Metrics are deduplicated by name: the ``labels`` list is the union of all
+    label keys seen across all samples of that metric.  Label *values* are
+    intentionally omitted -- the documentation page shows which metrics exist
+    and what dimensions they carry, not the actual runtime values.
+    """
+    if text_string_to_metric_families is None:
+        raise RuntimeError(
+            "prometheus_client is required: pip install prometheus-client"
+        )
+
+    metrics_map: dict[str, dict[str, Any]] = {}
+
+    for family in text_string_to_metric_families(content):
+        if family.name in metrics_map:
+            entry = metrics_map[family.name]
+        else:
+            entry = {
+                "name": family.name,
+                "type": family.type,
+                "help": family.documentation or "",
+                "labels": set(),
+            }
+            metrics_map[family.name] = entry
+
+        for sample in family.samples:
+            for label_key in sample.labels:
+                if label_key not in _EXCLUDED_LABELS:
+                    entry["labels"].add(label_key)
+
+    # Convert label sets to sorted lists for deterministic output.
+    result: list[dict[str, Any]] = []
+    for entry in metrics_map.values():
+        result.append({
+            "name": entry["name"],
+            "type": entry["type"],
+            "help": entry["help"],
+            "labels": sorted(entry["labels"]),
+        })
+
+    result.sort(key=lambda m: m["name"])
+    return result
+
+
+def collect_snapshots(
+    snapshot_dir: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """Read all ``metrics_snapshot_*.txt`` files in *snapshot_dir*.
+
+    Supports two directory layouts:
+
+    1. **Flat**: snapshot files directly in *snapshot_dir*::
+
+           snapshot_dir/metrics_snapshot_memory.txt
+
+    2. **Artifact subdirectories** (as produced by ``gh run download``)::
+
+           snapshot_dir/metrics_snapshot_memory/metrics_snapshot_memory.txt
+
+    Returns a dict mapping the backend name (extracted from the filename,
+    e.g. ``"memory"``, ``"elasticsearch"``) to the parsed metric list.
+    When duplicate backend names are found (e.g. from matrix variations),
+    the metrics are merged.
+    """
+    snapshots: dict[str, list[dict[str, Any]]] = {}
+    file_pattern = re.compile(r"^metrics_snapshot_(.+)\.txt$")
+
+    if not os.path.isdir(snapshot_dir):
+        print(f"Warning: snapshot directory does not exist: {snapshot_dir}",
+              file=sys.stderr)
+        return snapshots
+
+    snapshot_files: list[tuple[str, str]] = []  # (backend_name, filepath)
+
+    for entry in sorted(os.listdir(snapshot_dir)):
+        entry_path = os.path.join(snapshot_dir, entry)
+
+        # Case 1: file directly in snapshot_dir
+        if os.path.isfile(entry_path):
+            match = file_pattern.match(entry)
+            if match:
+                snapshot_files.append((match.group(1), entry_path))
+
+        # Case 2: subdirectory containing the snapshot file
+        elif os.path.isdir(entry_path):
+            for sub_entry in sorted(os.listdir(entry_path)):
+                match = file_pattern.match(sub_entry)
+                if match:
+                    sub_path = os.path.join(entry_path, sub_entry)
+                    if os.path.isfile(sub_path):
+                        snapshot_files.append((match.group(1), sub_path))
+
+    for backend, filepath in snapshot_files:
+        with open(filepath, "r") as f:
+            content = f.read()
+        parsed = parse_snapshot(content)
+        if backend in snapshots:
+            # Merge with existing: union of metrics
+            existing_names = {m["name"] for m in snapshots[backend]}
+            for metric in parsed:
+                if metric["name"] not in existing_names:
+                    snapshots[backend].append(metric)
+                    existing_names.add(metric["name"])
+            snapshots[backend].sort(key=lambda m: m["name"])
+        else:
+            snapshots[backend] = parsed
+
+    return snapshots
+
+
+def merge_snapshots(
+    snapshots: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Merge metrics from multiple backend snapshots into a unified list.
+
+    Because different backends exercise different code paths, the full set of
+    metrics is only available when all snapshots are combined.  Merging
+    unions the label sets and keeps the help/type from the first occurrence.
+
+    An extra field ``"sources"`` lists the backend names where each metric
+    was observed.
+    """
+    merged: dict[str, dict[str, Any]] = {}
+
+    for backend, metrics in sorted(snapshots.items()):
+        for metric in metrics:
+            name = metric["name"]
+            if name in merged:
+                existing = merged[name]
+                label_set = set(existing["labels"])
+                label_set.update(metric["labels"])
+                existing["labels"] = sorted(label_set)
+                if backend not in existing["sources"]:
+                    existing["sources"].append(backend)
+            else:
+                merged[name] = {
+                    "name": metric["name"],
+                    "type": metric["type"],
+                    "help": metric["help"],
+                    "labels": list(metric["labels"]),
+                    "sources": [backend],
+                }
+
+    result = sorted(merged.values(), key=lambda m: m["name"])
+    return result
+
+
+def build_yaml_output(
+    merged_metrics: list[dict[str, Any]],
+    per_backend: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Build the top-level YAML structure.
+
+    The output has two sections:
+
+    - ``metrics``: the merged list of all metrics across all backends.
+    - ``backends``: a mapping from backend name to its metric list,
+      useful for backend-specific documentation pages.
+
+    Each metric entry has:
+
+    - ``name``: Prometheus metric name.
+    - ``type``: Prometheus metric type (counter, gauge, histogram, etc.).
+    - ``help``: the HELP string from the Prometheus exposition.
+    - ``labels``: sorted list of label keys (excluding instance-specific ones).
+    - ``sources`` (merged only): list of backend names where this metric
+      was observed.
+    """
+    backends_summary: dict[str, dict[str, Any]] = {}
+    for backend_name in sorted(per_backend.keys()):
+        backend_metrics = per_backend[backend_name]
+        backends_summary[backend_name] = {
+            "count": len(backend_metrics),
+            "metrics": backend_metrics,
+        }
+
+    return {
+        "total_metrics": len(merged_metrics),
+        "total_backends": len(per_backend),
+        "metrics": merged_metrics,
+        "backends": backends_summary,
+    }
+
+
+def write_yaml(data: dict[str, Any], output_path: str) -> None:
+    """Write data to a YAML file."""
+    if yaml is None:
+        raise RuntimeError("PyYAML is required: pip install pyyaml")
+
+    with open(output_path, "w") as f:
+        yaml.dump(
+            data,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+    print(f"Metrics YAML written to {output_path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export Prometheus metrics snapshots to YAML for documentation"
+    )
+    parser.add_argument(
+        "--snapshot-dir",
+        required=True,
+        help="Directory containing metrics_snapshot_*.txt files",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="metrics.yaml",
+        help="Output YAML file path (default: metrics.yaml)",
+    )
+
+    args = parser.parse_args(argv)
+
+    snapshots = collect_snapshots(args.snapshot_dir)
+    if not snapshots:
+        print("No metrics snapshot files found.", file=sys.stderr)
+        return 1
+
+    merged = merge_snapshots(snapshots)
+    output_data = build_yaml_output(merged, snapshots)
+    write_yaml(output_data, args.output)
+
+    print(
+        f"Exported {output_data['total_metrics']} unique metrics "
+        f"from {output_data['total_backends']} backend(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e/export_metrics_to_yaml.py
+++ b/scripts/e2e/export_metrics_to_yaml.py
@@ -29,7 +29,6 @@ import argparse
 import os
 import re
 import sys
-from collections import defaultdict
 from typing import Any
 
 # PyYAML is preferred for output (human-readable, block style).
@@ -60,10 +59,10 @@ def parse_snapshot(content: str) -> list[dict[str, Any]]:
     Each dict has the following structure::
 
         {
-            "name": "http_server_duration_milliseconds_bucket",
+            "name": "http_server_duration_milliseconds",
             "type": "histogram",     # counter | gauge | histogram | summary | untyped
             "help": "Duration of HTTP server requests.",
-            "labels": ["le", "http_method", "http_route"],
+            "labels": ["http_method", "http_route", "le"],
         }
 
     Metrics are deduplicated by name: the ``labels`` list is the union of all

--- a/scripts/e2e/export_metrics_to_yaml.py
+++ b/scripts/e2e/export_metrics_to_yaml.py
@@ -161,13 +161,24 @@ def collect_snapshots(
             content = f.read()
         parsed = parse_snapshot(content)
         if backend in snapshots:
-            # Merge with existing: union of metrics
-            existing_names = {m["name"] for m in snapshots[backend]}
+            # Merge per-metric so that duplicate snapshot files for the same
+            # backend do not drop label keys that only appear in later
+            # snapshots. For duplicate metric names, union the ``labels`` list
+            # and keep the first-seen ``help`` / ``type`` (they should match
+            # in practice since Prometheus exposition normalizes these).
+            existing = {m["name"]: m for m in snapshots[backend]}
             for metric in parsed:
-                if metric["name"] not in existing_names:
-                    snapshots[backend].append(metric)
-                    existing_names.add(metric["name"])
-            snapshots[backend].sort(key=lambda m: m["name"])
+                name = metric["name"]
+                if name in existing:
+                    union_labels = sorted(
+                        set(existing[name]["labels"]) | set(metric["labels"])
+                    )
+                    existing[name]["labels"] = union_labels
+                else:
+                    existing[name] = metric
+            snapshots[backend] = sorted(
+                existing.values(), key=lambda m: m["name"]
+            )
         else:
             snapshots[backend] = parsed
 

--- a/scripts/e2e/export_metrics_to_yaml_test.py
+++ b/scripts/e2e/export_metrics_to_yaml_test.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2025 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from export_metrics_to_yaml import (
+    build_yaml_output,
+    collect_snapshots,
+    merge_snapshots,
+    parse_snapshot,
+)
+
+# Minimal Prometheus text-format snippets used across tests.
+_SNAPSHOT_MEMORY = """\
+# HELP http_server_duration_milliseconds Duration of HTTP server requests.
+# TYPE http_server_duration_milliseconds histogram
+http_server_duration_milliseconds_bucket{http_method="GET",http_route="/api/traces",le="100"} 5
+http_server_duration_milliseconds_bucket{http_method="GET",http_route="/api/traces",le="+Inf"} 10
+http_server_duration_milliseconds_count{http_method="GET",http_route="/api/traces"} 10
+http_server_duration_milliseconds_sum{http_method="GET",http_route="/api/traces"} 450
+# HELP jaeger_storage_spans_written_total Total number of spans written to storage.
+# TYPE jaeger_storage_spans_written_total counter
+jaeger_storage_spans_written_total{storage="memory"} 42
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 1.23
+"""
+
+_SNAPSHOT_CASSANDRA = """\
+# HELP http_server_duration_milliseconds Duration of HTTP server requests.
+# TYPE http_server_duration_milliseconds histogram
+http_server_duration_milliseconds_bucket{http_method="POST",http_route="/api/traces",le="100"} 3
+http_server_duration_milliseconds_bucket{http_method="POST",http_route="/api/traces",le="+Inf"} 8
+http_server_duration_milliseconds_count{http_method="POST",http_route="/api/traces"} 8
+http_server_duration_milliseconds_sum{http_method="POST",http_route="/api/traces"} 320
+# HELP jaeger_storage_spans_written_total Total number of spans written to storage.
+# TYPE jaeger_storage_spans_written_total counter
+jaeger_storage_spans_written_total{storage="cassandra"} 100
+# HELP jaeger_storage_cassandra_errors_total Total number of Cassandra errors.
+# TYPE jaeger_storage_cassandra_errors_total counter
+jaeger_storage_cassandra_errors_total{operation="write"} 0
+"""
+
+_SNAPSHOT_WITH_EXCLUDED_LABELS = """\
+# HELP my_metric A test metric.
+# TYPE my_metric gauge
+my_metric{job="jaeger",service_instance_id="abc-123",otel_scope_version="1.0"} 1
+"""
+
+
+class TestParseSnapshot(unittest.TestCase):
+    """Tests for parse_snapshot()."""
+
+    def test_parses_metric_names(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        names = [m["name"] for m in metrics]
+        self.assertIn("http_server_duration_milliseconds", names)
+        # prometheus_client parser uses family.name which strips _total suffix
+        self.assertIn("jaeger_storage_spans_written", names)
+        self.assertIn("process_cpu_seconds", names)
+
+    def test_parses_metric_types(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        by_name = {m["name"]: m for m in metrics}
+        self.assertEqual(by_name["http_server_duration_milliseconds"]["type"], "histogram")
+        self.assertEqual(by_name["jaeger_storage_spans_written"]["type"], "counter")
+
+    def test_parses_help_strings(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        by_name = {m["name"]: m for m in metrics}
+        self.assertIn("Duration of HTTP server requests", by_name["http_server_duration_milliseconds"]["help"])
+
+    def test_collects_label_keys(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        by_name = {m["name"]: m for m in metrics}
+        http_labels = by_name["http_server_duration_milliseconds"]["labels"]
+        self.assertIn("http_method", http_labels)
+        self.assertIn("http_route", http_labels)
+        self.assertIn("le", http_labels)
+        storage_labels = by_name["jaeger_storage_spans_written"]["labels"]
+        self.assertIn("storage", storage_labels)
+
+    def test_labels_are_sorted(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        for m in metrics:
+            self.assertEqual(m["labels"], sorted(m["labels"]))
+
+    def test_metrics_are_sorted_by_name(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        names = [m["name"] for m in metrics]
+        self.assertEqual(names, sorted(names))
+
+    def test_excludes_instance_labels(self):
+        metrics = parse_snapshot(_SNAPSHOT_WITH_EXCLUDED_LABELS)
+        by_name = {m["name"]: m for m in metrics}
+        labels = by_name["my_metric"]["labels"]
+        self.assertNotIn("service_instance_id", labels)
+        self.assertNotIn("otel_scope_version", labels)
+        self.assertIn("job", labels)
+
+    def test_metrics_without_labels(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        by_name = {m["name"]: m for m in metrics}
+        self.assertEqual(by_name["process_cpu_seconds"]["labels"], [])
+
+    def test_empty_input(self):
+        metrics = parse_snapshot("")
+        self.assertEqual(metrics, [])
+
+    def test_deduplicates_by_metric_name(self):
+        metrics = parse_snapshot(_SNAPSHOT_MEMORY)
+        names = [m["name"] for m in metrics]
+        self.assertEqual(len(names), len(set(names)))
+
+
+class TestCollectSnapshots(unittest.TestCase):
+    """Tests for collect_snapshots()."""
+
+    def test_reads_snapshot_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "metrics_snapshot_memory.txt")
+            with open(path, "w") as f:
+                f.write(_SNAPSHOT_MEMORY)
+            snapshots = collect_snapshots(tmpdir)
+            self.assertIn("memory", snapshots)
+            self.assertTrue(len(snapshots["memory"]) > 0)
+
+    def test_extracts_backend_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ["metrics_snapshot_memory.txt", "metrics_snapshot_cassandra.txt"]:
+                path = os.path.join(tmpdir, name)
+                with open(path, "w") as f:
+                    f.write(_SNAPSHOT_MEMORY)
+            snapshots = collect_snapshots(tmpdir)
+            self.assertIn("memory", snapshots)
+            self.assertIn("cassandra", snapshots)
+
+    def test_ignores_non_snapshot_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ["other_file.txt", "baseline_metrics.txt", "diff_metrics.txt"]:
+                path = os.path.join(tmpdir, name)
+                with open(path, "w") as f:
+                    f.write("not a snapshot")
+            snapshots = collect_snapshots(tmpdir)
+            self.assertEqual(len(snapshots), 0)
+
+    def test_reads_from_artifact_subdirectories(self):
+        """Supports the gh run download layout: subdir/metrics_snapshot_X.txt."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "metrics_snapshot_memory")
+            os.makedirs(subdir)
+            path = os.path.join(subdir, "metrics_snapshot_memory.txt")
+            with open(path, "w") as f:
+                f.write(_SNAPSHOT_MEMORY)
+            snapshots = collect_snapshots(tmpdir)
+            self.assertIn("memory", snapshots)
+            self.assertTrue(len(snapshots["memory"]) > 0)
+
+    def test_mixed_flat_and_subdirectory_layout(self):
+        """Collects from both flat files and subdirectories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Flat file
+            with open(os.path.join(tmpdir, "metrics_snapshot_memory.txt"), "w") as f:
+                f.write(_SNAPSHOT_MEMORY)
+            # Subdirectory
+            subdir = os.path.join(tmpdir, "metrics_snapshot_cassandra")
+            os.makedirs(subdir)
+            with open(os.path.join(subdir, "metrics_snapshot_cassandra.txt"), "w") as f:
+                f.write(_SNAPSHOT_CASSANDRA)
+            snapshots = collect_snapshots(tmpdir)
+            self.assertIn("memory", snapshots)
+            self.assertIn("cassandra", snapshots)
+
+    def test_missing_directory_returns_empty(self):
+        snapshots = collect_snapshots("/nonexistent/path")
+        self.assertEqual(len(snapshots), 0)
+
+
+class TestMergeSnapshots(unittest.TestCase):
+    """Tests for merge_snapshots()."""
+
+    def test_merges_metrics_from_multiple_backends(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "metrics_snapshot_memory.txt"), "w") as f:
+                f.write(_SNAPSHOT_MEMORY)
+            with open(os.path.join(tmpdir, "metrics_snapshot_cassandra.txt"), "w") as f:
+                f.write(_SNAPSHOT_CASSANDRA)
+            snapshots = collect_snapshots(tmpdir)
+            merged = merge_snapshots(snapshots)
+
+            names = [m["name"] for m in merged]
+            # Cassandra-specific metric should appear (family.name strips _total)
+            self.assertIn("jaeger_storage_cassandra_errors", names)
+            # Common metric should appear once
+            self.assertEqual(names.count("http_server_duration_milliseconds"), 1)
+
+    def test_sources_field_tracks_backends(self):
+        snapshots = {
+            "memory": parse_snapshot(_SNAPSHOT_MEMORY),
+            "cassandra": parse_snapshot(_SNAPSHOT_CASSANDRA),
+        }
+        merged = merge_snapshots(snapshots)
+        by_name = {m["name"]: m for m in merged}
+
+        # Common metric should list both backends
+        http_sources = by_name["http_server_duration_milliseconds"]["sources"]
+        self.assertIn("memory", http_sources)
+        self.assertIn("cassandra", http_sources)
+
+        # Cassandra-only metric (family.name strips _total suffix)
+        cass_sources = by_name["jaeger_storage_cassandra_errors"]["sources"]
+        self.assertEqual(cass_sources, ["cassandra"])
+
+    def test_labels_are_unioned(self):
+        # Both snapshots have http_server_duration_milliseconds with same labels.
+        # The union should be the same as either.
+        snapshots = {
+            "memory": parse_snapshot(_SNAPSHOT_MEMORY),
+            "cassandra": parse_snapshot(_SNAPSHOT_CASSANDRA),
+        }
+        merged = merge_snapshots(snapshots)
+        by_name = {m["name"]: m for m in merged}
+        labels = by_name["http_server_duration_milliseconds"]["labels"]
+        self.assertIn("http_method", labels)
+        self.assertIn("http_route", labels)
+
+    def test_merged_is_sorted_by_name(self):
+        snapshots = {
+            "memory": parse_snapshot(_SNAPSHOT_MEMORY),
+            "cassandra": parse_snapshot(_SNAPSHOT_CASSANDRA),
+        }
+        merged = merge_snapshots(snapshots)
+        names = [m["name"] for m in merged]
+        self.assertEqual(names, sorted(names))
+
+    def test_empty_snapshots(self):
+        merged = merge_snapshots({})
+        self.assertEqual(merged, [])
+
+
+class TestBuildYamlOutput(unittest.TestCase):
+    """Tests for build_yaml_output()."""
+
+    def test_output_structure(self):
+        snapshots = {
+            "memory": parse_snapshot(_SNAPSHOT_MEMORY),
+        }
+        merged = merge_snapshots(snapshots)
+        output = build_yaml_output(merged, snapshots)
+
+        self.assertIn("total_metrics", output)
+        self.assertIn("total_backends", output)
+        self.assertIn("metrics", output)
+        self.assertIn("backends", output)
+
+    def test_total_counts(self):
+        snapshots = {
+            "memory": parse_snapshot(_SNAPSHOT_MEMORY),
+            "cassandra": parse_snapshot(_SNAPSHOT_CASSANDRA),
+        }
+        merged = merge_snapshots(snapshots)
+        output = build_yaml_output(merged, snapshots)
+
+        self.assertEqual(output["total_backends"], 2)
+        self.assertGreater(output["total_metrics"], 0)
+
+    def test_backends_contain_metric_lists(self):
+        snapshots = {
+            "memory": parse_snapshot(_SNAPSHOT_MEMORY),
+        }
+        merged = merge_snapshots(snapshots)
+        output = build_yaml_output(merged, snapshots)
+
+        self.assertIn("memory", output["backends"])
+        self.assertIn("count", output["backends"]["memory"])
+        self.assertIn("metrics", output["backends"]["memory"])
+        self.assertEqual(
+            output["backends"]["memory"]["count"],
+            len(output["backends"]["memory"]["metrics"]),
+        )
+
+    def test_output_is_yaml_serializable(self):
+        snapshots = {
+            "memory": parse_snapshot(_SNAPSHOT_MEMORY),
+            "cassandra": parse_snapshot(_SNAPSHOT_CASSANDRA),
+        }
+        merged = merge_snapshots(snapshots)
+        output = build_yaml_output(merged, snapshots)
+
+        # Should not raise
+        yaml_str = yaml.dump(output, default_flow_style=False)
+        # Should be parseable back
+        reloaded = yaml.safe_load(yaml_str)
+        self.assertEqual(reloaded["total_metrics"], output["total_metrics"])
+        self.assertEqual(reloaded["total_backends"], output["total_backends"])
+
+
+class TestEndToEnd(unittest.TestCase):
+    """End-to-end test: snapshot files -> YAML output file."""
+
+    def test_full_pipeline(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write snapshot files
+            with open(os.path.join(tmpdir, "metrics_snapshot_memory.txt"), "w") as f:
+                f.write(_SNAPSHOT_MEMORY)
+            with open(os.path.join(tmpdir, "metrics_snapshot_cassandra.txt"), "w") as f:
+                f.write(_SNAPSHOT_CASSANDRA)
+
+            output_path = os.path.join(tmpdir, "metrics.yaml")
+
+            # Run the pipeline
+            snapshots = collect_snapshots(tmpdir)
+            merged = merge_snapshots(snapshots)
+            output = build_yaml_output(merged, snapshots)
+
+            yaml_str = yaml.dump(output, default_flow_style=False, sort_keys=False)
+            with open(output_path, "w") as f:
+                f.write(yaml_str)
+
+            # Verify file was written
+            self.assertTrue(os.path.exists(output_path))
+
+            # Verify content
+            with open(output_path, "r") as f:
+                loaded = yaml.safe_load(f)
+            self.assertEqual(loaded["total_backends"], 2)
+            self.assertGreater(loaded["total_metrics"], 0)
+
+            # Verify cassandra-only metric is present (family.name strips _total)
+            metric_names = [m["name"] for m in loaded["metrics"]]
+            self.assertIn("jaeger_storage_cassandra_errors", metric_names)
+
+            # Verify backends section
+            self.assertIn("memory", loaded["backends"])
+            self.assertIn("cassandra", loaded["backends"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses the final task in #6278: **implement a way to incorporate the metrics report into documentation website**.

This PR adds the tooling and CI integration to export Prometheus metrics snapshots to a structured YAML data file, following the same pattern as the CLI flags YAML files that were previously used by the documentation website (`data/cli/{version}/`).

### Changes

- **`scripts/e2e/export_metrics_to_yaml.py`**: New Python script that parses raw Prometheus text-format snapshot files (as scraped from Jaeger's `/metrics` endpoint during E2E integration tests) and produces a single YAML file containing:
  - Metric names, types (counter/gauge/histogram/summary), and HELP strings
  - Label keys (with instance-specific labels like `service_instance_id` excluded)
  - A merged view across all backends with source tracking
  - Per-backend metric lists for backend-specific documentation

- **`scripts/e2e/export_metrics_to_yaml_test.py`**: 26 unit tests covering parsing, collection (both flat and `gh run download` subdirectory layouts), merging, YAML serialization, and the full end-to-end pipeline.

- **`.github/workflows/ci-summary-report.yml`**: On main branch CI runs, exports the combined metrics as a YAML artifact (`jaeger-metrics-yaml`, 90-day retention) so it persists beyond the default 7-day artifact window.

- **`.github/workflows/ci-release.yml`**: During releases, downloads the metrics YAML artifact from the latest successful CI Orchestrator run on main and uploads it as a release asset (`jaeger-metrics.yaml`). The documentation repo can then fetch this asset during its release process and place it in `data/metrics/{version}/` for Hugo template rendering.

### How it fits together

```
E2E tests (scrapeMetrics) -> metrics_snapshot_*.txt artifacts
                                    |
                          ci-summary-report.yml
                                    |
                     export_metrics_to_yaml.py
                                    |
                        jaeger-metrics.yaml artifact
                                    |
                            ci-release.yml
                                    |
                    jaeger-metrics.yaml release asset
                                    |
                    documentation repo release process
                                    |
                     data/metrics/{version}/metrics.yaml
                                    |
                         Hugo template rendering
```

## Test plan

- [x] All 26 new unit tests pass locally
- [x] All 35 existing Python tests (compare_metrics, metrics_summary) still pass
- [x] Verify CI pipeline runs the export step on main branch
- [x] Verify release workflow downloads and uploads the metrics YAML
- [x] Verify the YAML output is suitable for Hugo template consumption in the documentation repo

Closes #6278