### PR TITLE
feat(query): Accept base64-encoded trace IDs in HTTP API endpoints

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -4,6 +4,7 @@
 package apiv3
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -140,7 +141,7 @@ func (*HTTPGateway) marshalResponse(response proto.Message, w http.ResponseWrite
 
 func (h *HTTPGateway) getTrace(w http.ResponseWriter, r *http.Request) {
 	traceIDVar := r.PathValue(paramTraceID)
-	traceID, err := model.TraceIDFromString(traceIDVar)
+	traceID, err := TraceIDFromString(traceIDVar)
 	if h.tryParamError(w, err, paramTraceID) {
 		return
 	}
@@ -242,4 +243,29 @@ func (h *HTTPGateway) getOperations(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	h.marshalResponse(&api_v3.GetOperationsResponse{Operations: apiOperations}, w)
+}
+
+// TraceIDFromString parses a trace ID from either a hex string or a base64 string.
+// It supports both standard and URL-safe base64, with or without padding.
+func TraceIDFromString(s string) (model.TraceID, error) {
+	traceID, err := model.TraceIDFromString(s)
+	if err == nil {
+		return traceID, nil
+	}
+	// 128-bit trace ID = 24 base64 chars with padding, 22 without.
+	if len(s) > 24 {
+		return model.TraceID{}, err
+	}
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.RawURLEncoding,
+	}
+	for _, enc := range encodings {
+		if b, b64Err := enc.DecodeString(s); b64Err == nil {
+			return model.TraceIDFromBytes(b)
+		}
+	}
+	return model.TraceID{}, err
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -670,6 +670,11 @@ func TestTraceIDFromString(t *testing.T) {
 			input:   "not-a-valid-id!",
 			wantErr: true,
 		},
+		{
+			name:    "too long for trace ID",
+			input:   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAlong",
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -163,6 +163,50 @@ func TestHTTPGatewayGetTrace(t *testing.T) {
 	}
 }
 
+func TestHTTPGatewayGetTraceBase64(t *testing.T) {
+	tests := []struct {
+		name    string
+		urlPath string
+		traceID pcommon.TraceID
+	}{
+		{
+			name:    "standard base64 with padding",
+			urlPath: "/api/v3/traces/AAAAAAAAAAAAAAAAAAAAAQ==",
+			traceID: traceID, // [16]byte{0,...,0,1}
+		},
+		{
+			// base64 contains "/" which must be percent-encoded in URL path
+			name:    "base64 with slash (url-encoded)",
+			urlPath: "/api/v3/traces/AAAAAAAAAP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2Fw==",
+			traceID: pcommon.TraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}),
+		},
+		{
+			// base64 contains "+" which must be percent-encoded in URL path
+			name:    "base64 with plus (url-encoded)",
+			urlPath: "/api/v3/traces/EjRWeJq83vD%2B3LqYdlQyEA==",
+			traceID: pcommon.TraceID([16]byte{0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := setupHTTPGatewayNoServer(t, "")
+			gw.reader.
+				On("GetTraces", matchContext, []tracestore.GetTraceParams{{TraceID: tc.traceID}}).
+				Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+					yield([]ptrace.Traces{makeTestTrace()}, nil)
+				})).Once()
+
+			r, err := http.NewRequest(http.MethodGet, tc.urlPath, http.NoBody)
+			require.NoError(t, err)
+			w := httptest.NewRecorder()
+			gw.router.ServeHTTP(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+			gw.reader.AssertCalled(t, "GetTraces", matchContext, []tracestore.GetTraceParams{{TraceID: tc.traceID}})
+		})
+	}
+}
+
 func TestHTTPGatewayGetTraceEmptyResponse(t *testing.T) {
 	gw := setupHTTPGatewayNoServer(t, "")
 	gw.reader.On("GetTraces", matchContext, mock.AnythingOfType("[]tracestore.GetTraceParams")).
@@ -558,4 +602,85 @@ func TestHTTPGatewayFindTraceSummariesError(t *testing.T) {
 	gw.router.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), assert.AnError.Error())
+}
+
+func TestTraceIDFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantHi  uint64
+		wantLo  uint64
+		wantErr bool
+	}{
+		{
+			name:   "hex 64-bit",
+			input:  "1",
+			wantLo: 1,
+		},
+		{
+			name:   "hex 128-bit",
+			input:  "00000000000000010000000000000002",
+			wantHi: 1,
+			wantLo: 2,
+		},
+		{
+			name:   "base64 with padding (128-bit)",
+			input:  "AAAAAAAAAAEAAAAAAAAAAQ==",
+			wantHi: 1,
+			wantLo: 1,
+		},
+		{
+			name:   "base64 without padding (128-bit)",
+			input:  "AAAAAAAAAAEAAAAAAAAAAQ",
+			wantHi: 1,
+			wantLo: 1,
+		},
+		{
+			name:   "base64 64-bit",
+			input:  "AAAAAAAAAAAAAAAAAAAAAQ==",
+			wantHi: 0,
+			wantLo: 1,
+		},
+		{
+			name:   "base64 with slash",
+			input:  "AAAAAAAAAP///////////w==",
+			wantHi: 0xFF,
+			wantLo: 0xFFFFFFFFFFFFFFFF,
+		},
+		{
+			name:   "base64 with plus",
+			input:  "EjRWeJq83vD+3LqYdlQyEA==",
+			wantHi: 0x123456789ABCDEF0,
+			wantLo: 0xFEDCBA9876543210,
+		},
+		{
+			name:   "url-safe base64 (dash instead of plus)",
+			input:  "EjRWeJq83vD-3LqYdlQyEA==",
+			wantHi: 0x123456789ABCDEF0,
+			wantLo: 0xFEDCBA9876543210,
+		},
+		{
+			name:   "url-safe base64 (underscore instead of slash)",
+			input:  "AAAAAAAAAP___________w==",
+			wantHi: 0xFF,
+			wantLo: 0xFFFFFFFFFFFFFFFF,
+		},
+		{
+			name:    "invalid string",
+			input:   "not-a-valid-id!",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tid, err := TraceIDFromString(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantHi, tid.High)
+			assert.Equal(t, tc.wantLo, tid.Low)
+		})
+	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3"
 	deepdependencies "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/qualitymetrics"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
@@ -429,7 +430,7 @@ func (*APIHandler) filterDependenciesByService(
 // Parses trace ID from URL like /traces/{trace-id}
 func (aH *APIHandler) parseTraceID(w http.ResponseWriter, r *http.Request) (model.TraceID, bool) {
 	traceIDVar := r.PathValue(traceIDParam)
-	traceID, err := model.TraceIDFromString(traceIDVar)
+	traceID, err := apiv3.TraceIDFromString(traceIDVar)
 	if aH.handleError(w, err, http.StatusBadRequest) {
 		return traceID, false
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -194,6 +194,19 @@ func TestGetTraceSuccess(t *testing.T) {
 	assert.Empty(t, response.Errors)
 }
 
+func TestGetTraceBase64Success(t *testing.T) {
+	ts := initializeTestServer(t)
+	ts.traceReader.On("GetTraces", mock.Anything, mock.Anything).
+		Return(tracesIter(makeMockPTrace())).Once()
+
+	// base64 of [16]byte{0,0,0,0,0,0,0,0xFF, 0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF}
+	// contains "/" which is percent-encoded in the URL
+	var response structuredResponse
+	err := getJSON(ts.server.URL+`/api/traces/AAAAAAAAAP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2Fw==`, &response)
+	require.NoError(t, err)
+	assert.Empty(t, response.Errors)
+}
+
 func extractTraces(t *testing.T, response *structuredResponse) []ui.Trace {
 	var traces []ui.Trace
 	b, err := json.Marshal(response.Data)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -195,12 +195,15 @@ func TestGetTraceSuccess(t *testing.T) {
 }
 
 func TestGetTraceBase64Success(t *testing.T) {
-	ts := initializeTestServer(t)
-	ts.traceReader.On("GetTraces", mock.Anything, mock.Anything).
-		Return(tracesIter(makeMockPTrace())).Once()
+	// base64 "AAAAAAAAAP///////////w==" decodes to traceID {High: 0xFF, Low: 0xFFFFFFFFFFFFFFFF}
+	expectedTraceID := v1adapter.FromV1TraceID(model.NewTraceID(0xFF, 0xFFFFFFFFFFFFFFFF))
 
-	// base64 of [16]byte{0,0,0,0,0,0,0,0xFF, 0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF}
-	// contains "/" which is percent-encoded in the URL
+	ts := initializeTestServer(t)
+	ts.traceReader.On("GetTraces", mock.Anything, mock.MatchedBy(func(params []tracestore.GetTraceParams) bool {
+		return len(params) == 1 && params[0].TraceID == expectedTraceID
+	})).Return(tracesIter(makeMockPTrace())).Once()
+
+	// "/" in base64 is percent-encoded as %2F in the URL path
 	var response structuredResponse
 	err := getJSON(ts.server.URL+`/api/traces/AAAAAAAAAP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2Fw==`, &response)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Add base64 trace ID parsing to `/api/traces/{traceID}` (v1) and `/api/v3/traces/{trace_id}` (v3) HTTP endpoints
- Parser tries hex first (backward compatible), then falls back to base64 (standard, URL-safe, with/without padding)
- Enables Jaeger UI to pass base64 trace IDs directly from OTLP/protobuf JSON responses without conversion

Required for https://github.com/jaegertracing/jaeger-ui/pull/4118

## Test plan

- [x] Unit tests for `traceIDFromString` covering hex, base64 with padding, base64 without padding, URL-safe base64, and invalid inputs
- [x] Integration test `TestHTTPGatewayGetTraceBase64` verifying end-to-end base64 trace ID in HTTP request
- [x] `make lint` passes
- [x] `make test` passes for affected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)