### PR TITLE
fix(jaegermcp): Validate span_id hex format in get_span_details handler

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details.go
@@ -137,6 +137,12 @@ func (h *getSpanDetailsHandler) buildQuery(input types.GetSpanDetailsInput) (que
 		)
 	}
 
+	for _, spanID := range input.SpanIDs {
+		if err := validateSpanID(spanID); err != nil {
+			return querysvc.GetTraceParams{}, fmt.Errorf("invalid span_id %q: %w", spanID, err)
+		}
+	}
+
 	traceID, err := parseTraceID(input.TraceID)
 	if err != nil {
 		return querysvc.GetTraceParams{}, fmt.Errorf("invalid trace_id: %w", err)
@@ -267,4 +273,15 @@ func parseTraceID(traceIDStr string) (pcommon.TraceID, error) {
 
 	copy(traceID[:], bytes)
 	return traceID, nil
+}
+
+// validateSpanID checks that a span ID string is a valid 16-character hex string.
+func validateSpanID(spanIDStr string) error {
+	if len(spanIDStr) != 16 {
+		return fmt.Errorf("span ID must be 16 hex characters, got %d", len(spanIDStr))
+	}
+	if _, err := hex.DecodeString(spanIDStr); err != nil {
+		return fmt.Errorf("invalid hex string: %w", err)
+	}
+	return nil
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_details_test.go
@@ -555,3 +555,103 @@ func TestParseTraceID(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSpanID(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError bool
+	}{
+		{
+			name:      "valid span ID",
+			input:     "0000000000000001",
+			wantError: false,
+		},
+		{
+			name:      "valid span ID - all lowercase hex",
+			input:     "abcdef0123456789",
+			wantError: false,
+		},
+		{
+			name:      "invalid span ID - too short",
+			input:     "abc",
+			wantError: true,
+		},
+		{
+			name:      "invalid span ID - too long",
+			input:     "000000000000000001",
+			wantError: true,
+		},
+		{
+			name:      "invalid span ID - non-hex characters",
+			input:     "ZZZZZZZZZZZZZZZZ",
+			wantError: true,
+		},
+		{
+			name:      "invalid span ID - contains dash",
+			input:     "not-a-hex-id!!--",
+			wantError: true,
+		},
+		{
+			name:      "empty span ID",
+			input:     "",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSpanID(tt.input)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetSpanDetailsHandler_Handle_InvalidSpanIDs(t *testing.T) {
+	tests := []struct {
+		name           string
+		spanIDs        []string
+		wantErrContain string
+	}{
+		{
+			name:           "span ID too short",
+			spanIDs:        []string{"abc"},
+			wantErrContain: "invalid span_id",
+		},
+		{
+			name:           "span ID with non-hex characters",
+			spanIDs:        []string{"not-a-hex-id!!!!"},
+			wantErrContain: "invalid span_id",
+		},
+		{
+			name:           "span ID too long",
+			spanIDs:        []string{"000000000000000001"},
+			wantErrContain: "invalid span_id",
+		},
+		{
+			name:           "one valid one invalid span ID",
+			spanIDs:        []string{spanIDToHex("span001"), "tooshort"},
+			wantErrContain: "invalid span_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewGetSpanDetailsHandler(nil, 50)
+
+			input := types.GetSpanDetailsInput{
+				TraceID: testTraceID,
+				SpanIDs: tt.spanIDs,
+			}
+
+			_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, input)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrContain)
+		})
+	}
+}


### PR DESCRIPTION
Previously the get_span_details handler validated trace_id via parseTraceID but performed no format check on individual span_ids. Malformed values (wrong length or non-hex characters) were silently accepted, causing an expensive backend trace fetch that was guaranteed to return 'spans not found'.

Add validateSpanID helper (mirroring parseTraceID) that rejects any span_id not exactly 16 hex characters before the query is issued.

Fixes #8843

## Which problem is this PR solving?
- Resolves #8843 

## Description of the changes
The `get_span_details` MCP handler validated `trace_id` via `parseTraceID()` before issuing any backend query, but performed no format check on individual `span_ids`. A valid OpenTelemetry Span ID must be exactly 16 hexadecimal characters (8 bytes). Malformed values such as `"abc"`, `"not-a-hex"`, or `"tooshort"` were silently accepted, causing the handler to:

1. Execute a full backend trace fetch
2. Iterate every span in the trace in memory
3. Return a vague `"spans not found"` error with no indication the input was invalid

This is particularly impactful when the tool is called by an LLM agent, which may hallucinate or truncate span IDs — each such call wastes an expensive DB round-trip.

**Fix**: Added a `validateSpanID` helper (mirroring `parseTraceID`) that checks each span ID for correct length (16 chars) and valid hex encoding before the query is issued. Invalid IDs now return an immediate, descriptive error like:

`invalid span_id "abc": span ID must be 16 hex characters, got 3`

## How was this change tested?
- Added `TestValidateSpanID` with 7 table-driven cases covering: valid hex IDs, too-short, too-long, non-hex characters, dash-containing strings, and empty string.
- Added `TestGetSpanDetailsHandler_Handle_InvalidSpanIDs` with 4 table-driven cases verifying the handler returns an `"invalid span_id"` error before querying the backend, for each class of malformed input.
- All existing tests in the `jaegermcp` package continue to pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
