### PR TITLE
fix(ai-sidecar): Close ACP Connection on agent_task cancellation

### DIFF
--- a/scripts/ai-sidecar/gemini/sidecar.py
+++ b/scripts/ai-sidecar/gemini/sidecar.py
@@ -31,10 +31,10 @@ from acp import (
     Agent,
     InitializeResponse,
     PromptResponse,
-    run_agent,
     text_block,
     update_agent_message,
 )
+from acp.agent.connection import AgentSideConnection
 from acp.helpers import start_tool_call, tool_content, update_tool_call
 from acp.interfaces import Client
 from acp.schema import (
@@ -442,6 +442,51 @@ class JaegerSidecarAgent(Agent):
             return PromptResponse(stop_reason="end_turn")
 
 
+async def _run_agent_with_cleanup(
+    agent: Agent,
+    agent_writer: asyncio.StreamWriter,
+    agent_reader: asyncio.StreamReader,
+) -> None:
+    """Run an ACP agent over the supplied streams and *always* close the
+    underlying Connection on exit.
+
+    The upstream ``acp.run_agent`` is roughly::
+
+        conn = AgentSideConnection(...)
+        await conn.listen()
+
+    with no ``try/finally``. ``handle_websocket`` below cancels this task
+    whenever a peer task (ws_read_task / ws_write_task) finishes first via
+    ``asyncio.wait(FIRST_COMPLETED)``. The cancellation propagates out of
+    ``listen()`` without invoking ``Connection.close()``, which leaves the
+    ``MessageSender._loop`` and ``MessageDispatcher._run`` tasks the
+    Connection's TaskSupervisor registered on the event loop orphaned.
+    Python's GC later destroys them while still pending and surfaces
+    "Task was destroyed but it is pending!" warnings followed by
+    "RuntimeError: cannot reuse already awaited coroutine" from the
+    supervisor's done callback.
+
+    See https://github.com/jaegertracing/jaeger/issues/8733 for the full
+    chain. The proper fix is upstream: ``AgentSideConnection`` should
+    expose a public ``close()``/``__aexit__``. Until then, reach into
+    the private ``_conn`` to drive the cleanup. ``asyncio.shield`` ensures
+    the close cancels the supervised tasks even if we ourselves are being
+    cancelled — the inner close task survives our cancellation and runs
+    to completion on the event loop.
+    """
+    conn = AgentSideConnection(agent, agent_writer, agent_reader, listening=False)
+    try:
+        await conn.listen()
+    finally:
+        try:
+            await asyncio.shield(conn._conn.close())  # noqa: SLF001
+        except asyncio.CancelledError:
+            # We've been re-cancelled while shielding the close. The inner
+            # close task is registered on the event loop and continues to
+            # completion; we let the cancellation propagate to our caller.
+            raise
+
+
 async def handle_websocket(websocket: Any, agent_factory: Callable[[], Agent] | None = None) -> None:
     logger.info("New websocket connection from Jaeger AI Gateway")
 
@@ -462,7 +507,10 @@ async def handle_websocket(websocket: Any, agent_factory: Callable[[], Agent] | 
             raise RuntimeError("agent_factory must be provided by the application entrypoint")
 
         agent = agent_factory()
-        agent_task = asyncio.create_task(run_agent(agent, agent_writer, agent_reader), name="agent_task")
+        agent_task = asyncio.create_task(
+            _run_agent_with_cleanup(agent, agent_writer, agent_reader),
+            name="agent_task",
+        )
 
         # Bridge the client ends of the socket pair up to the WebSocket
         ws_read_task = asyncio.create_task(ws_to_client_writer(websocket, client_writer), name="ws_read_task")

--- a/scripts/ai-sidecar/gemini/sidecar.py
+++ b/scripts/ai-sidecar/gemini/sidecar.py
@@ -467,12 +467,23 @@ async def _run_agent_with_cleanup(
     supervisor's done callback.
 
     See https://github.com/jaegertracing/jaeger/issues/8733 for the full
-    chain. The proper fix is upstream: ``AgentSideConnection`` should
-    expose a public ``close()``/``__aexit__``. Until then, reach into
-    the private ``_conn`` to drive the cleanup. ``asyncio.shield`` ensures
-    the close cancels the supervised tasks even if we ourselves are being
-    cancelled — the inner close task survives our cancellation and runs
-    to completion on the event loop.
+    chain and https://github.com/agentclientprotocol/python-sdk/issues/108
+    for the upstream tracking. The proper fix is upstream — either
+    ``run_agent`` grows a ``try/finally`` around ``await conn.listen()`` or
+    ``AgentSideConnection`` exposes a public ``close()``/``__aexit__``. Until
+    one of those lands, reach into the private ``_conn`` to drive the
+    cleanup. ``asyncio.shield`` ensures the close cancels the supervised
+    tasks even if we ourselves are being cancelled — the inner close task
+    survives our cancellation and runs to completion on the event loop.
+
+    What we lose vs upstream ``run_agent`` (acp/core.py:38-72) by
+    re-implementing here: the stdio fallback for ``input_stream``/
+    ``output_stream`` (we always pass streams), the ``use_unstable_protocol``
+    flag (we don't enable it), the ``stdio_buffer_limit_bytes`` knob (also
+    stdio-only), and ``**connection_kwargs`` forwarding (we use the
+    AgentSideConnection default constructor). If upstream adds a new
+    parameter we need, mirror it here too — or, better, switch to the
+    upstream fix once it lands and delete this wrapper.
     """
     conn = AgentSideConnection(agent, agent_writer, agent_reader, listening=False)
     try:

--- a/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
+++ b/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
@@ -243,3 +243,91 @@ async def run_workflow_test(prompt: str, cwd: str) -> None:
 def test_complete_acp_workflow_with_fake_agent() -> None:
     asyncio.run(run_workflow_test(DEFAULT_PROMPT, DEFAULT_CWD))
 
+
+async def run_initialize_only_cycles(num_cycles: int) -> list[dict[str, Any]]:
+    """Drive the AI health checker's access pattern N times: open WebSocket,
+    complete one `initialize` round-trip, close. Return whatever the asyncio
+    loop's exception handler captured during the run.
+
+    Under the bug fixed by #8733, each cycle leaves the Connection's
+    MessageSender._loop and MessageDispatcher._run tasks orphaned on the
+    event loop. Python's GC later destroys them and asyncio routes the
+    "Task was destroyed but it is pending!" notice through
+    loop.call_exception_handler(...) — which is what we capture here.
+    """
+    captured: list[dict[str, Any]] = []
+    loop = asyncio.get_running_loop()
+    original_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, ctx: captured.append(ctx))
+
+    try:
+        async with websockets.serve(
+            partial(sidecar.handle_websocket, agent_factory=FakeAgent),
+            "127.0.0.1",
+            0,
+        ) as server:
+            port = next(iter(server.sockets)).getsockname()[1]
+            uri = f"ws://127.0.0.1:{port}"
+
+            for _ in range(num_cycles):
+                pending = PendingRequests()
+                received: list[dict[str, Any]] = []
+                stop_event = asyncio.Event()
+                async with websockets.connect(uri) as websocket:
+                    receiver = asyncio.create_task(recv_loop(websocket, pending, received, stop_event))
+                    try:
+                        await send_request(
+                            websocket,
+                            pending,
+                            "initialize",
+                            {
+                                "protocolVersion": PROTOCOL_VERSION,
+                                "clientCapabilities": {
+                                    "fs": {"readTextFile": False, "writeTextFile": False},
+                                    "terminal": False,
+                                },
+                                "clientInfo": {
+                                    "name": "pytest-probe-client",
+                                    "title": "AI health-check probe",
+                                    "version": "test",
+                                },
+                            },
+                        )
+                    finally:
+                        receiver.cancel()
+                        with pytest.raises(asyncio.CancelledError):
+                            await receiver
+                # Give the server's handle_websocket finally-block time to run.
+                await asyncio.sleep(0.05)
+
+        # Force a GC cycle so any orphaned Task.__del__ logs fire before we check.
+        import gc
+        for _ in range(3):
+            gc.collect()
+            await asyncio.sleep(0.05)
+    finally:
+        loop.set_exception_handler(original_handler)
+
+    return captured
+
+
+def test_repeated_initialize_only_cycles_do_not_leak_asyncio_tasks() -> None:
+    """Regression for #8733.
+
+    The AI health checker (cmd/jaeger/.../aihealth) opens a fresh WebSocket
+    every ~30s, sends `initialize`, and closes immediately. Before the fix,
+    each cycle cancelled handle_websocket's agent_task mid-stream and skipped
+    Connection.close(), leaving MessageSender/MessageDispatcher tasks
+    orphaned. The asyncio loop's exception handler then received
+    "Task was destroyed but it is pending!" for each leaked task.
+
+    Verify that running three such cycles produces no destroyed-pending-task
+    notices.
+    """
+    captured = asyncio.run(run_initialize_only_cycles(num_cycles=3))
+    leaked = [
+        ctx for ctx in captured
+        if "destroyed but it is pending" in str(ctx.get("message", "")).lower()
+    ]
+    assert leaked == [], f"asyncio reported orphaned pending tasks: {leaked}"
+


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #8733.
- Upstream tracker: agentclientprotocol/python-sdk#108.

Every AI health-check cycle left a pile of asyncio warnings + errors in the sidecar log:

```
ERROR asyncio: Task was destroyed but it is pending!
  task: <Task pending name='acp.Sender.loop' …>
ERROR asyncio: Task was destroyed but it is pending!
  task: <Task pending name='acp.Dispatcher.loop' …>
ERROR root: Send loop failed
  RuntimeError: cannot reuse already awaited coroutine
```

The bug is in our `handle_websocket`. `asyncio.wait(FIRST_COMPLETED)` returns the moment the peer closes the WebSocket; we then `task.cancel()` the `agent_task`. The cancellation propagates through `acp.run_agent` → `Connection.listen()` → `_receive_loop()` without ever reaching `Connection.close()` (upstream `run_agent` has no `try/finally`), so the `MessageSender._loop` and `MessageDispatcher._run` tasks the `TaskSupervisor` registered are orphaned on the event loop. Python's GC later destroys them and asyncio reports both the pending-task notice and the supervisor's downstream `cannot reuse already awaited coroutine` error.

## Description of the changes
- **`_run_agent_with_cleanup`** in `sidecar.py` wraps the AgentSideConnection lifecycle ourselves. It constructs the connection with `listening=False`, runs `conn.listen()` in a `try`, and closes the underlying `Connection` in a `finally`. `asyncio.shield` keeps the close coroutine running when our caller is cancelling us — without it, the cleanup's own `await`s would re-raise CancelledError before MessageSender/MessageDispatcher shutdown completes.
- `handle_websocket` now schedules `_run_agent_with_cleanup` instead of `acp.run_agent` directly; nothing else in that function changes.
- The `conn._conn.close()` call is a private-attribute access. The docstring spells out why and links the upstream issue. **What we lose by re-implementing `run_agent`** is documented inline: stdio fallback (irrelevant — we always pass streams), `use_unstable_protocol` (unused), `stdio_buffer_limit_bytes` (stdio-only), `**connection_kwargs` (we use the default constructor). The docstring tells the next maintainer to either mirror new upstream parameters here or — preferably — drop this wrapper entirely once upstream lands the fix.

## How was this change tested?

Added **`test_repeated_initialize_only_cycles_do_not_leak_asyncio_tasks`** — drives the AI health checker's exact access pattern (three rapid open/initialize/close cycles) against the local `handle_websocket` server and asserts the asyncio loop's exception handler reports no `Task was destroyed but it is pending!` notices.

Verified the regression test:
- **Fails before this patch** with the exact symptoms from #8733:
  ```
  AssertionError: asyncio reported orphaned pending tasks: [
    Task<…name='acp.Sender.loop' …exception=RuntimeError('cannot reuse already awaited coroutine')>,
    Task<…name='acp.Dispatcher.loop' …exception=RuntimeError('cannot reuse already awaited coroutine')>,
    … (one Sender + one Dispatcher per cycle)
  ]
  ```
- **Passes after this patch.**

Existing `test_complete_acp_workflow_with_fake_agent` continues to pass. `make fmt` / `make lint` clean.

## Follow-up

Filed agentclientprotocol/python-sdk#108 asking upstream to either add a `try/finally` inside `run_agent` itself or expose a public `AgentSideConnection.close()` / `__aexit__`. When that lands, this wrapper can be deleted entirely.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes