### PR TITLE
[chore] Close idle connections for http clients in integration tests

### DIFF
--- a/cmd/jaeger/internal/integration/binary.go
+++ b/cmd/jaeger/internal/integration/binary.go
@@ -60,9 +60,9 @@ func (b *Binary) Start(t *testing.T) {
 			b.dumpLogs(t, outFile, errFile)
 		}
 	})
-
+	client := testingHttpClient(t)
 	// Wait for the binary to start and become ready to serve requests.
-	require.Eventually(t, func() bool { return b.doHealthCheck(t) },
+	require.Eventually(t, func() bool { return b.doHealthCheck(t, client) },
 		time.Minute, time.Second, "%s did not start", b.Name)
 	t.Logf("%s is ready", b.Name)
 }
@@ -80,7 +80,7 @@ func (b *Binary) Stop(t *testing.T) {
 	t.Logf("%s exited", b.Name)
 }
 
-func (b *Binary) doHealthCheck(t *testing.T) bool {
+func (b *Binary) doHealthCheck(t *testing.T, client *http.Client) bool {
 	healthCheckPort := b.HealthCheckPort
 	if healthCheckPort == 0 {
 		healthCheckPort = ports.CollectorV2HealthChecks
@@ -94,7 +94,7 @@ func (b *Binary) doHealthCheck(t *testing.T) bool {
 		t.Logf("HTTP request creation failed: %v", err)
 		return false
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Logf("HTTP request failed: %v", err)
 		return false

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -143,7 +143,7 @@ func (s *E2EStorageIntegration) scrapeMetrics(t *testing.T, storage string) {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, metricsUrl, http.NoBody)
 	require.NoError(t, err)
 
-	client := &http.Client{}
+	client := testingHttpClient(t)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -240,7 +240,7 @@ func purge(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, addr, http.NoBody)
 	require.NoError(t, err)
 
-	client := &http.Client{}
+	client := testingHttpClient(t)
 
 	resp, err := client.Do(r)
 	require.NoError(t, err)
@@ -249,4 +249,12 @@ func purge(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", string(body))
+}
+
+func testingHttpClient(t *testing.T) *http.Client {
+	cl := http.DefaultClient
+	t.Cleanup(func() {
+		cl.CloseIdleConnections()
+	})
+	return cl
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards: #8691 

## Description of the changes
- When jaeger is stopped in between the test, http clients for writing/reading phase still remain and so as their go routines causing leaks. To fix them, idle connections are closed on cleanup.

## How was this change tested?
- Integration Tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
