### PR TITLE
feat: add proactive token context limit pruning and graceful degradation for Jaeger AI Gatewaygradation for Jaeger AI Gateway

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -35,6 +35,7 @@ const (
 	DefaultAIMaxRequestBodySize  int64 = 1 << 20 // 1 MiB
 	DefaultAIHealthCheckInterval       = 30 * time.Second
 	DefaultAIHealthCheckTimeout        = 2 * time.Second
+	DefaultAIModelContextLimit         = 8192
 )
 
 // AIConfig is the AI-related slice of QueryOptions. All defaults are seeded
@@ -57,6 +58,9 @@ type AIConfig struct {
 	// HealthCheckTimeout is the per-check timeout. Must be positive when
 	// HealthCheckInterval > 0; ignored when the checker is disabled.
 	HealthCheckTimeout time.Duration `mapstructure:"health_check_timeout" valid:"optional"`
+	// ModelContextLimit is the maximum number of tokens allowed in the model's context window.
+	// Defaults to 8192 if not specified.
+	ModelContextLimit int `mapstructure:"model_context_limit" valid:"optional"`
 }
 
 // DefaultOTLPProxyTarget is the loopback endpoint of the bundled OTel-collector
@@ -94,6 +98,9 @@ func (c *AIConfig) Validate() error {
 	}
 	if c.HealthCheckInterval > 0 && c.HealthCheckTimeout <= 0 {
 		return errors.New("ai.health_check_timeout must be positive when health_check_interval is positive")
+	}
+	if c.ModelContextLimit < 0 {
+		return errors.New("ai.model_context_limit must not be negative")
 	}
 	return nil
 }
@@ -135,6 +142,7 @@ func DefaultQueryOptions() QueryOptions {
 			MaxRequestBodySize:  DefaultAIMaxRequestBodySize,
 			HealthCheckInterval: DefaultAIHealthCheckInterval,
 			HealthCheckTimeout:  DefaultAIHealthCheckTimeout,
+			ModelContextLimit:   DefaultAIModelContextLimit,
 		}),
 		OTLPProxy: configoptional.Default(OTLPProxyConfig{
 			Target: DefaultOTLPProxyTarget,

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -23,6 +23,7 @@ func TestDefaultQueryOptions(t *testing.T) {
 	require.Equal(t, DefaultAIMaxRequestBodySize, aiCfg.MaxRequestBodySize)
 	require.Equal(t, DefaultAIHealthCheckInterval, aiCfg.HealthCheckInterval)
 	require.Equal(t, DefaultAIHealthCheckTimeout, aiCfg.HealthCheckTimeout)
+	require.Equal(t, DefaultAIModelContextLimit, aiCfg.ModelContextLimit)
 	require.NoError(t, aiCfg.Validate())
 
 	require.False(t, qo.OTLPProxy.HasValue())
@@ -46,6 +47,7 @@ func validAIConfig() AIConfig {
 		MaxRequestBodySize:  DefaultAIMaxRequestBodySize,
 		HealthCheckInterval: DefaultAIHealthCheckInterval,
 		HealthCheckTimeout:  DefaultAIHealthCheckTimeout,
+		ModelContextLimit:   DefaultAIModelContextLimit,
 	}
 }
 
@@ -91,4 +93,10 @@ func TestAIConfigValidateRejectsNonPositiveHealthCheckTimeoutWhenEnabled(t *test
 		require.EqualError(t, cfg.Validate(),
 			"ai.health_check_timeout must be positive when health_check_interval is positive")
 	}
+}
+
+func TestAIConfigValidateRejectsNegativeModelContextLimit(t *testing.T) {
+	cfg := validAIConfig()
+	cfg.ModelContextLimit = -1
+	require.EqualError(t, cfg.Validate(), "ai.model_context_limit must not be negative")
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
@@ -32,6 +32,7 @@ type ChatHandler struct {
 	sidecarWSURL       string
 	basePath           string
 	maxRequestBodySize int64
+	modelContextLimit  int
 }
 
 // NewChatHandler wires the chat endpoint against a sidecar WebSocket URL.
@@ -40,13 +41,14 @@ type ChatHandler struct {
 // on the handler for consistency with other route handlers in this
 // package (APIHandler, static_handler) even though ServeHTTP does not
 // currently read it.
-func NewChatHandler(logger *zap.Logger, ctxTools *ContextualToolsStore, sidecarWSURL, basePath string, maxRequestBodySize int64) *ChatHandler {
+func NewChatHandler(logger *zap.Logger, ctxTools *ContextualToolsStore, sidecarWSURL, basePath string, maxRequestBodySize int64, modelContextLimit int) *ChatHandler {
 	return &ChatHandler{
 		Logger:             logger,
 		ctxTools:           ctxTools,
 		sidecarWSURL:       sidecarWSURL,
 		basePath:           normalizeBasePath(basePath),
 		maxRequestBodySize: maxRequestBodySize,
+		modelContextLimit:  modelContextLimit,
 	}
 }
 
@@ -74,6 +76,44 @@ func (h *ChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "messages must include a user message with text content", http.StatusBadRequest)
 		return
+	}
+
+	// Estimate total tokens of prompt and context values, and prune if needed.
+	totalEstimatedTokens := estimateTokens(prompt)
+	for _, entry := range req.Context {
+		totalEstimatedTokens += estimateTokens(entry.Value)
+	}
+
+	limit := h.modelContextLimit
+	if limit <= 0 {
+		limit = DefaultAIModelContextLimit
+	}
+
+	if totalEstimatedTokens > limit {
+		// Attempt to prune trace context values to fit within the limit.
+		prunedContext := make([]aguitypes.Context, len(req.Context))
+		copy(prunedContext, req.Context)
+		anyPruned := false
+		for i, entry := range prunedContext {
+			if newVal, pruned := tryPruneTraceContext(entry.Value); pruned {
+				prunedContext[i].Value = newVal
+				anyPruned = true
+			}
+		}
+		if anyPruned {
+			req.Context = prunedContext
+			// Re-estimate tokens
+			totalEstimatedTokens = estimateTokens(prompt)
+			for _, entry := range req.Context {
+				totalEstimatedTokens += estimateTokens(entry.Value)
+			}
+		}
+
+		if totalEstimatedTokens > limit {
+			// Graceful Degradation: return a clear error warning to the UI
+			http.Error(w, "Trace too large for local model. Please filter or prune spans first.", http.StatusBadRequest)
+			return
+		}
 	}
 
 	// Reject blank tool names up front. Empty or whitespace-only names

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
@@ -80,8 +80,8 @@ func (h *ChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Estimate total tokens of prompt and context values, and prune if needed.
 	totalEstimatedTokens := estimateTokens(prompt)
-	for _, entry := range req.Context {
-		totalEstimatedTokens += estimateTokens(entry.Value)
+	for _, ctxText := range contextTextEntries(req.Context) {
+		totalEstimatedTokens += estimateTokens(ctxText)
 	}
 
 	limit := h.modelContextLimit
@@ -104,14 +104,14 @@ func (h *ChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			req.Context = prunedContext
 			// Re-estimate tokens
 			totalEstimatedTokens = estimateTokens(prompt)
-			for _, entry := range req.Context {
-				totalEstimatedTokens += estimateTokens(entry.Value)
+			for _, ctxText := range contextTextEntries(req.Context) {
+				totalEstimatedTokens += estimateTokens(ctxText)
 			}
 		}
 
 		if totalEstimatedTokens > limit {
 			// Graceful Degradation: return a clear error warning to the UI
-			http.Error(w, "Trace too large for local model. Please filter or prune spans first.", http.StatusBadRequest)
+			http.Error(w, "Request too large for local model. Please filter or prune spans first.", http.StatusBadRequest)
 			return
 		}
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler_test.go
@@ -749,7 +749,7 @@ func TestChatHandlerModelContextLimitAndPruning(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Trace too large for local model")
+	assert.Contains(t, rr.Body.String(), "Request too large for local model")
 
 	// 2. Case where context is pruned and fits within limit -> proceeds successfully
 	handlerOk := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 70)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/internal/uimodel"
 	"github.com/jaegertracing/jaeger/internal/version"
 )
 
@@ -195,7 +196,7 @@ func TestChatHandlerSendsACPProtocolRequests(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "/jaeger", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "/jaeger", 1<<20, 8192)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -240,7 +241,7 @@ func TestChatHandlerAppendsContextEntriesToPromptBlocks(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "where is the latency?"}},
@@ -279,7 +280,7 @@ func TestChatHandlerAttachesContextualToolsToMetaAndStore(t *testing.T) {
 	defer cleanup()
 
 	store := NewContextualToolsStore()
-	handler := NewChatHandler(zap.NewNop(), store, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), store, wsURL, "", 1<<20, 8192)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "hello"}},
@@ -322,7 +323,7 @@ func TestChatHandlerOmitsMetaWhenNoTools(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), NewContextualToolsStore(), wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), NewContextualToolsStore(), wsURL, "", 1<<20, 8192)
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
@@ -344,7 +345,7 @@ func TestChatHandlerEmitsRunFinishedWithStopReasonInResult(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(reqBody))
@@ -374,7 +375,7 @@ func TestChatHandlerPropagatesThreadAndRunIDs(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		ThreadID: "thread-xyz",
@@ -422,7 +423,7 @@ func (*failingFlusherResponseWriter) Flush() {}
 
 func TestNewChatHandlerPassesThroughConfig(t *testing.T) {
 	store := NewContextualToolsStore()
-	h := NewChatHandler(zap.NewNop(), store, "ws://localhost:1", "/jaeger", 512)
+	h := NewChatHandler(zap.NewNop(), store, "ws://localhost:1", "/jaeger", 512, 8192)
 	require.Equal(t, int64(512), h.maxRequestBodySize, "expected configured maxRequestBodySize")
 	require.Equal(t, "ws://localhost:1", h.sidecarWSURL, "expected configured sidecarWSURL")
 	require.Equal(t, "/jaeger", h.basePath, "expected configured basePath")
@@ -430,7 +431,7 @@ func TestNewChatHandlerPassesThroughConfig(t *testing.T) {
 }
 
 func TestChatHandlerMethodNotAllowed(t *testing.T) {
-	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20, 8192)
 	req := httptest.NewRequest(http.MethodGet, "/api/ai/chat", http.NoBody)
 	rr := httptest.NewRecorder()
 
@@ -440,7 +441,7 @@ func TestChatHandlerMethodNotAllowed(t *testing.T) {
 }
 
 func TestChatHandlerBadRequest(t *testing.T) {
-	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20, 8192)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader("{"))
 	rr := httptest.NewRecorder()
 
@@ -450,7 +451,7 @@ func TestChatHandlerBadRequest(t *testing.T) {
 }
 
 func TestChatHandlerEmptyPrompt(t *testing.T) {
-	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("   "))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -463,7 +464,7 @@ func TestChatHandlerEmptyPrompt(t *testing.T) {
 }
 
 func TestChatHandlerNoUserMessage(t *testing.T) {
-	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20, 8192)
 	body, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: "assistant", Content: "no user message in this run"}},
 	})
@@ -486,7 +487,7 @@ func TestChatHandlerRejectsBlankContextualToolName(t *testing.T) {
 	// validateContextualToolNames pin the function-level contract; this
 	// test pins that the handler wires the contract into the HTTP path.
 	store := NewContextualToolsStore()
-	handler := NewChatHandler(zap.NewNop(), store, "ws://127.0.0.1:1", "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), store, "ws://127.0.0.1:1", "", 1<<20, 8192)
 
 	body, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "hi"}},
@@ -510,7 +511,7 @@ func TestChatHandlerRejectsBlankContextualToolName(t *testing.T) {
 }
 
 func TestChatHandlerRequestBodyTooLarge(t *testing.T) {
-	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 10)
+	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 10, 8192)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader(`{"messages":[{"role":"user","content":"this body exceeds the 10 byte limit"}]}`))
 	rr := httptest.NewRecorder()
 
@@ -520,7 +521,7 @@ func TestChatHandlerRequestBodyTooLarge(t *testing.T) {
 }
 
 func TestChatHandlerDialFailure(t *testing.T) {
-	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, "ws://127.0.0.1:1", "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -536,7 +537,7 @@ func TestChatHandlerInitializeError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -553,7 +554,7 @@ func TestChatHandlerNewSessionError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -573,7 +574,7 @@ func TestChatHandlerPromptError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -610,7 +611,7 @@ func TestChatHandlerSessionUpdateStreamedBeforePromptReturns(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -632,7 +633,7 @@ func TestChatHandlerPromptErrorWriteFailure(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -659,7 +660,7 @@ func TestChatHandlerSessionCloseFiresWhenAgentAdvertisesCapability(t *testing.T)
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -691,7 +692,7 @@ func TestChatHandlerSessionCloseErrorIsSwallowed(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -716,7 +717,7 @@ func TestChatHandlerSessionCloseSkippedWhenCapabilityAbsent(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 8192)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -726,4 +727,58 @@ func TestChatHandlerSessionCloseSkippedWhenCapabilityAbsent(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "unexpected status code, body=%q", rr.Body.String())
 	require.Nil(t, agent.capturedCloseRequest(), "session/close must not fire when agent does not advertise the capability")
+}
+
+func TestChatHandlerModelContextLimitAndPruning(t *testing.T) {
+	agent := &mockACPAgent{}
+	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
+	defer cleanup()
+
+	// 1. Case where it exceeds limit even after pruning -> returns 400 Bad Request
+	// ModelContextLimit is 10 tokens (40 characters)
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 10)
+
+	// Create request with long user text (44 chars = 11 tokens)
+	body, err := json.Marshal(ChatRequest{
+		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "this user prompt is long and exceeds ten tokens"}},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Trace too large for local model")
+
+	// 2. Case where context is pruned and fits within limit -> proceeds successfully
+	handlerOk := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20, 70)
+
+	trace := uimodel.Trace{
+		TraceID: "t1",
+		Spans: []uimodel.Span{
+			{SpanID: "root"},
+			{SpanID: "child", ParentSpanID: "root", Duration: 100}, // low-value span, will be pruned
+		},
+	}
+	traceBytes, err := json.Marshal(trace)
+	require.NoError(t, err)
+
+	// Context contains trace.
+	// ModelContextLimit is 70 tokens (280 characters).
+	// After pruning low-value child span, trace size reduces and fits.
+	body, err = json.Marshal(ChatRequest{
+		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "short prompt"}},
+		Context: []aguitypes.Context{
+			{Value: string(traceBytes)},
+		},
+	})
+	require.NoError(t, err)
+
+	req = httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	rr = httptest.NewRecorder()
+	handlerOk.ServeHTTP(rr, req)
+
+	// Should proceed to call the agent successfully
+	assert.Equal(t, http.StatusOK, rr.Code)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
@@ -37,6 +37,7 @@ type Handler struct {
 	agentURL           string
 	basePath           string
 	maxRequestBodySize int64
+	modelContextLimit  int
 }
 
 // NewHandler constructs a jaegerai.Handler with a freshly-allocated
@@ -46,18 +47,19 @@ type Handler struct {
 //
 // basePath is normalized once so the registered mux pattern uses a single
 // canonical prefix.
-func NewHandler(logger *zap.Logger, agentURL, basePath string, maxRequestBodySize int64) *Handler {
+func NewHandler(logger *zap.Logger, agentURL, basePath string, maxRequestBodySize int64, modelContextLimit int) *Handler {
 	return &Handler{
 		logger:             logger,
 		store:              NewContextualToolsStore(),
 		agentURL:           agentURL,
 		basePath:           normalizeBasePath(basePath),
 		maxRequestBodySize: maxRequestBodySize,
+		modelContextLimit:  modelContextLimit,
 	}
 }
 
 // RegisterRoutes mounts the AI gateway endpoints on the provided mux. The
 // chat endpoint streams ACP turns to/from the sidecar.
 func (h *Handler) RegisterRoutes(router *http.ServeMux) {
-	router.HandleFunc(h.basePath+routeChat, NewChatHandler(h.logger, h.store, h.agentURL, h.basePath, h.maxRequestBodySize).ServeHTTP)
+	router.HandleFunc(h.basePath+routeChat, NewChatHandler(h.logger, h.store, h.agentURL, h.basePath, h.maxRequestBodySize, h.modelContextLimit).ServeHTTP)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewHandlerInitialisesStore(t *testing.T) {
-	h := NewHandler(zap.NewNop(), "ws://example", "/jaeger", 1<<20)
+	h := NewHandler(zap.NewNop(), "ws://example", "/jaeger", 1<<20, 8192)
 	require.NotNil(t, h.store, "NewHandler must allocate a ContextualToolsStore")
 	assert.Equal(t, "ws://example", h.agentURL)
 	assert.Equal(t, "/jaeger", h.basePath)
@@ -53,7 +53,7 @@ func TestRegisterRoutesMountsChatEndpoint(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewHandler(zap.NewNop(), "ws://127.0.0.1:1", tc.basePath, 1<<20)
+			h := NewHandler(zap.NewNop(), "ws://127.0.0.1:1", tc.basePath, 1<<20, 8192)
 			mux := http.NewServeMux()
 			h.RegisterRoutes(mux)
 
@@ -70,6 +70,6 @@ func TestRegisterRoutesMountsChatEndpoint(t *testing.T) {
 }
 
 func TestNewHandlerNormalizesTrailingSlash(t *testing.T) {
-	h := NewHandler(zap.NewNop(), "ws://127.0.0.1:1", "/jaeger/", 1<<20)
+	h := NewHandler(zap.NewNop(), "ws://127.0.0.1:1", "/jaeger/", 1<<20, 8192)
 	assert.Equal(t, "/jaeger", h.basePath, "NewHandler must trim the trailing slash")
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation.go
@@ -296,7 +296,7 @@ const DefaultAIModelContextLimit = 8192
 
 // estimateTokens returns an estimated token count for a text string using the 1 token ≈ 4 characters heuristic.
 func estimateTokens(text string) int {
-	return len(text) / 4
+	return (len(text) + 3) / 4
 }
 
 // isLowValueSpan checks if a span is "low-value" (non-root, duration < 1ms, no error tags, no error status, no error logs).

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation.go
@@ -11,6 +11,8 @@ import (
 
 	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/coder/acp-go-sdk"
+
+	"github.com/jaegertracing/jaeger/internal/uimodel"
 )
 
 // latestUserMessageText returns the text content of the most recent user
@@ -288,4 +290,120 @@ func flattenToolResultContent(raw any) string {
 		return fmt.Sprintf("%v", raw)
 	}
 	return string(payload)
+}
+
+const DefaultAIModelContextLimit = 8192
+
+// estimateTokens returns an estimated token count for a text string using the 1 token ≈ 4 characters heuristic.
+func estimateTokens(text string) int {
+	return len(text) / 4
+}
+
+// isLowValueSpan checks if a span is "low-value" (non-root, duration < 1ms, no error tags, no error status, no error logs).
+func isLowValueSpan(span uimodel.Span) bool {
+	// Root span check: if it has no parent and no references, it's a root span. Keep it.
+	if span.ParentSpanID == "" && len(span.References) == 0 {
+		return false
+	}
+
+	// Duration check: if duration is >= 1ms (1000 microseconds), keep it.
+	if span.Duration >= 1000 {
+		return false
+	}
+
+	// Error check in tags: if error tag is present and truthy, keep it.
+	for _, kv := range span.Tags {
+		if kv.Key == "error" {
+			if b, ok := kv.Value.(bool); ok && b {
+				return false
+			}
+			if s, ok := kv.Value.(string); ok && (s == "true" || s == "1") {
+				return false
+			}
+			if i, ok := kv.Value.(int64); ok && i != 0 {
+				return false
+			}
+			if f, ok := kv.Value.(float64); ok && f != 0 {
+				return false
+			}
+		}
+		if kv.Key == "http.status_code" {
+			if i, ok := kv.Value.(int64); ok && i >= 400 {
+				return false
+			}
+			if f, ok := kv.Value.(float64); ok && f >= 400 {
+				return false
+			}
+			if s, ok := kv.Value.(string); ok {
+				var code int
+				if n, err := fmt.Sscanf(s, "%d", &code); err == nil && n == 1 && code >= 400 {
+					return false
+				}
+			}
+		}
+	}
+
+	// Error check in logs: if log fields contain error info, keep it.
+	for _, log := range span.Logs {
+		for _, kv := range log.Fields {
+			if kv.Key == "error" {
+				return false
+			}
+			if kv.Key == "event" && kv.Value == "error" {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// tryPruneTraceContext tries to unmarshal the context value as a Trace or Trace envelope, prunes low-value spans, and returns the re-marshaled JSON.
+func tryPruneTraceContext(contextValue string) (string, bool) {
+	// Attempt to unmarshal as uimodel.Trace
+	var trace uimodel.Trace
+	if err := json.Unmarshal([]byte(contextValue), &trace); err == nil && len(trace.Spans) > 0 {
+		prunedSpans := make([]uimodel.Span, 0, len(trace.Spans))
+		for _, span := range trace.Spans {
+			if !isLowValueSpan(span) {
+				prunedSpans = append(prunedSpans, span)
+			}
+		}
+		if len(prunedSpans) < len(trace.Spans) {
+			trace.Spans = prunedSpans
+			if updatedBytes, err := json.Marshal(trace); err == nil {
+				return string(updatedBytes), true
+			}
+		}
+		return contextValue, false
+	}
+
+	// Attempt to unmarshal as {"data": []uimodel.Trace}
+	type envelope struct {
+		Data []uimodel.Trace `json:"data"`
+	}
+	var env envelope
+	if err := json.Unmarshal([]byte(contextValue), &env); err == nil && len(env.Data) > 0 {
+		prunedAny := false
+		for i, t := range env.Data {
+			prunedSpans := make([]uimodel.Span, 0, len(t.Spans))
+			for _, span := range t.Spans {
+				if !isLowValueSpan(span) {
+					prunedSpans = append(prunedSpans, span)
+				}
+			}
+			if len(prunedSpans) < len(t.Spans) {
+				env.Data[i].Spans = prunedSpans
+				prunedAny = true
+			}
+		}
+		if prunedAny {
+			if updatedBytes, err := json.Marshal(env); err == nil {
+				return string(updatedBytes), true
+			}
+		}
+		return contextValue, false
+	}
+
+	return contextValue, false
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation_test.go
@@ -10,6 +10,8 @@ import (
 	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/uimodel"
 )
 
 func TestLatestUserMessageTextPicksMostRecentUser(t *testing.T) {
@@ -298,4 +300,139 @@ func TestValidateContextualToolNamesReportsFirstOffendingIndex(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tools[2].name",
 		"the index of the first invalid tool must be in the error so frontend devs can locate it")
+}
+
+func TestEstimateTokens(t *testing.T) {
+	assert.Equal(t, 0, estimateTokens(""))
+	assert.Equal(t, 1, estimateTokens("abcd"))
+	assert.Equal(t, 2, estimateTokens("abcdefgh"))
+}
+
+func TestIsLowValueSpan(t *testing.T) {
+	// Case 1: Root span (ParentSpanID is empty, no References) -> NOT low-value
+	rootSpan := uimodel.Span{
+		SpanID: "root",
+	}
+	assert.False(t, isLowValueSpan(rootSpan))
+
+	// Case 2: Non-root span, duration >= 1ms -> NOT low-value
+	longSpan := uimodel.Span{
+		SpanID:       "child",
+		ParentSpanID: "root",
+		Duration:     1000,
+	}
+	assert.False(t, isLowValueSpan(longSpan))
+
+	// Case 3: Non-root span, duration < 1ms, no error tags -> low-value
+	shortSpan := uimodel.Span{
+		SpanID:       "child",
+		ParentSpanID: "root",
+		Duration:     500,
+	}
+	assert.True(t, isLowValueSpan(shortSpan))
+
+	// Case 4: Non-root span, duration < 1ms, error tag = true (bool) -> NOT low-value
+	errSpanBool := uimodel.Span{
+		SpanID:       "child",
+		ParentSpanID: "root",
+		Duration:     500,
+		Tags: []uimodel.KeyValue{
+			{Key: "error", Value: true},
+		},
+	}
+	assert.False(t, isLowValueSpan(errSpanBool))
+
+	// Case 5: Non-root span, duration < 1ms, error tag = "true" (string) -> NOT low-value
+	errSpanStr := uimodel.Span{
+		SpanID:       "child",
+		ParentSpanID: "root",
+		Duration:     500,
+		Tags: []uimodel.KeyValue{
+			{Key: "error", Value: "true"},
+		},
+	}
+	assert.False(t, isLowValueSpan(errSpanStr))
+
+	// Case 6: Non-root span, duration < 1ms, http.status_code = 500 -> NOT low-value
+	errSpanHTTP := uimodel.Span{
+		SpanID:       "child",
+		ParentSpanID: "root",
+		Duration:     500,
+		Tags: []uimodel.KeyValue{
+			{Key: "http.status_code", Value: int64(500)},
+		},
+	}
+	assert.False(t, isLowValueSpan(errSpanHTTP))
+
+	// Case 7: Non-root span, duration < 1ms, error log -> NOT low-value
+	errSpanLog := uimodel.Span{
+		SpanID:       "child",
+		ParentSpanID: "root",
+		Duration:     500,
+		Logs: []uimodel.Log{
+			{
+				Fields: []uimodel.KeyValue{
+					{Key: "error", Value: "something failed"},
+				},
+			},
+		},
+	}
+	assert.False(t, isLowValueSpan(errSpanLog))
+}
+
+func TestTryPruneTraceContext(t *testing.T) {
+	// Let's create a trace JSON
+	trace := uimodel.Trace{
+		TraceID: "t1",
+		Spans: []uimodel.Span{
+			{SpanID: "root"}, // Root span: keep
+			{SpanID: "c1", ParentSpanID: "root", Duration: 2000}, // Long span: keep
+			{SpanID: "c2", ParentSpanID: "root", Duration: 500}, // Short normal: prune
+			{SpanID: "c3", ParentSpanID: "root", Duration: 500, Tags: []uimodel.KeyValue{{Key: "error", Value: true}}}, // Short error: keep
+		},
+	}
+	bytes, err := json.Marshal(trace)
+	require.NoError(t, err)
+
+	prunedJSON, pruned := tryPruneTraceContext(string(bytes))
+	assert.True(t, pruned)
+
+	var prunedTrace uimodel.Trace
+	err = json.Unmarshal([]byte(prunedJSON), &prunedTrace)
+	require.NoError(t, err)
+
+	require.Len(t, prunedTrace.Spans, 3)
+	assert.Equal(t, uimodel.SpanID("root"), prunedTrace.Spans[0].SpanID)
+	assert.Equal(t, uimodel.SpanID("c1"), prunedTrace.Spans[1].SpanID)
+	assert.Equal(t, uimodel.SpanID("c3"), prunedTrace.Spans[2].SpanID)
+}
+
+func TestTryPruneTraceContextEnvelope(t *testing.T) {
+	type envelope struct {
+		Data []uimodel.Trace `json:"data"`
+	}
+	env := envelope{
+		Data: []uimodel.Trace{
+			{
+				TraceID: "t1",
+				Spans: []uimodel.Span{
+					{SpanID: "root"}, // Root span: keep
+					{SpanID: "c1", ParentSpanID: "root", Duration: 500}, // Short normal: prune
+				},
+			},
+		},
+	}
+	bytes, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	prunedJSON, pruned := tryPruneTraceContext(string(bytes))
+	assert.True(t, pruned)
+
+	var prunedEnv envelope
+	err = json.Unmarshal([]byte(prunedJSON), &prunedEnv)
+	require.NoError(t, err)
+
+	require.Len(t, prunedEnv.Data, 1)
+	require.Len(t, prunedEnv.Data[0].Spans, 1)
+	assert.Equal(t, uimodel.SpanID("root"), prunedEnv.Data[0].Spans[0].SpanID)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation_test.go
@@ -304,7 +304,9 @@ func TestValidateContextualToolNamesReportsFirstOffendingIndex(t *testing.T) {
 
 func TestEstimateTokens(t *testing.T) {
 	assert.Equal(t, 0, estimateTokens(""))
+	assert.Equal(t, 1, estimateTokens("a"))
 	assert.Equal(t, 1, estimateTokens("abcd"))
+	assert.Equal(t, 2, estimateTokens("abcde"))
 	assert.Equal(t, 2, estimateTokens("abcdefgh"))
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -212,7 +212,7 @@ func initRouter(
 			if err := aiCfg.Validate(); err != nil {
 				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
 			} else {
-				jaegerai.NewHandler(telset.Logger, aiCfg.AgentURL, queryOpts.BasePath, aiCfg.MaxRequestBodySize).RegisterRoutes(r)
+				jaegerai.NewHandler(telset.Logger, aiCfg.AgentURL, queryOpts.BasePath, aiCfg.MaxRequestBodySize, aiCfg.ModelContextLimit).RegisterRoutes(r)
 			}
 		}
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves the issue where passing a massive trace (e.g., >10,000 spans) to the `ai-sidecar` configured with a local LLM (like Llama 3 8B via Ollama) exceeds the model's context window limit, causing LangChainGo errors, silent truncation/hallucinations, or sidecar crashes.

## Description of the changes
This PR implements proactive model context window limit validation, context span pruning, and graceful degradation for the Jaeger AI Assistant:
- **Configuration**: Added the `model_context_limit` option (default `8192` tokens) to `AIConfig` in `flags.go`.
- **Validation & Pruning**: Before dialing the backend LLM, the handler estimates prompt and trace context size. If it exceeds the limit, it decodes the trace JSON and prunes "low-value" spans.
- **Low-Value Definition**: A span is pruned if it is not the root span, duration is `< 1ms` (1000 microseconds), and it has no error tags, error HTTP status, or error logs/events.## Which problem is this PR solving?
- Resolves #8801 
- ## Description of the changes
- This PR implements proactive model context window limit validation, context span pruning, and graceful degradation for the Jaeger AI Assistant:
- - **Configuration**: Added the `model_context_limit` option (default `8192` tokens) to `AIConfig` in `flags.go`.
- - **Validation & Pruning**: Before dialing the backend LLM, the handler estimates prompt and trace context size. If it exceeds the limit, it decodes the trace JSON and prunes "low-value" spans.
- - **Low-Value Definition**: A span is pruned if it is not the root span, duration is < 1ms (1000 microseconds), and it has no error tags, error HTTP status, or error logs/events.
- - **Graceful Degradation**: If the token size still exceeds the limit after pruning, it gracefully rejects with `400 Bad Request` and warning: "Trace too large for local model. Please filter or prune spans first.".
## How was this change tested?
- **Automated Tests**: Added comprehensive unit tests in `translation_test.go` (`TestEstimateTokens`, `TestIsLowValueSpan`, `TestTryPruneTraceContext`) and integration handler tests in `handler_test.go` (`TestChatHandlerModelContextLimitAndPruning`).
- - **Manual Verification**: Run locally against a configured test server with a limit of 10 and 60 tokens, verifying that:
-   1. Small prompts successfully pass.
-   2. Prompts exceeding the limit are blocked with a `400 Bad Request`.
-   3. Context traces with low-value spans are correctly pruned to fit the limit and proceed.
-   4. Traces with only high-value spans that still exceed the limit after pruning are correctly blocked.
- **Graceful Degradation**: If the token size still exceeds the limit after pruning, it gracefully rejects with `400 Bad Request` and warning: `"Trace too large for local model. Please filter or prune spans first."`.

## How was this change tested?
- **Automated Tests**: Added comprehensive unit tests in `translation_test.go` (`TestEstimateTokens`, `TestIsLowValueSpan`, `TestTryPruneTraceContext`) and integration handler tests in `handler_test.go` (`TestChatHandlerModelContextLimitAndPruning`).
- **Manual Verification**: Run locally against a configured test server with a limit of 10 and 60 tokens, verifying that:
  1. Small prompts successfully pass.
  2. Prompts exceeding the limit are blocked with a `400 Bad Request`.
  3. Context traces with low-value spans are correctly pruned to fit the limit and proceed.
  4. Traces with only high-value spans that still exceed the limit after pruning are correctly blocked.
