### PR TITLE
refactor(es): Pass context to Elasticsearch client query methods

### DIFF
--- a/internal/storage/elasticsearch/client.go
+++ b/internal/storage/elasticsearch/client.go
@@ -13,13 +13,13 @@ import (
 
 // Client is an abstraction for elastic.Client
 type Client interface {
-	IndexExists(index string) IndicesExistsService
-	CreateIndex(index string) IndicesCreateService
-	CreateTemplate(id string) TemplateCreateService
+	IndexExists(ctx context.Context, index string) IndicesExistsService
+	CreateIndex(ctx context.Context, index string) IndicesCreateService
+	CreateTemplate(ctx context.Context, id string) TemplateCreateService
 	Index() IndexService
-	Search(indices ...string) SearchService
-	MultiSearch() MultiSearchService
-	DeleteIndex(index string) IndicesDeleteService
+	Search(ctx context.Context, indices ...string) SearchService
+	MultiSearch(ctx context.Context) MultiSearchService
+	DeleteIndex(ctx context.Context, index string) IndicesDeleteService
 	io.Closer
 	GetVersion() BackendVersion
 }

--- a/internal/storage/elasticsearch/mocks/mocks.go
+++ b/internal/storage/elasticsearch/mocks/mocks.go
@@ -90,16 +90,16 @@ func (_c *Client_Close_Call) RunAndReturn(run func() error) *Client_Close_Call {
 }
 
 // CreateIndex provides a mock function for the type Client
-func (_mock *Client) CreateIndex(index string) elasticsearch.IndicesCreateService {
-	ret := _mock.Called(index)
+func (_mock *Client) CreateIndex(ctx context.Context, index string) elasticsearch.IndicesCreateService {
+	ret := _mock.Called(ctx, index)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateIndex")
 	}
 
 	var r0 elasticsearch.IndicesCreateService
-	if returnFunc, ok := ret.Get(0).(func(string) elasticsearch.IndicesCreateService); ok {
-		r0 = returnFunc(index)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) elasticsearch.IndicesCreateService); ok {
+		r0 = returnFunc(ctx, index)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(elasticsearch.IndicesCreateService)
@@ -114,19 +114,25 @@ type Client_CreateIndex_Call struct {
 }
 
 // CreateIndex is a helper method to define mock.On call
+//   - ctx context.Context
 //   - index string
-func (_e *Client_Expecter) CreateIndex(index interface{}) *Client_CreateIndex_Call {
-	return &Client_CreateIndex_Call{Call: _e.mock.On("CreateIndex", index)}
+func (_e *Client_Expecter) CreateIndex(ctx interface{}, index interface{}) *Client_CreateIndex_Call {
+	return &Client_CreateIndex_Call{Call: _e.mock.On("CreateIndex", ctx, index)}
 }
 
-func (_c *Client_CreateIndex_Call) Run(run func(index string)) *Client_CreateIndex_Call {
+func (_c *Client_CreateIndex_Call) Run(run func(ctx context.Context, index string)) *Client_CreateIndex_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -137,22 +143,22 @@ func (_c *Client_CreateIndex_Call) Return(indicesCreateService elasticsearch.Ind
 	return _c
 }
 
-func (_c *Client_CreateIndex_Call) RunAndReturn(run func(index string) elasticsearch.IndicesCreateService) *Client_CreateIndex_Call {
+func (_c *Client_CreateIndex_Call) RunAndReturn(run func(ctx context.Context, index string) elasticsearch.IndicesCreateService) *Client_CreateIndex_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateTemplate provides a mock function for the type Client
-func (_mock *Client) CreateTemplate(id string) elasticsearch.TemplateCreateService {
-	ret := _mock.Called(id)
+func (_mock *Client) CreateTemplate(ctx context.Context, id string) elasticsearch.TemplateCreateService {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateTemplate")
 	}
 
 	var r0 elasticsearch.TemplateCreateService
-	if returnFunc, ok := ret.Get(0).(func(string) elasticsearch.TemplateCreateService); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) elasticsearch.TemplateCreateService); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(elasticsearch.TemplateCreateService)
@@ -167,19 +173,25 @@ type Client_CreateTemplate_Call struct {
 }
 
 // CreateTemplate is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *Client_Expecter) CreateTemplate(id interface{}) *Client_CreateTemplate_Call {
-	return &Client_CreateTemplate_Call{Call: _e.mock.On("CreateTemplate", id)}
+func (_e *Client_Expecter) CreateTemplate(ctx interface{}, id interface{}) *Client_CreateTemplate_Call {
+	return &Client_CreateTemplate_Call{Call: _e.mock.On("CreateTemplate", ctx, id)}
 }
 
-func (_c *Client_CreateTemplate_Call) Run(run func(id string)) *Client_CreateTemplate_Call {
+func (_c *Client_CreateTemplate_Call) Run(run func(ctx context.Context, id string)) *Client_CreateTemplate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -190,22 +202,22 @@ func (_c *Client_CreateTemplate_Call) Return(templateCreateService elasticsearch
 	return _c
 }
 
-func (_c *Client_CreateTemplate_Call) RunAndReturn(run func(id string) elasticsearch.TemplateCreateService) *Client_CreateTemplate_Call {
+func (_c *Client_CreateTemplate_Call) RunAndReturn(run func(ctx context.Context, id string) elasticsearch.TemplateCreateService) *Client_CreateTemplate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteIndex provides a mock function for the type Client
-func (_mock *Client) DeleteIndex(index string) elasticsearch.IndicesDeleteService {
-	ret := _mock.Called(index)
+func (_mock *Client) DeleteIndex(ctx context.Context, index string) elasticsearch.IndicesDeleteService {
+	ret := _mock.Called(ctx, index)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteIndex")
 	}
 
 	var r0 elasticsearch.IndicesDeleteService
-	if returnFunc, ok := ret.Get(0).(func(string) elasticsearch.IndicesDeleteService); ok {
-		r0 = returnFunc(index)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) elasticsearch.IndicesDeleteService); ok {
+		r0 = returnFunc(ctx, index)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(elasticsearch.IndicesDeleteService)
@@ -220,19 +232,25 @@ type Client_DeleteIndex_Call struct {
 }
 
 // DeleteIndex is a helper method to define mock.On call
+//   - ctx context.Context
 //   - index string
-func (_e *Client_Expecter) DeleteIndex(index interface{}) *Client_DeleteIndex_Call {
-	return &Client_DeleteIndex_Call{Call: _e.mock.On("DeleteIndex", index)}
+func (_e *Client_Expecter) DeleteIndex(ctx interface{}, index interface{}) *Client_DeleteIndex_Call {
+	return &Client_DeleteIndex_Call{Call: _e.mock.On("DeleteIndex", ctx, index)}
 }
 
-func (_c *Client_DeleteIndex_Call) Run(run func(index string)) *Client_DeleteIndex_Call {
+func (_c *Client_DeleteIndex_Call) Run(run func(ctx context.Context, index string)) *Client_DeleteIndex_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -243,7 +261,7 @@ func (_c *Client_DeleteIndex_Call) Return(indicesDeleteService elasticsearch.Ind
 	return _c
 }
 
-func (_c *Client_DeleteIndex_Call) RunAndReturn(run func(index string) elasticsearch.IndicesDeleteService) *Client_DeleteIndex_Call {
+func (_c *Client_DeleteIndex_Call) RunAndReturn(run func(ctx context.Context, index string) elasticsearch.IndicesDeleteService) *Client_DeleteIndex_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -339,16 +357,16 @@ func (_c *Client_Index_Call) RunAndReturn(run func() elasticsearch.IndexService)
 }
 
 // IndexExists provides a mock function for the type Client
-func (_mock *Client) IndexExists(index string) elasticsearch.IndicesExistsService {
-	ret := _mock.Called(index)
+func (_mock *Client) IndexExists(ctx context.Context, index string) elasticsearch.IndicesExistsService {
+	ret := _mock.Called(ctx, index)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IndexExists")
 	}
 
 	var r0 elasticsearch.IndicesExistsService
-	if returnFunc, ok := ret.Get(0).(func(string) elasticsearch.IndicesExistsService); ok {
-		r0 = returnFunc(index)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) elasticsearch.IndicesExistsService); ok {
+		r0 = returnFunc(ctx, index)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(elasticsearch.IndicesExistsService)
@@ -363,19 +381,25 @@ type Client_IndexExists_Call struct {
 }
 
 // IndexExists is a helper method to define mock.On call
+//   - ctx context.Context
 //   - index string
-func (_e *Client_Expecter) IndexExists(index interface{}) *Client_IndexExists_Call {
-	return &Client_IndexExists_Call{Call: _e.mock.On("IndexExists", index)}
+func (_e *Client_Expecter) IndexExists(ctx interface{}, index interface{}) *Client_IndexExists_Call {
+	return &Client_IndexExists_Call{Call: _e.mock.On("IndexExists", ctx, index)}
 }
 
-func (_c *Client_IndexExists_Call) Run(run func(index string)) *Client_IndexExists_Call {
+func (_c *Client_IndexExists_Call) Run(run func(ctx context.Context, index string)) *Client_IndexExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -386,22 +410,22 @@ func (_c *Client_IndexExists_Call) Return(indicesExistsService elasticsearch.Ind
 	return _c
 }
 
-func (_c *Client_IndexExists_Call) RunAndReturn(run func(index string) elasticsearch.IndicesExistsService) *Client_IndexExists_Call {
+func (_c *Client_IndexExists_Call) RunAndReturn(run func(ctx context.Context, index string) elasticsearch.IndicesExistsService) *Client_IndexExists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // MultiSearch provides a mock function for the type Client
-func (_mock *Client) MultiSearch() elasticsearch.MultiSearchService {
-	ret := _mock.Called()
+func (_mock *Client) MultiSearch(ctx context.Context) elasticsearch.MultiSearchService {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MultiSearch")
 	}
 
 	var r0 elasticsearch.MultiSearchService
-	if returnFunc, ok := ret.Get(0).(func() elasticsearch.MultiSearchService); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) elasticsearch.MultiSearchService); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(elasticsearch.MultiSearchService)
@@ -416,13 +440,20 @@ type Client_MultiSearch_Call struct {
 }
 
 // MultiSearch is a helper method to define mock.On call
-func (_e *Client_Expecter) MultiSearch() *Client_MultiSearch_Call {
-	return &Client_MultiSearch_Call{Call: _e.mock.On("MultiSearch")}
+//   - ctx context.Context
+func (_e *Client_Expecter) MultiSearch(ctx interface{}) *Client_MultiSearch_Call {
+	return &Client_MultiSearch_Call{Call: _e.mock.On("MultiSearch", ctx)}
 }
 
-func (_c *Client_MultiSearch_Call) Run(run func()) *Client_MultiSearch_Call {
+func (_c *Client_MultiSearch_Call) Run(run func(ctx context.Context)) *Client_MultiSearch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -432,18 +463,18 @@ func (_c *Client_MultiSearch_Call) Return(multiSearchService elasticsearch.Multi
 	return _c
 }
 
-func (_c *Client_MultiSearch_Call) RunAndReturn(run func() elasticsearch.MultiSearchService) *Client_MultiSearch_Call {
+func (_c *Client_MultiSearch_Call) RunAndReturn(run func(ctx context.Context) elasticsearch.MultiSearchService) *Client_MultiSearch_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Search provides a mock function for the type Client
-func (_mock *Client) Search(indices ...string) elasticsearch.SearchService {
+func (_mock *Client) Search(ctx context.Context, indices ...string) elasticsearch.SearchService {
 	var tmpRet mock.Arguments
 	if len(indices) > 0 {
-		tmpRet = _mock.Called(indices)
+		tmpRet = _mock.Called(ctx, indices)
 	} else {
-		tmpRet = _mock.Called()
+		tmpRet = _mock.Called(ctx)
 	}
 	ret := tmpRet
 
@@ -452,8 +483,8 @@ func (_mock *Client) Search(indices ...string) elasticsearch.SearchService {
 	}
 
 	var r0 elasticsearch.SearchService
-	if returnFunc, ok := ret.Get(0).(func(...string) elasticsearch.SearchService); ok {
-		r0 = returnFunc(indices...)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...string) elasticsearch.SearchService); ok {
+		r0 = returnFunc(ctx, indices...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(elasticsearch.SearchService)
@@ -468,22 +499,28 @@ type Client_Search_Call struct {
 }
 
 // Search is a helper method to define mock.On call
+//   - ctx context.Context
 //   - indices ...string
-func (_e *Client_Expecter) Search(indices ...interface{}) *Client_Search_Call {
+func (_e *Client_Expecter) Search(ctx interface{}, indices ...interface{}) *Client_Search_Call {
 	return &Client_Search_Call{Call: _e.mock.On("Search",
-		append([]interface{}{}, indices...)...)}
+		append([]interface{}{ctx}, indices...)...)}
 }
 
-func (_c *Client_Search_Call) Run(run func(indices ...string)) *Client_Search_Call {
+func (_c *Client_Search_Call) Run(run func(ctx context.Context, indices ...string)) *Client_Search_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
-		var variadicArgs []string
-		if len(args) > 0 {
-			variadicArgs = args[0].([]string)
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
 		}
-		arg0 = variadicArgs
+		var arg1 []string
+		var variadicArgs []string
+		if len(args) > 1 {
+			variadicArgs = args[1].([]string)
+		}
+		arg1 = variadicArgs
 		run(
-			arg0...,
+			arg0,
+			arg1...,
 		)
 	})
 	return _c
@@ -494,7 +531,7 @@ func (_c *Client_Search_Call) Return(searchService elasticsearch.SearchService) 
 	return _c
 }
 
-func (_c *Client_Search_Call) RunAndReturn(run func(indices ...string) elasticsearch.SearchService) *Client_Search_Call {
+func (_c *Client_Search_Call) RunAndReturn(run func(ctx context.Context, indices ...string) elasticsearch.SearchService) *Client_Search_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/storage/elasticsearch/wrapper/wrapper.go
+++ b/internal/storage/elasticsearch/wrapper/wrapper.go
@@ -43,22 +43,22 @@ func WrapESClient(client *elastic.Client, s *elastic.BulkProcessor, version es.B
 }
 
 // IndexExists calls this function to internal client.
-func (c ClientWrapper) IndexExists(index string) es.IndicesExistsService {
+func (c ClientWrapper) IndexExists(_ context.Context, index string) es.IndicesExistsService {
 	return WrapESIndicesExistsService(c.client.IndexExists(index))
 }
 
 // CreateIndex calls this function to internal client.
-func (c ClientWrapper) CreateIndex(index string) es.IndicesCreateService {
+func (c ClientWrapper) CreateIndex(_ context.Context, index string) es.IndicesCreateService {
 	return WrapESIndicesCreateService(c.client.CreateIndex(index))
 }
 
 // DeleteIndex calls this function to internal client.
-func (c ClientWrapper) DeleteIndex(index string) es.IndicesDeleteService {
+func (c ClientWrapper) DeleteIndex(_ context.Context, index string) es.IndicesDeleteService {
 	return WrapESIndicesDeleteService(c.client.DeleteIndex(index))
 }
 
 // CreateTemplate calls this function to internal client.
-func (c ClientWrapper) CreateTemplate(ttype string) es.TemplateCreateService {
+func (c ClientWrapper) CreateTemplate(_ context.Context, ttype string) es.TemplateCreateService {
 	if c.version.UsesV8API() {
 		return TemplateCreatorWrapperV8{
 			indicesV8:    c.clientV8.Indices,
@@ -75,7 +75,7 @@ func (c ClientWrapper) Index() es.IndexService {
 }
 
 // Search calls this function to internal client.
-func (c ClientWrapper) Search(indices ...string) es.SearchService {
+func (c ClientWrapper) Search(_ context.Context, indices ...string) es.SearchService {
 	searchService := c.client.Search(indices...)
 	if !c.version.SupportsTypedIndices() {
 		searchService = searchService.RestTotalHitsAsInt(true)
@@ -84,7 +84,7 @@ func (c ClientWrapper) Search(indices ...string) es.SearchService {
 }
 
 // MultiSearch calls this function to internal client.
-func (c ClientWrapper) MultiSearch() es.MultiSearchService {
+func (c ClientWrapper) MultiSearch(_ context.Context) es.MultiSearchService {
 	multiSearchService := c.client.MultiSearch()
 	return WrapESMultiSearchService(multiSearchService)
 }

--- a/internal/storage/metricstore/elasticsearch/query_builder.go
+++ b/internal/storage/metricstore/elasticsearch/query_builder.go
@@ -117,7 +117,7 @@ func (q *QueryBuilder) Execute(ctx context.Context, boolQuery elastic.BoolQuery,
 		time.UnixMilli(timeRange.endTimeMillis).UTC(),
 	)
 
-	return q.client.Search(idxList...).
+	return q.client.Search(ctx, idxList...).
 		IgnoreUnavailable(true).
 		Query(&boolQuery).
 		Size(0). // Set Size to 0 to return only aggregation results, excluding individual search hits

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -154,7 +154,7 @@ func (f *FactoryBase) CreateSamplingStore(int /* maxBuckets */) (samplingstore.S
 			return nil, err
 		}
 		templateName := f.config.Indices.IndexPrefix.Apply(config.SamplingIndexName)
-		if _, err := f.getClient().CreateTemplate(templateName).Body(samplingMapping).Do(context.Background()); err != nil {
+		if _, err := f.getClient().CreateTemplate(context.Background(), templateName).Body(samplingMapping).Do(context.Background()); err != nil {
 			return nil, fmt.Errorf("failed to create template: %w", err)
 		}
 	}
@@ -187,7 +187,7 @@ func (f *FactoryBase) Close() error {
 
 func (f *FactoryBase) Purge(ctx context.Context) error {
 	esClient := f.getClient()
-	_, err := esClient.DeleteIndex("*").Do(ctx)
+	_, err := esClient.DeleteIndex(ctx, "*").Do(ctx)
 	return err
 }
 
@@ -240,11 +240,11 @@ func (f *FactoryBase) createTemplates(ctx context.Context) error {
 		}
 		jaegerSpanIdx := f.config.Indices.IndexPrefix.Apply(config.SpanIndexName)
 		jaegerServiceIdx := f.config.Indices.IndexPrefix.Apply(config.ServiceIndexName)
-		_, err = f.getClient().CreateTemplate(jaegerSpanIdx).Body(spanMapping).Do(ctx)
+		_, err = f.getClient().CreateTemplate(ctx, jaegerSpanIdx).Body(spanMapping).Do(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create template %q: %w", jaegerSpanIdx, err)
 		}
-		_, err = f.getClient().CreateTemplate(jaegerServiceIdx).Body(serviceMapping).Do(ctx)
+		_, err = f.getClient().CreateTemplate(ctx, jaegerServiceIdx).Body(serviceMapping).Do(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create template %q: %w", jaegerServiceIdx, err)
 		}

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -91,7 +91,7 @@ func TestFactoryBase_Purge(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := &mocks.Client{}
 			mockDelete := &mocks.IndicesDeleteService{}
-			mockClient.On("DeleteIndex", "*").Return(mockDelete)
+			mockClient.On("DeleteIndex", mock.Anything, "*").Return(mockDelete)
 
 			tt.setupMock(mockDelete)
 
@@ -292,8 +292,8 @@ func TestCreateTemplates(t *testing.T) {
 		f.templateBuilder = es.TextTemplateBuilder{}
 		jaegerSpanId := test.indexPrefix.Apply(escfg.SpanIndexName)
 		jaegerServiceId := test.indexPrefix.Apply(escfg.ServiceIndexName)
-		mockClient.On("CreateTemplate", jaegerSpanId).Return(test.spanTemplateService())
-		mockClient.On("CreateTemplate", jaegerServiceId).Return(test.serviceTemplateService())
+		mockClient.On("CreateTemplate", mock.Anything, jaegerSpanId).Return(test.spanTemplateService())
+		mockClient.On("CreateTemplate", mock.Anything, jaegerServiceId).Return(test.serviceTemplateService())
 		err = f.createTemplates(context.Background())
 		if test.err != "" {
 			require.ErrorContains(t, err, test.err)

--- a/internal/storage/v1/elasticsearch/samplingstore/storage.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage.go
@@ -67,7 +67,7 @@ func (s *SamplingStore) InsertThroughput(throughput []*model.Throughput) error {
 func (s *SamplingStore) GetThroughput(start, end time.Time) ([]*model.Throughput, error) {
 	ctx := context.Background()
 	readIndices := s.rotation.ReadTargets(start, end)
-	searchResult, err := s.client().Search(readIndices...).
+	searchResult, err := s.client().Search(ctx, readIndices...).
 		Size(s.maxDocCount).
 		Query(buildTSQuery(start, end)).
 		IgnoreUnavailable(true).
@@ -110,7 +110,7 @@ func (s *SamplingStore) GetLatestProbabilities() (model.ServiceOperationProbabil
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest index: %w", err)
 	}
-	searchResult, err := clientFn.Search(index).
+	searchResult, err := clientFn.Search(ctx, index).
 		Size(s.maxDocCount).
 		IgnoreUnavailable(true).
 		Do(ctx)
@@ -149,7 +149,7 @@ func (s *SamplingStore) getLatestIndex(ctx context.Context, client es.Client) (s
 	now := time.Now().UTC()
 	candidates := s.rotation.ReadTargets(now.Add(-s.lookback), now)
 	for _, idx := range candidates {
-		exists, err := client.IndexExists(idx).Do(ctx)
+		exists, err := client.IndexExists(ctx, idx).Do(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to check index existence: %w", err)
 		}

--- a/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
+++ b/internal/storage/v1/elasticsearch/samplingstore/storage_test.go
@@ -97,12 +97,12 @@ func TestGetLatestIndex(t *testing.T) {
 				),
 			})
 			indexService := &mocks.IndicesExistsService{}
-			client.On("IndexExists", mock.Anything).Return(indexService)
+			client.On("IndexExists", mock.Anything, mock.Anything).Return(indexService)
 			indexService.On("Do", mock.Anything).Return(test.indexExist, test.indexError)
 
 			if test.indexExist && test.indexError == nil {
 				searchService := &mocks.SearchService{}
-				client.On("Search", mock.AnythingOfType("[]string")).Return(searchService)
+				client.On("Search", mock.Anything, mock.AnythingOfType("[]string")).Return(searchService)
 				searchService.On("Size", mock.Anything).Return(searchService)
 				searchService.On("IgnoreUnavailable", true).Return(searchService)
 				emptyResult := &elastic.SearchResult{Hits: &elastic.SearchHits{Hits: []*elastic.SearchHit{}}}
@@ -269,7 +269,7 @@ func TestGetThroughput(t *testing.T) {
 					test.indexPrefix += "-"
 				}
 				index := test.indexPrefix.Apply(test.index)
-				w.client.On("Search", []string{index}).Return(searchService)
+				w.client.On("Search", mock.Anything, []string{index}).Return(searchService)
 				searchService.On("Size", mock.Anything).Return(searchService)
 				searchService.On("Query", mock.Anything).Return(searchService)
 				searchService.On("IgnoreUnavailable", true).Return(searchService)
@@ -377,13 +377,13 @@ func TestGetLatestProbabilities(t *testing.T) {
 
 			searchService := &mocks.SearchService{}
 			index := test.indexPrefix.Apply(test.index)
-			client.On("Search", []string{index}).Return(searchService)
+			client.On("Search", mock.Anything, []string{index}).Return(searchService)
 			searchService.On("Size", mock.Anything).Return(searchService)
 			searchService.On("IgnoreUnavailable", true).Return(searchService)
 			searchService.On("Do", mock.Anything).Return(test.searchResult, test.searchError)
 
 			indicesexistsservice := &mocks.IndicesExistsService{}
-			client.On("IndexExists", index).Return(indicesexistsservice)
+			client.On("IndexExists", mock.Anything, index).Return(indicesexistsservice)
 			indicesexistsservice.On("Do", mock.Anything).Return(test.indexPresent, test.indexError)
 
 			actual, err := store.GetLatestProbabilities()

--- a/internal/storage/v2/elasticsearch/depstore/storage.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage.go
@@ -68,7 +68,7 @@ func (s *DependencyStore) WriteDependencies(ts time.Time, dependencies []dbmodel
 
 // CreateTemplates creates index templates.
 func (s *DependencyStore) CreateTemplates(dependenciesTemplate string) error {
-	_, err := s.client().CreateTemplate(config.DependencyIndexName).Body(dependenciesTemplate).Do(context.Background())
+	_, err := s.client().CreateTemplate(context.Background(), config.DependencyIndexName).Body(dependenciesTemplate).Do(context.Background())
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (s *DependencyStore) writeDependenciesToIndex(indexName string, ts time.Tim
 // GetDependencies returns all interservice dependencies
 func (s *DependencyStore) GetDependencies(ctx context.Context, endTs time.Time, lookback time.Duration) ([]dbmodel.DependencyLink, error) {
 	readIndices := s.rotation.ReadTargets(endTs.Add(-lookback), endTs)
-	searchResult, err := s.client().Search(readIndices...).
+	searchResult, err := s.client().Search(ctx, readIndices...).
 		Size(s.maxDocCount).
 		Query(buildTSQuery(endTs, lookback)).
 		IgnoreUnavailable(true).

--- a/internal/storage/v2/elasticsearch/depstore/storage_test.go
+++ b/internal/storage/v2/elasticsearch/depstore/storage_test.go
@@ -152,7 +152,7 @@ func TestGetDependencies(t *testing.T) {
 			fixedTime := time.Date(1995, time.April, 21, 4, 21, 19, 95, time.UTC)
 
 			searchService := &mocks.SearchService{}
-			r.client.On("Search", mock.AnythingOfType("[]string")).Return(searchService)
+			r.client.On("Search", mock.Anything, mock.AnythingOfType("[]string")).Return(searchService)
 
 			searchService.On("Size", mock.MatchedBy(func(size int) bool {
 				return size == testCase.maxDocCount

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -333,7 +333,7 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 		}
 		// set traceIDs to empty
 		traceIDs = nil
-		results, err := s.client().MultiSearch().Add(searchRequests...).Index(idxList...).Do(ctx)
+		results, err := s.client().MultiSearch(ctx).Add(searchRequests...).Index(idxList...).Do(ctx)
 		if err != nil {
 			err = es.DetailedError(err)
 			logErrorToSpan(childSpan, err)
@@ -463,7 +463,7 @@ func (s *SpanReader) findTraceIDsFromQuery(ctx context.Context, traceQuery dbmod
 	boolQuery := s.buildFindTraceIDsQuery(traceQuery)
 	jaegerIndices := s.spanRotation.ReadTargets(traceQuery.StartTimeMin, traceQuery.StartTimeMax)
 
-	searchService := s.client().Search(jaegerIndices...).
+	searchService := s.client().Search(ctx, jaegerIndices...).
 		Size(0). // set to 0 because we don't want actual documents.
 		Aggregation(traceIDAggregation, aggregation).
 		IgnoreUnavailable(true).

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -325,7 +325,7 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 
 		firstMultiSearch.On("Index", mock.AnythingOfType("[]string")).Return(firstMultiSearch)
 		secondMultiSearch.On("Index", mock.AnythingOfType("[]string")).Return(secondMultiSearch)
-		r.client.On("MultiSearch").Return(multiSearchService)
+		r.client.On("MultiSearch", mock.Anything).Return(multiSearchService)
 
 		fistMultiSearchMock := firstMultiSearch.On("Do", mock.Anything)
 		secondMultiSearchMock := secondMultiSearch.On("Do", mock.Anything)
@@ -920,7 +920,7 @@ func mockMultiSearchService(r *spanReaderTest) *mock.Call {
 	multiSearchService := &mocks.MultiSearchService{}
 	multiSearchService.On("Add", mock.Anything, mock.Anything, mock.Anything).Return(multiSearchService)
 	multiSearchService.On("Index", mock.AnythingOfType("[]string")).Return(multiSearchService)
-	r.client.On("MultiSearch").Return(multiSearchService)
+	r.client.On("MultiSearch", mock.Anything).Return(multiSearchService)
 	return multiSearchService.On("Do", mock.Anything)
 }
 
@@ -928,7 +928,7 @@ func mockArchiveMultiSearchService(r *spanReaderTest, indexName []string) *mock.
 	multiSearchService := &mocks.MultiSearchService{}
 	multiSearchService.On("Add", mock.Anything, mock.Anything, mock.Anything).Return(multiSearchService)
 	multiSearchService.On("Index", indexName).Return(multiSearchService)
-	r.client.On("MultiSearch").Return(multiSearchService)
+	r.client.On("MultiSearch", mock.Anything).Return(multiSearchService)
 	return multiSearchService.On("Do", mock.Anything)
 }
 
@@ -950,7 +950,7 @@ func mockSearchService(r *spanReaderTest) *mock.Call {
 	searchService.On("Aggregation", stringMatcher(servicesAggregation), mock.MatchedBy(matchTermsAggregation)).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(operationsAggregation), mock.MatchedBy(matchTermsAggregation)).Return(searchService)
 	searchService.On("Aggregation", stringMatcher(traceIDAggregation), mock.AnythingOfType("*elastic.TermsAggregation")).Return(searchService)
-	r.client.On("Search", mock.AnythingOfType("[]string")).Return(searchService)
+	r.client.On("Search", mock.Anything, mock.AnythingOfType("[]string")).Return(searchService)
 	return searchService.On("Do", mock.Anything)
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/service_operation.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/service_operation.go
@@ -70,7 +70,7 @@ func (s *ServiceOperationStorage) Write(indexName string, jsonSpan *dbmodel.Span
 func (s *ServiceOperationStorage) getServices(ctx context.Context, indices []string, maxDocCount int) ([]string, error) {
 	serviceAggregation := getServicesAggregation(maxDocCount)
 
-	searchService := s.client().Search(indices...).
+	searchService := s.client().Search(ctx, indices...).
 		Size(0). // set to 0 because we don't want actual documents.
 		IgnoreUnavailable(true).
 		Aggregation(servicesAggregation, serviceAggregation)
@@ -100,7 +100,7 @@ func (s *ServiceOperationStorage) getOperations(ctx context.Context, indices []s
 	serviceQuery := elastic.NewTermQuery(serviceName, service)
 	serviceFilter := getOperationsAggregation(maxDocCount)
 
-	searchService := s.client().Search(indices...).
+	searchService := s.client().Search(ctx, indices...).
 		Size(0).
 		Query(serviceQuery).
 		IgnoreUnavailable(true).


### PR DESCRIPTION
## Which problem is this PR solving?

The ES `Client` interface exposed several query-executing entry methods that did not accept a `context.Context`, so callers could not propagate cancellation/deadline/tracing context to the point where an operation against the backend is initiated.

## Description of the changes

- Added a `context.Context` first parameter to the query-executing entry methods of the `elasticsearch.Client` interface and its `eswrapper` implementation:
  - `Search`, `MultiSearch`, `IndexExists`, `CreateIndex`, `CreateTemplate`, `DeleteIndex`.
- Left unchanged the methods that do **not** execute a query:
  - pure request builders/setters (`Size`, `Query`, `Body`, `Id`, `BodyJson`, `Type`, `OpType`, `Aggregation`, `IgnoreUnavailable`, the `MultiSearch` `Add`/`Index`),
  - the async bulk-write entry `Index()` (the write is handed to the `BulkProcessor`, with no synchronous `Do`),
  - the cached `GetVersion()` getter and `Close()`.
- Updated all callers and regenerated mocks (`make generate-mocks`).

## How was this change tested?

- `make fmt`
- `go test ./internal/storage/v1/elasticsearch/... ./internal/storage/v2/elasticsearch/... ./internal/storage/metricstore/elasticsearch/...`

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality

> Note: opened at maintainer request; signature-only interface refactor with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)