### PR TITLE
feat(apiv3): support query.attributes[key]=value filter in GET /api/v3/traces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -41,7 +42,8 @@ const (
 	paramNumTraces      = "query.num_traces"
 	paramDurationMin    = "query.duration_min"
 	paramDurationMax    = "query.duration_max"
-	paramQueryRawTraces = "query.raw_traces"
+	paramQueryRawTraces     = "query.raw_traces"
+	paramAttributesPrefix   = "query.attributes["
 
 	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
 	routeFindTraces    = "/api/v3/traces"
@@ -204,11 +206,20 @@ func (h *HTTPGateway) findTraces(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*querysvc.TraceQueryParams, bool) {
+	attrs := pcommon.NewMap()
+	for param, vals := range q {
+		if strings.HasPrefix(param, paramAttributesPrefix) && strings.HasSuffix(param, "]") {
+			key := param[len(paramAttributesPrefix) : len(param)-1]
+			if key != "" {
+				attrs.PutStr(key, vals[0])
+			}
+		}
+	}
 	queryParams := &querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{
 			ServiceName:   q.Get(paramServiceName),
 			OperationName: q.Get(paramOperationName),
-			Attributes:    pcommon.NewMap(), // most curiously not supported by grpc-gateway
+			Attributes:    attrs,
 		},
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -429,3 +429,57 @@ func TestHTTPGatewayGetServicesEmptyResponse(t *testing.T) {
 	assert.JSONEq(t, `{"services":[]}`, w.Body.String())
 	gw.reader.AssertExpectations(t)
 }
+
+func TestHTTPGatewayFindTracesAttributes(t *testing.T) {
+	time1 := time.Now().UTC().Truncate(time.Nanosecond)
+	time2 := time1.Add(-time.Second).UTC().Truncate(time.Nanosecond)
+
+	attrs := pcommon.NewMap()
+	attrs.PutStr("http.method", "GET")
+	attrs.PutStr("status", "error")
+
+	expectedParams := tracestore.TraceQueryParams{
+		ServiceName:   "svc",
+		OperationName: "op",
+		Attributes:    attrs,
+		StartTimeMin:  time1,
+		StartTimeMax:  time2,
+		SearchDepth:   5,
+	}
+
+	q := url.Values{}
+	q.Set(paramServiceName, "svc")
+	q.Set(paramOperationName, "op")
+	q.Set(paramTimeMin, time1.Format(time.RFC3339Nano))
+	q.Set(paramTimeMax, time2.Format(time.RFC3339Nano))
+	q.Set(paramNumTraces, "5")
+	q["query.attributes[http.method]"] = []string{"GET"}
+	q["query.attributes[status]"] = []string{"error"}
+
+	gw := setupHTTPGatewayNoServer(t, "")
+	gw.reader.
+		On("FindTraces", matchContext, mock.MatchedBy(func(qp tracestore.TraceQueryParams) bool {
+			return qp.ServiceName == expectedParams.ServiceName &&
+				qp.OperationName == expectedParams.OperationName &&
+				qp.SearchDepth == expectedParams.SearchDepth &&
+				qp.Attributes.Len() == 2 &&
+				func() bool {
+					v, ok := qp.Attributes.Get("http.method")
+					return ok && v.AsString() == "GET"
+				}() &&
+				func() bool {
+					v, ok := qp.Attributes.Get("status")
+					return ok && v.AsString() == "error"
+				}()
+		})).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{makeTestTrace()}, nil)
+		})).Once()
+
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	gw.router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	gw.reader.AssertExpectations(t)
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #7594

Grafana and other clients that rely on `GET /api/v3/traces` for trace search have no way to filter by span attributes (tags). The gRPC `FindTracesRequest` already accepts a `map<string,string> attributes` field, but the HTTP gateway silently ignored it because the standard grpc-gateway encoding for proto map fields is unsupported by the gateway middleware.

## Description of the changes

**`http_gateway.go`**
- Add `paramAttributesPrefix = "query.attributes["` constant.
- In `parseFindTracesQuery`, scan all query parameters for the bracket-notation pattern `query.attributes[<key>]=<value>` and populate `tracestore.TraceQueryParams.Attributes` accordingly.
- Import `strings` for the prefix/suffix check.

Clients can now pass one or more attribute filters as URL query params:
```
GET /api/v3/traces
  ?query.service_name=frontend
  &query.start_time_min=...
  &query.start_time_max=...
  &query.attributes[http.method]=GET
  &query.attributes[http.status_code]=200
```

**`http_gateway_test.go`**
- Add `TestHTTPGatewayFindTracesAttributes` that sends two attribute filters and verifies the underlying `FindTraces` call receives the correct `pcommon.Map`.

## How was this change tested?

```
go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/... \
  -run "TestHTTPGatewayFindTracesAttributes|TestHTTPGatewayFindTracesErrors|TestHTTPGatewayGetTrace" -v
go vet ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...
```

All new and existing tests pass. Pre-existing snapshot failures on Windows (CRLF/LF) are unrelated.