### PR TITLE
fix(storage): Remove misleading error wrapper in getStorageFactory

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerstorage/extension.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/extension.go
@@ -49,14 +49,7 @@ func getStorageFactory(name string, host component.Host) (tracestore.Factory, er
 	if err != nil {
 		return nil, err
 	}
-	f, err := ext.TraceStorageFactory(name)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"cannot find definition of storage '%s' in the configuration for extension '%s': %w",
-			name, componentType, err,
-		)
-	}
-	return f, nil
+	return ext.TraceStorageFactory(name)
 }
 
 // GetMetricStorageFactory locates the extension in Host and retrieves
@@ -66,14 +59,7 @@ func GetMetricStorageFactory(name string, host component.Host) (storage.MetricSt
 	if err != nil {
 		return nil, err
 	}
-	mf, err := ext.MetricStorageFactory(name)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"cannot find metric storage '%s' declared by '%s' extension: %w",
-			name, componentType, err,
-		)
-	}
-	return mf, nil
+	return ext.MetricStorageFactory(name)
 }
 
 func GetTraceStoreFactory(name string, host component.Host) (tracestore.Factory, error) {


### PR DESCRIPTION
When storage initialization fails (e.g. backend returns an error during template creation), the error was wrapped with "cannot find definition of storage" — implying the storage name was missing from config, when in reality the config was found and initialization simply failed.

Both TraceStorageFactory and MetricStorageFactory already produce accurate error messages, so remove the redundant outer wrapping and return their errors directly.
