### PR TITLE
ci(retry): Add retry wrapper for transient docker image pulls

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -213,6 +213,7 @@ jobs:
 
     - name: validate renovate config
       run: |
+        bash scripts/utils/retry.sh docker pull ghcr.io/renovatebot/renovate:latest
         docker run \
           -v $PWD/renovate.json:/usr/src/app/renovate.json \
           ghcr.io/renovatebot/renovate:latest \

--- a/scripts/build/build-all-in-one-image.sh
+++ b/scripts/build/build-all-in-one-image.sh
@@ -63,6 +63,7 @@ make build-ui
 
 run_integration_test() {
   local image_name="$1"
+  bash scripts/utils/retry.sh docker pull "${image_name}:${GITHUB_SHA}"
   CID=$(docker run -d -p 16686:16686 -p 13133:13133 -p 5778:5778 "${image_name}:${GITHUB_SHA}")
 
   if ! make all-in-one-integration-test ; then

--- a/scripts/build/build-hotrod-image.sh
+++ b/scripts/build/build-hotrod-image.sh
@@ -140,10 +140,11 @@ if [[ "${runtime}" == "k8s" ]]; then
 
 else
   echo '::group:: docker compose'
-  JAEGER_VERSION=$GITHUB_SHA HOTROD_VERSION=$GITHUB_SHA REGISTRY="localhost:5000/" \
+  (
+    export JAEGER_VERSION=$GITHUB_SHA HOTROD_VERSION=$GITHUB_SHA REGISTRY="localhost:5000/"
     bash scripts/utils/retry.sh docker compose -f "$docker_compose_file" pull
-  JAEGER_VERSION=$GITHUB_SHA HOTROD_VERSION=$GITHUB_SHA REGISTRY="localhost:5000/" \
     docker compose -f "$docker_compose_file" up -d
+  )
   echo '::endgroup::'
 fi
 

--- a/scripts/build/build-hotrod-image.sh
+++ b/scripts/build/build-hotrod-image.sh
@@ -114,8 +114,8 @@ if [[ "${runtime}" == "k8s" ]]; then
   echo '::group:: run on Kubernetes'
   echo '::group:: Loading images into Kind cluster'
 
-  docker pull localhost:5000/jaegertracing/jaeger:"${GITHUB_SHA}"
-  docker pull localhost:5000/jaegertracing/example-hotrod:"${GITHUB_SHA}"
+  bash scripts/utils/retry.sh docker pull localhost:5000/jaegertracing/jaeger:"${GITHUB_SHA}"
+  bash scripts/utils/retry.sh docker pull localhost:5000/jaegertracing/example-hotrod:"${GITHUB_SHA}"
 
   # Get the actual cluster name
   CLUSTER_NAME=$(kind get clusters | head -n1)
@@ -140,7 +140,10 @@ if [[ "${runtime}" == "k8s" ]]; then
 
 else
   echo '::group:: docker compose'
-  JAEGER_VERSION=$GITHUB_SHA HOTROD_VERSION=$GITHUB_SHA REGISTRY="localhost:5000/" docker compose -f "$docker_compose_file" up -d
+  JAEGER_VERSION=$GITHUB_SHA HOTROD_VERSION=$GITHUB_SHA REGISTRY="localhost:5000/" \
+    bash scripts/utils/retry.sh docker compose -f "$docker_compose_file" pull
+  JAEGER_VERSION=$GITHUB_SHA HOTROD_VERSION=$GITHUB_SHA REGISTRY="localhost:5000/" \
+    docker compose -f "$docker_compose_file" up -d
   echo '::endgroup::'
 fi
 

--- a/scripts/e2e/cassandra.sh
+++ b/scripts/e2e/cassandra.sh
@@ -29,6 +29,7 @@ check_arg() {
 
 setup_cassandra() {
   local compose_file=$1
+  bash scripts/utils/retry.sh docker compose -f "$compose_file" pull
   docker compose -f "$compose_file" up -d
 }
 

--- a/scripts/e2e/clickhouse.sh
+++ b/scripts/e2e/clickhouse.sh
@@ -13,6 +13,7 @@ container_name="clickhouse"
 
 setup_clickhouse() {
     echo "Starting ClickHouse with $compose_file"
+    bash scripts/utils/retry.sh docker compose -f "$compose_file" pull
     docker compose -f "$compose_file" up -d
 }
 

--- a/scripts/e2e/elasticsearch.sh
+++ b/scripts/e2e/elasticsearch.sh
@@ -28,6 +28,7 @@ check_arg() {
 # start the elasticsearch/opensearch container
 setup_db() {
   local compose_file=$1
+  bash scripts/utils/retry.sh docker compose -f "${compose_file}" pull
   docker compose -f "${compose_file}" up -d
 }
 

--- a/scripts/e2e/kafka.sh
+++ b/scripts/e2e/kafka.sh
@@ -47,6 +47,7 @@ parse_args() {
 
 setup_kafka() {
   echo "Starting Kafka using Docker Compose..."
+  bash scripts/utils/retry.sh docker compose -f "${compose_file}" pull kafka
   docker compose -f "${compose_file}" up -d kafka
 }
 

--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -385,8 +385,23 @@ teardown_services() {
   docker compose -f $compose_file down
 }
 
+# Pre-pull all non-jaeger compose services with retry; the jaeger image is
+# built locally above as jaegertracing/jaeger:dev and would not be in any
+# registry, so pull it separately by service name.
+pre_pull_compose_images() {
+  local services=("microsim")
+  case "$METRICSTORE" in
+    prometheus) services+=("prometheus" "grafana") ;;
+    elasticsearch|opensearch|clickhouse) services+=("$METRICSTORE") ;;
+  esac
+  JAEGER_VERSION=dev bash scripts/utils/retry.sh \
+    docker compose -f "$compose_file" pull "${services[@]}"
+}
+
 main() {
-  (cd docker-compose/monitor && make build BINARY="jaeger" && make $make_target DOCKER_COMPOSE_ARGS="-d")
+  (cd docker-compose/monitor && make build BINARY="jaeger")
+  pre_pull_compose_images
+  (cd docker-compose/monitor && make $make_target DOCKER_COMPOSE_ARGS="-d")
 
   wait_for_services_to_be_healthy
   check_spm

--- a/scripts/e2e/spm.sh
+++ b/scripts/e2e/spm.sh
@@ -387,7 +387,7 @@ teardown_services() {
 
 # Pre-pull all non-jaeger compose services with retry; the jaeger image is
 # built locally above as jaegertracing/jaeger:dev and would not be in any
-# registry, so pull it separately by service name.
+# registry, so we only pull the external services explicitly by name.
 pre_pull_compose_images() {
   local services=("microsim")
   case "$METRICSTORE" in

--- a/scripts/e2e/ui-reverse-proxy.sh
+++ b/scripts/e2e/ui-reverse-proxy.sh
@@ -133,6 +133,14 @@ if [[ -z "$JAEGER_IMAGE" ]]; then
 fi
 log "Using Jaeger image: ${JAEGER_IMAGE}"
 
+# Pre-pull external images with retry. The compose file references httpd and
+# (when JAEGER_IMAGE points to a published image) the jaeger image. A locally
+# built image is already loaded, so skip it via `docker image inspect`.
+bash "${REPO_ROOT}/scripts/utils/retry.sh" docker pull httpd:2.4.67
+if ! docker image inspect "$JAEGER_IMAGE" >/dev/null 2>&1; then
+  bash "${REPO_ROOT}/scripts/utils/retry.sh" docker pull "$JAEGER_IMAGE"
+fi
+
 JAEGER_IMAGE="${JAEGER_IMAGE}" \
   docker compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" up -d
 

--- a/scripts/e2e/ui-reverse-proxy.sh
+++ b/scripts/e2e/ui-reverse-proxy.sh
@@ -133,13 +133,11 @@ if [[ -z "$JAEGER_IMAGE" ]]; then
 fi
 log "Using Jaeger image: ${JAEGER_IMAGE}"
 
-# Pre-pull external images with retry. The compose file references httpd and
-# (when JAEGER_IMAGE points to a published image) the jaeger image. A locally
-# built image is already loaded, so skip it via `docker image inspect`.
-bash "${REPO_ROOT}/scripts/utils/retry.sh" docker pull httpd:2.4.67
-if ! docker image inspect "$JAEGER_IMAGE" >/dev/null 2>&1; then
-  bash "${REPO_ROOT}/scripts/utils/retry.sh" docker pull "$JAEGER_IMAGE"
-fi
+# Pre-pull the httpd services with retry. The jaeger services aren't pulled
+# here because JAEGER_IMAGE may point to the locally built jaeger-local:e2e-ui-rp,
+# which isn't published in any registry.
+bash "${REPO_ROOT}/scripts/utils/retry.sh" \
+  docker compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" pull httpd-uc1 httpd-uc2 httpd-uc3
 
 JAEGER_IMAGE="${JAEGER_IMAGE}" \
   docker compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" up -d

--- a/scripts/e2e/ui-reverse-proxy.sh
+++ b/scripts/e2e/ui-reverse-proxy.sh
@@ -133,9 +133,9 @@ if [[ -z "$JAEGER_IMAGE" ]]; then
 fi
 log "Using Jaeger image: ${JAEGER_IMAGE}"
 
-# Pre-pull the httpd services with retry. The jaeger services aren't pulled
-# here because JAEGER_IMAGE may point to the locally built jaeger-local:e2e-ui-rp,
-# which isn't published in any registry.
+# Pre-pull the httpd services' images with retry. We don't pull the images for
+# the jaeger services because JAEGER_IMAGE may resolve to the locally built
+# jaeger-local:e2e-ui-rp, which isn't published in any registry.
 bash "${REPO_ROOT}/scripts/utils/retry.sh" \
   docker compose -p "${COMPOSE_PROJECT}" -f "${COMPOSE_FILE}" pull httpd-uc1 httpd-uc2 httpd-uc3
 

--- a/scripts/makefiles/Docker.mk
+++ b/scripts/makefiles/Docker.mk
@@ -35,13 +35,7 @@ prepare-docker-buildx:
 	@echo "::group:: prepare-docker-buildx"
 	docker buildx inspect jaeger-build > /dev/null || docker buildx create --use --name=jaeger-build --buildkitd-flags="--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --driver-opt="network=host"
 	docker inspect registry > /dev/null 2>&1 || \
-		{ for i in 1 2 3; do \
-		    docker pull registry:2 && break; \
-		    echo "Attempt $$i/3 to pull registry:2 failed"; \
-		    [ "$$i" -lt 3 ] && sleep 15; \
-		  done; \
-		  docker image inspect registry:2 > /dev/null 2>&1 \
-		    || { echo "ERROR: Failed to pull registry:2 after 3 attempts"; exit 1; }; \
+		{ bash scripts/utils/retry.sh docker pull registry:2; \
 		  docker run --rm -d -p 5000:5000 --name registry registry:2; }
 	@echo "::endgroup::"
 

--- a/scripts/utils/retry.sh
+++ b/scripts/utils/retry.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generic retry wrapper for transient command failures (e.g. CI image pulls).
+#
+# Usage: retry.sh <cmd> [args...]
+# Env vars:
+#   ATTEMPTS  total attempts before giving up   (default 3)
+#   BACKOFF   initial sleep between attempts    (default 15 seconds);
+#             doubles after each failed attempt (exponential).
+
+set -euf -o pipefail
+
+: "${ATTEMPTS:=3}"
+: "${BACKOFF:=15}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $(basename "$0") <cmd> [args...]" >&2
+  exit 2
+fi
+
+i=1
+backoff=$BACKOFF
+while true; do
+  if "$@"; then
+    exit 0
+  fi
+  if [ "$i" -ge "$ATTEMPTS" ]; then
+    echo "retry.sh: '$*' failed after $i attempts" >&2
+    exit 1
+  fi
+  echo "retry.sh: attempt $i/$ATTEMPTS of '$*' failed; sleeping ${backoff}s" >&2
+  sleep "$backoff"
+  i=$((i + 1))
+  backoff=$((backoff * 2))
+done

--- a/scripts/utils/retry.sh
+++ b/scripts/utils/retry.sh
@@ -21,6 +21,20 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
+# Validate env vars up-front: `[ "$i" -ge "$ATTEMPTS" ]` inside the `if`
+# condition below would otherwise be eaten by `set -e` on a non-numeric
+# value and the loop would spin forever.
+case "$ATTEMPTS" in
+  ''|*[!0-9]*) echo "retry.sh: ATTEMPTS must be a non-negative integer (got '$ATTEMPTS')" >&2; exit 2 ;;
+esac
+case "$BACKOFF" in
+  ''|*[!0-9]*) echo "retry.sh: BACKOFF must be a non-negative integer (got '$BACKOFF')" >&2; exit 2 ;;
+esac
+if [ "$ATTEMPTS" -lt 1 ]; then
+  echo "retry.sh: ATTEMPTS must be at least 1 (got '$ATTEMPTS')" >&2
+  exit 2
+fi
+
 i=1
 backoff=$BACKOFF
 while true; do

--- a/scripts/utils/retry.test.sh
+++ b/scripts/utils/retry.test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# shunit2 tests for retry.sh.
+
+SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
+
+retry="$(cd "$(dirname "$0")" && pwd)/retry.sh"
+
+oneTimeSetUp() {
+  TMPDIR_TEST=$(mktemp -d)
+}
+
+oneTimeTearDown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+testNoArgsPrintsUsage() {
+  out=$(bash "$retry" 2>&1)
+  rc=$?
+  assertEquals "exit 2 on no args" 2 $rc
+  assertContains "$out" "usage:"
+}
+
+testSucceedsOnFirstAttempt() {
+  out=$(ATTEMPTS=3 BACKOFF=0 bash "$retry" true 2>&1)
+  rc=$?
+  assertEquals "exit 0" 0 $rc
+  # No retry lines should be printed when the first attempt succeeds.
+  assertNotContains "$out" "sleeping"
+}
+
+testFailsAfterAttemptsExhausted() {
+  out=$(ATTEMPTS=3 BACKOFF=0 bash "$retry" false 2>&1)
+  rc=$?
+  assertEquals "exit 1" 1 $rc
+  assertContains "$out" "failed after 3 attempts"
+  # We expect 2 sleep messages between 3 attempts.
+  count=$(echo "$out" | grep -c "sleeping" || true)
+  assertEquals "two retries between three attempts" 2 "$count"
+}
+
+testSucceedsAfterTransientFailure() {
+  # cmd: increment counter file; fail on first two invocations, succeed on third.
+  counter="$TMPDIR_TEST/counter-$$"
+  echo 0 > "$counter"
+  cmd="$TMPDIR_TEST/cmd-$$"
+  cat > "$cmd" <<EOF
+#!/bin/bash
+n=\$(cat "$counter")
+n=\$((n + 1))
+echo \$n > "$counter"
+[ "\$n" -ge 3 ]
+EOF
+  chmod +x "$cmd"
+  out=$(ATTEMPTS=5 BACKOFF=0 bash "$retry" "$cmd" 2>&1)
+  rc=$?
+  assertEquals "exit 0" 0 $rc
+  assertEquals "three attempts ran" 3 "$(cat "$counter")"
+  rm -f "$counter" "$cmd"
+}
+
+testAttemptsEnvSingleTry() {
+  out=$(ATTEMPTS=1 BACKOFF=0 bash "$retry" false 2>&1)
+  rc=$?
+  assertEquals "exit 1" 1 $rc
+  assertContains "$out" "failed after 1 attempts"
+  count=$(echo "$out" | grep -c "sleeping" || true)
+  assertEquals "no sleeps with ATTEMPTS=1" 0 "$count"
+}
+
+# shellcheck disable=SC1091
+source "${SHUNIT2}/shunit2"

--- a/scripts/utils/retry.test.sh
+++ b/scripts/utils/retry.test.sh
@@ -71,5 +71,26 @@ testAttemptsEnvSingleTry() {
   assertEquals "no sleeps with ATTEMPTS=1" 0 "$count"
 }
 
+testRejectsNonNumericAttempts() {
+  out=$(ATTEMPTS=foo BACKOFF=0 bash "$retry" true 2>&1)
+  rc=$?
+  assertEquals "exit 2" 2 $rc
+  assertContains "$out" "ATTEMPTS must be a non-negative integer"
+}
+
+testRejectsNonNumericBackoff() {
+  out=$(ATTEMPTS=3 BACKOFF=bar bash "$retry" true 2>&1)
+  rc=$?
+  assertEquals "exit 2" 2 $rc
+  assertContains "$out" "BACKOFF must be a non-negative integer"
+}
+
+testRejectsZeroAttempts() {
+  out=$(ATTEMPTS=0 BACKOFF=0 bash "$retry" true 2>&1)
+  rc=$?
+  assertEquals "exit 2" 2 $rc
+  assertContains "$out" "ATTEMPTS must be at least 1"
+}
+
 # shellcheck disable=SC1091
 source "${SHUNIT2}/shunit2"

--- a/scripts/utils/run-tests.sh
+++ b/scripts/utils/run-tests.sh
@@ -10,6 +10,7 @@ REPO_ROOT="$UTILS_DIR/../.."
 # Define list of test files explicitly here , to be dynamic to the location of the test file
 TEST_FILES=(
     "$UTILS_DIR/compute-tags.test.sh"
+    "$UTILS_DIR/retry.test.sh"
     "$REPO_ROOT/internal/storage/v1/cassandra/schema/create.test.sh"
 )
 


### PR DESCRIPTION
## Summary

Fixes #8777.

- Adds `scripts/utils/retry.sh` — a generic exponential-backoff retry wrapper (default 3 attempts, 15s → 30s → 60s; `ATTEMPTS` and `BACKOFF` env-overridable).
- Migrates every CI docker pull site (12 files) to wrap its pull with the new helper. For compose-based sites, the implicit pull is split out of `up -d` so only the network-touching step is retried.
- Removes two pre-existing ad-hoc retry loops (`scripts/makefiles/Docker.mk` `for i in 1 2 3` and an inline image-inspect check) now covered by the helper.

## Design discussion

Per [the design discussion on the issue](https://github.com/jaegertracing/jaeger/issues/8777), the script lives in `scripts/utils/` rather than `scripts/build/` (nothing about it is build-specific) and is standalone rather than sourced (no shell-state coupling, plus a CLI form `bash scripts/utils/retry.sh docker pull ...` works from `Makefile` and workflow steps alike). It is intentionally not docker-aware — any future caller that needs retry can use it for any command.

## Files migrated

| Site | Change |
| --- | --- |
| `scripts/e2e/elasticsearch.sh` | retry pull before `up -d` (the failure that motivated #8777). Outer `for retry in 1 2 3` healthcheck loop unchanged. |
| `scripts/e2e/clickhouse.sh` | retry pull before `up -d`. |
| `scripts/e2e/kafka.sh` | retry pull before `up -d kafka`. |
| `scripts/e2e/cassandra.sh` | retry pull before `up -d`. |
| `scripts/e2e/spm.sh` | inject retry pull of external services (microsim/prometheus/grafana/etc.) between `make build` and `make $make_target` so the locally built `jaegertracing/jaeger:dev` is skipped. |
| `scripts/e2e/ui-reverse-proxy.sh` | retry-pull only the `httpd-uc*` services via `docker compose pull` — the jaeger services aren't pre-pulled because `JAEGER_IMAGE` may resolve to the locally built `jaeger-local:e2e-ui-rp` (CI's default), which isn't published in any registry. |
| `scripts/build/build-hotrod-image.sh` | retry the two `docker pull localhost:5000/...` calls and the docker-runtime `compose pull` (registry-startup race). |
| `scripts/build/build-all-in-one-image.sh` | retry-pull from local registry before `docker run`. |
| `scripts/makefiles/Docker.mk` | replace inline `for i in 1 2 3; do docker pull registry:2 && break; ...` loop with one `bash scripts/utils/retry.sh docker pull registry:2`. |
| `.github/workflows/ci-lint-checks.yaml` | pre-pull `ghcr.io/renovatebot/renovate:latest` with retry before the validator `docker run`. |

## Test plan

- [x] `make fmt` — clean
- [x] `make lint` — clean
- [x] `make test` — passes locally aside from a pre-existing flake in `internal/storage/v2/grpc` (reproduces on `main` without these changes; unrelated to this PR — it's a goroutine-leak in test setup dialing localhost).
- [x] New `scripts/utils/retry.test.sh` shunit2 tests cover: no-args usage, first-try success, transient failure that succeeds on attempt 3, exhausted attempts, `ATTEMPTS=1` single-try, and rejection of non-numeric / zero `ATTEMPTS` / non-numeric `BACKOFF` env values. Registered in `scripts/utils/run-tests.sh` and runs in the `lint-shell-scripts` CI job.
- [ ] Trigger `ci-e2e-elasticsearch.yml` and `ci-e2e-opensearch.yml` from this PR branch to confirm the migrated paths still work.

## Decisions (from #8777)

1. **Backoff**: exponential (15s → 30s → 60s).
2. **Permanent vs transient errors**: retry all (matches existing behavior).
3. **Image-cached short-circuit**: not implemented — not worth the complexity.
4. **Private-registry auth**: out of scope — no audited pull site requires auth.
5. **Outer `for retry in 1 2 3` in `elasticsearch.sh`**: kept — it guards container/healthcheck flakes, a different failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
