### PR TITLE
test(v1adapter): fix mock expectation validation in dependency reader tests

### DIFF
--- a/internal/storage/v2/v1adapter/depreader_test.go
+++ b/internal/storage/v2/v1adapter/depreader_test.go
@@ -43,7 +43,7 @@ func TestDependencyReader_GetDependencies(t *testing.T) {
 		EndTime:   end,
 	}
 	expectedDeps := []model.DependencyLink{{Parent: "parent", Child: "child", CallCount: 12}}
-	mr := new(dependencystoremocks.Reader)
+	mr := dependencystoremocks.NewReader(t)
 	mr.On("GetDependencies", mock.Anything, end, time.Minute).Return(expectedDeps, nil)
 	dr := NewDependencyReader(mr)
 	deps, err := dr.GetDependencies(context.Background(), query)
@@ -59,7 +59,7 @@ func TestDowngradedDependencyReader_GetDependencies(t *testing.T) {
 		EndTime:   end,
 	}
 	expectedDeps := []model.DependencyLink{{Parent: "parent", Child: "child", CallCount: 12}}
-	mr := new(depstoremocks.Reader)
+	mr := depstoremocks.NewReader(t)
 	mr.On("GetDependencies", mock.Anything, query).Return(expectedDeps, nil)
 	dr := &DowngradedDependencyReader{
 		reader: mr,


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #8741

## Description of the changes
- Refactored `TestDependencyReader_GetDependencies` and `TestDowngradedDependencyReader_GetDependencies` in [depreader_test.go](file:///d:/OpenSource/jaeger/internal/storage/v2/v1adapter/depreader_test.go) to initialize mock readers using the generated constructors `dependencystoremocks.NewReader(t)` and `depstoremocks.NewReader(t)`.
- These constructors automatically register cleanup-based expectation assertions (`AssertExpectations`) via `t.Cleanup`, ensuring mock calls are verified.

## How was this change tested?
- Ran the unit tests in the adapter package: `go test -v ./internal/storage/v2/v1adapter/...`.
- Manually verified that bypassing the mock delegate call in `depreader.go` (returning a hardcoded dependency list) now correctly triggers test failures as expectations are not met.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
