### PR TITLE
Fix(query): Use camelCase for APIv3 HTTP query parameters

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/gateway_test.go
@@ -131,7 +131,7 @@ func (gw *testGateway) runGatewayGetOperations(t *testing.T) {
 		On("GetOperations", matchContext, qp).
 		Return([]tracestore.Operation{{Name: "get_users", SpanKind: "server"}}, nil).Once()
 
-	body, statusCode := gw.execRequest(t, "/api/v3/operations?service=foo&span_kind=server")
+	body, statusCode := gw.execRequest(t, "/api/v3/operations?service=foo&spanKind=server")
 	require.Equal(t, http.StatusOK, statusCode)
 	body = gw.verifySnapshot(t, body)
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -30,27 +30,53 @@ import (
 )
 
 const (
-	paramTraceID       = "trace_id" // get trace by ID
-	paramStartTime     = "start_time"
-	paramEndTime       = "end_time"
-	paramRawTraces     = "raw_traces"
-	paramServiceName   = "query.service_name" // find traces
-	paramOperationName = "query.operation_name"
-	paramTimeMin       = "query.start_time_min"
-	paramTimeMax       = "query.start_time_max"
-	// paramSearchDepth is the canonical name matching the proto field and the future gRPC-gateway generated binding.
-	paramSearchDepth = "query.search_depth"
-	// paramNumTraces is a deprecated alias for paramSearchDepth kept for backwards compatibility.
-	paramNumTraces      = "query.num_traces"
-	paramDurationMin    = "query.duration_min"
-	paramDurationMax    = "query.duration_max"
-	paramQueryRawTraces = "query.raw_traces"
+	paramTraceID = "trace_id" // get trace by ID (path param, not a query param)
+
+	// Canonical query parameter names use camelCase, matching
+	// the proto3 JSON encoding convention and the OpenAPI spec.
+	paramStartTime      = "startTime"
+	paramEndTime        = "endTime"
+	paramRawTraces      = "rawTraces"
+	paramServiceName    = "query.serviceName"
+	paramOperationName  = "query.operationName"
+	paramTimeMin        = "query.startTimeMin"
+	paramTimeMax        = "query.startTimeMax"
+	paramSearchDepth    = "query.searchDepth"
+	paramDurationMin    = "query.durationMin"
+	paramDurationMax    = "query.durationMax"
+	paramQueryRawTraces = "query.rawTraces"
+	paramSpanKind       = "spanKind"
+
+	// Deprecated snake_case aliases kept for backwards compatibility.
+	// These will be removed in a future release.
+	deprecatedParamStartTime      = "start_time"
+	deprecatedParamEndTime        = "end_time"
+	deprecatedParamRawTraces      = "raw_traces"
+	deprecatedParamServiceName    = "query.service_name"
+	deprecatedParamOperationName  = "query.operation_name"
+	deprecatedParamTimeMin        = "query.start_time_min"
+	deprecatedParamTimeMax        = "query.start_time_max"
+	deprecatedParamSearchDepth    = "query.search_depth"
+	deprecatedParamNumTraces      = "query.num_traces"
+	deprecatedParamDurationMin    = "query.duration_min"
+	deprecatedParamDurationMax    = "query.duration_max"
+	deprecatedParamQueryRawTraces = "query.raw_traces"
+	deprecatedParamSpanKind       = "span_kind"
 
 	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
 	routeFindTraces    = "/api/v3/traces"
 	routeGetServices   = "/api/v3/services"
 	routeGetOperations = "/api/v3/operations"
 )
+
+// getQueryParam retrieves a query parameter by its canonical (camelCase) name,
+// falling back to the deprecated (snake_case) name for backwards compatibility.
+func getQueryParam(q url.Values, canonical, deprecated string) string {
+	if v := q.Get(canonical); v != "" {
+		return v
+	}
+	return q.Get(deprecated)
+}
 
 // HTTPGateway exposes APIv3 HTTP endpoints.
 type HTTPGateway struct {
@@ -167,7 +193,7 @@ func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	http_query := r.URL.Query()
-	startTime := http_query.Get(paramStartTime)
+	startTime := getQueryParam(http_query, paramStartTime, deprecatedParamStartTime)
 	if startTime != "" {
 		timeParsed, err := time.Parse(time.RFC3339Nano, startTime)
 		if h.tryParamError(w, err, paramStartTime) {
@@ -175,7 +201,7 @@ func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 		}
 		request.TraceIDs[0].Start = timeParsed.UTC()
 	}
-	endTime := http_query.Get(paramEndTime)
+	endTime := getQueryParam(http_query, paramEndTime, deprecatedParamEndTime)
 	if endTime != "" {
 		timeParsed, err := time.Parse(time.RFC3339Nano, endTime)
 		if h.tryParamError(w, err, paramEndTime) {
@@ -183,7 +209,7 @@ func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 		}
 		request.TraceIDs[0].End = timeParsed.UTC()
 	}
-	if r := http_query.Get(paramRawTraces); r != "" {
+	if r := getQueryParam(http_query, paramRawTraces, deprecatedParamRawTraces); r != "" {
 		rawTraces, err := strconv.ParseBool(r)
 		if h.tryParamError(w, err, paramRawTraces) {
 			return
@@ -209,14 +235,14 @@ func (h *HTTPGateway) findTraces(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*querysvc.TraceQueryParams, bool) {
 	queryParams := &querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{
-			ServiceName:   q.Get(paramServiceName),
-			OperationName: q.Get(paramOperationName),
+			ServiceName:   getQueryParam(q, paramServiceName, deprecatedParamServiceName),
+			OperationName: getQueryParam(q, paramOperationName, deprecatedParamOperationName),
 			Attributes:    pcommon.NewMap(), // most curiously not supported by grpc-gateway
 		},
 	}
 
-	timeMin := q.Get(paramTimeMin)
-	timeMax := q.Get(paramTimeMax)
+	timeMin := getQueryParam(q, paramTimeMin, deprecatedParamTimeMin)
+	timeMax := getQueryParam(q, paramTimeMax, deprecatedParamTimeMax)
 	if timeMin == "" || timeMax == "" {
 		err := fmt.Errorf("%s and %s are required", paramTimeMin, paramTimeMax)
 		h.tryHandleError(w, err, http.StatusBadRequest)
@@ -234,10 +260,10 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 	queryParams.StartTimeMax = timeMaxParsed
 
 	searchDepthParam := paramSearchDepth
-	n := q.Get(paramSearchDepth)
+	n := getQueryParam(q, paramSearchDepth, deprecatedParamSearchDepth)
 	if n == "" {
-		n = q.Get(paramNumTraces)
-		searchDepthParam = paramNumTraces
+		n = q.Get(deprecatedParamNumTraces)
+		searchDepthParam = deprecatedParamNumTraces
 	}
 	if n != "" {
 		searchDepth, err := strconv.Atoi(n)
@@ -247,21 +273,21 @@ func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) 
 		queryParams.SearchDepth = searchDepth
 	}
 
-	if d := q.Get(paramDurationMin); d != "" {
+	if d := getQueryParam(q, paramDurationMin, deprecatedParamDurationMin); d != "" {
 		dur, err := time.ParseDuration(d)
 		if h.tryParamError(w, err, paramDurationMin) {
 			return nil, true
 		}
 		queryParams.DurationMin = dur
 	}
-	if d := q.Get(paramDurationMax); d != "" {
+	if d := getQueryParam(q, paramDurationMax, deprecatedParamDurationMax); d != "" {
 		dur, err := time.ParseDuration(d)
 		if h.tryParamError(w, err, paramDurationMax) {
 			return nil, true
 		}
 		queryParams.DurationMax = dur
 	}
-	if r := q.Get(paramQueryRawTraces); r != "" {
+	if r := getQueryParam(q, paramQueryRawTraces, deprecatedParamQueryRawTraces); r != "" {
 		rawTraces, err := strconv.ParseBool(r)
 		if h.tryParamError(w, err, paramQueryRawTraces) {
 			return nil, true
@@ -288,7 +314,7 @@ func (h *HTTPGateway) getOperations(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	queryParams := tracestore.OperationQueryParams{
 		ServiceName: query.Get("service"),
-		SpanKind:    query.Get("span_kind"),
+		SpanKind:    getQueryParam(query, paramSpanKind, deprecatedParamSpanKind),
 	}
 	operations, err := h.QueryService.GetOperations(r.Context(), queryParams)
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -110,8 +110,8 @@ func TestHTTPGatewayGetTrace(t *testing.T) {
 		{
 			name: "TestGetTraceWithTimeWindow",
 			params: map[string]string{
-				"start_time": "2000-01-02T12:30:08.999999998Z",
-				"end_time":   "2000-04-05T21:55:16.999999992+08:00",
+				"startTime": "2000-01-02T12:30:08.999999998Z",
+				"endTime":   "2000-04-05T21:55:16.999999992+08:00",
 			},
 			expectedQuery: tracestore.GetTraceParams{
 				TraceID: traceID,
@@ -184,12 +184,12 @@ func TestHTTPGatewayFindTracesEmptyResponse(t *testing.T) {
 }
 
 // TestHTTPGatewayFindTracesDeprecatedNumTraces verifies that the deprecated
-// query.num_traces alias is accepted as a fallback for query.search_depth.
+// query.num_traces alias is accepted as a fallback for query.searchDepth.
 func TestHTTPGatewayFindTracesDeprecatedNumTraces(t *testing.T) {
 	q, qp := mockFindQueries()
-	// Replace canonical search_depth with the deprecated num_traces alias.
+	// Replace canonical searchDepth with the deprecated num_traces alias.
 	q.Del(paramSearchDepth)
-	q.Set(paramNumTraces, "10")
+	q.Set(deprecatedParamNumTraces, "10")
 	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -219,18 +219,23 @@ func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 		},
 		{
 			name:          "TestGetTraceWithInvalidStartTime",
-			requestUrl:    "/api/v3/traces/1?start_time=abc",
-			expectedError: "malformed parameter start_time",
+			requestUrl:    "/api/v3/traces/1?startTime=abc",
+			expectedError: "malformed parameter startTime",
 		},
 		{
 			name:          "TestGetTraceWithInvalidEndTime",
-			requestUrl:    "/api/v3/traces/1?end_time=xyz",
-			expectedError: "malformed parameter end_time",
+			requestUrl:    "/api/v3/traces/1?endTime=xyz",
+			expectedError: "malformed parameter endTime",
 		},
 		{
 			name:          "TestGetTraceWithInvalidRawTraces",
+			requestUrl:    "/api/v3/traces/1?rawTraces=foobar",
+			expectedError: "malformed parameter rawTraces",
+		},
+		{
+			name:          "TestGetTraceWithInvalidDeprecatedRawTraces",
 			requestUrl:    "/api/v3/traces/1?raw_traces=foobar",
-			expectedError: "malformed parameter raw_traces",
+			expectedError: "malformed parameter rawTraces",
 		},
 	}
 
@@ -327,14 +332,14 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 			expErr: paramTimeMax,
 		},
 		{
-			name:   "bad search_depth",
+			name:   "bad searchDepth",
 			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramSearchDepth: "NaN"},
 			expErr: paramSearchDepth,
 		},
 		{
 			name:   "bad num_traces (deprecated alias)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramNumTraces: "NaN"},
-			expErr: paramNumTraces,
+			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, deprecatedParamNumTraces: "NaN"},
+			expErr: deprecatedParamNumTraces,
 		},
 		{
 			name:   "bad min duration",
@@ -353,6 +358,16 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 				paramTimeMax:        goodTime,
 				paramDurationMax:    goodDuration,
 				paramQueryRawTraces: "foobar",
+			},
+			expErr: paramQueryRawTraces,
+		},
+		{
+			name: "bad deprecated raw traces",
+			params: map[string]string{
+				paramTimeMin:                  goodTime,
+				paramTimeMax:                  goodTime,
+				paramDurationMax:              goodDuration,
+				deprecatedParamQueryRawTraces: "foobar",
 			},
 			expErr: paramQueryRawTraces,
 		},
@@ -436,7 +451,7 @@ func TestHTTPGatewayGetOperationsErrors(t *testing.T) {
 		On("GetOperations", matchContext, qp).
 		Return(nil, assert.AnError).Once()
 
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&span_kind=server", http.NoBody)
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&spanKind=server", http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
@@ -456,4 +471,95 @@ func TestHTTPGatewayGetServicesEmptyResponse(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.JSONEq(t, `{"services":[]}`, w.Body.String())
 	gw.reader.AssertExpectations(t)
+}
+
+// TestHTTPGatewayGetTraceDeprecatedSnakeCaseParams verifies that the
+// deprecated snake_case query params (start_time, end_time)
+// are still accepted as a fallback for getTrace.
+func TestHTTPGatewayGetTraceDeprecatedSnakeCaseParams(t *testing.T) {
+	expectedQuery := tracestore.GetTraceParams{
+		TraceID: traceID,
+		Start:   time.Date(2000, time.January, 2, 12, 30, 8, 999999998, time.UTC),
+		End:     time.Date(2000, time.April, 5, 13, 55, 16, 999999992, time.UTC),
+	}
+	gw := setupHTTPGatewayNoServer(t, "")
+	gw.reader.
+		On("GetTraces", matchContext, []tracestore.GetTraceParams{expectedQuery}).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{makeTestTrace()}, nil)
+		})).Once()
+
+	q := url.Values{}
+	q.Set("start_time", "2000-01-02T12:30:08.999999998Z")
+	q.Set("end_time", "2000-04-05T21:55:16.999999992+08:00")
+
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces/1?"+q.Encode(), http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	gw.router.ServeHTTP(w, r)
+	gw.reader.AssertCalled(t, "GetTraces", matchContext, []tracestore.GetTraceParams{expectedQuery})
+}
+
+// TestHTTPGatewayFindTracesDeprecatedSnakeCaseParams verifies that the
+// deprecated snake_case query params are still accepted as a fallback for findTraces.
+func TestHTTPGatewayFindTracesDeprecatedSnakeCaseParams(t *testing.T) {
+	time1 := time.Date(2000, time.January, 2, 12, 30, 8, 999999998, time.UTC)
+	time2 := time.Date(2000, time.April, 5, 13, 55, 16, 999999992, time.UTC)
+	q := url.Values{}
+	q.Set(deprecatedParamServiceName, "foo")
+	q.Set(deprecatedParamOperationName, "bar")
+	q.Set(deprecatedParamTimeMin, time1.Format(time.RFC3339Nano))
+	q.Set(deprecatedParamTimeMax, time2.Format(time.RFC3339Nano))
+	q.Set(deprecatedParamDurationMin, "1s")
+	q.Set(deprecatedParamDurationMax, "2s")
+	q.Set(deprecatedParamSearchDepth, "10")
+
+	qp := tracestore.TraceQueryParams{
+		ServiceName:   "foo",
+		OperationName: "bar",
+		Attributes:    pcommon.NewMap(),
+		StartTimeMin:  time1,
+		StartTimeMax:  time2,
+		DurationMin:   1 * time.Second,
+		DurationMax:   2 * time.Second,
+		SearchDepth:   10,
+	}
+
+	gw := setupHTTPGatewayNoServer(t, "")
+	gw.reader.
+		On("FindTraces", matchContext, qp).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{}, nil)
+		})).Once()
+
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	gw.router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "No traces found")
+}
+
+// TestHTTPGatewayGetOperationsDeprecatedSpanKind verifies that the deprecated
+// span_kind query param is still accepted as a fallback for getOperations.
+func TestHTTPGatewayGetOperationsDeprecatedSpanKind(t *testing.T) {
+	gw := setupHTTPGatewayNoServer(t, "")
+
+	qp := tracestore.OperationQueryParams{ServiceName: "foo", SpanKind: "server"}
+	gw.reader.
+		On("GetOperations", matchContext, qp).
+		Return([]tracestore.Operation{
+			{Name: "get_users", SpanKind: "server"},
+		}, nil).Once()
+
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&span_kind=server", http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	gw.router.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response api_v3.GetOperationsResponse
+	require.NoError(t, jsonpb.Unmarshal(w.Body, &response))
+	require.Len(t, response.Operations, 1)
+	assert.Equal(t, "server", response.Operations[0].SpanKind)
 }


### PR DESCRIPTION
This PR addresses an inconsistency in the `/api/v3` HTTP endpoints where query parameters used `snake_case` while the JSON response bodies used `camelCase`. 

The query parameter handling in `http_gateway.go` has been updated to use `camelCase` by default, aligning with the [proto3 JSON encoding specification](https://protobuf.dev/programming-guides/proto3/#json) and the updated OpenAPI spec (jaegertracing/jaeger-idl#202). 

Deprecated `snake_case` parameters are preserved as fallbacks for backwards compatibility, and comprehensive tests have been added to verify both forms.

Resolves #8619 (2)