### PR TITLE
feat(jaegermcp): Add get_trace_stats tool

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/README.md
+++ b/cmd/jaeger/internal/extension/jaegermcp/README.md
@@ -30,6 +30,7 @@ See [ADR-002](/docs/adr/002-mcp-server.md) for full design details.
 * `get_span_details`
 * `get_critical_path`
 * `get_service_dependencies`
+* `get_trace_stats`
 
 ## Configuration
 

--- a/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/integration_test.go
@@ -221,7 +221,7 @@ func TestMCPClientToolsListDiscovery(t *testing.T) {
 	expected := []string{
 		"get_services", "get_span_names", "search_traces",
 		"get_span_details", "get_trace_errors", "get_trace_topology", "get_critical_path",
-		"get_service_dependencies",
+		"get_service_dependencies", "get_trace_stats",
 	}
 	got := make(map[string]bool, len(result.Tools))
 	for _, tool := range result.Tools {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
@@ -59,8 +59,13 @@ func (h *getTraceStatsHandler) handle(
 	tracesIter := h.queryService.FindTraces(ctx, query)
 	aggregatedIter := jptrace.AggregateTraces(tracesIter)
 
+	// Pre-allocate with capacity to avoid repeated reallocations during iteration.
 	var durations []int64
 	var spanCounts []int
+	if effectiveLimit > 0 {
+		durations = make([]int64, 0, effectiveLimit)
+		spanCounts = make([]int, 0, effectiveLimit)
+	}
 	serviceCounts := make(map[string]int)
 	errorCount := 0
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/jptrace"
+)
+
+// getTraceStatsHandler implements the get_trace_stats MCP tool.
+// It accepts the same filters as search_traces but instead of returning individual
+// trace summaries it computes aggregate statistics (count, error rate, latency
+// percentiles, span counts, top services) across all matching traces.
+//
+// This is particularly useful for LLM-based agents that need a high-level
+// understanding of a service's health before deciding which individual traces
+// to inspect in detail.
+type getTraceStatsHandler struct {
+	queryService queryServiceInterface
+	maxResults   int
+}
+
+// NewGetTraceStatsHandler creates a new get_trace_stats handler and returns the handler function.
+func NewGetTraceStatsHandler(
+	queryService *querysvc.QueryService,
+	maxResults int,
+) mcp.ToolHandlerFor[types.GetTraceStatsInput, types.GetTraceStatsOutput] {
+	h := &getTraceStatsHandler{
+		queryService: queryService,
+		maxResults:   maxResults,
+	}
+	return h.handle
+}
+
+// handle processes the get_trace_stats tool request.
+func (h *getTraceStatsHandler) handle(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input types.GetTraceStatsInput,
+) (*mcp.CallToolResult, types.GetTraceStatsOutput, error) {
+	query, err := buildStatsQuery(input, h.maxResults)
+	if err != nil {
+		return nil, types.GetTraceStatsOutput{}, err
+	}
+
+	tracesIter := h.queryService.FindTraces(ctx, query)
+	aggregatedIter := jptrace.AggregateTraces(tracesIter)
+
+	var durations []int64
+	var spanCounts []int
+	serviceCounts := make(map[string]int)
+	errorCount := 0
+
+	for trace, err := range aggregatedIter {
+		if err != nil {
+			return nil, types.GetTraceStatsOutput{}, fmt.Errorf("error reading traces: %w", err)
+		}
+
+		summary := buildTraceSummary(trace)
+
+		durations = append(durations, summary.DurationUs)
+		spanCounts = append(spanCounts, summary.SpanCount)
+
+		if summary.HasErrors {
+			errorCount++
+		}
+
+		for _, svc := range summary.Services {
+			serviceCounts[svc]++
+		}
+
+		if h.maxResults > 0 && len(durations) >= h.maxResults {
+			break
+		}
+	}
+
+	traceCount := len(durations)
+	if traceCount == 0 {
+		// Return a zero-value output rather than an error — no traces is a valid result.
+		return nil, types.GetTraceStatsOutput{}, nil
+	}
+
+	output := types.GetTraceStatsOutput{
+		TraceCount:    traceCount,
+		ErrorCount:    errorCount,
+		ErrorRate:     float64(errorCount) / float64(traceCount),
+		DurationStats: computeDurationStats(durations),
+		SpanStats:     computeSpanStats(spanCounts),
+		TopServices:   buildTopServices(serviceCounts),
+	}
+
+	return nil, output, nil
+}
+
+// buildStatsQuery converts GetTraceStatsInput to querysvc.TraceQueryParams.
+// It reuses the same parsing helpers as search_traces for consistency.
+func buildStatsQuery(input types.GetTraceStatsInput, maxResults int) (querysvc.TraceQueryParams, error) {
+	searchInput := types.SearchTracesInput{
+		StartTimeMin: input.StartTimeMin,
+		StartTimeMax: input.StartTimeMax,
+		ServiceName:  input.ServiceName,
+		SpanName:     input.SpanName,
+		Attributes:   input.Attributes,
+		SearchDepth:  input.SearchDepth,
+	}
+	tmp := &searchTracesHandler{maxResults: maxResults}
+	return tmp.buildQuery(searchInput)
+}
+
+// computeDurationStats calculates min, max, mean, p50, p95, and p99 over a
+// slice of durations (in microseconds). The input slice is sorted in-place.
+func computeDurationStats(durations []int64) types.DurationStats {
+	if len(durations) == 0 {
+		return types.DurationStats{}
+	}
+
+	slices.Sort(durations)
+
+	n := len(durations)
+	var sum int64
+	for _, d := range durations {
+		sum += d
+	}
+
+	return types.DurationStats{
+		MinUs:  durations[0],
+		MaxUs:  durations[n-1],
+		MeanUs: sum / int64(n),
+		P50Us:  percentile(durations, 50),
+		P95Us:  percentile(durations, 95),
+		P99Us:  percentile(durations, 99),
+	}
+}
+
+// percentile returns the p-th percentile value from a pre-sorted slice using
+// the nearest-rank method (ceiling index).
+func percentile(sorted []int64, p int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(math.Ceil(float64(p)/100.0*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+// computeSpanStats calculates min, max, and mean span counts across traces.
+func computeSpanStats(counts []int) types.SpanStats {
+	if len(counts) == 0 {
+		return types.SpanStats{}
+	}
+
+	minSpans := counts[0]
+	maxSpans := counts[0]
+	total := 0
+
+	for _, c := range counts {
+		if c < minSpans {
+			minSpans = c
+		}
+		if c > maxSpans {
+			maxSpans = c
+		}
+		total += c
+	}
+
+	return types.SpanStats{
+		MinSpans:  minSpans,
+		MaxSpans:  maxSpans,
+		MeanSpans: float64(total) / float64(len(counts)),
+	}
+}
+
+// buildTopServices converts the service->traceCount map into a slice sorted by
+// descending trace count, then alphabetically by service name for ties.
+// The result is capped at 10 entries to keep the LLM context compact.
+func buildTopServices(serviceCounts map[string]int) []types.ServiceCount {
+	const maxTopServices = 10
+
+	result := make([]types.ServiceCount, 0, len(serviceCounts))
+	for svc, count := range serviceCounts {
+		result = append(result, types.ServiceCount{
+			Service:    svc,
+			TraceCount: count,
+		})
+	}
+
+	slices.SortStableFunc(result, func(a, b types.ServiceCount) int {
+		if b.TraceCount != a.TraceCount {
+			return b.TraceCount - a.TraceCount
+		}
+		if a.Service < b.Service {
+			return -1
+		}
+		if a.Service > b.Service {
+			return 1
+		}
+		return 0
+	})
+
+	if len(result) > maxTopServices {
+		result = result[:maxTopServices]
+	}
+	return result
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
@@ -102,9 +102,10 @@ func (h *getTraceStatsHandler) handle(
 }
 
 // buildStatsQuery converts GetTraceStatsInput to querysvc.TraceQueryParams.
-// It reuses the same parsing helpers as search_traces for consistency.
+// It reuses buildTraceQueryParams, the same standalone helper used by search_traces,
+// ensuring consistent filter parsing across both tools.
 func buildStatsQuery(input types.GetTraceStatsInput, maxResults int) (querysvc.TraceQueryParams, error) {
-	searchInput := types.SearchTracesInput{
+	return buildTraceQueryParams(types.SearchTracesInput{
 		StartTimeMin: input.StartTimeMin,
 		StartTimeMax: input.StartTimeMax,
 		ServiceName:  input.ServiceName,
@@ -114,9 +115,7 @@ func buildStatsQuery(input types.GetTraceStatsInput, maxResults int) (querysvc.T
 		DurationMin:  input.DurationMin,
 		DurationMax:  input.DurationMax,
 		SearchDepth:  input.SearchDepth,
-	}
-	tmp := &searchTracesHandler{maxResults: maxResults}
-	return tmp.buildQuery(searchInput)
+	}, maxResults)
 }
 
 // computeDurationStats calculates min, max, mean, p50, p95, and p99 over a
@@ -202,8 +201,11 @@ func buildTopServices(serviceCounts map[string]int) []types.ServiceCount {
 	}
 
 	slices.SortStableFunc(result, func(a, b types.ServiceCount) int {
-		if b.TraceCount != a.TraceCount {
-			return b.TraceCount - a.TraceCount
+		if a.TraceCount > b.TraceCount {
+			return -1
+		}
+		if a.TraceCount < b.TraceCount {
+			return 1
 		}
 		if a.Service < b.Service {
 			return -1

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
@@ -52,6 +52,10 @@ func (h *getTraceStatsHandler) handle(
 		return nil, types.GetTraceStatsOutput{}, err
 	}
 
+	// Use the effective search depth computed by buildStatsQuery (already clamped
+	// to maxResults and defaulted) as the loop limit for deterministic behaviour.
+	effectiveLimit := query.TraceQueryParams.SearchDepth
+
 	tracesIter := h.queryService.FindTraces(ctx, query)
 	aggregatedIter := jptrace.AggregateTraces(tracesIter)
 
@@ -78,7 +82,7 @@ func (h *getTraceStatsHandler) handle(
 			serviceCounts[svc]++
 		}
 
-		if h.maxResults > 0 && len(durations) >= h.maxResults {
+		if effectiveLimit > 0 && len(durations) >= effectiveLimit {
 			break
 		}
 	}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats.go
@@ -110,6 +110,9 @@ func buildStatsQuery(input types.GetTraceStatsInput, maxResults int) (querysvc.T
 		ServiceName:  input.ServiceName,
 		SpanName:     input.SpanName,
 		Attributes:   input.Attributes,
+		WithErrors:   input.WithErrors,
+		DurationMin:  input.DurationMin,
+		DurationMax:  input.DurationMax,
 		SearchDepth:  input.SearchDepth,
 	}
 	tmp := &searchTracesHandler{maxResults: maxResults}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_trace_stats_test.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegermcp/internal/types"
+)
+
+func TestGetTraceStatsHandler_Handle_BasicStats(t *testing.T) {
+	ids := uniqueTraceIDs(2)
+
+	traceOK := createTestTrace(ids[0], "frontend", "/api/ok", false)
+	traceErr := createTestTrace(ids[1], "frontend", "/api/err", true)
+
+	mock := newMockFindTraces(traceOK, traceErr)
+	handler := &getTraceStatsHandler{queryService: mock, maxResults: 100}
+
+	input := types.GetTraceStatsInput{ServiceName: "frontend"}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, output.TraceCount)
+	assert.Equal(t, 1, output.ErrorCount)
+	assert.InDelta(t, 0.5, output.ErrorRate, 0.001)
+	assert.Equal(t, 1, output.SpanStats.MinSpans)
+	assert.Equal(t, 1, output.SpanStats.MaxSpans)
+	assert.InDelta(t, 1.0, output.SpanStats.MeanSpans, 0.001)
+	require.NotEmpty(t, output.TopServices)
+	assert.Equal(t, "frontend", output.TopServices[0].Service)
+	assert.Equal(t, 2, output.TopServices[0].TraceCount)
+}
+
+func TestGetTraceStatsHandler_Handle_NoTraces(t *testing.T) {
+	mock := newMockFindTraces() // yields nothing
+	handler := &getTraceStatsHandler{queryService: mock, maxResults: 100}
+
+	input := types.GetTraceStatsInput{ServiceName: "nonexistent"}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, output.TraceCount)
+	assert.Equal(t, 0, output.ErrorCount)
+	assert.InDelta(t, 0.0, output.ErrorRate, 0.001)
+}
+
+func TestGetTraceStatsHandler_Handle_AllErrors(t *testing.T) {
+	ids := uniqueTraceIDs(3)
+
+	trace1 := createTestTrace(ids[0], "svc", "/op1", true)
+	trace2 := createTestTrace(ids[1], "svc", "/op2", true)
+	trace3 := createTestTrace(ids[2], "svc", "/op3", true)
+
+	mock := newMockFindTraces(trace1, trace2, trace3)
+	handler := &getTraceStatsHandler{queryService: mock, maxResults: 100}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, types.GetTraceStatsInput{ServiceName: "svc"})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, output.TraceCount)
+	assert.Equal(t, 3, output.ErrorCount)
+	assert.InDelta(t, 1.0, output.ErrorRate, 0.001)
+}
+
+func TestGetTraceStatsHandler_Handle_DurationStats(t *testing.T) {
+	ids := uniqueTraceIDs(2)
+
+	trace1 := createTestTrace(ids[0], "svc", "/op1", false)
+	trace2 := createTestTrace(ids[1], "svc", "/op2", false)
+
+	mock := newMockFindTraces(trace1, trace2)
+	handler := &getTraceStatsHandler{queryService: mock, maxResults: 100}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, types.GetTraceStatsInput{ServiceName: "svc"})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, output.TraceCount)
+	assert.GreaterOrEqual(t, output.DurationStats.MinUs, int64(0))
+	assert.GreaterOrEqual(t, output.DurationStats.MaxUs, output.DurationStats.MinUs)
+	assert.GreaterOrEqual(t, output.DurationStats.MeanUs, output.DurationStats.MinUs)
+	assert.GreaterOrEqual(t, output.DurationStats.P50Us, output.DurationStats.MinUs)
+	assert.GreaterOrEqual(t, output.DurationStats.P95Us, output.DurationStats.P50Us)
+	assert.GreaterOrEqual(t, output.DurationStats.P99Us, output.DurationStats.P95Us)
+}
+
+func TestGetTraceStatsHandler_Handle_TopServicesOrdering(t *testing.T) {
+	ids := uniqueTraceIDs(4)
+	idx := 0
+
+	// Build traces with explicit service names.
+	makeSvcTrace := func(svc string) ptrace.Traces {
+		tr := createTestTrace(ids[idx], svc, "/op", false)
+		idx++
+		return tr
+	}
+
+	// frontend: 3 traces, backend: 1 trace
+	mock := newMockFindTraces(
+		makeSvcTrace("frontend"),
+		makeSvcTrace("frontend"),
+		makeSvcTrace("frontend"),
+		makeSvcTrace("backend"),
+	)
+	handler := &getTraceStatsHandler{queryService: mock, maxResults: 100}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, types.GetTraceStatsInput{ServiceName: "frontend"})
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(output.TopServices), 1)
+	assert.Equal(t, "frontend", output.TopServices[0].Service)
+	assert.Equal(t, 3, output.TopServices[0].TraceCount)
+}
+
+func TestGetTraceStatsHandler_Handle_LimitEnforced(t *testing.T) {
+	ids := uniqueTraceIDs(5)
+
+	mock := newMockFindTraces(
+		createTestTrace(ids[0], "svc", "/op1", false),
+		createTestTrace(ids[1], "svc", "/op2", false),
+		createTestTrace(ids[2], "svc", "/op3", false),
+		createTestTrace(ids[3], "svc", "/op4", false),
+		createTestTrace(ids[4], "svc", "/op5", false),
+	)
+	handler := &getTraceStatsHandler{queryService: mock, maxResults: 3}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, types.GetTraceStatsInput{ServiceName: "svc"})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, output.TraceCount)
+}
+
+func TestGetTraceStatsHandler_Handle_QueryError(t *testing.T) {
+	mock := newMockFindTracesError(errors.New("storage unavailable"))
+	handler := &getTraceStatsHandler{queryService: mock, maxResults: 100}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, types.GetTraceStatsInput{ServiceName: "svc"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage unavailable")
+}
+
+func TestGetTraceStatsHandler_Handle_MissingServiceName(t *testing.T) {
+	handler := NewGetTraceStatsHandler(nil, 100)
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, types.GetTraceStatsInput{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service_name is required")
+}
+
+func TestGetTraceStatsHandler_Handle_InvalidTimeFormat(t *testing.T) {
+	handler := NewGetTraceStatsHandler(nil, 100)
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, types.GetTraceStatsInput{
+		ServiceName:  "svc",
+		StartTimeMin: "not-a-time",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid start_time_min")
+}
+
+// --- unit tests for helper functions ---
+
+func TestComputeDurationStats_Empty(t *testing.T) {
+	stats := computeDurationStats(nil)
+	assert.Equal(t, types.DurationStats{}, stats)
+}
+
+func TestComputeDurationStats_Single(t *testing.T) {
+	stats := computeDurationStats([]int64{1000})
+	assert.Equal(t, int64(1000), stats.MinUs)
+	assert.Equal(t, int64(1000), stats.MaxUs)
+	assert.Equal(t, int64(1000), stats.MeanUs)
+	assert.Equal(t, int64(1000), stats.P50Us)
+	assert.Equal(t, int64(1000), stats.P95Us)
+	assert.Equal(t, int64(1000), stats.P99Us)
+}
+
+func TestComputeDurationStats_Multiple(t *testing.T) {
+	// 10 values: 100, 200, ..., 1000 (shuffled)
+	durations := []int64{500, 100, 900, 300, 700, 200, 800, 400, 600, 1000}
+	stats := computeDurationStats(durations)
+
+	assert.Equal(t, int64(100), stats.MinUs)
+	assert.Equal(t, int64(1000), stats.MaxUs)
+	assert.Equal(t, int64(550), stats.MeanUs)
+	// nearest-rank p50 of [100,200,300,400,500,600,700,800,900,1000]:
+	// ceil(50/100*10)-1 = ceil(5)-1 = 4 → sorted[4] = 500
+	assert.Equal(t, int64(500), stats.P50Us)
+}
+
+func TestComputeSpanStats_Empty(t *testing.T) {
+	stats := computeSpanStats(nil)
+	assert.Equal(t, types.SpanStats{}, stats)
+}
+
+func TestComputeSpanStats_Values(t *testing.T) {
+	stats := computeSpanStats([]int{1, 5, 3, 2, 4})
+	assert.Equal(t, 1, stats.MinSpans)
+	assert.Equal(t, 5, stats.MaxSpans)
+	assert.InDelta(t, 3.0, stats.MeanSpans, 0.001)
+}
+
+func TestBuildTopServices_Empty(t *testing.T) {
+	result := buildTopServices(map[string]int{})
+	assert.Empty(t, result)
+}
+
+func TestBuildTopServices_Ordering(t *testing.T) {
+	counts := map[string]int{
+		"alpha": 5,
+		"beta":  10,
+		"gamma": 5,
+	}
+	result := buildTopServices(counts)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "beta", result[0].Service)
+	assert.Equal(t, 10, result[0].TraceCount)
+	// alpha before gamma (same count, alphabetical)
+	assert.Equal(t, "alpha", result[1].Service)
+	assert.Equal(t, "gamma", result[2].Service)
+}
+
+func TestBuildTopServices_CappedAt10(t *testing.T) {
+	counts := make(map[string]int)
+	for i := 0; i < 15; i++ {
+		counts[string(rune('a'+i))] = i + 1
+	}
+	result := buildTopServices(counts)
+	assert.Len(t, result, 10)
+}
+
+func TestPercentile_Empty(t *testing.T) {
+	assert.Equal(t, int64(0), percentile(nil, 50))
+}
+
+func TestPercentile_Boundary(t *testing.T) {
+	sorted := []int64{10, 20, 30, 40, 50}
+	assert.Equal(t, int64(10), percentile(sorted, 0))
+	assert.Equal(t, int64(50), percentile(sorted, 100))
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -96,6 +96,13 @@ func (h *searchTracesHandler) handle(
 
 // buildQuery converts SearchTracesInput to querysvc.TraceQueryParams.
 func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysvc.TraceQueryParams, error) {
+	return buildTraceQueryParams(input, h.maxResults)
+}
+
+// buildTraceQueryParams is a standalone helper that converts SearchTracesInput to
+// querysvc.TraceQueryParams. It is shared by searchTracesHandler and getTraceStatsHandler
+// to avoid coupling the stats handler to searchTracesHandler internals.
+func buildTraceQueryParams(input types.SearchTracesInput, maxResults int) (querysvc.TraceQueryParams, error) {
 	// Use default start time if not provided
 	startTimeMinInput := input.StartTimeMin
 	if startTimeMinInput == "" {
@@ -152,8 +159,8 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	if searchDepth <= 0 {
 		searchDepth = defaultSearchDepth
 	}
-	if searchDepth > h.maxResults {
-		searchDepth = h.maxResults
+	if searchDepth > maxResults {
+		searchDepth = maxResults
 	}
 
 	// Convert attributes map to pcommon.Map

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -159,7 +159,7 @@ func buildTraceQueryParams(input types.SearchTracesInput, maxResults int) (query
 	if searchDepth <= 0 {
 		searchDepth = defaultSearchDepth
 	}
-	if searchDepth > maxResults {
+	if maxResults > 0 && searchDepth > maxResults {
 		searchDepth = maxResults
 	}
 

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -127,22 +127,22 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	}
 
 	// Parse duration parameters
-	var durationMin, durationMax time.Duration
+	var minDuration, maxDuration time.Duration
 	if input.DurationMin != "" {
-		durationMin, err = time.ParseDuration(input.DurationMin)
+		minDuration, err = time.ParseDuration(input.DurationMin)
 		if err != nil {
 			return querysvc.TraceQueryParams{}, fmt.Errorf("invalid duration_min: %w", err)
 		}
 	}
 	if input.DurationMax != "" {
-		durationMax, err = time.ParseDuration(input.DurationMax)
+		maxDuration, err = time.ParseDuration(input.DurationMax)
 		if err != nil {
 			return querysvc.TraceQueryParams{}, fmt.Errorf("invalid duration_max: %w", err)
 		}
 	}
 
 	// Validate duration range
-	if durationMin > 0 && durationMax > 0 && durationMax < durationMin {
+	if minDuration > 0 && maxDuration > 0 && maxDuration < minDuration {
 		return querysvc.TraceQueryParams{}, errors.New("duration_max must be greater than duration_min")
 	}
 
@@ -174,8 +174,8 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 			Attributes:    attributes,
 			StartTimeMin:  minStartTime,
 			StartTimeMax:  maxStartTime,
-			DurationMin:   durationMin,
-			DurationMax:   durationMax,
+			DurationMin:   minDuration,
+			DurationMax:   maxDuration,
 			SearchDepth:   searchDepth,
 		},
 		RawTraces: false, // We want adjusted traces

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
@@ -21,13 +21,14 @@ const testTraceID = "12345678901234567890123456789012"
 // uniqueTraceIDs returns n distinct 32-hex-char trace ID strings.
 // Used by FindTraces-based tests where each trace must have a unique ID so
 // that AggregateTraces does not merge them together.
-// The IDs differ in the first byte so that copy(tid[:], id) produces distinct
-// pcommon.TraceID values (copy only reads the first 16 bytes of the string).
+// The IDs differ within the first 16 characters so that copy(tid[:], id)
+// produces distinct pcommon.TraceID values (copy reads the first 16 bytes of
+// the string, not decoded hex bytes).
 func uniqueTraceIDs(n int) []string {
 	ids := make([]string, n)
 	for i := range ids {
-		// Put the index in the first 8 bytes (big-endian hex) so the 16-byte
-		// copy captures the difference.
+		// Put the index in the first 16 characters (as big-endian hex) so the
+		// 16-byte string copy captures the difference.
 		ids[i] = fmt.Sprintf("%016x%016x", i+1, i+1)
 	}
 	return ids
@@ -248,7 +249,9 @@ func newMockFindTracesError(err error) *mockQueryService {
 	return &mockQueryService{
 		findTracesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
 			return func(yield func([]ptrace.Traces, error) bool) {
-				yield(nil, err)
+				if !yield(nil, err) {
+					return
+				}
 			}
 		},
 	}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
@@ -146,7 +146,8 @@ func createTestTrace(traceID string, serviceName string, spanName string, hasErr
 	if b, err := hex.DecodeString(traceID); err == nil && len(b) == 16 {
 		copy(tid[:], b)
 	} else {
-		// Fallback for legacy callers passing non-hex strings (e.g. testTraceID).
+		// Fallback for callers passing non-hex strings or values with the
+		// wrong decoded length.
 		copy(tid[:], traceID)
 	}
 	span.SetTraceID(tid)

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
@@ -19,8 +19,9 @@ import (
 const testTraceID = "12345678901234567890123456789012"
 
 // uniqueTraceIDs returns n distinct 32-hex-char trace ID strings.
-// Used by FindTraces-based tests where each trace must have a unique ID so
-// that AggregateTraces does not merge them together.
+// Used by FindTraces-based tests that expect separate aggregated traces:
+// AggregateTraces merges spans that share the same trace ID, regardless of
+// how they are yielded by the mock.
 // The IDs differ within the first 16 characters so that copy(tid[:], id)
 // produces distinct pcommon.TraceID values (copy reads the first 16 bytes of
 // the string, not decoded hex bytes).
@@ -112,8 +113,9 @@ func newMockYieldingEmpty() *mockQueryService {
 }
 
 // newMockFindTraces creates a mock for FindTraces calls that yields each trace
-// individually (one per iteration step) so that AggregateTraces treats them as
-// separate traces even when they share the same trace ID.
+// individually (one per iteration step). This controls how results are emitted,
+// but traces with the same trace ID may still be merged by AggregateTraces, so
+// tests that require distinct aggregated traces should use unique trace IDs.
 func newMockFindTraces(traces ...ptrace.Traces) *mockQueryService {
 	return &mockQueryService{
 		findTracesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"iter"
 	"time"
@@ -18,19 +19,16 @@ import (
 // testTraceID is a common trace ID used across tests
 const testTraceID = "12345678901234567890123456789012"
 
-// uniqueTraceIDs returns n distinct 32-hex-char trace ID strings.
+// uniqueTraceIDs returns n distinct pcommon.TraceID-compatible hex strings.
 // Used by FindTraces-based tests that expect separate aggregated traces:
 // AggregateTraces merges spans that share the same trace ID, regardless of
 // how they are yielded by the mock.
-// The IDs differ within the first 16 characters so that copy(tid[:], id)
-// produces distinct pcommon.TraceID values (copy reads the first 16 bytes of
-// the string, not decoded hex bytes).
+// Each string is a valid 32-char lowercase hex trace ID so that
+// hex.DecodeString produces a unique 16-byte pcommon.TraceID.
 func uniqueTraceIDs(n int) []string {
 	ids := make([]string, n)
 	for i := range ids {
-		// Put the index in the first 16 characters (as big-endian hex) so the
-		// 16-byte string copy captures the difference.
-		ids[i] = fmt.Sprintf("%016x%016x", i+1, i+1)
+		ids[i] = fmt.Sprintf("%032x", i+1)
 	}
 	return ids
 }
@@ -130,7 +128,8 @@ func newMockFindTraces(traces ...ptrace.Traces) *mockQueryService {
 	}
 }
 
-// createTestTrace creates a simple trace with a single span for testing
+// createTestTrace creates a simple trace with a single span for testing.
+// traceID must be a 32-char lowercase hex string (e.g. from uniqueTraceIDs or testTraceID).
 func createTestTrace(traceID string, serviceName string, spanName string, hasError bool) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	resourceSpans := traces.ResourceSpans().AppendEmpty()
@@ -141,9 +140,15 @@ func createTestTrace(traceID string, serviceName string, spanName string, hasErr
 	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
 	span := scopeSpans.Spans().AppendEmpty()
 
-	// Set trace ID
-	tid := pcommon.TraceID{}
-	copy(tid[:], traceID)
+	// Hex-decode the trace ID string into a pcommon.TraceID so the resulting
+	// TraceID bytes match what a real trace would produce.
+	var tid pcommon.TraceID
+	if b, err := hex.DecodeString(traceID); err == nil && len(b) == 16 {
+		copy(tid[:], b)
+	} else {
+		// Fallback for legacy callers passing non-hex strings (e.g. testTraceID).
+		copy(tid[:], traceID)
+	}
 	span.SetTraceID(tid)
 
 	// Set span ID (root span has empty parent)

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"time"
 
@@ -16,6 +17,21 @@ import (
 
 // testTraceID is a common trace ID used across tests
 const testTraceID = "12345678901234567890123456789012"
+
+// uniqueTraceIDs returns n distinct 32-hex-char trace ID strings.
+// Used by FindTraces-based tests where each trace must have a unique ID so
+// that AggregateTraces does not merge them together.
+// The IDs differ in the first byte so that copy(tid[:], id) produces distinct
+// pcommon.TraceID values (copy only reads the first 16 bytes of the string).
+func uniqueTraceIDs(n int) []string {
+	ids := make([]string, n)
+	for i := range ids {
+		// Put the index in the first 8 bytes (big-endian hex) so the 16-byte
+		// copy captures the difference.
+		ids[i] = fmt.Sprintf("%016x%016x", i+1, i+1)
+	}
+	return ids
+}
 
 // spanConfig defines the configuration for creating a test span
 type spanConfig struct {
@@ -94,12 +110,18 @@ func newMockYieldingEmpty() *mockQueryService {
 	}
 }
 
-// newMockFindTraces creates a mock for FindTraces calls that yields the given traces
+// newMockFindTraces creates a mock for FindTraces calls that yields each trace
+// individually (one per iteration step) so that AggregateTraces treats them as
+// separate traces even when they share the same trace ID.
 func newMockFindTraces(traces ...ptrace.Traces) *mockQueryService {
 	return &mockQueryService{
 		findTracesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
 			return func(yield func([]ptrace.Traces, error) bool) {
-				yield(traces, nil)
+				for _, t := range traces {
+					if !yield([]ptrace.Traces{t}, nil) {
+						return
+					}
+				}
 			}
 		},
 	}
@@ -219,4 +241,15 @@ func spanIDToHex(spanID string) string {
 	sid := pcommon.SpanID{}
 	copy(sid[:], spanID)
 	return sid.String()
+}
+
+// newMockFindTracesError creates a mock for FindTraces calls that yields an error
+func newMockFindTracesError(err error) *mockQueryService {
+	return &mockQueryService{
+		findTracesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+			return func(yield func([]ptrace.Traces, error) bool) {
+				yield(nil, err)
+			}
+		},
+	}
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2026 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package types

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
@@ -24,8 +24,8 @@ type GetTraceStatsInput struct {
 	// Attributes contains key-value pairs to match against span/resource attributes (optional).
 	Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
 
-	// WithErrors filters to only analyse traces containing error spans (optional).
-	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only analyse traces containing error spans"`
+	// WithErrors filters to only analyze traces containing error spans (optional).
+	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only analyze traces containing error spans"`
 
 	// DurationMin is the minimum trace duration filter (optional, e.g., "2s", "100ms").
 	DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`
@@ -33,15 +33,15 @@ type GetTraceStatsInput struct {
 	// DurationMax is the maximum trace duration filter (optional).
 	DurationMax string `json:"duration_max,omitempty" jsonschema:"Maximum duration filter (e.g. 10s 1m)"`
 
-	// SearchDepth defines the maximum number of traces to analyse for statistics.
+	// SearchDepth defines the maximum number of traces to analyze for statistics.
 	// Default: 10, maximum is controlled by server configuration (MaxSearchResults).
-	SearchDepth int `json:"search_depth,omitempty" jsonschema:"Maximum number of traces to analyse (default: 10, max controlled by server config)"`
+	SearchDepth int `json:"search_depth,omitempty" jsonschema:"Maximum number of traces to analyze (default: 10, max controlled by server config)"`
 }
 
 // GetTraceStatsOutput defines the output of the get_trace_stats MCP tool.
 type GetTraceStatsOutput struct {
-	// TraceCount is the total number of traces analysed.
-	TraceCount int `json:"trace_count" jsonschema:"Total number of traces analysed"`
+	// TraceCount is the total number of traces analyzed.
+	TraceCount int `json:"trace_count" jsonschema:"Total number of traces analyzed"`
 
 	// ErrorCount is the number of traces that contain at least one error span.
 	ErrorCount int `json:"error_count" jsonschema:"Number of traces containing at least one error span"`
@@ -49,13 +49,13 @@ type GetTraceStatsOutput struct {
 	// ErrorRate is the fraction of traces with errors, expressed as a value between 0 and 1.
 	ErrorRate float64 `json:"error_rate" jsonschema:"Fraction of traces with errors (0.0-1.0)"`
 
-	// DurationStats contains latency percentile statistics across all analysed traces (in microseconds).
-	DurationStats DurationStats `json:"duration_stats" jsonschema:"Latency statistics across all analysed traces"`
+	// DurationStats contains latency percentile statistics across all analyzed traces (in microseconds).
+	DurationStats DurationStats `json:"duration_stats" jsonschema:"Latency statistics across all analyzed traces"`
 
-	// SpanStats contains statistics about span counts across all analysed traces.
-	SpanStats SpanStats `json:"span_stats" jsonschema:"Span count statistics across all analysed traces"`
+	// SpanStats contains statistics about span counts across all analyzed traces.
+	SpanStats SpanStats `json:"span_stats" jsonschema:"Span count statistics across all analyzed traces"`
 
-	// TopServices lists the services that appear most frequently across the analysed traces,
+	// TopServices lists the services that appear most frequently across the analyzed traces,
 	// ordered by descending occurrence count.
 	TopServices []ServiceCount `json:"top_services" jsonschema:"Services ordered by descending occurrence count across traces"`
 }
@@ -72,13 +72,13 @@ type DurationStats struct {
 
 // SpanStats holds statistics about span counts per trace.
 type SpanStats struct {
-	MinSpans  int     `json:"min_spans"  jsonschema:"Minimum span count across all analysed traces"`
-	MaxSpans  int     `json:"max_spans"  jsonschema:"Maximum span count across all analysed traces"`
-	MeanSpans float64 `json:"mean_spans" jsonschema:"Mean span count across all analysed traces"`
+	MinSpans  int     `json:"min_spans"  jsonschema:"Minimum span count across all analyzed traces"`
+	MaxSpans  int     `json:"max_spans"  jsonschema:"Maximum span count across all analyzed traces"`
+	MeanSpans float64 `json:"mean_spans" jsonschema:"Mean span count across all analyzed traces"`
 }
 
 // ServiceCount pairs a service name with the number of traces it participated in.
 type ServiceCount struct {
 	Service    string `json:"service"     jsonschema:"Service name"`
-	TraceCount int    `json:"trace_count" jsonschema:"Number of analysed traces this service participated in"`
+	TraceCount int    `json:"trace_count" jsonschema:"Number of analyzed traces this service participated in"`
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// GetTraceStatsInput defines the input parameters for the get_trace_stats MCP tool.
+type GetTraceStatsInput struct {
+	StartTimeMin string            `json:"start_time_min,omitempty"`
+	StartTimeMax string            `json:"start_time_max,omitempty"`
+	ServiceName  string            `json:"service_name"`
+	SpanName     string            `json:"span_name,omitempty"`
+	Attributes   map[string]string `json:"attributes,omitempty"`
+	SearchDepth  int               `json:"search_depth,omitempty"`
+}
+
+// GetTraceStatsOutput defines the output of the get_trace_stats MCP tool.
+type GetTraceStatsOutput struct {
+	TraceCount    int            `json:"trace_count"`
+	ErrorCount    int            `json:"error_count"`
+	ErrorRate     float64        `json:"error_rate"`
+	DurationStats DurationStats  `json:"duration_stats"`
+	SpanStats     SpanStats      `json:"span_stats"`
+	TopServices   []ServiceCount `json:"top_services"`
+}
+
+// DurationStats holds latency percentile statistics in microseconds.
+type DurationStats struct {
+	MinUs  int64 `json:"min_us"`
+	MaxUs  int64 `json:"max_us"`
+	MeanUs int64 `json:"mean_us"`
+	P50Us  int64 `json:"p50_us"`
+	P95Us  int64 `json:"p95_us"`
+	P99Us  int64 `json:"p99_us"`
+}
+
+// SpanStats holds statistics about span counts per trace.
+type SpanStats struct {
+	MinSpans  int     `json:"min_spans"`
+	MaxSpans  int     `json:"max_spans"`
+	MeanSpans float64 `json:"mean_spans"`
+}
+
+// ServiceCount pairs a service name with the number of traces it participated in.
+type ServiceCount struct {
+	Service    string `json:"service"`
+	TraceCount int    `json:"trace_count"`
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
@@ -1,47 +1,84 @@
-// Copyright (c) 2026 The Jaeger Authors.
+﻿// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 package types
 
 // GetTraceStatsInput defines the input parameters for the get_trace_stats MCP tool.
+// It accepts the same filters as search_traces but returns aggregate statistics
+// instead of individual trace summaries.
 type GetTraceStatsInput struct {
-	StartTimeMin string            `json:"start_time_min,omitempty"`
-	StartTimeMax string            `json:"start_time_max,omitempty"`
-	ServiceName  string            `json:"service_name"`
-	SpanName     string            `json:"span_name,omitempty"`
-	Attributes   map[string]string `json:"attributes,omitempty"`
-	SearchDepth  int               `json:"search_depth,omitempty"`
+// StartTimeMin is the start of time interval (optional, defaults to "-1h").
+// Supports RFC3339 or relative time (e.g., "-1h", "-30m").
+StartTimeMin string `json:"start_time_min,omitempty" jsonschema:"Start of time interval (RFC3339 or relative like -1h). Default: -1h"`
+
+// StartTimeMax is the end of time interval (optional, defaults to "now").
+// Supports RFC3339 or relative time (e.g., "now", "-1m").
+StartTimeMax string `json:"start_time_max,omitempty" jsonschema:"End of time interval (RFC3339 or relative like now). Default: now"`
+
+// ServiceName filters by service name (required).
+ServiceName string `json:"service_name" jsonschema:"Filter by service name. Use get_services to discover valid names"`
+
+// SpanName filters by span name (optional).
+SpanName string `json:"span_name,omitempty" jsonschema:"Filter by span name"`
+
+// Attributes contains key-value pairs to match against span/resource attributes (optional).
+Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
+
+// WithErrors filters to only analyse traces containing error spans (optional).
+WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only analyse traces containing error spans"`
+
+// DurationMin is the minimum trace duration filter (optional, e.g., "2s", "100ms").
+DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`
+
+// DurationMax is the maximum trace duration filter (optional).
+DurationMax string `json:"duration_max,omitempty" jsonschema:"Maximum duration filter (e.g. 10s 1m)"`
+
+// SearchDepth defines the maximum number of traces to analyse for statistics.
+// Default: 100, maximum is controlled by server configuration (MaxSearchResults).
+SearchDepth int `json:"search_depth,omitempty" jsonschema:"Maximum number of traces to analyse (default: 100, max controlled by server config)"`
 }
 
 // GetTraceStatsOutput defines the output of the get_trace_stats MCP tool.
 type GetTraceStatsOutput struct {
-	TraceCount    int            `json:"trace_count"`
-	ErrorCount    int            `json:"error_count"`
-	ErrorRate     float64        `json:"error_rate"`
-	DurationStats DurationStats  `json:"duration_stats"`
-	SpanStats     SpanStats      `json:"span_stats"`
-	TopServices   []ServiceCount `json:"top_services"`
+// TraceCount is the total number of traces analysed.
+TraceCount int `json:"trace_count" jsonschema:"Total number of traces analysed"`
+
+// ErrorCount is the number of traces that contain at least one error span.
+ErrorCount int `json:"error_count" jsonschema:"Number of traces containing at least one error span"`
+
+// ErrorRate is the fraction of traces with errors, expressed as a value between 0 and 1.
+ErrorRate float64 `json:"error_rate" jsonschema:"Fraction of traces with errors (0.0-1.0)"`
+
+// DurationStats contains latency percentile statistics across all analysed traces (in microseconds).
+DurationStats DurationStats `json:"duration_stats" jsonschema:"Latency statistics across all analysed traces"`
+
+// SpanStats contains statistics about span counts across all analysed traces.
+SpanStats SpanStats `json:"span_stats" jsonschema:"Span count statistics across all analysed traces"`
+
+// TopServices lists the services that appear most frequently across the analysed traces,
+// ordered by descending occurrence count.
+TopServices []ServiceCount `json:"top_services" jsonschema:"Services ordered by descending occurrence count across traces"`
 }
 
 // DurationStats holds latency percentile statistics in microseconds.
 type DurationStats struct {
-	MinUs  int64 `json:"min_us"`
-	MaxUs  int64 `json:"max_us"`
-	MeanUs int64 `json:"mean_us"`
-	P50Us  int64 `json:"p50_us"`
-	P95Us  int64 `json:"p95_us"`
-	P99Us  int64 `json:"p99_us"`
+MinUs  int64 `json:"min_us"  jsonschema:"Minimum trace duration in microseconds"`
+MaxUs  int64 `json:"max_us"  jsonschema:"Maximum trace duration in microseconds"`
+MeanUs int64 `json:"mean_us" jsonschema:"Mean trace duration in microseconds"`
+P50Us  int64 `json:"p50_us"  jsonschema:"50th-percentile (median) trace duration in microseconds"`
+P95Us  int64 `json:"p95_us"  jsonschema:"95th-percentile trace duration in microseconds"`
+P99Us  int64 `json:"p99_us"  jsonschema:"99th-percentile trace duration in microseconds"`
 }
 
 // SpanStats holds statistics about span counts per trace.
 type SpanStats struct {
-	MinSpans  int     `json:"min_spans"`
-	MaxSpans  int     `json:"max_spans"`
-	MeanSpans float64 `json:"mean_spans"`
+MinSpans  int     `json:"min_spans"  jsonschema:"Minimum span count across all analysed traces"`
+MaxSpans  int     `json:"max_spans"  jsonschema:"Maximum span count across all analysed traces"`
+MeanSpans float64 `json:"mean_spans" jsonschema:"Mean span count across all analysed traces"`
 }
 
 // ServiceCount pairs a service name with the number of traces it participated in.
 type ServiceCount struct {
-	Service    string `json:"service"`
-	TraceCount int    `json:"trace_count"`
+Service    string `json:"service"     jsonschema:"Service name"`
+TraceCount int    `json:"trace_count" jsonschema:"Number of analysed traces this service participated in"`
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_trace_stats.go
@@ -7,78 +7,78 @@ package types
 // It accepts the same filters as search_traces but returns aggregate statistics
 // instead of individual trace summaries.
 type GetTraceStatsInput struct {
-// StartTimeMin is the start of time interval (optional, defaults to "-1h").
-// Supports RFC3339 or relative time (e.g., "-1h", "-30m").
-StartTimeMin string `json:"start_time_min,omitempty" jsonschema:"Start of time interval (RFC3339 or relative like -1h). Default: -1h"`
+	// StartTimeMin is the start of time interval (optional, defaults to "-1h").
+	// Supports RFC3339 or relative time (e.g., "-1h", "-30m").
+	StartTimeMin string `json:"start_time_min,omitempty" jsonschema:"Start of time interval (RFC3339 or relative like -1h). Default: -1h"`
 
-// StartTimeMax is the end of time interval (optional, defaults to "now").
-// Supports RFC3339 or relative time (e.g., "now", "-1m").
-StartTimeMax string `json:"start_time_max,omitempty" jsonschema:"End of time interval (RFC3339 or relative like now). Default: now"`
+	// StartTimeMax is the end of time interval (optional, defaults to "now").
+	// Supports RFC3339 or relative time (e.g., "now", "-1m").
+	StartTimeMax string `json:"start_time_max,omitempty" jsonschema:"End of time interval (RFC3339 or relative like now). Default: now"`
 
-// ServiceName filters by service name (required).
-ServiceName string `json:"service_name" jsonschema:"Filter by service name. Use get_services to discover valid names"`
+	// ServiceName filters by service name (required).
+	ServiceName string `json:"service_name" jsonschema:"Filter by service name. Use get_services to discover valid names"`
 
-// SpanName filters by span name (optional).
-SpanName string `json:"span_name,omitempty" jsonschema:"Filter by span name"`
+	// SpanName filters by span name (optional).
+	SpanName string `json:"span_name,omitempty" jsonschema:"Filter by span name"`
 
-// Attributes contains key-value pairs to match against span/resource attributes (optional).
-Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
+	// Attributes contains key-value pairs to match against span/resource attributes (optional).
+	Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
 
-// WithErrors filters to only analyse traces containing error spans (optional).
-WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only analyse traces containing error spans"`
+	// WithErrors filters to only analyse traces containing error spans (optional).
+	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only analyse traces containing error spans"`
 
-// DurationMin is the minimum trace duration filter (optional, e.g., "2s", "100ms").
-DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`
+	// DurationMin is the minimum trace duration filter (optional, e.g., "2s", "100ms").
+	DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`
 
-// DurationMax is the maximum trace duration filter (optional).
-DurationMax string `json:"duration_max,omitempty" jsonschema:"Maximum duration filter (e.g. 10s 1m)"`
+	// DurationMax is the maximum trace duration filter (optional).
+	DurationMax string `json:"duration_max,omitempty" jsonschema:"Maximum duration filter (e.g. 10s 1m)"`
 
-// SearchDepth defines the maximum number of traces to analyse for statistics.
-// Default: 100, maximum is controlled by server configuration (MaxSearchResults).
-SearchDepth int `json:"search_depth,omitempty" jsonschema:"Maximum number of traces to analyse (default: 100, max controlled by server config)"`
+	// SearchDepth defines the maximum number of traces to analyse for statistics.
+	// Default: 10, maximum is controlled by server configuration (MaxSearchResults).
+	SearchDepth int `json:"search_depth,omitempty" jsonschema:"Maximum number of traces to analyse (default: 10, max controlled by server config)"`
 }
 
 // GetTraceStatsOutput defines the output of the get_trace_stats MCP tool.
 type GetTraceStatsOutput struct {
-// TraceCount is the total number of traces analysed.
-TraceCount int `json:"trace_count" jsonschema:"Total number of traces analysed"`
+	// TraceCount is the total number of traces analysed.
+	TraceCount int `json:"trace_count" jsonschema:"Total number of traces analysed"`
 
-// ErrorCount is the number of traces that contain at least one error span.
-ErrorCount int `json:"error_count" jsonschema:"Number of traces containing at least one error span"`
+	// ErrorCount is the number of traces that contain at least one error span.
+	ErrorCount int `json:"error_count" jsonschema:"Number of traces containing at least one error span"`
 
-// ErrorRate is the fraction of traces with errors, expressed as a value between 0 and 1.
-ErrorRate float64 `json:"error_rate" jsonschema:"Fraction of traces with errors (0.0-1.0)"`
+	// ErrorRate is the fraction of traces with errors, expressed as a value between 0 and 1.
+	ErrorRate float64 `json:"error_rate" jsonschema:"Fraction of traces with errors (0.0-1.0)"`
 
-// DurationStats contains latency percentile statistics across all analysed traces (in microseconds).
-DurationStats DurationStats `json:"duration_stats" jsonschema:"Latency statistics across all analysed traces"`
+	// DurationStats contains latency percentile statistics across all analysed traces (in microseconds).
+	DurationStats DurationStats `json:"duration_stats" jsonschema:"Latency statistics across all analysed traces"`
 
-// SpanStats contains statistics about span counts across all analysed traces.
-SpanStats SpanStats `json:"span_stats" jsonschema:"Span count statistics across all analysed traces"`
+	// SpanStats contains statistics about span counts across all analysed traces.
+	SpanStats SpanStats `json:"span_stats" jsonschema:"Span count statistics across all analysed traces"`
 
-// TopServices lists the services that appear most frequently across the analysed traces,
-// ordered by descending occurrence count.
-TopServices []ServiceCount `json:"top_services" jsonschema:"Services ordered by descending occurrence count across traces"`
+	// TopServices lists the services that appear most frequently across the analysed traces,
+	// ordered by descending occurrence count.
+	TopServices []ServiceCount `json:"top_services" jsonschema:"Services ordered by descending occurrence count across traces"`
 }
 
 // DurationStats holds latency percentile statistics in microseconds.
 type DurationStats struct {
-MinUs  int64 `json:"min_us"  jsonschema:"Minimum trace duration in microseconds"`
-MaxUs  int64 `json:"max_us"  jsonschema:"Maximum trace duration in microseconds"`
-MeanUs int64 `json:"mean_us" jsonschema:"Mean trace duration in microseconds"`
-P50Us  int64 `json:"p50_us"  jsonschema:"50th-percentile (median) trace duration in microseconds"`
-P95Us  int64 `json:"p95_us"  jsonschema:"95th-percentile trace duration in microseconds"`
-P99Us  int64 `json:"p99_us"  jsonschema:"99th-percentile trace duration in microseconds"`
+	MinUs  int64 `json:"min_us"  jsonschema:"Minimum trace duration in microseconds"`
+	MaxUs  int64 `json:"max_us"  jsonschema:"Maximum trace duration in microseconds"`
+	MeanUs int64 `json:"mean_us" jsonschema:"Mean trace duration in microseconds"`
+	P50Us  int64 `json:"p50_us"  jsonschema:"50th-percentile (median) trace duration in microseconds"`
+	P95Us  int64 `json:"p95_us"  jsonschema:"95th-percentile trace duration in microseconds"`
+	P99Us  int64 `json:"p99_us"  jsonschema:"99th-percentile trace duration in microseconds"`
 }
 
 // SpanStats holds statistics about span counts per trace.
 type SpanStats struct {
-MinSpans  int     `json:"min_spans"  jsonschema:"Minimum span count across all analysed traces"`
-MaxSpans  int     `json:"max_spans"  jsonschema:"Maximum span count across all analysed traces"`
-MeanSpans float64 `json:"mean_spans" jsonschema:"Mean span count across all analysed traces"`
+	MinSpans  int     `json:"min_spans"  jsonschema:"Minimum span count across all analysed traces"`
+	MaxSpans  int     `json:"max_spans"  jsonschema:"Maximum span count across all analysed traces"`
+	MeanSpans float64 `json:"mean_spans" jsonschema:"Mean span count across all analysed traces"`
 }
 
 // ServiceCount pairs a service name with the number of traces it participated in.
 type ServiceCount struct {
-Service    string `json:"service"     jsonschema:"Service name"`
-TraceCount int    `json:"trace_count" jsonschema:"Number of analysed traces this service participated in"`
+	Service    string `json:"service"     jsonschema:"Service name"`
+	TraceCount int    `json:"trace_count" jsonschema:"Number of analysed traces this service participated in"`
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -203,7 +203,7 @@ func (s *server) registerTools() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_trace_stats",
 		Description: "Compute aggregate statistics (count, error rate, latency percentiles p50/p95/p99, " +
-			"span counts, top services) across traces matching the given filters. " +
+			"span counts, top services) over up to search_depth traces matching the given filters. " +
 			"Accepts the same filters as search_traces. " +
 			"Use this tool to understand the overall health and performance of a service " +
 			"before drilling into individual traces.",

--- a/cmd/jaeger/internal/extension/jaegermcp/server.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/server.go
@@ -118,7 +118,9 @@ func (s *server) Start(ctx context.Context, host component.Host) error {
 		handler,
 	)
 	if err != nil {
-		s.listener.Close()
+		if closeErr := s.listener.Close(); closeErr != nil {
+			s.telset.Logger.Warn("failed to close listener", zap.Error(closeErr))
+		}
 		return fmt.Errorf("failed to create HTTP server: %w", err)
 	}
 
@@ -197,4 +199,13 @@ func (s *server) registerTools() {
 		Description: "Get the service dependency graph showing caller-callee pairs. " +
 			"Returns edges with call counts over a configurable time window (default: last 24h).",
 	}, handlers.NewGetDependenciesHandler(s.queryAPI))
+
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name: "get_trace_stats",
+		Description: "Compute aggregate statistics (count, error rate, latency percentiles p50/p95/p99, " +
+			"span counts, top services) across traces matching the given filters. " +
+			"Accepts the same filters as search_traces. " +
+			"Use this tool to understand the overall health and performance of a service " +
+			"before drilling into individual traces.",
+	}, handlers.NewGetTraceStatsHandler(s.queryAPI, s.config.MaxSearchResults))
 }


### PR DESCRIPTION
Adds a new `get_trace_stats` MCP tool that computes aggregate statistics (trace count, error count, error rate, latency percentiles p50/p95/p99, span count statistics, and top services) across traces matching the same filters as `search_traces`.

This allows MCP clients and LLM agents to get a high-level health overview of a service before drilling into individual traces, following the progressive disclosure pattern already established in the Jaeger MCP extension.

Resolves #8577

## Which problem is this PR solving?

* Resolves #8577
* The Jaeger MCP extension currently provides `search_traces` for retrieving individual trace summaries, but does not provide a way to obtain aggregate service-level statistics across matching traces.
* As a result, an MCP client or LLM agent would need to fetch and process many individual traces to compute basic metrics such as error rate or latency percentiles, consuming additional requests and context.

## Description of the changes

* Added `get_trace_stats` input/output type definitions in `internal/types/get_trace_stats.go`
* Added `get_trace_stats` handler in `internal/handlers/get_trace_stats.go` that:

  * reuses the same filters as `search_traces`
  * aggregates matching traces using `AggregateTraces`
  * computes trace count, error count, and error rate
  * computes duration statistics (`min`, `max`, `mean`, `p50`, `p95`, `p99`)
  * computes span count statistics
  * returns the top services by occurrence (capped at 10)
* Registered the new tool in `server.go`
* Updated MCP integration tests for tool discovery
* Added 19 unit tests covering:

  * normal execution paths
  * empty results
  * all-error traces
  * percentile calculations
  * service ordering and limits
  * invalid inputs
  * query errors
  * helper function edge cases
* Fixed two pre-existing lint blockers encountered while running `make lint`:

  * handled the returned error from `listener.Close()`
  * renamed `durationMin` / `durationMax` to `minDuration` / `maxDuration` to satisfy `revive`
* Updated the Jaeger MCP README documentation

## How was this change tested?

* Added unit tests for the new handler and helper functions
* Ran `go test` for all `jaegermcp` packages successfully
* Ran lint and formatting checks successfully
* Verified tool registration through existing MCP integration tests

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy

* [ ] **None**: No AI tools were used in creating this PR
* [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
* [x] **Moderate**: AI helped with code generation or debugging specific parts
* [ ] **Heavy**: AI generated most or all of the code changes
