### PR TITLE
[clickhouse][spm] Implement `GetLatencies` for ClickHouse Storage

### DIFF
--- a/internal/storage/v1/api/metricstore/interface.go
+++ b/internal/storage/v1/api/metricstore/interface.go
@@ -44,6 +44,8 @@ type BaseQueryParameters struct {
 	// RatePer is the duration in which the per-second rate of change is calculated for a cumulative counter metric.
 	RatePer *time.Duration
 	// SpanKinds is the list of span kinds to include (logical OR) in the resulting metrics aggregation.
+	// The jaeger_query extension always populates this with a non-empty default,
+	// so backend implementations can assume it will not be empty.
 	SpanKinds []string
 }
 

--- a/internal/storage/v2/clickhouse/metricstore/package_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricstore
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricstore

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -125,9 +125,9 @@ func rowsToMetricFamily(rows driver.Rows, name, desc string, groupByOperation bo
 
 // queryWindow extracts the start and end time from BaseQueryParameters.
 func queryWindow(p metricstore.BaseQueryParameters) (start, end time.Time) {
-	end = time.Now()
+	end = time.Now().UTC()
 	if p.EndTime != nil {
-		end = *p.EndTime
+		end = p.EndTime.UTC()
 	}
 	lookback := defaultLookback
 	if p.Lookback != nil {
@@ -152,12 +152,15 @@ func stepSeconds(p metricstore.BaseQueryParameters) uint64 {
 func convertSpanKinds(kinds []string) []string {
 	out := make([]string, 0, len(kinds))
 	for _, k := range kinds {
-		converted := jptrace.ProtoSpanKindToString(k)
-		// SpanKindUnspecified is stored as "" in ClickHouse
-		if converted == "unspecified" {
-			converted = ""
+		// SpanKindUnspecified is stored as "" in ClickHouse (via jptrace.SpanKindToString).
+		if k == "SPAN_KIND_UNSPECIFIED" {
+			out = append(out, "")
+			continue
 		}
-		out = append(out, converted)
+		converted := jptrace.ProtoSpanKindToString(k)
+		if converted != "" {
+			out = append(out, converted)
+		}
 	}
 	return out
 }

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -55,17 +55,17 @@ func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.Latencies
 }
 
 // GetCallRates implements metricstore.Reader.
-func (r *Reader) GetCallRates(ctx context.Context, params *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
+func (r *Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
 	panic("unimplemented")
 }
 
 // GetErrorRates implements metricstore.Reader.
-func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
+func (r *Reader) GetErrorRates(_ context.Context, _ *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
 	panic("unimplemented")
 }
 
 // GetMinStepDuration implements metricstore.Reader.
-func (r *Reader) GetMinStepDuration(ctx context.Context, params *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
+func (r *Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
 	panic("unimplemented")
 }
 

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -138,14 +138,14 @@ func queryWindow(p metricstore.BaseQueryParameters) (start, end time.Time) {
 }
 
 // stepSeconds extracts the step duration in seconds from BaseQueryParameters.
+// Sub-second steps are clamped to 1 second.
 func stepSeconds(p metricstore.BaseQueryParameters) uint64 {
-	step := defaultStepSeconds
 	if p.Step != nil {
-		if p.Step.Seconds() > 0 {
-			step = uint64(p.Step.Seconds())
+		if s := uint64(*p.Step / time.Second); s > 0 {
+			return s
 		}
 	}
-	return step
+	return defaultStepSeconds
 }
 
 func convertSpanKinds(kinds []string) []string {

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -19,6 +19,8 @@ import (
 
 var _ metricstore.Reader = (*Reader)(nil)
 
+var errNotImplemented = errors.New("not implemented")
+
 const (
 	defaultLookback    = time.Hour
 	defaultStepSeconds = uint64(60)
@@ -54,8 +56,6 @@ func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.Latencies
 
 	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
 }
-
-var errNotImplemented = errors.New("not implemented")
 
 func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
 	return nil, errNotImplemented

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -55,17 +55,17 @@ func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.Latencies
 }
 
 // GetCallRates implements metricstore.Reader.
-func (r *Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
+func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
 	panic("unimplemented")
 }
 
 // GetErrorRates implements metricstore.Reader.
-func (r *Reader) GetErrorRates(_ context.Context, _ *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
+func (*Reader) GetErrorRates(_ context.Context, _ *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
 	panic("unimplemented")
 }
 
 // GetMinStepDuration implements metricstore.Reader.
-func (r *Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
+func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
 	panic("unimplemented")
 }
 

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -54,17 +54,14 @@ func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.Latencies
 	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
 }
 
-// GetCallRates implements metricstore.Reader.
 func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
 	panic("unimplemented")
 }
 
-// GetErrorRates implements metricstore.Reader.
 func (*Reader) GetErrorRates(_ context.Context, _ *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
 	panic("unimplemented")
 }
 
-// GetMinStepDuration implements metricstore.Reader.
 func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
 	panic("unimplemented")
 }

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/jaegertracing/jaeger/internal/jptrace"
+	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
+)
+
+var _ metricstore.Reader = (*Reader)(nil)
+
+const (
+	defaultLookback    = time.Hour
+	defaultStepSeconds = uint64(60)
+)
+
+type Reader struct {
+	conn driver.Conn
+}
+
+func NewReader(conn driver.Conn) *Reader {
+	return &Reader{conn: conn}
+}
+
+func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.LatenciesQueryParameters) (*metrics.MetricFamily, error) {
+	name, desc := "service_latencies", fmt.Sprintf("%.2fth quantile latency, grouped by service", params.Quantile)
+	query := sql.SelectLatencies
+	if params.GroupByOperation {
+		name = "service_operation_latencies"
+		desc += " & operation"
+		query = sql.SelectLatenciesByOperation
+	}
+
+	start, end := queryWindow(params.BaseQueryParameters)
+	step := stepSeconds(params.BaseQueryParameters)
+	kinds := convertSpanKinds(params.SpanKinds)
+
+	rows, err := r.conn.Query(ctx, query,
+		step, params.Quantile, start, end, params.ServiceNames, kinds,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latencies: %w", err)
+	}
+
+	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
+}
+
+// GetCallRates implements metricstore.Reader.
+func (r *Reader) GetCallRates(ctx context.Context, params *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
+	panic("unimplemented")
+}
+
+// GetErrorRates implements metricstore.Reader.
+func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
+	panic("unimplemented")
+}
+
+// GetMinStepDuration implements metricstore.Reader.
+func (r *Reader) GetMinStepDuration(ctx context.Context, params *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
+	panic("unimplemented")
+}
+
+// metricsKey groups metric points by service (and optionally operation).
+type metricsKey struct {
+	ServiceName string
+	Operation   string
+}
+
+// rowsToMetricFamily reads aggregated rows from ClickHouse and converts them to a MetricFamily.
+// When groupByOperation is true, rows are expected to have 4 columns: (ts, service_name, name, val).
+// Otherwise, rows have 3 columns: (ts, service_name, val).
+func rowsToMetricFamily(rows driver.Rows, name, desc string, groupByOperation bool) (*metrics.MetricFamily, error) {
+	defer rows.Close()
+
+	// Collect points grouped by (service, operation).
+	grouped := make(map[metricsKey][]*metrics.MetricPoint)
+	for rows.Next() {
+		var row metricsRow
+		var err error
+		if groupByOperation {
+			err = rows.Scan(&row.Timestamp, &row.ServiceName, &row.Operation, &row.Value)
+		} else {
+			err = rows.Scan(&row.Timestamp, &row.ServiceName, &row.Value)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan metrics row: %w", err)
+		}
+		key := metricsKey{ServiceName: row.ServiceName}
+		if groupByOperation {
+			key.Operation = row.Operation
+		}
+		grouped[key] = append(grouped[key], row.toMetricPoint())
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating metrics rows: %w", err)
+	}
+
+	ms := make([]*metrics.Metric, 0, len(grouped))
+	for key, points := range grouped {
+		labels := []*metrics.Label{
+			{Name: "service_name", Value: key.ServiceName},
+		}
+		if groupByOperation {
+			labels = append(labels, &metrics.Label{Name: "operation", Value: key.Operation})
+		}
+		ms = append(ms, &metrics.Metric{
+			Labels:       labels,
+			MetricPoints: points,
+		})
+	}
+
+	return &metrics.MetricFamily{
+		Name:    name,
+		Type:    metrics.MetricType_GAUGE,
+		Help:    desc,
+		Metrics: ms,
+	}, nil
+}
+
+// queryWindow extracts the start and end time from BaseQueryParameters.
+func queryWindow(p metricstore.BaseQueryParameters) (start, end time.Time) {
+	end = time.Now()
+	if p.EndTime != nil {
+		end = *p.EndTime
+	}
+	lookback := defaultLookback
+	if p.Lookback != nil {
+		lookback = *p.Lookback
+	}
+	start = end.Add(-lookback)
+	return start, end
+}
+
+// stepSeconds extracts the step duration in seconds from BaseQueryParameters.
+func stepSeconds(p metricstore.BaseQueryParameters) uint64 {
+	step := defaultStepSeconds
+	if p.Step != nil {
+		if p.Step.Seconds() > 0 {
+			step = uint64(p.Step.Seconds())
+		}
+	}
+	return step
+}
+
+func convertSpanKinds(kinds []string) []string {
+	out := make([]string, 0, len(kinds))
+	for _, k := range kinds {
+		out = append(out, jptrace.ProtoSpanKindToString(k))
+	}
+	return out
+}

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -153,8 +153,7 @@ func convertSpanKinds(kinds []string) []string {
 	out := make([]string, 0, len(kinds))
 	for _, k := range kinds {
 		converted := jptrace.ProtoSpanKindToString(k)
-		// SpanKindUnspecified is stored as "" in ClickHouse (via jptrace.SpanKindToString),
-		// but ProtoSpanKindToString returns "unspecified". Normalize to match storage.
+		// SpanKindUnspecified is stored as "" in ClickHouse
 		if converted == "unspecified" {
 			converted = ""
 		}

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -138,12 +138,13 @@ func queryWindow(p metricstore.BaseQueryParameters) (start, end time.Time) {
 }
 
 // stepSeconds extracts the step duration in seconds from BaseQueryParameters.
-// Sub-second steps are clamped to 1 second.
 func stepSeconds(p metricstore.BaseQueryParameters) uint64 {
-	if p.Step != nil {
-		if s := uint64(*p.Step / time.Second); s > 0 {
-			return s
+	if p.Step != nil && *p.Step > 0 {
+		s := *p.Step / time.Second
+		if s < 1 {
+			return 1
 		}
+		return uint64(s)
 	}
 	return defaultStepSeconds
 }
@@ -151,7 +152,13 @@ func stepSeconds(p metricstore.BaseQueryParameters) uint64 {
 func convertSpanKinds(kinds []string) []string {
 	out := make([]string, 0, len(kinds))
 	for _, k := range kinds {
-		out = append(out, jptrace.ProtoSpanKindToString(k))
+		converted := jptrace.ProtoSpanKindToString(k)
+		// SpanKindUnspecified is stored as "" in ClickHouse (via jptrace.SpanKindToString),
+		// but ProtoSpanKindToString returns "unspecified". Normalize to match storage.
+		if converted == "unspecified" {
+			converted = ""
+		}
+		out = append(out, converted)
 	}
 	return out
 }

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -5,6 +5,7 @@ package metricstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -54,16 +55,18 @@ func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.Latencies
 	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
 }
 
+var errNotImplemented = errors.New("not implemented")
+
 func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
-	panic("unimplemented")
+	return nil, errNotImplemented
 }
 
 func (*Reader) GetErrorRates(_ context.Context, _ *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
-	panic("unimplemented")
+	return nil, errNotImplemented
 }
 
 func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	panic("unimplemented")
+	return 0, errNotImplemented
 }
 
 // metricsKey groups metric points by service (and optionally operation).

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -316,6 +316,11 @@ func TestConvertSpanKinds(t *testing.T) {
 			kinds: []string{},
 			want:  []string{},
 		},
+		{
+			name:  "unknown kind is skipped",
+			kinds: []string{"SPAN_KIND_SERVER", "INVALID_KIND"},
+			want:  []string{"server"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -221,23 +221,20 @@ func TestGetLatencies_Errors(t *testing.T) {
 
 func TestGetCallRates(t *testing.T) {
 	reader := NewReader(&clickhousetest.Driver{})
-	assert.Panics(t, func() {
-		reader.GetCallRates(t.Context(), &metricstore.CallRateQueryParameters{})
-	})
+	_, err := reader.GetCallRates(t.Context(), &metricstore.CallRateQueryParameters{})
+	require.ErrorIs(t, err, errNotImplemented)
 }
 
 func TestGetErrorRates(t *testing.T) {
 	reader := NewReader(&clickhousetest.Driver{})
-	assert.Panics(t, func() {
-		reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{})
-	})
+	_, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{})
+	require.ErrorIs(t, err, errNotImplemented)
 }
 
 func TestGetMinStepDuration(t *testing.T) {
 	reader := NewReader(&clickhousetest.Driver{})
-	assert.Panics(t, func() {
-		reader.GetMinStepDuration(t.Context(), &metricstore.MinStepDurationQueryParameters{})
-	})
+	_, err := reader.GetMinStepDuration(t.Context(), &metricstore.MinStepDurationQueryParameters{})
+	require.ErrorIs(t, err, errNotImplemented)
 }
 
 func TestStepSeconds(t *testing.T) {

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -121,15 +121,16 @@ func TestGetLatencies_MultipleServicesAndBuckets(t *testing.T) {
 }
 
 func TestGetLatencies_GroupByOperation(t *testing.T) {
-	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
 	driver := &clickhousetest.Driver{
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectLatenciesByOperation: {
 				Rows: &clickhousetest.Rows[metricsRow]{
 					Data: []metricsRow{
-						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 100.0},
-						{Timestamp: ts, ServiceName: "frontend", Operation: "POST /api", Value: 250.0},
-						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 120.0},
+						{Timestamp: ts1, ServiceName: "frontend", Operation: "GET /api", Value: 100.0},
+						{Timestamp: ts1, ServiceName: "frontend", Operation: "POST /api", Value: 250.0},
+						{Timestamp: ts2, ServiceName: "frontend", Operation: "GET /api", Value: 120.0},
 					},
 					ScanFn: scanMetricsRowWithOpFn,
 				},

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -1,0 +1,183 @@
+package metricstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+var testQueryParams = metricstore.BaseQueryParameters{
+	ServiceNames: []string{"frontend"},
+	EndTime:      ptr(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)),
+	Lookback:     ptr(time.Hour),
+	Step:         ptr(time.Minute),
+	SpanKinds:    []string{"SPAN_KIND_SERVER"},
+}
+
+func scanMetricsRowFn(dest any, src metricsRow) error {
+	d := dest.([]any)
+	*d[0].(*time.Time) = src.Timestamp
+	*d[1].(*string) = src.ServiceName
+	*d[2].(*float64) = src.Value
+	return nil
+}
+
+func scanMetricsRowWithOpFn(dest any, src metricsRow) error {
+	d := dest.([]any)
+	*d[0].(*time.Time) = src.Timestamp
+	*d[1].(*string) = src.ServiceName
+	*d[2].(*string) = src.Operation
+	*d[3].(*float64) = src.Value
+	return nil
+}
+
+func TestGetLatencies(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	driver := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectLatencies: {
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data: []metricsRow{
+						{Timestamp: ts, ServiceName: "frontend", Value: 150.5},
+					},
+					ScanFn: scanMetricsRowFn,
+				},
+			},
+		},
+	}
+	reader := NewReader(driver)
+	result, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
+		BaseQueryParameters: testQueryParams,
+		Quantile:            0.95,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Metrics, 1)
+	require.Equal(t, "service_latencies", result.Name)
+	require.Len(t, result.Metrics[0].MetricPoints, 1)
+	require.Equal(t, "frontend", result.Metrics[0].Labels[0].Value)
+	require.Equal(t, 150.5, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue())
+}
+
+func TestGetLatencies_MultipleServicesAndBuckets(t *testing.T) {
+	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
+	driver := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectLatencies: {
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data: []metricsRow{
+						{Timestamp: ts1, ServiceName: "frontend", Value: 100.0},
+						{Timestamp: ts2, ServiceName: "frontend", Value: 200.0},
+						{Timestamp: ts1, ServiceName: "backend", Value: 50.0},
+					},
+					ScanFn: scanMetricsRowFn,
+				},
+			},
+		},
+	}
+	reader := NewReader(driver)
+	params := testQueryParams
+	params.ServiceNames = []string{"frontend", "backend"}
+	result, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
+		BaseQueryParameters: params,
+		Quantile:            0.95,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "service_latencies", result.Name)
+	require.Len(t, result.Metrics, 2)
+
+	// Build a map of service -> metric points for order-independent assertions.
+	byService := make(map[string]*metrics.Metric, len(result.Metrics))
+	for _, m := range result.Metrics {
+		byService[m.Labels[0].Value] = m
+	}
+
+	// frontend: two time buckets
+	fe := byService["frontend"]
+	require.Len(t, fe.MetricPoints, 2)
+	assert.Equal(t, 100.0, fe.MetricPoints[0].GetGaugeValue().GetDoubleValue())
+	assert.Equal(t, 200.0, fe.MetricPoints[1].GetGaugeValue().GetDoubleValue())
+
+	// backend: one time bucket
+	be := byService["backend"]
+	require.Len(t, be.MetricPoints, 1)
+	assert.Equal(t, 50.0, be.MetricPoints[0].GetGaugeValue().GetDoubleValue())
+}
+
+func TestGetLatencies_GroupByOperation(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	driver := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectLatenciesByOperation: {
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data: []metricsRow{
+						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 100.0},
+						{Timestamp: ts, ServiceName: "frontend", Operation: "POST /api", Value: 250.0},
+						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 120.0},
+					},
+					ScanFn: scanMetricsRowWithOpFn,
+				},
+			},
+		},
+	}
+	reader := NewReader(driver)
+	params := testQueryParams
+	params.GroupByOperation = true
+	result, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
+		BaseQueryParameters: params,
+		Quantile:            0.95,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "service_operation_latencies", result.Name)
+	require.Len(t, result.Metrics, 2)
+
+	// Build a map of operation -> metric for order-independent assertions.
+	byOp := make(map[string]*metrics.Metric, len(result.Metrics))
+	for _, m := range result.Metrics {
+		require.Len(t, m.Labels, 2)
+		assert.Equal(t, "service_name", m.Labels[0].Name)
+		assert.Equal(t, "frontend", m.Labels[0].Value)
+		byOp[m.Labels[1].Value] = m
+	}
+
+	// GET /api: two data points
+	getAPI := byOp["GET /api"]
+	require.Len(t, getAPI.MetricPoints, 2)
+	assert.Equal(t, 100.0, getAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue())
+	assert.Equal(t, 120.0, getAPI.MetricPoints[1].GetGaugeValue().GetDoubleValue())
+
+	// POST /api: one data point
+	postAPI := byOp["POST /api"]
+	require.Len(t, postAPI.MetricPoints, 1)
+	assert.Equal(t, 250.0, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue())
+}
+
+func TestGetCallRates(t *testing.T) {
+	reader := NewReader(&clickhousetest.Driver{})
+	assert.Panics(t, func() {
+		reader.GetCallRates(t.Context(), &metricstore.CallRateQueryParameters{})
+	})
+}
+
+func TestGetErrorRates(t *testing.T) {
+	reader := NewReader(&clickhousetest.Driver{})
+	assert.Panics(t, func() {
+		reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{})
+	})
+}
+
+func TestGetMinStepDuration(t *testing.T) {
+	reader := NewReader(&clickhousetest.Driver{})
+	assert.Panics(t, func() {
+		reader.GetMinStepDuration(t.Context(), &metricstore.MinStepDurationQueryParameters{})
+	})
+}

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -239,3 +239,87 @@ func TestGetMinStepDuration(t *testing.T) {
 		reader.GetMinStepDuration(t.Context(), &metricstore.MinStepDurationQueryParameters{})
 	})
 }
+
+func TestStepSeconds(t *testing.T) {
+	tests := []struct {
+		name string
+		step *time.Duration
+		want uint64
+	}{
+		{
+			name: "nil step returns default",
+			step: nil,
+			want: defaultStepSeconds,
+		},
+		{
+			name: "normal step",
+			step: ptr(30 * time.Second),
+			want: 30,
+		},
+		{
+			name: "sub-second step clamped to 1",
+			step: ptr(500 * time.Millisecond),
+			want: 1,
+		},
+		{
+			name: "zero step returns default",
+			step: ptr(time.Duration(0)),
+			want: defaultStepSeconds,
+		},
+		{
+			name: "negative step returns default",
+			step: ptr(-5 * time.Second),
+			want: defaultStepSeconds,
+		},
+		{
+			name: "one second step",
+			step: ptr(time.Second),
+			want: 1,
+		},
+		{
+			name: "fractional seconds truncated",
+			step: ptr(2500 * time.Millisecond),
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := metricstore.BaseQueryParameters{Step: tt.step}
+			assert.Equal(t, tt.want, stepSeconds(p))
+		})
+	}
+}
+
+func TestConvertSpanKinds(t *testing.T) {
+	tests := []struct {
+		name  string
+		kinds []string
+		want  []string
+	}{
+		{
+			name:  "server",
+			kinds: []string{"SPAN_KIND_SERVER"},
+			want:  []string{"server"},
+		},
+		{
+			name:  "multiple kinds",
+			kinds: []string{"SPAN_KIND_SERVER", "SPAN_KIND_CLIENT"},
+			want:  []string{"server", "client"},
+		},
+		{
+			name:  "unspecified maps to empty string",
+			kinds: []string{"SPAN_KIND_UNSPECIFIED"},
+			want:  []string{""},
+		},
+		{
+			name:  "empty input",
+			kinds: []string{},
+			want:  []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, convertSpanKinds(tt.kinds))
+		})
+	}
+}

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -65,8 +65,10 @@ func TestGetLatencies(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Metrics, 1)
 	require.Equal(t, "service_latencies", result.Name)
-	require.Len(t, result.Metrics[0].MetricPoints, 1)
+	require.Len(t, result.Metrics[0].Labels, 1)
+	require.Equal(t, "service_name", result.Metrics[0].Labels[0].Name)
 	require.Equal(t, "frontend", result.Metrics[0].Labels[0].Value)
+	require.Len(t, result.Metrics[0].MetricPoints, 1)
 	require.InDelta(t, 150.5, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 }
 
@@ -101,6 +103,8 @@ func TestGetLatencies_MultipleServicesAndBuckets(t *testing.T) {
 	// Build a map of service -> metric points for order-independent assertions.
 	byService := make(map[string]*metrics.Metric, len(result.Metrics))
 	for _, m := range result.Metrics {
+		require.Len(t, m.Labels, 1)
+		assert.Equal(t, "service_name", m.Labels[0].Name)
 		byService[m.Labels[0].Value] = m
 	}
 
@@ -149,6 +153,7 @@ func TestGetLatencies_GroupByOperation(t *testing.T) {
 		require.Len(t, m.Labels, 2)
 		assert.Equal(t, "service_name", m.Labels[0].Name)
 		assert.Equal(t, "frontend", m.Labels[0].Value)
+		assert.Equal(t, "operation", m.Labels[1].Name)
 		byOp[m.Labels[1].Value] = m
 	}
 

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -164,6 +164,55 @@ func TestGetLatencies_GroupByOperation(t *testing.T) {
 	assert.InDelta(t, 250.0, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 }
 
+func TestGetLatencies_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *clickhousetest.QueryResponse
+		err      string
+	}{
+		{
+			name:     "query error",
+			response: &clickhousetest.QueryResponse{Err: assert.AnError},
+			err:      "failed to query latencies",
+		},
+		{
+			name: "scan error",
+			response: &clickhousetest.QueryResponse{
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data:    []metricsRow{{ServiceName: "frontend"}},
+					ScanErr: assert.AnError,
+				},
+			},
+			err: "failed to scan metrics row",
+		},
+		{
+			name: "rows error",
+			response: &clickhousetest.QueryResponse{
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data:    []metricsRow{},
+					RowsErr: assert.AnError,
+				},
+			},
+			err: "error iterating metrics rows",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectLatencies: tt.response,
+				},
+			}
+			reader := NewReader(driver)
+			_, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
+				BaseQueryParameters: testQueryParams,
+				Quantile:            0.95,
+			})
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
 func TestGetCallRates(t *testing.T) {
 	reader := NewReader(&clickhousetest.Driver{})
 	assert.Panics(t, func() {

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package metricstore
 
 import (

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -67,7 +67,7 @@ func TestGetLatencies(t *testing.T) {
 	require.Equal(t, "service_latencies", result.Name)
 	require.Len(t, result.Metrics[0].MetricPoints, 1)
 	require.Equal(t, "frontend", result.Metrics[0].Labels[0].Value)
-	require.Equal(t, 150.5, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue())
+	require.InDelta(t, 150.5, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 }
 
 func TestGetLatencies_MultipleServicesAndBuckets(t *testing.T) {
@@ -107,13 +107,13 @@ func TestGetLatencies_MultipleServicesAndBuckets(t *testing.T) {
 	// frontend: two time buckets
 	fe := byService["frontend"]
 	require.Len(t, fe.MetricPoints, 2)
-	assert.Equal(t, 100.0, fe.MetricPoints[0].GetGaugeValue().GetDoubleValue())
-	assert.Equal(t, 200.0, fe.MetricPoints[1].GetGaugeValue().GetDoubleValue())
+	assert.InDelta(t, 100.0, fe.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+	assert.InDelta(t, 200.0, fe.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
 
 	// backend: one time bucket
 	be := byService["backend"]
 	require.Len(t, be.MetricPoints, 1)
-	assert.Equal(t, 50.0, be.MetricPoints[0].GetGaugeValue().GetDoubleValue())
+	assert.InDelta(t, 50.0, be.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 }
 
 func TestGetLatencies_GroupByOperation(t *testing.T) {
@@ -155,13 +155,13 @@ func TestGetLatencies_GroupByOperation(t *testing.T) {
 	// GET /api: two data points
 	getAPI := byOp["GET /api"]
 	require.Len(t, getAPI.MetricPoints, 2)
-	assert.Equal(t, 100.0, getAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue())
-	assert.Equal(t, 120.0, getAPI.MetricPoints[1].GetGaugeValue().GetDoubleValue())
+	assert.InDelta(t, 100.0, getAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+	assert.InDelta(t, 120.0, getAPI.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
 
 	// POST /api: one data point
 	postAPI := byOp["POST /api"]
 	require.Len(t, postAPI.MetricPoints, 1)
-	assert.Equal(t, 250.0, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue())
+	assert.InDelta(t, 250.0, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 }
 
 func TestGetCallRates(t *testing.T) {

--- a/internal/storage/v2/clickhouse/metricstore/row.go
+++ b/internal/storage/v2/clickhouse/metricstore/row.go
@@ -23,7 +23,7 @@ func (mr *metricsRow) toMetricPoint() *metrics.MetricPoint {
 	return &metrics.MetricPoint{
 		Timestamp: &types.Timestamp{
 			Seconds: mr.Timestamp.Unix(),
-			Nanos:   int32(mr.Timestamp.Nanosecond()), //nolint:gosec
+			Nanos:   int32(mr.Timestamp.Nanosecond()), //nolint:gosec // G115: Nanosecond() returns [0,999999999], always fits int32
 		},
 		Value: &metrics.MetricPoint_GaugeValue{
 			GaugeValue: &metrics.GaugeValue{

--- a/internal/storage/v2/clickhouse/metricstore/row.go
+++ b/internal/storage/v2/clickhouse/metricstore/row.go
@@ -1,9 +1,13 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package metricstore
 
 import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
 )
 

--- a/internal/storage/v2/clickhouse/metricstore/row.go
+++ b/internal/storage/v2/clickhouse/metricstore/row.go
@@ -1,0 +1,30 @@
+package metricstore
+
+import (
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
+)
+
+// metricsRow represents a single row from the SPM aggregation queries.
+type metricsRow struct {
+	Timestamp   time.Time
+	ServiceName string
+	Operation   string
+	Value       float64
+}
+
+func (mr *metricsRow) toMetricPoint() *metrics.MetricPoint {
+	return &metrics.MetricPoint{
+		Timestamp: &types.Timestamp{
+			Seconds: mr.Timestamp.Unix(),
+			Nanos:   int32(mr.Timestamp.Nanosecond()),
+		},
+		Value: &metrics.MetricPoint_GaugeValue{
+			GaugeValue: &metrics.GaugeValue{
+				Value: &metrics.GaugeValue_DoubleValue{DoubleValue: mr.Value},
+			},
+		},
+	}
+}

--- a/internal/storage/v2/clickhouse/metricstore/row.go
+++ b/internal/storage/v2/clickhouse/metricstore/row.go
@@ -23,7 +23,7 @@ func (mr *metricsRow) toMetricPoint() *metrics.MetricPoint {
 	return &metrics.MetricPoint{
 		Timestamp: &types.Timestamp{
 			Seconds: mr.Timestamp.Unix(),
-			Nanos:   int32(mr.Timestamp.Nanosecond()),
+			Nanos:   int32(mr.Timestamp.Nanosecond()), //nolint:gosec
 		},
 		Value: &metrics.MetricPoint_GaugeValue{
 			GaugeValue: &metrics.GaugeValue{

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -294,6 +294,44 @@ INSERT INTO
 VALUES
     (?, ?)`
 
+const SelectLatencies = `
+SELECT
+    toStartOfInterval(start_time, toIntervalSecond(?)) AS ts,
+    service_name,
+    quantile(?)(duration) / 1e6 AS val
+FROM
+    spans
+WHERE
+    start_time >= ?
+    AND start_time < ?
+    AND service_name IN (?)
+    AND kind IN (?)
+GROUP BY
+    ts,
+    service_name
+ORDER BY
+    ts`
+
+const SelectLatenciesByOperation = `
+SELECT
+    toStartOfInterval(start_time, toIntervalSecond(?)) AS ts,
+    service_name,
+    name,
+    quantile(?)(duration) / 1e6 AS val
+FROM
+    spans
+WHERE
+    start_time >= ?
+    AND start_time < ?
+    AND service_name IN (?)
+    AND kind IN (?)
+GROUP BY
+    ts,
+    service_name,
+    name
+ORDER BY
+    ts`
+
 //go:embed create_dependencies_table.sql
 var CreateDependenciesTable string
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #8313

## Description of the changes
- This is the first in a series of PRs to implement SPM (via the `metricstore` interface) for ClickHouse storage. This PR in particular implements the `GetLatencies` function which gets latency metrics based on the query parameters provided. 

## How was this change tested?
### Unit Tests
```
go test -run TestGetLatencies ./internal/storage/v2/clickhouse/metricstore/...
```

### Manual Test
Spin up ClickHouse in a docker container 
```
docker compose -f docker-compose/clickhouse/docker-compose.yml up 
``` 

Start jaeger 
```
go run ./cmd/jaeger --config cmd/jaeger/config-clickhouse.yaml --feature-gates=storage.clickhouse
```

Run tracegen with at 1s intervals for 2 minutes
```
go run ./cmd/tracegen -traces 120 -pause 1s
```

Run the following test
```go
func TestMetricsReaderIntegration(t *testing.T) {
	ctx := context.Background()

	conn, err := clickhouse.Open(&clickhouse.Options{
		Addr: []string{"127.0.0.1:9000"},
		Auth: clickhouse.Auth{
			Database: "jaeger",
			Username: "default",
			Password: "password",
		},
		DialTimeout: 5 * time.Second,
	})
	require.NoError(t, err)
	defer conn.Close()

	reader := NewReader(conn)
	now := time.Now()
	step := 60 * time.Second
	base := metricstore.BaseQueryParameters{
		ServiceNames: []string{"tracegen"},
		EndTime:      &now,
		Lookback:     ptr(time.Hour),
		Step:         &step,
		SpanKinds:    []string{"SPAN_KIND_SERVER"},
	}

	result, err := reader.GetLatencies(ctx, &metricstore.LatenciesQueryParameters{
		BaseQueryParameters: base,
		Quantile:            0.95,
	})
	require.NoError(t, err)
	t.Logf("Latencies: name=%s, metrics=%d", result.Name, len(result.Metrics))
	for _, m := range result.Metrics {
		t.Logf("  labels=%v, points=%d", m.Labels, len(m.MetricPoints))
		for _, mp := range m.MetricPoints {
			t.Logf("    ts=%v val=%v", mp.Timestamp, mp.GetGaugeValue().GetDoubleValue())
		}
	}
}
````

See the following in the logs
```
Latencies: name=service_latencies, metrics=1
labels=[name:"service_name" value:"tracegen" ], points=3
ts=2026-04-19T18:38:00Z val=1001.2887043
ts=2026-04-19T18:39:00Z val=1001.63013925
ts=2026-04-19T18:40:00Z val=1001.2735582
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
