### PR TITLE
fix(jptrace): Tolerate non-slice warnings attribute in AddWarnings

### DIFF
--- a/internal/jptrace/warning.go
+++ b/internal/jptrace/warning.go
@@ -11,7 +11,16 @@ import (
 func AddWarnings(span ptrace.Span, warnings ...string) {
 	var w pcommon.Slice
 	if currWarnings, ok := span.Attributes().Get(WarningsAttribute); ok {
-		w = currWarnings.Slice()
+		if currWarnings.Type() == pcommon.ValueTypeSlice {
+			w = currWarnings.Slice()
+		} else {
+			// The attribute may round-trip through storage backends that do not
+			// support slice-typed tags and come back as a plain string
+			// (mirrors the malformed-data fallback in GetWarnings).
+			prev := currWarnings.AsString()
+			w = span.Attributes().PutEmptySlice(WarningsAttribute)
+			w.AppendEmpty().SetStr(prev)
+		}
 	} else {
 		w = span.Attributes().PutEmptySlice(WarningsAttribute)
 	}

--- a/internal/jptrace/warning_test.go
+++ b/internal/jptrace/warning_test.go
@@ -58,6 +58,17 @@ func TestAddWarning(t *testing.T) {
 	}
 }
 
+func TestAddWarnings_NonSliceAttribute(t *testing.T) {
+	// Simulates a warnings attribute that round-tripped through a storage
+	// backend without slice-typed tag support (e.g. Elasticsearch stores it
+	// as a string tag). AddWarnings must not panic and must preserve the
+	// previous value. See https://github.com/jaegertracing/jaeger/issues/8746.
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr(WarningsAttribute, "warning A")
+	AddWarnings(span, "warning B")
+	assert.Equal(t, []string{"warning A", "warning B"}, GetWarnings(span))
+}
+
 func TestAddWarning_MultipleWarnings(t *testing.T) {
 	span := ptrace.NewSpan()
 	AddWarnings(span, "warning-1", "warning-2")


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #8746.

`jptrace.AddWarnings` assumes the `@jaeger@warnings` attribute, when present, is slice-typed. That holds for traces that never left memory, but not for traces read back from storage backends without slice-typed tag support. The v2 Elasticsearch write path degrades slice attributes to string tags (`to_dbmodel.go` stores them via `attr.AsString()`), and the read path restores them with `PutStr`. When the query path then adds another warning (e.g. the clock-skew adjuster on a multi-chunk trace), `Value.Slice()` on the string-typed value returns a zero-value `pcommon.Slice`, and `AppendEmpty()` panics with the nil-pointer dereference in `internal.(*State).AssertMutable` shown in the issue.

## Description of the changes
- `AddWarnings` now checks the attribute type before calling `Slice()`. If the existing value is not a slice, it preserves the previous value (via `AsString()`, read before `PutEmptySlice` overwrites the map entry) as the first element of a fresh slice, then appends the new warnings. This mirrors the existing malformed-data fallback in `GetWarnings` in the same file.
- The fix is in the shared helper rather than the ES read path, so any backend that degrades the attribute type (ClickHouse string tags, v1 adapters) is covered by the same guard.
- A degraded string that originally held multiple warnings is preserved as one element rather than re-parsed; keeping the fallback symmetric with `GetWarnings` seemed preferable to guessing at the stored encoding.

## How was this change tested?
- New regression test `TestAddWarnings_NonSliceAttribute` reproduces the exact panic without the fix:

```
--- FAIL: TestAddWarnings_NonSliceAttribute (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
go.opentelemetry.io/collector/pdata/internal.(*State).AssertMutable(...)
go.opentelemetry.io/collector/pdata/pcommon.Slice.AppendEmpty({0x0?, 0x0?})
github.com/jaegertracing/jaeger/internal/jptrace.AddWarnings(...)
	internal/jptrace/warning.go:19
```

- `make fmt` and `make lint` clean; `make test` passes (3554 tests, 0 failures; ran with `RACE=` because this workstation has no cgo toolchain, relying on CI for the race lane).

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes
