### PR TITLE
[chore]: Add Binary.Stop() and BinaryPath for mid-test process control

### DIFF
--- a/cmd/jaeger/internal/integration/binary.go
+++ b/cmd/jaeger/internal/integration/binary.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -52,12 +53,7 @@ func (b *Binary) Start(t *testing.T) {
 	require.NoError(t, b.Cmd.Start())
 
 	t.Cleanup(func() {
-		if err := b.Process.Kill(); err != nil {
-			t.Errorf("Failed to kill %s process: %v", b.Name, err)
-		}
-		t.Logf("Waiting for %s to exit", b.Name)
-		b.Process.Wait()
-		t.Logf("%s exited", b.Name)
+		b.Stop(t)
 		// Dump logs if test failed, or if running in GitHub Actions where
 		// t.Failed() may not return true when the test times out with a panic.
 		if t.Failed() || os.Getenv("GITHUB_ACTIONS") == "true" {
@@ -69,6 +65,19 @@ func (b *Binary) Start(t *testing.T) {
 	require.Eventually(t, func() bool { return b.doHealthCheck(t) },
 		time.Minute, time.Second, "%s did not start", b.Name)
 	t.Logf("%s is ready", b.Name)
+}
+
+// Stop kills the process and waits for it to exit. It is safe to call more than
+// once (and after the process has already exited): once the process has been
+// reaped, Kill returns os.ErrProcessDone, which is treated as a successful stop.
+func (b *Binary) Stop(t *testing.T) {
+	t.Helper()
+	if err := b.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Errorf("Failed to kill %s process: %v", b.Name, err)
+	}
+	t.Logf("Waiting for %s to exit", b.Name)
+	b.Process.Wait()
+	t.Logf("%s exited", b.Name)
 }
 
 func (b *Binary) doHealthCheck(t *testing.T) bool {

--- a/cmd/jaeger/internal/integration/binary_test.go
+++ b/cmd/jaeger/internal/integration/binary_test.go
@@ -11,27 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBinaryStop(t *testing.T) {
-	sleepPath, err := exec.LookPath("sleep")
-	if err != nil {
-		t.Skip("sleep binary not found; this test requires a POSIX environment")
-	}
-
-	b := &Binary{
-		Name: "test-sleep",
-		Cmd: exec.Cmd{
-			Path: sleepPath,
-			Args: []string{"sleep", "100"},
-		},
-	}
-	require.NoError(t, b.Cmd.Start())
-
-	b.Stop(t)
-
-	_, err = b.Process.Wait()
-	assert.Error(t, err, "process should have already been waited on by Stop()")
-}
-
 func TestBinaryStop_Idempotent(t *testing.T) {
 	sleepPath, err := exec.LookPath("sleep")
 	if err != nil {

--- a/cmd/jaeger/internal/integration/binary_test.go
+++ b/cmd/jaeger/internal/integration/binary_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinaryStop(t *testing.T) {
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep binary not found; this test requires a POSIX environment")
+	}
+
+	b := &Binary{
+		Name: "test-sleep",
+		Cmd: exec.Cmd{
+			Path: sleepPath,
+			Args: []string{"sleep", "100"},
+		},
+	}
+	require.NoError(t, b.Cmd.Start())
+
+	b.Stop(t)
+
+	_, err = b.Process.Wait()
+	assert.Error(t, err, "process should have already been waited on by Stop()")
+}
+
+func TestBinaryStop_Idempotent(t *testing.T) {
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep binary not found; this test requires a POSIX environment")
+	}
+
+	b := &Binary{
+		Name: "test-sleep",
+		Cmd: exec.Cmd{
+			Path: sleepPath,
+			Args: []string{"sleep", "100"},
+		},
+	}
+	require.NoError(t, b.Cmd.Start())
+
+	b.Stop(t)
+	b.Stop(t) // second call must not fail the test (Kill returns os.ErrProcessDone)
+	_, err = b.Process.Wait()
+	assert.Error(t, err, "process should have already been waited on by Stop()")
+}

--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -42,6 +42,7 @@ type E2EStorageIntegration struct {
 	SkipStorageCleaner bool
 	ConfigFile         string
 	BinaryName         string
+	BinaryPath         string // overrides default "./cmd/jaeger/jaeger"; resolved relative to the repo root
 
 	MetricsPort     int // overridable, default to 8888
 	HealthCheckPort int // overridable for tests (e.g. Kafka, query) which run two binaries and need different ports
@@ -56,6 +57,8 @@ type E2EStorageIntegration struct {
 	PropagateEnvVars []string
 	// FeatureGates contains a list of feature gate IDs to enable for the Jaeger binary.
 	FeatureGates []string
+
+	binary *Binary // set by e2eInitialize; allows mid-test shutdown via binary.Stop(t)
 }
 
 func (s *E2EStorageIntegration) args(configFile string) []string {
@@ -97,11 +100,15 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 		}
 	}
 
+	binaryPath := s.BinaryPath
+	if binaryPath == "" {
+		binaryPath = "./cmd/jaeger/jaeger"
+	}
 	cmd := Binary{
 		Name:            s.BinaryName,
 		HealthCheckPort: s.HealthCheckPort,
 		Cmd: exec.Cmd{
-			Path: "./cmd/jaeger/jaeger",
+			Path: binaryPath,
 			Args: s.args(configFile),
 			// Change the working directory to the root of this project
 			// since the binary config file jaeger_query's ui.config_file points to
@@ -111,6 +118,7 @@ func (s *E2EStorageIntegration) e2eInitialize(t *testing.T, storage string) {
 		},
 	}
 	cmd.Start(t)
+	s.binary = &cmd
 
 	s.TraceWriter, err = createTraceWriter(logger, otlpPort)
 	require.NoError(t, err)


### PR DESCRIPTION
## Which problem is this PR solving?

- The integration test harness has no way to stop a binary mid-test and start a different one, which is needed for backward compatibility testing (start old binary, write data, stop it, start new binary, verify reads). This PR adds that capability as infrastructure towards #8691.

## Description of the changes

- Added a Stop() method to Binary that kills the process and waits for it to exit, so a test can shut a binary down mid-test (not just during cleanup).
- Made Stop() idempotent via a stopped flag, so calling it mid-test and again from t.Cleanup won't double-kill or double-wait.
- Consolidated the existing t.Cleanup kill/wait logic in Start() to call Stop() instead of duplicating it.
- Added a BinaryPath field to E2EStorageIntegration to allow swapping the binary at runtime.
- Stored the running *Binary on E2EStorageIntegration so tests can call Stop() mid-test.

## How was this change tested?

- Added TestBinaryStop and TestBinaryStop_Idempotent in binary_test.go
- Integration tests
 
## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: make lint test

## AI Usage in this PR 

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x]  **Light**: AI provided minor assistance (formatting, simple suggestions)