### PR TITLE
fix(es): Improve ES/OS integration test CI coverage and reduce noise

### DIFF
--- a/.github/workflows/ci-e2e-elasticsearch.yml
+++ b/.github/workflows/ci-e2e-elasticsearch.yml
@@ -70,6 +70,6 @@ jobs:
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:
-        files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
+        files: cover.out
         flag: ${{ matrix.version.distribution }}-${{ matrix.version.major }}-${{ matrix.version.storage_test }}
 

--- a/.github/workflows/ci-e2e-elasticsearch.yml
+++ b/.github/workflows/ci-e2e-elasticsearch.yml
@@ -35,6 +35,9 @@ jobs:
           storage_test: e2e
         - major: 9.x
           distribution: elasticsearch
+          storage_test: direct
+        - major: 9.x
+          distribution: elasticsearch
           storage_test: e2e
     name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.storage_test }}
     steps:

--- a/.github/workflows/ci-e2e-opensearch.yml
+++ b/.github/workflows/ci-e2e-opensearch.yml
@@ -32,6 +32,9 @@ jobs:
           storage_test: e2e
         - major: 3.x
           distribution: opensearch
+          storage_test: direct
+        - major: 3.x
+          distribution: opensearch
           storage_test: e2e
     name: ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.storage_test }}
     steps:

--- a/.github/workflows/ci-e2e-opensearch.yml
+++ b/.github/workflows/ci-e2e-opensearch.yml
@@ -66,5 +66,5 @@ jobs:
     - name: Upload coverage to codecov
       uses: ./.github/actions/upload-codecov
       with:
-        files: cover.out,cover-index-cleaner.out,cover-index-rollover.out
+        files: cover.out
         flag: ${{ matrix.version.distribution }}-${{ matrix.version.major }}-${{ matrix.version.storage_test }}

--- a/cmd/es-rollover/app/init/action.go
+++ b/cmd/es-rollover/app/init/action.go
@@ -45,6 +45,9 @@ func (c Action) Do() error {
 		if !version.SupportsILM() {
 			return fmt.Errorf("ILM/ISM is not supported in %s", version)
 		}
+		if ilm, ok := c.ILMClient.(*client.ILMClient); ok && version.IsOpenSearch() {
+			ilm.UseOpenSearchISM = true
+		}
 		policyExist, err := c.ILMClient.Exists(c.Config.ILMPolicyName)
 		if err != nil {
 			return err

--- a/cmd/es-rollover/app/init/action_test.go
+++ b/cmd/es-rollover/app/init/action_test.go
@@ -5,28 +5,40 @@ package init
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
 	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/client"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/client/mocks"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 )
 
 func applyTestDefaults(cfg *Config) {
-	// Set defaults only if missing
-	if cfg.Indices.Spans.Shards == 0 {
-		cfg.Indices.Spans.Shards = 3
+	indices := []*config.IndexOptions{
+		&cfg.Indices.Spans,
+		&cfg.Indices.Services,
+		&cfg.Indices.Dependencies,
+		&cfg.Indices.Sampling,
 	}
-	if cfg.Indices.Spans.Replicas == nil {
-		cfg.Indices.Spans.Replicas = new(int64(1))
-	}
-	if cfg.Indices.Spans.Priority == 0 {
-		cfg.Indices.Spans.Priority = 10
+	for _, idx := range indices {
+		if idx.Shards == 0 {
+			idx.Shards = 3
+		}
+		if idx.Replicas == nil {
+			idx.Replicas = new(int64(1))
+		}
+		if idx.Priority == 0 {
+			idx.Priority = 10
+		}
 	}
 }
 
@@ -274,4 +286,49 @@ func TestRolloverAction(t *testing.T) {
 			ilmClient.AssertExpectations(t)
 		})
 	}
+}
+
+func TestRolloverAction_OpenSearchUsesISMEndpoint(t *testing.T) {
+	// Verify that when the backend is OpenSearch, the concrete ILMClient
+	// gets UseOpenSearchISM=true and queries the ISM endpoint.
+	var ismEndpointCalled bool
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if strings.Contains(req.URL.String(), "_plugins/_ism/policies/") {
+			ismEndpointCalled = true
+		}
+		res.WriteHeader(http.StatusOK)
+	}))
+	defer testServer.Close()
+
+	clusterClient := &mocks.ClusterAPI{}
+	clusterClient.On("Version").Return(es.OpenSearch2, nil)
+
+	ilmClient := &client.ILMClient{
+		Client: client.Client{
+			Client:   testServer.Client(),
+			Endpoint: testServer.URL,
+		},
+		Logger: zap.NewNop(),
+	}
+
+	cfg := Config{Config: app.Config{UseILM: true, ILMPolicyName: "test-policy"}}
+	applyTestDefaults(&cfg)
+
+	indexClient := &mocks.IndexAPI{}
+	indexClient.On("CreateTemplate", mock.Anything, mock.Anything).Return(nil)
+	indexClient.On("IndexExists", mock.Anything).Return(true, nil)
+	indexClient.On("GetJaegerIndices", "").Return([]client.Index{}, nil)
+	indexClient.On("CreateAlias", mock.Anything).Return(nil)
+
+	action := Action{
+		Config:        cfg,
+		IndicesClient: indexClient,
+		ClusterClient: clusterClient,
+		ILMClient:     ilmClient,
+	}
+
+	err := action.Do()
+	require.NoError(t, err)
+	assert.True(t, ilmClient.UseOpenSearchISM)
+	assert.True(t, ismEndpointCalled, "expected ISM endpoint to be called")
 }

--- a/cmd/es-rollover/app/init/action_test.go
+++ b/cmd/es-rollover/app/init/action_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -291,10 +292,10 @@ func TestRolloverAction(t *testing.T) {
 func TestRolloverAction_OpenSearchUsesISMEndpoint(t *testing.T) {
 	// Verify that when the backend is OpenSearch, the concrete ILMClient
 	// gets UseOpenSearchISM=true and queries the ISM endpoint.
-	var ismEndpointCalled bool
+	var ismEndpointCalled atomic.Bool
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.URL.String(), "_plugins/_ism/policies/") {
-			ismEndpointCalled = true
+			ismEndpointCalled.Store(true)
 		}
 		res.WriteHeader(http.StatusOK)
 	}))
@@ -330,5 +331,5 @@ func TestRolloverAction_OpenSearchUsesISMEndpoint(t *testing.T) {
 	err := action.Do()
 	require.NoError(t, err)
 	assert.True(t, ilmClient.UseOpenSearchISM)
-	assert.True(t, ismEndpointCalled, "expected ISM endpoint to be called")
+	assert.True(t, ismEndpointCalled.Load(), "expected ISM endpoint to be called")
 }

--- a/internal/storage/elasticsearch/client/ilm_client.go
+++ b/internal/storage/elasticsearch/client/ilm_client.go
@@ -22,17 +22,24 @@ const (
 var _ IndexManagementLifecycleAPI = (*ILMClient)(nil)
 
 // ILMClient is a client used to manipulate Index lifecycle management policies.
+// It supports both Elasticsearch ILM and OpenSearch ISM APIs.
 type ILMClient struct {
 	Client
 	MasterTimeoutSeconds int
 	Logger               *zap.Logger
+	// UseOpenSearchISM switches from _ilm/policy/ to _plugins/_ism/policies/.
+	UseOpenSearchISM bool
 }
 
-// Exists verify if a ILM policy exists
+// Exists verify if a ILM/ISM policy exists
 func (i ILMClient) Exists(name string) (bool, error) {
+	endpoint := "_ilm/policy/" + name
+	if i.UseOpenSearchISM {
+		endpoint = "_plugins/_ism/policies/" + name
+	}
 	operation := func() ([]byte, error) {
 		bytes, err := i.request(elasticRequest{
-			endpoint: "_ilm/policy/" + name,
+			endpoint: endpoint,
 			method:   http.MethodGet,
 		})
 		if err != nil {

--- a/internal/storage/elasticsearch/client/ilm_client.go
+++ b/internal/storage/elasticsearch/client/ilm_client.go
@@ -44,7 +44,7 @@ func (i ILMClient) Exists(name string) (bool, error) {
 		})
 		if err != nil {
 			i.Logger.Warn(
-				"Retryable error while getting ILM policy",
+				"Retryable error while getting ILM/ISM policy",
 				zap.String("name", name),
 				zap.Error(err),
 			)

--- a/internal/storage/elasticsearch/client/ilm_client_test.go
+++ b/internal/storage/elasticsearch/client/ilm_client_test.go
@@ -69,6 +69,60 @@ func TestExists(t *testing.T) {
 	}
 }
 
+func TestExists_OpenSearchISM(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		responseCode   int
+		response       string
+		errContains    string
+		expectedResult bool
+	}{
+		{
+			name:           "found",
+			responseCode:   http.StatusOK,
+			expectedResult: true,
+		},
+		{
+			name:         "not found",
+			responseCode: http.StatusNotFound,
+			response:     esErrResponse,
+		},
+		{
+			name:         "client error",
+			responseCode: http.StatusBadRequest,
+			response:     esErrResponse,
+			errContains:  "failed to get ILM policy: jaeger-ilm-policy",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				assert.True(t, strings.HasSuffix(req.URL.String(), "_plugins/_ism/policies/jaeger-ilm-policy"))
+				assert.Equal(t, http.MethodGet, req.Method)
+				res.WriteHeader(test.responseCode)
+				res.Write([]byte(test.response))
+			}))
+			defer testServer.Close()
+
+			c := &ILMClient{
+				Client: Client{
+					Client:   testServer.Client(),
+					Endpoint: testServer.URL,
+				},
+				Logger:           zap.NewNop(),
+				UseOpenSearchISM: true,
+			}
+			result, err := c.Exists("jaeger-ilm-policy")
+			if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
+			}
+			assert.Equal(t, test.expectedResult, result)
+		})
+	}
+}
+
 func TestExists_Retries(t *testing.T) {
 	t.Parallel()
 	var callCount int

--- a/internal/storage/integration/es_index_rollover_test.go
+++ b/internal/storage/integration/es_index_rollover_test.go
@@ -5,13 +5,18 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/olivere/elastic/v7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/testutils"
 )
 
@@ -74,8 +79,12 @@ func TestIndexRollover_CreateIndicesWithILM(t *testing.T) {
 func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 	client, err := createESClient(t, getESHttpClient(t))
 	require.NoError(t, err)
-	esVersion, err := getVersion(client)
+	version, err := getBackendVersion(client)
 	require.NoError(t, err)
+
+	if !version.SupportsILM() {
+		t.Skipf("ILM/ISM not supported in %s", version)
+	}
 
 	envVars := []string{
 		"ES_USE_ILM=true",
@@ -85,21 +94,19 @@ func runCreateIndicesWithILM(t *testing.T, ilmPolicyName string) {
 		envVars = append(envVars, "ES_ILM_POLICY_NAME="+ilmPolicyName)
 	}
 
-	if esVersion >= 7 {
-		expectedIndices := []string{"jaeger-span-000001", "jaeger-service-000001", "jaeger-dependencies-000001"}
-		t.Run("NoPrefix", func(t *testing.T) {
-			runIndexRolloverWithILMTest(t, client, "", expectedIndices, envVars, ilmPolicyName, false)
-		})
-		t.Run("WithPrefix", func(t *testing.T) {
-			runIndexRolloverWithILMTest(t, client, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, false)
-		})
-		t.Run("WithAdaptiveSampling", func(t *testing.T) {
-			runIndexRolloverWithILMTest(t, client, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, true)
-		})
-	}
+	expectedIndices := []string{"jaeger-span-000001", "jaeger-service-000001", "jaeger-dependencies-000001"}
+	t.Run("NoPrefix", func(t *testing.T) {
+		runIndexRolloverWithILMTest(t, client, version, "", expectedIndices, envVars, ilmPolicyName, false)
+	})
+	t.Run("WithPrefix", func(t *testing.T) {
+		runIndexRolloverWithILMTest(t, client, version, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, false)
+	})
+	t.Run("WithAdaptiveSampling", func(t *testing.T) {
+		runIndexRolloverWithILMTest(t, client, version, indexPrefix, expectedIndices, append(envVars, "INDEX_PREFIX="+indexPrefix), ilmPolicyName, true)
+	})
 }
 
-func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, prefix string, expectedIndices, envVars []string, ilmPolicyName string, adaptiveSampling bool) {
+func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, version es.BackendVersion, prefix string, expectedIndices, envVars []string, ilmPolicyName string, adaptiveSampling bool) {
 	writeAliases := []string{"jaeger-service-write", "jaeger-span-write", "jaeger-dependencies-write"}
 	if adaptiveSampling {
 		writeAliases = append(writeAliases, "jaeger-sampling-write")
@@ -112,8 +119,7 @@ func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, prefix st
 	// make sure ES is cleaned after test
 	defer cleanES(t, client, ilmPolicyName)
 	defer cleanESIndexTemplates(t, client, v8Client, prefix)
-	err = createILMPolicy(client, ilmPolicyName)
-	require.NoError(t, err)
+	createILMPolicy(t, client, version, ilmPolicyName)
 
 	if prefix != "" {
 		prefix += "-"
@@ -133,13 +139,16 @@ func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, prefix st
 	indices, err := client.IndexNames()
 	require.NoError(t, err)
 
-	// Get ILM Policy Attached
+	// Get settings and verify ILM/ISM policy is attached
 	settings, err := client.IndexGetSettings(expected...).FlatSettings(true).Do(context.Background())
 	require.NoError(t, err)
-	// Check ILM Policy is attached and Get rollover alias attached
 	for _, v := range settings {
-		assert.Equal(t, ilmPolicyName, v.Settings["index.lifecycle.name"])
-		actualWriteAliases = append(actualWriteAliases, v.Settings["index.lifecycle.rollover_alias"].(string))
+		if version.IsOpenSearch() {
+			actualWriteAliases = append(actualWriteAliases, v.Settings["index.plugins.index_state_management.rollover_alias"].(string))
+		} else {
+			assert.Equal(t, ilmPolicyName, v.Settings["index.lifecycle.name"])
+			actualWriteAliases = append(actualWriteAliases, v.Settings["index.lifecycle.rollover_alias"].(string))
+		}
 	}
 	// Check indices created
 	assert.ElementsMatch(t, indices, expected)
@@ -147,29 +156,71 @@ func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, prefix st
 	assert.ElementsMatch(t, actualWriteAliases, expectedWriteAliases)
 }
 
-func getVersion(client *elastic.Client) (uint, error) {
+func getBackendVersion(client *elastic.Client) (es.BackendVersion, error) {
 	pingResult, _, err := client.Ping(queryURL).Do(context.Background())
 	if err != nil {
 		return 0, err
 	}
-	esVersion, err := strconv.Atoi(string(pingResult.Version.Number[0]))
+	majorVersion, err := strconv.Atoi(string(pingResult.Version.Number[0]))
 	if err != nil {
 		return 0, err
 	}
-	return uint(esVersion), nil
+	return es.DetectBackendVersion(pingResult.TagLine, majorVersion), nil
 }
 
-func createILMPolicy(client *elastic.Client, policyName string) error {
-	_, err := client.XPackIlmPutLifecycle().Policy(policyName).BodyString(`{"policy": {"phases": {"hot": {"min_age": "0ms","actions": {"rollover": {"max_age": "1d"},"set_priority": {"priority": 100}}}}}}`).Do(context.Background())
-	return err
+func createILMPolicy(t *testing.T, client *elastic.Client, version es.BackendVersion, policyName string) {
+	if version.IsOpenSearch() {
+		createISMPolicy(t, policyName)
+	} else {
+		_, err := client.XPackIlmPutLifecycle().Policy(policyName).BodyString(`{"policy": {"phases": {"hot": {"min_age": "0ms","actions": {"rollover": {"max_age": "1d"},"set_priority": {"priority": 100}}}}}}`).Do(context.Background())
+		require.NoError(t, err)
+	}
+}
+
+func createISMPolicy(t *testing.T, policyName string) {
+	policyBody := `{
+		"policy": {
+			"description": "Jaeger ILM integration test policy",
+			"default_state": "hot",
+			"states": [{
+				"name": "hot",
+				"actions": [{"rollover": {"min_index_age": "1d"}}],
+				"transitions": []
+			}]
+		}
+	}`
+	url := fmt.Sprintf("%s/_plugins/_ism/policies/%s", queryURL, policyName)
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(policyBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getESHttpClient(t).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "failed to create ISM policy: %s", string(body))
+}
+
+func deleteISMPolicy(t *testing.T, policyName string) {
+	url := fmt.Sprintf("%s/_plugins/_ism/policies/%s", queryURL, policyName)
+	req, err := http.NewRequest(http.MethodDelete, url, http.NoBody)
+	require.NoError(t, err)
+	resp, err := getESHttpClient(t).Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	// 404 is expected if the policy doesn't exist yet
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		assert.Fail(t, "Not able to clean up ISM Policy", "status: %d", resp.StatusCode)
+	}
 }
 
 func cleanES(t *testing.T, client *elastic.Client, policyName string) {
 	_, err := client.DeleteIndex("*").Do(context.Background())
 	require.NoError(t, err)
-	esVersion, err := getVersion(client)
+	version, err := getBackendVersion(client)
 	require.NoError(t, err)
-	if esVersion >= 7 {
+	if version.IsOpenSearch() {
+		deleteISMPolicy(t, policyName)
+	} else if version.SupportsILM() {
 		_, err = client.XPackIlmDeleteLifecycle().Policy(policyName).Do(context.Background())
 		if err != nil && !elastic.IsNotFound(err) {
 			assert.Fail(t, "Not able to clean up ILM Policy")

--- a/internal/storage/integration/es_index_rollover_test.go
+++ b/internal/storage/integration/es_index_rollover_test.go
@@ -161,7 +161,8 @@ func getBackendVersion(client *elastic.Client) (es.BackendVersion, error) {
 	if err != nil {
 		return 0, err
 	}
-	majorVersion, err := strconv.Atoi(string(pingResult.Version.Number[0]))
+	parts := strings.SplitN(pingResult.Version.Number, ".", 2)
+	majorVersion, err := strconv.Atoi(parts[0])
 	if err != nil {
 		return 0, err
 	}

--- a/internal/storage/integration/es_index_rollover_test.go
+++ b/internal/storage/integration/es_index_rollover_test.go
@@ -198,7 +198,8 @@ func createISMPolicy(t *testing.T, policyName string) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
-	require.Equal(t, http.StatusCreated, resp.StatusCode, "failed to create ISM policy: %s", string(body))
+	require.True(t, resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK,
+		"failed to create ISM policy (status %d): %s", resp.StatusCode, string(body))
 }
 
 func deleteISMPolicy(t *testing.T, policyName string) {

--- a/internal/storage/integration/es_index_rollover_test.go
+++ b/internal/storage/integration/es_index_rollover_test.go
@@ -139,7 +139,7 @@ func runIndexRolloverWithILMTest(t *testing.T, client *elastic.Client, version e
 	indices, err := client.IndexNames()
 	require.NoError(t, err)
 
-	// Get settings and verify ILM/ISM policy is attached
+	// Get settings and verify ILM policy name (ES) or ISM rollover alias (OpenSearch)
 	settings, err := client.IndexGetSettings(expected...).FlatSettings(true).Do(context.Background())
 	require.NoError(t, err)
 	for _, v := range settings {

--- a/scripts/e2e/elasticsearch.sh
+++ b/scripts/e2e/elasticsearch.sh
@@ -28,7 +28,7 @@ check_arg() {
 # start the elasticsearch/opensearch container
 setup_db() {
   local compose_file=$1
-  echo "::group::docker compose pull"
+  echo "::group::⬇️ docker compose pull"
   bash scripts/utils/retry.sh docker compose -f "${compose_file}" pull
   echo "::endgroup::"
   docker compose -f "${compose_file}" up -d
@@ -117,10 +117,10 @@ build_local_img(){
     make build-es-index-cleaner GOOS=linux
     make build-es-rollover GOOS=linux
     make create-baseimg PLATFORMS="linux/$(go env GOARCH)"
-    echo "::group::Build jaeger-es-index-cleaner image"
+    echo "::group::🚧 Build jaeger-es-index-cleaner image"
     GITHUB_SHA=local-test BRANCH=local-test bash scripts/build/build-upload-a-docker-image.sh -l -b -c jaeger-es-index-cleaner -d cmd/es-index-cleaner -t release -p "linux/$(go env GOARCH)"
     echo "::endgroup::"
-    echo "::group::Build jaeger-es-rollover image"
+    echo "::group::🚧 Build jaeger-es-rollover image"
     GITHUB_SHA=local-test BRANCH=local-test bash scripts/build/build-upload-a-docker-image.sh -l -b -c jaeger-es-rollover -d cmd/es-rollover -t release -p "linux/$(go env GOARCH)"
     echo "::endgroup::"
 }
@@ -138,6 +138,10 @@ main() {
   if [[ "${storage_test}" == "e2e" ]]; then
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
   elif [[ "${storage_test}" == "direct" ]]; then
+    echo "::group::⬇️ Pre-pull test docker images"
+    docker pull localhost:5000/jaegertracing/jaeger-es-index-cleaner:local-test
+    docker pull localhost:5000/jaegertracing/jaeger-es-rollover:local-test
+    echo "::endgroup::"
     STORAGE=${distro} make storage-integration-test
   else
     echo "ERROR: Invalid argument value storage_test=${storage_test}, expecting direct or e2e"

--- a/scripts/e2e/elasticsearch.sh
+++ b/scripts/e2e/elasticsearch.sh
@@ -139,8 +139,6 @@ main() {
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
   elif [[ "${storage_test}" == "direct" ]]; then
     STORAGE=${distro} make storage-integration-test
-    cp cover.out cover-index-cleaner.out
-    cp cover.out cover-index-rollover.out
   else
     echo "ERROR: Invalid argument value storage_test=${storage_test}, expecting direct or e2e"
     exit 1

--- a/scripts/e2e/elasticsearch.sh
+++ b/scripts/e2e/elasticsearch.sh
@@ -28,7 +28,9 @@ check_arg() {
 # start the elasticsearch/opensearch container
 setup_db() {
   local compose_file=$1
+  echo "::group::docker compose pull"
   bash scripts/utils/retry.sh docker compose -f "${compose_file}" pull
+  echo "::endgroup::"
   docker compose -f "${compose_file}" up -d
 }
 
@@ -46,12 +48,13 @@ wait_for_storage() {
   )
   local max_attempts=60
   local attempt=0
-  echo "Waiting for ${distro} to be available at ${url}..."
+  echo "::group::Waiting for ${distro} to be available at ${url}"
   until [[ "$(curl "${params[@]}" "${url}")" == "200" ]] || (( attempt >= max_attempts )); do
     attempt=$(( attempt + 1 ))
     echo "Attempt: ${attempt} ${distro} is not yet available at ${url}..."
     sleep 10
   done
+  echo "::endgroup::"
 
   # if after all the attempts the storage is not accessible, terminate it and exit
   if [[ "$(curl "${params[@]}" "${url}")" != "200" ]]; then
@@ -114,9 +117,12 @@ build_local_img(){
     make build-es-index-cleaner GOOS=linux
     make build-es-rollover GOOS=linux
     make create-baseimg PLATFORMS="linux/$(go env GOARCH)"
-    #build es-index-cleaner and es-rollover images
+    echo "::group::Build jaeger-es-index-cleaner image"
     GITHUB_SHA=local-test BRANCH=local-test bash scripts/build/build-upload-a-docker-image.sh -l -b -c jaeger-es-index-cleaner -d cmd/es-index-cleaner -t release -p "linux/$(go env GOARCH)"
+    echo "::endgroup::"
+    echo "::group::Build jaeger-es-rollover image"
     GITHUB_SHA=local-test BRANCH=local-test bash scripts/build/build-upload-a-docker-image.sh -l -b -c jaeger-es-rollover -d cmd/es-rollover -t release -p "linux/$(go env GOARCH)"
+    echo "::endgroup::"
 }
 
 main() {
@@ -133,8 +139,8 @@ main() {
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
   elif [[ "${storage_test}" == "direct" ]]; then
     STORAGE=${distro} make storage-integration-test
-    make index-cleaner-integration-test
-    make index-rollover-integration-test
+    cp cover.out cover-index-cleaner.out
+    cp cover.out cover-index-rollover.out
   else
     echo "ERROR: Invalid argument value storage_test=${storage_test}, expecting direct or e2e"
     exit 1

--- a/scripts/makefiles/IntegrationTests.mk
+++ b/scripts/makefiles/IntegrationTests.mk
@@ -3,6 +3,7 @@
 
 STORAGE_PKGS = ./internal/storage/integration/...
 JAEGER_V2_STORAGE_PKGS = ./cmd/jaeger/internal/integration
+INTEGRATION_TEST_FLAGS = --format standard-verbose --format-icons hivis
 
 .PHONY: all-in-one-integration-test
 all-in-one-integration-test: $(GOTESTSUM)
@@ -17,14 +18,17 @@ jaeger-v2-storage-integration-test: $(GOTESTSUM)
 	# Expire tests results for jaeger storage integration tests since the environment
 	# might have changed even though the code remains the same.
 	go clean -testcache
-	$(GOTESTSUM) $(GOTESTSUM_FLAGS) -- $(RACE) -coverpkg=./... -coverprofile $(COVEROUT) $(JAEGER_V2_STORAGE_PKGS)
+	$(GOTESTSUM) $(INTEGRATION_TEST_FLAGS) -- $(RACE) -coverpkg=./... -coverprofile $(COVEROUT) $(JAEGER_V2_STORAGE_PKGS)
 
 .PHONY: storage-integration-test
 storage-integration-test: $(GOTESTSUM)
+ifndef STORAGE
+	$(error STORAGE environment variable must be set, e.g. elasticsearch, opensearch, badger, grpc)
+endif
 	# Expire tests results for storage integration tests since the environment might change
 	# even though the code remains the same.
 	go clean -testcache
-	$(GOTESTSUM) $(GOTESTSUM_FLAGS) -- $(RACE) -coverpkg=./... -coverprofile $(COVEROUT) $(STORAGE_PKGS)
+	$(GOTESTSUM) $(INTEGRATION_TEST_FLAGS) -- $(RACE) -coverpkg=./... -coverprofile $(COVEROUT) $(STORAGE_PKGS)
 
 .PHONY: badger-storage-integration-test
 badger-storage-integration-test:
@@ -33,16 +37,6 @@ badger-storage-integration-test:
 .PHONY: grpc-storage-integration-test
 grpc-storage-integration-test:
 	STORAGE=grpc $(MAKE) storage-integration-test
-
-# this test assumes STORAGE environment variable is set to elasticsearch|opensearch
-.PHONY: index-cleaner-integration-test
-index-cleaner-integration-test: docker-images-elastic
-	$(MAKE) storage-integration-test COVEROUT=cover-index-cleaner.out
-
-# this test assumes STORAGE environment variable is set to elasticsearch|opensearch
-.PHONY: index-rollover-integration-test
-index-rollover-integration-test: docker-images-elastic
-	$(MAKE) storage-integration-test COVEROUT=cover-index-rollover.out
 
 .PHONY: tail-sampling-integration-test
 tail-sampling-integration-test:


### PR DESCRIPTION
## Summary

- Add OpenSearch 3.x and Elasticsearch 9.x `direct` mode to CI matrix
- Fix ISM (Index State Management) rollover support for OpenSearch:
  - Route ILM client to `_plugins/_ism/policies/` endpoint on OpenSearch
  - Fix version parsing to handle multi-digit major versions
  - Add unit tests for ISM endpoint routing
- Reduce CI noise and redundant work:
  - Wrap docker pull, wait-for-storage, and image build logs in `::group::` blocks
  - Remove redundant `index-cleaner-integration-test` / `index-rollover-integration-test`
    make targets that rebuilt binaries/images already built by the script, and ran the full
    test suite without STORAGE set (causing all tests to silently skip)
  - Add `ifndef STORAGE` guard to `storage-integration-test` to fail fast
  - Switch integration tests to `--format standard-verbose` for better CI log visibility
  - Remove duplicate coverage file uploads

## Test plan

- [x] Verified ISM endpoint path with `TestExists_OpenSearchISM`
- [x] Verified `UseOpenSearchISM` gets set via `TestRolloverAction_OpenSearchUsesISMEndpoint`
- [x] Verified `make storage-integration-test` fails without STORAGE env var
- [x] `make fmt && make lint` pass
- [x] CI runs for OpenSearch 3.x direct and Elasticsearch 9.x direct pass

Closes #8829

🤖 Generated with [Claude Code](https://claude.com/claude-code)