### PR TITLE
feat(grpc-storage): Add max_recv_msg_size_mib config for gRPC storage client

### DIFF
--- a/internal/storage/v2/grpc/config.go
+++ b/internal/storage/v2/grpc/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	// If not defined the main endpoint is used for reads and writes.
 	Writer configgrpc.ClientConfig `mapstructure:"writer"`
 
+	// MaxRecvMsgSizeMiB is the maximum message size in MiB the client can receive.
+	// Defaults to 4 MiB (gRPC default). Set to a larger value when the storage
+	// backend returns responses exceeding 4 MiB (e.g. large traces).
+	MaxRecvMsgSizeMiB int `mapstructure:"max_recv_msg_size_mib"`
+
 	Tenancy                      tenancy.Options                    `mapstructure:"multi_tenancy"`
 	HeaderForwarding             []headerforwarding.ForwardedHeader `mapstructure:"header_forwarding"`
 	exporterhelper.TimeoutConfig `mapstructure:",squash"`

--- a/internal/storage/v2/grpc/config_test.go
+++ b/internal/storage/v2/grpc/config_test.go
@@ -12,4 +12,5 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 	require.NotEmpty(t, cfg.Timeout)
+	require.Zero(t, cfg.MaxRecvMsgSizeMiB, "default should use gRPC's built-in 4 MiB limit")
 }

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -143,8 +144,14 @@ func (f *Factory) initializeConnections(
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 	}
 	if f.config.MaxRecvMsgSizeMiB > 0 {
+		// Compute in int64 to avoid overflow on 32-bit platforms, then clamp
+		// to math.MaxInt since grpc.MaxCallRecvMsgSize accepts an int.
+		size64 := int64(f.config.MaxRecvMsgSizeMiB) * 1024 * 1024
+		if size64 > math.MaxInt {
+			size64 = math.MaxInt
+		}
 		baseOpts = append(baseOpts, grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(f.config.MaxRecvMsgSizeMiB*1024*1024),
+			grpc.MaxCallRecvMsgSize(int(size64)),
 		))
 	}
 

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -122,6 +122,10 @@ func (f *Factory) initializeConnections(
 	if f.config.Auth.HasValue() {
 		return errors.New("authenticator is not supported")
 	}
+	const maxRecvMsgSizeMiB = math.MaxInt / (1024 * 1024)
+	if f.config.MaxRecvMsgSizeMiB < 0 || f.config.MaxRecvMsgSizeMiB > maxRecvMsgSizeMiB {
+		return fmt.Errorf("max_recv_msg_size_mib must be between 0 and %d, got %d", maxRecvMsgSizeMiB, f.config.MaxRecvMsgSizeMiB)
+	}
 
 	unaryInterceptors := []grpc.UnaryClientInterceptor{bearertoken.NewUnaryClientInterceptor()}
 	streamInterceptors := []grpc.StreamClientInterceptor{bearertoken.NewStreamClientInterceptor()}
@@ -144,14 +148,8 @@ func (f *Factory) initializeConnections(
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 	}
 	if f.config.MaxRecvMsgSizeMiB > 0 {
-		// Compute in int64 to avoid overflow on 32-bit platforms, then clamp
-		// to math.MaxInt since grpc.MaxCallRecvMsgSize accepts an int.
-		size64 := int64(f.config.MaxRecvMsgSizeMiB) * 1024 * 1024
-		if size64 > math.MaxInt {
-			size64 = math.MaxInt
-		}
 		baseOpts = append(baseOpts, grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(int(size64)),
+			grpc.MaxCallRecvMsgSize(f.config.MaxRecvMsgSizeMiB*1024*1024),
 		))
 	}
 

--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -142,6 +142,11 @@ func (f *Factory) initializeConnections(
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 	}
+	if f.config.MaxRecvMsgSizeMiB > 0 {
+		baseOpts = append(baseOpts, grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(f.config.MaxRecvMsgSizeMiB*1024*1024),
+		))
+	}
 
 	createConn := func(telset component.TelemetrySettings, gcs *configgrpc.ClientConfig) (*grpc.ClientConn, error) {
 		opts := append(baseOpts, grpc.WithStatsHandler(

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -5,6 +5,7 @@ package grpc
 
 import (
 	"context"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -22,6 +23,14 @@ import (
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
+
+func TestNewFactory_InvalidMaxRecvMsgSize(t *testing.T) {
+	for _, v := range []int{-1, math.MaxInt} {
+		cfg := &Config{MaxRecvMsgSizeMiB: v}
+		_, err := NewFactory(context.Background(), *cfg, telemetry.NoopSettings())
+		require.ErrorContains(t, err, "max_recv_msg_size_mib must be between 0 and")
+	}
+}
 
 func TestNewFactory_NonEmptyAuthenticator(t *testing.T) {
 	cfg := &Config{

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -140,6 +140,32 @@ func TestNewFactory_WithHeaderForwarding(t *testing.T) {
 	require.Equal(t, lis.Addr().String(), f.readerConn.Target())
 }
 
+func TestNewFactory_MaxRecvMsgSize(t *testing.T) {
+	capture := func(cfg Config) []grpc.DialOption {
+		var captured []grpc.DialOption
+		f := &Factory{config: cfg}
+		noopTelset := telemetry.NoopSettings().ToOtelComponent()
+		_ = f.initializeConnections(
+			noopTelset, noopTelset,
+			&cfg.ClientConfig, &cfg.ClientConfig,
+			func(_ component.TelemetrySettings, _ *configgrpc.ClientConfig, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+				captured = opts
+				return nil, assert.AnError // stop after first capture; error is ignored by caller
+			},
+		)
+		return captured
+	}
+
+	base := Config{ClientConfig: configgrpc.ClientConfig{Endpoint: "localhost:0"}}
+	withSize := base
+	withSize.MaxRecvMsgSizeMiB = 16
+
+	optsBase := capture(base)
+	optsWithSize := capture(withSize)
+
+	assert.Greater(t, len(optsWithSize), len(optsBase), "MaxRecvMsgSizeMiB > 0 should add a WithDefaultCallOptions dial option")
+}
+
 func TestInitializeConnections_ClientError(t *testing.T) {
 	f, err := NewFactory(
 		context.Background(),


### PR DESCRIPTION

The gRPC default client receive limit is 4 MiB. When a storage backend returns large traces this results in:
```
  grpc: received message larger than max (N vs. 4194304)
```

OTel's configgrpc.ClientConfig does not expose a client-side receive size limit (only ServerConfig has max_recv_msg_size_mib), so we add it directly to the gRPC storage Config and wire it via `grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(...))`.

Closes #7670

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes
