### PR TITLE
fix(query): return HTTP 400 for invalid limit and time range parameters

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -652,6 +652,19 @@ func TestSearchFailures(t *testing.T) {
 			`/api/traces?service=service&start=0&end=0&operation=operation&maxDuration=10ms&limit=200&minDuration=20ms`,
 			parsedError(400, "'maxDuration' should be greater than 'minDuration'"),
 		},
+		{
+			`/api/traces?service=service&start=0&end=0&operation=operation&limit=0`,
+			parsedError(400, "parameter 'limit' must be greater than 0"),
+		},
+		{
+			`/api/traces?service=service&start=0&end=0&operation=operation&limit=-1`,
+			parsedError(400, "parameter 'limit' must be greater than 0"),
+		},
+		{
+			// start=1000 microseconds after epoch is after end=0 (epoch)
+			`/api/traces?service=service&start=1000&end=0&operation=operation&limit=200`,
+			parsedError(400, "'start' must not be later than 'end'"),
+		},
 	}
 	for _, test := range tests {
 		testIndividualSearchFailures(t, test.urlStr, test.errMsg)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -42,6 +42,12 @@ var (
 
 	// errServiceParameterRequired occurs when no service name is defined.
 	errServiceParameterRequired = fmt.Errorf("parameter '%s' is required", serviceParam)
+
+	// errLimitMustBePositive occurs when the limit parameter is zero or negative.
+	errLimitMustBePositive = fmt.Errorf("parameter '%s' must be greater than 0", limitParam)
+
+	// errStartTimeAfterEnd occurs when the start time is after the end time.
+	errStartTimeAfterEnd = fmt.Errorf("'%s' must not be later than '%s'", startTimeParam, endTimeParam)
 )
 
 type (
@@ -361,6 +367,12 @@ func mapSpanKindsToOpenTelemetry(spanKinds []string) ([]string, error) {
 func (*queryParser) validateQuery(traceQuery *traceQueryParameters) error {
 	if len(traceQuery.TraceIDs) == 0 && traceQuery.ServiceName == "" {
 		return errServiceParameterRequired
+	}
+	if len(traceQuery.TraceIDs) == 0 && traceQuery.SearchDepth <= 0 {
+		return errLimitMustBePositive
+	}
+	if traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {
+		return errStartTimeAfterEnd
 	}
 	if traceQuery.DurationMin != 0 && traceQuery.DurationMax != 0 {
 		if traceQuery.DurationMax < traceQuery.DurationMin {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -371,7 +371,7 @@ func (*queryParser) validateQuery(traceQuery *traceQueryParameters) error {
 	if len(traceQuery.TraceIDs) == 0 && traceQuery.SearchDepth <= 0 {
 		return errLimitMustBePositive
 	}
-	if traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {
+	if len(traceQuery.TraceIDs) == 0 && traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {
 		return errStartTimeAfterEnd
 	}
 	if traceQuery.DurationMin != 0 && traceQuery.DurationMax != 0 {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -39,6 +39,10 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", `unable to parse param 'maxDuration': time: missing unit in duration "?30"?$`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `malformed 'tag' parameter, expecting key:value, received: k`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=25s&maxDuration=1s", `'maxDuration' should be greater than 'minDuration'`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=0", `parameter 'limit' must be greater than 0`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=-1", `parameter 'limit' must be greater than 0`, nil},
+		// start=1000 (1ms since epoch) is after end=0 (epoch)
+		{"x?service=service&start=1000&end=0&operation=operation&limit=200", `'start' must not be later than 'end'`, nil},
 		{
 			"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
 			&traceQueryParameters{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -43,6 +43,8 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&start=0&end=0&operation=operation&limit=-1", `parameter 'limit' must be greater than 0`, nil},
 		// start=1000 (1ms since epoch) is after end=0 (epoch)
 		{"x?service=service&start=1000&end=0&operation=operation&limit=200", `'start' must not be later than 'end'`, nil},
+		// trace-ID-only query with no start/end must not be rejected by the start>end check
+		{"x?traceID=abc123", noErr, nil},
 		{
 			"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
 			&traceQueryParameters{


### PR DESCRIPTION
## Summary

Closes #8436.

The HTTP search API had two cases where invalid query parameters weren't caught early enough:

1. **`limit=0` or `limit<0`** — the request would pass through to the storage layer, which then returned an error that bubbled up as HTTP 500. The error message ("search depth must be greater than 0") was a storage implementation detail, not a proper API error.

2. **`start` after `end`** — the request would silently return HTTP 200 with an empty trace list, giving no indication that the time range was invalid.

Both are clearly malformed requests that should be rejected at the API layer with HTTP 400.

## Changes

- Added `errLimitMustBePositive` and `errStartTimeAfterEnd` error variables in `query_parser.go`
- Extended `validateQuery` to check these conditions before the query reaches storage
- Added unit tests for the new validation cases in `query_parser_test.go`
- Added integration tests that verify the HTTP 400 response in `http_handler_test.go`

The limit check only applies when searching by service (not when looking up specific trace IDs by `traceID=` param), matching the existing behavior for the service-required validation.