### PR TITLE
fix(jaegermcp): enforce critical path span bounds

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath.go
@@ -69,7 +69,7 @@ func computeCriticalPath(
 			SectionEnd:   endTime,
 		}
 
-		if spanCriticalSection.SectionStart != spanCriticalSection.SectionEnd {
+		if spanCriticalSection.SectionStart < spanCriticalSection.SectionEnd {
 			criticalPath = append(criticalPath, spanCriticalSection)
 		}
 
@@ -88,7 +88,7 @@ func computeCriticalPath(
 			SectionEnd:   endTime,
 		}
 
-		if spanCriticalSection.SectionStart != spanCriticalSection.SectionEnd {
+		if spanCriticalSection.SectionStart < spanCriticalSection.SectionEnd {
 			criticalPath = append(criticalPath, spanCriticalSection)
 		}
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/criticalpath_test.go
@@ -178,6 +178,35 @@ func TestComputeCriticalPath_Internal_LastFinishingChild_Recursive(t *testing.T)
 	// 3. span 1: 100-120 (before child starts)
 }
 
+func TestComputeCriticalPath_Internal_SkipsReversedSections(t *testing.T) {
+	rootID := pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1})
+	childID := pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2})
+
+	spanMap := map[pcommon.SpanID]CPSpan{
+		rootID: {
+			SpanID:       rootID,
+			StartTime:    0,
+			Duration:     100,
+			ChildSpanIDs: []pcommon.SpanID{childID},
+		},
+		childID: {
+			SpanID:       childID,
+			ParentSpanID: rootID,
+			StartTime:    10,
+			Duration:     200,
+		},
+	}
+
+	result := computeCriticalPath(spanMap, rootID, nil, nil)
+	require.Len(t, result, 2)
+
+	for _, section := range result {
+		assert.Less(t, section.SectionStart, section.SectionEnd)
+	}
+	assert.Equal(t, Section{SpanID: "0000000000000002", SectionStart: 10, SectionEnd: 210}, result[0])
+	assert.Equal(t, Section{SpanID: "0000000000000001", SectionStart: 0, SectionEnd: 10}, result[1])
+}
+
 func TestFindLastFinishingChildSpan_MissingChild(t *testing.T) {
 	// Test findLastFinishingChildSpan with child ID in list but missing from map (find_lfc.go line 23)
 	parentSpan := CPSpan{

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/sanitize.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/sanitize.go
@@ -12,93 +12,125 @@ import (
 // The function adjusts the start time and duration of overflowing child spans
 // to ensure they fit within the time range of their parent span.
 func removeOverflowingChildren(spanMap map[pcommon.SpanID]CPSpan) map[pcommon.SpanID]CPSpan {
-	// Get all span IDs
-	spanIDs := make([]pcommon.SpanID, 0, len(spanMap))
-	for spanID := range spanMap {
-		spanIDs = append(spanIDs, spanID)
+	rootSpanIDs := make([]pcommon.SpanID, 0, len(spanMap))
+	missingParentSpanIDs := make([]pcommon.SpanID, 0)
+
+	for spanID, span := range spanMap {
+		if span.ParentSpanID.IsEmpty() {
+			rootSpanIDs = append(rootSpanIDs, spanID)
+		} else if _, parentExists := spanMap[span.ParentSpanID]; !parentExists {
+			missingParentSpanIDs = append(missingParentSpanIDs, spanID)
+		}
 	}
 
-	for _, spanID := range spanIDs {
-		span, ok := spanMap[spanID]
-		if !ok || span.ParentSpanID.IsEmpty() {
-			continue
-		}
+	for _, spanID := range missingParentSpanIDs {
+		deleteSpanAndDescendants(spanMap, spanID)
+	}
 
-		// parentSpan will be undefined when its parent was dropped previously
-		parentSpan, parentExists := spanMap[span.ParentSpanID]
-		if !parentExists {
-			// Drop the child spans of dropped parent span
-			delete(spanMap, span.SpanID)
-			continue
-		}
-
-		childEndTime := span.StartTime + span.Duration
-		parentEndTime := parentSpan.StartTime + parentSpan.Duration
-
-		if span.StartTime >= parentSpan.StartTime {
-			if span.StartTime >= parentEndTime {
-				// child outside of parent range => drop the child span
-				//      |----parent----|
-				//                        |----child--|
-				delete(spanMap, span.SpanID)
-
-				// Remove the childSpanId from its parent span
-				filteredChildren := make([]pcommon.SpanID, 0, len(parentSpan.ChildSpanIDs))
-				for _, childID := range parentSpan.ChildSpanIDs {
-					if childID != span.SpanID {
-						filteredChildren = append(filteredChildren, childID)
-					}
-				}
-				parentSpan.ChildSpanIDs = filteredChildren
-				spanMap[parentSpan.SpanID] = parentSpan
-				continue
-			}
-			if childEndTime > parentEndTime {
-				// child end after parent, truncate is needed
-				//      |----parent----|
-				//              |----child--|
-				span.Duration = parentEndTime - span.StartTime
-				spanMap[span.SpanID] = span
-				continue
-			}
-			// everything looks good
-			// |----parent----|
-			//   |----child--|
-			continue
-		}
-
-		switch {
-		case childEndTime <= parentSpan.StartTime:
-			// child outside of parent range => drop the child span
-			//                      |----parent----|
-			//       |----child--|
-			delete(spanMap, span.SpanID)
-
-			// Remove the childSpanId from its parent span
-			filteredChildren := make([]pcommon.SpanID, 0, len(parentSpan.ChildSpanIDs))
-			for _, childID := range parentSpan.ChildSpanIDs {
-				if childID != span.SpanID {
-					filteredChildren = append(filteredChildren, childID)
-				}
-			}
-			parentSpan.ChildSpanIDs = filteredChildren
-			spanMap[parentSpan.SpanID] = parentSpan
-		case childEndTime <= parentEndTime:
-			// child start before parent, truncate is needed
-			//      |----parent----|
-			//   |----child--|
-			span.StartTime = parentSpan.StartTime
-			span.Duration = childEndTime - parentSpan.StartTime
-			spanMap[span.SpanID] = span
-		default:
-			// child start before parent and end after parent, truncate is needed
-			//      |----parent----|
-			//  |---------child---------|
-			span.StartTime = parentSpan.StartTime
-			span.Duration = parentEndTime - parentSpan.StartTime
-			spanMap[span.SpanID] = span
-		}
+	for _, spanID := range rootSpanIDs {
+		sanitizeDescendants(spanMap, spanID)
 	}
 
 	return spanMap
+}
+
+func sanitizeDescendants(spanMap map[pcommon.SpanID]CPSpan, parentSpanID pcommon.SpanID) {
+	parentSpan, ok := spanMap[parentSpanID]
+	if !ok {
+		return
+	}
+
+	childSpanIDs := append([]pcommon.SpanID(nil), parentSpan.ChildSpanIDs...)
+	for _, childSpanID := range childSpanIDs {
+		childSpan, ok := spanMap[childSpanID]
+		if !ok {
+			continue
+		}
+
+		parentSpan = spanMap[parentSpanID]
+		sanitizedChildSpan, keepChild := fitSpanWithinParent(childSpan, parentSpan)
+		if !keepChild {
+			deleteSpanAndDescendants(spanMap, childSpanID)
+			removeChildSpanID(spanMap, parentSpanID, childSpanID)
+			continue
+		}
+
+		spanMap[childSpanID] = sanitizedChildSpan
+		sanitizeDescendants(spanMap, childSpanID)
+	}
+}
+
+func fitSpanWithinParent(span CPSpan, parentSpan CPSpan) (CPSpan, bool) {
+	childEndTime := span.StartTime + span.Duration
+	parentEndTime := parentSpan.StartTime + parentSpan.Duration
+
+	if span.StartTime >= parentSpan.StartTime {
+		if span.StartTime >= parentEndTime {
+			// child outside of parent range => drop the child span
+			//      |----parent----|
+			//                        |----child--|
+			return span, false
+		}
+		if childEndTime > parentEndTime {
+			// child end after parent, truncate is needed
+			//      |----parent----|
+			//              |----child--|
+			span.Duration = parentEndTime - span.StartTime
+		}
+
+		// everything looks good
+		// |----parent----|
+		//   |----child--|
+		return span, true
+	}
+
+	switch {
+	case childEndTime <= parentSpan.StartTime:
+		// child outside of parent range => drop the child span
+		//                      |----parent----|
+		//       |----child--|
+		return span, false
+	case childEndTime <= parentEndTime:
+		// child start before parent, truncate is needed
+		//      |----parent----|
+		//   |----child--|
+		span.StartTime = parentSpan.StartTime
+		span.Duration = childEndTime - parentSpan.StartTime
+	default:
+		// child start before parent and end after parent, truncate is needed
+		//      |----parent----|
+		//  |---------child---------|
+		span.StartTime = parentSpan.StartTime
+		span.Duration = parentEndTime - parentSpan.StartTime
+	}
+
+	return span, true
+}
+
+func deleteSpanAndDescendants(spanMap map[pcommon.SpanID]CPSpan, spanID pcommon.SpanID) {
+	span, ok := spanMap[spanID]
+	if !ok {
+		return
+	}
+
+	for _, childSpanID := range span.ChildSpanIDs {
+		deleteSpanAndDescendants(spanMap, childSpanID)
+	}
+	delete(spanMap, spanID)
+}
+
+func removeChildSpanID(spanMap map[pcommon.SpanID]CPSpan, parentSpanID pcommon.SpanID, childSpanID pcommon.SpanID) {
+	parentSpan, ok := spanMap[parentSpanID]
+	if !ok {
+		return
+	}
+
+	filteredChildren := make([]pcommon.SpanID, 0, len(parentSpan.ChildSpanIDs))
+	for _, currentChildSpanID := range parentSpan.ChildSpanIDs {
+		if currentChildSpanID != childSpanID {
+			filteredChildren = append(filteredChildren, currentChildSpanID)
+		}
+	}
+	parentSpan.ChildSpanIDs = filteredChildren
+	spanMap[parentSpanID] = parentSpan
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/sanitize_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath/sanitize_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -295,4 +296,54 @@ func TestSanitizeOverFlowingChildren_MultipleChildren(t *testing.T) {
 	assert.False(t, ok3)
 	_, ok4 := result[[8]byte{4}]
 	assert.False(t, ok4)
+}
+
+func TestSanitizeOverFlowingChildren_ParentsBeforeDescendants(t *testing.T) {
+	rootID := pcommon.SpanID([8]byte{1})
+	midID := pcommon.SpanID([8]byte{2})
+	leafID := pcommon.SpanID([8]byte{3})
+
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		input := map[pcommon.SpanID]CPSpan{
+			rootID: {
+				SpanID:       rootID,
+				StartTime:    0,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{midID},
+			},
+			midID: {
+				SpanID:       midID,
+				ParentSpanID: rootID,
+				StartTime:    10,
+				Duration:     200,
+				ChildSpanIDs: []pcommon.SpanID{leafID},
+			},
+			leafID: {
+				SpanID:       leafID,
+				ParentSpanID: midID,
+				StartTime:    50,
+				Duration:     100,
+			},
+		}
+
+		result := removeOverflowingChildren(input)
+
+		for spanID, span := range result {
+			if span.ParentSpanID.IsEmpty() {
+				continue
+			}
+
+			parentSpan, ok := result[span.ParentSpanID]
+			require.True(t, ok, "iteration %d: parent span %v missing", i, span.ParentSpanID)
+
+			parentEndTime := parentSpan.StartTime + parentSpan.Duration
+			spanEndTime := span.StartTime + span.Duration
+
+			assert.GreaterOrEqualf(t, span.StartTime, parentSpan.StartTime,
+				"iteration %d: span %v starts before parent", i, spanID)
+			assert.LessOrEqualf(t, spanEndTime, parentEndTime,
+				"iteration %d: span %v ends after parent", i, spanID)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- process critical-path sanitization from roots down so descendants are checked after parent spans have already been tightened
- drop invalid descendant subtrees when a parent is removed and refresh references after sanitization
- skip reversed critical-path sections so downstream uint64 duration math cannot underflow

Fixes #8462

## Testing
- `go test ./cmd/jaeger/internal/extension/jaegermcp/internal/criticalpath`
- `go test ./cmd/jaeger/internal/extension/jaegermcp/internal/...`
- `go test ./cmd/jaeger/internal/extension/jaegermcp`
- `git diff --check`