### PR TITLE
fix(test): Stabilize TestPasswordFromFile on password rotation

### DIFF
--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -371,6 +371,10 @@ func runPasswordFromFileTest(t *testing.T) {
 	var authReceived sync.Map
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("request to fake ES server: %v", r)
+		w.Write(mockEsServerResponse)
+		if r.Method != http.MethodPost {
+			return
+		}
 		// epecting header in the form Authorization:[Basic OmZpcnN0IHBhc3N3b3Jk]
 		h := strings.Split(r.Header.Get("Authorization"), " ")
 		if !assert.Len(t, h, 2) {
@@ -382,7 +386,6 @@ func runPasswordFromFileTest(t *testing.T) {
 		auth := string(authBytes)
 		authReceived.Store(auth, auth)
 		t.Logf("request to fake ES server contained auth=%s", auth)
-		w.Write(mockEsServerResponse)
 	}))
 	t.Cleanup(server.Close)
 
@@ -390,8 +393,9 @@ func runPasswordFromFileTest(t *testing.T) {
 	require.NoError(t, os.WriteFile(pwdFile, []byte(pwd1), 0o600))
 
 	cfg := escfg.Configuration{
-		Servers:  []string{server.URL},
-		LogLevel: "debug",
+		Servers:            []string{server.URL},
+		DisableHealthCheck: true, // test validates write auth, not health probes
+		LogLevel:           "debug",
 		Authentication: escfg.Authentication{
 			BasicAuthentication: configoptional.Some(escfg.BasicAuthentication{
 				Username:         "user",
@@ -399,8 +403,9 @@ func runPasswordFromFileTest(t *testing.T) {
 			}),
 		},
 		BulkProcessing: escfg.BulkProcessing{
-			MaxBytes:   -1, // disable bulk
-			MaxActions: -1, // disable bulk; the test only validates auth headers
+			MaxBytes:      -1,               // disable bulk
+			MaxActions:    -1,               // disable bulk; the test only validates auth headers
+			FlushInterval: time.Millisecond, // flush write requests for POST auth assertions
 		},
 	}
 	f, err := NewFactoryBase(context.Background(), cfg, metrics.NullFactory, zap.NewNop(), nil)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4743
This should fix the TestPasswordFromFile test keeps failing randomly , basically old client background requests can still show up with the first password even after the password file is swapped.

## Description of the changes
Looked at the issue + older PRs (#4884, #8104, #8150) first. some parts were already fixed but not everything together, DisableHealthCheck: true since we care about write auth here, not health checks only track auth headers on POST in the mock server ,
FlushInterval: time.Millisecond so bulk actually flushes , without this, with MaxActions: -1 from #8104, the POST assertions can timeout under -race
Only touched factory_test.go, no prod changes ,
## How was this change tested?
- go test -race -count=100 -run TestPasswordFromFile   ./internal/storage/v1/elasticsearch/. . .
- go test -race . /internal/storage/v1/elasticsearch/. . .
- make fmt && make lint && make test
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality ( existing used not new unit tests )
- [x] I have run lint and test steps successfully: `make lint test`
## AI USAGE
- [x]  Light: AI provided minor assistance (formatting, simple suggestions)