### PR TITLE
fix(ci): Stabilize CodeQL check results

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,3 +65,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      with:
+        category: ".github/workflows/codeql.yml:codeql-analyze/language:${{ matrix.language }}"

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -336,7 +336,7 @@ func (r *TraceReader) indexSeeksToTraceIDs(plan *executionPlan, indexSeeks [][]b
 }
 
 func filterIDs(plan *executionPlan, innerIDs [][]byte) []model.TraceID {
-	traces := make([]model.TraceID, 0, plan.limit)
+	traces := make([]model.TraceID, 0)
 
 	items := 0
 	for i := range innerIDs {


### PR DESCRIPTION
## Summary

- set an explicit CodeQL analysis category so reusable workflow uploads match the configuration names GitHub sees on `main`
- avoid preallocating Badger trace ID results with the request-derived search limit that CodeQL flagged as an uncontrolled allocation size

## Root cause

The CodeQL workflow is invoked through the CI orchestrator, so GitHub generated PR analysis categories from `.github/workflows/ci-orchestrator.yml` while the baseline configurations on `main` were recorded under `.github/workflows/codeql.yml`. That produced the "configurations not found" warning even though the Go and Python CodeQL jobs completed successfully.

The same PR check also surfaced a high CodeQL alert in Badger storage because `filterIDs` used `plan.limit`, derived from query input, as the slice capacity.

## Validation

- `make fmt`
- `make lint`
- `make test`
