### PR TITLE
fix(test): Surface trace writer chunk errors

### DIFF
--- a/cmd/jaeger/internal/integration/trace_writer.go
+++ b/cmd/jaeger/internal/integration/trace_writer.go
@@ -94,7 +94,9 @@ func (w *traceWriter) WriteTraces(ctx context.Context, td ptrace.Traces) error {
 		)
 
 		if spanCount == MaxChunkSize {
-			err = w.exporter.ConsumeTraces(ctx, currentChunk)
+			if err = w.exporter.ConsumeTraces(ctx, currentChunk); err != nil {
+				return false
+			}
 			currentChunk = ptrace.NewTraces()
 			spanCount = 0
 			currentResourceIndex = -1
@@ -123,10 +125,13 @@ func (w *traceWriter) WriteTraces(ctx context.Context, td ptrace.Traces) error {
 
 		return true
 	})
+	if err != nil {
+		return err
+	}
 
 	// write the last chunk if it has any spans
 	if spanCount > 0 {
-		err = w.exporter.ConsumeTraces(ctx, currentChunk)
+		return w.exporter.ConsumeTraces(ctx, currentChunk)
 	}
-	return err
+	return nil
 }

--- a/cmd/jaeger/internal/integration/trace_writer_test.go
+++ b/cmd/jaeger/internal/integration/trace_writer_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -121,4 +122,37 @@ func TestWriteTraces(t *testing.T) {
 	assert.Equal(t, "NoServiceName3", thirdChunkResource.Resource().Attributes().AsRaw()["service.name"])
 	thirdChunkScope := thirdChunkResource.ScopeSpans().At(0)
 	assert.Equal(t, "span5", thirdChunkScope.Spans().At(0).Name())
+}
+
+func TestWriteTracesReturnsIntermediateChunkError(t *testing.T) {
+	td := ptrace.NewTraces()
+	resource := td.ResourceSpans().AppendEmpty()
+	scope := resource.ScopeSpans().AppendEmpty()
+	for i := 1; i <= 3; i++ {
+		span := scope.Spans().AppendEmpty()
+		span.SetSpanID(pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, byte(i)}))
+		span.SetName(fmt.Sprintf("span%d", i))
+	}
+
+	expectedErr := errors.New("send failed")
+	mockExporter := &MockExporter{}
+	mockExporter.On("ConsumeTraces", mock.Anything, mock.Anything).Return(expectedErr).Once()
+	tw := &traceWriter{
+		logger:   zaptest.NewLogger(t),
+		exporter: mockExporter,
+	}
+
+	origMaxChunkSize := MaxChunkSize
+	MaxChunkSize = 2
+	defer func() {
+		MaxChunkSize = origMaxChunkSize
+	}()
+
+	err := tw.WriteTraces(context.Background(), td)
+
+	require.ErrorIs(t, err, expectedErr)
+	mockExporter.AssertNumberOfCalls(t, "ConsumeTraces", 1)
+	mockExporter.AssertExpectations(t)
+	require.Len(t, mockExporter.chunks, 1)
+	assert.Equal(t, 2, mockExporter.chunks[0].SpanCount())
 }


### PR DESCRIPTION
## Summary
- stop the e2e trace writer when an intermediate OTLP chunk send fails
- return that send error instead of allowing a later successful chunk to mask it
- add regression coverage for the hidden intermediate chunk error case

## Background
PR #8537 exposed this through the badger e2e metrics gate: the test accepted 10,252 spans, but the Jaeger storage exporter reported 10,247 sent spans plus `otelcol_exporter_send_failed_spans{exporter="jaeger_storage_exporter"} 5`. That means a 5-span chunk failed, but the storage integration test still passed.

## When this was introduced
The error-masking behavior dates back to commit `83b64d6617e7a844e298ecf09e2359f0d61fdc06` / PR #6437, `Upgrade storage integration test: use TraceWriter`, committed January 2, 2025. That introduced `traceWriter.WriteTraces`, which stores each chunk send error in `err` but continues iterating; a later successful final chunk can overwrite the earlier error with `nil`.

The metrics symptom became visible after commit `75b78cdd3d66e568a1702a44c061afeb37303d54` / PR #6330, `[ci] Scrape and verify metrics at the end of e2e tests`, committed January 17, 2025, which added e2e metrics snapshot verification including the badger workflow. The likelihood/visibility of a 5-span failed chunk increased after commit `ed0527d4d444d4ab535a23c499aa2cadad667247` / PR #7812, `[test] Refactor integration tests to directly write/read ptrace.Traces`, committed February 12, 2026, which documents reducing `MaxChunkSize` to 5.

## Testing
- `go test ./cmd/jaeger/internal/integration -run TestWriteTraces -count=1`
- `make fmt`
- `make lint`
- `make test`
- `git diff --check -- cmd/jaeger/internal/integration/trace_writer.go cmd/jaeger/internal/integration/trace_writer_test.go`

Note: I temporarily moved local `python-sidecar/.venv` out of the checkout while running `make fmt` / `make lint`; otherwise the existing local virtualenv causes `scripts/lint/updateLicense.py` to scan an empty file under `.venv` and fail. The virtualenv was restored afterward.
