### PR TITLE
[es] Enable reader to search on scope and link attributes

### DIFF
--- a/cmd/jaeger/internal/integration/elasticsearch_test.go
+++ b/cmd/jaeger/internal/integration/elasticsearch_test.go
@@ -58,7 +58,7 @@ func TestElasticsearchStorage_BackwardCompatibility(t *testing.T) {
 		FeatureGates: structuredFilterGates,
 		StorageIntegration: integration.StorageIntegration{
 			Fixtures:     integration.LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
-			Capabilities: capabilities.Elasticsearch(),
+			Capabilities: capabilities.ElasticsearchBackwardCompat(),
 		},
 	})
 }

--- a/cmd/jaeger/internal/integration/opensearch_test.go
+++ b/cmd/jaeger/internal/integration/opensearch_test.go
@@ -97,7 +97,7 @@ func TestOpenSearchStorage_BackwardCompatibility(t *testing.T) {
 		FeatureGates: structuredFilterGates,
 		StorageIntegration: integration.StorageIntegration{
 			Fixtures:     integration.LoadAndParseQueryTestCases(t, "fixtures/queries_es.json"),
-			Capabilities: capabilities.OpenSearch(),
+			Capabilities: capabilities.OpenSearchBackwardCompat(),
 		},
 	})
 }

--- a/internal/storage/elasticsearch/query/nested_query.go
+++ b/internal/storage/elasticsearch/query/nested_query.go
@@ -5,10 +5,12 @@ package query
 
 // NestedQuery runs an inner query against a nested-field path. It renders to
 // {"nested": {"path": path, "query": <inner>}}, matching what the storage layer
-// previously produced.
+// previously produced. When ignoreUnmapped is set, it renders to
+// {"nested": {"path": path, "query": <inner>, "ignore_unmapped": true}}.
 type NestedQuery struct {
-	path  string
-	query Query
+	path           string
+	query          Query
+	ignoreUnmapped bool
 }
 
 // NewNestedQuery creates a NestedQuery over path running the given inner query.
@@ -16,15 +18,29 @@ func NewNestedQuery(path string, query Query) *NestedQuery {
 	return &NestedQuery{path: path, query: query}
 }
 
+// IgnoreUnmapped decides what happens when path is not mapped in an index the
+// search touches. Elasticsearch's default is to fail the whole search, which is
+// wrong for paths that only newer documents carry: an index written before the
+// field existed has no mapping for it and would take the query down with it.
+// Setting it treats such an index as matching nothing instead.
+func (q *NestedQuery) IgnoreUnmapped(ignoreUnmapped bool) *NestedQuery {
+	q.ignoreUnmapped = ignoreUnmapped
+	return q
+}
+
 func (q *NestedQuery) Source() (any, error) {
 	inner, err := q.query.Source()
 	if err != nil {
 		return nil, err
 	}
+	nested := map[string]any{
+		"path":  q.path,
+		"query": inner,
+	}
+	if q.ignoreUnmapped {
+		nested["ignore_unmapped"] = true
+	}
 	return map[string]any{
-		"nested": map[string]any{
-			"path":  q.path,
-			"query": inner,
-		},
+		"nested": nested,
 	}, nil
 }

--- a/internal/storage/integration/capabilities/capabilities.go
+++ b/internal/storage/integration/capabilities/capabilities.go
@@ -90,7 +90,7 @@ func Elasticsearch() Capabilities {
 		// TODO: remove this flag after ES supports returning spanKind
 		//  Issue https://github.com/jaegertracing/jaeger/issues/1923
 		getOperationsMissingSpanKind: true,
-		skipList:                     []string{scopeAttributesTest, linkAttributesTest, FindTraceSummariesTest},
+		skipList:                     []string{FindTraceSummariesTest},
 	}
 }
 
@@ -98,7 +98,7 @@ func Elasticsearch() Capabilities {
 func OpenSearch() Capabilities {
 	return Capabilities{
 		getOperationsMissingSpanKind: true,
-		skipList:                     []string{scopeAttributesTest, linkAttributesTest, FindTraceSummariesTest},
+		skipList:                     []string{FindTraceSummariesTest},
 	}
 }
 

--- a/internal/storage/integration/capabilities/capabilities.go
+++ b/internal/storage/integration/capabilities/capabilities.go
@@ -156,3 +156,17 @@ func E2EWithoutNativeFilters() Capabilities {
 		skipList: []string{structuredFilterTest},
 	}
 }
+
+func ElasticsearchBackwardCompat() Capabilities {
+	return Capabilities{
+		getOperationsMissingSpanKind: true,
+		skipList:                     []string{scopeAttributesTest, linkAttributesTest, attributeOrderingTest},
+	}
+}
+
+func OpenSearchBackwardCompat() Capabilities {
+	return Capabilities{
+		getOperationsMissingSpanKind: true,
+		skipList:                     []string{scopeAttributesTest, linkAttributesTest, attributeOrderingTest},
+	}
+}

--- a/internal/storage/integration/capabilities/capabilities.go
+++ b/internal/storage/integration/capabilities/capabilities.go
@@ -114,7 +114,7 @@ func Elasticsearch() Capabilities {
 		// This schema indexes every attribute as a keyword, so ordering one is refused rather than
 		// answered lexicographically, and the battery's paired refusal case is the one to run
 		// (RFC 0015 is what changes that).
-		skipList: []string{scopeAttributesTest, linkAttributesTest, attributeOrderingTest},
+		skipList: []string{attributeOrderingTest},
 	}
 }
 
@@ -124,8 +124,6 @@ func ElasticsearchSmokeTest() Capabilities {
 	return Capabilities{
 		getOperationsMissingSpanKind: true,
 		skipList: []string{
-			scopeAttributesTest,
-			linkAttributesTest,
 			structuredFilterTest,
 			"GetLargeTrace",
 			"GetTraceWithDuplicateSpans",
@@ -138,7 +136,7 @@ func OpenSearch() Capabilities {
 	return Capabilities{
 		getOperationsMissingSpanKind: true,
 		// Same keyword mapping as Elasticsearch; see the note there.
-		skipList: []string{scopeAttributesTest, linkAttributesTest, attributeOrderingTest},
+		skipList: []string{attributeOrderingTest},
 	}
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
@@ -57,16 +57,21 @@ type Span struct {
 	Duration        uint64     `json:"duration"` // microseconds
 	Tags            []KeyValue `json:"tags"`
 	// Alternative representation of tags for better kibana support
-	Tag     map[string]any `json:"tag,omitempty"`
-	Logs    []Log          `json:"logs"`
-	Process Process        `json:"process"`
+	Tag       map[string]any `json:"tag,omitempty"`
+	Logs      []Log          `json:"logs"`
+	Process   Process        `json:"process"`
+	ScopeTags []KeyValue     `json:"scopeTags,omitempty"`
+	ScopeTag  map[string]any `json:"scopeTag,omitempty"`
 }
 
 // Reference is a reference from one span to another
 type Reference struct {
-	RefType ReferenceType `json:"refType"`
-	TraceID TraceID       `json:"traceID"`
-	SpanID  SpanID        `json:"spanID"`
+	RefType    ReferenceType `json:"refType"`
+	TraceID    TraceID       `json:"traceID"`
+	SpanID     SpanID        `json:"spanID"`
+	TraceState string        `json:"traceState,omitempty"`
+	Flags      uint32        `json:"flags,omitempty"`
+	Tags       []KeyValue    `json:"tags,omitempty"`
 }
 
 // Process is the process emitting a set of spans

--- a/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
@@ -61,9 +61,11 @@ type Span struct {
 	Duration        uint64     `json:"duration"` // microseconds
 	Tags            []KeyValue `json:"tags"`
 	// Alternative representation of tags for better kibana support
-	Tag     map[string]any `json:"tag,omitempty"`
-	Logs    []Log          `json:"logs"`
-	Process Process        `json:"process"`
+	Tag       map[string]any `json:"tag,omitempty"`
+	Logs      []Log          `json:"logs"`
+	Process   Process        `json:"process"`
+	ScopeTags []KeyValue     `json:"scopeTags,omitempty"`
+	ScopeTag  map[string]any `json:"scopeTag,omitempty"`
 	// Timestamp is the span's start time as an RFC 3339 string, written only on the
 	// data stream path; other rotation strategies leave it empty. It has to be the
 	// string form rather than a number (RFC 0004 §3.3).
@@ -72,9 +74,12 @@ type Span struct {
 
 // Reference is a reference from one span to another
 type Reference struct {
-	RefType ReferenceType `json:"refType"`
-	TraceID TraceID       `json:"traceID"`
-	SpanID  SpanID        `json:"spanID"`
+	RefType    ReferenceType `json:"refType"`
+	TraceID    TraceID       `json:"traceID"`
+	SpanID     SpanID        `json:"spanID"`
+	TraceState string        `json:"traceState,omitempty"`
+	Flags      uint32        `json:"flags,omitempty"`
+	Tags       []KeyValue    `json:"tags,omitempty"`
 }
 
 // Process is the process emitting a set of spans

--- a/internal/storage/v2/elasticsearch/tracestore/core/filter.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/filter.go
@@ -62,8 +62,8 @@ func (r reference) isField(level expression.Level, name string) bool {
 // object fields, whose leaf is the attribute key, and the nested key/value arrays. Both are
 // searched because which of the two the write path produced depends on the tags-as-fields
 // setting in force when the span was indexed, and that setting can change over the life of
-// an index. Instrumentation-scope attributes are folded into the span's own tags and link
-// attributes are not indexed at all, so neither level appears here (RFC 0005 §1.6).
+// an index. Instrumentation-scope and link attributes now have fields of their own, but no
+// scope or link level is served off them yet, so neither appears here (RFC 0005 §1.6).
 var attributeLocations = map[expression.Level]attributeLocation{
 	expression.LevelSpan: {
 		object: []string{objectTagsField},
@@ -79,8 +79,12 @@ var attributeLocations = map[expression.Level]attributeLocation{
 	// An unqualified reference searches the span and resource levels (RFC 0005 §5.1). It
 	// deliberately stops short of the event level that the legacy Tags search also covers:
 	// the legacy field keeps its behavior, and the filter follows the documented contract.
+	// The two field lists are spelled out rather than borrowed from the legacy search's
+	// objectTagFieldList, which also carries the scope field: taking that list would search
+	// elevated scope attributes and not nested ones, making an unqualified match depend on
+	// the tags-as-fields setting the span was written under.
 	"": {
-		object: objectTagFieldList,
+		object: []string{objectTagsField, objectProcessTagsField},
 		nested: []string{nestedTagsField, nestedProcessTagsField},
 	},
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_01.json
@@ -24,6 +24,17 @@
         }
       },
       {
+        "bool":{
+          "must":{
+            "regexp":{
+              "scopeTag.bat@foo":{
+                "value":"spook"
+              }
+            }
+          }
+        }
+      },
+      {
         "nested":{
           "path":"tags",
           "query":{
@@ -90,6 +101,58 @@
                   "regexp":{
                     "logs.fields.value":{
                       "value":"spook"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested": {
+          "ignore_unmapped": true,
+          "path": "scopeTags",
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "match": {
+                    "scopeTags.key": {
+                      "query": "bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp": {
+                    "scopeTags.value": {
+                      "value": "spook"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested": {
+          "ignore_unmapped": true,
+          "path": "references.tags",
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "match": {
+                    "references.tags.key": {
+                      "query": "bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp": {
+                    "references.tags.value": {
+                      "value": "spook"
                     }
                   }
                 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_02.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_02.json
@@ -24,6 +24,17 @@
         }
       },
       {
+        "bool":{
+          "must":{
+            "regexp":{
+              "scopeTag.bat@foo":{
+                "value":"spo.*"
+              }
+            }
+          }
+        }
+      },
+      {
         "nested":{
           "path":"tags",
           "query":{
@@ -90,6 +101,58 @@
                   "regexp":{
                     "logs.fields.value":{
                       "value":"spo.*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested": {
+          "ignore_unmapped": true,
+          "path": "scopeTags",
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "match": {
+                    "scopeTags.key": {
+                      "query": "bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp": {
+                    "scopeTags.value": {
+                      "value": "spo.*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested": {
+          "ignore_unmapped": true,
+          "path": "references.tags",
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "match": {
+                    "references.tags.key": {
+                      "query": "bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp": {
+                    "references.tags.value": {
+                      "value": "spo.*"
                     }
                   }
                 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_03.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_03.json
@@ -24,6 +24,17 @@
         }
       },
       {
+        "bool":{
+          "must":{
+            "regexp":{
+              "scopeTag.bat@foo":{
+                "value":"spo\\*"
+              }
+            }
+          }
+        }
+      },
+      {
         "nested":{
           "path":"tags",
           "query":{
@@ -89,6 +100,58 @@
                 {
                   "regexp":{
                     "logs.fields.value":{
+                      "value":"spo\\*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested":{
+          "ignore_unmapped": true,
+          "path":"scopeTags",
+          "query":{
+            "bool":{
+              "must":[
+                {
+                  "match":{
+                    "scopeTags.key":{
+                      "query":"bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp":{
+                    "scopeTags.value":{
+                      "value":"spo\\*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "nested":{
+          "ignore_unmapped": true,
+          "path":"references.tags",
+          "query":{
+            "bool":{
+              "must":[
+                {
+                  "match":{
+                    "references.tags.key":{
+                      "query":"bat.foo"
+                    }
+                  }
+                },
+                {
+                  "regexp":{
+                    "references.tags.value":{
                       "value":"spo\\*"
                     }
                   }

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -48,6 +48,10 @@ const (
 	tagKeyField            = "key"
 	tagValueField          = "value"
 
+	objectScopeTagsField      = "scopeTag"
+	nestedScopeTagsField      = "scopeTags"
+	nestedReferencesTagsField = "references.tags"
+
 	defaultSearchDepth = 100
 
 	dawnOfTimeSpanAge = time.Hour * 24 * 365 * 50
@@ -74,9 +78,9 @@ var (
 
 	defaultMaxDuration = model.DurationAsMicroseconds(time.Hour * 24)
 
-	objectTagFieldList = []string{objectTagsField, objectProcessTagsField}
+	objectTagFieldList = []string{objectTagsField, objectProcessTagsField, objectScopeTagsField}
 
-	nestedTagFieldList = []string{nestedTagsField, nestedProcessTagsField, nestedLogFieldsField}
+	nestedTagFieldList = []string{nestedTagsField, nestedProcessTagsField, nestedLogFieldsField, nestedScopeTagsField, nestedReferencesTagsField}
 
 	_ Reader = (*SpanReader)(nil) // check API conformance
 
@@ -622,7 +626,11 @@ func (*SpanReader) buildNestedQuery(field string, k string, v string) elastic.Qu
 	keyQuery := elastic.NewMatchQuery(keyField, k)
 	valueQuery := elastic.NewRegexpQuery(valueField, v)
 	tagBoolQuery := elastic.NewBoolQuery().Must(keyQuery, valueQuery)
-	return elastic.NewNestedQuery(field, tagBoolQuery)
+	query := elastic.NewNestedQuery(field, tagBoolQuery)
+	if field == nestedScopeTagsField || field == nestedReferencesTagsField {
+		return query.IgnoreUnmapped(true)
+	}
+	return query
 }
 
 func (*SpanReader) buildObjectQuery(field string, k string, v string) elastic.Query {
@@ -636,6 +644,8 @@ func (s *SpanReader) mergeAllNestedAndElevatedTagsOfSpan(span *dbmodel.Span) {
 	span.Process.Tags = processTags
 	spanTags := s.mergeNestedAndElevatedTags(span.Tags, span.Tag)
 	span.Tags = spanTags
+	scopeTags := s.mergeNestedAndElevatedTags(span.ScopeTags, span.ScopeTag)
+	span.ScopeTags = scopeTags
 }
 
 func (s *SpanReader) mergeNestedAndElevatedTags(nestedTags []dbmodel.KeyValue, elevatedTags map[string]any) []dbmodel.KeyValue {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -46,6 +46,10 @@ const (
 	tagValueField          = "value"
 	errorTag               = "error"
 
+	objectScopeTagsField      = "scopeTag"
+	nestedScopeTagsField      = "scopeTags"
+	nestedReferencesTagsField = "references.tags"
+
 	defaultSearchDepth = 100
 
 	DawnOfTimeSpanAge = time.Hour * 24 * 365 * 50
@@ -69,9 +73,9 @@ var (
 
 	defaultMaxDuration = model.DurationAsMicroseconds(time.Hour * 24)
 
-	objectTagFieldList = []string{objectTagsField, objectProcessTagsField}
+	objectTagFieldList = []string{objectTagsField, objectProcessTagsField, objectScopeTagsField}
 
-	nestedTagFieldList = []string{nestedTagsField, nestedProcessTagsField, nestedLogFieldsField}
+	nestedTagFieldList = []string{nestedTagsField, nestedProcessTagsField, nestedLogFieldsField, nestedScopeTagsField, nestedReferencesTagsField}
 
 	_ Reader = (*SpanReader)(nil) // check API conformance
 )
@@ -610,7 +614,11 @@ func (*SpanReader) buildNestedQuery(field string, k string, v string) esquery.Qu
 	keyQuery := esquery.NewMatchQuery(keyField, k)
 	valueQuery := esquery.NewRegexpQuery(valueField, v)
 	tagBoolQuery := esquery.NewBoolQuery().Must(keyQuery, valueQuery)
-	return esquery.NewNestedQuery(field, tagBoolQuery)
+	query := esquery.NewNestedQuery(field, tagBoolQuery)
+	if field == nestedScopeTagsField || field == nestedReferencesTagsField {
+		return query.IgnoreUnmapped(true)
+	}
+	return query
 }
 
 func (*SpanReader) buildObjectQuery(field string, k string, v string) esquery.Query {
@@ -624,6 +632,8 @@ func (s *SpanReader) mergeAllNestedAndElevatedTagsOfSpan(span *dbmodel.Span) {
 	span.Process.Tags = processTags
 	spanTags := s.mergeNestedAndElevatedTags(span.Tags, span.Tag)
 	span.Tags = spanTags
+	scopeTags := s.mergeNestedAndElevatedTags(span.ScopeTags, span.ScopeTag)
+	span.ScopeTags = scopeTags
 }
 
 func (s *SpanReader) mergeNestedAndElevatedTags(nestedTags []dbmodel.KeyValue, elevatedTags map[string]any) []dbmodel.KeyValue {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -1404,21 +1404,27 @@ func TestTagsMap(t *testing.T) {
 				},
 			}
 			spanTags := make(map[string]any)
+			scopeTags := make(map[string]any)
 			maps.Copy(spanTags, test.fieldTags)
+			maps.Copy(scopeTags, test.fieldTags)
 			span := &dbmodel.Span{
 				Process: dbmodel.Process{
 					Tag:  test.fieldTags,
 					Tags: tags,
 				},
-				Tag:  spanTags,
-				Tags: tags,
+				Tag:       spanTags,
+				Tags:      tags,
+				ScopeTags: tags,
+				ScopeTag:  scopeTags,
 			}
 			reader.mergeAllNestedAndElevatedTagsOfSpan(span)
 			tags = append(tags, test.expected)
 			assert.Empty(t, span.Tag)
 			assert.Empty(t, span.Process.Tag)
+			assert.Empty(t, span.ScopeTag)
 			assert.Equal(t, tags, span.Tags)
 			assert.Equal(t, tags, span.Process.Tags)
+			assert.Equal(t, tags, span.ScopeTags)
 		})
 	}
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -1323,21 +1323,27 @@ func TestTagsMap(t *testing.T) {
 				},
 			}
 			spanTags := make(map[string]any)
+			scopeTags := make(map[string]any)
 			maps.Copy(spanTags, test.fieldTags)
+			maps.Copy(scopeTags, test.fieldTags)
 			span := &dbmodel.Span{
 				Process: dbmodel.Process{
 					Tag:  test.fieldTags,
 					Tags: tags,
 				},
-				Tag:  spanTags,
-				Tags: tags,
+				Tag:       spanTags,
+				Tags:      tags,
+				ScopeTags: tags,
+				ScopeTag:  scopeTags,
 			}
 			reader.mergeAllNestedAndElevatedTagsOfSpan(span)
 			tags = append(tags, test.expected)
 			assert.Empty(t, span.Tag)
 			assert.Empty(t, span.Process.Tag)
+			assert.Empty(t, span.ScopeTag)
 			assert.Equal(t, tags, span.Tags)
 			assert.Equal(t, tags, span.Process.Tags)
+			assert.Equal(t, tags, span.ScopeTags)
 		})
 	}
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_ids.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_ids.json
@@ -89,6 +89,17 @@
                   }
                 },
                 {
+                  "bool": {
+                    "must": {
+                      "regexp": {
+                        "scopeTag.httpstatus_code": {
+                          "value": "200"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
                   "nested": {
                     "path": "tags",
                     "query": {
@@ -154,6 +165,58 @@
                           {
                             "regexp": {
                               "logs.fields.value": {
+                                "value": "200"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "nested": {
+                    "ignore_unmapped": true,
+                    "path": "scopeTags",
+                    "query": {
+                      "bool": {
+                        "must": [
+                          {
+                            "match": {
+                              "scopeTags.key": {
+                                "query": "http.status_code"
+                              }
+                            }
+                          },
+                          {
+                            "regexp": {
+                              "scopeTags.value": {
+                                "value": "200"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "nested": {
+                    "ignore_unmapped": true,
+                    "path": "references.tags",
+                    "query": {
+                      "bool": {
+                        "must": [
+                          {
+                            "match": {
+                              "references.tags.key": {
+                                "query": "http.status_code"
+                              }
+                            }
+                          },
+                          {
+                            "regexp": {
+                              "references.tags.value": {
                                 "value": "200"
                               }
                             }

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_summaries.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_summaries.json
@@ -40,6 +40,17 @@
                     }
                   },
                   {
+                    "bool": {
+                      "must": {
+                        "regexp": {
+                          "scopeTag.error": {
+                            "value": "true"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
                     "nested": {
                       "path": "tags",
                       "query": {
@@ -105,6 +116,58 @@
                             {
                               "regexp": {
                                 "logs.fields.value": {
+                                  "value": "true"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nested": {
+                      "ignore_unmapped": true,
+                      "path": "scopeTags",
+                      "query": {
+                        "bool": {
+                          "must": [
+                            {
+                              "match": {
+                                "scopeTags.key": {
+                                  "query": "error"
+                                }
+                              }
+                            },
+                            {
+                              "regexp": {
+                                "scopeTags.value": {
+                                  "value": "true"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nested": {
+                      "ignore_unmapped": true,
+                      "path": "references.tags",
+                      "query": {
+                        "bool": {
+                          "must": [
+                            {
+                              "match": {
+                                "references.tags.key": {
+                                  "query": "error"
+                                }
+                              }
+                            },
+                            {
+                              "regexp": {
+                                "references.tags.value": {
                                   "value": "true"
                                 }
                               }
@@ -195,6 +258,17 @@
                         }
                       },
                       {
+                        "bool": {
+                          "must": {
+                            "regexp": {
+                              "scopeTag.error": {
+                                "value": "true"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
                         "nested": {
                           "path": "tags",
                           "query": {
@@ -260,6 +334,58 @@
                                 {
                                   "regexp": {
                                     "logs.fields.value": {
+                                      "value": "true"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nested": {
+                          "ignore_unmapped": true,
+                          "path": "scopeTags",
+                          "query": {
+                            "bool": {
+                              "must": [
+                                {
+                                  "match": {
+                                    "scopeTags.key": {
+                                      "query": "error"
+                                    }
+                                  }
+                                },
+                                {
+                                  "regexp": {
+                                    "scopeTags.value": {
+                                      "value": "true"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nested": {
+                          "ignore_unmapped": true,
+                          "path": "references.tags",
+                          "query": {
+                            "bool": {
+                              "must": [
+                                {
+                                  "match": {
+                                    "references.tags.key": {
+                                      "query": "error"
+                                    }
+                                  }
+                                },
+                                {
+                                  "regexp": {
+                                    "references.tags.value": {
                                       "value": "true"
                                     }
                                   }

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer.go
@@ -146,6 +146,9 @@ func (s *SpanWriter) convertNestedTagsToFieldTags(span *dbmodel.Span) {
 	nestedTags, fieldTags := s.splitElevatedTags(span.Tags)
 	span.Tags = nestedTags
 	span.Tag = fieldTags
+	scopeNestedTags, scopeFieldTags := s.splitElevatedTags(span.ScopeTags)
+	span.ScopeTags = scopeNestedTags
+	span.ScopeTag = scopeFieldTags
 }
 
 // Close closes SpanWriter

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer.go
@@ -134,6 +134,9 @@ func (s *SpanWriter) convertNestedTagsToFieldTags(span *dbmodel.Span) {
 	nestedTags, fieldTags := s.splitElevatedTags(span.Tags)
 	span.Tags = nestedTags
 	span.Tag = fieldTags
+	scopeNestedTags, scopeFieldTags := s.splitElevatedTags(span.ScopeTags)
+	span.ScopeTags = scopeNestedTags
+	span.ScopeTag = scopeFieldTags
 }
 
 // Close is a no-op: the writer owns no resources. The bulk indexer that backs it

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
@@ -377,7 +377,12 @@ func TestTagMap(t *testing.T) {
 			Type:  dbmodel.Int64Type,
 		},
 	}
-	dbSpan := dbmodel.Span{Tags: tags, Process: dbmodel.Process{Tags: tags}}
+	dbSpan := dbmodel.Span{
+		Tags:       tags,
+		Process:    dbmodel.Process{Tags: tags},
+		ScopeTags:  tags,
+		References: []dbmodel.Reference{{Tags: tags}},
+	}
 	converter := NewSpanWriter(SpanWriterParams{
 		Logger:            zap.NewNop(),
 		MetricsFactory:    metrics.NullFactory,
@@ -391,12 +396,15 @@ func TestTagMap(t *testing.T) {
 	assert.Equal(t, "foo", dbSpan.Tags[0].Key)
 	assert.Len(t, dbSpan.Process.Tags, 1)
 	assert.Equal(t, "foo", dbSpan.Process.Tags[0].Key)
+	assert.Len(t, dbSpan.ScopeTags, 1)
+	assert.Equal(t, "foo", dbSpan.ScopeTags[0].Key)
 
 	tagsMap := map[string]any{}
 	tagsMap["a"] = true
 	tagsMap["b:b"] = int64(1)
 	assert.Equal(t, tagsMap, dbSpan.Tag)
 	assert.Equal(t, tagsMap, dbSpan.Process.Tag)
+	assert.Equal(t, tagsMap, dbSpan.ScopeTag)
 }
 
 func TestNewSpanTags(t *testing.T) {

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
@@ -521,7 +521,12 @@ func TestTagMap(t *testing.T) {
 			Type:  dbmodel.Int64Type,
 		},
 	}
-	dbSpan := dbmodel.Span{Tags: tags, Process: dbmodel.Process{Tags: tags}}
+	dbSpan := dbmodel.Span{
+		Tags:       tags,
+		Process:    dbmodel.Process{Tags: tags},
+		ScopeTags:  tags,
+		References: []dbmodel.Reference{{Tags: tags}},
+	}
 	converter := NewSpanWriter(SpanWriterParams{
 		Logger:            zap.NewNop(),
 		MetricsFactory:    metrics.NullFactory,
@@ -535,12 +540,15 @@ func TestTagMap(t *testing.T) {
 	assert.Equal(t, "foo", dbSpan.Tags[0].Key)
 	assert.Len(t, dbSpan.Process.Tags, 1)
 	assert.Equal(t, "foo", dbSpan.Process.Tags[0].Key)
+	assert.Len(t, dbSpan.ScopeTags, 1)
+	assert.Equal(t, "foo", dbSpan.ScopeTags[0].Key)
 
 	tagsMap := map[string]any{}
 	tagsMap["a"] = true
 	tagsMap["b:b"] = int64(1)
 	assert.Equal(t, tagsMap, dbSpan.Tag)
 	assert.Equal(t, tagsMap, dbSpan.Process.Tag)
+	assert.Equal(t, tagsMap, dbSpan.ScopeTag)
 }
 
 func TestNewSpanTags(t *testing.T) {

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
@@ -12,7 +12,31 @@
     {
       "refType": "FOLLOWS_FROM",
       "traceID": "00000000000000010000000000000000",
-      "spanID": "0000000000000004"
+      "spanID": "0000000000000004",
+      "traceState": "some-link-state",
+      "flags": 1,
+      "tags": [
+        {
+          "key": "peer.service",
+          "type": "string",
+          "value": "service-y"
+        },
+        {
+          "key": "peer.ipv4",
+          "type": "int64",
+          "value": 23456
+        },
+        {
+          "key": "blob",
+          "type": "binary",
+          "value": "00003039"
+        },
+        {
+          "key": "temperature",
+          "type": "float64",
+          "value": 72.5
+        }
+      ]
     },
     {
       "refType": "CHILD_OF",
@@ -96,5 +120,27 @@
         "value": "1.2.1"
       }
     ]
-  }
+  },
+  "scopeTags": [
+    {
+      "key": "peer.service",
+      "type": "string",
+      "value": "service-y"
+    },
+    {
+      "key": "peer.ipv4",
+      "type": "int64",
+      "value": 23456
+    },
+    {
+      "key": "blob",
+      "type": "binary",
+      "value": "00003039"
+    },
+    {
+      "key": "temperature",
+      "type": "float64",
+      "value": 72.5
+    }
+  ]
 }

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
@@ -13,7 +13,31 @@
     {
       "refType": "FOLLOWS_FROM",
       "traceID": "00000000000000010000000000000000",
-      "spanID": "0000000000000004"
+      "spanID": "0000000000000004",
+      "traceState": "some-link-state",
+      "flags": 1,
+      "tags": [
+        {
+          "key": "peer.service",
+          "type": "string",
+          "value": "service-y"
+        },
+        {
+          "key": "peer.ipv4",
+          "type": "int64",
+          "value": 23456
+        },
+        {
+          "key": "blob",
+          "type": "binary",
+          "value": "00003039"
+        },
+        {
+          "key": "temperature",
+          "type": "float64",
+          "value": 72.5
+        }
+      ]
     },
     {
       "refType": "CHILD_OF",
@@ -97,5 +121,27 @@
         "value": "1.2.1"
       }
     ]
-  }
+  },
+  "scopeTags": [
+    {
+      "key": "peer.service",
+      "type": "string",
+      "value": "service-y"
+    },
+    {
+      "key": "peer.ipv4",
+      "type": "int64",
+      "value": 23456
+    },
+    {
+      "key": "blob",
+      "type": "binary",
+      "value": "00003039"
+    },
+    {
+      "key": "temperature",
+      "type": "float64",
+      "value": 72.5
+    }
+  ]
 }

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
@@ -7,17 +7,45 @@
     {
       "refType": "CHILD_OF",
       "traceID": "00000000000000010000000000000000",
-      "spanID": "0000000000000003"
+      "spanID": "0000000000000003",
+      "traceState": "",
+      "flags": 0
     },
     {
       "refType": "FOLLOWS_FROM",
       "traceID": "00000000000000010000000000000000",
-      "spanID": "0000000000000004"
+      "spanID": "0000000000000004",
+      "traceState": "some-link-state",
+      "flags": 1,
+      "tags": [
+        {
+          "key": "peer.service",
+          "type": "string",
+          "value": "service-y"
+        },
+        {
+          "key": "peer.ipv4",
+          "type": "int64",
+          "value": "23456"
+        },
+        {
+          "key": "blob",
+          "type": "binary",
+          "value": "00003039"
+        },
+        {
+          "key": "temperature",
+          "type": "float64",
+          "value": "72.5"
+        }
+      ]
     },
     {
       "refType": "CHILD_OF",
       "traceID": "00000000000000ff0000000000000000",
-      "spanID": "00000000000000ff"
+      "spanID": "00000000000000ff",
+      "traceState": "",
+      "flags": 0
     }
   ],
   "startTime": 1485467191639875,
@@ -96,5 +124,27 @@
         "value": "1.2.1"
       }
     ]
-  }
+  },
+  "scopeTags": [
+    {
+      "key": "peer.service",
+      "type": "string",
+      "value": "service-y"
+    },
+    {
+      "key": "peer.ipv4",
+      "type": "int64",
+      "value": "23456"
+    },
+    {
+      "key": "blob",
+      "type": "binary",
+      "value": "00003039"
+    },
+    {
+      "key": "temperature",
+      "type": "float64",
+      "value": "72.5"
+    }
+  ]
 }

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
@@ -8,17 +8,45 @@
     {
       "refType": "CHILD_OF",
       "traceID": "00000000000000010000000000000000",
-      "spanID": "0000000000000003"
+      "spanID": "0000000000000003",
+      "traceState": "",
+      "flags": 0
     },
     {
       "refType": "FOLLOWS_FROM",
       "traceID": "00000000000000010000000000000000",
-      "spanID": "0000000000000004"
+      "spanID": "0000000000000004",
+      "traceState": "some-link-state",
+      "flags": 1,
+      "tags": [
+        {
+          "key": "peer.service",
+          "type": "string",
+          "value": "service-y"
+        },
+        {
+          "key": "peer.ipv4",
+          "type": "int64",
+          "value": "23456"
+        },
+        {
+          "key": "blob",
+          "type": "binary",
+          "value": "00003039"
+        },
+        {
+          "key": "temperature",
+          "type": "float64",
+          "value": "72.5"
+        }
+      ]
     },
     {
       "refType": "CHILD_OF",
       "traceID": "00000000000000ff0000000000000000",
-      "spanID": "00000000000000ff"
+      "spanID": "00000000000000ff",
+      "traceState": "",
+      "flags": 0
     }
   ],
   "startTime": 1485467191639875,
@@ -97,5 +125,27 @@
         "value": "1.2.1"
       }
     ]
-  }
+  },
+  "scopeTags": [
+    {
+      "key": "peer.service",
+      "type": "string",
+      "value": "service-y"
+    },
+    {
+      "key": "peer.ipv4",
+      "type": "int64",
+      "value": "23456"
+    },
+    {
+      "key": "blob",
+      "type": "binary",
+      "value": "00003039"
+    },
+    {
+      "key": "temperature",
+      "type": "float64",
+      "value": "72.5"
+    }
+  ]
 }

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/otel_traces_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/otel_traces_01.json
@@ -21,7 +21,33 @@
         {
           "scope": {
             "name": "testing-library",
-            "version": "1.1.1"
+            "version": "1.1.1",
+            "attributes": [
+              {
+                "key": "peer.service",
+                "value": {
+                  "stringValue": "service-y"
+                }
+              },
+              {
+                "key": "peer.ipv4",
+                "value": {
+                  "intValue": "23456"
+                }
+              },
+              {
+                "key": "blob",
+                "value": {
+                  "bytesValue": "AAAwOQ=="
+                }
+              },
+              {
+                "key": "temperature",
+                "value": {
+                  "doubleValue": 72.5
+                }
+              }
+            ]
           },
           "spans": [
             {
@@ -87,14 +113,40 @@
                 {
                   "traceId": "00000000000000010000000000000000",
                   "spanId": "0000000000000004",
+                  "traceState": "some-link-state",
                   "attributes": [
                     {
                       "key": "opentracing.ref_type",
                       "value": {
                         "stringValue": "follows_from"
                       }
+                    },
+                    {
+                      "key": "peer.service",
+                      "value": {
+                        "stringValue": "service-y"
+                      }
+                    },
+                    {
+                      "key": "peer.ipv4",
+                      "value": {
+                        "intValue": "23456"
+                      }
+                    },
+                    {
+                      "key": "blob",
+                      "value": {
+                        "bytesValue": "AAAwOQ=="
+                      }
+                    },
+                    {
+                      "key": "temperature",
+                      "value": {
+                        "doubleValue": 72.5
+                      }
                     }
-                  ]
+                  ],
+                  "flags": 1
                 },
                 {
                   "traceId": "00000000000000ff0000000000000000",

--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
@@ -428,6 +428,9 @@ func dbSpanRefsToSpanEvents(refs []dbmodel.Reference, excludeParentID dbmodel.Sp
 		link.SetTraceID(refTraceId)
 		link.SetSpanID(refSpanId)
 		link.Attributes().PutStr(conventions.AttributeOpentracingRefType, dbRefTypeToAttribute(ref.RefType))
+		link.TraceState().FromRaw(ref.TraceState)
+		link.SetFlags(ref.Flags)
+		dbTagsToAttributes(ref.Tags, link.Attributes())
 	}
 	return nil
 }
@@ -449,6 +452,7 @@ func dbSpanToScope(span *dbmodel.Span, scopeSpan ptrace.ScopeSpans) {
 			scopeSpan.Scope().SetVersion(libraryVersion)
 		}
 	}
+	dbTagsToAttributes(span.ScopeTags, scopeSpan.Scope().Attributes())
 }
 
 func getAndDeleteTag(span *dbmodel.Span, key string) (string, bool) {

--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
@@ -351,6 +351,9 @@ func dbSpanRefsToSpanEvents(refs []dbmodel.Reference, excludeParentID dbmodel.Sp
 		link.SetTraceID(refTraceId)
 		link.SetSpanID(refSpanId)
 		link.Attributes().PutStr(conventions.AttributeOpentracingRefType, dbRefTypeToAttribute(ref.RefType))
+		link.TraceState().FromRaw(ref.TraceState)
+		link.SetFlags(ref.Flags)
+		dbTagsToAttributes(ref.Tags, link.Attributes())
 	}
 	return nil
 }
@@ -372,6 +375,7 @@ func dbSpanToScope(span *dbmodel.Span, scopeSpan ptrace.ScopeSpans) {
 			scopeSpan.Scope().SetVersion(libraryVersion)
 		}
 	}
+	dbTagsToAttributes(span.ScopeTags, scopeSpan.Scope().Attributes())
 }
 
 func getAndDeleteTag(span *dbmodel.Span, key string) (string, bool) {

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -139,6 +139,7 @@ func spanToDbSpan(span ptrace.Span, libraryTags pcommon.InstrumentationScope, pr
 		Logs:            spanEventsToDbSpanLogs(span.Events()),
 		Process:         process,
 		Flags:           span.Flags(),
+		ScopeTags:       getScopeTags(libraryTags),
 	}
 }
 
@@ -223,15 +224,22 @@ func linksToDbSpanRefs(links ptrace.SpanLinkSlice, parentSpanID dbmodel.SpanID, 
 		linkTraceID := dbmodel.TraceID(link.TraceID().String())
 		linkSpanID := dbmodel.SpanID(link.SpanID().String())
 		linkRefType := refTypeFromLink(link)
+		refTags := getLinkTags(link)
 		if parentSpanID != "" && linkTraceID == traceID && linkSpanID == parentSpanID {
 			// We already added a reference to this span, but maybe with the wrong type, so override.
 			refs[0].RefType = linkRefType
+			refs[0].TraceState = link.TraceState().AsRaw()
+			refs[0].Flags = link.Flags()
+			refs[0].Tags = refTags
 			continue
 		}
 		refs = append(refs, dbmodel.Reference{
-			TraceID: linkTraceID,
-			SpanID:  linkSpanID,
-			RefType: linkRefType,
+			TraceID:    linkTraceID,
+			SpanID:     linkSpanID,
+			RefType:    linkRefType,
+			TraceState: link.TraceState().AsRaw(),
+			Flags:      link.Flags(),
+			Tags:       refTags,
 		})
 	}
 
@@ -372,4 +380,24 @@ func strToDbSpanRefType(attr string) dbmodel.ReferenceType {
 	// There are only 2 types of SpanRefType we assume that everything
 	// that's not a model.ChildOf is a model.FollowsFrom
 	return dbmodel.FollowsFrom
+}
+
+func getScopeTags(scope pcommon.InstrumentationScope) []dbmodel.KeyValue {
+	scopeTags := make([]dbmodel.KeyValue, 0, scope.Attributes().Len())
+	for key, val := range scope.Attributes().All() {
+		scopeTags = append(scopeTags, attributeToDbTag(key, val))
+	}
+	return scopeTags
+}
+
+func getLinkTags(link ptrace.SpanLink) []dbmodel.KeyValue {
+	tags := make([]dbmodel.KeyValue, 0, link.Attributes().Len())
+	for key, val := range link.Attributes().All() {
+		// this is preserved in RefType of dbmodel.Reference
+		if key == conventions.AttributeOpentracingRefType {
+			continue
+		}
+		tags = append(tags, attributeToDbTag(key, val))
+	}
+	return tags
 }

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -162,6 +162,7 @@ func spanToDbSpan(span ptrace.Span, libraryTags pcommon.InstrumentationScope, pr
 		Logs:            spanEventsToDbSpanLogs(span.Events()),
 		Process:         process,
 		Flags:           span.Flags(),
+		ScopeTags:       getScopeTags(libraryTags),
 	}
 }
 
@@ -251,15 +252,22 @@ func linksToDbSpanRefs(links ptrace.SpanLinkSlice, parentSpanID dbmodel.SpanID, 
 		linkTraceID := dbmodel.TraceID(link.TraceID().String())
 		linkSpanID := dbmodel.SpanID(link.SpanID().String())
 		linkRefType := refTypeFromLink(link)
+		refTags := getLinkTags(link)
 		if includeParentRef && linkTraceID == traceID && linkSpanID == parentSpanID {
 			// We already added a reference to this span, but maybe with the wrong type, so override.
 			refs[0].RefType = linkRefType
+			refs[0].TraceState = link.TraceState().AsRaw()
+			refs[0].Flags = link.Flags()
+			refs[0].Tags = refTags
 			continue
 		}
 		refs = append(refs, dbmodel.Reference{
-			TraceID: linkTraceID,
-			SpanID:  linkSpanID,
-			RefType: linkRefType,
+			TraceID:    linkTraceID,
+			SpanID:     linkSpanID,
+			RefType:    linkRefType,
+			TraceState: link.TraceState().AsRaw(),
+			Flags:      link.Flags(),
+			Tags:       refTags,
 		})
 	}
 
@@ -400,4 +408,24 @@ func strToDbSpanRefType(attr string) dbmodel.ReferenceType {
 	// There are only 2 types of SpanRefType we assume that everything
 	// that's not a model.ChildOf is a model.FollowsFrom
 	return dbmodel.FollowsFrom
+}
+
+func getScopeTags(scope pcommon.InstrumentationScope) []dbmodel.KeyValue {
+	scopeTags := make([]dbmodel.KeyValue, 0, scope.Attributes().Len())
+	for key, val := range scope.Attributes().All() {
+		scopeTags = append(scopeTags, attributeToDbTag(key, val))
+	}
+	return scopeTags
+}
+
+func getLinkTags(link ptrace.SpanLink) []dbmodel.KeyValue {
+	tags := make([]dbmodel.KeyValue, 0, link.Attributes().Len())
+	for key, val := range link.Attributes().All() {
+		// this is preserved in RefType of dbmodel.Reference
+		if key == conventions.AttributeOpentracingRefType {
+			continue
+		}
+		tags = append(tags, attributeToDbTag(key, val))
+	}
+	return tags
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards: #8078 

## Description of the changes
- Add missing fields to dbmodel of ES/OS and enable reader to filter on them

## How was this change tested?
- Unit And Integration tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
