### PR TITLE
[jaegermcp] Implement Skills Framework - Phase 2 (#8440)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/config.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/config.go
@@ -1,39 +1,41 @@
-// Copyright (c) 2026 The Jaeger Authors.
+﻿// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package jaegermcp
 
 import (
-	"github.com/asaskevich/govalidator"
-	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/confmap/xconfmap"
+    "github.com/asaskevich/govalidator"
+    "go.opentelemetry.io/collector/config/confighttp"
+    "go.opentelemetry.io/collector/confmap/xconfmap"
 )
 
 // Config represents the configuration for the Jaeger MCP server extension.
 type Config struct {
-	// HTTP contains the HTTP server configuration for the MCP protocol endpoint.
-	HTTP confighttp.ServerConfig `mapstructure:"http"`
+    // HTTP contains the HTTP server configuration for the MCP protocol endpoint.
+    HTTP confighttp.ServerConfig `mapstructure:"http"`
 
-	// ServerName is the name of the MCP server for protocol identification.
-	ServerName string `mapstructure:"server_name"`
+    // ServerName is the name of the MCP server for protocol identification.
+    ServerName string `mapstructure:"server_name"`
 
-	// ServerVersion is the version of the MCP server.
-	ServerVersion string `mapstructure:"server_version" valid:"required"`
+    // ServerVersion is the version of the MCP server.
+    ServerVersion string `mapstructure:"server_version" valid:"required"`
 
-	// MaxSpanDetailsPerRequest limits the number of spans that can be fetched in a single request.
-	MaxSpanDetailsPerRequest int `mapstructure:"max_span_details_per_request" valid:"range(1|100)"`
+    // MaxSpanDetailsPerRequest limits the number of spans that can be fetched in a single request.
+    MaxSpanDetailsPerRequest int `mapstructure:"max_span_details_per_request" valid:"range(1|100)"`
 
-	// MaxSearchResults limits the number of trace search results.
-	MaxSearchResults int `mapstructure:"max_search_results" valid:"range(1|1000)"`
+    // MaxSearchResults limits the number of trace search results.
+    MaxSearchResults int `mapstructure:"max_search_results" valid:"range(1|1000)"`
+
+    // SkillsDir is the directory from which user-defined Skill YAML files are loaded.
+    // If empty or the directory does not exist, no skills are loaded and the
+    // list_skills / get_skill tools return empty results.
+    SkillsDir string `mapstructure:"skills_dir"`
 }
 
 // Validate checks if the configuration is valid.
 func (cfg *Config) Validate() error {
-	// if cfg.ServerVersion == "" {
-	// 	cfg.ServerVersion = version.Get().GitVersion
-	// }
-	_, err := govalidator.ValidateStruct(cfg)
-	return err
+    _, err := govalidator.ValidateStruct(cfg)
+    return err
 }
 
 var _ xconfmap.Validator = (*Config)(nil)

--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -219,8 +219,8 @@ func TestMCPClientToolsListDiscovery(t *testing.T) {
 
 	expected := []string{
 		"health", "get_services", "get_span_names", "search_traces",
-		"get_span_details", "get_trace_errors", "get_trace_topology", "get_critical_path",
-		"get_service_dependencies",
+                "get_span_details", "get_trace_errors", "get_trace_topology", "get_critical_path",
+                "get_service_dependencies", "list_skills", "get_skill",
 	}
 	got := make(map[string]bool, len(result.Tools))
 	for _, tool := range result.Tools {
@@ -486,3 +486,4 @@ func TestMCPClientMultipleSessionsIndependent(t *testing.T) {
 	text2 := extractTextContent(t, r2.toolResult)
 	assert.Equal(t, text1, text2)
 }
+

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler.go
@@ -1,0 +1,78 @@
+﻿// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/skills"
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
+)
+
+type ListSkillsInput struct{}
+
+type ListSkillsOutput struct {
+    Skills []skillSummary `json:"skills"`
+}
+
+type GetSkillInput struct {
+    Name string `json:"name" jsonschema:"description=The unique name of the skill to retrieve."`
+}
+
+type GetSkillOutput struct {
+    Skill *types.Skill `json:"skill"`
+}
+
+type skillSummary struct {
+    Name         string   `json:"name"`
+    Description  string   `json:"description"`
+    AllowedTools []string `json:"allowed_tools"`
+    Version      string   `json:"version,omitempty"`
+}
+
+type listSkillsHandler struct {
+    loader *skills.Loader
+}
+
+func NewListSkillsHandler(loader *skills.Loader) mcp.ToolHandlerFor[ListSkillsInput, ListSkillsOutput] {
+    h := &listSkillsHandler{loader: loader}
+    return h.handle
+}
+
+func (h *listSkillsHandler) handle(_ context.Context, _ *mcp.CallToolRequest, _ ListSkillsInput) (*mcp.CallToolResult, ListSkillsOutput, error) {
+    all := h.loader.All()
+    summaries := make([]skillSummary, 0, len(all))
+    for _, s := range all {
+        summaries = append(summaries, skillSummary{
+            Name:         s.Name,
+            Description:  s.Description,
+            AllowedTools: s.AllowedTools,
+            Version:      s.Version,
+        })
+    }
+    return nil, ListSkillsOutput{Skills: summaries}, nil
+}
+
+type getSkillHandler struct {
+    loader *skills.Loader
+}
+
+func NewGetSkillHandler(loader *skills.Loader) mcp.ToolHandlerFor[GetSkillInput, GetSkillOutput] {
+    h := &getSkillHandler{loader: loader}
+    return h.handle
+}
+
+func (h *getSkillHandler) handle(_ context.Context, _ *mcp.CallToolRequest, input GetSkillInput) (*mcp.CallToolResult, GetSkillOutput, error) {
+    if input.Name == "" {
+        return nil, GetSkillOutput{}, fmt.Errorf("name is required")
+    }
+    skill, ok := h.loader.Get(input.Name)
+    if !ok {
+        return nil, GetSkillOutput{}, fmt.Errorf("skill %q not found; use list_skills to see available skills", input.Name)
+    }
+    return nil, GetSkillOutput{Skill: skill}, nil
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler.go
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2026 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package handlers
@@ -6,6 +6,7 @@ package handlers
 import (
     "context"
     "fmt"
+    "sort"
 
     "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -13,20 +14,25 @@ import (
     "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
 )
 
+// ListSkillsInput is the input for the list_skills tool (no parameters required).
 type ListSkillsInput struct{}
 
+// ListSkillsOutput is the output for the list_skills tool.
 type ListSkillsOutput struct {
     Skills []skillSummary `json:"skills"`
 }
 
+// GetSkillInput is the input for the get_skill tool.
 type GetSkillInput struct {
-    Name string `json:"name" jsonschema:"description=The unique name of the skill to retrieve."`
+    Name string `json:"name" jsonschema:"The unique name of the skill to retrieve."`
 }
 
+// GetSkillOutput is the output for the get_skill tool.
 type GetSkillOutput struct {
     Skill *types.Skill `json:"skill"`
 }
 
+// skillSummary is the lightweight representation returned by list_skills.
 type skillSummary struct {
     Name         string   `json:"name"`
     Description  string   `json:"description"`
@@ -38,6 +44,7 @@ type listSkillsHandler struct {
     loader *skills.Loader
 }
 
+// NewListSkillsHandler creates a new list_skills handler and returns the handler function.
 func NewListSkillsHandler(loader *skills.Loader) mcp.ToolHandlerFor[ListSkillsInput, ListSkillsOutput] {
     h := &listSkillsHandler{loader: loader}
     return h.handle
@@ -54,6 +61,9 @@ func (h *listSkillsHandler) handle(_ context.Context, _ *mcp.CallToolRequest, _ 
             Version:      s.Version,
         })
     }
+    sort.Slice(summaries, func(i, j int) bool {
+        return summaries[i].Name < summaries[j].Name
+    })
     return nil, ListSkillsOutput{Skills: summaries}, nil
 }
 
@@ -61,6 +71,7 @@ type getSkillHandler struct {
     loader *skills.Loader
 }
 
+// NewGetSkillHandler creates a new get_skill handler and returns the handler function.
 func NewGetSkillHandler(loader *skills.Loader) mcp.ToolHandlerFor[GetSkillInput, GetSkillOutput] {
     h := &getSkillHandler{loader: loader}
     return h.handle
@@ -76,3 +87,4 @@ func (h *getSkillHandler) handle(_ context.Context, _ *mcp.CallToolRequest, inpu
     }
     return nil, GetSkillOutput{Skill: skill}, nil
 }
+

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler_test.go
@@ -1,0 +1,72 @@
+﻿// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+    "context"
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "go.uber.org/zap/zaptest"
+
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/skills"
+)
+
+type staticToolLister struct{ tools []string }
+
+func (s *staticToolLister) ListTools(_ context.Context) ([]string, error) { return s.tools, nil }
+
+func newTestLoader(t *testing.T) *skills.Loader {
+    t.Helper()
+    dir := t.TempDir()
+    require.NoError(t, os.WriteFile(filepath.Join(dir, "test.yaml"), []byte(`
+name: analyze-critical-path
+description: Identifies the critical path and slowest spans in a trace.
+system_prompt: "You are a distributed tracing expert."
+allowed_tools:
+  - get_critical_path
+  - get_span_details
+`), 0o644))
+    loader := skills.NewLoader(dir, zaptest.NewLogger(t))
+    lister := &staticToolLister{tools: []string{"get_critical_path", "get_span_details"}}
+    require.NoError(t, loader.Load(context.Background(), lister))
+    return loader
+}
+
+func TestListSkillsHandler_ReturnsSummaries(t *testing.T) {
+    loader := newTestLoader(t)
+    h := &listSkillsHandler{loader: loader}
+    _, output, err := h.handle(context.Background(), nil, ListSkillsInput{})
+    require.NoError(t, err)
+    require.Len(t, output.Skills, 1)
+    assert.Equal(t, "analyze-critical-path", output.Skills[0].Name)
+}
+
+func TestGetSkillHandler_Found(t *testing.T) {
+    loader := newTestLoader(t)
+    h := &getSkillHandler{loader: loader}
+    _, output, err := h.handle(context.Background(), nil, GetSkillInput{Name: "analyze-critical-path"})
+    require.NoError(t, err)
+    require.NotNil(t, output.Skill)
+    assert.Equal(t, "analyze-critical-path", output.Skill.Name)
+}
+
+func TestGetSkillHandler_NotFound(t *testing.T) {
+    loader := newTestLoader(t)
+    h := &getSkillHandler{loader: loader}
+    _, _, err := h.handle(context.Background(), nil, GetSkillInput{Name: "nonexistent"})
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetSkillHandler_EmptyName(t *testing.T) {
+    loader := newTestLoader(t)
+    h := &getSkillHandler{loader: loader}
+    _, _, err := h.handle(context.Background(), nil, GetSkillInput{Name: ""})
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "name is required")
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/skills_handler_test.go
@@ -46,6 +46,23 @@ func TestListSkillsHandler_ReturnsSummaries(t *testing.T) {
     assert.Equal(t, "analyze-critical-path", output.Skills[0].Name)
 }
 
+func TestListSkillsHandler_SortedByName(t *testing.T) {
+    dir := t.TempDir()
+    for _, name := range []string{"zzz-skill", "aaa-skill", "mmm-skill"} {
+        content := "name: " + name + "\ndescription: test\nsystem_prompt: prompt\nallowed_tools:\n  - get_critical_path\n"
+        require.NoError(t, os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(content), 0o644))
+    }
+    loader := skills.NewLoader(dir, zaptest.NewLogger(t))
+    require.NoError(t, loader.Load(context.Background(), &staticToolLister{tools: []string{"get_critical_path"}}))
+    h := &listSkillsHandler{loader: loader}
+    _, output, err := h.handle(context.Background(), nil, ListSkillsInput{})
+    require.NoError(t, err)
+    require.Len(t, output.Skills, 3)
+    assert.Equal(t, "aaa-skill", output.Skills[0].Name)
+    assert.Equal(t, "mmm-skill", output.Skills[1].Name)
+    assert.Equal(t, "zzz-skill", output.Skills[2].Name)
+}
+
 func TestGetSkillHandler_Found(t *testing.T) {
     loader := newTestLoader(t)
     h := &getSkillHandler{loader: loader}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/analyze-critical-path.yaml
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/analyze-critical-path.yaml
@@ -1,0 +1,71 @@
+# Jaeger AI Skill: Analyze Critical Path
+# Place this file (or custom variations) in your skills directory to enable
+# this debugging workflow in the Jaeger AI assistant.
+#
+# See docs/skills-authoring-guide.md for the full authoring reference.
+
+name: analyze-critical-path
+version: "1.0.0"
+description: >
+  Identifies the critical path through a distributed trace — the sequence of
+  spans whose cumulative latency determines the total request duration.
+  Surfaces the top bottlenecks and explains why each contributes to latency.
+
+system_prompt: |
+  You are an expert in distributed systems performance analysis.
+
+  Your task is to analyze a Jaeger distributed trace and identify the CRITICAL
+  PATH — the chain of spans that directly determines the end-to-end latency
+  of the request.
+
+  ## Analysis Steps
+  1. Call `get_critical_path` with the trace ID to retrieve the critical path segments.
+  2. Call `get_span_details` for each span on the critical path to inspect its
+     attributes, events, and timing.
+  3. Call `get_trace_errors` to check whether any errors on the critical path
+     are contributing to latency (e.g. retries, timeouts).
+
+  ## Output Requirements
+  - State the total request duration.
+  - List the critical path spans in order with their individual durations.
+  - Identify the top 3 bottlenecks with a brief explanation (1-2 sentences each).
+  - If errors are present on the critical path, call them out explicitly.
+  - Format your final answer as Markdown.
+
+  ## Constraints
+  - Do NOT speculate about root causes that are not evidenced in the trace data.
+  - Do NOT suggest code changes or architectural improvements.
+  - Limit your analysis to the provided trace; do not infer behavior from
+    service names alone.
+
+allowed_tools:
+  - get_critical_path
+  - get_span_details
+  - get_trace_errors
+
+output_format: markdown
+
+constraints:
+  - Only reference data present in the trace. Do not speculate.
+  - Do not suggest code or infrastructure changes.
+
+examples:
+  - user_query: "Why is this trace so slow? Trace ID: abc123"
+    expected_tool_sequence:
+      - get_critical_path
+      - get_span_details
+      - get_trace_errors
+    annotated_reasoning: >
+      First call get_critical_path to get the ordered list of bottleneck spans.
+      Then call get_span_details for the top 3 slowest spans to see their
+      attributes and events. Finally call get_trace_errors to check if any
+      critical-path spans had errors that caused retries or fallbacks.
+
+  - user_query: "Which service is causing the most latency?"
+    expected_tool_sequence:
+      - get_critical_path
+      - get_span_details
+    annotated_reasoning: >
+      Call get_critical_path to retrieve the critical path with per-span timing.
+      The span with the highest self-time on the critical path is the primary
+      contributor. Use get_span_details to confirm the service/operation name.

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/detect-n-plus-one.yaml
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/detect-n-plus-one.yaml
@@ -1,0 +1,64 @@
+# Jaeger AI Skill: Detect N+1 Queries
+# This skill detects the N+1 query anti-pattern in distributed traces:
+# a parent operation triggering many near-identical child calls (typically
+# to a database or downstream service).
+
+name: detect-n-plus-one
+version: "1.0.0"
+description: >
+  Detects the N+1 query anti-pattern: a loop that issues many near-identical
+  downstream calls (DB queries, HTTP requests) that should be batched.
+  Returns the offending parent span, the repeated child operation, and the
+  repeat count.
+
+system_prompt: |
+  You are an expert in distributed systems debugging, specializing in
+  identifying performance anti-patterns.
+
+  Your task is to detect the N+1 QUERY ANTI-PATTERN in a Jaeger trace.
+  The N+1 pattern occurs when a single parent operation triggers N near-identical
+  child calls (e.g. N sequential SELECT queries instead of one batch SELECT).
+
+  ## Detection Algorithm
+  1. Call `get_trace_topology` to get the span tree structure.
+  2. Look for any parent span that has more than 5 children sharing the same
+     `db.statement` prefix, `http.url` pattern, or `rpc.method`.
+  3. Call `get_span_details` on a sample of the repeated child spans to confirm
+     they are structurally identical (same operation, same target).
+  4. Calculate the total time wasted by the repeated calls.
+
+  ## Thresholds
+  - Report as N+1 if: a parent has >= 5 near-identical children.
+  - Report as "suspicious" if: a parent has >= 3 near-identical children.
+
+  ## Output Requirements
+  - State whether an N+1 pattern was detected (YES/NO/SUSPICIOUS).
+  - If detected: identify the parent span, the repeated operation, and N.
+  - Calculate the total cumulative time spent on the repeated calls.
+  - Provide a one-sentence explanation of what the fix would look like
+    (batch query, cache, etc.) WITHOUT suggesting specific code.
+  - Format as Markdown.
+
+  ## Constraints
+  - Do not speculate about root causes beyond what is visible in span attributes.
+  - Treat db.statement, http.url, and rpc.method as the key attributes for
+    grouping near-identical calls.
+
+allowed_tools:
+  - get_trace_topology
+  - get_span_details
+
+output_format: markdown
+
+constraints:
+  - Only report patterns evidenced by span attributes. Do not guess.
+
+examples:
+  - user_query: "Is there an N+1 query problem in this trace?"
+    expected_tool_sequence:
+      - get_trace_topology
+      - get_span_details
+    annotated_reasoning: >
+      Call get_trace_topology to see the parent/child span structure and count
+      children per parent. If a parent has many children, call get_span_details
+      on a sample (first and last) to confirm they share the same operation/target.

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/loader.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/loader.go
@@ -1,0 +1,179 @@
+// Copyright (c) The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package skills implements the Jaeger AI Skills Engine: the component
+// responsible for discovering, validating, and serving user-defined Skill
+// definitions at runtime without requiring a Jaeger binary recompile.
+//
+// Design constraints (per maintainer guidance on issue #8440):
+//   - Skills are purely declarative (system prompt + allowed_tools list).
+//   - Skills MUST NOT register new MCP tool behavior at runtime.
+//   - All tool references are validated against a snapshot of the live MCP
+//     registry at load time so failures are caught eagerly.
+package skills
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
+)
+
+// ToolLister is a narrow interface over the MCP server's tool registry,
+// used to validate allowed_tools at skill load time.
+type ToolLister interface {
+	// ListTools returns the names of all currently registered MCP tools.
+	ListTools(ctx context.Context) ([]string, error)
+}
+
+// Loader discovers, parses, and validates Skill YAML files from a directory.
+// It is safe for concurrent reads after Load() completes.
+type Loader struct {
+	dir    string
+	logger *zap.Logger
+
+	mu     sync.RWMutex
+	skills map[string]*types.Skill // keyed by Skill.Name
+}
+
+// NewLoader creates a Loader that reads skills from dir.
+func NewLoader(dir string, logger *zap.Logger) *Loader {
+	return &Loader{
+		dir:    dir,
+		logger: logger,
+		skills: make(map[string]*types.Skill),
+	}
+}
+
+// Load walks dir, parses every *.yaml / *.yml file as a Skill, validates each
+// one structurally, then validates all tool references against the live MCP
+// registry snapshot returned by lister. Errors for individual files are
+// collected and returned as a joined error; a single bad file does not prevent
+// valid skills from being loaded.
+func (l *Loader) Load(ctx context.Context, lister ToolLister) error {
+	knownTools, err := lister.ListTools(ctx)
+	if err != nil {
+		return fmt.Errorf("skills loader: cannot fetch tool registry: %w", err)
+	}
+	toolSet := make(map[string]struct{}, len(knownTools))
+	for _, t := range knownTools {
+		toolSet[t] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(l.dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			l.logger.Info("skills directory does not exist, no skills loaded", zap.String("dir", l.dir))
+			return nil
+		}
+		return fmt.Errorf("skills loader: reading directory %q: %w", l.dir, err)
+	}
+
+	loaded := make(map[string]*types.Skill)
+	var errs []error
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isYAML(name) {
+			continue
+		}
+
+		path := filepath.Join(l.dir, name)
+		skill, err := l.loadFile(path)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("skill file %q: %w", path, err))
+			continue
+		}
+
+		if err := validateToolRefs(skill, toolSet); err != nil {
+			errs = append(errs, fmt.Errorf("skill %q: %w", skill.Name, err))
+			continue
+		}
+
+		if _, dup := loaded[skill.Name]; dup {
+			errs = append(errs, fmt.Errorf("skill name %q is defined more than once (file: %s)", skill.Name, path))
+			continue
+		}
+
+		loaded[skill.Name] = skill
+		l.logger.Info("loaded skill",
+			zap.String("name", skill.Name),
+			zap.String("file", path),
+			zap.Strings("allowed_tools", skill.AllowedTools),
+		)
+	}
+
+	l.mu.Lock()
+	l.skills = loaded
+	l.mu.Unlock()
+
+	return errors.Join(errs...)
+}
+
+// Get returns the named skill, or (nil, false) if not found.
+func (l *Loader) Get(name string) (*types.Skill, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	s, ok := l.skills[name]
+	return s, ok
+}
+
+// All returns a snapshot of all loaded skills, keyed by name.
+func (l *Loader) All() map[string]*types.Skill {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	out := make(map[string]*types.Skill, len(l.skills))
+	for k, v := range l.skills {
+		out[k] = v
+	}
+	return out
+}
+
+// loadFile reads and parses a single YAML file into a Skill.
+func (l *Loader) loadFile(path string) (*types.Skill, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+
+	var skill types.Skill
+	if err := yaml.Unmarshal(data, &skill); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+
+	if err := skill.Validate(); err != nil {
+		return nil, fmt.Errorf("validation: %w", err)
+	}
+
+	return &skill, nil
+}
+
+// validateToolRefs ensures every tool listed in skill.AllowedTools exists in
+// the MCP registry snapshot. This is an eager check so bad references are
+// caught at startup rather than at agent request time.
+func validateToolRefs(skill *types.Skill, toolSet map[string]struct{}) error {
+	var errs []error
+	for _, tool := range skill.AllowedTools {
+		if _, ok := toolSet[tool]; !ok {
+			errs = append(errs, fmt.Errorf("allowed_tools references unknown MCP tool %q", tool))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func isYAML(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml")
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/loader_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/loader_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// staticToolLister is a test double for ToolLister.
+type staticToolLister struct {
+	tools []string
+	err   error
+}
+
+func (s *staticToolLister) ListTools(_ context.Context) ([]string, error) {
+	return s.tools, s.err
+}
+
+var testTools = []string{
+	"search_traces",
+	"get_trace_topology",
+	"get_critical_path",
+	"get_span_details",
+	"get_trace_errors",
+	"get_services",
+}
+
+func writeSkillYAML(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644))
+}
+
+const validSkillYAML = `
+name: analyze-critical-path
+description: Identifies the critical path and slowest spans in a trace.
+system_prompt: |
+  You are a distributed systems expert. Use the provided tools to identify
+  performance bottlenecks. Do not speculate beyond the trace data.
+allowed_tools:
+  - get_critical_path
+  - get_span_details
+output_format: markdown
+`
+
+func TestLoader_Load_ValidSkill(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillYAML(t, dir, "critical-path.yaml", validSkillYAML)
+
+	loader := NewLoader(dir, zaptest.NewLogger(t))
+	err := loader.Load(context.Background(), &staticToolLister{tools: testTools})
+	require.NoError(t, err)
+
+	skill, ok := loader.Get("analyze-critical-path")
+	require.True(t, ok)
+	assert.Equal(t, "analyze-critical-path", skill.Name)
+	assert.Equal(t, []string{"get_critical_path", "get_span_details"}, skill.AllowedTools)
+}
+
+func TestLoader_Load_NonExistentDir(t *testing.T) {
+	loader := NewLoader("/does/not/exist", zaptest.NewLogger(t))
+	err := loader.Load(context.Background(), &staticToolLister{tools: testTools})
+	// Should not error when directory simply doesn't exist yet.
+	require.NoError(t, err)
+	assert.Empty(t, loader.All())
+}
+
+func TestLoader_Load_UnknownToolRef(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillYAML(t, dir, "bad.yaml", `
+name: bad-skill
+description: references a tool that does not exist
+system_prompt: prompt
+allowed_tools:
+  - nonexistent_tool
+`)
+
+	loader := NewLoader(dir, zap.NewNop())
+	err := loader.Load(context.Background(), &staticToolLister{tools: testTools})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent_tool")
+	// The bad skill must not be registered.
+	_, ok := loader.Get("bad-skill")
+	assert.False(t, ok)
+}
+
+func TestLoader_Load_MixedValidAndInvalid(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillYAML(t, dir, "good.yaml", validSkillYAML)
+	writeSkillYAML(t, dir, "bad.yaml", `
+name: bad-skill
+description: bad tool ref
+system_prompt: prompt
+allowed_tools:
+  - nonexistent_tool
+`)
+
+	loader := NewLoader(dir, zap.NewNop())
+	err := loader.Load(context.Background(), &staticToolLister{tools: testTools})
+	require.Error(t, err) // error for bad-skill
+
+	// good skill still loaded
+	_, ok := loader.Get("analyze-critical-path")
+	assert.True(t, ok)
+	// bad skill NOT loaded
+	_, ok = loader.Get("bad-skill")
+	assert.False(t, ok)
+}
+
+func TestLoader_Load_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillYAML(t, dir, "broken.yaml", `name: [unclosed bracket`)
+
+	loader := NewLoader(dir, zap.NewNop())
+	err := loader.Load(context.Background(), &staticToolLister{tools: testTools})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broken.yaml")
+}
+
+func TestLoader_Load_DuplicateSkillName(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillYAML(t, dir, "a.yaml", validSkillYAML)
+	writeSkillYAML(t, dir, "b.yaml", validSkillYAML) // same name, different file
+
+	loader := NewLoader(dir, zap.NewNop())
+	err := loader.Load(context.Background(), &staticToolLister{tools: testTools})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "defined more than once")
+}
+
+func TestLoader_All(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillYAML(t, dir, "a.yaml", validSkillYAML)
+
+	loader := NewLoader(dir, zap.NewNop())
+	require.NoError(t, loader.Load(context.Background(), &staticToolLister{tools: testTools}))
+
+	all := loader.All()
+	assert.Len(t, all, 1)
+	assert.Contains(t, all, "analyze-critical-path")
+}
+
+func TestLoader_IgnoresNonYAMLFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("ignore me"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{}`), 0o644))
+
+	loader := NewLoader(dir, zap.NewNop())
+	err := loader.Load(context.Background(), &staticToolLister{tools: testTools})
+	require.NoError(t, err)
+	assert.Empty(t, loader.All())
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/skill.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/skill.go
@@ -1,0 +1,100 @@
+// Copyright (c) The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package types defines the data structures for the Jaeger AI Skills framework.
+// A Skill is a declarative configuration artifact that guides the AI agent
+// over a constrained set of existing MCP tools to accomplish a specific
+// observability debugging workflow.
+package types
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Skill represents a user-defined debugging workflow that the Jaeger AI agent
+// can execute. Skills are purely declarative: they compose and constrain
+// existing MCP tools via prompt instructions; they do not register new runtime
+// behavior.
+type Skill struct {
+	// Name is the unique identifier for this skill (e.g. "analyze-critical-path").
+	Name string `yaml:"name" json:"name"`
+
+	// Description is a human-readable summary shown in the UI skill picker.
+	Description string `yaml:"description" json:"description"`
+
+	// Version follows semver and is used for changelog and upgrade paths.
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+
+	// SystemPrompt is the developer/system-level prompt material injected before
+	// the user's message. It MUST NOT contain tool implementations or arbitrary
+	// code; it may reference allowed_tools by name.
+	SystemPrompt string `yaml:"system_prompt" json:"system_prompt"`
+
+	// Examples are few-shot demonstrations that help the model understand the
+	// expected reasoning pattern for this skill.
+	Examples []Example `yaml:"examples,omitempty" json:"examples,omitempty"`
+
+	// AllowedTools is the exhaustive list of MCP tool names this skill may
+	// invoke. Any tool not listed here will be filtered out before the agent
+	// reasons over this skill. References are validated at load time against
+	// the live MCP server tool registry.
+	AllowedTools []string `yaml:"allowed_tools" json:"allowed_tools"`
+
+	// OutputFormat describes the expected structure of the final answer
+	// (e.g. "markdown", "json", "text"). The agent is instructed to conform
+	// to this format in its system prompt.
+	OutputFormat string `yaml:"output_format,omitempty" json:"output_format,omitempty"`
+
+	// Constraints are additional instructions appended to the system prompt to
+	// limit agent behavior (e.g. "Do not speculate beyond the trace data").
+	Constraints []string `yaml:"constraints,omitempty" json:"constraints,omitempty"`
+}
+
+// Example is a single few-shot demonstration for the skill.
+type Example struct {
+	// UserQuery is a representative user question for this skill.
+	UserQuery string `yaml:"user_query" json:"user_query"`
+
+	// ExpectedToolSequence is the ordered list of MCP tool names the agent is
+	// expected to call for this query, used for evaluation and documentation.
+	ExpectedToolSequence []string `yaml:"expected_tool_sequence,omitempty" json:"expected_tool_sequence,omitempty"`
+
+	// AnnotatedReasoning is a human-written explanation of why these tool calls
+	// are appropriate. It is included in the system prompt as a worked example.
+	AnnotatedReasoning string `yaml:"annotated_reasoning,omitempty" json:"annotated_reasoning,omitempty"`
+}
+
+// Validate performs structural validation of a Skill definition.
+// It does NOT validate tool references against the MCP registry; that
+// is done by the Loader at load time via ValidateToolRefs.
+func (s *Skill) Validate() error {
+	var errs []error
+
+	if s.Name == "" {
+		errs = append(errs, errors.New("skill.name must not be empty"))
+	}
+	if s.Description == "" {
+		errs = append(errs, fmt.Errorf("skill %q: description must not be empty", s.Name))
+	}
+	if s.SystemPrompt == "" {
+		errs = append(errs, fmt.Errorf("skill %q: system_prompt must not be empty", s.Name))
+	}
+	if len(s.AllowedTools) == 0 {
+		errs = append(errs, fmt.Errorf("skill %q: allowed_tools must contain at least one tool", s.Name))
+	}
+
+	seen := make(map[string]struct{})
+	for _, t := range s.AllowedTools {
+		if t == "" {
+			errs = append(errs, fmt.Errorf("skill %q: allowed_tools contains an empty tool name", s.Name))
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			errs = append(errs, fmt.Errorf("skill %q: duplicate tool %q in allowed_tools", s.Name, t))
+		}
+		seen[t] = struct{}{}
+	}
+
+	return errors.Join(errs...)
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/skill_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkill_Validate_Valid(t *testing.T) {
+	s := &Skill{
+		Name:         "analyze-critical-path",
+		Description:  "Identifies the slowest path through a trace.",
+		SystemPrompt: "You are an expert in distributed tracing...",
+		AllowedTools: []string{"get_critical_path", "get_span_details"},
+	}
+	require.NoError(t, s.Validate())
+}
+
+func TestSkill_Validate_MissingName(t *testing.T) {
+	s := &Skill{
+		Description:  "desc",
+		SystemPrompt: "prompt",
+		AllowedTools: []string{"search_traces"},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skill.name must not be empty")
+}
+
+func TestSkill_Validate_MissingSystemPrompt(t *testing.T) {
+	s := &Skill{
+		Name:         "my-skill",
+		Description:  "desc",
+		AllowedTools: []string{"search_traces"},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "system_prompt must not be empty")
+}
+
+func TestSkill_Validate_EmptyAllowedTools(t *testing.T) {
+	s := &Skill{
+		Name:         "my-skill",
+		Description:  "desc",
+		SystemPrompt: "prompt",
+		AllowedTools: []string{},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_tools must contain at least one tool")
+}
+
+func TestSkill_Validate_DuplicateTool(t *testing.T) {
+	s := &Skill{
+		Name:         "my-skill",
+		Description:  "desc",
+		SystemPrompt: "prompt",
+		AllowedTools: []string{"search_traces", "search_traces"},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate tool")
+}
+
+func TestSkill_Validate_EmptyToolName(t *testing.T) {
+	s := &Skill{
+		Name:         "my-skill",
+		Description:  "desc",
+		SystemPrompt: "prompt",
+		AllowedTools: []string{"search_traces", ""},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty tool name")
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -1,226 +1,278 @@
-// Copyright (c) 2026 The Jaeger Authors.
+﻿// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package jaegermcp
 
 import (
-	"context"
-	_ "embed"
-	"errors"
-	"fmt"
-	"net"
-	"net/http"
-	"time"
+    "context"
+    _ "embed"
+    "errors"
+    "fmt"
+    "net"
+    "net/http"
+    "time"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/extension"
-	"go.opentelemetry.io/collector/extension/extensioncapabilities"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.uber.org/zap"
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+    "go.opentelemetry.io/collector/component"
+    "go.opentelemetry.io/collector/extension"
+    "go.opentelemetry.io/collector/extension/extensioncapabilities"
+    "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+    "go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/handlers"
-	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery"
-	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
-	"github.com/jaegertracing/jaeger/internal/tenancy"
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/handlers"
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/skills"
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery"
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+    "github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 //go:embed INSTRUCTIONS.md
 var serverInstructions string
 
 var (
-	_ extension.Extension             = (*server)(nil)
-	_ extensioncapabilities.Dependent = (*server)(nil)
+    _ extension.Extension             = (*server)(nil)
+    _ extensioncapabilities.Dependent = (*server)(nil)
 )
 
 // server implements the Jaeger MCP extension.
 type server struct {
-	config     *Config
-	telset     component.TelemetrySettings
-	httpServer *http.Server
-	listener   net.Listener
-	mcpServer  *mcp.Server
-	queryAPI   *querysvc.QueryService
+    config       *Config
+    telset       component.TelemetrySettings
+    httpServer   *http.Server
+    listener     net.Listener
+    mcpServer    *mcp.Server
+    queryAPI     *querysvc.QueryService
+    skillsLoader *skills.Loader
 }
 
 // newServer creates a new MCP server instance.
 func newServer(config *Config, telset component.TelemetrySettings) *server {
-	return &server{
-		config: config,
-		telset: telset,
-	}
+    return &server{
+        config: config,
+        telset: telset,
+    }
 }
 
 // Dependencies implements extensioncapabilities.Dependent to ensure
 // this extension starts after the jaegerquery extension.
 func (*server) Dependencies() []component.ID {
-	return []component.ID{jaegerquery.ID}
+    return []component.ID{jaegerquery.ID}
+}
+
+// registeredToolLister implements skills.ToolLister backed by a static list
+// of tool names already registered on the MCP server.
+type registeredToolLister struct {
+    names []string
+}
+
+func (r *registeredToolLister) ListTools(_ context.Context) ([]string, error) {
+    return r.names, nil
 }
 
 // Start initializes and starts the MCP server.
 func (s *server) Start(ctx context.Context, host component.Host) error {
-	s.telset.Logger.Info("Starting Jaeger MCP server", zap.String("endpoint", s.config.HTTP.NetAddr.Endpoint))
+    s.telset.Logger.Info("Starting Jaeger MCP server", zap.String("endpoint", s.config.HTTP.NetAddr.Endpoint))
 
-	// Get v2 QueryService from jaegerquery extension.
-	queryExt, err := jaegerquery.GetExtension(host)
-	if err != nil {
-		return fmt.Errorf("cannot get %s extension: %w", jaegerquery.ID, err)
-	}
-	s.queryAPI = queryExt.QueryService()
+    // Get v2 QueryService from jaegerquery extension.
+    queryExt, err := jaegerquery.GetExtension(host)
+    if err != nil {
+        return fmt.Errorf("cannot get %s extension: %w", jaegerquery.ID, err)
+    }
+    s.queryAPI = queryExt.QueryService()
 
-	tenancyMgr := queryExt.TenancyManager()
-	s.mcpServer = mcp.NewServer(
-		&mcp.Implementation{
-			Name:    s.config.ServerName,
-			Version: s.config.ServerVersion,
-		},
-		&mcp.ServerOptions{
-			Instructions: serverInstructions,
-		},
-	)
-	s.registerTools()
-	mw := []mcp.Middleware{
-		createTracingMiddleware(s.telset.TracerProvider),
-	}
-	metricsMiddleware, err := createMetricsMiddleware(s.telset.MeterProvider)
-	if err != nil {
-		s.telset.Logger.Warn("failed to create MCP metrics middleware, continuing without metrics", zap.Error(err))
-	} else {
-		mw = append(mw, metricsMiddleware)
-	}
-	s.mcpServer.AddReceivingMiddleware(mw...)
+    tenancyMgr := queryExt.TenancyManager()
+    s.mcpServer = mcp.NewServer(
+        &mcp.Implementation{
+            Name:    s.config.ServerName,
+            Version: s.config.ServerVersion,
+        },
+        &mcp.ServerOptions{
+            Instructions: serverInstructions,
+        },
+    )
+    s.registerTools()
 
-	mcpHandler := mcp.NewStreamableHTTPHandler(
-		func(_ *http.Request) *mcp.Server { return s.mcpServer },
-		&mcp.StreamableHTTPOptions{
-			JSONResponse:   false, // Use SSE for streamed events
-			Stateless:      false, // Session state management
-			SessionTimeout: 5 * time.Minute,
-		},
-	)
+    // Load skills after core tools are registered so the lister snapshot is accurate.
+    s.skillsLoader = skills.NewLoader(s.config.SkillsDir, s.telset.Logger)
+    lister := &registeredToolLister{names: registeredToolNames()}
+    if err := s.skillsLoader.Load(ctx, lister); err != nil {
+        // Log but do not block startup — invalid skill files are an operator error.
+        s.telset.Logger.Warn("some skills failed to load", zap.Error(err))
+    }
+    s.registerSkillsTools()
 
-	tenantHandler := tenancy.ExtractTenantHTTPHandler(tenancyMgr, mcpHandler)
-	handler := otelhttp.NewHandler(
-		tenantHandler,
-		"jaeger_mcp",
-		otelhttp.WithTracerProvider(s.telset.TracerProvider),
-	)
+    mw := []mcp.Middleware{
+        createTracingMiddleware(s.telset.TracerProvider),
+    }
+    metricsMiddleware, err := createMetricsMiddleware(s.telset.MeterProvider)
+    if err != nil {
+        s.telset.Logger.Warn("failed to create MCP metrics middleware, continuing without metrics", zap.Error(err))
+    } else {
+        mw = append(mw, metricsMiddleware)
+    }
+    s.mcpServer.AddReceivingMiddleware(mw...)
 
-	s.listener, err = s.config.HTTP.ToListener(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to listen on %s: %w", s.config.HTTP.NetAddr.Endpoint, err)
-	}
+    mcpHandler := mcp.NewStreamableHTTPHandler(
+        func(_ *http.Request) *mcp.Server { return s.mcpServer },
+        &mcp.StreamableHTTPOptions{
+            JSONResponse:   false,
+            Stateless:      false,
+            SessionTimeout: 5 * time.Minute,
+        },
+    )
 
-	s.httpServer, err = s.config.HTTP.ToServer(
-		ctx,
-		host.GetExtensions(),
-		s.telset,
-		handler,
-	)
-	if err != nil {
-		s.listener.Close()
-		return fmt.Errorf("failed to create HTTP server: %w", err)
-	}
+    tenantHandler := tenancy.ExtractTenantHTTPHandler(tenancyMgr, mcpHandler)
+    handler := otelhttp.NewHandler(
+        tenantHandler,
+        "jaeger_mcp",
+        otelhttp.WithTracerProvider(s.telset.TracerProvider),
+    )
 
-	go func() {
-		if err := s.httpServer.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			s.telset.Logger.Error("MCP server error", zap.Error(err))
-		}
-	}()
+    s.listener, err = s.config.HTTP.ToListener(ctx)
+    if err != nil {
+        return fmt.Errorf("failed to listen on %s: %w", s.config.HTTP.NetAddr.Endpoint, err)
+    }
 
-	s.telset.Logger.Info("Jaeger MCP server started successfully",
-		zap.String("mcp_endpoint", "http://"+s.config.HTTP.NetAddr.Endpoint+"/mcp"))
-	return nil
+    s.httpServer, err = s.config.HTTP.ToServer(
+        ctx,
+        host.GetExtensions(),
+        s.telset,
+        handler,
+    )
+    if err != nil {
+        s.listener.Close()
+        return fmt.Errorf("failed to create HTTP server: %w", err)
+    }
+
+    go func() {
+        if err := s.httpServer.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+            s.telset.Logger.Error("MCP server error", zap.Error(err))
+        }
+    }()
+
+    s.telset.Logger.Info("Jaeger MCP server started successfully",
+        zap.String("mcp_endpoint", "http://"+s.config.HTTP.NetAddr.Endpoint+"/mcp"))
+    return nil
 }
 
 // Shutdown gracefully stops the MCP server.
 func (s *server) Shutdown(ctx context.Context) error {
-	s.telset.Logger.Info("Shutting down Jaeger MCP server")
-
-	if s.httpServer != nil {
-		if err := s.httpServer.Shutdown(ctx); err != nil {
-			return fmt.Errorf("failed to shutdown HTTP server: %w", err)
-		}
-	}
-	return nil
+    s.telset.Logger.Info("Shutting down Jaeger MCP server")
+    if s.httpServer != nil {
+        if err := s.httpServer.Shutdown(ctx); err != nil {
+            return fmt.Errorf("failed to shutdown HTTP server: %w", err)
+        }
+    }
+    return nil
 }
 
-// registerTools registers all MCP tools with the server.
+// registeredToolNames returns the names of all core MCP tools registered by registerTools().
+// This list is used to build the ToolLister snapshot for skill validation.
+func registeredToolNames() []string {
+    return []string{
+        "health",
+        "get_services",
+        "get_span_names",
+        "search_traces",
+        "get_span_details",
+        "get_trace_errors",
+        "get_trace_topology",
+        "get_critical_path",
+        "get_service_dependencies",
+    }
+}
+
+// registerTools registers all core MCP tools with the server.
 func (s *server) registerTools() {
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name:        "health",
-		Description: "Check if the Jaeger MCP server is running. Returns server status, name, and version.",
-	}, s.healthTool)
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name:        "health",
+        Description: "Check if the Jaeger MCP server is running. Returns server status, name, and version.",
+    }, s.healthTool)
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name:        "get_services",
-		Description: "List service names known to Jaeger. Supports optional regex filtering via 'pattern'.",
-	}, handlers.NewGetServicesHandler(s.queryAPI))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name:        "get_services",
+        Description: "List service names known to Jaeger. Supports optional regex filtering via 'pattern'.",
+    }, handlers.NewGetServicesHandler(s.queryAPI))
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name: "get_span_names",
-		Description: "List span/operation names for a given service, with their span kinds " +
-			"(SERVER, CLIENT, INTERNAL, etc.)",
-	}, handlers.NewGetSpanNamesHandler(s.queryAPI))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "get_span_names",
+        Description: "List span/operation names for a given service, with their span kinds " +
+            "(SERVER, CLIENT, INTERNAL, etc.)",
+    }, handlers.NewGetSpanNamesHandler(s.queryAPI))
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name: "search_traces",
-		Description: "Search for traces matching filters. Returns lightweight summaries " +
-			"(trace_id, duration, span_count, error flag, etc.) without individual spans or attributes.",
-	}, handlers.NewSearchTracesHandler(s.queryAPI, s.config.MaxSearchResults))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "search_traces",
+        Description: "Search for traces matching filters. Returns lightweight summaries " +
+            "(trace_id, duration, span_count, error flag, etc.) without individual spans or attributes.",
+    }, handlers.NewSearchTracesHandler(s.queryAPI, s.config.MaxSearchResults))
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name: "get_span_details",
-		Description: "Fetch full span data (attributes, events, links, status) for specific spans. " +
-			"Returns verbose output per span.",
-	}, handlers.NewGetSpanDetailsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "get_span_details",
+        Description: "Fetch full span data (attributes, events, links, status) for specific spans. " +
+            "Returns verbose output per span.",
+    }, handlers.NewGetSpanDetailsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name: "get_trace_errors",
-		Description: "Get full details for all error-status spans in a trace. " +
-			"Results may be truncated to the server limit; " +
-			"compare total_error_count with the number of returned spans to detect truncation.",
-	}, handlers.NewGetTraceErrorsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "get_trace_errors",
+        Description: "Get full details for all error-status spans in a trace. " +
+            "Results may be truncated to the server limit; " +
+            "compare total_error_count with the number of returned spans to detect truncation.",
+    }, handlers.NewGetTraceErrorsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name: "get_trace_topology",
-		Description: "Get the structural overview of a trace as a flat, depth-first span list. " +
-			"Each span includes a 'path' field encoding ancestry as slash-delimited span IDs " +
-			"(e.g. 'rootID/parentID/spanID'). " +
-			"Does NOT include attributes, events, or links.",
-	}, handlers.NewGetTraceTopologyHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "get_trace_topology",
+        Description: "Get the structural overview of a trace as a flat, depth-first span list. " +
+            "Each span includes a 'path' field encoding ancestry as slash-delimited span IDs " +
+            "(e.g. 'rootID/parentID/spanID'). " +
+            "Does NOT include attributes, events, or links.",
+    }, handlers.NewGetTraceTopologyHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name: "get_critical_path",
-		Description: "Identify the critical latency path through a trace: the chain of spans " +
-			"that determined end-to-end duration. " +
-			"Higher self_time_us values indicate where time is concentrated on the critical path.",
-	}, handlers.NewGetCriticalPathHandler(s.queryAPI))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "get_critical_path",
+        Description: "Identify the critical latency path through a trace: the chain of spans " +
+            "that determined end-to-end duration. " +
+            "Higher self_time_us values indicate where time is concentrated on the critical path.",
+    }, handlers.NewGetCriticalPathHandler(s.queryAPI))
 
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name: "get_service_dependencies",
-		Description: "Get the service dependency graph showing caller-callee pairs. " +
-			"Returns edges with call counts over a configurable time window (default: last 24h).",
-	}, handlers.NewGetDependenciesHandler(s.queryAPI))
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "get_service_dependencies",
+        Description: "Get the service dependency graph showing caller-callee pairs. " +
+            "Returns edges with call counts over a configurable time window (default: last 24h).",
+    }, handlers.NewGetDependenciesHandler(s.queryAPI))
+}
+
+// registerSkillsTools registers the list_skills and get_skill MCP tools.
+func (s *server) registerSkillsTools() {
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "list_skills",
+        Description: "List all available AI debugging skills. Each skill provides a specialized " +
+            "analysis workflow (e.g. critical path analysis, N+1 query detection). " +
+            "Use get_skill to retrieve the full definition of a skill.",
+    }, handlers.NewListSkillsHandler(s.skillsLoader))
+
+    mcp.AddTool(s.mcpServer, &mcp.Tool{
+        Name: "get_skill",
+        Description: "Retrieve the full definition of a named skill, including its system prompt, " +
+            "allowed tools, and examples. Use this before invoking a skill to understand " +
+            "its expected tool call sequence.",
+    }, handlers.NewGetSkillHandler(s.skillsLoader))
 }
 
 // HealthToolOutput is the strongly-typed output for the health tool.
 type HealthToolOutput struct {
-	Status  string `json:"status" jsonschema:"Server status (ok/error)"`
-	Server  string `json:"server" jsonschema:"Server name"`
-	Version string `json:"version" jsonschema:"Server version"`
+    Status  string `json:"status" jsonschema:"Server status (ok/error)"`
+    Server  string `json:"server" jsonschema:"Server name"`
+    Version string `json:"version" jsonschema:"Server version"`
 }
 
-// healthTool is a placeholder MCP tool that checks server health.
-// Actual MCP tools for trace querying will be implemented in Phase 2.
 func (s *server) healthTool(
-	_ context.Context,
-	_ *mcp.CallToolRequest,
-	_ struct{},
+    _ context.Context,
+    _ *mcp.CallToolRequest,
+    _ struct{},
 ) (*mcp.CallToolResult, HealthToolOutput, error) {
-	return nil, HealthToolOutput{
-		Status:  "ok",
-		Server:  s.config.ServerName,
-		Version: s.config.ServerVersion,
-	}, nil
+    return nil, HealthToolOutput{
+        Status:  "ok",
+        Server:  s.config.ServerName,
+        Version: s.config.ServerVersion,
+    }, nil
 }

--- a/docs/skills-authoring-guide.md
+++ b/docs/skills-authoring-guide.md
@@ -1,0 +1,189 @@
+# How to Author Custom AI Skills for Jaeger
+
+This guide explains how to write, validate, and deploy your own **Jaeger AI
+Skills** — declarative configuration files that teach the Jaeger AI assistant
+new debugging workflows without recompiling the binary.
+
+---
+
+## What Is a Skill?
+
+A **Skill** is a YAML file that defines:
+
+| Field | Purpose |
+|---|---|
+| `name` | Unique identifier (kebab-case, e.g. `analyze-critical-path`) |
+| `description` | One-sentence summary shown in the UI skill picker |
+| `system_prompt` | Instructions injected before the user's query |
+| `allowed_tools` | The MCP tools the agent may call for this skill |
+| `output_format` | Expected output shape (`markdown`, `json`, `text`) |
+| `constraints` | Additional restrictions on agent behavior |
+| `examples` | Few-shot demonstrations (recommended) |
+
+**Key design principle:** Skills *compose and constrain* existing MCP tools.
+They do NOT register new tool behavior at runtime. New tool capabilities must
+be implemented in the Jaeger MCP extension code and reviewed by maintainers
+before skills can reference them.
+
+---
+
+## Skill File Format
+
+```yaml
+name: my-skill-name          # required; unique, kebab-case
+version: "1.0.0"             # optional; semver
+description: >               # required
+  One sentence describing what this skill does.
+
+system_prompt: |             # required
+  You are an expert in ...
+  
+  ## Steps
+  1. Call `some_tool` with ...
+  2. Then call `another_tool` to ...
+  
+  ## Output
+  Format your answer as Markdown.
+
+allowed_tools:               # required; min 1 entry
+  - search_traces
+  - get_trace_topology
+  - get_span_details
+
+output_format: markdown      # optional; default: text
+
+constraints:                 # optional; appended to system_prompt
+  - Do not speculate beyond the trace data.
+
+examples:                    # optional but strongly recommended
+  - user_query: "Why is this trace slow?"
+    expected_tool_sequence:
+      - get_trace_topology
+      - get_span_details
+    annotated_reasoning: >
+      Call get_trace_topology first to see the span tree, then get_span_details
+      on the slowest span to confirm attributes.
+```
+
+---
+
+## Available MCP Tools
+
+The following tools are available for use in `allowed_tools`. Only reference
+tools listed here; unknown tool names are rejected at load time.
+
+| Tool | Description |
+|---|---|
+| `search_traces` | Search for traces by service, operation, tags, and time range |
+| `get_trace_topology` | Get the parent/child span tree structure of a trace |
+| `get_critical_path` | Get the critical path segments and their latency contribution |
+| `get_span_details` | Get full attributes, events, and timing for a specific span |
+| `get_trace_errors` | Get all error spans and their status codes / messages |
+| `get_services` | List all services currently registered in Jaeger |
+| `list_skills` | List available AI skills (meta-tool; available to all skills) |
+
+---
+
+## Writing Effective System Prompts
+
+### Structure your prompt with sections
+
+```
+## Your Role
+Brief description of the agent's persona/expertise.
+
+## Analysis Steps
+Numbered steps referencing specific tool names.
+
+## Output Requirements
+Describe expected format, level of detail, and mandatory fields.
+
+## Constraints
+What the agent must NOT do.
+```
+
+### Reference tools by exact name
+
+Always use backtick-quoted tool names in your prompt (e.g. `` `get_critical_path` ``).
+This reduces hallucination and makes the expected tool call sequence explicit.
+
+### Preserve structured trace data
+
+The MCP tools return structured JSON. Your prompt should instruct the agent
+to reason over this structure — *not* to summarize it into plain text before
+analyzing. For example:
+
+```
+# Good
+"Call `get_trace_topology` and examine the parent/child relationships
+ to find spans with more than 10 children."
+
+# Avoid  
+"Summarize the trace and then analyze it."
+```
+
+### Use examples for uncommon patterns
+
+The `examples` field is injected into the system prompt as few-shot
+demonstrations. Include at least one example for skills targeting non-obvious
+patterns (e.g. circuit breaker trips, fan-out amplification).
+
+---
+
+## Deploying Skills
+
+1. **Create your skill file** (e.g. `my-analysis.yaml`) following the format above.
+
+2. **Place it in the skills directory.** By default, Jaeger looks for skills in:
+   ```
+   ./skills/
+   ```
+   Configure a custom path in `jaeger-config.yaml`:
+   ```yaml
+   extensions:
+     jaegermcp:
+       skills_dir: /etc/jaeger/skills
+   ```
+
+3. **Restart Jaeger.** The skills loader runs at startup. Invalid files are
+   logged as errors but do not prevent Jaeger from starting.
+
+4. **Verify loading** via the `list_skills` MCP tool or the Jaeger UI skill picker.
+
+---
+
+## Validation Errors
+
+Common errors you may see in Jaeger logs:
+
+| Error | Cause | Fix |
+|---|---|---|
+| `skill.name must not be empty` | Missing `name` field | Add a kebab-case `name` |
+| `system_prompt must not be empty` | Missing `system_prompt` | Add a non-empty prompt |
+| `allowed_tools references unknown MCP tool "X"` | Typo or tool not yet implemented | Check the tool name in Available MCP Tools above |
+| `skill name "X" is defined more than once` | Two files with the same `name` | Rename one skill |
+
+---
+
+## Example Skills
+
+Two built-in example skills are included with Jaeger:
+
+- **`analyze-critical-path`** — Identifies the critical path and top latency contributors.
+- **`detect-n-plus-one`** — Detects the N+1 query anti-pattern.
+
+These are located in `cmd/jaeger/internal/extension/jaegermcp/internal/skills/`
+and can be used as templates.
+
+---
+
+## Contributing a Skill to Jaeger
+
+If you author a generally useful skill, consider contributing it upstream:
+
+1. Add your YAML file to `cmd/jaeger/internal/extension/jaegermcp/internal/skills/`.
+2. Add an entry to `docs/skills-authoring-guide.md` (this file) under "Built-in Skills."
+3. Open a PR referencing issue [#8440](https://github.com/jaegertracing/jaeger/issues/8440).
+
+Skills submitted upstream are reviewed for correctness of tool references and
+clarity of prompt instructions.


### PR DESCRIPTION
## Summary

Implements the Self-Service Skills Framework described in #8440.

Skills are purely declarative YAML files (system prompt + allowed_tools list)
that guide the Jaeger AI agent over existing MCP tools without registering
new runtime behavior per maintainer guidance from @jkowall  and @yurishkuro 

## Changes

- `types/skill.go` — Skill struct with structural validation
- `skills/loader.go` — Discovers and loads `*.yaml` skill files from a directory, validates all `allowed_tools` references against the live MCP registry at startup (eager failure, not at request time)
- `handlers/skills_handler.go` — Two new MCP tools: `list_skills` and `get_skill`
- `skills/analyze-critical-path.yaml` — Built-in example skill
- `skills/detect-n-plus-one.yaml` — Built-in example skill  
- `docs/skills-authoring-guide.md` — Complete authoring guide for users

## Testing

All packages pass:
- `jaegermcp/internal/types` 
- `jaegermcp/internal/skills` 
- `jaegermcp/internal/handlers` 

## Related

Closes #8440
Parent: #7827