### PR TITLE
feat(test): Ship integration tests as a binary artifact

### DIFF
--- a/internal/storage/v2/grpc/README.md
+++ b/internal/storage/v2/grpc/README.md
@@ -22,18 +22,13 @@ ensuring a clean state before each test run.
 
 To verify that your remote storage backend works correctly with Jaeger, you can run the integration tests provided by the Jaeger project.
 
-### Step 1: Clone the Jaeger Repository
+### Step 1: Download the Integration Tester
 
-Begin by cloning the Jaeger repository to your local machine:
-
-```bash
-git clone https://github.com/jaegertracing/jaeger.git
-cd jaeger
-```
+Download the `jaeger-tools` archive for your platform from the [Jaeger Releases](https://github.com/jaegertracing/jaeger/releases) page and extract the `jaeger-integration-tester` binary.
 
 ### Step 2: Run the Integration Tests
 
-Run the integration tests for the gRPC storage backend using the following command:
+Run the integration tests for the gRPC storage backend using the downloaded binary:
 
 ```bash
 STORAGE=grpc \
@@ -41,7 +36,7 @@ CUSTOM_STORAGE=true \
 REMOTE_STORAGE_ENDPOINT=${MY_REMOTE_STORAGE_ENDPOINT} \
 REMOTE_STORAGE_WRITER_ENDPOINT=${MY_REMOTE_STORAGE_WRITER_ENDPOINT} \
 PURGER_ENDPOINT=${MY_PURGER_ENDPOINT} \
-make jaeger-v2-storage-integration-test
+./jaeger-integration-tester -test.v -test.run TestGRPCStorage
 ```
 
 The diagram below demonstrates the architecture of the gRPC storage integration test.

--- a/scripts/build/package-deploy.sh
+++ b/scripts/build/package-deploy.sh
@@ -57,6 +57,7 @@ function stage-tool-platform-files {
     cp "./cmd/es-index-cleaner/es-index-cleaner-${PLATFORM}"        "${TOOLS_PACKAGE_STAGING_DIR}/jaeger-es-index-cleaner${FILE_EXTENSION}"
     cp "./cmd/es-rollover/es-rollover-${PLATFORM}"                  "${TOOLS_PACKAGE_STAGING_DIR}/jaeger-es-rollover${FILE_EXTENSION}"
     cp "./cmd/esmapping-generator/esmapping-generator-${PLATFORM}"  "${TOOLS_PACKAGE_STAGING_DIR}/jaeger-esmapping-generator${FILE_EXTENSION}"
+    cp "./cmd/integration-tester/integration-tester-${PLATFORM}"    "${TOOLS_PACKAGE_STAGING_DIR}/jaeger-integration-tester${FILE_EXTENSION}"
 }
 
 # package pulls built files for the platform ($2) and compresses it using the compression ($1).

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -74,6 +74,11 @@ build-es-index-cleaner:
 build-es-rollover:
 	$(call GOBUILD,es-rollover) -o ./cmd/es-rollover/es-rollover-$(GOOS)-$(GOARCH) ./cmd/es-rollover/
 
+.PHONY: build-integration-tester
+build-integration-tester:
+	@printf "building test binary '$(STYLE_BOLD_ORANGE)integration-tester$(STYLE_RESET)' for $$(go env GOOS)-$$(go env GOARCH)\n"
+	CGO_ENABLED=0 installsuffix=cgo $(GO) test -c -trimpath -o ./cmd/integration-tester/integration-tester-$(GOOS)-$(GOARCH) ./internal/storage/integration/
+
 # Requires variables: $(BIN_NAME) $(BIN_PATH) $(GO_TAGS) $(DISABLE_OPTIMIZATIONS) $(SUFFIX) $(GOOS) $(GOARCH) $(BUILD_INFO)
 # Other targets can depend on this one but with a unique suffix to ensure it is always executed.
 BIN_PATH = ./cmd/$(BIN_NAME)
@@ -153,7 +158,8 @@ _build-platform-binaries: \
 		build-anonymizer \
 		build-esmapping-generator \
 		build-es-index-cleaner \
-		build-es-rollover
+		build-es-rollover \
+		build-integration-tester
 # invoke make recursively such that DEBUG_BINARY=1 can take effect
 # skip debug builds if SKIP_DEBUG_BINARIES is set to 1 (e.g., during PRs to save CI time)
 ifneq ($(SKIP_DEBUG_BINARIES),1)


### PR DESCRIPTION
Fixes #6813

## Which problem is this PR solving?
This PR addresses the need for third-party storage plugins to verify their compliance against Jaeger's integration tests without having to clone the Jaeger repository or import Jaeger internals.

As discussed in #6813, since third-party storage is implemented via the gRPC remote API, external developers only need a compiled test binary that invokes the internal test suite against their provided gRPC endpoint.

## Description of the changes
- **Compilation Target:** Added a `build-integration-tester` target to `BuildBinaries.mk` which uses `go test -c` to compile `internal/storage/integration` into a standalone binary.
- **Cross-Platform CI Matrix:** Included the new tester in the `_build-platform-binaries` suite, meaning it compiles for all architectures during release.
- **Release Packaging:** Modified `scripts/build/package-deploy.sh` to seamlessly bundle the new `jaeger-integration-tester` binary into the `jaeger-tools` release archive (`.tar.gz` and `.zip`).
- **Documentation:** Completely rewrote the "Certifying compliance" section in `internal/storage/v2/grpc/README.md` to instruct users to download the tool from the GitHub Releases page instead of cloning the repository.

## How was this change tested?
- Local Makefile validation (`make build-binaries-linux-amd64`) to confirm the successful compilation of the `go test` binary into the `cmd/integration-tester` output directory.
- Reviewed and verified `package-deploy.sh` modifications accurately target the new executable for the `jaeger-tools` archive output.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR
- [ ] None: No AI tools were used in creating this PR
- [x] Light: AI provided minor assistance (formatting, simple suggestions)
- [ ] Moderate: AI helped with code generation or debugging specific parts
- [ ] Heavy: AI generated most or all of the code changes
