### PR TITLE
Document OpenSSF Gold badge evidence refresh

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -145,3 +145,4 @@ For more detailed security information, see:
 | [Security Architecture](docs/security/architecture.md) | TLS and cryptographic practices |
 | [Self-Assessment](docs/security/self-assessment.md) | CNCF TAG Security self-assessment |
 | [Release Verification](docs/security/verifying-releases.md) | Release signature verification |
+| [OpenSSF Gold Evidence](docs/security/openssf-gold-evidence.md) | Current OpenSSF Best Practices badge evidence |

--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -10,18 +10,28 @@ Jaeger supports TLS for all its network communications, including span ingestion
 
 TLS can be configured for both clients and servers across all Jaeger components (Collector, Query, Ingester, Agent).
 
-- **Supported TLS Versions**: Jaeger can be configured to use TLS 1.2 and 1.3, and these are the only versions that should be used in production. Users should configure the minimum supported version as TLS 1.2 or higher using the `--tls.min-version` flag (or corresponding YAML configuration), with TLS 1.3 recommended where available. While TLS 1.0 and 1.1 may still be technically supported for legacy interoperability, they are deprecated, have known security weaknesses, and **must not be enabled in production environments**.
-- **Cipher Suites**: A custom list of allowed cipher suites can be configured to ensure only strong cryptographic algorithms are used.
 - **Certificate Management**:
     - **CA Certificate**: Can be provided to verify the server's or client's certificate.
     - **Server Certificate and Key**: Required for enabling TLS on servers.
     - **Client Authentication (mTLS)**: Jaeger supports mutual TLS, requiring clients to provide a valid certificate for authentication.
 - **Reloading Certificates**: Jaeger supports hot-reloading of TLS certificates and keys from the filesystem without restarting the service, controlled by a configurable reload interval.
 
+### TLS Version
+
+Jaeger can be configured to use TLS 1.2 and 1.3, and these are the only versions that should be used in production. Users should configure the minimum supported version as TLS 1.2 or higher using the `--tls.min-version` flag, or the corresponding YAML configuration, with TLS 1.3 recommended where available. While TLS 1.0 and 1.1 may still be technically supported for legacy interoperability, they are deprecated, have known security weaknesses, and **must not be enabled in production environments**.
+
+### Algorithm Support
+
+Jaeger uses Go's standard `crypto/tls` implementation for TLS. Operators can configure the allowed cipher suites to ensure only strong cryptographic algorithms are used in their deployment.
+
 ### Secure Defaults
 
 - **Certificate Verification**: When TLS is enabled, certificate verification is performed by default.
 - **Insecure Communication**: Users must explicitly set `insecure: true` or `insecure_skip_verify: true` to bypass security controls, which is strongly discouraged for production environments.
+
+### Certificate Verification
+
+Jaeger verifies TLS certificates during the TLS handshake before application data is transmitted. Certificate verification is enabled by default when TLS is configured, and operators must explicitly opt out with insecure settings such as `insecure_skip_verify`.
 
 ## Input Validation
 
@@ -59,6 +69,7 @@ Jaeger is designed to be deployed in a hardened manner.
 - **No Hardcoded Credentials**: Jaeger does not contain any hardcoded credentials. All secrets (passwords, tokens, etc.) must be provided via environment variables, command-line flags, or configuration files.
 - **Environment Variables**: Recommended for providing sensitive information in containerized environments.
 - **Secure Storage**: Users are encouraged to use secure secret management systems (like Kubernetes Secrets or HashiCorp Vault) to manage Jaeger's credentials.
+- **Credential Agility**: TLS certificates, private keys, passwords, and tokens are provided outside the compiled binary. Operators can rotate these credentials by updating referenced files, configuration, environment variables, or secret-manager entries.
 
 ## References
 

--- a/docs/security/openssf-gold-evidence.md
+++ b/docs/security/openssf-gold-evidence.md
@@ -1,0 +1,65 @@
+# OpenSSF Best Practices Gold Evidence
+
+This page tracks durable Jaeger evidence for the OpenSSF Best Practices badge entry at <https://www.bestpractices.dev/projects/1273>. It is maintained so badge evidence can point at current `main` branch resources instead of retired branches, old CI systems, or issue-only evidence.
+
+Last reviewed: 2026-05-06.
+
+## Badge Evidence Refresh
+
+Use the following replacements for stale badge evidence.
+
+| Badge criterion | Replace stale evidence | Current evidence |
+| --- | --- | --- |
+| `contribution` | `https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md` |
+| `contribution_requirements` | `https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#making-a-change` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#contributing-code` |
+| `license_location` | `https://github.com/jaegertracing/jaeger/blob/master/LICENSE` | `https://github.com/jaegertracing/jaeger/blob/main/LICENSE` |
+| `release_notes` | `https://github.com/jaegertracing/jaeger/blob/master/CHANGELOG.md` | `https://github.com/jaegertracing/jaeger/blob/main/CHANGELOG.md` |
+| `report_process` | `https://github.com/jaegertracing/jaeger#questions-discussions-bug-reports` | `https://github.com/jaegertracing/jaeger/blob/main/README.md#get-in-touch` and `https://github.com/jaegertracing/jaeger/issues` |
+| `build` | `https://github.com/jaegertracing/jaeger/blob/master/Makefile` | `https://github.com/jaegertracing/jaeger/blob/main/Makefile` |
+| `build_common_tools` | `https://github.com/jaegertracing/jaeger/blob/master/Makefile` | `https://github.com/jaegertracing/jaeger/blob/main/Makefile` |
+| `test_most` | `https://coveralls.io/github/jaegertracing/jaeger?branch=master` | `https://codecov.io/gh/jaegertracing/jaeger/branch/main/` and `https://github.com/jaegertracing/jaeger/blob/main/docs/adr/004-migrating-coverage-gating-to-github-actions.md` |
+| `test_policy` | `https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#making-a-change` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#testing-guidelines` |
+| `tests_documented_added` | `https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md#making-a-change` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#testing-guidelines` |
+| `test_continuous_integration` | `https://travis-ci.org/jaegertracing/jaeger` | `https://github.com/jaegertracing/jaeger/actions/workflows/ci-orchestrator.yml?query=branch%3Amain` and `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md` |
+| `dco` | `https://github.com/jaegertracing/jaeger/blob/master/DCO` | `https://github.com/jaegertracing/jaeger/blob/main/DCO` and `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#contributing-code` |
+| `governance` | `https://github.com/jaegertracing/jaeger/blob/master/GOVERNANCE.md` | `https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md` |
+| `code_of_conduct` | `https://github.com/jaegertracing/jaeger/blob/master/CODE_OF_CONDUCT.md` | `https://github.com/jaegertracing/jaeger/blob/main/CODE_OF_CONDUCT.md` |
+| `maintenance_or_update` | `https://github.com/jaegertracing/jaeger/blob/master/CHANGELOG.md` | `https://github.com/jaegertracing/jaeger/blob/main/CHANGELOG.md` and `https://github.com/jaegertracing/jaeger/blob/main/RELEASE.md` |
+| `coding_standards` | `https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md` and `https://github.com/jaegertracing/jaeger/blob/main/Makefile` |
+| `build_repeatable` | Mentions `Gopkg.lock` | `https://github.com/jaegertracing/jaeger/blob/main/go.mod`, `https://github.com/jaegertracing/jaeger/blob/main/go.sum`, and `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started` |
+| `installation_development_quick` | `https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started` |
+| `external_dependencies` | `https://github.com/jaegertracing/jaeger/blob/master/Gopkg.toml` | `https://github.com/jaegertracing/jaeger/blob/main/go.mod`, `https://github.com/jaegertracing/jaeger/blob/main/go.sum`, `https://github.com/jaegertracing/jaeger/blob/main/internal/tools/go.mod`, and `https://github.com/jaegertracing/jaeger/blob/main/SECURITY.md#dependency-policy` |
+| `automated_integration_testing` | `https://travis-ci.org/jaegertracing/jaeger` | `https://github.com/jaegertracing/jaeger/actions/workflows/ci-e2e-all.yml?query=branch%3Amain` and `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md#e2e-test-workflows` |
+| `test_statement_coverage80` | `https://codecov.io/gh/jaegertracing/jaeger/branch/master/` | `https://codecov.io/gh/jaegertracing/jaeger/branch/main/` and `https://github.com/jaegertracing/jaeger/blob/main/docs/adr/004-migrating-coverage-gating-to-github-actions.md` |
+| `crypto_used_network` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#tls-configuration` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#tls-configuration` |
+| `crypto_tls12` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#tls-version` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#tls-version` |
+| `crypto_certificate_verification` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#certificate-verification` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#certificate-verification` |
+| `crypto_verification_private` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#certificate-verification` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#certificate-verification` |
+| `hardening` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#hardening` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#system-hardening` and current CI hardening evidence in `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md#stage-3-expensive-checks--static-analysis` |
+| `input_validation` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#input-validation` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#input-validation` |
+| `crypto_algorithm_agility` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#algorithm-support` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#algorithm-support` |
+| `crypto_credential_agility` | `https://github.com/jaegertracing/jaeger/blob/main/SECURITY-ARCHITECTURE.md#credential-management` | `https://github.com/jaegertracing/jaeger/blob/main/docs/security/architecture.md#credential-management` |
+
+## Gold Criteria With Current Evidence
+
+| Gold criterion | Current evidence |
+| --- | --- |
+| `bus_factor` | `https://github.com/jaegertracing/jaeger/blob/main/MAINTAINERS.md` and `https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md` |
+| `contributors_unassociated` | GitHub contributors and maintainers from multiple organizations; use `https://github.com/jaegertracing/jaeger/graphs/contributors`, `https://github.com/jaegertracing/jaeger/blob/main/MAINTAINERS.md`, and CNCF project governance evidence. |
+| `small_tasks` | `https://github.com/jaegertracing/jaeger/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22` and `https://github.com/jaegertracing/jaeger/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22help%20wanted%22` |
+| `test_invocation` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started` and `https://github.com/jaegertracing/jaeger/blob/main/Makefile` |
+| `test_continuous_integration` | `https://github.com/jaegertracing/jaeger/actions/workflows/ci-orchestrator.yml?query=branch%3Amain` and `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md` |
+| `security_review` | Historical public audits are available at `https://github.com/jaegertracing/security-audits`; current-within-5-years evidence is tracked by issue `https://github.com/jaegertracing/jaeger/issues/8485`. |
+
+## Remaining Gold Work
+
+The following criteria need more than URL refresh and are tracked by the Gold badge parent issue.
+
+| Area | Tracking issue |
+| --- | --- |
+| Code review requirements and maintainer 2FA policy | `https://github.com/jaegertracing/jaeger/issues/8486` |
+| Per-file copyright and SPDX compliance | `https://github.com/jaegertracing/jaeger/issues/8487` |
+| Newcomer task maintenance | `https://github.com/jaegertracing/jaeger/issues/8483` |
+| Reproducible build, coverage, hardened headers, and dynamic analysis | `https://github.com/jaegertracing/jaeger/issues/8484` |
+| Current security review evidence | `https://github.com/jaegertracing/jaeger/issues/8485` |
+


### PR DESCRIPTION
## Summary

- add a maintained OpenSSF Gold evidence map for refreshing stale BadgeApp URLs
- add durable anchors in the security architecture doc for TLS, certificate verification, algorithm support, and credential agility evidence
- link the evidence map from SECURITY.md

Refs #8482.
Part of #8481.

## Notes

The BadgeApp evidence still needs to be updated by a project member with badge access. This PR documents the current repo-side evidence and makes the security evidence links durable on `main`.

## Testing

- make fmt
- make lint
- make test
- git diff --check