### PR TITLE
fix(test): Abort FindTraces early on subtest failure to prevent cascading timeouts

### DIFF
--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -243,13 +243,27 @@ func (s *StorageIntegration) waitForBackendReady(t *testing.T, traces map[string
 	t.Logf("Waiting for backend to be ready for attribute-based queries (testing with service=%s, attribute count=%d)",
 		serviceName, sampleAttrs.Len())
 
+	// Derive a tight time range from the sample trace so the readiness query can match
+	// fixtures that use fixed historical timestamps.
+	var minStart, maxEnd time.Time
+	for _, span := range jptrace.SpanIter(sampleTrace) {
+		start := span.StartTimestamp().AsTime()
+		end := span.EndTimestamp().AsTime()
+		if minStart.IsZero() || start.Before(minStart) {
+			minStart = start
+		}
+		if maxEnd.IsZero() || end.After(maxEnd) {
+			maxEnd = end
+		}
+	}
+
 	// Try a simple query with the sample attribute to ensure attribute metadata is available
 	found := s.waitForCondition(t, func(t *testing.T) bool {
 		query := tracestore.TraceQueryParams{
 			ServiceName:  serviceName,
 			Attributes:   sampleAttrs,
-			StartTimeMin: time.Now().Add(-72 * time.Hour),
-			StartTimeMax: time.Now().Add(1 * time.Hour),
+			StartTimeMin: minStart.Add(-time.Minute),
+			StartTimeMax: maxEnd.Add(time.Minute),
 			SearchDepth:  10,
 		}
 		iterTraces := s.TraceReader.FindTraces(context.Background(), query)

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -248,7 +248,7 @@ func (s *StorageIntegration) waitForBackendReady(t *testing.T, traces map[string
 		query := tracestore.TraceQueryParams{
 			ServiceName:  serviceName,
 			Attributes:   sampleAttrs,
-			StartTimeMin: time.Now().Add(-1 * time.Hour),
+			StartTimeMin: time.Now().Add(-72 * time.Hour),
 			StartTimeMax: time.Now().Add(1 * time.Hour),
 			SearchDepth:  10,
 		}

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -156,6 +156,104 @@ func (*StorageIntegration) waitForCondition(t *testing.T, predicate func(t *test
 	return predicate(t)
 }
 
+// waitForBackendReady ensures the storage backend has completed any asynchronous indexing
+// operations before running queries. This is particularly important for backends like
+// ClickHouse that use materialized views to populate metadata tables.
+//
+// For queries involving tags/attributes, the backend needs to have:
+// 1. Ingested the span data
+// 2. Updated any materialized views or secondary indexes
+// 3. Made attribute metadata available for query building
+//
+// This method performs a sample query with attributes to verify the backend is ready.
+func (s *StorageIntegration) waitForBackendReady(t *testing.T, traces map[string]ptrace.Traces) {
+	// Pick a trace that has attributes to test attribute metadata availability
+	var sampleTrace ptrace.Traces
+	for _, trace := range traces {
+		// Look for a trace with resource or span attributes
+		for pos, span := range jptrace.SpanIter(trace) {
+			if pos.Resource.Resource().Attributes().Len() > 0 || span.Attributes().Len() > 0 {
+				sampleTrace = trace
+				break
+			}
+		}
+		if sampleTrace.SpanCount() > 0 {
+			break
+		}
+	}
+
+	// If no traces with attributes found, skip this check
+	if sampleTrace.SpanCount() == 0 {
+		return
+	}
+
+	// Extract service name and a sample attribute from the trace
+	var serviceName string
+	sampleAttrs := pcommon.NewMap()
+	for pos, span := range jptrace.SpanIter(sampleTrace) {
+		if name, ok := pos.Resource.Resource().Attributes().Get("service.name"); ok {
+			serviceName = name.Str()
+		}
+		// Get one non-service.name attribute to test metadata lookup
+		// Try resource attributes first
+		pos.Resource.Resource().Attributes().Range(func(k string, v pcommon.Value) bool {
+			if k != "service.name" && sampleAttrs.Len() == 0 {
+				v.CopyTo(sampleAttrs.PutEmpty(k))
+				return false // stop after first attribute
+			}
+			return true
+		})
+		// If no resource attributes, try span attributes
+		if sampleAttrs.Len() == 0 {
+			span.Attributes().Range(func(k string, v pcommon.Value) bool {
+				if sampleAttrs.Len() == 0 {
+					v.CopyTo(sampleAttrs.PutEmpty(k))
+					return false // stop after first attribute
+				}
+				return true
+			})
+		}
+		if serviceName != "" && sampleAttrs.Len() > 0 {
+			break
+		}
+	}
+
+	// If we couldn't extract necessary info, skip
+	if serviceName == "" || sampleAttrs.Len() == 0 {
+		return
+	}
+
+	t.Logf("Waiting for backend to be ready for attribute-based queries (testing with service=%s, attribute count=%d)",
+		serviceName, sampleAttrs.Len())
+
+	// Try a simple query with the sample attribute to ensure attribute metadata is available
+	found := s.waitForCondition(t, func(t *testing.T) bool {
+		query := tracestore.TraceQueryParams{
+			ServiceName:  serviceName,
+			Attributes:   sampleAttrs,
+			StartTimeMin: time.Now().Add(-1 * time.Hour),
+			StartTimeMax: time.Now().Add(1 * time.Hour),
+			SearchDepth:  10,
+		}
+		iterTraces := s.TraceReader.FindTraces(context.Background(), query)
+		traces, err := jiter.CollectWithErrors(jptrace.AggregateTraces(iterTraces))
+		if err != nil {
+			t.Logf("Backend not ready yet - query failed: %v", err)
+			return false
+		}
+		if len(traces) == 0 {
+			t.Logf("Backend not ready yet - query returned no traces")
+			return false
+		}
+		t.Logf("Backend is ready - successfully queried traces with attributes")
+		return true
+	})
+
+	if !found {
+		t.Log("Warning: Backend did not become ready within timeout, but proceeding with tests")
+	}
+}
+
 func (s *StorageIntegration) testGetServices(t *testing.T) {
 	s.skipIfNeeded(t)
 	defer s.cleanUp(t)
@@ -366,6 +464,12 @@ func (s *StorageIntegration) testFindTraces(t *testing.T) {
 		}
 		expectedTracesPerTestCase = append(expectedTracesPerTestCase, expected)
 	}
+
+	// For storage backends that use asynchronous indexing (e.g., ClickHouse materialized views),
+	// wait for the backend to be ready before running queries. This is especially important for
+	// tag-based queries that depend on attribute metadata being populated.
+	s.waitForBackendReady(t, allTraceFixtures)
+
 	for i, queryTestCase := range s.Fixtures {
 		t.Run(queryTestCase.Caption, func(t *testing.T) {
 			s.skipIfNeeded(t)
@@ -373,6 +477,9 @@ func (s *StorageIntegration) testFindTraces(t *testing.T) {
 			actual := s.findTracesByQuery(t, queryTestCase.Query.ToTraceQueryParams(t), expected)
 			CompareTraceSlices(t, expected, actual)
 		})
+		if t.Failed() {
+			t.Fatal("Aborting remaining FindTraces queries because a subtest failed, to prevent cascading timeouts")
+		}
 	}
 }
 

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -197,18 +197,18 @@ func (s *StorageIntegration) waitForBackendReady(t *testing.T, traces map[string
 		// Get one non-service.name attribute to test metadata lookup
 		// Try resource attributes first
 		pos.Resource.Resource().Attributes().Range(func(k string, v pcommon.Value) bool {
-			if k != "service.name" && sampleAttrs.Len() == 0 {
-				v.CopyTo(sampleAttrs.PutEmpty(k))
-				return false // stop after first attribute
+			if k != "service.name" && sampleAttrs.Len() == 0 && v.Type() == pcommon.ValueTypeStr {
+				sampleAttrs.PutStr(k, v.Str())
+				return false // stop after first queryable attribute
 			}
 			return true
 		})
 		// If no resource attributes, try span attributes
 		if sampleAttrs.Len() == 0 {
 			span.Attributes().Range(func(k string, v pcommon.Value) bool {
-				if sampleAttrs.Len() == 0 {
-					v.CopyTo(sampleAttrs.PutEmpty(k))
-					return false // stop after first attribute
+				if sampleAttrs.Len() == 0 && v.Type() == pcommon.ValueTypeStr {
+					sampleAttrs.PutStr(k, v.Str())
+					return false // stop after first queryable attribute
 				}
 				return true
 			})

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -170,9 +170,26 @@ func (s *StorageIntegration) waitForBackendReady(t *testing.T, traces map[string
 	// Pick a trace that has attributes to test attribute metadata availability
 	var sampleTrace ptrace.Traces
 	for _, trace := range traces {
-		// Look for a trace with resource or span attributes
+		// Look for a trace with at least one queryable (string) attribute besides service.name.
 		for pos, span := range jptrace.SpanIter(trace) {
-			if pos.Resource.Resource().Attributes().Len() > 0 || span.Attributes().Len() > 0 {
+			hasQueryableAttr := false
+			pos.Resource.Resource().Attributes().Range(func(k string, v pcommon.Value) bool {
+				if k != "service.name" && v.Type() == pcommon.ValueTypeStr {
+					hasQueryableAttr = true
+					return false
+				}
+				return true
+			})
+			if !hasQueryableAttr {
+				span.Attributes().Range(func(_ string, v pcommon.Value) bool {
+					if v.Type() == pcommon.ValueTypeStr {
+						hasQueryableAttr = true
+						return false
+					}
+					return true
+				})
+			}
+			if hasQueryableAttr {
 				sampleTrace = trace
 				break
 			}

--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -266,9 +266,7 @@ func (s *StorageIntegration) waitForBackendReady(t *testing.T, traces map[string
 		return true
 	})
 
-	if !found {
-		t.Log("Warning: Backend did not become ready within timeout, but proceeding with tests")
-	}
+	require.True(t, found, "timed out waiting for backend to be ready for attribute-based queries (service=%s, attribute count=%d)", serviceName, sampleAttrs.Len())
 }
 
 func (s *StorageIntegration) testGetServices(t *testing.T) {


### PR DESCRIPTION
### Description
This PR addresses the root cause behind the confusing and completely opaque (unknown) test panics surfacing sporadically during CI runs for ClickHouse (`TestClickHouseStorage/FindTraces`).

Because ClickHouse utilizes asynchronous indexing (such as materialized views) to populate its metadata tables, queries targeting tags or attributes can execute before the indexing is complete. 

Additionally, if one subtest fails, subsequent subtests continue to run and block on their predicates, resulting in cascading timeouts that obscure the actual root failure.

### Short description of the changes
- Added a `waitForBackendReady` helper function to `StorageIntegration` that extracts a test attribute from the traces map and queries the reader until it returns the expected span.
- Integrated `waitForBackendReady` into `testFindTraces` so that tag-based queries are held back until the backend is ready.
- Updated the subtest loop in `testFindTraces` to call `t.Fatal` when a subtest fails, avoiding cascading timeouts.

### How was this tested?
- Formatted and ran `go vet ./internal/storage/integration/...`
- Ran integration tests locally via `go test -v ./internal/storage/integration/...`
