### PR TITLE
chore: Expand AGENTS.md with PR policy, test, and scope guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@ If checking out a fresh repository, initialize submodules:
 git submodule update --init --recursive
 ```
 
+## Pull Requests
+
+- **Require an issue:** Do not open a Pull Request unless there is an existing, open GitHub Issue that explicitly requests the work. Speculative refactors and unsolicited feature work are not accepted.
+- **Stay inside the issue's scope:** Implement only what the issue describes. If you discover related problems, mention them in the PR description or open a separate issue rather than fixing them in the same PR.
+- **One issue, one PR:** Do not bundle multiple issues into a single PR.
+- **No PR for chores already handled by automation:** Dependency bumps managed by Dependabot and similar housekeeping are handled automatically. Do not open PRs that duplicate that work.
+
 ## Required Workflow
 
 **Before considering any task complete**, you MUST verify:
@@ -19,6 +26,8 @@ git submodule update --init --recursive
 3. Run `make test` and ensure all tests pass
 
 These checks are mandatory for the entire repository, not just files you modified.
+
+Do not skip, disable, or bypass these checks (e.g. `--no-verify`, commenting out linters, adding broad `//nolint` directives) to make CI pass. Fix the underlying issue.
 
 ## Permissions
 
@@ -45,3 +54,21 @@ Run these commands without asking for permission:
 
 **Submodules:**
 - `jaeger-ui` and `idl` are submodules. Modifications there require PRs to their respective repositories.
+
+## Tests
+
+- All new functionality must include tests.
+- Bug fixes must include a regression test that fails without the fix.
+- Do not delete existing tests to make a build green. If a test is genuinely wrong, explain why in the PR description.
+- Do not weaken assertions (e.g. replacing exact checks with `assert.NotNil`) just to make a flaky test pass.
+- Every package must have at least one `*_test.go` file (enforced by `make nocover`). If no tests are possible (e.g. a package that only defines types), create an empty `empty_test.go`.
+
+## Scope Discipline
+
+- Do not reformat, rename, or restructure code outside the scope of the requested change.
+- Do not bump dependencies unless the task requires it.
+- Do not change CI workflows or release tooling unless explicitly asked.
+
+## When in Doubt
+
+Stop and ask rather than guessing. It is better to surface a question in the PR description than to invent behavior, fabricate API names, or silence failing checks.


### PR DESCRIPTION
## Summary

Expands `AGENTS.md` with additional guidance for AI agents, adapted from [KEDA's AGENTS.md](https://github.com/kedacore/keda/blob/main/AGENTS.md):

- **Pull Requests**: require an open issue before opening a PR, stay inside issue scope, one issue per PR, don't duplicate Dependabot automation
- **Required Workflow**: explicit rule against bypassing checks via `--no-verify` or broad `//nolint` directives
- **Tests**: regression tests required for bug fixes, don't delete or weaken existing tests, every package needs a `*_test.go`
- **Scope Discipline**: no drive-by reformats/renames, no unsolicited dependency bumps, no CI workflow changes without being asked
- **When in Doubt**: stop and ask rather than invent behavior

Points about issue assignment were omitted as Jaeger does not use that workflow.

## Test plan

- [ ] No code changes; verify the file reads correctly