### PR TITLE
feat(clickhouse): add TLS configuration

### DIFF
--- a/internal/storage/v2/clickhouse/config.go
+++ b/internal/storage/v2/clickhouse/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configtls"
 )
 
 const (
@@ -31,6 +32,16 @@ type Configuration struct {
 	Database string `mapstructure:"database"`
 	// Auth contains the authentication configuration to connect to ClickHouse.
 	Auth Authentication `mapstructure:"auth"`
+	// TLS, when present, enables and configures the TLS transport used to
+	// connect to ClickHouse. Omitting the block (or leaving it absent) keeps
+	// the connection in plaintext, preserving backwards compatibility. When
+	// the block is provided it is loaded via the OpenTelemetry configtls
+	// helpers, so it supports CA files, client certs, server-name overrides,
+	// and the standard insecure-skip-verify escape hatch. This makes managed
+	// ClickHouse services (e.g. ClickHouse Cloud) and clusters fronted by
+	// load balancers terminating TLS on 9440 (native) or 8443 (HTTP)
+	// reachable from Jaeger v2.
+	TLS configoptional.Optional[configtls.ClientConfig] `mapstructure:"tls"`
 	// DialTimeout is the timeout for establishing a connection to ClickHouse.
 	DialTimeout time.Duration `mapstructure:"dial_timeout"`
 	// CreateSchema, if set to true, will create the ClickHouse schema if it does not exist.

--- a/internal/storage/v2/clickhouse/config.go
+++ b/internal/storage/v2/clickhouse/config.go
@@ -32,15 +32,7 @@ type Configuration struct {
 	Database string `mapstructure:"database"`
 	// Auth contains the authentication configuration to connect to ClickHouse.
 	Auth Authentication `mapstructure:"auth"`
-	// TLS, when present, enables and configures the TLS transport used to
-	// connect to ClickHouse. Omitting the block (or leaving it absent) keeps
-	// the connection in plaintext, preserving backwards compatibility. When
-	// the block is provided it is loaded via the OpenTelemetry configtls
-	// helpers, so it supports CA files, client certs, server-name overrides,
-	// and the standard insecure-skip-verify escape hatch. This makes managed
-	// ClickHouse services (e.g. ClickHouse Cloud) and clusters fronted by
-	// load balancers terminating TLS on 9440 (native) or 8443 (HTTP)
-	// reachable from Jaeger v2.
+	// TLS, when present, enables TLS for the ClickHouse connection.
 	TLS configoptional.Optional[configtls.ClientConfig] `mapstructure:"tls"`
 	// DialTimeout is the timeout for establishing a connection to ClickHouse.
 	DialTimeout time.Duration `mapstructure:"dial_timeout"`

--- a/internal/storage/v2/clickhouse/config_test.go
+++ b/internal/storage/v2/clickhouse/config_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configtls"
 )
 
 func TestValidate(t *testing.T) {
@@ -94,6 +96,37 @@ func TestConfigurationApplyDefaults(t *testing.T) {
 	require.Equal(t, defaultMaxSearchDepth, config.MaxSearchDepth)
 	require.Equal(t, defaultAttributeMetadataCacheTTL, config.AttributeMetadataCacheTTL)
 	require.Equal(t, defaultAttributeMetadataCacheMaxSize, config.AttributeMetadataCacheMaxSize)
+}
+
+func TestConfiguration_TLS(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  configoptional.Optional[configtls.ClientConfig]
+	}{
+		{
+			name: "TLS omitted (plaintext)",
+		},
+		{
+			name: "TLS enabled with default verification",
+			tls:  configoptional.Some(configtls.ClientConfig{}),
+		},
+		{
+			name: "TLS enabled with InsecureSkipVerify",
+			tls: configoptional.Some(configtls.ClientConfig{
+				InsecureSkipVerify: true,
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Configuration{
+				Addresses: []string{"localhost:9000"},
+				TLS:       tt.tls,
+			}
+			require.NoError(t, cfg.Validate())
+		})
+	}
 }
 
 func TestConfiguration_Validate_TTL(t *testing.T) {

--- a/internal/storage/v2/clickhouse/factory.go
+++ b/internal/storage/v2/clickhouse/factory.go
@@ -159,6 +159,13 @@ The schema is subject to breaking changes in future releases.
 		opts.Auth.Username = basicAuth.Username
 		opts.Auth.Password = string(basicAuth.Password)
 	}
+	if tlsCfg := f.config.TLS.Get(); tlsCfg != nil {
+		loaded, tlsErr := tlsCfg.LoadTLSConfig(ctx)
+		if tlsErr != nil {
+			return nil, fmt.Errorf("failed to load TLS configuration: %w", tlsErr)
+		}
+		opts.TLS = loaded
+	}
 	conn, err := clickhouse.Open(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ClickHouse connection: %w", err)

--- a/internal/storage/v2/clickhouse/factory_test.go
+++ b/internal/storage/v2/clickhouse/factory_test.go
@@ -332,6 +332,22 @@ func TestNewFactory_TLSLoadError(t *testing.T) {
 	require.Nil(t, f)
 }
 
+func TestNewFactory_TLSLoadSuccess(t *testing.T) {
+	srv := clickhousetest.NewServer(clickhousetest.FailureConfig{})
+	defer srv.Close()
+	cfg := Configuration{
+		Protocol:  "native",
+		Addresses: []string{srv.Listener.Addr().String()},
+		TLS: configoptional.Some(configtls.ClientConfig{
+			InsecureSkipVerify: true,
+		}),
+	}
+	// TLS config loads successfully; connection fails because the test server is plain (no TLS).
+	_, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "failed to load TLS configuration")
+}
+
 func TestNewFactory_FeatureGateDisabled(t *testing.T) {
 	require.NoError(t, featuregate.GlobalRegistry().Set(clickhouseStorageGate.ID(), false))
 	t.Cleanup(func() {

--- a/internal/storage/v2/clickhouse/factory_test.go
+++ b/internal/storage/v2/clickhouse/factory_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
@@ -314,6 +315,21 @@ func TestGetProtocol(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestNewFactory_TLSLoadError(t *testing.T) {
+	cfg := Configuration{
+		Protocol:  "native",
+		Addresses: []string{"localhost:9440"},
+		TLS: configoptional.Some(configtls.ClientConfig{
+			Config: configtls.Config{
+				CAFile: "/nonexistent/ca.pem",
+			},
+		}),
+	}
+	f, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
+	require.ErrorContains(t, err, "failed to load TLS configuration")
+	require.Nil(t, f)
 }
 
 func TestNewFactory_FeatureGateDisabled(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #7868

The v2 ClickHouse storage backend exposes no TLS configuration today. Users reaching managed ClickHouse services (ClickHouse Cloud) or clusters fronted by load balancers terminating TLS on the standard 9440 (native) or 8443 (HTTP) ports cannot connect: adding a `tls:` block to the storage config returns `invalid keys: tls`, and removing it leaves the connection in plaintext, which is rejected by the secure endpoint.

## Description of the changes

- Add an opt-in `tls` field to `clickhouse.Configuration`, backed by `configtls.ClientConfig` and wrapped in `configoptional.Optional`. This mirrors the existing `auth.basic` pattern in the same struct.
- In `NewFactory`, when the block is provided, load it through `configtls.LoadTLSConfig` and pass the resulting `*tls.Config` to `clickhouse.Options.TLS`. When the block is absent, the connection stays in plaintext, so the change is backwards compatible.
- Surface TLS-load errors with a clear `failed to load TLS configuration` message rather than letting the driver fail later with an opaque connection error.

Example configuration:

```yaml
jaeger_storage:
  backends:
    some-storage:
      clickhouse:
        addresses:
          - clickhouse.example.com:9440
        database: jaeger
        tls:
          ca_file: /etc/ssl/certs/clickhouse-ca.pem
          # or, for managed services using public CAs:
          # insecure_skip_verify: false
```

## How was this change tested?

- `TestConfiguration_TLS` covers the three configuration shapes: TLS omitted (plaintext, the default), TLS provided with default verification, and TLS provided with `insecure_skip_verify`.
- `TestNewFactory_TLSLoadError` verifies that an invalid TLS config (non-existent CA file) returns the expected wrapped error and does not produce a half-initialised factory.
- All existing `TestFactory`, `TestNewFactory_Errors`, `TestPurge`, and feature-gate tests still pass without modification, confirming the change is backwards compatible.

The single pre-existing failure in `internal/storage/v2/clickhouse/tracestore` (`TestWriter_Success` snapshot mismatch) reproduces on `upstream/main` without my changes and is unrelated.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps locally