### PR TITLE
feat(ocb): Wire build-ocb to the Workspace Overwrite pattern

### DIFF
--- a/.github/workflows/ci-ocb-build.yml
+++ b/.github/workflows/ci-ocb-build.yml
@@ -41,6 +41,11 @@ jobs:
     - name: Build Jaeger with ocb
       run: make build-ocb
 
+    - name: Verify Jaeger subcommands present
+      run: |
+        ./cmd/jaeger/_build/jaeger version
+        ./cmd/jaeger/_build/jaeger elasticsearch-mappings --help
+
     - name: Run ocb-built binary
       run: |
         ./cmd/jaeger/_build/jaeger --config cmd/jaeger/config-ocb-smoketest.yaml &

--- a/cmd/jaeger/jaegercli/main.go.tmpl
+++ b/cmd/jaeger/jaegercli/main.go.tmpl
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Workspace-overwrite entrypoint for custom OCB-built Jaeger distributions:
+// build-ocb copies it over OCB's generated main.go before compiling so the
+// binary keeps Jaeger's subcommands and embedded all-in-one config.
+// components() is provided by OCB's generated components.go.
+package main
+
+import (
+	"log"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/jaegercli"
+)
+
+func main() {
+	factories, err := components()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := jaegercli.NewCommand(factories).Execute(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -186,5 +186,5 @@ build-ocb: $(OCB)
 	rm -f cmd/jaeger/_build/main*.go
 	cp cmd/jaeger/jaegercli/main.go.tmpl cmd/jaeger/_build/main.go
 	@echo "Compiling ocb-built Jaeger"
-	cd cmd/jaeger/_build && go mod tidy && go build -o jaeger .
+	cd cmd/jaeger/_build && go mod tidy && go build $(BUILD_INFO) -o jaeger .
 	@echo "✅ ocb build successful: cmd/jaeger/_build/jaeger"

--- a/scripts/makefiles/BuildBinaries.mk
+++ b/scripts/makefiles/BuildBinaries.mk
@@ -174,10 +174,17 @@ build-all-platforms:
 	  $(MAKE) build-binaries-$$platform; \
 	done
 
-# Build Jaeger using ocb (OpenTelemetry Collector Builder).
-# This validates that the public facade packages work correctly with ocb.
+# Build Jaeger using ocb (OpenTelemetry Collector Builder) with the Workspace
+# Overwrite pattern: ocb generates the sources, then we replace its vanilla
+# main.go with one that calls jaegercli.NewCommand so the binary keeps Jaeger's
+# subcommands and embedded all-in-one config.
 .PHONY: build-ocb
 build-ocb: $(OCB)
-	@echo "Building Jaeger with ocb"
-	$(OCB) --config cmd/jaeger/builder.yaml --skip-strict-versioning
-	@echo "✅ ocb build successful: cmd/jaeger/_build/"
+	@echo "Generating Jaeger sources with ocb"
+	$(OCB) --config cmd/jaeger/builder.yaml --skip-strict-versioning --skip-compilation
+	# replace ocb's entrypoint (main.go + its main_{others,windows}.go wrappers)
+	rm -f cmd/jaeger/_build/main*.go
+	cp cmd/jaeger/jaegercli/main.go.tmpl cmd/jaeger/_build/main.go
+	@echo "Compiling ocb-built Jaeger"
+	cd cmd/jaeger/_build && go mod tidy && go build -o jaeger .
+	@echo "✅ ocb build successful: cmd/jaeger/_build/jaeger"


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards #8831

When Jaeger is built with OCB, the generated `main.go` uses a plain `otelcol.NewCommand`, so the resulting binary loses Jaeger's own CLI commands such as `elasticsearch-mappings`. This builds on the now merged Step 1 (#8835) and makes
the OCB build reuse Jaeger's CLI.

## Description of the changes
- `build-ocb` now runs OCB with `--skip-compilation` so it only generates `components.go`
- It then drops in `cmd/jaeger/jaegercli/main.go.tmpl` as the entrypoint, which calls `jaegercli.NewCommand` so the binary keeps the full Jaeger CLI
- The OCB CI job now checks that the built binary actually exposes the `version` and `elasticsearch-mappings` commands

## How was this change tested?
- Ran `make build-ocb` and confirmed the binary compiles
- Ran `version` and `elasticsearch-mappings` on the built binary

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality (no new unit-testable code, the OCB CI job validates the binary)
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
