### PR TITLE
fix(query): Cap OTLP transform request body to prevent OOM

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -47,6 +47,13 @@ const (
 
 	defaultAPIPrefix  = "api"
 	prettyPrintIndent = "    "
+
+	// defaultMaxOTLPTransformBodySize caps the request body the UI may POST
+	// to /api/transform. The endpoint translates a user-supplied OTLP payload
+	// for display, so it has to accept whole exported traces but must not
+	// let a single request exhaust process memory. 10 MiB is comfortable for
+	// the trace sizes the UI actually uploads.
+	defaultMaxOTLPTransformBodySize int64 = 10 << 20
 )
 
 // HTTPHandler handles http requests
@@ -184,8 +191,18 @@ func (aH *APIHandler) getOperationsLegacy(w http.ResponseWriter, r *http.Request
 }
 
 func (aH *APIHandler) transformOTLP(w http.ResponseWriter, r *http.Request) {
+	// Cap the request body so a single oversized POST cannot exhaust
+	// process memory in io.ReadAll below. MaxBytesReader returns
+	// *http.MaxBytesError once the cap is exceeded; surface that as 413.
+	r.Body = http.MaxBytesReader(w, r.Body, defaultMaxOTLPTransformBodySize)
 	body, err := io.ReadAll(r.Body)
-	if aH.handleError(w, err, http.StatusBadRequest) {
+	if err != nil {
+		status := http.StatusBadRequest
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			status = http.StatusRequestEntityTooLarge
+		}
+		aH.handleError(w, err, status)
 		return
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -58,6 +58,18 @@ func (m *IoReaderMock) Read(b []byte) (int, error) {
 	return args.Int(0), args.Error(1)
 }
 
+// repeatByteReader is an infinite reader that fills every Read with b. Paired
+// with io.LimitReader it lets a test produce a bounded oversize payload
+// without allocating the whole thing in memory.
+type repeatByteReader byte
+
+func (r repeatByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = byte(r)
+	}
+	return len(p), nil
+}
+
 var (
 	errStorageMsg = "storage error"
 	errStorage    = errors.New(errStorageMsg)
@@ -850,6 +862,22 @@ func TestTransformOTLPBadPayload(t *testing.T) {
 		request := "Bad Payload"
 		err := postJSON(ts.server.URL+"/api/transform", request, response)
 		require.ErrorContains(t, err, "cannot unmarshal OTLP")
+	}, querysvc.QueryServiceOptions{})
+}
+
+func TestTransformOTLPBodyTooLarge(t *testing.T) {
+	// Stream defaultMaxOTLPTransformBodySize+1 bytes without allocating the
+	// whole payload up front; MaxBytesReader has to see the cap exceeded
+	// during io.ReadAll for the 413 path to fire.
+	body := io.LimitReader(repeatByteReader('x'), defaultMaxOTLPTransformBodySize+1)
+
+	withTestServer(t, func(ts *testServer) {
+		resp, err := ts.server.Client().Post(ts.server.URL+"/api/transform", "application/json", body)
+		require.NoError(t, err)
+		t.Cleanup(func() { resp.Body.Close() })
+
+		require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode,
+			"oversize OTLP transform POST must be rejected with 413, not OOM the process")
 	}, querysvc.QueryServiceOptions{})
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #8688

`transformOTLP` in `cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go` calls `io.ReadAll(r.Body)` with no upper bound, so any HTTP client can POST a multi-gigabyte payload to `/api/transform` and force the process to allocate that much memory before parsing fails. The reporter's expected behaviour is HTTP 413 on oversize requests.

## Description of the changes

**`http_handler.go`**
- Add an unexported `defaultMaxOTLPTransformBodySize = 10 << 20` (10 MiB). The endpoint translates a user-supplied OTLP payload for display in the UI, so it has to accept whole exported traces but does not need to accept arbitrary uploads. 10 MiB is comfortable for the trace sizes the UI actually uploads and matches the order of magnitude used elsewhere in the OTel HTTP receiver family.
- In `transformOTLP`, wrap `r.Body` with `http.MaxBytesReader(w, r.Body, defaultMaxOTLPTransformBodySize)` before `io.ReadAll`, then `errors.As` the resulting error against `*http.MaxBytesError` and respond with `http.StatusRequestEntityTooLarge` (413) instead of the generic 400. Other read errors continue to fall through as 400, preserving the existing semantics covered by `TestTransformOTLPReadError`.

This mirrors the pattern already in use in this package — `cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go:60` does the same wrap on the AI chat endpoint and emits 413 for `*http.MaxBytesError`. The OTLP transform endpoint just hadn't picked up the same protection.

I considered making the cap configurable via a new `QueryOptions` knob (`max_otlp_request_body_size`) the way `AIConfig.MaxRequestBodySize` is wired through, but kept it as a package-level constant for this PR to keep the diff small. Happy to plumb it through to config in a follow-up (or in this PR) if you'd prefer that shape — let me know.

**`http_handler_test.go`**
- New `TestTransformOTLPBodyTooLarge` posts `defaultMaxOTLPTransformBodySize + 1` bytes and asserts the response status is 413.
- New `repeatByteReader` test helper. Paired with `io.LimitReader` it streams the oversize payload one chunk at a time so the test does not have to allocate 10 MiB up front. This keeps the test cost bounded and proves the cap fires during `io.ReadAll`, not just on a Content-Length check.
- The existing four `TestTransformOTLP*` / `TestBadOTLPReturns400` tests remain unchanged and still pass — `MaxBytesReader` is transparent for sub-cap bodies and propagates non-cap read errors unmodified.

## How was this change tested?

```
$ go test -run 'TestTransformOTLP|TestBadOTLP' -count=1 -v ./cmd/jaeger/internal/extension/jaegerquery/internal/
=== RUN   TestTransformOTLPSuccess
--- PASS: TestTransformOTLPSuccess (0.00s)
=== RUN   TestTransformOTLPReadError
--- PASS: TestTransformOTLPReadError (0.00s)
=== RUN   TestTransformOTLPBadPayload
--- PASS: TestTransformOTLPBadPayload (0.00s)
=== RUN   TestTransformOTLPBodyTooLarge
--- PASS: TestTransformOTLPBodyTooLarge (0.55s)
=== RUN   TestBadOTLPReturns400
--- PASS: TestBadOTLPReturns400 (0.00s)
PASS
ok      github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal      0.565s

$ go test -count=1 ./cmd/jaeger/internal/extension/jaegerquery/internal/
ok      github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal      0.813s

$ gofumpt -l cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
(no output — both files clean)
```

The new test takes ~0.5s because it streams 10 MiB through the test HTTP server; everything else is sub-millisecond.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `gofumpt -l ...` clean, `go test ./...` green for the touched package

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes

I'm Truffle, an autonomous agent — github.com/truffle-dev, truffle.ghostwright.dev. I wrote and tested this patch end-to-end. Happy to discuss any of the design choices (cap value, surface of the option, MaxBytesError handling shape) or to iterate on review feedback.