### PR TITLE
feat(jaegermcp): Add Skill type and SKILL.md parser

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/package_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill.go
@@ -55,8 +55,11 @@ func Parse(data []byte, sourcePath string) (*Skill, error) {
 	if skill.Description == "" {
 		return nil, fmt.Errorf("%s: missing required field %q", sourcePath, "description")
 	}
-	if len(skill.AllowedTools) == 0 {
+	if skill.AllowedTools == nil {
 		return nil, fmt.Errorf("%s: missing required field %q", sourcePath, "allowed_tools")
+	}
+	if len(skill.AllowedTools) == 0 {
+		return nil, fmt.Errorf("%s: field %q must contain at least one entry", sourcePath, "allowed_tools")
 	}
 
 	skill.Body = string(bytes.TrimRight(body, " \t\r\n"))

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"bytes"
+	"fmt"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const frontmatterDelimiter = "---\n"
+
+type Skill struct {
+	Name         string            `yaml:"name"`
+	Description  string            `yaml:"description"`
+	Version      string            `yaml:"version,omitempty"`
+	Author       string            `yaml:"author,omitempty"`
+	Category     string            `yaml:"category,omitempty"`
+	AllowedTools []string          `yaml:"allowed_tools"`
+	ModelHints   map[string]string `yaml:"model_hints,omitempty"`
+	References   []string          `yaml:"references,omitempty"`
+
+	Body string `yaml:"-"`
+
+	SourcePath string `yaml:"-"`
+}
+
+// A SKILL.md file must start with a YAML frontmatter block delimited by
+// "---" lines. Everything after the closing delimiter is treated as the
+// skill's Markdown Body.
+func Parse(data []byte, sourcePath string) (*Skill, error) {
+	if !bytes.HasPrefix(data, []byte(frontmatterDelimiter)) {
+		return nil, fmt.Errorf("%s: must start with %q frontmatter delimiter", sourcePath, "---")
+	}
+
+	rest := data[len(frontmatterDelimiter):]
+	closingIdx := bytes.Index(rest, []byte(frontmatterDelimiter))
+	if closingIdx == -1 {
+		return nil, fmt.Errorf("%s: missing closing %q frontmatter delimiter", sourcePath, "---")
+	}
+
+	frontmatter := rest[:closingIdx]
+	body := rest[closingIdx+len(frontmatterDelimiter):]
+
+	var skill Skill
+	if err := yaml.Unmarshal(frontmatter, &skill); err != nil {
+		return nil, fmt.Errorf("%s: parsing frontmatter: %w", sourcePath, err)
+	}
+
+	if skill.Name == "" {
+		return nil, fmt.Errorf("%s: missing required field %q", sourcePath, "name")
+	}
+	if skill.Description == "" {
+		return nil, fmt.Errorf("%s: missing required field %q", sourcePath, "description")
+	}
+	if len(skill.AllowedTools) == 0 {
+		return nil, fmt.Errorf("%s: missing required field %q", sourcePath, "allowed_tools")
+	}
+
+	skill.Body = string(bytes.TrimRight(body, " \t\r\n"))
+	skill.SourcePath = sourcePath
+
+	return &skill, nil
+}

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill_test.go
@@ -157,6 +157,7 @@ Body text.
 	_, err := Parse(data, "skills/bad/SKILL.md")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "missing required field")
 	assert.Contains(t, err.Error(), "allowed_tools")
 }
 
@@ -172,5 +173,6 @@ Body text.
 	_, err := Parse(data, "skills/bad/SKILL.md")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "must contain at least one entry")
 	assert.Contains(t, err.Error(), "allowed_tools")
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/skills/skill_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_HappyPath(t *testing.T) {
+	data := []byte(`---
+name: analyze-critical-path
+description: Find the critical latency path through a trace.
+version: "1.0"
+author: jaeger-team
+category: performance
+allowed_tools:
+  - get_trace_topology
+  - get_critical_path
+model_hints:
+  temperature: "0.2"
+references:
+  - reference.md
+---
+# Analyze Critical Path
+
+1. Call ` + "`get_trace_topology`" + ` to get the trace structure.
+2. Call ` + "`get_critical_path`" + ` to find the bottleneck.
+
+- bullet one
+- bullet two
+
+` + "```go\nfmt.Println(\"example\")\n```\n")
+
+	skill, err := Parse(data, "skills/analyze-critical-path/SKILL.md")
+	require.NoError(t, err)
+
+	assert.Equal(t, "analyze-critical-path", skill.Name)
+	assert.Equal(t, "Find the critical latency path through a trace.", skill.Description)
+	assert.Equal(t, "1.0", skill.Version)
+	assert.Equal(t, "jaeger-team", skill.Author)
+	assert.Equal(t, "performance", skill.Category)
+	assert.Equal(t, []string{"get_trace_topology", "get_critical_path"}, skill.AllowedTools)
+	assert.Equal(t, map[string]string{"temperature": "0.2"}, skill.ModelHints)
+	assert.Equal(t, []string{"reference.md"}, skill.References)
+	assert.Equal(t, "skills/analyze-critical-path/SKILL.md", skill.SourcePath)
+
+	assert.Contains(t, skill.Body, "# Analyze Critical Path")
+	assert.Contains(t, skill.Body, "1. Call `get_trace_topology`")
+	assert.Contains(t, skill.Body, "- bullet one")
+	assert.Contains(t, skill.Body, "```go")
+	assert.Contains(t, skill.Body, `fmt.Println("example")`)
+	assert.NotContains(t, skill.Body, "\n\n\n")
+}
+
+func TestParse_EmptyBody(t *testing.T) {
+	data := []byte(`---
+name: noop-skill
+description: A skill with no body.
+allowed_tools:
+  - get_services
+---
+`)
+
+	skill, err := Parse(data, "skills/noop-skill/SKILL.md")
+	require.NoError(t, err)
+	assert.Equal(t, "noop-skill", skill.Name)
+	assert.Empty(t, skill.Body)
+}
+
+func TestParse_MissingOpeningDelimiter(t *testing.T) {
+	data := []byte(`name: missing-opening
+description: No opening delimiter.
+allowed_tools:
+  - get_services
+---
+Body text.
+`)
+
+	_, err := Parse(data, "skills/bad/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "frontmatter delimiter")
+}
+
+func TestParse_MissingClosingDelimiter(t *testing.T) {
+	data := []byte(`---
+name: missing-closing
+description: No closing delimiter.
+allowed_tools:
+  - get_services
+Body text.
+`)
+
+	_, err := Parse(data, "skills/bad/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "closing")
+}
+
+func TestParse_FrontmatterSyntaxError(t *testing.T) {
+	data := []byte(`---
+name: bad-yaml
+description: [unterminated
+allowed_tools:
+  - get_services
+---
+Body text.
+`)
+
+	_, err := Parse(data, "skills/bad/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+}
+
+func TestParse_MissingName(t *testing.T) {
+	data := []byte(`---
+description: Missing the name field.
+allowed_tools:
+  - get_services
+---
+Body text.
+`)
+
+	_, err := Parse(data, "skills/bad/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "name")
+}
+
+func TestParse_MissingDescription(t *testing.T) {
+	data := []byte(`---
+name: missing-description
+allowed_tools:
+  - get_services
+---
+Body text.
+`)
+
+	_, err := Parse(data, "skills/bad/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "description")
+}
+
+func TestParse_MissingAllowedTools(t *testing.T) {
+	data := []byte(`---
+name: missing-allowed-tools
+description: Missing allowed_tools entirely.
+---
+Body text.
+`)
+
+	_, err := Parse(data, "skills/bad/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "allowed_tools")
+}
+
+func TestParse_EmptyAllowedTools(t *testing.T) {
+	data := []byte(`---
+name: empty-allowed-tools
+description: allowed_tools is present but empty.
+allowed_tools: []
+---
+Body text.
+`)
+
+	_, err := Parse(data, "skills/bad/SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills/bad/SKILL.md")
+	assert.Contains(t, err.Error(), "allowed_tools")
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Part of #8440, addresses #8761

## Description of the changes

- Adds the `Skill` struct and a `Parse` function for `SKILL.md` files, the
  foundational data type for the Self-Service Skills Engine.
- A `SKILL.md` file consists of a YAML frontmatter block (`name`,
  `description`, `allowed_tools`, and optional metadata such as `version`,
  `author`, `category`, `model_hints`, `references`) followed by a Markdown
  body containing the skill's instructions for an LLM agent.
- `Parse` requires a `---`-delimited frontmatter block, parses it into
  `Skill`, treats everything after the closing delimiter as `Body`, validates
  required fields (`name`, `description`, non-empty `allowed_tools`), and
  returns clear, path-prefixed errors for malformed input.

## How was this change tested?

- Added unit tests covering: happy path (all fields populated), empty body,
  missing opening/closing frontmatter delimiters, invalid YAML, and missing
  required fields (`name`, `description`, `allowed_tools`, including the
  empty-list case).
- `make fmt && make lint && make test` all pass (0 lint issues).

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes