### PR TITLE
fix(storage/badger): support spanKind filtering in GetOperations

### DIFF
--- a/internal/storage/v1/badger/spanstore/cache.go
+++ b/internal/storage/v1/badger/spanstore/cache.go
@@ -4,7 +4,9 @@
 package spanstore
 
 import (
+	"cmp"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -83,13 +85,15 @@ func (c *CacheStore) GetOperations(query tracestore.OperationQueryParams) ([]tra
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 
-	if v, ok := c.services[query.ServiceName]; ok {
-		if v < t {
-			// Expired, remove
-			delete(c.services, query.ServiceName)
-			delete(c.operations, query.ServiceName)
-			return []tracestore.Operation{}, nil // empty slice rather than nil
-		}
+	v, ok := c.services[query.ServiceName]
+	if !ok {
+		return []tracestore.Operation{}, nil
+	}
+	if v < t {
+		// Expired, remove
+		delete(c.services, query.ServiceName)
+		delete(c.operations, query.ServiceName)
+		return []tracestore.Operation{}, nil
 	}
 
 	var result []tracestore.Operation
@@ -104,19 +108,7 @@ func (c *CacheStore) GetOperations(query tracestore.OperationQueryParams) ([]tra
 	}
 
 	slices.SortFunc(result, func(a, b tracestore.Operation) int {
-		if a.Name != b.Name {
-			if a.Name < b.Name {
-				return -1
-			}
-			return 1
-		}
-		if a.SpanKind < b.SpanKind {
-			return -1
-		}
-		if a.SpanKind > b.SpanKind {
-			return 1
-		}
-		return 0
+		return cmp.Or(strings.Compare(a.Name, b.Name), strings.Compare(a.SpanKind, b.SpanKind))
 	})
 
 	return result, nil

--- a/internal/storage/v1/badger/spanstore/cache.go
+++ b/internal/storage/v1/badger/spanstore/cache.go
@@ -18,7 +18,7 @@ type CacheStore struct {
 	// Given the small amount of data these will store, we use the same structure as the memory store
 	cacheLock  sync.Mutex // write heavy - Mutex is faster than RWMutex for writes
 	services   map[string]uint64
-	operations map[string]map[string]uint64
+	operations map[string]map[tracestore.Operation]uint64
 
 	store *badger.DB
 	ttl   time.Duration
@@ -28,7 +28,7 @@ type CacheStore struct {
 func NewCacheStore(db *badger.DB, ttl time.Duration) *CacheStore {
 	cs := &CacheStore{
 		services:   make(map[string]uint64),
-		operations: make(map[string]map[string]uint64),
+		operations: make(map[string]map[tracestore.Operation]uint64),
 		ttl:        ttl,
 		store:      db,
 	}
@@ -48,66 +48,77 @@ func (c *CacheStore) AddService(service string, keyTTL uint64) {
 }
 
 // AddOperation adds the cache with operation names with most updated expiration time
-func (c *CacheStore) AddOperation(service, operation string, keyTTL uint64) {
+func (c *CacheStore) AddOperation(service, operation, spanKind string, keyTTL uint64) {
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 	if _, found := c.operations[service]; !found {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[tracestore.Operation]uint64)
 	}
-	if v, found := c.operations[service][operation]; found {
+	op := tracestore.Operation{Name: operation, SpanKind: spanKind}
+	if v, found := c.operations[service][op]; found {
 		if v > keyTTL {
 			return
 		}
 	}
-	c.operations[service][operation] = keyTTL
+	c.operations[service][op] = keyTTL
 }
 
 // Update caches the results of service and service + operation indexes and maintains their TTL
-func (c *CacheStore) Update(service, operation string, expireTime uint64) {
+func (c *CacheStore) Update(service, operation, spanKind string, expireTime uint64) {
 	c.cacheLock.Lock()
 
 	c.services[service] = expireTime
 	if _, ok := c.operations[service]; !ok {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[tracestore.Operation]uint64)
 	}
-	c.operations[service][operation] = expireTime
+	op := tracestore.Operation{Name: operation, SpanKind: spanKind}
+	c.operations[service][op] = expireTime
 	c.cacheLock.Unlock()
 }
 
 // GetOperations returns all operations for a specific service & spanKind traced by Jaeger
-func (c *CacheStore) GetOperations(service string) ([]tracestore.Operation, error) {
-	operations := make([]string, 0, len(c.services))
+func (c *CacheStore) GetOperations(query tracestore.OperationQueryParams) ([]tracestore.Operation, error) {
 	//nolint:gosec // G115
 	t := uint64(time.Now().Unix())
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 
-	if v, ok := c.services[service]; ok {
+	if v, ok := c.services[query.ServiceName]; ok {
 		if v < t {
 			// Expired, remove
-			delete(c.services, service)
-			delete(c.operations, service)
+			delete(c.services, query.ServiceName)
+			delete(c.operations, query.ServiceName)
 			return []tracestore.Operation{}, nil // empty slice rather than nil
 		}
-		for o, e := range c.operations[service] {
-			if e > t {
-				operations = append(operations, o)
-			} else {
-				delete(c.operations[service], o)
-			}
+	}
+
+	var result []tracestore.Operation
+	for op, e := range c.operations[query.ServiceName] {
+		if e <= t {
+			delete(c.operations[query.ServiceName], op)
+			continue
+		}
+		if query.SpanKind == "" || query.SpanKind == op.SpanKind {
+			result = append(result, op)
 		}
 	}
 
-	slices.Sort(operations)
+	slices.SortFunc(result, func(a, b tracestore.Operation) int {
+		if a.Name != b.Name {
+			if a.Name < b.Name {
+				return -1
+			}
+			return 1
+		}
+		if a.SpanKind < b.SpanKind {
+			return -1
+		}
+		if a.SpanKind > b.SpanKind {
+			return 1
+		}
+		return 0
+	})
 
-	// TODO: https://github.com/jaegertracing/jaeger/issues/1922
-	// 	- return the operations with actual spanKind
-	result := make([]tracestore.Operation, 0, len(operations))
-	for _, op := range operations {
-		result = append(result, tracestore.Operation{
-			Name: op,
-		})
-	}
 	return result, nil
 }
 

--- a/internal/storage/v1/badger/spanstore/cache_test.go
+++ b/internal/storage/v1/badger/spanstore/cache_test.go
@@ -78,6 +78,26 @@ func TestSpanKindFiltering(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, clients, 1)
 		assert.Equal(t, "op2", clients[0].Name)
+
+		// Empty SpanKind matches all operations regardless of their span kind.
+		allViaEmpty, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc", SpanKind: ""})
+		require.NoError(t, err)
+		assert.Len(t, allViaEmpty, 3, "empty SpanKind should return all operations")
+
+		// Non-existent span kind returns empty slice.
+		none, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc", SpanKind: "producer"})
+		require.NoError(t, err)
+		assert.Empty(t, none, "unknown SpanKind should return no operations")
+	})
+}
+
+func TestGetOperationsUnknownService(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		cache := NewCacheStore(store, time.Hour)
+
+		ops, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "nonexistent"})
+		require.NoError(t, err)
+		assert.Empty(t, ops, "unknown service should return empty operations slice")
 	})
 }
 

--- a/internal/storage/v1/badger/spanstore/cache_test.go
+++ b/internal/storage/v1/badger/spanstore/cache_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
 /*
-	Additional cache store tests that need to access internal parts. As such, package must be spanstore and not spanstore_test
+Additional cache store tests that need to access internal parts. As such, package must be spanstore and not spanstore_test
 */
 
 func TestExpiredItems(t *testing.T) {
@@ -24,8 +26,8 @@ func TestExpiredItems(t *testing.T) {
 
 		// Expired service
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "op1", "server", expireTime)
+		cache.Update("service1", "op2", "", expireTime)
 
 		services, err := cache.GetServices()
 		require.NoError(t, err)
@@ -33,23 +35,49 @@ func TestExpiredItems(t *testing.T) {
 
 		// Expired service for operations
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "op1", "server", expireTime)
+		cache.Update("service1", "op2", "", expireTime)
 
-		operations, err := cache.GetOperations("service1")
+		operations, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "service1"})
 		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
 
 		// Expired operations, stable service
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "op1", "server", expireTime)
+		cache.Update("service1", "op2", "", expireTime)
 
 		cache.services["service1"] = uint64(time.Now().Unix() + 1e10)
 
-		operations, err = cache.GetOperations("service1")
+		operations, err = cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "service1"})
 		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
+	})
+}
+
+func TestSpanKindFiltering(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		cache := NewCacheStore(store, time.Hour)
+		expireTime := uint64(time.Now().Add(cache.ttl).Unix())
+
+		cache.Update("svc", "op1", "server", expireTime)
+		cache.Update("svc", "op2", "client", expireTime)
+		cache.Update("svc", "op3", "", expireTime)
+
+		all, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc"})
+		require.NoError(t, err)
+		assert.Len(t, all, 3)
+
+		servers, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc", SpanKind: "server"})
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		assert.Equal(t, "op1", servers[0].Name)
+		assert.Equal(t, "server", servers[0].SpanKind)
+
+		clients, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc", SpanKind: "client"})
+		require.NoError(t, err)
+		require.Len(t, clients, 1)
+		assert.Equal(t, "op2", clients[0].Name)
 	})
 }
 

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -248,7 +248,7 @@ func (r *TraceReader) GetOperations(
 	_ context.Context,
 	query tracestore.OperationQueryParams,
 ) ([]tracestore.Operation, error) {
-	return r.cache.GetOperations(query.ServiceName)
+	return r.cache.GetOperations(query)
 }
 
 // setQueryDefaults alters the query with defaults if certain parameters are not set
@@ -654,10 +654,17 @@ func (r *TraceReader) preloadOperations(service string) {
 
 		// Seek all the services first
 		for it.Seek(serviceKey); it.ValidForPrefix(serviceKey); it.Next() {
-			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
-			operationName := string(it.Item().Key()[len(serviceKey):timestampStartIndex])
-			keyTTL := it.Item().ExpiresAt()
-			r.cache.AddOperation(service, operationName, keyTTL)
+			item := it.Item()
+			timestampStartIndex := len(item.Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
+			operationName := string(item.Key()[len(serviceKey):timestampStartIndex])
+			keyTTL := item.ExpiresAt()
+			// The value holds the span kind stored by the writer (empty string if not set).
+			var spanKind string
+			_ = item.Value(func(val []byte) error {
+				spanKind = string(val)
+				return nil
+			})
+			r.cache.AddOperation(service, operationName, spanKind, keyTTL)
 		}
 		return nil
 	})

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -660,10 +660,12 @@ func (r *TraceReader) preloadOperations(service string) {
 			keyTTL := item.ExpiresAt()
 			// The value holds the span kind stored by the writer (empty string if not set).
 			var spanKind string
-			_ = item.Value(func(val []byte) error {
+			if err := item.Value(func(val []byte) error {
 				spanKind = string(val)
 				return nil
-			})
+			}); err != nil {
+				spanKind = "" // value unreadable; cache operation without span kind
+			}
 			r.cache.AddOperation(service, operationName, spanKind, keyTTL)
 		}
 		return nil

--- a/internal/storage/v1/badger/spanstore/rw_internal_test.go
+++ b/internal/storage/v1/badger/spanstore/rw_internal_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
 func TestEncodingTypes(t *testing.T) {
@@ -217,15 +218,16 @@ func TestOldReads(t *testing.T) {
 
 		nuTid := tid.Add(1 * time.Hour)
 
-		cache.Update("service1", "operation1", uint64(tid.Unix()))
+		cache.Update("service1", "operation1", "", uint64(tid.Unix()))
 		cache.services["service1"] = uint64(nuTid.Unix())
-		cache.operations["service1"]["operation1"] = uint64(nuTid.Unix())
+		op1Key := tracestore.Operation{Name: "operation1"}
+		cache.operations["service1"][op1Key] = uint64(nuTid.Unix())
 
 		// This is equivalent to populate caches of cache
 		_ = NewTraceReader(store, cache, true)
 
 		// Now make sure we didn't use the older timestamps from the DB
 		assert.Equal(t, uint64(nuTid.Unix()), cache.services["service1"])
-		assert.Equal(t, uint64(nuTid.Unix()), cache.operations["service1"]["operation1"])
+		assert.Equal(t, uint64(nuTid.Unix()), cache.operations["service1"][op1Key])
 	})
 }

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -16,6 +16,16 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 )
 
+// getSpanKind extracts the span.kind tag value from a span's tags.
+func getSpanKind(span *model.Span) string {
+	for _, tag := range span.Tags {
+		if tag.Key == model.SpanKindKey {
+			return tag.VStr
+		}
+	}
+	return ""
+}
+
 /*
 	This store should be easily modified to use any sorted KV-store, which allows set/get/iterators.
 	That includes RocksDB also (this key structure should work as-is with RocksDB)
@@ -67,11 +77,12 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 		return err
 	}
 
+	spanKind := getSpanKind(span)
 	entriesToStore = append(
 		entriesToStore,
 		trace,
 		w.createBadgerEntry(createIndexKey(serviceNameIndexKey, []byte(span.Process.ServiceName), startTime, span.TraceID), nil, expireTime),
-		w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), nil, expireTime),
+		w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), []byte(spanKind), expireTime),
 	)
 
 	// It doesn't matter if we overwrite Duration index keys, everything is read at Trace level in any case
@@ -112,7 +123,7 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	})
 
 	// Do cache refresh here to release the transaction earlier
-	w.cache.Update(span.Process.ServiceName, span.OperationName, expireTime)
+	w.cache.Update(span.Process.ServiceName, span.OperationName, spanKind, expireTime)
 
 	return err
 }


### PR DESCRIPTION
## Summary

Resolves the TODO comment in `CacheStore.GetOperations` that has been tracking this since 2018 (see inline `// TODO: https://github.com/jaegertracing/jaeger/issues/1922`).

### Changes

**`cache.go`**
- `operations` map changed from `map[string]map[string]uint64` to `map[string]map[tracestore.Operation]uint64`; each cached entry now carries both operation name and span kind.
- `Update` and `AddOperation` accept a new `spanKind string` parameter.
- `GetOperations` accepts the full `OperationQueryParams` and filters by `SpanKind` when it is non-empty (empty string returns all operations, matching the Cassandra and memory-store semantics).

**`writer.go`**
- Extracts the `span.kind` tag value from the span before writing.
- Passes the span kind to `cache.Update`.
- Stores the span kind as the **value** of the `operationNameIndexKey` badger entry (previously `nil`) so the information survives restarts.

**`reader.go`**
- `preloadOperations` now reads the value bytes from each index entry as the span kind and passes it to `cache.AddOperation`, restoring per-operation span kind info after a restart.
- `GetOperations` forwards the full `OperationQueryParams` to the cache (previously only passed the service name string).

**Tests**
- Updated `cache_test.go` and `rw_internal_test.go` for the new signatures.
- Added `TestSpanKindFiltering` in `cache_test.go` to verify server/client/unset operations are returned and filtered correctly.

Fixes #1922

## Test plan

- [ ] `go test ./internal/storage/v1/badger/...` passes
- [ ] `TestSpanKindFiltering` validates that querying with `SpanKind: "server"` returns only server-kind operations
- [ ] Existing `TestWriteReadBack` and `TestExpiredItems` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)