### PR TITLE
chore(jaegermcp): Remove non-standard health MCP tool

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/README.md
+++ b/cmd/jaeger/internal/extension/jaegermcp/README.md
@@ -30,7 +30,6 @@ See [ADR-002](/docs/adr/002-mcp-server.md) for full design details.
 * `get_span_details`
 * `get_critical_path`
 * `get_service_dependencies`
-* `health`
 
 ## Configuration
 

--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -59,7 +60,7 @@ func (s *mcpSession) callTool(t *testing.T, name string, args map[string]any) st
 // connectMCPSession starts a test server backed by the given mock reader,
 // connects an MCP SDK client, and returns the session with a 5s context.
 // Pass nil for tests that only exercise protocol-level operations (initialize,
-// tools/list, health) which do not hit storage. Passing nil creates a
+// tools/list) which do not hit storage. Passing nil creates a
 // QueryService backed by empty mocks that will panic on unexpected storage calls.
 func connectMCPSession(t *testing.T, mockReader *tracestoremocks.Reader) *mcpSession {
 	t.Helper()
@@ -218,7 +219,7 @@ func TestMCPClientToolsListDiscovery(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []string{
-		"health", "get_services", "get_span_names", "search_traces",
+		"get_services", "get_span_names", "search_traces",
 		"get_span_details", "get_trace_errors", "get_trace_topology", "get_critical_path",
 		"get_service_dependencies",
 	}
@@ -233,17 +234,6 @@ func TestMCPClientToolsListDiscovery(t *testing.T) {
 }
 
 // --- Tool invocation tests ---
-
-func TestMCPClientHealthTool(t *testing.T) {
-	s := connectMCPSession(t, nil)
-	text := s.callTool(t, "health", nil)
-
-	var health HealthToolOutput
-	require.NoError(t, json.Unmarshal([]byte(text), &health))
-	assert.Equal(t, "ok", health.Status)
-	assert.Equal(t, "jaeger", health.Server)
-	assert.Equal(t, "1.0.0", health.Version)
-}
 
 func TestMCPClientGetServices(t *testing.T) {
 	mockReader := &tracestoremocks.Reader{}
@@ -461,20 +451,20 @@ func TestMCPClientMultipleSessionsIndependent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	type callResult struct {
-		toolResult *mcp.CallToolResult
-		err        error
+	type listResult struct {
+		result *mcp.ListToolsResult
+		err    error
 	}
-	ch1 := make(chan callResult, 1)
-	ch2 := make(chan callResult, 1)
+	ch1 := make(chan listResult, 1)
+	ch2 := make(chan listResult, 1)
 
 	go func() {
-		r, err := session1.CallTool(ctx, &mcp.CallToolParams{Name: "health"})
-		ch1 <- callResult{toolResult: r, err: err}
+		r, err := session1.ListTools(ctx, nil)
+		ch1 <- listResult{result: r, err: err}
 	}()
 	go func() {
-		r, err := session2.CallTool(ctx, &mcp.CallToolParams{Name: "health"})
-		ch2 <- callResult{toolResult: r, err: err}
+		r, err := session2.ListTools(ctx, nil)
+		ch2 <- listResult{result: r, err: err}
 	}()
 
 	r1 := <-ch1
@@ -482,7 +472,17 @@ func TestMCPClientMultipleSessionsIndependent(t *testing.T) {
 
 	require.NoError(t, r1.err)
 	require.NoError(t, r2.err)
-	text1 := extractTextContent(t, r1.toolResult)
-	text2 := extractTextContent(t, r2.toolResult)
-	assert.Equal(t, text1, text2)
+	require.Len(t, r1.result.Tools, len(r2.result.Tools))
+	names1 := toolNamesFromList(r1.result.Tools)
+	names2 := toolNamesFromList(r2.result.Tools)
+	assert.Equal(t, names1, names2)
+}
+
+func toolNamesFromList(tools []*mcp.Tool) []string {
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	slices.Sort(names)
+	return names
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/middleware_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/middleware_test.go
@@ -155,7 +155,7 @@ func TestTracingMiddlewareCreatesChildSpanWhenParentExists(t *testing.T) {
 	parentSpanID := parentSpan.SpanContext().SpanID()
 	parentTraceID := parentSpan.SpanContext().TraceID()
 
-	_, err := wrapped(parentCtx, mcpMethodToolsCall, newToolCallRequest("health"))
+	_, err := wrapped(parentCtx, mcpMethodToolsCall, newToolCallRequest("get_services"))
 	require.NoError(t, err)
 
 	parentSpan.End()
@@ -164,7 +164,7 @@ func TestTracingMiddlewareCreatesChildSpanWhenParentExists(t *testing.T) {
 	var childSpan tracetest.SpanStub
 	foundChild := false
 	for _, span := range spans {
-		if span.Name == mcpMethodToolsCall+" health" {
+		if span.Name == mcpMethodToolsCall+" get_services" {
 			childSpan = span
 			foundChild = true
 			break
@@ -261,7 +261,7 @@ func TestContextWithRequestMetaTraceContextNilCases(t *testing.T) {
 }
 
 func TestContextWithRequestMetaTraceContextExtractsBaggage(t *testing.T) {
-	req := newToolCallRequestWithMeta("health", mcp.Meta{
+	req := newToolCallRequestWithMeta("get_services", mcp.Meta{
 		traceContextMetaBaggage: "tenant.id=acme",
 	})
 
@@ -278,7 +278,7 @@ func TestContextWithRequestMetaTraceContextReplacesExistingBaggage(t *testing.T)
 	require.NoError(t, err)
 	baseCtx := baggageapi.ContextWithBaggage(context.Background(), baseBag)
 
-	req := newToolCallRequestWithMeta("health", mcp.Meta{
+	req := newToolCallRequestWithMeta("get_services", mcp.Meta{
 		traceContextMetaBaggage: "env=prod",
 	})
 
@@ -303,7 +303,7 @@ func TestContextWithRequestMetaTraceContextIgnoresInvalidTraceparent(t *testing.
 	})
 	parentCtx := traceapi.ContextWithRemoteSpanContext(context.Background(), parentSC)
 
-	req := newToolCallRequestWithMeta("health", mcp.Meta{
+	req := newToolCallRequestWithMeta("get_services", mcp.Meta{
 		traceContextMetaTraceParent: "invalid-traceparent",
 	})
 	ctx := contextWithRequestMetaTraceContext(parentCtx, req)
@@ -386,19 +386,19 @@ func TestSessionIDFromRequestNilCases(t *testing.T) {
 
 	req := &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
 		Session: nil,
-		Params:  &mcp.CallToolParamsRaw{Name: "health"},
+		Params:  &mcp.CallToolParamsRaw{Name: "get_services"},
 	}
 	assert.Empty(t, sessionIDFromRequest(req))
 
 	clientReq := &mcp.ClientRequest[*mcp.CallToolParamsRaw]{
 		Session: (*mcp.ClientSession)(nil),
-		Params:  &mcp.CallToolParamsRaw{Name: "health"},
+		Params:  &mcp.CallToolParamsRaw{Name: "get_services"},
 	}
 	assert.Empty(t, sessionIDFromRequest(clientReq))
 
 	serverReq := &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
 		Session: (*mcp.ServerSession)(nil),
-		Params:  &mcp.CallToolParamsRaw{Name: "health"},
+		Params:  &mcp.CallToolParamsRaw{Name: "get_services"},
 	}
 	assert.Empty(t, sessionIDFromRequest(serverReq))
 }
@@ -406,13 +406,13 @@ func TestSessionIDFromRequestNilCases(t *testing.T) {
 func TestSessionIDFromRequestWithNonNilSession(t *testing.T) {
 	clientReq := &mcp.ClientRequest[*mcp.CallToolParamsRaw]{
 		Session: &mcp.ClientSession{},
-		Params:  &mcp.CallToolParamsRaw{Name: "health"},
+		Params:  &mcp.CallToolParamsRaw{Name: "get_services"},
 	}
 	assert.Empty(t, sessionIDFromRequest(clientReq))
 
 	serverReq := &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
 		Session: &mcp.ServerSession{},
-		Params:  &mcp.CallToolParamsRaw{Name: "health"},
+		Params:  &mcp.CallToolParamsRaw{Name: "get_services"},
 	}
 	assert.Empty(t, sessionIDFromRequest(serverReq))
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -148,11 +148,6 @@ func (s *server) Shutdown(ctx context.Context) error {
 // registerTools registers all MCP tools with the server.
 func (s *server) registerTools() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
-		Name:        "health",
-		Description: "Check if the Jaeger MCP server is running. Returns server status, name, and version.",
-	}, s.healthTool)
-
-	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name:        "get_services",
 		Description: "List service names known to Jaeger. Supports optional regex filtering via 'pattern'.",
 	}, handlers.NewGetServicesHandler(s.queryAPI))
@@ -202,25 +197,4 @@ func (s *server) registerTools() {
 		Description: "Get the service dependency graph showing caller-callee pairs. " +
 			"Returns edges with call counts over a configurable time window (default: last 24h).",
 	}, handlers.NewGetDependenciesHandler(s.queryAPI))
-}
-
-// HealthToolOutput is the strongly-typed output for the health tool.
-type HealthToolOutput struct {
-	Status  string `json:"status" jsonschema:"Server status (ok/error)"`
-	Server  string `json:"server" jsonschema:"Server name"`
-	Version string `json:"version" jsonschema:"Server version"`
-}
-
-// healthTool is a placeholder MCP tool that checks server health.
-// Actual MCP tools for trace querying will be implemented in Phase 2.
-func (s *server) healthTool(
-	_ context.Context,
-	_ *mcp.CallToolRequest,
-	_ struct{},
-) (*mcp.CallToolResult, HealthToolOutput, error) {
-	return nil, HealthToolOutput{
-		Status:  "ok",
-		Server:  s.config.ServerName,
-		Version: s.config.ServerVersion,
-	}, nil
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server_test.go
@@ -490,28 +490,6 @@ func TestNewServer(t *testing.T) {
 	assert.Nil(t, server.listener)
 }
 
-func TestHealthTool(t *testing.T) {
-	telset := componenttest.NewNopTelemetrySettings()
-	config := &Config{
-		ServerName:               "test-server",
-		ServerVersion:            "2.0.0",
-		MaxSpanDetailsPerRequest: 20,
-		MaxSearchResults:         100,
-	}
-
-	server := newServer(config, telset)
-
-	// Call the healthTool directly
-	result, output, err := server.healthTool(context.Background(), nil, struct{}{})
-
-	// Verify the results
-	require.NoError(t, err)
-	assert.Nil(t, result)
-	assert.Equal(t, "ok", output.Status)
-	assert.Equal(t, "test-server", output.Server)
-	assert.Equal(t, "2.0.0", output.Version)
-}
-
 // TestSearchTracesToolIntegration tests calling the search_traces MCP tool
 // through the full HTTP stack with mocked trace data.
 func TestSearchTracesToolIntegration(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/tracing_integration_test.go
@@ -10,17 +10,24 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
+	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
 )
 
 func TestTracingE2E_MetaPropagation(t *testing.T) {
 	capture := newTraceCapture(t)
-	_, addr := startTestServerWithTelemetry(t, nil, telsetFromCapture(capture))
+	mockReader := &tracestoremocks.Reader{}
+	mockReader.On("GetServices", mock.Anything).Return([]string{"svc"}, nil)
+	svc := querysvc.NewQueryService(mockReader, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
+	_, addr := startTestServerWithTelemetry(t, svc, telsetFromCapture(capture))
 	session := connectMCPClient(t, addr)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -35,12 +42,12 @@ func TestTracingE2E_MetaPropagation(t *testing.T) {
 
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
 		Meta: meta,
-		Name: "health",
+		Name: "get_services",
 	})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 
-	span := findSpanByName(t, capture, "tools/call health")
+	span := findSpanByName(t, capture, "tools/call get_services")
 	assert.Equal(t, sc.TraceID(), span.SpanContext.TraceID(),
 		"MCP middleware span should belong to the same trace as the client")
 	assert.Equal(t, sc.SpanID(), span.Parent.SpanID(),


### PR DESCRIPTION
## Which problem is this PR solving?
- #8546 

## Description of the changes
The health tool is not part of the MCP protocol; the spec's initialize
handshake already provides server identity (name, version) and readiness.
Exposing an extra non-standard tool just adds noise to every agent's
tools/list response without adding value.
- Drop health registration, HealthToolOutput, and healthTool from server.go
- Remove TestHealthTool and TestMCPClientHealthTool
- Update TestMCPClientToolsListDiscovery expected list
- Switch TestMCPClientMultipleSessionsIndependent to ListTools so it no
  longer depends on the health tool
- Update middleware_test.go and tracing_integration_test.go to use
  get_services as the placeholder tool name
- Remove health from README Available Tools list


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
