### PR TITLE
fix(aihealth): Silence ACP SDK's per-cycle "connection closed" log

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/aihealth/acp_check.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/aihealth/acp_check.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 
 	acp "github.com/coder/acp-go-sdk"
 	"go.uber.org/zap"
@@ -14,6 +16,15 @@ import (
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai"
 	"github.com/jaegertracing/jaeger/internal/version"
 )
+
+// silentACPLogger discards the ACP SDK's internal diagnostics for the
+// probe-connection lifecycle. The SDK logs every disconnect at INFO via
+// slog.Default() — useful for long-lived chat sessions, but spammy for the
+// AI health checker, which by design opens a connection, sends one
+// `initialize` request, and closes immediately. Transport- and protocol-
+// level errors are still returned to the caller from acp.SendRequest, so
+// nothing diagnostic is lost.
+var silentACPLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 
 // NewACPCheck returns a check function that opens a fresh WebSocket
 // connection to agentURL, performs one ACP `initialize` round-trip, and
@@ -34,6 +45,7 @@ func NewACPCheck(agentURL string, logger *zap.Logger) func(ctx context.Context) 
 		defer adapter.Close()
 
 		conn := acp.NewConnection(noopMethodHandler, adapter, adapter)
+		conn.SetLogger(silentACPLogger)
 
 		req := acp.InitializeRequest{
 			ProtocolVersion: acp.ProtocolVersionNumber,


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #8734.

Operators running the launcher (#8732) reported a steady drip of:

```
INFO connection closed cause="read tcp [::1]:...->[::1]:16688: use of closed network connection"
```

— one line per AI health-check cycle. The line comes from the acp-go-sdk `Connection`'s internal logger, which defaults to `slog.Default()`. For long-lived chat sessions it's useful diagnostics; for the probe (open WS → `initialize` → close, every 30s by default) it's expected and noisy.

## Description of the changes
- `aihealth.NewACPCheck` now installs an `slog.New(slog.NewTextHandler(io.Discard, nil))` on each probe `Connection` via the SDK's `Connection.SetLogger` API.
- Errors are unaffected — they're returned to the caller from `acp.SendRequest` and surface as the existing "AI sidecar health check failed" Debug log in `Checker.runOnce`. Only the per-cycle close info is silenced.

## How was this change tested?
- Existing `aihealth` tests still pass (`go test ./cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/aihealth/... -race`).
- `make fmt`, `make lint` clean.
- Locally, the noise is gone after this patch; failing-probe path (sidecar down) still produces the expected error in `Current()` → `false`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality — N/A, silences a third-party logger; tests would have to grep the SDK's log output.
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes