### PR TITLE
fix(storage): Populate req.GetBody before SigV4 signing, not after

### DIFF
--- a/internal/storage/elasticsearch/clientbuilder/builder.go
+++ b/internal/storage/elasticsearch/clientbuilder/builder.go
@@ -378,17 +378,18 @@ func GetHTTPRoundTripper(ctx context.Context, c *config.Configuration, logger *z
 	}
 
 	// Apply HTTP authenticator extension if configured (e.g., SigV4).
-	// Wrap with getBodyFixRoundTripper first so that authenticators that
-	// rely on req.GetBody for payload hashing (such as sigv4auth) see
-	// a properly populated GetBody even when the upstream HTTP client
-	// (olivere/elastic) does not set it.
+	// The getBodyFixRoundTripper must wrap OUTSIDE the authenticator so it
+	// runs first: authenticators like sigv4auth hash the payload via
+	// req.GetBody at the start of their RoundTrip, before delegating to the
+	// inner transport. The upstream HTTP client (olivere/elastic) sets
+	// req.Body without setting GetBody, so GetBody must be populated before
+	// the authenticator sees the request, not after.
 	if httpAuth != nil {
-		roundTripper = &getBodyFixRoundTripper{base: roundTripper}
 		wrappedRT, err := httpAuth.RoundTripper(roundTripper)
 		if err != nil {
 			return nil, fmt.Errorf("failed to wrap round tripper with HTTP authenticator: %w", err)
 		}
-		return wrappedRT, nil
+		return &getBodyFixRoundTripper{base: wrappedRT}, nil
 	}
 
 	return roundTripper, nil

--- a/internal/storage/elasticsearch/clientbuilder/builder_test.go
+++ b/internal/storage/elasticsearch/clientbuilder/builder_test.go
@@ -1246,8 +1246,12 @@ func TestGetHTTPRoundTripperWithHTTPAuthSuccess(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, rt)
-	wrappedRT, ok := rt.(*mockWrappedRoundTripper)
-	require.True(t, ok, "Should be wrapped round tripper")
+	// getBodyFixRoundTripper must be outermost so that it populates
+	// req.GetBody before the authenticator hashes the payload.
+	bodyFixRT, ok := rt.(*getBodyFixRoundTripper)
+	require.True(t, ok, "outermost round tripper should be getBodyFixRoundTripper")
+	wrappedRT, ok := bodyFixRT.base.(*mockWrappedRoundTripper)
+	require.True(t, ok, "authenticator wrapper should be inside getBodyFixRoundTripper")
 	require.NotNil(t, wrappedRT)
 }
 
@@ -1265,6 +1269,60 @@ type mockWrappedRoundTripper struct {
 
 func (m *mockWrappedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return m.base.RoundTrip(req)
+}
+
+// getBodyRecordingAuth mimics an authenticator like sigv4auth: its
+// RoundTripper inspects req.GetBody at the start of RoundTrip (where
+// sigv4auth hashes the payload) before delegating to the base transport.
+type getBodyRecordingAuth struct {
+	sawGetBody bool
+}
+
+func (a *getBodyRecordingAuth) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+	return &getBodyRecordingRoundTripper{auth: a, base: base}, nil
+}
+
+type getBodyRecordingRoundTripper struct {
+	auth *getBodyRecordingAuth
+	base http.RoundTripper
+}
+
+func (rt *getBodyRecordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.auth.sawGetBody = req.GetBody != nil
+	// Short-circuit instead of hitting the network.
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}
+
+// TestGetHTTPRoundTripper_AuthSeesGetBody verifies that an HTTP
+// authenticator sees a populated req.GetBody at signing time for requests
+// where the client set req.Body without GetBody (as olivere/elastic does).
+// If getBodyFixRoundTripper is wrapped inside the authenticator instead of
+// outside, the authenticator hashes an empty payload and AWS-managed
+// OpenSearch rejects every body-bearing request with HTTP 403.
+func TestGetHTTPRoundTripper_AuthSeesGetBody(t *testing.T) {
+	recordingAuth := &getBodyRecordingAuth{}
+
+	c := &config.Configuration{
+		Servers:  []string{"http://localhost:9200"},
+		LogLevel: "error",
+		TLS:      configtls.ClientConfig{Insecure: true},
+	}
+
+	rt, err := GetHTTPRoundTripper(context.Background(), c, zap.NewNop(), recordingAuth)
+	require.NoError(t, err)
+
+	// Mimic olivere/elastic: Body set directly, GetBody left nil.
+	req, err := http.NewRequest(http.MethodPut, "http://localhost:9200/_index_template/test", http.NoBody)
+	require.NoError(t, err)
+	req.Body = io.NopCloser(bytes.NewReader([]byte(`{"index_patterns":["jaeger-*"]}`)))
+	req.GetBody = nil
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.True(t, recordingAuth.sawGetBody,
+		"authenticator must see req.GetBody populated at signing time")
 }
 
 func TestBulkCallbackInvoke_NilResponse(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #8760

With `sigv4auth` against AWS-managed OpenSearch (FGAC enabled), startup fails on the index-template PUT with HTTP 403, while bodyless GETs succeed. The request is signed over an empty payload hash.

## Description of the changes

#8308 introduced `getBodyFixRoundTripper` to populate `req.GetBody` for authenticators that hash the payload from it (olivere/elastic sets `req.Body` without `GetBody`). But it composes the chain as `sigv4 → getBodyFix → transport`:

```go
roundTripper = &getBodyFixRoundTripper{base: roundTripper}
wrappedRT, err := httpAuth.RoundTripper(roundTripper)
```

RoundTrippers execute outermost-first. sigv4auth's `RoundTrip` hashes the payload via `hashPayload(req)` **before** delegating to its inner transport, and `hashPayload` returns the empty-payload SHA-256 (`e3b0c44…`) whenever `req.GetBody == nil` ([signingroundtripper.go at v0.153.0, the version pinned in go.mod](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/extension/sigv4authextension/v0.153.0/extension/sigv4authextension/signingroundtripper.go#L37-L50)). So at signing time `GetBody` is still nil; `getBodyFixRoundTripper` populates it one layer too late, and every body-bearing request is signed over an empty hash — exactly the bodyless-works/body-fails split reported in #8760.

The fix swaps the composition so `getBodyFixRoundTripper` is outermost:

```go
wrappedRT, err := httpAuth.RoundTripper(roundTripper)
...
return &getBodyFixRoundTripper{base: wrappedRT}, nil
```

`GetBody` is now populated before the authenticator runs.

Credit to @gusse for pinpointing the wrap order in the report — the diagnosis verified exactly.

## How was this change tested?

- New `TestGetHTTPRoundTripper_AuthSeesGetBody`: a stub authenticator that mimics sigv4auth (inspects `req.GetBody` at the start of its `RoundTrip`) composed through `GetHTTPRoundTripper`, driven with a request shaped like olivere/elastic's (`Body` set, `GetBody` nil). On the old order this test fails (`sawGetBody == false`); with the fix it passes. The existing unit tests for `getBodyFixRoundTripper` in isolation could not catch this — they never exercised the composition.
- Updated `TestGetHTTPRoundTripperWithHTTPAuthSuccess`, which asserted the authenticator wrapper was the outermost return value, i.e. it pinned the broken order; it now asserts `getBodyFixRoundTripper` outermost with the authenticator inside.
- `go test ./internal/storage/elasticsearch/config/` green locally.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
