### PR TITLE
ci: replace write-all with least-privilege permissions in orchestrator workflows

### DIFF
--- a/.github/workflows/ci-orchestrator-stage1.yml
+++ b/.github/workflows/ci-orchestrator-stage1.yml
@@ -3,6 +3,9 @@ name: "CI Orchestrator: Stage 1 (Linters)"
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint-checks:
     uses: ./.github/workflows/ci-lint-checks.yaml

--- a/.github/workflows/ci-orchestrator-stage2.yml
+++ b/.github/workflows/ci-orchestrator-stage2.yml
@@ -3,6 +3,10 @@ name: "CI Orchestrator: Stage 2 (Unit Tests)"
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   unit-tests:
     uses: ./.github/workflows/ci-unit-tests.yml

--- a/.github/workflows/ci-orchestrator-stage2.yml
+++ b/.github/workflows/ci-orchestrator-stage2.yml
@@ -5,13 +5,17 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   unit-tests:
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/ci-unit-tests.yml
     secrets: inherit
 
   ai-sidecar-gemini:
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci-ai-sidecar-gemini.yml
     secrets: inherit

--- a/.github/workflows/ci-orchestrator-stage3.yml
+++ b/.github/workflows/ci-orchestrator-stage3.yml
@@ -3,6 +3,12 @@ name: "CI Orchestrator: Stage 3 (Docker, E2E, Binaries, Static Analysis)"
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+  actions: read
+
 jobs:
   build-binaries:
     uses: ./.github/workflows/ci-build-binaries.yml

--- a/.github/workflows/ci-orchestrator-stage3.yml
+++ b/.github/workflows/ci-orchestrator-stage3.yml
@@ -5,39 +5,55 @@ on:
 
 permissions:
   contents: read
-  packages: read
-  security-events: write
-  actions: read
 
 jobs:
   build-binaries:
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci-build-binaries.yml
     secrets: inherit
 
   docker-build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci-docker-build.yml
     secrets: inherit
 
   docker-all-in-one:
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/ci-docker-all-in-one.yml
     secrets: inherit
 
   docker-hotrod:
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci-docker-hotrod.yml
     secrets: inherit
 
   e2e-tests:
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci-e2e-all.yml
     secrets: inherit
 
   codeql:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     uses: ./.github/workflows/codeql.yml
     secrets: inherit
 
   dependency-review:
+    permissions:
+      contents: read
     uses: ./.github/workflows/dependency-review.yml
     secrets: inherit
 
   fossa:
+    permissions:
+      contents: read
     uses: ./.github/workflows/fossa.yml
     secrets: inherit

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -11,9 +11,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Grant all permissions to allow child workflows to request what they need
-# Child workflows can downgrade permissions as needed (principle of least privilege)
-permissions: write-all
+# Default to least privilege at the workflow level. Individual jobs that call
+# reusable workflows elevate permissions only as needed (principle of least
+# privilege). The matching permissions are also declared in the called
+# workflows so they are correct when invoked directly.
+permissions:
+  contents: read
 
 jobs:
   # ============================================================================
@@ -167,18 +170,28 @@ jobs:
   stage1-seq:
     needs: [setup]
     if: ${{ needs.setup.outputs.parallel == 'false' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci-orchestrator-stage1.yml
     secrets: inherit
 
   stage2-seq:
     needs: [setup, stage1-seq]
     if: ${{ needs.setup.outputs.parallel == 'false' }}
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/ci-orchestrator-stage2.yml
     secrets: inherit
 
   stage3-seq:
     needs: [setup, stage2-seq]
     if: ${{ needs.setup.outputs.parallel == 'false' }}
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+      actions: read
     uses: ./.github/workflows/ci-orchestrator-stage3.yml
     secrets: inherit
 
@@ -190,18 +203,28 @@ jobs:
   stage1-fast:
     needs: [setup]
     if: ${{ needs.setup.outputs.parallel == 'true' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci-orchestrator-stage1.yml
     secrets: inherit
 
   stage2-fast:
     needs: [setup]
     if: ${{ needs.setup.outputs.parallel == 'true' }}
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/ci-orchestrator-stage2.yml
     secrets: inherit
 
   stage3-fast:
     needs: [setup]
     if: ${{ needs.setup.outputs.parallel == 'true' }}
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+      actions: read
     uses: ./.github/workflows/ci-orchestrator-stage3.yml
     secrets: inherit
 

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -293,5 +293,8 @@ jobs:
     name: CI Summary Report
     needs: [ci-success]
     if: always() && needs.ci-success.result == 'success'
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/ci-summary-report.yml
     secrets: inherit


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #8161.

The OpenSSF Scorecard Token-Permissions check flags the orchestrator workflows because:

- `ci-orchestrator-stage1.yml`, `ci-orchestrator-stage2.yml`, `ci-orchestrator-stage3.yml` — no top-level `permissions:` defined, so they inherit the default repository token scope.
- `ci-orchestrator.yml` — top-level `permissions: write-all`, granting the `GITHUB_TOKEN` the maximum set of privileges.

Both violate the principle of least privilege.

## Description of the changes

- **`ci-orchestrator.yml`** — replaced workflow-level `permissions: write-all` with `permissions: contents: read`. Added per-job `permissions:` blocks on every stage caller (`stage{1,2,3}-{seq,fast}`) granting only the scopes that stage needs.
- **`ci-orchestrator-stage1.yml`** — added `permissions: contents: read`.
- **`ci-orchestrator-stage2.yml`** — added `permissions: contents: read` and `checks: write` (for unit-test reporters).
- **`ci-orchestrator-stage3.yml`** — added `permissions: contents: read`, `packages: read`, `security-events: write` (CodeQL), `actions: read` (dependency-review / docker / e2e jobs).

### Why permissions are declared on both the calling job and the called workflow

Per GitHub's reusable-workflow [permissions rules](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions), the effective permissions of a called workflow are the **intersection** of (calling job's `permissions:`) and (called workflow's `permissions:`). Both sides must grant a scope for it to apply.

Declaring on the called workflow as well keeps each stage correct if invoked directly by a different caller in the future, and gives a single point of truth for what each stage needs.

## How was this change tested?

- `actionlint` clean on all four files locally.
- Permission scopes derived from the child workflows actually invoked by each stage (CodeQL → `security-events: write`, docker/e2e → `packages: read` + `actions: read`, unit tests → `checks: write`).
- Will rely on this PR's CI run as the integration test — any missing scope will surface as a job failure here.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality — *N/A, CI workflow change*
- [x] I have run lint and test steps locally — `actionlint` clean