### PR TITLE
fix(build): Make rebuild-ui also copy assets into Go source tree

### DIFF
--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -46,9 +46,9 @@ $(JAEGER_UI_DIR)/packages/jaeger-ui/build/index.html:
 rebuild-ui:
 	@echo "::group::rebuild-ui logs"
 	JAEGER_UI_DIR="$(JAEGER_UI_DIR)" bash ./scripts/build/rebuild-ui.sh
-	@echo "NOTE: This target only rebuilds the UI assets inside $(JAEGER_UI_DIR)/packages/jaeger-ui/build/."
-	@echo "NOTE: To make them usable from query-service run 'make build-ui'."
 	@echo "::endgroup::"
+	rm -f cmd/jaeger/internal/extension/jaegerquery/internal/ui/actual/index.html.gz
+	$(MAKE) build-ui
 
 .PHONY: build-examples
 build-examples:


### PR DESCRIPTION
## Summary
- `make rebuild-ui` now automatically invokes `build-ui` after building JS assets, so the gzipped assets are copied into the query-service Go source tree in one step.
- Removes the need to run `make build-ui` separately after `make rebuild-ui`.

## Test plan
- [ ] Run `make rebuild-ui JAEGER_UI_DIR=/path/to/jaeger-ui` and verify assets appear in `cmd/jaeger/internal/extension/jaegerquery/internal/ui/actual/`
- [ ] Run `make build-ui` independently and verify it still works as a no-op when assets are up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)