### PR TITLE
docs: add documentation for NumTraces field in TraceQueryParameters

### DIFF
--- a/internal/storage/v1/api/spanstore/interface.go
+++ b/internal/storage/v1/api/spanstore/interface.go
@@ -66,6 +66,8 @@ type TraceQueryParameters struct {
 	StartTimeMax  time.Time
 	DurationMin   time.Duration
 	DurationMax   time.Duration
+	// NumTraces specifies the maximum number of traces to return.
+	// If set to 0, defaults to 100.
 	NumTraces     int
 }
 


### PR DESCRIPTION
## What This PR Does

I've added documentation comments to the `NumTraces` field in the `TraceQueryParameters` struct. It was previously undocumented, which made it confusing for developers reading the code.

## Why I Did This

While exploring the codebase, I noticed the `NumTraces` field had no explanation of what it actually does. The field name alone doesn't clearly indicate that it:
- Specifies the **maximum number of traces** to return
- **Defaults to 100** when set to 0

This became clear after reading how it's used in `internal/storage/v1/cassandra/spanstore/reader.go` where it's used as a limit in the query results.

## The Change

Added two comment lines that explain:
1. What the field does (max number of traces to return)
2. The default behavior (100 when set to 0)

This makes the code more readable and helps the next person understand the purpose at a glance.

## Testing

- [x] `go build ./...` passes with no errors
- [x] Code follows Go documentation conventions
- [x] No functional changes, only documentation

## Additional Context

This relates to the ongoing v1/v2 storage migration where v2 uses `SearchDepth` (clearer name) but v1 still uses `NumTraces`. Better documentation here will help developers understand the difference between the two naming approaches. 

<img width="452" height="108" alt="SCR-20260418-ncdo" src="https://github.com/user-attachments/assets/cc98cda4-ce4b-4693-9999-e168a9fd43e0" />


