### PR TITLE
[chore] Enable revive argument-limit linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -138,9 +138,6 @@ linters:
         # too pendantic
         - name: function-length
           disabled: true
-        # definitely a good one, needs cleanup first
-        - name: argument-limit
-          disabled: true
         # this is idiocy, promotes less readable code. Don't enable.
         - name: var-declaration
           disabled: true


### PR DESCRIPTION
## Which problem is this PR solving?

Enables the `argument-limit` revive linter rule (default threshold: 8 params), part of #5506.

## Description of the changes

Removes the disable entry for `argument-limit` from `.golangci.yml`. The codebase currently has zero violations at the default threshold of 8.

A previous PR (#8048) attempted this with a threshold of 7, which required refactoring one test helper function with 8 params. That PR went stale. With the default threshold of 8, no code changes are needed — the rule passes cleanly.

## How was this change tested?

- YAML validity confirmed via Node.js yaml parser
- Rule verification: @mishradwaterlaw confirmed zero violations on main (2026-06-07)
- CI will validate via `make lint`

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- [x] I have signed all commits
- [x] I have discussed the change in #5506 before opening this PR