### PR TITLE
bugFix: HTTP API returns HTTP 500 instead of 400 for invalid query parameters (limit<=0, end<start)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -69,6 +69,12 @@ func (h *Handler) internalFindTraces(
 		query.GetStartTimeMax().IsZero() {
 		return errors.New("start time min and max are required parameters")
 	}
+	if query.GetStartTimeMin().After(query.GetStartTimeMax()) {
+		return status.Error(codes.InvalidArgument, "start time min must be before or equal to start time max")
+	}
+	if query.GetSearchDepth() <= 0 {
+		return status.Error(codes.InvalidArgument, "search depth must be greater than 0")
+	}
 
 	queryParams := querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -70,7 +70,7 @@ func (h *Handler) internalFindTraces(
 		return errors.New("start time min and max are required parameters")
 	}
 	if query.GetStartTimeMin().After(query.GetStartTimeMax()) {
-		return status.Error(codes.InvalidArgument, "start time min must be before or equal to start time max")
+		return status.Error(codes.InvalidArgument, "start_time_min must be before start_time_max")
 	}
 	if query.GetSearchDepth() <= 0 {
 		return status.Error(codes.InvalidArgument, "search depth must be greater than 0")

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -203,6 +203,7 @@ func TestFindTracesSendError(t *testing.T) {
 			Query: &api_v3.TraceQueryParameters{
 				StartTimeMin: time.Now().Add(-2 * time.Hour),
 				StartTimeMax: time.Now(),
+				SearchDepth:  10,
 			},
 		},
 		/* streamSend= */ func(*jptrace.TracesData) error {
@@ -241,6 +242,7 @@ func TestFindTracesStorageError(t *testing.T) {
 		Query: &api_v3.TraceQueryParameters{
 			StartTimeMin: time.Now().Add(-2 * time.Hour),
 			StartTimeMax: time.Now(),
+			SearchDepth:  10,
 		},
 	})
 	require.NoError(t, err)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -224,7 +224,12 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		return nil, true
 	}
 	timeMaxParsed, err := time.Parse(time.RFC3339Nano, timeMax)
-	if h.tryParamError(w, err, paramTimeMax) {
+	if err := h.tryParamError(w, err, paramTimeMax); err {
+		return nil, true
+	}
+	if timeMinParsed.After(timeMaxParsed) {
+		err := fmt.Errorf("start_time_min must be before start_time_max")
+		h.tryHandleError(w, err, http.StatusBadRequest)
 		return nil, true
 	}
 	queryParams.StartTimeMin = timeMinParsed
@@ -233,6 +238,11 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 	if n := q.Get(paramNumTraces); n != "" {
 		numTraces, err := strconv.Atoi(n)
 		if h.tryParamError(w, err, paramNumTraces) {
+			return nil, true
+		}
+		if numTraces <= 0 {
+			err := fmt.Errorf("%s must be greater than 0", paramNumTraces)
+			h.tryHandleError(w, err, http.StatusBadRequest)
 			return nil, true
 		}
 		queryParams.SearchDepth = numTraces

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -362,6 +362,14 @@ func (*queryParser) validateQuery(traceQuery *traceQueryParameters) error {
 	if len(traceQuery.TraceIDs) == 0 && traceQuery.ServiceName == "" {
 		return errServiceParameterRequired
 	}
+	if traceQuery.SearchDepth <= 0 {
+		return fmt.Errorf("invalid parameter: %s must be greater than 0", limitParam)
+	}
+	if !traceQuery.StartTimeMin.IsZero() && !traceQuery.StartTimeMax.IsZero() {
+		if traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {
+			return fmt.Errorf("invalid parameter: %s time must be before %s time", startTimeParam, endTimeParam)
+		}
+	}
 	if traceQuery.DurationMin != 0 && traceQuery.DurationMax != 0 {
 		if traceQuery.DurationMax < traceQuery.DurationMin {
 			return errMaxDurationGreaterThanMin


### PR DESCRIPTION

## Which problem is this PR solving?
Resolves #8436 

## Description of the changes

This PR ensures that a user's trace query parameters are valid before trying to process them. Specifically:
1.Time Range Validation: It checks that the provided start time (StartTimeMin) is strictly before the end time (StartTimeMax).
2. Search Depth / Limit Validation: It verifies that the requested number of traces to fetch (SearchDepth or limit) is strictly greater than 0. 

## How was this change tested?
Bug-1a :
<img width="1359" height="83" alt="Screenshot_27-Apr_23-35-54_10387" src="https://github.com/user-attachments/assets/c328d000-b3d7-4b52-a326-bd8afcbfb5f0" />

Bug-1b:
<img width="1419" height="498" alt="Screenshot_27-Apr_23-41-45_25831" src="https://github.com/user-attachments/assets/515328c2-8f77-4720-bd66-537bec2b2b8c" />

Bug-2:

<img width="1488" height="496" alt="Screenshot_28-Apr_00-32-55_32236" src="https://github.com/user-attachments/assets/68999ee6-3efb-4cf2-9924-6de1364c6b83" />


Bug-3:


<img width="1778" height="471" alt="Screenshot_28-Apr_00-44-27_3095" src="https://github.com/user-attachments/assets/4b32aa55-4fbc-4060-845d-7391925822b1" />




- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
