### PR TITLE
[clickhouse][spm] Implement `GetMinStepDuration` for ClickHouse Storage

### DIFF
--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -5,7 +5,6 @@ package metricstore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -19,9 +18,8 @@ import (
 
 var _ metricstore.Reader = (*Reader)(nil)
 
-var errNotImplemented = errors.New("not implemented")
-
 const (
+	minStep            = time.Millisecond
 	defaultLookback    = time.Hour
 	defaultStepSeconds = uint64(60)
 )
@@ -80,7 +78,7 @@ func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRat
 }
 
 func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	return 0, errNotImplemented
+	return minStep, nil
 }
 
 type metricsQuery struct {

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -263,8 +263,9 @@ func TestMetricStore_Errors(t *testing.T) {
 
 func TestGetMinStepDuration(t *testing.T) {
 	reader := NewReader(&clickhousetest.Driver{})
-	_, err := reader.GetMinStepDuration(t.Context(), &metricstore.MinStepDurationQueryParameters{})
-	require.ErrorIs(t, err, errNotImplemented)
+	minStep, err := reader.GetMinStepDuration(t.Context(), &metricstore.MinStepDurationQueryParameters{})
+	require.NoError(t, err)
+	assert.Equal(t, time.Millisecond, minStep)
 }
 
 func TestStepSeconds(t *testing.T) {


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Towards #8313

## Description of the changes
- Implement `GetMinStepDuration` for ClickHouse storage. Returns the same value as Prometheus and ES backends. This function just returns the smallest time resolution supported by ClickHouse. 

## How was this change tested?
- Unit tests 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
