### PR TITLE
refactor(es): Migrate depstore and metricstore to use Rotation interface

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	"github.com/jaegertracing/jaeger/internal/metrics"
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	eswrapper "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/wrapper"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore/spanstoremetrics"
 )
@@ -555,6 +556,43 @@ func RolloverFrequencyDuration(frequency string) time.Duration {
 		return time.Hour
 	}
 	return 24 * time.Hour
+}
+
+// RotationParams holds parameters for BuildRotation.
+type RotationParams struct {
+	IndexPrefix    string
+	IndexOptions   IndexOptions
+	ExplicitWrite  string
+	ExplicitRead   string
+	UseAliases     bool
+	WriteAlias     string
+	ReadAlias      string
+	RemoteClusters []string
+}
+
+// BuildRotation constructs the appropriate Rotation from the given parameters.
+func BuildRotation(p RotationParams, logger *zap.Logger) indices.Rotation {
+	var r indices.Rotation
+	switch {
+	case p.ExplicitWrite != "" && p.ExplicitRead != "":
+		r = indices.NewAliasedRotation(p.ExplicitWrite, p.ExplicitRead)
+	case p.UseAliases:
+		writeSuffix := "write"
+		if p.WriteAlias != "" {
+			writeSuffix = p.WriteAlias
+		}
+		readSuffix := "read"
+		if p.ReadAlias != "" {
+			readSuffix = p.ReadAlias
+		}
+		r = indices.NewAliasedRotation(p.IndexPrefix+writeSuffix, p.IndexPrefix+readSuffix)
+	default:
+		r = indices.NewPeriodicRotation(p.IndexPrefix, p.IndexOptions.DateLayout, RolloverFrequencyDuration(p.IndexOptions.RolloverFrequency))
+	}
+	if len(p.RemoteClusters) > 0 {
+		r = indices.NewRemoteClusterRotation(r, p.RemoteClusters)
+	}
+	return indices.NewLoggingRotation(r, logger)
 }
 
 // TagKeysAsFields returns tags from the file and command line merged

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -2071,10 +2071,10 @@ func TestBuildRotation(t *testing.T) {
 	ts := time.Date(2024, time.March, 15, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
-		name         string
-		params       RotationParams
-		wantWrite    string
-		wantRead     []string
+		name      string
+		params    RotationParams
+		wantWrite string
+		wantRead  []string
 	}{
 		{
 			name: "periodic rotation",

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -2066,6 +2066,80 @@ func TestNewClient_NoCapturedHeaders_NoForwardedHeader(t *testing.T) {
 	}
 }
 
+func TestBuildRotation(t *testing.T) {
+	logger := zap.NewNop()
+	ts := time.Date(2024, time.March, 15, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		params       RotationParams
+		wantWrite    string
+		wantRead     []string
+	}{
+		{
+			name: "periodic rotation",
+			params: RotationParams{
+				IndexPrefix:  "jaeger-span-",
+				IndexOptions: IndexOptions{DateLayout: "2006-01-02", RolloverFrequency: "day"},
+			},
+			wantWrite: "jaeger-span-2024-03-15",
+			wantRead:  []string{"jaeger-span-2024-03-15"},
+		},
+		{
+			name: "explicit aliases",
+			params: RotationParams{
+				IndexPrefix:   "jaeger-span-",
+				IndexOptions:  IndexOptions{DateLayout: "2006-01-02", RolloverFrequency: "day"},
+				ExplicitWrite: "my-write-alias",
+				ExplicitRead:  "my-read-alias",
+			},
+			wantWrite: "my-write-alias",
+			wantRead:  []string{"my-read-alias"},
+		},
+		{
+			name: "use aliases with defaults",
+			params: RotationParams{
+				IndexPrefix:  "jaeger-span-",
+				IndexOptions: IndexOptions{DateLayout: "2006-01-02", RolloverFrequency: "day"},
+				UseAliases:   true,
+			},
+			wantWrite: "jaeger-span-write",
+			wantRead:  []string{"jaeger-span-read"},
+		},
+		{
+			name: "use aliases with custom suffixes",
+			params: RotationParams{
+				IndexPrefix:  "jaeger-span-",
+				IndexOptions: IndexOptions{DateLayout: "2006-01-02", RolloverFrequency: "day"},
+				UseAliases:   true,
+				WriteAlias:   "w",
+				ReadAlias:    "r",
+			},
+			wantWrite: "jaeger-span-w",
+			wantRead:  []string{"jaeger-span-r"},
+		},
+		{
+			name: "with remote clusters",
+			params: RotationParams{
+				IndexPrefix:    "jaeger-span-",
+				IndexOptions:   IndexOptions{DateLayout: "2006-01-02", RolloverFrequency: "day"},
+				UseAliases:     true,
+				RemoteClusters: []string{"cluster-a", "cluster-b"},
+			},
+			wantWrite: "jaeger-span-write",
+			wantRead:  []string{"jaeger-span-read", "cluster-a:jaeger-span-read", "cluster-b:jaeger-span-read"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := BuildRotation(tt.params, logger)
+			assert.Equal(t, tt.wantWrite, r.WriteTarget(ts))
+			assert.Equal(t, tt.wantRead, r.ReadTargets(ts, ts))
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	testutils.VerifyGoLeaks(m)
 }

--- a/internal/storage/elasticsearch/indices/rotation.go
+++ b/internal/storage/elasticsearch/indices/rotation.go
@@ -5,6 +5,13 @@ package indices
 
 import "time"
 
+const (
+	SpanIndexBaseName       = "jaeger-span-"
+	ServiceIndexBaseName    = "jaeger-service-"
+	DependencyIndexBaseName = "jaeger-dependencies-"
+	SamplingIndexBaseName   = "jaeger-sampling-"
+)
+
 // WriteOpType represents the Elasticsearch bulk operation type.
 type WriteOpType string
 

--- a/internal/storage/elasticsearch/indices/rotation.go
+++ b/internal/storage/elasticsearch/indices/rotation.go
@@ -6,14 +6,15 @@ package indices
 import "time"
 
 const (
-	SpanIndexBaseName       = "jaeger-span-"
-	ServiceIndexBaseName    = "jaeger-service-"
-	DependencyIndexBaseName = "jaeger-dependencies-"
-	SamplingIndexBaseName   = "jaeger-sampling-"
-
 	SpanTemplateName       = "jaeger-span"
 	ServiceTemplateName    = "jaeger-service"
+	DependencyTemplateName = "jaeger-dependencies"
 	SamplingTemplateName   = "jaeger-sampling"
+
+	SpanIndexBaseName       = SpanTemplateName + "-"
+	ServiceIndexBaseName    = ServiceTemplateName + "-"
+	DependencyIndexBaseName = DependencyTemplateName + "-"
+	SamplingIndexBaseName   = SamplingTemplateName + "-"
 )
 
 // WriteOpType represents the Elasticsearch bulk operation type.

--- a/internal/storage/elasticsearch/indices/rotation.go
+++ b/internal/storage/elasticsearch/indices/rotation.go
@@ -10,6 +10,10 @@ const (
 	ServiceIndexBaseName    = "jaeger-service-"
 	DependencyIndexBaseName = "jaeger-dependencies-"
 	SamplingIndexBaseName   = "jaeger-sampling-"
+
+	SpanTemplateName       = "jaeger-span"
+	ServiceTemplateName    = "jaeger-service"
+	SamplingTemplateName   = "jaeger-sampling"
 )
 
 // WriteOpType represents the Elasticsearch bulk operation type.

--- a/internal/storage/metricstore/elasticsearch/factory.go
+++ b/internal/storage/metricstore/elasticsearch/factory.go
@@ -10,6 +10,7 @@ import (
 
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore/metricstoremetrics"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
@@ -47,7 +48,7 @@ func NewFactory(
 // CreateMetricsReader implements storage.MetricStoreFactory.
 func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
 	spanRotation := config.BuildRotation(config.RotationParams{
-		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-span-"),
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply(indices.SpanIndexBaseName),
 		IndexOptions:   f.config.Indices.Spans,
 		UseAliases:     f.config.UseReadWriteAliases,
 		ReadAlias:      f.config.ReadAliasSuffix,

--- a/internal/storage/metricstore/elasticsearch/factory.go
+++ b/internal/storage/metricstore/elasticsearch/factory.go
@@ -50,7 +50,10 @@ func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
 	spanRotation := config.BuildRotation(config.RotationParams{
 		IndexPrefix:    f.config.Indices.IndexPrefix.Apply(indices.SpanIndexBaseName),
 		IndexOptions:   f.config.Indices.Spans,
+		ExplicitWrite:  f.config.SpanWriteAlias,
+		ExplicitRead:   f.config.SpanReadAlias,
 		UseAliases:     f.config.UseReadWriteAliases,
+		WriteAlias:     f.config.WriteAliasSuffix,
 		ReadAlias:      f.config.ReadAliasSuffix,
 		RemoteClusters: f.config.RemoteReadClusters,
 	}, f.telset.Logger)

--- a/internal/storage/metricstore/elasticsearch/factory.go
+++ b/internal/storage/metricstore/elasticsearch/factory.go
@@ -46,7 +46,14 @@ func NewFactory(
 
 // CreateMetricsReader implements storage.MetricStoreFactory.
 func (f *Factory) CreateMetricsReader() (metricstore.Reader, error) {
-	mr := NewMetricsReader(f.client, f.config, f.telset.Logger, f.telset.TracerProvider)
+	spanRotation := config.BuildRotation(config.RotationParams{
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-span-"),
+		IndexOptions:   f.config.Indices.Spans,
+		UseAliases:     f.config.UseReadWriteAliases,
+		ReadAlias:      f.config.ReadAliasSuffix,
+		RemoteClusters: f.config.RemoteReadClusters,
+	}, f.telset.Logger)
+	mr := NewMetricsReader(f.client, f.config, f.telset.Logger, f.telset.TracerProvider, spanRotation)
 	return metricstoremetrics.NewReaderDecorator(mr, f.telset.Metrics), nil
 }
 

--- a/internal/storage/metricstore/elasticsearch/query_builder.go
+++ b/internal/storage/metricstore/elasticsearch/query_builder.go
@@ -20,6 +20,24 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
 
+func buildSpanRotation(cfg config.Configuration, logger *zap.Logger) indices.Rotation {
+	spanPrefix := cfg.Indices.IndexPrefix.Apply("jaeger-span-")
+	var r indices.Rotation
+	if cfg.UseReadWriteAliases {
+		readSuffix := "read"
+		if cfg.ReadAliasSuffix != "" {
+			readSuffix = cfg.ReadAliasSuffix
+		}
+		r = indices.NewAliasedRotation(spanPrefix+"write", spanPrefix+readSuffix)
+	} else {
+		r = indices.NewPeriodicRotation(spanPrefix, cfg.Indices.Spans.DateLayout, config.RolloverFrequencyDuration(cfg.Indices.Spans.RolloverFrequency))
+	}
+	if len(cfg.RemoteReadClusters) > 0 {
+		r = indices.NewRemoteClusterRotation(r, cfg.RemoteReadClusters)
+	}
+	return indices.NewLoggingRotation(r, logger)
+}
+
 // These constants define the specific names of aggregations used within Elasticsearch
 // queries. They are crucial for both constructing the query sent to Elasticsearch
 // and for correctly extracting the corresponding data from the Elasticsearch response.
@@ -33,20 +51,17 @@ const (
 // QueryBuilder is responsible for constructing Elasticsearch queries (bool and aggregation)
 // based on provided parameters and executing them to retrieve raw search results.
 type QueryBuilder struct {
-	client           es.Client
-	cfg              config.Configuration
-	timeRangeIndices indices.TimeRangeIndexFn
+	client       es.Client
+	cfg          config.Configuration
+	spanRotation indices.Rotation
 }
 
 // NewQueryBuilder creates a new QueryBuilder instance.
 func NewQueryBuilder(client es.Client, cfg config.Configuration, logger *zap.Logger) *QueryBuilder {
 	return &QueryBuilder{
-		client: client,
-		cfg:    cfg,
-		timeRangeIndices: indices.LoggingTimeRangeIndexFn(
-			logger,
-			indices.TimeRangeIndicesFn(cfg.UseReadWriteAliases, cfg.ReadAliasSuffix, cfg.RemoteReadClusters),
-		),
+		client:       client,
+		cfg:          cfg,
+		spanRotation: buildSpanRotation(cfg, logger),
 	}
 }
 
@@ -116,13 +131,9 @@ func (*QueryBuilder) buildTimeSeriesAggQuery(params metricstore.BaseQueryParamet
 
 // Execute runs the Elasticsearch search with the provided bool and aggregation queries.
 func (q *QueryBuilder) Execute(ctx context.Context, boolQuery elastic.BoolQuery, aggQuery elastic.Aggregation, timeRange TimeRange) (*elastic.SearchResult, error) {
-	indexName := q.cfg.Indices.IndexPrefix.Apply("jaeger-span-")
-	idxList := q.timeRangeIndices(
-		indexName,
-		q.cfg.Indices.Spans.DateLayout,
+	idxList := q.spanRotation.ReadTargets(
 		time.UnixMilli(timeRange.extendedStartTimeMillis).UTC(),
 		time.UnixMilli(timeRange.endTimeMillis).UTC(),
-		config.RolloverFrequencyAsNegativeDuration(q.cfg.Indices.Spans.RolloverFrequency),
 	)
 
 	return q.client.Search(idxList...).

--- a/internal/storage/metricstore/elasticsearch/query_builder.go
+++ b/internal/storage/metricstore/elasticsearch/query_builder.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/olivere/elastic/v7"
-	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
@@ -19,24 +18,6 @@ import (
 	esquery "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/query"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
-
-func buildSpanRotation(cfg config.Configuration, logger *zap.Logger) indices.Rotation {
-	spanPrefix := cfg.Indices.IndexPrefix.Apply("jaeger-span-")
-	var r indices.Rotation
-	if cfg.UseReadWriteAliases {
-		readSuffix := "read"
-		if cfg.ReadAliasSuffix != "" {
-			readSuffix = cfg.ReadAliasSuffix
-		}
-		r = indices.NewAliasedRotation(spanPrefix+"write", spanPrefix+readSuffix)
-	} else {
-		r = indices.NewPeriodicRotation(spanPrefix, cfg.Indices.Spans.DateLayout, config.RolloverFrequencyDuration(cfg.Indices.Spans.RolloverFrequency))
-	}
-	if len(cfg.RemoteReadClusters) > 0 {
-		r = indices.NewRemoteClusterRotation(r, cfg.RemoteReadClusters)
-	}
-	return indices.NewLoggingRotation(r, logger)
-}
 
 // These constants define the specific names of aggregations used within Elasticsearch
 // queries. They are crucial for both constructing the query sent to Elasticsearch
@@ -57,11 +38,11 @@ type QueryBuilder struct {
 }
 
 // NewQueryBuilder creates a new QueryBuilder instance.
-func NewQueryBuilder(client es.Client, cfg config.Configuration, logger *zap.Logger) *QueryBuilder {
+func NewQueryBuilder(client es.Client, cfg config.Configuration, spanRotation indices.Rotation) *QueryBuilder {
 	return &QueryBuilder{
 		client:       client,
 		cfg:          cfg,
-		spanRotation: buildSpanRotation(cfg, logger),
+		spanRotation: spanRotation,
 	}
 }
 

--- a/internal/storage/metricstore/elasticsearch/query_builder_test.go
+++ b/internal/storage/metricstore/elasticsearch/query_builder_test.go
@@ -17,6 +17,7 @@ import (
 
 	esmetrics "github.com/jaegertracing/jaeger/internal/metrics"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
 
@@ -39,12 +40,20 @@ var testIndicesConfig = config.Indices{
 	},
 }
 
+func testSpanRotation() indices.Rotation {
+	return indices.NewPeriodicRotation(
+		testIndicesConfig.IndexPrefix.Apply("jaeger-span-"),
+		testIndicesConfig.Spans.DateLayout,
+		config.RolloverFrequencyDuration(testIndicesConfig.Spans.RolloverFrequency),
+	)
+}
+
 // Test helper functions
 func setupTestQB() *QueryBuilder {
 	return NewQueryBuilder(nil, config.Configuration{
 		Indices: testIndicesConfig,
 		Tags:    config.TagsAsFields{DotReplacement: "_"},
-	}, zap.NewNop())
+	}, testSpanRotation())
 }
 
 func testAggregationStructure(t *testing.T, agg elastic.Aggregation, expectedInterval string, validateSubAggs func(map[string]any)) {
@@ -152,7 +161,7 @@ func TestExecute(t *testing.T) {
 		LogLevel: "debug",
 	}
 	client := clientProvider(t, cfg, zap.NewNop(), esmetrics.NullFactory)
-	qb := NewQueryBuilder(client, *cfg, zap.NewNop())
+	qb := NewQueryBuilder(client, *cfg, testSpanRotation())
 
 	boolQuery := elastic.NewBoolQuery()
 	aggQuery := elastic.NewDateHistogramAggregation().Field("startTimeMillis").FixedInterval("60000ms")

--- a/internal/storage/metricstore/elasticsearch/reader.go
+++ b/internal/storage/metricstore/elasticsearch/reader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
 
@@ -59,11 +60,11 @@ type Pair struct {
 }
 
 // NewMetricsReader initializes a new MetricsReader.
-func NewMetricsReader(client es.Client, cfg config.Configuration, logger *zap.Logger, tracer trace.TracerProvider) *MetricsReader {
+func NewMetricsReader(client es.Client, cfg config.Configuration, logger *zap.Logger, tracer trace.TracerProvider, spanRotation indices.Rotation) *MetricsReader {
 	tr := tracer.Tracer("elasticsearch-metricstore")
 	return &MetricsReader{
 		queryLogger:  NewQueryLogger(logger, tr),
-		queryBuilder: NewQueryBuilder(client, cfg, logger),
+		queryBuilder: NewQueryBuilder(client, cfg, spanRotation),
 	}
 }
 

--- a/internal/storage/metricstore/elasticsearch/reader_test.go
+++ b/internal/storage/metricstore/elasticsearch/reader_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 )
 
@@ -1092,7 +1093,8 @@ func setupMetricsReaderFromServer(t *testing.T, mockServer *httptest.Server) (*M
 	}
 
 	client := clientProvider(t, &cfg, logger, esmetrics.NullFactory)
-	reader := NewMetricsReader(client, cfg, logger, tracer)
+	spanRotation := indices.NewPeriodicRotation("jaeger-span-", "2006-01-02", config.RolloverFrequencyDuration("day"))
+	reader := NewMetricsReader(client, cfg, logger, tracer, spanRotation)
 	require.NotNil(t, reader)
 
 	return reader, exporter

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -169,7 +169,7 @@ func (f *FactoryBase) CreateSamplingStore(int /* maxBuckets */) (samplingstore.S
 		if err != nil {
 			return nil, err
 		}
-		templateName := f.config.Indices.IndexPrefix.Apply("jaeger-sampling")
+		templateName := f.config.Indices.IndexPrefix.Apply(indices.SamplingTemplateName)
 		if _, err := f.getClient().CreateTemplate(templateName).Body(samplingMapping).Do(context.Background()); err != nil {
 			return nil, fmt.Errorf("failed to create template: %w", err)
 		}
@@ -244,6 +244,8 @@ func loadTokenFromFile(path string) (string, error) {
 	return strings.TrimRight(string(b), "\r\n"), nil
 }
 
+// TODO: Support UseAliases/RemoteClusters for sampling via a feature flag.
+// Currently these params are silently ignored for sampling indices.
 func (f *FactoryBase) buildSamplingRotation() indices.Rotation {
 	return config.BuildRotation(config.RotationParams{
 		IndexPrefix:  f.config.Indices.IndexPrefix.Apply(indices.SamplingIndexBaseName),
@@ -293,8 +295,8 @@ func (f *FactoryBase) createTemplates(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		jaegerSpanIdx := f.config.Indices.IndexPrefix.Apply("jaeger-span")
-		jaegerServiceIdx := f.config.Indices.IndexPrefix.Apply("jaeger-service")
+		jaegerSpanIdx := f.config.Indices.IndexPrefix.Apply(indices.SpanTemplateName)
+		jaegerServiceIdx := f.config.Indices.IndexPrefix.Apply(indices.ServiceTemplateName)
 		_, err = f.getClient().CreateTemplate(jaegerSpanIdx).Body(spanMapping).Do(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create template %q: %w", jaegerSpanIdx, err)

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -245,74 +245,44 @@ func loadTokenFromFile(path string) (string, error) {
 }
 
 func (f *FactoryBase) buildSamplingRotation() indices.Rotation {
-	samplingPrefix := f.config.Indices.IndexPrefix.Apply("jaeger-sampling-")
-	return indices.NewPeriodicRotation(samplingPrefix, f.config.Indices.Sampling.DateLayout, config.RolloverFrequencyDuration(f.config.Indices.Sampling.RolloverFrequency))
+	return config.BuildRotation(config.RotationParams{
+		IndexPrefix:  f.config.Indices.IndexPrefix.Apply("jaeger-sampling-"),
+		IndexOptions: f.config.Indices.Sampling,
+	}, f.logger)
 }
 
 func (f *FactoryBase) buildDependencyRotation() indices.Rotation {
-	depPrefix := f.config.Indices.IndexPrefix.Apply("jaeger-dependencies-")
-	var r indices.Rotation
-	if f.config.UseReadWriteAliases {
-		writeSuffix := "write"
-		if f.config.WriteAliasSuffix != "" {
-			writeSuffix = f.config.WriteAliasSuffix
-		}
-		readSuffix := "read"
-		if f.config.ReadAliasSuffix != "" {
-			readSuffix = f.config.ReadAliasSuffix
-		}
-		r = indices.NewAliasedRotation(depPrefix+writeSuffix, depPrefix+readSuffix)
-	} else {
-		r = indices.NewPeriodicRotation(depPrefix, f.config.Indices.Dependencies.DateLayout, config.RolloverFrequencyDuration(f.config.Indices.Dependencies.RolloverFrequency))
-	}
-	if len(f.config.RemoteReadClusters) > 0 {
-		r = indices.NewRemoteClusterRotation(r, f.config.RemoteReadClusters)
-	}
-	return indices.NewLoggingRotation(r, f.logger)
+	return config.BuildRotation(config.RotationParams{
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-dependencies-"),
+		IndexOptions:   f.config.Indices.Dependencies,
+		UseAliases:     f.config.UseReadWriteAliases,
+		WriteAlias:     f.config.WriteAliasSuffix,
+		ReadAlias:      f.config.ReadAliasSuffix,
+		RemoteClusters: f.config.RemoteReadClusters,
+	}, f.logger)
 }
 
 func (f *FactoryBase) buildRotations() (spanRotation, serviceRotation indices.Rotation) {
-	spanPrefix := f.config.Indices.IndexPrefix.Apply("jaeger-span-")
-	servicePrefix := f.config.Indices.IndexPrefix.Apply("jaeger-service-")
-
-	type aliasConfig struct {
-		explicitWrite string
-		explicitRead  string
-	}
-
-	buildOne := func(prefix string, aliases aliasConfig, idxOpts config.IndexOptions) indices.Rotation {
-		var r indices.Rotation
-		switch {
-		case aliases.explicitWrite != "" && aliases.explicitRead != "":
-			r = indices.NewAliasedRotation(aliases.explicitWrite, aliases.explicitRead)
-		case f.config.UseReadWriteAliases:
-			writeSuffix := "write"
-			if f.config.WriteAliasSuffix != "" {
-				writeSuffix = f.config.WriteAliasSuffix
-			}
-			readSuffix := "read"
-			if f.config.ReadAliasSuffix != "" {
-				readSuffix = f.config.ReadAliasSuffix
-			}
-			r = indices.NewAliasedRotation(prefix+writeSuffix, prefix+readSuffix)
-		default:
-			r = indices.NewPeriodicRotation(prefix, idxOpts.DateLayout, config.RolloverFrequencyDuration(idxOpts.RolloverFrequency))
-		}
-		if len(f.config.RemoteReadClusters) > 0 {
-			r = indices.NewRemoteClusterRotation(r, f.config.RemoteReadClusters)
-		}
-		r = indices.NewLoggingRotation(r, f.logger)
-		return r
-	}
-
-	spanRotation = buildOne(spanPrefix, aliasConfig{
-		explicitWrite: f.config.SpanWriteAlias,
-		explicitRead:  f.config.SpanReadAlias,
-	}, f.config.Indices.Spans)
-	serviceRotation = buildOne(servicePrefix, aliasConfig{
-		explicitWrite: f.config.ServiceWriteAlias,
-		explicitRead:  f.config.ServiceReadAlias,
-	}, f.config.Indices.Services)
+	spanRotation = config.BuildRotation(config.RotationParams{
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-span-"),
+		IndexOptions:   f.config.Indices.Spans,
+		ExplicitWrite:  f.config.SpanWriteAlias,
+		ExplicitRead:   f.config.SpanReadAlias,
+		UseAliases:     f.config.UseReadWriteAliases,
+		WriteAlias:     f.config.WriteAliasSuffix,
+		ReadAlias:      f.config.ReadAliasSuffix,
+		RemoteClusters: f.config.RemoteReadClusters,
+	}, f.logger)
+	serviceRotation = config.BuildRotation(config.RotationParams{
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-service-"),
+		IndexOptions:   f.config.Indices.Services,
+		ExplicitWrite:  f.config.ServiceWriteAlias,
+		ExplicitRead:   f.config.ServiceReadAlias,
+		UseAliases:     f.config.UseReadWriteAliases,
+		WriteAlias:     f.config.WriteAliasSuffix,
+		ReadAlias:      f.config.ReadAliasSuffix,
+		RemoteClusters: f.config.RemoteReadClusters,
+	}, f.logger)
 	return spanRotation, serviceRotation
 }
 

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -146,12 +146,10 @@ func (f *FactoryBase) GetSpanWriterParams() esspanstore.SpanWriterParams {
 // GetDependencyStoreParams returns the esdepstorev2.Params which can be used to initialize the v1 and v2 dependency stores.
 func (f *FactoryBase) GetDependencyStoreParams() esdepstorev2.Params {
 	return esdepstorev2.Params{
-		Client:              f.getClient,
-		Logger:              f.logger,
-		IndexPrefix:         f.config.Indices.IndexPrefix,
-		IndexDateLayout:     f.config.Indices.Dependencies.DateLayout,
-		MaxDocCount:         f.config.MaxDocCount,
-		UseReadWriteAliases: f.config.UseReadWriteAliases,
+		Client:      f.getClient,
+		Logger:      f.logger,
+		MaxDocCount: f.config.MaxDocCount,
+		Rotation:    f.buildDependencyRotation(),
 	}
 }
 
@@ -245,6 +243,28 @@ func loadTokenFromFile(path string) (string, error) {
 		return "", err
 	}
 	return strings.TrimRight(string(b), "\r\n"), nil
+}
+
+func (f *FactoryBase) buildDependencyRotation() indices.Rotation {
+	depPrefix := f.config.Indices.IndexPrefix.Apply("jaeger-dependencies-")
+	var r indices.Rotation
+	if f.config.UseReadWriteAliases {
+		writeSuffix := "write"
+		if f.config.WriteAliasSuffix != "" {
+			writeSuffix = f.config.WriteAliasSuffix
+		}
+		readSuffix := "read"
+		if f.config.ReadAliasSuffix != "" {
+			readSuffix = f.config.ReadAliasSuffix
+		}
+		r = indices.NewAliasedRotation(depPrefix+writeSuffix, depPrefix+readSuffix)
+	} else {
+		r = indices.NewPeriodicRotation(depPrefix, f.config.Indices.Dependencies.DateLayout, config.RolloverFrequencyDuration(f.config.Indices.Dependencies.RolloverFrequency))
+	}
+	if len(f.config.RemoteReadClusters) > 0 {
+		r = indices.NewRemoteClusterRotation(r, f.config.RemoteReadClusters)
+	}
+	return indices.NewLoggingRotation(r, f.logger)
 }
 
 func (f *FactoryBase) buildRotations() (spanRotation, serviceRotation indices.Rotation) {

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -155,13 +155,11 @@ func (f *FactoryBase) GetDependencyStoreParams() esdepstorev2.Params {
 
 func (f *FactoryBase) CreateSamplingStore(int /* maxBuckets */) (samplingstore.Store, error) {
 	params := essamplestore.Params{
-		Client:                 f.getClient,
-		Logger:                 f.logger,
-		IndexPrefix:            f.config.Indices.IndexPrefix,
-		IndexDateLayout:        f.config.Indices.Sampling.DateLayout,
-		IndexRolloverFrequency: config.RolloverFrequencyAsNegativeDuration(f.config.Indices.Sampling.RolloverFrequency),
-		Lookback:               f.config.AdaptiveSamplingLookback,
-		MaxDocCount:            f.config.MaxDocCount,
+		Client:      f.getClient,
+		Logger:      f.logger,
+		Lookback:    f.config.AdaptiveSamplingLookback,
+		MaxDocCount: f.config.MaxDocCount,
+		Rotation:    f.buildSamplingRotation(),
 	}
 	store := essamplestore.NewSamplingStore(params)
 
@@ -171,7 +169,8 @@ func (f *FactoryBase) CreateSamplingStore(int /* maxBuckets */) (samplingstore.S
 		if err != nil {
 			return nil, err
 		}
-		if _, err := f.getClient().CreateTemplate(params.PrefixedIndexName()).Body(samplingMapping).Do(context.Background()); err != nil {
+		templateName := f.config.Indices.IndexPrefix.Apply("jaeger-sampling")
+		if _, err := f.getClient().CreateTemplate(templateName).Body(samplingMapping).Do(context.Background()); err != nil {
 			return nil, fmt.Errorf("failed to create template: %w", err)
 		}
 	}
@@ -243,6 +242,11 @@ func loadTokenFromFile(path string) (string, error) {
 		return "", err
 	}
 	return strings.TrimRight(string(b), "\r\n"), nil
+}
+
+func (f *FactoryBase) buildSamplingRotation() indices.Rotation {
+	samplingPrefix := f.config.Indices.IndexPrefix.Apply("jaeger-sampling-")
+	return indices.NewPeriodicRotation(samplingPrefix, f.config.Indices.Sampling.DateLayout, config.RolloverFrequencyDuration(f.config.Indices.Sampling.RolloverFrequency))
 }
 
 func (f *FactoryBase) buildDependencyRotation() indices.Rotation {

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -246,14 +246,14 @@ func loadTokenFromFile(path string) (string, error) {
 
 func (f *FactoryBase) buildSamplingRotation() indices.Rotation {
 	return config.BuildRotation(config.RotationParams{
-		IndexPrefix:  f.config.Indices.IndexPrefix.Apply("jaeger-sampling-"),
+		IndexPrefix:  f.config.Indices.IndexPrefix.Apply(indices.SamplingIndexBaseName),
 		IndexOptions: f.config.Indices.Sampling,
 	}, f.logger)
 }
 
 func (f *FactoryBase) buildDependencyRotation() indices.Rotation {
 	return config.BuildRotation(config.RotationParams{
-		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-dependencies-"),
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply(indices.DependencyIndexBaseName),
 		IndexOptions:   f.config.Indices.Dependencies,
 		UseAliases:     f.config.UseReadWriteAliases,
 		WriteAlias:     f.config.WriteAliasSuffix,
@@ -264,7 +264,7 @@ func (f *FactoryBase) buildDependencyRotation() indices.Rotation {
 
 func (f *FactoryBase) buildRotations() (spanRotation, serviceRotation indices.Rotation) {
 	spanRotation = config.BuildRotation(config.RotationParams{
-		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-span-"),
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply(indices.SpanIndexBaseName),
 		IndexOptions:   f.config.Indices.Spans,
 		ExplicitWrite:  f.config.SpanWriteAlias,
 		ExplicitRead:   f.config.SpanReadAlias,
@@ -274,7 +274,7 @@ func (f *FactoryBase) buildRotations() (spanRotation, serviceRotation indices.Ro
 		RemoteClusters: f.config.RemoteReadClusters,
 	}, f.logger)
 	serviceRotation = config.BuildRotation(config.RotationParams{
-		IndexPrefix:    f.config.Indices.IndexPrefix.Apply("jaeger-service-"),
+		IndexPrefix:    f.config.Indices.IndexPrefix.Apply(indices.ServiceIndexBaseName),
 		IndexOptions:   f.config.Indices.Services,
 		ExplicitWrite:  f.config.ServiceWriteAlias,
 		ExplicitRead:   f.config.ServiceReadAlias,

--- a/internal/storage/v1/elasticsearch/samplingstore/storage.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage.go
@@ -146,7 +146,8 @@ func (s *SamplingStore) writeProbabilitiesAndQPS(indexName string, ts time.Time,
 }
 
 func (s *SamplingStore) getLatestIndex(ctx context.Context, client es.Client) (string, error) {
-	candidates := s.rotation.ReadTargets(time.Now().UTC().Add(-s.lookback), time.Now().UTC())
+	now := time.Now().UTC()
+	candidates := s.rotation.ReadTargets(now.Add(-s.lookback), now)
 	for _, idx := range candidates {
 		exists, err := client.IndexExists(idx).Do(ctx)
 		if err != nil {

--- a/internal/storage/v1/elasticsearch/samplingstore/storage.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage.go
@@ -108,7 +108,7 @@ func (s *SamplingStore) GetLatestProbabilities() (model.ServiceOperationProbabil
 	clientFn := s.client()
 	index, err := s.getLatestIndex(ctx, clientFn)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get latest indices: %w", err)
+		return nil, fmt.Errorf("failed to get latest index: %w", err)
 	}
 	searchResult, err := clientFn.Search(index).
 		Size(s.maxDocCount).

--- a/internal/storage/v1/elasticsearch/samplingstore/storage.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
-	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	esquery "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/query"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore/model"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch/samplingstore/dbmodel"
@@ -27,40 +27,34 @@ const (
 )
 
 type SamplingStore struct {
-	client                 func() es.Client
-	logger                 *zap.Logger
-	samplingIndexPrefix    string
-	indexDateLayout        string
-	maxDocCount            int
-	indexRolloverFrequency time.Duration
-	lookback               time.Duration
+	client      func() es.Client
+	logger      *zap.Logger
+	maxDocCount int
+	lookback    time.Duration
+	rotation    indices.Rotation
 }
 
 type Params struct {
-	Client                 func() es.Client
-	Logger                 *zap.Logger
-	IndexPrefix            config.IndexPrefix
-	IndexDateLayout        string
-	IndexRolloverFrequency time.Duration
-	Lookback               time.Duration
-	MaxDocCount            int
+	Client      func() es.Client
+	Logger      *zap.Logger
+	Lookback    time.Duration
+	MaxDocCount int
+	Rotation    indices.Rotation
 }
 
 func NewSamplingStore(p Params) *SamplingStore {
 	return &SamplingStore{
-		client:                 p.Client,
-		logger:                 p.Logger,
-		samplingIndexPrefix:    p.PrefixedIndexName() + config.IndexPrefixSeparator,
-		indexDateLayout:        p.IndexDateLayout,
-		maxDocCount:            p.MaxDocCount,
-		indexRolloverFrequency: p.IndexRolloverFrequency,
-		lookback:               p.Lookback,
+		client:      p.Client,
+		logger:      p.Logger,
+		maxDocCount: p.MaxDocCount,
+		lookback:    p.Lookback,
+		rotation:    p.Rotation,
 	}
 }
 
 func (s *SamplingStore) InsertThroughput(throughput []*model.Throughput) error {
 	ts := time.Now()
-	indexName := indexWithDate(s.samplingIndexPrefix, s.indexDateLayout, ts)
+	indexName := s.rotation.WriteTarget(ts)
 	for _, eachThroughput := range dbmodel.FromThroughputs(throughput) {
 		s.client().Index().Index(indexName).Type(throughputType).
 			BodyJson(&dbmodel.TimeThroughput{
@@ -73,8 +67,8 @@ func (s *SamplingStore) InsertThroughput(throughput []*model.Throughput) error {
 
 func (s *SamplingStore) GetThroughput(start, end time.Time) ([]*model.Throughput, error) {
 	ctx := context.Background()
-	indices := getReadIndices(s.samplingIndexPrefix, s.indexDateLayout, start, end, s.indexRolloverFrequency)
-	searchResult, err := s.client().Search(indices...).
+	readIndices := s.rotation.ReadTargets(start, end)
+	searchResult, err := s.client().Search(readIndices...).
 		Size(s.maxDocCount).
 		Query(buildTSQuery(start, end)).
 		IgnoreUnavailable(true).
@@ -100,7 +94,7 @@ func (s *SamplingStore) InsertProbabilitiesAndQPS(hostname string,
 	qps model.ServiceOperationQPS,
 ) error {
 	ts := time.Now()
-	writeIndexName := indexWithDate(s.samplingIndexPrefix, s.indexDateLayout, ts)
+	writeIndexName := s.rotation.WriteTarget(ts)
 	val := dbmodel.ProbabilitiesAndQPS{
 		Hostname:      hostname,
 		Probabilities: probabilities,
@@ -113,11 +107,11 @@ func (s *SamplingStore) InsertProbabilitiesAndQPS(hostname string,
 func (s *SamplingStore) GetLatestProbabilities() (model.ServiceOperationProbabilities, error) {
 	ctx := context.Background()
 	clientFn := s.client()
-	indices, err := getLatestIndices(s.samplingIndexPrefix, s.indexDateLayout, clientFn, s.indexRolloverFrequency, s.lookback)
+	index, err := s.getLatestIndex(ctx, clientFn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest indices: %w", err)
 	}
-	searchResult, err := clientFn.Search(indices...).
+	searchResult, err := clientFn.Search(index).
 		Size(s.maxDocCount).
 		IgnoreUnavailable(true).
 		Do(ctx)
@@ -152,48 +146,20 @@ func (s *SamplingStore) writeProbabilitiesAndQPS(indexName string, ts time.Time,
 		}).Add()
 }
 
-func getLatestIndices(indexPrefix, indexDateLayout string, clientFn es.Client, rollover time.Duration, maxDuration time.Duration) ([]string, error) {
-	ctx := context.Background()
-	now := time.Now().UTC()
-	earliest := now.Add(-maxDuration)
-	earliestIndex := indexWithDate(indexPrefix, indexDateLayout, earliest)
-	for {
-		currentIndex := indexWithDate(indexPrefix, indexDateLayout, now)
-		exists, err := clientFn.IndexExists(currentIndex).Do(ctx)
+func (s *SamplingStore) getLatestIndex(ctx context.Context, client es.Client) (string, error) {
+	candidates := s.rotation.ReadTargets(time.Now().UTC().Add(-s.lookback), time.Now().UTC())
+	for _, idx := range candidates {
+		exists, err := client.IndexExists(idx).Do(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check index existence: %w", err)
+			return "", fmt.Errorf("failed to check index existence: %w", err)
 		}
 		if exists {
-			return []string{currentIndex}, nil
+			return idx, nil
 		}
-		if currentIndex == earliestIndex {
-			return nil, errors.New("falied to find latest index")
-		}
-		now = now.Add(rollover) // rollover is negative
 	}
-}
-
-func getReadIndices(indexName, indexDateLayout string, startTime time.Time, endTime time.Time, rollover time.Duration) []string {
-	var indices []string
-	firstIndex := indexWithDate(indexName, indexDateLayout, startTime)
-	currentIndex := indexWithDate(indexName, indexDateLayout, endTime)
-	for currentIndex != firstIndex {
-		indices = append(indices, currentIndex)
-		endTime = endTime.Add(rollover) // rollover is negative
-		currentIndex = indexWithDate(indexName, indexDateLayout, endTime)
-	}
-	indices = append(indices, firstIndex)
-	return indices
-}
-
-func (p *Params) PrefixedIndexName() string {
-	return p.IndexPrefix.Apply(samplingIndexBaseName)
+	return "", errors.New("failed to find latest index")
 }
 
 func buildTSQuery(start, end time.Time) elastic.Query {
 	return esquery.NewRangeQuery("timestamp").Gte(start).Lte(end)
-}
-
-func indexWithDate(indexNamePrefix, indexDateLayout string, date time.Time) string {
-	return indexNamePrefix + date.UTC().Format(indexDateLayout)
 }

--- a/internal/storage/v1/elasticsearch/samplingstore/storage.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage.go
@@ -21,9 +21,8 @@ import (
 )
 
 const (
-	samplingIndexBaseName = "jaeger-sampling"
-	throughputType        = "throughput-sampling"
-	probabilitiesType     = "probabilities-sampling"
+	throughputType    = "throughput-sampling"
+	probabilitiesType = "probabilities-sampling"
 )
 
 type SamplingStore struct {

--- a/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
@@ -33,15 +33,7 @@ type samplingStorageTest struct {
 	storage   *SamplingStore
 }
 
-func samplingRotation(prefix config.IndexPrefix) indices.Rotation {
-	return indices.NewPeriodicRotation(
-		prefix.Apply("jaeger-sampling-"),
-		"2006-01-02",
-		config.RolloverFrequencyDuration("day"),
-	)
-}
-
-func withEsSampling(prefix config.IndexPrefix, maxDocCount int, fn func(w *samplingStorageTest)) {
+func withEsSampling(indexPrefix config.IndexPrefix, indexDateLayout string, maxDocCount int, fn func(w *samplingStorageTest)) {
 	client := &mocks.Client{}
 	logger, logBuffer := testutils.NewLogger()
 	w := &samplingStorageTest{
@@ -52,7 +44,11 @@ func withEsSampling(prefix config.IndexPrefix, maxDocCount int, fn func(w *sampl
 			Client:      func() es.Client { return client },
 			Logger:      logger,
 			MaxDocCount: maxDocCount,
-			Rotation:    samplingRotation(prefix),
+			Rotation: indices.NewPeriodicRotation(
+				indexPrefix.Apply("jaeger-sampling-"),
+				indexDateLayout,
+				config.RolloverFrequencyDuration("day"),
+			),
 		}),
 	}
 	fn(w)
@@ -94,7 +90,11 @@ func TestGetLatestIndex(t *testing.T) {
 				Logger:      zap.NewNop(),
 				MaxDocCount: defaultMaxDocCount,
 				Lookback:    test.lookback,
-				Rotation:    samplingRotation(""),
+				Rotation: indices.NewPeriodicRotation(
+					"jaeger-sampling-",
+					"2006-01-02",
+					config.RolloverFrequencyDuration("day"),
+				),
 			})
 			indexService := &mocks.IndicesExistsService{}
 			client.On("IndexExists", mock.Anything).Return(indexService)
@@ -122,41 +122,69 @@ func TestGetLatestIndex(t *testing.T) {
 }
 
 func TestInsertThroughput(t *testing.T) {
-	withEsSampling("", defaultMaxDocCount, func(w *samplingStorageTest) {
-		throughputs := []*samplemodel.Throughput{
-			{Service: "my-svc", Operation: "op"},
-			{Service: "our-svc", Operation: "op2"},
-		}
-		fixedTime := time.Now()
-		indexName := "jaeger-sampling-" + fixedTime.UTC().Format("2006-01-02")
-		writeService := &mocks.IndexService{}
-		w.client.On("Index").Return(writeService)
-		writeService.On("Index", stringMatcher(indexName)).Return(writeService)
-		writeService.On("Type", stringMatcher(throughputType)).Return(writeService)
-		writeService.On("BodyJson", mock.Anything).Return(writeService)
-		writeService.On("Add", mock.Anything)
-		err := w.storage.InsertThroughput(throughputs)
-		require.NoError(t, err)
+	test := struct {
+		name          string
+		expectedError string
+	}{
+		name:          "insert throughput",
+		expectedError: "",
+	}
+
+	t.Run(test.name, func(t *testing.T) {
+		withEsSampling("", "2006-01-02", defaultMaxDocCount, func(w *samplingStorageTest) {
+			throughputs := []*samplemodel.Throughput{
+				{Service: "my-svc", Operation: "op"},
+				{Service: "our-svc", Operation: "op2"},
+			}
+			fixedTime := time.Now()
+			indexName := "jaeger-sampling-" + fixedTime.UTC().Format("2006-01-02")
+			writeService := &mocks.IndexService{}
+			w.client.On("Index").Return(writeService)
+			writeService.On("Index", stringMatcher(indexName)).Return(writeService)
+			writeService.On("Type", stringMatcher(throughputType)).Return(writeService)
+			writeService.On("BodyJson", mock.Anything).Return(writeService)
+			writeService.On("Add", mock.Anything)
+			err := w.storage.InsertThroughput(throughputs)
+			if test.expectedError != "" {
+				require.EqualError(t, err, test.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	})
 }
 
 func TestInsertProbabilitiesAndQPS(t *testing.T) {
-	withEsSampling("", defaultMaxDocCount, func(w *samplingStorageTest) {
-		pAQ := dbmodel.ProbabilitiesAndQPS{
-			Hostname:      "dell11eg843d",
-			Probabilities: samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
-			QPS:           samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
-		}
-		fixedTime := time.Now()
-		indexName := "jaeger-sampling-" + fixedTime.UTC().Format("2006-01-02")
-		writeService := &mocks.IndexService{}
-		w.client.On("Index").Return(writeService)
-		writeService.On("Index", stringMatcher(indexName)).Return(writeService)
-		writeService.On("Type", stringMatcher(probabilitiesType)).Return(writeService)
-		writeService.On("BodyJson", mock.Anything).Return(writeService)
-		writeService.On("Add", mock.Anything)
-		err := w.storage.InsertProbabilitiesAndQPS(pAQ.Hostname, pAQ.Probabilities, pAQ.QPS)
-		require.NoError(t, err)
+	test := struct {
+		name          string
+		expectedError string
+	}{
+		name:          "insert probabilities and qps",
+		expectedError: "",
+	}
+
+	t.Run(test.name, func(t *testing.T) {
+		withEsSampling("", "2006-01-02", defaultMaxDocCount, func(w *samplingStorageTest) {
+			pAQ := dbmodel.ProbabilitiesAndQPS{
+				Hostname:      "dell11eg843d",
+				Probabilities: samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
+				QPS:           samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
+			}
+			fixedTime := time.Now()
+			indexName := "jaeger-sampling-" + fixedTime.UTC().Format("2006-01-02")
+			writeService := &mocks.IndexService{}
+			w.client.On("Index").Return(writeService)
+			writeService.On("Index", stringMatcher(indexName)).Return(writeService)
+			writeService.On("Type", stringMatcher(probabilitiesType)).Return(writeService)
+			writeService.On("BodyJson", mock.Anything).Return(writeService)
+			writeService.On("Add", mock.Anything)
+			err := w.storage.InsertProbabilitiesAndQPS(pAQ.Hostname, pAQ.Probabilities, pAQ.QPS)
+			if test.expectedError != "" {
+				require.EqualError(t, err, test.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	})
 }
 
@@ -180,6 +208,19 @@ func TestGetThroughput(t *testing.T) {
 		maxDocCount    int
 		index          string
 	}{
+		{
+			name:         "good throughputs without prefix",
+			searchResult: createSearchResult(goodThroughputs),
+			expectedOutput: []*samplemodel.Throughput{
+				{
+					Service:   "my-svc",
+					Operation: "op",
+					Count:     10,
+				},
+			},
+			index:       mockIndex,
+			maxDocCount: 1000,
+		},
 		{
 			name:         "good throughputs without prefix",
 			searchResult: createSearchResult(goodThroughputs),
@@ -222,13 +263,12 @@ func TestGetThroughput(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			withEsSampling(test.indexPrefix, defaultMaxDocCount, func(w *samplingStorageTest) {
+			withEsSampling(test.indexPrefix, "2006-01-02", defaultMaxDocCount, func(w *samplingStorageTest) {
 				searchService := &mocks.SearchService{}
-				prefix := test.indexPrefix
-				if prefix != "" {
-					prefix += "-"
+				if test.indexPrefix != "" {
+					test.indexPrefix += "-"
 				}
-				index := prefix.Apply(test.index)
+				index := test.indexPrefix.Apply(test.index)
 				w.client.On("Search", []string{index}).Return(searchService)
 				searchService.On("Size", mock.Anything).Return(searchService)
 				searchService.On("Query", mock.Anything).Return(searchService)
@@ -328,7 +368,11 @@ func TestGetLatestProbabilities(t *testing.T) {
 				Logger:      zap.NewNop(),
 				MaxDocCount: defaultMaxDocCount,
 				Lookback:    72 * time.Hour,
-				Rotation:    samplingRotation(test.indexPrefix),
+				Rotation: indices.NewPeriodicRotation(
+					test.indexPrefix.Apply("jaeger-sampling-"),
+					"2006-01-02",
+					config.RolloverFrequencyDuration("day"),
+				),
 			})
 
 			searchService := &mocks.SearchService{}

--- a/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
@@ -17,6 +17,7 @@ import (
 
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/mocks"
 	samplemodel "github.com/jaegertracing/jaeger/internal/storage/v1/api/samplingstore/model"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/elasticsearch/samplingstore/dbmodel"
@@ -32,7 +33,15 @@ type samplingStorageTest struct {
 	storage   *SamplingStore
 }
 
-func withEsSampling(indexPrefix config.IndexPrefix, indexDateLayout string, maxDocCount int, fn func(w *samplingStorageTest)) {
+func samplingRotation(prefix config.IndexPrefix) indices.Rotation {
+	return indices.NewPeriodicRotation(
+		prefix.Apply("jaeger-sampling-"),
+		"2006-01-02",
+		config.RolloverFrequencyDuration("day"),
+	)
+}
+
+func withEsSampling(prefix config.IndexPrefix, maxDocCount int, fn func(w *samplingStorageTest)) {
 	client := &mocks.Client{}
 	logger, logBuffer := testutils.NewLogger()
 	w := &samplingStorageTest{
@@ -40,189 +49,114 @@ func withEsSampling(indexPrefix config.IndexPrefix, indexDateLayout string, maxD
 		logger:    logger,
 		logBuffer: logBuffer,
 		storage: NewSamplingStore(Params{
-			Client:          func() es.Client { return client },
-			Logger:          logger,
-			IndexPrefix:     indexPrefix,
-			IndexDateLayout: indexDateLayout,
-			MaxDocCount:     maxDocCount,
+			Client:      func() es.Client { return client },
+			Logger:      logger,
+			MaxDocCount: maxDocCount,
+			Rotation:    samplingRotation(prefix),
 		}),
 	}
 	fn(w)
 }
 
-func TestNewIndexPrefix(t *testing.T) {
+func TestGetLatestIndex(t *testing.T) {
 	tests := []struct {
-		name     string
-		prefix   config.IndexPrefix
-		expected string
+		name          string
+		lookback      time.Duration
+		expectedError string
+		indexError    error
+		indexExist    bool
 	}{
 		{
-			name:     "without prefix",
-			prefix:   "",
-			expected: "",
+			name:       "with index",
+			lookback:   24 * time.Hour,
+			indexExist: true,
 		},
 		{
-			name:     "with prefix",
-			prefix:   "foo",
-			expected: "foo-",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			client := &mocks.Client{}
-			r := NewSamplingStore(Params{
-				Client:          func() es.Client { return client },
-				Logger:          zap.NewNop(),
-				IndexPrefix:     test.prefix,
-				IndexDateLayout: "2006-01-02",
-				MaxDocCount:     defaultMaxDocCount,
-			})
-			assert.Equal(t, test.expected+samplingIndexBaseName+config.IndexPrefixSeparator, r.samplingIndexPrefix)
-		})
-	}
-}
-
-func TestGetReadIndices(t *testing.T) {
-	test := struct {
-		name  string
-		start time.Time
-		end   time.Time
-	}{
-		name:  "",
-		start: time.Date(2024, time.February, 10, 0, 0, 0, 0, time.UTC),
-		end:   time.Date(2024, time.February, 12, 0, 0, 0, 0, time.UTC),
-	}
-	t.Run(test.name, func(t *testing.T) {
-		expectedIndices := []string{
-			"prefix-jaeger-sampling-2024-02-12",
-			"prefix-jaeger-sampling-2024-02-11",
-			"prefix-jaeger-sampling-2024-02-10",
-		}
-		rollover := -time.Hour * 24
-		indices := getReadIndices("prefix-jaeger-sampling-", "2006-01-02", test.start, test.end, rollover)
-		assert.Equal(t, expectedIndices, indices)
-	})
-}
-
-func TestGetLatestIndices(t *testing.T) {
-	tests := []struct {
-		name            string
-		indexDateLayout string
-		maxDuration     time.Duration
-		expectedIndices []string
-		expectedError   string
-		IndexExistError error
-		indexExist      bool
-	}{
-		{
-			name:            "with index",
-			indexDateLayout: "2006-01-02",
-			maxDuration:     24 * time.Hour,
-			expectedIndices: []string{indexWithDate("", "2006-01-02", time.Now().UTC())},
-			expectedError:   "",
-			indexExist:      true,
+			name:          "without index",
+			lookback:      72 * time.Hour,
+			expectedError: "failed to find latest index",
+			indexExist:    false,
 		},
 		{
-			name:            "without index",
-			indexDateLayout: "2006-01-02",
-			maxDuration:     72 * time.Hour,
-			expectedError:   "falied to find latest index",
-			indexExist:      false,
-		},
-		{
-			name:            "check index existence",
-			indexDateLayout: "2006-01-02",
-			maxDuration:     24 * time.Hour,
-			expectedError:   "failed to check index existence: fail",
-			indexExist:      true,
-			IndexExistError: errors.New("fail"),
+			name:          "check index existence error",
+			lookback:      24 * time.Hour,
+			expectedError: "failed to check index existence: fail",
+			indexExist:    true,
+			indexError:    errors.New("fail"),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			withEsSampling("", test.indexDateLayout, defaultMaxDocCount, func(w *samplingStorageTest) {
-				indexService := &mocks.IndicesExistsService{}
-				w.client.On("IndexExists", mock.Anything).Return(indexService)
-				indexService.On("Do", mock.Anything).Return(test.indexExist, test.IndexExistError)
-				clientFnMock := w.storage.client()
-				actualIndices, err := getLatestIndices("", test.indexDateLayout, clientFnMock, -24*time.Hour, test.maxDuration)
-				if test.expectedError != "" {
-					require.EqualError(t, err, test.expectedError)
-					assert.Nil(t, actualIndices)
-				} else {
-					require.NoError(t, err)
-					require.Equal(t, test.expectedIndices, actualIndices)
-				}
+			client := &mocks.Client{}
+			store := NewSamplingStore(Params{
+				Client:      func() es.Client { return client },
+				Logger:      zap.NewNop(),
+				MaxDocCount: defaultMaxDocCount,
+				Lookback:    test.lookback,
+				Rotation:    samplingRotation(""),
 			})
+			indexService := &mocks.IndicesExistsService{}
+			client.On("IndexExists", mock.Anything).Return(indexService)
+			indexService.On("Do", mock.Anything).Return(test.indexExist, test.indexError)
+
+			if test.indexExist && test.indexError == nil {
+				searchService := &mocks.SearchService{}
+				client.On("Search", mock.AnythingOfType("[]string")).Return(searchService)
+				searchService.On("Size", mock.Anything).Return(searchService)
+				searchService.On("IgnoreUnavailable", true).Return(searchService)
+				emptyResult := &elastic.SearchResult{Hits: &elastic.SearchHits{Hits: []*elastic.SearchHit{}}}
+				searchService.On("Do", mock.Anything).Return(emptyResult, nil)
+			}
+
+			actual, err := store.GetLatestProbabilities()
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+				assert.Nil(t, actual)
+			} else {
+				require.NoError(t, err)
+				assert.Nil(t, actual)
+			}
 		})
 	}
 }
 
 func TestInsertThroughput(t *testing.T) {
-	test := struct {
-		name          string
-		expectedError string
-	}{
-		name:          "insert throughput",
-		expectedError: "",
-	}
-
-	t.Run(test.name, func(t *testing.T) {
-		withEsSampling("", "2006-01-02", defaultMaxDocCount, func(w *samplingStorageTest) {
-			throughputs := []*samplemodel.Throughput{
-				{Service: "my-svc", Operation: "op"},
-				{Service: "our-svc", Operation: "op2"},
-			}
-			fixedTime := time.Now()
-			indexName := indexWithDate("", "2006-01-02", fixedTime)
-			writeService := &mocks.IndexService{}
-			w.client.On("Index").Return(writeService)
-			writeService.On("Index", stringMatcher(indexName)).Return(writeService)
-			writeService.On("Type", stringMatcher(throughputType)).Return(writeService)
-			writeService.On("BodyJson", mock.Anything).Return(writeService)
-			writeService.On("Add", mock.Anything)
-			err := w.storage.InsertThroughput(throughputs)
-			if test.expectedError != "" {
-				require.EqualError(t, err, test.expectedError)
-			} else {
-				require.NoError(t, err)
-			}
-		})
+	withEsSampling("", defaultMaxDocCount, func(w *samplingStorageTest) {
+		throughputs := []*samplemodel.Throughput{
+			{Service: "my-svc", Operation: "op"},
+			{Service: "our-svc", Operation: "op2"},
+		}
+		fixedTime := time.Now()
+		indexName := "jaeger-sampling-" + fixedTime.UTC().Format("2006-01-02")
+		writeService := &mocks.IndexService{}
+		w.client.On("Index").Return(writeService)
+		writeService.On("Index", stringMatcher(indexName)).Return(writeService)
+		writeService.On("Type", stringMatcher(throughputType)).Return(writeService)
+		writeService.On("BodyJson", mock.Anything).Return(writeService)
+		writeService.On("Add", mock.Anything)
+		err := w.storage.InsertThroughput(throughputs)
+		require.NoError(t, err)
 	})
 }
 
 func TestInsertProbabilitiesAndQPS(t *testing.T) {
-	test := struct {
-		name          string
-		expectedError string
-	}{
-		name:          "insert probabilities and qps",
-		expectedError: "",
-	}
-
-	t.Run(test.name, func(t *testing.T) {
-		withEsSampling("", "2006-01-02", defaultMaxDocCount, func(w *samplingStorageTest) {
-			pAQ := dbmodel.ProbabilitiesAndQPS{
-				Hostname:      "dell11eg843d",
-				Probabilities: samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
-				QPS:           samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
-			}
-			fixedTime := time.Now()
-			indexName := indexWithDate("", "2006-01-02", fixedTime)
-			writeService := &mocks.IndexService{}
-			w.client.On("Index").Return(writeService)
-			writeService.On("Index", stringMatcher(indexName)).Return(writeService)
-			writeService.On("Type", stringMatcher(probabilitiesType)).Return(writeService)
-			writeService.On("BodyJson", mock.Anything).Return(writeService)
-			writeService.On("Add", mock.Anything)
-			err := w.storage.InsertProbabilitiesAndQPS(pAQ.Hostname, pAQ.Probabilities, pAQ.QPS)
-			if test.expectedError != "" {
-				require.EqualError(t, err, test.expectedError)
-			} else {
-				require.NoError(t, err)
-			}
-		})
+	withEsSampling("", defaultMaxDocCount, func(w *samplingStorageTest) {
+		pAQ := dbmodel.ProbabilitiesAndQPS{
+			Hostname:      "dell11eg843d",
+			Probabilities: samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
+			QPS:           samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
+		}
+		fixedTime := time.Now()
+		indexName := "jaeger-sampling-" + fixedTime.UTC().Format("2006-01-02")
+		writeService := &mocks.IndexService{}
+		w.client.On("Index").Return(writeService)
+		writeService.On("Index", stringMatcher(indexName)).Return(writeService)
+		writeService.On("Type", stringMatcher(probabilitiesType)).Return(writeService)
+		writeService.On("BodyJson", mock.Anything).Return(writeService)
+		writeService.On("Add", mock.Anything)
+		err := w.storage.InsertProbabilitiesAndQPS(pAQ.Hostname, pAQ.Probabilities, pAQ.QPS)
+		require.NoError(t, err)
 	})
 }
 
@@ -246,19 +180,6 @@ func TestGetThroughput(t *testing.T) {
 		maxDocCount    int
 		index          string
 	}{
-		{
-			name:         "good throughputs without prefix",
-			searchResult: createSearchResult(goodThroughputs),
-			expectedOutput: []*samplemodel.Throughput{
-				{
-					Service:   "my-svc",
-					Operation: "op",
-					Count:     10,
-				},
-			},
-			index:       mockIndex,
-			maxDocCount: 1000,
-		},
 		{
 			name:         "good throughputs without prefix",
 			searchResult: createSearchResult(goodThroughputs),
@@ -301,12 +222,13 @@ func TestGetThroughput(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			withEsSampling(test.indexPrefix, "2006-01-02", defaultMaxDocCount, func(w *samplingStorageTest) {
+			withEsSampling(test.indexPrefix, defaultMaxDocCount, func(w *samplingStorageTest) {
 				searchService := &mocks.SearchService{}
-				if test.indexPrefix != "" {
-					test.indexPrefix += "-"
+				prefix := test.indexPrefix
+				if prefix != "" {
+					prefix += "-"
 				}
-				index := test.indexPrefix.Apply(test.index)
+				index := prefix.Apply(test.index)
 				w.client.On("Search", []string{index}).Return(searchService)
 				searchService.On("Size", mock.Anything).Return(searchService)
 				searchService.On("Query", mock.Anything).Return(searchService)
@@ -400,27 +322,34 @@ func TestGetLatestProbabilities(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			withEsSampling(test.indexPrefix, "2006-01-02", defaultMaxDocCount, func(w *samplingStorageTest) {
-				searchService := &mocks.SearchService{}
-				index := test.indexPrefix.Apply(test.index)
-				w.client.On("Search", []string{index}).Return(searchService)
-				searchService.On("Size", mock.Anything).Return(searchService)
-				searchService.On("IgnoreUnavailable", true).Return(searchService)
-				searchService.On("Do", mock.Anything).Return(test.searchResult, test.searchError)
-
-				indicesexistsservice := &mocks.IndicesExistsService{}
-				w.client.On("IndexExists", index).Return(indicesexistsservice)
-				indicesexistsservice.On("Do", mock.Anything).Return(test.indexPresent, test.indexError)
-
-				actual, err := w.storage.GetLatestProbabilities()
-				if test.expectedError != "" {
-					require.EqualError(t, err, test.expectedError)
-					assert.Nil(t, actual)
-				} else {
-					require.NoError(t, err)
-					assert.Equal(t, test.expectedOutput, actual)
-				}
+			client := &mocks.Client{}
+			store := NewSamplingStore(Params{
+				Client:      func() es.Client { return client },
+				Logger:      zap.NewNop(),
+				MaxDocCount: defaultMaxDocCount,
+				Lookback:    72 * time.Hour,
+				Rotation:    samplingRotation(test.indexPrefix),
 			})
+
+			searchService := &mocks.SearchService{}
+			index := test.indexPrefix.Apply(test.index)
+			client.On("Search", []string{index}).Return(searchService)
+			searchService.On("Size", mock.Anything).Return(searchService)
+			searchService.On("IgnoreUnavailable", true).Return(searchService)
+			searchService.On("Do", mock.Anything).Return(test.searchResult, test.searchError)
+
+			indicesexistsservice := &mocks.IndicesExistsService{}
+			client.On("IndexExists", index).Return(indicesexistsservice)
+			indicesexistsservice.On("Do", mock.Anything).Return(test.indexPresent, test.indexError)
+
+			actual, err := store.GetLatestProbabilities()
+			if test.expectedError != "" {
+				require.EqualError(t, err, test.expectedError)
+				assert.Nil(t, actual)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedOutput, actual)
+			}
 		})
 	}
 }

--- a/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
@@ -316,7 +316,7 @@ func TestGetLatestProbabilities(t *testing.T) {
 		{
 			name:          "index check fail",
 			indexError:    errors.New("index check failure"),
-			expectedError: "failed to get latest indices: failed to check index existence: index check failure",
+			expectedError: "failed to get latest index: failed to check index existence: index check failure",
 			index:         mockIndex,
 		},
 	}

--- a/internal/storage/v2/elasticsearch/depstore/storage.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage.go
@@ -20,10 +20,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch/depstore/dbmodel"
 )
 
-const (
-	dependencyType          = "dependencies"
-	dependencyIndexBaseName = "jaeger-dependencies-"
-)
+const dependencyType = "dependencies"
 
 // CoreDependencyStore is a DB Level abstraction which directly read/write dependencies into ElasticSearch
 type CoreDependencyStore interface {

--- a/internal/storage/v2/elasticsearch/depstore/storage.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage.go
@@ -67,7 +67,7 @@ func (s *DependencyStore) WriteDependencies(ts time.Time, dependencies []dbmodel
 
 // CreateTemplates creates index templates.
 func (s *DependencyStore) CreateTemplates(dependenciesTemplate string) error {
-	_, err := s.client().CreateTemplate("jaeger-dependencies").Body(dependenciesTemplate).Do(context.Background())
+	_, err := s.client().CreateTemplate(indices.DependencyTemplateName).Body(dependenciesTemplate).Do(context.Background())
 	if err != nil {
 		return err
 	}

--- a/internal/storage/v2/elasticsearch/depstore/storage.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
-	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	esquery "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/query"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch/depstore/dbmodel"
 )
@@ -37,39 +37,33 @@ type CoreDependencyStore interface {
 
 // DependencyStore handles all queries and insertions to ElasticSearch dependencies
 type DependencyStore struct {
-	client                func() es.Client
-	logger                *zap.Logger
-	dependencyIndexPrefix string
-	indexDateLayout       string
-	maxDocCount           int
-	useReadWriteAliases   bool
+	client      func() es.Client
+	logger      *zap.Logger
+	maxDocCount int
+	rotation    indices.Rotation
 }
 
-// DependencyStoreParams holds constructor parameters for NewDependencyStore
+// Params holds constructor parameters for NewDependencyStore
 type Params struct {
-	Client              func() es.Client
-	Logger              *zap.Logger
-	IndexPrefix         config.IndexPrefix
-	IndexDateLayout     string
-	MaxDocCount         int
-	UseReadWriteAliases bool
+	Client      func() es.Client
+	Logger      *zap.Logger
+	MaxDocCount int
+	Rotation    indices.Rotation
 }
 
 // NewDependencyStore returns a DependencyStore
 func NewDependencyStore(p Params) *DependencyStore {
 	return &DependencyStore{
-		client:                p.Client,
-		logger:                p.Logger,
-		dependencyIndexPrefix: p.IndexPrefix.Apply(dependencyIndexBaseName),
-		indexDateLayout:       p.IndexDateLayout,
-		maxDocCount:           p.MaxDocCount,
-		useReadWriteAliases:   p.UseReadWriteAliases,
+		client:      p.Client,
+		logger:      p.Logger,
+		maxDocCount: p.MaxDocCount,
+		rotation:    p.Rotation,
 	}
 }
 
 // WriteDependencies write dependencies to Elasticsearch
 func (s *DependencyStore) WriteDependencies(ts time.Time, dependencies []dbmodel.DependencyLink) error {
-	writeIndexName := s.getWriteIndex(ts)
+	writeIndexName := s.rotation.WriteTarget(ts)
 	s.writeDependenciesToIndex(writeIndexName, ts, dependencies)
 	return nil
 }
@@ -93,8 +87,8 @@ func (s *DependencyStore) writeDependenciesToIndex(indexName string, ts time.Tim
 
 // GetDependencies returns all interservice dependencies
 func (s *DependencyStore) GetDependencies(ctx context.Context, endTs time.Time, lookback time.Duration) ([]dbmodel.DependencyLink, error) {
-	indices := s.getReadIndices(endTs, lookback)
-	searchResult, err := s.client().Search(indices...).
+	readIndices := s.rotation.ReadTargets(endTs.Add(-lookback), endTs)
+	searchResult, err := s.client().Search(readIndices...).
 		Size(s.maxDocCount).
 		Query(buildTSQuery(endTs, lookback)).
 		IgnoreUnavailable(true).
@@ -118,30 +112,4 @@ func (s *DependencyStore) GetDependencies(ctx context.Context, endTs time.Time, 
 
 func buildTSQuery(endTs time.Time, lookback time.Duration) elastic.Query {
 	return esquery.NewRangeQuery("timestamp").Gte(endTs.Add(-lookback)).Lte(endTs)
-}
-
-func (s *DependencyStore) getReadIndices(ts time.Time, lookback time.Duration) []string {
-	if s.useReadWriteAliases {
-		return []string{s.dependencyIndexPrefix + "read"}
-	}
-	var indices []string
-	firstIndex := indexWithDate(s.dependencyIndexPrefix, s.indexDateLayout, ts.Add(-lookback))
-	currentIndex := indexWithDate(s.dependencyIndexPrefix, s.indexDateLayout, ts)
-	for currentIndex != firstIndex {
-		indices = append(indices, currentIndex)
-		ts = ts.Add(-24 * time.Hour)
-		currentIndex = indexWithDate(s.dependencyIndexPrefix, s.indexDateLayout, ts)
-	}
-	return append(indices, firstIndex)
-}
-
-func indexWithDate(indexNamePrefix, indexDateLayout string, date time.Time) string {
-	return indexNamePrefix + date.UTC().Format(indexDateLayout)
-}
-
-func (s *DependencyStore) getWriteIndex(ts time.Time) string {
-	if s.useReadWriteAliases {
-		return s.dependencyIndexPrefix + "write"
-	}
-	return indexWithDate(s.dependencyIndexPrefix, s.indexDateLayout, ts)
 }

--- a/internal/storage/v2/elasticsearch/depstore/storage_test.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage_test.go
@@ -19,6 +19,7 @@ import (
 
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch/depstore/dbmodel"
 	"github.com/jaegertracing/jaeger/internal/testutils"
@@ -33,7 +34,7 @@ type depStorageTest struct {
 	storage   *DependencyStore
 }
 
-func withDepStorage(indexPrefix config.IndexPrefix, indexDateLayout string, maxDocCount int, fn func(r *depStorageTest)) {
+func withDepStorage(rotation indices.Rotation, maxDocCount int, fn func(r *depStorageTest)) {
 	client := &mocks.Client{}
 	logger, logBuffer := testutils.NewLogger()
 	r := &depStorageTest{
@@ -41,40 +42,24 @@ func withDepStorage(indexPrefix config.IndexPrefix, indexDateLayout string, maxD
 		logger:    logger,
 		logBuffer: logBuffer,
 		storage: NewDependencyStore(Params{
-			Client:          func() es.Client { return client },
-			Logger:          logger,
-			IndexPrefix:     indexPrefix,
-			IndexDateLayout: indexDateLayout,
-			MaxDocCount:     maxDocCount,
+			Client:      func() es.Client { return client },
+			Logger:      logger,
+			MaxDocCount: maxDocCount,
+			Rotation:    rotation,
 		}),
 	}
 	fn(r)
 }
 
-var _ CoreDependencyStore = &DependencyStore{} // check API conformance
-
-func TestNewSpanReaderIndexPrefix(t *testing.T) {
-	testCases := []struct {
-		prefix   config.IndexPrefix
-		expected string
-	}{
-		{prefix: "", expected: ""},
-		{prefix: "foo", expected: "foo-"},
-		{prefix: ":", expected: ":-"},
-	}
-	for _, testCase := range testCases {
-		client := &mocks.Client{}
-		r := NewDependencyStore(Params{
-			Client:          func() es.Client { return client },
-			Logger:          zap.NewNop(),
-			IndexPrefix:     testCase.prefix,
-			IndexDateLayout: "2006-01-02",
-			MaxDocCount:     defaultMaxDocCount,
-		})
-
-		assert.Equal(t, testCase.expected+dependencyIndexBaseName, r.dependencyIndexPrefix)
-	}
+func periodicRotation(prefix config.IndexPrefix, dateLayout string) indices.Rotation {
+	return indices.NewPeriodicRotation(
+		prefix.Apply(dependencyIndexBaseName),
+		dateLayout,
+		config.RolloverFrequencyDuration("day"),
+	)
 }
+
+var _ CoreDependencyStore = &DependencyStore{} // check API conformance
 
 func TestWriteDependencies(t *testing.T) {
 	testCases := []struct {
@@ -88,15 +73,16 @@ func TestWriteDependencies(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		withDepStorage("", "2006-01-02", defaultMaxDocCount, func(r *depStorageTest) {
+		rotation := periodicRotation("", "2006-01-02")
+		withDepStorage(rotation, defaultMaxDocCount, func(r *depStorageTest) {
 			fixedTime := time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC)
-			indexName := indexWithDate("", "2006-01-02", fixedTime)
+			expectedIndex := "jaeger-dependencies-1995-04-21"
 			writeService := &mocks.IndexService{}
 
 			r.client.On("Index").Return(writeService)
 			r.client.On("GetVersion").Return(testCase.esVersion)
 
-			writeService.On("Index", stringMatcher(indexName)).Return(writeService)
+			writeService.On("Index", stringMatcher(expectedIndex)).Return(writeService)
 			writeService.On("Type", stringMatcher(dependencyType)).Return(writeService)
 			writeService.On("BodyJson", mock.Anything).Return(writeService)
 			writeService.On("Add", mock.Anything).Return(nil, testCase.writeError)
@@ -141,7 +127,7 @@ func TestGetDependencies(t *testing.T) {
 				},
 			},
 			indices:     []any{"jaeger-dependencies-1995-04-21", "jaeger-dependencies-1995-04-20"},
-			maxDocCount: 1000, // can be anything, assertion will check this value is used in search query.
+			maxDocCount: 1000,
 		},
 		{
 			searchResult:  createSearchResult(badDependencies),
@@ -161,7 +147,8 @@ func TestGetDependencies(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		withDepStorage(testCase.indexPrefix, "2006-01-02", testCase.maxDocCount, func(r *depStorageTest) {
+		rotation := periodicRotation(testCase.indexPrefix, "2006-01-02")
+		withDepStorage(rotation, testCase.maxDocCount, func(r *depStorageTest) {
 			fixedTime := time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC)
 
 			searchService := &mocks.SearchService{}
@@ -196,22 +183,22 @@ func createSearchResult(dependencyLink string) *elastic.SearchResult {
 	return searchResult
 }
 
-func TestGetReadIndices(t *testing.T) {
+func TestReadTargets(t *testing.T) {
 	fixedTime := time.Date(1995, time.April, 21, 4, 12, 19, 95, time.UTC)
 	testCases := []struct {
-		indices  []string
+		rotation indices.Rotation
 		lookback time.Duration
-		params   Params
+		indices  []string
 	}{
 		{
-			params:   Params{IndexPrefix: "", IndexDateLayout: "2006-01-02", UseReadWriteAliases: true},
+			rotation: indices.NewAliasedRotation(dependencyIndexBaseName+"write", dependencyIndexBaseName+"read"),
 			lookback: 23 * time.Hour,
 			indices: []string{
 				dependencyIndexBaseName + "read",
 			},
 		},
 		{
-			params:   Params{IndexPrefix: "", IndexDateLayout: "2006-01-02"},
+			rotation: periodicRotation("", "2006-01-02"),
 			lookback: 23 * time.Hour,
 			indices: []string{
 				dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
@@ -219,7 +206,7 @@ func TestGetReadIndices(t *testing.T) {
 			},
 		},
 		{
-			params:   Params{IndexPrefix: "", IndexDateLayout: "2006-01-02"},
+			rotation: periodicRotation("", "2006-01-02"),
 			lookback: 13 * time.Hour,
 			indices: []string{
 				dependencyIndexBaseName + fixedTime.UTC().Format("2006-01-02"),
@@ -227,14 +214,14 @@ func TestGetReadIndices(t *testing.T) {
 			},
 		},
 		{
-			params:   Params{IndexPrefix: "foo:", IndexDateLayout: "2006-01-02"},
+			rotation: periodicRotation("foo:", "2006-01-02"),
 			lookback: 1 * time.Hour,
 			indices: []string{
 				"foo:" + config.IndexPrefixSeparator + dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
 			},
 		},
 		{
-			params:   Params{IndexPrefix: "foo-", IndexDateLayout: "2006-01-02"},
+			rotation: periodicRotation("foo-", "2006-01-02"),
 			lookback: 0,
 			indices: []string{
 				"foo" + config.IndexPrefixSeparator + dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
@@ -242,30 +229,29 @@ func TestGetReadIndices(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		s := NewDependencyStore(testCase.params)
-		assert.Equal(t, testCase.indices, s.getReadIndices(fixedTime, testCase.lookback))
+		actual := testCase.rotation.ReadTargets(fixedTime.Add(-testCase.lookback), fixedTime)
+		assert.Equal(t, testCase.indices, actual)
 	}
 }
 
-func TestGetWriteIndex(t *testing.T) {
+func TestWriteTarget(t *testing.T) {
 	fixedTime := time.Date(1995, time.April, 21, 4, 12, 19, 95, time.UTC)
 	testCases := []struct {
+		rotation   indices.Rotation
 		writeIndex string
-		lookback   time.Duration
-		params     Params
 	}{
 		{
-			params:     Params{IndexPrefix: "", IndexDateLayout: "2006-01-02", UseReadWriteAliases: true},
+			rotation:   indices.NewAliasedRotation(dependencyIndexBaseName+"write", dependencyIndexBaseName+"read"),
 			writeIndex: dependencyIndexBaseName + "write",
 		},
 		{
-			params:     Params{IndexPrefix: "", IndexDateLayout: "2006-01-02", UseReadWriteAliases: false},
+			rotation:   periodicRotation("", "2006-01-02"),
 			writeIndex: dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
 		},
 	}
 	for _, testCase := range testCases {
-		s := NewDependencyStore(testCase.params)
-		assert.Equal(t, testCase.writeIndex, s.getWriteIndex(fixedTime))
+		actual := testCase.rotation.WriteTarget(fixedTime)
+		assert.Equal(t, testCase.writeIndex, actual)
 	}
 }
 

--- a/internal/storage/v2/elasticsearch/depstore/storage_test.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage_test.go
@@ -53,7 +53,7 @@ func withDepStorage(rotation indices.Rotation, maxDocCount int, fn func(r *depSt
 
 func periodicRotation(prefix config.IndexPrefix, dateLayout string) indices.Rotation {
 	return indices.NewPeriodicRotation(
-		prefix.Apply(dependencyIndexBaseName),
+		prefix.Apply(indices.DependencyIndexBaseName),
 		dateLayout,
 		config.RolloverFrequencyDuration("day"),
 	)
@@ -191,40 +191,40 @@ func TestReadTargets(t *testing.T) {
 		indices  []string
 	}{
 		{
-			rotation: indices.NewAliasedRotation(dependencyIndexBaseName+"write", dependencyIndexBaseName+"read"),
+			rotation: indices.NewAliasedRotation(indices.DependencyIndexBaseName+"write", indices.DependencyIndexBaseName+"read"),
 			lookback: 23 * time.Hour,
 			indices: []string{
-				dependencyIndexBaseName + "read",
+				indices.DependencyIndexBaseName + "read",
 			},
 		},
 		{
 			rotation: periodicRotation("", "2006-01-02"),
 			lookback: 23 * time.Hour,
 			indices: []string{
-				dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
-				dependencyIndexBaseName + fixedTime.Add(-23*time.Hour).Format("2006-01-02"),
+				indices.DependencyIndexBaseName + fixedTime.Format("2006-01-02"),
+				indices.DependencyIndexBaseName + fixedTime.Add(-23*time.Hour).Format("2006-01-02"),
 			},
 		},
 		{
 			rotation: periodicRotation("", "2006-01-02"),
 			lookback: 13 * time.Hour,
 			indices: []string{
-				dependencyIndexBaseName + fixedTime.UTC().Format("2006-01-02"),
-				dependencyIndexBaseName + fixedTime.Add(-13*time.Hour).Format("2006-01-02"),
+				indices.DependencyIndexBaseName + fixedTime.UTC().Format("2006-01-02"),
+				indices.DependencyIndexBaseName + fixedTime.Add(-13*time.Hour).Format("2006-01-02"),
 			},
 		},
 		{
 			rotation: periodicRotation("foo:", "2006-01-02"),
 			lookback: 1 * time.Hour,
 			indices: []string{
-				"foo:" + config.IndexPrefixSeparator + dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
+				"foo:" + config.IndexPrefixSeparator + indices.DependencyIndexBaseName + fixedTime.Format("2006-01-02"),
 			},
 		},
 		{
 			rotation: periodicRotation("foo-", "2006-01-02"),
 			lookback: 0,
 			indices: []string{
-				"foo" + config.IndexPrefixSeparator + dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
+				"foo" + config.IndexPrefixSeparator + indices.DependencyIndexBaseName + fixedTime.Format("2006-01-02"),
 			},
 		},
 	}
@@ -241,12 +241,12 @@ func TestWriteTarget(t *testing.T) {
 		writeIndex string
 	}{
 		{
-			rotation:   indices.NewAliasedRotation(dependencyIndexBaseName+"write", dependencyIndexBaseName+"read"),
-			writeIndex: dependencyIndexBaseName + "write",
+			rotation:   indices.NewAliasedRotation(indices.DependencyIndexBaseName+"write", indices.DependencyIndexBaseName+"read"),
+			writeIndex: indices.DependencyIndexBaseName + "write",
 		},
 		{
 			rotation:   periodicRotation("", "2006-01-02"),
-			writeIndex: dependencyIndexBaseName + fixedTime.Format("2006-01-02"),
+			writeIndex: indices.DependencyIndexBaseName + fixedTime.Format("2006-01-02"),
 		},
 	}
 	for _, testCase := range testCases {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	spanIndexBaseName    = "jaeger-span-"
-	serviceIndexBaseName = "jaeger-service-"
 	traceIDAggregation   = "traceIDs"
 	indexPrefixSeparator = "-"
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -117,8 +117,8 @@ func withSpanReader(t *testing.T, fn func(r *spanReaderTest)) {
 			MaxSpanAge:        0,
 			TagDotReplacement: "@",
 			MaxDocCount:       defaultMaxDocCount,
-			SpanRotation:      indices.NewPeriodicRotation(spanIndexBaseName, "2006-01-02", 24*time.Hour),
-			ServiceRotation:   indices.NewPeriodicRotation(serviceIndexBaseName, "2006-01-02", 24*time.Hour),
+			SpanRotation:      indices.NewPeriodicRotation(indices.SpanIndexBaseName, "2006-01-02", 24*time.Hour),
+			ServiceRotation:   indices.NewPeriodicRotation(indices.ServiceIndexBaseName, "2006-01-02", 24*time.Hour),
 		}),
 	}
 	fn(r)
@@ -136,11 +136,11 @@ func withArchiveSpanReader(t *testing.T, readAlias bool, readAliasSuffix string,
 		if readAliasSuffix != "" {
 			suffix = readAliasSuffix
 		}
-		spanRotation = indices.NewAliasedRotation(spanIndexBaseName+suffix, spanIndexBaseName+suffix)
-		serviceRotation = indices.NewAliasedRotation(serviceIndexBaseName+suffix, serviceIndexBaseName+suffix)
+		spanRotation = indices.NewAliasedRotation(indices.SpanIndexBaseName+suffix, indices.SpanIndexBaseName+suffix)
+		serviceRotation = indices.NewAliasedRotation(indices.ServiceIndexBaseName+suffix, indices.ServiceIndexBaseName+suffix)
 	} else {
-		spanRotation = indices.NewPeriodicRotation(spanIndexBaseName, "2006-01-02", 24*time.Hour)
-		serviceRotation = indices.NewPeriodicRotation(serviceIndexBaseName, "2006-01-02", 24*time.Hour)
+		spanRotation = indices.NewPeriodicRotation(indices.SpanIndexBaseName, "2006-01-02", 24*time.Hour)
+		serviceRotation = indices.NewPeriodicRotation(indices.ServiceIndexBaseName, "2006-01-02", 24*time.Hour)
 	}
 
 	r := &spanReaderTest{
@@ -188,8 +188,8 @@ func TestSpanReaderRotations(t *testing.T) {
 	}{
 		{
 			name:            "periodic rotations",
-			spanRotation:    indices.NewPeriodicRotation(spanIndexBaseName, "2006-01-02-15", 24*time.Hour),
-			serviceRotation: indices.NewPeriodicRotation(serviceIndexBaseName, "2006-01-02", 24*time.Hour),
+			spanRotation:    indices.NewPeriodicRotation(indices.SpanIndexBaseName, "2006-01-02-15", 24*time.Hour),
+			serviceRotation: indices.NewPeriodicRotation(indices.ServiceIndexBaseName, "2006-01-02", 24*time.Hour),
 			expectedIndices: []string{"jaeger-span-2019-10-10-05", "jaeger-service-2019-10-10"},
 		},
 		{
@@ -201,11 +201,11 @@ func TestSpanReaderRotations(t *testing.T) {
 		{
 			name: "with remote clusters",
 			spanRotation: indices.NewRemoteClusterRotation(
-				indices.NewPeriodicRotation(spanIndexBaseName, "2006-01-02-15", 24*time.Hour),
+				indices.NewPeriodicRotation(indices.SpanIndexBaseName, "2006-01-02-15", 24*time.Hour),
 				[]string{"cluster_one", "cluster_two"},
 			),
 			serviceRotation: indices.NewRemoteClusterRotation(
-				indices.NewPeriodicRotation(serviceIndexBaseName, "2006-01-02", 24*time.Hour),
+				indices.NewPeriodicRotation(indices.ServiceIndexBaseName, "2006-01-02", 24*time.Hour),
 				[]string{"cluster_one", "cluster_two"},
 			),
 			expectedIndices: []string{
@@ -518,28 +518,28 @@ func TestSpanReaderFindIndices(t *testing.T) {
 			startTime: today.Add(-time.Millisecond),
 			endTime:   today,
 			expected: []string{
-				indices.IndexWithDate(spanIndexBaseName, dateLayout, today),
+				indices.IndexWithDate(indices.SpanIndexBaseName, dateLayout, today),
 			},
 		},
 		{
 			startTime: today.Add(-13 * time.Hour),
 			endTime:   today,
 			expected: []string{
-				indices.IndexWithDate(spanIndexBaseName, dateLayout, today),
-				indices.IndexWithDate(spanIndexBaseName, dateLayout, yesterday),
+				indices.IndexWithDate(indices.SpanIndexBaseName, dateLayout, today),
+				indices.IndexWithDate(indices.SpanIndexBaseName, dateLayout, yesterday),
 			},
 		},
 		{
 			startTime: today.Add(-48 * time.Hour),
 			endTime:   today,
 			expected: []string{
-				indices.IndexWithDate(spanIndexBaseName, dateLayout, today),
-				indices.IndexWithDate(spanIndexBaseName, dateLayout, yesterday),
-				indices.IndexWithDate(spanIndexBaseName, dateLayout, twoDaysAgo),
+				indices.IndexWithDate(indices.SpanIndexBaseName, dateLayout, today),
+				indices.IndexWithDate(indices.SpanIndexBaseName, dateLayout, yesterday),
+				indices.IndexWithDate(indices.SpanIndexBaseName, dateLayout, twoDaysAgo),
 			},
 		},
 	}
-	rotation := indices.NewPeriodicRotation(spanIndexBaseName, dateLayout, 24*time.Hour)
+	rotation := indices.NewPeriodicRotation(indices.SpanIndexBaseName, dateLayout, 24*time.Hour)
 	for _, testCase := range testCases {
 		actual := rotation.ReadTargets(testCase.startTime, testCase.endTime)
 		assert.Equal(t, testCase.expected, actual)
@@ -548,7 +548,7 @@ func TestSpanReaderFindIndices(t *testing.T) {
 
 func TestSpanReaderIndexWithDate(t *testing.T) {
 	withSpanReader(t, func(_ *spanReaderTest) {
-		actual := indices.IndexWithDate(spanIndexBaseName, "2006-01-02", time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC))
+		actual := indices.IndexWithDate(indices.SpanIndexBaseName, "2006-01-02", time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC))
 		assert.Equal(t, "jaeger-span-1995-04-21", actual)
 	})
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
@@ -43,8 +43,8 @@ func withSpanWriter(fn func(w *spanWriterTest)) {
 			Client:          func() es.Client { return client },
 			Logger:          logger,
 			MetricsFactory:  metricsFactory,
-			SpanRotation:    indices.NewPeriodicRotation(spanIndexBaseName, "2006-01-02", 24*time.Hour),
-			ServiceRotation: indices.NewPeriodicRotation(serviceIndexBaseName, "2006-01-02", 24*time.Hour),
+			SpanRotation:    indices.NewPeriodicRotation(indices.SpanIndexBaseName, "2006-01-02", 24*time.Hour),
+			ServiceRotation: indices.NewPeriodicRotation(indices.ServiceIndexBaseName, "2006-01-02", 24*time.Hour),
 		}),
 	}
 	fn(w)
@@ -66,8 +66,8 @@ func TestSpanWriterRotations(t *testing.T) {
 	}{
 		{
 			name:            "periodic rotations",
-			spanRotation:    indices.NewPeriodicRotation(spanIndexBaseName, "2006-01-02-15", 24*time.Hour),
-			serviceRotation: indices.NewPeriodicRotation(serviceIndexBaseName, "2006-01-02", 24*time.Hour),
+			spanRotation:    indices.NewPeriodicRotation(indices.SpanIndexBaseName, "2006-01-02-15", 24*time.Hour),
+			serviceRotation: indices.NewPeriodicRotation(indices.ServiceIndexBaseName, "2006-01-02", 24*time.Hour),
 			expectedSpan:    "jaeger-span-2019-10-10-05",
 			expectedService: "jaeger-service-2019-10-10",
 		},
@@ -185,8 +185,8 @@ func TestSpanIndexName(t *testing.T) {
 	span := &model.Span{
 		StartTime: date,
 	}
-	spanIndexName := indices.IndexWithDate(spanIndexBaseName, "2006-01-02", span.StartTime)
-	serviceIndexName := indices.IndexWithDate(serviceIndexBaseName, "2006-01-02", span.StartTime)
+	spanIndexName := indices.IndexWithDate(indices.SpanIndexBaseName, "2006-01-02", span.StartTime)
+	serviceIndexName := indices.IndexWithDate(indices.ServiceIndexBaseName, "2006-01-02", span.StartTime)
 	assert.Equal(t, "jaeger-span-1995-04-21", spanIndexName)
 	assert.Equal(t, "jaeger-service-1995-04-21", serviceIndexName)
 }


### PR DESCRIPTION
## Summary
- Migrates the dependency store, metric store, and sampling store to use the `Rotation` interface introduced in #8808
- Removes legacy `TimeRangeIndexFn`-based index computation and `useReadWriteAliases` boolean branching from these stores
- All ES storage components now use the unified Rotation abstraction for index name computation

Closes #8808 (follow-up: dep/metric/sampling stores were missed in that PR)

## Changes
- **depstore**: Replace `useReadWriteAliases`/`indexDateLayout`/`dependencyIndexPrefix` fields with a single `Rotation` field. Remove `getReadIndices`/`getWriteIndex`/`indexWithDate` helper methods.
- **metricstore QueryBuilder**: Replace `timeRangeIndices` field with `spanRotation`. Add `buildSpanRotation` helper.
- **samplingstore**: Replace `indexDateLayout`/`indexRolloverFrequency`/`samplingIndexPrefix` fields with a single `Rotation` field. The `getLatestIndex` method now iterates over `ReadTargets` candidates and probes ES for existence.
- **factory**: Add `buildDependencyRotation()` and `buildSamplingRotation()` methods; update `GetDependencyStoreParams()` and `CreateSamplingStore()` to pass `Rotation` instead of raw config fields.

## Test plan
- [x] All existing tests pass (`make test` — 3579 tests, 0 failures)
- [x] `make lint` passes with 0 issues
- [x] Depstore tests rewritten to test via `Rotation` interface directly
- [x] Sampling store tests rewritten to use `Rotation` interface
- [x] Metricstore Execute test still validates correct index pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)