### PR TITLE
fix: validate duration range in v3 trace query parser

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go
@@ -110,6 +110,9 @@ func parseFindTracesQuery(q url.Values) (*querysvc.TraceQueryParams, error) {
 		if err != nil {
 			return nil, fmt.Errorf("malformed parameter %s: %w", searchDepthParam, err)
 		}
+		if searchDepth <= 0 {
+			return nil, fmt.Errorf("malformed parameter %s: value must be greater than 0", searchDepthParam)
+		}
 		queryParams.SearchDepth = searchDepth
 	} else {
 		queryParams.SearchDepth = defaultSearchDepth
@@ -128,6 +131,11 @@ func parseFindTracesQuery(q url.Values) (*querysvc.TraceQueryParams, error) {
 			return nil, fmt.Errorf("malformed parameter %s: %w", paramName, err)
 		}
 		queryParams.DurationMax = dur
+	}
+	if queryParams.DurationMin != 0 && queryParams.DurationMax != 0 {
+		if queryParams.DurationMax < queryParams.DurationMin {
+			return nil, fmt.Errorf("%s must be greater than %s", paramDurationMax, paramDurationMin)
+		}
 	}
 	if r, paramName := getQueryParam(q, paramQueryRawTraces, paramQueryRawTracesDeprecated); r != "" {
 		rawTraces, err := strconv.ParseBool(r)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser_test.go
@@ -176,6 +176,16 @@ func TestParseFindTracesQuery(t *testing.T) {
 			wantErr: "malformed parameter " + paramNumTraces,
 		},
 		{
+			name:    "negative searchDepth",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "-1"},
+			wantErr: "malformed parameter " + paramSearchDepth + ": value must be greater than 0",
+		},
+		{
+			name:    "zero searchDepth",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramSearchDepth: "0"},
+			wantErr: "malformed parameter " + paramSearchDepth + ": value must be greater than 0",
+		},
+		{
 			name:    "bad durationMin (canonical)",
 			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramDurationMin: "NaN"},
 			wantErr: "malformed parameter " + paramDurationMin,
@@ -194,6 +204,11 @@ func TestParseFindTracesQuery(t *testing.T) {
 			name:    "bad duration_max (deprecated)",
 			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramDurationMaxDeprecated: "NaN"},
 			wantErr: "malformed parameter " + paramDurationMaxDeprecated,
+		},
+		{
+			name:    "durationMax less than durationMin",
+			params:  map[string]string{paramTimeMin: goodMin, paramTimeMax: goodMax, paramDurationMin: "10s", paramDurationMax: "1s"},
+			wantErr: paramDurationMax + " must be greater than " + paramDurationMin,
 		},
 		{
 			name:    "bad rawTraces (canonical)",

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -125,12 +125,15 @@ func (p *queryParser) parseTraceQueryParams(r *http.Request) (*traceQueryParamet
 		return nil, err
 	}
 
-	limitParam := r.URL.Query().Get(limitParam)
+	limitVal := r.URL.Query().Get(limitParam)
 	limit := defaultQueryLimit
-	if limitParam != "" {
-		limitParsed, err := strconv.ParseInt(limitParam, 10, 32)
+	if limitVal != "" {
+		limitParsed, err := strconv.ParseInt(limitVal, 10, 32)
 		if err != nil {
-			return nil, err
+			return nil, newParseError(err, limitParam)
+		}
+		if limitParsed <= 0 {
+			return nil, newParseError(errors.New("value must be greater than 0"), limitParam)
 		}
 		limit = int(limitParsed)
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -35,6 +35,8 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&start=string", errParseInt, nil},
 		{"x?service=service&end=string", errParseInt, nil},
 		{"x?service=service&limit=string", errParseInt, nil},
+		{"x?service=service&limit=0", `unable to parse param 'limit': value must be greater than 0`, nil},
+		{"x?service=service&limit=-1", `unable to parse param 'limit': value must be greater than 0`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20", `unable to parse param 'minDuration': time: missing unit in duration "?20"?$`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", `unable to parse param 'maxDuration': time: missing unit in duration "?30"?$`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `malformed 'tag' parameter, expecting key:value, received: k`, nil},


### PR DESCRIPTION
## SUMMARY

This PR adds validation for trace duration filters in the v3 query parser to ensure `durationMax` is not smaller than `durationMin`. It aligns the v3 API behavior with the existing validation already present in the v1 query parser and prevents invalid duration ranges from being silently forwarded to the storage layer.

Primary changes are in `cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/query_parser.go` and its associated tests in `query_parser_test.go`.

## FIX

```go
//Before
// durationMin and durationMax are parsed independently
queryParams.DurationMin = dur
queryParams.DurationMax = dur


//After
if queryParams.DurationMin != 0 && queryParams.DurationMax != 0 {
    if queryParams.DurationMax < queryParams.DurationMin {
        return nil, fmt.Errorf("%s must be greater than %s", paramDurationMax, paramDurationMin)
    }
}
```

