### PR TITLE
fix(apiv3): Accept camelCase HTTP query params, keep snake_case as deprecated aliases

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/gateway_test.go
@@ -131,7 +131,7 @@ func (gw *testGateway) runGatewayGetOperations(t *testing.T) {
 		On("GetOperations", matchContext, qp).
 		Return([]tracestore.Operation{{Name: "get_users", SpanKind: "server"}}, nil).Once()
 
-	body, statusCode := gw.execRequest(t, "/api/v3/operations?service=foo&span_kind=server")
+	body, statusCode := gw.execRequest(t, "/api/v3/operations?service=foo&spanKind=server")
 	require.Equal(t, http.StatusOK, statusCode)
 	body = gw.verifySnapshot(t, body)
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -8,13 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -27,29 +25,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
-)
-
-const (
-	paramTraceID       = "trace_id" // get trace by ID
-	paramStartTime     = "start_time"
-	paramEndTime       = "end_time"
-	paramRawTraces     = "raw_traces"
-	paramServiceName   = "query.service_name" // find traces
-	paramOperationName = "query.operation_name"
-	paramTimeMin       = "query.start_time_min"
-	paramTimeMax       = "query.start_time_max"
-	// paramSearchDepth is the canonical name matching the proto field and the future gRPC-gateway generated binding.
-	paramSearchDepth = "query.search_depth"
-	// paramNumTraces is a deprecated alias for paramSearchDepth kept for backwards compatibility.
-	paramNumTraces      = "query.num_traces"
-	paramDurationMin    = "query.duration_min"
-	paramDurationMax    = "query.duration_max"
-	paramQueryRawTraces = "query.raw_traces"
-
-	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
-	routeFindTraces    = "/api/v3/traces"
-	routeGetServices   = "/api/v3/services"
-	routeGetOperations = "/api/v3/operations"
 )
 
 // HTTPGateway exposes APIv3 HTTP endpoints.
@@ -166,26 +141,24 @@ func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	}
-	http_query := r.URL.Query()
-	startTime := http_query.Get(paramStartTime)
-	if startTime != "" {
+	q := r.URL.Query()
+	if startTime, paramName := getQueryParam(q, paramStartTime, paramStartTimeDeprecated); startTime != "" {
 		timeParsed, err := time.Parse(time.RFC3339Nano, startTime)
-		if h.tryParamError(w, err, paramStartTime) {
+		if h.tryParamError(w, err, paramName) {
 			return
 		}
 		request.TraceIDs[0].Start = timeParsed.UTC()
 	}
-	endTime := http_query.Get(paramEndTime)
-	if endTime != "" {
+	if endTime, paramName := getQueryParam(q, paramEndTime, paramEndTimeDeprecated); endTime != "" {
 		timeParsed, err := time.Parse(time.RFC3339Nano, endTime)
-		if h.tryParamError(w, err, paramEndTime) {
+		if h.tryParamError(w, err, paramName) {
 			return
 		}
 		request.TraceIDs[0].End = timeParsed.UTC()
 	}
-	if r := http_query.Get(paramRawTraces); r != "" {
-		rawTraces, err := strconv.ParseBool(r)
-		if h.tryParamError(w, err, paramRawTraces) {
+	if rawStr, paramName := getQueryParam(q, paramRawTraces, paramRawTracesDeprecated); rawStr != "" {
+		rawTraces, err := strconv.ParseBool(rawStr)
+		if h.tryParamError(w, err, paramName) {
 			return
 		}
 		request.RawTraces = rawTraces
@@ -206,71 +179,6 @@ func (h *HTTPGateway) findTraces(w http.ResponseWriter, r *http.Request) {
 	h.returnTraces(traces, err, w)
 }
 
-func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*querysvc.TraceQueryParams, bool) {
-	queryParams := &querysvc.TraceQueryParams{
-		TraceQueryParams: tracestore.TraceQueryParams{
-			ServiceName:   q.Get(paramServiceName),
-			OperationName: q.Get(paramOperationName),
-			Attributes:    pcommon.NewMap(), // most curiously not supported by grpc-gateway
-		},
-	}
-
-	timeMin := q.Get(paramTimeMin)
-	timeMax := q.Get(paramTimeMax)
-	if timeMin == "" || timeMax == "" {
-		err := fmt.Errorf("%s and %s are required", paramTimeMin, paramTimeMax)
-		h.tryHandleError(w, err, http.StatusBadRequest)
-		return nil, true
-	}
-	timeMinParsed, err := time.Parse(time.RFC3339Nano, timeMin)
-	if h.tryParamError(w, err, paramTimeMin) {
-		return nil, true
-	}
-	timeMaxParsed, err := time.Parse(time.RFC3339Nano, timeMax)
-	if h.tryParamError(w, err, paramTimeMax) {
-		return nil, true
-	}
-	queryParams.StartTimeMin = timeMinParsed
-	queryParams.StartTimeMax = timeMaxParsed
-
-	searchDepthParam := paramSearchDepth
-	n := q.Get(paramSearchDepth)
-	if n == "" {
-		n = q.Get(paramNumTraces)
-		searchDepthParam = paramNumTraces
-	}
-	if n != "" {
-		searchDepth, err := strconv.Atoi(n)
-		if h.tryParamError(w, err, searchDepthParam) {
-			return nil, true
-		}
-		queryParams.SearchDepth = searchDepth
-	}
-
-	if d := q.Get(paramDurationMin); d != "" {
-		dur, err := time.ParseDuration(d)
-		if h.tryParamError(w, err, paramDurationMin) {
-			return nil, true
-		}
-		queryParams.DurationMin = dur
-	}
-	if d := q.Get(paramDurationMax); d != "" {
-		dur, err := time.ParseDuration(d)
-		if h.tryParamError(w, err, paramDurationMax) {
-			return nil, true
-		}
-		queryParams.DurationMax = dur
-	}
-	if r := q.Get(paramQueryRawTraces); r != "" {
-		rawTraces, err := strconv.ParseBool(r)
-		if h.tryParamError(w, err, paramQueryRawTraces) {
-			return nil, true
-		}
-		queryParams.RawTraces = rawTraces
-	}
-	return queryParams, false
-}
-
 func (h *HTTPGateway) getServices(w http.ResponseWriter, r *http.Request) {
 	services, err := h.QueryService.GetServices(r.Context())
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {
@@ -285,10 +193,11 @@ func (h *HTTPGateway) getServices(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPGateway) getOperations(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query()
+	q := r.URL.Query()
+	spanKind, _ := getQueryParam(q, paramSpanKind, paramSpanKindDeprecated)
 	queryParams := tracestore.OperationQueryParams{
-		ServiceName: query.Get("service"),
-		SpanKind:    query.Get("span_kind"),
+		ServiceName: q.Get("service"),
+		SpanKind:    spanKind,
 	}
 	operations, err := h.QueryService.GetOperations(r.Context(), queryParams)
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -5,7 +5,6 @@ package apiv3
 
 import (
 	"errors"
-	"fmt"
 	"iter"
 	"net/http"
 	"net/http/httptest"
@@ -110,8 +109,8 @@ func TestHTTPGatewayGetTrace(t *testing.T) {
 		{
 			name: "camelCase time window",
 			params: map[string]string{
-				paramStartTime: "2000-01-02T12:30:08.999999998Z",
-				paramEndTime:   "2000-04-05T21:55:16.999999992+08:00",
+				"startTime": "2000-01-02T12:30:08.999999998Z",
+				"endTime":   "2000-04-05T21:55:16.999999992+08:00",
 			},
 			expectedQuery: tracestore.GetTraceParams{
 				TraceID: traceID,
@@ -122,8 +121,8 @@ func TestHTTPGatewayGetTrace(t *testing.T) {
 		{
 			name: "deprecated snake_case time window",
 			params: map[string]string{
-				paramStartTimeDeprecated: "2000-01-02T12:30:08.999999998Z",
-				paramEndTimeDeprecated:   "2000-04-05T21:55:16.999999992+08:00",
+				"start_time": "2000-01-02T12:30:08.999999998Z",
+				"end_time":   "2000-04-05T21:55:16.999999992+08:00",
 			},
 			expectedQuery: tracestore.GetTraceParams{
 				TraceID: traceID,
@@ -203,13 +202,13 @@ func TestHTTPGatewayFindTracesDeprecatedParams(t *testing.T) {
 	time1 := qp.StartTimeMin
 	time2 := qp.StartTimeMax
 	q := url.Values{}
-	q.Set(paramServiceNameDeprecated, "foo")
-	q.Set(paramOperationNameDeprecated, "bar")
-	q.Set(paramTimeMinDeprecated, time1.Format(time.RFC3339Nano))
-	q.Set(paramTimeMaxDeprecated, time2.Format(time.RFC3339Nano))
-	q.Set(paramDurationMinDeprecated, "1s")
-	q.Set(paramDurationMaxDeprecated, "2s")
-	q.Set(paramSearchDepthDeprecated, "10")
+	q.Set("query.service_name", "foo")
+	q.Set("query.operation_name", "bar")
+	q.Set("query.start_time_min", time1.Format(time.RFC3339Nano))
+	q.Set("query.start_time_max", time2.Format(time.RFC3339Nano))
+	q.Set("query.duration_min", "1s")
+	q.Set("query.duration_max", "2s")
+	q.Set("query.search_depth", "10")
 
 	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
 	require.NoError(t, err)
@@ -232,8 +231,8 @@ func TestHTTPGatewayFindTracesDeprecatedParams(t *testing.T) {
 func TestHTTPGatewayFindTracesDeprecatedNumTraces(t *testing.T) {
 	q, qp := mockFindQueries()
 	// Replace canonical searchDepth with the deprecated num_traces alias.
-	q.Del(paramSearchDepth)
-	q.Set(paramNumTraces, "10")
+	q.Del("query.searchDepth")
+	q.Set("query.num_traces", "10")
 	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -331,13 +330,13 @@ func mockFindQueries() (url.Values, tracestore.TraceQueryParams) {
 	time1 := time.Now().UTC().Truncate(time.Nanosecond)
 	time2 := time1.Add(-time.Second).UTC().Truncate(time.Nanosecond)
 	q := url.Values{}
-	q.Set(paramServiceName, "foo")
-	q.Set(paramOperationName, "bar")
-	q.Set(paramTimeMin, time1.Format(time.RFC3339Nano))
-	q.Set(paramTimeMax, time2.Format(time.RFC3339Nano))
-	q.Set(paramDurationMin, "1s")
-	q.Set(paramDurationMax, "2s")
-	q.Set(paramSearchDepth, "10")
+	q.Set("query.serviceName", "foo")
+	q.Set("query.operationName", "bar")
+	q.Set("query.startTimeMin", time1.Format(time.RFC3339Nano))
+	q.Set("query.startTimeMax", time2.Format(time.RFC3339Nano))
+	q.Set("query.durationMin", "1s")
+	q.Set("query.durationMax", "2s")
+	q.Set("query.searchDepth", "10")
 
 	return q, tracestore.TraceQueryParams{
 		ServiceName:   "foo",
@@ -355,7 +354,7 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 	goodTimeV := time.Now()
 	goodTime := goodTimeV.Format(time.RFC3339Nano)
 	goodDuration := "1s"
-	timeRangeErr := fmt.Sprintf("%s and %s are required", paramTimeMin, paramTimeMax)
+	timeRangeErr := "query.startTimeMin and query.startTimeMax are required"
 	testCases := []struct {
 		name   string
 		params map[string]string
@@ -367,88 +366,88 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 		},
 		{
 			name:   "no max time",
-			params: map[string]string{paramTimeMin: goodTime},
+			params: map[string]string{"query.startTimeMin": goodTime},
 			expErr: timeRangeErr,
 		},
 		{
 			name:   "no min time",
-			params: map[string]string{paramTimeMax: goodTime},
+			params: map[string]string{"query.startTimeMax": goodTime},
 			expErr: timeRangeErr,
 		},
 		{
 			name:   "bad startTimeMin (canonical)",
-			params: map[string]string{paramTimeMin: "NaN", paramTimeMax: goodTime},
-			expErr: paramTimeMin,
+			params: map[string]string{"query.startTimeMin": "NaN", "query.startTimeMax": goodTime},
+			expErr: "query.startTimeMin",
 		},
 		{
 			name:   "bad start_time_min (deprecated)",
-			params: map[string]string{paramTimeMinDeprecated: "NaN", paramTimeMaxDeprecated: goodTime},
-			expErr: paramTimeMinDeprecated,
+			params: map[string]string{"query.start_time_min": "NaN", "query.start_time_max": goodTime},
+			expErr: "query.start_time_min",
 		},
 		{
 			name:   "bad startTimeMax (canonical)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: "NaN"},
-			expErr: paramTimeMax,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": "NaN"},
+			expErr: "query.startTimeMax",
 		},
 		{
 			name:   "bad start_time_max (deprecated)",
-			params: map[string]string{paramTimeMinDeprecated: goodTime, paramTimeMaxDeprecated: "NaN"},
-			expErr: paramTimeMaxDeprecated,
+			params: map[string]string{"query.start_time_min": goodTime, "query.start_time_max": "NaN"},
+			expErr: "query.start_time_max",
 		},
 		{
 			name:   "bad searchDepth (canonical)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramSearchDepth: "NaN"},
-			expErr: paramSearchDepth,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": goodTime, "query.searchDepth": "NaN"},
+			expErr: "query.searchDepth",
 		},
 		{
 			name:   "bad search_depth (deprecated)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramSearchDepthDeprecated: "NaN"},
-			expErr: paramSearchDepthDeprecated,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": goodTime, "query.search_depth": "NaN"},
+			expErr: "query.search_depth",
 		},
 		{
 			name:   "bad num_traces (deprecated alias)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramNumTraces: "NaN"},
-			expErr: paramNumTraces,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": goodTime, "query.num_traces": "NaN"},
+			expErr: "query.num_traces",
 		},
 		{
 			name:   "bad durationMin (canonical)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMin: "NaN"},
-			expErr: paramDurationMin,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": goodTime, "query.durationMin": "NaN"},
+			expErr: "query.durationMin",
 		},
 		{
 			name:   "bad duration_min (deprecated)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMinDeprecated: "NaN"},
-			expErr: paramDurationMinDeprecated,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": goodTime, "query.duration_min": "NaN"},
+			expErr: "query.duration_min",
 		},
 		{
 			name:   "bad durationMax (canonical)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMax: "NaN"},
-			expErr: paramDurationMax,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": goodTime, "query.durationMax": "NaN"},
+			expErr: "query.durationMax",
 		},
 		{
 			name:   "bad duration_max (deprecated)",
-			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMaxDeprecated: "NaN"},
-			expErr: paramDurationMaxDeprecated,
+			params: map[string]string{"query.startTimeMin": goodTime, "query.startTimeMax": goodTime, "query.duration_max": "NaN"},
+			expErr: "query.duration_max",
 		},
 		{
 			name: "bad rawTraces (canonical)",
 			params: map[string]string{
-				paramTimeMin:        goodTime,
-				paramTimeMax:        goodTime,
-				paramDurationMax:    goodDuration,
-				paramQueryRawTraces: "foobar",
+				"query.startTimeMin": goodTime,
+				"query.startTimeMax": goodTime,
+				"query.durationMax":  goodDuration,
+				"query.rawTraces":    "foobar",
 			},
-			expErr: paramQueryRawTraces,
+			expErr: "query.rawTraces",
 		},
 		{
 			name: "bad raw_traces (deprecated)",
 			params: map[string]string{
-				paramTimeMin:                  goodTime,
-				paramTimeMax:                  goodTime,
-				paramDurationMaxDeprecated:    goodDuration,
-				paramQueryRawTracesDeprecated: "foobar",
+				"query.startTimeMin": goodTime,
+				"query.startTimeMax": goodTime,
+				"query.duration_max": goodDuration,
+				"query.raw_traces":   "foobar",
 			},
-			expErr: paramQueryRawTracesDeprecated,
+			expErr: "query.raw_traces",
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -101,17 +101,29 @@ func TestHTTPGatewayGetTrace(t *testing.T) {
 		expectedQuery tracestore.GetTraceParams
 	}{
 		{
-			name:   "TestGetTrace",
+			name:   "no params",
 			params: map[string]string{},
 			expectedQuery: tracestore.GetTraceParams{
 				TraceID: traceID,
 			},
 		},
 		{
-			name: "TestGetTraceWithTimeWindow",
+			name: "camelCase time window",
 			params: map[string]string{
-				"start_time": "2000-01-02T12:30:08.999999998Z",
-				"end_time":   "2000-04-05T21:55:16.999999992+08:00",
+				paramStartTime: "2000-01-02T12:30:08.999999998Z",
+				paramEndTime:   "2000-04-05T21:55:16.999999992+08:00",
+			},
+			expectedQuery: tracestore.GetTraceParams{
+				TraceID: traceID,
+				Start:   time.Date(2000, time.January, 2, 12, 30, 8, 999999998, time.UTC),
+				End:     time.Date(2000, time.April, 5, 13, 55, 16, 999999992, time.UTC),
+			},
+		},
+		{
+			name: "deprecated snake_case time window",
+			params: map[string]string{
+				paramStartTimeDeprecated: "2000-01-02T12:30:08.999999998Z",
+				paramEndTimeDeprecated:   "2000-04-05T21:55:16.999999992+08:00",
 			},
 			expectedQuery: tracestore.GetTraceParams{
 				TraceID: traceID,
@@ -183,11 +195,43 @@ func TestHTTPGatewayFindTracesEmptyResponse(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "No traces found")
 }
 
+// TestHTTPGatewayFindTracesDeprecatedParams verifies that deprecated snake_case query params
+// are accepted as fallbacks for the canonical camelCase params.
+func TestHTTPGatewayFindTracesDeprecatedParams(t *testing.T) {
+	_, qp := mockFindQueries()
+	// Build query using deprecated snake_case param names.
+	time1 := qp.StartTimeMin
+	time2 := qp.StartTimeMax
+	q := url.Values{}
+	q.Set(paramServiceNameDeprecated, "foo")
+	q.Set(paramOperationNameDeprecated, "bar")
+	q.Set(paramTimeMinDeprecated, time1.Format(time.RFC3339Nano))
+	q.Set(paramTimeMaxDeprecated, time2.Format(time.RFC3339Nano))
+	q.Set(paramDurationMinDeprecated, "1s")
+	q.Set(paramDurationMaxDeprecated, "2s")
+	q.Set(paramSearchDepthDeprecated, "10")
+
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	gw := setupHTTPGatewayNoServer(t, "")
+	gw.reader.
+		On("FindTraces", matchContext, qp).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{}, nil)
+		})).Once()
+
+	gw.router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "No traces found")
+}
+
 // TestHTTPGatewayFindTracesDeprecatedNumTraces verifies that the deprecated
-// query.num_traces alias is accepted as a fallback for query.search_depth.
+// query.num_traces alias is accepted as a fallback for query.searchDepth.
 func TestHTTPGatewayFindTracesDeprecatedNumTraces(t *testing.T) {
 	q, qp := mockFindQueries()
-	// Replace canonical search_depth with the deprecated num_traces alias.
+	// Replace canonical searchDepth with the deprecated num_traces alias.
 	q.Del(paramSearchDepth)
 	q.Set(paramNumTraces, "10")
 	r, err := http.NewRequest(http.MethodGet, "/api/v3/traces?"+q.Encode(), http.NoBody)
@@ -213,22 +257,37 @@ func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:          "TestGetTrace",
+			name:          "bad trace ID",
 			requestUrl:    "/api/v3/traces/xyz",
 			expectedError: "malformed parameter trace_id",
 		},
 		{
-			name:          "TestGetTraceWithInvalidStartTime",
+			name:          "invalid startTime (canonical)",
+			requestUrl:    "/api/v3/traces/1?startTime=abc",
+			expectedError: "malformed parameter startTime",
+		},
+		{
+			name:          "invalid start_time (deprecated)",
 			requestUrl:    "/api/v3/traces/1?start_time=abc",
 			expectedError: "malformed parameter start_time",
 		},
 		{
-			name:          "TestGetTraceWithInvalidEndTime",
+			name:          "invalid endTime (canonical)",
+			requestUrl:    "/api/v3/traces/1?endTime=xyz",
+			expectedError: "malformed parameter endTime",
+		},
+		{
+			name:          "invalid end_time (deprecated)",
 			requestUrl:    "/api/v3/traces/1?end_time=xyz",
 			expectedError: "malformed parameter end_time",
 		},
 		{
-			name:          "TestGetTraceWithInvalidRawTraces",
+			name:          "invalid rawTraces (canonical)",
+			requestUrl:    "/api/v3/traces/1?rawTraces=foobar",
+			expectedError: "malformed parameter rawTraces",
+		},
+		{
+			name:          "invalid raw_traces (deprecated)",
 			requestUrl:    "/api/v3/traces/1?raw_traces=foobar",
 			expectedError: "malformed parameter raw_traces",
 		},
@@ -317,19 +376,34 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 			expErr: timeRangeErr,
 		},
 		{
-			name:   "bax min time",
+			name:   "bad startTimeMin (canonical)",
 			params: map[string]string{paramTimeMin: "NaN", paramTimeMax: goodTime},
 			expErr: paramTimeMin,
 		},
 		{
-			name:   "bax max time",
+			name:   "bad start_time_min (deprecated)",
+			params: map[string]string{paramTimeMinDeprecated: "NaN", paramTimeMaxDeprecated: goodTime},
+			expErr: paramTimeMinDeprecated,
+		},
+		{
+			name:   "bad startTimeMax (canonical)",
 			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: "NaN"},
 			expErr: paramTimeMax,
 		},
 		{
-			name:   "bad search_depth",
+			name:   "bad start_time_max (deprecated)",
+			params: map[string]string{paramTimeMinDeprecated: goodTime, paramTimeMaxDeprecated: "NaN"},
+			expErr: paramTimeMaxDeprecated,
+		},
+		{
+			name:   "bad searchDepth (canonical)",
 			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramSearchDepth: "NaN"},
 			expErr: paramSearchDepth,
+		},
+		{
+			name:   "bad search_depth (deprecated)",
+			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramSearchDepthDeprecated: "NaN"},
+			expErr: paramSearchDepthDeprecated,
 		},
 		{
 			name:   "bad num_traces (deprecated alias)",
@@ -337,17 +411,27 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 			expErr: paramNumTraces,
 		},
 		{
-			name:   "bad min duration",
+			name:   "bad durationMin (canonical)",
 			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMin: "NaN"},
 			expErr: paramDurationMin,
 		},
 		{
-			name:   "bad max duration",
+			name:   "bad duration_min (deprecated)",
+			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMinDeprecated: "NaN"},
+			expErr: paramDurationMinDeprecated,
+		},
+		{
+			name:   "bad durationMax (canonical)",
 			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMax: "NaN"},
 			expErr: paramDurationMax,
 		},
 		{
-			name: "bad raw traces",
+			name:   "bad duration_max (deprecated)",
+			params: map[string]string{paramTimeMin: goodTime, paramTimeMax: goodTime, paramDurationMaxDeprecated: "NaN"},
+			expErr: paramDurationMaxDeprecated,
+		},
+		{
+			name: "bad rawTraces (canonical)",
 			params: map[string]string{
 				paramTimeMin:        goodTime,
 				paramTimeMax:        goodTime,
@@ -355,6 +439,16 @@ func TestHTTPGatewayFindTracesErrors(t *testing.T) {
 				paramQueryRawTraces: "foobar",
 			},
 			expErr: paramQueryRawTraces,
+		},
+		{
+			name: "bad raw_traces (deprecated)",
+			params: map[string]string{
+				paramTimeMin:                  goodTime,
+				paramTimeMax:                  goodTime,
+				paramDurationMaxDeprecated:    goodDuration,
+				paramQueryRawTracesDeprecated: "foobar",
+			},
+			expErr: paramQueryRawTracesDeprecated,
 		},
 	}
 	for _, tc := range testCases {
@@ -434,11 +528,19 @@ func TestHTTPGatewayGetOperationsErrors(t *testing.T) {
 	qp := tracestore.OperationQueryParams{ServiceName: "foo", SpanKind: "server"}
 	gw.reader.
 		On("GetOperations", matchContext, qp).
-		Return(nil, assert.AnError).Once()
+		Return(nil, assert.AnError).Twice()
 
-	r, err := http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&span_kind=server", http.NoBody)
+	// canonical camelCase
+	r, err := http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&spanKind=server", http.NoBody)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
+	gw.router.ServeHTTP(w, r)
+	assert.Contains(t, w.Body.String(), assert.AnError.Error())
+
+	// deprecated snake_case
+	r, err = http.NewRequest(http.MethodGet, "/api/v3/operations?service=foo&span_kind=server", http.NoBody)
+	require.NoError(t, err)
+	w = httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
 	assert.Contains(t, w.Body.String(), assert.AnError.Error())
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package apiv3
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+)
+
+const (
+	paramTraceID = "trace_id" // path parameter
+
+	// Canonical camelCase query params matching proto3 JSON encoding.
+	paramStartTime      = "startTime"
+	paramEndTime        = "endTime"
+	paramRawTraces      = "rawTraces"
+	paramServiceName    = "query.serviceName"
+	paramOperationName  = "query.operationName"
+	paramTimeMin        = "query.startTimeMin"
+	paramTimeMax        = "query.startTimeMax"
+	paramSearchDepth    = "query.searchDepth"
+	paramDurationMin    = "query.durationMin"
+	paramDurationMax    = "query.durationMax"
+	paramQueryRawTraces = "query.rawTraces"
+	paramSpanKind       = "spanKind"
+
+	// Deprecated snake_case aliases kept for backward compatibility.
+	paramStartTimeDeprecated      = "start_time"
+	paramEndTimeDeprecated        = "end_time"
+	paramRawTracesDeprecated      = "raw_traces"
+	paramServiceNameDeprecated    = "query.service_name"
+	paramOperationNameDeprecated  = "query.operation_name"
+	paramTimeMinDeprecated        = "query.start_time_min"
+	paramTimeMaxDeprecated        = "query.start_time_max"
+	paramSearchDepthDeprecated    = "query.search_depth"
+	paramNumTraces                = "query.num_traces" // deprecated alias for paramSearchDepth
+	paramDurationMinDeprecated    = "query.duration_min"
+	paramDurationMaxDeprecated    = "query.duration_max"
+	paramQueryRawTracesDeprecated = "query.raw_traces"
+	paramSpanKindDeprecated       = "span_kind"
+
+	routeGetTrace      = "/api/v3/traces/{" + paramTraceID + "}"
+	routeFindTraces    = "/api/v3/traces"
+	routeGetServices   = "/api/v3/services"
+	routeGetOperations = "/api/v3/operations"
+)
+
+// getQueryParam returns the value and effective param name, preferring the canonical name
+// and falling back to the deprecated alias.
+func getQueryParam(q url.Values, canonical, deprecated string) (value string, paramName string) {
+	if v := q.Get(canonical); v != "" {
+		return v, canonical
+	}
+	return q.Get(deprecated), deprecated
+}
+
+func (h *HTTPGateway) parseFindTracesQuery(q url.Values, w http.ResponseWriter) (*querysvc.TraceQueryParams, bool) {
+	serviceName, _ := getQueryParam(q, paramServiceName, paramServiceNameDeprecated)
+	operationName, _ := getQueryParam(q, paramOperationName, paramOperationNameDeprecated)
+	queryParams := &querysvc.TraceQueryParams{
+		TraceQueryParams: tracestore.TraceQueryParams{
+			ServiceName:   serviceName,
+			OperationName: operationName,
+			Attributes:    pcommon.NewMap(), // most curiously not supported by grpc-gateway
+		},
+	}
+
+	timeMinStr, timeMinParam := getQueryParam(q, paramTimeMin, paramTimeMinDeprecated)
+	timeMaxStr, timeMaxParam := getQueryParam(q, paramTimeMax, paramTimeMaxDeprecated)
+	if timeMinStr == "" || timeMaxStr == "" {
+		err := fmt.Errorf("%s and %s are required", paramTimeMin, paramTimeMax)
+		h.tryHandleError(w, err, http.StatusBadRequest)
+		return nil, true
+	}
+	timeMinParsed, err := time.Parse(time.RFC3339Nano, timeMinStr)
+	if h.tryParamError(w, err, timeMinParam) {
+		return nil, true
+	}
+	timeMaxParsed, err := time.Parse(time.RFC3339Nano, timeMaxStr)
+	if h.tryParamError(w, err, timeMaxParam) {
+		return nil, true
+	}
+	queryParams.StartTimeMin = timeMinParsed
+	queryParams.StartTimeMax = timeMaxParsed
+
+	n, searchDepthParam := getQueryParam(q, paramSearchDepth, paramSearchDepthDeprecated)
+	if n == "" {
+		n = q.Get(paramNumTraces)
+		searchDepthParam = paramNumTraces
+	}
+	if n != "" {
+		searchDepth, err := strconv.Atoi(n)
+		if h.tryParamError(w, err, searchDepthParam) {
+			return nil, true
+		}
+		queryParams.SearchDepth = searchDepth
+	}
+
+	if d, paramName := getQueryParam(q, paramDurationMin, paramDurationMinDeprecated); d != "" {
+		dur, err := time.ParseDuration(d)
+		if h.tryParamError(w, err, paramName) {
+			return nil, true
+		}
+		queryParams.DurationMin = dur
+	}
+	if d, paramName := getQueryParam(q, paramDurationMax, paramDurationMaxDeprecated); d != "" {
+		dur, err := time.ParseDuration(d)
+		if h.tryParamError(w, err, paramName) {
+			return nil, true
+		}
+		queryParams.DurationMax = dur
+	}
+	if r, paramName := getQueryParam(q, paramQueryRawTraces, paramQueryRawTracesDeprecated); r != "" {
+		rawTraces, err := strconv.ParseBool(r)
+		if h.tryParamError(w, err, paramName) {
+			return nil, true
+		}
+		queryParams.RawTraces = rawTraces
+	}
+	return queryParams, false
+}


### PR DESCRIPTION
## Summary

Part 2 of #8619.

- Moves all query param constants and `parseFindTracesQuery` into a new `query_parser.go`
- Canonical param names are now camelCase (e.g. `query.serviceName`, `startTime`, `spanKind`) matching proto3 JSON encoding convention used by gRPC-gateway
- All previous snake_case names (`query.service_name`, `start_time`, `span_kind`, etc.) are kept as deprecated fallbacks via a `getQueryParam` helper that prefers the canonical name
- `query.num_traces` remains a deprecated alias for `query.searchDepth` (on top of the snake_case alias `query.search_depth`)

No response body changes — the server already returns camelCase via `jsonpb.Marshaler`.

## Test plan

- [ ] All existing tests pass
- [ ] New `TestHTTPGatewayFindTracesDeprecatedParams` verifies all snake_case fallbacks for FindTraces
- [ ] `TestHTTPGatewayGetTrace` has canonical + deprecated subtests for time window params
- [ ] `TestHTTPGatewayGetOperationsErrors` tests both `spanKind` (canonical) and `span_kind` (deprecated)
- [ ] Error messages include the actual param name used (canonical or deprecated), so clients get actionable feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)