### PR TITLE
fix(prometheus): remove dead v1 flag path and stale v1 references

### DIFF
--- a/internal/config/promcfg/config.go
+++ b/internal/config/promcfg/config.go
@@ -34,27 +34,8 @@ func (c *Configuration) Validate() error {
 	if _, err := govalidator.ValidateStruct(c); err != nil {
 		return err
 	}
-	// An empty LatencyUnit is allowed: it means "use the default" ("ms"). That
-	// default is normally populated when the config is loaded (the CLI flag
-	// default for v1, DefaultConfig for v2), but programmatically-constructed
-	// configs may leave it empty, so callers must not assume LatencyUnit is
-	// non-empty after Validate.
-	if c.LatencyUnit != "" && !IsValidLatencyUnit(c.LatencyUnit) {
-		return LatencyUnitError(c.LatencyUnit)
+	if u := c.LatencyUnit; u != "" && u != "ms" && u != "s" {
+		return fmt.Errorf(`latency_unit must be "ms" or "s", not %q`, u)
 	}
 	return nil
-}
-
-// IsValidLatencyUnit reports whether u is a latency unit the Prometheus metric
-// name builder understands. It is the single source of truth shared by this
-// validation and the v1 flag path in prometheus/options.go.
-func IsValidLatencyUnit(u string) bool {
-	return u == "ms" || u == "s"
-}
-
-// LatencyUnitError reports that the configured latency unit is unsupported. It is
-// shared by the v2 config validation and the v1 flag path so both surfaces emit
-// an identical message.
-func LatencyUnitError(value string) error {
-	return fmt.Errorf(`latency_unit must be "ms" or "s", not %q`, value)
 }

--- a/internal/storage/metricstore/prometheus/factory.go
+++ b/internal/storage/metricstore/prometheus/factory.go
@@ -38,7 +38,7 @@ func (f *Factory) Initialize(telset telemetry.Settings) error {
 
 // CreateMetricsReader implements storage.V1MetricStoreFactory.
 func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
-	mr, err := prometheusstore.NewMetricsReader(f.options.Configuration, f.telset.Logger, f.telset.TracerProvider, f.httpAuth)
+	mr, err := prometheusstore.NewMetricsReader(*f.options, f.telset.Logger, f.telset.TracerProvider, f.httpAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -63,9 +63,7 @@ func NewFactoryWithConfig(
 		cfg.LatencyUnit = defaultLatencyUnit
 	}
 	f := NewFactory()
-	f.options = &Options{
-		Configuration: cfg,
-	}
+	f.options = &cfg
 	f.httpAuth = httpAuth
 	err := f.Initialize(telset)
 	return f, err

--- a/internal/storage/metricstore/prometheus/options.go
+++ b/internal/storage/metricstore/prometheus/options.go
@@ -4,34 +4,14 @@
 package prometheus
 
 import (
-	"flag"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/spf13/viper"
-
 	config "github.com/jaegertracing/jaeger/internal/config/promcfg"
-	"github.com/jaegertracing/jaeger/internal/config/tlscfg"
 )
 
 const (
-	prefix = "prometheus"
-
-	suffixServerURL           = ".server-url"
-	suffixConnectTimeout      = ".connect-timeout"
-	suffixTokenFilePath       = ".token-file"
-	suffixOverrideFromContext = ".token-override-from-context"
-
-	suffixMetricNamespace   = ".query.namespace"
-	suffixLatencyUnit       = ".query.duration-unit"
-	suffixNormalizeCalls    = ".query.normalize-calls"
-	suffixNormalizeDuration = ".query.normalize-duration"
-	suffixExtraQueryParams  = ".query.extra-query-params"
-
 	defaultServerURL      = "http://localhost:9090"
 	defaultConnectTimeout = 30 * time.Second
-	defaultTokenFilePath  = ""
 
 	// the default configuration here matches the default namespace in the span metrics connector
 	defaultMetricNamespace   = "traces_span_metrics"
@@ -42,10 +22,8 @@ const (
 
 // Options stores the configuration entries for this storage.
 type Options struct {
-	config.Configuration `mapstructure:",squash"`
+	config.Configuration
 }
-
-var tlsFlagsCfg = tlscfg.ClientFlagsConfig{Prefix: prefix}
 
 func DefaultConfig() config.Configuration {
 	return config.Configuration{
@@ -55,7 +33,7 @@ func DefaultConfig() config.Configuration {
 		MetricNamespace:   defaultMetricNamespace,
 		LatencyUnit:       defaultLatencyUnit,
 		NormalizeCalls:    defaultNormalizeCalls,
-		NormalizeDuration: defaultNormalizeCalls,
+		NormalizeDuration: defaultNormalizeDuration,
 	}
 }
 
@@ -64,91 +42,4 @@ func NewOptions() *Options {
 	return &Options{
 		Configuration: DefaultConfig(),
 	}
-}
-
-// AddFlags from this storage to the CLI.
-func (*Options) AddFlags(flagSet *flag.FlagSet) {
-	flagSet.String(prefix+suffixServerURL, defaultServerURL,
-		"The Prometheus server's URL, must include the protocol scheme e.g. http://localhost:9090")
-	flagSet.Duration(prefix+suffixConnectTimeout, defaultConnectTimeout,
-		"The period to wait for a connection to Prometheus when executing queries.")
-	flagSet.String(prefix+suffixTokenFilePath, defaultTokenFilePath,
-		"The path to a file containing the bearer token which will be included when executing queries against the Prometheus API.")
-	flagSet.Bool(prefix+suffixOverrideFromContext, true,
-		"Whether the bearer token should be overridden from context (incoming request)")
-	flagSet.String(prefix+suffixMetricNamespace, defaultMetricNamespace,
-		`The metric namespace that is prefixed to the metric name. A '.' separator will be added between `+
-			`the namespace and the metric name.`)
-	flagSet.String(prefix+suffixLatencyUnit, defaultLatencyUnit,
-		`The units used for the "latency" histogram. It can be either "ms" or "s" and should be consistent with the `+
-			`histogram unit value set in the spanmetrics connector (see: `+
-			`https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector#configurations). `+
-			`This also helps jaeger-query determine the metric name when querying for "latency" metrics.`)
-	flagSet.Bool(prefix+suffixNormalizeCalls, defaultNormalizeCalls,
-		`Whether to normalize the "calls" metric name according to `+
-			`https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/prometheus/README.md. `+
-			`For example: `+
-			`"calls" (not normalized) -> "calls_total" (normalized), `)
-	flagSet.Bool(prefix+suffixNormalizeDuration, defaultNormalizeDuration,
-		`Whether to normalize the "duration" metric name according to `+
-			`https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/prometheus/README.md. `+
-			`For example: `+
-			`"duration_bucket" (not normalized) -> "duration_milliseconds_bucket (normalized)"`)
-	flagSet.String(prefix+suffixExtraQueryParams, "",
-		"A comma separated list of param=value pairs of query parameters, which are appended on all API requests to the Prometheus API. "+
-			"Example: param1=value2,param2=value2")
-
-	tlsFlagsCfg.AddFlags(flagSet)
-}
-
-// InitFromViper initializes the options struct with values from Viper.
-func (opt *Options) InitFromViper(v *viper.Viper) error {
-	opt.ServerURL = stripWhiteSpace(v.GetString(prefix + suffixServerURL))
-	opt.ConnectTimeout = v.GetDuration(prefix + suffixConnectTimeout)
-	opt.TokenFilePath = v.GetString(prefix + suffixTokenFilePath)
-
-	opt.MetricNamespace = v.GetString(prefix + suffixMetricNamespace)
-	opt.LatencyUnit = v.GetString(prefix + suffixLatencyUnit)
-	opt.NormalizeCalls = v.GetBool(prefix + suffixNormalizeCalls)
-	opt.NormalizeDuration = v.GetBool(prefix + suffixNormalizeDuration)
-	opt.TokenOverrideFromContext = v.GetBool(prefix + suffixOverrideFromContext)
-
-	var err error
-	opt.ExtraQueryParams, err = parseKV(stripWhiteSpace(v.GetString(prefix + suffixExtraQueryParams)))
-	if err != nil {
-		return fmt.Errorf("failed to parse extra query params: %w", err)
-	}
-
-	if !config.IsValidLatencyUnit(opt.LatencyUnit) {
-		return config.LatencyUnitError(opt.LatencyUnit)
-	}
-
-	tlsCfg, err := tlsFlagsCfg.InitFromViper(v)
-	if err != nil {
-		return fmt.Errorf("failed to process Prometheus TLS options: %w", err)
-	}
-	opt.TLS = tlsCfg
-	return nil
-}
-
-// stripWhiteSpace removes all whitespace characters from a string.
-func stripWhiteSpace(str string) string {
-	return strings.ReplaceAll(str, " ", "")
-}
-
-// parseKV parses a comma separated list of key=value pairs into a map
-func parseKV(input string) (map[string]string, error) {
-	if input == "" {
-		return map[string]string{}, nil
-	}
-
-	ret := map[string]string{}
-	for entry := range strings.SplitSeq(input, ",") {
-		kv := strings.Split(entry, "=")
-		if len(kv) != 2 {
-			return map[string]string{}, fmt.Errorf("failed to parse '%s'. Expected format: 'param1=value1,param2=value2'", input)
-		}
-		ret[kv[0]] = kv[1]
-	}
-	return ret, nil
 }

--- a/internal/storage/metricstore/prometheus/options.go
+++ b/internal/storage/metricstore/prometheus/options.go
@@ -20,10 +20,8 @@ const (
 	defaultNormalizeDuration = false
 )
 
-// Options stores the configuration entries for this storage.
-type Options struct {
-	config.Configuration
-}
+// Options is an alias for the Prometheus storage configuration.
+type Options = config.Configuration
 
 func DefaultConfig() config.Configuration {
 	return config.Configuration{
@@ -37,9 +35,8 @@ func DefaultConfig() config.Configuration {
 	}
 }
 
-// NewOptions creates a new Options struct.
+// NewOptions creates a new Options with default values.
 func NewOptions() *Options {
-	return &Options{
-		Configuration: DefaultConfig(),
-	}
+	cfg := DefaultConfig()
+	return &cfg
 }

--- a/internal/storage/metricstore/prometheus/options_test.go
+++ b/internal/storage/metricstore/prometheus/options_test.go
@@ -4,92 +4,18 @@
 package prometheus
 
 import (
-	"errors"
-	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	jconfig "github.com/jaegertracing/jaeger/internal/config"
-	config "github.com/jaegertracing/jaeger/internal/config/promcfg"
 )
 
-func TestCLI(t *testing.T) {
-	opts := Options{
-		Configuration: config.Configuration{
-			ExtraQueryParams: map[string]string{"key1": "value1"},
-		},
-	}
-
-	assert.Equal(t, map[string]string{"key1": "value1"}, opts.ExtraQueryParams)
-}
-
-func TestCLIError(t *testing.T) {
-	_, err := parseKV("key1")
-	assert.ErrorContains(t, err, "failed to parse 'key1'. Expected format: 'param1=value1,param2=value2'")
-}
-
-func TestInitFromViperLatencyUnit(t *testing.T) {
-	t.Run("invalid unit is rejected", func(t *testing.T) {
-		opts := NewOptions()
-		v, _ := jconfig.Viperize(opts.AddFlags)
-		v.Set(prefix+suffixLatencyUnit, "us")
-		err := opts.InitFromViper(v)
-		require.EqualError(t, err, `latency_unit must be "ms" or "s", not "us"`)
-	})
-	t.Run("valid unit is accepted", func(t *testing.T) {
-		opts := NewOptions()
-		v, _ := jconfig.Viperize(opts.AddFlags)
-		v.Set(prefix+suffixLatencyUnit, "s")
-		err := opts.InitFromViper(v)
-		require.NoError(t, err)
-		assert.Equal(t, "s", opts.LatencyUnit)
-	})
-	t.Run("empty unit is rejected at the flag layer", func(t *testing.T) {
-		// Unlike NewFactoryWithConfig (which normalizes empty to the default),
-		// the v1 flag path rejects an explicitly empty unit.
-		opts := NewOptions()
-		v, _ := jconfig.Viperize(opts.AddFlags)
-		v.Set(prefix+suffixLatencyUnit, "")
-		err := opts.InitFromViper(v)
-		require.EqualError(t, err, `latency_unit must be "ms" or "s", not ""`)
-	})
-}
-
-func TestParseKV(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected map[string]string
-		err      error
-	}{
-		{
-			input:    "",
-			expected: map[string]string{},
-			err:      nil,
-		},
-		{
-			input:    "key1=value1",
-			expected: map[string]string{"key1": "value1"},
-			err:      nil,
-		},
-		{
-			input:    "key1=value1,key2=value2",
-			expected: map[string]string{"key1": "value1", "key2": "value2"},
-			err:      nil,
-		},
-		{
-			input:    "key1=value1,key2",
-			expected: map[string]string{},
-			err:      errors.New("failed to parse 'key1=value1,key2'. Expected format: 'param1=value1,param2=value2'"),
-		},
-	}
-
-	for i, test := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			kv, err := parseKV(test.input)
-			assert.Equal(t, test.expected, kv)
-			assert.Equal(t, test.err, err)
-		})
-	}
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, "http://localhost:9090", cfg.ServerURL)
+	assert.Equal(t, 30*time.Second, cfg.ConnectTimeout)
+	assert.Equal(t, "traces_span_metrics", cfg.MetricNamespace)
+	assert.Equal(t, "ms", cfg.LatencyUnit)
+	assert.False(t, cfg.NormalizeCalls)
+	assert.False(t, cfg.NormalizeDuration)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Follow-up to #8711 per @yurishkuro's post-merge feedback.

## Description of the changes
- Cleaned up stale v1/v2 references from comments in `config.go`
- Removed the dead flag path (`AddFlags`, `InitFromViper`) and helpers that only served it (`parseKV`, `stripWhiteSpace`, related consts and imports)
- Inlined `latency_unit` validation into `Validate()` and dropped the exported `IsValidLatencyUnit`/`LatencyUnitError` helpers since they had no other callers
- Removed tests covering the dead path, added `TestDefaultConfig` instead
- Minor copy-paste fix in `DefaultConfig`: `NormalizeDuration` was set to `defaultNormalizeCalls`, now correctly uses `defaultNormalizeDuration`. No behavior change since both are `false`, happy to split into a separate PR if preferred

## How was this change tested?
- `go build ./...` and `go vet ./...` pass
- `go test -count=1 ./internal/config/promcfg/... ./internal/storage/metricstore/prometheus/...` passes with 100% coverage on both packages
- Could not run full `make lint test` locally (Windows box), relying on CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Moderate**: AI helped with code generation or debugging specific parts