### PR TITLE
[badger] Add spanKind support to GetOperations (#1922)

### DIFF
--- a/internal/storage/integration/badgerstore_test.go
+++ b/internal/storage/integration/badgerstore_test.go
@@ -54,10 +54,7 @@ func TestBadgerStorage(t *testing.T) {
 		testutils.VerifyGoLeaksOnce(t)
 	})
 	s := &BadgerIntegrationStorage{
-		StorageIntegration: StorageIntegration{
-			// TODO: remove this badger supports returning spanKind from GetOperations
-			GetOperationsMissingSpanKind: true,
-		},
+		StorageIntegration: StorageIntegration{},
 	}
 	s.CleanUp = s.cleanUp
 	s.initialize(t)

--- a/internal/storage/v1/badger/spanstore/cache.go
+++ b/internal/storage/v1/badger/spanstore/cache.go
@@ -4,6 +4,7 @@
 package spanstore
 
 import (
+	"cmp"
 	"slices"
 	"sync"
 	"time"
@@ -18,7 +19,7 @@ type CacheStore struct {
 	// Given the small amount of data these will store, we use the same structure as the memory store
 	cacheLock  sync.Mutex // write heavy - Mutex is faster than RWMutex for writes
 	services   map[string]uint64
-	operations map[string]map[string]uint64
+	operations map[string]map[tracestore.Operation]uint64
 
 	store *badger.DB
 	ttl   time.Duration
@@ -28,7 +29,7 @@ type CacheStore struct {
 func NewCacheStore(db *badger.DB, ttl time.Duration) *CacheStore {
 	cs := &CacheStore{
 		services:   make(map[string]uint64),
-		operations: make(map[string]map[string]uint64),
+		operations: make(map[string]map[tracestore.Operation]uint64),
 		ttl:        ttl,
 		store:      db,
 	}
@@ -48,35 +49,37 @@ func (c *CacheStore) AddService(service string, keyTTL uint64) {
 }
 
 // AddOperation adds the cache with operation names with most updated expiration time
-func (c *CacheStore) AddOperation(service, operation string, keyTTL uint64) {
+func (c *CacheStore) AddOperation(service, operation, spanKind string, keyTTL uint64) {
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 	if _, found := c.operations[service]; !found {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[tracestore.Operation]uint64)
 	}
-	if v, found := c.operations[service][operation]; found {
+	op := tracestore.Operation{Name: operation, SpanKind: spanKind}
+	if v, found := c.operations[service][op]; found {
 		if v > keyTTL {
 			return
 		}
 	}
-	c.operations[service][operation] = keyTTL
+	c.operations[service][op] = keyTTL
 }
 
 // Update caches the results of service and service + operation indexes and maintains their TTL
-func (c *CacheStore) Update(service, operation string, expireTime uint64) {
+func (c *CacheStore) Update(service, operation, spanKind string, expireTime uint64) {
 	c.cacheLock.Lock()
 
 	c.services[service] = expireTime
 	if _, ok := c.operations[service]; !ok {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[tracestore.Operation]uint64)
 	}
-	c.operations[service][operation] = expireTime
+	op := tracestore.Operation{Name: operation, SpanKind: spanKind}
+	c.operations[service][op] = expireTime
 	c.cacheLock.Unlock()
 }
 
 // GetOperations returns all operations for a specific service & spanKind traced by Jaeger
-func (c *CacheStore) GetOperations(service string) ([]tracestore.Operation, error) {
-	operations := make([]string, 0, len(c.services))
+func (c *CacheStore) GetOperations(service, spanKind string) ([]tracestore.Operation, error) {
+	result := make([]tracestore.Operation, 0, len(c.services))
 	//nolint:gosec // G115
 	t := uint64(time.Now().Unix())
 	c.cacheLock.Lock()
@@ -89,25 +92,25 @@ func (c *CacheStore) GetOperations(service string) ([]tracestore.Operation, erro
 			delete(c.operations, service)
 			return []tracestore.Operation{}, nil // empty slice rather than nil
 		}
-		for o, e := range c.operations[service] {
+		for op, e := range c.operations[service] {
 			if e > t {
-				operations = append(operations, o)
+				// Empty spanKind returns all, otherwise filter by kind
+				if spanKind == "" || op.SpanKind == spanKind {
+					result = append(result, op)
+				}
 			} else {
-				delete(c.operations[service], o)
+				delete(c.operations[service], op)
 			}
 		}
 	}
 
-	slices.Sort(operations)
+	slices.SortFunc(result, func(a, b tracestore.Operation) int {
+		if n := cmp.Compare(a.Name, b.Name); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.SpanKind, b.SpanKind)
+	})
 
-	// TODO: https://github.com/jaegertracing/jaeger/issues/1922
-	// 	- return the operations with actual spanKind
-	result := make([]tracestore.Operation, 0, len(operations))
-	for _, op := range operations {
-		result = append(result, tracestore.Operation{
-			Name: op,
-		})
-	}
 	return result, nil
 }
 

--- a/internal/storage/v1/badger/spanstore/cache_test.go
+++ b/internal/storage/v1/badger/spanstore/cache_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
 /*
@@ -24,8 +26,8 @@ func TestExpiredItems(t *testing.T) {
 
 		// Expired service
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "op1", "", expireTime)
+		cache.Update("service1", "op2", "", expireTime)
 
 		services, err := cache.GetServices()
 		require.NoError(t, err)
@@ -33,23 +35,110 @@ func TestExpiredItems(t *testing.T) {
 
 		// Expired service for operations
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "op1", "", expireTime)
+		cache.Update("service1", "op2", "", expireTime)
 
-		operations, err := cache.GetOperations("service1")
+		operations, err := cache.GetOperations("service1", "")
 		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
 
 		// Expired operations, stable service
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "op1", "", expireTime)
+		cache.Update("service1", "op2", "", expireTime)
 
 		cache.services["service1"] = uint64(time.Now().Unix() + 1e10)
 
-		operations, err = cache.GetOperations("service1")
+		operations, err = cache.GetOperations("service1", "")
 		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
+	})
+}
+
+func TestSpanKindFilter(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		cache := NewCacheStore(store, time.Duration(1*time.Hour))
+
+		expireTime := uint64(time.Now().Add(1 * time.Hour).Unix())
+
+		cache.Update("svc", "op-a", "server", expireTime)
+		cache.Update("svc", "op-b", "client", expireTime)
+		cache.Update("svc", "op-a", "client", expireTime)
+		cache.Update("svc", "op-c", "", expireTime)
+
+		// Empty spanKind returns all
+		ops, err := cache.GetOperations("svc", "")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []tracestore.Operation{
+			{Name: "op-a", SpanKind: "server"},
+			{Name: "op-b", SpanKind: "client"},
+			{Name: "op-a", SpanKind: "client"},
+			{Name: "op-c", SpanKind: ""},
+		}, ops)
+
+		// Filter server
+		ops, err = cache.GetOperations("svc", "server")
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "op-a", SpanKind: "server"},
+		}, ops)
+
+		// Filter client
+		ops, err = cache.GetOperations("svc", "client")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []tracestore.Operation{
+			{Name: "op-a", SpanKind: "client"},
+			{Name: "op-b", SpanKind: "client"},
+		}, ops)
+
+		// Filter with no matches
+		ops, err = cache.GetOperations("svc", "producer")
+		require.NoError(t, err)
+		assert.Empty(t, ops)
+	})
+}
+
+func TestAddOperationKeepsLaterTTL(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		cache := NewCacheStore(store, time.Duration(1*time.Hour))
+
+		later := uint64(time.Now().Add(2 * time.Hour).Unix())
+		earlier := uint64(time.Now().Add(1 * time.Hour).Unix())
+
+		// First add with later TTL
+		cache.AddOperation("svc", "op", "server", later)
+		// Second add with earlier TTL — should be ignored
+		cache.AddOperation("svc", "op", "server", earlier)
+
+		// Force service alive so cache returns operations
+		cache.services["svc"] = later
+
+		ops, err := cache.GetOperations("svc", "server")
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "op", SpanKind: "server"},
+		}, ops)
+		// Verify internal map has the later TTL (not overwritten)
+		assert.Equal(t, later, cache.operations["svc"][tracestore.Operation{Name: "op", SpanKind: "server"}])
+	})
+}
+
+func TestSpanKindExpiry(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		cache := NewCacheStore(store, time.Duration(1*time.Hour))
+
+		fresh := uint64(time.Now().Add(1 * time.Hour).Unix())
+		stale := uint64(time.Now().Add(-1 * time.Hour).Unix())
+
+		cache.Update("svc", "op-a", "server", fresh)
+		cache.Update("svc", "op-b", "client", stale)
+		cache.services["svc"] = fresh // keep service alive
+
+		ops, err := cache.GetOperations("svc", "")
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "op-a", SpanKind: "server"},
+		}, ops)
 	})
 }
 

--- a/internal/storage/v1/badger/spanstore/get_operations_test.go
+++ b/internal/storage/v1/badger/spanstore/get_operations_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package spanstore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/badger"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+// openBadgerFactory opens a persistent Badger factory at dir and runs the test.
+// The factory is closed after the test completes.
+func openBadgerFactory(t *testing.T, dir string, test func(t *testing.T, sw spanstore.Writer, sr spanstore.Reader)) {
+	f := badger.NewFactory()
+	f.Config.Directories.Keys = dir
+	f.Config.Directories.Values = dir
+	f.Config.Ephemeral = false
+	f.Config.SyncWrites = true
+	err := f.Initialize(metrics.NullFactory, zap.NewNop())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, f.Close())
+	}()
+
+	sw, err := f.CreateSpanWriter()
+	require.NoError(t, err)
+	sr, err := f.CreateSpanReader()
+	require.NoError(t, err)
+
+	test(t, sw, sr)
+}
+
+// TestGetOperationsWithSpanKind verifies that GetOperations filters by spanKind
+// and returns populated SpanKind fields when spans have span.kind tags.
+func TestGetOperationsWithSpanKind(t *testing.T) {
+	runFactoryTest(t, func(_ testing.TB, sw spanstore.Writer, sr spanstore.Reader) {
+		spans := []model.Span{
+			{
+				TraceID:       model.TraceID{Low: 1, High: 1},
+				SpanID:        model.SpanID(1),
+				OperationName: "get-users",
+				Process:       &model.Process{ServiceName: "api-gateway"},
+				Tags:          model.KeyValues{model.String("span.kind", "server")},
+				StartTime:     time.Now(),
+				Duration:      time.Millisecond,
+			},
+			{
+				TraceID:       model.TraceID{Low: 1, High: 1},
+				SpanID:        model.SpanID(2),
+				OperationName: "db-query",
+				Process:       &model.Process{ServiceName: "api-gateway"},
+				Tags:          model.KeyValues{model.String("span.kind", "client")},
+				StartTime:     time.Now(),
+				Duration:      time.Millisecond,
+			},
+			{
+				TraceID:       model.TraceID{Low: 2, High: 1},
+				SpanID:        model.SpanID(3),
+				OperationName: "get-users",
+				Process:       &model.Process{ServiceName: "api-gateway"},
+				Tags:          model.KeyValues{model.String("span.kind", "client")},
+				StartTime:     time.Now(),
+				Duration:      time.Millisecond,
+			},
+		}
+		for i := range spans {
+			require.NoError(t, sw.WriteSpan(context.Background(), &spans[i]))
+		}
+
+		// Empty spanKind returns all
+		ops, err := sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "api-gateway",
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []tracestore.Operation{
+			{Name: "get-users", SpanKind: "server"},
+			{Name: "db-query", SpanKind: "client"},
+			{Name: "get-users", SpanKind: "client"},
+		}, ops)
+
+		// Filter server
+		ops, err = sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "api-gateway",
+			SpanKind:    "server",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "get-users", SpanKind: "server"},
+		}, ops)
+
+		// Filter client
+		ops, err = sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "api-gateway",
+			SpanKind:    "client",
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []tracestore.Operation{
+			{Name: "db-query", SpanKind: "client"},
+			{Name: "get-users", SpanKind: "client"},
+		}, ops)
+
+		// Filter with no matches
+		ops, err = sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "api-gateway",
+			SpanKind:    "producer",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, ops)
+	})
+}
+
+// TestGetOperationsWithoutSpanKind verifies backward compatibility: spans without
+// span.kind tags appear with empty SpanKind and are excluded when filtering by kind.
+func TestGetOperationsWithoutSpanKind(t *testing.T) {
+	runFactoryTest(t, func(_ testing.TB, sw spanstore.Writer, sr spanstore.Reader) {
+		s := model.Span{
+			TraceID:       model.TraceID{Low: 1, High: 1},
+			SpanID:        model.SpanID(1),
+			OperationName: "legacy-op",
+			Process:       &model.Process{ServiceName: "old-service"},
+			StartTime:     time.Now(),
+			Duration:      time.Millisecond,
+		}
+		require.NoError(t, sw.WriteSpan(context.Background(), &s))
+
+		// Empty spanKind returns the entry with empty SpanKind
+		ops, err := sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "old-service",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "legacy-op", SpanKind: ""},
+		}, ops)
+
+		// Filter by specific kind excludes the entry
+		ops, err = sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "old-service",
+			SpanKind:    "server",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, ops)
+	})
+}
+
+// TestGetOperationsSpanKindPersistence verifies that 0x85 index keys survive
+// DB close/reopen and preload correctly into the cache with spanKind.
+func TestGetOperationsSpanKindPersistence(t *testing.T) {
+	dir := t.TempDir()
+
+	// Phase 1: write spans with spanKind, then close
+	openBadgerFactory(t, dir, func(t *testing.T, sw spanstore.Writer, _ spanstore.Reader) {
+		spans := []model.Span{
+			{
+				TraceID:       model.TraceID{Low: 1, High: 1},
+				SpanID:        model.SpanID(1),
+				OperationName: "get-users",
+				Process:       &model.Process{ServiceName: "api-gateway"},
+				Tags:          model.KeyValues{model.String("span.kind", "server")},
+				StartTime:     time.Now(),
+				Duration:      time.Millisecond,
+			},
+			{
+				TraceID:       model.TraceID{Low: 1, High: 1},
+				SpanID:        model.SpanID(2),
+				OperationName: "db-query",
+				Process:       &model.Process{ServiceName: "api-gateway"},
+				Tags:          model.KeyValues{model.String("span.kind", "client")},
+				StartTime:     time.Now(),
+				Duration:      time.Millisecond,
+			},
+		}
+		for i := range spans {
+			require.NoError(t, sw.WriteSpan(context.Background(), &spans[i]))
+		}
+	})
+
+	// Phase 2: reopen, verify spanKind preloaded from 0x85 keys
+	openBadgerFactory(t, dir, func(t *testing.T, _ spanstore.Writer, sr spanstore.Reader) {
+		ops, err := sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "api-gateway",
+			SpanKind:    "server",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "get-users", SpanKind: "server"},
+		}, ops)
+
+		ops, err = sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "api-gateway",
+			SpanKind:    "client",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "db-query", SpanKind: "client"},
+		}, ops)
+	})
+}
+
+// TestGetOperationsSpanKindCaseHandling verifies that uppercase span.kind
+// values are not recognized at write time and treated as unspecified/empty
+// in GetOperations results.
+func TestGetOperationsSpanKindCaseHandling(t *testing.T) {
+	dir := t.TempDir()
+
+	openBadgerFactory(t, dir, func(t *testing.T, sw spanstore.Writer, _ spanstore.Reader) {
+		s := model.Span{
+			TraceID:       model.TraceID{Low: 1, High: 1},
+			SpanID:        model.SpanID(1),
+			OperationName: "op",
+			Process:       &model.Process{ServiceName: "svc"},
+			Tags:          model.KeyValues{model.String("span.kind", "SERVER")},
+			StartTime:     time.Now(),
+			Duration:      time.Millisecond,
+		}
+		require.NoError(t, sw.WriteSpan(context.Background(), &s))
+	})
+
+	// Reopen forces preload from 0x85 keys on disk
+	openBadgerFactory(t, dir, func(t *testing.T, _ spanstore.Writer, sr spanstore.Reader) {
+		ops, err := sr.GetOperations(context.Background(), tracestore.OperationQueryParams{
+			ServiceName: "svc",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "op", SpanKind: ""},
+		}, ops)
+	})
+}

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -248,7 +248,7 @@ func (r *TraceReader) GetOperations(
 	_ context.Context,
 	query tracestore.OperationQueryParams,
 ) ([]tracestore.Operation, error) {
-	return r.cache.GetOperations(query.ServiceName)
+	return r.cache.GetOperations(query.ServiceName, query.SpanKind)
 }
 
 // setQueryDefaults alters the query with defaults if certain parameters are not set
@@ -648,17 +648,20 @@ func (r *TraceReader) preloadOperations(service string) {
 		it := txn.NewIterator(opts)
 		defer it.Close()
 
-		serviceKey := make([]byte, len(service)+1)
-		serviceKey[0] = operationNameIndexKey
-		copy(serviceKey[1:], service)
+		// Scan 0x85 keys with spanKind (replaces 0x82 scan for cache preload)
+		serviceKindKey := make([]byte, len(service)+1)
+		serviceKindKey[0] = operationKindIndexKey
+		copy(serviceKindKey[1:], service)
 
-		// Seek all the services first
-		for it.Seek(serviceKey); it.ValidForPrefix(serviceKey); it.Next() {
-			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
-			operationName := string(it.Item().Key()[len(serviceKey):timestampStartIndex])
+		for it.Seek(serviceKindKey); it.ValidForPrefix(serviceKindKey); it.Next() {
+			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8)
+			// Key layout after prefix: [serviceName][kindByte][operationName][startTime][traceID]
+			kindByte := it.Item().Key()[len(serviceKindKey)]
+			operationName := string(it.Item().Key()[len(serviceKindKey)+1 : timestampStartIndex])
 			keyTTL := it.Item().ExpiresAt()
-			r.cache.AddOperation(service, operationName, keyTTL)
+			r.cache.AddOperation(service, operationName, spanKindByteToString(kindByte), keyTTL)
 		}
+
 		return nil
 	})
 }

--- a/internal/storage/v1/badger/spanstore/rw_internal_test.go
+++ b/internal/storage/v1/badger/spanstore/rw_internal_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
 func TestEncodingTypes(t *testing.T) {
@@ -217,15 +218,122 @@ func TestOldReads(t *testing.T) {
 
 		nuTid := tid.Add(1 * time.Hour)
 
-		cache.Update("service1", "operation1", uint64(tid.Unix()))
+		cache.Update("service1", "operation1", "", uint64(tid.Unix()))
 		cache.services["service1"] = uint64(nuTid.Unix())
-		cache.operations["service1"]["operation1"] = uint64(nuTid.Unix())
+		cache.operations["service1"][tracestore.Operation{Name: "operation1"}] = uint64(nuTid.Unix())
 
 		// This is equivalent to populate caches of cache
 		_ = NewTraceReader(store, cache, true)
 
 		// Now make sure we didn't use the older timestamps from the DB
 		assert.Equal(t, uint64(nuTid.Unix()), cache.services["service1"])
-		assert.Equal(t, uint64(nuTid.Unix()), cache.operations["service1"]["operation1"])
+		assert.Equal(t, uint64(nuTid.Unix()), cache.operations["service1"][tracestore.Operation{Name: "operation1"}])
+	})
+}
+
+func TestSpanKindByteMappings(t *testing.T) {
+	tests := []struct {
+		kind string
+		b    byte
+	}{
+		{"", 0},
+		{"internal", 1},
+		{"server", 2},
+		{"client", 3},
+		{"producer", 4},
+		{"consumer", 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			assert.Equal(t, tt.b, spanKindToByte(model.SpanKind(tt.kind)))
+			assert.Equal(t, tt.kind, spanKindByteToString(tt.b))
+		})
+	}
+	// Unknown byte maps to empty string
+	assert.Empty(t, spanKindByteToString(0xFF))
+}
+
+func TestOperationKindIndexKeyLayout(t *testing.T) {
+	service := "mysvc"
+	operation := "myop"
+	var kindByte byte = 2 // server
+	startTime := uint64(1000)
+	traceID := model.TraceID{High: 1, Low: 2}
+
+	// Build the composite value the same way the writer does
+	value := make([]byte, len(service)+1+len(operation))
+	copy(value, service)
+	value[len(service)] = kindByte
+	copy(value[len(service)+1:], operation)
+
+	key := createIndexKey(operationKindIndexKey, value, startTime, traceID)
+
+	// Verify prefix byte
+	assert.Equal(t, byte(0x85), key[0])
+
+	// Verify service name
+	assert.Equal(t, service, string(key[1:1+len(service)]))
+
+	// Verify kind byte sits between service and operation
+	assert.Equal(t, kindByte, key[1+len(service)])
+
+	// Verify operation name
+	opStart := 1 + len(service) + 1
+	opEnd := len(key) - sizeOfTraceID - 8 // before startTime and traceID
+	assert.Equal(t, operation, string(key[opStart:opEnd]))
+}
+
+func TestPreloadOperationsWithSpanKind(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		timeNow := model.TimeAsEpochMicroseconds(time.Now())
+		tid := time.Now().Add(1 * time.Minute)
+
+		// Write 0x81 service key
+		s1Key := createIndexKey(serviceNameIndexKey, []byte("svc1"), timeNow, model.TraceID{High: 0, Low: 0})
+
+		// Write 0x85 operation+kind keys directly
+		serverValue := make([]byte, len("svc1")+1+len("get-users"))
+		copy(serverValue, "svc1")
+		serverValue[len("svc1")] = 2 // server
+		copy(serverValue[len("svc1")+1:], "get-users")
+		kindKey1 := createIndexKey(operationKindIndexKey, serverValue, timeNow, model.TraceID{High: 0, Low: 1})
+
+		clientValue := make([]byte, len("svc1")+1+len("db-call"))
+		copy(clientValue, "svc1")
+		clientValue[len("svc1")] = 3 // client
+		copy(clientValue[len("svc1")+1:], "db-call")
+		kindKey2 := createIndexKey(operationKindIndexKey, clientValue, timeNow, model.TraceID{High: 0, Low: 2})
+
+		store.Update(func(txn *badger.Txn) error {
+			txn.SetEntry(&badger.Entry{Key: s1Key, ExpiresAt: uint64(tid.Unix())})
+			txn.SetEntry(&badger.Entry{Key: kindKey1, ExpiresAt: uint64(tid.Unix())})
+			txn.SetEntry(&badger.Entry{Key: kindKey2, ExpiresAt: uint64(tid.Unix())})
+			return nil
+		})
+
+		cache := NewCacheStore(store, time.Duration(1*time.Hour))
+		_ = NewTraceReader(store, cache, true)
+
+		// Filter server — preloaded from 0x85 disk keys
+		ops, err := cache.GetOperations("svc1", "server")
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "get-users", SpanKind: "server"},
+		}, ops)
+
+		// Filter client — preloaded from 0x85 disk keys
+		ops, err = cache.GetOperations("svc1", "client")
+		require.NoError(t, err)
+		assert.Equal(t, []tracestore.Operation{
+			{Name: "db-call", SpanKind: "client"},
+		}, ops)
+
+		// All operations
+		ops, err = cache.GetOperations("svc1", "")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []tracestore.Operation{
+			{Name: "get-users", SpanKind: "server"},
+			{Name: "db-call", SpanKind: "client"},
+		}, ops)
 	})
 }

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/gogo/protobuf/proto"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/jptrace"
 )
 
 /*
@@ -30,10 +32,20 @@ const (
 	operationNameIndexKey byte = 0x82
 	tagIndexKey           byte = 0x83
 	durationIndexKey      byte = 0x84
+	operationKindIndexKey byte = 0x85
 	jsonEncoding          byte = 0x01 // Last 4 bits of the meta byte are for encoding type
 	protoEncoding         byte = 0x02 // Last 4 bits of the meta byte are for encoding type
 	defaultEncoding       byte = protoEncoding
 )
+
+func spanKindToByte(sk model.SpanKind) byte {
+	//nolint:gosec // G115: SpanKind values are 0-5, safe for byte
+	return byte(jptrace.StringToSpanKind(string(sk)))
+}
+
+func spanKindByteToString(b byte) string {
+	return jptrace.SpanKindToString(ptrace.SpanKind(b))
+}
 
 // SpanWriter for writing spans to badger
 type SpanWriter struct {
@@ -60,17 +72,25 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	startTime := model.TimeAsEpochMicroseconds(span.StartTime)
 
 	// Avoid doing as much as possible inside the transaction boundary, create entries here
-	entriesToStore := make([]*badger.Entry, 0, len(span.Tags)+4+len(span.Process.Tags)+len(span.Logs)*4)
+	entriesToStore := make([]*badger.Entry, 0, len(span.Tags)+5+len(span.Process.Tags)+len(span.Logs)*4)
 
 	trace, err := w.createTraceEntry(span, startTime, expireTime)
 	if err != nil {
 		return err
 	}
 
+	spanKind, _ := span.GetSpanKind()
+	kindByte := spanKindToByte(spanKind)
+	operationKindValue := make([]byte, len(span.Process.ServiceName)+1+len(span.OperationName))
+	copy(operationKindValue, span.Process.ServiceName)
+	operationKindValue[len(span.Process.ServiceName)] = kindByte
+	copy(operationKindValue[len(span.Process.ServiceName)+1:], span.OperationName)
+
 	entriesToStore = append(entriesToStore,
 		trace,
 		w.createBadgerEntry(createIndexKey(serviceNameIndexKey, []byte(span.Process.ServiceName), startTime, span.TraceID), nil, expireTime),
 		w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), nil, expireTime),
+		w.createBadgerEntry(createIndexKey(operationKindIndexKey, operationKindValue, startTime, span.TraceID), nil, expireTime),
 	)
 
 	// It doesn't matter if we overwrite Duration index keys, everything is read at Trace level in any case
@@ -111,7 +131,7 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	})
 
 	// Do cache refresh here to release the transaction earlier
-	w.cache.Update(span.Process.ServiceName, span.OperationName, expireTime)
+	w.cache.Update(span.Process.ServiceName, span.OperationName, string(spanKind), expireTime)
 
 	return err
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1922

## Description of the changes

### What changed

- New index key `0x85` stores spanKind as a fixed-width byte between
  `serviceName` and `operationName`, written alongside existing `0x82`.
- Writer extracts spanKind via `GetSpanKind()` and encodes it using.
  OTel proto enum values (0=unspecified, 1=internal, 2=server, etc.).
- Cache keys changed from `operation name` to `{name, spanKind}`,
  with filtering when spanKind is specified.
- Reader preloads operations from `0x85` keys on startup.
- Integration test workaround `GetOperationsMissingSpanKind` removed.

### Backward compatibility

- **Trace search**: unaffected. Both `0x82` and `0x85` are written on
  every span; `FindTraceIDs` still uses `0x82`.
- **GetOperations after restart**: old data without `0x85` keys will
  not appear until new spans are written or old data expires via TTL
  (default 72h). Same tradeoff accepted for other storage backends.

## How was this change tested?
- Unit tests: `go test ./internal/storage/v1/badger/...` (all pass)
- Integration test: `STORAGE=badger go test ./internal/storage/integration/ -run TestBadger` (all pass, `GetOperationsMissingSpanKind` workaround removed)
- New tests in `get_operations_test.go`: spanKind filtering, backward compat, persistence across restart, uppercase handling
- New tests in `rw_internal_test.go`: byte mapping round-trip, 0x85 key layout, preload from disk
- New tests in `cache_test.go`: spanKind filter, expiry with spanKind
- `make lint test` passes (excluding pre-existing `TestRegisterStaticHandler` failure on main)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`
  — `TestRegisterStaticHandler` fails on main (unrelated, `gitVersion` build info issue)

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
