### PR TITLE
[codex] Deploy OKE demo from snapshot images

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 13 * * *'  # Daily at 8:00 AM US Eastern Time (ET)
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Snapshot image tag to deploy. Defaults to the workflow SHA.'
+        required: false
 
 permissions: read-all
 
@@ -20,6 +24,11 @@ jobs:
       OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
       OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
       OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+      JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY: jaegertracing/jaeger-snapshot
+      JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY: jaegertracing/example-hotrod-snapshot
+      JAEGER_DEMO_IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
+      JAEGER_DEMO_IMAGE_PULL_POLICY: Always
+      RUN_PUBLIC_SMOKE_TESTS: "true"
 
     steps:
     - name: Configure kubectl with OKE
@@ -37,10 +46,10 @@ jobs:
     - name: Deploy using appropriate script
       run: |
         if [ "${{ github.event_name }}" = "schedule" ]; then
-          echo "🕒 Scheduled run - using deploy-all.sh (upgrade mode)"
+          echo "🕒 Scheduled run - deploying snapshot image tag ${JAEGER_DEMO_IMAGE_TAG}"
           bash ./examples/oci/deploy-all.sh
         else
-          echo "🔄 Manual run - using deploy-all.sh with clean mode (uninstall/install)"
+          echo "🔄 Manual run - clean install using snapshot image tag ${JAEGER_DEMO_IMAGE_TAG}"
           bash ./examples/oci/deploy-all.sh clean
         fi
 
@@ -63,4 +72,3 @@ jobs:
 
           <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|🔗 View Failed Run>
         SLACK_FOOTER: 'Jaeger CI/CD Pipeline'
-

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -6,7 +6,13 @@
 set -euo pipefail
 
 MODE="${1:-upgrade}"
-IMAGE_TAG="${2:-latest}"
+IMAGE_TAG="${2:-${JAEGER_DEMO_IMAGE_TAG:-}}"
+LOCAL_IMAGE_TAG="${2:-${JAEGER_DEMO_IMAGE_TAG:-latest}}"
+JAEGER_IMAGE_REPOSITORY="${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY:-jaegertracing/jaeger}"
+HOTROD_IMAGE_REPOSITORY="${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY:-jaegertracing/example-hotrod}"
+IMAGE_PULL_POLICY="${JAEGER_DEMO_IMAGE_PULL_POLICY:-IfNotPresent}"
+PUBLIC_BASE_URL="${JAEGER_DEMO_PUBLIC_BASE_URL:-https://demo.jaegertracing.io}"
+RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
 PROMETHEUS_STACK_CHART="prometheus-community/kube-prometheus-stack"
 PROMETHEUS_STACK_CHART_VERSION="${PROMETHEUS_STACK_CHART_VERSION:-82.10.4}"
 
@@ -32,8 +38,8 @@ case "$MODE" in
 esac
 
 if [[ "$MODE" == "upgrade" ]]; then
-  HELM_JAEGER_CMD="upgrade --install --force"
-  HELM_PROM_CMD="upgrade --install --force"
+  HELM_JAEGER_CMD="upgrade --install --force --wait"
+  HELM_PROM_CMD="upgrade --install --force --wait"
 else
   echo "🟣 Clean mode: Uninstalling Jaeger and Prometheus..."
   helm uninstall jaeger --ignore-not-found || true
@@ -43,8 +49,8 @@ else
       echo "Waiting for Helm release $name to be deleted..."
     done
   done
-  HELM_JAEGER_CMD="install"
-  HELM_PROM_CMD="install"
+  HELM_JAEGER_CMD="install --wait"
+  HELM_PROM_CMD="install --wait"
 fi
 
 # Navigate to the script's directory (examples/oci)
@@ -79,21 +85,35 @@ if [[ "$MODE" == "local" ]]; then
     --set hotrod.enabled=true \
     --set global.imageRegistry="" \
     --set allInOne.image.repository="localhost:5000/jaegertracing/jaeger" \
-    --set allInOne.image.tag="${IMAGE_TAG}"  \
+    --set allInOne.image.tag="${LOCAL_IMAGE_TAG}"  \
     --set allInOne.image.pullPolicy="Never" \
     --set hotrod.image.repository="localhost:5000/jaegertracing/example-hotrod" \
-    --set hotrod.image.tag="${IMAGE_TAG}"  \
+    --set hotrod.image.tag="${LOCAL_IMAGE_TAG}"  \
     --set hotrod.image.pullPolicy="Never" \
     --set-file userconfig="./config.yaml" \
     --set-file uiconfig="./ui-config.json" \
     -f ./jaeger-values.yaml
 else
-  echo "🟣 Deploying Jaeger..."
+  image_args=(
+    --set allInOne.image.repository="${JAEGER_IMAGE_REPOSITORY}"
+    --set allInOne.image.pullPolicy="${IMAGE_PULL_POLICY}"
+    --set hotrod.image.repository="${HOTROD_IMAGE_REPOSITORY}"
+    --set hotrod.image.pullPolicy="${IMAGE_PULL_POLICY}"
+  )
+  if [[ -n "$IMAGE_TAG" ]]; then
+    image_args+=(
+      --set allInOne.image.tag="${IMAGE_TAG}"
+      --set hotrod.image.tag="${IMAGE_TAG}"
+    )
+  fi
+
+  echo "🟣 Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${IMAGE_TAG:-chart-default}"
+  echo "🟣 Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${IMAGE_TAG:-values-default}"
   helm $HELM_JAEGER_CMD --timeout 10m0s jaeger ./helm-charts/charts/jaeger \
     --set provisionDataStore.cassandra=false \
     --set allInOne.enabled=true \
     --set storage.type=memory \
-    --set allInOne.image.repository="jaegertracing/jaeger" \
+    "${image_args[@]}" \
     --set-file userconfig="./config.yaml" \
     --set-file uiconfig="./ui-config.json" \
     -f ./jaeger-values.yaml
@@ -101,7 +121,7 @@ fi
 
 echo "🟢 Deploying Prometheus..."
 kubectl apply -f prometheus-svc.yaml
-helm $HELM_PROM_CMD prometheus "$PROMETHEUS_STACK_CHART" \
+helm $HELM_PROM_CMD --timeout 10m0s prometheus "$PROMETHEUS_STACK_CHART" \
   --version "$PROMETHEUS_STACK_CHART_VERSION" \
   --set crds.upgradeJob.enabled=true \
   --set crds.upgradeJob.forceConflicts=true \
@@ -118,6 +138,39 @@ kubectl apply -f ./load-generator/load-generator.yaml
 # Deploy ingress changes
 echo "🟡 Step 5: Deploying Ingress Resource..."
 kubectl apply -f ingress.yaml
+
+echo "🔎 Step 6: Verifying rollout status..."
+kubectl rollout status deployment/jaeger --timeout=5m
+kubectl rollout status deployment/jaeger-hotrod --timeout=5m
+kubectl rollout status deployment/trace-generator --timeout=5m
+kubectl get pods,svc,ingress
+
+smoke_expect() {
+  local url=$1
+  local expected=$2
+  local output=$3
+
+  for attempt in $(seq 1 12); do
+    if curl -fsS "$url" -o "$output" && grep -q "$expected" "$output"; then
+      echo "✅ Smoke check passed: $url"
+      return 0
+    fi
+    echo "Waiting for $url to return expected content (attempt $attempt/12)..."
+    sleep 10
+  done
+
+  echo "❌ Smoke check failed: $url"
+  echo "Expected content: $expected"
+  echo "Last response:"
+  cat "$output" 2>/dev/null || true
+  return 1
+}
+
+if [[ "$RUN_PUBLIC_SMOKE_TESTS" == "true" ]]; then
+  echo "🔎 Step 7: Verifying public demo endpoints..."
+  smoke_expect "${PUBLIC_BASE_URL}/hotrod/dispatch?customer=123" '"Driver"' /tmp/hotrod-smoke.json
+  smoke_expect "${PUBLIC_BASE_URL}/jaeger/api/services" '"frontend"' /tmp/jaeger-services.json
+fi
 
 # Output Port-forward Instructions
 echo "✅ Deployment Complete!"


### PR DESCRIPTION
## Summary

- deploy the OKE demo from `jaeger-snapshot` and `example-hotrod-snapshot` images instead of release image repositories
- default the deployed snapshot tag to the workflow SHA, with a manual override for workflow dispatch
- make the deploy job wait for Helm releases, verify Kubernetes rollouts, and smoke-test public Jaeger and HotROD endpoints

## Root cause

The deploy job could succeed while not deploying the current main build. Main CI publishes snapshot images tagged by SHA, but the OKE deploy script used the release-style `jaegertracing/jaeger` repository without a tag override. The workflow also stopped after Helm and `kubectl apply`, so it did not prove that the public demo was actually reachable.

## Validation

- `bash -n examples/oci/deploy-all.sh`
- YAML parse of `.github/workflows/ci-deploy-demo.yml`
- `git diff --check`
- `make fmt`
- `make lint`
- `make test`
