### PR TITLE
[clickhouse] Integrate ClickHouse Metric Storage into Jaeger Storage Extension

### DIFF
--- a/cmd/internal/storageconfig/config.go
+++ b/cmd/internal/storageconfig/config.go
@@ -46,9 +46,10 @@ type TraceBackend struct {
 
 // MetricBackend contains configuration for a single metric storage backend.
 type MetricBackend struct {
-	Prometheus    *PrometheusConfiguration `mapstructure:"prometheus"`
-	Elasticsearch *escfg.Configuration     `mapstructure:"elasticsearch"`
-	Opensearch    *escfg.Configuration     `mapstructure:"opensearch"`
+	Prometheus    *PrometheusConfiguration  `mapstructure:"prometheus"`
+	Elasticsearch *escfg.Configuration      `mapstructure:"elasticsearch"`
+	Opensearch    *escfg.Configuration      `mapstructure:"opensearch"`
+	ClickHouse    *clickhouse.Configuration `mapstructure:"clickhouse"`
 }
 
 type PrometheusConfiguration struct {
@@ -148,6 +149,9 @@ func (cfg *MetricBackend) Unmarshal(conf *confmap.Conf) error {
 		v := es.DefaultConfig()
 		cfg.Opensearch = &v
 	}
+	if conf.IsSet("clickhouse") {
+		cfg.ClickHouse = &clickhouse.Configuration{}
+	}
 	return conf.Unmarshal(cfg)
 }
 
@@ -161,6 +165,9 @@ func (cfg *MetricBackend) Validate() error {
 	}
 	if cfg.Opensearch != nil {
 		backends = append(backends, "opensearch")
+	}
+	if cfg.ClickHouse != nil {
+		backends = append(backends, "clickhouse")
 	}
 	if len(backends) == 0 {
 		return errors.New("empty configuration")

--- a/cmd/internal/storageconfig/config_test.go
+++ b/cmd/internal/storageconfig/config_test.go
@@ -270,6 +270,16 @@ func TestMetricBackendUnmarshal(t *testing.T) {
 				require.NotNil(t, mb.Opensearch)
 			},
 		},
+		{
+			name: "clickhouse backend",
+			configMap: map[string]any{
+				"clickhouse": map[string]any{},
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, mb *MetricBackend) {
+				require.NotNil(t, mb.ClickHouse)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/jaeger/config-clickhouse.yaml
+++ b/cmd/jaeger/config-clickhouse.yaml
@@ -29,6 +29,7 @@ extensions:
   jaeger_query:
     storage:
       traces: some-storage
+      metrics: some-metrics
     ui:
       config_file: ./cmd/jaeger/config-ui.json
   jaeger_storage:
@@ -43,6 +44,16 @@ extensions:
               username: default
               password: password
           create_schema: true
+    metric_backends:
+      some-metrics:
+        clickhouse:
+          addresses:
+            - localhost:9000
+          database: jaeger
+          auth:
+            basic:
+              username: default
+              password: password
 
 receivers:
   otlp:

--- a/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/config_test.go
@@ -140,3 +140,17 @@ metric_backends:
 	require.NoError(t, conf.Unmarshal(cfg))
 	assert.NotEmpty(t, cfg.MetricBackends["some_metrics_storage"].Opensearch.Servers)
 }
+
+func TestConfigDefaultClickHouseAsMetricsBackend(t *testing.T) {
+	conf := loadConf(t, `
+metric_backends:
+  some_metrics_storage:
+    clickhouse:
+      addresses:
+        - localhost:9000
+`)
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.NotNil(t, cfg.MetricBackends["some_metrics_storage"].ClickHouse)
+	assert.NotEmpty(t, cfg.MetricBackends["some_metrics_storage"].ClickHouse.Addresses)
+}

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/metrics"
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	chmetrics "github.com/jaegertracing/jaeger/internal/storage/metricstore/clickhouse"
 	esmetrics "github.com/jaegertracing/jaeger/internal/storage/metricstore/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore/prometheus"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
@@ -282,6 +283,15 @@ func (s *storageExt) createMetricStorageFactory(name string, cfg storageconfig.M
 			*cfg.Opensearch,
 			osTelset,
 			httpAuth,
+		)
+
+	case cfg.ClickHouse != nil:
+		chTelset := telset
+		chTelset.Metrics = scopedMetricsFactory(name, "clickhouse", "metricstore")
+		metricStoreFactory, err = chmetrics.NewFactory(
+			context.Background(),
+			*cfg.ClickHouse,
+			chTelset,
 		)
 
 	default:

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -18,11 +18,11 @@ import (
 	"github.com/jaegertracing/jaeger/internal/metrics"
 	"github.com/jaegertracing/jaeger/internal/metrics/otelmetrics"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
-	chmetrics "github.com/jaegertracing/jaeger/internal/storage/metricstore/clickhouse"
 	esmetrics "github.com/jaegertracing/jaeger/internal/storage/metricstore/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/metricstore/prometheus"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 )
 
@@ -288,7 +288,7 @@ func (s *storageExt) createMetricStorageFactory(name string, cfg storageconfig.M
 	case cfg.ClickHouse != nil:
 		chTelset := telset
 		chTelset.Metrics = scopedMetricsFactory(name, "clickhouse", "metricstore")
-		metricStoreFactory, err = chmetrics.NewFactory(
+		metricStoreFactory, err = clickhouse.NewFactory(
 			context.Background(),
 			*cfg.ClickHouse,
 			chTelset,

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -437,6 +437,17 @@ func TestMetricStorageStartError(t *testing.T) {
 			},
 			expectedError: "Servers: non zero value required",
 		},
+		{
+			name: "ClickHouse backend initialization error",
+			config: storageconfig.Config{
+				MetricBackends: map[string]storageconfig.MetricBackend{
+					"foo": {
+						ClickHouse: &clickhouse.Configuration{},
+					},
+				},
+			},
+			expectedError: "Addresses: non zero value required",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension_test.go
@@ -446,7 +446,7 @@ func TestMetricStorageStartError(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "Addresses: non zero value required",
+			expectedError: "failed to initialize metrics storage 'foo'",
 		},
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
@@ -6,8 +6,9 @@ package jaegerstorage
 import (
 	"testing"
 
-	"github.com/jaegertracing/jaeger/internal/testutils"
 	"go.opentelemetry.io/collector/featuregate"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
@@ -7,8 +7,12 @@ import (
 	"testing"
 
 	"github.com/jaegertracing/jaeger/internal/testutils"
+	"go.opentelemetry.io/collector/featuregate"
 )
 
 func TestMain(m *testing.M) {
+	if err := featuregate.GlobalRegistry().Set("storage.clickhouse", true); err != nil {
+		panic(err)
+	}
 	testutils.VerifyGoLeaks(m)
 }

--- a/internal/storage/v2/clickhouse/factory.go
+++ b/internal/storage/v2/clickhouse/factory.go
@@ -18,9 +18,12 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore/metricstoremetrics"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	chdepstore "github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/depstore"
+	chmetricstore "github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/metricstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 	chtracestore "github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/tracestore"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
@@ -35,10 +38,11 @@ var clickhouseStorageGate = featuregate.GlobalRegistry().MustRegister(
 )
 
 var (
-	_ io.Closer          = (*Factory)(nil)
-	_ depstore.Factory   = (*Factory)(nil)
-	_ tracestore.Factory = (*Factory)(nil)
-	_ storage.Purger     = (*Factory)(nil)
+	_ io.Closer                  = (*Factory)(nil)
+	_ depstore.Factory           = (*Factory)(nil)
+	_ tracestore.Factory         = (*Factory)(nil)
+	_ storage.MetricStoreFactory = (*Factory)(nil)
+	_ storage.Purger             = (*Factory)(nil)
 )
 
 type schemaTemplateParams struct {
@@ -200,6 +204,13 @@ func (f *Factory) CreateDependencyReader() (depstore.Reader, error) {
 
 func (f *Factory) CreateDependencyWriter() (depstore.Writer, error) {
 	return chdepstore.NewDependencyWriter(f.conn), nil
+}
+
+func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
+	return metricstoremetrics.NewReaderDecorator(
+		chmetricstore.NewReader(f.conn),
+		f.telset.Metrics,
+	), nil
 }
 
 func (f *Factory) Close() error {

--- a/internal/storage/v2/clickhouse/factory_test.go
+++ b/internal/storage/v2/clickhouse/factory_test.go
@@ -71,6 +71,10 @@ func TestFactory(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, dr)
 
+			mr, err := f.CreateMetricsReader()
+			require.NoError(t, err)
+			require.NotNil(t, mr)
+
 			err = f.Purge(context.Background())
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #8313 

## Description of the changes
- Wires up the ClickHouse Metric Storage into Jaeger. This effectively enables SPM with ClickHouse Storage.

## How was this change tested?
Spin up ClickHouse in a docker container
```
docker compose -f docker-compose/clickhouse/docker-compose.yml up
```

Start jaeger with the configuration for ClickHouse
```
go run ./cmd/jaeger --config cmd/jaeger/config-clickhouse.yaml --feature-gates=storage.clickhouse
```

Generate some traces
```
go run ./cmd/tracegen -traces 120 -pause 1s
```

See the metrics on the jaeger-ui (http://localhost:16686/monitor)
<img width="1470" height="695" alt="Screenshot 2026-04-22 at 9 14 23 PM" src="https://github.com/user-attachments/assets/1ee00195-cc25-4394-b904-7ccd2f9877aa" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
