### PR TITLE
fix(mcp): Add truncation metadata to get_trace_topology 

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology.go
@@ -66,12 +66,13 @@ func (h *getTraceTopologyHandler) handle(
 
 	tracesIter := h.queryService.GetTraces(ctx, params)
 
-	// AggregateTracesWithLimit ensures a complete trace view while bounding server-side
-	// memory to maxSpanDetailsPerRequest spans, preventing unbounded work on large traces.
-	aggregatedIter := jptrace.AggregateTracesWithLimit(tracesIter, h.maxSpanDetailsPerRequest)
+	// AggregateTraces reassembles the full trace so TotalSpanCount reflects every span.
+	// The collected rawSpan slice is capped inside the iteration loop below.
+	aggregatedIter := jptrace.AggregateTraces(tracesIter)
 
-	// Collect all spans from the trace
+	// Collect spans from the trace, counting total and capping collected details.
 	var spans []rawSpan
+	totalSpanCount := 0
 	traceFound := false
 
 	for trace, err := range aggregatedIter {
@@ -80,13 +81,13 @@ func (h *getTraceTopologyHandler) handle(
 		}
 
 		traceFound = true
+		totalSpanCount += trace.SpanCount()
 
-		// Iterate through all spans in the trace and collect them
 		for pos, span := range jptrace.SpanIter(trace) {
-			spans = append(spans, extractRawSpan(pos, span))
 			if h.maxSpanDetailsPerRequest > 0 && len(spans) >= h.maxSpanDetailsPerRequest {
 				break
 			}
+			spans = append(spans, extractRawSpan(pos, span))
 		}
 	}
 
@@ -94,10 +95,15 @@ func (h *getTraceTopologyHandler) handle(
 		return nil, types.GetTraceTopologyOutput{}, errors.New("trace not found")
 	}
 
-	// Build the flat topology list from the collected spans
+	// Build the flat topology list from the collected spans.
+	// Depth filtering may further reduce the number of returned spans.
+	topologySpans := h.buildFlatTopology(spans, input.Depth)
+
 	output := types.GetTraceTopologyOutput{
-		TraceID: input.TraceID,
-		Spans:   h.buildFlatTopology(spans, input.Depth),
+		TraceID:           input.TraceID,
+		TotalSpanCount:    totalSpanCount,
+		ReturnedSpanCount: len(topologySpans),
+		Spans:             topologySpans,
 	}
 
 	return nil, output, nil

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology_test.go
@@ -66,6 +66,8 @@ func TestGetTraceTopologyHandler_Handle_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, traceID, output.TraceID)
 	require.Len(t, output.Spans, 3)
+	assert.Equal(t, 3, output.TotalSpanCount)
+	assert.Equal(t, 3, output.ReturnedSpanCount)
 
 	root := findSpanByName(output.Spans, "/api/checkout")
 	require.NotNil(t, root)
@@ -105,6 +107,7 @@ func TestGetTraceTopologyHandler_Handle_DepthLimit(t *testing.T) {
 		dontExpectNames      []string
 		expectRootTruncated  int
 		expectChildTruncated int
+		expectReturnedCount  int
 	}{
 		{
 			name:                 "depth 0 returns full tree",
@@ -112,6 +115,7 @@ func TestGetTraceTopologyHandler_Handle_DepthLimit(t *testing.T) {
 			expectSpanNames:      []string{"/api/checkout", "getCart", "queryDB"},
 			expectRootTruncated:  0,
 			expectChildTruncated: 0,
+			expectReturnedCount:  3,
 		},
 		{
 			name:                 "depth 1 returns only root",
@@ -120,6 +124,7 @@ func TestGetTraceTopologyHandler_Handle_DepthLimit(t *testing.T) {
 			dontExpectNames:      []string{"getCart", "queryDB"},
 			expectRootTruncated:  1, // 1 child truncated at root
 			expectChildTruncated: 0,
+			expectReturnedCount:  1,
 		},
 		{
 			name:                 "depth 2 returns root and children",
@@ -128,6 +133,7 @@ func TestGetTraceTopologyHandler_Handle_DepthLimit(t *testing.T) {
 			dontExpectNames:      []string{"queryDB"},
 			expectRootTruncated:  0,
 			expectChildTruncated: 1, // 1 grandchild truncated at child level
+			expectReturnedCount:  2,
 		},
 		{
 			name:                 "depth 3 returns full tree",
@@ -135,6 +141,7 @@ func TestGetTraceTopologyHandler_Handle_DepthLimit(t *testing.T) {
 			expectSpanNames:      []string{"/api/checkout", "getCart", "queryDB"},
 			expectRootTruncated:  0,
 			expectChildTruncated: 0,
+			expectReturnedCount:  3,
 		},
 	}
 
@@ -143,6 +150,12 @@ func TestGetTraceTopologyHandler_Handle_DepthLimit(t *testing.T) {
 			input := types.GetTraceTopologyInput{TraceID: traceID, Depth: tt.depth}
 			_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 			require.NoError(t, err)
+
+			// TotalSpanCount always reflects the full trace
+			assert.Equal(t, 3, output.TotalSpanCount)
+			// ReturnedSpanCount reflects spans after depth filtering
+			assert.Equal(t, tt.expectReturnedCount, output.ReturnedSpanCount)
+			assert.Len(t, output.Spans, tt.expectReturnedCount)
 
 			byName := make(map[string]types.TopologySpan)
 			for _, s := range output.Spans {
@@ -598,4 +611,31 @@ func TestGetTraceTopologyHandler_Handle_LimitEnforced(t *testing.T) {
 	require.NoError(t, err)
 	// Exactly 3 spans returned — 6-span trace with limit=3 must truncate to exactly 3
 	assert.Len(t, output.Spans, 3)
+	// Truncation metadata must report the full trace size
+	assert.Equal(t, 6, output.TotalSpanCount)
+	assert.Equal(t, 3, output.ReturnedSpanCount)
+}
+
+func TestGetTraceTopologyHandler_Handle_NoLimitReportsEqualCounts(t *testing.T) {
+	traceID := testTraceID
+
+	spanConfigs := []spanConfig{
+		{spanID: "root001", operation: "root"},
+		{spanID: "span002", parentSpanID: "root001", operation: "child1"},
+		{spanID: "span003", parentSpanID: "root001", operation: "child2"},
+	}
+
+	testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+	mock := newMockYieldingTraces(testTrace)
+
+	// No limit (0 means unlimited)
+	handler := &getTraceTopologyHandler{queryService: mock}
+
+	input := types.GetTraceTopologyInput{TraceID: traceID}
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Len(t, output.Spans, 3)
+	assert.Equal(t, 3, output.TotalSpanCount)
+	assert.Equal(t, 3, output.ReturnedSpanCount)
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_topology.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_topology.go
@@ -17,9 +17,14 @@ type GetTraceTopologyInput struct {
 // Spans is a flat, depth-first ordered list. The Path field on each span encodes
 // the tree structure as a slash-delimited sequence of span IDs from the root to
 // that span (e.g. "rootID/parentID/spanID").
+// When a trace exceeds the per-request span limit, only the first
+// ReturnedSpanCount spans are included and TotalSpanCount reports the full size
+// so callers can detect truncation.
 type GetTraceTopologyOutput struct {
-	TraceID string         `json:"trace_id" jsonschema:"Unique identifier for the trace"`
-	Spans   []TopologySpan `json:"spans"    jsonschema:"Flat depth-first list of spans; Path encodes parent-child relationships"`
+	TraceID           string         `json:"trace_id"             jsonschema:"Unique identifier for the trace"`
+	TotalSpanCount    int            `json:"total_span_count"     jsonschema:"Total number of spans in the trace (may exceed returned spans due to per-request limits)"`
+	ReturnedSpanCount int            `json:"returned_span_count"  jsonschema:"Number of spans included in this response"`
+	Spans             []TopologySpan `json:"spans"                jsonschema:"Flat depth-first list of spans; Path encodes parent-child relationships"`
 }
 
 // TopologySpan represents a span in the flat trace topology output.


### PR DESCRIPTION

## Summary                                                                                                                                        
  - Added `total_span_count` and `returned_span_count` fields to `GetTraceTopologyOutput`                                                           
  - Switched from `AggregateTracesWithLimit` to `AggregateTraces` so the handler can count all spans before capping the collected details (same  pattern as `get_trace_errors`)                                                                                                                    
  - Updated and added tests asserting truncation metadata                                                                                           
                                                                                                                                                    
  ## Test plan                                                                                                                                      
  - [x] `make fmt`  clean                                                                                                                          
  - [x] `make lint`  0 issues                                                                                                                      
  - [x] `make test` 3310 pass
  - [x] Runtime verified: 26-span trace returns `total_span_count: 26, returned_span_count: 20`

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [X ] **Light**: AI provided minor assistance (formatting, simple suggestions) -  yes mostly to maintain the code consistency in this repo
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
