### PR TITLE
ci(metrics): Make PR metric diffs informational

### DIFF
--- a/.github/scripts/ci-summary-report-publish.js
+++ b/.github/scripts/ci-summary-report-publish.js
@@ -121,8 +121,9 @@ function computeMetrics(s) {
   const hasInfraErrors = s.metrics_has_infra_errors === true;
   const totalChanges   = safeNum(s.metrics_total_changes);
   const snapshots      = sanitizeSnapshots(s.metrics_snapshots);
-  // Derive conclusion from the same conditions that drive text so they are always consistent.
-  const conclusion     = (hasInfraErrors || totalChanges === null || totalChanges > 0) ? 'failure' : 'success';
+  // Metric diffs are informational on PRs because the snapshot set can include
+  // nondeterministic runtime series. Infra/reporting failures still block.
+  const conclusion     = (hasInfraErrors || totalChanges === null) ? 'failure' : 'success';
 
   let text;
   if (hasInfraErrors) {
@@ -130,7 +131,7 @@ function computeMetrics(s) {
   } else if (totalChanges === null) {
     text = '❌ Could not read metrics_total_changes from summary';
   } else if (totalChanges > 0) {
-    text = `❌ ${totalChanges} metric change(s) detected`;
+    text = `⚠️ ${totalChanges} metric change(s) detected (informational)`;
   } else {
     text = '✅ No significant metric changes';
   }

--- a/.github/scripts/ci-summary-report-publish.test.js
+++ b/.github/scripts/ci-summary-report-publish.test.js
@@ -227,10 +227,10 @@ describe('computeMetrics', () => {
     expect(r.snapshots).toBeNull();
   });
 
-  test('failure when total changes > 0', () => {
+  test('success with warning text when total changes > 0', () => {
     const r = computeMetrics({ metrics_has_infra_errors: false, metrics_total_changes: 3 });
-    expect(r.conclusion).toBe('failure');
-    expect(r.text).toBe('❌ 3 metric change(s) detected');
+    expect(r.conclusion).toBe('success');
+    expect(r.text).toBe('⚠️ 3 metric change(s) detected (informational)');
     expect(r.totalChanges).toBe(3);
   });
 
@@ -485,7 +485,7 @@ describe('buildCommentBody', () => {
       added: 1, removed: 0, modified: 1,
       metric_names: ['http_server_duration'],
     }];
-    const body = buildCommentBody('❌ 2 metric change(s) detected', coverageText, footer, { metricsSnapshots: snapshots });
+    const body = buildCommentBody('⚠️ 2 metric change(s) detected (informational)', coverageText, footer, { metricsSnapshots: snapshots });
     expect(body).toContain('<details>');
     expect(body).toContain('**cassandra_v2**');
     expect(body).toContain('- `http_server_duration`');
@@ -506,7 +506,7 @@ describe('buildCommentBody', () => {
       artifact_id: null,
     }];
     const ciRunUrl = 'https://github.com/org/repo/actions/runs/999';
-    const body = buildCommentBody('❌ 1 metric change(s) detected', coverageText, footer, { metricsSnapshots: snapshots, ciRunUrl });
+    const body = buildCommentBody('⚠️ 1 metric change(s) detected (informational)', coverageText, footer, { metricsSnapshots: snapshots, ciRunUrl });
     expect(body).toContain(`[CI run](${ciRunUrl})`);
     expect(body).toContain('Compare metrics and generate summary');
   });
@@ -519,7 +519,7 @@ describe('buildCommentBody', () => {
       artifact_id: 6359406281,
     }];
     const artifactUrlPrefix = 'https://github.com/org/repo/actions/runs/999/artifacts';
-    const body = buildCommentBody('❌ 1 metric change(s) detected', coverageText, footer, { metricsSnapshots: snapshots, artifactUrlPrefix });
+    const body = buildCommentBody('⚠️ 1 metric change(s) detected (informational)', coverageText, footer, { metricsSnapshots: snapshots, artifactUrlPrefix });
     expect(body).toContain(`[⬇️ download diff](${artifactUrlPrefix}/6359406281)`);
   });
 });

--- a/.github/workflows/ci-summary-report.yml
+++ b/.github/workflows/ci-summary-report.yml
@@ -273,8 +273,9 @@ jobs:
           path: .artifacts/baseline-coverage.txt
           key: coverage-baseline_${{ github.run_id }}
 
-      # Fail the job (and the calling CI Orchestrator run) so the coverage/metrics
-      # regression is immediately visible in the PR Checks table.
+      # Fail the job (and the calling CI Orchestrator run) for blocking gates.
+      # Metric diffs are informational on PRs, but missing metrics diff artifacts
+      # still fail via the metrics conclusion because they indicate an infra issue.
       # The ci-summary artifact is already uploaded above (if: always()), so
       # ci-summary-report-publish.yml can still post the PR comment and check runs.
       - name: Fail if coverage or metrics gate failed

--- a/scripts/e2e/metrics_summary.sh
+++ b/scripts/e2e/metrics_summary.sh
@@ -152,9 +152,9 @@ echo "TOTAL_CHANGES=$total_changes" >> "$GITHUB_OUTPUT"
 
 if [ ${#missing_diffs[@]} -gt 0 ]; then
     echo "CONCLUSION=failure" >> "$GITHUB_OUTPUT"
-elif [ "$total_changes" -gt 0 ]; then
-    echo "CONCLUSION=failure" >> "$GITHUB_OUTPUT"
 else
+    # Metric diffs are reported in the PR summary, but they are not a blocking
+    # CI failure. Missing diff artifacts remain blocking infra errors above.
     echo "CONCLUSION=success" >> "$GITHUB_OUTPUT"
 fi
 
@@ -214,7 +214,7 @@ if [ ${#missing_diffs[@]} -gt 0 ]; then
 fi
 
 if [ "$total_changes" -gt 0 ]; then
-    echo "::error::${total_changes} metric change(s) detected across all snapshots"
+    echo "::warning::${total_changes} metric change(s) detected across all snapshots"
     echo ""
     for summary_file in "${summary_files[@]}"; do
         file_name=$(basename "$summary_file" .md)


### PR DESCRIPTION
## Summary
- Make PR metrics comparison non-blocking when snapshot diffs are found.
- Keep metrics infra/reporting failures blocking when diff artifacts are missing or totals cannot be read.
- Render metric diffs as warning/informational in PR comments and check summaries.

## Context
Recent PRs have been blocked by flaky metric snapshot diffs unrelated to the PR changes. For example, PR #8603 had all CI jobs pass, then failed Metrics Comparison because one Elasticsearch 9.x E2E snapshot observed transient FindTraces error-path series while the other did not.

This preserves visibility into metric diffs without making unrelated PRs depend on deterministic runtime metric presence.

## Follow-ups
- Add explicit exclusions for known nondeterministic error-path series, such as jaeger_storage_requests/latency with result=err and rpc_server_call_duration with UNKNOWN/non-OK status.
- Make hard metric gating opt-in through a label or path-based trigger for telemetry/metrics-sensitive changes.
- Stabilize the E2E metric snapshot source by making the tests wait for backend readiness before query retries or by deliberately exercising a deterministic set of success/error paths before scraping.
- Consider retry/quorum semantics for metrics diffs, rerunning only the affected E2E matrix entry before reporting a blocking failure.
- Move hard metric snapshot gating to main/nightly/release validation while keeping PR-level reporting informational.

## Testing
- npm test -- ci-summary-report-publish.test.js
- make fmt
- make lint
- make test

Note: make lint and make test needed to be rerun with normal local access because the sandbox blocked the Go build cache and local test listeners.