### PR TITLE
[fix][clickhouse] Add missing scope attributes in ClickHouse's query builder

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/query_builder.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder.go
@@ -225,11 +225,14 @@ func buildSimpleAttributeCondition(q *strings.Builder, args []any, key string, v
 	appendArrayExists(q, 2, "resource", valueType)
 	appendNewlineAndIndent(q, 2)
 	q.WriteString("OR")
+	appendArrayExists(q, 2, "scope", valueType)
+	appendNewlineAndIndent(q, 2)
+	q.WriteString("OR")
 	appendNestedArrayExists(q, 2, "events", valueType)
 	appendNewlineAndIndent(q, 2)
 	q.WriteString("OR")
 	appendNestedArrayExists(q, 2, "links", valueType)
-	return append(args, key, value, key, value, key, value, key, value)
+	return append(args, key, value, key, value, key, value, key, value, key, value)
 }
 
 func buildBytesAttributeCondition(q *strings.Builder, args []any, key string, attr pcommon.Value) []any {

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
@@ -18,6 +18,8 @@ FROM (
 			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_bool_attributes.key, s.resource_bool_attributes.value)
 			OR
+			arrayExists((key, value) -> key = ? AND value = ?, s.scope_bool_attributes.key, s.scope_bool_attributes.value)
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.events)
 			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.links)
@@ -26,6 +28,8 @@ FROM (
 			arrayExists((key, value) -> key = ? AND value = ?, s.double_attributes.key, s.double_attributes.value)
 			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_double_attributes.key, s.resource_double_attributes.value)
+			OR
+			arrayExists((key, value) -> key = ? AND value = ?, s.scope_double_attributes.key, s.scope_double_attributes.value)
 			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.double_attributes.key, x.double_attributes.value), s.events)
 			OR
@@ -36,6 +40,8 @@ FROM (
 			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_int_attributes.key, s.resource_int_attributes.value)
 			OR
+			arrayExists((key, value) -> key = ? AND value = ?, s.scope_int_attributes.key, s.scope_int_attributes.value)
+			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.events)
 			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.links)
@@ -45,14 +51,7 @@ FROM (
 			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
 			OR
-			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-			OR
-			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
-		)
-		AND (
-			arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-			OR
-			arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
+			arrayExists((key, value) -> key = ? AND value = ?, s.scope_complex_attributes.key, s.scope_complex_attributes.value)
 			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
 			OR
@@ -62,6 +61,19 @@ FROM (
 			arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
 			OR
 			arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
+			OR
+			arrayExists((key, value) -> key = ? AND value = ?, s.scope_complex_attributes.key, s.scope_complex_attributes.value)
+			OR
+			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
+			OR
+			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
+		)
+		AND (
+			arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
+			OR
+			arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
+			OR
+			arrayExists((key, value) -> key = ? AND value = ?, s.scope_complex_attributes.key, s.scope_complex_attributes.value)
 			OR
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
 			OR

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
@@ -91,6 +91,8 @@ WHERE s.trace_id IN (
 					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_bool_attributes.key, s.resource_bool_attributes.value)
 					OR
+					arrayExists((key, value) -> key = ? AND value = ?, s.scope_bool_attributes.key, s.scope_bool_attributes.value)
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.events)
 					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.bool_attributes.key, x.bool_attributes.value), s.links)
@@ -99,6 +101,8 @@ WHERE s.trace_id IN (
 					arrayExists((key, value) -> key = ? AND value = ?, s.double_attributes.key, s.double_attributes.value)
 					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_double_attributes.key, s.resource_double_attributes.value)
+					OR
+					arrayExists((key, value) -> key = ? AND value = ?, s.scope_double_attributes.key, s.scope_double_attributes.value)
 					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.double_attributes.key, x.double_attributes.value), s.events)
 					OR
@@ -109,6 +113,8 @@ WHERE s.trace_id IN (
 					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_int_attributes.key, s.resource_int_attributes.value)
 					OR
+					arrayExists((key, value) -> key = ? AND value = ?, s.scope_int_attributes.key, s.scope_int_attributes.value)
+					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.events)
 					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.int_attributes.key, x.int_attributes.value), s.links)
@@ -118,14 +124,7 @@ WHERE s.trace_id IN (
 					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
 					OR
-					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
-					OR
-					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
-				)
-				AND (
-					arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
-					OR
-					arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
+					arrayExists((key, value) -> key = ? AND value = ?, s.scope_complex_attributes.key, s.scope_complex_attributes.value)
 					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
 					OR
@@ -135,6 +134,19 @@ WHERE s.trace_id IN (
 					arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
 					OR
 					arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
+					OR
+					arrayExists((key, value) -> key = ? AND value = ?, s.scope_complex_attributes.key, s.scope_complex_attributes.value)
+					OR
+					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
+					OR
+					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.links)
+				)
+				AND (
+					arrayExists((key, value) -> key = ? AND value = ?, s.complex_attributes.key, s.complex_attributes.value)
+					OR
+					arrayExists((key, value) -> key = ? AND value = ?, s.resource_complex_attributes.key, s.resource_complex_attributes.value)
+					OR
+					arrayExists((key, value) -> key = ? AND value = ?, s.scope_complex_attributes.key, s.scope_complex_attributes.value)
 					OR
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.complex_attributes.key, x.complex_attributes.value), s.events)
 					OR


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/pull/8435#issuecomment-4321894272

## Description of the changes
- Scope attributes weren't being appended in the query builder for non-string attributes

## How was this change tested?
- Unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
