### PR TITLE
[clickhouse] Enable Direct Integration Tests For ClickHouse Storage

### DIFF
--- a/.github/workflows/ci-e2e-clickhouse.yml
+++ b/.github/workflows/ci-e2e-clickhouse.yml
@@ -15,6 +15,13 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   clickhouse:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        storage_test:
+        - e2e
+        - direct
+    name: clickhouse ${{ matrix.storage_test }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -29,9 +36,10 @@ jobs:
 
     - name: Run ClickHouse integration tests
       id: test-execution
-      run: bash scripts/e2e/clickhouse.sh
+      run: bash scripts/e2e/clickhouse.sh ${{ matrix.storage_test }}
      
     - uses: ./.github/actions/verify-metrics-snapshot
+      if: matrix.storage_test == 'e2e'
       with:
         snapshot: metrics_snapshot_clickhouse
         artifact_key: metrics_snapshot_clickhouse
@@ -40,6 +48,6 @@ jobs:
       uses: ./.github/actions/upload-codecov
       with:
         files: cover.out
-        flag: clickhouse
+        flag: clickhouse-${{ matrix.storage_test }}
     
     

--- a/cmd/jaeger/internal/integration/clickhouse_test.go
+++ b/cmd/jaeger/internal/integration/clickhouse_test.go
@@ -14,10 +14,11 @@ func TestClickHouseStorage(t *testing.T) {
 	s := &E2EStorageIntegration{
 		ConfigFile: "../../config-clickhouse.yaml",
 		StorageIntegration: integration.StorageIntegration{
-			CleanUp: purge,
+			CleanUp:  purge,
+			SkipList: []string{"GetThroughput", "GetLatestProbability"},
 		},
 		FeatureGates: []string{"storage.clickhouse"},
 	}
 	s.e2eInitialize(t, "clickhouse")
-	s.RunSpanStoreTests(t)
+	s.RunAll(t)
 }

--- a/cmd/jaeger/internal/integration/clickhouse_test.go
+++ b/cmd/jaeger/internal/integration/clickhouse_test.go
@@ -14,11 +14,10 @@ func TestClickHouseStorage(t *testing.T) {
 	s := &E2EStorageIntegration{
 		ConfigFile: "../../config-clickhouse.yaml",
 		StorageIntegration: integration.StorageIntegration{
-			CleanUp:  purge,
-			SkipList: []string{"GetThroughput", "GetLatestProbability"},
+			CleanUp: purge,
 		},
 		FeatureGates: []string{"storage.clickhouse"},
 	}
 	s.e2eInitialize(t, "clickhouse")
-	s.RunAll(t)
+	s.RunSpanStoreTests(t)
 }

--- a/internal/storage/integration/clickhouse_test.go
+++ b/internal/storage/integration/clickhouse_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/featuregate"
 
 	ch "github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse"
@@ -29,6 +31,12 @@ func (s *ClickHouseStorageIntegration) initialize(t *testing.T) {
 	cfg := ch.Configuration{
 		Addresses: []string{"127.0.0.1:9000"},
 		Database:  "jaeger",
+		Auth: ch.Authentication{
+			Basic: configoptional.Some(basicauthextension.ClientAuthSettings{
+				Username: "default",
+				Password: "password",
+			}),
+		},
 	}
 	f, err := ch.NewFactory(context.Background(), cfg, telemetry.NoopSettings())
 	require.NoError(t, err)

--- a/internal/storage/integration/clickhouse_test.go
+++ b/internal/storage/integration/clickhouse_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
+
+	ch "github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse"
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+type ClickHouseStorageIntegration struct {
+	StorageIntegration
+	factory *ch.Factory
+}
+
+func (s *ClickHouseStorageIntegration) initialize(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set("storage.clickhouse", true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set("storage.clickhouse", false))
+	})
+
+	cfg := ch.Configuration{
+		Addresses: []string{"127.0.0.1:9000"},
+		Database:  "jaeger",
+	}
+	f, err := ch.NewFactory(context.Background(), cfg, telemetry.NoopSettings())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	s.factory = f
+
+	s.DependencyReader, err = f.CreateDependencyReader()
+	require.NoError(t, err)
+	s.DependencyWriter, err = f.CreateDependencyWriter()
+	require.NoError(t, err)
+}
+
+func (s *ClickHouseStorageIntegration) cleanUp(t *testing.T) {
+	require.NoError(t, s.factory.Purge(context.Background()))
+}
+
+func TestClickHouseStorage(t *testing.T) {
+	SkipUnlessEnv(t, "clickhouse")
+	t.Cleanup(func() {
+		testutils.VerifyGoLeaksOnce(t)
+	})
+	s := &ClickHouseStorageIntegration{
+		StorageIntegration: StorageIntegration{
+			SkipList: []string{"GetThroughput", "GetLatestProbability"},
+		},
+	}
+	s.CleanUp = s.cleanUp
+	s.initialize(t)
+	s.RunAll(t)
+}

--- a/internal/storage/integration/clickhouse_test.go
+++ b/internal/storage/integration/clickhouse_test.go
@@ -29,8 +29,9 @@ func (s *ClickHouseStorageIntegration) initialize(t *testing.T) {
 	})
 
 	cfg := ch.Configuration{
-		Addresses: []string{"127.0.0.1:9000"},
-		Database:  "jaeger",
+		Addresses:    []string{"127.0.0.1:9000"},
+		Database:     "jaeger",
+		CreateSchema: true,
 		Auth: ch.Authentication{
 			Basic: configoptional.Some(basicauthextension.ClientAuthSettings{
 				Username: "default",

--- a/internal/storage/integration/clickhouse_test.go
+++ b/internal/storage/integration/clickhouse_test.go
@@ -43,6 +43,10 @@ func (s *ClickHouseStorageIntegration) initialize(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, f.Close()) })
 	s.factory = f
 
+	s.TraceReader, err = f.CreateTraceReader()
+	require.NoError(t, err)
+	s.TraceWriter, err = f.CreateTraceWriter()
+	require.NoError(t, err)
 	s.DependencyReader, err = f.CreateDependencyReader()
 	require.NoError(t, err)
 	s.DependencyWriter, err = f.CreateDependencyWriter()

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"slices"
@@ -88,7 +89,12 @@ func (q *Query) ToTraceQueryParams(t *testing.T) *tracestore.TraceQueryParams {
 		case int:
 			attributes.PutInt(k, int64(v))
 		case float64:
-			attributes.PutDouble(k, v)
+			// JSON numbers are always float64 in Go; detect integers.
+			if v == math.Trunc(v) && !math.IsInf(v, 0) && !math.IsNaN(v) {
+				attributes.PutInt(k, int64(v))
+			} else {
+				attributes.PutDouble(k, v)
+			}
 		case bool:
 			attributes.PutBool(k, v)
 		default:

--- a/internal/storage/v2/clickhouse/factory.go
+++ b/internal/storage/v2/clickhouse/factory.go
@@ -139,6 +139,10 @@ func (f *Factory) CreateDependencyReader() (depstore.Reader, error) {
 	return chdepstore.NewDependencyReader(f.conn), nil
 }
 
+func (f *Factory) CreateDependencyWriter() (depstore.Writer, error) {
+	return chdepstore.NewDependencyWriter(f.conn), nil
+}
+
 func (f *Factory) Close() error {
 	return f.conn.Close()
 }

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -281,7 +281,7 @@ const (
 
 const SelectDependencies = `
 SELECT
-    dependencies
+    dependencies_json
 FROM
     dependencies
 WHERE

--- a/scripts/e2e/clickhouse.sh
+++ b/scripts/e2e/clickhouse.sh
@@ -47,16 +47,25 @@ teardown_clickhouse() {
 }
 
 run_integration_test() {
+    local storage_test=${1:-e2e}
     setup_clickhouse
     trap teardown_clickhouse EXIT
     healthcheck_clickhouse
-    STORAGE=clickhouse make jaeger-v2-storage-integration-test
+    if [[ "${storage_test}" == "e2e" ]]; then
+        STORAGE=clickhouse make jaeger-v2-storage-integration-test
+    elif [[ "${storage_test}" == "direct" ]]; then
+        STORAGE=clickhouse make storage-integration-test
+    else
+        echo "ERROR: Invalid argument value storage_test=${storage_test}, expecting direct or e2e"
+        exit 1
+    fi
     success="true"
 }
 
 main() {
-    echo "Executing ClickHouse integration tests"
-    run_integration_test
+    local storage_test=${1:-e2e}
+    echo "Executing ClickHouse ${storage_test} integration tests"
+    run_integration_test "${storage_test}"
 }
 
-main
+main "$@"


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #8359 
- Resolves #7136

## Description of the changes
- Enables direct integration tests for ClickHouse storage. As a result of this change, we now have integration tests for ClickHouse's dependency store.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
