### PR TITLE
feat(ci): Improve snapshot UI builds: skip unshallow fetch and show correct UI version

### DIFF
--- a/scripts/build/checkout-ui-for-snapshot.sh
+++ b/scripts/build/checkout-ui-for-snapshot.sh
@@ -15,8 +15,10 @@
 # The selected UI commit is deterministic: given the same backend SHA, the same
 # UI SHA is always chosen.
 #
-# In CI (GITHUB_ENV is set): writes JAEGER_UI_DIR and JAEGER_UI_SHA to $GITHUB_ENV
-#   so they are available to subsequent workflow steps.
+# In CI (GITHUB_ENV is set): writes the following to $GITHUB_ENV so they are
+#   available to subsequent workflow steps:
+#     JAEGER_UI_DIR              — path to the snapshot checkout
+#     JAEGER_UI_SKIP_RELEASE_CHECK — tells rebuild-ui.sh to skip the tag lookup
 # Locally (no GITHUB_ENV): eval the output to set the variables in the current shell:
 #   eval "$(bash scripts/build/checkout-ui-for-snapshot.sh)"
 

--- a/scripts/build/checkout-ui-for-snapshot.sh
+++ b/scripts/build/checkout-ui-for-snapshot.sh
@@ -48,10 +48,14 @@ git -C "${WORK_DIR}" fetch --quiet --depth=1 origin "${UI_SHA}"
 git -C "${WORK_DIR}" checkout --quiet FETCH_HEAD
 
 # Export JAEGER_UI_DIR so subsequent `make build-ui` uses this checkout instead of
-# the submodule. In CI (GITHUB_ENV set) the variable persists to following steps;
+# the submodule. JAEGER_UI_SKIP_RELEASE_CHECK tells rebuild-ui.sh to skip the
+# git fetch --unshallow + tag lookup (the snapshot commit is never a release tag).
+# In CI (GITHUB_ENV set) the variables persist to following steps;
 # locally, eval the output: eval "$(bash scripts/build/checkout-ui-for-snapshot.sh)"
 if [[ -n "${GITHUB_ENV:-}" ]]; then
     echo "JAEGER_UI_DIR=${WORK_DIR}" >> "${GITHUB_ENV}"
+    echo "JAEGER_UI_SKIP_RELEASE_CHECK=true" >> "${GITHUB_ENV}"
 else
     echo "export JAEGER_UI_DIR='${WORK_DIR}'"
+    echo "export JAEGER_UI_SKIP_RELEASE_CHECK=true"
 fi

--- a/scripts/build/checkout-ui-for-snapshot.sh
+++ b/scripts/build/checkout-ui-for-snapshot.sh
@@ -47,6 +47,22 @@ git -C "${WORK_DIR}" remote add origin "https://github.com/${JAEGER_UI_REPO}.git
 git -C "${WORK_DIR}" fetch --quiet --depth=1 origin "${UI_SHA}"
 git -C "${WORK_DIR}" checkout --quiet FETCH_HEAD
 
+# Patch the version in package.json to include the short SHA, so the About panel
+# shows e.g. "Jaeger UI v2.18.0-1c082b77" instead of "v2.18.0".  This only
+# modifies the ephemeral WORK_DIR checkout; the submodule is untouched.
+UI_SHORT_SHA="${UI_SHA:0:8}"
+PKG="${WORK_DIR}/packages/jaeger-ui/package.json"
+BASE_VERSION=$(python3 -c "import sys,json; print(json.load(open(sys.argv[1]))['version'])" "${PKG}")
+python3 -c "
+import sys, json
+path = sys.argv[1]
+short_sha = sys.argv[2]
+d = json.load(open(path))
+d['version'] = d['version'] + '-' + short_sha
+open(path, 'w').write(json.dumps(d, indent=2) + '\n')
+" "${PKG}" "${UI_SHORT_SHA}"
+echo "Patched jaeger-ui version to ${BASE_VERSION}-${UI_SHORT_SHA}" >&2
+
 # Export JAEGER_UI_DIR so subsequent `make build-ui` uses this checkout instead of
 # the submodule. JAEGER_UI_SKIP_RELEASE_CHECK tells rebuild-ui.sh to skip the
 # git fetch --unshallow + tag lookup (the snapshot commit is never a release tag).

--- a/scripts/build/rebuild-ui.sh
+++ b/scripts/build/rebuild-ui.sh
@@ -11,29 +11,34 @@ JAEGER_UI_DIR="${JAEGER_UI_DIR:-jaeger-ui}"
 
 cd "${JAEGER_UI_DIR}"
 
-if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
-    git fetch --unshallow
-fi
-git fetch --all --tags
-git log --oneline --decorate=full -n 10 | cat
+# When JAEGER_UI_SKIP_RELEASE_CHECK is set (e.g. snapshot builds pointing at a
+# non-release commit), skip the tag lookup and go straight to the npm build.
+# This avoids a costly git fetch --unshallow + fetch --all --tags on a shallow clone.
+if [[ -z "${JAEGER_UI_SKIP_RELEASE_CHECK:-}" ]]; then
+    if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+        git fetch --unshallow
+    fi
+    git fetch --all --tags
+    git log --oneline --decorate=full -n 10 | cat
 
-last_tag=$(git describe --tags --dirty 2>/dev/null)
+    last_tag=$(git describe --tags --dirty 2>/dev/null)
 
-if [[ "$last_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]];  then
-    branch_hash=$(git rev-parse HEAD)
-    last_tag_hash=$(git rev-parse "$last_tag")
+    if [[ "$last_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]];  then
+        branch_hash=$(git rev-parse HEAD)
+        last_tag_hash=$(git rev-parse "$last_tag")
 
-    if [[ "$branch_hash" == "$last_tag_hash" ]]; then
-        temp_file=$(mktemp)
-        # shellcheck disable=SC2064
-        trap "rm -f ${temp_file}" EXIT
-        release_url="https://github.com/jaegertracing/jaeger-ui/releases/download/${last_tag}/assets.tar.gz"
-        if curl --silent --fail --location --output "$temp_file" "$release_url"; then
+        if [[ "$branch_hash" == "$last_tag_hash" ]]; then
+            temp_file=$(mktemp)
+            # shellcheck disable=SC2064
+            trap "rm -f ${temp_file}" EXIT
+            release_url="https://github.com/jaegertracing/jaeger-ui/releases/download/${last_tag}/assets.tar.gz"
+            if curl --silent --fail --location --output "$temp_file" "$release_url"; then
 
-            mkdir -p packages/jaeger-ui/build/
-            rm -r -f packages/jaeger-ui/build/
-            tar -zxvf "$temp_file" packages/jaeger-ui/build/
-            exit 0
+                mkdir -p packages/jaeger-ui/build/
+                rm -r -f packages/jaeger-ui/build/
+                tar -zxvf "$temp_file" packages/jaeger-ui/build/
+                exit 0
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
Follow-up to #8653 and #8654.

## Problems

1. **`git fetch --unshallow`**: `rebuild-ui.sh` detects the shallow clone created by `checkout-ui-for-snapshot.sh` and runs `git fetch --unshallow` followed by `git fetch --all --tags`, downloading the entire jaeger-ui history. This is only needed to check whether the HEAD is exactly on a release tag — which can never be true for a snapshot commit.

2. **Wrong UI version in About panel**: The About panel showed "Jaeger UI v2.18.0" even when the snapshot was built from a commit 28 commits ahead of that release, because `package.json` only gets updated on official releases.

## Fixes

### Skip the tag-check block (`rebuild-ui.sh`)

Introduce `JAEGER_UI_SKIP_RELEASE_CHECK` env var. When set, `rebuild-ui.sh` skips the unshallow + fetch + `git describe` block and goes straight to `npm ci`. `checkout-ui-for-snapshot.sh` sets this variable since snapshot commits are never release tags. The submodule/PR path is unchanged.

### Patch `package.json` version with short SHA (`checkout-ui-for-snapshot.sh`)

After checking out the snapshot, patch `packages/jaeger-ui/package.json` in the ephemeral `$WORK_DIR` to append the short SHA to the version string, e.g. `2.18.0` → `2.18.0-1c082b77`. The About panel then shows "Jaeger UI v2.18.0-1c082b77", making it clear which exact UI commit is embedded. The submodule and all other files are untouched.

## Variables exported by `checkout-ui-for-snapshot.sh`

| Variable | Purpose |
|---|---|
| `JAEGER_UI_DIR` | Path to the snapshot checkout; picked up by `make build-ui` via `JAEGER_UI_DIR ?= jaeger-ui` |
| `JAEGER_UI_SKIP_RELEASE_CHECK` | Tells `rebuild-ui.sh` to skip the tag lookup and go straight to npm |

🤖 Generated with [Claude Code](https://claude.com/claude-code)