### PR TITLE
fix(remotesampling): Wait for HTTP and gRPC serve goroutines during Shutdown

### DIFF
--- a/cmd/jaeger/internal/extension/remotesampling/extension.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension.go
@@ -149,6 +149,8 @@ func (ext *rsExtension) Shutdown(ctx context.Context) error {
 		ext.grpcServer.GracefulStop()
 	}
 
+	ext.shutdownWG.Wait()
+
 	if ext.distLock != nil {
 		errs = append(errs, ext.distLock.Close())
 	}

--- a/cmd/jaeger/internal/extension/remotesampling/extension_test.go
+++ b/cmd/jaeger/internal/extension/remotesampling/extension_test.go
@@ -669,3 +669,55 @@ func (*mockFailingProvider) GetSamplingStrategy(_ context.Context, _ string) (*a
 func (*mockFailingProvider) Close() error {
 	return errors.New("mock provider close error")
 }
+
+func TestShutdownBlocksUntilServersExit(t *testing.T) {
+	ext := &rsExtension{
+		cfg:       &Config{},
+		telemetry: componenttest.NewNopTelemetrySettings(),
+	}
+
+	srv := &http.Server{
+		Addr: "localhost:0",
+	}
+	ln, err := net.Listen("tcp", srv.Addr)
+	require.NoError(t, err)
+
+	ext.httpServer = srv
+
+	serveFinished := make(chan struct{})
+	ext.shutdownWG.Go(func() {
+		defer close(serveFinished)
+		_ = ext.httpServer.Serve(ln)
+	})
+
+	grpcSrv := grpc.NewServer()
+	gln, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	ext.grpcServer = grpcSrv
+
+	grpcFinished := make(chan struct{})
+	ext.shutdownWG.Go(func() {
+		defer close(grpcFinished)
+		_ = ext.grpcServer.Serve(gln)
+	})
+
+	// Call Shutdown
+	err = ext.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	// Since Shutdown should block on shutdownWG.Wait(), both goroutines should have completed and closed their channels.
+	select {
+	case <-serveFinished:
+		// HTTP goroutine finished
+	default:
+		t.Fatal("Shutdown returned before the HTTP serve goroutine finished")
+	}
+
+	select {
+	case <-grpcFinished:
+		// gRPC goroutine finished
+	default:
+		t.Fatal("Shutdown returned before the gRPC serve goroutine finished")
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?
* Resolves #8817

## Description of the changes
- In `cmd/jaeger/internal/extension/remotesampling/extension.go`, added `ext.shutdownWG.Wait()` inside the `Shutdown` method. This blocks return until the serve goroutines spawned for HTTP and gRPC servers have terminated.
- In `cmd/jaeger/internal/extension/remotesampling/extension_test.go`, added the `TestShutdownBlocksUntilServersExit` unit test to verify that `Shutdown` waits for both serve goroutines to terminate before returning.

## How was this change tested?
Ran unit tests in the package:
```bash
go test -v ./cmd/jaeger/internal/extension/remotesampling/...
