### PR TITLE
fix(es): surface async bulk-write errors from v2 WriteTraces

### DIFF
--- a/internal/storage/elasticsearch/client.go
+++ b/internal/storage/elasticsearch/client.go
@@ -22,6 +22,13 @@ type Client interface {
 	DeleteIndex(index string) IndicesDeleteService
 	io.Closer
 	GetVersion() uint
+	// LastBulkWriteError returns and clears the most recent asynchronous
+	// bulk-write error observed by the bulk processor. Implementations should
+	// return nil when no error has been recorded since the previous call.
+	// This is the mechanism the v2 tracestore.Writer uses to surface bulk
+	// failures to its caller on a best-effort basis (see WriteTraces contract
+	// in internal/storage/v2/api/tracestore/writer.go).
+	LastBulkWriteError() error
 }
 
 // IndicesExistsService is an abstraction for elastic.IndicesExistsService

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -80,6 +81,36 @@ type bulkCallback struct {
 	startTimes sync.Map
 	sm         *spanstoremetrics.WriteMetrics
 	logger     *zap.Logger
+	// errTracker captures the most recent bulk failure so that synchronous
+	// callers of WriteTraces / WriteSpan can surface async write errors on the
+	// next call. See bulkErrorTracker for the consume-and-clear semantics.
+	errTracker *bulkErrorTracker
+}
+
+// bulkErrorTracker stores the most recent error observed by the bulk-processor
+// After callback. It is safe for concurrent use. The Take method returns and
+// clears the stored error so each error is reported to at most one caller.
+type bulkErrorTracker struct {
+	err atomic.Pointer[error]
+}
+
+// Record stores err as the most recent bulk-write error, overwriting any
+// previously stored value. Storing nil is a no-op.
+func (t *bulkErrorTracker) Record(err error) {
+	if err == nil {
+		return
+	}
+	t.err.Store(&err)
+}
+
+// Take returns and clears the most recent stored error. It returns nil when
+// no error has been recorded since the previous call.
+func (t *bulkErrorTracker) Take() error {
+	p := t.err.Swap(nil)
+	if p == nil {
+		return nil
+	}
+	return *p
 }
 
 type IndexPrefix string
@@ -280,8 +311,9 @@ func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metric
 	}
 
 	bcb := bulkCallback{
-		sm:     spanstoremetrics.NewWriter(metricsFactory, "bulk_index"),
-		logger: logger,
+		sm:         spanstoremetrics.NewWriter(metricsFactory, "bulk_index"),
+		logger:     logger,
+		errTracker: &bulkErrorTracker{},
 	}
 
 	if c.Version == 0 {
@@ -348,7 +380,7 @@ func NewClient(ctx context.Context, c *Configuration, logger *zap.Logger, metric
 		return nil, err
 	}
 
-	return eswrapper.WrapESClient(rawClient, bulkProc, c.Version, rawClientV8), nil
+	return eswrapper.WrapESClient(rawClient, bulkProc, c.Version, rawClientV8, bcb.errTracker), nil
 }
 
 func (bcb *bulkCallback) invoke(id int64, requests []elastic.BulkableRequest, response *elastic.BulkResponse, err error) {
@@ -394,6 +426,20 @@ func (bcb *bulkCallback) invoke(id int64, requests []elastic.BulkableRequest, re
 			zap.Int("failed_count", failed),
 			zap.Error(err),
 			zap.Any("response", response))
+	}
+
+	// Surface async failures to the next synchronous caller so that the
+	// tracestore.Writer contract ("if any of the spans fail to be written an
+	// error is returned") is honored on a best-effort basis. We record the
+	// transport-level err first because it implies the whole batch failed;
+	// otherwise we summarise per-item failures from the response.
+	if bcb.errTracker != nil {
+		switch {
+		case err != nil:
+			bcb.errTracker.Record(fmt.Errorf("elasticsearch bulk request failed: %w", err))
+		case failed > 0:
+			bcb.errTracker.Record(fmt.Errorf("elasticsearch bulk request had %d of %d items fail", failed, total))
+		}
 	}
 }
 

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -2066,6 +2066,66 @@ func TestNewClient_NoCapturedHeaders_NoForwardedHeader(t *testing.T) {
 	}
 }
 
+func TestBulkErrorTracker(t *testing.T) {
+	t.Run("Take returns nil when empty", func(t *testing.T) {
+		tr := &bulkErrorTracker{}
+		require.NoError(t, tr.Take())
+	})
+	t.Run("Record then Take returns the stored error and clears", func(t *testing.T) {
+		tr := &bulkErrorTracker{}
+		want := errors.New("bulk failed")
+		tr.Record(want)
+		require.ErrorIs(t, tr.Take(), want)
+		require.NoError(t, tr.Take(), "second Take must clear the slot")
+	})
+	t.Run("Record nil is a no-op", func(t *testing.T) {
+		tr := &bulkErrorTracker{}
+		tr.Record(nil)
+		require.NoError(t, tr.Take())
+	})
+	t.Run("Record overwrites the previously stored error", func(t *testing.T) {
+		tr := &bulkErrorTracker{}
+		tr.Record(errors.New("first"))
+		tr.Record(errors.New("second"))
+		require.ErrorContains(t, tr.Take(), "second")
+	})
+}
+
+func TestBulkCallback_RecordsErrors(t *testing.T) {
+	newCallback := func() *bulkCallback {
+		return &bulkCallback{
+			sm:         spanstoremetrics.NewWriter(metrics.NullFactory, "bulk_index"),
+			logger:     zap.NewNop(),
+			errTracker: &bulkErrorTracker{},
+		}
+	}
+	t.Run("transport-level err is recorded", func(t *testing.T) {
+		bcb := newCallback()
+		transportErr := errors.New("connection refused")
+		bcb.invoke(1, nil, nil, transportErr)
+		require.ErrorIs(t, bcb.errTracker.Take(), transportErr)
+	})
+	t.Run("per-item failures recorded with item count", func(t *testing.T) {
+		bcb := newCallback()
+		resp := &elastic.BulkResponse{
+			Errors: true,
+			Items: []map[string]*elastic.BulkResponseItem{
+				{"index": {Status: 201}}, // success (2xx)
+				{"index": {Status: 409, Error: &elastic.ErrorDetails{Type: "version_conflict"}}},
+			},
+		}
+		bcb.invoke(1, []elastic.BulkableRequest{nil, nil}, resp, nil)
+		err := bcb.errTracker.Take()
+		require.ErrorContains(t, err, "items fail")
+		require.ErrorContains(t, err, "of 2")
+	})
+	t.Run("success leaves tracker empty", func(t *testing.T) {
+		bcb := newCallback()
+		bcb.invoke(1, nil, &elastic.BulkResponse{}, nil)
+		require.NoError(t, bcb.errTracker.Take())
+	})
+}
+
 func TestMain(m *testing.M) {
 	testutils.VerifyGoLeaks(m)
 }

--- a/internal/storage/elasticsearch/mocks/mocks.go
+++ b/internal/storage/elasticsearch/mocks/mocks.go
@@ -391,6 +391,50 @@ func (_c *Client_IndexExists_Call) RunAndReturn(run func(index string) elasticse
 	return _c
 }
 
+// LastBulkWriteError provides a mock function for the type Client
+func (_mock *Client) LastBulkWriteError() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for LastBulkWriteError")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Client_LastBulkWriteError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LastBulkWriteError'
+type Client_LastBulkWriteError_Call struct {
+	*mock.Call
+}
+
+// LastBulkWriteError is a helper method to define mock.On call
+func (_e *Client_Expecter) LastBulkWriteError() *Client_LastBulkWriteError_Call {
+	return &Client_LastBulkWriteError_Call{Call: _e.mock.On("LastBulkWriteError")}
+}
+
+func (_c *Client_LastBulkWriteError_Call) Run(run func()) *Client_LastBulkWriteError_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Client_LastBulkWriteError_Call) Return(err error) *Client_LastBulkWriteError_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Client_LastBulkWriteError_Call) RunAndReturn(run func() error) *Client_LastBulkWriteError_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MultiSearch provides a mock function for the type Client
 func (_mock *Client) MultiSearch() elasticsearch.MultiSearchService {
 	ret := _mock.Called()

--- a/internal/storage/elasticsearch/wrapper/wrapper.go
+++ b/internal/storage/elasticsearch/wrapper/wrapper.go
@@ -19,12 +19,21 @@ import (
 
 // This file avoids lint because the Id and Json are required to be capitalized, but must match an outside library.
 
+// BulkErrorTaker is implemented by anything that can consume the most recent
+// asynchronous bulk-write error. The config package's bulkErrorTracker
+// satisfies this interface. Returning nil means no error has been recorded
+// since the previous call.
+type BulkErrorTaker interface {
+	Take() error
+}
+
 // ClientWrapper is a wrapper around elastic.Client
 type ClientWrapper struct {
 	client      *elastic.Client
 	bulkService *elastic.BulkProcessor
 	esVersion   uint
 	clientV8    *esv8.Client
+	bulkErrors  BulkErrorTaker
 }
 
 // GetVersion returns the ElasticSearch Version
@@ -32,13 +41,28 @@ func (c ClientWrapper) GetVersion() uint {
 	return c.esVersion
 }
 
-// WrapESClient creates a ESClient out of *elastic.Client.
-func WrapESClient(client *elastic.Client, s *elastic.BulkProcessor, esVersion uint, clientV8 *esv8.Client) ClientWrapper {
+// LastBulkWriteError returns and clears the most recent asynchronous
+// bulk-write error observed by the bulk processor. Returns nil when no error
+// has been recorded since the previous call, or when the wrapper was
+// constructed without an error taker.
+func (c ClientWrapper) LastBulkWriteError() error {
+	if c.bulkErrors == nil {
+		return nil
+	}
+	return c.bulkErrors.Take()
+}
+
+// WrapESClient creates a ESClient out of *elastic.Client. The bulkErrors
+// taker, when non-nil, lets callers surface async bulk failures on subsequent
+// synchronous writes; pass nil to opt out (e.g. in tests that bypass the bulk
+// processor entirely).
+func WrapESClient(client *elastic.Client, s *elastic.BulkProcessor, esVersion uint, clientV8 *esv8.Client, bulkErrors BulkErrorTaker) ClientWrapper {
 	return ClientWrapper{
 		client:      client,
 		bulkService: s,
 		esVersion:   esVersion,
 		clientV8:    clientV8,
+		bulkErrors:  bulkErrors,
 	}
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/mocks/mocks.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/mocks/mocks.go
@@ -449,6 +449,50 @@ func (_c *Writer_Close_Call) RunAndReturn(run func() error) *Writer_Close_Call {
 	return _c
 }
 
+// TakeBulkError provides a mock function for the type Writer
+func (_mock *Writer) TakeBulkError() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for TakeBulkError")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Writer_TakeBulkError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TakeBulkError'
+type Writer_TakeBulkError_Call struct {
+	*mock.Call
+}
+
+// TakeBulkError is a helper method to define mock.On call
+func (_e *Writer_Expecter) TakeBulkError() *Writer_TakeBulkError_Call {
+	return &Writer_TakeBulkError_Call{Call: _e.mock.On("TakeBulkError")}
+}
+
+func (_c *Writer_TakeBulkError_Call) Run(run func()) *Writer_TakeBulkError_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Writer_TakeBulkError_Call) Return(err error) *Writer_TakeBulkError_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Writer_TakeBulkError_Call) RunAndReturn(run func() error) *Writer_TakeBulkError_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WriteSpan provides a mock function for the type Writer
 func (_mock *Writer) WriteSpan(spanStartTime time.Time, span *dbmodel.Span) {
 	_mock.Called(spanStartTime, span)

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer.go
@@ -45,6 +45,9 @@ type SpanWriter struct {
 type Writer interface {
 	// WriteSpan writes a span and its corresponding service:operation in ElasticSearch
 	WriteSpan(spanStartTime time.Time, span *dbmodel.Span)
+	// TakeBulkError returns and clears the most recent asynchronous bulk-write
+	// error observed by the underlying ES client. Returns nil when none.
+	TakeBulkError() error
 	// Close closes Writer
 	Close() error
 }
@@ -146,6 +149,12 @@ func (s *SpanWriter) convertNestedTagsToFieldTags(span *dbmodel.Span) {
 	nestedTags, fieldTags := s.splitElevatedTags(span.Tags)
 	span.Tags = nestedTags
 	span.Tag = fieldTags
+}
+
+// TakeBulkError returns and clears the most recent asynchronous bulk-write
+// error observed by the underlying ES client.
+func (s *SpanWriter) TakeBulkError() error {
+	return s.client().LastBulkWriteError()
 }
 
 // Close closes SpanWriter

--- a/internal/storage/v2/elasticsearch/tracestore/writer.go
+++ b/internal/storage/v2/elasticsearch/tracestore/writer.go
@@ -23,14 +23,22 @@ func NewTraceWriter(p core.SpanWriterParams) *TraceWriter {
 	}
 }
 
-// WriteTraces convert the traces to ES Span model and write into the database
+// WriteTraces converts the traces to the ES span model and enqueues them into
+// the bulk processor. The underlying bulk processor is asynchronous, so most
+// write failures are reported via the processor's After callback rather than
+// directly here. To honor the tracestore.Writer contract on a best-effort
+// basis we drain any bulk-write error that was recorded since the previous
+// call before enqueueing the current batch, returning it as the result of
+// this call. Errors are therefore associated with the next subsequent call
+// rather than the failing one; see issue #8476 for the design discussion.
 func (t *TraceWriter) WriteTraces(_ context.Context, td ptrace.Traces) error {
+	prevErr := t.spanWriter.TakeBulkError()
 	dbSpans := ToDBModel(td)
 	for i := range dbSpans {
 		span := &dbSpans[i]
 		t.spanWriter.WriteSpan(model.EpochMicrosecondsAsTime(span.StartTime), span)
 	}
-	return nil
+	return prevErr
 }
 
 func (t *TraceWriter) Close() error {

--- a/internal/storage/v2/elasticsearch/tracestore/writer_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/writer_test.go
@@ -27,9 +27,28 @@ func TestTraceWriter_WriteTraces(t *testing.T) {
 	span.SetName("op-1")
 	dbSpan := ToDBModel(td)
 	writer := TraceWriter{spanWriter: coreWriter}
+	coreWriter.On("TakeBulkError").Return(nil)
 	coreWriter.On("WriteSpan", model.EpochMicrosecondsAsTime(dbSpan[0].StartTime), &dbSpan[0])
 	err := writer.WriteTraces(context.Background(), td)
 	require.NoError(t, err)
+}
+
+func TestTraceWriter_WriteTraces_SurfacesPriorBulkError(t *testing.T) {
+	coreWriter := &mocks.Writer{}
+	td := ptrace.NewTraces()
+	resourceSpans := td.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr("service.name", "svc")
+	span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("op-1")
+	dbSpan := ToDBModel(td)
+
+	wantErr := assert.AnError
+	coreWriter.On("TakeBulkError").Return(wantErr)
+	coreWriter.On("WriteSpan", model.EpochMicrosecondsAsTime(dbSpan[0].StartTime), &dbSpan[0])
+
+	writer := TraceWriter{spanWriter: coreWriter}
+	err := writer.WriteTraces(context.Background(), td)
+	require.ErrorIs(t, err, wantErr)
 }
 
 func TestTraceWriter_Close(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Refs #8476.

The v2 Elasticsearch `TraceWriter.WriteTraces` currently returns `nil` unconditionally after enqueueing spans into the olivere/elastic `BulkProcessor`, even when the eventual bulk flush returns errors. That violates the `tracestore.Writer` contract (`"if any of the spans fail to be written an error is returned"`), which the Cassandra and ClickHouse v2 writers both honor synchronously.

Opening as a **draft** to keep the design discussion on the issue moving — happy to drop this and implement option (2) or (3) from [the comment on #8476](https://github.com/jaegertracing/jaeger/issues/8476#issuecomment-4565765323) if maintainers prefer.

## Description of the changes

Because the bulk processor is async by design (`Add()` enqueues, errors arrive via the `After` callback after `WriteTraces` has returned), a fully synchronous fix would require either a per-call `Flush()` (kills batching throughput) or per-batch tracking with sequence numbers (substantial refactor for marginal correctness gain — the failing batch has already left the caller's frame).

This change applies the lightest fix that closes the contract gap:

- `bulkErrorTracker` stores the most recent async bulk-write error behind an `atomic.Pointer` with consume-and-clear semantics.
- `bulkCallback.invoke` records transport-level errors and per-item failures into the tracker.
- The tracker is plumbed through `eswrapper.WrapESClient` and exposed on the `es.Client` interface as `LastBulkWriteError()`.
- The v2 `SpanWriter` exposes `TakeBulkError()`; the v2 `TraceWriter` drains it at the start of `WriteTraces` and returns it as the result of the current call.

**Trade-off (documented in code):** errors are associated with the *next* subsequent call rather than the failing one. WriteTraces semantics are best-effort async; metrics in the existing `bcb.invoke` path are unaffected. Throughput characteristics of the bulk processor are unchanged.

## How was this change tested?

New unit tests:

- `TestBulkErrorTracker` — store / take / clear / overwrite / nil-no-op behaviour.
- `TestBulkCallback_RecordsErrors` — transport-level errors and per-item failures both propagate; success path leaves the tracker empty.
- `TestTraceWriter_WriteTraces_SurfacesPriorBulkError` — verifies the v2 writer drains and returns the tracker's value.
- Existing `TestTraceWriter_WriteTraces` updated to set the new `TakeBulkError` mock expectation.

Mocks regenerated via `mockery` v3.7.0.

The two `TestFromDbModel_Fixtures` / `TestToDbModel_Fixtures` failures reproduce on upstream `main` without my changes (snapshot fixtures need regeneration); the two `BearerToken_file_error` failures are Windows-vs-Linux path-message differences and also pre-existing.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps locally