### PR TITLE
fix(tracegen): Fail visibly on invalid flags

### DIFF
--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -59,10 +59,16 @@ func main() {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 	jaegerclientenv2otel.MapJaegerToOtelEnvVars(logger)
 
+	if err := run(cfg, logger); err != nil {
+		logger.Fatal("trace generation failed", zap.Error(err))
+	}
+}
+
+func run(cfg *tracegen.Config, logger *zap.Logger) error {
 	tracers, shutdown := createTracers(cfg, logger)
 	defer shutdown(context.Background())
 
-	tracegen.Run(cfg, tracers, logger)
+	return tracegen.Run(cfg, tracers, logger)
 }
 
 func createTracers(cfg *tracegen.Config, logger *zap.Logger) ([]trace.Tracer, func(context.Context) error) {

--- a/cmd/tracegen/main_test.go
+++ b/cmd/tracegen/main_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+	"github.com/jaegertracing/jaeger/internal/tracegen"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}
+
+func TestRunReturnsTracegenValidationError(t *testing.T) {
+	cfg := &tracegen.Config{
+		TraceExporter: "stdout",
+	}
+
+	err := run(cfg, zap.NewNop())
+	require.EqualError(t, err, "either `traces` or `duration` must be greater than 0")
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- fixes #8526 
## Description of the changes
- Added `run` helper in `cmd/tracegen` that return `tracegen.Run` error.
- Made `main` log fatal error when trace generation fail.
- Added regression test for invalid trace generation config.

## How was this change tested?
- Added unit test `cmd/tracegen/main_test.go`.
- Ran `make lint test`. All pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **Moderate**: AI helped with code generation or debugging specific parts
