### PR TITLE
feat(badger): Make span encoding type configurable

### DIFF
--- a/internal/storage/v1/badger/config.go
+++ b/internal/storage/v1/badger/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	// SyncWrites, if set to true, will immediately sync all writes to disk. Note that
 	// setting this field to true will affect write performance.
 	SyncWrites bool `mapstructure:"consistency"`
-	// Encoding, will determine the encoding type for stored spans. Supported values are
+	// Encoding determines the encoding type for stored spans. Supported values are
 	// json and protobuf (default).
 	Encoding string `mapstructure:"encoding"`
 	// MaintenanceInterval is the regular interval after which a maintenance job is

--- a/internal/storage/v1/badger/config.go
+++ b/internal/storage/v1/badger/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	// SyncWrites, if set to true, will immediately sync all writes to disk. Note that
 	// setting this field to true will affect write performance.
 	SyncWrites bool `mapstructure:"consistency"`
+	// Encoding, will determine the encoding type for stored spans. Supported values are
+	// json and protobuf (default).
+	Encoding string `mapstructure:"encoding"`
 	// MaintenanceInterval is the regular interval after which a maintenance job is
 	// run on the values in the store.
 	MaintenanceInterval time.Duration `mapstructure:"maintenance_interval"`
@@ -67,8 +70,9 @@ func DefaultConfig() *Config {
 		TTL: TTL{
 			Spans: defaultTTL,
 		},
-		SyncWrites: false, // Performance over durability
-		Ephemeral:  true,  // Default is ephemeral storage
+		SyncWrites: false,      // Performance over durability
+		Encoding:   "protobuf", // Default encoding is protobuf
+		Ephemeral:  true,       // Default is ephemeral storage
 		Directories: Directories{
 			Keys:   defaultBadgerDataDir + defaultKeysDir,
 			Values: defaultBadgerDataDir + defaultValueDir,

--- a/internal/storage/v1/badger/factory.go
+++ b/internal/storage/v1/badger/factory.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"expvar"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -152,6 +153,9 @@ func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
 
 // CreateSpanWriter creates a spanstore.Writer.
 func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
+	if f.Config.Encoding != "json" && f.Config.Encoding != "protobuf" {
+		return nil, fmt.Errorf("unknown encoding type: %s", f.Config.Encoding)
+	}
 	return badgerstore.NewSpanWriter(f.store, f.cache, f.Config.TTL.Spans, f.Config.Encoding), nil
 }
 

--- a/internal/storage/v1/badger/factory.go
+++ b/internal/storage/v1/badger/factory.go
@@ -152,7 +152,7 @@ func (f *Factory) CreateSpanReader() (spanstore.Reader, error) {
 
 // CreateSpanWriter creates a spanstore.Writer.
 func (f *Factory) CreateSpanWriter() (spanstore.Writer, error) {
-	return badgerstore.NewSpanWriter(f.store, f.cache, f.Config.TTL.Spans), nil
+	return badgerstore.NewSpanWriter(f.store, f.cache, f.Config.TTL.Spans, f.Config.Encoding), nil
 }
 
 // CreateDependencyReader creates a dependencystore.Reader.

--- a/internal/storage/v1/badger/options.go
+++ b/internal/storage/v1/badger/options.go
@@ -17,6 +17,7 @@ const (
 	suffixEphemeral           = ".ephemeral"
 	suffixSpanstoreTTL        = ".span-store-ttl"
 	suffixSyncWrite           = ".consistency"
+	suffixEncoding            = ".encoding"
 	suffixMaintenanceInterval = ".maintenance-interval"
 	suffixMetricsInterval     = ".metrics-update-interval" // Intended only for testing purposes
 	suffixReadOnly            = ".read-only"
@@ -49,6 +50,11 @@ func (c *Config) AddFlags(flagSet *flag.FlagSet) {
 		c.SyncWrites,
 		"If all writes should be synced immediately to physical disk. This will impact write performance.",
 	)
+	flagSet.String(
+		prefix+suffixEncoding,
+		c.Encoding,
+		"Encoding type for stored spans. Supported values are json and protobuf (default).",
+	)
 	flagSet.Duration(
 		prefix+suffixMaintenanceInterval,
 		c.MaintenanceInterval,
@@ -76,6 +82,7 @@ func initFromViper(config *Config, v *viper.Viper, _ *zap.Logger) {
 	config.Directories.Keys = v.GetString(prefix + suffixKeyDirectory)
 	config.Directories.Values = v.GetString(prefix + suffixValueDirectory)
 	config.SyncWrites = v.GetBool(prefix + suffixSyncWrite)
+	config.Encoding = v.GetString(prefix + suffixEncoding)
 	config.TTL.Spans = v.GetDuration(prefix + suffixSpanstoreTTL)
 	config.MaintenanceInterval = v.GetDuration(prefix + suffixMaintenanceInterval)
 	config.MetricsUpdateInterval = v.GetDuration(prefix + suffixMetricsInterval)

--- a/internal/storage/v1/badger/options.go
+++ b/internal/storage/v1/badger/options.go
@@ -82,7 +82,9 @@ func initFromViper(config *Config, v *viper.Viper, _ *zap.Logger) {
 	config.Directories.Keys = v.GetString(prefix + suffixKeyDirectory)
 	config.Directories.Values = v.GetString(prefix + suffixValueDirectory)
 	config.SyncWrites = v.GetBool(prefix + suffixSyncWrite)
-	config.Encoding = v.GetString(prefix + suffixEncoding)
+	if v.IsSet(prefix + suffixEncoding) {
+		config.Encoding = v.GetString(prefix + suffixEncoding)
+	}
 	config.TTL.Spans = v.GetDuration(prefix + suffixSpanstoreTTL)
 	config.MaintenanceInterval = v.GetDuration(prefix + suffixMaintenanceInterval)
 	config.MetricsUpdateInterval = v.GetDuration(prefix + suffixMetricsInterval)

--- a/internal/storage/v1/badger/spanstore/rw_internal_test.go
+++ b/internal/storage/v1/badger/spanstore/rw_internal_test.go
@@ -24,7 +24,7 @@ func TestEncodingTypes(t *testing.T) {
 		testSpan := createDummySpan()
 
 		cache := NewCacheStore(store, time.Duration(1*time.Hour))
-		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour))
+		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour), "protobuf")
 		rw := NewTraceReader(store, cache, true)
 
 		sw.encodingType = jsonEncoding
@@ -41,7 +41,7 @@ func TestEncodingTypes(t *testing.T) {
 		testSpan := createDummySpan()
 
 		cache := NewCacheStore(store, time.Duration(1*time.Hour))
-		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour))
+		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour), "protobuf")
 		// rw := NewTraceReader(store, cache)
 
 		sw.encodingType = 0x04
@@ -54,7 +54,7 @@ func TestEncodingTypes(t *testing.T) {
 		testSpan := createDummySpan()
 
 		cache := NewCacheStore(store, time.Duration(1*time.Hour))
-		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour))
+		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour), "protobuf")
 		rw := NewTraceReader(store, cache, true)
 
 		err := sw.WriteSpan(context.Background(), &testSpan)
@@ -89,11 +89,17 @@ func TestDecodeErrorReturns(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestToByteEncoding(t *testing.T) {
+	assert.Equal(t, jsonEncoding, toByteEncoding("json"))
+	assert.Equal(t, protoEncoding, toByteEncoding("protobuf"))
+	assert.Equal(t, defaultEncoding, toByteEncoding("unknown"))
+}
+
 func TestDuplicateTraceIDDetection(t *testing.T) {
 	runWithBadger(t, func(store *badger.DB, t *testing.T) {
 		testSpan := createDummySpan()
 		cache := NewCacheStore(store, time.Duration(1*time.Hour))
-		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour))
+		sw := NewSpanWriter(store, cache, time.Duration(1*time.Hour), "protobuf")
 		rw := NewTraceReader(store, cache, true)
 		origStartTime := testSpan.StartTime
 

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -43,13 +43,25 @@ type SpanWriter struct {
 	encodingType byte
 }
 
-// NewSpanWriter returns a SpawnWriter with cache
-func NewSpanWriter(db *badger.DB, c *CacheStore, ttl time.Duration) *SpanWriter {
+// NewSpanWriter returns a SpanWriter with cache
+func NewSpanWriter(db *badger.DB, c *CacheStore, ttl time.Duration, encoding string) *SpanWriter {
 	return &SpanWriter{
 		store:        db,
 		ttl:          ttl,
 		cache:        c,
-		encodingType: defaultEncoding, // TODO Make configurable
+		encodingType: toByteEncoding(encoding),
+	}
+}
+
+// toByteEncoding converts the string encoding type to the corresponding byte value
+func toByteEncoding(encoding string) byte {
+	switch encoding {
+	case "json":
+		return jsonEncoding
+	case "protobuf":
+		return protoEncoding
+	default:
+		return defaultEncoding
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
-  The badger span store hardcodes protobuf as the encoding type with no way for operators to configure it. This is tracked as a TODO in the code at `internal/storage/v1/badger/spanstore/writer.go`.

## Description of the changes
- Added `Encoding` field to badger `Config` struct
- Exposed it as a CLI flag `--badger.encoding` with supported values `protobuf` (default) and `json`
- Updated `NewSpanWriter` to accept and use the configured encoding type
- Added `toByteEncoding` helper to convert string config value to internal byte constant

## How was this change tested?
- Added `TestToByteEncoding` unit test
- Ran `make lint test` successfully

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
