### PR TITLE
feat(tracegen): add --scenario genai flag for OTel GenAI semantic con…

### DIFF
--- a/internal/tracegen/config.go
+++ b/internal/tracegen/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Duration      time.Duration
 	Service       string
 	TraceExporter string
+	Scenario      string
 }
 
 // Flags registers config flags.
@@ -47,6 +48,7 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Service, "service", "tracegen", "Service name prefix to use")
 	fs.IntVar(&c.Services, "services", 1, "Number of unique suffixes to add to service name when generating traces, e.g. tracegen-01 (but only one service per trace)")
 	fs.StringVar(&c.TraceExporter, "trace-exporter", "otlp-http", "Trace exporter (otlp/otlp-http|otlp-grpc|stdout). Exporters can be additionally configured via environment variables, see https://github.com/jaegertracing/jaeger/blob/main/cmd/tracegen/README.md")
+	fs.StringVar(&c.Scenario, "scenario", "default", "Trace scenario to generate. 'default' emits basic client/server spans. 'genai' emits spans following OpenTelemetry GenAI semantic conventions (gen_ai.*).")
 }
 
 // Run executes the test scenario.

--- a/internal/tracegen/config_test.go
+++ b/internal/tracegen/config_test.go
@@ -76,6 +76,7 @@ func Test_Flags(t *testing.T) {
 		Service:       "tracegen",
 		Services:      1,
 		TraceExporter: "otlp-http",
+		Scenario:      "default",
 	}
 
 	config.Flags(fs)

--- a/internal/tracegen/worker.go
+++ b/internal/tracegen/worker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -36,7 +37,11 @@ const (
 func (w *worker) simulateTraces() {
 	for atomic.LoadUint32(w.running) == 1 {
 		svcNo := w.traceNo % len(w.tracers)
-		w.simulateOneTrace(w.tracers[svcNo])
+		if w.Scenario == "genai" {
+			w.simulateGenAITrace(w.tracers[svcNo])
+		} else {
+			w.simulateOneTrace(w.tracers[svcNo])
+		}
 		w.traceNo++
 		if w.Traces != 0 {
 			if w.traceNo >= w.Traces {
@@ -111,5 +116,101 @@ func (w *worker) simulateChildSpans(ctx context.Context, start time.Time, tracer
 				trace.WithTimestamp(childStart.Add(fakeSpanDuration)),
 			)
 		}
+	}
+}
+
+// simulateGenAITrace emits a multi-span trace following OpenTelemetry GenAI
+// semantic conventions. The trace shape mirrors a realistic agentic workflow:
+//
+//	gen_ai.execute_agent (root)
+//	└── gen_ai.chat      (LLM call with token usage)
+//	    └── gen_ai.execute_tool  (tool invocation)
+//	        └── HTTP POST /tool-api  (downstream infra span, no gen_ai.* attrs)
+//	└── gen_ai.retrieve  (RAG retrieval)
+//
+// Token counts are varied per trace using the worker's trace counter so that
+// consecutive traces produce distinct attribute values.
+func (w *worker) simulateGenAITrace(tracer trace.Tracer) {
+	ctx := context.Background()
+	start := time.Now()
+
+	inputTokens := 100 + (w.traceNo*37)%900
+	outputTokens := 20 + (w.traceNo*13)%480
+
+	useFakeTime := w.Pause == 0
+
+	startSpanOpts := func(offset time.Duration, kind trace.SpanKind, attrs ...attribute.KeyValue) []trace.SpanStartOption {
+		opts := []trace.SpanStartOption{
+			trace.WithSpanKind(kind),
+			trace.WithAttributes(attrs...),
+		}
+		if useFakeTime {
+			opts = append(opts, trace.WithTimestamp(start.Add(offset)))
+		}
+		return opts
+	}
+
+	// Root: agent span
+	ctx, agentSpan := tracer.Start(ctx, "gen_ai.execute_agent",
+		startSpanOpts(0, trace.SpanKindServer,
+			attribute.String("gen_ai.operation.name", "execute_agent"),
+			attribute.String("gen_ai.system", "openai"),
+			attribute.String("gen_ai.agent.name", "tracegen-agent"),
+		)...,
+	)
+
+	// Child 1: LLM chat span
+	chatCtx, chatSpan := tracer.Start(ctx, "gen_ai.chat",
+		startSpanOpts(10*fakeSpanDuration, trace.SpanKindClient,
+			attribute.String("gen_ai.operation.name", "chat"),
+			attribute.String("gen_ai.system", "openai"),
+			attribute.String("gen_ai.request.model", "gpt-4o"),
+			attribute.Int("gen_ai.usage.input_tokens", inputTokens),
+			attribute.Int("gen_ai.usage.output_tokens", outputTokens),
+		)...,
+	)
+
+	// Child 1.1: tool call span
+	toolCtx, toolSpan := tracer.Start(chatCtx, "gen_ai.execute_tool",
+		startSpanOpts(50*fakeSpanDuration, trace.SpanKindClient,
+			attribute.String("gen_ai.operation.name", "execute_tool"),
+			attribute.String("gen_ai.tool.name", "get_weather"),
+			attribute.String("gen_ai.tool.call.id", fmt.Sprintf("call-%d", w.traceNo)),
+		)...,
+	)
+
+	// Child 1.1.1: infra HTTP span (no gen_ai.* attrs — used to test logical view filter)
+	_, httpSpan := tracer.Start(toolCtx, "HTTP POST /tool-api",
+		startSpanOpts(60*fakeSpanDuration, trace.SpanKindClient,
+			attribute.String("http.method", "POST"),
+			attribute.String("http.url", "http://tool-api/get_weather"),
+			attribute.Int("http.status_code", 200),
+		)...,
+	)
+
+	// Child 2: retrieval span (sibling of chat, child of agent)
+	_, retrieveSpan := tracer.Start(ctx, "gen_ai.retrieve",
+		startSpanOpts(420*fakeSpanDuration, trace.SpanKindClient,
+			attribute.String("gen_ai.operation.name", "retrieve"),
+			attribute.String("gen_ai.system", "openai"),
+			attribute.String("gen_ai.retrieval.query", fmt.Sprintf("tracegen query %d", w.traceNo)),
+		)...,
+	)
+
+	if w.Pause != 0 {
+		time.Sleep(w.Pause)
+		httpSpan.End()
+		toolSpan.End()
+		chatSpan.End()
+		retrieveSpan.End()
+		agentSpan.SetStatus(codes.Ok, "")
+		agentSpan.End()
+	} else {
+		httpSpan.End(trace.WithTimestamp(start.Add(160 * fakeSpanDuration)))
+		toolSpan.End(trace.WithTimestamp(start.Add(250 * fakeSpanDuration)))
+		chatSpan.End(trace.WithTimestamp(start.Add(400 * fakeSpanDuration)))
+		retrieveSpan.End(trace.WithTimestamp(start.Add(490 * fakeSpanDuration)))
+		agentSpan.SetStatus(codes.Ok, "")
+		agentSpan.End(trace.WithTimestamp(start.Add(500 * fakeSpanDuration)))
 	}
 }

--- a/internal/tracegen/worker_test.go
+++ b/internal/tracegen/worker_test.go
@@ -9,11 +9,71 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/testutils"
 )
+
+func Test_SimulateGenAITrace(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exporter),
+	)
+	tracers := []trace.Tracer{tp.Tracer("genai-test")}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var running uint32 = 1
+	w := &worker{
+		logger:  zap.NewNop(),
+		tracers: tracers,
+		wg:      &wg,
+		id:      0,
+		running: &running,
+		Config: Config{
+			Traces:   1,
+			Pause:    0,
+			Service:  "tracegen",
+			Scenario: "genai",
+		},
+	}
+	w.simulateTraces()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 5, "expected 5 spans: agent, chat, execute_tool, http, retrieve")
+
+	spanNames := make(map[string]tracetest.SpanStub)
+	for _, s := range spans {
+		spanNames[s.Name] = s
+	}
+
+	assert.Contains(t, spanNames, "gen_ai.execute_agent")
+	assert.Contains(t, spanNames, "gen_ai.chat")
+	assert.Contains(t, spanNames, "gen_ai.execute_tool")
+	assert.Contains(t, spanNames, "HTTP POST /tool-api")
+	assert.Contains(t, spanNames, "gen_ai.retrieve")
+
+	// Verify gen_ai.* attributes are present on the LLM chat span.
+	chatSpan := spanNames["gen_ai.chat"]
+	attrMap := make(map[string]string)
+	for _, kv := range chatSpan.Attributes {
+		attrMap[string(kv.Key)] = kv.Value.AsString()
+	}
+	assert.Equal(t, "chat", attrMap["gen_ai.operation.name"])
+	assert.Equal(t, "openai", attrMap["gen_ai.system"])
+	assert.Equal(t, "gpt-4o", attrMap["gen_ai.request.model"])
+
+	// Verify the infra span carries no gen_ai.* attributes.
+	httpSpan := spanNames["HTTP POST /tool-api"]
+	for _, kv := range httpSpan.Attributes {
+		assert.NotContains(t, string(kv.Key), "gen_ai.",
+			"infra span must not carry gen_ai.* attributes")
+	}
+}
 
 func Test_SimulateTraces(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #8495

`tracegen` only generates basic client/server span pairs with synthetic HTTP-style
attributes. There is no way to produce traces containing `gen_ai.*` attributes —
the kind of spans produced by LLM applications following OpenTelemetry GenAI
semantic conventions.

Issue #8490 adds a static YAML fixture for unit testing, but a static file cannot
produce continuous live traffic. Anyone building or manually testing the GenAI
visualization work from #8401 (span icons, logical view toggle, rich side panel)
currently has no first-party tool to generate the traces they need. They must
either wire up a real LLM application or hand-craft OTLP payloads each time.

## Short description of the changes

Added `--scenario` flag to `tracegen` with two values:

- `--scenario default` — existing behavior, zero change
- `--scenario genai` — emits multi-span traces following OTel GenAI semantic conventions

When `--scenario genai` is set, each trace has the following shape:

```
gen_ai.execute_agent            (root, SpanKindServer)
├── gen_ai.chat                 (LLM call, input/output token counts varied per trace)
│   └── gen_ai.execute_tool     (tool invocation with tool name and call ID)
│       └── HTTP POST /tool-api (plain infra span — no gen_ai.* attrs)
└── gen_ai.retrieve             (RAG retrieval with query string)
```

Token counts (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`) are
varied per trace using the worker's trace counter so consecutive traces produce
distinct values. The infra HTTP child span intentionally carries no `gen_ai.*`
attributes, making it useful for testing the logical view filter in #8401.

**Files changed:**

| File | Change |
|---|---|
| `internal/tracegen/config.go` | Added `Scenario string` field + `--scenario` flag (default: `"default"`) |
| `internal/tracegen/worker.go` | Dispatch to `simulateGenAITrace()` when `Scenario == "genai"`; added `simulateGenAITrace()` |
| `internal/tracegen/worker_test.go` | New `Test_SimulateGenAITrace` using in-memory OTel exporter |
| `internal/tracegen/config_test.go` | Updated `Test_Flags` expected config to include `Scenario: "default"` |
