### PR TITLE
feat(apiv3): Implement GetDependencies gRPC RPC handler

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -172,6 +172,38 @@ func (h *Handler) GetOperations(ctx context.Context, request *api_v3.GetOperatio
 	}, nil
 }
 
+// GetDependencies implements api_v3.QueryServiceServer's GetDependencies
+func (h *Handler) GetDependencies(ctx context.Context, request *api_v3.GetDependenciesRequest) (*api_v3.DependenciesResponse, error) {
+	if request.GetStartTime().IsZero() {
+		return nil, status.Error(codes.InvalidArgument, "start_time is required")
+	}
+	if request.GetEndTime().IsZero() {
+		return nil, status.Error(codes.InvalidArgument, "end_time is required")
+	}
+
+	startTime := request.GetStartTime()
+	endTime := request.GetEndTime()
+
+	if !endTime.After(startTime) {
+		return nil, status.Error(codes.InvalidArgument, "end_time must be after start_time")
+	}
+
+	lookback := endTime.Sub(startTime)
+	deps, err := h.QueryService.GetDependencies(ctx, endTime, lookback)
+	if err != nil {
+		return nil, err
+	}
+	links := make([]*api_v3.Dependency, len(deps))
+	for i, dep := range deps {
+		links[i] = &api_v3.Dependency{
+			Parent:    dep.Parent,
+			Child:     dep.Child,
+			CallCount: dep.CallCount,
+		}
+	}
+	return &api_v3.DependenciesResponse{Dependencies: links}, nil
+}
+
 func receiveTraces(
 	seq iter.Seq2[[]ptrace.Traces, error],
 	sendFn func(*jptrace.TracesData) error,

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -19,10 +19,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	_ "github.com/jaegertracing/jaeger/internal/gogocodec" // force gogo codec registration
 	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	dependencystoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
@@ -45,20 +47,22 @@ func newGrpcServer(t *testing.T, handler *Handler) (*grpc.Server, net.Addr) {
 }
 
 type testServerClient struct {
-	server  *grpc.Server
-	address net.Addr
-	reader  *tracestoremocks.Reader
-	client  api_v3.QueryServiceClient
+	server     *grpc.Server
+	address    net.Addr
+	reader     *tracestoremocks.Reader
+	depsReader *dependencystoremocks.Reader
+	client     api_v3.QueryServiceClient
 }
 
 func newTestServerClient(t *testing.T) *testServerClient {
 	tsc := &testServerClient{
-		reader: &tracestoremocks.Reader{},
+		reader:     &tracestoremocks.Reader{},
+		depsReader: &dependencystoremocks.Reader{},
 	}
 
 	q := querysvc.NewQueryService(
 		tsc.reader,
-		&dependencystoremocks.Reader{},
+		tsc.depsReader,
 		querysvc.QueryServiceOptions{},
 	)
 	h := &Handler{
@@ -363,4 +367,79 @@ func TestGetOperationsStorageError(t *testing.T) {
 	response, err := tsc.client.GetOperations(context.Background(), &api_v3.GetOperationsRequest{})
 	require.ErrorContains(t, err, assert.AnError.Error())
 	assert.Nil(t, response)
+}
+
+func TestGetDependencies(t *testing.T) {
+	tsc := newTestServerClient(t)
+	endTime := time.Now().UTC()
+	lookback := 24 * time.Hour
+
+	expectedDeps := []model.DependencyLink{
+		{
+			Parent:    "frontend",
+			Child:     "backend",
+			CallCount: 100,
+			Source:    "traces",
+		},
+	}
+
+	tsc.depsReader.On("GetDependencies", matchContext, mock.MatchedBy(func(p depstore.QueryParameters) bool {
+		return p.EndTime.Equal(endTime) && p.StartTime.Equal(endTime.Add(-lookback))
+	})).Return(expectedDeps, nil).Once()
+
+	response, err := tsc.client.GetDependencies(context.Background(), &api_v3.GetDependenciesRequest{
+		StartTime: endTime.Add(-lookback),
+		EndTime:   endTime,
+	})
+	require.NoError(t, err)
+	assert.Len(t, response.GetDependencies(), 1)
+	assert.Equal(t, "frontend", response.GetDependencies()[0].Parent)
+	assert.Equal(t, "backend", response.GetDependencies()[0].Child)
+	assert.Equal(t, uint64(100), response.GetDependencies()[0].CallCount)
+}
+
+func TestGetDependenciesStorageError(t *testing.T) {
+	tsc := newTestServerClient(t)
+	tsc.depsReader.On("GetDependencies", matchContext, mock.Anything).Return(
+		nil, assert.AnError).Once()
+
+	endTime := time.Now().UTC()
+	response, err := tsc.client.GetDependencies(context.Background(), &api_v3.GetDependenciesRequest{
+		StartTime: endTime.Add(-24 * time.Hour),
+		EndTime:   endTime,
+	})
+	require.ErrorContains(t, err, assert.AnError.Error())
+	assert.Nil(t, response)
+}
+
+func TestGetDependencies_InvalidArguments(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *api_v3.GetDependenciesRequest
+		errMsg  string
+	}{
+		{
+			name:    "zero StartTime",
+			request: &api_v3.GetDependenciesRequest{EndTime: time.Now().UTC()},
+			errMsg:  "start_time is required",
+		},
+		{
+			name:    "zero EndTime",
+			request: &api_v3.GetDependenciesRequest{StartTime: time.Now().UTC()},
+			errMsg:  "end_time is required",
+		},
+		{
+			name:    "end_time before start_time",
+			request: &api_v3.GetDependenciesRequest{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(-1 * time.Hour)},
+			errMsg:  "end_time must be after start_time",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tsc := newTestServerClient(t)
+			response, err := tsc.client.GetDependencies(context.Background(), tt.request)
+			require.ErrorContains(t, err, tt.errMsg)
+			assert.Nil(t, response)
+		})
+	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -401,7 +401,8 @@ func TestGetDependencies(t *testing.T) {
 func TestGetDependenciesStorageError(t *testing.T) {
 	tsc := newTestServerClient(t)
 	tsc.depsReader.On("GetDependencies", matchContext, mock.Anything).Return(
-		nil, assert.AnError).Once()
+		nil, assert.AnError,
+	).Once()
 
 	endTime := time.Now().UTC()
 	response, err := tsc.client.GetDependencies(context.Background(), &api_v3.GetDependenciesRequest{


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #7595 (Part 1 of 2: gRPC Handler)
- The API v3 QueryService protobuf definition includes a `GetDependencies` RPC, but it was never actually implemented in the V3 `Handler`. As a result, any client attempting to query service dependencies via the V3 gRPC API receives an "Unimplemented" error. 
-  the original attempt to add `GetDependencies` to both endpoints was split into two separate, smaller PRs for easier review. This PR exclusively adds the gRPC RPC handler. A separate PR will follow for the HTTP Gateway implementation.*

## Description of the changes
- Added the `GetDependencies` implementation to the `Handler` struct in `cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go` to fulfill the `api_v3.QueryServiceServer` interface.
- Mapped the incoming `start_time` and `end_time` protocol buffer timestamps into the `endTime` and `lookback` duration format expected by the internal `querysvc.QueryService`.
- Added request validation to ensure both `start_time` and `end_time` are provided and that `end_time` is after `start_time`.
- Added comprehensive unit tests in `grpc_handler_test.go` covering the happy path, storage errors, and parameter validation failures.

## How was this change tested?
- Added new table-driven unit tests to `grpc_handler_test.go` (`TestGetDependencies`, `TestGetDependenciesStorageError`, `TestGetDependencies_InvalidArguments`).
- Ran `make test` for the `apiv3` package to verify the handler correctly mocks and queries the dependency store.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Moderate**: AI helped with code generation or debugging specific parts