### PR TITLE
[mcp] Make `service_name` optional in `search_traces` 

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -122,10 +122,6 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 		return querysvc.TraceQueryParams{}, errors.New("start_time_max must be after start_time_min")
 	}
 
-	if input.ServiceName == "" {
-		return querysvc.TraceQueryParams{}, errors.New("service_name is required")
-	}
-
 	// Parse duration parameters
 	var durationMin, durationMax time.Duration
 	if input.DurationMin != "" {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -379,18 +379,34 @@ func TestSearchTracesHandler_Handle_PartialResults(t *testing.T) {
 	assert.Contains(t, output.Error, "temporary failure")
 }
 
-func TestSearchTracesHandler_Handle_MissingServiceName(t *testing.T) {
-	handler := NewSearchTracesHandler(nil, 100)
+func TestSearchTracesHandler_Handle_CrossServiceSearch(t *testing.T) {
+	// service_name is optional — omitting it should search across all services.
+	traceA := createTestTrace("traceA", "frontend", "/checkout", false)
+	traceB := createTestTrace("traceB", "payment", "/charge", false)
+
+	mock := &mockQueryService{
+		findTracesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+			// Empty service name must be passed through to storage unchanged.
+			assert.Equal(t, "", query.ServiceName)
+			return func(yield func([]ptrace.Traces, error) bool) {
+				yield([]ptrace.Traces{traceA}, nil)
+				yield([]ptrace.Traces{traceB}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 100}
 
 	input := types.SearchTracesInput{
 		StartTimeMin: "-1h",
-		// Missing ServiceName
+		// ServiceName intentionally omitted
 	}
 
-	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, input)
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "service_name is required")
+	require.NoError(t, err)
+	require.Len(t, output.Traces, 2)
+	assert.Empty(t, output.Error)
 }
 
 func TestSearchTracesHandler_Handle_InvalidTimeFormat(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/search_traces.go
@@ -13,8 +13,10 @@ type SearchTracesInput struct {
 	// Supports RFC3339 or relative time (e.g., "now", "-1m").
 	StartTimeMax string `json:"start_time_max,omitempty" jsonschema:"End of time interval (RFC3339 or relative like now). Default: now"`
 
-	// ServiceName filters by service name (required).
-	ServiceName string `json:"service_name" jsonschema:"Filter by service name. Use get_services to discover valid names"`
+	// ServiceName filters by service name (optional).
+	// When omitted, the search runs across all services. This may be slower on large deployments.
+	// Use get_services to discover valid service names.
+	ServiceName string `json:"service_name,omitempty" jsonschema:"Filter by service name. Omit to search across all services (may be slower on large deployments). Use get_services to discover valid names"`
 
 	// SpanName filters by span name (optional).
 	SpanName string `json:"span_name,omitempty" jsonschema:"Filter by span name"`


### PR DESCRIPTION
Resolves #8492

## Which problem is this PR solving?

The `search_traces` MCP tool hard-rejected any request where `service_name` was
empty, even though the underlying storage `FindTraces` API on every backend
(Elasticsearch, Cassandra, ClickHouse, Badger, Memory) already accepts an empty
`ServiceName` and treats it as an unfiltered cross-service query.

This forced AI agents into an expensive workaround: call `get_services` first,
then loop `search_traces` N times (once per service), then merge results in the
LLM context window. A common and legitimate query like "show me all HTTP 500
errors in the last 10 minutes" was impossible in a single tool call.

## Short description of the changes

- Removed the `service_name is required` validation guard from `buildQuery` in
  `search_traces.go`. An empty `ServiceName` now passes through to `FindTraces`
  unchanged.
- Changed the `service_name` JSON tag in `SearchTracesInput` from required to
  `omitempty` and updated the schema description to inform MCP clients that
  omitting the field searches across all services (and may be slower on large
  deployments).
- Replaced `TestSearchTracesHandler_Handle_MissingServiceName` (which tested
  the now-removed error) with `TestSearchTracesHandler_Handle_CrossServiceSearch`,
  which verifies that an empty `service_name` produces no error and that the
  empty string is passed through to the storage layer unchanged.