### PR TITLE
docs: fix typos in README files

### DIFF
--- a/cmd/jaeger/README.md
+++ b/cmd/jaeger/README.md
@@ -7,7 +7,7 @@ Read the [blog post](https://medium.com/jaegertracing/towards-jaeger-v2-moar-ope
 
 * Download `docker-compose.yml` from https://github.com/jaegertracing/jaeger/blob/main/examples/hotrod/docker-compose.yml, e.g.:
   * `curl -O https://raw.githubusercontent.com/jaegertracing/jaeger/refs/heads/main/examples/hotrod/docker-compose.yml`
-* Optional: find the latest images versions (see https://www.jaegertracing.io/download/) and pass them via environment variables `JAEGER_VERSION` and `HOTROD_VERSION`. Otherwise `docker compose` will use the `latest` tag, which is fine for the first time you download the images, but once they are in your local registry the `latest` tag is never updated and you may be running stale (and possibly incompatible) verions of Jaeger and the HotROD app.
+* Optional: find the latest images versions (see https://www.jaegertracing.io/download/) and pass them via environment variables `JAEGER_VERSION` and `HOTROD_VERSION`. Otherwise `docker compose` will use the `latest` tag, which is fine for the first time you download the images, but once they are in your local registry the `latest` tag is never updated and you may be running stale (and possibly incompatible) versions of Jaeger and the HotROD app.
 * Run Jaeger backend and HotROD demo, e.g.:
   * `JAEGER_VERSION=2.0.0 HOTROD_VERSION=1.63.0 docker compose -f docker-compose.yml up`
 * Access Jaeger UI at http://localhost:16686 and HotROD app at http://localhost:8080

--- a/cmd/jaeger/internal/extension/expvar/README.md
+++ b/cmd/jaeger/internal/extension/expvar/README.md
@@ -2,5 +2,5 @@
 
 Adds a standard expvar HTTP handler to a port that allows introspection.
 
-This is a temporary implementaion until upstream ticket is addressed:
+This is a temporary implementation until upstream ticket is addressed:
 https://github.com/open-telemetry/opentelemetry-collector/issues/11081

--- a/cmd/jaeger/internal/extension/remotesampling/README.md
+++ b/cmd/jaeger/internal/extension/remotesampling/README.md
@@ -32,7 +32,7 @@ flowchart LR
         AdaptiveSamplingProcessor -->|"[]*model.Span"| AdaptiveSamplingProcessorV1
         AdaptiveSamplingProcessorV1 ---|use| SamplingStorage
 
-        subgraph JaegerStorageExension[Jaeger Storage Exension]
+        subgraph JaegerStorageExtension[Jaeger Storage Extension]
             Storage[[Storage
                      Config]]
         end

--- a/cmd/jaeger/internal/integration/README.md
+++ b/cmd/jaeger/internal/integration/README.md
@@ -52,7 +52,7 @@ flowchart LR
         Processor
         Exporter
 
-        subgraph JaegerStorageExension[Jaeger Storage Exension]
+        subgraph JaegerStorageExtension[Jaeger Storage Extension]
             Storage[(Trace
                      Storage)]
         end


### PR DESCRIPTION
Fixes several spelling typos in README files as identified in #8773: 'verions' → 'versions', 'Exension' → 'Extension' (two files), and 'implementaion' → 'implementation'.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._