### PR TITLE
feat(query): Support OTLP export from Jaeger UI without CORS

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -6,8 +6,6 @@ package app
 
 import (
 	"errors"
-	"fmt"
-	"net/url"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -62,39 +60,21 @@ type AIConfig struct {
 }
 
 // DefaultOTLPProxyTarget is the loopback endpoint of the bundled OTel-collector
-// OTLP HTTP receiver. Used when the operator opts into the otlp_proxy block
-// without overriding `target` themselves.
+// OTLP HTTP receiver.
 const DefaultOTLPProxyTarget = "http://127.0.0.1:4318"
 
-// OTLPProxyConfig opts the query extension into mounting an HTTP reverse
-// proxy at `/api/otlp/v1/*` that forwards to an OTel-collector OTLP HTTP
-// receiver. The motivating use case is browser-side telemetry from the
-// Jaeger UI: same-origin POSTs to the query port avoid the CORS preflight
-// round-trip and the operator-side allow-list config that a cross-port
-// alternative would require.
+// OTLPProxyConfig mounts an HTTP reverse proxy at `<basePath>/api/otlp/v1/*`
+// that strips the `/api/otlp` prefix and forwards to Target. Intended for
+// same-origin browser telemetry from the SPA — POSTs to the query port
+// avoid the CORS preflight a cross-port OTLP receiver would need.
 type OTLPProxyConfig struct {
 	// Target is the base URL of the OTLP HTTP receiver to forward to.
-	// The proxy strips the `/api/otlp` prefix before forwarding, so a POST
-	// to `<query>/api/otlp/v1/traces` becomes `<target>/v1/traces`.
 	Target string `mapstructure:"target" valid:"required"`
 }
 
-// Validate is a pure check; the default value is supplied by DefaultQueryOptions
-// (see the OTLPProxyConfig type-level comment) so an operator who opts into the
-// block without overrides still gets a valid Target.
 func (c *OTLPProxyConfig) Validate() error {
 	if c.Target == "" {
 		return errors.New("otlp_proxy.target is required")
-	}
-	u, err := url.Parse(c.Target)
-	if err != nil {
-		return fmt.Errorf("otlp_proxy.target must be a valid URL: %w", err)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("otlp_proxy.target must use http or https scheme, got %q", u.Scheme)
-	}
-	if u.Host == "" {
-		return errors.New("otlp_proxy.target must include a host")
 	}
 	return nil
 }
@@ -143,8 +123,7 @@ type QueryOptions struct {
 	GRPC configgrpc.ServerConfig `mapstructure:"grpc"`
 	// AI holds configuration related to Jaeger AI gateway integration.
 	AI configoptional.Optional[AIConfig] `mapstructure:"ai"`
-	// OTLPProxy, when present, mounts a same-origin OTLP HTTP reverse proxy
-	// at `/api/otlp/v1/*` on the query port. Absent (default) ⇒ no proxy route.
+	// OTLPProxy, when present, mounts an OTLP HTTP reverse proxy — see OTLPProxyConfig.
 	OTLPProxy configoptional.Optional[OTLPProxyConfig] `mapstructure:"otlp_proxy"`
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -6,6 +6,8 @@ package app
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -59,6 +61,44 @@ type AIConfig struct {
 	HealthCheckTimeout time.Duration `mapstructure:"health_check_timeout" valid:"optional"`
 }
 
+// DefaultOTLPProxyTarget is the loopback endpoint of the bundled OTel-collector
+// OTLP HTTP receiver. Used when the operator opts into the otlp_proxy block
+// without overriding `target` themselves.
+const DefaultOTLPProxyTarget = "http://127.0.0.1:4318"
+
+// OTLPProxyConfig opts the query extension into mounting an HTTP reverse
+// proxy at `/api/otlp/v1/*` that forwards to an OTel-collector OTLP HTTP
+// receiver. The motivating use case is browser-side telemetry from the
+// Jaeger UI: same-origin POSTs to the query port avoid the CORS preflight
+// round-trip and the operator-side allow-list config that a cross-port
+// alternative would require.
+type OTLPProxyConfig struct {
+	// Target is the base URL of the OTLP HTTP receiver to forward to.
+	// The proxy strips the `/api/otlp` prefix before forwarding, so a POST
+	// to `<query>/api/otlp/v1/traces` becomes `<target>/v1/traces`.
+	Target string `mapstructure:"target" valid:"required"`
+}
+
+// Validate is a pure check; the default value is supplied by DefaultQueryOptions
+// (see the OTLPProxyConfig type-level comment) so an operator who opts into the
+// block without overrides still gets a valid Target.
+func (c *OTLPProxyConfig) Validate() error {
+	if c.Target == "" {
+		return errors.New("otlp_proxy.target is required")
+	}
+	u, err := url.Parse(c.Target)
+	if err != nil {
+		return fmt.Errorf("otlp_proxy.target must be a valid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("otlp_proxy.target must use http or https scheme, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return errors.New("otlp_proxy.target must include a host")
+	}
+	return nil
+}
+
 // Validate is a pure check; defaults are supplied by DefaultQueryOptions
 // (see the AIConfig type-level comment) so by the time Validate runs the
 // caller's struct already has sensible values for any field they omitted.
@@ -103,6 +143,9 @@ type QueryOptions struct {
 	GRPC configgrpc.ServerConfig `mapstructure:"grpc"`
 	// AI holds configuration related to Jaeger AI gateway integration.
 	AI configoptional.Optional[AIConfig] `mapstructure:"ai"`
+	// OTLPProxy, when present, mounts a same-origin OTLP HTTP reverse proxy
+	// at `/api/otlp/v1/*` on the query port. Absent (default) ⇒ no proxy route.
+	OTLPProxy configoptional.Optional[OTLPProxyConfig] `mapstructure:"otlp_proxy"`
 }
 
 func DefaultQueryOptions() QueryOptions {
@@ -113,6 +156,9 @@ func DefaultQueryOptions() QueryOptions {
 			MaxRequestBodySize:  DefaultAIMaxRequestBodySize,
 			HealthCheckInterval: DefaultAIHealthCheckInterval,
 			HealthCheckTimeout:  DefaultAIHealthCheckTimeout,
+		}),
+		OTLPProxy: configoptional.Default(OTLPProxyConfig{
+			Target: DefaultOTLPProxyTarget,
 		}),
 		HTTP: confighttp.ServerConfig{
 			NetAddr: confignet.AddrConfig{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -24,6 +24,40 @@ func TestDefaultQueryOptions(t *testing.T) {
 	require.Equal(t, DefaultAIHealthCheckInterval, aiCfg.HealthCheckInterval)
 	require.Equal(t, DefaultAIHealthCheckTimeout, aiCfg.HealthCheckTimeout)
 	require.NoError(t, aiCfg.Validate())
+
+	require.False(t, qo.OTLPProxy.HasValue())
+	otlpCfg := qo.OTLPProxy.GetOrInsertDefault()
+	require.NotNil(t, otlpCfg)
+	require.Equal(t, DefaultOTLPProxyTarget, otlpCfg.Target)
+	require.NoError(t, otlpCfg.Validate())
+}
+
+func TestOTLPProxyConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		wantErr string
+	}{
+		{name: "valid http", target: "http://127.0.0.1:4318"},
+		{name: "valid https", target: "https://collector.example.com:4318"},
+		{name: "default target", target: DefaultOTLPProxyTarget},
+		{name: "empty rejected", target: "", wantErr: "otlp_proxy.target is required"},
+		{name: "non-URL rejected", target: "://not a url", wantErr: "must be a valid URL"},
+		{name: "missing host rejected", target: "http://", wantErr: "must include a host"},
+		{name: "non-http scheme rejected", target: "ws://localhost:4318", wantErr: `must use http or https scheme, got "ws"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := OTLPProxyConfig{Target: tc.target}
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }
 
 // validAIConfig returns an AIConfig that passes Validate; tests mutate the

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -33,31 +33,8 @@ func TestDefaultQueryOptions(t *testing.T) {
 }
 
 func TestOTLPProxyConfigValidate(t *testing.T) {
-	tests := []struct {
-		name    string
-		target  string
-		wantErr string
-	}{
-		{name: "valid http", target: "http://127.0.0.1:4318"},
-		{name: "valid https", target: "https://collector.example.com:4318"},
-		{name: "default target", target: DefaultOTLPProxyTarget},
-		{name: "empty rejected", target: "", wantErr: "otlp_proxy.target is required"},
-		{name: "non-URL rejected", target: "://not a url", wantErr: "must be a valid URL"},
-		{name: "missing host rejected", target: "http://", wantErr: "must include a host"},
-		{name: "non-http scheme rejected", target: "ws://localhost:4318", wantErr: `must use http or https scheme, got "ws"`},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := OTLPProxyConfig{Target: tc.target}
-			err := cfg.Validate()
-			if tc.wantErr == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.wantErr)
-		})
-	}
+	require.NoError(t, (&OTLPProxyConfig{Target: DefaultOTLPProxyTarget}).Validate())
+	require.EqualError(t, (&OTLPProxyConfig{Target: ""}).Validate(), "otlp_proxy.target is required")
 }
 
 // validAIConfig returns an AIConfig that passes Validate; tests mutate the

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"path"
 	"strings"
 	"sync"
@@ -19,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp/xconfighttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -214,6 +217,17 @@ func initRouter(
 		}
 	}
 
+	// OTLP HTTP reverse proxy. When the operator opts into the otlp_proxy
+	// block, mount a proxy at `<basePath>/api/otlp/v1/*` that forwards to the
+	// configured OTel-collector OTLP HTTP receiver. The motivating use case
+	// is browser-side telemetry from the SPA: same-origin POSTs avoid the
+	// CORS preflight an alternate-port receiver would need. The otelhttp
+	// instrumentation in createHTTPServer is filtered out for the proxied
+	// path prefix so we don't trace our own trace-ingest endpoint.
+	if queryOpts.OTLPProxy.HasValue() {
+		registerOTLPProxy(r, queryOpts, telset)
+	}
+
 	r.HandleFunc(apiNotFoundPattern, func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "404 page not found", http.StatusNotFound)
 	})
@@ -232,6 +246,54 @@ func initRouter(
 	}
 	handler = traceResponseHandler(handler)
 	return handler, staticHandlerCloser
+}
+
+// otlpProxyPathPrefix returns the routing prefix the OTLP proxy is mounted at,
+// honoring the configured BasePath. The trailing slash is intentional — the
+// http.ServeMux interprets a trailing slash as a subtree match so the proxy
+// catches /v1/traces, /v1/logs, /v1/metrics, and any future OTLP endpoint.
+func otlpProxyPathPrefix(basePath string) string {
+	prefix := "/api/otlp"
+	if basePath != "" && basePath != "/" {
+		prefix = basePath + prefix
+	}
+	return prefix
+}
+
+// registerOTLPProxy installs an HTTP reverse proxy at <basePath>/api/otlp/v1/*
+// that forwards to queryOpts.OTLPProxy.Get().Target. The `/api/otlp` prefix is
+// stripped before forwarding so the downstream receiver sees its native
+// `/v1/...` path.
+//
+// The handler is wrapped with otelhttp using a no-op tracer provider but the
+// real meter provider, so requests show up in the standard HTTP server
+// metrics (http.server.request.duration etc.) without producing a server
+// span — we don't want to trace our own trace-ingest endpoint. The
+// otelhttp filter in createHTTPServer correspondingly skips this prefix so
+// the per-route wrap here is the only otelhttp layer in the chain.
+//
+// Callers must check queryOpts.OTLPProxy.HasValue() before invoking.
+func registerOTLPProxy(r *http.ServeMux, queryOpts *QueryOptions, telset telemetry.Settings) {
+	cfg := queryOpts.OTLPProxy.Get()
+	target, err := url.Parse(cfg.Target)
+	if err != nil {
+		// Validate ran earlier in the load path, so reaching here means the
+		// caller skipped it. Log and disable the route rather than panic.
+		telset.Logger.Error("Invalid OTLP proxy target, route disabled", zap.String("target", cfg.Target), zap.Error(err))
+		return
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	prefix := otlpProxyPathPrefix(queryOpts.BasePath)
+	instrumented := otelhttp.NewHandler(
+		http.StripPrefix(prefix, proxy),
+		"otlp.proxy",
+		otelhttp.WithTracerProvider(nooptrace.NewTracerProvider()),
+		otelhttp.WithMeterProvider(telset.MeterProvider),
+	)
+	r.Handle(prefix+"/v1/", instrumented)
+	telset.Logger.Info("OTLP proxy registered",
+		zap.String("path_prefix", prefix+"/v1/"),
+		zap.String("target", cfg.Target))
 }
 
 func createHTTPServer(
@@ -261,8 +323,20 @@ func createHTTPServer(
 		handler,
 		xconfighttp.WithOtelHTTPOptions(
 			otelhttp.WithFilter(func(r *http.Request) bool {
-				ignorePath := path.Join("/", queryOpts.BasePath, "static")
-				return !strings.HasPrefix(r.URL.Path, ignorePath)
+				ignoreStatic := path.Join("/", queryOpts.BasePath, "static")
+				// Always exclude `/api/otlp/*` from server-side instrumentation,
+				// whether or not the proxy is enabled. When enabled, this avoids
+				// the obvious feedback loop of tracing our own trace-ingest
+				// endpoint; when disabled, the request 404s and the missing
+				// span is irrelevant.
+				ignoreOTLP := otlpProxyPathPrefix(queryOpts.BasePath)
+				if strings.HasPrefix(r.URL.Path, ignoreStatic) {
+					return false
+				}
+				if strings.HasPrefix(r.URL.Path, ignoreOTLP) {
+					return false
+				}
+				return true
 			}),
 			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 				// Use just the route pattern without the HTTP method prefix or basePath

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -176,7 +176,7 @@ func initRouter(
 	aiHealthCheck func() bool,
 	tenancyMgr *tenancy.Manager,
 	telset telemetry.Settings,
-) (http.Handler, io.Closer) {
+) (http.Handler, io.Closer, error) {
 	apiHandlerOptions := []HandlerOption{
 		HandlerOptions.Logger(telset.Logger),
 		HandlerOptions.Tracer(telset.TracerProvider),
@@ -218,7 +218,9 @@ func initRouter(
 	}
 
 	if queryOpts.OTLPProxy.HasValue() {
-		registerOTLPProxy(r, queryOpts, telset)
+		if err := registerOTLPProxy(r, queryOpts, telset); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	r.HandleFunc(apiNotFoundPattern, func(w http.ResponseWriter, _ *http.Request) {
@@ -238,7 +240,7 @@ func initRouter(
 		handler = tenancy.ExtractTenantHTTPHandler(tenancyMgr, handler)
 	}
 	handler = traceResponseHandler(handler)
-	return handler, staticHandlerCloser
+	return handler, staticHandlerCloser, nil
 }
 
 func otlpProxyPathPrefix(basePath string) string {
@@ -254,12 +256,11 @@ func otlpProxyPathPrefix(basePath string) string {
 // provider so HTTP server metrics flow without producing a self-referential
 // server span; the top-level otelhttp filter excludes this prefix so the
 // per-route wrap is the only instrumentation layer.
-func registerOTLPProxy(r *http.ServeMux, queryOpts *QueryOptions, telset telemetry.Settings) {
+func registerOTLPProxy(r *http.ServeMux, queryOpts *QueryOptions, telset telemetry.Settings) error {
 	cfg := queryOpts.OTLPProxy.Get()
 	target, err := url.Parse(cfg.Target)
 	if err != nil {
-		telset.Logger.Error("Invalid OTLP proxy target, route disabled", zap.String("target", cfg.Target), zap.Error(err))
-		return
+		return fmt.Errorf("invalid OTLP proxy target %q: %w", cfg.Target, err)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	prefix := otlpProxyPathPrefix(queryOpts.BasePath)
@@ -273,6 +274,7 @@ func registerOTLPProxy(r *http.ServeMux, queryOpts *QueryOptions, telset telemet
 	telset.Logger.Info("OTLP proxy registered",
 		zap.String("path_prefix", prefix+"/v1/"),
 		zap.String("target", cfg.Target))
+	return nil
 }
 
 func createHTTPServer(
@@ -285,7 +287,10 @@ func createHTTPServer(
 	tm *tenancy.Manager,
 	telset telemetry.Settings,
 ) (*httpServer, error) {
-	handler, staticHandlerCloser := initRouter(querySvc, metricsQuerySvc, queryOpts, caps, aiHealthCheck, tm, telset)
+	handler, staticHandlerCloser, err := initRouter(querySvc, metricsQuerySvc, queryOpts, caps, aiHealthCheck, tm, telset)
+	if err != nil {
+		return nil, err
+	}
 	handler = recoveryhandler.NewRecoveryHandler(telset.Logger, true)(handler)
 	var extensions map[component.ID]component.Component
 	if telset.Host != nil {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -217,13 +217,6 @@ func initRouter(
 		}
 	}
 
-	// OTLP HTTP reverse proxy. When the operator opts into the otlp_proxy
-	// block, mount a proxy at `<basePath>/api/otlp/v1/*` that forwards to the
-	// configured OTel-collector OTLP HTTP receiver. The motivating use case
-	// is browser-side telemetry from the SPA: same-origin POSTs avoid the
-	// CORS preflight an alternate-port receiver would need. The otelhttp
-	// instrumentation in createHTTPServer is filtered out for the proxied
-	// path prefix so we don't trace our own trace-ingest endpoint.
 	if queryOpts.OTLPProxy.HasValue() {
 		registerOTLPProxy(r, queryOpts, telset)
 	}
@@ -248,10 +241,6 @@ func initRouter(
 	return handler, staticHandlerCloser
 }
 
-// otlpProxyPathPrefix returns the routing prefix the OTLP proxy is mounted at,
-// honoring the configured BasePath. The trailing slash is intentional — the
-// http.ServeMux interprets a trailing slash as a subtree match so the proxy
-// catches /v1/traces, /v1/logs, /v1/metrics, and any future OTLP endpoint.
 func otlpProxyPathPrefix(basePath string) string {
 	prefix := "/api/otlp"
 	if basePath != "" && basePath != "/" {
@@ -260,25 +249,15 @@ func otlpProxyPathPrefix(basePath string) string {
 	return prefix
 }
 
-// registerOTLPProxy installs an HTTP reverse proxy at <basePath>/api/otlp/v1/*
-// that forwards to queryOpts.OTLPProxy.Get().Target. The `/api/otlp` prefix is
-// stripped before forwarding so the downstream receiver sees its native
-// `/v1/...` path.
-//
-// The handler is wrapped with otelhttp using a no-op tracer provider but the
-// real meter provider, so requests show up in the standard HTTP server
-// metrics (http.server.request.duration etc.) without producing a server
-// span — we don't want to trace our own trace-ingest endpoint. The
-// otelhttp filter in createHTTPServer correspondingly skips this prefix so
-// the per-route wrap here is the only otelhttp layer in the chain.
-//
-// Callers must check queryOpts.OTLPProxy.HasValue() before invoking.
+// registerOTLPProxy mounts the route described by OTLPProxyConfig. The proxy
+// handler is wrapped with otelhttp using a no-op tracer but the real meter
+// provider so HTTP server metrics flow without producing a self-referential
+// server span; the top-level otelhttp filter excludes this prefix so the
+// per-route wrap is the only instrumentation layer.
 func registerOTLPProxy(r *http.ServeMux, queryOpts *QueryOptions, telset telemetry.Settings) {
 	cfg := queryOpts.OTLPProxy.Get()
 	target, err := url.Parse(cfg.Target)
 	if err != nil {
-		// Validate ran earlier in the load path, so reaching here means the
-		// caller skipped it. Log and disable the route rather than panic.
 		telset.Logger.Error("Invalid OTLP proxy target, route disabled", zap.String("target", cfg.Target), zap.Error(err))
 		return
 	}
@@ -324,19 +303,9 @@ func createHTTPServer(
 		xconfighttp.WithOtelHTTPOptions(
 			otelhttp.WithFilter(func(r *http.Request) bool {
 				ignoreStatic := path.Join("/", queryOpts.BasePath, "static")
-				// Always exclude `/api/otlp/*` from server-side instrumentation,
-				// whether or not the proxy is enabled. When enabled, this avoids
-				// the obvious feedback loop of tracing our own trace-ingest
-				// endpoint; when disabled, the request 404s and the missing
-				// span is irrelevant.
 				ignoreOTLP := otlpProxyPathPrefix(queryOpts.BasePath)
-				if strings.HasPrefix(r.URL.Path, ignoreStatic) {
-					return false
-				}
-				if strings.HasPrefix(r.URL.Path, ignoreOTLP) {
-					return false
-				}
-				return true
+				return !strings.HasPrefix(r.URL.Path, ignoreStatic) &&
+					!strings.HasPrefix(r.URL.Path, ignoreOTLP)
 			}),
 			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 				// Use just the route pattern without the HTTP method prefix or basePath

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -251,6 +251,21 @@ func otlpProxyPathPrefix(basePath string) string {
 	return prefix
 }
 
+func otelFilterFunc(basePath string) func(*http.Request) bool {
+	prefixes := []string{
+		path.Join("/", basePath, "static"),
+		otlpProxyPathPrefix(basePath),
+	}
+	return func(r *http.Request) bool {
+		for _, p := range prefixes {
+			if strings.HasPrefix(r.URL.Path, p) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // registerOTLPProxy mounts the route described by OTLPProxyConfig. The proxy
 // handler is wrapped with otelhttp using a no-op tracer but the real meter
 // provider so HTTP server metrics flow without producing a self-referential
@@ -306,12 +321,7 @@ func createHTTPServer(
 		},
 		handler,
 		xconfighttp.WithOtelHTTPOptions(
-			otelhttp.WithFilter(func(r *http.Request) bool {
-				ignoreStatic := path.Join("/", queryOpts.BasePath, "static")
-				ignoreOTLP := otlpProxyPathPrefix(queryOpts.BasePath)
-				return !strings.HasPrefix(r.URL.Path, ignoreStatic) &&
-					!strings.HasPrefix(r.URL.Path, ignoreOTLP)
-			}),
+			otelhttp.WithFilter(otelFilterFunc(queryOpts.BasePath)),
 			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 				// Use just the route pattern without the HTTP method prefix or basePath
 				// r.Pattern includes the method like "GET /jaeger/api/v3/traces/{trace_id}"

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -1258,13 +1258,15 @@ func TestInitRouterOTLPProxyEmitsMetrics(t *testing.T) {
 	}))
 	t.Cleanup(upstream.Close)
 
-	// A manual-reader meter provider so we can assert against captured metric
-	// data after the request.
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { require.NoError(t, mp.Shutdown(context.Background())) })
 
-	telset := initTelSet(zaptest.NewLogger(t), nooptrace.NewTracerProvider())
+	spanExporter := tracetest.NewInMemoryExporter()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSyncer(spanExporter))
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+
+	telset := initTelSet(zaptest.NewLogger(t), tp)
 	telset.MeterProvider = mp
 
 	opts := DefaultQueryOptions()
@@ -1283,13 +1285,12 @@ func TestInitRouterOTLPProxyEmitsMetrics(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 	}
 
+	require.Empty(t, spanExporter.GetSpans(),
+		"OTLP proxy route must not produce server spans (uses noop tracer)")
+
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
 
-	// We don't pin to a specific metric name — the otelhttp instrumentation
-	// has shifted between `http.server.duration` and
-	// `http.server.request.duration` across versions. What we assert is that
-	// at least one HTTP server metric reported a measurement for our path.
 	var foundCount uint64
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
@@ -1306,8 +1307,6 @@ func TestInitRouterOTLPProxyEmitsMetrics(t *testing.T) {
 					foundCount += dp.Count
 				}
 			default:
-				// Other aggregations (sum, gauge, etc.) don't carry the
-				// per-request count we use for this assertion. Ignore them.
 			}
 		}
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -1154,6 +1154,22 @@ func TestOTLPProxyPathPrefix(t *testing.T) {
 	require.Equal(t, "/jaeger/api/otlp", otlpProxyPathPrefix("/jaeger"))
 }
 
+func TestOtelFilterFunc(t *testing.T) {
+	filter := otelFilterFunc("")
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/api/services", true},
+		{"/static/bundle.js", false},
+		{"/api/otlp/v1/traces", false},
+	}
+	for _, tt := range tests {
+		req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
+		assert.Equal(t, tt.want, filter(req), "path: %s", tt.path)
+	}
+}
+
 func TestInitRouterOTLPProxy(t *testing.T) {
 	telset := initTelSet(zaptest.NewLogger(t), nooptrace.NewTracerProvider())
 	querySvc := makeQuerySvc()

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	traceapi "go.opentelemetry.io/otel/trace"
@@ -46,6 +48,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"github.com/jaegertracing/jaeger/internal/testutils"
 )
 
 var testCertKeyLocation = "../../../../../../internal/config/tlscfg/testdata"
@@ -1140,4 +1143,178 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 
 		require.Equal(t, http.StatusBadGateway, rr.Code)
 	})
+}
+
+func TestOTLPProxyPathPrefix(t *testing.T) {
+	require.Equal(t, "/api/otlp", otlpProxyPathPrefix(""))
+	require.Equal(t, "/api/otlp", otlpProxyPathPrefix("/"))
+	require.Equal(t, "/jaeger/api/otlp", otlpProxyPathPrefix("/jaeger"))
+}
+
+func TestInitRouterOTLPProxy(t *testing.T) {
+	telset := initTelSet(zaptest.NewLogger(t), nooptrace.NewTracerProvider())
+	querySvc := makeQuerySvc()
+	tenancyMgr := tenancy.NewManager(&tenancy.Options{})
+
+	t.Run("absent block does not register the route", func(t *testing.T) {
+		opts := DefaultQueryOptions()
+		require.False(t, opts.OTLPProxy.HasValue())
+
+		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+		req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader(`{}`))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	// Spin up a stub upstream so we can verify the proxy forwards correctly.
+	type captured struct {
+		path        string
+		body        string
+		contentType string
+	}
+	stub := func() (*httptest.Server, *captured) {
+		got := &captured{}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got.path = r.URL.Path
+			got.contentType = r.Header.Get("Content-Type")
+			buf := make([]byte, r.ContentLength)
+			n, _ := r.Body.Read(buf)
+			got.body = string(buf[:n])
+			w.WriteHeader(http.StatusOK)
+		}))
+		return srv, got
+	}
+
+	t.Run("forwards to upstream with prefix stripped", func(t *testing.T) {
+		upstream, got := stub()
+		t.Cleanup(upstream.Close)
+
+		opts := DefaultQueryOptions()
+		opts.OTLPProxy = configoptional.Some(OTLPProxyConfig{Target: upstream.URL})
+
+		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+		req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader("payload"))
+		req.Header.Set("Content-Type", "application/x-protobuf")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(t, "/v1/traces", got.path, "the /api/otlp prefix must be stripped before forwarding")
+		require.Equal(t, "application/x-protobuf", got.contentType)
+		require.Equal(t, "payload", got.body)
+	})
+
+	t.Run("honors BasePath", func(t *testing.T) {
+		upstream, got := stub()
+		t.Cleanup(upstream.Close)
+
+		opts := DefaultQueryOptions()
+		opts.BasePath = "/jaeger"
+		opts.OTLPProxy = configoptional.Some(OTLPProxyConfig{Target: upstream.URL})
+
+		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+		req := httptest.NewRequest(http.MethodPost, "/jaeger/api/otlp/v1/traces", strings.NewReader("payload"))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(t, "/v1/traces", got.path)
+
+		// The same request without the BasePath should miss the proxy and 404
+		// via the apiNotFoundPattern catch-all.
+		got.path = ""
+		req2 := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader("payload"))
+		rr2 := httptest.NewRecorder()
+		handler.ServeHTTP(rr2, req2)
+		require.Equal(t, http.StatusNotFound, rr2.Code)
+		require.Empty(t, got.path, "request without BasePath must not reach the upstream")
+	})
+
+	t.Run("logs an error and skips registration when target is unparseable", func(t *testing.T) {
+		logger, logBuf := testutils.NewLogger()
+		errTelset := telset
+		errTelset.Logger = logger
+
+		opts := DefaultQueryOptions()
+		opts.OTLPProxy = configoptional.Some(OTLPProxyConfig{Target: "://not a url"})
+
+		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, errTelset)
+		t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+		req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader("{}"))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusNotFound, rr.Code)
+		require.Contains(t, logBuf.String(), "Invalid OTLP proxy target")
+	})
+}
+
+func TestInitRouterOTLPProxyEmitsMetrics(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	// A manual-reader meter provider so we can assert against captured metric
+	// data after the request.
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, mp.Shutdown(context.Background())) })
+
+	telset := initTelSet(zaptest.NewLogger(t), nooptrace.NewTracerProvider())
+	telset.MeterProvider = mp
+
+	opts := DefaultQueryOptions()
+	opts.OTLPProxy = configoptional.Some(OTLPProxyConfig{Target: upstream.URL})
+
+	querySvc := makeQuerySvc()
+	tenancyMgr := tenancy.NewManager(&tenancy.Options{})
+	handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+	t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+	for range 3 {
+		req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader("payload"))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	// We don't pin to a specific metric name — the otelhttp instrumentation
+	// has shifted between `http.server.duration` and
+	// `http.server.request.duration` across versions. What we assert is that
+	// at least one HTTP server metric reported a measurement for our path.
+	var foundCount uint64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if !strings.HasPrefix(m.Name, "http.server.") {
+				continue
+			}
+			switch agg := m.Data.(type) {
+			case metricdata.Histogram[float64]:
+				for _, dp := range agg.DataPoints {
+					foundCount += dp.Count
+				}
+			case metricdata.Histogram[int64]:
+				for _, dp := range agg.DataPoints {
+					foundCount += dp.Count
+				}
+			default:
+				// Other aggregations (sum, gauge, etc.) don't carry the
+				// per-request count we use for this assertion. Ignore them.
+			}
+		}
+	}
+	require.GreaterOrEqual(t, foundCount, uint64(3),
+		"expected at least 3 HTTP server metric measurements (one per request) from the OTLP proxy")
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
-	"github.com/jaegertracing/jaeger/internal/testutils"
 )
 
 var testCertKeyLocation = "../../../../../../internal/config/tlscfg/testdata"
@@ -1073,7 +1072,8 @@ func TestInitRouter_HeaderForwarding(t *testing.T) {
 		{HTTPName: "x-user", Role: headerforwarding.RoleUsername},
 	}
 
-	handler, closer := initRouter(qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+	handler, closer, err := initRouter(qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, closer.Close()) })
 
 	req := httptest.NewRequest(http.MethodGet, "/api/services", http.NoBody)
@@ -1099,7 +1099,8 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 		opts := DefaultQueryOptions()
 		opts.AI = configoptional.Some(AIConfig{AgentURL: ""})
 
-		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, closer.Close())
 		})
@@ -1115,7 +1116,8 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 		opts := DefaultQueryOptions()
 		opts.AI = configoptional.Some(AIConfig{AgentURL: "ws://127.0.0.1:1", MaxRequestBodySize: 1 << 20})
 
-		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, closer.Close())
 		})
@@ -1132,7 +1134,8 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 		opts.BasePath = "/jaeger"
 		opts.AI = configoptional.Some(AIConfig{AgentURL: "ws://127.0.0.1:1", MaxRequestBodySize: 1 << 20})
 
-		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, closer.Close())
 		})
@@ -1160,7 +1163,8 @@ func TestInitRouterOTLPProxy(t *testing.T) {
 		opts := DefaultQueryOptions()
 		require.False(t, opts.OTLPProxy.HasValue())
 
-		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, closer.Close()) })
 
 		req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader(`{}`))
@@ -1195,7 +1199,8 @@ func TestInitRouterOTLPProxy(t *testing.T) {
 		opts := DefaultQueryOptions()
 		opts.OTLPProxy = configoptional.Some(OTLPProxyConfig{Target: upstream.URL})
 
-		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, closer.Close()) })
 
 		req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader("payload"))
@@ -1217,7 +1222,8 @@ func TestInitRouterOTLPProxy(t *testing.T) {
 		opts.BasePath = "/jaeger"
 		opts.OTLPProxy = configoptional.Some(OTLPProxyConfig{Target: upstream.URL})
 
-		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, closer.Close()) })
 
 		req := httptest.NewRequest(http.MethodPost, "/jaeger/api/otlp/v1/traces", strings.NewReader("payload"))
@@ -1237,23 +1243,12 @@ func TestInitRouterOTLPProxy(t *testing.T) {
 		require.Empty(t, got.path, "request without BasePath must not reach the upstream")
 	})
 
-	t.Run("logs an error and skips registration when target is unparseable", func(t *testing.T) {
-		logger, logBuf := testutils.NewLogger()
-		errTelset := telset
-		errTelset.Logger = logger
-
+	t.Run("returns error when target is unparseable", func(t *testing.T) {
 		opts := DefaultQueryOptions()
 		opts.OTLPProxy = configoptional.Some(OTLPProxyConfig{Target: "://not a url"})
 
-		handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, errTelset)
-		t.Cleanup(func() { require.NoError(t, closer.Close()) })
-
-		req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader("{}"))
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-
-		require.Equal(t, http.StatusNotFound, rr.Code)
-		require.Contains(t, logBuf.String(), "Invalid OTLP proxy target")
+		_, _, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.ErrorContains(t, err, "invalid OTLP proxy target")
 	})
 }
 
@@ -1277,7 +1272,8 @@ func TestInitRouterOTLPProxyEmitsMetrics(t *testing.T) {
 
 	querySvc := makeQuerySvc()
 	tenancyMgr := tenancy.NewManager(&tenancy.Options{})
-	handler, closer := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+	handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, closer.Close()) })
 
 	for range 3 {


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #8739.

The Jaeger SPA wants to submit browser-side spans (page-load instrumentation, AI-chat telemetry, whatever). Browsers can only POST to the same origin without a CORS preflight, and the OTel-collector OTLP HTTP receiver listens on a different port (4318 by default). The choices are: configure a CORS allow-list on the receiver, or expose an OTLP path on the query port. This PR takes the second route.

## Description of the changes

**New config block (off by default).**

```yaml
extensions:
  jaeger_query:
    otlp_proxy:
      target: http://127.0.0.1:4318    # default; loopback by design
```

Absent ⇒ no route. Present ⇒ proxy mounted at `<basePath>/api/otlp/v1/*`. An empty or unparseable target is a fatal configuration error that prevents startup.

**Routing.**

`registerOTLPProxy` builds an `httputil.NewSingleHostReverseProxy(target)` and registers it under `<basePath>/api/otlp/v1/` with `http.StripPrefix("<basePath>/api/otlp", ...)`. The trailing-slash pattern catches `/v1/traces`, `/v1/logs`, `/v1/metrics`, and any future OTLP HTTP endpoint.

**Tracing + metrics separation.**

The top-level otelhttp middleware that confighttp installs is filtered out for `/api/otlp/*`. A per-route `otelhttp.NewHandler` wraps the proxy with a **no-op TracerProvider** but the **real MeterProvider** — so requests fire the standard `http.server.*` histograms under operation name `otlp.proxy`, but no server span is produced. This avoids the obvious self-referential "trace our own trace-ingest" loop while keeping operator-visible throughput/latency metrics.

## How was this change tested?

- `TestOTLPProxyConfigValidate` — table of `Validate()` cases (empty, valid).
- `TestOTLPProxyPathPrefix` — prefix calculation with empty/`/`/`/jaeger` BasePath.
- `TestInitRouterOTLPProxy`:
  - **absent block** → request returns 404 (no route registered)
  - **forwards to upstream with prefix stripped** → upstream sees `/v1/traces` and the original body/headers
  - **honors BasePath** → `/jaeger/api/otlp/v1/traces` forwards; `/api/otlp/v1/traces` 404s
  - **invalid target** → returns error, preventing startup (bad config is a fatal error)
- `TestInitRouterOTLPProxyEmitsMetrics` — real TracerProvider with in-memory exporter + manual-reader MeterProvider; three POSTs produce ≥3 `http.server.*` histogram measurements and zero spans, validating the "metrics yes, spans no" design.

`make fmt`, `make lint`, full `go test ./cmd/jaeger/internal/extension/jaegerquery/... -race` all clean.

## Out of scope

- Auth gate on the proxied routes — a separate concern; today the operator-recommended deployment binds the OTLP receiver to 127.0.0.1 so the proxy is the only external path in.
- gRPC OTLP. Browsers can't speak it; only the HTTP path matters here.
- Logs / metrics receiver wiring. The proxy will happily forward `/api/otlp/v1/logs` and `/api/otlp/v1/metrics` if those receivers are configured, but Jaeger 2 doesn't ship them today.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes