### PR TITLE
chore(lint): enable revive argument-limit rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -138,9 +138,7 @@ linters:
         # too pendantic
         - name: function-length
           disabled: true
-        # definitely a good one, needs cleanup first
         - name: argument-limit
-          disabled: true
         # this is idiocy, promotes less readable code. Don't enable.
         - name: var-declaration
           disabled: true


### PR DESCRIPTION


## Which problem is this PR solving?
Part of #5506

## Description of the changes
Enables the `argument-limit` revive linter rule.

Running golangci-lint locally with this rule enabled against the 
current main branch shows zero violations, the codebase already 
naturally complies with the default threshold.

Changes:
- `.golangci.yml`: remove `disabled: true` on `argument-limit`
- `.golangci.yml`: remove stale comment ("needs cleanup first")
- 

## How was this change tested?
Ran `.tools/golangci-lint run ./... 2>&1 | grep "argument-limit"` locally 
against current main — zero violations.
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
