### PR TITLE
perf(cassandra): Replace json.Unmarshal with json.Valid in shouldIndexTag

### DIFF
--- a/internal/storage/v1/cassandra/spanstore/writer.go
+++ b/internal/storage/v1/cassandra/spanstore/writer.go
@@ -259,9 +259,8 @@ func (s *SpanWriter) indexByOperation(span *dbmodel.Span) error {
 // shouldIndexTag checks to see if the tag is json or not, if it's UTF8 valid and it's not too large
 func (*SpanWriter) shouldIndexTag(tag dbmodel.TagInsertion) bool {
 	isJSON := func(s string) bool {
-		var js json.RawMessage
 		// poor man's string-is-a-json check shortcircuits full unmarshalling
-		return strings.HasPrefix(s, "{") && json.Unmarshal([]byte(s), &js) == nil
+		return strings.HasPrefix(s, "{") && json.Valid([]byte(s))
 	}
 
 	return len(tag.TagKey) < maximumTagKeyOrValueSize &&

--- a/internal/storage/v1/cassandra/spanstore/writer_test.go
+++ b/internal/storage/v1/cassandra/spanstore/writer_test.go
@@ -404,3 +404,44 @@ func TestStorageMode_StoreWithoutIndexing(t *testing.T) {
 		w.session.AssertNotCalled(t, "Query", serviceNameIndex, mock.Anything)
 	}, StoreWithoutIndexing())
 }
+
+func BenchmarkShouldIndexTag(b *testing.B) {
+	writer := &SpanWriter{}
+	
+	tests := []struct {
+		name string
+		tag  dbmodel.TagInsertion
+	}{
+		{
+			name: "short_string",
+			tag: dbmodel.TagInsertion{
+				TagKey:   "key",
+				TagValue: "value",
+			},
+		},
+		{
+			name: "json_string",
+			tag: dbmodel.TagInsertion{
+				TagKey:   "key",
+				TagValue: `{"foo": "bar", "baz": 123}`,
+			},
+		},
+		{
+			name: "invalid_json_prefix",
+			tag: dbmodel.TagInsertion{
+				TagKey:   "key",
+				TagValue: `{invalid json`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				writer.shouldIndexTag(tt.tag)
+			}
+		})
+	}
+}

--- a/internal/storage/v1/cassandra/spanstore/writer_test.go
+++ b/internal/storage/v1/cassandra/spanstore/writer_test.go
@@ -407,7 +407,7 @@ func TestStorageMode_StoreWithoutIndexing(t *testing.T) {
 
 func BenchmarkShouldIndexTag(b *testing.B) {
 	writer := &SpanWriter{}
-	
+
 	tests := []struct {
 		name string
 		tag  dbmodel.TagInsertion


### PR DESCRIPTION
 <html>
<body>
<!--StartFragment--><html><head></head><body><h2>Resolves</h2>
<p>Fixes  #8758  </p><h2>Which problem is this PR solving?</h2>
<p>The <code>shouldIndexTag</code> function in the Cassandra span writer uses <code>json.Unmarshal</code> to check if a tag value is valid JSON. This is unnecessarily expensive because <code>json.Unmarshal</code> performs full parsing and allocates a <code>json.RawMessage</code> object, which is immediately discarded. </p>
<h2>Description of the changes</h2>
<ul>
<li>Replaced <code>json.Unmarshal([]byte(s), &amp;js)</code> with <code>json.Valid([]byte(s))</code> in the <code>isJSON</code> helper inside <code>shouldIndexTag</code>. <code>json.Valid</code> only performs syntax validation without allocating any Go objects, significantly reducing CPU overhead and memory allocations.</li>
<li>Added <code>BenchmarkShouldIndexTag</code> to measure the performance of <code>shouldIndexTag</code> across three cases: short strings, valid JSON strings, and invalid JSON with a <code>{</code> prefix.</li>
</ul>
<h3>Benchmark results</h3>
<p><strong>Before (<code>json.Unmarshal</code>):</strong></p>
<img width="1023" height="332" alt="Screenshot 2026-06-12 000437" src="https://github.com/user-attachments/assets/a435feaf-d194-44d4-b774-efa873b77ffb" />

<pre><code>BenchmarkShouldIndexTag/short_string-12         31675975    34.59 ns/op    24 B/op    1 allocs/op
BenchmarkShouldIndexTag/json_string-12            3065476   382.2  ns/op   240 B/op    5 allocs/op
BenchmarkShouldIndexTag/invalid_json_prefix-12    4540975   247.7  ns/op   296 B/op    8 allocs/op
</code></pre>
<p><strong>After (<code>json.Valid</code>):</strong></p>
<img width="1027" height="323" alt="Screenshot 2026-06-12 000515" src="https://github.com/user-attachments/assets/d6265dbb-8712-47f2-ac80-1d14073ce983" />

<pre><code>BenchmarkShouldIndexTag/short_string-12          70471335    16.08 ns/op     0 B/op    0 allocs/op
BenchmarkShouldIndexTag/json_string-12           10821406   102.7  ns/op     0 B/op    0 allocs/op
BenchmarkShouldIndexTag/invalid_json_prefix-12    7545584   156.5  ns/op   104 B/op    4 allocs/op
</code></pre>
<p><strong>Summary:</strong></p>

Case | Speedup | Allocs before | Allocs after
-- | -- | -- | --
json_string | 3.8× faster | 5 | 0
short_string | 2.1× faster | 1 | 0
invalid_json_prefix | 1.7× faster | 8 | 4


<h2>How was this change tested?</h2>
<ul>
<li>Existing <code>TestSpanWriterSkippingTags</code> passes and validates correctness of <code>shouldIndexTag</code> for all cases (short string, valid JSON, invalid JSON prefix, oversized keys/values).</li>
<li>Added <code>BenchmarkShouldIndexTag</code> with before/after results shown above.</li>
</ul>
<h2>Checklist</h2>
<ul>
<li>[x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md</li>
<li>[x] I have signed all commits</li>
<li>[x] I have added unit tests for the new functionality</li>
<li>[x] I have run lint and test steps successfully: <code>make lint test</code></li>
</ul>
<h2>AI Usage </h2>
<p>See <a href="https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy">AI Usage Policy</a>.</p>
<ul>
<li>[ ] <strong>None</strong>: No AI tools were used in creating this PR</li>
<li>[ ] <strong>Light</strong>: AI provided minor assistance (formatting, simple suggestions)</li>
<li>[x] <strong>Moderate</strong>: AI helped with code generation or debugging specific parts</li>
<li>[ ] <strong>Heavy</strong>: AI generated most or all of the code changes</li>
</ul></body></html><!--EndFragment-->
</body>
</html>