### PR TITLE
Add span kind to MCP span outputs

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
@@ -202,6 +202,7 @@ func buildSpanDetail(pos jptrace.SpanIterPos, span ptrace.Span) types.SpanDetail
 		ParentSpanID: parentSpanID,
 		Service:      serviceName,
 		SpanName:     span.Name(),
+		SpanKind:     span.Kind().String(),
 		StartTime:    span.StartTimestamp().AsTime().Format(time.RFC3339Nano),
 		DurationUs:   durationUs,
 		Status:       status,

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
@@ -30,6 +30,7 @@ func TestGetSpanDetailsHandler_Handle_Success(t *testing.T) {
 		{
 			spanID:    spanID1,
 			operation: "/api/test1",
+			kind:      ptrace.SpanKindServer,
 			attributes: map[string]string{
 				"http.method": "GET",
 				"http.url":    "/api/test1",
@@ -87,6 +88,7 @@ func TestGetSpanDetailsHandler_Handle_Success(t *testing.T) {
 
 	require.NotNil(t, span1)
 	assert.Equal(t, "/api/test1", span1.SpanName)
+	assert.Equal(t, "Server", span1.SpanKind)
 	assert.Equal(t, "Ok", span1.Status.Code)
 	assert.Equal(t, "GET", span1.Attributes["http.method"])
 	assert.Equal(t, "/api/test1", span1.Attributes["http.url"])

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_errors_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_errors_test.go
@@ -30,6 +30,7 @@ func TestGetTraceErrorsHandler_Handle_Success(t *testing.T) {
 		{
 			spanID:       "span002",
 			operation:    "/api/error1",
+			kind:         ptrace.SpanKindClient,
 			hasError:     true,
 			errorMessage: "First error",
 			attributes: map[string]string{
@@ -72,12 +73,15 @@ func TestGetTraceErrorsHandler_Handle_Success(t *testing.T) {
 
 	// Verify both error operations are present
 	operations := make(map[string]bool)
+	spanKinds := make(map[string]string)
 	for _, span := range output.Spans {
 		operations[span.SpanName] = true
+		spanKinds[span.SpanName] = span.SpanKind
 	}
 	assert.True(t, operations["/api/error1"])
 	assert.True(t, operations["/api/error2"])
 	assert.False(t, operations["/api/ok"]) // OK span should not be included
+	assert.Equal(t, "Client", spanKinds["/api/error1"])
 }
 
 func TestGetTraceErrorsHandler_Handle_NoErrors(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology.go
@@ -46,6 +46,7 @@ type rawSpan struct {
 	parentID   string // empty string if this is a root span
 	service    string
 	spanName   string
+	spanKind   string
 	startTime  string
 	durationUs int64
 	status     string
@@ -145,6 +146,7 @@ func extractRawSpan(pos jptrace.SpanIterPos, span ptrace.Span) rawSpan {
 		parentID:   parentSpanID,
 		service:    serviceName,
 		spanName:   span.Name(),
+		spanKind:   span.Kind().String(),
 		startTime:  span.StartTimestamp().AsTime().Format(time.RFC3339Nano),
 		durationUs: duration.Microseconds(),
 		status:     span.Status().Code().String(),
@@ -228,6 +230,7 @@ func (h *getTraceTopologyHandler) dfs(
 		StartTime:         span.startTime,
 		DurationUs:        span.durationUs,
 		Status:            span.status,
+		SpanKind:          span.spanKind,
 		TruncatedChildren: truncated,
 	})
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_topology_test.go
@@ -38,6 +38,7 @@ func TestGetTraceTopologyHandler_Handle_Success(t *testing.T) {
 		{
 			spanID:    rootSpanID,
 			operation: "/api/checkout",
+			kind:      ptrace.SpanKindServer,
 			attributes: map[string]string{
 				"http.method": "GET",
 			},
@@ -70,6 +71,7 @@ func TestGetTraceTopologyHandler_Handle_Success(t *testing.T) {
 	root := findSpanByName(output.Spans, "/api/checkout")
 	require.NotNil(t, root)
 	assert.Equal(t, "Ok", root.Status)
+	assert.Equal(t, "Server", root.SpanKind)
 
 	getCart := findSpanByName(output.Spans, "getCart")
 	require.NotNil(t, getCart)

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
@@ -22,6 +22,7 @@ type spanConfig struct {
 	spanID       string
 	parentSpanID string
 	operation    string
+	kind         ptrace.SpanKind
 	hasError     bool
 	errorMessage string
 	attributes   map[string]string
@@ -172,6 +173,7 @@ func createTestTraceWithSpans(traceID string, spanConfigs []spanConfig) ptrace.T
 		}
 
 		span.SetName(config.operation)
+		span.SetKind(config.kind)
 		span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(-5 * time.Second)))
 		span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_span_details.go
@@ -27,6 +27,7 @@ type SpanDetail struct {
 	ParentSpanID string         `json:"parent_span_id,omitempty" jsonschema:"Parent span identifier"`
 	Service      string         `json:"service" jsonschema:"Service name from resource attributes"`
 	SpanName     string         `json:"span_name" jsonschema:"Span name"`
+	SpanKind     string         `json:"span_kind,omitempty" jsonschema:"Span kind (e.g. SERVER CLIENT PRODUCER CONSUMER INTERNAL)"`
 	StartTime    string         `json:"start_time" jsonschema:"Span start time in RFC3339 format"`
 	DurationUs   int64          `json:"duration_us" jsonschema:"Span duration in microseconds"`
 	Status       SpanStatus     `json:"status" jsonschema:"Span status information"`

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_topology.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_topology.go
@@ -37,5 +37,6 @@ type TopologySpan struct {
 	StartTime         string `json:"start_time"                   jsonschema:"Span start time in RFC3339 format"`
 	DurationUs        int64  `json:"duration_us"                  jsonschema:"Span duration in microseconds"`
 	Status            string `json:"status"                       jsonschema:"Span status (Unset Ok Error)"`
+	SpanKind          string `json:"span_kind,omitempty"          jsonschema:"Span kind (SERVER CLIENT PRODUCER CONSUMER INTERNAL)"`
 	TruncatedChildren int    `json:"truncated_children,omitempty" jsonschema:"Number of direct children excluded due to depth limit"`
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #8563 

## Description of the changes
- Added `SpanKind` to `SpanDetail`
- Added `SpanKind` to `TopologySpan`
- Populated `SpanKind` from `span.Kind().String()`
- Extended test helpers to allow explicit span kinds in test traces
- Updated tests for:
  - `get_span_details`
  - `get_trace_errors`
  - `get_trace_topology`

## How was this change tested?
- [x] `go test ./cmd/jaeger/internal/extension/jaegermcp/internal/handlers`
- [x] `go test ./cmd/jaeger/internal/extension/jaegermcp/...`
- [X] `make fmt`
- [X] `make lint`
- [x] `make test`

## Additional validation
I also verified that the updated tests fail when the handler changes that populate `span_kind` are temporarily removed, and pass again after restoring the implementation.

With the fix applied, the targeted tests pass:

```text
--- PASS: TestGetSpanDetailsHandler_Handle_Success (0.00s)
--- PASS: TestGetTraceErrorsHandler_Handle_Success (0.00s)
--- PASS: TestGetTraceTopologyHandler_Handle_Success (0.00s)
PASS
```

After temporarily stashing the handler changes, the same tests fail:
```text
--- FAIL: TestGetSpanDetailsHandler_Handle_Success (0.00s)
--- FAIL: TestGetTraceErrorsHandler_Handle_Success (0.00s)
--- FAIL: TestGetTraceTopologyHandler_Handle_Success (0.00s)
FAIL
```

After restoring the handler changes, the targeted tests pass again:
```text
--- PASS: TestGetSpanDetailsHandler_Handle_Success (0.00s)
--- PASS: TestGetTraceErrorsHandler_Handle_Success (0.00s)
--- PASS: TestGetTraceTopologyHandler_Handle_Success (0.00s)
PASS
```

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [X] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes

Primarily helped with understanding the codebase more as this is my first PR in the repo