### PR TITLE
[jaegermcp] Add get_service_dependencies tool

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -368,11 +368,13 @@ func TestMCPClientGetServiceDependencies(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(text), &output))
 	require.Len(t, output.Dependencies, 2)
-	assert.Equal(t, "frontend", output.Dependencies[0].Caller)
-	assert.Equal(t, "backend", output.Dependencies[0].Callee)
-	assert.Equal(t, uint64(100), output.Dependencies[0].CallCount)
-	assert.Equal(t, "database", output.Dependencies[1].Callee)
-	assert.Equal(t, uint64(50), output.Dependencies[1].CallCount)
+	// Sorted by caller then callee: backend->database before frontend->backend
+	assert.Equal(t, "backend", output.Dependencies[0].Caller)
+	assert.Equal(t, "database", output.Dependencies[0].Callee)
+	assert.Equal(t, uint64(50), output.Dependencies[0].CallCount)
+	assert.Equal(t, "frontend", output.Dependencies[1].Caller)
+	assert.Equal(t, "backend", output.Dependencies[1].Callee)
+	assert.Equal(t, uint64(100), output.Dependencies[1].CallCount)
 }
 
 // --- End-to-end workflow test ---

--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	model "github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
@@ -72,6 +73,17 @@ func connectMCPSession(t *testing.T, mockReader *tracestoremocks.Reader) *mcpSes
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
+	return &mcpSession{ClientSession: session, ctx: ctx}
+}
+
+// connectMCPSessionWithQueryService is like connectMCPSession but accepts a
+// pre-built QueryService, allowing custom dep/trace reader mocks.
+func connectMCPSessionWithQueryService(t *testing.T, svc *querysvc.QueryService) *mcpSession {
+	t.Helper()
+	_, addr := startTestServerWithQueryService(t, svc, nil)
+	session := connectMCPClient(t, addr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
 	return &mcpSession{ClientSession: session, ctx: ctx}
 }
 
@@ -332,6 +344,35 @@ func TestMCPClientGetCriticalPath(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(text), &output))
 	assert.Equal(t, testTraceID.String(), output.TraceID)
 	assert.NotEmpty(t, output.Segments)
+}
+
+func TestMCPClientGetServiceDependencies(t *testing.T) {
+	mockDepReader := &depstoremocks.Reader{}
+	mockDepReader.On("GetDependencies", mock.Anything, mock.Anything).Return(
+		[]model.DependencyLink{
+			{Parent: "frontend", Child: "backend", CallCount: 100},
+			{Parent: "backend", Child: "database", CallCount: 50},
+		}, nil,
+	)
+	svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, mockDepReader, querysvc.QueryServiceOptions{})
+	s := connectMCPSessionWithQueryService(t, svc)
+
+	text := s.callTool(t, "get_service_dependencies", nil)
+
+	var output struct {
+		Dependencies []struct {
+			Caller    string `json:"caller"`
+			Callee    string `json:"callee"`
+			CallCount uint64 `json:"call_count"`
+		} `json:"dependencies"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &output))
+	require.Len(t, output.Dependencies, 2)
+	assert.Equal(t, "frontend", output.Dependencies[0].Caller)
+	assert.Equal(t, "backend", output.Dependencies[0].Callee)
+	assert.Equal(t, uint64(100), output.Dependencies[0].CallCount)
+	assert.Equal(t, "database", output.Dependencies[1].Callee)
+	assert.Equal(t, uint64(50), output.Dependencies[1].CallCount)
 }
 
 // --- End-to-end workflow test ---

--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -208,6 +208,7 @@ func TestMCPClientToolsListDiscovery(t *testing.T) {
 	expected := []string{
 		"health", "get_services", "get_span_names", "search_traces",
 		"get_span_details", "get_trace_errors", "get_trace_topology", "get_critical_path",
+		"get_service_dependencies",
 	}
 	got := make(map[string]bool, len(result.Tools))
 	for _, tool := range result.Tools {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
@@ -4,9 +4,11 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -69,6 +71,14 @@ func (h *getDependenciesHandler) handle(
 			CallCount: d.CallCount,
 		})
 	}
+
+	// Sort by caller then callee for consistent ordering
+	slices.SortFunc(links, func(a, b types.DependencyLink) int {
+		if c := cmp.Compare(a.Caller, b.Caller); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Callee, b.Callee)
+	})
 
 	return nil, types.GetDependenciesOutput{
 		Dependencies: links,

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	model "github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+)
+
+const defaultDependencyLookback = 24 * time.Hour
+
+// queryServiceGetDependenciesInterface defines the interface needed from QueryService for testing.
+type queryServiceGetDependenciesInterface interface {
+	GetDependencies(ctx context.Context, endTs time.Time, lookback time.Duration) ([]model.DependencyLink, error)
+}
+
+type getDependenciesHandler struct {
+	queryService queryServiceGetDependenciesInterface
+}
+
+// NewGetDependenciesHandler creates a new get_service_dependencies handler.
+func NewGetDependenciesHandler(
+	queryService *querysvc.QueryService,
+) mcp.ToolHandlerFor[types.GetDependenciesInput, types.GetDependenciesOutput] {
+	h := &getDependenciesHandler{
+		queryService: queryService,
+	}
+	return h.handle
+}
+
+func (h *getDependenciesHandler) handle(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input types.GetDependenciesInput,
+) (*mcp.CallToolResult, types.GetDependenciesOutput, error) {
+	lookback := defaultDependencyLookback
+	if input.Lookback != "" {
+		parsed, err := time.ParseDuration(input.Lookback)
+		if err != nil {
+			return nil, types.GetDependenciesOutput{}, fmt.Errorf("invalid lookback: %w", err)
+		}
+		lookback = parsed
+	}
+
+	endTs := time.Now()
+	deps, err := h.queryService.GetDependencies(ctx, endTs, lookback)
+	if err != nil {
+		return nil, types.GetDependenciesOutput{}, fmt.Errorf("failed to get dependencies: %w", err)
+	}
+
+	links := make([]types.DependencyLink, 0, len(deps))
+	for _, d := range deps {
+		links = append(links, types.DependencyLink{
+			Parent:    d.Parent,
+			Child:     d.Child,
+			CallCount: d.CallCount,
+			Source:    d.Source,
+		})
+	}
+
+	return nil, types.GetDependenciesOutput{
+		Dependencies: links,
+	}, nil
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 )
 
-// queryServiceGetDependenciesInterface defines the interface needed from QueryService for testing.
+// queryServiceGetDependenciesInterface defines the interface we need from QueryService for testing.
 type queryServiceGetDependenciesInterface interface {
 	GetDependencies(ctx context.Context, endTs time.Time, lookback time.Duration) ([]model.DependencyLink, error)
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
@@ -47,6 +47,9 @@ func (h *getDependenciesHandler) handle(
 		if err != nil {
 			return nil, types.GetDependenciesOutput{}, fmt.Errorf("invalid lookback: %w", err)
 		}
+		if parsed <= 0 {
+			return nil, types.GetDependenciesOutput{}, fmt.Errorf("lookback must be positive, got %s", parsed)
+		}
 		lookback = parsed
 	}
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 )
-
-const defaultDependencyLookback = 24 * time.Hour
 
 // queryServiceGetDependenciesInterface defines the interface needed from QueryService for testing.
 type queryServiceGetDependenciesInterface interface {
@@ -41,20 +40,23 @@ func (h *getDependenciesHandler) handle(
 	_ *mcp.CallToolRequest,
 	input types.GetDependenciesInput,
 ) (*mcp.CallToolResult, types.GetDependenciesOutput, error) {
-	lookback := defaultDependencyLookback
-	if input.Lookback != "" {
-		parsed, err := time.ParseDuration(input.Lookback)
-		if err != nil {
-			return nil, types.GetDependenciesOutput{}, fmt.Errorf("invalid lookback: %w", err)
-		}
-		if parsed <= 0 {
-			return nil, types.GetDependenciesOutput{}, fmt.Errorf("lookback must be positive, got %s", parsed)
-		}
-		lookback = parsed
+	endTime, err := parseDependencyTime(input.EndTime, time.Now())
+	if err != nil {
+		return nil, types.GetDependenciesOutput{}, fmt.Errorf("invalid end_time: %w", err)
 	}
 
-	endTs := time.Now()
-	deps, err := h.queryService.GetDependencies(ctx, endTs, lookback)
+	defaultStart := endTime.Add(-24 * time.Hour)
+	startTime, err := parseDependencyTime(input.StartTime, defaultStart)
+	if err != nil {
+		return nil, types.GetDependenciesOutput{}, fmt.Errorf("invalid start_time: %w", err)
+	}
+
+	if !startTime.Before(endTime) {
+		return nil, types.GetDependenciesOutput{}, errors.New("start_time must be before end_time")
+	}
+
+	lookback := endTime.Sub(startTime)
+	deps, err := h.queryService.GetDependencies(ctx, endTime, lookback)
 	if err != nil {
 		return nil, types.GetDependenciesOutput{}, fmt.Errorf("failed to get dependencies: %w", err)
 	}
@@ -62,14 +64,21 @@ func (h *getDependenciesHandler) handle(
 	links := make([]types.DependencyLink, 0, len(deps))
 	for _, d := range deps {
 		links = append(links, types.DependencyLink{
-			Parent:    d.Parent,
-			Child:     d.Child,
+			Caller:    d.Parent,
+			Callee:    d.Child,
 			CallCount: d.CallCount,
-			Source:    d.Source,
 		})
 	}
 
 	return nil, types.GetDependenciesOutput{
 		Dependencies: links,
 	}, nil
+}
+
+// parseDependencyTime parses a time string, returning the default if the input is empty.
+func parseDependencyTime(input string, defaultTime time.Time) (time.Time, error) {
+	if input == "" {
+		return defaultTime, nil
+	}
+	return parseTimeParam(input)
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	model "github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
+)
+
+type mockDependencyService struct {
+	deps []model.DependencyLink
+	err  error
+}
+
+func (m *mockDependencyService) GetDependencies(_ context.Context, _ time.Time, _ time.Duration) ([]model.DependencyLink, error) {
+	return m.deps, m.err
+}
+
+func TestGetDependenciesHandler_Handle_Success(t *testing.T) {
+	deps := []model.DependencyLink{
+		{Parent: "api-gateway", Child: "payment-service", CallCount: 150},
+		{Parent: "payment-service", Child: "database", CallCount: 300},
+		{Parent: "api-gateway", Child: "user-service", CallCount: 200},
+	}
+	h := &getDependenciesHandler{queryService: &mockDependencyService{deps: deps}}
+
+	_, output, err := h.handle(context.Background(), nil, types.GetDependenciesInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Dependencies, 3)
+	assert.Equal(t, "api-gateway", output.Dependencies[0].Parent)
+	assert.Equal(t, "payment-service", output.Dependencies[0].Child)
+	assert.Equal(t, uint64(150), output.Dependencies[0].CallCount)
+}
+
+func TestGetDependenciesHandler_Handle_WithLookback(t *testing.T) {
+	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "1h"})
+	require.NoError(t, err)
+}
+
+func TestGetDependenciesHandler_Handle_InvalidLookback(t *testing.T) {
+	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "invalid"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid lookback")
+}
+
+func TestGetDependenciesHandler_Handle_StorageError(t *testing.T) {
+	h := &getDependenciesHandler{
+		queryService: &mockDependencyService{err: errors.New("storage unavailable")},
+	}
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get dependencies")
+}
+
+func TestGetDependenciesHandler_Handle_EmptyResult(t *testing.T) {
+	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+
+	_, output, err := h.handle(context.Background(), nil, types.GetDependenciesInput{})
+	require.NoError(t, err)
+	assert.Empty(t, output.Dependencies)
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
@@ -17,11 +17,13 @@ import (
 )
 
 type mockDependencyService struct {
-	deps []model.DependencyLink
-	err  error
+	deps             []model.DependencyLink
+	err              error
+	capturedLookback time.Duration
 }
 
-func (m *mockDependencyService) GetDependencies(_ context.Context, _ time.Time, _ time.Duration) ([]model.DependencyLink, error) {
+func (m *mockDependencyService) GetDependencies(_ context.Context, _ time.Time, lookback time.Duration) ([]model.DependencyLink, error) {
+	m.capturedLookback = lookback
 	return m.deps, m.err
 }
 
@@ -41,11 +43,22 @@ func TestGetDependenciesHandler_Handle_Success(t *testing.T) {
 	assert.Equal(t, uint64(150), output.Dependencies[0].CallCount)
 }
 
-func TestGetDependenciesHandler_Handle_WithLookback(t *testing.T) {
-	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+func TestGetDependenciesHandler_Handle_DefaultLookback(t *testing.T) {
+	mock := &mockDependencyService{}
+	h := &getDependenciesHandler{queryService: mock}
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{})
+	require.NoError(t, err)
+	assert.Equal(t, defaultDependencyLookback, mock.capturedLookback)
+}
+
+func TestGetDependenciesHandler_Handle_CustomLookback(t *testing.T) {
+	mock := &mockDependencyService{}
+	h := &getDependenciesHandler{queryService: mock}
 
 	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "1h"})
 	require.NoError(t, err)
+	assert.Equal(t, time.Hour, mock.capturedLookback)
 }
 
 func TestGetDependenciesHandler_Handle_InvalidLookback(t *testing.T) {
@@ -54,6 +67,22 @@ func TestGetDependenciesHandler_Handle_InvalidLookback(t *testing.T) {
 	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "invalid"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid lookback")
+}
+
+func TestGetDependenciesHandler_Handle_NegativeLookback(t *testing.T) {
+	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "-1h"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookback must be positive")
+}
+
+func TestGetDependenciesHandler_Handle_ZeroLookback(t *testing.T) {
+	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "0s"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lookback must be positive")
 }
 
 func TestGetDependenciesHandler_Handle_StorageError(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
@@ -131,3 +131,8 @@ func TestGetDependenciesHandler_Handle_EmptyResult(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, output.Dependencies)
 }
+
+func TestNewGetDependenciesHandler(t *testing.T) {
+	handler := NewGetDependenciesHandler(nil)
+	assert.NotNil(t, handler)
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_dependencies_test.go
@@ -19,10 +19,12 @@ import (
 type mockDependencyService struct {
 	deps             []model.DependencyLink
 	err              error
+	capturedEndTs    time.Time
 	capturedLookback time.Duration
 }
 
-func (m *mockDependencyService) GetDependencies(_ context.Context, _ time.Time, lookback time.Duration) ([]model.DependencyLink, error) {
+func (m *mockDependencyService) GetDependencies(_ context.Context, endTs time.Time, lookback time.Duration) ([]model.DependencyLink, error) {
+	m.capturedEndTs = endTs
 	m.capturedLookback = lookback
 	return m.deps, m.err
 }
@@ -38,51 +40,78 @@ func TestGetDependenciesHandler_Handle_Success(t *testing.T) {
 	_, output, err := h.handle(context.Background(), nil, types.GetDependenciesInput{})
 	require.NoError(t, err)
 	require.Len(t, output.Dependencies, 3)
-	assert.Equal(t, "api-gateway", output.Dependencies[0].Parent)
-	assert.Equal(t, "payment-service", output.Dependencies[0].Child)
+	assert.Equal(t, "api-gateway", output.Dependencies[0].Caller)
+	assert.Equal(t, "payment-service", output.Dependencies[0].Callee)
 	assert.Equal(t, uint64(150), output.Dependencies[0].CallCount)
 }
 
-func TestGetDependenciesHandler_Handle_DefaultLookback(t *testing.T) {
+func TestGetDependenciesHandler_Handle_DefaultTimeRange(t *testing.T) {
 	mock := &mockDependencyService{}
 	h := &getDependenciesHandler{queryService: mock}
 
+	before := time.Now()
 	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{})
 	require.NoError(t, err)
-	assert.Equal(t, defaultDependencyLookback, mock.capturedLookback)
+
+	// Default lookback should be 24h
+	assert.InDelta(t, (24 * time.Hour).Seconds(), mock.capturedLookback.Seconds(), 1)
+	// End time should be approximately now
+	assert.WithinDuration(t, before, mock.capturedEndTs, 2*time.Second)
 }
 
-func TestGetDependenciesHandler_Handle_CustomLookback(t *testing.T) {
+func TestGetDependenciesHandler_Handle_CustomTimeRange(t *testing.T) {
 	mock := &mockDependencyService{}
 	h := &getDependenciesHandler{queryService: mock}
 
-	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "1h"})
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{
+		StartTime: "-1h",
+		EndTime:   "now",
+	})
 	require.NoError(t, err)
-	assert.Equal(t, time.Hour, mock.capturedLookback)
+	assert.InDelta(t, time.Hour.Seconds(), mock.capturedLookback.Seconds(), 1)
 }
 
-func TestGetDependenciesHandler_Handle_InvalidLookback(t *testing.T) {
-	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+func TestGetDependenciesHandler_Handle_RFC3339TimeRange(t *testing.T) {
+	mock := &mockDependencyService{}
+	h := &getDependenciesHandler{queryService: mock}
 
-	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "invalid"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid lookback")
+	endTime := time.Now().UTC().Truncate(time.Second)
+	startTime := endTime.Add(-2 * time.Hour)
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{
+		StartTime: startTime.Format(time.RFC3339),
+		EndTime:   endTime.Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, (2 * time.Hour).Seconds(), mock.capturedLookback.Seconds(), 1)
+	assert.WithinDuration(t, endTime, mock.capturedEndTs, time.Second)
 }
 
-func TestGetDependenciesHandler_Handle_NegativeLookback(t *testing.T) {
+func TestGetDependenciesHandler_Handle_InvalidStartTime(t *testing.T) {
 	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
 
-	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "-1h"})
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{StartTime: "invalid"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "lookback must be positive")
+	assert.Contains(t, err.Error(), "invalid start_time")
 }
 
-func TestGetDependenciesHandler_Handle_ZeroLookback(t *testing.T) {
+func TestGetDependenciesHandler_Handle_InvalidEndTime(t *testing.T) {
 	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
 
-	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{Lookback: "0s"})
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{EndTime: "invalid"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "lookback must be positive")
+	assert.Contains(t, err.Error(), "invalid end_time")
+}
+
+func TestGetDependenciesHandler_Handle_StartAfterEnd(t *testing.T) {
+	h := &getDependenciesHandler{queryService: &mockDependencyService{}}
+
+	_, _, err := h.handle(context.Background(), nil, types.GetDependenciesInput{
+		StartTime: "now",
+		EndTime:   "-1h",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start_time must be before end_time")
 }
 
 func TestGetDependenciesHandler_Handle_StorageError(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_dependencies.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// GetDependenciesInput defines the input parameters for the get_service_dependencies MCP tool.
+type GetDependenciesInput struct {
+	// Lookback defines the time window to query for dependencies (e.g., "1h", "24h").
+	// Defaults to "24h" if not specified.
+	Lookback string `json:"lookback,omitempty" jsonschema:"Time window for dependency data (e.g. 1h, 24h). Default: 24h"`
+}
+
+// GetDependenciesOutput defines the output of the get_service_dependencies MCP tool.
+type GetDependenciesOutput struct {
+	Dependencies []DependencyLink `json:"dependencies" jsonschema:"Service-to-service dependency edges with call counts"`
+}
+
+// DependencyLink represents a dependency between two services.
+type DependencyLink struct {
+	Parent    string `json:"parent" jsonschema:"Calling service name"`
+	Child     string `json:"child" jsonschema:"Called service name"`
+	CallCount uint64 `json:"call_count" jsonschema:"Number of calls from parent to child in the time window"`
+	Source    string `json:"source,omitempty" jsonschema:"Source of the dependency data"`
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_dependencies.go
@@ -5,9 +5,13 @@ package types
 
 // GetDependenciesInput defines the input parameters for the get_service_dependencies MCP tool.
 type GetDependenciesInput struct {
-	// Lookback defines the time window to query for dependencies (e.g., "1h", "24h").
-	// Defaults to "24h" if not specified.
-	Lookback string `json:"lookback,omitempty" jsonschema:"Time window for dependency data (e.g. 1h, 24h). Default: 24h"`
+	// StartTime is the start of the time range (optional, defaults to "-24h").
+	// Supports RFC3339 or relative time (e.g., "-1h", "-24h").
+	StartTime string `json:"start_time,omitempty" jsonschema:"Start of time range (RFC3339 or relative like -24h). Default: -24h"`
+
+	// EndTime is the end of the time range (optional, defaults to "now").
+	// Supports RFC3339 or relative time (e.g., "now", "-1h").
+	EndTime string `json:"end_time,omitempty" jsonschema:"End of time range (RFC3339 or relative like now). Default: now"`
 }
 
 // GetDependenciesOutput defines the output of the get_service_dependencies MCP tool.
@@ -17,8 +21,7 @@ type GetDependenciesOutput struct {
 
 // DependencyLink represents a dependency between two services.
 type DependencyLink struct {
-	Parent    string `json:"parent" jsonschema:"Calling service name"`
-	Child     string `json:"child" jsonschema:"Called service name"`
-	CallCount uint64 `json:"call_count" jsonschema:"Number of calls from parent to child in the time window"`
-	Source    string `json:"source,omitempty" jsonschema:"Source of the dependency data"`
+	Caller    string `json:"caller" jsonschema:"Calling service name"`
+	Callee    string `json:"callee" jsonschema:"Called service name"`
+	CallCount uint64 `json:"call_count" jsonschema:"Number of calls from caller to callee in the time window"`
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -190,8 +190,8 @@ func (s *server) registerTools() {
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_service_dependencies",
-		Description: "Get the service dependency graph showing which services call which. " +
-			"Returns edges with call counts over a configurable time window (default 24h).",
+		Description: "Get the service dependency graph showing caller-callee pairs. " +
+			"Returns edges with call counts over a configurable time window (default: last 24h).",
 	}, handlers.NewGetDependenciesHandler(s.queryAPI))
 }
 

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -187,6 +187,12 @@ func (s *server) registerTools() {
 			"that determined end-to-end duration. " +
 			"Higher self_time_us values indicate where time is concentrated on the critical path.",
 	}, handlers.NewGetCriticalPathHandler(s.queryAPI))
+
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name: "get_service_dependencies",
+		Description: "Get the service dependency graph showing which services call which. " +
+			"Returns edges with call counts over a configurable time window (default 24h).",
+	}, handlers.NewGetDependenciesHandler(s.queryAPI))
 }
 
 // HealthToolOutput is the strongly-typed output for the health tool.


### PR DESCRIPTION
## Which problem is this PR solving?

- Part of #7827

`QueryService.GetDependencies()` is the only QueryService method with no MCP tool. An agent investigating service relationships has to fetch individual traces and reconstruct the dependency graph manually, even though Jaeger already computes and stores this data.

## Description of the changes

Adds a `get_service_dependencies` tool that returns the service-to-service dependency graph with call counts over a configurable time window (default: last 24h).

**Input:**
- `start_time` (optional): start of time range (RFC3339 or relative like `-24h`). Defaults to `-24h`.
- `end_time` (optional): end of time range (RFC3339 or relative like `now`). Defaults to `now`.

**Output:**
- `dependencies[]`: sorted list of edges, each with `caller`, `callee`, and `call_count`.

**Use cases for an LLM agent:**
- "Which services does payment-service call?" - one tool call
- "What's the blast radius if database-service goes down?" - filter results by callee
- "Show me the service architecture" - full graph in one response

**Files:**
- `internal/handlers/get_dependencies.go` - handler wrapping `QueryService.GetDependencies()`
- `internal/types/get_dependencies.go` - input/output types with jsonschema tags
- `internal/handlers/get_dependencies_test.go` - 10 unit tests (handler + constructor)
- `server.go` - tool registration
- `integration_test.go` - tool discovery + end-to-end invocation test

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegermcp/...` - all passing
- `make lint` - 0 issues
- `make fmt` - clean

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)