### PR TITLE
fix(jaegermcp): normalize span_kind input to lowercase before querying storage

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -61,7 +62,7 @@ func (h *getSpanNamesHandler) handle(
 	// Build query parameters
 	query := tracestore.OperationQueryParams{
 		ServiceName: input.ServiceName,
-		SpanKind:    input.SpanKind,
+		SpanKind:    strings.ToLower(input.SpanKind),
 	}
 
 	// Get operations from storage

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names_test.go
@@ -192,6 +192,27 @@ func TestGetSpanNamesHandler_Handle(t *testing.T) {
 	}
 }
 
+func TestGetSpanNamesHandler_SpanKindCaseNormalization(t *testing.T) {
+	// Storage backends store span kinds in lowercase; verify uppercase input is normalized.
+	var capturedQuery tracestore.OperationQueryParams
+	mock := &mockGetOperationsQueryService{
+		getOperationsFunc: func(_ context.Context, query tracestore.OperationQueryParams) ([]tracestore.Operation, error) {
+			capturedQuery = query
+			return []tracestore.Operation{}, nil
+		},
+	}
+
+	handler := &getSpanNamesHandler{queryService: mock}
+	input := types.GetSpanNamesInput{
+		ServiceName: "frontend",
+		SpanKind:    "SERVER",
+	}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	assert.Equal(t, "server", capturedQuery.SpanKind)
+}
+
 func TestNewGetSpanNamesHandler(t *testing.T) {
 	// Test that NewGetSpanNamesHandler returns a valid handler function
 	handler := NewGetSpanNamesHandler(nil)


### PR DESCRIPTION
## Summary

The `get_span_names` MCP tool passes the `span_kind` input directly to the storage layer without case normalization. Storage backends (Cassandra, Elasticsearch, etc.) store span kinds in lowercase (e.g. `server`, `client`). When an MCP client sends an uppercase value like `SERVER` or `CLIENT` — as the tool's own schema documentation suggests — the filter doesn't match anything and the tool returns an empty list.

**Fix:** call `strings.ToLower` on `input.SpanKind` before building the `OperationQueryParams`.

## Changes

- `get_span_names.go`: normalize `SpanKind` to lowercase before the storage query
- `get_span_names_test.go`: add `TestGetSpanNamesHandler_SpanKindCaseNormalization` that captures the query sent to storage and asserts the span kind is lowercased

## Test plan

- [x] `go test ./cmd/jaeger/internal/extension/jaegermcp/internal/handlers/...` passes
- [x] New test `TestGetSpanNamesHandler_SpanKindCaseNormalization` verifies "SERVER" becomes "server" in the storage query