### PR TITLE
feat(badger): add spanKind support to GetOperations

### DIFF
--- a/internal/storage/integration/capabilities/capabilities.go
+++ b/internal/storage/integration/capabilities/capabilities.go
@@ -78,9 +78,7 @@ func ClickHouse() Capabilities {
 // Badger defines the capabilities for the Badger storage backend.
 func Badger() Capabilities {
 	return Capabilities{
-		// TODO: remove this once Badger supports returning spanKind from GetOperations
-		getOperationsMissingSpanKind: true,
-		skipList:                     []string{scopeAttributesTest, linkAttributesTest, FindTraceSummariesTest},
+		skipList: []string{scopeAttributesTest, linkAttributesTest, FindTraceSummariesTest},
 	}
 }
 

--- a/internal/storage/v1/badger/spanstore/cache.go
+++ b/internal/storage/v1/badger/spanstore/cache.go
@@ -4,6 +4,7 @@
 package spanstore
 
 import (
+	"cmp"
 	"slices"
 	"sync"
 	"time"
@@ -18,7 +19,7 @@ type CacheStore struct {
 	// Given the small amount of data these will store, we use the same structure as the memory store
 	cacheLock  sync.Mutex // write heavy - Mutex is faster than RWMutex for writes
 	services   map[string]uint64
-	operations map[string]map[string]uint64
+	operations map[string]map[tracestore.Operation]uint64
 
 	store *badger.DB
 	ttl   time.Duration
@@ -28,7 +29,7 @@ type CacheStore struct {
 func NewCacheStore(db *badger.DB, ttl time.Duration) *CacheStore {
 	cs := &CacheStore{
 		services:   make(map[string]uint64),
-		operations: make(map[string]map[string]uint64),
+		operations: make(map[string]map[tracestore.Operation]uint64),
 		ttl:        ttl,
 		store:      db,
 	}
@@ -47,67 +48,70 @@ func (c *CacheStore) AddService(service string, keyTTL uint64) {
 	c.services[service] = keyTTL
 }
 
-// AddOperation adds the cache with operation names with most updated expiration time
-func (c *CacheStore) AddOperation(service, operation string, keyTTL uint64) {
+// AddOperation adds the cache with operation names with most updated expiration time.
+// spanKind may be empty when the value is not known (e.g. when preloading from legacy index).
+func (c *CacheStore) AddOperation(service, spanKind, operation string, keyTTL uint64) {
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 	if _, found := c.operations[service]; !found {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[tracestore.Operation]uint64)
 	}
-	if v, found := c.operations[service][operation]; found {
+	op := tracestore.Operation{Name: operation, SpanKind: spanKind}
+	if v, found := c.operations[service][op]; found {
 		if v > keyTTL {
 			return
 		}
 	}
-	c.operations[service][operation] = keyTTL
+	c.operations[service][op] = keyTTL
 }
 
-// Update caches the results of service and service + operation indexes and maintains their TTL
-func (c *CacheStore) Update(service, operation string, expireTime uint64) {
+// Update caches the results of service and service + operation indexes and maintains their TTL.
+// spanKind may be empty when the value is not known (e.g. when preloading from legacy index).
+func (c *CacheStore) Update(service, spanKind, operation string, expireTime uint64) {
 	c.cacheLock.Lock()
 
 	c.services[service] = expireTime
 	if _, ok := c.operations[service]; !ok {
-		c.operations[service] = make(map[string]uint64)
+		c.operations[service] = make(map[tracestore.Operation]uint64)
 	}
-	c.operations[service][operation] = expireTime
+	c.operations[service][tracestore.Operation{Name: operation, SpanKind: spanKind}] = expireTime
 	c.cacheLock.Unlock()
 }
 
-// GetOperations returns all operations for a specific service & spanKind traced by Jaeger
-func (c *CacheStore) GetOperations(service string) ([]tracestore.Operation, error) {
-	operations := make([]string, 0, len(c.services))
+// GetOperations returns all operations for a specific service, optionally filtered by spanKind.
+func (c *CacheStore) GetOperations(query tracestore.OperationQueryParams) ([]tracestore.Operation, error) {
 	//nolint:gosec // G115
 	t := uint64(time.Now().Unix())
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 
-	if v, ok := c.services[service]; ok {
+	if v, ok := c.services[query.ServiceName]; ok {
 		if v < t {
 			// Expired, remove
-			delete(c.services, service)
-			delete(c.operations, service)
+			delete(c.services, query.ServiceName)
+			delete(c.operations, query.ServiceName)
 			return []tracestore.Operation{}, nil // empty slice rather than nil
 		}
-		for o, e := range c.operations[service] {
-			if e > t {
-				operations = append(operations, o)
-			} else {
-				delete(c.operations[service], o)
-			}
+	}
+
+	var result []tracestore.Operation
+	for op, e := range c.operations[query.ServiceName] {
+		if e <= t {
+			delete(c.operations[query.ServiceName], op)
+			continue
+		}
+		if query.SpanKind == "" || query.SpanKind == op.SpanKind {
+			result = append(result, op)
 		}
 	}
 
-	slices.Sort(operations)
+	slices.SortFunc(result, func(a, b tracestore.Operation) int {
+		if c := cmp.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.SpanKind, b.SpanKind)
+	})
 
-	// TODO: https://github.com/jaegertracing/jaeger/issues/1922
-	// 	- return the operations with actual spanKind
-	result := make([]tracestore.Operation, 0, len(operations))
-	for _, op := range operations {
-		result = append(result, tracestore.Operation{
-			Name: op,
-		})
-	}
 	return result, nil
 }
 

--- a/internal/storage/v1/badger/spanstore/cache.go
+++ b/internal/storage/v1/badger/spanstore/cache.go
@@ -94,7 +94,7 @@ func (c *CacheStore) GetOperations(query tracestore.OperationQueryParams) ([]tra
 		}
 	}
 
-	var result []tracestore.Operation
+	result := make([]tracestore.Operation, 0)
 	for op, e := range c.operations[query.ServiceName] {
 		if e <= t {
 			delete(c.operations[query.ServiceName], op)

--- a/internal/storage/v1/badger/spanstore/cache_test.go
+++ b/internal/storage/v1/badger/spanstore/cache_test.go
@@ -84,7 +84,7 @@ func TestGetOperationsSpanKindFilter(t *testing.T) {
 		// Non-existent service
 		ops, err = cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "nosvc"})
 		require.NoError(t, err)
-		assert.Nil(t, ops)
+		assert.Empty(t, ops)
 	})
 }
 

--- a/internal/storage/v1/badger/spanstore/cache_test.go
+++ b/internal/storage/v1/badger/spanstore/cache_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
 /*
@@ -24,8 +26,8 @@ func TestExpiredItems(t *testing.T) {
 
 		// Expired service
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "server", "op1", expireTime)
+		cache.Update("service1", "client", "op2", expireTime)
 
 		services, err := cache.GetServices()
 		require.NoError(t, err)
@@ -33,23 +35,56 @@ func TestExpiredItems(t *testing.T) {
 
 		// Expired service for operations
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "server", "op1", expireTime)
+		cache.Update("service1", "client", "op2", expireTime)
 
-		operations, err := cache.GetOperations("service1")
+		operations, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "service1"})
 		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
 
 		// Expired operations, stable service
 
-		cache.Update("service1", "op1", expireTime)
-		cache.Update("service1", "op2", expireTime)
+		cache.Update("service1", "server", "op1", expireTime)
+		cache.Update("service1", "client", "op2", expireTime)
 
 		cache.services["service1"] = uint64(time.Now().Unix() + 1e10)
 
-		operations, err = cache.GetOperations("service1")
+		operations, err = cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "service1"})
 		require.NoError(t, err)
 		assert.Empty(t, operations) // Everything should be expired
+	})
+}
+
+func TestGetOperationsSpanKindFilter(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		cache := NewCacheStore(store, time.Duration(1*time.Hour))
+		expireTime := uint64(time.Now().Add(cache.ttl).Unix())
+
+		cache.Update("svc", "server", "op1", expireTime)
+		cache.Update("svc", "client", "op2", expireTime)
+		cache.Update("svc", "", "op3", expireTime) // preloaded without spanKind
+
+		// All operations
+		ops, err := cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc"})
+		require.NoError(t, err)
+		assert.Len(t, ops, 3)
+
+		// Filter by server
+		ops, err = cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc", SpanKind: "server"})
+		require.NoError(t, err)
+		require.Len(t, ops, 1)
+		assert.Equal(t, tracestore.Operation{Name: "op1", SpanKind: "server"}, ops[0])
+
+		// Filter by client
+		ops, err = cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "svc", SpanKind: "client"})
+		require.NoError(t, err)
+		require.Len(t, ops, 1)
+		assert.Equal(t, tracestore.Operation{Name: "op2", SpanKind: "client"}, ops[0])
+
+		// Non-existent service
+		ops, err = cache.GetOperations(tracestore.OperationQueryParams{ServiceName: "nosvc"})
+		require.NoError(t, err)
+		assert.Nil(t, ops)
 	})
 }
 

--- a/internal/storage/v1/badger/spanstore/read_write_test.go
+++ b/internal/storage/v1/badger/spanstore/read_write_test.go
@@ -363,6 +363,39 @@ func TestMenuSeeks(t *testing.T) {
 	})
 }
 
+func TestSpanKindAppearsInGetOperations(t *testing.T) {
+	runFactoryTest(t, func(_ testing.TB, sw spanstore.Writer, sr spanstore.Reader) {
+		err := sw.WriteSpan(context.Background(), &model.Span{
+			TraceID:       model.TraceID{Low: 1, High: 1},
+			SpanID:        model.SpanID(1),
+			OperationName: "checkout",
+			Process:       &model.Process{ServiceName: "shop"},
+			Tags: model.KeyValues{
+				{Key: model.SpanKindKey, VStr: "server", VType: model.StringType},
+			},
+			StartTime: time.Now(),
+			Duration:  time.Millisecond,
+		})
+		require.NoError(t, err)
+
+		ops, err := sr.GetOperations(context.Background(), tracestore.OperationQueryParams{ServiceName: "shop"})
+		require.NoError(t, err)
+		require.Len(t, ops, 1)
+		assert.Equal(t, "checkout", ops[0].Name)
+		assert.Equal(t, "server", ops[0].SpanKind)
+
+		// SpanKind filter matches
+		ops, err = sr.GetOperations(context.Background(), tracestore.OperationQueryParams{ServiceName: "shop", SpanKind: "server"})
+		require.NoError(t, err)
+		assert.Len(t, ops, 1)
+
+		// SpanKind filter excludes
+		ops, err = sr.GetOperations(context.Background(), tracestore.OperationQueryParams{ServiceName: "shop", SpanKind: "client"})
+		require.NoError(t, err)
+		assert.Empty(t, ops)
+	})
+}
+
 func TestPersist(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -248,7 +248,7 @@ func (r *TraceReader) GetOperations(
 	_ context.Context,
 	query tracestore.OperationQueryParams,
 ) ([]tracestore.Operation, error) {
-	return r.cache.GetOperations(query.ServiceName)
+	return r.cache.GetOperations(query)
 }
 
 // setQueryDefaults alters the query with defaults if certain parameters are not set
@@ -657,7 +657,7 @@ func (r *TraceReader) preloadOperations(service string) {
 			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
 			operationName := string(it.Item().Key()[len(serviceKey):timestampStartIndex])
 			keyTTL := it.Item().ExpiresAt()
-			r.cache.AddOperation(service, operationName, keyTTL)
+			r.cache.AddOperation(service, "", operationName, keyTTL)
 		}
 		return nil
 	})

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -243,7 +243,7 @@ func (r *TraceReader) GetServices(context.Context) ([]string, error) {
 	return r.cache.GetServices()
 }
 
-// GetOperations fetches operations in the service and empty slice if service does not exists
+// GetOperations returns operations for the given service, optionally filtered by SpanKind.
 func (r *TraceReader) GetOperations(
 	_ context.Context,
 	query tracestore.OperationQueryParams,

--- a/internal/storage/v1/badger/spanstore/rw_internal_test.go
+++ b/internal/storage/v1/badger/spanstore/rw_internal_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
 func TestEncodingTypes(t *testing.T) {
@@ -217,15 +218,15 @@ func TestOldReads(t *testing.T) {
 
 		nuTid := tid.Add(1 * time.Hour)
 
-		cache.Update("service1", "operation1", uint64(tid.Unix()))
+		cache.Update("service1", "", "operation1", uint64(tid.Unix()))
 		cache.services["service1"] = uint64(nuTid.Unix())
-		cache.operations["service1"]["operation1"] = uint64(nuTid.Unix())
+		cache.operations["service1"][tracestore.Operation{Name: "operation1"}] = uint64(nuTid.Unix())
 
 		// This is equivalent to populate caches of cache
 		_ = NewTraceReader(store, cache, true)
 
 		// Now make sure we didn't use the older timestamps from the DB
 		assert.Equal(t, uint64(nuTid.Unix()), cache.services["service1"])
-		assert.Equal(t, uint64(nuTid.Unix()), cache.operations["service1"]["operation1"])
+		assert.Equal(t, uint64(nuTid.Unix()), cache.operations["service1"][tracestore.Operation{Name: "operation1"}])
 	})
 }

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -79,7 +79,11 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	binary.BigEndian.PutUint64(durationValue, uint64(model.DurationAsMicroseconds(span.Duration)))
 	entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(durationIndexKey, durationValue, startTime, span.TraceID), nil, expireTime))
 
+	var spanKind string
 	for _, kv := range span.Tags {
+		if kv.Key == model.SpanKindKey {
+			spanKind = kv.AsString()
+		}
 		// Convert everything to string since queries are done that way also
 		// KEY: it<serviceName><tagsKey><traceId> VALUE: <tagsValue>
 		entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(tagIndexKey, []byte(span.Process.ServiceName+kv.Key+kv.AsString()), startTime, span.TraceID), nil, expireTime))
@@ -112,10 +116,6 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	})
 
 	// Do cache refresh here to release the transaction earlier
-	var spanKind string
-	if kv, ok := model.KeyValues(span.Tags).FindByKey(model.SpanKindKey); ok {
-		spanKind = kv.AsString()
-	}
 	w.cache.Update(span.Process.ServiceName, spanKind, span.OperationName, expireTime)
 
 	return err

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -112,7 +112,11 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	})
 
 	// Do cache refresh here to release the transaction earlier
-	w.cache.Update(span.Process.ServiceName, span.OperationName, expireTime)
+	var spanKind string
+	if kv, ok := model.KeyValues(span.Tags).FindByKey(model.SpanKindKey); ok {
+		spanKind = kv.AsString()
+	}
+	w.cache.Update(span.Process.ServiceName, spanKind, span.OperationName, expireTime)
 
 	return err
 }


### PR DESCRIPTION
## Description of the changes

Badger currently drops `span.kind` information when caching operations, which means `GetOperations` cannot return or filter operations by `SpanKind`.

This PR updates the Badger operation cache to store `SpanKind` alongside the operation name, enabling operation queries to return and filter operations by span kind. It also removes the Badger-specific `getOperationsMissingSpanKind` capability workaround and enables the existing integration test expectations for Badger.

## How was this change tested?

- Added unit tests for operation filtering by span kind

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

- [ ] None: No AI tools were used in creating this PR
- [ ] Light: AI provided minor assistance (formatting, simple suggestions)
- [x] Moderate: AI helped with code generation or debugging specific parts
- [ ] Heavy: AI generated most or all of the code changes