### PR TITLE
Fix/monitor healthchecks

### DIFF
--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -21,6 +21,16 @@ services:
       - "8889:8889"
       - "4317:4317"
       - "4318:4318"
+    restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:16686/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    depends_on:
+      prometheus:
+        condition: service_healthy
 
   microsim:
     networks:
@@ -30,7 +40,9 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://jaeger:4318/v1/traces
     depends_on:
-      - jaeger
+      jaeger:
+        condition: service_healthy
+    restart: on-failure
 
   prometheus:
     networks:
@@ -40,6 +52,13 @@ services:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
     ports:
       - "9090:9090"
+    restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/-/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   grafana:
     networks:
@@ -53,8 +72,16 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     ports:
       - "3000:3000"
+    restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
 
 networks:
   backend:


### PR DESCRIPTION
## Summary

Fixes startup race conditions in the local monitoring stack under `docker-compose/monitor/`.

Previously, `microsim` could start before Jaeger finished initializing, causing intermittent `connection refused` errors on `:16686` during local development.

This PR improves reliability by adding health checks, restart policies, and startup ordering between services.

Closes part of #8440.

---

## Changes

### Docker Compose Reliability Improvements

* Added healthcheck for `jaeger`
* Added healthcheck for `prometheus`
* Added healthcheck for `grafana`
* Added `depends_on: condition: service_healthy`
* Added `restart: on-failure` policies

---

## Verification

Tested locally with:

```bash
cd docker-compose/monitor
docker compose up -d
```

Verified:

* Jaeger UI becomes reachable consistently on `localhost:16686`
* Containers transition to healthy state correctly
* `microsim` starts only after Jaeger is healthy
* No manual restart/retry required after cold start

---

