### PR TITLE
Enable Corepack for snapshot UI builds

### DIFF
--- a/.github/actions/setup-node.js/action.yml
+++ b/.github/actions/setup-node.js/action.yml
@@ -9,10 +9,15 @@ runs:
     - name: Get Node.js version from jaeger-ui
       shell: bash
       run: |
-        echo "JAEGER_UI_NODE_JS_VERSION=$(cat jaeger-ui/.nvmrc)" >> ${GITHUB_ENV}
+        JAEGER_UI_NODE_DIR="${JAEGER_UI_DIR:-jaeger-ui}"
+        echo "JAEGER_UI_NODE_JS_VERSION=$(cat "${JAEGER_UI_NODE_DIR}/.nvmrc")" >> "${GITHUB_ENV}"
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ env.JAEGER_UI_NODE_JS_VERSION }}
         cache: 'npm'
         cache-dependency-path: jaeger-ui/package-lock.json
+
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable npm


### PR DESCRIPTION
Fixes #8796

## Summary
- Read the Node.js version from the active Jaeger UI checkout, respecting `JAEGER_UI_DIR` for snapshot builds.
- Enable Corepack after `actions/setup-node` so the UI rebuild uses the npm version declared by the checked-out UI package metadata.

## Why
Main currently fails to publish `jaegertracing/jaeger-snapshot` in `stage3-fast / docker-all-in-one / all-in-one`. The failing job rebuilds UI from `/home/runner/work/_temp/jaeger-ui-snapshot`, but npm is still 11.13.0 while the snapshot UI expects 11.17.0. Without a new all-in-one snapshot image, the OKE demo can keep serving the old Jaeger UI/version even when HotROD has a newer image.

## Validation
- `git diff --check`
- YAML parse with Ruby `YAML.load_file`
- `corepack enable npm`
- `make fmt`
- `make lint`
- `go test -race -tags=memory_storage_integration ./internal/storage/v2/grpc`
- `make test`

Note: the first full `make test` run hit an unrelated goleak timing failure in `internal/storage/v2/grpc`; the package passed when rerun directly, and the second full `make test` passed.