### PR TITLE
[es] Replace v8 client with typed client

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -326,7 +326,7 @@ func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metric
 		c.Version = uint(esVersion)
 	}
 
-	var rawClientV8 *esv8.Client
+	var rawClientV8 *esv8.TypedClient
 	if c.Version >= 8 {
 		rawClientV8, err = newElasticsearchV8(ctx, c, logger, httpAuth)
 		if err != nil {
@@ -397,7 +397,7 @@ func (bcb *bulkCallback) invoke(id int64, requests []elastic.BulkableRequest, re
 	}
 }
 
-func newElasticsearchV8(ctx context.Context, c *Configuration, logger *zap.Logger, httpAuth extensionauth.HTTPClient) (*esv8.Client, error) {
+func newElasticsearchV8(ctx context.Context, c *Configuration, logger *zap.Logger, httpAuth extensionauth.HTTPClient) (*esv8.TypedClient, error) {
 	var options esv8.Config
 	options.Addresses = c.Servers
 	if c.Authentication.BasicAuthentication.HasValue() {
@@ -424,7 +424,7 @@ func newElasticsearchV8(ctx context.Context, c *Configuration, logger *zap.Logge
 	// (populated by the jaeger_query header_forwarding middleware/interceptors)
 	// onto every outbound request to Elasticsearch.
 	options.Transport = headerforwarding.NewHTTPClientRoundTripper(transport)
-	return esv8.NewClient(options)
+	return esv8.NewTypedClient(options)
 }
 
 func setDefaultIndexOptions(target, source *IndexOptions) {

--- a/internal/storage/elasticsearch/wrapper/wrapper.go
+++ b/internal/storage/elasticsearch/wrapper/wrapper.go
@@ -6,12 +6,12 @@ package eswrapper
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"net/http"
-	"strings"
 
 	esv8 "github.com/elastic/go-elasticsearch/v9"
-	esv8api "github.com/elastic/go-elasticsearch/v9/esapi"
+	esv8api "github.com/elastic/go-elasticsearch/v9/typedapi"
+	"github.com/elastic/go-elasticsearch/v9/typedapi/indices/putindextemplate"
 	"github.com/olivere/elastic/v7"
 
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
@@ -24,7 +24,7 @@ type ClientWrapper struct {
 	client      *elastic.Client
 	bulkService *elastic.BulkProcessor
 	esVersion   uint
-	clientV8    *esv8.Client
+	clientV8    *esv8.TypedClient
 }
 
 // GetVersion returns the ElasticSearch Version
@@ -33,7 +33,7 @@ func (c ClientWrapper) GetVersion() uint {
 }
 
 // WrapESClient creates a ESClient out of *elastic.Client.
-func WrapESClient(client *elastic.Client, s *elastic.BulkProcessor, esVersion uint, clientV8 *esv8.Client) ClientWrapper {
+func WrapESClient(client *elastic.Client, s *elastic.BulkProcessor, esVersion uint, clientV8 *esv8.TypedClient) ClientWrapper {
 	return ClientWrapper{
 		client:      client,
 		bulkService: s,
@@ -173,7 +173,7 @@ func (c TemplateCreateServiceWrapper) Do(ctx context.Context) (*elastic.IndicesP
 
 // TemplateCreatorWrapperV8 implements es.TemplateCreateService.
 type TemplateCreatorWrapperV8 struct {
-	indicesV8       *esv8api.Indices
+	indicesV8       esv8api.MethodIndices
 	templateName    string
 	templateMapping string
 }
@@ -186,13 +186,17 @@ func (c TemplateCreatorWrapperV8) Body(mapping string) es.TemplateCreateService 
 }
 
 // Do executes Put Template command.
-func (c TemplateCreatorWrapperV8) Do(context.Context) (*elastic.IndicesPutTemplateResponse, error) {
-	resp, err := c.indicesV8.PutIndexTemplate(c.templateName, strings.NewReader(c.templateMapping))
+func (c TemplateCreatorWrapperV8) Do(ctx context.Context) (*elastic.IndicesPutTemplateResponse, error) {
+	var req putindextemplate.Request
+	if err := json.Unmarshal([]byte(c.templateMapping), &req); err != nil {
+		return nil, err
+	}
+	resp, err := c.indicesV8.PutIndexTemplate(c.templateName).Request(&req).Do(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error creating index template %s: %w", c.templateName, err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error creating index template %s: %s", c.templateName, resp)
+	if !resp.Acknowledged {
+		return nil, fmt.Errorf("error creating index template %s: no acknowledgment from database", c.templateName)
 	}
 	return nil, nil // no response expected by span writer
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- A structured response is required as described in https://github.com/jaegertracing/jaeger/pull/8473#discussion_r3218375327 and for that TypedClient is better than raw client.

## Description of the changes
- As said above.

## How was this change tested?
- Unit and Integration Tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
