### PR TITLE
docs(security): Document code review and 2FA policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,20 @@ $ cat ./pkg/cassandra/config/.nocover
 requires connection to Cassandra
 ```
 
+## Code review requirements
+
+Jaeger changes are reviewed through GitHub pull requests. Reviewers are expected to evaluate whether a change is appropriate for the project, whether the implementation is correct and maintainable, and whether it is covered by suitable tests and documentation.
+
+Before approving a pull request, reviewers should check that:
+
+* the change is understandable, scoped to the stated problem, and consistent with the project's architecture and coding style,
+* new behavior has tests, bug fixes include regression coverage where feasible, and required CI checks are passing,
+* security-sensitive changes, dependency changes, authentication or authorization changes, network-facing behavior, release tooling, and configuration defaults receive extra scrutiny from maintainers familiar with the affected area,
+* generated files are not edited manually; contributors must update the source definitions and regenerate files with the documented targets,
+* the pull request title and commit history are suitable for the project's squash-merge workflow.
+
+Non-trivial pull requests should be reviewed and approved by a maintainer or knowledgeable contributor other than the author before merge. Trivial documentation, typo, formatting, or mechanical follow-up changes may be merged by a maintainer without a separate approval when the risk is low and CI is passing.
+
 ## Merging PRs
 **For maintainers:** before merging a PR make sure the title is descriptive and follows [a good commit message](./CONTRIBUTING_GUIDELINES.md)
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -63,6 +63,12 @@ Former maintainers are recognized with an honorary _Emeritus Maintainer_ status,
 
 Maintainers will be added to the GitHub @jaegertracing/jaeger-maintainers team, and made a GitHub maintainer of that team. They will be given write permission to the Jaeger GitHub repository https://github.com/jaegertracing/jaeger.
 
+### Maintainer account security
+
+Maintainers with write, maintain, or administrative access to Jaeger repositories must keep two-factor authentication enabled on their GitHub accounts. This requirement applies to changes in the central source repositories and to access to private project security information, including private vulnerability reports.
+
+Maintainers should prefer phishing-resistant second factors where available, such as passkeys or hardware security keys. Authenticator applications using time-based one-time passwords are acceptable fallbacks, while SMS-only two-factor authentication is discouraged because it does not provide phishing-resistant protection.
+
 ## Changes in Governance
 
 All changes in Governance require a 2/3 majority vote by maintainers.

--- a/docs/security/openssf-gold-evidence.md
+++ b/docs/security/openssf-gold-evidence.md
@@ -48,17 +48,20 @@ The stale-evidence refresh is tracked by `https://github.com/jaegertracing/jaege
 | `bus_factor` | `https://github.com/jaegertracing/jaeger/blob/main/MAINTAINERS.md` and `https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md` |
 | `contributors_unassociated` | GitHub contributors and maintainers from multiple organizations; use `https://github.com/jaegertracing/jaeger/graphs/contributors`, `https://github.com/jaegertracing/jaeger/blob/main/MAINTAINERS.md`, and CNCF project governance evidence. |
 | `small_tasks` | `https://github.com/jaegertracing/jaeger/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22` and `https://github.com/jaegertracing/jaeger/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22help%20wanted%22` |
+| `require_2FA` | `https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md#maintainer-account-security` |
+| `secure_2FA` | `https://github.com/jaegertracing/jaeger/blob/main/GOVERNANCE.md#maintainer-account-security` |
+| `code_review_standards` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#code-review-requirements` |
+| `two_person_review` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#code-review-requirements` |
 | `test_invocation` | `https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md#getting-started` and `https://github.com/jaegertracing/jaeger/blob/main/Makefile` |
 | `test_continuous_integration` | `https://github.com/jaegertracing/jaeger/actions/workflows/ci-orchestrator.yml?query=branch%3Amain` and `https://github.com/jaegertracing/jaeger/blob/main/.github/workflows/README.md` |
 | `security_review` | Historical public audits are available at `https://github.com/jaegertracing/security-audits`; current-within-5-years evidence is tracked by issue `https://github.com/jaegertracing/jaeger/issues/8485`. |
 
-## Pending Gold Work
+## Remaining Gold Work
 
 The following criteria need more than URL refresh and are tracked by the Gold badge parent issue.
 
 | Tracking issue | Pending criteria | Evidence needed before badge update |
 | --- | --- | --- |
-| `https://github.com/jaegertracing/jaeger/issues/8486` | `require_2FA`, `secure_2FA`, `code_review_standards`, `two_person_review` | Linkable maintainer account-security policy and code-review requirements covering reviewer responsibilities, approval expectations, tests, generated files, and security-sensitive changes. |
 | `https://github.com/jaegertracing/jaeger/issues/8487` | `copyright_per_file`, `license_per_file` | In-scope source files carry copyright and SPDX license identifiers, with CI enforcement to prevent regressions. |
 | `https://github.com/jaegertracing/jaeger/issues/8483` | `small_tasks` | Active newcomer-task evidence, discoverable issue labels, and a lightweight maintainer process for keeping suitable tasks available. |
 | `https://github.com/jaegertracing/jaeger/issues/8484` | `build_reproducible`, `test_statement_coverage90`, `test_branch_coverage80`, `hardened_site`, `hardening`, `dynamic_analysis`, `dynamic_analysis_enable_assertions` | Maintained technical evidence or justified exceptions for reproducible builds, coverage, hardened headers, hardening, and release-time dynamic analysis. |


### PR DESCRIPTION
## Summary
- add explicit code review requirements to CONTRIBUTING.md
- document maintainer GitHub 2FA expectations in GOVERNANCE.md
- add OpenSSF Gold evidence links for `require_2FA`, `secure_2FA`, `code_review_standards`, and `two_person_review`

Refs #8486

## Testing
- `git diff --check`
- `make test`
- `make fmt` failed locally because `scripts/lint/updateLicense.py` scanned untracked `python-sidecar/.venv` content and crashed on an empty third-party package file
- `make lint` failed for the same local untracked `.venv` license-scan issue