### PR TITLE
fix(prometheus): validate latency_unit to prevent startup panic

### DIFF
--- a/internal/config/promcfg/config.go
+++ b/internal/config/promcfg/config.go
@@ -34,16 +34,16 @@ func (c *Configuration) Validate() error {
 	if _, err := govalidator.ValidateStruct(c); err != nil {
 		return err
 	}
-	// LatencyUnit must be "ms" or "s". An empty value is allowed because the
-	// default ("ms") is applied during config unmarshalling. Without this check
-	// an invalid unit passes validation and later panics when the metric name
-	// is built (see buildFullLatencyMetricName). This mirrors the validation
-	// already done for the v1 flag path in
-	// internal/storage/metricstore/prometheus/options.go.
-	switch c.LatencyUnit {
-	case "", "ms", "s":
-	default:
+	// Empty is allowed because the default ("ms") is applied during unmarshalling.
+	if c.LatencyUnit != "" && !IsValidLatencyUnit(c.LatencyUnit) {
 		return fmt.Errorf(`latency_unit must be "ms" or "s", not %q`, c.LatencyUnit)
 	}
 	return nil
+}
+
+// IsValidLatencyUnit reports whether u is a latency unit the Prometheus metric
+// name builder understands. It is the single source of truth shared by this
+// validation and the v1 flag path in prometheus/options.go.
+func IsValidLatencyUnit(u string) bool {
+	return u == "ms" || u == "s"
 }

--- a/internal/config/promcfg/config.go
+++ b/internal/config/promcfg/config.go
@@ -4,6 +4,7 @@
 package promcfg
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -30,6 +31,19 @@ type Configuration struct {
 }
 
 func (c *Configuration) Validate() error {
-	_, err := govalidator.ValidateStruct(c)
-	return err
+	if _, err := govalidator.ValidateStruct(c); err != nil {
+		return err
+	}
+	// LatencyUnit must be "ms" or "s". An empty value is allowed because the
+	// default ("ms") is applied during config unmarshalling. Without this check
+	// an invalid unit passes validation and later panics when the metric name
+	// is built (see buildFullLatencyMetricName). This mirrors the validation
+	// already done for the v1 flag path in
+	// internal/storage/metricstore/prometheus/options.go.
+	switch c.LatencyUnit {
+	case "", "ms", "s":
+	default:
+		return fmt.Errorf(`latency_unit must be "ms" or "s", not %q`, c.LatencyUnit)
+	}
+	return nil
 }

--- a/internal/config/promcfg/config.go
+++ b/internal/config/promcfg/config.go
@@ -34,9 +34,13 @@ func (c *Configuration) Validate() error {
 	if _, err := govalidator.ValidateStruct(c); err != nil {
 		return err
 	}
-	// Empty is allowed because the default ("ms") is applied during unmarshalling.
+	// An empty LatencyUnit is allowed: it means "use the default" ("ms"). That
+	// default is normally populated when the config is loaded (the CLI flag
+	// default for v1, DefaultConfig for v2), but programmatically-constructed
+	// configs may leave it empty, so callers must not assume LatencyUnit is
+	// non-empty after Validate.
 	if c.LatencyUnit != "" && !IsValidLatencyUnit(c.LatencyUnit) {
-		return fmt.Errorf(`latency_unit must be "ms" or "s", not %q`, c.LatencyUnit)
+		return LatencyUnitError(c.LatencyUnit)
 	}
 	return nil
 }
@@ -46,4 +50,11 @@ func (c *Configuration) Validate() error {
 // validation and the v1 flag path in prometheus/options.go.
 func IsValidLatencyUnit(u string) bool {
 	return u == "ms" || u == "s"
+}
+
+// LatencyUnitError reports that the configured latency unit is unsupported. It is
+// shared by the v2 config validation and the v1 flag path so both surfaces emit
+// an identical message.
+func LatencyUnitError(value string) error {
+	return fmt.Errorf(`latency_unit must be "ms" or "s", not %q`, value)
 }

--- a/internal/config/promcfg/config_test.go
+++ b/internal/config/promcfg/config_test.go
@@ -22,6 +22,34 @@ func TestValidate(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidateLatencyUnit(t *testing.T) {
+	tests := []struct {
+		name        string
+		latencyUnit string
+		wantErr     string
+	}{
+		{name: "empty is allowed (default applied later)", latencyUnit: ""},
+		{name: "ms is valid", latencyUnit: "ms"},
+		{name: "s is valid", latencyUnit: "s"},
+		{name: "invalid unit is rejected", latencyUnit: "us", wantErr: "latency_unit"},
+		{name: "long form is rejected", latencyUnit: "milliseconds", wantErr: "latency_unit"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := Configuration{
+				ServerURL:   "localhost:1234",
+				LatencyUnit: test.latencyUnit,
+			}
+			err := cfg.Validate()
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	testutils.VerifyGoLeaks(m)
 }

--- a/internal/config/promcfg/config_test.go
+++ b/internal/config/promcfg/config_test.go
@@ -33,11 +33,12 @@ func TestValidateLatencyUnit(t *testing.T) {
 		{name: "s is valid", latencyUnit: "s"},
 		{name: "invalid unit is rejected", latencyUnit: "us", wantErr: "latency_unit"},
 		{name: "long form is rejected", latencyUnit: "milliseconds", wantErr: "latency_unit"},
+		{name: "uppercase is rejected (case-sensitive)", latencyUnit: "MS", wantErr: "latency_unit"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := Configuration{
-				ServerURL:   "localhost:1234",
+				ServerURL:   "http://localhost:1234",
 				LatencyUnit: test.latencyUnit,
 			}
 			err := cfg.Validate()

--- a/internal/storage/metricstore/prometheus/factory.go
+++ b/internal/storage/metricstore/prometheus/factory.go
@@ -56,9 +56,9 @@ func NewFactoryWithConfig(
 		return nil, err
 	}
 	// Validate permits an empty LatencyUnit (it means "use the default"), so
-	// normalize it here before storing. Otherwise a config with NormalizeDuration
-	// set would reach the reader with an empty unit and panic when building the
-	// metric name.
+	// normalize it to the default before storing so downstream code never sees an
+	// empty unit. Without this, a config with NormalizeDuration enabled would
+	// reach the reader with an empty unit and panic when building the metric name.
 	if cfg.LatencyUnit == "" {
 		cfg.LatencyUnit = defaultLatencyUnit
 	}

--- a/internal/storage/metricstore/prometheus/factory.go
+++ b/internal/storage/metricstore/prometheus/factory.go
@@ -55,6 +55,13 @@ func NewFactoryWithConfig(
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
+	// Validate permits an empty LatencyUnit (it means "use the default"), so
+	// normalize it here before storing. Otherwise a config with NormalizeDuration
+	// set would reach the reader with an empty unit and panic when building the
+	// metric name.
+	if cfg.LatencyUnit == "" {
+		cfg.LatencyUnit = defaultLatencyUnit
+	}
 	f := NewFactory()
 	f.options = &Options{
 		Configuration: cfg,

--- a/internal/storage/metricstore/prometheus/factory_test.go
+++ b/internal/storage/metricstore/prometheus/factory_test.go
@@ -95,12 +95,11 @@ func TestWithConfiguration(t *testing.T) {
 			ServerURL:   "http://localhost:9090",
 			LatencyUnit: "milliseconds",
 		}
-		// NewFactoryWithConfig should validate and reject invalid latency unit
-		// However, the validation is currently not implemented in Configuration.Validate()
-		// So this test now just creates the factory successfully
-		f, err := NewFactoryWithConfig(cfg, telemetry.NoopSettings(), nil)
-		require.NoError(t, err)
-		assert.Equal(t, "milliseconds", f.options.LatencyUnit)
+		// NewFactoryWithConfig validates the config and rejects an invalid
+		// latency unit instead of letting it panic later when the metric name
+		// is built.
+		_, err := NewFactoryWithConfig(cfg, telemetry.NoopSettings(), nil)
+		require.ErrorContains(t, err, "latency_unit")
 	})
 }
 

--- a/internal/storage/metricstore/prometheus/factory_test.go
+++ b/internal/storage/metricstore/prometheus/factory_test.go
@@ -99,7 +99,7 @@ func TestWithConfiguration(t *testing.T) {
 		// latency unit instead of letting it panic later when the metric name
 		// is built.
 		_, err := NewFactoryWithConfig(cfg, telemetry.NoopSettings(), nil)
-		require.ErrorContains(t, err, "latency_unit")
+		require.EqualError(t, err, `latency_unit must be "ms" or "s", not "milliseconds"`)
 	})
 }
 

--- a/internal/storage/metricstore/prometheus/factory_test.go
+++ b/internal/storage/metricstore/prometheus/factory_test.go
@@ -101,6 +101,22 @@ func TestWithConfiguration(t *testing.T) {
 		_, err := NewFactoryWithConfig(cfg, telemetry.NoopSettings(), nil)
 		require.EqualError(t, err, `latency_unit must be "ms" or "s", not "milliseconds"`)
 	})
+	t.Run("empty latency unit with normalize_duration is normalized to the default", func(t *testing.T) {
+		cfg := promcfg.Configuration{
+			ServerURL:         "http://localhost:9090",
+			NormalizeDuration: true,
+			LatencyUnit:       "", // empty: must be normalized to the default, not panic later
+		}
+		f, err := NewFactoryWithConfig(cfg, telemetry.NoopSettings(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, "ms", f.options.LatencyUnit)
+		// Building the reader must not panic now that the unit is normalized.
+		require.NotPanics(t, func() {
+			reader, err := f.CreateMetricsReader()
+			require.NoError(t, err)
+			assert.NotNil(t, reader)
+		})
+	})
 }
 
 func TestEmptyFactoryConfig(t *testing.T) {

--- a/internal/storage/metricstore/prometheus/options.go
+++ b/internal/storage/metricstore/prometheus/options.go
@@ -119,8 +119,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) error {
 		return fmt.Errorf("failed to parse extra query params: %w", err)
 	}
 
-	isValidUnit := map[string]bool{"ms": true, "s": true}
-	if _, ok := isValidUnit[opt.LatencyUnit]; !ok {
+	if !config.IsValidLatencyUnit(opt.LatencyUnit) {
 		return fmt.Errorf(`duration-unit must be one of "ms" or "s", not %q`, opt.LatencyUnit)
 	}
 

--- a/internal/storage/metricstore/prometheus/options.go
+++ b/internal/storage/metricstore/prometheus/options.go
@@ -120,7 +120,7 @@ func (opt *Options) InitFromViper(v *viper.Viper) error {
 	}
 
 	if !config.IsValidLatencyUnit(opt.LatencyUnit) {
-		return fmt.Errorf(`duration-unit must be one of "ms" or "s", not %q`, opt.LatencyUnit)
+		return config.LatencyUnitError(opt.LatencyUnit)
 	}
 
 	tlsCfg, err := tlsFlagsCfg.InitFromViper(v)

--- a/internal/storage/metricstore/prometheus/options_test.go
+++ b/internal/storage/metricstore/prometheus/options_test.go
@@ -46,6 +46,15 @@ func TestInitFromViperLatencyUnit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "s", opts.LatencyUnit)
 	})
+	t.Run("empty unit is rejected at the flag layer", func(t *testing.T) {
+		// Unlike NewFactoryWithConfig (which normalizes empty to the default),
+		// the v1 flag path rejects an explicitly empty unit.
+		opts := NewOptions()
+		v, _ := jconfig.Viperize(opts.AddFlags)
+		v.Set(prefix+suffixLatencyUnit, "")
+		err := opts.InitFromViper(v)
+		require.EqualError(t, err, `latency_unit must be "ms" or "s", not ""`)
+	})
 }
 
 func TestParseKV(t *testing.T) {

--- a/internal/storage/metricstore/prometheus/options_test.go
+++ b/internal/storage/metricstore/prometheus/options_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	jconfig "github.com/jaegertracing/jaeger/internal/config"
 	config "github.com/jaegertracing/jaeger/internal/config/promcfg"
 )
 
@@ -26,6 +28,24 @@ func TestCLI(t *testing.T) {
 func TestCLIError(t *testing.T) {
 	_, err := parseKV("key1")
 	assert.ErrorContains(t, err, "failed to parse 'key1'. Expected format: 'param1=value1,param2=value2'")
+}
+
+func TestInitFromViperLatencyUnit(t *testing.T) {
+	t.Run("invalid unit is rejected", func(t *testing.T) {
+		opts := NewOptions()
+		v, _ := jconfig.Viperize(opts.AddFlags)
+		v.Set(prefix+suffixLatencyUnit, "us")
+		err := opts.InitFromViper(v)
+		require.EqualError(t, err, `latency_unit must be "ms" or "s", not "us"`)
+	})
+	t.Run("valid unit is accepted", func(t *testing.T) {
+		opts := NewOptions()
+		v, _ := jconfig.Viperize(opts.AddFlags)
+		v.Set(prefix+suffixLatencyUnit, "s")
+		err := opts.InitFromViper(v)
+		require.NoError(t, err)
+		assert.Equal(t, "s", opts.LatencyUnit)
+	})
 }
 
 func TestParseKV(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #8710. Setting `latency_unit` to an invalid value in the v2 Prometheus config panicked at startup instead of returning a clean error.

## Description of the changes
- Added `latency_unit` validation to `promcfg.Configuration.Validate()`. Bad values now get rejected at config load before reaching the reader.
- `NewFactoryWithConfig` now normalizes empty `latency_unit` to `ms` before storing, so a config with `normalize_duration: true` can't reach the reader with an empty unit (per review feedback).
- Shared the validation between v1 and v2 via `IsValidLatencyUnit` and `LatencyUnitError` so both paths emit the same message.
- Left the `panic` in `buildFullLatencyMetricName` alone since it's now unreachable from any validated config path. Happy to change it to return an error if preferred.


## How was this change tested?
- Added `TestValidateLatencyUnit` for valid (`ms`, `s`, empty) and invalid (`us`, `milliseconds`) values.
- Added `TestInitFromViperLatencyUnit` for the v1 flag path.
- Updated `factory_test.go` to cover the empty + `normalize_duration` case through the factory.
- `TestInvalidLatencyUnit` still passes.
- `go test`, `go vet`, `go build ./...` all pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes