### PR TITLE
ci: exclude dev-only modules from FOSSA workspace scan

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -29,6 +29,14 @@ jobs:
           echo "GOPATH=$(go env GOPATH)" >>"$GITHUB_ENV"
           echo "$GOPATH/bin" >>"$GITHUB_PATH"
 
+      - name: Remove excluded development-only modules before FOSSA scan
+        run: |
+          # FOSSA still discovers nested manifests under excluded paths.
+          # Remove the dev-only modules that are already excluded in .fossa.yml
+          # so they cannot be auto-detected during analysis.
+          rm -rf internal/tools
+          rm -rf scripts/build/docker/debug
+
       - name: Run FOSSA scan and upload report
         uses: fossa-contrib/fossa-action@3d2ef181b1820d6dcd1972f86a767d18167fa19b # v3.0.1
         with:


### PR DESCRIPTION
## Summary
This updates the FOSSA workflow to remove development-only Go modules from the CI workspace before running the FOSSA scan.

## Problem
Jaeger's `.fossa.yml` already excludes `internal/tools` and `scripts/build/docker/debug`, but FOSSA still discovers nested `go.mod` manifests under those paths during analysis. That causes development-only tooling dependencies, including GPL-licensed `golangci-lint` plugins, to appear in the scan even though those modules are not part of the distributed Jaeger binaries.

In practice, the scan was treating path exclusion and manifest discovery as separate concerns, so the config intent was not fully enforced by the CI job.

## Fix
Add a pre-scan workflow step in `.github/workflows/fossa.yml` that removes the dev-only module directories already excluded in `.fossa.yml`:
- `internal/tools`
- `scripts/build/docker/debug`

This keeps the existing config as the documented source of truth while making the CI workspace match that exclusion set before FOSSA begins recursive target discovery.

## Why this approach
The current `fossa-contrib/fossa-action` interface does not expose a precise manifest-path exclusion mechanism for this job. Pruning the already-excluded directories before the scan is the narrowest workflow change that reliably prevents false-positive discovery of dev-only manifests without changing Jaeger's production dependency graph.

## Verification
Ran successfully in the fork after the change:
- `make fmt`
- `make lint`
- `make test`

## Risk
Low. The change only affects the FOSSA CI job workspace and only removes directories that are already declared out of scope for license scanning.
