### PR TITLE
feat: Add ui_base_path config for external URL prefix 

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -46,6 +46,8 @@ func (c AIConfig) Validate() error {
 type QueryOptions struct {
 	// BasePath is the base path for all HTTP routes.
 	BasePath string `mapstructure:"base_path"`
+	// UIBasePath is the base path for external routes
+	UIBasePath string `mapstructure:"ui_base_path"`
 	// UIConfig contains configuration related to the Jaeger UIConfig.
 	UIConfig UIConfig `mapstructure:"ui"`
 	// BearerTokenPropagation activate/deactivate bearer token propagation to storage.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler.go
@@ -38,6 +38,7 @@ func RegisterStaticHandler(r *http.ServeMux, logger *zap.Logger, qOpts *QueryOpt
 	staticHandler, err := NewStaticAssetsHandler(qOpts.UIConfig.AssetsPath, StaticAssetsHandlerOptions{
 		UIConfig:            qOpts.UIConfig,
 		BasePath:            qOpts.BasePath,
+		UIBasePath:          qOpts.UIBasePath,
 		StorageCapabilities: qCapabilities,
 		Logger:              logger,
 	})
@@ -62,6 +63,7 @@ type StaticAssetsHandler struct {
 type StaticAssetsHandlerOptions struct {
 	UIConfig
 	BasePath            string
+	UIBasePath          string
 	StorageCapabilities querysvc.StorageCapabilities
 	Logger              *zap.Logger
 }
@@ -123,11 +125,17 @@ func (sH *StaticAssetsHandler) loadAndEnrichIndexHTML(open func(string) (http.Fi
 	if sH.options.BasePath == "" {
 		sH.options.BasePath = "/"
 	}
-	if sH.options.BasePath != "/" {
-		if !strings.HasPrefix(sH.options.BasePath, "/") || strings.HasSuffix(sH.options.BasePath, "/") {
-			return nil, fmt.Errorf("invalid base path '%s'. Must start but not end with a slash '/', e.g. '/jaeger/ui'", sH.options.BasePath)
+
+	// if ui base path is empty, default to base path
+	if sH.options.UIBasePath == "" {
+		sH.options.UIBasePath = sH.options.BasePath
+	}
+
+	if sH.options.UIBasePath != "/" {
+		if !strings.HasPrefix(sH.options.UIBasePath, "/") || strings.HasSuffix(sH.options.UIBasePath, "/") {
+			return nil, fmt.Errorf("invalid base path '%s'. Must start but not end with a slash '/', e.g. '/jaeger/ui'", sH.options.UIBasePath)
 		}
-		indexBytes = basePathPattern.ReplaceAll(indexBytes, fmt.Appendf(nil, `<base href="%s/"`, sH.options.BasePath))
+		indexBytes = basePathPattern.ReplaceAll(indexBytes, fmt.Appendf(nil, `<base href="%s/"`, sH.options.UIBasePath))
 	}
 
 	return indexBytes, nil

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler.go
@@ -125,6 +125,11 @@ func (sH *StaticAssetsHandler) loadAndEnrichIndexHTML(open func(string) (http.Fi
 	if sH.options.BasePath == "" {
 		sH.options.BasePath = "/"
 	}
+	if sH.options.BasePath != "/" {
+		if !strings.HasPrefix(sH.options.BasePath, "/") || strings.HasSuffix(sH.options.BasePath, "/") {
+			return nil, fmt.Errorf("invalid base path '%s'. Must start but not end with a slash '/', e.g. '/jaeger/ui'", sH.options.BasePath)
+		}
+	}
 
 	// if ui base path is empty, default to base path
 	if sH.options.UIBasePath == "" {
@@ -133,7 +138,7 @@ func (sH *StaticAssetsHandler) loadAndEnrichIndexHTML(open func(string) (http.Fi
 
 	if sH.options.UIBasePath != "/" {
 		if !strings.HasPrefix(sH.options.UIBasePath, "/") || strings.HasSuffix(sH.options.UIBasePath, "/") {
-			return nil, fmt.Errorf("invalid base path '%s'. Must start but not end with a slash '/', e.g. '/jaeger/ui'", sH.options.UIBasePath)
+			return nil, fmt.Errorf("invalid ui base path '%s'. Must start but not end with a slash '/', e.g. '/jaeger/ui'", sH.options.UIBasePath)
 		}
 		indexBytes = basePathPattern.ReplaceAll(indexBytes, fmt.Appendf(nil, `<base href="%s/"`, sH.options.UIBasePath))
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler_test.go
@@ -59,6 +59,7 @@ func TestRegisterStaticHandlerPanic(t *testing.T) {
 func TestRegisterStaticHandler(t *testing.T) {
 	testCases := []struct {
 		basePath                    string // input to the test
+		uiBasePath                  string // input to the test
 		subroute                    bool   // should we create a subroute?
 		baseURL                     string // expected URL prefix
 		archiveStorage              bool   // archive storage enabled?
@@ -71,6 +72,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 	}{
 		{
 			basePath:                    "",
+			uiBasePath:                  "",
 			baseURL:                     "/",
 			expectedBaseHTML:            `<base href="/"`,
 			archiveStorage:              false,
@@ -81,6 +83,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 		},
 		{
 			basePath:                    "/",
+			uiBasePath:                  "",
 			baseURL:                     "/",
 			archiveStorage:              false,
 			expectedBaseHTML:            `<base href="/"`,
@@ -90,6 +93,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 		},
 		{
 			basePath:                    "/jaeger",
+			uiBasePath:                  "",
 			baseURL:                     "/jaeger/",
 			expectedBaseHTML:            `<base href="/jaeger/"`,
 			subroute:                    true,
@@ -100,6 +104,7 @@ func TestRegisterStaticHandler(t *testing.T) {
 		},
 		{
 			basePath:                    "/metrics",
+			uiBasePath:                  "",
 			baseURL:                     "/metrics/",
 			expectedBaseHTML:            `<base href="/metrics/"`,
 			subroute:                    true,
@@ -107,6 +112,17 @@ func TestRegisterStaticHandler(t *testing.T) {
 			UIConfigPath:                "fixture/ui-config.js",
 			expectedUIConfig:            "function UIConfig(){",
 			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":false,"metricsStorage":true};`,
+		},
+		{
+			basePath:                    "/",
+			uiBasePath:                  "/jaeger",
+			baseURL:                     "/",
+			expectedBaseHTML:            `<base href="/jaeger/"`,
+			archiveStorage:              false,
+			logAccess:                   true,
+			UIConfigPath:                "",
+			expectedUIConfig:            "JAEGER_CONFIG=DEFAULT_CONFIG;",
+			expectedStorageCapabilities: `JAEGER_STORAGE_CAPABILITIES = {"archiveStorage":false,"metricsStorage":false};`,
 		},
 	}
 	httpClient = &http.Client{
@@ -122,7 +138,8 @@ func TestRegisterStaticHandler(t *testing.T) {
 					AssetsPath: "fixture",
 					LogAccess:  testCase.logAccess,
 				},
-				BasePath: testCase.basePath,
+				BasePath:   testCase.basePath,
+				UIBasePath: testCase.uiBasePath,
 			},
 				querysvc.StorageCapabilities{ArchiveStorage: testCase.archiveStorage, MetricsStorage: testCase.metricsStorage},
 			)
@@ -177,7 +194,18 @@ func TestNewStaticAssetsHandlerErrors(t *testing.T) {
 			BasePath: base,
 			Logger:   zap.NewNop(),
 		})
-		assert.ErrorContainsf(t, err, "invalid base path", "basePath=%s", base)
+		require.ErrorContainsf(t, err, "invalid base path", "basePath=%s", base)
+	}
+
+	for _, uiBase := range []string{"x", "x/", "/x/"} {
+		_, err := NewStaticAssetsHandler("fixture", StaticAssetsHandlerOptions{
+			UIConfig: UIConfig{
+				ConfigFile: "fixture/ui-config.json",
+			},
+			UIBasePath: uiBase,
+			Logger:     zap.NewNop(),
+		})
+		require.ErrorContainsf(t, err, "invalid ui base path", "uiBasePath=%s", uiBase)
 	}
 }
 


### PR DESCRIPTION

## Which problem is this PR solving?
Resolves: https://github.com/jaegertracing/jaeger/issues/5157

## Description of the changes
- Added "ui_base_path" config option to support external URL prefix when running behind a URL rewriting proxy
- "ui_base_path" control base href injected into the UI html
- If "ui_base_path" is empty, default to "base_path" to preserve existing behavior

## How was this change tested?
- I manually tested three different scenarios to ensure UI loads properly
-Case 1: Ran the default "go run ./cmd/jaeger". UI loaded
-Case 2: Ran the reverse-proxy example. UI loaded
-Case 3: Modified the httpd.conf in reverse-proxy to rewrite /jaeger/prefix/ to /. Ran Jaeger with --set extensions.jaeger_query.ui_base_path=/jaeger/prefix. Visited http://localhost:18080/jaeger/prefix. UI loaded 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
