### PR TITLE
 perf(memory): Replace O(n^2) linear scan with map lookup in getDependencies

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -1196,3 +1196,54 @@ func TestFindTraces_OTLPFields(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkGetDependencies(b *testing.B) {
+	for _, numSpans := range []int{100, 500, 2000} {
+		b.Run(fmt.Sprintf("spans=%d", numSpans), func(b *testing.B) {
+			store, err := NewStore(Configuration{MaxTraces: 10})
+			require.NoError(b, err)
+
+			// Build a chain of spans across alternating ResourceSpans.
+			// span[i] has parent = span[i-1], placed in a different ResourceSpan.
+			// This forces the old linear scan to go deeper each time.
+			traceID := pcommon.TraceID([16]byte{1})
+			td := ptrace.NewTraces()
+
+			for i := 0; i < numSpans; i++ {
+				svcName := "service-A"
+				if i%2 == 1 {
+					svcName = "service-B"
+				}
+				rs := td.ResourceSpans().AppendEmpty()
+				rs.Resource().Attributes().PutStr("service.name", svcName)
+				span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+				span.SetTraceID(traceID)
+				spanID := pcommon.SpanID([8]byte{byte(i >> 8), byte(i)})
+				span.SetSpanID(spanID)
+				if i > 0 {
+					parentID := pcommon.SpanID([8]byte{byte((i - 1) >> 8), byte(i - 1)})
+					span.SetParentSpanID(parentID)
+				}
+				span.SetStartTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+				span.SetEndTimestamp(pcommon.Timestamp(time.Now().Add(time.Millisecond).UnixNano()))
+			}
+
+			err = store.WriteTraces(context.Background(), td)
+			require.NoError(b, err)
+
+			query := depstore.QueryParameters{
+				StartTime: time.Now().Add(-1 * time.Hour),
+				EndTime:   time.Now().Add(1 * time.Hour),
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := store.GetDependencies(context.Background(), query)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -1460,3 +1460,54 @@ func TestFindTraces_MutatingReaderDoesNotCorruptStore(t *testing.T) {
 	assert.Equal(t, "original", firstSpanAttr(t, store.GetTraces(context.Background(),
 		tracestore.GetTraceParams{TraceID: traceID}), "secret"))
 }
+
+func BenchmarkGetDependencies(b *testing.B) {
+	for _, numSpans := range []int{100, 500, 2000} {
+		b.Run(fmt.Sprintf("spans=%d", numSpans), func(b *testing.B) {
+			store, err := NewStore(Configuration{MaxTraces: 10})
+			require.NoError(b, err)
+
+			// Build a chain of spans across alternating ResourceSpans.
+			// span[i] has parent = span[i-1], placed in a different ResourceSpan.
+			// This forces the old linear scan to go deeper each time.
+			traceID := pcommon.TraceID([16]byte{1})
+			td := ptrace.NewTraces()
+
+			for i := 0; i < numSpans; i++ {
+				svcName := "service-A"
+				if i%2 == 1 {
+					svcName = "service-B"
+				}
+				rs := td.ResourceSpans().AppendEmpty()
+				rs.Resource().Attributes().PutStr("service.name", svcName)
+				span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+				span.SetTraceID(traceID)
+				spanID := pcommon.SpanID([8]byte{byte(i >> 8), byte(i)})
+				span.SetSpanID(spanID)
+				if i > 0 {
+					parentID := pcommon.SpanID([8]byte{byte((i - 1) >> 8), byte(i - 1)})
+					span.SetParentSpanID(parentID)
+				}
+				span.SetStartTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+				span.SetEndTimestamp(pcommon.Timestamp(time.Now().Add(time.Millisecond).UnixNano()))
+			}
+
+			err = store.WriteTraces(context.Background(), td)
+			require.NoError(b, err)
+
+			query := depstore.QueryParameters{
+				StartTime: time.Now().Add(-1 * time.Hour),
+				EndTime:   time.Now().Add(1 * time.Hour),
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := store.GetDependencies(context.Background(), query)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -172,6 +172,9 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 		if !traceWithTime.traceIsBetweenStartAndEnd(query.StartTime, query.EndTime) {
 			continue
 		}
+		// Build a spanID -> serviceName map for O(1) parent lookups
+		// instead of scanning all spans for each parent (O(n^2) -> O(n)).
+		spanServiceMap := buildSpanServiceMap(traceWithTime.trace)
 		for _, resourceSpan := range traceWithTime.trace.ResourceSpans().All() {
 			for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
 				for _, span := range scopeSpan.Spans().All() {
@@ -179,7 +182,7 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 						continue
 					}
 					spanServiceName := getServiceNameFromResource(resourceSpan.Resource())
-					parentSpanServiceName, found := findServiceNameWithSpanId(traceWithTime.trace, span.ParentSpanID())
+					parentSpanServiceName, found := spanServiceMap[span.ParentSpanID()]
 					if !found {
 						continue
 					}
@@ -204,17 +207,19 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 	return retMe, nil
 }
 
-func findServiceNameWithSpanId(trace ptrace.Traces, spanId pcommon.SpanID) (string, bool) {
+// buildSpanServiceMap builds a map from span ID to service name for all spans
+// in the trace. This allows O(1) parent span lookups in getDependencies.
+func buildSpanServiceMap(trace ptrace.Traces) map[pcommon.SpanID]string {
+	m := make(map[pcommon.SpanID]string)
 	for _, resourceSpan := range trace.ResourceSpans().All() {
+		serviceName := getServiceNameFromResource(resourceSpan.Resource())
 		for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
 			for _, span := range scopeSpan.Spans().All() {
-				if span.SpanID() == spanId {
-					return getServiceNameFromResource(resourceSpan.Resource()), true
-				}
+				m[span.SpanID()] = serviceName
 			}
 		}
 	}
-	return "", false
+	return m
 }
 
 func validTrace(td ptrace.Traces, query tracestore.TraceQueryParams) bool {

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -177,6 +177,9 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 		if !traceWithTime.traceIsBetweenStartAndEnd(query.StartTime, query.EndTime) {
 			continue
 		}
+		// Build a spanID -> serviceName map for O(1) parent lookups
+		// instead of scanning all spans for each parent (O(n^2) -> O(n)).
+		spanServiceMap := buildSpanServiceMap(traceWithTime.trace)
 		for _, resourceSpan := range traceWithTime.trace.ResourceSpans().All() {
 			for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
 				for _, span := range scopeSpan.Spans().All() {
@@ -184,7 +187,7 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 						continue
 					}
 					spanServiceName := getServiceNameFromResource(resourceSpan.Resource())
-					parentSpanServiceName, found := findServiceNameWithSpanId(traceWithTime.trace, span.ParentSpanID())
+					parentSpanServiceName, found := spanServiceMap[span.ParentSpanID()]
 					if !found {
 						continue
 					}
@@ -209,17 +212,19 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 	return retMe, nil
 }
 
-func findServiceNameWithSpanId(trace ptrace.Traces, spanId pcommon.SpanID) (string, bool) {
+// buildSpanServiceMap builds a map from span ID to service name for all spans
+// in the trace. This allows O(1) parent span lookups in getDependencies.
+func buildSpanServiceMap(trace ptrace.Traces) map[pcommon.SpanID]string {
+	m := make(map[pcommon.SpanID]string)
 	for _, resourceSpan := range trace.ResourceSpans().All() {
+		serviceName := getServiceNameFromResource(resourceSpan.Resource())
 		for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
 			for _, span := range scopeSpan.Spans().All() {
-				if span.SpanID() == spanId {
-					return getServiceNameFromResource(resourceSpan.Resource()), true
-				}
+				m[span.SpanID()] = serviceName
 			}
 		}
 	}
-	return "", false
+	return m
 }
 
 func validTrace(td ptrace.Traces, query tracestore.TraceQueryParams) bool {


### PR DESCRIPTION
 ## Which problem is this PR solving?

Fixes #8766 

In the memory store's `getDependencies`, the `findServiceNameWithSpanId` function performs an O(n) linear scan through all spans to find a parent span's service name. Since this is called for every child span in the trace, the overall complexity is O(n^2) per trace.

## Description of the changes
- Replaced the per-span `findServiceNameWithSpanId` linear scan with a `buildSpanServiceMap` function that builds a `map[SpanID]string` once per trace, enabling O(1) parent lookups.
- Removed the now-unused `findServiceNameWithSpanId` function.
- Added `BenchmarkGetDependencies` with a chain topology that exposes the quadratic behavior.

### Benchmark results (Intel Core i5-12450H)

**Before (linear scan):**
<img width="1105" height="338" alt="image" src="https://github.com/user-attachments/assets/ac187df3-5b4b-4e5c-a43c-2a937449648c" />

**After (map lookup):**
<img width="1102" height="326" alt="image" src="https://github.com/user-attachments/assets/fd2e9158-5e26-44da-9c17-e1b274356ad9" />

**Summary:**
| Spans | Before (ns/op) | After (ns/op) | Speedup |
|-------|---------------|--------------|---------|
| 100 | 20,924 | 15,776 | 1.3x |
| 500 | 461,071 | 91,301 | 5x |
| 2000 | 9,099,179 | 423,557 | 21.5x |

The quadratic scaling is clearly visible in the before results (5x more spans = 22x slower), while the after results scale linearly (5x more spans = 5.8x slower). The tradeoff is higher memory usage for the map, but the CPU improvement grows with trace size.

## How was this change tested?
- Existing `TestGetDependencies` passes and validates correctness.
- Added `BenchmarkGetDependencies` with before/after results shown above.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
