### PR TITLE
[codex] Bound OKE demo clean deploys

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -9,7 +9,13 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Snapshot image tag to deploy. Defaults to the workflow SHA.'
+        description: 'Snapshot image tag to deploy for both images. Defaults to the workflow SHA.'
+        required: false
+      jaeger_image_tag:
+        description: 'Jaeger snapshot image tag override. Defaults to image_tag or the workflow SHA.'
+        required: false
+      hotrod_image_tag:
+        description: 'HotROD snapshot image tag override. Defaults to image_tag or the workflow SHA.'
         required: false
       deploy_mode:
         description: 'Deployment mode. Defaults to upgrade; use clean only to reinstall the demo.'
@@ -35,6 +41,8 @@ jobs:
       JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY: jaegertracing/jaeger-snapshot
       JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY: jaegertracing/example-hotrod-snapshot
       JAEGER_DEMO_IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
+      JAEGER_DEMO_JAEGER_IMAGE_TAG: ${{ github.event.inputs.jaeger_image_tag || github.event.inputs.image_tag || github.sha }}
+      JAEGER_DEMO_HOTROD_IMAGE_TAG: ${{ github.event.inputs.hotrod_image_tag || github.event.inputs.image_tag || github.sha }}
       JAEGER_DEMO_IMAGE_PULL_POLICY: Always
       JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
       RUN_PUBLIC_SMOKE_TESTS: "true"
@@ -54,7 +62,8 @@ jobs:
 
     - name: Deploy using appropriate script
       run: |
-        echo "🔄 Deploying snapshot image tag ${JAEGER_DEMO_IMAGE_TAG} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
+        echo "🔄 Deploying Jaeger snapshot image tag ${JAEGER_DEMO_JAEGER_IMAGE_TAG} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
+        echo "🔄 Deploying HotROD snapshot image tag ${JAEGER_DEMO_HOTROD_IMAGE_TAG} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
         bash ./examples/oci/deploy-all.sh "${JAEGER_DEMO_DEPLOY_MODE}"
 
     - name: Send detailed Slack notification on failure

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -11,6 +11,14 @@ on:
       image_tag:
         description: 'Snapshot image tag to deploy. Defaults to the workflow SHA.'
         required: false
+      deploy_mode:
+        description: 'Deployment mode. Defaults to upgrade; use clean only to reinstall the demo.'
+        required: false
+        default: upgrade
+        type: choice
+        options:
+          - upgrade
+          - clean
 
 permissions: read-all
 
@@ -28,6 +36,7 @@ jobs:
       JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY: jaegertracing/example-hotrod-snapshot
       JAEGER_DEMO_IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
       JAEGER_DEMO_IMAGE_PULL_POLICY: Always
+      JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
       RUN_PUBLIC_SMOKE_TESTS: "true"
 
     steps:
@@ -45,13 +54,8 @@ jobs:
 
     - name: Deploy using appropriate script
       run: |
-        if [ "${{ github.event_name }}" = "schedule" ]; then
-          echo "🕒 Scheduled run - deploying snapshot image tag ${JAEGER_DEMO_IMAGE_TAG}"
-          bash ./examples/oci/deploy-all.sh
-        else
-          echo "🔄 Manual run - clean install using snapshot image tag ${JAEGER_DEMO_IMAGE_TAG}"
-          bash ./examples/oci/deploy-all.sh clean
-        fi
+        echo "🔄 Deploying snapshot image tag ${JAEGER_DEMO_IMAGE_TAG} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
+        bash ./examples/oci/deploy-all.sh "${JAEGER_DEMO_DEPLOY_MODE}"
 
     - name: Send detailed Slack notification on failure
       if: failure()

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -15,6 +15,18 @@ PUBLIC_BASE_URL="${JAEGER_DEMO_PUBLIC_BASE_URL:-https://demo.jaegertracing.io}"
 RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
 PROMETHEUS_STACK_CHART="prometheus-community/kube-prometheus-stack"
 PROMETHEUS_STACK_CHART_VERSION="${PROMETHEUS_STACK_CHART_VERSION:-82.10.4}"
+CLEAN_UNINSTALL_TIMEOUT="${JAEGER_DEMO_CLEAN_UNINSTALL_TIMEOUT:-10m0s}"
+
+uninstall_release() {
+  local name=$1
+
+  if ! helm uninstall "$name" --ignore-not-found --wait --timeout "$CLEAN_UNINSTALL_TIMEOUT"; then
+    echo "❌ Failed to uninstall Helm release $name within $CLEAN_UNINSTALL_TIMEOUT"
+    helm status "$name" || true
+    helm list --all --filter "^${name}$" || true
+    return 1
+  fi
+}
 
 case "$MODE" in
   upgrade|clean|local)
@@ -42,13 +54,8 @@ if [[ "$MODE" == "upgrade" ]]; then
   HELM_PROM_CMD="upgrade --install --force --wait"
 else
   echo "🟣 Clean mode: Uninstalling Jaeger and Prometheus..."
-  helm uninstall jaeger --ignore-not-found || true
-  helm uninstall prometheus --ignore-not-found || true
-  for name in jaeger prometheus; do
-    while helm list --filter "^${name}$" | grep "$name" &>/dev/null; do
-      echo "Waiting for Helm release $name to be deleted..."
-    done
-  done
+  uninstall_release jaeger
+  uninstall_release prometheus
   HELM_JAEGER_CMD="install --wait"
   HELM_PROM_CMD="install --wait"
 fi

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -10,6 +10,8 @@ IMAGE_TAG="${2:-${JAEGER_DEMO_IMAGE_TAG:-}}"
 LOCAL_IMAGE_TAG="${2:-${JAEGER_DEMO_IMAGE_TAG:-latest}}"
 JAEGER_IMAGE_REPOSITORY="${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY:-jaegertracing/jaeger}"
 HOTROD_IMAGE_REPOSITORY="${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY:-jaegertracing/example-hotrod}"
+JAEGER_IMAGE_TAG="${JAEGER_DEMO_JAEGER_IMAGE_TAG:-$IMAGE_TAG}"
+HOTROD_IMAGE_TAG="${JAEGER_DEMO_HOTROD_IMAGE_TAG:-$IMAGE_TAG}"
 IMAGE_PULL_POLICY="${JAEGER_DEMO_IMAGE_PULL_POLICY:-IfNotPresent}"
 PUBLIC_BASE_URL="${JAEGER_DEMO_PUBLIC_BASE_URL:-https://demo.jaegertracing.io}"
 RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
@@ -107,15 +109,16 @@ else
     --set hotrod.image.repository="${HOTROD_IMAGE_REPOSITORY}"
     --set hotrod.image.pullPolicy="${IMAGE_PULL_POLICY}"
   )
-  if [[ -n "$IMAGE_TAG" ]]; then
-    image_args+=(
-      --set allInOne.image.tag="${IMAGE_TAG}"
-      --set hotrod.image.tag="${IMAGE_TAG}"
-    )
+  if [[ -n "$JAEGER_IMAGE_TAG" ]]; then
+    image_args+=(--set allInOne.image.tag="${JAEGER_IMAGE_TAG}")
+  fi
+  if [[ -n "$HOTROD_IMAGE_TAG" ]]; then
+    image_args+=(--set hotrod.image.tag="${HOTROD_IMAGE_TAG}")
   fi
 
-  echo "🟣 Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${IMAGE_TAG:-chart-default}"
-  echo "🟣 Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${IMAGE_TAG:-values-default}"
+  echo "🟣 Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG:-chart-default}"
+  echo "🟣 Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${HOTROD_IMAGE_TAG:-values-default}"
+
   helm $HELM_JAEGER_CMD --timeout 10m0s jaeger ./helm-charts/charts/jaeger \
     --set provisionDataStore.cassandra=false \
     --set allInOne.enabled=true \


### PR DESCRIPTION
## Summary

- make manual OKE demo workflow dispatch use upgrade mode by default
- add an explicit `deploy_mode` input so clean reinstalls are opt-in
- replace the unbounded clean-mode Helm deletion loop with `helm uninstall --wait --timeout` and release diagnostics on failure

## Root cause

The manual workflow path always ran `deploy-all.sh clean`. Clean mode uninstalled Helm releases and then used a tight `helm list` polling loop with no sleep and no timeout, so a release stuck during deletion could leave the GitHub Actions job running indefinitely.

## Validation

- `bash -n examples/oci/deploy-all.sh`
- Ruby YAML parse of `.github/workflows/ci-deploy-demo.yml`
- `git diff --check`
- `make fmt`
- `make lint`
- `make test`

## Operational note

Run 27640429328 was cancelled after hanging in `Deploy using appropriate script`. The public demo endpoints were still returning 200 after cancellation.