### PR TITLE
docs(security): Accept branch protection scorecard finding

### DIFF
--- a/docs/security/openssf-gold-evidence.md
+++ b/docs/security/openssf-gold-evidence.md
@@ -47,7 +47,10 @@ The public OpenSSF Scorecard result remains detection-based. These entries docum
 
 | Scorecard check | Current score | Decision | Rationale |
 | --- | ---: | --- | --- |
+| `Branch-Protection` | `8` | Accepted exception | Jaeger keeps `main` protected with pull requests required, CODEOWNERS review required, required status checks configured, branch protection enforced for administrators, force pushes disabled, and branch deletion disabled. Maintainers accept one required approving review instead of raising the requirement to two solely for additional Scorecard credit. |
 | `Fuzzing` | `0` | Accepted exception | Jaeger is not adding fuzzing solely to improve Scorecard. Useful fuzzing would need explicit target selection, seed corpora, invariants, ownership, triage, and non-PR infrastructure. Placeholder fuzz targets would be misleading. Revisit only for a specific untrusted-input parser or decoder with an owner and clear triage path. |
+
+The branch protection exception is tracked by `https://github.com/jaegertracing/jaeger/issues/8674`.
 
 The fuzzing exception is tracked by `https://github.com/jaegertracing/jaeger/issues/8636`.
 


### PR DESCRIPTION
## Summary

- document `Branch-Protection` as an accepted OpenSSF Scorecard exception
- record that maintainers accept one required approving review on `main` instead of raising it to two solely for Scorecard credit
- link the exception back to #8674

Fixes #8674

## Testing

- `make fmt`
- `make lint`
- `make test`
