### PR TITLE
security: add fuzz targets and harden leader election defaults

### DIFF
--- a/docs/security/openssf-gold-evidence.md
+++ b/docs/security/openssf-gold-evidence.md
@@ -50,8 +50,9 @@ Use the following replacements for stale badge evidence.
 | `test_invocation` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started` and `https://github.com/jaegertracing/jaeger/blob/main/Makefile` |
 | `test_continuous_integration` | `https://github.com/jaegertracing/jaeger/actions/workflows/ci-orchestrator.yml?query=branch%3Amain` and `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md` |
 | `security_review` | Historical public audits are available at `https://github.com/jaegertracing/security-audits`; current-within-5-years evidence is tracked by issue `https://github.com/jaegertracing/jaeger/issues/8485`. |
-| `hardened_headers` | `https://github.com/jaegertracing/documentation/blob/main/netlify.toml` and verified headers for `https://www.jaegertracing.io/` via audit in issue `#8484` |
-| `dynamic_analysis` | Go native fuzzing implemented for critical paths: sampling strategy parsing (`internal/sampling/samplingstrategy/file/fuzz_test.go`) and UTF-8 sanitization (`internal/jptrace/sanitizer/fuzz_test.go`). |
+| `hardened_headers` | `https://github.com/jaegertracing/documentation/blob/main/netlify.toml` and verified headers for `https://www.jaegertracing.io/` via audit in issue `https://github.com/jaegertracing/jaeger/issues/8484` |
+
+| `dynamic_analysis` | Go native fuzzing implemented for critical paths: sampling strategy parsing (`https://github.com/jaegertracing/jaeger/blob/main/internal/sampling/samplingstrategy/file/fuzz_test.go`) and UTF-8 sanitization (`https://github.com/jaegertracing/jaeger/blob/main/internal/jptrace/sanitizer/fuzz_test.go`). |
 
 ## Remaining Gold Work
 

--- a/docs/security/openssf-gold-evidence.md
+++ b/docs/security/openssf-gold-evidence.md
@@ -51,6 +51,7 @@ Use the following replacements for stale badge evidence.
 | `test_continuous_integration` | `https://github.com/jaegertracing/jaeger/actions/workflows/ci-orchestrator.yml?query=branch%3Amain` and `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md` |
 | `security_review` | Historical public audits are available at `https://github.com/jaegertracing/security-audits`; current-within-5-years evidence is tracked by issue `https://github.com/jaegertracing/jaeger/issues/8485`. |
 | `hardened_headers` | `https://github.com/jaegertracing/documentation/blob/main/netlify.toml` and verified headers for `https://www.jaegertracing.io/` via audit in issue `#8484` |
+| `dynamic_analysis` | Go native fuzzing implemented for critical paths: sampling strategy parsing (`internal/sampling/samplingstrategy/file/fuzz_test.go`) and UTF-8 sanitization (`internal/jptrace/sanitizer/fuzz_test.go`). |
 
 ## Remaining Gold Work
 

--- a/docs/security/openssf-gold-evidence.md
+++ b/docs/security/openssf-gold-evidence.md
@@ -50,6 +50,7 @@ Use the following replacements for stale badge evidence.
 | `test_invocation` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started` and `https://github.com/jaegertracing/jaeger/blob/main/Makefile` |
 | `test_continuous_integration` | `https://github.com/jaegertracing/jaeger/actions/workflows/ci-orchestrator.yml?query=branch%3Amain` and `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md` |
 | `security_review` | Historical public audits are available at `https://github.com/jaegertracing/security-audits`; current-within-5-years evidence is tracked by issue `https://github.com/jaegertracing/jaeger/issues/8485`. |
+| `hardened_headers` | `https://github.com/jaegertracing/documentation/blob/main/netlify.toml` and verified headers for `https://www.jaegertracing.io/` via audit in issue `#8484` |
 
 ## Remaining Gold Work
 

--- a/internal/jptrace/sanitizer/fuzz_test.go
+++ b/internal/jptrace/sanitizer/fuzz_test.go
@@ -15,6 +15,9 @@ func FuzzUTF8Sanitizer(f *testing.F) {
 	f.Add("\xff\xfe\xfd", "invalid utf8")
 
 	f.Fuzz(func(t *testing.T, key string, val string) {
+		if len(key) > 1024 || len(val) > 1024 {
+			t.Skip()
+		}
 		traces := ptrace.NewTraces()
 		rs := traces.ResourceSpans().AppendEmpty()
 		ss := rs.ScopeSpans().AppendEmpty()
@@ -32,6 +35,9 @@ func FuzzAttributesSanitizer(f *testing.F) {
 	f.Add("\xff", "\xfe")
 
 	f.Fuzz(func(t *testing.T, k string, v string) {
+		if len(k) > 1024 || len(v) > 1024 {
+			t.Skip()
+		}
 		m := pcommon.NewMap()
 		m.PutStr(k, v)
 		sanitizeAttributes(m)

--- a/internal/jptrace/sanitizer/fuzz_test.go
+++ b/internal/jptrace/sanitizer/fuzz_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package sanitizer
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func FuzzUTF8Sanitizer(f *testing.F) {
+	f.Add("valid string", "another valid")
+	f.Add("\xff\xfe\xfd", "invalid utf8")
+
+	f.Fuzz(func(t *testing.T, key string, val string) {
+		traces := ptrace.NewTraces()
+		rs := traces.ResourceSpans().AppendEmpty()
+		ss := rs.ScopeSpans().AppendEmpty()
+		span := ss.Spans().AppendEmpty()
+
+		span.SetName(key)
+		span.Attributes().PutStr(key, val)
+
+		_ = sanitizeUTF8(traces)
+	})
+}
+
+func FuzzAttributesSanitizer(f *testing.F) {
+	f.Add("key1", "val1")
+	f.Add("\xff", "\xfe")
+
+	f.Fuzz(func(t *testing.T, k string, v string) {
+		m := pcommon.NewMap()
+		m.PutStr(k, v)
+		sanitizeAttributes(m)
+	})
+}

--- a/internal/leaderelection/leader_election.go
+++ b/internal/leaderelection/leader_election.go
@@ -44,12 +44,13 @@ type ElectionParticipantOptions struct {
 }
 
 func (o *ElectionParticipantOptions) applyDefaults() {
-	if o.LeaderLeaseRefreshInterval == 0 {
+	if o.LeaderLeaseRefreshInterval <= 0 {
 		o.LeaderLeaseRefreshInterval = 5 * time.Second
 	}
-	if o.FollowerLeaseRefreshInterval == 0 {
+	if o.FollowerLeaseRefreshInterval <= 0 {
 		o.FollowerLeaseRefreshInterval = 60 * time.Second
 	}
+
 	if o.Logger == nil {
 		o.Logger = zap.NewNop()
 	}

--- a/internal/leaderelection/leader_election.go
+++ b/internal/leaderelection/leader_election.go
@@ -36,15 +36,28 @@ type DistributedElectionParticipant struct {
 	wg           sync.WaitGroup
 }
 
-// ElectionParticipantOptions control behavior of the election participant. TODO func applyDefaults(), parameter error checking, etc.
+// ElectionParticipantOptions control behavior of the election participant.
 type ElectionParticipantOptions struct {
 	LeaderLeaseRefreshInterval   time.Duration
 	FollowerLeaseRefreshInterval time.Duration
 	Logger                       *zap.Logger
 }
 
+func (o *ElectionParticipantOptions) applyDefaults() {
+	if o.LeaderLeaseRefreshInterval == 0 {
+		o.LeaderLeaseRefreshInterval = 5 * time.Second
+	}
+	if o.FollowerLeaseRefreshInterval == 0 {
+		o.FollowerLeaseRefreshInterval = 60 * time.Second
+	}
+	if o.Logger == nil {
+		o.Logger = zap.NewNop()
+	}
+}
+
 // NewElectionParticipant returns a ElectionParticipant which attempts to become leader.
 func NewElectionParticipant(lock dl.Lock, resourceName string, options ElectionParticipantOptions) *DistributedElectionParticipant {
+	options.applyDefaults()
 	return &DistributedElectionParticipant{
 		ElectionParticipantOptions: options,
 		lock:                       lock,

--- a/internal/leaderelection/leader_election_test.go
+++ b/internal/leaderelection/leader_election_test.go
@@ -95,6 +95,14 @@ func TestRunAcquireLockLoopFollowerOnly(t *testing.T) {
 	assert.False(t, p.IsLeader())
 }
 
+func TestOptionsDefaults(t *testing.T) {
+	opts := ElectionParticipantOptions{}
+	opts.applyDefaults()
+	assert.Equal(t, 5*time.Second, opts.LeaderLeaseRefreshInterval)
+	assert.Equal(t, 60*time.Second, opts.FollowerLeaseRefreshInterval)
+	assert.NotNil(t, opts.Logger)
+}
+
 func TestMain(m *testing.M) {
 	testutils.VerifyGoLeaks(m)
 }

--- a/internal/sampling/samplingstrategy/file/fuzz_test.go
+++ b/internal/sampling/samplingstrategy/file/fuzz_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package file
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func FuzzUpdateSamplingStrategy(f *testing.F) {
+	// Add some valid seeds from fixtures
+	f.Add([]byte(`{"default_strategy":{"type":"probabilistic","param":0.5}}`))
+	f.Add([]byte(`{"service_strategies":[{"service":"foo","type":"ratelimiting","param":10}]}`))
+	f.Add([]byte(`{"default_strategy":{"type":"probabilistic","param":0.5},"service_strategies":[{"service":"foo","operation_strategies":[{"operation":"bar","type":"probabilistic","param":0.8}]}]}`))
+
+	h := &samplingProvider{
+		logger:  zap.NewNop(),
+		options: Options{DefaultSamplingProbability: 0.001},
+	}
+	h.storedStrategies.Store(defaultStrategies(0.001))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// We don't care about the error, just that it doesn't panic
+		_ = h.updateSamplingStrategy(data)
+	})
+}

--- a/internal/sampling/samplingstrategy/file/fuzz_test.go
+++ b/internal/sampling/samplingstrategy/file/fuzz_test.go
@@ -10,18 +10,21 @@ import (
 )
 
 func FuzzUpdateSamplingStrategy(f *testing.F) {
-	// Add some valid seeds from fixtures
+	// Add some valid sampling strategy JSON seeds
 	f.Add([]byte(`{"default_strategy":{"type":"probabilistic","param":0.5}}`))
 	f.Add([]byte(`{"service_strategies":[{"service":"foo","type":"ratelimiting","param":10}]}`))
 	f.Add([]byte(`{"default_strategy":{"type":"probabilistic","param":0.5},"service_strategies":[{"service":"foo","operation_strategies":[{"operation":"bar","type":"probabilistic","param":0.8}]}]}`))
 
 	h := &samplingProvider{
 		logger:  zap.NewNop(),
-		options: Options{DefaultSamplingProbability: 0.001},
+		options: Options{DefaultSamplingProbability: DefaultSamplingProbability},
 	}
-	h.storedStrategies.Store(defaultStrategies(0.001))
+	h.storedStrategies.Store(defaultStrategies(DefaultSamplingProbability))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
 		// We don't care about the error, just that it doesn't panic
 		_ = h.updateSamplingStrategy(data)
 	})


### PR DESCRIPTION
## Which problem is this PR solving?

Refs #8484
Part of #8481

This PR adds technical evidence for the OpenSSF Gold work related to dynamic analysis, hardened defaults, and security evidence mapping.

## Description of the changes

* Added native Go fuzz targets for critical input paths:

  * UTF-8 sanitization in `internal/jptrace/sanitizer`
  * Sampling strategy JSON parsing in `internal/sampling/samplingstrategy/file`
* Implemented `applyDefaults()` for `ElectionParticipantOptions` in `internal/leaderelection`
* Added unit coverage for default option handling and nil logger handling
* Updated `docs/security/openssf-gold-evidence.md` with dynamic analysis and hardened headers evidence references

## How was this change tested?

Verified locally with:

* `make fmt`
* `make lint`
* `go test -v ./internal/leaderelection`
* `go test -fuzz=FuzzUTF8Sanitizer -fuzztime=10s ./internal/jptrace/sanitizer`
* `go test -fuzz=FuzzUpdateSamplingStrategy -fuzztime=10s ./internal/sampling/samplingstrategy/file`

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR

* [x] **Moderate**: AI helped with code generation or debugging specific parts

AI-assisted tooling was used during fuzz target generation and edge-case validation. The implementation, testing, and architectural changes were manually reviewed and adapted to align with existing Jaeger patterns and project conventions.