### PR TITLE
Fix OKE demo upgrades and OTel stack rollout

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -55,6 +55,7 @@ jobs:
       JAEGER_DEMO_IMAGE_PULL_POLICY: Always
       JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
       JAEGER_DEMO_STACK: ${{ github.event.inputs.demo_stack || 'oci' }}
+      JAEGER_OTEL_DEMO_DEPLOY_SCOPE: jaeger
       RUN_PUBLIC_SMOKE_TESTS: "true"
 
     steps:

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -34,6 +34,14 @@ on:
           - oci
           - otel
           - all
+      otel_deploy_scope:
+        description: 'OTel demo deploy scope. Use all to refresh OpenSearch and the OTel app.'
+        required: false
+        default: jaeger
+        type: choice
+        options:
+          - jaeger
+          - all
 
 permissions: read-all
 
@@ -55,7 +63,7 @@ jobs:
       JAEGER_DEMO_IMAGE_PULL_POLICY: Always
       JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
       JAEGER_DEMO_STACK: ${{ github.event.inputs.demo_stack || 'oci' }}
-      JAEGER_OTEL_DEMO_DEPLOY_SCOPE: jaeger
+      JAEGER_OTEL_DEMO_DEPLOY_SCOPE: ${{ github.event.inputs.otel_deploy_scope || 'jaeger' }}
       RUN_PUBLIC_SMOKE_TESTS: "true"
 
     steps:

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -25,6 +25,15 @@ on:
         options:
           - upgrade
           - clean
+      demo_stack:
+        description: 'Demo stack to deploy. Defaults to the original OCI demo.'
+        required: false
+        default: oci
+        type: choice
+        options:
+          - oci
+          - otel
+          - all
 
 permissions: read-all
 
@@ -45,6 +54,7 @@ jobs:
       JAEGER_DEMO_HOTROD_IMAGE_TAG: ${{ github.event.inputs.hotrod_image_tag || github.event.inputs.image_tag || github.sha }}
       JAEGER_DEMO_IMAGE_PULL_POLICY: Always
       JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
+      JAEGER_DEMO_STACK: ${{ github.event.inputs.demo_stack || 'oci' }}
       RUN_PUBLIC_SMOKE_TESTS: "true"
 
     steps:
@@ -62,9 +72,26 @@ jobs:
 
     - name: Deploy using appropriate script
       run: |
-        echo "🔄 Deploying Jaeger snapshot image tag ${JAEGER_DEMO_JAEGER_IMAGE_TAG} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
-        echo "🔄 Deploying HotROD snapshot image tag ${JAEGER_DEMO_HOTROD_IMAGE_TAG} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
-        bash ./examples/oci/deploy-all.sh "${JAEGER_DEMO_DEPLOY_MODE}"
+        echo "🔄 Deploying demo stack ${JAEGER_DEMO_STACK} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
+        echo "🔄 Deploying Jaeger snapshot image tag ${JAEGER_DEMO_JAEGER_IMAGE_TAG}"
+        echo "🔄 Deploying HotROD snapshot image tag ${JAEGER_DEMO_HOTROD_IMAGE_TAG}"
+
+        case "${JAEGER_DEMO_STACK}" in
+          oci)
+            bash ./examples/oci/deploy-all.sh "${JAEGER_DEMO_DEPLOY_MODE}"
+            ;;
+          otel)
+            bash ./examples/otel-demo/deploy-all.sh "${JAEGER_DEMO_DEPLOY_MODE}" "${JAEGER_DEMO_JAEGER_IMAGE_TAG}"
+            ;;
+          all)
+            bash ./examples/oci/deploy-all.sh "${JAEGER_DEMO_DEPLOY_MODE}"
+            bash ./examples/otel-demo/deploy-all.sh "${JAEGER_DEMO_DEPLOY_MODE}" "${JAEGER_DEMO_JAEGER_IMAGE_TAG}"
+            ;;
+          *)
+            echo "Unsupported demo stack: ${JAEGER_DEMO_STACK}"
+            exit 1
+            ;;
+        esac
 
     - name: Send detailed Slack notification on failure
       if: failure()

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -31,7 +31,10 @@ uninstall_release() {
 }
 
 release_status() {
-  helm status "$1" 2>/dev/null | awk -F': ' '$1 == "STATUS" { print $2; exit }'
+  local output
+
+  output=$(helm status "$1" 2>/dev/null || true)
+  awk -F': ' '$1 == "STATUS" { print $2 }' <<< "$output"
 }
 
 prepare_upgrade_release() {

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -52,8 +52,8 @@ case "$MODE" in
 esac
 
 if [[ "$MODE" == "upgrade" ]]; then
-  HELM_JAEGER_CMD="upgrade --install --force --wait"
-  HELM_PROM_CMD="upgrade --install --force --wait"
+  HELM_JAEGER_CMD="upgrade --install --wait"
+  HELM_PROM_CMD="upgrade --install --wait"
 else
   echo "🟣 Clean mode: Uninstalling Jaeger and Prometheus..."
   uninstall_release jaeger

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -18,6 +18,7 @@ RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
 PROMETHEUS_STACK_CHART="prometheus-community/kube-prometheus-stack"
 PROMETHEUS_STACK_CHART_VERSION="${PROMETHEUS_STACK_CHART_VERSION:-82.10.4}"
 CLEAN_UNINSTALL_TIMEOUT="${JAEGER_DEMO_CLEAN_UNINSTALL_TIMEOUT:-10m0s}"
+DEPLOY_PROMETHEUS=true
 
 uninstall_release() {
   local name=$1
@@ -75,7 +76,21 @@ esac
 
 if [[ "$MODE" == "upgrade" ]]; then
   prepare_upgrade_release jaeger
-  prepare_upgrade_release prometheus
+  PROMETHEUS_RELEASE_STATUS=$(release_status prometheus)
+  case "$PROMETHEUS_RELEASE_STATUS" in
+    deployed)
+      DEPLOY_PROMETHEUS=true
+      ;;
+    "")
+      DEPLOY_PROMETHEUS=false
+      echo "🟡 Prometheus Helm release is not installed. Skipping Prometheus in upgrade mode."
+      ;;
+    *)
+      DEPLOY_PROMETHEUS=false
+      echo "🟡 Prometheus Helm release is in '$PROMETHEUS_RELEASE_STATUS' state. Skipping Prometheus in upgrade mode."
+      echo "🟡 Use clean mode or repair the Prometheus release separately to reinstall monitoring."
+      ;;
+  esac
   HELM_JAEGER_CMD="upgrade --install --wait"
   HELM_PROM_CMD="upgrade --install --wait"
 else
@@ -155,11 +170,15 @@ fi
 
 echo "🟢 Deploying Prometheus..."
 kubectl apply -f prometheus-svc.yaml
-helm $HELM_PROM_CMD --timeout 10m0s prometheus "$PROMETHEUS_STACK_CHART" \
-  --version "$PROMETHEUS_STACK_CHART_VERSION" \
-  --set crds.upgradeJob.enabled=true \
-  --set crds.upgradeJob.forceConflicts=true \
-  -f monitoring-values.yaml
+if [[ "$DEPLOY_PROMETHEUS" == "true" ]]; then
+  helm $HELM_PROM_CMD --timeout 10m0s prometheus "$PROMETHEUS_STACK_CHART" \
+    --version "$PROMETHEUS_STACK_CHART_VERSION" \
+    --set crds.upgradeJob.enabled=true \
+    --set crds.upgradeJob.forceConflicts=true \
+    -f monitoring-values.yaml
+else
+  echo "🟡 Skipped Prometheus Helm deployment."
+fi
 
 # Create ConfigMap for Trace Generator
 echo "🔵 Step 3: Creating ConfigMap for Trace Generator..."

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -34,7 +34,13 @@ uninstall_release() {
 release_status() {
   local output
 
-  output=$(helm status "$1" 2>/dev/null || true)
+  if ! output=$(helm status "$1" 2>&1); then
+    if grep -q "release: not found" <<< "$output"; then
+      return 0
+    fi
+    echo "$output" >&2
+    return 1
+  fi
   awk -F': ' '$1 == "STATUS" { print $2 }' <<< "$output"
 }
 

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -30,6 +30,25 @@ uninstall_release() {
   fi
 }
 
+release_status() {
+  helm status "$1" 2>/dev/null | awk -F': ' '$1 == "STATUS" { print $2; exit }'
+}
+
+prepare_upgrade_release() {
+  local name=$1
+  local status
+
+  status=$(release_status "$name")
+  case "$status" in
+    ""|deployed)
+      ;;
+    *)
+      echo "🟡 Helm release $name is in '$status' state. Reinstalling before upgrade."
+      uninstall_release "$name"
+      ;;
+  esac
+}
+
 case "$MODE" in
   upgrade|clean|local)
     echo "🔵 Running in '$MODE' mode..."
@@ -52,6 +71,8 @@ case "$MODE" in
 esac
 
 if [[ "$MODE" == "upgrade" ]]; then
+  prepare_upgrade_release jaeger
+  prepare_upgrade_release prometheus
   HELM_JAEGER_CMD="upgrade --install --wait"
   HELM_PROM_CMD="upgrade --install --wait"
 else

--- a/examples/otel-demo/README.md
+++ b/examples/otel-demo/README.md
@@ -43,7 +43,7 @@ ROLLOUT_TIMEOUT=900 ./deploy-all.sh clean
   - OpenSearch (single node) StatefulSet
   - OpenSearch Dashboards Deployment
 - Namespace `jaeger`:
-  - Jaeger all-in-one Deployment (storage=none)
+  - Jaeger all-in-one Deployment with OpenSearch-backed trace storage
   - HOTROD application
   - Jaeger Query ClusterIP service (jaeger-query-clusterip)
 - Namespace `otel-demo`:
@@ -69,6 +69,7 @@ kubectl get svc -n otel-demo
  - OpenSearch Dashboards:
 ```bash path=null start=null
 ./start-port-forward.sh
+```
 
 
 ## Customization
@@ -81,6 +82,11 @@ kubectl get svc -n otel-demo
   - `jaeger-query-service.yaml`
 
 You can adjust these files and re-run `./deploy-all.sh upgrade` to apply changes.
+
+The Jaeger deployment uses `jaeger-config.yaml` to configure the Jaeger v2
+`jaeger_storage` extension against the in-cluster OpenSearch service. The Helm
+chart storage type is set to `elasticsearch` for compatibility with the chart's
+persistent-storage wiring, while the Jaeger runtime config points at OpenSearch.
 
 ## Clean-up
 - Clean uninstall using cleanup.sh :
@@ -95,6 +101,5 @@ helm uninstall jaeger -n jaeger || true
 helm uninstall otel-demo -n otel-demo || true
 kubectl delete namespace opensearch jaeger otel-demo --ignore-not-found=true
 ```
-
 
 

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -156,6 +156,18 @@ adopt_resource_for_helm_release() {
     --overwrite
 }
 
+delete_deployment_before_helm_upgrade() {
+  local namespace=$1
+  local deployment=$2
+
+  if ! kubectl get deployment "$deployment" -n "$namespace" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "Deleting existing deployment $namespace/$deployment before Helm upgrade"
+  kubectl delete deployment "$deployment" -n "$namespace" --wait=true --timeout=120s
+}
+
 smoke_expect() {
   local url=$1
   local expected=$2
@@ -347,7 +359,7 @@ main() {
   if [[ "$MODE" == "upgrade" ]]; then
     adopt_resource_for_helm_release jaeger serviceaccount jaeger-hotrod jaeger
     adopt_resource_for_helm_release jaeger service jaeger-hotrod jaeger
-    adopt_resource_for_helm_release jaeger deployment jaeger-hotrod jaeger
+    delete_deployment_before_helm_upgrade jaeger jaeger-hotrod
   fi
 
   log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -16,6 +16,7 @@ HOTROD_IMAGE_TAG="${JAEGER_DEMO_HOTROD_IMAGE_TAG:-1.72.0}"
 IMAGE_PULL_POLICY="${JAEGER_DEMO_IMAGE_PULL_POLICY:-IfNotPresent}"
 PUBLIC_JAEGER_URL="${JAEGER_OTEL_DEMO_JAEGER_URL:-https://jaeger.demo.jaegertracing.io}"
 RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
+DEPLOY_SCOPE="${JAEGER_OTEL_DEMO_DEPLOY_SCOPE:-all}"
 
 case "$MODE" in
   upgrade|clean)
@@ -35,6 +36,16 @@ case "$MODE" in
     exit 1
     ;;
  esac
+
+case "$DEPLOY_SCOPE" in
+  jaeger|all)
+    ;;
+  *)
+    echo "Error: Invalid deploy scope '$DEPLOY_SCOPE'"
+    echo "Expected JAEGER_OTEL_DEMO_DEPLOY_SCOPE to be 'jaeger' or 'all'"
+    exit 1
+    ;;
+esac
 
 if [[ "$MODE" == "upgrade" ]]; then
   HELM_JAEGER_CMD="upgrade --install --wait"
@@ -140,6 +151,10 @@ smoke_expect() {
   log "Last response:"
   cat "$output" 2>/dev/null || true
   return 1
+}
+
+deploy_full_stack() {
+  [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" == "all" ]]
 }
 
 cleanup() {
@@ -285,22 +300,25 @@ main() {
   helm repo update >/dev/null
   clone_jaeger_v2
 
-  log "Deploying OpenSearch"
-  helm upgrade --install opensearch opensearch/opensearch \
-    --namespace opensearch --create-namespace \
-    --version 2.19.0 \
-    --set image.tag=2.11.0 \
-    -f "$SCRIPT_DIR/opensearch-values.yaml" \
-    --wait --timeout 10m
-  wait_for_statefulset opensearch opensearch-cluster-single "${ROLLOUT_TIMEOUT}s"
+  if deploy_full_stack; then
+    log "Deploying OpenSearch"
+    helm upgrade --install opensearch opensearch/opensearch \
+      --namespace opensearch --create-namespace \
+      --version 2.19.0 \
+      --set image.tag=2.11.0 \
+      -f "$SCRIPT_DIR/opensearch-values.yaml" \
+      --wait --timeout 10m
+    wait_for_statefulset opensearch opensearch-cluster-single "${ROLLOUT_TIMEOUT}s"
 
-  log "Deploying OpenSearch Dashboards"
-  helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards \
-    --namespace opensearch \
-    -f "$SCRIPT_DIR/opensearch-dashboard-values.yaml" \
-    --wait --timeout 10m
-  wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
-
+    log "Deploying OpenSearch Dashboards"
+    helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards \
+      --namespace opensearch \
+      -f "$SCRIPT_DIR/opensearch-dashboard-values.yaml" \
+      --wait --timeout 10m
+    wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
+  else
+    log "Skipping OpenSearch refresh in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
+  fi
 
   log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"
   log "Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${HOTROD_IMAGE_TAG}"
@@ -335,14 +353,18 @@ main() {
   kubectl apply -n jaeger -f "$SCRIPT_DIR/load-generator.yaml"
   wait_for_deployment jaeger trace-generator "${ROLLOUT_TIMEOUT}s"
 
-  log "Deploying OpenTelemetry Demo (with in-cluster Collector)"
-  helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
-    -f "$SCRIPT_DIR/otel-demo-values.yaml" \
-    --namespace otel-demo --create-namespace \
-    --wait --timeout 15m
-  wait_for_deployment otel-demo otel-collector "${ROLLOUT_TIMEOUT}s"
-  wait_for_deployment otel-demo frontend "${ROLLOUT_TIMEOUT}s"
-  wait_for_deployment otel-demo load-generator "${ROLLOUT_TIMEOUT}s"
+  if deploy_full_stack; then
+    log "Deploying OpenTelemetry Demo (with in-cluster Collector)"
+    helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
+      -f "$SCRIPT_DIR/otel-demo-values.yaml" \
+      --namespace otel-demo --create-namespace \
+      --wait --timeout 15m
+    wait_for_deployment otel-demo otel-collector "${ROLLOUT_TIMEOUT}s"
+    wait_for_deployment otel-demo frontend "${ROLLOUT_TIMEOUT}s"
+    wait_for_deployment otel-demo load-generator "${ROLLOUT_TIMEOUT}s"
+  else
+    log "Skipping OpenTelemetry Demo refresh in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
+  fi
 
   log "All components deployed successfully"
 

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -109,6 +109,21 @@ diagnose_deployment_failure() {
   kubectl -n "$namespace" get events --sort-by=.lastTimestamp | tail -80 || true
 }
 
+diagnose_otel_demo_failure() {
+  log "Collecting diagnostics for namespace otel-demo"
+  kubectl -n otel-demo get deploy,daemonset,replicaset,pods,svc,endpoints -o wide || true
+  kubectl -n otel-demo describe daemonset otel-collector-agent || true
+  kubectl -n otel-demo describe deployment postgresql || true
+  kubectl -n otel-demo describe deployment product-catalog || true
+  kubectl -n otel-demo describe pods -l app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/instance=otel-demo || true
+  kubectl -n otel-demo describe pods -l opentelemetry.io/name=postgresql || true
+  kubectl -n otel-demo describe pods -l opentelemetry.io/name=product-catalog || true
+  kubectl -n otel-demo logs -l app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/instance=otel-demo --all-containers --tail=200 --prefix || true
+  kubectl -n otel-demo logs -l opentelemetry.io/name=postgresql --all-containers --tail=200 --prefix || true
+  kubectl -n otel-demo logs -l opentelemetry.io/name=product-catalog --all-containers --tail=200 --prefix || true
+  kubectl -n otel-demo get events --sort-by=.lastTimestamp | tail -120 || true
+}
+
 wait_for_statefulset() {
   local namespace="$1"
   local sts="$2"
@@ -412,10 +427,13 @@ main() {
 
   if deploy_full_stack; then
     log "Deploying OpenTelemetry Demo (with in-cluster Collector)"
-    helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
+    if ! helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
       -f "$SCRIPT_DIR/otel-demo-values.yaml" \
       --namespace otel-demo --create-namespace \
-      --wait --timeout 15m
+      --wait --timeout 15m; then
+      diagnose_otel_demo_failure
+      err "Helm release otel-demo failed"
+    fi
     wait_for_deployment otel-demo otel-collector "${ROLLOUT_TIMEOUT}s"
     wait_for_deployment otel-demo frontend "${ROLLOUT_TIMEOUT}s"
     wait_for_deployment otel-demo load-generator "${ROLLOUT_TIMEOUT}s"

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -8,7 +8,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-600}"
 
 MODE="${1:-upgrade}"
-IMAGE_TAG="${2:-latest}"
+IMAGE_TAG="${2:-${JAEGER_DEMO_IMAGE_TAG:-latest}}"
+JAEGER_IMAGE_REPOSITORY="${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY:-jaegertracing/jaeger}"
+HOTROD_IMAGE_REPOSITORY="${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY:-jaegertracing/example-hotrod}"
+JAEGER_IMAGE_TAG="${JAEGER_DEMO_JAEGER_IMAGE_TAG:-$IMAGE_TAG}"
+HOTROD_IMAGE_TAG="${JAEGER_DEMO_HOTROD_IMAGE_TAG:-1.72.0}"
+IMAGE_PULL_POLICY="${JAEGER_DEMO_IMAGE_PULL_POLICY:-IfNotPresent}"
+PUBLIC_JAEGER_URL="${JAEGER_OTEL_DEMO_JAEGER_URL:-https://jaeger.demo.jaegertracing.io}"
+RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
 
 case "$MODE" in
   upgrade|clean)
@@ -30,10 +37,10 @@ case "$MODE" in
  esac
 
 if [[ "$MODE" == "upgrade" ]]; then
-  HELM_JAEGER_CMD="upgrade --install --force"
+  HELM_JAEGER_CMD="upgrade --install --wait"
 else
   # For clean mode, use install after cleanup
-  HELM_JAEGER_CMD="install"
+  HELM_JAEGER_CMD="install --wait"
 fi
 
 log() { echo "[$(date +"%F %T")] $*"; }
@@ -112,6 +119,27 @@ wait_for_service_endpoints() {
   kubectl get svc "$service" -n "$namespace" -o wide || true
   kubectl get endpoints "$service" -n "$namespace" -o yaml || true
   err "Service $service in $namespace has no ready endpoints after ${timeout_secs}s"
+}
+
+smoke_expect() {
+  local url=$1
+  local expected=$2
+  local output=$3
+
+  for attempt in $(seq 1 12); do
+    if curl -fsS "$url" -o "$output" && grep -q "$expected" "$output"; then
+      log "Smoke check passed: $url"
+      return 0
+    fi
+    log "Waiting for $url to return expected content (attempt $attempt/12)..."
+    sleep 10
+  done
+
+  log "Smoke check failed: $url"
+  log "Expected content: $expected"
+  log "Last response:"
+  cat "$output" 2>/dev/null || true
+  return 1
 }
 
 cleanup() {
@@ -274,16 +302,21 @@ main() {
   wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
 
 
-  log "Deploying Jaeger (all-in-one, no storage)"
+  log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"
+  log "Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${HOTROD_IMAGE_TAG}"
   helm $HELM_JAEGER_CMD jaeger "$SCRIPT_DIR/helm-charts/charts/jaeger" \
     --namespace jaeger --create-namespace \
     --set allInOne.enabled=true \
     --set storage.type=none \
-    --set allInOne.image.repository=jaegertracing/jaeger \
-    --set allInOne.image.tag="${IMAGE_TAG}" \
+    --set allInOne.image.repository="${JAEGER_IMAGE_REPOSITORY}" \
+    --set allInOne.image.tag="${JAEGER_IMAGE_TAG}" \
+    --set allInOne.image.pullPolicy="${IMAGE_PULL_POLICY}" \
+    --set hotrod.image.repository="${HOTROD_IMAGE_REPOSITORY}" \
+    --set hotrod.image.tag="${HOTROD_IMAGE_TAG}" \
+    --set hotrod.image.pullPolicy="${IMAGE_PULL_POLICY}" \
     --set-file userconfig="$SCRIPT_DIR/jaeger-config.yaml" \
     -f "$SCRIPT_DIR/jaeger-values.yaml" \
-    --wait --timeout 10m
+    --timeout 10m
   wait_for_deployment jaeger jaeger "${ROLLOUT_TIMEOUT}s"
 
 
@@ -315,6 +348,12 @@ main() {
 
   # Deploy HTTPS ingress
   deploy_ingress
+
+  if [[ "$RUN_PUBLIC_SMOKE_TESTS" == "true" ]]; then
+    log "Verifying public OTel demo endpoints..."
+    smoke_expect "${PUBLIC_JAEGER_URL}/search" "${JAEGER_IMAGE_TAG}" /tmp/otel-jaeger-search.html
+    smoke_expect "${PUBLIC_JAEGER_URL}/api/services" "otelstore-frontend-ui" /tmp/otel-jaeger-services.json
+  fi
 
   log "🎉 Deployment complete! Stack is ready."
 

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -452,7 +452,7 @@ main() {
 
   if [[ "$RUN_PUBLIC_SMOKE_TESTS" == "true" ]]; then
     log "Verifying public OTel demo endpoints..."
-    smoke_expect "${PUBLIC_JAEGER_URL}/search" "${JAEGER_IMAGE_TAG}" /tmp/otel-jaeger-search.html
+    smoke_expect "${PUBLIC_JAEGER_URL}/search" "Jaeger UI" /tmp/otel-jaeger-search.html
     smoke_expect "${PUBLIC_JAEGER_URL}/api/services" "otelstore-frontend-ui" /tmp/otel-jaeger-services.json
   fi
 

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -132,24 +132,25 @@ wait_for_service_endpoints() {
   err "Service $service in $namespace has no ready endpoints after ${timeout_secs}s"
 }
 
-adopt_service_for_helm_release() {
+adopt_resource_for_helm_release() {
   local namespace=$1
-  local service=$2
-  local release=$3
+  local kind=$2
+  local name=$3
+  local release=$4
 
-  if ! kubectl get service "$service" -n "$namespace" >/dev/null 2>&1; then
+  if ! kubectl get "$kind" "$name" -n "$namespace" >/dev/null 2>&1; then
     return 0
   fi
 
   local managed_by
-  managed_by=$(kubectl get service "$service" -n "$namespace" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>/dev/null || true)
+  managed_by=$(kubectl get "$kind" "$name" -n "$namespace" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>/dev/null || true)
   if [[ "$managed_by" == "Helm" ]]; then
     return 0
   fi
 
-  log "Adopting existing service $namespace/$service into Helm release $release"
-  kubectl label service "$service" -n "$namespace" app.kubernetes.io/managed-by=Helm --overwrite
-  kubectl annotate service "$service" -n "$namespace" \
+  log "Adopting existing $kind $namespace/$name into Helm release $release"
+  kubectl label "$kind" "$name" -n "$namespace" app.kubernetes.io/managed-by=Helm --overwrite
+  kubectl annotate "$kind" "$name" -n "$namespace" \
     meta.helm.sh/release-name="$release" \
     meta.helm.sh/release-namespace="$namespace" \
     --overwrite
@@ -344,7 +345,9 @@ main() {
   fi
 
   if [[ "$MODE" == "upgrade" ]]; then
-    adopt_service_for_helm_release jaeger jaeger-hotrod jaeger
+    adopt_resource_for_helm_release jaeger serviceaccount jaeger-hotrod jaeger
+    adopt_resource_for_helm_release jaeger service jaeger-hotrod jaeger
+    adopt_resource_for_helm_release jaeger deployment jaeger-hotrod jaeger
   fi
 
   log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -132,6 +132,29 @@ wait_for_service_endpoints() {
   err "Service $service in $namespace has no ready endpoints after ${timeout_secs}s"
 }
 
+adopt_service_for_helm_release() {
+  local namespace=$1
+  local service=$2
+  local release=$3
+
+  if ! kubectl get service "$service" -n "$namespace" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local managed_by
+  managed_by=$(kubectl get service "$service" -n "$namespace" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>/dev/null || true)
+  if [[ "$managed_by" == "Helm" ]]; then
+    return 0
+  fi
+
+  log "Adopting existing service $namespace/$service into Helm release $release"
+  kubectl label service "$service" -n "$namespace" app.kubernetes.io/managed-by=Helm --overwrite
+  kubectl annotate service "$service" -n "$namespace" \
+    meta.helm.sh/release-name="$release" \
+    meta.helm.sh/release-namespace="$namespace" \
+    --overwrite
+}
+
 smoke_expect() {
   local url=$1
   local expected=$2
@@ -318,6 +341,10 @@ main() {
     wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
   else
     log "Skipping OpenSearch refresh in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
+  fi
+
+  if [[ "$MODE" == "upgrade" ]]; then
+    adopt_service_for_helm_release jaeger jaeger-hotrod jaeger
   fi
 
   log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -91,10 +91,22 @@ wait_for_deployment() {
   if ! kubectl rollout status "deployment/$deployment" -n "$namespace" --timeout="$timeout"; then
     kubectl -n "$namespace" get deploy "$deployment" -o wide || true
     kubectl -n "$namespace" describe deploy "$deployment" || true
-    kubectl -n "$namespace" get pods -l app.kubernetes.io/name="$deployment" -o wide || true
+    kubectl -n "$namespace" get pods -o wide || true
     err "Deployment $deployment failed to become ready in $namespace"
   fi
   log "Deployment $deployment is ready"
+}
+
+diagnose_deployment_failure() {
+  local namespace=$1
+  local deployment=$2
+
+  log "Collecting diagnostics for deployment $namespace/$deployment"
+  kubectl -n "$namespace" get deploy,replicaset,pods,svc,endpoints -o wide || true
+  kubectl -n "$namespace" describe deploy "$deployment" || true
+  kubectl -n "$namespace" describe pods -l app.kubernetes.io/instance=jaeger || true
+  kubectl -n "$namespace" logs -l app.kubernetes.io/instance=jaeger --all-containers --tail=200 --prefix || true
+  kubectl -n "$namespace" get events --sort-by=.lastTimestamp | tail -80 || true
 }
 
 wait_for_statefulset() {
@@ -364,10 +376,10 @@ main() {
 
   log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"
   log "Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${HOTROD_IMAGE_TAG}"
-  helm $HELM_JAEGER_CMD jaeger "$SCRIPT_DIR/helm-charts/charts/jaeger" \
+  if ! helm $HELM_JAEGER_CMD jaeger "$SCRIPT_DIR/helm-charts/charts/jaeger" \
     --namespace jaeger --create-namespace \
     --set allInOne.enabled=true \
-    --set storage.type=none \
+    --set storage.type=memory \
     --set allInOne.image.repository="${JAEGER_IMAGE_REPOSITORY}" \
     --set allInOne.image.tag="${JAEGER_IMAGE_TAG}" \
     --set allInOne.image.pullPolicy="${IMAGE_PULL_POLICY}" \
@@ -376,7 +388,10 @@ main() {
     --set hotrod.image.pullPolicy="${IMAGE_PULL_POLICY}" \
     --set-file userconfig="$SCRIPT_DIR/jaeger-config.yaml" \
     -f "$SCRIPT_DIR/jaeger-values.yaml" \
-    --timeout 10m
+    --timeout 10m; then
+    diagnose_deployment_failure jaeger jaeger
+    err "Helm release jaeger failed"
+  fi
   wait_for_deployment jaeger jaeger "${ROLLOUT_TIMEOUT}s"
 
 

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -14,9 +14,9 @@ HOTROD_IMAGE_REPOSITORY="${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY:-jaegertracing/ex
 JAEGER_IMAGE_TAG="${JAEGER_DEMO_JAEGER_IMAGE_TAG:-$IMAGE_TAG}"
 HOTROD_IMAGE_TAG="${JAEGER_DEMO_HOTROD_IMAGE_TAG:-1.72.0}"
 IMAGE_PULL_POLICY="${JAEGER_DEMO_IMAGE_PULL_POLICY:-IfNotPresent}"
-PUBLIC_JAEGER_URL="${JAEGER_OTEL_DEMO_JAEGER_URL:-https://jaeger.demo.jaegertracing.io}"
+PUBLIC_JAEGER_URL="${JAEGER_DEMO_PUBLIC_JAEGER_URL:-${JAEGER_OTEL_DEMO_JAEGER_URL:-https://jaeger.demo.jaegertracing.io}}"
 RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
-DEPLOY_SCOPE="${JAEGER_OTEL_DEMO_DEPLOY_SCOPE:-all}"
+DEPLOY_SCOPE="${JAEGER_OTEL_DEMO_DEPLOY_SCOPE:-jaeger}"
 
 case "$MODE" in
   upgrade|clean)
@@ -201,7 +201,7 @@ smoke_expect() {
   local output=$3
 
   for attempt in $(seq 1 12); do
-    if curl -fsS "$url" -o "$output" && grep -q "$expected" "$output"; then
+    if curl --connect-timeout 5 --max-time 20 -fsS "$url" -o "$output" && grep -Fq "$expected" "$output"; then
       log "Smoke check passed: $url"
       return 0
     fi
@@ -394,7 +394,11 @@ main() {
   if ! helm $HELM_JAEGER_CMD jaeger "$SCRIPT_DIR/helm-charts/charts/jaeger" \
     --namespace jaeger --create-namespace \
     --set allInOne.enabled=true \
-    --set storage.type=memory \
+    --set storage.type=elasticsearch \
+    --set storage.elasticsearch.anonymous=true \
+    --set storage.elasticsearch.usePassword=false \
+    --set storage.elasticsearch.host=opensearch-cluster-single.opensearch.svc.cluster.local \
+    --set storage.elasticsearch.port=9200 \
     --set allInOne.image.repository="${JAEGER_IMAGE_REPOSITORY}" \
     --set allInOne.image.tag="${JAEGER_IMAGE_TAG}" \
     --set allInOne.image.pullPolicy="${IMAGE_PULL_POLICY}" \

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -85,6 +85,16 @@ components:
 opentelemetry-collector:
   image:
     repository: docker.io/otel/opentelemetry-collector-contrib
+  presets:
+    hostMetrics:
+      enabled: false
+    kubeletMetrics:
+      enabled: false
+    clusterMetrics:
+      enabled: false
+    annotationDiscovery:
+      metrics:
+        enabled: false
   config:
     receivers:
       otlp:
@@ -119,7 +129,14 @@ opentelemetry-collector:
       debug: null
       otlp: null
     service:
-      telemetry: null
+      telemetry:
+        metrics:
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: 8888
       pipelines:
         traces:
           receivers: [otlp]

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -19,8 +19,41 @@ default:
     # Narrower service namespace + explicit environment tag
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),service.namespace=otel-demo,deployment.environment=oke-dev
+    # The in-cluster collector is traces-only. Disable SDK logs/metrics export noise.
+    - name: OTEL_LOGS_EXPORTER
+      value: none
+    - name: OTEL_METRICS_EXPORTER
+      value: none
 
 components:
+  ad:
+    useDefault:
+      env: false
+    env:
+      - name: OTEL_SERVICE_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: "metadata.labels['app.kubernetes.io/component']"
+      - name: OTEL_COLLECTOR_NAME
+        value: otel-collector
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        value: cumulative
+      - name: OTEL_LOGS_EXPORTER
+        value: none
+      - name: OTEL_METRICS_EXPORTER
+        value: none
+      - name: AD_PORT
+        value: "8080"
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4318
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        value: service.name=$(OTEL_SERVICE_NAME),service.namespace=otel-demo,deployment.environment=oke-dev
+
   accounting:
     initContainers:
       - name: wait-for-kafka

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -13,25 +13,12 @@ grafana:
 opensearch:
   enabled: false
 
-# Preserve default.env (to keep OTEL_SERVICE_NAME and OTEL_COLLECTOR_NAME) and override only what we need
+# Preserve default.env (to keep OTEL_SERVICE_NAME and OTEL_COLLECTOR_NAME) and add only shared attributes.
 default:
   envOverrides:
     # Narrower service namespace + explicit environment tag
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=$(OTEL_SERVICE_NAME),service.namespace=otel-demo,deployment.environment=oke-dev
-    # Send OTLP over HTTP by default and disable metrics/logs exporters (traces only)
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://otel-collector:4318
-    - name: OTEL_EXPORTER_OTLP_PROTOCOL
-      value: http/protobuf
-    - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-      value: http/protobuf
-    - name: OTEL_LOGS_EXPORTER
-      value: none
-    - name: OTEL_METRICS_EXPORTER
-      value: none
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
 
 components:
   accounting:

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -69,6 +69,9 @@ components:
       tag: "8.1.3-alpine"
 
   postgresql:
+    imageOverride:
+      repository: docker.io/library/postgres
+      tag: "17.6"
     resources:
       limits:
         memory: 256Mi
@@ -134,7 +137,10 @@ opentelemetry-collector:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
     processors:
-      memory_limiter: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       k8sattributes: {}
       resource:
         attributes:

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -68,6 +68,31 @@ components:
       repository: docker.io/valkey/valkey
       tag: "8.1.3-alpine"
 
+  postgresql:
+    resources:
+      limits:
+        memory: 256Mi
+
+  product-catalog:
+    env:
+      - name: PRODUCT_CATALOG_PORT
+        value: "8080"
+      - name: FLAGD_HOST
+        value: flagd
+      - name: FLAGD_PORT
+        value: "8013"
+      - name: GOMEMLIMIT
+        value: 48MiB
+      - name: DB_CONNECTION_STRING
+        value: postgres://otelu:otelp@postgresql/otel?sslmode=disable
+      - name: OTEL_SEMCONV_STABILITY_OPT_IN
+        value: database
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://$(OTEL_COLLECTOR_NAME):4317
+    resources:
+      limits:
+        memory: 64Mi
+
 # Override Collector config to export traces to Jaeger only and drop demo metrics/logs
 opentelemetry-collector:
   image:
@@ -82,7 +107,20 @@ opentelemetry-collector:
     annotationDiscovery:
       metrics:
         enabled: false
-  config:
+  ports:
+    otlp:
+      hostPort: null
+    otlp-http:
+      hostPort: null
+    jaeger-compact:
+      hostPort: null
+    jaeger-grpc:
+      hostPort: null
+    jaeger-thrift:
+      hostPort: null
+    zipkin:
+      hostPort: null
+  alternateConfig:
     receivers:
       otlp:
         protocols:
@@ -92,8 +130,9 @@ opentelemetry-collector:
               allowed_origins:
                 - http://*
                 - https://*
-      httpcheck/frontend-proxy: null
-      redis: null
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     processors:
       memory_limiter: {}
       k8sattributes: {}
@@ -102,20 +141,14 @@ opentelemetry-collector:
           - key: service.instance.id
             from_attribute: k8s.pod.uid
             action: insert
-      transform: null
       batch: {}
-    connectors:
-      spanmetrics: null
     exporters:
       otlp/jaeger:
         endpoint: jaeger-collector.jaeger.svc.cluster.local:4317
         tls:
           insecure: true
-      opensearch: null
-      otlphttp/prometheus: null
-      debug: null
-      otlp: null
     service:
+      extensions: [health_check]
       telemetry:
         metrics:
           readers:
@@ -129,5 +162,3 @@ opentelemetry-collector:
           receivers: [otlp]
           processors: [memory_limiter, k8sattributes, resource, batch]
           exporters: [otlp/jaeger]
-        metrics: null
-        logs: null


### PR DESCRIPTION
Fixes #8798

## Summary
- Remove `--force` from OKE demo Helm upgrades so Helm v4 can roll the demo forward.
- Keep normal upgrade mode as `helm upgrade --install --wait` for Jaeger image/tag roll-forward.
- Add workflow controls for selecting the original OCI demo, the OTel demo, or both demo stacks.
- Add an OTel deploy scope so routine upgrades can refresh only Jaeger while clean installs or explicit `all` scope can refresh OpenSearch and the OTel app.
- Harden live-rollout recovery and diagnostics for stale Helm releases, adopted HotROD resources, OTel collector config, and demo smoke tests.

## Why
After #8797 published fresh Jaeger and HotROD snapshot images, manual OKE deploy run `27698433713` failed under Helm v4.2.1. Helm reported:

```text
Flag --force has been deprecated, use --force-replace instead
Error: UPGRADE FAILED: invalid operation: cannot use server-side apply and force replace together
```

Follow-up manual deploy runs exposed additional live-cluster state in the OKE demos: a non-deployed Prometheus release, pre-existing HotROD resources, OTel collector config drift, ambiguous OTel demo deploy scope, and an OTel Jaeger storage mismatch. This PR keeps the original fix and folds in the rollout guards needed for the demo workflow to recover predictably.

## Validation
- `bash -n examples/otel-demo/deploy-all.sh examples/oci/deploy-all.sh`
- `git diff --check`
- `helm lint /tmp/jaeger-helm-charts-v2/charts/jaeger -f examples/otel-demo/jaeger-values.yaml ...`
- `helm lint /tmp/otel-demo-lint/opentelemetry-demo -f examples/otel-demo/otel-demo-values.yaml`
- Rendered the Jaeger Helm chart and verified `SPAN_STORAGE_TYPE=elasticsearch`, the OpenSearch service URL, no ES password secret, and the custom `jaeger_storage` config.
- Rendered the OTel demo chart and verified the collector config has `memory_limiter.check_interval=5s`, `health_check`, and no rendered `hostPort`.
- `make fmt`
- `make lint`
- `make test`
