### PR TITLE
fix(cassandra): Optimize IntersectTraceIDs to iterate over the smallest set

### DIFF
--- a/internal/storage/v1/cassandra/spanstore/dbmodel/unique_ids.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/unique_ids.go
@@ -23,11 +23,15 @@ func (u UniqueTraceIDs) Add(traceID TraceID) {
 
 // IntersectTraceIDs takes a list of UniqueTraceIDs and intersects them.
 func IntersectTraceIDs(uniqueTraceIdsList []UniqueTraceIDs) UniqueTraceIDs {
+	if len(uniqueTraceIdsList) == 0 {
+		return UniqueTraceIDs{}
+	}
+
 	// Find the smallest set to iterate over, as the intersection
 	// can never be larger than the smallest input set.
 	smallestIdx := 0
-	for i := range uniqueTraceIdsList {
-		if len(uniqueTraceIdsList[i]) < len(uniqueTraceIdsList[smallestIdx]) { //nolint:gosec // G602 false positive: smallestIdx is always a valid index
+	for i := 1; i < len(uniqueTraceIdsList); i++ {
+		if len(uniqueTraceIdsList[i]) < len(uniqueTraceIdsList[smallestIdx]) {
 			smallestIdx = i
 		}
 	}

--- a/internal/storage/v1/cassandra/spanstore/dbmodel/unique_ids.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/unique_ids.go
@@ -23,10 +23,21 @@ func (u UniqueTraceIDs) Add(traceID TraceID) {
 
 // IntersectTraceIDs takes a list of UniqueTraceIDs and intersects them.
 func IntersectTraceIDs(uniqueTraceIdsList []UniqueTraceIDs) UniqueTraceIDs {
+	// Find the smallest set to iterate over, as the intersection
+	// can never be larger than the smallest input set.
+	smallestIdx := 0
+	for i := range uniqueTraceIdsList {
+		if len(uniqueTraceIdsList[i]) < len(uniqueTraceIdsList[smallestIdx]) { //nolint:gosec // G602 false positive: smallestIdx is always a valid index
+			smallestIdx = i
+		}
+	}
 	retMe := UniqueTraceIDs{}
-	for key, value := range uniqueTraceIdsList[0] {
+	for key, value := range uniqueTraceIdsList[smallestIdx] {
 		keyExistsInAll := true
-		for _, otherTraceIds := range uniqueTraceIdsList[1:] {
+		for i, otherTraceIds := range uniqueTraceIdsList {
+			if i == smallestIdx {
+				continue
+			}
 			if _, ok := otherTraceIds[key]; !ok {
 				keyExistsInAll = false
 				break

--- a/internal/storage/v1/cassandra/spanstore/dbmodel/unique_ids_test.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/unique_ids_test.go
@@ -13,6 +13,9 @@ import (
 var (
 	firstTraceID  = TraceID{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1}
 	secondTraceID = TraceID{0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2}
+
+	// benchSink prevents the compiler from optimizing away benchmark results.
+	benchSink UniqueTraceIDs
 )
 
 func TestGetIntersectedTraceIDs(t *testing.T) {
@@ -51,4 +54,58 @@ func TestFromList(t *testing.T) {
 	uniqueTraceIDs := UniqueTraceIDsFromList(traceIDList)
 	assert.Len(t, uniqueTraceIDs, 1)
 	assert.Contains(t, uniqueTraceIDs, someID)
+}
+
+func TestIntersectTraceIDs_SmallestSetNotFirst(t *testing.T) {
+	// The smallest set is the last element; verify the result is
+	// identical regardless of ordering.
+	large := UniqueTraceIDs{}
+	for i := range 1000 {
+		var id TraceID
+		id[15] = byte(i)
+		id[14] = byte(i >> 8)
+		large[id] = struct{}{}
+	}
+	// Build a shared ID that is guaranteed to be in the large set.
+	var sharedID TraceID
+	sharedID[15] = byte(42)
+	small := UniqueTraceIDs{
+		sharedID: {},
+	}
+	actual := IntersectTraceIDs([]UniqueTraceIDs{large, small})
+	expected := UniqueTraceIDs{
+		sharedID: {},
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func BenchmarkIntersectTraceIDs_Asymmetric(b *testing.B) {
+	// Build two sets with asymmetric sizes: one large (10 000 IDs),
+	// one small (10 IDs) that is a subset of the large set.
+	large := make(UniqueTraceIDs, 10_000)
+	for i := range 10_000 {
+		var id TraceID
+		id[15] = byte(i)
+		id[14] = byte(i >> 8)
+		large[id] = struct{}{}
+	}
+	small := make(UniqueTraceIDs, 10)
+	i := 0
+	for id := range large {
+		if i >= 10 {
+			break
+		}
+		small[id] = struct{}{}
+		i++
+	}
+
+	// Place the large set first so the old code would iterate 10 000 entries,
+	// while the optimized code iterates only 10.
+	sets := []UniqueTraceIDs{large, small}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		benchSink = IntersectTraceIDs(sets)
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

When searching for traces by multiple tags, `IntersectTraceIDs` blindly iterates over `uniqueTraceIdsList[0]` to compute the intersection. Because the list of sets is generated by iterating over a `pcommon.Map` (which has no guaranteed order), the first set could be extremely large (e.g., 50,000 IDs) while another set is very small (e.g., 5 IDs). This results in unnecessary O(N_large) map lookups instead of O(N_small).

## Description of the changes

- Modified `IntersectTraceIDs` to first find the set with the minimum length and use that as the base for iteration, reducing the complexity from O(N_random) to O(N_min).
- Added a `//nolint:gosec` directive for a G602 false positive -`smallestIdx` is always a valid index since it is only assigned from a valid loop variable.
- Added `TestIntersectTraceIDs_SmallestSetNotFirst` to verify correctness when the smallest set is not the first element.
- Added `BenchmarkIntersectTraceIDs_Asymmetric` to demonstrate the performance improvement with asymmetric sets (10,000 vs 10 IDs).

## How was this change tested?

- All existing unit tests pass without modification, proving the intersection output is identical.
- New unit test `TestIntersectTraceIDs_SmallestSetNotFirst` validates correctness regardless of set ordering.
- `make fmt` and `make lint` pass (only pre-existing unrelated `gocritic` issue in `http_handler_test.go`).

### Benchmark results (10,000 IDs vs 10 IDs, large set placed first)

**Before (`main` - always iterates over the first set):**

<img width="1208" height="159" alt="image" src="https://github.com/user-attachments/assets/7b41e48c-69e3-4733-9578-d356468e82c0" />

BenchmarkIntersectTraceIDs_Asymmetric-12  7965  203053 ns/op  328 B/op  3 allocs/op


**After (this PR- iterates over the smallest set):**

<img width="1201" height="158" alt="image" src="https://github.com/user-attachments/assets/0f544a62-eb16-418e-817c-0e92a9b04a4f" />

BenchmarkIntersectTraceIDs_Asymmetric-12  2084946  520.5 ns/op  328 B/op  3 allocs/op


**~390x improvement in execution time** by iterating over the smallest set instead of an arbitrary one.

Fixes #8701 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR 
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
