### PR TITLE
[chore] Enable revive flag-parameter linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,9 +129,6 @@ linters:
         # wtf: "you have exceeded the maximum number of public struct declarations"
         - name: max-public-structs
           disabled: true
-        # often looks like a red herring, needs investigation
-        - name: flag-parameter
-          disabled: true
         # looks like a good linter, needs cleanup
         # - name: confusing-naming
         #   disabled: true


### PR DESCRIPTION
## Which problem is this PR solving?

Enables the `flag-parameter` revive linter rule, part of #5506.

## Description of the changes

Removes the disable entry for `flag-parameter` from `.golangci.yml`. This rule detects control coupling — functions that accept a boolean and immediately branch on it.

As noted by @mishradwaterlaw in the [issue discussion](https://github.com/jaegertracing/jaeger/issues/5506#issuecomment-4675625820) (2026-06-07), running golangci-lint with this rule enabled produces **zero violations** on the current `main` branch. The codebase has naturally evolved away from this pattern, so we can enforce it to prevent regressions.

## How was this change tested?

- YAML validity confirmed via `node -e "yaml.parse(...)"`
- Rule verification: @mishradwaterlaw confirmed zero violations on main (2026-06-07)
- CI will validate via `make lint`

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- [x] I have signed all commits
- [x] I have discussed the change in #5506 before opening this PR

Signed-off-by: amarkdotdev <amarkdotdev@users.noreply.github.com>