### PR TITLE
fix(storage): pin ClickHouse images to 25.8.x LTS instead of monthly stable

### DIFF
--- a/docker-compose/clickhouse/docker-compose.yml
+++ b/docker-compose/clickhouse/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12.11@sha256:8a790dd3468db22b1d4e7b18a176f378ff5ff6053b9c48dd4ea1fa71a24c5ba6
+    image: clickhouse/clickhouse-server:25.8.24.21@sha256:0fa332a9a05ce4138b16d883f9c9d124c8d9d81cf4e52046878d537558626e49
     container_name: clickhouse
     environment:
       - CLICKHOUSE_USER=default

--- a/docker-compose/monitor/docker-compose-clickhouse.yml
+++ b/docker-compose/monitor/docker-compose-clickhouse.yml
@@ -3,7 +3,7 @@
 
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:26.5.1@sha256:07afc18d8a9706eb9d85c5c5d2752e5270f91bbc2894caeaecb73e4d0f603bf5
+    image: clickhouse/clickhouse-server:25.8.24.21@sha256:0fa332a9a05ce4138b16d883f9c9d124c8d9d81cf4e52046878d537558626e49
     networks:
       - backend
     environment:


### PR DESCRIPTION
## Summary

Fixes #8664 by moving Jaeger's ClickHouse Docker images from monthly stable releases to the supported 25.8.x LTS line.

## Problem

Issue #8664 identified that Jaeger CI and example deployments were pinned to ClickHouse monthly stable releases, which do not receive long-term backports and may introduce unnecessary upgrade risk.

## Changes

* Updated `docker-compose/clickhouse/docker-compose.yml`
* Updated `docker-compose/monitor/docker-compose-clickhouse.yml`
* Replaced monthly stable image pins with 25.8.x LTS image pins

## Testing

* Verified image pin updates
* Ran local ClickHouse e2e validation

## Screenshots

### Image pin migration

<img width="900" alt="ClickHouse LTS migration" src="https://github.com/user-attachments/assets/ccd4192b-6b95-48f6-9c50-453e2fcc6045" />

Fixes #8664
