### PR TITLE
chore(deps): block go-elasticsearch v9.4.0+ until binary size regression is fixed upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -342,3 +342,7 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 )
+
+// Block go-elasticsearch v9.4.0+ until binary size regression is fixed upstream.
+// See https://github.com/elastic/go-elasticsearch/issues/1472
+exclude github.com/elastic/go-elasticsearch/v9 v9.4.0

--- a/renovate.json
+++ b/renovate.json
@@ -183,6 +183,11 @@
         "docker-compose/monitor/docker-compose-elasticsearch.yml"
       ],
       "allowedVersions": "9.x"
+    },
+    {
+      "matchPackageNames": ["github.com/elastic/go-elasticsearch/v9"],
+      "allowedVersions": "< 9.4.0",
+      "description": "Block v9.4.0+ until binary size regression is fixed upstream. See https://github.com/elastic/go-elasticsearch/issues/1472"
     }
   ]
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #8548
Refs #8515

## Description of the changes
Block `go-elasticsearch` v9.4.0+ due to a binary size regression (~43MB).
Upstream issue: https://github.com/elastic/go-elasticsearch/issues/1472

- Added `exclude` directive to `go.mod` for `github.com/elastic/go-elasticsearch/v9 v9.4.0`.
- Added a package rule to `renovate.json` to restrict `allowedVersions` to `< 9.4.0`.

## How was this change tested?
- Verified `go mod tidy` succeeds.
- Verified `CGO_ENABLED=0 go build ./cmd/jaeger` succeeds.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully: `make lint-fmt lint-license lint-imports`

## AI Usage in this PR
- [x] **Light**: AI provided assistance in identifying the root cause and suggesting the configuration changes.