### PR TITLE
[linter] Enable revive comment-spacings rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,9 +146,6 @@ linters:
         # looks useful, but requires refactoring: "calls to log.Fatal only in main() or init() functions"
         - name: deep-exit
           disabled: true
-        # this rule conflicts with nolintlint which does insist on no-space in //nolint
-        - name: comment-spacings
-          disabled: true
         # existing packages conflict with stdlib names or use underscores; cannot rename
         - name: package-naming
           disabled: true


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #5506

## Description of the changes

Enables the `comment-spacings` revive linter rule by removing it from the disabled list in `.golangci.yml`.

This rule was originally disabled because it conflicted with `nolintlint` -- it would flag `//nolint:` directives as missing a space after `//`. That conflict has since been fixed upstream in revive ([mgechev/revive#986](https://github.com/mgechev/revive/pull/986), [mgechev/revive#988](https://github.com/mgechev/revive/pull/988)). The rule now uses the official Go directive regexp to recognize machine-readable comments like `//nolint:`, `//go:generate`, etc., and no longer flags them.

**Violations fixed: 0** -- the codebase already conforms to this rule. The change is config-only.

## How was this change tested?

- `make lint` passes with 0 issues
- `make fmt` produces no changes
- Verified that existing `//nolint:` directives (48 occurrences) are not flagged

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`