### PR TITLE
chore(ci): Remove redundant name field from SPM matrix

### DIFF
--- a/.github/workflows/ci-e2e-spm.yml
+++ b/.github/workflows/ci-e2e-spm.yml
@@ -21,14 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         mode:
-        - name: v2
-          metricstore: prometheus
-        - name: v2 with ES
-          metricstore: elasticsearch
-        - name: v2 with OS
-          metricstore: opensearch
-        - name: v2 with ClickHouse
-          metricstore: clickhouse
+        - metricstore: prometheus
+        - metricstore: elasticsearch
+        - metricstore: opensearch
+        - metricstore: clickhouse
 
     steps:
     - name: Harden Runner


### PR DESCRIPTION
The 'name' field in the matrix entries was unused in the workflow steps; only 'metricstore' is referenced.
