### PR TITLE
feat(query): add trace summaries endpoint

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -43,10 +43,11 @@ const (
 	paramDurationMax    = "query.duration_max"
 	paramQueryRawTraces = "query.raw_traces"
 
-	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
-	routeFindTraces    = "/api/v3/traces"
-	routeGetServices   = "/api/v3/services"
-	routeGetOperations = "/api/v3/operations"
+	routeGetTrace       = "/api/v3/traces/{" + paramTraceID + "}"
+	routeFindTraces     = "/api/v3/traces"
+	routeTraceSummaries = "/api/v3/trace-summaries"
+	routeGetServices    = "/api/v3/services"
+	routeGetOperations  = "/api/v3/operations"
 )
 
 // HTTPGateway exposes APIv3 HTTP endpoints.
@@ -61,6 +62,7 @@ type HTTPGateway struct {
 func (h *HTTPGateway) RegisterRoutes(router *http.ServeMux) {
 	h.addRoute(router, h.getTrace, routeGetTrace, http.MethodGet)
 	h.addRoute(router, h.findTraces, routeFindTraces, http.MethodGet)
+	h.addRoute(router, h.findTraceSummaries, routeTraceSummaries, http.MethodGet)
 	h.addRoute(router, h.getServices, routeGetServices, http.MethodGet)
 	h.addRoute(router, h.getOperations, routeGetOperations, http.MethodGet)
 }
@@ -203,6 +205,23 @@ func (h *HTTPGateway) findTraces(w http.ResponseWriter, r *http.Request) {
 	h.returnTraces(traces, err, w)
 }
 
+func (h *HTTPGateway) findTraceSummaries(w http.ResponseWriter, r *http.Request) {
+	queryParams, shouldReturn := h.parseFindTracesQuery(r.URL.Query(), w)
+	if shouldReturn {
+		return
+	}
+
+	summariesIter := h.QueryService.FindTraceSummaries(r.Context(), *queryParams)
+	summaries, err := jiter.FlattenWithErrors(summariesIter)
+	if h.tryHandleError(w, err, http.StatusInternalServerError) {
+		return
+	}
+	if summaries == nil {
+		summaries = []tracestore.TraceSummary{}
+	}
+	h.writeJSON(newTraceSummariesResponse(summaries), w)
+}
+
 func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*querysvc.TraceQueryParams, bool) {
 	queryParams := &querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{
@@ -260,6 +279,72 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		queryParams.RawTraces = rawTraces
 	}
 	return queryParams, false
+}
+
+type traceSummariesResponse struct {
+	Summaries []traceSummary `json:"summaries"`
+}
+
+type traceSummary struct {
+	TraceID              string           `json:"traceID"`
+	RootServiceName      string           `json:"rootServiceName"`
+	RootOperationName    string           `json:"rootOperationName"`
+	MinStartTimeUnixNano uint64           `json:"minStartTimeUnixNano"`
+	MaxEndTimeUnixNano   uint64           `json:"maxEndTimeUnixNano"`
+	SpanCount            int              `json:"spanCount"`
+	ErrorSpanCount       int              `json:"errorSpanCount"`
+	OrphanSpanCount      int              `json:"orphanSpanCount"`
+	Services             []serviceSummary `json:"services"`
+}
+
+type serviceSummary struct {
+	Name           string `json:"name"`
+	SpanCount      int    `json:"spanCount"`
+	ErrorSpanCount int    `json:"errorSpanCount"`
+}
+
+func newTraceSummariesResponse(summaries []tracestore.TraceSummary) traceSummariesResponse {
+	response := traceSummariesResponse{
+		Summaries: make([]traceSummary, len(summaries)),
+	}
+	for i := range summaries {
+		response.Summaries[i] = newTraceSummary(summaries[i])
+	}
+	return response
+}
+
+func newTraceSummary(summary tracestore.TraceSummary) traceSummary {
+	services := make([]serviceSummary, len(summary.Services))
+	for i := range summary.Services {
+		services[i] = serviceSummary{
+			Name:           summary.Services[i].Name,
+			SpanCount:      summary.Services[i].SpanCount,
+			ErrorSpanCount: summary.Services[i].ErrorSpanCount,
+		}
+	}
+	return traceSummary{
+		TraceID:              summary.TraceID.String(),
+		RootServiceName:      summary.RootServiceName,
+		RootOperationName:    summary.RootOperationName,
+		MinStartTimeUnixNano: unixNano(summary.MinStartTime),
+		MaxEndTimeUnixNano:   unixNano(summary.MaxEndTime),
+		SpanCount:            summary.SpanCount,
+		ErrorSpanCount:       summary.ErrorSpanCount,
+		OrphanSpanCount:      summary.OrphanSpanCount,
+		Services:             services,
+	}
+}
+
+func unixNano(t time.Time) uint64 {
+	if t.IsZero() {
+		return 0
+	}
+	return uint64(t.UnixNano())
+}
+
+func (*HTTPGateway) writeJSON(response any, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 func (h *HTTPGateway) getServices(w http.ResponseWriter, r *http.Request) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -4,6 +4,7 @@
 package apiv3
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -181,6 +182,44 @@ func TestHTTPGatewayFindTracesEmptyResponse(t *testing.T) {
 	gw.router.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 	assert.Contains(t, w.Body.String(), "No traces found")
+}
+
+func TestHTTPGatewayFindTraceSummaries(t *testing.T) {
+	q, qp := mockFindQueries()
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/trace-summaries?"+q.Encode(), http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	trace := ptrace.NewTraces()
+	resource := trace.ResourceSpans().AppendEmpty()
+	resource.Resource().Attributes().PutStr("service.name", "frontend")
+	span := resource.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetTraceID(traceID)
+	span.SetSpanID(pcommon.SpanID([8]byte{1}))
+	span.SetName("GET /api")
+	start := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(start.Add(15 * time.Millisecond)))
+
+	gw := setupHTTPGatewayNoServer(t, "")
+	gw.reader.
+		On("FindTraces", matchContext, qp).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{trace}, nil)
+		})).Once()
+
+	gw.router.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response traceSummariesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Summaries, 1)
+	assert.Equal(t, traceID.String(), response.Summaries[0].TraceID)
+	assert.Equal(t, "frontend", response.Summaries[0].RootServiceName)
+	assert.Equal(t, "GET /api", response.Summaries[0].RootOperationName)
+	assert.Equal(t, uint64(start.UnixNano()), response.Summaries[0].MinStartTimeUnixNano)
+	assert.Equal(t, uint64(start.Add(15*time.Millisecond).UnixNano()), response.Summaries[0].MaxEndTimeUnixNano)
+	assert.Equal(t, 1, response.Summaries[0].SpanCount)
 }
 
 func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	"github.com/jaegertracing/jaeger/internal/tracesummary"
 )
 
 var errNoArchiveSpanStorage = errors.New("archive span storage was not configured")
@@ -156,6 +157,59 @@ func (qs QueryService) FindTraces(
 		tracesIter := qs.traceReader.FindTraces(ctx, query.TraceQueryParams)
 		qs.receiveTraces(tracesIter, yield, query.RawTraces)
 	}
+}
+
+// FindTraceSummaries searches for traces matching the query parameters and
+// returns compact summaries. Storage backends that implement
+// tracestore.SummaryReader can provide native summaries; all other backends
+// fall back to deriving summaries from complete traces.
+func (qs QueryService) FindTraceSummaries(
+	ctx context.Context,
+	query TraceQueryParams,
+) iter.Seq2[[]tracestore.TraceSummary, error] {
+	query.RawTraces = false
+	if summaryReader, ok := findSummaryReader(qs.traceReader); ok {
+		return summaryReader.FindTraceSummaries(ctx, query.TraceQueryParams)
+	}
+	return func(yield func([]tracestore.TraceSummary, error) bool) {
+		for traces, err := range qs.FindTraces(ctx, query) {
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			summaries := make([]tracestore.TraceSummary, 0, len(traces))
+			for _, trace := range traces {
+				summary := tracesummary.FromTrace(trace)
+				if summary.SpanCount == 0 {
+					continue
+				}
+				summaries = append(summaries, summary)
+			}
+			if !yield(summaries, nil) {
+				return
+			}
+		}
+	}
+}
+
+type traceReaderUnwrapper interface {
+	Unwrap() tracestore.Reader
+}
+
+func findSummaryReader(reader tracestore.Reader) (tracestore.SummaryReader, bool) {
+	for reader != nil {
+		if summaryReader, ok := reader.(tracestore.SummaryReader); ok {
+			return summaryReader, true
+		}
+		unwrapper, ok := reader.(traceReaderUnwrapper)
+		if !ok {
+			return nil, false
+		}
+		reader = unwrapper.Unwrap()
+	}
+	return nil, false
 }
 
 // ArchiveTrace archives a trace specified by the given query parameters.

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
@@ -618,6 +618,91 @@ func TestFindTraces_WithRawTraces_PerformsAggregation(t *testing.T) {
 	}
 }
 
+func TestFindTraceSummaries_UsesNativeSummaryReader(t *testing.T) {
+	queryParams := tracestore.TraceQueryParams{ServiceName: "service"}
+	expected := []tracestore.TraceSummary{{TraceID: testTraceID, SpanCount: 2}}
+	reader := &nativeSummaryReader{
+		Reader: &tracestoremocks.Reader{},
+		iter: iter.Seq2[[]tracestore.TraceSummary, error](func(yield func([]tracestore.TraceSummary, error) bool) {
+			yield(expected, nil)
+		}),
+	}
+	qs := NewQueryService(reader, &depstoremocks.Reader{}, QueryServiceOptions{})
+
+	summaries, err := jiter.FlattenWithErrors(qs.FindTraceSummaries(context.Background(), TraceQueryParams{
+		TraceQueryParams: queryParams,
+	}))
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, summaries)
+	assert.Equal(t, queryParams, reader.query)
+	reader.AssertNotCalled(t, "FindTraces", mock.Anything, mock.Anything)
+}
+
+func TestFindTraceSummaries_FallbackAggregatesRawTraceChunks(t *testing.T) {
+	tqs := initializeTestService()
+	traceChunk1 := ptrace.NewTraces()
+	span1 := traceChunk1.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span1.SetTraceID(testTraceID)
+	span1.SetSpanID(pcommon.SpanID([8]byte{1}))
+	traceChunk2 := ptrace.NewTraces()
+	span2 := traceChunk2.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span2.SetTraceID(testTraceID)
+	span2.SetSpanID(pcommon.SpanID([8]byte{2}))
+
+	tqs.traceReader.On("FindTraces", mock.Anything, tracestore.TraceQueryParams{}).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{traceChunk1, traceChunk2}, nil)
+		})).Once()
+
+	summaries, err := jiter.FlattenWithErrors(tqs.queryService.FindTraceSummaries(context.Background(), TraceQueryParams{
+		RawTraces: true,
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, 2, summaries[0].SpanCount)
+}
+
+func TestFindTraceSummaries_FindsNativeSummaryReaderBehindWrapper(t *testing.T) {
+	expected := []tracestore.TraceSummary{{TraceID: testTraceID, SpanCount: 1}}
+	reader := &nativeSummaryReader{
+		Reader: &tracestoremocks.Reader{},
+		iter: iter.Seq2[[]tracestore.TraceSummary, error](func(yield func([]tracestore.TraceSummary, error) bool) {
+			yield(expected, nil)
+		}),
+	}
+	qs := NewQueryService(wrappedTraceReader{Reader: &tracestoremocks.Reader{}, wrapped: reader}, nil, QueryServiceOptions{})
+
+	summaries, err := jiter.FlattenWithErrors(qs.FindTraceSummaries(context.Background(), TraceQueryParams{}))
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, summaries)
+}
+
+type wrappedTraceReader struct {
+	*tracestoremocks.Reader
+	wrapped tracestore.Reader
+}
+
+func (w wrappedTraceReader) Unwrap() tracestore.Reader {
+	return w.wrapped
+}
+
+type nativeSummaryReader struct {
+	*tracestoremocks.Reader
+	query tracestore.TraceQueryParams
+	iter  iter.Seq2[[]tracestore.TraceSummary, error]
+}
+
+func (r *nativeSummaryReader) FindTraceSummaries(
+	_ context.Context,
+	query tracestore.TraceQueryParams,
+) iter.Seq2[[]tracestore.TraceSummary, error] {
+	r.query = query
+	return r.iter
+}
+
 func TestArchiveTrace(t *testing.T) {
 	paramsTraceIDs := []tracestore.GetTraceParams{{TraceID: testTraceID}}
 	tests := []struct {

--- a/docker-compose/monitor/docker-compose.yml
+++ b/docker-compose/monitor/docker-compose.yml
@@ -21,6 +21,16 @@ services:
       - "8889:8889"
       - "4317:4317"
       - "4318:4318"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:16686/ || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    depends_on:
+      prometheus:
+        condition: service_healthy
 
   microsim:
     networks:
@@ -30,7 +40,9 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://jaeger:4318/v1/traces
     depends_on:
-      - jaeger
+      jaeger:
+        condition: service_healthy
+    restart: on-failure
 
   prometheus:
     networks:
@@ -40,6 +52,13 @@ services:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
     ports:
       - "9090:9090"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:9090/-/ready || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   grafana:
     networks:
@@ -51,10 +70,19 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_LOG_LEVEL=debug
     ports:
       - "3000:3000"
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
 
 networks:
   backend:

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FileLoader loads and validates skill definitions from a directory.
+type FileLoader struct {
+	Dir string
+}
+
+// Load discovers .json/.yaml/.yml skill files and validates merged definitions.
+func (l FileLoader) Load(ctx context.Context) ([]Definition, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	if strings.TrimSpace(l.Dir) == "" {
+		return nil, fmt.Errorf("skills directory must not be empty")
+	}
+
+	entries, err := os.ReadDir(l.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("read skills directory %q: %w", l.Dir, err)
+	}
+
+	defs := make([]Definition, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isSupportedSkillsConfig(name) {
+			continue
+		}
+
+		filePath := filepath.Join(l.Dir, name)
+		data, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read skills file %q: %w", filePath, readErr)
+		}
+
+		parsed, parseErr := ParseDefinitions(name, data)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse skills file %q: %w", filePath, parseErr)
+		}
+		defs = append(defs, parsed...)
+	}
+
+	if err := ValidateDefinitions(defs); err != nil {
+		return nil, err
+	}
+	return defs, nil
+}
+
+// WatchEvents is a lightweight event channel type for future hot-reload integration.
+type WatchEvents <-chan fs.FileInfo
+
+func isSupportedSkillsConfig(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".json" || ext == ".yaml" || ext == ".yml"
+}

--- a/internal/skills/parser.go
+++ b/internal/skills/parser.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// ParseDefinitions parses a skills config payload from JSON or YAML.
+func ParseDefinitions(fileName string, data []byte) ([]Definition, error) {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	switch ext {
+	case ".json":
+		return parseJSON(data)
+	case ".yaml", ".yml":
+		return parseYAML(data)
+	default:
+		return nil, fmt.Errorf("unsupported skills config extension %q", ext)
+	}
+}
+
+func parseJSON(data []byte) ([]Definition, error) {
+	var defs []Definition
+	if err := json.Unmarshal(data, &defs); err == nil {
+		return defs, nil
+	}
+
+	var wrapped struct {
+		Skills []Definition `json:"skills"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("parse json skills config: %w", err)
+	}
+	return wrapped.Skills, nil
+}
+
+func parseYAML(data []byte) ([]Definition, error) {
+	var defs []Definition
+	if err := yaml.Unmarshal(data, &defs); err == nil {
+		return defs, nil
+	}
+
+	var wrapped struct {
+		Skills []Definition `yaml:"skills"`
+	}
+	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("parse yaml skills config: %w", err)
+	}
+	return wrapped.Skills, nil
+}

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Registry stores runtime-discoverable skills that can be updated without recompilation.
+type Registry struct {
+	mu     sync.RWMutex
+	skills map[string]Definition
+}
+
+// NewRegistry creates an empty runtime registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		skills: make(map[string]Definition),
+	}
+}
+
+// Register adds or replaces a skill by name.
+func (r *Registry) Register(def Definition) error {
+	if err := ValidateDefinition(def); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.skills[def.Name] = def
+	return nil
+}
+
+// RegisterAll registers all skills from a collection.
+func (r *Registry) RegisterAll(defs []Definition) error {
+	for _, def := range defs {
+		if err := r.Register(def); err != nil {
+			return fmt.Errorf("register %q: %w", def.Name, err)
+		}
+	}
+	return nil
+}
+
+// Unregister removes a skill by name.
+func (r *Registry) Unregister(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.skills, name)
+}
+
+// Get returns a skill definition by name.
+func (r *Registry) Get(name string) (Definition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	def, ok := r.skills[name]
+	return def, ok
+}
+
+// List returns all registered skills sorted by name.
+func (r *Registry) List() []Definition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]Definition, 0, len(r.skills))
+	for _, def := range r.skills {
+		out = append(out, def)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import "testing"
+
+func TestParseSkillYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		yaml      string
+		shouldErr bool
+	}{
+		{
+			name: "valid YAML",
+			yaml: `
+skills:
+  - name: trace_explainer
+    version: "1.0.0"
+    system_prompt: "Explain trace behavior"
+    allowed_tools: ["query_traces"]
+    reasoning_hints: ["focus on latency"]
+    max_iterations: 3
+    output_contract:
+      fields: ["summary", "actions"]
+      max_tokens: 512
+      format: "json"
+`,
+		},
+		{
+			name: "missing name",
+			yaml: `
+skills:
+  - version: "1.0.0"
+    system_prompt: "Explain trace behavior"
+    allowed_tools: ["query_traces"]
+    max_iterations: 3
+    output_contract:
+      fields: ["summary"]
+      max_tokens: 512
+      format: "json"
+`,
+			shouldErr: true,
+		},
+		{
+			name: "missing system_prompt",
+			yaml: `
+skills:
+  - name: trace_explainer
+    version: "1.0.0"
+    allowed_tools: ["query_traces"]
+    max_iterations: 3
+    output_contract:
+      fields: ["summary"]
+      max_tokens: 512
+      format: "json"
+`,
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defs, err := ParseDefinitions("skills.yaml", []byte(tt.yaml))
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+
+			err = ValidateDefinitions(defs)
+			if tt.shouldErr && err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			if !tt.shouldErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSkill(t *testing.T) {
+	t.Parallel()
+
+	validSkill := Definition{
+		Name:          "trace_explainer",
+		Version:       "1.0.0",
+		SystemPrompt:  "Explain a trace execution path.",
+		AllowedTools:  []string{"query_traces"},
+		MaxIterations: 3,
+		OutputContract: OutputContract{
+			Fields:    []string{"summary", "actions"},
+			MaxTokens: 512,
+			Format:    "json",
+		},
+	}
+
+	tests := []struct {
+		name  string
+		skill Definition
+		valid bool
+	}{
+		{
+			name:  "valid skill",
+			skill: validSkill,
+			valid: true,
+		},
+		{
+			name: "empty allowed_tools",
+			skill: Definition{
+				Name:          validSkill.Name,
+				Version:       validSkill.Version,
+				SystemPrompt:  validSkill.SystemPrompt,
+				AllowedTools:  []string{},
+				MaxIterations: validSkill.MaxIterations,
+				OutputContract: OutputContract{
+					Fields:    []string{"summary"},
+					MaxTokens: 256,
+					Format:    "json",
+				},
+			},
+		},
+		{
+			name: "name with uppercase",
+			skill: Definition{
+				Name:          "TraceExplainer",
+				Version:       validSkill.Version,
+				SystemPrompt:  validSkill.SystemPrompt,
+				AllowedTools:  []string{"query_traces"},
+				MaxIterations: validSkill.MaxIterations,
+				OutputContract: OutputContract{
+					Fields:    []string{"summary"},
+					MaxTokens: 256,
+					Format:    "json",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDefinition(tt.skill)
+			if tt.valid && err != nil {
+				t.Fatalf("expected valid skill, got %v", err)
+			}
+			if !tt.valid && err == nil {
+				t.Fatalf("expected invalid skill, got nil")
+			}
+		})
+	}
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -154,3 +154,70 @@ func TestValidateSkill(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDefinitions(t *testing.T) {
+	t.Parallel()
+
+	validSkill := Definition{
+		Name:          "trace_explainer",
+		Version:       "1.0.0",
+		SystemPrompt:  "Explain a trace execution path.",
+		AllowedTools:  []string{"query_traces"},
+		MaxIterations: 3,
+		OutputContract: OutputContract{
+			Fields:    []string{"summary", "actions"},
+			MaxTokens: 512,
+			Format:    "json",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		defs    []Definition
+		wantErr bool
+	}{
+		{
+			name:    "duplicate skill names",
+			defs:    []Definition{validSkill, validSkill},
+			wantErr: true,
+		},
+		{
+			name: "name with leading whitespace",
+			defs: []Definition{{
+				Name:           " trace_explainer",
+				Version:        validSkill.Version,
+				SystemPrompt:   validSkill.SystemPrompt,
+				AllowedTools:   validSkill.AllowedTools,
+				MaxIterations:  validSkill.MaxIterations,
+				OutputContract: validSkill.OutputContract,
+			}},
+			wantErr: true,
+		},
+		{
+			name: "name with trailing whitespace",
+			defs: []Definition{{
+				Name:           "trace_explainer ",
+				Version:        validSkill.Version,
+				SystemPrompt:   validSkill.SystemPrompt,
+				AllowedTools:   validSkill.AllowedTools,
+				MaxIterations:  validSkill.MaxIterations,
+				OutputContract: validSkill.OutputContract,
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDefinitions(tt.defs)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -3,10 +3,7 @@
 
 package skills
 
-import (
-	"context"
-	"os"
-)
+import "context"
 
 // SkillDefinition describes a single skill loaded from static config.
 type SkillDefinition struct {
@@ -67,11 +64,6 @@ func DefaultExecutorConfig() ExecutorConfig {
 		},
 	}
 
-	if os.Getenv("OPENAI_API_KEY") == "" && os.Getenv("ANTHROPIC_API_KEY") == "" {
-		return cfg
-	}
-
-	// Keep local as the default even if cloud keys exist.
 	return cfg
 }
 

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"context"
+	"os"
+)
+
+// SkillDefinition describes a single skill loaded from static config.
+type SkillDefinition struct {
+	Name           string         `json:"name" yaml:"name"`
+	Version        string         `json:"version,omitempty" yaml:"version,omitempty"`
+	SystemPrompt   string         `json:"system_prompt" yaml:"system_prompt"`
+	AllowedTools   []string       `json:"allowed_tools" yaml:"allowed_tools"`
+	ReasoningHints []string       `json:"reasoning_hints,omitempty" yaml:"reasoning_hints,omitempty"`
+	MaxIterations  int            `json:"max_iterations" yaml:"max_iterations"`
+	OutputContract OutputContract `json:"output_contract" yaml:"output_contract"`
+}
+
+// OutputContract defines the expected output format for a skill.
+type OutputContract struct {
+	Fields    []string `json:"fields" yaml:"fields"`
+	MaxTokens int      `json:"max_tokens" yaml:"max_tokens"`
+	Format    string   `json:"format" yaml:"format"`
+}
+
+// Backward-compatible alias for existing parser/registry scaffolding.
+type Definition = SkillDefinition
+
+// Tool represents an optional tool declaration a skill may use.
+type Tool struct {
+	Name        string            `json:"name" yaml:"name"`
+	Description string            `json:"description" yaml:"description"`
+	Config      map[string]string `json:"config,omitempty" yaml:"config,omitempty"`
+}
+
+// WorkflowStep represents one deterministic step in a skill workflow.
+type WorkflowStep struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Action      string `json:"action" yaml:"action"`
+}
+
+// LocalLLMConfig captures local-first runtime defaults.
+type LocalLLMConfig struct {
+	Provider string `json:"provider" yaml:"provider"`
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	Model    string `json:"model,omitempty" yaml:"model,omitempty"`
+}
+
+// ExecutorConfig captures placeholder integration points for AI execution.
+type ExecutorConfig struct {
+	Orchestrator string         `json:"orchestrator" yaml:"orchestrator"`
+	LocalLLM     LocalLLMConfig `json:"local_llm" yaml:"local_llm"`
+}
+
+// DefaultExecutorConfig returns local-first defaults.
+// If no external key is configured, it explicitly targets a local Ollama endpoint.
+func DefaultExecutorConfig() ExecutorConfig {
+	cfg := ExecutorConfig{
+		Orchestrator: "langchaingo",
+		LocalLLM: LocalLLMConfig{
+			Provider: "ollama",
+			Endpoint: "http://localhost:11434",
+		},
+	}
+
+	if os.Getenv("OPENAI_API_KEY") == "" && os.Getenv("ANTHROPIC_API_KEY") == "" {
+		return cfg
+	}
+
+	// Keep local as the default even if cloud keys exist.
+	return cfg
+}
+
+// RuntimeSkillLoader defines dynamic discovery and loading behavior.
+type RuntimeSkillLoader interface {
+	Load(ctx context.Context) ([]Definition, error)
+}
+
+// RuntimeSkillExecutor defines a placeholder reasoning loop contract.
+type RuntimeSkillExecutor interface {
+	Execute(ctx context.Context, skillName string, input map[string]any) (map[string]any, error)
+}

--- a/internal/skills/validator.go
+++ b/internal/skills/validator.go
@@ -15,7 +15,7 @@ var skillNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 // ValidateDefinitions validates a full set of parsed skill definitions.
 func ValidateDefinitions(defs []Definition) error {
 	if len(defs) == 0 {
-		return errors.New("no skills definitions provided")
+		return errors.New("no skill definitions provided")
 	}
 
 	seen := make(map[string]struct{}, len(defs))

--- a/internal/skills/validator.go
+++ b/internal/skills/validator.go
@@ -34,6 +34,9 @@ func ValidateDefinitions(defs []Definition) error {
 // ValidateDefinition validates a single skill definition.
 func ValidateDefinition(def Definition) error {
 	name := strings.TrimSpace(def.Name)
+	if def.Name != name {
+		return fmt.Errorf("name %q must not contain leading or trailing whitespace", def.Name)
+	}
 	if name == "" {
 		return errors.New("name is required")
 	}

--- a/internal/skills/validator.go
+++ b/internal/skills/validator.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var skillNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+// ValidateDefinitions validates a full set of parsed skill definitions.
+func ValidateDefinitions(defs []Definition) error {
+	if len(defs) == 0 {
+		return errors.New("no skills definitions provided")
+	}
+
+	seen := make(map[string]struct{}, len(defs))
+	for i, def := range defs {
+		if err := ValidateDefinition(def); err != nil {
+			return fmt.Errorf("invalid skill at index %d: %w", i, err)
+		}
+		if _, ok := seen[def.Name]; ok {
+			return fmt.Errorf("duplicate skill name %q", def.Name)
+		}
+		seen[def.Name] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateDefinition validates a single skill definition.
+func ValidateDefinition(def Definition) error {
+	name := strings.TrimSpace(def.Name)
+	if name == "" {
+		return errors.New("name is required")
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("name %q must be lowercase alphanumeric with optional '-' or '_'", def.Name)
+	}
+	if strings.TrimSpace(def.SystemPrompt) == "" {
+		return fmt.Errorf("system_prompt is required for %q", def.Name)
+	}
+	if len(def.AllowedTools) == 0 {
+		return fmt.Errorf("allowed_tools must include at least one tool for %q", def.Name)
+	}
+	if len(def.OutputContract.Fields) == 0 {
+		return fmt.Errorf("output_contract.fields must include at least one field for %q", def.Name)
+	}
+	if strings.TrimSpace(def.OutputContract.Format) == "" {
+		return fmt.Errorf("output_contract.format is required for %q", def.Name)
+	}
+	if def.OutputContract.MaxTokens <= 0 {
+		return fmt.Errorf("output_contract.max_tokens must be greater than zero for %q", def.Name)
+	}
+	return nil
+}

--- a/internal/storage/v2/api/tracestore/reader.go
+++ b/internal/storage/v2/api/tracestore/reader.go
@@ -62,6 +62,15 @@ type Reader interface {
 	FindTraceIDs(ctx context.Context, query TraceQueryParams) iter.Seq2[[]FoundTraceID, error]
 }
 
+// SummaryReader is an optional extension implemented by storage backends that
+// can compute trace summaries without loading full trace payloads.
+type SummaryReader interface {
+	// FindTraceSummaries returns lightweight summaries for traces matching query
+	// parameters. It must preserve the same filtering and ordering semantics as
+	// Reader.FindTraces.
+	FindTraceSummaries(ctx context.Context, query TraceQueryParams) iter.Seq2[[]TraceSummary, error]
+}
+
 // GetTraceParams contains single-trace parameters for a GetTraces request.
 // Some storage backends (e.g. Tempo) perform GetTraces much more efficiently
 // if they know the approximate time range of the trace.
@@ -100,6 +109,26 @@ type FoundTraceID struct {
 	TraceID pcommon.TraceID
 	Start   time.Time
 	End     time.Time
+}
+
+// TraceSummary is a compact search-result representation of a trace.
+type TraceSummary struct {
+	TraceID           pcommon.TraceID  `json:"traceID"`
+	RootServiceName   string           `json:"rootServiceName"`
+	RootOperationName string           `json:"rootOperationName"`
+	MinStartTime      time.Time        `json:"minStartTime"`
+	MaxEndTime        time.Time        `json:"maxEndTime"`
+	SpanCount         int              `json:"spanCount"`
+	ErrorSpanCount    int              `json:"errorSpanCount"`
+	OrphanSpanCount   int              `json:"orphanSpanCount"`
+	Services          []ServiceSummary `json:"services"`
+}
+
+// ServiceSummary contains span and error counts for one service in a trace.
+type ServiceSummary struct {
+	Name           string `json:"name"`
+	SpanCount      int    `json:"spanCount"`
+	ErrorSpanCount int    `json:"errorSpanCount"`
 }
 
 // OperationQueryParams contains parameters of query operations, empty spanKind means get operations for all kinds of span.

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics.go
@@ -64,6 +64,11 @@ func buildQueryMetrics(operation string, metricsFactory metrics.Factory) *queryM
 	return qMetrics
 }
 
+// Unwrap returns the underlying reader for optional interface discovery.
+func (m *ReadMetricsDecorator) Unwrap() tracestore.Reader {
+	return m.traceReader
+}
+
 // FindTraces implements tracestore.Reader#FindTraces
 func (m *ReadMetricsDecorator) FindTraces(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
 	return func(yield func([]ptrace.Traces, error) bool) {

--- a/internal/tracesummary/summary.go
+++ b/internal/tracesummary/summary.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracesummary
+
+import (
+	"sort"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/jptrace"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+const serviceNameAttr = "service.name"
+
+// FromTrace derives a compact summary from a single trace.
+func FromTrace(trace ptrace.Traces) tracestore.TraceSummary {
+	var b builder
+	b.services = make(map[string]*tracestore.ServiceSummary)
+	b.spanIDs = make(map[pcommon.SpanID]struct{})
+
+	for _, span := range jptrace.SpanIter(trace) {
+		b.spanIDs[span.SpanID()] = struct{}{}
+	}
+	for pos, span := range jptrace.SpanIter(trace) {
+		b.observeSpan(pos.Resource.Resource().Attributes(), span)
+	}
+
+	return b.build()
+}
+
+type builder struct {
+	summary             tracestore.TraceSummary
+	services            map[string]*tracestore.ServiceSummary
+	spanIDs             map[pcommon.SpanID]struct{}
+	rootSpan            ptrace.Span
+	rootServiceName     string
+	hasRootSpan         bool
+	fallbackSpan        ptrace.Span
+	fallbackServiceName string
+	hasFallbackSpan     bool
+	hasStartTime        bool
+	startTime           time.Time
+	endTime             time.Time
+}
+
+func (b *builder) observeSpan(resourceAttrs pcommon.Map, span ptrace.Span) {
+	serviceName := serviceName(resourceAttrs)
+	if b.summary.TraceID.IsEmpty() {
+		b.summary.TraceID = span.TraceID()
+	}
+	b.summary.SpanCount++
+	if span.Status().Code() == ptrace.StatusCodeError {
+		b.summary.ErrorSpanCount++
+	}
+
+	breakdown := b.services[serviceName]
+	if breakdown == nil {
+		breakdown = &tracestore.ServiceSummary{Name: serviceName}
+		b.services[serviceName] = breakdown
+	}
+	breakdown.SpanCount++
+	if span.Status().Code() == ptrace.StatusCodeError {
+		breakdown.ErrorSpanCount++
+	}
+
+	start := span.StartTimestamp().AsTime()
+	end := span.EndTimestamp().AsTime()
+	if !b.hasStartTime || start.Before(b.startTime) {
+		b.startTime = start
+		b.hasStartTime = true
+	}
+	if end.After(b.endTime) {
+		b.endTime = end
+	}
+
+	if b.isBetterRoot(span) {
+		b.rootSpan = span
+		b.rootServiceName = serviceName
+		b.hasRootSpan = true
+	}
+	if b.isBetterFallback(span) {
+		b.fallbackSpan = span
+		b.fallbackServiceName = serviceName
+		b.hasFallbackSpan = true
+	}
+	if b.isOrphan(span) {
+		b.summary.OrphanSpanCount++
+	}
+}
+
+func (b *builder) isBetterRoot(span ptrace.Span) bool {
+	if !b.isRootCandidate(span) {
+		return false
+	}
+	if !b.hasRootSpan {
+		return true
+	}
+	rootStart := b.rootSpan.StartTimestamp()
+	spanStart := span.StartTimestamp()
+	if spanStart != rootStart {
+		return spanStart < rootStart
+	}
+	return span.SpanID().String() < b.rootSpan.SpanID().String()
+}
+
+func (b *builder) isBetterFallback(span ptrace.Span) bool {
+	if !b.hasFallbackSpan {
+		return true
+	}
+	fallbackStart := b.fallbackSpan.StartTimestamp()
+	spanStart := span.StartTimestamp()
+	if spanStart != fallbackStart {
+		return spanStart < fallbackStart
+	}
+	return span.SpanID().String() < b.fallbackSpan.SpanID().String()
+}
+
+func (b *builder) isRootCandidate(span ptrace.Span) bool {
+	parentSpanID := span.ParentSpanID()
+	if parentSpanID.IsEmpty() {
+		return true
+	}
+	return b.isOrphan(span)
+}
+
+func (b *builder) isOrphan(span ptrace.Span) bool {
+	parentSpanID := span.ParentSpanID()
+	if parentSpanID.IsEmpty() {
+		return false
+	}
+	_, parentInTrace := b.spanIDs[parentSpanID]
+	return !parentInTrace
+}
+
+func (b *builder) build() tracestore.TraceSummary {
+	if b.hasRootSpan {
+		b.summary.RootServiceName = b.rootServiceName
+		b.summary.RootOperationName = b.rootSpan.Name()
+	} else if b.hasFallbackSpan {
+		b.summary.RootServiceName = b.fallbackServiceName
+		b.summary.RootOperationName = b.fallbackSpan.Name()
+	}
+	if b.hasStartTime {
+		b.summary.MinStartTime = b.startTime
+		b.summary.MaxEndTime = b.endTime
+	}
+
+	b.summary.Services = make([]tracestore.ServiceSummary, 0, len(b.services))
+	for _, breakdown := range b.services {
+		b.summary.Services = append(b.summary.Services, *breakdown)
+	}
+	sort.Slice(b.summary.Services, func(i, j int) bool {
+		return b.summary.Services[i].Name < b.summary.Services[j].Name
+	})
+	return b.summary
+}
+
+func serviceName(attrs pcommon.Map) string {
+	if value, ok := attrs.Get(serviceNameAttr); ok {
+		return value.AsString()
+	}
+	return ""
+}

--- a/internal/tracesummary/summary_test.go
+++ b/internal/tracesummary/summary_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracesummary
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+var testTraceID = pcommon.TraceID([16]byte{1})
+
+func TestFromTrace(t *testing.T) {
+	start := time.Unix(10, 0).UTC()
+	trace := ptrace.NewTraces()
+	appendSpan(trace, "frontend", "root", [8]byte{1}, [8]byte{}, start, 20*time.Millisecond, ptrace.StatusCodeUnset)
+	appendSpan(trace, "backend", "child", [8]byte{2}, [8]byte{1}, start.Add(time.Millisecond), 5*time.Millisecond, ptrace.StatusCodeError)
+	appendSpan(trace, "frontend", "child-2", [8]byte{3}, [8]byte{1}, start.Add(2*time.Millisecond), 2*time.Millisecond, ptrace.StatusCodeError)
+
+	summary := FromTrace(trace)
+
+	require.Equal(t, testTraceID, summary.TraceID)
+	assert.Equal(t, "frontend", summary.RootServiceName)
+	assert.Equal(t, "root", summary.RootOperationName)
+	assert.Equal(t, start, summary.MinStartTime)
+	assert.Equal(t, start.Add(20*time.Millisecond), summary.MaxEndTime)
+	assert.Equal(t, 3, summary.SpanCount)
+	assert.Equal(t, 2, summary.ErrorSpanCount)
+	assert.Zero(t, summary.OrphanSpanCount)
+	assert.Equal(t, "backend", summary.Services[0].Name)
+	assert.Equal(t, 1, summary.Services[0].SpanCount)
+	assert.Equal(t, 1, summary.Services[0].ErrorSpanCount)
+	assert.Equal(t, "frontend", summary.Services[1].Name)
+	assert.Equal(t, 2, summary.Services[1].SpanCount)
+	assert.Equal(t, 1, summary.Services[1].ErrorSpanCount)
+}
+
+func TestFromTraceSelectsDeterministicRoot(t *testing.T) {
+	start := time.Unix(10, 0).UTC()
+	trace := ptrace.NewTraces()
+	appendSpan(trace, "svc-b", "root-b", [8]byte{2}, [8]byte{}, start, time.Millisecond, ptrace.StatusCodeUnset)
+	appendSpan(trace, "svc-a", "root-a", [8]byte{1}, [8]byte{}, start, time.Millisecond, ptrace.StatusCodeUnset)
+
+	summary := FromTrace(trace)
+
+	assert.Equal(t, "svc-a", summary.RootServiceName)
+	assert.Equal(t, "root-a", summary.RootOperationName)
+}
+
+func TestFromTraceUsesOrphanAsRootCandidate(t *testing.T) {
+	start := time.Unix(10, 0).UTC()
+	trace := ptrace.NewTraces()
+	appendSpan(trace, "svc", "orphan", [8]byte{1}, [8]byte{9}, start, time.Millisecond, ptrace.StatusCodeUnset)
+
+	summary := FromTrace(trace)
+
+	assert.Equal(t, "svc", summary.RootServiceName)
+	assert.Equal(t, "orphan", summary.RootOperationName)
+	assert.Equal(t, 1, summary.OrphanSpanCount)
+}
+
+func TestFromTraceFallsBackWhenTraceHasNoRoot(t *testing.T) {
+	start := time.Unix(10, 0).UTC()
+	trace := ptrace.NewTraces()
+	appendSpan(trace, "svc-b", "cycle-b", [8]byte{2}, [8]byte{1}, start.Add(time.Millisecond), time.Millisecond, ptrace.StatusCodeUnset)
+	appendSpan(trace, "svc-a", "cycle-a", [8]byte{1}, [8]byte{2}, start, time.Millisecond, ptrace.StatusCodeUnset)
+
+	summary := FromTrace(trace)
+
+	assert.Equal(t, "svc-a", summary.RootServiceName)
+	assert.Equal(t, "cycle-a", summary.RootOperationName)
+	assert.Zero(t, summary.OrphanSpanCount)
+}
+
+func TestFromTraceEmptyTrace(t *testing.T) {
+	summary := FromTrace(ptrace.NewTraces())
+
+	assert.True(t, summary.TraceID.IsEmpty())
+	assert.Zero(t, summary.SpanCount)
+	assert.Empty(t, summary.Services)
+}
+
+func BenchmarkFromTrace(b *testing.B) {
+	trace := ptrace.NewTraces()
+	start := time.Unix(10, 0).UTC()
+	for i := 0; i < 1000; i++ {
+		parentID := [8]byte{1, 0}
+		if i == 0 {
+			parentID = [8]byte{}
+		}
+		status := ptrace.StatusCodeUnset
+		if i%10 == 0 {
+			status = ptrace.StatusCodeError
+		}
+		appendSpan(
+			trace,
+			[]string{"frontend", "backend", "database"}[i%3],
+			"operation",
+			[8]byte{byte(i>>8) + 1, byte(i)},
+			parentID,
+			start.Add(time.Duration(i)*time.Microsecond),
+			time.Millisecond,
+			status,
+		)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = FromTrace(trace)
+	}
+}
+
+func appendSpan(
+	trace ptrace.Traces,
+	serviceName string,
+	operationName string,
+	spanID [8]byte,
+	parentSpanID [8]byte,
+	start time.Time,
+	duration time.Duration,
+	status ptrace.StatusCode,
+) {
+	resourceSpans := trace.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr(serviceNameAttr, serviceName)
+	spans := resourceSpans.ScopeSpans().AppendEmpty().Spans()
+	span := spans.AppendEmpty()
+	span.SetTraceID(testTraceID)
+	span.SetSpanID(pcommon.SpanID(spanID))
+	span.SetParentSpanID(pcommon.SpanID(parentSpanID))
+	span.SetName(operationName)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(start.Add(duration)))
+	span.Status().SetCode(status)
+}


### PR DESCRIPTION
# Summary

Adds an initial backend implementation of the Trace Summary API proposed in ADR-010.

This introduces a lightweight:

`GET /api/v3/trace-summaries`

endpoint that returns compact trace summary metadata instead of full trace payloads.

The goal is to reduce:

* query payload size
* backend memory pressure
* browser memory usage
* client-side aggregation work
* latency for large/high-cardinality traces

This follows the architectural direction discussed in:

* #1051
* #2693
* jaeger-ui#3816
* #8604
* jaeger-ui#3941

---

## What Changed

### New API Endpoint

Added:

`GET /api/v3/trace-summaries`

The endpoint reuses existing trace search parameters and returns lightweight summary objects.

---

### Added `SummaryReader`

Introduced optional:

`tracestore.SummaryReader`

Storage backends capable of native summary aggregation can implement this interface directly.

This is intentionally optional and fully backward compatible.

---

### Added Trace Summary Models

Introduced:

* `tracestore.TraceSummary`
* `tracestore.ServiceSummary`

Current response shape includes:

* `traceID`
* `rootServiceName`
* `rootOperationName`
* `minStartTimeUnixNano`
* `maxEndTimeUnixNano`
* `spanCount`
* `errorSpanCount`
* `orphanSpanCount`
* `services[]`

---

### Added Fallback Aggregation Path

Added reusable fallback aggregation logic in:

`internal/tracesummary`

Behavior:

* uses native `SummaryReader` support when available
* otherwise derives summaries from full traces

The fallback path is designed to:

* avoid duplicated aggregation logic
* keep deterministic behavior
* minimize allocations where practical
* remain reusable for future storage implementations

---

### Query Service Changes

Added:

`QueryService.FindTraceSummaries`

Behavior:

* detects native summary support
* unwraps reader decorators so native implementations are discoverable
* gracefully falls back to trace aggregation when unsupported

---

### Tests Added

Coverage includes:

* deterministic root span selection
* malformed/no-root traces
* orphan spans
* empty traces
* service aggregation
* native summary path
* fallback aggregation path
* HTTP endpoint behavior

---

### Benchmark

Current fallback aggregation benchmark:

```text id="pxvhl8"
BenchmarkFromTrace-12
143627 ns/op
42179 B/op
31 allocs/op
(1,000 span trace)
```

---

## Design Notes

### Backward Compatibility

This change is intentionally non-breaking:

* existing `/api/v3/traces` behavior is unchanged
* `SummaryReader` is optional
* unsupported storage backends transparently fall back to aggregation

---

### Why Fallback Aggregation Exists

Some backends (e.g. Elasticsearch / ClickHouse) can compute summaries natively.

However not all storage backends support this efficiently.

The fallback aggregation path ensures:

* feature parity across storage backends
* incremental adoption
* future optimization flexibility

---

### Deterministic Root Span Selection

Aggregation intentionally uses deterministic root span selection to:

* stabilize API responses
* reduce flaky tests
* ensure reproducible UI behavior

---

## Validation

Validated locally with:

```bash
go test ./internal/tracesummary ./cmd/jaeger/internal/extension/jaegerquery/querysvc ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3 ./internal/storage/v2/ api/tracestore/...
```

Benchmark:

```bash
go test ./internal/tracesummary -bench BenchmarkFromTrace -benchmem -run '^$'
```

Additional validation:

```bash
git diff --check
```

---

## Environment Limitations Encountered

Some repository-wide validation could not complete locally due Windows/toolchain limitations:

* `make fmt`

  * `make` not installed locally

* `golangci-lint`

  * `golangci-lint` not installed locally

* `go test -race -tags=memory_storage_integration ./...`

  * failed due Windows cgo toolchain limitation:
    `cc1.exe: sorry, unimplemented: 64-bit mode not compiled in`

* full integration test suite

  * eventually failed due unrelated Windows-specific temp/disk allocation issues

The targeted packages relevant to this change were validated successfully.

---

## Notes

I intentionally did not modify `jaeger-ui` in this repository because the repository instructions indicate that `jaeger-ui` is managed separately as a submodule.

The backend response shape and API direction were aligned with the ongoing upstream discussions in:

* #8604
* jaeger-ui#3941

---

## Future Follow-Ups

Potential follow-up work:

* native Elasticsearch summary aggregation
* native ClickHouse summary aggregation
* UI migration to consume `/api/v3/trace-summaries`
* payload size comparison benchmarks
* further allocation reductions in fallback aggregation
* pagination optimization for very large result sets
#8606 