### PR TITLE
[clickhouse][spm] Implement `GetCallRates` for ClickHouse Storage

### DIFF
--- a/internal/storage/v2/clickhouse/clickhousetest/driver.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver.go
@@ -7,24 +7,18 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
-type TestRows interface {
-	driver.Rows
-	Reset()
-}
-
 type QueryResponse struct {
-	Rows TestRows
+	Rows driver.Rows
 	Err  error
 }
 
 func (r *QueryResponse) Reset() {
-	if r.Rows != nil {
-		r.Rows.Reset()
+	if rows, ok := r.Rows.(interface{ Reset() }); ok {
+		rows.Reset()
 	}
 }
 
@@ -33,10 +27,11 @@ type BatchResponse struct {
 	Err   error
 }
 
+// Driver is a test double for driver.Conn, which is an interface to manage connections to a ClickHouse database.
+// It returns pre-configured response entries matched by query substring.
 type Driver struct {
 	driver.Conn
 
-	T               *testing.T
 	QueryResponses  map[string]*QueryResponse
 	BatchResponses  map[string]*BatchResponse
 	RecordedQueries []string
@@ -64,8 +59,11 @@ func (d *Driver) PrepareBatch(
 ) (driver.Batch, error) {
 	d.RecordedQueries = append(d.RecordedQueries, query)
 
+	// Normalize whitespace so substring matching works regardless of indentation.
+	normalized := strings.Join(strings.Fields(query), " ")
 	for querySubstring, response := range d.BatchResponses {
-		if strings.Contains(query, querySubstring) {
+		normalizedSubstring := strings.Join(strings.Fields(querySubstring), " ")
+		if strings.Contains(normalized, normalizedSubstring) {
 			return response.Batch, response.Err
 		}
 	}
@@ -73,9 +71,10 @@ func (d *Driver) PrepareBatch(
 	return nil, nil
 }
 
+// Batch is a test double for driver.Batch, which is an interface
+// to allow inserting multiple rows in a single operation.
 type Batch struct {
 	driver.Batch
-	T          *testing.T
 	Appended   [][]any
 	AppendErr  error
 	SendCalled bool
@@ -102,6 +101,7 @@ func (*Batch) Close() error {
 	return nil
 }
 
+// Rows is a generic test double for driver.Rows, which is an interface representing a query response.
 type Rows[T any] struct {
 	driver.Rows
 
@@ -126,35 +126,35 @@ func (r *Rows[T]) Err() error {
 }
 
 func (r *Rows[T]) Next() bool {
-	return r.Index < len(r.Data)
+	if r.Index >= len(r.Data) {
+		return false
+	}
+	r.Index++
+	return true
 }
 
 func (r *Rows[T]) ScanStruct(dest any) error {
 	if r.ScanErr != nil {
 		return r.ScanErr
 	}
-	if r.Index >= len(r.Data) {
+	if r.Index <= 0 || r.Index > len(r.Data) {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
-		return errors.New("ScanFn is not provided")
+		return errors.New("scanFn is not provided")
 	}
-	err := r.ScanFn(dest, r.Data[r.Index])
-	r.Index++
-	return err
+	return r.ScanFn(dest, r.Data[r.Index-1])
 }
 
 func (r *Rows[T]) Scan(dest ...any) error {
 	if r.ScanErr != nil {
 		return r.ScanErr
 	}
-	if r.Index >= len(r.Data) {
+	if r.Index <= 0 || r.Index > len(r.Data) {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
-		return errors.New("ScanFn is not provided")
+		return errors.New("scanFn is not provided")
 	}
-	err := r.ScanFn(dest, r.Data[r.Index])
-	r.Index++
-	return err
+	return r.ScanFn(dest, r.Data[r.Index-1])
 }

--- a/internal/storage/v2/clickhouse/clickhousetest/driver.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver.go
@@ -7,13 +7,25 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
+type TestRows interface {
+	driver.Rows
+	Reset()
+}
+
 type QueryResponse struct {
-	Rows driver.Rows
+	Rows TestRows
 	Err  error
+}
+
+func (r *QueryResponse) Reset() {
+	if r.Rows != nil {
+		r.Rows.Reset()
+	}
 }
 
 type BatchResponse struct {
@@ -21,11 +33,10 @@ type BatchResponse struct {
 	Err   error
 }
 
-// Driver is a test double for driver.Conn, which is an interface to manage connections to a ClickHouse database.
-// It returns pre-configured response entries matched by query substring.
 type Driver struct {
 	driver.Conn
 
+	T               *testing.T
 	QueryResponses  map[string]*QueryResponse
 	BatchResponses  map[string]*BatchResponse
 	RecordedQueries []string
@@ -53,11 +64,8 @@ func (d *Driver) PrepareBatch(
 ) (driver.Batch, error) {
 	d.RecordedQueries = append(d.RecordedQueries, query)
 
-	// Normalize whitespace so substring matching works regardless of indentation.
-	normalized := strings.Join(strings.Fields(query), " ")
 	for querySubstring, response := range d.BatchResponses {
-		normalizedSubstring := strings.Join(strings.Fields(querySubstring), " ")
-		if strings.Contains(normalized, normalizedSubstring) {
+		if strings.Contains(query, querySubstring) {
 			return response.Batch, response.Err
 		}
 	}
@@ -65,10 +73,9 @@ func (d *Driver) PrepareBatch(
 	return nil, nil
 }
 
-// Batch is a test double for driver.Batch, which is an interface
-// to allow inserting multiple rows in a single operation.
 type Batch struct {
 	driver.Batch
+	T          *testing.T
 	Appended   [][]any
 	AppendErr  error
 	SendCalled bool
@@ -95,7 +102,6 @@ func (*Batch) Close() error {
 	return nil
 }
 
-// Rows is a generic test double for driver.Rows, which is an interface representing a query response.
 type Rows[T any] struct {
 	driver.Rows
 
@@ -107,6 +113,10 @@ type Rows[T any] struct {
 	RowsErr  error
 }
 
+func (r *Rows[T]) Reset() {
+	r.Index = 0
+}
+
 func (r *Rows[T]) Close() error {
 	return r.CloseErr
 }
@@ -116,35 +126,35 @@ func (r *Rows[T]) Err() error {
 }
 
 func (r *Rows[T]) Next() bool {
-	if r.Index >= len(r.Data) {
-		return false
-	}
-	r.Index++
-	return true
+	return r.Index < len(r.Data)
 }
 
 func (r *Rows[T]) ScanStruct(dest any) error {
 	if r.ScanErr != nil {
 		return r.ScanErr
 	}
-	if r.Index <= 0 || r.Index > len(r.Data) {
+	if r.Index >= len(r.Data) {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
-		return errors.New("scanFn is not provided")
+		return errors.New("ScanFn is not provided")
 	}
-	return r.ScanFn(dest, r.Data[r.Index-1])
+	err := r.ScanFn(dest, r.Data[r.Index])
+	r.Index++
+	return err
 }
 
 func (r *Rows[T]) Scan(dest ...any) error {
 	if r.ScanErr != nil {
 		return r.ScanErr
 	}
-	if r.Index <= 0 || r.Index > len(r.Data) {
+	if r.Index >= len(r.Data) {
 		return errors.New("no more rows")
 	}
 	if r.ScanFn == nil {
-		return errors.New("scanFn is not provided")
+		return errors.New("ScanFn is not provided")
 	}
-	return r.ScanFn(dest, r.Data[r.Index-1])
+	err := r.ScanFn(dest, r.Data[r.Index])
+	r.Index++
+	return err
 }

--- a/internal/storage/v2/clickhouse/clickhousetest/driver.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver.go
@@ -11,14 +11,19 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
+type TestRows interface {
+	driver.Rows
+	Reset()
+}
+
 type QueryResponse struct {
-	Rows driver.Rows
+	Rows TestRows
 	Err  error
 }
 
 func (r *QueryResponse) Reset() {
-	if rows, ok := r.Rows.(interface{ Reset() }); ok {
-		rows.Reset()
+	if r.Rows != nil {
+		r.Rows.Reset()
 	}
 }
 

--- a/internal/storage/v2/clickhouse/clickhousetest/driver_test.go
+++ b/internal/storage/v2/clickhouse/clickhousetest/driver_test.go
@@ -208,3 +208,25 @@ func TestRows_Scan_NilScanFn(t *testing.T) {
 	r.Next()
 	require.Error(t, r.Scan(nil))
 }
+
+func TestRows_Reset(t *testing.T) {
+	r := &Rows[string]{Data: []string{"a", "b"}}
+	assert.True(t, r.Next())
+	assert.True(t, r.Next())
+	assert.False(t, r.Next())
+	assert.Equal(t, 2, r.Index)
+	r.Reset()
+	assert.Equal(t, 0, r.Index)
+}
+
+func TestQueryResponse_Reset(t *testing.T) {
+	r := &Rows[string]{Data: []string{"a"}, Index: 1}
+	qr := &QueryResponse{Rows: r}
+	qr.Reset()
+	assert.Equal(t, 0, r.Index)
+}
+
+func TestQueryResponse_Reset_NilRows(t *testing.T) {
+	qr := &QueryResponse{}
+	require.NotPanics(t, func() { qr.Reset() })
+}

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -49,8 +49,19 @@ func (r *Reader) GetLatencies(ctx context.Context, params *metricstore.Latencies
 	}, base)
 }
 
-func (*Reader) GetCallRates(_ context.Context, _ *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
-	return nil, errNotImplemented
+func (r *Reader) GetCallRates(ctx context.Context, params *metricstore.CallRateQueryParameters) (*metrics.MetricFamily, error) {
+	base := params.BaseQueryParameters
+	start, end := queryWindow(base)
+	step := stepSeconds(base)
+	kinds := convertSpanKinds(base.SpanKinds)
+	return r.queryMetrics(ctx, metricsQuery{
+		baseName:  "service_call_rate",
+		opName:    "service_operation_call_rate",
+		baseDesc:  "calls/sec, grouped by service",
+		baseQuery: sql.SelectCallRates,
+		opQuery:   sql.SelectCallRatesByOperation,
+		args:      []any{step, step, start, end, base.ServiceNames, kinds},
+	}, base)
 }
 
 func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -92,7 +92,7 @@ var testCases = []testCase{
 	},
 }
 
-func TestMetricQueries_SingleService(t *testing.T) {
+func TestMetricStore_SingleService(t *testing.T) {
 	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
 	for _, mt := range testCases {
 		t.Run(mt.name, func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestMetricQueries_SingleService(t *testing.T) {
 	}
 }
 
-func TestMetricQueries_MultipleServicesAndBuckets(t *testing.T) {
+func TestMetricStore_MultipleServicesAndBuckets(t *testing.T) {
 	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
 	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
 	for _, mt := range testCases {
@@ -164,7 +164,7 @@ func TestMetricQueries_MultipleServicesAndBuckets(t *testing.T) {
 	}
 }
 
-func TestMetricQueries_GroupByOperation(t *testing.T) {
+func TestMetricStore_GroupByOperation(t *testing.T) {
 	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
 	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
 	for _, mt := range testCases {
@@ -211,7 +211,7 @@ func TestMetricQueries_GroupByOperation(t *testing.T) {
 	}
 }
 
-func TestMetricQueries_Errors(t *testing.T) {
+func TestMetricStore_Errors(t *testing.T) {
 	errorTests := []struct {
 		name     string
 		response *clickhousetest.QueryResponse

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -43,309 +43,176 @@ func scanMetricsRowWithOpFn(dest any, src metricsRow) error {
 	return nil
 }
 
-func TestGetLatencies(t *testing.T) {
-	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
-	driver := &clickhousetest.Driver{
-		QueryResponses: map[string]*clickhousetest.QueryResponse{
-			sql.SelectLatencies: {
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data: []metricsRow{
-						{Timestamp: ts, ServiceName: "frontend", Value: 150.5},
-					},
-					ScanFn: scanMetricsRowFn,
-				},
-			},
-		},
-	}
-	reader := NewReader(driver)
-	result, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
-		BaseQueryParameters: testQueryParams,
-		Quantile:            0.95,
-	})
-	require.NoError(t, err)
-	require.Len(t, result.Metrics, 1)
-	require.Equal(t, "service_latencies", result.Name)
-	require.Len(t, result.Metrics[0].Labels, 1)
-	require.Equal(t, "service_name", result.Metrics[0].Labels[0].Name)
-	require.Equal(t, "frontend", result.Metrics[0].Labels[0].Value)
-	require.Len(t, result.Metrics[0].MetricPoints, 1)
-	require.InDelta(t, 150.5, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+type testCase struct {
+	name      string // e.g. "Latencies"
+	baseQuery string // SQL query for base case
+	opQuery   string // SQL query for GroupByOperation case
+	baseName  string // expected MetricFamily.Name for base case
+	opName    string // expected MetricFamily.Name for GroupByOperation case
+	queryFn   func(*testing.T, *Reader, metricstore.BaseQueryParameters) (*metrics.MetricFamily, error)
 }
 
-func TestGetLatencies_MultipleServicesAndBuckets(t *testing.T) {
-	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
-	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
-	driver := &clickhousetest.Driver{
-		QueryResponses: map[string]*clickhousetest.QueryResponse{
-			sql.SelectLatencies: {
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data: []metricsRow{
-						{Timestamp: ts1, ServiceName: "frontend", Value: 100.0},
-						{Timestamp: ts2, ServiceName: "frontend", Value: 200.0},
-						{Timestamp: ts1, ServiceName: "backend", Value: 50.0},
-					},
-					ScanFn: scanMetricsRowFn,
-				},
-			},
-		},
-	}
-	reader := NewReader(driver)
-	params := testQueryParams
-	params.ServiceNames = []string{"frontend", "backend"}
-	result, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
-		BaseQueryParameters: params,
-		Quantile:            0.95,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "service_latencies", result.Name)
-	require.Len(t, result.Metrics, 2)
-
-	// Build a map of service -> metric points for order-independent assertions.
-	byService := make(map[string]*metrics.Metric, len(result.Metrics))
-	for _, m := range result.Metrics {
-		require.Len(t, m.Labels, 1)
-		assert.Equal(t, "service_name", m.Labels[0].Name)
-		byService[m.Labels[0].Value] = m
-	}
-
-	// frontend: two time buckets
-	fe := byService["frontend"]
-	require.Len(t, fe.MetricPoints, 2)
-	assert.InDelta(t, 100.0, fe.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
-	assert.InDelta(t, 200.0, fe.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
-
-	// backend: one time bucket
-	be := byService["backend"]
-	require.Len(t, be.MetricPoints, 1)
-	assert.InDelta(t, 50.0, be.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
-}
-
-func TestGetLatencies_GroupByOperation(t *testing.T) {
-	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
-	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
-	driver := &clickhousetest.Driver{
-		QueryResponses: map[string]*clickhousetest.QueryResponse{
-			sql.SelectLatenciesByOperation: {
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data: []metricsRow{
-						{Timestamp: ts1, ServiceName: "frontend", Operation: "GET /api", Value: 100.0},
-						{Timestamp: ts1, ServiceName: "frontend", Operation: "POST /api", Value: 250.0},
-						{Timestamp: ts2, ServiceName: "frontend", Operation: "GET /api", Value: 120.0},
-					},
-					ScanFn: scanMetricsRowWithOpFn,
-				},
-			},
-		},
-	}
-	reader := NewReader(driver)
-	params := testQueryParams
-	params.GroupByOperation = true
-	result, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
-		BaseQueryParameters: params,
-		Quantile:            0.95,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "service_operation_latencies", result.Name)
-	require.Len(t, result.Metrics, 2)
-
-	// Build a map of operation -> metric for order-independent assertions.
-	byOp := make(map[string]*metrics.Metric, len(result.Metrics))
-	for _, m := range result.Metrics {
-		require.Len(t, m.Labels, 2)
-		assert.Equal(t, "service_name", m.Labels[0].Name)
-		assert.Equal(t, "frontend", m.Labels[0].Value)
-		assert.Equal(t, "operation", m.Labels[1].Name)
-		byOp[m.Labels[1].Value] = m
-	}
-
-	// GET /api: two data points
-	getAPI := byOp["GET /api"]
-	require.Len(t, getAPI.MetricPoints, 2)
-	assert.InDelta(t, 100.0, getAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
-	assert.InDelta(t, 120.0, getAPI.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
-
-	// POST /api: one data point
-	postAPI := byOp["POST /api"]
-	require.Len(t, postAPI.MetricPoints, 1)
-	assert.InDelta(t, 250.0, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
-}
-
-func TestGetLatencies_Errors(t *testing.T) {
-	tests := []struct {
-		name     string
-		response *clickhousetest.QueryResponse
-		err      string
-	}{
-		{
-			name:     "query error",
-			response: &clickhousetest.QueryResponse{Err: assert.AnError},
-			err:      "failed to query service_latencies",
-		},
-		{
-			name: "scan error",
-			response: &clickhousetest.QueryResponse{
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data:    []metricsRow{{ServiceName: "frontend"}},
-					ScanErr: assert.AnError,
-				},
-			},
-			err: "failed to scan metrics row",
-		},
-		{
-			name: "rows error",
-			response: &clickhousetest.QueryResponse{
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data:    []metricsRow{},
-					RowsErr: assert.AnError,
-				},
-			},
-			err: "error iterating metrics rows",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			driver := &clickhousetest.Driver{
-				QueryResponses: map[string]*clickhousetest.QueryResponse{
-					sql.SelectLatencies: tt.response,
-				},
-			}
-			reader := NewReader(driver)
-			_, err := reader.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
-				BaseQueryParameters: testQueryParams,
+var testCases = []testCase{
+	{
+		name:      "Latencies",
+		baseQuery: sql.SelectLatencies,
+		opQuery:   sql.SelectLatenciesByOperation,
+		baseName:  "service_latencies",
+		opName:    "service_operation_latencies",
+		queryFn: func(t *testing.T, r *Reader, base metricstore.BaseQueryParameters) (*metrics.MetricFamily, error) {
+			return r.GetLatencies(t.Context(), &metricstore.LatenciesQueryParameters{
+				BaseQueryParameters: base,
 				Quantile:            0.95,
 			})
-			require.ErrorContains(t, err, tt.err)
+		},
+	},
+	{
+		name:      "CallRates",
+		baseQuery: sql.SelectCallRates,
+		opQuery:   sql.SelectCallRatesByOperation,
+		baseName:  "service_call_rate",
+		opName:    "service_operation_call_rate",
+		queryFn: func(t *testing.T, r *Reader, base metricstore.BaseQueryParameters) (*metrics.MetricFamily, error) {
+			return r.GetCallRates(t.Context(), &metricstore.CallRateQueryParameters{
+				BaseQueryParameters: base,
+			})
+		},
+	},
+	{
+		name:      "ErrorRates",
+		baseQuery: sql.SelectErrorRates,
+		opQuery:   sql.SelectErrorRatesByOperation,
+		baseName:  "service_error_rate",
+		opName:    "service_operation_error_rate",
+		queryFn: func(t *testing.T, r *Reader, base metricstore.BaseQueryParameters) (*metrics.MetricFamily, error) {
+			return r.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
+				BaseQueryParameters: base,
+			})
+		},
+	},
+}
+
+func TestMetricQueries_SingleService(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+	for _, mt := range testCases {
+		t.Run(mt.name, func(t *testing.T) {
+			driver := &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					mt.baseQuery: {
+						Rows: &clickhousetest.Rows[metricsRow]{
+							Data:   []metricsRow{{Timestamp: ts, ServiceName: "frontend", Value: 1.5}},
+							ScanFn: scanMetricsRowFn,
+						},
+					},
+				},
+			}
+			result, err := mt.queryFn(t, NewReader(driver), testQueryParams)
+			require.NoError(t, err)
+			require.Equal(t, mt.baseName, result.Name)
+			require.Len(t, result.Metrics, 1)
+			require.Len(t, result.Metrics[0].Labels, 1)
+			assert.Equal(t, "service_name", result.Metrics[0].Labels[0].Name)
+			assert.Equal(t, "frontend", result.Metrics[0].Labels[0].Value)
+			require.Len(t, result.Metrics[0].MetricPoints, 1)
+			assert.InDelta(t, 1.5, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 		})
 	}
 }
 
-func TestGetCallRates(t *testing.T) {
-	reader := NewReader(&clickhousetest.Driver{})
-	_, err := reader.GetCallRates(t.Context(), &metricstore.CallRateQueryParameters{})
-	require.ErrorIs(t, err, errNotImplemented)
-}
-
-func TestGetErrorRates(t *testing.T) {
-	ts := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
-	driver := &clickhousetest.Driver{
-		QueryResponses: map[string]*clickhousetest.QueryResponse{
-			sql.SelectErrorRates: {
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data: []metricsRow{
-						{Timestamp: ts, ServiceName: "frontend", Value: 0.05},
-					},
-					ScanFn: scanMetricsRowFn,
-				},
-			},
-		},
-	}
-	reader := NewReader(driver)
-	result, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
-		BaseQueryParameters: testQueryParams,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "service_error_rate", result.Name)
-	require.Len(t, result.Metrics, 1)
-	require.Len(t, result.Metrics[0].Labels, 1)
-	require.Equal(t, "service_name", result.Metrics[0].Labels[0].Name)
-	require.Equal(t, "frontend", result.Metrics[0].Labels[0].Value)
-	require.Len(t, result.Metrics[0].MetricPoints, 1)
-	require.InDelta(t, 0.05, result.Metrics[0].MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
-}
-
-func TestGetErrorRates_MultipleServicesAndBuckets(t *testing.T) {
+func TestMetricQueries_MultipleServicesAndBuckets(t *testing.T) {
 	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
 	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
-	driver := &clickhousetest.Driver{
-		QueryResponses: map[string]*clickhousetest.QueryResponse{
-			sql.SelectErrorRates: {
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data: []metricsRow{
-						{Timestamp: ts1, ServiceName: "frontend", Value: 0.10},
-						{Timestamp: ts2, ServiceName: "frontend", Value: 0.15},
-						{Timestamp: ts1, ServiceName: "backend", Value: 0.02},
+	for _, mt := range testCases {
+		t.Run(mt.name, func(t *testing.T) {
+			driver := &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					mt.baseQuery: {
+						Rows: &clickhousetest.Rows[metricsRow]{
+							Data: []metricsRow{
+								{Timestamp: ts1, ServiceName: "frontend", Value: 10.0},
+								{Timestamp: ts2, ServiceName: "frontend", Value: 20.0},
+								{Timestamp: ts1, ServiceName: "backend", Value: 5.0},
+							},
+							ScanFn: scanMetricsRowFn,
+						},
 					},
-					ScanFn: scanMetricsRowFn,
 				},
-			},
-		},
+			}
+			params := testQueryParams
+			params.ServiceNames = []string{"frontend", "backend"}
+			result, err := mt.queryFn(t, NewReader(driver), params)
+			require.NoError(t, err)
+			require.Equal(t, mt.baseName, result.Name)
+			require.Len(t, result.Metrics, 2)
+
+			byService := make(map[string]*metrics.Metric, len(result.Metrics))
+			for _, m := range result.Metrics {
+				require.Len(t, m.Labels, 1)
+				assert.Equal(t, "service_name", m.Labels[0].Name)
+				byService[m.Labels[0].Value] = m
+			}
+
+			fe := byService["frontend"]
+			require.Len(t, fe.MetricPoints, 2)
+			assert.InDelta(t, 10.0, fe.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+			assert.InDelta(t, 20.0, fe.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
+
+			be := byService["backend"]
+			require.Len(t, be.MetricPoints, 1)
+			assert.InDelta(t, 5.0, be.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+		})
 	}
-	reader := NewReader(driver)
-	params := testQueryParams
-	params.ServiceNames = []string{"frontend", "backend"}
-	result, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
-		BaseQueryParameters: params,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "service_error_rate", result.Name)
-	require.Len(t, result.Metrics, 2)
-
-	byService := make(map[string]*metrics.Metric, len(result.Metrics))
-	for _, m := range result.Metrics {
-		require.Len(t, m.Labels, 1)
-		assert.Equal(t, "service_name", m.Labels[0].Name)
-		byService[m.Labels[0].Value] = m
-	}
-
-	fe := byService["frontend"]
-	require.Len(t, fe.MetricPoints, 2)
-	assert.InDelta(t, 0.10, fe.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
-	assert.InDelta(t, 0.15, fe.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
-
-	be := byService["backend"]
-	require.Len(t, be.MetricPoints, 1)
-	assert.InDelta(t, 0.02, be.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 }
 
-func TestGetErrorRates_GroupByOperation(t *testing.T) {
+func TestMetricQueries_GroupByOperation(t *testing.T) {
 	ts1 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
 	ts2 := time.Date(2025, 1, 1, 11, 31, 0, 0, time.UTC)
-	driver := &clickhousetest.Driver{
-		QueryResponses: map[string]*clickhousetest.QueryResponse{
-			sql.SelectErrorRatesByOperation: {
-				Rows: &clickhousetest.Rows[metricsRow]{
-					Data: []metricsRow{
-						{Timestamp: ts1, ServiceName: "frontend", Operation: "GET /api", Value: 0.03},
-						{Timestamp: ts1, ServiceName: "frontend", Operation: "POST /api", Value: 0.12},
-						{Timestamp: ts2, ServiceName: "frontend", Operation: "GET /api", Value: 0.05},
+	for _, mt := range testCases {
+		t.Run(mt.name, func(t *testing.T) {
+			driver := &clickhousetest.Driver{
+				QueryResponses: map[string]*clickhousetest.QueryResponse{
+					mt.opQuery: {
+						Rows: &clickhousetest.Rows[metricsRow]{
+							Data: []metricsRow{
+								{Timestamp: ts1, ServiceName: "frontend", Operation: "GET /api", Value: 100.0},
+								{Timestamp: ts1, ServiceName: "frontend", Operation: "POST /api", Value: 250.0},
+								{Timestamp: ts2, ServiceName: "frontend", Operation: "GET /api", Value: 120.0},
+							},
+							ScanFn: scanMetricsRowWithOpFn,
+						},
 					},
-					ScanFn: scanMetricsRowWithOpFn,
 				},
-			},
-		},
+			}
+			params := testQueryParams
+			params.GroupByOperation = true
+			result, err := mt.queryFn(t, NewReader(driver), params)
+			require.NoError(t, err)
+			require.Equal(t, mt.opName, result.Name)
+			require.Len(t, result.Metrics, 2)
+
+			byOp := make(map[string]*metrics.Metric, len(result.Metrics))
+			for _, m := range result.Metrics {
+				require.Len(t, m.Labels, 2)
+				assert.Equal(t, "service_name", m.Labels[0].Name)
+				assert.Equal(t, "frontend", m.Labels[0].Value)
+				assert.Equal(t, "operation", m.Labels[1].Name)
+				byOp[m.Labels[1].Value] = m
+			}
+
+			getAPI := byOp["GET /api"]
+			require.Len(t, getAPI.MetricPoints, 2)
+			assert.InDelta(t, 100.0, getAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+			assert.InDelta(t, 120.0, getAPI.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
+
+			postAPI := byOp["POST /api"]
+			require.Len(t, postAPI.MetricPoints, 1)
+			assert.InDelta(t, 250.0, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
+		})
 	}
-	reader := NewReader(driver)
-	params := testQueryParams
-	params.GroupByOperation = true
-	result, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
-		BaseQueryParameters: params,
-	})
-	require.NoError(t, err)
-	require.Equal(t, "service_operation_error_rate", result.Name)
-	require.Contains(t, result.Help, "& operation")
-	require.Len(t, result.Metrics, 2)
-
-	byOp := make(map[string]*metrics.Metric, len(result.Metrics))
-	for _, m := range result.Metrics {
-		require.Len(t, m.Labels, 2)
-		assert.Equal(t, "service_name", m.Labels[0].Name)
-		assert.Equal(t, "frontend", m.Labels[0].Value)
-		assert.Equal(t, "operation", m.Labels[1].Name)
-		byOp[m.Labels[1].Value] = m
-	}
-
-	getAPI := byOp["GET /api"]
-	require.Len(t, getAPI.MetricPoints, 2)
-	assert.InDelta(t, 0.03, getAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
-	assert.InDelta(t, 0.05, getAPI.MetricPoints[1].GetGaugeValue().GetDoubleValue(), 0.001)
-
-	postAPI := byOp["POST /api"]
-	require.Len(t, postAPI.MetricPoints, 1)
-	assert.InDelta(t, 0.12, postAPI.MetricPoints[0].GetGaugeValue().GetDoubleValue(), 0.001)
 }
 
-func TestGetErrorRates_Errors(t *testing.T) {
-	tests := []struct {
+func TestMetricQueries_Errors(t *testing.T) {
+	errorTests := []struct {
 		name     string
 		response *clickhousetest.QueryResponse
 		err      string
@@ -353,7 +220,7 @@ func TestGetErrorRates_Errors(t *testing.T) {
 		{
 			name:     "query error",
 			response: &clickhousetest.QueryResponse{Err: assert.AnError},
-			err:      "failed to query service_error_rate",
+			err:      "failed to query",
 		},
 		{
 			name: "scan error",
@@ -376,18 +243,20 @@ func TestGetErrorRates_Errors(t *testing.T) {
 			err: "error iterating metrics rows",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			driver := &clickhousetest.Driver{
-				QueryResponses: map[string]*clickhousetest.QueryResponse{
-					sql.SelectErrorRates: tt.response,
-				},
+	for _, mt := range testCases {
+		t.Run(mt.name, func(t *testing.T) {
+			for _, tt := range errorTests {
+				t.Run(tt.name, func(t *testing.T) {
+					t.Cleanup(tt.response.Reset)
+					driver := &clickhousetest.Driver{
+						QueryResponses: map[string]*clickhousetest.QueryResponse{
+							mt.baseQuery: tt.response,
+						},
+					}
+					_, err := mt.queryFn(t, NewReader(driver), testQueryParams)
+					require.ErrorContains(t, err, tt.err)
+				})
 			}
-			reader := NewReader(driver)
-			_, err := reader.GetErrorRates(t.Context(), &metricstore.ErrorRateQueryParameters{
-				BaseQueryParameters: testQueryParams,
-			})
-			require.ErrorContains(t, err, tt.err)
 		})
 	}
 }

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -332,6 +332,44 @@ GROUP BY
 ORDER BY
     ts`
 
+const SelectCallRates = `
+SELECT
+    toStartOfInterval(start_time, toIntervalSecond(?)) AS ts,
+    service_name,
+    count(*) / ? AS val
+FROM
+    spans
+WHERE
+    start_time >= ?
+    AND start_time < ?
+    AND service_name IN (?)
+    AND kind IN (?)
+GROUP BY
+    ts,
+    service_name
+ORDER BY
+    ts`
+
+const SelectCallRatesByOperation = `
+SELECT
+    toStartOfInterval(start_time, toIntervalSecond(?)) AS ts,
+    service_name,
+    name,
+    count(*) / ? AS val
+FROM
+    spans
+WHERE
+    start_time >= ?
+    AND start_time < ?
+    AND service_name IN (?)
+    AND kind IN (?)
+GROUP BY
+    ts,
+    service_name,
+    name
+ORDER BY
+    ts`
+
 const SelectErrorRates = `
 SELECT
     toStartOfInterval(start_time, toIntervalSecond(?)) AS ts,


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #8313

## Description of the changes
- This PR implements the `GetCallRates` function for ClickHouse storage which calculates the calls/second based on the query parameters provided. 

## How was this change tested?
### Unit Tests
```
go test -run TestMetricStore ./internal/storage/v2/clickhouse/metricstore/...
```

### Manual Test
Spin up ClickHouse in a docker container
```
docker compose -f docker-compose/clickhouse/docker-compose.yml up
```

Start jaeger
```
go run ./cmd/jaeger --config cmd/jaeger/config-clickhouse.yaml --feature-gates=storage.clickhouse
```

Generate ~1 span / sec
```
go run ./cmd/tracegen -traces 120 -pause 1s
```

Run the following test
```go
func TestGetCallRatesIntegration(t *testing.T) {
	ctx := context.Background()
	conn, err := clickhouse.Open(&clickhouse.Options{
		Addr: []string{"127.0.0.1:9000"},
		Auth: clickhouse.Auth{
			Database: "jaeger",
			Username: "default",
			Password: "password",
		},
		DialTimeout: 5 * time.Second,
	})
	require.NoError(t, err)
	defer conn.Close()

	reader := NewReader(conn)
	now := time.Now()
	step := 60 * time.Second
	result, err := reader.GetCallRates(ctx, &metricstore.CallRateQueryParameters{
		BaseQueryParameters: metricstore.BaseQueryParameters{
			ServiceNames: []string{"tracegen"},
			EndTime:      &now,
			Lookback:     ptr(time.Hour),
			Step:         &step,
			SpanKinds:    []string{"SPAN_KIND_SERVER"},
		},
	})
	require.NoError(t, err)
	t.Logf("Call rates: name=%s, metrics=%d", result.Name, len(result.Metrics))
	for _, m := range result.Metrics {
		t.Logf("  labels=%v, points=%d", m.Labels, len(m.MetricPoints))
		for _, mp := range m.MetricPoints {
			t.Logf("    ts=%v val=%.4f calls/sec", mp.Timestamp, mp.GetGaugeValue().GetDoubleValue())
		}
	}
}
```

See the following results (1st and 3rd bucket got split but add up to 1 call/sec)
```
Call rates: name=service_call_rate, metrics=1
labels=[name:"service_name" value:"tracegen" ], points=3
ts=2026-04-22T03:56:00Z val=0.3667 calls/sec
ts=2026-04-22T03:57:00Z val=1.0000 calls/sec
ts=2026-04-22T03:58:00Z val=0.6333 calls/sec
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
