### PR TITLE
docs(rfc): Align RFC 0003 with implemented config surface

### DIFF
--- a/docs/rfc/0003-simplify-ai-sidecar-setup.md
+++ b/docs/rfc/0003-simplify-ai-sidecar-setup.md
@@ -225,18 +225,22 @@ pattern can be retired without further UI changes.
 
 #### 4.1.2 Liveness probe
 
-When the `jaeger_query.ai` config block is absent, the reconciler is
+When the `jaeger_query.ai` config block is absent, the checker is
 not started at all and `aiAssistant` is statically `false` — there's
-nothing to probe. When the block is present, the backend runs a small
-reconciler loop that periodically opens an ACP WebSocket to
-`agent_url`, completes the `initialize` handshake, and closes. Each
-probe records a result and a timestamp into an atomic struct. The
-reconciler:
+nothing to check. When the block is present, the backend runs a small
+loop that periodically opens an ACP WebSocket to `agent_url`,
+completes the `initialize` handshake, and closes. Each check records
+its result into an atomic boolean. The loop:
 
 - Default interval: **5 s**. Configurable via
-  `jaeger_query.ai.health_probe_interval` for tuning; `0` disables
-  probing (capability is then always `false`).
-- Default per-probe timeout: **2 s**.
+  `jaeger_query.ai.health_check_interval` for tuning. `0` (the zero
+  value) selects the default in keeping with Go's `time.Duration`
+  convention; a negative duration is an optional within-block disable
+  signal for config templates that always include the `ai:` block.
+  The operator-facing way to disable AI is to omit the `ai:` block
+  entirely (see §3.2).
+- Default per-check timeout: **2 s**. Configurable via
+  `jaeger_query.ai.health_check_timeout`.
 - Probe payload: a minimal ACP `initialize` request. No `session/new` or
   `prompt` — initialize is the cheapest reachability test that exercises
   the actual protocol path the chat handler uses, not just a TCP dial.
@@ -296,9 +300,9 @@ during boot. Same shape and pattern as `storageCapabilities` today.
 
 - **Stale until reload.** A sidecar that comes up after Jaeger requires
   the user to refresh the page before the chat surface appears.
-- **Couples the static handler to the AI reconciler.** Small but real:
-  the handler needs to subscribe to probe state changes to trigger
-  re-rendering of `index.html`.
+- **Couples the static handler to the AI checker.** The handler needs
+  to either subscribe to check state changes or call `Current()` at
+  serve time (the latter is what the implementation ended up doing).
 - **Every future dynamic-state capability we add inherits the same
   reload-to-update behavior.** Survivable for one capability; less great
   as the list grows.
@@ -318,7 +322,7 @@ channel.
   anything else that changes capabilities — the UI sees it within a
   polling interval (or push event).
 - **Decouples runtime state from static assets.** The asset handler no
-  longer needs to know about reconcilers.
+  longer needs to know about background checkers.
 - **Aligns with the existing direction** of moving components onto the
   `useConfig` hook: one centralized capability source, all consumers
   subscribe, dynamic updates are free.
@@ -510,14 +514,14 @@ capabilities channel is the natural place to ship its result.
 Simpler implementation: advertise `aiAssistant = true` whenever the
 `jaeger_query.ai` block is present in the config (or equivalently,
 whenever `agent_url != ""` after `configoptional` defaulting). No
-background reconciler, no atomic swap, no probe interval to tune.
+background checker, no per-request derivation, no interval to tune.
 
 **Rejected** because it lies any time the operator's config has the
 block but the sidecar isn't running — which is the *default* state
 when using the shipped example `cmd/jaeger/config.yaml` without
 starting a sidecar. The UI would render the chat surface and every
-call would fail. A liveness probe is cheap (one ACP `initialize` every
-30 s) and removes an entire class of "I deleted the sidecar but the
+call would fail. A liveness check is cheap (one ACP `initialize` every
+5 s) and removes an entire class of "I deleted the sidecar but the
 chat surface is still there" bug reports.
 
 ### 5.4 In-process sidecar supervision
@@ -571,15 +575,16 @@ Backend (`cmd/jaeger/internal/extension/jaegerquery/`):
   future-proofing) `archiveStorage` / `metricsStorage` mirrored from
   `storageCapabilities`, so the legacy storage pattern can be retired
   cleanly once both backends and UIs are upgraded.
-- New `aireconciler` package (or similar) implementing the periodic
-  ACP `initialize` probe described in §4.1.2. Exposes `Current() bool`
-  and a change callback.
-- The static handler subscribes to the change callback and atomically
-  re-derives `indexHTML` via the existing `indexHTML.Store(...)` path
-  in `static_handler.go:97,133`.
-- New config fields `jaeger_query.ai.health_probe_interval` (default
-  `30s`) and `jaeger_query.ai.health_probe_timeout` (default `2s`)
-  in `flags.go` alongside the existing `AgentURL`.
+- New `jaegerai/aihealth` package implementing the periodic ACP
+  `initialize` check described in §4.1.2. Exposes `Current() bool`; the
+  ACP-specific check function is `aihealth.NewACPCheck(agentURL, logger)`.
+- The static handler derives `index.html` per request, calling
+  `aiHealthCheck()` inline so the injected `aiAssistant` flag always
+  reflects the latest health-check value (no subscribe / cache-invalidate
+  machinery).
+- New config fields `jaeger_query.ai.health_check_interval` (default
+  `5s`) and `jaeger_query.ai.health_check_timeout` (default `2s`) in
+  `flags.go` alongside the existing `AgentURL`.
 
 Docs:
 
@@ -611,7 +616,7 @@ The two PRs are independent: §4.1 stands on its own; §4.2 is useful even if
 
 ### 7.1 Probe interval and timeout defaults
 
-`30 s` / `2 s` are educated guesses. Too aggressive wastes connections;
+`5 s` / `2 s` are educated guesses. Too aggressive wastes connections;
 too lazy delays UI recovery after a sidecar restart. A few questions:
 
 - Should the interval back off when the sidecar is reachable (cheap to


### PR DESCRIPTION
## Which problem is this PR solving?
Follow-up doc fixes for the four RFC-mismatch threads on #8727 (Copilot pointed them out; they all describe the same drift between the RFC text and what shipped).

## Description of the changes
- Config keys: `health_probe_interval` / `health_probe_timeout` → `health_check_interval` / `health_check_timeout` (matching the `AIConfig` mapstructure tags).
- Default interval: `30s` → `5s`. Default timeout: `2s` (unchanged).
- Disable semantics: documented as **omit the `jaeger_query.ai` block entirely** (`configoptional.HasValue() = false` ⇒ no checker constructed ⇒ `aiAssistant: false`). Within the block, `0` selects the default per Go's `time.Duration` convention; negative is an optional within-block disable signal for config templates.
- Vocabulary: "reconciler" → "checker" in narrative text, matching the package name (`jaegerai/aihealth.Checker`) and the user-facing `health_check_*` config terminology.
- §6 PR1 implementation plan now matches what shipped in #8728 + #8727 (per-request derivation, no subscribe/atomic-swap).

Doc-only change. No code touched.

## How was this change tested?
- N/A — markdown only.
- Re-read the RFC end-to-end; `grep -n 'reconciler\\|health_probe\\|30 ?s'` returns only a hypothetical async-poll discussion in §7.4 (unrelated to the backend defaults).

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality (N/A — doc-only)
- [x] I have run lint and test steps successfully: `make lint test` (N/A — doc-only)

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **Heavy**: AI generated most or all of the code changes