### PR TITLE
fix(clickhouse): Reduce attribute metadata cache TTL to prevent stale partial snapshots

### DIFF
--- a/cmd/jaeger/config-clickhouse.yaml
+++ b/cmd/jaeger/config-clickhouse.yaml
@@ -47,6 +47,9 @@ extensions:
               username: default
               password: password
           create_schema: true
+          # Short TTL so integration test retries observe the fully populated
+          # attribute_metadata table instead of a stale partial cache snapshot.
+          attribute_metadata_cache_ttl: 5s
     metric_backends:
       some-metrics:
         clickhouse:

--- a/internal/storage/integration/clickhouse_test.go
+++ b/internal/storage/integration/clickhouse_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,9 @@ func (s *ClickHouseStorageIntegration) initialize(t *testing.T) {
 		Addresses:    []string{"127.0.0.1:9000"},
 		Database:     "jaeger",
 		CreateSchema: true,
+		// Short TTL so test retries observe the fully populated
+		// attribute_metadata table instead of a stale partial cache snapshot.
+		AttributeMetadataCacheTTL: 5 * time.Second,
 		Auth: ch.Authentication{
 			Basic: configoptional.Some(basicauthextension.ClientAuthSettings{
 				Username: "default",

--- a/internal/storage/v2/clickhouse/config.go
+++ b/internal/storage/v2/clickhouse/config.go
@@ -18,7 +18,7 @@ const (
 	defaultDatabase                      = "jaeger"
 	defaultSearchDepth                   = 1000
 	defaultMaxSearchDepth                = 10000
-	defaultAttributeMetadataCacheTTL     = time.Hour
+	defaultAttributeMetadataCacheTTL     = 10 * time.Minute
 	defaultAttributeMetadataCacheMaxSize = 1000
 )
 
@@ -48,7 +48,9 @@ type Configuration struct {
 	// AttributeMetadataCacheTTL is the time-to-live for cached attribute metadata entries.
 	// Attribute metadata maps attribute keys to their stored types and levels,
 	// which is needed to build type-correct queries for querying attributes.
-	// Default is 1h.
+	// The metadata table is populated incrementally as span batches are inserted,
+	// so a cache entry captured mid-ingestion may be a partial snapshot; a shorter
+	// TTL bounds how long such stale entries can affect queries. Default is 10m.
 	AttributeMetadataCacheTTL time.Duration `mapstructure:"attribute_metadata_cache_ttl"`
 	// AttributeMetadataCacheMaxSize is the maximum number of entries in the attribute metadata cache.
 	// Default is 1000.


### PR DESCRIPTION
Fixes #8780

## Which problem is this PR solving?
The ClickHouse e2e test `TestClickHouseStorage/FindTraces` was flaky: tag-based queries would fail for all 100 retry iterations, eventually exceeding Go's 10-minute test timeout and killing the process with `(unknown)`.

As @yurishkuro diagnosed, the root cause is a cache invalidation problem in `getAttributeMetadata` (`attribute_metadata.go`), not a query-generation problem:

- The `attribute_metadata` table is populated by materialized views that fire synchronously on each ClickHouse INSERT, but the OTel batch processor flushes spans in **multiple batches**, so the table grows incrementally.
- If a query runs between two batch flushes, `getAttributeMetadata` caches a **partial snapshot** (e.g. `{span: [str]}` for an attribute that also exists at `resource`/`scope` level in a later batch).
- The cache had a 1-hour TTL and no invalidation, so the stale partial entry persisted for the entire test run, causing tag queries to miss traces at the uncached levels no matter how many times the test retried.

## Description of the changes
Per maintainer feedback, this fixes the cache layer instead of widening the generated SQL (my earlier approach, now reverted — query widening imposed a permanent cost on every attribute filter even in steady-state production):

- **`cmd/jaeger/config-clickhouse.yaml`**: set `attribute_metadata_cache_ttl: 5s` so the existing retry loop in the integration tests naturally outlasts the TTL — even if a query races a partial flush, the cache expires and the next retry reads the fully populated table.
- **`internal/storage/integration/clickhouse_test.go`**: same 5s TTL for the direct (non-e2e) ClickHouse integration test, which constructs the config in Go.
- **`internal/storage/v2/clickhouse/config.go`**: reduced `defaultAttributeMetadataCacheTTL` from `1h` to `10m` to shrink the blast radius in production when a new attribute key is introduced mid-ingestion.

No changes to query generation or to the shared integration test harness.

## How was this change tested?
- `go test ./internal/storage/v2/clickhouse/...` — config tests pass (pre-existing Windows-only CRLF snapshot mismatch in `TestWriter_Success` is unrelated and also fails on clean main locally)
- `go test ./internal/storage/integration/` — passes

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality (N/A — config-only change; the default TTL is covered by the existing `TestConfigurationApplyDefaults`, and the flake fix itself is exercised by the ClickHouse integration/e2e tests)
- [x] I have run lint and test steps successfully: `make lint test`


