### PR TITLE
fix(es-rollover): parameterize archive template mappings and add inte…

### DIFF
--- a/cmd/es-rollover/app/init/action.go
+++ b/cmd/es-rollover/app/init/action.go
@@ -33,6 +33,7 @@ func (c Action) getMapping(version uint, mappingType mappings.MappingType) (stri
 		UseILM:          c.Config.UseILM,
 		ILMPolicyName:   c.Config.ILMPolicyName,
 		EsVersion:       version,
+		Archive:         c.Config.Archive,
 	}
 
 	return mappingBuilder.GetMapping(mappingType)

--- a/internal/storage/integration/es_index_rollover_test.go
+++ b/internal/storage/integration/es_index_rollover_test.go
@@ -178,3 +178,59 @@ func cleanES(t *testing.T, client *elastic.Client, policyName string) {
 	_, err = client.IndexDeleteTemplate("*").Do(context.Background())
 	require.NoError(t, err)
 }
+
+func TestIndexRollover_ArchiveIndicesWithILM(t *testing.T) {
+	SkipUnlessEnv(t, "elasticsearch", "opensearch")
+	t.Cleanup(func() {
+		testutils.VerifyGoLeaksOnceForES(t)
+	})
+
+	client, err := createESClient(t, getESHttpClient(t))
+	require.NoError(t, err)
+	esVersion, err := getVersion(client)
+	require.NoError(t, err)
+
+	if esVersion < 7 {
+		t.Skip("ILM is only supported in ES 7+")
+	}
+
+	ilmPolicyName := defaultILMPolicyName
+	envVars := []string{
+		"ES_USE_ILM=true",
+		"ARCHIVE=true",
+		"INDEX_PREFIX=",
+	}
+
+	expectedIndex := "jaeger-span-archive-000001"
+	expectedWriteAlias := "jaeger-span-archive-write"
+
+	// Ensure ES is completely clean before and after the test
+	cleanES(t, client, ilmPolicyName)
+	v8Client, err := createESV8Client(getESHttpClient(t).Transport)
+	require.NoError(t, err)
+	defer cleanES(t, client, ilmPolicyName)
+	defer cleanESIndexTemplates(t, client, v8Client, "")
+
+	err = createILMPolicy(client, ilmPolicyName)
+	require.NoError(t, err)
+
+	// Run the es-rollover init command with the archive flag
+	err = runEsRollover("init", envVars, false)
+	require.NoError(t, err)
+
+	// Fetch the actual indices created in the database
+	indices, err := client.IndexNames()
+	require.NoError(t, err)
+	assert.Contains(t, indices, expectedIndex)
+
+	// Fetch the settings injected into the archive index
+	settings, err := client.IndexGetSettings(expectedIndex).FlatSettings(true).Do(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, settings, 1)
+	for _, v := range settings {
+		assert.Equal(t, ilmPolicyName, v.Settings["index.lifecycle.name"])
+		assert.Equal(t, expectedWriteAlias, v.Settings["index.lifecycle.rollover_alias"],
+			"The rollover alias must match the archive write alias to prevent ILM collisions")
+	}
+}

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-7.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-7.json
@@ -2,7 +2,7 @@
   "index_patterns": "*{{ .IndexPrefix }}jaeger-span-*",
   {{- if .UseILM }}
   "aliases": {
-    "{{ .IndexPrefix }}jaeger-span-read": {}
+    "{{ .ReadAlias }}": {}
   },
   {{- end }}
   "settings":{
@@ -13,7 +13,7 @@
     {{- if .UseILM }}
     ,"lifecycle": {
       "name": "{{ .ILMPolicyName }}",
-      "rollover_alias": "{{ .IndexPrefix }}jaeger-span-write"
+      "rollover_alias": "{{ .RolloverAlias }}"
     }
     {{- end }}
   },

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-8.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-8.json
@@ -5,7 +5,7 @@
 
     {{- if .UseILM}}
     "aliases": {
-      "{{ .IndexPrefix }}jaeger-span-read": {}
+      "{{ .ReadAlias }}": {}
     },
     {{- end}}
     "settings": {
@@ -16,7 +16,7 @@
       {{- if .UseILM }},
       "lifecycle": {
         "name": "{{ .ILMPolicyName }}",
-        "rollover_alias": "{{ .IndexPrefix }}jaeger-span-write"
+        "rollover_alias": "{{ .RolloverAlias }}"
       }
       {{- end }}
     },

--- a/internal/storage/v1/elasticsearch/mappings/mapping.go
+++ b/internal/storage/v1/elasticsearch/mappings/mapping.go
@@ -34,6 +34,7 @@ type MappingBuilder struct {
 	EsVersion       uint
 	UseILM          bool
 	ILMPolicyName   string
+	Archive         bool
 }
 
 // templateParams holds parameters required to render an elasticsearch index template
@@ -44,6 +45,8 @@ type templateParams struct {
 	Shards        int64
 	Replicas      int64
 	Priority      int64
+	RolloverAlias string
+	ReadAlias     string
 }
 
 func (mb MappingBuilder) getMappingTemplateOptions(mappingType MappingType) templateParams {
@@ -56,6 +59,14 @@ func (mb MappingBuilder) getMappingTemplateOptions(mappingType MappingType) temp
 		mappingOpts.Shards = mb.Indices.Spans.Shards
 		mappingOpts.Replicas = *mb.Indices.Spans.Replicas
 		mappingOpts.Priority = mb.Indices.Spans.Priority
+		prefix := mb.Indices.IndexPrefix.Apply("")
+		if mb.Archive {
+			mappingOpts.RolloverAlias = prefix + "jaeger-span-archive-write"
+			mappingOpts.ReadAlias = prefix + "jaeger-span-archive-read"
+		} else {
+			mappingOpts.RolloverAlias = prefix + "jaeger-span-write"
+			mappingOpts.ReadAlias = prefix + "jaeger-span-read"
+		}
 	case ServiceMapping:
 		mappingOpts.Shards = mb.Indices.Services.Shards
 		mappingOpts.Replicas = *mb.Indices.Services.Replicas

--- a/internal/storage/v1/elasticsearch/mappings/mapping_test.go
+++ b/internal/storage/v1/elasticsearch/mappings/mapping_test.go
@@ -414,3 +414,27 @@ func TestGetMappingTemplateOptions_DefaultCase(t *testing.T) {
 func TestMain(m *testing.M) {
 	testutils.VerifyGoLeaks(m)
 }
+
+func TestGetMappingTemplateOptions_ArchiveILM(t *testing.T) {
+	replicas := int64(1)
+	mappingBuilder := &MappingBuilder{
+		Indices: config.Indices{
+			IndexPrefix: "test-",
+			Spans: config.IndexOptions{
+				Shards:   2,
+				Replicas: &replicas,
+				Priority: 10,
+			},
+		},
+		UseILM:        true,
+		ILMPolicyName: "archive-policy",
+		Archive:       true,
+	}
+
+	opts := mappingBuilder.getMappingTemplateOptions(SpanMapping)
+
+	assert.Equal(t, "test-jaeger-span-archive-write", opts.RolloverAlias)
+	assert.Equal(t, "test-jaeger-span-archive-read", opts.ReadAlias)
+	assert.True(t, opts.UseILM)
+	assert.Equal(t, "archive-policy", opts.ILMPolicyName)
+}


### PR DESCRIPTION
Fixes https://github.com/jaegertracing/jaeger/issues/8292

Description:
Resolves the ILM index collision bug where archive data overwrote primary storage. Parameterized the MappingBuilder to dynamically inject the -archive- segment into the rollover_alias of the Elasticsearch templates during initialization, aligning the JSON blueprint with the CLI output.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
