### PR TITLE
[sampling] Default leader election options

### DIFF
--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -84,9 +84,16 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Adaptive.HasValue() {
 		// Validate adaptive config fields
-		_, err := govalidator.ValidateStruct(cfg.Adaptive.Get())
+		adaptiveCfg := cfg.Adaptive.Get()
+		_, err := govalidator.ValidateStruct(adaptiveCfg)
 		if err != nil {
 			return err
+		}
+		if adaptiveCfg.LeaderLeaseRefreshInterval <= 0 {
+			return errors.New("leader lease refresh interval must be a positive value")
+		}
+		if adaptiveCfg.FollowerLeaseRefreshInterval <= 0 {
+			return errors.New("follower lease refresh interval must be a positive value")
 		}
 	}
 

--- a/cmd/jaeger/internal/extension/remotesampling/config_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config_test.go
@@ -5,14 +5,23 @@ package remotesampling
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/confmap"
+
+	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/adaptive"
 )
 
 func Test_Validate(t *testing.T) {
+	defaultAdaptiveOptions := adaptive.DefaultOptions()
+	zeroLeaderLeaseOptions := adaptive.DefaultOptions()
+	zeroLeaderLeaseOptions.LeaderLeaseRefreshInterval = 0
+	negativeFollowerLeaseOptions := adaptive.DefaultOptions()
+	negativeFollowerLeaseOptions.FollowerLeaseRefreshInterval = -time.Second
+
 	tests := []struct {
 		name        string
 		config      *Config
@@ -41,7 +50,10 @@ func Test_Validate(t *testing.T) {
 		{
 			name: "Only Adaptive provider specified",
 			config: &Config{
-				Adaptive: configoptional.Some(AdaptiveConfig{SamplingStore: "test-store"}),
+				Adaptive: configoptional.Some(AdaptiveConfig{
+					SamplingStore: "test-store",
+					Options:       defaultAdaptiveOptions,
+				}),
 			},
 			expectedErr: "",
 		},
@@ -76,9 +88,32 @@ func Test_Validate(t *testing.T) {
 		{
 			name: "Invalid Adaptive provider",
 			config: &Config{
-				Adaptive: configoptional.Some(AdaptiveConfig{SamplingStore: ""}),
+				Adaptive: configoptional.Some(AdaptiveConfig{
+					SamplingStore: "",
+					Options:       defaultAdaptiveOptions,
+				}),
 			},
 			expectedErr: "SamplingStore: non zero value required",
+		},
+		{
+			name: "Adaptive provider has zero leader lease refresh interval",
+			config: &Config{
+				Adaptive: configoptional.Some(AdaptiveConfig{
+					SamplingStore: "test-store",
+					Options:       zeroLeaderLeaseOptions,
+				}),
+			},
+			expectedErr: "leader lease refresh interval must be a positive value",
+		},
+		{
+			name: "Adaptive provider has negative follower lease refresh interval",
+			config: &Config{
+				Adaptive: configoptional.Some(AdaptiveConfig{
+					SamplingStore: "test-store",
+					Options:       negativeFollowerLeaseOptions,
+				}),
+			},
+			expectedErr: "follower lease refresh interval must be a positive value",
 		},
 	}
 

--- a/internal/leaderelection/leader_election.go
+++ b/internal/leaderelection/leader_election.go
@@ -36,7 +36,7 @@ type DistributedElectionParticipant struct {
 	wg           sync.WaitGroup
 }
 
-// ElectionParticipantOptions control behavior of the election participant. TODO func applyDefaults(), parameter error checking, etc.
+// ElectionParticipantOptions control behavior of the election participant.
 type ElectionParticipantOptions struct {
 	LeaderLeaseRefreshInterval   time.Duration
 	FollowerLeaseRefreshInterval time.Duration


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #8429

## Description of the changes
- Applies default leader and follower lease refresh intervals when `ElectionParticipantOptions` contains zero or negative durations.
- Provides a no-op logger when no logger is supplied.
- Adds unit coverage for default application and default acquire-lock behavior.

## How was this change tested?
- `go test ./internal/leaderelection`
- `make fmt`
- `make lint`
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
