### PR TITLE
fix(leaderelection): Validate and default lease refresh intervals to prevent ticker panics

### DIFF
--- a/internal/leaderelection/leader_election.go
+++ b/internal/leaderelection/leader_election.go
@@ -51,23 +51,29 @@ type ElectionParticipantOptions struct {
 // NewElectionParticipant returns a ElectionParticipant which attempts to become leader.
 // Invalid duration values (zero or negative) will be replaced with sensible defaults and a warning will be logged.
 func NewElectionParticipant(lock dl.Lock, resourceName string, options ElectionParticipantOptions) *DistributedElectionParticipant {
+	defaultDuration := func(optionName string, currentValue, defaultValue time.Duration) time.Duration {
+		if currentValue <= 0 {
+			if options.Logger != nil {
+				options.Logger.Warn(optionName+" is invalid, using default",
+					zap.Duration("invalid_value", currentValue),
+					zap.Duration("default_value", defaultValue))
+			}
+			return defaultValue
+		}
+		return currentValue
+	}
+
 	// Set sensible defaults if durations are zero or negative
-	if options.LeaderLeaseRefreshInterval <= 0 {
-		if options.Logger != nil {
-			options.Logger.Warn("LeaderLeaseRefreshInterval is invalid, using default",
-				zap.Duration("invalid_value", options.LeaderLeaseRefreshInterval),
-				zap.Duration("default_value", defaultLeaderLeaseRefreshInterval))
-		}
-		options.LeaderLeaseRefreshInterval = defaultLeaderLeaseRefreshInterval
-	}
-	if options.FollowerLeaseRefreshInterval <= 0 {
-		if options.Logger != nil {
-			options.Logger.Warn("FollowerLeaseRefreshInterval is invalid, using default",
-				zap.Duration("invalid_value", options.FollowerLeaseRefreshInterval),
-				zap.Duration("default_value", defaultFollowerLeaseRefreshInterval))
-		}
-		options.FollowerLeaseRefreshInterval = defaultFollowerLeaseRefreshInterval
-	}
+	options.LeaderLeaseRefreshInterval = defaultDuration(
+		"LeaderLeaseRefreshInterval",
+		options.LeaderLeaseRefreshInterval,
+		defaultLeaderLeaseRefreshInterval,
+	)
+	options.FollowerLeaseRefreshInterval = defaultDuration(
+		"FollowerLeaseRefreshInterval",
+		options.FollowerLeaseRefreshInterval,
+		defaultFollowerLeaseRefreshInterval,
+	)
 
 	return &DistributedElectionParticipant{
 		ElectionParticipantOptions: options,

--- a/internal/leaderelection/leader_election.go
+++ b/internal/leaderelection/leader_election.go
@@ -15,7 +15,9 @@ import (
 )
 
 const (
-	acquireLockErrMsg = "Failed to acquire lock"
+	acquireLockErrMsg                   = "Failed to acquire lock"
+	defaultLeaderLeaseRefreshInterval   = 5 * time.Second
+	defaultFollowerLeaseRefreshInterval = 10 * time.Second
 )
 
 // ElectionParticipant partakes in leader election to become leader.
@@ -36,7 +38,10 @@ type DistributedElectionParticipant struct {
 	wg           sync.WaitGroup
 }
 
-// ElectionParticipantOptions control behavior of the election participant. TODO func applyDefaults(), parameter error checking, etc.
+// ElectionParticipantOptions control behavior of the election participant.
+// If LeaderLeaseRefreshInterval or FollowerLeaseRefreshInterval are zero or negative,
+// they will be replaced with sensible defaults (5 seconds and 10 seconds, respectively).
+// A warning will be logged when this occurs to help detect configuration issues.
 type ElectionParticipantOptions struct {
 	LeaderLeaseRefreshInterval   time.Duration
 	FollowerLeaseRefreshInterval time.Duration
@@ -44,7 +49,26 @@ type ElectionParticipantOptions struct {
 }
 
 // NewElectionParticipant returns a ElectionParticipant which attempts to become leader.
+// Invalid duration values (zero or negative) will be replaced with sensible defaults and a warning will be logged.
 func NewElectionParticipant(lock dl.Lock, resourceName string, options ElectionParticipantOptions) *DistributedElectionParticipant {
+	// Set sensible defaults if durations are zero or negative
+	if options.LeaderLeaseRefreshInterval <= 0 {
+		if options.Logger != nil {
+			options.Logger.Warn("LeaderLeaseRefreshInterval is invalid, using default",
+				zap.Duration("invalid_value", options.LeaderLeaseRefreshInterval),
+				zap.Duration("default_value", defaultLeaderLeaseRefreshInterval))
+		}
+		options.LeaderLeaseRefreshInterval = defaultLeaderLeaseRefreshInterval
+	}
+	if options.FollowerLeaseRefreshInterval <= 0 {
+		if options.Logger != nil {
+			options.Logger.Warn("FollowerLeaseRefreshInterval is invalid, using default",
+				zap.Duration("invalid_value", options.FollowerLeaseRefreshInterval),
+				zap.Duration("default_value", defaultFollowerLeaseRefreshInterval))
+		}
+		options.FollowerLeaseRefreshInterval = defaultFollowerLeaseRefreshInterval
+	}
+
 	return &DistributedElectionParticipant{
 		ElectionParticipantOptions: options,
 		lock:                       lock,

--- a/internal/leaderelection/leader_election_test.go
+++ b/internal/leaderelection/leader_election_test.go
@@ -96,6 +96,71 @@ func TestRunAcquireLockLoopFollowerOnly(t *testing.T) {
 	assert.False(t, p.IsLeader())
 }
 
+func TestNewElectionParticipantWithInvalidDurations(t *testing.T) {
+	tests := []struct {
+		name                     string
+		leaderInterval           time.Duration
+		followerInterval         time.Duration
+		expectedLeaderInterval   time.Duration
+		expectedFollowerInterval time.Duration
+	}{
+		{
+			name:                     "zero leader and follower intervals",
+			leaderInterval:           0,
+			followerInterval:         0,
+			expectedLeaderInterval:   defaultLeaderLeaseRefreshInterval,
+			expectedFollowerInterval: defaultFollowerLeaseRefreshInterval,
+		},
+		{
+			name:                     "negative leader interval",
+			leaderInterval:           -1 * time.Second,
+			followerInterval:         5 * time.Millisecond,
+			expectedLeaderInterval:   defaultLeaderLeaseRefreshInterval,
+			expectedFollowerInterval: 5 * time.Millisecond,
+		},
+		{
+			name:                     "negative follower interval",
+			leaderInterval:           1 * time.Millisecond,
+			followerInterval:         -10 * time.Second,
+			expectedLeaderInterval:   1 * time.Millisecond,
+			expectedFollowerInterval: defaultFollowerLeaseRefreshInterval,
+		},
+		{
+			name:                     "both negative intervals",
+			leaderInterval:           -5 * time.Second,
+			followerInterval:         -10 * time.Second,
+			expectedLeaderInterval:   defaultLeaderLeaseRefreshInterval,
+			expectedFollowerInterval: defaultFollowerLeaseRefreshInterval,
+		},
+		{
+			name:                     "valid positive intervals unchanged",
+			leaderInterval:           2 * time.Second,
+			followerInterval:         8 * time.Second,
+			expectedLeaderInterval:   2 * time.Second,
+			expectedFollowerInterval: 8 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			logger, _ := testutils.NewLogger()
+			mockLock := &lmocks.Lock{}
+
+			p := NewElectionParticipant(
+				mockLock, "test_lock", ElectionParticipantOptions{
+					LeaderLeaseRefreshInterval:   test.leaderInterval,
+					FollowerLeaseRefreshInterval: test.followerInterval,
+					Logger:                       logger,
+				},
+			)
+
+			assert.Equal(t, test.expectedLeaderInterval, p.LeaderLeaseRefreshInterval)
+			assert.Equal(t, test.expectedFollowerInterval, p.FollowerLeaseRefreshInterval)
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	testutils.VerifyGoLeaks(m)
 }


### PR DESCRIPTION
## Problem
The `leader_election.go` file could hard-crash startup if either `LeaderLeaseRefreshInterval` or `FollowerLeaseRefreshInterval` configuration values were set to zero or negative values. The `time.NewTicker()` function rejects non-positive durations and will panic, but there was no validation before the configuration values were used to create tickers.

This issue occurred at two locations:
- Line 79: `ticker := time.NewTicker(p.acquireLock())`
- Line 105: Inside the loop when creating new ticker instances

## Solution
Implemented **Option 2**: Set sensible default values if the configuration provides zero or negative durations. This provides graceful degradation and prevents application crashes.

### Changes Made:
1. **Added validation in `NewElectionParticipant()` constructor** with defaults:
   - `LeaderLeaseRefreshInterval`: defaults to 5 seconds if ≤ 0
   - `FollowerLeaseRefreshInterval`: defaults to 10 seconds if ≤ 0

2. **Added comprehensive test coverage** (`TestNewElectionParticipantWithInvalidDurations`) that verifies:
   - Zero leader and follower intervals are replaced with defaults
   - Negative intervals are replaced with defaults
   - Valid positive intervals remain unchanged
   - All five test cases pass successfully

### Testing
- All existing tests pass (6 test cases in `TestAcquireLock`)
- New test suite with 5 subtests covers edge cases
- No interference with other modules

## Impact
This is a **defensive fix** that prevents application crashes from misconfiguration while maintaining backward compatibility with valid configurations.