### PR TITLE
perf: preallocate buckets array to avoid reallocations

### DIFF
--- a/internal/storage/v1/cassandra/dependencystore/storage.go
+++ b/internal/storage/v1/cassandra/dependencystore/storage.go
@@ -134,8 +134,13 @@ func (s *DependencyStore) GetDependencies(_ context.Context, endTs time.Time, lo
 }
 
 func getBuckets(startTs time.Time, endTs time.Time) []time.Time {
-	// TODO: Preallocate the array using some maths and maybe use a pool? This endpoint probably isn't used enough to warrant this.
-	var tsBuckets []time.Time
+	// Calculate number of buckets needed to avoid reallocations
+	duration := endTs.Sub(startTs)
+	numBuckets := int(duration/tsBucket) + 1
+	
+	// Preallocate slice with exact capacity
+	tsBuckets := make([]time.Time, 0, numBuckets)
+	
 	for ts := startTs.Truncate(tsBucket); ts.Before(endTs); ts = ts.Add(tsBucket) {
 		tsBuckets = append(tsBuckets, ts)
 	}


### PR DESCRIPTION
## What This Does

I found a TODO in the `getBuckets` function and decided to implement it. The function currently creates an empty time slice and keeps appending to it, which causes Go to reallocate and copy the array multiple times as it grows.

## The Issue

Every time the slice reaches capacity and you append again, Go has to create a bigger array and copy all the old data over. This happens several times in the loop, which is wasteful.

## My Fix

I calculate upfront how many time buckets we need, then create the slice with that exact capacity. Now all the appends fit without any reallocations.

## Why It Matters

- Only one memory allocation instead of many
- No copying data around during the loop
- Better performance overall

The TODO comment said this endpoint isn't used much, so I get if this feels like over-engineering. But it's a small, clean fix and the logic is simple, so I thought why not. If you'd rather not merge this, that's totally fine too.

## How I Tested It

- Built the code successfully
- All 10 existing tests pass
- The `TestGetBuckets` test specifically verifies this function works correctly
- No behavior changed, just performance improved

This addresses the TODO at line 137 of `internal/storage/v1/cassandra/dependencystore/storage.go`.

<img width="585" height="234" alt="image" src="https://github.com/user-attachments/assets/602514ea-2d53-47e3-a865-40637f1715e2" />
