### PR TITLE
fix(monitoring): migrate static alert rules to Jaeger v2 metrics

### DIFF
--- a/monitoring/jaeger-mixin/prometheus_alerts.yml
+++ b/monitoring/jaeger-mixin/prometheus_alerts.yml
@@ -4,59 +4,19 @@
 "groups":
 - "name": "jaeger_alerts"
   "rules":
-  - "alert": "JaegerHTTPServerErrs"
-    "annotations":
-      "message": |
-        {{ $labels.job }} {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% HTTP errors.
-    "expr": "100 * sum(rate(jaeger_agent_http_server_errors_total[1m])) by (instance, job, namespace) / sum(rate(jaeger_agent_http_server_total[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerRPCRequestsErrors"
-    "annotations":
-      "message": |
-        {{ $labels.job }} {{ $labels.instance }} is experiencing {{ printf "%.2f" $value }}% RPC HTTP errors.
-    "expr": "100 * sum(rate(jaeger_client_jaeger_rpc_http_requests{status_code=~\"4xx|5xx\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_client_jaeger_rpc_http_requests[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerClientSpansDropped"
-    "annotations":
-      "message": |
-        service {{ $labels.job }} {{ $labels.instance }} is dropping {{ printf "%.2f" $value }}% spans.
-    "expr": "100 * sum(rate(jaeger_reporter_spans{result=~\"dropped|err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_reporter_spans[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerAgentSpansDropped"
-    "annotations":
-      "message": |
-        agent {{ $labels.job }} {{ $labels.instance }} is dropping {{ printf "%.2f" $value }}% spans.
-    "expr": "100 * sum(rate(jaeger_agent_reporter_batches_failures_total[1m])) by (instance, job, namespace) / sum(rate(jaeger_agent_reporter_batches_submitted_total[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
   - "alert": "JaegerCollectorDroppingSpans"
     "annotations":
       "message": |
-        collector {{ $labels.job }} {{ $labels.instance }} is dropping {{ printf "%.2f" $value }}% spans.
-    "expr": "100 * sum(rate(jaeger_collector_spans_dropped_total[1m])) by (instance, job, namespace) / sum(rate(jaeger_collector_spans_received_total[1m])) by (instance, job, namespace)> 1"
+        {{ $labels.job }} {{ $labels.instance }} receiver {{ $labels.receiver }} transport {{ $labels.transport }} is refusing {{ printf "%.2f" $value }}% of received spans.
+    "expr": "100 * sum(rate(otelcol_receiver_refused_spans_total[1m]) or 0 * rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport) / (sum(rate(otelcol_receiver_accepted_spans_total[1m]) or 0 * rate(otelcol_receiver_refused_spans_total[1m])) by (instance, job, namespace, receiver, transport) + sum(rate(otelcol_receiver_refused_spans_total[1m]) or 0 * rate(otelcol_receiver_accepted_spans_total[1m])) by (instance, job, namespace, receiver, transport)) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"
-  - "alert": "JaegerSamplingUpdateFailing"
+  - "alert": "JaegerExporterFailingSpans"
     "annotations":
       "message": |
-        {{ $labels.job }} {{ $labels.instance }} is failing {{ printf "%.2f" $value }}% in updating sampling policies.
-    "expr": "100 * sum(rate(jaeger_sampler_queries{result=\"err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_sampler_queries[1m])) by (instance, job, namespace)> 1"
-    "for": "15m"
-    "labels":
-      "severity": "warning"
-  - "alert": "JaegerThrottlingUpdateFailing"
-    "annotations":
-      "message": |
-        {{ $labels.job }} {{ $labels.instance }} is failing {{ printf "%.2f" $value }}% in updating throttling policies.
-    "expr": "100 * sum(rate(jaeger_throttler_updates{result=\"err\"}[1m])) by (instance, job, namespace) / sum(rate(jaeger_throttler_updates[1m])) by (instance, job, namespace)> 1"
+        {{ $labels.job }} {{ $labels.instance }} exporter {{ $labels.exporter }} is failing to export {{ printf "%.2f" $value }}% of spans.
+    "expr": "100 * sum(rate(otelcol_exporter_send_failed_spans_total[1m]) or 0 * rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace) / (sum(rate(otelcol_exporter_sent_spans_total[1m]) or 0 * rate(otelcol_exporter_send_failed_spans_total[1m])) by (exporter, instance, job, namespace) + sum(rate(otelcol_exporter_send_failed_spans_total[1m]) or 0 * rate(otelcol_exporter_sent_spans_total[1m])) by (exporter, instance, job, namespace)) > 1"
     "for": "15m"
     "labels":
       "severity": "warning"


### PR DESCRIPTION
Title: fix(monitoring): migrate static alert rules to Jaeger v2 metrics

Description:
Fixes #8479

What happened:
The v2 monitoring mixin was still referencing obsolete v1 metrics in its Prometheus alerts, causing them to silently fail.

Note on Generation Architecture:
Following up on the discussion in closed PR #8480, I audited the monitoring/jaeger-mixin directory to apply these metric migrations via the generator path. However, per the README.md and generate/main.go source, only dashboard-for-grafana.json is currently generated via the grafana-foundation-sdk. The prometheus_alerts.yml file remains a static, committed artifact following the deprecation of the old Jsonnet toolchain (ADR-007).

Until an alert generator is implemented in the new Go SDK toolchain, manual updates to prometheus_alerts.yml are required.

Changes:
Applied the correct v2 metric translations directly to the static file to unblock v2 users:

Deleted 6 obsolete v1 alerts that no longer apply to v2 architecture.

Updated JaegerCollectorDroppingSpans to use otelcol_receiver_* metrics.

Replaced exporter alerts with JaegerExporterFailingSpans using otelcol_exporter_* metrics.

Validated syntax and PromQL via promtool check rules