### PR TITLE
feat(query): Add configurable header forwarding to gRPC storage backend

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configoptional"
 
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 	"github.com/jaegertracing/jaeger/ports"
 )
@@ -60,6 +61,8 @@ type QueryOptions struct {
 	UIConfig UIConfig `mapstructure:"ui"`
 	// BearerTokenPropagation activate/deactivate bearer token propagation to storage.
 	BearerTokenPropagation bool `mapstructure:"bearer_token_propagation"`
+	// HeaderForwarding lists additional request headers to extract and forward to the storage backend.
+	HeaderForwarding []headerforwarding.ForwardedHeader `mapstructure:"header_forwarding"`
 	// Tenancy holds the multi-tenancy configuration.
 	Tenancy tenancy.Options `mapstructure:"multi_tenancy"`
 	// MaxClockSkewAdjust is the maximum duration by which jaeger-query will adjust a span.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/auth/bearertoken"
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
 	"github.com/jaegertracing/jaeger/internal/recoveryhandler"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
@@ -129,6 +130,12 @@ func createGRPCServer(
 		streamInterceptors = append(streamInterceptors, tenancy.NewGuardingStreamInterceptor(tm))
 	}
 
+	//nolint:contextcheck // The context is handled by the interceptors
+	if len(options.HeaderForwarding) > 0 {
+		unaryInterceptors = append(unaryInterceptors, headerforwarding.NewUnaryServerInterceptor(options.HeaderForwarding))
+		streamInterceptors = append(streamInterceptors, headerforwarding.NewStreamServerInterceptor(options.HeaderForwarding))
+	}
+
 	grpcOpts = append(
 		grpcOpts,
 		configgrpc.WithGrpcServerOption(grpc.ChainUnaryInterceptor(unaryInterceptors...)),
@@ -214,6 +221,9 @@ func initRouter(
 	var handler http.Handler = r
 	if queryOpts.BearerTokenPropagation {
 		handler = bearertoken.PropagationHandler(telset.Logger, handler)
+	}
+	if len(queryOpts.HeaderForwarding) > 0 {
+		handler = headerforwarding.HTTPServerMiddleware(queryOpts.HeaderForwarding, handler)
 	}
 	if tenancyMgr.Enabled {
 		handler = tenancy.ExtractTenantHTTPHandler(tenancyMgr, handler)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -1010,39 +1010,37 @@ func TestServerAPINotFound(t *testing.T) {
 
 func TestInitRouter_HeaderForwarding(t *testing.T) {
 	telset := initTelSet(zaptest.NewLogger(t), nooptrace.NewTracerProvider())
-	querySvc := makeQuerySvc()
-	tenancyMgr := tenancy.NewManager(&tenancy.Options{})
+	traceReader := &tracestoremocks.Reader{}
+	dependencyReader := &depsmocks.Reader{}
 
+	// Capture the context that reaches GetServices so we can assert the middleware injected the header.
+	var capturedCtx context.Context
+	traceReader.On("GetServices", mock.Anything).
+		Run(func(args mock.Arguments) { capturedCtx = args.Get(0).(context.Context) }).
+		Return([]string{"svc"}, nil)
+	qs := querysvc.NewQueryService(traceReader, dependencyReader, querysvc.QueryServiceOptions{})
+
+	tenancyMgr := tenancy.NewManager(&tenancy.Options{})
 	opts := DefaultQueryOptions()
 	opts.HeaderForwarding = []headerforwarding.ForwardedHeader{
 		{HTTPName: "x-user", Role: headerforwarding.RoleUsername},
 	}
 
-	handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, tenancyMgr, telset)
+	handler, closer := initRouter(qs, nil, &opts, querysvc.StorageCapabilities{}, tenancyMgr, telset)
 	t.Cleanup(func() { require.NoError(t, closer.Close()) })
 
-	// Verify the header-forwarding middleware is active by observing the context value it injects.
-	var gotUser string
-	probe := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		for _, c := range headerforwarding.CapturedFromContext(r.Context()) {
-			if c.Header.HTTPName == "x-user" {
-				gotUser = c.Value
-			}
-		}
-	})
-	wrappedHandler := headerforwarding.HTTPServerMiddleware(opts.HeaderForwarding, probe)
-
-	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req := httptest.NewRequest(http.MethodGet, "/api/services", http.NoBody)
 	req.Header.Set("x-user", "alice")
-	wrappedHandler.ServeHTTP(httptest.NewRecorder(), req)
-	assert.Equal(t, "alice", gotUser)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
 
-	// Also confirm initRouter produces a handler that doesn't break with the header present.
-	req2 := httptest.NewRequest(http.MethodGet, "/api/services", http.NoBody)
-	req2.Header.Set("x-user", "alice")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req2)
-	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, capturedCtx, "GetServices was not called")
+	var gotUser string
+	for _, c := range headerforwarding.CapturedFromContext(capturedCtx) {
+		if c.Header.HTTPName == "x-user" {
+			gotUser = c.Value
+		}
+	}
+	assert.Equal(t, "alice", gotUser)
 }
 
 func TestInitRouterAIHandlerRegistration(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
@@ -1006,6 +1007,49 @@ func TestServerAPINotFound(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServerGRPC_HeaderForwarding(t *testing.T) {
+	traceReader := &tracestoremocks.Reader{}
+	dependencyReader := &depsmocks.Reader{}
+
+	var capturedCtx context.Context
+	traceReader.On("GetServices", mock.Anything).
+		Run(func(args mock.Arguments) { capturedCtx = args.Get(0).(context.Context) }).
+		Return([]string{"svc"}, nil)
+	qs := querysvc.NewQueryService(traceReader, dependencyReader, querysvc.QueryServiceOptions{})
+
+	opts := &QueryOptions{
+		HeaderForwarding: []headerforwarding.ForwardedHeader{
+			{HTTPName: "x-user", GRPCName: "x-grpc-user", Role: headerforwarding.RoleUsername},
+		},
+		HTTP: confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":0", Transport: confignet.TransportTypeTCP}},
+		GRPC: configgrpc.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: ":0", Transport: confignet.TransportTypeTCP}},
+	}
+	telset := initTelSet(zaptest.NewLogger(t), nooptrace.NewTracerProvider())
+	server, err := NewServer(context.Background(), qs, nil, opts, querysvc.StorageCapabilities{}, tenancy.NewManager(&tenancy.Options{}), telset)
+	require.NoError(t, err)
+	require.NoError(t, server.Start(context.Background()))
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("x-grpc-user", "alice"))
+
+	client := newGRPCClient(t, server.GRPCAddr())
+	t.Cleanup(func() { require.NoError(t, client.conn.Close()) })
+
+	_, err = client.GetServices(ctx, &api_v2.GetServicesRequest{})
+	require.NoError(t, err)
+
+	require.NotNil(t, capturedCtx, "GetServices was not called")
+	var gotUser string
+	for _, c := range headerforwarding.CapturedFromContext(capturedCtx) {
+		if c.Header.HTTPName == "x-user" {
+			gotUser = c.Value
+		}
+	}
+	assert.Equal(t, "alice", gotUser)
 }
 
 func TestInitRouter_HeaderForwarding(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/grpctest"
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	depsmocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
@@ -1005,6 +1006,43 @@ func TestServerAPINotFound(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInitRouter_HeaderForwarding(t *testing.T) {
+	telset := initTelSet(zaptest.NewLogger(t), nooptrace.NewTracerProvider())
+	querySvc := makeQuerySvc()
+	tenancyMgr := tenancy.NewManager(&tenancy.Options{})
+
+	opts := DefaultQueryOptions()
+	opts.HeaderForwarding = []headerforwarding.ForwardedHeader{
+		{HTTPName: "x-user", Role: headerforwarding.RoleUsername},
+	}
+
+	handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, tenancyMgr, telset)
+	t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+	// Verify the header-forwarding middleware is active by observing the context value it injects.
+	var gotUser string
+	probe := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		for _, c := range headerforwarding.CapturedFromContext(r.Context()) {
+			if c.Header.HTTPName == "x-user" {
+				gotUser = c.Value
+			}
+		}
+	})
+	wrappedHandler := headerforwarding.HTTPServerMiddleware(opts.HeaderForwarding, probe)
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req.Header.Set("x-user", "alice")
+	wrappedHandler.ServeHTTP(httptest.NewRecorder(), req)
+	assert.Equal(t, "alice", gotUser)
+
+	// Also confirm initRouter produces a handler that doesn't break with the header present.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/services", http.NoBody)
+	req2.Header.Set("x-user", "alice")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req2)
+	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestInitRouterAIHandlerRegistration(t *testing.T) {

--- a/internal/headerforwarding/config.go
+++ b/internal/headerforwarding/config.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding
+
+// HeaderRole describes the semantic role of a forwarded header value.
+type HeaderRole string
+
+const (
+	// RoleUsername indicates the header carries a username identity.
+	RoleUsername HeaderRole = "username"
+	// RoleEmail indicates the header carries an email identity.
+	RoleEmail HeaderRole = "email"
+)
+
+// ForwardedHeader describes one header to be forwarded from inbound requests to outbound gRPC storage calls.
+type ForwardedHeader struct {
+	// HTTPName is the name of the HTTP request header to extract on inbound HTTP requests.
+	HTTPName string `mapstructure:"http_name"`
+	// GRPCName is the name of the gRPC metadata key to extract on inbound gRPC requests.
+	// When empty, HTTPName is used as the fallback.
+	GRPCName string `mapstructure:"grpc_name"`
+	// Role describes the semantic meaning of the header value (e.g. username, email).
+	// Jaeger does not act on this today; it is informational for downstream consumers.
+	Role HeaderRole `mapstructure:"header_role"`
+	// GRPCOutboundName is the metadata key used when forwarding the value to the gRPC storage backend.
+	// When empty, GRPCName/HTTPName is used as the fallback (in that order).
+	GRPCOutboundName string `mapstructure:"grpc_outbound_name"`
+}
+
+// inboundGRPCName returns the key to look for in incoming gRPC metadata.
+func (h *ForwardedHeader) inboundGRPCName() string {
+	if h.GRPCName != "" {
+		return h.GRPCName
+	}
+	return h.HTTPName
+}
+
+// outboundGRPCName returns the metadata key to use when forwarding to storage.
+func (h *ForwardedHeader) outboundGRPCName() string {
+	if h.GRPCOutboundName != "" {
+		return h.GRPCOutboundName
+	}
+	return h.inboundGRPCName()
+}

--- a/internal/headerforwarding/context.go
+++ b/internal/headerforwarding/context.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding
+
+import "context"
+
+type contextKeyType int
+
+const contextKey = contextKeyType(iota)
+
+// CapturedHeader pairs a runtime value with the config entry that described it.
+type CapturedHeader struct {
+	Header *ForwardedHeader
+	Value  string
+}
+
+// ContextWithCaptured stores captured header pairs in the context.
+func ContextWithCaptured(ctx context.Context, captured []CapturedHeader) context.Context {
+	if len(captured) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey, captured)
+}
+
+// CapturedFromContext retrieves captured header pairs from the context.
+func CapturedFromContext(ctx context.Context) []CapturedHeader {
+	if v, ok := ctx.Value(contextKey).([]CapturedHeader); ok {
+		return v
+	}
+	return nil
+}

--- a/internal/headerforwarding/context_test.go
+++ b/internal/headerforwarding/context_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
+)
+
+func makeHeader(httpName string) headerforwarding.ForwardedHeader {
+	return headerforwarding.ForwardedHeader{HTTPName: httpName, Role: headerforwarding.RoleUsername}
+}
+
+func TestContextRoundtrip(t *testing.T) {
+	hdr := makeHeader("x-user")
+
+	// Verify storage and retrieval of a single captured header.
+	ctx := headerforwarding.ContextWithCaptured(context.Background(), []headerforwarding.CapturedHeader{
+		{Header: &hdr, Value: "alice"},
+	})
+	got := headerforwarding.CapturedFromContext(ctx)
+	require.Len(t, got, 1)
+	assert.Equal(t, "alice", got[0].Value)
+	assert.Equal(t, &hdr, got[0].Header)
+}
+
+func TestCapturedFromContext_Missing(t *testing.T) {
+	assert.Nil(t, headerforwarding.CapturedFromContext(context.Background()))
+}
+
+func TestContextWithCaptured_Empty(t *testing.T) {
+	ctx := headerforwarding.ContextWithCaptured(context.Background(), nil)
+	assert.Nil(t, headerforwarding.CapturedFromContext(ctx))
+
+	ctx2 := headerforwarding.ContextWithCaptured(context.Background(), []headerforwarding.CapturedHeader{})
+	assert.Nil(t, headerforwarding.CapturedFromContext(ctx2))
+}

--- a/internal/headerforwarding/grpc.go
+++ b/internal/headerforwarding/grpc.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// serverStream wraps grpc.ServerStream to carry an updated context.
+type serverStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *serverStream) Context() context.Context {
+	return s.ctx
+}
+
+func extractFromIncomingMetadata(ctx context.Context, headers []ForwardedHeader) []CapturedHeader {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil
+	}
+	captured := make([]CapturedHeader, 0, len(headers))
+	for i := range headers {
+		if vals := md.Get(headers[i].inboundGRPCName()); len(vals) == 1 {
+			captured = append(captured, CapturedHeader{Header: &headers[i], Value: vals[0]})
+		}
+	}
+	return captured
+}
+
+// NewUnaryServerInterceptor returns a gRPC unary server interceptor that extracts
+// the configured headers from incoming metadata and stores them in the context.
+func NewUnaryServerInterceptor(headers []ForwardedHeader) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if incoming := extractFromIncomingMetadata(ctx, headers); len(incoming) > 0 {
+			ctx = ContextWithCaptured(ctx, incoming)
+		}
+		return handler(ctx, req)
+	}
+}
+
+// NewStreamServerInterceptor returns a gRPC streaming server interceptor that extracts
+// the configured headers from incoming metadata and stores them in the context.
+func NewStreamServerInterceptor(headers []ForwardedHeader) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ss.Context()
+		if incoming := extractFromIncomingMetadata(ctx, headers); len(incoming) > 0 {
+			ss = &serverStream{ServerStream: ss, ctx: ContextWithCaptured(ctx, incoming)}
+		}
+		return handler(srv, ss)
+	}
+}
+
+// NewUnaryClientInterceptor returns a gRPC unary client interceptor that forwards
+// header values stored in the context as outgoing metadata to the storage backend.
+func NewUnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx = appendOutgoing(ctx)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// NewStreamClientInterceptor returns a gRPC streaming client interceptor that forwards
+// header values stored in the context as outgoing metadata to the storage backend.
+func NewStreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx = appendOutgoing(ctx)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+func appendOutgoing(ctx context.Context) context.Context {
+	for _, c := range CapturedFromContext(ctx) {
+		ctx = metadata.AppendToOutgoingContext(ctx, c.Header.outboundGRPCName(), c.Value)
+	}
+	return ctx
+}

--- a/internal/headerforwarding/grpc.go
+++ b/internal/headerforwarding/grpc.go
@@ -27,7 +27,7 @@ func extractFromIncomingMetadata(ctx context.Context, headers []ForwardedHeader)
 	}
 	captured := make([]CapturedHeader, 0, len(headers))
 	for i := range headers {
-		if vals := md.Get(headers[i].inboundGRPCName()); len(vals) == 1 {
+		if vals := md.Get(headers[i].inboundGRPCName()); len(vals) > 0 {
 			captured = append(captured, CapturedHeader{Header: &headers[i], Value: vals[0]})
 		}
 	}

--- a/internal/headerforwarding/grpc_test.go
+++ b/internal/headerforwarding/grpc_test.go
@@ -73,6 +73,20 @@ func TestUnaryServerInterceptor_ExtractsFromMetadata(t *testing.T) {
 	}, gotMap)
 }
 
+func TestUnaryServerInterceptor_MultiValueUsesFirst(t *testing.T) {
+	md := metadata.Pairs("x-grpc-user", "alice", "x-grpc-user", "bob")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	interceptor := headerforwarding.NewUnaryServerInterceptor(testHeaders)
+	var gotMap map[string]string
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, func(ctx context.Context, _ any) (any, error) {
+		gotMap = capturedToMap(headerforwarding.CapturedFromContext(ctx))
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "alice", gotMap["x-user"])
+}
+
 func TestUnaryServerInterceptor_NoMetadata(t *testing.T) {
 	interceptor := headerforwarding.NewUnaryServerInterceptor(testHeaders)
 	var got []headerforwarding.CapturedHeader

--- a/internal/headerforwarding/grpc_test.go
+++ b/internal/headerforwarding/grpc_test.go
@@ -85,7 +85,6 @@ func TestUnaryServerInterceptor_NoMetadata(t *testing.T) {
 	assert.Nil(t, got)
 }
 
-
 func TestStreamServerInterceptor_ExtractsFromMetadata(t *testing.T) {
 	md := metadata.New(map[string]string{"x-grpc-user": "alice"})
 	ctx := metadata.NewIncomingContext(context.Background(), md)

--- a/internal/headerforwarding/grpc_test.go
+++ b/internal/headerforwarding/grpc_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
+)
+
+// testHeaders has all four fields populated to exercise the full propagation path.
+var testHeaders = []headerforwarding.ForwardedHeader{
+	{
+		HTTPName:         "x-user",
+		GRPCName:         "x-grpc-user",
+		Role:             headerforwarding.RoleUsername,
+		GRPCOutboundName: "x-forwarded-user",
+	},
+	{
+		HTTPName: "x-email",
+		Role:     headerforwarding.RoleEmail,
+		// GRPCName and GRPCOutboundName both fall back to HTTPName
+	},
+}
+
+// mockServerStream implements grpc.ServerStream for testing.
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context { return m.ctx }
+
+// capturedToMap converts []CapturedHeader to a map[httpName]value for easy assertion.
+func capturedToMap(captured []headerforwarding.CapturedHeader) map[string]string {
+	if captured == nil {
+		return nil
+	}
+	m := make(map[string]string, len(captured))
+	for _, c := range captured {
+		m[c.Header.HTTPName] = c.Value
+	}
+	return m
+}
+
+// --- Server interceptor tests ---
+
+func TestUnaryServerInterceptor_ExtractsFromMetadata(t *testing.T) {
+	md := metadata.New(map[string]string{
+		"x-grpc-user": "alice",
+		"x-email":     "alice@example.com",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	interceptor := headerforwarding.NewUnaryServerInterceptor(testHeaders)
+	var gotMap map[string]string
+	handler := func(ctx context.Context, _ any) (any, error) {
+		gotMap = capturedToMap(headerforwarding.CapturedFromContext(ctx))
+		return nil, nil
+	}
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"x-user":  "alice",
+		"x-email": "alice@example.com",
+	}, gotMap)
+}
+
+func TestUnaryServerInterceptor_NoMetadata(t *testing.T) {
+	interceptor := headerforwarding.NewUnaryServerInterceptor(testHeaders)
+	var got []headerforwarding.CapturedHeader
+	handler := func(ctx context.Context, _ any) (any, error) {
+		got = headerforwarding.CapturedFromContext(ctx)
+		return nil, nil
+	}
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{}, handler)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+
+func TestStreamServerInterceptor_ExtractsFromMetadata(t *testing.T) {
+	md := metadata.New(map[string]string{"x-grpc-user": "alice"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	interceptor := headerforwarding.NewStreamServerInterceptor(testHeaders)
+	var gotMap map[string]string
+	handler := func(_ any, ss grpc.ServerStream) error {
+		gotMap = capturedToMap(headerforwarding.CapturedFromContext(ss.Context()))
+		return nil
+	}
+	err := interceptor(nil, &mockServerStream{ctx: ctx}, &grpc.StreamServerInfo{}, handler)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"x-user": "alice"}, gotMap)
+}
+
+// --- Client interceptor tests ---
+
+func TestUnaryClientInterceptor_ForwardsHeaders(t *testing.T) {
+	ctx := headerforwarding.ContextWithCaptured(context.Background(), []headerforwarding.CapturedHeader{
+		{Header: &testHeaders[0], Value: "alice"},
+		{Header: &testHeaders[1], Value: "alice@example.com"},
+	})
+
+	interceptor := headerforwarding.NewUnaryClientInterceptor()
+	var gotMD metadata.MD
+	invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		gotMD, _ = metadata.FromOutgoingContext(ctx)
+		return nil
+	}
+	err := interceptor(ctx, "method", nil, nil, nil, invoker)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alice"}, gotMD.Get("x-forwarded-user"))
+	assert.Equal(t, []string{"alice@example.com"}, gotMD.Get("x-email"))
+}
+
+func TestUnaryClientInterceptor_NoHeaders(t *testing.T) {
+	interceptor := headerforwarding.NewUnaryClientInterceptor()
+	var gotMD metadata.MD
+	invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		gotMD, _ = metadata.FromOutgoingContext(ctx)
+		return nil
+	}
+	err := interceptor(context.Background(), "method", nil, nil, nil, invoker)
+	require.NoError(t, err)
+	assert.Empty(t, gotMD)
+}
+
+func TestStreamClientInterceptor_ForwardsHeaders(t *testing.T) {
+	ctx := headerforwarding.ContextWithCaptured(context.Background(), []headerforwarding.CapturedHeader{
+		{Header: &testHeaders[0], Value: "alice"},
+	})
+
+	interceptor := headerforwarding.NewStreamClientInterceptor()
+	var gotMD metadata.MD
+	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+		gotMD, _ = metadata.FromOutgoingContext(ctx)
+		return nil, nil
+	}
+	_, err := interceptor(ctx, &grpc.StreamDesc{}, nil, "method", streamer)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alice"}, gotMD.Get("x-forwarded-user"))
+}
+
+// --- Fallback tests ---
+
+func TestHeaderFallbacks(t *testing.T) {
+	t.Run("no GRPCName or GRPCOutboundName: all fall back to HTTPName", func(t *testing.T) {
+		hdr := headerforwarding.ForwardedHeader{HTTPName: "x-user", Role: headerforwarding.RoleUsername}
+		headers := []headerforwarding.ForwardedHeader{hdr}
+
+		md := metadata.New(map[string]string{"x-user": "alice"})
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		var gotMap map[string]string
+		_, err := headerforwarding.NewUnaryServerInterceptor(headers)(ctx, nil, &grpc.UnaryServerInfo{}, func(ctx context.Context, _ any) (any, error) {
+			gotMap = capturedToMap(headerforwarding.CapturedFromContext(ctx))
+			return nil, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"x-user": "alice"}, gotMap)
+
+		clientCtx := headerforwarding.ContextWithCaptured(context.Background(), []headerforwarding.CapturedHeader{
+			{Header: &headers[0], Value: "alice"},
+		})
+		var gotMD metadata.MD
+		err = headerforwarding.NewUnaryClientInterceptor()(clientCtx, "m", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			gotMD, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"alice"}, gotMD.Get("x-user"))
+	})
+
+	t.Run("GRPCName set, no GRPCOutboundName: outbound falls back to GRPCName", func(t *testing.T) {
+		hdr := headerforwarding.ForwardedHeader{HTTPName: "x-user", GRPCName: "x-grpc-user", Role: headerforwarding.RoleUsername}
+		clientCtx := headerforwarding.ContextWithCaptured(context.Background(), []headerforwarding.CapturedHeader{
+			{Header: &hdr, Value: "alice"},
+		})
+		var gotMD metadata.MD
+		err := headerforwarding.NewUnaryClientInterceptor()(clientCtx, "m", nil, nil, nil, func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			gotMD, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"alice"}, gotMD.Get("x-grpc-user"))
+		assert.Empty(t, gotMD.Get("x-user"))
+	})
+}

--- a/internal/headerforwarding/http.go
+++ b/internal/headerforwarding/http.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding
+
+import "net/http"
+
+// HTTPMiddleware returns an http.Handler that extracts the configured headers from
+// inbound HTTP requests and stores them in the request context for downstream propagation.
+func HTTPServerMiddleware(headers []ForwardedHeader, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured := make([]CapturedHeader, 0, len(headers))
+		for i := range headers {
+			if v := r.Header.Get(headers[i].HTTPName); v != "" {
+				captured = append(captured, CapturedHeader{Header: &headers[i], Value: v})
+			}
+		}
+		if len(captured) > 0 {
+			r = r.WithContext(ContextWithCaptured(r.Context(), captured))
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/headerforwarding/http.go
+++ b/internal/headerforwarding/http.go
@@ -5,7 +5,7 @@ package headerforwarding
 
 import "net/http"
 
-// HTTPMiddleware returns an http.Handler that extracts the configured headers from
+// HTTPServerMiddleware returns an http.Handler that extracts the configured headers from
 // inbound HTTP requests and stores them in the request context for downstream propagation.
 func HTTPServerMiddleware(headers []ForwardedHeader, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/headerforwarding/http_test.go
+++ b/internal/headerforwarding/http_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
+)
+
+func TestHTTPServerMiddleware(t *testing.T) {
+	headers := []headerforwarding.ForwardedHeader{
+		{HTTPName: "x-user", Role: headerforwarding.RoleUsername},
+		{HTTPName: "x-email", Role: headerforwarding.RoleEmail},
+	}
+
+	tests := []struct {
+		name     string
+		reqHdrs  map[string]string
+		wantVals map[string]string // httpName -> value
+	}{
+		{
+			name:     "no headers",
+			reqHdrs:  nil,
+			wantVals: nil,
+		},
+		{
+			name:     "one matching header",
+			reqHdrs:  map[string]string{"x-user": "alice"},
+			wantVals: map[string]string{"x-user": "alice"},
+		},
+		{
+			name:     "both headers",
+			reqHdrs:  map[string]string{"x-user": "alice", "x-email": "alice@example.com"},
+			wantVals: map[string]string{"x-user": "alice", "x-email": "alice@example.com"},
+		},
+		{
+			name:     "unknown header ignored",
+			reqHdrs:  map[string]string{"x-other": "value"},
+			wantVals: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotVals map[string]string
+			inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				captured := headerforwarding.CapturedFromContext(r.Context())
+				if captured != nil {
+					gotVals = make(map[string]string)
+					for _, c := range captured {
+						gotVals[c.Header.HTTPName] = c.Value
+					}
+				}
+			})
+			h := headerforwarding.HTTPServerMiddleware(headers, inner)
+
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			for k, v := range tt.reqHdrs {
+				req.Header.Set(k, v)
+			}
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			assert.Equal(t, tt.wantVals, gotVals)
+		})
+	}
+}

--- a/internal/headerforwarding/package_test.go
+++ b/internal/headerforwarding/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package headerforwarding_test
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/storage/v2/grpc/config.go
+++ b/internal/storage/v2/grpc/config.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
@@ -18,7 +19,8 @@ type Config struct {
 	// If not defined the main endpoint is used for reads and writes.
 	Writer configgrpc.ClientConfig `mapstructure:"writer"`
 
-	Tenancy                      tenancy.Options `mapstructure:"multi_tenancy"`
+	Tenancy                      tenancy.Options                    `mapstructure:"multi_tenancy"`
+	HeaderForwarding             []headerforwarding.ForwardedHeader `mapstructure:"header_forwarding"`
 	exporterhelper.TimeoutConfig `mapstructure:",squash"`
 }
 

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -130,6 +130,9 @@ func (f *Factory) initializeConnections(
 		streamInterceptors = append(streamInterceptors, tenancy.NewClientStreamInterceptor(tenancyMgr))
 	}
 
+	// HeaderForwarding acts as an enable switch: header capture happens on the query
+	// server side (HTTP/gRPC server interceptors); the client interceptors here simply
+	// forward whatever was captured into outgoing metadata.
 	if len(f.config.HeaderForwarding) > 0 {
 		unaryInterceptors = append(unaryInterceptors, headerforwarding.NewUnaryClientInterceptor())
 		streamInterceptors = append(streamInterceptors, headerforwarding.NewStreamClientInterceptor())

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/jaegertracing/jaeger/internal/auth/bearertoken"
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
@@ -127,6 +128,11 @@ func (f *Factory) initializeConnections(
 	if tenancyMgr := tenancy.NewManager(&f.config.Tenancy); tenancyMgr.Enabled {
 		unaryInterceptors = append(unaryInterceptors, tenancy.NewClientUnaryInterceptor(tenancyMgr))
 		streamInterceptors = append(streamInterceptors, tenancy.NewClientStreamInterceptor(tenancyMgr))
+	}
+
+	if len(f.config.HeaderForwarding) > 0 {
+		unaryInterceptors = append(unaryInterceptors, headerforwarding.NewUnaryClientInterceptor())
+		streamInterceptors = append(streamInterceptors, headerforwarding.NewStreamClientInterceptor())
 	}
 
 	baseOpts := []grpc.DialOption{

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/grpc"
 
+	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
@@ -115,6 +116,28 @@ func TestFactory(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, tr)
 	})
+}
+
+func TestNewFactory_WithHeaderForwarding(t *testing.T) {
+	lis, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "failed to listen")
+	t.Cleanup(func() { require.NoError(t, lis.Close()) })
+
+	cfg := Config{
+		ClientConfig: configgrpc.ClientConfig{
+			Endpoint: lis.Addr().String(),
+		},
+		TimeoutConfig: exporterhelper.TimeoutConfig{
+			Timeout: 1 * time.Second,
+		},
+		HeaderForwarding: []headerforwarding.ForwardedHeader{
+			{HTTPName: "x-user", Role: headerforwarding.RoleUsername},
+		},
+	}
+	f, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	require.Equal(t, lis.Addr().String(), f.readerConn.Target())
 }
 
 func TestInitializeConnections_ClientError(t *testing.T) {


### PR DESCRIPTION
Add a new internal/headerforwarding package that extracts specified headers from inbound HTTP or gRPC requests and forwards them as gRPC metadata on outbound calls to the remote storage backend.

Each forwarded header is configured with:
- http_name: HTTP request header to extract
- grpc_name: inbound gRPC metadata key (falls back to http_name)
- header_role: semantic role (username|email), informational only
- grpc_outbound_name: outbound metadata key (falls back to grpc_name/http_name)

Wire into jaeger-query (HTTP middleware + gRPC server interceptors) and the gRPC storage factory (client interceptors).

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes
