### PR TITLE
Rebuild services and operations maps on trace eviction

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -696,6 +696,62 @@ func TestNewStore_TracesLimit(t *testing.T) {
 	assert.Len(t, tenant.ids, maxTraces)
 }
 
+func TestEviction_RemovesStaleServicesAndOperations(t *testing.T) {
+	store, err := NewStore(Configuration{
+		MaxTraces: 2,
+	})
+	require.NoError(t, err)
+
+	// Write a trace for "evicted-service"
+	td1 := ptrace.NewTraces()
+	rs1 := td1.ResourceSpans().AppendEmpty()
+	rs1.Resource().Attributes().PutStr(conventions.ServiceNameKey, "evicted-service")
+	span1 := rs1.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span1.SetTraceID(fromString(t, "00000000000000010000000000000000"))
+	span1.SetName("evicted-op")
+	span1.SetKind(ptrace.SpanKindServer)
+	err = store.WriteTraces(context.Background(), td1)
+	require.NoError(t, err)
+
+	// Verify "evicted-service" is initially present
+	services, err := store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, services, "evicted-service")
+
+	// Write 2 traces for "retained-service" to fill the ring buffer and evict the first trace
+	for i := 2; i <= 3; i++ {
+		td := ptrace.NewTraces()
+		rs := td.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "retained-service")
+		span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(fromString(t, fmt.Sprintf("000000000000000%d0000000000000000", i)))
+		span.SetName("retained-op")
+		span.SetKind(ptrace.SpanKindClient)
+		err = store.WriteTraces(context.Background(), td)
+		require.NoError(t, err)
+	}
+
+	// After eviction, "evicted-service" should no longer appear
+	services, err = store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"retained-service"}, services)
+
+	// Operations for "evicted-service" should be empty
+	evictedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "evicted-service",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, evictedOps)
+
+	// Operations for "retained-service" should still be present
+	retainedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "retained-service",
+	})
+	require.NoError(t, err)
+	assert.Len(t, retainedOps, 1)
+	assert.Equal(t, "retained-op", retainedOps[0].Name)
+}
+
 func TestNewStore_ReverseChronologicalOrder(t *testing.T) {
 	maxTraces := 8
 	store, err := NewStore(Configuration{

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -104,7 +104,8 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 		sameTraceIDResourceSpan.MoveAndAppendTo(traces.ResourceSpans())
 		t.mostRecent = (t.mostRecent + 1) % t.config.MaxTraces
 		// if there is already a trace in lastEvicted position, remove its ID from ids map
-		if !t.traces[t.mostRecent].id.IsEmpty() {
+		evicted := !t.traces[t.mostRecent].id.IsEmpty()
+		if evicted {
 			delete(t.ids, t.traces[t.mostRecent].id)
 		}
 		// update the ring with the trace id
@@ -115,7 +116,41 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 			startTime: startTime,
 			endTime:   endTime,
 		}
+		if evicted {
+			t.rebuildServicesAndOperations()
+		}
 	}
+}
+
+func (t *Tenant) rebuildServicesAndOperations() {
+	services := make(map[string]struct{})
+	operations := make(map[string]map[tracestore.Operation]struct{})
+	for _, traceEntry := range t.traces {
+		if traceEntry.id.IsEmpty() {
+			continue
+		}
+		for _, resourceSpan := range traceEntry.trace.ResourceSpans().All() {
+			serviceName := getServiceNameFromResource(resourceSpan.Resource())
+			if serviceName == "" {
+				continue
+			}
+			services[serviceName] = struct{}{}
+			for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
+				for _, span := range scopeSpan.Spans().All() {
+					op := tracestore.Operation{
+						Name:     span.Name(),
+						SpanKind: fromOTELSpanKind(span.Kind()),
+					}
+					if _, ok := operations[serviceName]; !ok {
+						operations[serviceName] = make(map[tracestore.Operation]struct{})
+					}
+					operations[serviceName][op] = struct{}{}
+				}
+			}
+		}
+	}
+	t.services = services
+	t.operations = operations
 }
 
 func (t *Tenant) findTraceAndIds(query tracestore.TraceQueryParams) ([]traceAndId, error) {


### PR DESCRIPTION
Fixes #8703.
When Jaeger uses memory storage with a limited max_traces value, evicting a trace from the ring buffer does not clean up its service name and operations from the metadata maps (services and operations). This causes the UI to list "ghost" services and operations that have zero traces in the storage.

This PR introduces an eviction-triggered rebuild logic:
1. When a trace is overwritten/evicted, `rebuildServicesAndOperations() is invoked.
2. The method scans all active traces in the ring buffer and reconstructs t.services and t.operations maps.
3. Added a regression test TestEviction_RemovesStaleServicesAndOperations reproducing this exact scenario to ensure service/operation maps are properly cleaned up upon eviction.