### PR TITLE
Revert "Update clickhouse/clickhouse-server Docker tag to v26 (#8521)"

### DIFF
--- a/docker-compose/monitor/docker-compose-clickhouse.yml
+++ b/docker-compose/monitor/docker-compose-clickhouse.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:26.4.2@sha256:6d8f358747b59f7db044749eaf951e828e75cc16f9c487f855b114272c44b82c
+    image: clickhouse/clickhouse-server:25.12.11@sha256:8a790dd3468db22b1d4e7b18a176f378ff5ff6053b9c48dd4ea1fa71a24c5ba6
     networks:
       - backend
     environment:


### PR DESCRIPTION
This reverts commit 227cc536c9765707bd159a2cb9082db5756bf766 because it introduced CI failures.

