### PR TITLE
fix(mcp): Serialize span kind in span detail responses

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
@@ -202,6 +202,7 @@ func buildSpanDetail(pos jptrace.SpanIterPos, span ptrace.Span) types.SpanDetail
 		ParentSpanID: parentSpanID,
 		Service:      serviceName,
 		SpanName:     span.Name(),
+		SpanKind:     span.Kind().String(),
 		StartTime:    span.StartTimestamp().AsTime().Format(time.RFC3339Nano),
 		DurationUs:   durationUs,
 		Status:       status,

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
@@ -100,6 +100,61 @@ func TestGetSpanDetailsHandler_Handle_Success(t *testing.T) {
 	assert.Equal(t, "error_event", span2.Events[0].Name)
 }
 
+func TestGetSpanDetailsHandler_Handle_SpanKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		spanKind ptrace.SpanKind
+		expected string
+	}{
+		{
+			name:     "server span",
+			spanKind: ptrace.SpanKindServer,
+			expected: ptrace.SpanKindServer.String(),
+		},
+		{
+			name:     "client span",
+			spanKind: ptrace.SpanKindClient,
+			expected: ptrace.SpanKindClient.String(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			traceID := testTraceID
+			spanID := "span001"
+
+			spanConfigs := []spanConfig{
+				{
+					spanID:    spanID,
+					operation: "/api/test",
+					spanKind:  tt.spanKind,
+					attributes: map[string]string{
+						"http.method": "GET",
+					},
+				},
+			}
+
+			testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+			mock := newMockYieldingTraces(testTrace)
+			handler := &getSpanDetailsHandler{queryService: mock, maxSpanDetailsPerRequest: 50}
+
+			input := types.GetSpanDetailsInput{
+				TraceID: traceID,
+				SpanIDs: []string{spanIDToHex(spanID)},
+			}
+
+			_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+			require.NoError(t, err)
+			require.Len(t, output.Spans, 1)
+			assert.Equal(t, tt.expected, output.Spans[0].SpanKind)
+			assert.Equal(t, "/api/test", output.Spans[0].SpanName)
+			assert.Equal(t, "Ok", output.Spans[0].Status.Code)
+			assert.Equal(t, "GET", output.Spans[0].Attributes["http.method"])
+		})
+	}
+}
+
 func TestGetSpanDetailsHandler_Handle_SingleSpan(t *testing.T) {
 	traceID := testTraceID
 	spanID := "span001"

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/test_helpers_test.go
@@ -22,6 +22,7 @@ type spanConfig struct {
 	spanID       string
 	parentSpanID string
 	operation    string
+	spanKind     ptrace.SpanKind
 	hasError     bool
 	errorMessage string
 	attributes   map[string]string
@@ -174,6 +175,10 @@ func createTestTraceWithSpans(traceID string, spanConfigs []spanConfig) ptrace.T
 		span.SetName(config.operation)
 		span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(-5 * time.Second)))
 		span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+		if config.spanKind != ptrace.SpanKindUnspecified {
+			span.SetKind(config.spanKind)
+		}
 
 		// Set status
 		if config.hasError {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_span_details.go
@@ -27,6 +27,7 @@ type SpanDetail struct {
 	ParentSpanID string         `json:"parent_span_id,omitempty" jsonschema:"Parent span identifier"`
 	Service      string         `json:"service" jsonschema:"Service name from resource attributes"`
 	SpanName     string         `json:"span_name" jsonschema:"Span name"`
+	SpanKind     string         `json:"span_kind" jsonschema:"Span kind"`
 	StartTime    string         `json:"start_time" jsonschema:"Span start time in RFC3339 format"`
 	DurationUs   int64          `json:"duration_us" jsonschema:"Span duration in microseconds"`
 	Status       SpanStatus     `json:"status" jsonschema:"Span status information"`


### PR DESCRIPTION
## Which problem is this PR solving?
`get_span_details` was returning a lot of useful span data, but it was missing span kind.  
Without span kind (SERVER/CLIENT/etc.), it’s harder for MCP consumers to understand request direction and service interaction context.

## Description of the changes
- Added a new `span_kind` field to the `SpanDetail` response model.
- Populated it in `buildSpanDetail` using `span.Kind().String()`.
- Added table-driven tests to verify serialization for both SERVER and CLIENT spans.
- No behavior changes to existing fields—this is additive only.

## How was this change tested?
- `go test ./cmd/jaeger/internal/extension/jaegermcp/internal/handlers -run TestGetSpanDetailsHandler_Handle_SpanKind`

I also attempted to run the full repo checks in a Linux Docker container from PowerShell:
- `make fmt` ran import-order cleanup and gofmt successfully, but failed at gofumpt due to a host runtime issue:
  `WSL ... UtilBindVsockAnyPort ... socket failed 1`
- `make lint` and `make test` were not run after that because fmt is blocked by the same environment issue.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes