### PR TITLE
Return empty traces instead of 404 in findTraces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -106,10 +106,18 @@ func (h *HTTPGateway) returnTrace(td ptrace.Traces, w http.ResponseWriter) {
 }
 
 func (h *HTTPGateway) returnTraces(traces []ptrace.Traces, err error, w http.ResponseWriter) {
+	h.returnTracesInternal(traces, err, w, false)
+}
+
+func (h *HTTPGateway) returnTracesOrEmpty(traces []ptrace.Traces, err error, w http.ResponseWriter) {
+	h.returnTracesInternal(traces, err, w, true)
+}
+
+func (h *HTTPGateway) returnTracesInternal(traces []ptrace.Traces, err error, w http.ResponseWriter, allowEmpty bool) {
 	if h.tryHandleError(w, err, http.StatusInternalServerError) {
 		return
 	}
-	if len(traces) == 0 {
+	if len(traces) == 0 && !allowEmpty {
 		errorResponse := api_v3.GRPCGatewayError{
 			Error: &api_v3.GRPCGatewayError_GRPCGatewayErrorDetails{
 				HttpCode: http.StatusNotFound,
@@ -120,6 +128,8 @@ func (h *HTTPGateway) returnTraces(traces []ptrace.Traces, err error, w http.Res
 		http.Error(w, string(resp), http.StatusNotFound)
 		return
 	}
+	// Consolidate traces into a single payload. If traces is empty and allowEmpty is true,
+	// this naturally produces a valid empty traces result, keeping the response schema consistent.
 	// TODO: the response should be streamed back to the client
 	// https://github.com/jaegertracing/jaeger/issues/6467
 	combinedTrace := ptrace.NewTraces()
@@ -186,7 +196,7 @@ func (h *HTTPGateway) findTraces(w http.ResponseWriter, r *http.Request) {
 
 	findTracesIter := h.QueryService.FindTraces(r.Context(), *queryParams)
 	traces, err := jiter.FlattenWithErrors(findTracesIter)
-	h.returnTraces(traces, err, w)
+	h.returnTracesOrEmpty(traces, err, w)
 }
 
 func (h *HTTPGateway) findTraceSummaries(w http.ResponseWriter, r *http.Request) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -192,8 +192,11 @@ func TestHTTPGatewayFindTracesEmptyResponse(t *testing.T) {
 		})).Once()
 
 	gw.router.ServeHTTP(w, r)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Contains(t, w.Body.String(), "No traces found")
+	assert.Equal(t, http.StatusOK, w.Code)
+	var response api_v3.GRPCGatewayWrapper
+	require.NoError(t, jsonpb.Unmarshal(w.Body, &response))
+	require.NotNil(t, response.Result)
+	assert.Equal(t, 0, response.Result.ToTraces().ResourceSpans().Len())
 }
 
 // TestHTTPGatewayFindTracesDeprecatedParams verifies that deprecated snake_case query params
@@ -224,8 +227,11 @@ func TestHTTPGatewayFindTracesDeprecatedParams(t *testing.T) {
 		})).Once()
 
 	gw.router.ServeHTTP(w, r)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Contains(t, w.Body.String(), "No traces found")
+	assert.Equal(t, http.StatusOK, w.Code)
+	var response api_v3.GRPCGatewayWrapper
+	require.NoError(t, jsonpb.Unmarshal(w.Body, &response))
+	require.NotNil(t, response.Result)
+	assert.Equal(t, 0, response.Result.ToTraces().ResourceSpans().Len())
 }
 
 // TestHTTPGatewayFindTracesDeprecatedNumTraces verifies that the deprecated
@@ -247,8 +253,11 @@ func TestHTTPGatewayFindTracesDeprecatedNumTraces(t *testing.T) {
 		})).Once()
 
 	gw.router.ServeHTTP(w, r)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Contains(t, w.Body.String(), "No traces found")
+	assert.Equal(t, http.StatusOK, w.Code)
+	var response api_v3.GRPCGatewayWrapper
+	require.NoError(t, jsonpb.Unmarshal(w.Body, &response))
+	require.NotNil(t, response.Result)
+	assert.Equal(t, 0, response.Result.ToTraces().ResourceSpans().Len())
 }
 
 func TestHTTPGatewayGetTraceMalformedInputErrors(t *testing.T) {


### PR DESCRIPTION
Resolves #8707

## Summary

- Add an `allowEmpty` boolean parameter to the internal `returnTraces` helper in the v3 HTTP gateway.
- Update the `/api/v3/traces` (`findTraces`) endpoint to return a `200 OK` with an empty trace payload (`{"result":{}}`) when no matching traces are found.
- Keep the `404 Not Found` response behavior for specific trace ID requests (`getTrace`).
- Update related test cases in `http_gateway_test.go` to assert a `200 OK` status and check for empty trace response payloads.

## Why

Currently, querying the v3 HTTP gateway for traces that do not exist results in a `404 Not Found` response code. In RESTful API design, search/query endpoints should return a successful `200 OK` with an empty collection when no results match the criteria, rather than generating an error code.

## Validation

- `go test -count=1 ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [X] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
