### PR TITLE
fix(mcp): Add trace_count field to search_traces output

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -84,7 +84,10 @@ func (h *searchTracesHandler) handle(
 		}
 	}
 
-	output := types.SearchTracesOutput{Traces: summaries}
+	output := types.SearchTracesOutput{
+		TraceCount: len(summaries),
+		Traces:     summaries,
+	}
 
 	// If we encountered errors during processing, include them in the output
 	if len(processErrs) > 0 {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -108,6 +108,7 @@ func TestSearchTracesHandler_Handle_FullWorkflow(t *testing.T) {
 	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 
 	require.NoError(t, err)
+	assert.Equal(t, 1, output.TraceCount)
 	require.Len(t, output.Traces, 1)
 	assert.Equal(t, "cart-service", output.Traces[0].RootService)
 	assert.Equal(t, "/get-cart", output.Traces[0].RootSpanName)
@@ -129,6 +130,7 @@ func TestSearchTracesHandler_Handle_WithStartTimeMax(t *testing.T) {
 	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 
 	require.NoError(t, err)
+	assert.Equal(t, 1, output.TraceCount)
 	require.Len(t, output.Traces, 1)
 }
 
@@ -157,6 +159,7 @@ func TestSearchTracesHandler_Handle_WithDurations(t *testing.T) {
 	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 
 	require.NoError(t, err)
+	assert.Equal(t, 1, output.TraceCount)
 	require.Len(t, output.Traces, 1)
 }
 
@@ -188,6 +191,7 @@ func TestSearchTracesHandler_Handle_WithAttributes(t *testing.T) {
 	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 
 	require.NoError(t, err)
+	assert.Equal(t, 1, output.TraceCount)
 	require.Len(t, output.Traces, 1)
 }
 
@@ -220,6 +224,7 @@ func TestSearchTracesHandler_Handle_WithErrorsFilter(t *testing.T) {
 
 	require.NoError(t, err)
 	// Only error trace should be returned
+	assert.Equal(t, 1, output.TraceCount)
 	require.Len(t, output.Traces, 1)
 	assert.True(t, output.Traces[0].HasErrors)
 }
@@ -255,6 +260,7 @@ func TestSearchTracesHandler_Handle_WithErrorsFilter_UsingMemoryStore(t *testing
 	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 
 	require.NoError(t, err)
+	assert.Equal(t, 1, output.TraceCount)
 	require.Len(t, output.Traces, 1)
 	assert.True(t, output.Traces[0].HasErrors)
 	assert.Equal(t, "test", output.Traces[0].RootService)
@@ -335,6 +341,7 @@ func TestSearchTracesHandler_Handle_QueryError(t *testing.T) {
 
 	// Should not return an error - instead returns partial results with Error field
 	require.NoError(t, err)
+	assert.Equal(t, 1, output.TraceCount)
 	assert.Len(t, output.Traces, 1)
 	assert.NotEmpty(t, output.Error)
 	assert.Contains(t, output.Error, "partial results")
@@ -373,10 +380,34 @@ func TestSearchTracesHandler_Handle_PartialResults(t *testing.T) {
 	// Should not return an error - instead returns partial results with Error field
 	require.NoError(t, err)
 	// Should have all 3 traces since we continue processing after error
+	assert.Equal(t, 3, output.TraceCount)
 	assert.Len(t, output.Traces, 3)
 	assert.NotEmpty(t, output.Error)
 	assert.Contains(t, output.Error, "partial results")
 	assert.Contains(t, output.Error, "temporary failure")
+}
+
+func TestSearchTracesHandler_Handle_EmptyResults(t *testing.T) {
+	mock := &mockQueryService{
+		findTracesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+			return func(_ func([]ptrace.Traces, error) bool) {
+				// No traces yielded
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "nonexistent",
+	}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, output.TraceCount)
+	assert.Empty(t, output.Traces)
 }
 
 func TestSearchTracesHandler_Handle_MissingServiceName(t *testing.T) {
@@ -564,6 +595,7 @@ func TestSearchTracesHandler_Handle_DefaultStartTime(t *testing.T) {
 	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 
 	require.NoError(t, err)
+	assert.Equal(t, 1, output.TraceCount)
 	require.Len(t, output.Traces, 1)
 }
 
@@ -601,5 +633,6 @@ func TestSearchTracesHandler_Handle_LimitEnforced(t *testing.T) {
 
 	require.NoError(t, err)
 	// Returned traces are capped at exactly the limit (5 traces, limit=3 → exactly 3 traces)
+	assert.Equal(t, 3, output.TraceCount)
 	assert.Len(t, output.Traces, 3)
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/search_traces.go
@@ -41,8 +41,9 @@ type SearchTracesInput struct {
 
 // SearchTracesOutput defines the output of the search_traces MCP tool.
 type SearchTracesOutput struct {
-	Traces []TraceSummary `json:"traces,omitempty" jsonschema:"List of trace summaries matching the search criteria"`
-	Error  string         `json:"error,omitempty" jsonschema:"Error message if partial results were returned"`
+	TraceCount int            `json:"trace_count" jsonschema:"Number of traces returned"`
+	Traces     []TraceSummary `json:"traces,omitempty" jsonschema:"List of trace summaries matching the search criteria"`
+	Error      string         `json:"error,omitempty" jsonschema:"Error message if partial results were returned"`
 }
 
 // TraceSummary contains lightweight metadata about a single trace.

--- a/cmd/jaeger/internal/extension/jaegermcp/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server_test.go
@@ -652,6 +652,11 @@ func TestSearchTracesToolEmptyResults(t *testing.T) {
 	// Verify that traces:null is NOT present (the validation error we fixed)
 	assert.NotContains(t, bodyStr, `"traces":null`)
 	assert.NotContains(t, bodyStr, `"traces": null`)
+	// trace_count must always be present and 0 for empty results
+	assert.True(t,
+		bytes.Contains(body, []byte(`"trace_count":0`)) || bytes.Contains(body, []byte(`"trace_count": 0`)),
+		"expected response to contain trace_count set to 0",
+	)
 
 	// Clean up MCP session to avoid goroutine leaks
 	deleteReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("http://%s/mcp", addr), http.NoBody)


### PR DESCRIPTION
## Summary

  The `search_traces` MCP tool returns `{}` on empty results, giving no indication whether the search found nothing or encountered an error. Thisadds a top-level `trace_count` field to `SearchTracesOutput`, following the existing pattern used by other MCP tools:
  - `get_trace_errors` → `total_error_count`
  - `get_trace_topology` → `total_span_count`
  - 
  Discussed with @yurishkuro in Slack.

  ## Before / After

  ```json
  // Before (empty results)
  {}

  // After (empty results)
  {"trace_count": 0}

  // After (with results)
  {"trace_count": 2, "traces": [...]}
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
