### PR TITLE
storage/elasticsearch: support spanKind in GetOperations

### DIFF
--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-service-6.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-service-6.json
@@ -39,6 +39,10 @@
           "type":"keyword",
           "ignore_above":256
         },
+        "spanKind":{
+          "type":"keyword",
+          "ignore_above":256
+        },
         "operationName":{
           "type":"keyword",
           "ignore_above":256

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-service-7.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-service-7.json
@@ -39,6 +39,10 @@
         "type":"keyword",
         "ignore_above":256
       },
+      "spanKind":{
+        "type":"keyword",
+        "ignore_above":256
+      },
       "operationName":{
         "type":"keyword",
         "ignore_above":256

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-service-8.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-service-8.json
@@ -41,6 +41,10 @@
           "type": "keyword",
           "ignore_above": 256
         },
+        "spanKind": {
+          "type": "keyword",
+          "ignore_above": 256
+        },
         "operationName": {
           "type": "keyword",
           "ignore_above": 256

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-service-6.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-service-6.json
@@ -39,6 +39,10 @@
           "type":"keyword",
           "ignore_above":256
         },
+        "spanKind":{
+          "type":"keyword",
+          "ignore_above":256
+        },
         "operationName":{
           "type":"keyword",
           "ignore_above":256

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-service-7.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-service-7.json
@@ -43,6 +43,10 @@
         "type":"keyword",
         "ignore_above":256
       },
+      "spanKind":{
+        "type":"keyword",
+        "ignore_above":256
+      },
       "operationName":{
         "type":"keyword",
         "ignore_above":256

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-service-8.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-service-8.json
@@ -45,6 +45,10 @@
           "type": "keyword",
           "ignore_above": 256
         },
+        "spanKind": {
+          "type": "keyword",
+          "ignore_above": 256
+        },
         "operationName": {
           "type": "keyword",
           "ignore_above": 256

--- a/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
@@ -93,6 +93,7 @@ type KeyValue struct {
 // Service is the JSON struct for service:operation documents in ElasticSearch
 type Service struct {
 	ServiceName   string `json:"serviceName"`
+	SpanKind      string `json:"spanKind,omitempty"`
 	OperationName string `json:"operationName"`
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -255,20 +255,7 @@ func (s *SpanReader) GetOperations(
 		currentTime,
 		cfg.RolloverFrequencyAsNegativeDuration(s.serviceIndex.RolloverFrequency),
 	)
-	operations, err := s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query.ServiceName, s.maxDocCount)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: https://github.com/jaegertracing/jaeger/issues/1923
-	// 	- return the operations with actual span kind that meet requirement
-	var result []dbmodel.Operation
-	for _, operation := range operations {
-		result = append(result, dbmodel.Operation{
-			Name: operation,
-		})
-	}
-	return result, err
+	return s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query.ServiceName, query.SpanKind, s.maxDocCount)
 }
 
 func bucketToStringArray[T ~string](buckets []*elastic.AggregationBucketKeyItem) ([]T, error) {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -464,7 +464,47 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, string(expectedData), string(actualData))
 		}
+		})
+	}
+
+func TestSpanReader_multiRead_withReadWriteAliasesAddsTimeRange(t *testing.T) {
+	client := &mocks.Client{}
+	tracer, _, closer := tracerProvider(t)
+	defer closer()
+
+	reader := NewSpanReader(SpanReaderParams{
+		Client:              func() es.Client { return client },
+		Logger:              zap.NewNop(),
+		Tracer:              tracer.Tracer("test"),
+		MaxSpanAge:          0,
+		TagDotReplacement:   "@",
+		MaxDocCount:         defaultMaxDocCount,
+		UseReadWriteAliases: true,
 	})
+
+	traceID := dbmodel.TraceID(testingTraceId)
+	startTime := time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+	endTime := startTime.Add(time.Hour)
+	nextTime := model.TimeAsEpochMicroseconds(startTime.Add(-time.Hour))
+
+	traceQuery := buildTraceByIDQuery(traceID)
+	startTimeRangeQuery := reader.buildStartTimeQuery(startTime.Add(-24*time.Hour), endTime.Add(24*time.Hour))
+	expectedQuery := elastic.NewBoolQuery().Must(traceQuery, startTimeRangeQuery)
+	expectedSearch := newSearchRequest(reader.sourceFn(expectedQuery, nextTime).TrackTotalHits(true))
+
+	multiSearchService := &mocks.MultiSearchService{}
+	multiSearchService.On("Add", mock.MatchedBy(func(searches []*elastic.SearchRequest) bool {
+		return len(searches) == 1 && reflect.DeepEqual(searches[0], expectedSearch)
+	})).Return(multiSearchService).Once()
+	multiSearchService.On("Index", mock.AnythingOfType("[]string")).Return(multiSearchService)
+	multiSearchService.On("Do", mock.Anything).Return(&elastic.MultiSearchResult{
+		Responses: []*elastic.SearchResult{},
+	}, nil).Once()
+	client.On("MultiSearch").Return(multiSearchService)
+
+	traces, err := reader.multiRead(context.Background(), []dbmodel.TraceID{traceID}, startTime, endTime)
+	require.NoError(t, err)
+	assert.Empty(t, traces)
 }
 
 func TestSpanReader_SearchAfter(t *testing.T) {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -464,8 +464,8 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, string(expectedData), string(actualData))
 		}
-		})
-	}
+	})
+}
 
 func TestSpanReader_multiRead_withReadWriteAliasesAddsTimeRange(t *testing.T) {
 	client := &mocks.Client{}

--- a/internal/storage/v2/elasticsearch/tracestore/core/service_operation.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/service_operation.go
@@ -25,6 +25,10 @@ const (
 
 	operationsAggregation = "distinct_operations"
 	servicesAggregation   = "distinct_services"
+
+	spanKindField       = "spanKind"
+	spanKindAggregation = "distinct_span_kinds"
+	spanKindTagKey      = "span.kind"
 )
 
 // ServiceOperationStorage stores service to operation pairs.
@@ -54,9 +58,10 @@ func NewServiceOperationStorage(
 
 // Write saves a service to operation pair.
 func (s *ServiceOperationStorage) Write(indexName string, jsonSpan *dbmodel.Span) {
-	// Insert serviceName:operationName document
+	// Insert serviceName:spanKind:operationName document
 	service := dbmodel.Service{
 		ServiceName:   jsonSpan.Process.ServiceName,
+		SpanKind:      getSpanKindFromSpan(jsonSpan),
 		OperationName: jsonSpan.OperationName,
 	}
 
@@ -65,6 +70,26 @@ func (s *ServiceOperationStorage) Write(indexName string, jsonSpan *dbmodel.Span
 		s.client().Index().Index(indexName).Type(serviceType).Id(cacheKey).BodyJson(service).Add()
 		writeCache(cacheKey, s.serviceCache)
 	}
+}
+
+// getSpanKindFromSpan extracts the span kind string from the span's tags.
+// The span kind is stored as a "span.kind" tag in OpenTracing/Jaeger spans.
+// Returns an empty string if the tag is not present.
+func getSpanKindFromSpan(span *dbmodel.Span) string {
+	for _, tag := range span.Tags {
+		if tag.Key == spanKindTagKey {
+			if v, ok := tag.Value.(string); ok {
+				return v
+			}
+		}
+	}
+	// Fall back to the flat tag map if populated.
+	if v, ok := span.Tag[spanKindTagKey]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 func (s *ServiceOperationStorage) getServices(ctx context.Context, indices []string, maxDocCount int) ([]string, error) {
@@ -96,40 +121,93 @@ func getServicesAggregation(maxDocCount int) elastic.Query {
 		Size(maxDocCount) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
 }
 
-func (s *ServiceOperationStorage) getOperations(ctx context.Context, indices []string, service string, maxDocCount int) ([]string, error) {
+func (s *ServiceOperationStorage) getOperations(
+	ctx context.Context,
+	indices []string,
+	service string,
+	spanKind string,
+	maxDocCount int,
+) ([]dbmodel.Operation, error) {
 	serviceQuery := elastic.NewTermQuery(serviceName, service)
-	serviceFilter := getOperationsAggregation(maxDocCount)
+
+	var query elastic.Query = serviceQuery
+	if spanKind != "" {
+		query = elastic.NewBoolQuery().Must(
+			serviceQuery,
+			elastic.NewTermQuery(spanKindField, spanKind),
+		)
+	}
 
 	searchService := s.client().Search(indices...).
 		Size(0).
-		Query(serviceQuery).
+		Query(query).
 		IgnoreUnavailable(true).
-		Aggregation(operationsAggregation, serviceFilter)
+		Aggregation(operationsAggregation, getOperationsAggregation(maxDocCount))
 
 	searchResult, err := searchService.Do(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("search operations failed: %w", es.DetailedError(err))
 	}
 	if searchResult.Aggregations == nil {
-		return []string{}, nil
+		return []dbmodel.Operation{}, nil
 	}
 	bucket, found := searchResult.Aggregations.Terms(operationsAggregation)
 	if !found {
 		return nil, errors.New("could not find aggregation of " + operationsAggregation)
 	}
-	operationNamesBucket := bucket.Buckets
-	return bucketToStringArray[string](operationNamesBucket)
+	return operationsBucketToOperations(bucket.Buckets)
 }
 
-func getOperationsAggregation(maxDocCount int) elastic.Query {
+// getOperationsAggregation returns a terms aggregation on operationName with a nested
+// sub-aggregation on spanKind, so that each unique (operationName, spanKind) pair is returned.
+func getOperationsAggregation(maxDocCount int) elastic.Aggregation {
+	spanKindAgg := elastic.NewTermsAggregation().
+		Field(spanKindField).
+		Size(10) // there are at most 7 span kinds defined in the OpenTelemetry spec
 	return elastic.NewTermsAggregation().
 		Field(operationNameField).
-		Size(maxDocCount) // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
+		Size(maxDocCount). // ES deprecated size omission for aggregating all. https://github.com/elastic/elasticsearch/issues/18838
+		SubAggregation(spanKindAggregation, spanKindAgg)
+}
+
+// operationsBucketToOperations converts Elasticsearch aggregation buckets into Operation slices.
+// Each operationName bucket may contain a nested spanKind sub-aggregation; if present, one
+// Operation is emitted per (operationName, spanKind) pair. If the sub-aggregation is absent or
+// empty (e.g. legacy data without span kind), a single Operation with an empty SpanKind is emitted
+// to preserve backward compatibility.
+func operationsBucketToOperations(buckets []*elastic.AggregationBucketKeyItem) ([]dbmodel.Operation, error) {
+	operations := make([]dbmodel.Operation, 0, len(buckets))
+	for _, opBucket := range buckets {
+		opName, ok := opBucket.Key.(string)
+		if !ok {
+			return nil, errors.New("could not convert operation name bucket key to string")
+		}
+		kindBuckets, found := opBucket.Terms(spanKindAggregation)
+		if !found || len(kindBuckets.Buckets) == 0 {
+			// Legacy document or data without span kind — emit with empty SpanKind.
+			operations = append(operations, dbmodel.Operation{Name: opName})
+			continue
+		}
+		for _, kb := range kindBuckets.Buckets {
+			kind, ok := kb.Key.(string)
+			if !ok {
+				return nil, errors.New("could not convert span kind bucket key to string")
+			}
+			operations = append(operations, dbmodel.Operation{
+				Name:     opName,
+				SpanKind: kind,
+			})
+		}
+	}
+	return operations, nil
 }
 
 func hashCode(s dbmodel.Service) string {
 	h := fnv.New64a()
 	h.Write([]byte(s.ServiceName))
+	h.Write([]byte("|"))
+	h.Write([]byte(s.SpanKind))
+	h.Write([]byte("|"))
 	h.Write([]byte(s.OperationName))
 	return strconv.FormatUint(h.Sum64(), 16)
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
@@ -7,6 +7,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/olivere/elastic/v7"
@@ -127,16 +128,34 @@ func TestSpanReader_GetOperations(t *testing.T) {
 
 func TestSpanReader_GetOperationsWithSpanKind(t *testing.T) {
 	withSpanReader(t, func(r *spanReaderTest) {
+		searchService := &mocks.SearchService{}
+
+		expectedQuery := elastic.NewBoolQuery().Must(
+			elastic.NewTermQuery(serviceName, "myService"),
+			elastic.NewTermQuery(spanKindField, "server"),
+		)
+
+		searchService.On("Query", mock.MatchedBy(func(query elastic.Query) bool {
+			actualSource, err := query.Source()
+			require.NoError(t, err)
+			expectedSource, err := expectedQuery.Source()
+			require.NoError(t, err)
+			return reflect.DeepEqual(actualSource, expectedSource)
+		})).Return(searchService)
+		searchService.On("IgnoreUnavailable", mock.AnythingOfType("bool")).Return(searchService)
+		searchService.On("Size", 0).Return(searchService)
+		searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)
+		r.client.On("Search", mock.AnythingOfType("[]string")).Return(searchService)
+
 		// Aggregation result that includes a spanKind sub-aggregation.
 		rawMessage, err := json.Marshal(map[string]any{
 			"buckets": []map[string]any{
 				{
 					"key":       "myOperation",
-					"doc_count": 5,
+					"doc_count": 3,
 					spanKindAggregation: map[string]any{
 						"buckets": []map[string]any{
 							{"key": "server", "doc_count": 3},
-							{"key": "client", "doc_count": 2},
 						},
 					},
 				},
@@ -147,7 +166,7 @@ func TestSpanReader_GetOperationsWithSpanKind(t *testing.T) {
 		aggs := elastic.Aggregations(map[string]json.RawMessage{
 			operationsAggregation: rawMessage,
 		})
-		mockSearchService(r).Return(&elastic.SearchResult{Aggregations: aggs}, nil)
+		searchService.On("Do", mock.Anything).Return(&elastic.SearchResult{Aggregations: aggs}, nil)
 
 		ops, err := r.reader.GetOperations(
 			context.Background(),
@@ -156,7 +175,6 @@ func TestSpanReader_GetOperationsWithSpanKind(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []dbmodel.Operation{
 			{Name: "myOperation", SpanKind: "server"},
-			{Name: "myOperation", SpanKind: "client"},
 		}, ops)
 	})
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/olivere/elastic/v7"
@@ -22,7 +23,8 @@ func TestWriteService(t *testing.T) {
 		indexService := &mocks.IndexService{}
 
 		indexName := "jaeger-1995-04-21"
-		serviceHash := "de3b5a8f1a79989d"
+		// Hash of "service||operation" (service=service, spanKind="", operation=operation)
+		serviceHash := "d17b3510df3ba545"
 
 		indexService.On("Index", stringMatcher(indexName)).Return(indexService)
 		indexService.On("Type", stringMatcher(serviceType)).Return(indexService)
@@ -52,12 +54,47 @@ func TestWriteService(t *testing.T) {
 	})
 }
 
+func TestWriteServiceWithSpanKind(t *testing.T) {
+	withSpanWriter(func(w *spanWriterTest) {
+		indexService := &mocks.IndexService{}
+
+		indexName := "jaeger-1995-04-21"
+		// Hash of "service|client|operation"
+		serviceHash := "cbeb6711d7d10522"
+
+		indexService.On("Index", stringMatcher(indexName)).Return(indexService)
+		indexService.On("Type", stringMatcher(serviceType)).Return(indexService)
+		indexService.On("Id", stringMatcher(serviceHash)).Return(indexService)
+		indexService.On("BodyJson", mock.AnythingOfType("dbmodel.Service")).Return(indexService)
+		indexService.On("Add")
+
+		w.client.On("Index").Return(indexService)
+
+		jsonSpan := &dbmodel.Span{
+			TraceID:       dbmodel.TraceID("1"),
+			SpanID:        dbmodel.SpanID("0"),
+			OperationName: "operation",
+			Tags: []dbmodel.KeyValue{
+				{Key: spanKindTagKey, Value: "client"},
+			},
+			Process: dbmodel.Process{
+				ServiceName: "service",
+			},
+		}
+
+		w.writer.writeService(indexName, jsonSpan)
+
+		indexService.AssertNumberOfCalls(t, "Add", 1)
+		assert.Empty(t, w.logBuffer.String())
+	})
+}
+
 func TestWriteServiceError(*testing.T) {
 	withSpanWriter(func(w *spanWriterTest) {
 		indexService := &mocks.IndexService{}
 
 		indexName := "jaeger-1995-04-21"
-		serviceHash := "de3b5a8f1a79989d"
+		serviceHash := "d17b3510df3ba545"
 
 		indexService.On("Index", stringMatcher(indexName)).Return(indexService)
 		indexService.On("Type", stringMatcher(serviceType)).Return(indexService)
@@ -86,6 +123,42 @@ func TestSpanReader_GetServices(t *testing.T) {
 
 func TestSpanReader_GetOperations(t *testing.T) {
 	testGet(operationsAggregation, t)
+}
+
+func TestSpanReader_GetOperationsWithSpanKind(t *testing.T) {
+	withSpanReader(t, func(r *spanReaderTest) {
+		// Aggregation result that includes a spanKind sub-aggregation.
+		rawMessage, err := json.Marshal(map[string]any{
+			"buckets": []map[string]any{
+				{
+					"key":       "myOperation",
+					"doc_count": 5,
+					spanKindAggregation: map[string]any{
+						"buckets": []map[string]any{
+							{"key": "server", "doc_count": 3},
+							{"key": "client", "doc_count": 2},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		aggs := elastic.Aggregations(map[string]json.RawMessage{
+			operationsAggregation: rawMessage,
+		})
+		mockSearchService(r).Return(&elastic.SearchResult{Aggregations: aggs}, nil)
+
+		ops, err := r.reader.GetOperations(
+			context.Background(),
+			dbmodel.OperationQueryParameters{ServiceName: "myService", SpanKind: "server"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []dbmodel.Operation{
+			{Name: "myOperation", SpanKind: "server"},
+			{Name: "myOperation", SpanKind: "client"},
+		}, ops)
+	})
 }
 
 func TestSpanReader_GetServicesEmptyIndex(t *testing.T) {
@@ -117,4 +190,59 @@ func TestSpanReader_GetOperationsEmptyIndex(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, services)
 	})
+}
+
+func TestGetSpanKindFromSpan(t *testing.T) {
+	tests := []struct {
+		name     string
+		span     *dbmodel.Span
+		expected string
+	}{
+		{
+			name: "span kind from Tags slice",
+			span: &dbmodel.Span{
+				Tags: []dbmodel.KeyValue{
+					{Key: spanKindTagKey, Value: "server"},
+				},
+			},
+			expected: "server",
+		},
+		{
+			name: "span kind from flat Tag map",
+			span: &dbmodel.Span{
+				Tag: map[string]any{spanKindTagKey: "client"},
+			},
+			expected: "client",
+		},
+		{
+			name:     "no span kind returns empty string",
+			span:     &dbmodel.Span{},
+			expected: "",
+		},
+		{
+			name: "Tags slice takes priority over Tag map",
+			span: &dbmodel.Span{
+				Tags: []dbmodel.KeyValue{
+					{Key: spanKindTagKey, Value: "producer"},
+				},
+				Tag: map[string]any{spanKindTagKey: "consumer"},
+			},
+			expected: "producer",
+		},
+		{
+			name: "non-string tag value is skipped",
+			span: &dbmodel.Span{
+				Tags: []dbmodel.KeyValue{
+					{Key: spanKindTagKey, Value: 42},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getSpanKindFromSpan(tc.span))
+		})
+	}
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
@@ -246,3 +246,34 @@ func TestGetSpanKindFromSpan(t *testing.T) {
 		})
 	}
 }
+
+func TestOperationsBucketToOperations_InvalidOperationNameKey(t *testing.T) {
+	_, err := operationsBucketToOperations([]*elastic.AggregationBucketKeyItem{
+		{Key: 123},
+	})
+
+	require.EqualError(t, err, "could not convert operation name bucket key to string")
+}
+
+func TestOperationsBucketToOperations_InvalidSpanKindKey(t *testing.T) {
+	rawMessage, err := json.Marshal(map[string]any{
+		"buckets": []map[string]any{
+			{
+				"key":       "myOperation",
+				"doc_count": 1,
+				spanKindAggregation: map[string]any{
+					"buckets": []map[string]any{
+						{"key": 123, "doc_count": 1},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var bucket elastic.AggregationBucketKeyItems
+	require.NoError(t, json.Unmarshal(rawMessage, &bucket))
+
+	_, err = operationsBucketToOperations(bucket.Buckets)
+	require.EqualError(t, err, "could not convert span kind bucket key to string")
+}

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
@@ -199,7 +199,7 @@ func TestSpanWriter_WriteSpan(t *testing.T) {
 
 				spanIndexName := "jaeger-span-1995-04-21"
 				serviceIndexName := "jaeger-service-1995-04-21"
-				serviceHash := "de3b5a8f1a79989d"
+				serviceHash := "d17b3510df3ba545" // hash of "service||operation" (spanKind is empty)
 
 				indexService := &mocks.IndexService{}
 				indexServicePut := &mocks.IndexService{}


### PR DESCRIPTION
Fixes #1923.

## Problem

The Elasticsearch service-operation storage wrote only `(serviceName, operationName)` pairs and `GetOperations` returned operations without any span kind information. A TODO comment has been sitting in `reader.go` since the issue was filed pointing to this gap.

## Solution

This change brings the Elasticsearch implementation in line with the Cassandra storage, which already supports span kind.

### What changed

**`internal/storage/elasticsearch/dbmodel/model.go`**
- Added `SpanKind string` field to the `Service` struct (stored as `spanKind` in the ES document, `omitempty` so existing data is unaffected).

**`internal/storage/v1/elasticsearch/spanstore/service_operation.go`**
- `Write()`: extracts the span kind from the span's `"span.kind"` tag (checked in both the `Tags` slice and the flat `Tag` map) and includes it in the service document. The FNV hash used as the ES document ID now covers all three fields so distinct `(operationName, spanKind)` pairs are stored as separate documents.
- `getOperations()`: accepts an optional `spanKind` filter; when provided a bool query restricts the search to that kind. A `spanKind` sub-aggregation is nested under the `operationName` terms aggregation so each unique `(operationName, spanKind)` pair is returned. Legacy documents without the sub-aggregation fall back to an empty `SpanKind`, preserving backward compatibility.

**`internal/storage/v1/elasticsearch/spanstore/reader.go`**
- Removed the TODO comment and wired `GetOperations` to pass `query.SpanKind` through to `getOperations`.

### Tests added
- `TestWriteServiceWithSpanKind` — verifies the correct document ID is generated when a span carries a span kind tag.
- `TestSpanReader_GetOperationsWithSpanKind` — verifies that a result containing a nested `spanKind` sub-aggregation is decoded into `[]Operation` with `SpanKind` populated.
- `TestGetSpanKindFromSpan` — unit tests for the `getSpanKindFromSpan` helper covering the `Tags` slice, flat `Tag` map, priority between the two, missing tag, and non-string tag value.

## Reference implementation

The Cassandra storage in `internal/storage/v1/cassandra/spanstore/operation_names.go` was used as the reference for the read/write pattern.