### PR TITLE
feat(es): Add configurable max_trace_duration and improve time-range design

### DIFF
--- a/examples/otel-demo/jaeger-config.yaml
+++ b/examples/otel-demo/jaeger-config.yaml
@@ -26,6 +26,7 @@ extensions:
     backends:
       some_storage: &opensearch_config
         opensearch:
+          max_span_age: 720h
           server_urls:
             - http://opensearch-cluster-single.opensearch.svc.cluster.local:9200
           indices:

--- a/examples/otel-demo/jaeger-config.yaml
+++ b/examples/otel-demo/jaeger-config.yaml
@@ -26,7 +26,6 @@ extensions:
     backends:
       some_storage: &opensearch_config
         opensearch:
-          max_span_age: 720h
           server_urls:
             - http://opensearch-cluster-single.opensearch.svc.cluster.local:9200
           indices:

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -235,7 +235,16 @@ type Configuration struct {
 	// MaxDocCount Defines maximum number of results to fetch from storage per query.
 	MaxDocCount int `mapstructure:"max_doc_count"`
 	// MaxSpanAge configures the maximum lookback on span reads.
+	// For alias-based rotation (manual_rollover/auto_rollover), this should be set
+	// to match the ILM/ISM data retention policy so that GetTraces can find traces
+	// up to that age.
 	MaxSpanAge time.Duration `mapstructure:"max_span_age"`
+	// MaxTraceDuration is the maximum expected duration of a single trace
+	// (time between the earliest and latest span in the trace).
+	// Used to widen time-range filters when reading spans, ensuring that all spans
+	// of a trace are found even if they extend beyond the search window.
+	// Defaults to 24h.
+	MaxTraceDuration time.Duration `mapstructure:"max_trace_duration"`
 	// ServiceCacheTTL contains the TTL for the cache of known service names.
 	ServiceCacheTTL time.Duration `mapstructure:"service_cache_ttl"`
 	// AdaptiveSamplingLookback contains the duration to look back for the
@@ -528,6 +537,9 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	}
 	if c.MaxSpanAge == 0 {
 		c.MaxSpanAge = source.MaxSpanAge
+	}
+	if c.MaxTraceDuration == 0 {
+		c.MaxTraceDuration = source.MaxTraceDuration
 	}
 	if c.AdaptiveSamplingLookback == 0 {
 		c.AdaptiveSamplingLookback = source.AdaptiveSamplingLookback

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.opentelemetry.io/otel"
@@ -91,15 +92,23 @@ func (f *FactoryBase) GetSpanReaderParams() esspanstore.SpanReaderParams {
 	spanRC := f.config.ResolvedSpanRotation(spanPrefix)
 	maxSpanAge := f.config.MaxSpanAge
 	// See timeRangeDesign comment in reader.go.
-	// Aliases cover all data, so we use a large maxSpanAge to ensure GetTraces by ID
-	// can reach any trace regardless of age.
-	if !spanRC.Periodic.HasValue() {
+	// For alias-based rotation, ReadTargets ignores the time range (always returns
+	// the alias), but maxSpanAge still controls the time-range filter in the ES query.
+	// We use DawnOfTimeSpanAge to ensure GetTraces can reach any trace within the
+	// data retention window. Operators should set max_span_age to match their
+	// ILM/ISM retention policy to avoid this fallback.
+	if !spanRC.Periodic.HasValue() && f.config.MaxSpanAge <= 72*time.Hour {
+		f.logger.Warn(
+			"Using default max_span_age with alias-based rotation; " +
+				"set max_span_age to your data retention period for optimal performance",
+		)
 		maxSpanAge = esspanstore.DawnOfTimeSpanAge
 	}
 	return esspanstore.SpanReaderParams{
 		Client:            f.getClient,
 		MaxDocCount:       f.config.MaxDocCount,
 		MaxSpanAge:        maxSpanAge,
+		MaxTraceDuration:  f.config.MaxTraceDuration,
 		TagDotReplacement: f.config.Tags.DotReplacement,
 		Logger:            f.logger,
 		Tracer:            f.tracer.Tracer("esspanstore.SpanReader"),

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.opentelemetry.io/otel"
@@ -97,7 +96,7 @@ func (f *FactoryBase) GetSpanReaderParams() esspanstore.SpanReaderParams {
 	// We use DawnOfTimeSpanAge to ensure GetTraces can reach any trace within the
 	// data retention window. Operators should set max_span_age to match their
 	// ILM/ISM retention policy to avoid this fallback.
-	if !spanRC.Periodic.HasValue() && f.config.MaxSpanAge <= 72*time.Hour {
+	if !spanRC.Periodic.HasValue() && f.config.MaxSpanAge == defaultMaxSpanAge {
 		f.logger.Warn(
 			"Using default max_span_age with alias-based rotation; " +
 				"set max_span_age to your data retention period for optimal performance",

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -92,15 +92,10 @@ func (f *FactoryBase) GetSpanReaderParams() esspanstore.SpanReaderParams {
 	maxSpanAge := f.config.MaxSpanAge
 	// See timeRangeDesign comment in reader.go.
 	// For alias-based rotation, ReadTargets ignores the time range (always returns
-	// the alias), but maxSpanAge still controls the time-range filter in the ES query.
-	// We use DawnOfTimeSpanAge to ensure GetTraces can reach any trace within the
-	// data retention window. Operators should set max_span_age to match their
-	// ILM/ISM retention policy to avoid this fallback.
-	if !spanRC.Periodic.HasValue() && f.config.MaxSpanAge == defaultMaxSpanAge {
-		f.logger.Warn(
-			"Using default max_span_age with alias-based rotation; " +
-				"set max_span_age to your data retention period for optimal performance",
-		)
+	// the alias), so max_span_age is irrelevant for index selection. We override it
+	// to DawnOfTimeSpanAge so the time-range filter in the ES query doesn't exclude
+	// old traces.
+	if !spanRC.Periodic.HasValue() {
 		maxSpanAge = esspanstore.DawnOfTimeSpanAge
 	}
 	return esspanstore.SpanReaderParams{

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -697,6 +697,35 @@ func TestGetSpanReaderParams_NonPeriodicMaxSpanAge(t *testing.T) {
 	assert.Equal(t, core.DawnOfTimeSpanAge, params.MaxSpanAge)
 }
 
+func TestGetSpanReaderParams_NonPeriodicExplicitMaxSpanAge(t *testing.T) {
+	cfg := escfg.Configuration{
+		Indices: escfg.Indices{
+			Spans: escfg.IndexOptions{
+				Rotation: escfg.RotationConfig{
+					ManualRollover: configoptional.Some(escfg.ManualRolloverRotation{
+						ReadAlias:  "span-read",
+						WriteAlias: "span-write",
+					}),
+				},
+			},
+			Services: escfg.IndexOptions{
+				Rotation: escfg.RotationConfig{
+					ManualRollover: configoptional.Some(escfg.ManualRolloverRotation{
+						ReadAlias:  "svc-read",
+						WriteAlias: "svc-write",
+					}),
+				},
+			},
+		},
+		MaxSpanAge:       30 * 24 * time.Hour, // 30 days — explicitly set to match retention
+		MaxTraceDuration: 2 * time.Hour,
+	}
+	f := &FactoryBase{config: &cfg, logger: zap.NewNop(), tracer: otel.GetTracerProvider()}
+	params := f.GetSpanReaderParams()
+	assert.Equal(t, 30*24*time.Hour, params.MaxSpanAge)
+	assert.Equal(t, 2*time.Hour, params.MaxTraceDuration)
+}
+
 // mockHTTPAuthenticator implements extensionauth.HTTPClient for testing
 type mockHTTPAuthenticator struct{}
 

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -697,32 +697,32 @@ func TestGetSpanReaderParams_NonPeriodicMaxSpanAge(t *testing.T) {
 	assert.Equal(t, core.DawnOfTimeSpanAge, params.MaxSpanAge)
 }
 
-func TestGetSpanReaderParams_NonPeriodicExplicitMaxSpanAge(t *testing.T) {
+func TestGetSpanReaderParams_MaxTraceDuration(t *testing.T) {
 	cfg := escfg.Configuration{
 		Indices: escfg.Indices{
 			Spans: escfg.IndexOptions{
 				Rotation: escfg.RotationConfig{
-					ManualRollover: configoptional.Some(escfg.ManualRolloverRotation{
-						ReadAlias:  "span-read",
-						WriteAlias: "span-write",
+					Periodic: configoptional.Default(escfg.PeriodicRotation{
+						DateLayout:        "2006-01-02",
+						RolloverFrequency: "day",
 					}),
 				},
 			},
 			Services: escfg.IndexOptions{
 				Rotation: escfg.RotationConfig{
-					ManualRollover: configoptional.Some(escfg.ManualRolloverRotation{
-						ReadAlias:  "svc-read",
-						WriteAlias: "svc-write",
+					Periodic: configoptional.Default(escfg.PeriodicRotation{
+						DateLayout:        "2006-01-02",
+						RolloverFrequency: "day",
 					}),
 				},
 			},
 		},
-		MaxSpanAge:       30 * 24 * time.Hour, // 30 days — explicitly set to match retention
+		MaxSpanAge:       72 * time.Hour,
 		MaxTraceDuration: 2 * time.Hour,
 	}
 	f := &FactoryBase{config: &cfg, logger: zap.NewNop(), tracer: otel.GetTracerProvider()}
 	params := f.GetSpanReaderParams()
-	assert.Equal(t, 30*24*time.Hour, params.MaxSpanAge)
+	assert.Equal(t, 72*time.Hour, params.MaxSpanAge)
 	assert.Equal(t, 2*time.Hour, params.MaxTraceDuration)
 }
 

--- a/internal/storage/v1/elasticsearch/options.go
+++ b/internal/storage/v1/elasticsearch/options.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 )
 
+const defaultMaxSpanAge = 72 * time.Hour
+
 var defaultIndexOptions = config.IndexOptions{
 	Shards:   5,
 	Replicas: new(int64(1)),
@@ -49,7 +51,7 @@ func DefaultConfig() config.Configuration {
 			Enabled: false,
 		},
 		DisableHealthCheck:       false,
-		MaxSpanAge:               72 * time.Hour,
+		MaxSpanAge:               defaultMaxSpanAge,
 		MaxTraceDuration:         24 * time.Hour,
 		AdaptiveSamplingLookback: 72 * time.Hour,
 		BulkProcessing: config.BulkProcessing{

--- a/internal/storage/v1/elasticsearch/options.go
+++ b/internal/storage/v1/elasticsearch/options.go
@@ -12,8 +12,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 )
 
-const defaultMaxSpanAge = 72 * time.Hour
-
 var defaultIndexOptions = config.IndexOptions{
 	Shards:   5,
 	Replicas: new(int64(1)),
@@ -51,7 +49,7 @@ func DefaultConfig() config.Configuration {
 			Enabled: false,
 		},
 		DisableHealthCheck:       false,
-		MaxSpanAge:               defaultMaxSpanAge,
+		MaxSpanAge:               72 * time.Hour,
 		MaxTraceDuration:         24 * time.Hour,
 		AdaptiveSamplingLookback: 72 * time.Hour,
 		BulkProcessing: config.BulkProcessing{

--- a/internal/storage/v1/elasticsearch/options.go
+++ b/internal/storage/v1/elasticsearch/options.go
@@ -50,6 +50,7 @@ func DefaultConfig() config.Configuration {
 		},
 		DisableHealthCheck:       false,
 		MaxSpanAge:               72 * time.Hour,
+		MaxTraceDuration:         24 * time.Hour,
 		AdaptiveSamplingLookback: 72 * time.Hour,
 		BulkProcessing: config.BulkProcessing{
 			MaxBytes:      5 * 1000 * 1000,

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -101,20 +101,18 @@ func init() {
 //     - Periodic indices: maxSpanAge should match data retention (e.g., 7d). ReadTargets generates
 //       only existing indices within that window.
 //     - Alias indices: a single alias covers all data. The factory overrides maxSpanAge to
-//       DawnOfTimeSpanAge (50 years) to ensure old traces are reachable by ID.
+//       DawnOfTimeSpanAge (50 years) when the operator hasn't explicitly configured max_span_age
+//       beyond the default. Operators should set max_span_age to their ILM/ISM retention period.
 //
 // multiRead always adds a time-range filter to the ES query for shard pruning (helps ES skip
 // irrelevant shards). This is harmless for periodic indices and essential for aliases.
 //
 // multiRead is called from both paths. When called from FindTraces, the time range is the user's
-// search window — but a trace may extend beyond it. The ±1h padding on index selection is a
-// heuristic for traces straddling index boundaries.
+// search window — but a trace may extend beyond it. The ±maxTraceDuration padding on index
+// selection and the ES time filter ensure all spans of a trace are found even when they extend
+// beyond the search window.
 //
-// TODO: future improvements:
-//   - Replace DawnOfTimeSpanAge with a configurable DataRetentionInterval that operators set
-//     to match their ILM/ISM policy. This removes the need for the 50-year hack.
-//   - Replace the hardcoded ±1h padding with a configurable maxTraceDuration, making the read
-//     window [startTime-maxTraceDuration, endTime+maxTraceDuration]. This handles long traces.
+// TODO: future improvement:
 //   - With data streams, store a materialized view of (traceID, minStartTime, maxEndTime) to
 //     enable precise time-range scoping for GetTraces (similar to ClickHouse approach).
 
@@ -124,6 +122,7 @@ type SpanReader struct {
 	// The age of the oldest service/operation we will look for. Because indices in ElasticSearch are by day,
 	// this will be rounded down to UTC 00:00 of that day.
 	maxSpanAge              time.Duration
+	maxTraceDuration        time.Duration
 	serviceOperationStorage *ServiceOperationStorage
 	spanRotation            indices.Rotation
 	serviceRotation         indices.Rotation
@@ -138,6 +137,7 @@ type SpanReader struct {
 type SpanReaderParams struct {
 	Client            func() es.Client
 	MaxSpanAge        time.Duration
+	MaxTraceDuration  time.Duration
 	MaxDocCount       int
 	TagDotReplacement string
 	Logger            *zap.Logger
@@ -151,6 +151,7 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 	return &SpanReader{
 		client:                  p.Client,
 		maxSpanAge:              p.MaxSpanAge,
+		maxTraceDuration:        p.MaxTraceDuration,
 		serviceOperationStorage: NewServiceOperationStorage(p.Client, p.Logger, 0), // the decorator takes care of metrics
 		spanRotation:            p.SpanRotation,
 		serviceRotation:         p.ServiceRotation,
@@ -306,9 +307,9 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 		return traces, nil
 	}
 
-	// See timeRangeDesign above for context on the ±1h padding and the alias filter.
-	idxList := s.spanRotation.ReadTargets(startTime.Add(-time.Hour), endTime.Add(time.Hour))
-	nextTime := model.TimeAsEpochMicroseconds(startTime.Add(-time.Hour))
+	// See timeRangeDesign above for context on the padding and the alias filter.
+	idxList := s.spanRotation.ReadTargets(startTime.Add(-s.maxTraceDuration), endTime.Add(s.maxTraceDuration))
+	nextTime := model.TimeAsEpochMicroseconds(startTime.Add(-s.maxTraceDuration))
 	searchAfterTime := make(map[dbmodel.TraceID]uint64)
 	totalDocumentsFetched := make(map[dbmodel.TraceID]int)
 	tracesMap := make(map[dbmodel.TraceID]*dbmodel.Trace)
@@ -316,7 +317,7 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 		searchRequests := make([]*elastic.SearchRequest, len(traceIDs))
 		for i, traceID := range traceIDs {
 			traceQuery := buildTraceByIDQuery(traceID)
-			startTimeRangeQuery := s.buildStartTimeQuery(startTime.Add(-time.Hour*24), endTime.Add(time.Hour*24))
+			startTimeRangeQuery := s.buildStartTimeQuery(startTime.Add(-s.maxTraceDuration), endTime.Add(s.maxTraceDuration))
 			query := elastic.NewBoolQuery().
 				Must(traceQuery).
 				Must(startTimeRangeQuery)

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -101,8 +101,7 @@ func init() {
 //     - Periodic indices: maxSpanAge should match data retention (e.g., 7d). ReadTargets generates
 //       only existing indices within that window.
 //     - Alias indices: a single alias covers all data. The factory overrides maxSpanAge to
-//       DawnOfTimeSpanAge (50 years) when the operator hasn't explicitly configured max_span_age
-//       beyond the default. Operators should set max_span_age to their ILM/ISM retention period.
+//       DawnOfTimeSpanAge (50 years) so the time-range filter doesn't exclude old traces.
 //
 // multiRead always adds a time-range filter to the ES query for shard pruning (helps ES skip
 // irrelevant shards). This is harmless for periodic indices and essential for aliases.

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -115,6 +115,7 @@ func withSpanReader(t *testing.T, fn func(r *spanReaderTest)) {
 			Logger:            zap.NewNop(),
 			Tracer:            tracer.Tracer("test"),
 			MaxSpanAge:        0,
+			MaxTraceDuration:  24 * time.Hour,
 			TagDotReplacement: "@",
 			MaxDocCount:       defaultMaxDocCount,
 			SpanRotation:      indices.NewPeriodicRotation(indices.SpanIndexBaseName, "2006-01-02", 24*time.Hour),
@@ -153,6 +154,7 @@ func withArchiveSpanReader(t *testing.T, readAlias bool, readAliasSuffix string,
 			Logger:            zap.NewNop(),
 			Tracer:            tracer.Tracer("test"),
 			MaxSpanAge:        0,
+			MaxTraceDuration:  24 * time.Hour,
 			TagDotReplacement: "@",
 			SpanRotation:      spanRotation,
 			ServiceRotation:   serviceRotation,
@@ -297,13 +299,13 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 		spanBytesID2, err := json.Marshal(spanID2)
 		require.NoError(t, err)
 
-		startTimeRangeQuery := r.reader.buildStartTimeQuery(date.Add(-time.Hour*24), date.Add(time.Hour*24))
+		startTimeRangeQuery := r.reader.buildStartTimeQuery(date.Add(-24*time.Hour), date.Add(24*time.Hour))
 		traceID1Query := elastic.NewTermQuery(traceIDField, string(traceID1))
 		id1Query := elastic.NewBoolQuery().Must(traceID1Query).Must(startTimeRangeQuery)
-		id1Search := newSearchRequest(r.reader.sourceFn(id1Query, model.TimeAsEpochMicroseconds(date.Add(-time.Hour))).TrackTotalHits(true))
+		id1Search := newSearchRequest(r.reader.sourceFn(id1Query, model.TimeAsEpochMicroseconds(date.Add(-24*time.Hour))).TrackTotalHits(true))
 		traceID2Query := elastic.NewTermQuery(traceIDField, string(traceID2))
 		id2Query := elastic.NewBoolQuery().Must(traceID2Query).Must(startTimeRangeQuery)
-		id2Search := newSearchRequest(r.reader.sourceFn(id2Query, model.TimeAsEpochMicroseconds(date.Add(-time.Hour))).TrackTotalHits(true))
+		id2Search := newSearchRequest(r.reader.sourceFn(id2Query, model.TimeAsEpochMicroseconds(date.Add(-24*time.Hour))).TrackTotalHits(true))
 		id1SearchSpanTime := newSearchRequest(r.reader.sourceFn(id1Query, spanID1.StartTime).TrackTotalHits(true))
 
 		multiSearchService := &mocks.MultiSearchService{}


### PR DESCRIPTION
## Summary

Introduces a new `max_trace_duration` configuration option (default: **24h**) that controls how far beyond the requested time window the ES/OS reader looks for spans belonging to a trace.

### 🛑 Breaking change

Previously, `FindTraces` used a hardcoded **±1h** padding on the time window when selecting indices and positioning the search cursor. The new default is **±24h**. This improves correctness — traces whose spans straddle index boundaries or extend beyond the search window are now reliably found in full — but may increase query cost for some deployments (e.g., more periodic indices are queried, or the search cursor starts further back).

**Mitigation:** Set `max_trace_duration` to a value that matches your longest expected trace (e.g., `1h` to restore the previous behavior, or `5m` for short-lived microservice traces).

Related to #8331

## Test plan
- [x] Reader tests updated for new default padding
- [x] New factory test verifies `MaxTraceDuration` is plumbed through
- [x] `make fmt && make lint && make test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)