### PR TITLE
fix(memory): translate OTel error status to error attribute for indexing

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces.go
@@ -164,7 +164,7 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 
 	// If WithErrors is requested, add error attribute filter
 	if input.WithErrors {
-		attributes.PutStr("error", "true")
+		attributes.PutBool("error", true)
 	}
 
 	return querysvc.TraceQueryParams{

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/search_traces_test.go
@@ -199,7 +199,8 @@ func TestSearchTracesHandler_Handle_WithErrorsFilter(t *testing.T) {
 			// Verify that error attribute filter is added
 			errorAttr, ok := query.Attributes.Get("error")
 			assert.True(t, ok)
-			assert.Equal(t, "true", errorAttr.Str())
+			assert.Equal(t, pcommon.ValueTypeBool, errorAttr.Type())
+			assert.True(t, errorAttr.Bool())
 
 			return func(yield func([]ptrace.Traces, error) bool) {
 				// Return only error traces (simulating storage filtering)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #8553

When the in-memory storage backend ingests OpenTelemetry traces, it was failing to translate `ptrace.StatusCodeError` into the legacy `error=true` attribute tag. Because the `search_traces` API relies on this boolean tag for filtering, OTel error traces were silently dropped from search results. 

## Description of the changes
search_traces.go: Changed attributes.PutStr("error", "true") to attributes.PutBool("error", true) in the buildQuery function.

Why this fixes #8553:
The memory storage backend's validSpan function already correctly translates the legacy error attribute into an OpenTelemetry span.Status().Code() == ptrace.StatusCodeError check. However, it specifically expects the error attribute to be a strictly typed boolean. Because the MCP handler was previously injecting a string ("true"), the memory store's internal attribute validation silently skipped the translation, causing OTel error traces to be dropped. Correcting the data type in the API handler restores the expected behavior without requiring any in-place mutations of the stored telemetry payload.

## How was this change tested?
Test Plan
Context
The memory store's validSpan function correctly translates legacy error queries into OpenTelemetry StatusCode == Error evaluations. However, it requires the attribute to be a strictly typed boolean. The MCP handler was previously injecting a string ("true"), causing the memory store to silently reject the filter.

Reproduction Steps

Initialize Jaeger all-in-one using the in-memory storage backend.

Ingest a standard OpenTelemetry trace payload where a span possesses Status.Code = Error (ensure the legacy boolean attribute "error": true is explicitly omitted from the payload).

Execute a trace search query via the search_traces MCP endpoint (or the UI) with the parameter WithErrors = true.

Before Patch: The API returns 0 results. The string "true" fails strict type validation in validSpan, bypassing the status code evaluation entirely.

After Patch: The API returns the correct error trace. The handler now injects a boolean true, which successfully triggers the OTel status code translation inside the memory store.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)