### PR TITLE
fix(apiv3): Rename query.num_traces to query.search_depth, keep deprecated alias

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -240,11 +240,11 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		searchDepthParam = paramNumTraces
 	}
 	if n != "" {
-		numTraces, err := strconv.Atoi(n)
+		searchDepth, err := strconv.Atoi(n)
 		if h.tryParamError(w, err, searchDepthParam) {
 			return nil, true
 		}
-		queryParams.SearchDepth = numTraces
+		queryParams.SearchDepth = searchDepth
 	}
 
 	if d := q.Get(paramDurationMin); d != "" {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -30,14 +30,17 @@ import (
 )
 
 const (
-	paramTraceID        = "trace_id" // get trace by ID
-	paramStartTime      = "start_time"
-	paramEndTime        = "end_time"
-	paramRawTraces      = "raw_traces"
-	paramServiceName    = "query.service_name" // find traces
-	paramOperationName  = "query.operation_name"
-	paramTimeMin        = "query.start_time_min"
-	paramTimeMax        = "query.start_time_max"
+	paramTraceID       = "trace_id" // get trace by ID
+	paramStartTime     = "start_time"
+	paramEndTime       = "end_time"
+	paramRawTraces     = "raw_traces"
+	paramServiceName   = "query.service_name" // find traces
+	paramOperationName = "query.operation_name"
+	paramTimeMin       = "query.start_time_min"
+	paramTimeMax       = "query.start_time_max"
+	// paramSearchDepth is the canonical name matching the proto field and the future gRPC-gateway generated binding.
+	paramSearchDepth = "query.search_depth"
+	// paramNumTraces is a deprecated alias for paramSearchDepth kept for backwards compatibility.
 	paramNumTraces      = "query.num_traces"
 	paramDurationMin    = "query.duration_min"
 	paramDurationMax    = "query.duration_max"
@@ -230,9 +233,15 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 	queryParams.StartTimeMin = timeMinParsed
 	queryParams.StartTimeMax = timeMaxParsed
 
-	if n := q.Get(paramNumTraces); n != "" {
+	searchDepthParam := paramSearchDepth
+	n := q.Get(paramSearchDepth)
+	if n == "" {
+		n = q.Get(paramNumTraces)
+		searchDepthParam = paramNumTraces
+	}
+	if n != "" {
 		numTraces, err := strconv.Atoi(n)
-		if h.tryParamError(w, err, paramNumTraces) {
+		if h.tryParamError(w, err, searchDepthParam) {
 			return nil, true
 		}
 		queryParams.SearchDepth = numTraces

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -183,6 +183,29 @@ func TestHTTPGatewayFindTracesEmptyResponse(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "No traces found")
 }
 
+// TestHTTPGatewayFindTracesDeprecatedNumTraces verifies that the deprecated
+// query.num_traces alias is accepted as a fallback for query.search_depth.
+func TestHTTPGatewayFindTracesDeprecatedNumTraces(t *testing.T) {
+	q, qp := mockFindQueries()
+	// Replace canonical search_depth with the deprecated num_traces alias.
+	q.Del(paramSearchDepth)
+	q.Set(paramNumTraces, "10")
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	gw := setupHTTPGatewayNoServer(t, "")
+	gw.reader.
+		On("FindTraces", matchContext, qp).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{}, nil)
+		})).Once()
+
+	gw.router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "No traces found")
+}
+
 func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -255,7 +278,7 @@ func mockFindQueries() (url.Values, tracestore.TraceQueryParams) {
 	q.Set(paramTimeMax, time2.Format(time.RFC3339Nano))
 	q.Set(paramDurationMin, "1s")
 	q.Set(paramDurationMax, "2s")
-	q.Set(paramNumTraces, "10")
+	q.Set(paramSearchDepth, "10")
 
 	return q, tracestore.TraceQueryParams{
 		ServiceName:   "foo",
@@ -304,7 +327,12 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 			expErr: paramTimeMax,
 		},
 		{
-			name:   "bad num_traces",
+			name:   "bad search_depth",
+			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramSearchDepth: "NaN"},
+			expErr: paramSearchDepth,
+		},
+		{
+			name:   "bad num_traces (deprecated alias)",
 			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramNumTraces: "NaN"},
 			expErr: paramNumTraces,
 		},


### PR DESCRIPTION
## Summary

- Adds `query.search_depth` as the canonical parameter name for `GET /api/v3/traces` (matches the proto field `TraceQueryParameters.search_depth` and what the future gRPC-gateway binding will generate)
- Keeps `query.num_traces` as a deprecated backwards-compatible alias — existing callers are not broken
- Adds a test case covering the deprecated alias path

## Test plan

- [ ] `GET /api/v3/traces?query.search_depth=20` works (new canonical name)
- [ ] `GET /api/v3/traces?query.num_traces=20` continues to work (deprecated alias)
- [ ] Unit tests pass: `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...`
- [ ] `make lint` and `make test` pass

Fixes #8617

🤖 Generated with [Claude Code](https://claude.com/claude-code)