### PR TITLE
fix(ci): Always use submodule for npm cache key in setup-node.js action

### DIFF
--- a/.github/actions/setup-node.js/action.yml
+++ b/.github/actions/setup-node.js/action.yml
@@ -9,10 +9,10 @@ runs:
     - name: Get Node.js version from jaeger-ui
       shell: bash
       run: |
-        echo "JAEGER_UI_NODE_JS_VERSION=$(cat ${JAEGER_UI_DIR:-jaeger-ui}/.nvmrc)" >> ${GITHUB_ENV}
+        echo "JAEGER_UI_NODE_JS_VERSION=$(cat jaeger-ui/.nvmrc)" >> ${GITHUB_ENV}
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.JAEGER_UI_NODE_JS_VERSION }}
         cache: 'npm'
-        cache-dependency-path: ${{ env.JAEGER_UI_DIR || 'jaeger-ui' }}/package-lock.json
+        cache-dependency-path: jaeger-ui/package-lock.json


### PR DESCRIPTION
Fixes the CI failure introduced by #8653.

## Root Cause

In #8653, `setup-node.js` was updated to use `${JAEGER_UI_DIR}/package-lock.json` as `cache-dependency-path`. On snapshot builds (push to main), `JAEGER_UI_DIR` is set by the `checkout-ui-for-snapshot.sh` step — but `actions/setup-node` evaluated the path at step startup before the git `fetch`+`checkout` in that script had finished writing the working tree to disk. The file wasn't there, producing:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

## Fix

Revert `setup-node.js` to always use the submodule's `jaeger-ui/package-lock.json` for both node version detection and the npm cache key. The submodule is always present and its version matches `jaeger-ui/main` closely enough that the cache remains effective. The snapshot build does a full `npm ci` anyway, so cache key precision is not critical there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)