### PR TITLE
fix(monitoring): Migrate alert rules to Jaeger v2 otelcol metrics

### DIFF
--- a/monitoring/jaeger-mixin/prometheus_alerts.yml
+++ b/monitoring/jaeger-mixin/prometheus_alerts.yml
@@ -4,59 +4,19 @@
 "groups":
 - "name": "jaeger_alerts"
   "rules":
-  - "alert": "JaegerHTTPServerErrs"
-    "annotations":
-      "message": |
-        {{ $labels.job }} {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% HTTP errors.
-    "expr": "100 * sum(rate(jaeger_agent_http_server_errors_total[1m])) by (instance, job, namespace) / sum(rate(jaeger_agent_http_server_total[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerRPCRequestsErrors"
-    "annotations":
-      "message": |
-        {{ $labels.job }} {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% RPC HTTP errors.
-    "expr": "100 * sum(rate(jaeger_client_jaeger_rpc_http_requests{status_code=~\"4xx|5xx\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_client_jaeger_rpc_http_requests[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerClientSpansDropped"
-    "annotations":
-      "message": |
-        service {{ $labels.job }} {{ $labels.instance }} is dropping {{ printf "%.2f" $value }}% spans.
-    "expr": "100 * sum(rate(jaeger_reporter_spans{result=~\"dropped|err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_reporter_spans[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerAgentSpansDropped"
-    "annotations":
-      "message": |
-        agent {{ $labels.job }} {{ $labels.instance }} is dropping {{ printf "%.2f" $value }}% spans.
-    "expr": "100 * sum(rate(jaeger_agent_reporter_batches_failures_total[1m])) by (instance, job, namespace) / sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
   - "alert": "JaegerCollectorDroppingSpans"
     "annotations":
       "message": |
-        collector {{ $labels.job }} {{ $labels.instance }} is dropping {{ printf "%.2f" $value }}% spans.
-    "expr": "100 * sum(rate(jaeger_collector_spans_dropped_total[1m])) by (instance, job, namespace) / sum(rate(jaeger_collector_spans_received_total[1m])) by (instance, job, namespace)> 1"
+        {{ $labels.job }} {{ $labels.instance }} is refusing {{ printf "%.2f" $value }}% of received spans.
+    "expr": "100 * sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace) / (sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace) + sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace)) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"
-  - "alert": "JaegerSamplingUpdateFailing"
+  - "alert": "JaegerExporterFailingSpans"
     "annotations":
       "message": |
-        {{ $labels.job }} {{ $labels.instance }} is failing {{ printf "%.2f" $value }}% in updating sampling policies.
-    "expr": "100 * sum(rate(jaeger_sampler_queries{result=\"err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_sampler_queries[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerThrottlingUpdateFailing"
-    "annotations":
-      "message": |
-        {{ $labels.job }} {{ $labels.instance }} is failing {{ printf "%.2f" $value }}% in updating throttling policies.
-    "expr": "100 * sum(rate(jaeger_throttler_updates{result=\"err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_throttler_updates[1m])) by (instance, job, namespace)> 1"
+        {{ $labels.job }} {{ $labels.instance }} is failing to export {{ printf "%.2f" $value }}% of spans.
+    "expr": "100 * sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (instance, job, namespace) / (sum(rate(otelcol_exporter_sent_spans_total[1m])) by (instance, job, namespace) + sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (instance, job, namespace)) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"

--- a/monitoring/jaeger-mixin/prometheus_alerts.yml
+++ b/monitoring/jaeger-mixin/prometheus_alerts.yml
@@ -7,16 +7,16 @@
   - "alert": "JaegerCollectorDroppingSpans"
     "annotations":
       "message": |
-        {{ $labels.job }} {{ $labels.instance }} is refusing {{ printf "%.2f" $value }}% of received spans.
-    "expr": "100 * sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace) / (sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace) + sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace)) > 1"
+        {{ $labels.job }} {{ $labels.instance }} receiver {{ $labels.receiver }} transport {{ $labels.transport }} is refusing {{ printf "%.2f" $value }}% of received spans.
+    "expr": "100 * ((sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport)) or on(instance, job, namespace, receiver, transport) (0 * sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport))) / (((sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport)) or on(instance, job, namespace, receiver, transport) (0 * sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport))) + ((sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport)) or on(instance, job, namespace, receiver, transport) (0 * sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport)))) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"
   - "alert": "JaegerExporterFailingSpans"
     "annotations":
       "message": |
-        {{ $labels.job }} {{ $labels.instance }} is failing to export {{ printf "%.2f" $value }}% of spans.
-    "expr": "100 * sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (instance, job, namespace) / (sum(rate(otelcol_exporter_sent_spans_total[1m])) by (instance, job, namespace) + sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (instance, job, namespace)) > 1"
+        {{ $labels.job }} {{ $labels.instance }} exporter {{ $labels.exporter }} is failing to export {{ printf "%.2f" $value }}% of spans.
+    "expr": "100 * ((sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace)) or on(exporter, instance, job, namespace) (0 * sum(rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace))) / (((sum(rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace)) or on(exporter, instance, job, namespace) (0 * sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace))) + ((sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace)) or on(exporter, instance, job, namespace) (0 * sum(rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace)))) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"

--- a/monitoring/jaeger-mixin/prometheus_alerts.yml
+++ b/monitoring/jaeger-mixin/prometheus_alerts.yml
@@ -8,7 +8,7 @@
     "annotations":
       "message": |
         {{ $labels.job }} {{ $labels.instance }} receiver {{ $labels.receiver }} transport {{ $labels.transport }} is refusing {{ printf "%.2f" $value }}% of received spans.
-    "expr": "100 * ((sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport)) or on(instance, job, namespace, receiver, transport) (0 * sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport))) / (((sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport)) or on(instance, job, namespace, receiver, transport) (0 * sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport))) + ((sum(rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport)) or on(instance, job, namespace, receiver, transport) (0 * sum(rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport)))) > 1"
+    "expr": "100 * sum(rate(otelcol_receiver_refused_spans_total[1m]) or 0 * rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport) / (sum(rate(otelcol_receiver_accepted_spans_total[1m]) or 0 * rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport) + sum(rate(otelcol_receiver_refused_spans_total[1m]) or 0 * rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport)) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -16,7 +16,7 @@
     "annotations":
       "message": |
         {{ $labels.job }} {{ $labels.instance }} exporter {{ $labels.exporter }} is failing to export {{ printf "%.2f" $value }}% of spans.
-    "expr": "100 * ((sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace)) or on(exporter, instance, job, namespace) (0 * sum(rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace))) / (((sum(rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace)) or on(exporter, instance, job, namespace) (0 * sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace))) + ((sum(rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace)) or on(exporter, instance, job, namespace) (0 * sum(rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace)))) > 1"
+    "expr": "100 * sum(rate(otelcol_exporter_send_failed_spans_total[1m]) or 0 * rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace) / (sum(rate(otelcol_exporter_sent_spans_total[1m]) or 0 * rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace) + sum(rate(otelcol_exporter_send_failed_spans_total[1m]) or 0 * rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace)) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
### Fixes - #8479 
- Resolves the monitoring mixin alert-rule mismatch for Jaeger v2 metrics.
- In `monitoring/jaeger-mixin/prometheus_alerts.yml`, most rules still referenced Jaeger v1 metrics that are not emitted by Jaeger v2, so those alerts would never fire.

## Description of the changes
- Replaced the collector ingest alert expression with Jaeger v2-compatible OTel Collector metrics:
  - `otelcol_receiver_refused_spans_total`
  - `otelcol_receiver_accepted_spans_total`
- Removed obsolete alert rules tied to Jaeger v1-only components/metrics that do not apply cleanly to Jaeger v2.
- Kept `JaegerQueryReqsFailing` unchanged, since `jaeger_query_requests_total` is still valid in v2.
- Preserved the existing alert name `JaegerCollectorDroppingSpans` to avoid breaking downstream Alertmanager routing, silences, or runbooks while still migrating the rule to v2 metrics.
- Added an exporter failure alert based on `otelcol_exporter_send_failed_spans_total` / `otelcol_exporter_sent_spans_total`.

## How was this change tested?
- Reviewed the updated alert expressions against the Jaeger v2 monitoring metrics already used by the mixin dashboard.
- Verified that the remaining query alert still references a metric documented as present in v2.

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [X] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
