### PR TITLE
fix(query): Reject invalid trace query bounds

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -38,12 +38,12 @@ const (
 )
 
 var (
-	errMaxDurationGreaterThanMin = fmt.Errorf("'%s' should be greater than '%s'", maxDurationParam, minDurationParam)
+	errMaxDurationGreaterThanMin = errors.New("'" + maxDurationParam + "' should be greater than '" + minDurationParam + "'")
 
 	// errServiceParameterRequired occurs when no service name is defined.
-	errServiceParameterRequired = fmt.Errorf("parameter '%s' is required", serviceParam)
-	errSearchDepthMustBePositive = fmt.Errorf("'%s' must be greater than 0", limitParam)
-	errStartAfterEnd            = fmt.Errorf("'%s' must not be after '%s'", startTimeParam, endTimeParam)
+	errServiceParameterRequired = errors.New("parameter '" + serviceParam + "' is required")
+	errSearchDepthMustBePositive = errors.New("'" + limitParam + "' must be greater than 0")
+	errStartAfterEnd            = errors.New("'" + startTimeParam + "' must not be after '" + endTimeParam + "'")
 )
 
 type (

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -42,6 +42,8 @@ var (
 
 	// errServiceParameterRequired occurs when no service name is defined.
 	errServiceParameterRequired = fmt.Errorf("parameter '%s' is required", serviceParam)
+	errSearchDepthMustBePositive = fmt.Errorf("'%s' must be greater than 0", limitParam)
+	errStartAfterEnd            = fmt.Errorf("'%s' must not be after '%s'", startTimeParam, endTimeParam)
 )
 
 type (
@@ -361,6 +363,12 @@ func mapSpanKindsToOpenTelemetry(spanKinds []string) ([]string, error) {
 func (*queryParser) validateQuery(traceQuery *traceQueryParameters) error {
 	if len(traceQuery.TraceIDs) == 0 && traceQuery.ServiceName == "" {
 		return errServiceParameterRequired
+	}
+	if traceQuery.SearchDepth <= 0 {
+		return errSearchDepthMustBePositive
+	}
+	if traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {
+		return errStartAfterEnd
 	}
 	if traceQuery.DurationMin != 0 && traceQuery.DurationMax != 0 {
 		if traceQuery.DurationMax < traceQuery.DurationMin {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -38,12 +38,12 @@ const (
 )
 
 var (
-	errMaxDurationGreaterThanMin = errors.New("'" + maxDurationParam + "' should be greater than '" + minDurationParam + "'")
+	errMaxDurationGreaterThanMin = fmt.Errorf("'%s' should be greater than '%s'", maxDurationParam, minDurationParam)
 
 	// errServiceParameterRequired occurs when no service name is defined.
-	errServiceParameterRequired = errors.New("parameter '" + serviceParam + "' is required")
-	errSearchDepthMustBePositive = errors.New("'" + limitParam + "' must be greater than 0")
-	errStartAfterEnd            = errors.New("'" + startTimeParam + "' must not be after '" + endTimeParam + "'")
+	errServiceParameterRequired  = fmt.Errorf("parameter '%s' is required", serviceParam)
+	errSearchDepthMustBePositive = fmt.Errorf("'%s' must be greater than 0", limitParam)
+	errStartAfterEnd             = fmt.Errorf("'%s' must not be after '%s'", startTimeParam, endTimeParam)
 )
 
 type (
@@ -127,12 +127,15 @@ func (p *queryParser) parseTraceQueryParams(r *http.Request) (*traceQueryParamet
 		return nil, err
 	}
 
-	limitParam := r.URL.Query().Get(limitParam)
+	limitStr := r.URL.Query().Get(limitParam)
 	limit := defaultQueryLimit
-	if limitParam != "" {
-		limitParsed, err := strconv.ParseInt(limitParam, 10, 32)
+	if limitStr != "" {
+		limitParsed, err := strconv.ParseInt(limitStr, 10, 32)
 		if err != nil {
 			return nil, err
+		}
+		if limitParsed <= 0 {
+			return nil, errSearchDepthMustBePositive
 		}
 		limit = int(limitParsed)
 	}
@@ -364,7 +367,7 @@ func (*queryParser) validateQuery(traceQuery *traceQueryParameters) error {
 	if len(traceQuery.TraceIDs) == 0 && traceQuery.ServiceName == "" {
 		return errServiceParameterRequired
 	}
-	if traceQuery.SearchDepth <= 0 {
+	if traceQuery.SearchDepth < 0 {
 		return errSearchDepthMustBePositive
 	}
 	if traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -362,3 +362,32 @@ func TestParameterErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTraceQueryBounds(t *testing.T) {
+	tests := []struct {
+		name   string
+		urlStr string
+		errMsg string
+	}{
+		{"limit_zero", "x?service=svc&start=0&end=0&limit=0", "'limit' must be greater than 0"},
+		{"limit_negative", "x?service=svc&start=0&end=0&limit=-1", "'limit' must be greater than 0"},
+		{"start_after_end", "x?service=svc&start=200&end=100", "'start' must not be after 'end'"},
+		{"valid_range", "x?service=svc&start=100&end=200&limit=5", ""},
+		{"missing_service_and_traceid", "x", "parameter 'service' is required"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tc.urlStr, http.NoBody)
+			require.NoError(t, err)
+			parser := &queryParser{timeNow: time.Now}
+			_, err = parser.parseTraceQueryParams(req)
+			if tc.errMsg == "" {
+				require.NoError(t, err)
+			} else {
+				// Use substring match for error messages
+				assert.ErrorContains(t, err, tc.errMsg)
+			}
+		})
+	}
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -369,11 +369,12 @@ func TestValidateTraceQueryBounds(t *testing.T) {
 		urlStr string
 		errMsg string
 	}{
-		{"limit_zero", "x?service=svc&start=0&end=0&limit=0", "'limit' must be greater than 0"},
-		{"limit_negative", "x?service=svc&start=0&end=0&limit=-1", "'limit' must be greater than 0"},
-		{"start_after_end", "x?service=svc&start=200&end=100", "'start' must not be after 'end'"},
-		{"valid_range", "x?service=svc&start=100&end=200&limit=5", ""},
-		{"missing_service_and_traceid", "x", "parameter 'service' is required"},
+			{"limit_zero", "x?service=svc&start=100&end=200&limit=0", "'limit' must be greater than 0"},
+			{"limit_negative", "x?service=svc&start=100&end=200&limit=-1", "'limit' must be greater than 0"},
+			{"default_limit_when_omitted", "x?service=svc&start=100&end=200", ""},
+			{"start_after_end", "x?service=svc&start=200&end=100", "'start' must not be after 'end'"},
+			{"valid_range", "x?service=svc&start=100&end=200&limit=5", ""},
+			{"missing_service_and_traceid", "x", "parameter 'service' is required"},
 	}
 
 	for _, tc := range tests {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -369,12 +369,12 @@ func TestValidateTraceQueryBounds(t *testing.T) {
 		urlStr string
 		errMsg string
 	}{
-			{"limit_zero", "x?service=svc&start=100&end=200&limit=0", "'limit' must be greater than 0"},
-			{"limit_negative", "x?service=svc&start=100&end=200&limit=-1", "'limit' must be greater than 0"},
-			{"default_limit_when_omitted", "x?service=svc&start=100&end=200", ""},
-			{"start_after_end", "x?service=svc&start=200&end=100", "'start' must not be after 'end'"},
-			{"valid_range", "x?service=svc&start=100&end=200&limit=5", ""},
-			{"missing_service_and_traceid", "x", "parameter 'service' is required"},
+		{"limit_zero", "x?service=svc&start=100&end=200&limit=0", "'limit' must be greater than 0"},
+		{"limit_negative", "x?service=svc&start=100&end=200&limit=-1", "'limit' must be greater than 0"},
+		{"default_limit_when_omitted", "x?service=svc&start=100&end=200", ""},
+		{"start_after_end", "x?service=svc&start=200&end=100", "'start' must not be after 'end'"},
+		{"valid_range", "x?service=svc&start=100&end=200&limit=5", ""},
+		{"missing_service_and_traceid", "x", "parameter 'service' is required"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
Enforce valid trace query bounds at the API boundary -require positive `limit` and non-inverted `start`/`end`, and add unit tests.

## Which problem is this PR solving?
- Reject invalid trace query bounds at the API boundary so bad requests fail early and consistently.

## Description of the changes
- Validate that `limit` / `SearchDepth` is greater than 0.
- Validate that `start` is not after `end`.
- Keep the existing duration range checks unchanged.
- Keep the existing service/traceID requirement unchanged.
- Add table-driven tests covering zero and negative limits, inverted time bounds, a valid range, and the existing missing service/traceID case.

## How was this change tested?
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal -run TestValidateTraceQueryBounds -v`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes