### PR TITLE
chore: replace fswatcher with periodic refresh in ES factory

### DIFF
--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -6,7 +6,6 @@ package elasticsearch
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,13 +13,14 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"time"
+
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/internal/fswatcher"
 	"github.com/jaegertracing/jaeger/internal/metrics"
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
@@ -46,7 +46,7 @@ type FactoryBase struct {
 
 	client atomic.Pointer[es.Client]
 
-	pwdFileWatcher *fswatcher.FSWatcher
+	pwdRefreshStop chan struct{}
 
 	templateBuilder es.TemplateBuilder
 
@@ -82,11 +82,11 @@ func NewFactoryBase(
 
 	if f.config.Authentication.BasicAuthentication.HasValue() {
 		if file := f.config.Authentication.BasicAuthentication.Get().PasswordFilePath; file != "" {
-			watcher, err := fswatcher.New([]string{file}, f.onPasswordChange, f.logger)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create watcher for ES client's password: %w", err)
+			if _, err := loadTokenFromFile(file); err != nil {
+				return nil, fmt.Errorf("failed to initialize basic authentication: %w", fmt.Errorf("failed to get token from file: %w", err))
 			}
-			f.pwdFileWatcher = watcher
+			f.pwdRefreshStop = make(chan struct{})
+			go f.refreshPasswordFromFile(file)
 		}
 	}
 
@@ -192,14 +192,23 @@ func (f *FactoryBase) mappingBuilderFromConfig(cfg *config.Configuration) mappin
 
 // Close closes the resources held by the factory
 func (f *FactoryBase) Close() error {
-	var errs []error
-
-	if f.pwdFileWatcher != nil {
-		errs = append(errs, f.pwdFileWatcher.Close())
+	if f.pwdRefreshStop != nil {
+		close(f.pwdRefreshStop)
 	}
-	errs = append(errs, f.getClient().Close())
+	return f.getClient().Close()
+}
 
-	return errors.Join(errs...)
+func (f *FactoryBase) refreshPasswordFromFile(filePath string) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			f.onPasswordChange()
+		case <-f.pwdRefreshStop:
+			return
+		}
+	}
 }
 
 func (f *FactoryBase) onPasswordChange() {

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -497,7 +497,7 @@ func TestPasswordFromFileErrors(t *testing.T) {
 	f.onPasswordChange()
 }
 
-func TestFactoryBase_NewClient_WatcherError(t *testing.T) {
+func TestFactoryBase_NewClient_PasswordFileError(t *testing.T) {
 	cfg := escfg.Configuration{
 		Servers:  []string{"http://localhost:9200"},
 		LogLevel: "debug",


### PR DESCRIPTION
Closes #8748

The only remaining use of `fswatcher` was in `internal/storage/v1/elasticsearch/factory.go` to watch the password file and recreate the ES client when it changed.

This replaces it with a background goroutine that polls the password file every minute and calls `onPasswordChange` if the file can be read. This removes the `fsnotify` dependency from this code path and eliminates the historically flaky unit tests associated with the file watcher.

**Changes:**
- Remove `pwdFileWatcher *fswatcher.FSWatcher` field, replace with `pwdRefreshStop chan struct{}`
- Validate password file is readable on startup (preserves error behavior)
- Start background goroutine `refreshPasswordFromFile` that ticks every minute
- Stop goroutine cleanly in `Close()`
- Rename test to reflect new behavior