### PR TITLE
[clickhouse][spm] Implement `GetErrorRates` for ClickHouse Storage

### DIFF
--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -61,8 +61,27 @@ func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParam
 	return nil, errNotImplemented
 }
 
-func (*Reader) GetErrorRates(_ context.Context, _ *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
-	return nil, errNotImplemented
+func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
+	name, desc := "service_error_rate", "error rate, grouped by service"
+	query := sql.SelectErrorRates
+	if params.GroupByOperation {
+		name = "service_operation_error_rate"
+		desc += " & operation"
+		query = sql.SelectErrorRatesByOperation
+	}
+
+	start, end := queryWindow(params.BaseQueryParameters)
+	step := stepSeconds(params.BaseQueryParameters)
+	kinds := convertSpanKinds(params.SpanKinds)
+
+	rows, err := r.conn.Query(ctx, query,
+		step, start, end, params.ServiceNames, kinds,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query error rates: %w", err)
+	}
+
+	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
 }
 
 func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -34,27 +34,24 @@ func NewReader(conn driver.Conn) *Reader {
 	return &Reader{conn: conn}
 }
 
+// metricsQueryConfig holds the query-specific metadata that varies between
+// different metric types (latencies, error rates, call rates).
+type metricsQueryConfig struct {
+	baseName  string
+	opName    string
+	baseDesc  string
+	baseQuery string
+	opQuery   string
+}
+
 func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.LatenciesQueryParameters) (*metrics.MetricFamily, error) {
-	name, desc := "service_latencies", fmt.Sprintf("%.2fth quantile latency, grouped by service", params.Quantile)
-	query := sql.SelectLatencies
-	if params.GroupByOperation {
-		name = "service_operation_latencies"
-		desc += " & operation"
-		query = sql.SelectLatenciesByOperation
-	}
-
-	start, end := queryWindow(params.BaseQueryParameters)
-	step := stepSeconds(params.BaseQueryParameters)
-	kinds := convertSpanKinds(params.SpanKinds)
-
-	rows, err := r.conn.Query(ctx, query,
-		step, params.Quantile, start, end, params.ServiceNames, kinds,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query latencies: %w", err)
-	}
-
-	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
+	return r.queryMetrics(ctx, metricsQueryConfig{
+		baseName:  "service_latencies",
+		opName:    "service_operation_latencies",
+		baseDesc:  fmt.Sprintf("%.2fth quantile latency, grouped by service", params.Quantile),
+		baseQuery: sql.SelectLatencies,
+		opQuery:   sql.SelectLatenciesByOperation,
+	}, params.BaseQueryParameters, params.Quantile)
 }
 
 func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
@@ -62,30 +59,50 @@ func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParam
 }
 
 func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
-	name, desc := "service_error_rate", "error rate, grouped by service"
-	query := sql.SelectErrorRates
-	if params.GroupByOperation {
-		name = "service_operation_error_rate"
-		desc += " & operation"
-		query = sql.SelectErrorRatesByOperation
-	}
-
-	start, end := queryWindow(params.BaseQueryParameters)
-	step := stepSeconds(params.BaseQueryParameters)
-	kinds := convertSpanKinds(params.SpanKinds)
-
-	rows, err := r.conn.Query(ctx, query,
-		step, start, end, params.ServiceNames, kinds,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query error rates: %w", err)
-	}
-
-	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
+	return r.queryMetrics(ctx, metricsQueryConfig{
+		baseName:  "service_error_rate",
+		opName:    "service_operation_error_rate",
+		baseDesc:  "error rate, grouped by service",
+		baseQuery: sql.SelectErrorRates,
+		opQuery:   sql.SelectErrorRatesByOperation,
+	}, params.BaseQueryParameters)
 }
 
 func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
 	return 0, errNotImplemented
+}
+
+// queryMetrics executes a metrics query against ClickHouse and returns the
+// result as a MetricFamily. extraArgs are inserted between the step and the
+// time-window arguments (e.g. quantile for latencies).
+func (r *Reader) queryMetrics(
+	ctx context.Context,
+	cfg metricsQueryConfig,
+	base metricstore.BaseQueryParameters,
+	extraArgs ...any,
+) (*metrics.MetricFamily, error) {
+	name, desc := cfg.baseName, cfg.baseDesc
+	query := cfg.baseQuery
+	if base.GroupByOperation {
+		name = cfg.opName
+		desc += " & operation"
+		query = cfg.opQuery
+	}
+
+	start, end := queryWindow(base)
+	step := stepSeconds(base)
+	kinds := convertSpanKinds(base.SpanKinds)
+
+	args := make([]any, 0, 6)
+	args = append(args, step)
+	args = append(args, extraArgs...)
+	args = append(args, start, end, base.ServiceNames, kinds)
+
+	rows, err := r.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query %s: %w", name, err)
+	}
+	return rowsToMetricFamily(rows, name, desc, base.GroupByOperation)
 }
 
 // metricsKey groups metric points by service (and optionally operation).

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -34,24 +34,19 @@ func NewReader(conn driver.Conn) *Reader {
 	return &Reader{conn: conn}
 }
 
-// metricsQueryConfig holds the query-specific metadata that varies between
-// different metric types (latencies, error rates, call rates).
-type metricsQueryConfig struct {
-	baseName  string
-	opName    string
-	baseDesc  string
-	baseQuery string
-	opQuery   string
-}
-
 func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.LatenciesQueryParameters) (*metrics.MetricFamily, error) {
-	return r.queryMetrics(ctx, metricsQueryConfig{
+	base := params.BaseQueryParameters
+	start, end := queryWindow(base)
+	step := stepSeconds(base)
+	kinds := convertSpanKinds(base.SpanKinds)
+	return r.queryMetrics(ctx, metricsQuery{
 		baseName:  "service_latencies",
 		opName:    "service_operation_latencies",
 		baseDesc:  fmt.Sprintf("%.2fth quantile latency, grouped by service", params.Quantile),
 		baseQuery: sql.SelectLatencies,
 		opQuery:   sql.SelectLatenciesByOperation,
-	}, params.BaseQueryParameters, params.Quantile)
+		args:      []any{step, params.Quantile, start, end, base.ServiceNames, kinds},
+	}, base)
 }
 
 func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
@@ -59,50 +54,53 @@ func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParam
 }
 
 func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
-	return r.queryMetrics(ctx, metricsQueryConfig{
+	base := params.BaseQueryParameters
+	start, end := queryWindow(base)
+	step := stepSeconds(base)
+	kinds := convertSpanKinds(base.SpanKinds)
+	return r.queryMetrics(ctx, metricsQuery{
 		baseName:  "service_error_rate",
 		opName:    "service_operation_error_rate",
 		baseDesc:  "error rate, grouped by service",
 		baseQuery: sql.SelectErrorRates,
 		opQuery:   sql.SelectErrorRatesByOperation,
-	}, params.BaseQueryParameters)
+		args:      []any{step, start, end, base.ServiceNames, kinds},
+	}, base)
 }
 
 func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
 	return 0, errNotImplemented
 }
 
+type metricsQuery struct {
+	baseName  string
+	opName    string
+	baseDesc  string
+	baseQuery string
+	opQuery   string
+	args      []any
+}
+
 // queryMetrics executes a metrics query against ClickHouse and returns the
-// result as a MetricFamily. extraArgs are inserted between the step and the
-// time-window arguments (e.g. quantile for latencies).
+// result as a MetricFamily.
 func (r *Reader) queryMetrics(
 	ctx context.Context,
-	cfg metricsQueryConfig,
-	base metricstore.BaseQueryParameters,
-	extraArgs ...any,
+	cfg metricsQuery,
+	params metricstore.BaseQueryParameters,
 ) (*metrics.MetricFamily, error) {
 	name, desc := cfg.baseName, cfg.baseDesc
 	query := cfg.baseQuery
-	if base.GroupByOperation {
+	if params.GroupByOperation {
 		name = cfg.opName
 		desc += " & operation"
 		query = cfg.opQuery
 	}
 
-	start, end := queryWindow(base)
-	step := stepSeconds(base)
-	kinds := convertSpanKinds(base.SpanKinds)
-
-	args := make([]any, 0, 6)
-	args = append(args, step)
-	args = append(args, extraArgs...)
-	args = append(args, start, end, base.ServiceNames, kinds)
-
-	rows, err := r.conn.Query(ctx, query, args...)
+	rows, err := r.conn.Query(ctx, query, cfg.args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query %s: %w", name, err)
 	}
-	return rowsToMetricFamily(rows, name, desc, base.GroupByOperation)
+	return rowsToMetricFamily(rows, name, desc, params.GroupByOperation)
 }
 
 // metricsKey groups metric points by service (and optionally operation).

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -298,15 +298,16 @@ func TestGetErrorRates_MultipleServicesAndBuckets(t *testing.T) {
 }
 
 func TestGetErrorRates_GroupByOperation(t *testing.T) {
-	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
 	driver := &clickhousetest.Driver{
 		QueryResponses: map[string]*clickhousetest.QueryResponse{
 			sql.SelectErrorRatesByOperation: {
 				Rows: &clickhousetest.Rows[metricsRow]{
 					Data: []metricsRow{
-						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 0.03},
-						{Timestamp: ts, ServiceName: "frontend", Operation: "POST /api", Value: 0.12},
-						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 0.05},
+						{Timestamp: ts1, ServiceName: "frontend", Operation: "GET /api", Value: 0.03},
+						{Timestamp: ts1, ServiceName: "frontend", Operation: "POST /api", Value: 0.12},
+						{Timestamp: ts2, ServiceName: "frontend", Operation: "GET /api", Value: 0.05},
 					},
 					ScanFn: scanMetricsRowWithOpFn,
 				},

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -179,7 +179,7 @@ func TestGetLatencies_Errors(t *testing.T) {
 		{
 			name:     "query error",
 			response: &clickhousetest.QueryResponse{Err: assert.AnError},
-			err:      "failed to query latencies",
+			err:      "failed to query service_latencies",
 		},
 		{
 			name: "scan error",
@@ -353,7 +353,7 @@ func TestGetErrorRates_Errors(t *testing.T) {
 		{
 			name:     "query error",
 			response: &clickhousetest.QueryResponse{Err: assert.AnError},
-			err:      "failed to query error rates",
+			err:      "failed to query service_error_rate",
 		},
 		{
 			name: "scan error",

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -226,9 +226,169 @@ func TestGetCallRates(t *testing.T) {
 }
 
 func TestGetErrorRates(t *testing.T) {
-	reader := NewReader(&clickhousetest.Driver{})
-	_, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{})
-	require.ErrorIs(t, err, errNotImplemented)
+	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	driver := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectErrorRates: {
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data: []metricsRow{
+						{Timestamp: ts, ServiceName: "frontend", Value: 0.05},
+					},
+					ScanFn: scanMetricsRowFn,
+				},
+			},
+		},
+	}
+	reader := NewReader(driver)
+	result, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
+		BaseQueryParameters: testQueryParams,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "service_error_rate", result.Name)
+	require.Len(t, result.Metrics, 1)
+	require.Len(t, result.Metrics[0].Labels, 1)
+	require.Equal(t, "service_name", result.Metrics[0].Labels[0].Name)
+	require.Equal(t, "frontend", result.Metrics[0].Labels[0].Value)
+	require.Len(t, result.Metrics[0].MetricPoints, 1)
+	require.InDelta(t, 0.05, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+}
+
+func TestGetErrorRates_MultipleServicesAndBuckets(t *testing.T) {
+	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
+	driver := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectErrorRates: {
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data: []metricsRow{
+						{Timestamp: ts1, ServiceName: "frontend", Value: 0.10},
+						{Timestamp: ts2, ServiceName: "frontend", Value: 0.15},
+						{Timestamp: ts1, ServiceName: "backend", Value: 0.02},
+					},
+					ScanFn: scanMetricsRowFn,
+				},
+			},
+		},
+	}
+	reader := NewReader(driver)
+	params := testQueryParams
+	params.ServiceNames = []string{"frontend", "backend"}
+	result, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
+		BaseQueryParameters: params,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "service_error_rate", result.Name)
+	require.Len(t, result.Metrics, 2)
+
+	byService := make(map[string]*metrics.Metric, len(result.Metrics))
+	for _, m := range result.Metrics {
+		require.Len(t, m.Labels, 1)
+		assert.Equal(t, "service_name", m.Labels[0].Name)
+		byService[m.Labels[0].Value] = m
+	}
+
+	fe := byService["frontend"]
+	require.Len(t, fe.MetricPoints, 2)
+	assert.InDelta(t, 0.10, fe.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+	assert.InDelta(t, 0.15, fe.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
+
+	be := byService["backend"]
+	require.Len(t, be.MetricPoints, 1)
+	assert.InDelta(t, 0.02, be.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+}
+
+func TestGetErrorRates_GroupByOperation(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	driver := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectErrorRatesByOperation: {
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data: []metricsRow{
+						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 0.03},
+						{Timestamp: ts, ServiceName: "frontend", Operation: "POST /api", Value: 0.12},
+						{Timestamp: ts, ServiceName: "frontend", Operation: "GET /api", Value: 0.05},
+					},
+					ScanFn: scanMetricsRowWithOpFn,
+				},
+			},
+		},
+	}
+	reader := NewReader(driver)
+	params := testQueryParams
+	params.GroupByOperation = true
+	result, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
+		BaseQueryParameters: params,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "service_operation_error_rate", result.Name)
+	require.Contains(t, result.Help, "& operation")
+	require.Len(t, result.Metrics, 2)
+
+	byOp := make(map[string]*metrics.Metric, len(result.Metrics))
+	for _, m := range result.Metrics {
+		require.Len(t, m.Labels, 2)
+		assert.Equal(t, "service_name", m.Labels[0].Name)
+		assert.Equal(t, "frontend", m.Labels[0].Value)
+		assert.Equal(t, "operation", m.Labels[1].Name)
+		byOp[m.Labels[1].Value] = m
+	}
+
+	getAPI := byOp["GET /api"]
+	require.Len(t, getAPI.MetricPoints, 2)
+	assert.InDelta(t, 0.03, getAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+	assert.InDelta(t, 0.05, getAPI.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
+
+	postAPI := byOp["POST /api"]
+	require.Len(t, postAPI.MetricPoints, 1)
+	assert.InDelta(t, 0.12, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+}
+
+func TestGetErrorRates_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *clickhousetest.QueryResponse
+		err      string
+	}{
+		{
+			name:     "query error",
+			response: &clickhousetest.QueryResponse{Err: assert.AnError},
+			err:      "failed to query error rates",
+		},
+		{
+			name: "scan error",
+			response: &clickhousetest.QueryResponse{
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data:    []metricsRow{{ServiceName: "frontend"}},
+					ScanErr: assert.AnError,
+				},
+			},
+			err: "failed to scan metrics row",
+		},
+		{
+			name: "rows error",
+			response: &clickhousetest.QueryResponse{
+				Rows: &clickhousetest.Rows[metricsRow]{
+					Data:    []metricsRow{},
+					RowsErr: assert.AnError,
+				},
+			},
+			err: "error iterating metrics rows",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					sql.SelectErrorRates: tt.response,
+				},
+			}
+			reader := NewReader(driver)
+			_, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
+				BaseQueryParameters: testQueryParams,
+			})
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
 }
 
 func TestGetMinStepDuration(t *testing.T) {

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -332,6 +332,44 @@ GROUP BY
 ORDER BY
     ts`
 
+const SelectErrorRates = `
+SELECT
+    toStartOfInterval(start_time, toIntervalSecond(?)) AS ts,
+    service_name,
+    countIf(status_code = 'Error') / count(*) AS val
+FROM
+    spans
+WHERE
+    start_time >= ?
+    AND start_time < ?
+    AND service_name IN (?)
+    AND kind IN (?)
+GROUP BY
+    ts,
+    service_name
+ORDER BY
+    ts`
+
+const SelectErrorRatesByOperation = `
+SELECT
+    toStartOfInterval(start_time, toIntervalSecond(?)) AS ts,
+    service_name,
+    name,
+    countIf(status_code = 'Error') / count(*) AS val
+FROM
+    spans
+WHERE
+    start_time >= ?
+    AND start_time < ?
+    AND service_name IN (?)
+    AND kind IN (?)
+GROUP BY
+    ts,
+    service_name,
+    name
+ORDER BY
+    ts`
+
 //go:embed create_dependencies_table.sql
 var CreateDependenciesTable string
 


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #8313

## Description of the changes
- This PR in particular implements the `GetErrorRates` function for ClickHouse storage which gets error rate metrics based on the query parameters provided. 

## How was this change tested?
### Unit Tests
```
go test -run TestGetErrorRates ./internal/storage/v2/clickhouse/metricstore/...
```

### Manual Test

Spin up ClickHouse in a docker container

```
docker compose -f docker-compose/clickhouse/docker-compose.yml up 
```

Manually insert spans
```
docker exec clickhouse clickhouse-client --database=jaeger -q "INSERT INTO spans (id, trace_id, name, kind, start_time, status_code, duration, service_name) VALUES ('e01','t01','lets-go','server',now()-30,'Error',500000000,'tracegen'),('e02','t02','lets-go','server',now()-30,'Error',600000000,'tracegen'),('e03','t03','lets-go','server',now()-30,'Unset',400000000,'tracegen'),('e04','t04','lets-go','server',now()-90,'Error',550000000,'tracegen'),('e05','t05','lets-go','server',now()-90,'Unset',450000000,'tracegen'),('e06','t06','lets-go','server',now()-90,'Unset',700000000,'tracegen'),('e07','t07','lets-go','server',now()-90,'Unset',350000000,'tracegen'),('e08','t08','lets-go','server',now()-150,'Error',800000000,'tracegen'),('e09','t09','lets-go','server',now()-150,'Error',900000000,'tracegen'),('e10','t10','lets-go','server',now()-150,'Error',300000000,'tracegen')"
```

Run the following test
```go
func TestGetErrorRatesIntegration(t *testing.T) {
    ctx := context.Background()
    conn, err := clickhouse.Open(&clickhouse.Options{
        Addr: []string{"127.0.0.1:9000"},
        Auth: clickhouse.Auth{
            Database: "jaeger",
            Username: "default",
            Password: "password",
        },
        DialTimeout: 5 * time.Second,
    })
    require.NoError(t, err)
    defer conn.Close()

    reader := NewReader(conn)
    now := time.Now()
    step := 60 * time.Second
    result, err := reader.GetErrorRates(ctx, &metricstore.ErrorRateQueryParameters{
        BaseQueryParameters: metricstore.BaseQueryParameters{
            ServiceNames: []string{"tracegen"},
            EndTime:      &now,
            Lookback:     ptr(time.Hour),
            Step:         &step,
            SpanKinds:    []string{"SPAN_KIND_SERVER"},
        },
    })
    require.NoError(t, err)
    t.Logf("Error rates: name=%s, metrics=%d", result.Name, len(result.Metrics))
    for _, m := range result.Metrics {
        t.Logf("  labels=%v, points=%d", m.Labels, len(m.MetricPoints))
        for _, mp := range m.MetricPoints {
            t.Logf("    ts=%v val=%.4f", mp.Timestamp, mp.GetGaugeValue().GetDoubleValue())
        }
    }
}
```

See the following in the logs (3/3=1.0, 1/4=0.25, 2/3≈0.6667):
```
Error rates: name=service_error_rate, metrics=1
  labels=[name:"service_name" value:"tracegen" ], points=3
    ts=2026-04-21T03:20:00Z val=1.0000
    ts=2026-04-21T03:21:00Z val=0.2500
    ts=2026-04-21T03:22:00Z val=0.6667
```


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
