### PR TITLE
[metricstore] Remove min step API from metricstore

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -379,18 +379,6 @@ func (aH *APIHandler) errors(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (aH *APIHandler) minStep(w http.ResponseWriter, r *http.Request) {
-	minStep, err := aH.metricsQueryService.GetMinStepDuration(r.Context(), &metricstore.MinStepDurationQueryParameters{})
-	if aH.handleError(w, err, http.StatusInternalServerError) {
-		return
-	}
-
-	structuredRes := structuredResponse{
-		Data: minStep.Milliseconds(),
-	}
-	aH.writeJSON(w, r, &structuredRes)
-}
-
 func (aH *APIHandler) metrics(w http.ResponseWriter, r *http.Request, getMetrics func(context.Context, metricstore.BaseQueryParameters) (*metrics.MetricFamily, error)) {
 	requestParams, err := aH.queryParser.parseMetricsQueryParams(r)
 	if aH.handleError(w, err, http.StatusBadRequest) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -119,7 +119,6 @@ func (aH *APIHandler) RegisterRoutes(router *http.ServeMux) {
 	aH.handleFunc(router, aH.latencies, http.MethodGet, "/metrics/latencies")
 	aH.handleFunc(router, aH.calls, http.MethodGet, "/metrics/calls")
 	aH.handleFunc(router, aH.errors, http.MethodGet, "/metrics/errors")
-	aH.handleFunc(router, aH.minStep, http.MethodGet, "/metrics/minstep")
 	aH.handleFunc(router, aH.getQualityMetrics, http.MethodGet, "/quality-metrics")
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -1010,11 +1010,6 @@ func TestMetricsQueryDisabled(t *testing.T) {
 			urlPath:          "/api/metrics/latencies?service=emailservice&quantile=0.95",
 			wantErrorMessage: "metrics querying is currently disabled",
 		},
-		{
-			name:             "metrics query disabled error returned when fetching min step duration",
-			urlPath:          "/api/metrics/minstep",
-			wantErrorMessage: "metrics querying is currently disabled",
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -974,13 +974,6 @@ func TestMetricsReaderError(t *testing.T) {
 			mockedResponse:             nil,
 			wantErrorMessage:           "error fetching call rates",
 		},
-		{
-			urlPath:                    "/api/metrics/minstep",
-			mockedQueryMethod:          "GetMinStepDuration",
-			mockedQueryMethodParamType: "*metricstore.MinStepDurationQueryParameters",
-			mockedResponse:             time.Duration(0),
-			wantErrorMessage:           "error fetching min step duration",
-		},
 	} {
 		t.Run(tc.wantErrorMessage, func(t *testing.T) {
 			// Prepare
@@ -1032,26 +1025,6 @@ func TestMetricsQueryDisabled(t *testing.T) {
 			assert.ErrorContains(t, err, tc.wantErrorMessage)
 		})
 	}
-}
-
-func TestGetMinStep(t *testing.T) {
-	metricsReader := &metricsmocks.Reader{}
-	ts := initializeTestServer(t, HandlerOptions.MetricsQueryService(metricsReader))
-	defer ts.server.Close()
-	// Prepare
-	metricsReader.On(
-		"GetMinStepDuration",
-		mock.Anything,
-		mock.AnythingOfType("*metricstore.MinStepDurationQueryParameters"),
-	).Return(5*time.Millisecond, nil).Once()
-
-	// Test
-	var response structuredResponse
-	err := getJSON(ts.server.URL+"/api/metrics/minstep", &response)
-
-	// Verify
-	require.NoError(t, err)
-	assert.InDelta(t, float64(5), response.Data, 0.01)
 }
 
 // getJSON fetches a JSON document from a server via HTTP GET

--- a/internal/storage/metricstore/disabled/reader.go
+++ b/internal/storage/metricstore/disabled/reader.go
@@ -5,7 +5,6 @@ package disabled
 
 import (
 	"context"
-	"time"
 
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
@@ -45,9 +44,4 @@ func (*MetricsReader) GetCallRates(context.Context, *metricstore.CallRateQueryPa
 // GetErrorRates gets the error rate metrics for the given set of error rate query parameters.
 func (*MetricsReader) GetErrorRates(context.Context, *metricstore.ErrorRateQueryParameters) (*metrics.MetricFamily, error) {
 	return nil, ErrDisabled
-}
-
-// GetMinStepDuration gets the minimum step duration (the smallest possible duration between two data points in a time series) supported.
-func (*MetricsReader) GetMinStepDuration(context.Context, *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	return 0, ErrDisabled
 }

--- a/internal/storage/metricstore/disabled/reader_test.go
+++ b/internal/storage/metricstore/disabled/reader_test.go
@@ -48,15 +48,3 @@ func TestGetErrorRates(t *testing.T) {
 	require.ErrorIs(t, err, ErrDisabled)
 	require.EqualError(t, err, ErrDisabled.Error())
 }
-
-func TestGetMinStepDurations(t *testing.T) {
-	reader, err := NewMetricsReader()
-	require.NoError(t, err)
-	require.NotNil(t, reader)
-
-	qParams := &metricstore.MinStepDurationQueryParameters{}
-	r, err := reader.GetMinStepDuration(context.Background(), qParams)
-	assert.Zero(t, r)
-	require.ErrorIs(t, err, ErrDisabled)
-	require.EqualError(t, err, ErrDisabled.Error())
-}

--- a/internal/storage/metricstore/elasticsearch/reader.go
+++ b/internal/storage/metricstore/elasticsearch/reader.go
@@ -20,8 +20,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
 
-const minStep = time.Millisecond
-
 // MetricsReader orchestrates metrics queries by:
 // 1. Calculating time ranges from query parameters.
 // 2. Delegating query construction and execution to Query.
@@ -164,11 +162,6 @@ func (r MetricsReader) GetErrorRates(ctx context.Context, params *metricstore.Er
 	}
 
 	return CalculateErrorRates(rawErrorsMetrics, callRateMetrics, params.BaseQueryParameters, timeRange), nil
-}
-
-// GetMinStepDuration returns the minimum step duration.
-func (MetricsReader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	return minStep, nil
 }
 
 // bucketsToPoints is a helper function for getting points value from ES AGG bucket

--- a/internal/storage/metricstore/elasticsearch/reader_test.go
+++ b/internal/storage/metricstore/elasticsearch/reader_test.go
@@ -878,15 +878,6 @@ func TestGetErrorRates(t *testing.T) {
 	}
 }
 
-func TestGetMinStepDuration(t *testing.T) {
-	mockServer := startMockEsServer(t, "", mockEsValidResponse)
-	defer mockServer.Close()
-	reader, _ := setupMetricsReaderFromServer(t, mockServer)
-	minStep, err := reader.GetMinStepDuration(context.Background(), &metricstore.MinStepDurationQueryParameters{})
-	require.NoError(t, err)
-	assert.Equal(t, time.Millisecond, minStep)
-}
-
 func TestGetCallRateBucketsToPoints_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/storage/metricstore/prometheus/metricstore/reader.go
+++ b/internal/storage/metricstore/prometheus/metricstore/reader.go
@@ -30,10 +30,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
 )
 
-const (
-	minStep = time.Millisecond
-)
-
 type (
 	// MetricsReader is a Prometheus metrics reader.
 	MetricsReader struct {
@@ -252,11 +248,6 @@ func (m MetricsReader) GetErrorRates(ctx context.Context, requestParams *metrics
 
 	errorMetrics.Metrics = zeroErrorMetrics
 	return errorMetrics, nil
-}
-
-// GetMinStepDuration gets the minimum step duration (the smallest possible duration between two data points in a time series) supported.
-func (MetricsReader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	return minStep, nil
 }
 
 // executeQuery executes a query against a Prometheus-compliant metrics backend.

--- a/internal/storage/metricstore/prometheus/metricstore/reader_test.go
+++ b/internal/storage/metricstore/prometheus/metricstore/reader_test.go
@@ -6,7 +6,6 @@ package metricstore
 import (
 	"context"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -89,26 +88,6 @@ func TestNewMetricsReaderInvalidAddress(t *testing.T) {
 	}, logger, tracer, nil)
 	require.Error(t, err)
 	assert.Nil(t, reader)
-}
-
-func TestGetMinStepDuration(t *testing.T) {
-	params := metricstore.MinStepDurationQueryParameters{}
-	logger := zap.NewNop()
-	tracer, _, closer := tracerProvider(t)
-	defer closer()
-	listener, err := net.Listen("tcp", "localhost:")
-	require.NoError(t, err)
-	assert.NotNil(t, listener)
-
-	reader, err := NewMetricsReader(config.Configuration{
-		ServerURL:      "http://" + listener.Addr().String(),
-		ConnectTimeout: defaultTimeout,
-	}, logger, tracer, nil)
-	require.NoError(t, err)
-
-	minStep, err := reader.GetMinStepDuration(context.Background(), &params)
-	require.NoError(t, err)
-	assert.Equal(t, time.Millisecond, minStep)
 }
 
 func TestMetricsServerError(t *testing.T) {

--- a/internal/storage/v1/api/metricstore/interface.go
+++ b/internal/storage/v1/api/metricstore/interface.go
@@ -66,6 +66,3 @@ type CallRateQueryParameters struct {
 type ErrorRateQueryParameters struct {
 	BaseQueryParameters
 }
-
-// MinStepDurationQueryParameters contains the parameters required for fetching the minimum step duration.
-type MinStepDurationQueryParameters struct{}

--- a/internal/storage/v1/api/metricstore/interface.go
+++ b/internal/storage/v1/api/metricstore/interface.go
@@ -21,9 +21,6 @@ type Reader interface {
 	// GetErrorRates gets the error rate metrics for a given list of services grouped by service
 	// and optionally grouped by operation.
 	GetErrorRates(ctx context.Context, params *ErrorRateQueryParameters) (*metrics.MetricFamily, error)
-	// GetMinStepDuration gets the min time resolution supported by the backing metrics store,
-	// e.g. 10s means the backend can only return data points that are at least 10s apart, not closer.
-	GetMinStepDuration(ctx context.Context, params *MinStepDurationQueryParameters) (time.Duration, error)
 }
 
 // BaseQueryParameters contains the common set of parameters used by all metrics queries:

--- a/internal/storage/v1/api/metricstore/metricstoremetrics/decorator.go
+++ b/internal/storage/v1/api/metricstore/metricstoremetrics/decorator.go
@@ -14,11 +14,10 @@ import (
 
 // ReadMetricsDecorator wraps a metricstore.Reader and collects metrics around each read operation.
 type ReadMetricsDecorator struct {
-	reader                    metricstore.Reader
-	getLatenciesMetrics       *queryMetrics
-	getCallRatesMetrics       *queryMetrics
-	getErrorRatesMetrics      *queryMetrics
-	getMinStepDurationMetrics *queryMetrics
+	reader               metricstore.Reader
+	getLatenciesMetrics  *queryMetrics
+	getCallRatesMetrics  *queryMetrics
+	getErrorRatesMetrics *queryMetrics
 }
 
 type queryMetrics struct {
@@ -41,11 +40,10 @@ func (q *queryMetrics) emit(err error, latency time.Duration) {
 // NewReadMetricsDecorator returns a new ReadMetricsDecorator.
 func NewReaderDecorator(reader metricstore.Reader, metricsFactory metrics.Factory) *ReadMetricsDecorator {
 	return &ReadMetricsDecorator{
-		reader:                    reader,
-		getLatenciesMetrics:       buildQueryMetrics("get_latencies", metricsFactory),
-		getCallRatesMetrics:       buildQueryMetrics("get_call_rates", metricsFactory),
-		getErrorRatesMetrics:      buildQueryMetrics("get_error_rates", metricsFactory),
-		getMinStepDurationMetrics: buildQueryMetrics("get_min_step_duration", metricsFactory),
+		reader:               reader,
+		getLatenciesMetrics:  buildQueryMetrics("get_latencies", metricsFactory),
+		getCallRatesMetrics:  buildQueryMetrics("get_call_rates", metricsFactory),
+		getErrorRatesMetrics: buildQueryMetrics("get_error_rates", metricsFactory),
 	}
 }
 
@@ -77,13 +75,5 @@ func (m *ReadMetricsDecorator) GetErrorRates(ctx context.Context, params *metric
 	start := time.Now()
 	retMe, err := m.reader.GetErrorRates(ctx, params)
 	m.getErrorRatesMetrics.emit(err, time.Since(start))
-	return retMe, err
-}
-
-// GetMinStepDuration implements metricstore.Reader#GetMinStepDuration
-func (m *ReadMetricsDecorator) GetMinStepDuration(ctx context.Context, params *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	start := time.Now()
-	retMe, err := m.reader.GetMinStepDuration(ctx, params)
-	m.getMinStepDurationMetrics.emit(err, time.Since(start))
 	return retMe, err
 }

--- a/internal/storage/v1/api/metricstore/metricstoremetrics/decorator_test.go
+++ b/internal/storage/v1/api/metricstore/metricstoremetrics/decorator_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -38,11 +37,6 @@ func TestSuccessfulUnderlyingCalls(t *testing.T) {
 	mockReader.On("GetErrorRates", context.Background(), gerParams).
 		Return(&protometrics.MetricFamily{}, nil)
 	mrs.GetErrorRates(context.Background(), gerParams)
-
-	msdParams := &metricstore.MinStepDurationQueryParameters{}
-	mockReader.On("GetMinStepDuration", context.Background(), msdParams).
-		Return(time.Second, nil)
-	mrs.GetMinStepDuration(context.Background(), msdParams)
 
 	counters, gauges := mf.Snapshot()
 	wantCounts := map[string]int64{
@@ -111,11 +105,6 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 	mockReader.On("GetErrorRates", context.Background(), gerParams).
 		Return(&protometrics.MetricFamily{}, errors.New("failure"))
 	mrs.GetErrorRates(context.Background(), gerParams)
-
-	msdParams := &metricstore.MinStepDurationQueryParameters{}
-	mockReader.On("GetMinStepDuration", context.Background(), msdParams).
-		Return(time.Second, errors.New("failure"))
-	mrs.GetMinStepDuration(context.Background(), msdParams)
 
 	counters, gauges := mf.Snapshot()
 	wantCounts := map[string]int64{

--- a/internal/storage/v1/api/metricstore/metricstoremetrics/decorator_test.go
+++ b/internal/storage/v1/api/metricstore/metricstoremetrics/decorator_test.go
@@ -40,14 +40,12 @@ func TestSuccessfulUnderlyingCalls(t *testing.T) {
 
 	counters, gauges := mf.Snapshot()
 	wantCounts := map[string]int64{
-		"requests|operation=get_latencies|result=ok":          1,
-		"requests|operation=get_latencies|result=err":         0,
-		"requests|operation=get_call_rates|result=ok":         1,
-		"requests|operation=get_call_rates|result=err":        0,
-		"requests|operation=get_error_rates|result=ok":        1,
-		"requests|operation=get_error_rates|result=err":       0,
-		"requests|operation=get_min_step_duration|result=ok":  1,
-		"requests|operation=get_min_step_duration|result=err": 0,
+		"requests|operation=get_latencies|result=ok":    1,
+		"requests|operation=get_latencies|result=err":   0,
+		"requests|operation=get_call_rates|result=ok":   1,
+		"requests|operation=get_call_rates|result=err":  0,
+		"requests|operation=get_error_rates|result=ok":  1,
+		"requests|operation=get_error_rates|result=err": 0,
 	}
 
 	// This is not exhaustive.
@@ -108,14 +106,12 @@ func TestFailingUnderlyingCalls(t *testing.T) {
 
 	counters, gauges := mf.Snapshot()
 	wantCounts := map[string]int64{
-		"requests|operation=get_latencies|result=ok":          0,
-		"requests|operation=get_latencies|result=err":         1,
-		"requests|operation=get_call_rates|result=ok":         0,
-		"requests|operation=get_call_rates|result=err":        1,
-		"requests|operation=get_error_rates|result=ok":        0,
-		"requests|operation=get_error_rates|result=err":       1,
-		"requests|operation=get_min_step_duration|result=ok":  0,
-		"requests|operation=get_min_step_duration|result=err": 1,
+		"requests|operation=get_latencies|result=ok":    0,
+		"requests|operation=get_latencies|result=err":   1,
+		"requests|operation=get_call_rates|result=ok":   0,
+		"requests|operation=get_call_rates|result=err":  1,
+		"requests|operation=get_error_rates|result=ok":  0,
+		"requests|operation=get_error_rates|result=err": 1,
 	}
 
 	// This is not exhaustive.

--- a/internal/storage/v1/api/metricstore/mocks/mocks.go
+++ b/internal/storage/v1/api/metricstore/mocks/mocks.go
@@ -11,7 +11,6 @@ package mocks
 
 import (
 	"context"
-	"time"
 
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
@@ -245,72 +244,6 @@ func (_c *Reader_GetLatencies_Call) Return(metricFamily *metrics.MetricFamily, e
 }
 
 func (_c *Reader_GetLatencies_Call) RunAndReturn(run func(ctx context.Context, params *metricstore.LatenciesQueryParameters) (*metrics.MetricFamily, error)) *Reader_GetLatencies_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetMinStepDuration provides a mock function for the type Reader
-func (_mock *Reader) GetMinStepDuration(ctx context.Context, params *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	ret := _mock.Called(ctx, params)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetMinStepDuration")
-	}
-
-	var r0 time.Duration
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *metricstore.MinStepDurationQueryParameters) (time.Duration, error)); ok {
-		return returnFunc(ctx, params)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *metricstore.MinStepDurationQueryParameters) time.Duration); ok {
-		r0 = returnFunc(ctx, params)
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *metricstore.MinStepDurationQueryParameters) error); ok {
-		r1 = returnFunc(ctx, params)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// Reader_GetMinStepDuration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMinStepDuration'
-type Reader_GetMinStepDuration_Call struct {
-	*mock.Call
-}
-
-// GetMinStepDuration is a helper method to define mock.On call
-//   - ctx context.Context
-//   - params *metricstore.MinStepDurationQueryParameters
-func (_e *Reader_Expecter) GetMinStepDuration(ctx interface{}, params interface{}) *Reader_GetMinStepDuration_Call {
-	return &Reader_GetMinStepDuration_Call{Call: _e.mock.On("GetMinStepDuration", ctx, params)}
-}
-
-func (_c *Reader_GetMinStepDuration_Call) Run(run func(ctx context.Context, params *metricstore.MinStepDurationQueryParameters)) *Reader_GetMinStepDuration_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 *metricstore.MinStepDurationQueryParameters
-		if args[1] != nil {
-			arg1 = args[1].(*metricstore.MinStepDurationQueryParameters)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *Reader_GetMinStepDuration_Call) Return(duration time.Duration, err error) *Reader_GetMinStepDuration_Call {
-	_c.Call.Return(duration, err)
-	return _c
-}
-
-func (_c *Reader_GetMinStepDuration_Call) RunAndReturn(run func(ctx context.Context, params *metricstore.MinStepDurationQueryParameters) (time.Duration, error)) *Reader_GetMinStepDuration_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/storage/v2/clickhouse/metricstore/reader.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader.go
@@ -5,7 +5,6 @@ package metricstore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -18,8 +17,6 @@ import (
 )
 
 var _ metricstore.Reader = (*Reader)(nil)
-
-var errNotImplemented = errors.New("not implemented")
 
 const (
 	defaultLookback    = time.Hour
@@ -77,10 +74,6 @@ func (r *Reader) GetErrorRates(ctx context.Context, params *metricstore.ErrorRat
 		opQuery:   sql.SelectErrorRatesByOperation,
 		args:      []any{step, start, end, base.ServiceNames, kinds},
 	}, base)
-}
-
-func (*Reader) GetMinStepDuration(_ context.Context, _ *metricstore.MinStepDurationQueryParameters) (time.Duration, error) {
-	return 0, errNotImplemented
 }
 
 type metricsQuery struct {

--- a/internal/storage/v2/clickhouse/metricstore/reader_test.go
+++ b/internal/storage/v2/clickhouse/metricstore/reader_test.go
@@ -261,12 +261,6 @@ func TestMetricStore_Errors(t *testing.T) {
 	}
 }
 
-func TestGetMinStepDuration(t *testing.T) {
-	reader := NewReader(&clickhousetest.Driver{})
-	_, err := reader.GetMinStepDuration(t.Context(), &metricstore.MinStepDurationQueryParameters{})
-	require.ErrorIs(t, err, errNotImplemented)
-}
-
 func TestStepSeconds(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #8313 
- Addresses https://github.com/jaegertracing/jaeger/pull/8421#discussion_r3125567612

## Description of the changes
- Removes the `GetMinStepDuration` function and all its implementations as it is not used by the UI today.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
