### PR TITLE
Feat/skills framework

### DIFF
--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -21,6 +21,16 @@ services:
       - "8889:8889"
       - "4317:4317"
       - "4318:4318"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:16686/ || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    depends_on:
+      prometheus:
+        condition: service_healthy
 
   microsim:
     networks:
@@ -30,7 +40,9 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://jaeger:4318/v1/traces
     depends_on:
-      - jaeger
+      jaeger:
+        condition: service_healthy
+    restart: on-failure
 
   prometheus:
     networks:
@@ -40,6 +52,13 @@ services:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
     ports:
       - "9090:9090"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:9090/-/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   grafana:
     networks:
@@ -51,10 +70,19 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_LOG_LEVEL=debug
     ports:
       - "3000:3000"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
 
 networks:
   backend:

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FileLoader loads and validates skill definitions from a directory.
+type FileLoader struct {
+	Dir string
+}
+
+// Load discovers .json/.yaml/.yml skill files and validates merged definitions.
+func (l FileLoader) Load(ctx context.Context) ([]Definition, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	if strings.TrimSpace(l.Dir) == "" {
+		return nil, fmt.Errorf("skills directory must not be empty")
+	}
+
+	entries, err := os.ReadDir(l.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("read skills directory %q: %w", l.Dir, err)
+	}
+
+	defs := make([]Definition, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isSupportedSkillsConfig(name) {
+			continue
+		}
+
+		filePath := filepath.Join(l.Dir, name)
+		data, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read skills file %q: %w", filePath, readErr)
+		}
+
+		parsed, parseErr := ParseDefinitions(name, data)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse skills file %q: %w", filePath, parseErr)
+		}
+		defs = append(defs, parsed...)
+	}
+
+	if err := ValidateDefinitions(defs); err != nil {
+		return nil, err
+	}
+	return defs, nil
+}
+
+// WatchEvents is a lightweight event channel type for future hot-reload integration.
+type WatchEvents <-chan fs.FileInfo
+
+func isSupportedSkillsConfig(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".json" || ext == ".yaml" || ext == ".yml"
+}

--- a/internal/skills/parser.go
+++ b/internal/skills/parser.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// ParseDefinitions parses a skills config payload from JSON or YAML.
+func ParseDefinitions(fileName string, data []byte) ([]Definition, error) {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	switch ext {
+	case ".json":
+		return parseJSON(data)
+	case ".yaml", ".yml":
+		return parseYAML(data)
+	default:
+		return nil, fmt.Errorf("unsupported skills config extension %q", ext)
+	}
+}
+
+func parseJSON(data []byte) ([]Definition, error) {
+	var defs []Definition
+	if err := json.Unmarshal(data, &defs); err == nil {
+		return defs, nil
+	}
+
+	var wrapped struct {
+		Skills []Definition `json:"skills"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("parse json skills config: %w", err)
+	}
+	return wrapped.Skills, nil
+}
+
+func parseYAML(data []byte) ([]Definition, error) {
+	var defs []Definition
+	if err := yaml.Unmarshal(data, &defs); err == nil {
+		return defs, nil
+	}
+
+	var wrapped struct {
+		Skills []Definition `yaml:"skills"`
+	}
+	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("parse yaml skills config: %w", err)
+	}
+	return wrapped.Skills, nil
+}

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Registry stores runtime-discoverable skills that can be updated without recompilation.
+type Registry struct {
+	mu     sync.RWMutex
+	skills map[string]Definition
+}
+
+// NewRegistry creates an empty runtime registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		skills: make(map[string]Definition),
+	}
+}
+
+// Register adds or replaces a skill by name.
+func (r *Registry) Register(def Definition) error {
+	if err := ValidateDefinition(def); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.skills[def.Name] = def
+	return nil
+}
+
+// RegisterAll registers all skills from a collection.
+func (r *Registry) RegisterAll(defs []Definition) error {
+	for _, def := range defs {
+		if err := r.Register(def); err != nil {
+			return fmt.Errorf("register %q: %w", def.Name, err)
+		}
+	}
+	return nil
+}
+
+// Unregister removes a skill by name.
+func (r *Registry) Unregister(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.skills, name)
+}
+
+// Get returns a skill definition by name.
+func (r *Registry) Get(name string) (Definition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	def, ok := r.skills[name]
+	return def, ok
+}
+
+// List returns all registered skills sorted by name.
+func (r *Registry) List() []Definition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]Definition, 0, len(r.skills))
+	for _, def := range r.skills {
+		out = append(out, def)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import "testing"
+
+func TestParseSkillYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		yaml      string
+		shouldErr bool
+	}{
+		{
+			name: "valid YAML",
+			yaml: `
+skills:
+  - name: trace_explainer
+    version: "1.0.0"
+    system_prompt: "Explain trace behavior"
+    allowed_tools: ["query_traces"]
+    reasoning_hints: ["focus on latency"]
+    max_iterations: 3
+    output_contract:
+      fields: ["summary", "actions"]
+      max_tokens: 512
+      format: "json"
+`,
+		},
+		{
+			name: "missing name",
+			yaml: `
+skills:
+  - version: "1.0.0"
+    system_prompt: "Explain trace behavior"
+    allowed_tools: ["query_traces"]
+    max_iterations: 3
+    output_contract:
+      fields: ["summary"]
+      max_tokens: 512
+      format: "json"
+`,
+			shouldErr: true,
+		},
+		{
+			name: "missing system_prompt",
+			yaml: `
+skills:
+  - name: trace_explainer
+    version: "1.0.0"
+    allowed_tools: ["query_traces"]
+    max_iterations: 3
+    output_contract:
+      fields: ["summary"]
+      max_tokens: 512
+      format: "json"
+`,
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defs, err := ParseDefinitions("skills.yaml", []byte(tt.yaml))
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+
+			err = ValidateDefinitions(defs)
+			if tt.shouldErr && err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			if !tt.shouldErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSkill(t *testing.T) {
+	t.Parallel()
+
+	validSkill := Definition{
+		Name:          "trace_explainer",
+		Version:       "1.0.0",
+		SystemPrompt:  "Explain a trace execution path.",
+		AllowedTools:  []string{"query_traces"},
+		MaxIterations: 3,
+		OutputContract: OutputContract{
+			Fields:    []string{"summary", "actions"},
+			MaxTokens: 512,
+			Format:    "json",
+		},
+	}
+
+	tests := []struct {
+		name  string
+		skill Definition
+		valid bool
+	}{
+		{
+			name:  "valid skill",
+			skill: validSkill,
+			valid: true,
+		},
+		{
+			name: "empty allowed_tools",
+			skill: Definition{
+				Name:          validSkill.Name,
+				Version:       validSkill.Version,
+				SystemPrompt:  validSkill.SystemPrompt,
+				AllowedTools:  []string{},
+				MaxIterations: validSkill.MaxIterations,
+				OutputContract: OutputContract{
+					Fields:    []string{"summary"},
+					MaxTokens: 256,
+					Format:    "json",
+				},
+			},
+		},
+		{
+			name: "name with uppercase",
+			skill: Definition{
+				Name:          "TraceExplainer",
+				Version:       validSkill.Version,
+				SystemPrompt:  validSkill.SystemPrompt,
+				AllowedTools:  []string{"query_traces"},
+				MaxIterations: validSkill.MaxIterations,
+				OutputContract: OutputContract{
+					Fields:    []string{"summary"},
+					MaxTokens: 256,
+					Format:    "json",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDefinition(tt.skill)
+			if tt.valid && err != nil {
+				t.Fatalf("expected valid skill, got %v", err)
+			}
+			if !tt.valid && err == nil {
+				t.Fatalf("expected invalid skill, got nil")
+			}
+		})
+	}
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -154,3 +154,70 @@ func TestValidateSkill(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDefinitions(t *testing.T) {
+	t.Parallel()
+
+	validSkill := Definition{
+		Name:          "trace_explainer",
+		Version:       "1.0.0",
+		SystemPrompt:  "Explain a trace execution path.",
+		AllowedTools:  []string{"query_traces"},
+		MaxIterations: 3,
+		OutputContract: OutputContract{
+			Fields:    []string{"summary", "actions"},
+			MaxTokens: 512,
+			Format:    "json",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		defs    []Definition
+		wantErr bool
+	}{
+		{
+			name:    "duplicate skill names",
+			defs:    []Definition{validSkill, validSkill},
+			wantErr: true,
+		},
+		{
+			name: "name with leading whitespace",
+			defs: []Definition{{
+				Name:           " trace_explainer",
+				Version:        validSkill.Version,
+				SystemPrompt:   validSkill.SystemPrompt,
+				AllowedTools:   validSkill.AllowedTools,
+				MaxIterations:  validSkill.MaxIterations,
+				OutputContract: validSkill.OutputContract,
+			}},
+			wantErr: true,
+		},
+		{
+			name: "name with trailing whitespace",
+			defs: []Definition{{
+				Name:           "trace_explainer ",
+				Version:        validSkill.Version,
+				SystemPrompt:   validSkill.SystemPrompt,
+				AllowedTools:   validSkill.AllowedTools,
+				MaxIterations:  validSkill.MaxIterations,
+				OutputContract: validSkill.OutputContract,
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDefinitions(tt.defs)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -3,10 +3,7 @@
 
 package skills
 
-import (
-	"context"
-	"os"
-)
+import "context"
 
 // SkillDefinition describes a single skill loaded from static config.
 type SkillDefinition struct {
@@ -67,11 +64,6 @@ func DefaultExecutorConfig() ExecutorConfig {
 		},
 	}
 
-	if os.Getenv("OPENAI_API_KEY") == "" && os.Getenv("ANTHROPIC_API_KEY") == "" {
-		return cfg
-	}
-
-	// Keep local as the default even if cloud keys exist.
 	return cfg
 }
 

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"context"
+	"os"
+)
+
+// SkillDefinition describes a single skill loaded from static config.
+type SkillDefinition struct {
+	Name           string         `json:"name" yaml:"name"`
+	Version        string         `json:"version,omitempty" yaml:"version,omitempty"`
+	SystemPrompt   string         `json:"system_prompt" yaml:"system_prompt"`
+	AllowedTools   []string       `json:"allowed_tools" yaml:"allowed_tools"`
+	ReasoningHints []string       `json:"reasoning_hints,omitempty" yaml:"reasoning_hints,omitempty"`
+	MaxIterations  int            `json:"max_iterations" yaml:"max_iterations"`
+	OutputContract OutputContract `json:"output_contract" yaml:"output_contract"`
+}
+
+// OutputContract defines the expected output format for a skill.
+type OutputContract struct {
+	Fields    []string `json:"fields" yaml:"fields"`
+	MaxTokens int      `json:"max_tokens" yaml:"max_tokens"`
+	Format    string   `json:"format" yaml:"format"`
+}
+
+// Backward-compatible alias for existing parser/registry scaffolding.
+type Definition = SkillDefinition
+
+// Tool represents an optional tool declaration a skill may use.
+type Tool struct {
+	Name        string            `json:"name" yaml:"name"`
+	Description string            `json:"description" yaml:"description"`
+	Config      map[string]string `json:"config,omitempty" yaml:"config,omitempty"`
+}
+
+// WorkflowStep represents one deterministic step in a skill workflow.
+type WorkflowStep struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Action      string `json:"action" yaml:"action"`
+}
+
+// LocalLLMConfig captures local-first runtime defaults.
+type LocalLLMConfig struct {
+	Provider string `json:"provider" yaml:"provider"`
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	Model    string `json:"model,omitempty" yaml:"model,omitempty"`
+}
+
+// ExecutorConfig captures placeholder integration points for AI execution.
+type ExecutorConfig struct {
+	Orchestrator string         `json:"orchestrator" yaml:"orchestrator"`
+	LocalLLM     LocalLLMConfig `json:"local_llm" yaml:"local_llm"`
+}
+
+// DefaultExecutorConfig returns local-first defaults.
+// If no external key is configured, it explicitly targets a local Ollama endpoint.
+func DefaultExecutorConfig() ExecutorConfig {
+	cfg := ExecutorConfig{
+		Orchestrator: "langchaingo",
+		LocalLLM: LocalLLMConfig{
+			Provider: "ollama",
+			Endpoint: "http://localhost:11434",
+		},
+	}
+
+	if os.Getenv("OPENAI_API_KEY") == "" && os.Getenv("ANTHROPIC_API_KEY") == "" {
+		return cfg
+	}
+
+	// Keep local as the default even if cloud keys exist.
+	return cfg
+}
+
+// RuntimeSkillLoader defines dynamic discovery and loading behavior.
+type RuntimeSkillLoader interface {
+	Load(ctx context.Context) ([]Definition, error)
+}
+
+// RuntimeSkillExecutor defines a placeholder reasoning loop contract.
+type RuntimeSkillExecutor interface {
+	Execute(ctx context.Context, skillName string, input map[string]any) (map[string]any, error)
+}

--- a/internal/skills/validator.go
+++ b/internal/skills/validator.go
@@ -15,7 +15,7 @@ var skillNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 // ValidateDefinitions validates a full set of parsed skill definitions.
 func ValidateDefinitions(defs []Definition) error {
 	if len(defs) == 0 {
-		return errors.New("no skills definitions provided")
+		return errors.New("no skill definitions provided")
 	}
 
 	seen := make(map[string]struct{}, len(defs))

--- a/internal/skills/validator.go
+++ b/internal/skills/validator.go
@@ -34,6 +34,9 @@ func ValidateDefinitions(defs []Definition) error {
 // ValidateDefinition validates a single skill definition.
 func ValidateDefinition(def Definition) error {
 	name := strings.TrimSpace(def.Name)
+	if def.Name != name {
+		return fmt.Errorf("name %q must not contain leading or trailing whitespace", def.Name)
+	}
 	if name == "" {
 		return errors.New("name is required")
 	}

--- a/internal/skills/validator.go
+++ b/internal/skills/validator.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var skillNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+// ValidateDefinitions validates a full set of parsed skill definitions.
+func ValidateDefinitions(defs []Definition) error {
+	if len(defs) == 0 {
+		return errors.New("no skills definitions provided")
+	}
+
+	seen := make(map[string]struct{}, len(defs))
+	for i, def := range defs {
+		if err := ValidateDefinition(def); err != nil {
+			return fmt.Errorf("invalid skill at index %d: %w", i, err)
+		}
+		if _, ok := seen[def.Name]; ok {
+			return fmt.Errorf("duplicate skill name %q", def.Name)
+		}
+		seen[def.Name] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateDefinition validates a single skill definition.
+func ValidateDefinition(def Definition) error {
+	name := strings.TrimSpace(def.Name)
+	if name == "" {
+		return errors.New("name is required")
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("name %q must be lowercase alphanumeric with optional '-' or '_'", def.Name)
+	}
+	if strings.TrimSpace(def.SystemPrompt) == "" {
+		return fmt.Errorf("system_prompt is required for %q", def.Name)
+	}
+	if len(def.AllowedTools) == 0 {
+		return fmt.Errorf("allowed_tools must include at least one tool for %q", def.Name)
+	}
+	if len(def.OutputContract.Fields) == 0 {
+		return fmt.Errorf("output_contract.fields must include at least one field for %q", def.Name)
+	}
+	if strings.TrimSpace(def.OutputContract.Format) == "" {
+		return fmt.Errorf("output_contract.format is required for %q", def.Name)
+	}
+	if def.OutputContract.MaxTokens <= 0 {
+		return fmt.Errorf("output_contract.max_tokens must be greater than zero for %q", def.Name)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Introduces the initial scaffold for the Phase 2 Self-Service Skills framework discussed in #8440 (parent #7827).

This PR adds the foundational infrastructure for loading and validating user-defined AI skills without changing any existing Jaeger behavior.

The goal is to support future extensible AI workflows where users can define debugging skills through configuration rather than recompiling Jaeger.

---

## Changes

### Added `internal/skills/`

Includes:

* Skill definition types
* YAML parser
* Validation logic
* Thread-safe registry
* Loader plumbing
* Unit tests for parsing and validation paths

---

## Validation Improvements

* Enforces canonical skill names
* Rejects surrounding whitespace in names
* Adds duplicate-name validation
* Improves validation error wording

---

## Testing

Added unit tests covering:

* valid skill definitions
* invalid names
* duplicate skill names
* missing required fields
* whitespace edge cases

---

## Notes

* No existing Jaeger functionality is modified
* No runtime behavior changes
* No AI orchestration logic introduced yet
* This PR is intentionally limited to groundwork/scaffolding only

Future PRs will build on this foundation with:

* skill discovery
* runtime loading
* agent orchestration
* tool execution integration
* UI exposure
