### PR TITLE
fix(clickhouse): Remove trailing spaces from generated OR clauses

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/query_builder.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder.go
@@ -82,16 +82,16 @@ func appendNestedArrayExists(q *strings.Builder, indent int, nestedArray string,
 func appendStringAttributeFallback(q *strings.Builder, args []any, key string, attr pcommon.Value) []any {
 	appendArrayExists(q, 2, "", pcommon.ValueTypeStr)
 	appendNewlineAndIndent(q, 2)
-	q.WriteString("OR ")
+	q.WriteString("OR")
 	appendArrayExists(q, 2, "resource", pcommon.ValueTypeStr)
 	appendNewlineAndIndent(q, 2)
-	q.WriteString("OR ")
+	q.WriteString("OR")
 	appendArrayExists(q, 2, "scope", pcommon.ValueTypeStr)
 	appendNewlineAndIndent(q, 2)
-	q.WriteString("OR ")
+	q.WriteString("OR")
 	appendNestedArrayExists(q, 2, "events", pcommon.ValueTypeStr)
 	appendNewlineAndIndent(q, 2)
-	q.WriteString("OR ")
+	q.WriteString("OR")
 	appendNestedArrayExists(q, 2, "links", pcommon.ValueTypeStr)
 	return append(args, key, attr.Str(), key, attr.Str(), key, attr.Str(), key, attr.Str(), key, attr.Str())
 }
@@ -221,13 +221,13 @@ func buildAttributeConditions(q *strings.Builder, args []any, attributes pcommon
 func buildSimpleAttributeCondition(q *strings.Builder, args []any, key string, valueType pcommon.ValueType, value any) []any {
 	appendArrayExists(q, 2, "", valueType)
 	appendNewlineAndIndent(q, 2)
-	q.WriteString("OR ")
+	q.WriteString("OR")
 	appendArrayExists(q, 2, "resource", valueType)
 	appendNewlineAndIndent(q, 2)
-	q.WriteString("OR ")
+	q.WriteString("OR")
 	appendNestedArrayExists(q, 2, "events", valueType)
 	appendNewlineAndIndent(q, 2)
-	q.WriteString("OR ")
+	q.WriteString("OR")
 	appendNestedArrayExists(q, 2, "links", valueType)
 	return append(args, key, value, key, value, key, value, key, value)
 }
@@ -321,7 +321,7 @@ func buildStringAttributeCondition(
 
 			if generatedCondition {
 				appendNewlineAndIndent(q, 2)
-				q.WriteString("OR ")
+				q.WriteString("OR")
 			}
 			generatedCondition = true
 

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
@@ -15,67 +15,67 @@ FROM (
 		AND s.start_time <= ?
 		AND (
 			arrayExists((key, value) -> key = ? AND value = ?, s.bool_attributes.key, s.bool_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_bool_attributes.key, s.resource_bool_attributes.value)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.events)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.links)
 		)
 		AND (
 			arrayExists((key, value) -> key = ? AND value = ?, s.double_attributes.key, s.double_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_double_attributes.key, s.resource_double_attributes.value)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.double_attributes.key, x.double_attributes.value), s.events)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.double_attributes.key, x.double_attributes.value), s.links)
 		)
 		AND (
 			arrayExists((key, value) -> key = ? AND value = ?, s.int_attributes.key, s.int_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_int_attributes.key, s.resource_int_attributes.value)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.events)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.links)
 		)
 		AND (
 			arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
 		)
 		AND (
 			arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
 		)
 		AND (
 			arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
 		)
 		AND (
 			arrayExists((key, value) -> key = ? AND value = ?, s.str_attributes.key, s.str_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_str_attributes.key, s.resource_str_attributes.value)
-			OR 
+			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.scope_str_attributes.key, s.scope_str_attributes.value)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.str_attributes.key, x.str_attributes.value), s.events)
-			OR 
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.str_attributes.key, x.str_attributes.value), s.links)
 		)
 		AND (

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
@@ -88,67 +88,67 @@ WHERE s.trace_id IN (
 				AND s.start_time <= ?
 				AND (
 					arrayExists((key, value) -> key = ? AND value = ?, s.bool_attributes.key, s.bool_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_bool_attributes.key, s.resource_bool_attributes.value)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.events)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.links)
 				)
 				AND (
 					arrayExists((key, value) -> key = ? AND value = ?, s.double_attributes.key, s.double_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_double_attributes.key, s.resource_double_attributes.value)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.double_attributes.key, x.double_attributes.value), s.events)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.double_attributes.key, x.double_attributes.value), s.links)
 				)
 				AND (
 					arrayExists((key, value) -> key = ? AND value = ?, s.int_attributes.key, s.int_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_int_attributes.key, s.resource_int_attributes.value)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.events)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.links)
 				)
 				AND (
 					arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
 				)
 				AND (
 					arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
 				)
 				AND (
 					arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
 				)
 				AND (
 					arrayExists((key, value) -> key = ? AND value = ?, s.str_attributes.key, s.str_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_str_attributes.key, s.resource_str_attributes.value)
-					OR 
+					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.scope_str_attributes.key, s.scope_str_attributes.value)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.str_attributes.key, x.str_attributes.value), s.events)
-					OR 
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.str_attributes.key, x.str_attributes.value), s.links)
 				)
 				AND (


### PR DESCRIPTION
The SQL query builder was emitting `OR ` (with trailing space) at the end of lines, which conflicted with the new check-line-endings linter that strips trailing whitespace. Fix the generator to emit `OR` and update snapshots accordingly. In preparation for #8393.

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
