### PR TITLE
refactor(es): Thread context.Context through the ES REST client

### DIFF
--- a/cmd/es-index-cleaner/main.go
+++ b/cmd/es-index-cleaner/main.go
@@ -81,7 +81,7 @@ func main() {
 				IgnoreUnavailableIndex: true,
 			}
 
-			indices, err := i.GetJaegerIndices(cfg.IndexPrefix)
+			indices, err := i.GetJaegerIndices(ctx, cfg.IndexPrefix)
 			if err != nil {
 				return err
 			}
@@ -104,7 +104,7 @@ func main() {
 				return nil
 			}
 			logger.Info("Deleting indices", zap.Any("indices", indices))
-			return i.DeleteIndices(indices)
+			return i.DeleteIndices(ctx, indices)
 		},
 	}
 

--- a/cmd/es-rollover/app/init/action.go
+++ b/cmd/es-rollover/app/init/action.go
@@ -4,6 +4,7 @@
 package init
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
@@ -37,7 +38,8 @@ func (c Action) getMapping(version es.BackendVersion, mappingType mappings.Mappi
 
 // Do the init action
 func (c Action) Do() error {
-	version, err := c.ClusterClient.Version()
+	ctx := context.TODO()
+	version, err := c.ClusterClient.Version(ctx)
 	if err != nil {
 		return err
 	}
@@ -48,7 +50,7 @@ func (c Action) Do() error {
 		if ilm, ok := c.ILMClient.(*client.ILMClient); ok && version.IsOpenSearch() {
 			ilm.UseOpenSearchISM = true
 		}
-		policyExist, err := c.ILMClient.Exists(c.Config.ILMPolicyName)
+		policyExist, err := c.ILMClient.Exists(ctx, c.Config.ILMPolicyName)
 		if err != nil {
 			return err
 		}
@@ -58,32 +60,32 @@ func (c Action) Do() error {
 	}
 	rolloverIndices := app.RolloverIndices(c.Config.Archive, c.Config.SkipDependencies, c.Config.AdaptiveSampling, c.Config.Config.IndexPrefix)
 	for _, indexName := range rolloverIndices {
-		if err := c.init(version, indexName); err != nil {
+		if err := c.init(ctx, version, indexName); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func createIndexIfNotExist(c client.IndexAPI, index string) error {
-	exists, err := c.IndexExists(index)
+func createIndexIfNotExist(ctx context.Context, c client.IndexAPI, index string) error {
+	exists, err := c.IndexExists(ctx, index)
 	if err != nil {
 		return err
 	}
 	if exists {
 		return nil
 	}
-	aliasExists, err := c.AliasExists(index)
+	aliasExists, err := c.AliasExists(ctx, index)
 	if err != nil {
 		return err
 	}
 	if aliasExists {
 		return nil
 	}
-	return c.CreateIndex(index)
+	return c.CreateIndex(ctx, index)
 }
 
-func (c Action) init(version es.BackendVersion, indexopt app.IndexOption) error {
+func (c Action) init(ctx context.Context, version es.BackendVersion, indexopt app.IndexOption) error {
 	mappingType, err := mappings.MappingTypeFromString(indexopt.Mapping)
 	if err != nil {
 		return err
@@ -94,18 +96,18 @@ func (c Action) init(version es.BackendVersion, indexopt app.IndexOption) error 
 		return err
 	}
 
-	err = c.IndicesClient.CreateTemplate(mapping, indexopt.TemplateName())
+	err = c.IndicesClient.CreateTemplate(ctx, mapping, indexopt.TemplateName())
 	if err != nil {
 		return err
 	}
 
 	index := indexopt.InitialRolloverIndex()
-	err = createIndexIfNotExist(c.IndicesClient, index)
+	err = createIndexIfNotExist(ctx, c.IndicesClient, index)
 	if err != nil {
 		return err
 	}
 
-	jaegerIndices, err := c.IndicesClient.GetJaegerIndices(c.Config.Config.IndexPrefix)
+	jaegerIndices, err := c.IndicesClient.GetJaegerIndices(ctx, c.Config.Config.IndexPrefix)
 	if err != nil {
 		return err
 	}
@@ -131,7 +133,7 @@ func (c Action) init(version es.BackendVersion, indexopt app.IndexOption) error 
 	}
 
 	if len(aliases) > 0 {
-		err = c.IndicesClient.CreateAlias(aliases)
+		err = c.IndicesClient.CreateAlias(ctx, aliases)
 		if err != nil {
 			return err
 		}

--- a/cmd/es-rollover/app/init/action_test.go
+++ b/cmd/es-rollover/app/init/action_test.go
@@ -4,6 +4,7 @@
 package init
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -84,10 +85,10 @@ func TestIndexCreateIfNotExist(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			indexClient := &mocks.IndexAPI{}
-			indexClient.On("IndexExists", "jaeger-span").Return(test.indexExists, test.indexExistsErr)
-			indexClient.On("AliasExists", "jaeger-span").Return(test.aliasExists, test.aliasExistsErr)
-			indexClient.On("CreateIndex", "jaeger-span").Return(test.createIndexErr)
-			err := createIndexIfNotExist(indexClient, "jaeger-span")
+			indexClient.On("IndexExists", mock.Anything, "jaeger-span").Return(test.indexExists, test.indexExistsErr)
+			indexClient.On("AliasExists", mock.Anything, "jaeger-span").Return(test.aliasExists, test.aliasExistsErr)
+			indexClient.On("CreateIndex", mock.Anything, "jaeger-span").Return(test.createIndexErr)
+			err := createIndexIfNotExist(context.Background(), indexClient, "jaeger-span")
 			if test.expectedError != "" {
 				assert.EqualError(t, err, test.expectedError)
 			}
@@ -105,7 +106,7 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "Unsupported version",
 			setupCallExpectations: func(_ *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, _ *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV6, nil)
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV6, nil)
 			},
 			config: Config{
 				Config: app.Config{
@@ -118,7 +119,7 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "error getting version",
 			setupCallExpectations: func(_ *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, _ *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.BackendVersion(0), errors.New("version error"))
+				clusterClient.On("Version", mock.Anything).Return(es.BackendVersion(0), errors.New("version error"))
 			},
 			expectedErr: errors.New("version error"),
 			config: Config{
@@ -131,8 +132,8 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "ilm doesnt exist",
 			setupCallExpectations: func(_ *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, ilmClient *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV7, nil)
-				ilmClient.On("Exists", "myilmpolicy").Return(false, nil)
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
+				ilmClient.On("Exists", mock.Anything, "myilmpolicy").Return(false, nil)
 			},
 			expectedErr: errors.New("ILM policy myilmpolicy doesn't exist in Elasticsearch. Please create it and re-run init"),
 			config: Config{
@@ -146,8 +147,8 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "fail get ilm policy",
 			setupCallExpectations: func(_ *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, ilmClient *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV7, nil)
-				ilmClient.On("Exists", "myilmpolicy").Return(false, errors.New("error getting ilm policy"))
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
+				ilmClient.On("Exists", mock.Anything, "myilmpolicy").Return(false, errors.New("error getting ilm policy"))
 			},
 			expectedErr: errors.New("error getting ilm policy"),
 			config: Config{
@@ -161,8 +162,8 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "fail to create template",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, _ *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV7, nil)
-				indexClient.On("CreateTemplate", mock.Anything, "jaeger-span").Return(errors.New("error creating template"))
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
+				indexClient.On("CreateTemplate", mock.Anything, mock.Anything, "jaeger-span").Return(errors.New("error creating template"))
 			},
 			expectedErr: errors.New("error creating template"),
 			config: Config{
@@ -175,12 +176,12 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "fail to get jaeger indices",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, _ *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV7, nil)
-				indexClient.On("IndexExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("AliasExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("CreateTemplate", mock.Anything, "jaeger-span").Return(nil)
-				indexClient.On("CreateIndex", "jaeger-span-archive-000001").Return(nil)
-				indexClient.On("GetJaegerIndices", "").Return([]client.Index{}, errors.New("error getting jaeger indices"))
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
+				indexClient.On("IndexExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("AliasExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("CreateTemplate", mock.Anything, mock.Anything, "jaeger-span").Return(nil)
+				indexClient.On("CreateIndex", mock.Anything, "jaeger-span-archive-000001").Return(nil)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, errors.New("error getting jaeger indices"))
 			},
 			expectedErr: errors.New("error getting jaeger indices"),
 			config: Config{
@@ -193,13 +194,13 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "fail to create alias",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, _ *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV7, nil)
-				indexClient.On("IndexExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("AliasExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("CreateTemplate", mock.Anything, "jaeger-span").Return(nil)
-				indexClient.On("CreateIndex", "jaeger-span-archive-000001").Return(nil)
-				indexClient.On("GetJaegerIndices", "").Return([]client.Index{}, nil)
-				indexClient.On("CreateAlias", []client.Alias{
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
+				indexClient.On("IndexExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("AliasExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("CreateTemplate", mock.Anything, mock.Anything, "jaeger-span").Return(nil)
+				indexClient.On("CreateIndex", mock.Anything, "jaeger-span-archive-000001").Return(nil)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, nil)
+				indexClient.On("CreateAlias", mock.Anything, []client.Alias{
 					{Index: "jaeger-span-archive-000001", Name: "jaeger-span-archive-read", IsWriteIndex: false},
 					{Index: "jaeger-span-archive-000001", Name: "jaeger-span-archive-write", IsWriteIndex: false},
 				}).Return(errors.New("error creating aliases"))
@@ -215,13 +216,13 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "create rollover index",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, _ *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV7, nil)
-				indexClient.On("IndexExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("AliasExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("CreateTemplate", mock.Anything, "jaeger-span").Return(nil)
-				indexClient.On("CreateIndex", "jaeger-span-archive-000001").Return(nil)
-				indexClient.On("GetJaegerIndices", "").Return([]client.Index{}, nil)
-				indexClient.On("CreateAlias", []client.Alias{
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
+				indexClient.On("IndexExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("AliasExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("CreateTemplate", mock.Anything, mock.Anything, "jaeger-span").Return(nil)
+				indexClient.On("CreateIndex", mock.Anything, "jaeger-span-archive-000001").Return(nil)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, nil)
+				indexClient.On("CreateAlias", mock.Anything, []client.Alias{
 					{Index: "jaeger-span-archive-000001", Name: "jaeger-span-archive-read", IsWriteIndex: false},
 					{Index: "jaeger-span-archive-000001", Name: "jaeger-span-archive-write", IsWriteIndex: false},
 				}).Return(nil)
@@ -237,14 +238,14 @@ func TestRolloverAction(t *testing.T) {
 		{
 			name: "create rollover index with ilm",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, ilmClient *mocks.IndexManagementLifecycleAPI) {
-				clusterClient.On("Version").Return(es.ElasticV7, nil)
-				indexClient.On("IndexExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("AliasExists", "jaeger-span-archive-000001").Return(false, nil)
-				indexClient.On("CreateTemplate", mock.Anything, "jaeger-span").Return(nil)
-				indexClient.On("CreateIndex", "jaeger-span-archive-000001").Return(nil)
-				indexClient.On("GetJaegerIndices", "").Return([]client.Index{}, nil)
-				ilmClient.On("Exists", "jaeger-ilm").Return(true, nil)
-				indexClient.On("CreateAlias", []client.Alias{
+				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
+				indexClient.On("IndexExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("AliasExists", mock.Anything, "jaeger-span-archive-000001").Return(false, nil)
+				indexClient.On("CreateTemplate", mock.Anything, mock.Anything, "jaeger-span").Return(nil)
+				indexClient.On("CreateIndex", mock.Anything, "jaeger-span-archive-000001").Return(nil)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, nil)
+				ilmClient.On("Exists", mock.Anything, "jaeger-ilm").Return(true, nil)
+				indexClient.On("CreateAlias", mock.Anything, []client.Alias{
 					{Index: "jaeger-span-archive-000001", Name: "jaeger-span-archive-read", IsWriteIndex: false},
 					{Index: "jaeger-span-archive-000001", Name: "jaeger-span-archive-write", IsWriteIndex: true},
 				}).Return(nil)
@@ -302,7 +303,7 @@ func TestRolloverAction_OpenSearchUsesISMEndpoint(t *testing.T) {
 	defer testServer.Close()
 
 	clusterClient := &mocks.ClusterAPI{}
-	clusterClient.On("Version").Return(es.OpenSearch2, nil)
+	clusterClient.On("Version", mock.Anything).Return(es.OpenSearch2, nil)
 
 	ilmClient := &client.ILMClient{
 		Client: client.Client{
@@ -316,10 +317,10 @@ func TestRolloverAction_OpenSearchUsesISMEndpoint(t *testing.T) {
 	applyTestDefaults(&cfg)
 
 	indexClient := &mocks.IndexAPI{}
-	indexClient.On("CreateTemplate", mock.Anything, mock.Anything).Return(nil)
-	indexClient.On("IndexExists", mock.Anything).Return(true, nil)
-	indexClient.On("GetJaegerIndices", "").Return([]client.Index{}, nil)
-	indexClient.On("CreateAlias", mock.Anything).Return(nil)
+	indexClient.On("CreateTemplate", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	indexClient.On("IndexExists", mock.Anything, mock.Anything).Return(true, nil)
+	indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, nil)
+	indexClient.On("CreateAlias", mock.Anything, mock.Anything).Return(nil)
 
 	action := Action{
 		Config:        cfg,

--- a/cmd/es-rollover/app/lookback/action.go
+++ b/cmd/es-rollover/app/lookback/action.go
@@ -4,6 +4,7 @@
 package lookback
 
 import (
+	"context"
 	"time"
 
 	"go.uber.org/zap"
@@ -24,17 +25,18 @@ type Action struct {
 
 // Do the lookback action
 func (a *Action) Do() error {
+	ctx := context.TODO()
 	rolloverIndices := app.RolloverIndices(a.Config.Archive, a.Config.SkipDependencies, a.Config.AdaptiveSampling, a.Config.IndexPrefix)
 	for _, indexName := range rolloverIndices {
-		if err := a.lookback(indexName); err != nil {
+		if err := a.lookback(ctx, indexName); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (a *Action) lookback(indexSet app.IndexOption) error {
-	jaegerIndex, err := a.IndicesClient.GetJaegerIndices(a.Config.IndexPrefix)
+func (a *Action) lookback(ctx context.Context, indexSet app.IndexOption) error {
+	jaegerIndex, err := a.IndicesClient.GetJaegerIndices(ctx, a.Config.IndexPrefix)
 	if err != nil {
 		return err
 	}
@@ -60,5 +62,5 @@ func (a *Action) lookback(indexSet app.IndexOption) error {
 		a.Logger.Info("To be removed", zap.String("index", index.Index), zap.String("creationTime", index.CreationTime.String()))
 	}
 
-	return a.IndicesClient.DeleteAlias(aliases)
+	return a.IndicesClient.DeleteAlias(ctx, aliases)
 }

--- a/cmd/es-rollover/app/lookback/action_test.go
+++ b/cmd/es-rollover/app/lookback/action_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -72,8 +73,8 @@ func TestLookBackAction(t *testing.T) {
 		{
 			name: "success",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI) {
-				indexClient.On("GetJaegerIndices", "").Return(indices, nil)
-				indexClient.On("DeleteAlias", []client.Alias{
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return(indices, nil)
+				indexClient.On("DeleteAlias", mock.Anything, []client.Alias{
 					{
 						Index: "jaeger-span-archive-0001",
 						Name:  "jaeger-span-archive-read",
@@ -93,7 +94,7 @@ func TestLookBackAction(t *testing.T) {
 		{
 			name: "get indices error",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI) {
-				indexClient.On("GetJaegerIndices", "").Return(indices, errors.New("get indices error"))
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return(indices, errors.New("get indices error"))
 			},
 			config: Config{
 				Unit:      "days",
@@ -108,7 +109,7 @@ func TestLookBackAction(t *testing.T) {
 		{
 			name: "empty indices",
 			setupCallExpectations: func(indexClient *mocks.IndexAPI) {
-				indexClient.On("GetJaegerIndices", "").Return([]client.Index{}, nil)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, nil)
 			},
 			config: Config{
 				Unit:      "days",

--- a/cmd/es-rollover/app/rollover/action.go
+++ b/cmd/es-rollover/app/rollover/action.go
@@ -4,6 +4,7 @@
 package rollover
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
@@ -19,16 +20,17 @@ type Action struct {
 
 // Do the rollover action
 func (a *Action) Do() error {
+	ctx := context.TODO()
 	rolloverIndices := app.RolloverIndices(a.Config.Archive, a.Config.SkipDependencies, a.Config.AdaptiveSampling, a.Config.IndexPrefix)
 	for _, indexName := range rolloverIndices {
-		if err := a.rollover(indexName); err != nil {
+		if err := a.rollover(ctx, indexName); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (a *Action) rollover(indexSet app.IndexOption) error {
+func (a *Action) rollover(ctx context.Context, indexSet app.IndexOption) error {
 	conditionsMap := map[string]any{}
 	if a.Conditions != "" {
 		err := json.Unmarshal([]byte(a.Config.Conditions), &conditionsMap)
@@ -39,11 +41,11 @@ func (a *Action) rollover(indexSet app.IndexOption) error {
 
 	writeAlias := indexSet.WriteAliasName()
 	readAlias := indexSet.ReadAliasName()
-	err := a.IndicesClient.Rollover(writeAlias, conditionsMap)
+	err := a.IndicesClient.Rollover(ctx, writeAlias, conditionsMap)
 	if err != nil {
 		return err
 	}
-	jaegerIndex, err := a.IndicesClient.GetJaegerIndices(a.Config.IndexPrefix)
+	jaegerIndex, err := a.IndicesClient.GetJaegerIndices(ctx, a.Config.IndexPrefix)
 	if err != nil {
 		return err
 	}
@@ -59,5 +61,5 @@ func (a *Action) rollover(indexSet app.IndexOption) error {
 	if len(aliases) == 0 {
 		return nil
 	}
-	return a.IndicesClient.CreateAlias(aliases)
+	return a.IndicesClient.CreateAlias(ctx, aliases)
 }

--- a/cmd/es-rollover/app/rollover/action_test.go
+++ b/cmd/es-rollover/app/rollover/action_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/es-rollover/app"
@@ -44,9 +45,9 @@ func TestRolloverAction(t *testing.T) {
 			expectedError: false,
 			indices:       readIndices,
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, test *testCase) {
-				indexClient.On("GetJaegerIndices", "").Return(test.indices, test.getJaegerIndicesErr)
-				indexClient.On("CreateAlias", aliasToCreate).Return(test.createAliasErr)
-				indexClient.On("Rollover", "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return(test.indices, test.getJaegerIndicesErr)
+				indexClient.On("CreateAlias", mock.Anything, aliasToCreate).Return(test.createAliasErr)
+				indexClient.On("Rollover", mock.Anything, "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
 			},
 		},
 		{
@@ -62,8 +63,8 @@ func TestRolloverAction(t *testing.T) {
 				},
 			},
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, test *testCase) {
-				indexClient.On("GetJaegerIndices", "").Return(test.indices, test.getJaegerIndicesErr)
-				indexClient.On("Rollover", "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return(test.indices, test.getJaegerIndicesErr)
+				indexClient.On("Rollover", mock.Anything, "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
 			},
 		},
 		{
@@ -73,8 +74,8 @@ func TestRolloverAction(t *testing.T) {
 			getJaegerIndicesErr: errors.New("unable to get indices"),
 			indices:             readIndices,
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, test *testCase) {
-				indexClient.On("Rollover", "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
-				indexClient.On("GetJaegerIndices", "").Return(test.indices, test.getJaegerIndicesErr)
+				indexClient.On("Rollover", mock.Anything, "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return(test.indices, test.getJaegerIndicesErr)
 			},
 		},
 		{
@@ -84,7 +85,7 @@ func TestRolloverAction(t *testing.T) {
 			rolloverErr:   errors.New("unable to rollover"),
 			indices:       readIndices,
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, test *testCase) {
-				indexClient.On("Rollover", "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
+				indexClient.On("Rollover", mock.Anything, "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
 			},
 		},
 		{
@@ -94,9 +95,9 @@ func TestRolloverAction(t *testing.T) {
 			createAliasErr: errors.New("unable to create alias"),
 			indices:        readIndices,
 			setupCallExpectations: func(indexClient *mocks.IndexAPI, test *testCase) {
-				indexClient.On("GetJaegerIndices", "").Return(test.indices, test.getJaegerIndicesErr)
-				indexClient.On("CreateAlias", aliasToCreate).Return(test.createAliasErr)
-				indexClient.On("Rollover", "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
+				indexClient.On("GetJaegerIndices", mock.Anything, "").Return(test.indices, test.getJaegerIndicesErr)
+				indexClient.On("CreateAlias", mock.Anything, aliasToCreate).Return(test.createAliasErr)
+				indexClient.On("Rollover", mock.Anything, "jaeger-span-archive-write", map[string]any{"max_age": "2d"}).Return(test.rolloverErr)
 			},
 		},
 		{

--- a/internal/storage/elasticsearch/client/client.go
+++ b/internal/storage/elasticsearch/client/client.go
@@ -59,15 +59,15 @@ type elasticRequest struct {
 	method   string
 }
 
-func (c *Client) request(esRequest elasticRequest) ([]byte, error) {
+func (c *Client) request(ctx context.Context, esRequest elasticRequest) ([]byte, error) {
 	var reader *bytes.Buffer
 	var r *http.Request
 	var err error
 	if len(esRequest.body) > 0 {
 		reader = bytes.NewBuffer(esRequest.body)
-		r, err = http.NewRequestWithContext(context.Background(), esRequest.method, fmt.Sprintf("%s/%s", c.Endpoint, esRequest.endpoint), reader)
+		r, err = http.NewRequestWithContext(ctx, esRequest.method, fmt.Sprintf("%s/%s", c.Endpoint, esRequest.endpoint), reader)
 	} else {
-		r, err = http.NewRequestWithContext(context.Background(), esRequest.method, fmt.Sprintf("%s/%s", c.Endpoint, esRequest.endpoint), http.NoBody)
+		r, err = http.NewRequestWithContext(ctx, esRequest.method, fmt.Sprintf("%s/%s", c.Endpoint, esRequest.endpoint), http.NoBody)
 	}
 	if err != nil {
 		return []byte{}, err

--- a/internal/storage/elasticsearch/client/cluster_client.go
+++ b/internal/storage/elasticsearch/client/cluster_client.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -21,12 +22,12 @@ type ClusterClient struct {
 }
 
 // Version returns the detected backend version.
-func (c *ClusterClient) Version() (es.BackendVersion, error) {
+func (c *ClusterClient) Version(ctx context.Context) (es.BackendVersion, error) {
 	type clusterInfo struct {
 		Version map[string]any `json:"version"`
 		TagLine string         `json:"tagline"`
 	}
-	body, err := c.request(elasticRequest{
+	body, err := c.request(ctx, elasticRequest{
 		endpoint: "",
 		method:   http.MethodGet,
 	})

--- a/internal/storage/elasticsearch/client/cluster_client_test.go
+++ b/internal/storage/elasticsearch/client/cluster_client_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -250,7 +251,7 @@ func TestVersion(t *testing.T) {
 					BasicAuth: "foobar",
 				},
 			}
-			result, err := c.Version()
+			result, err := c.Version(context.Background())
 			if test.errContains != "" {
 				require.ErrorContains(t, err, test.errContains)
 				return

--- a/internal/storage/elasticsearch/client/ilm_client.go
+++ b/internal/storage/elasticsearch/client/ilm_client.go
@@ -32,13 +32,13 @@ type ILMClient struct {
 }
 
 // Exists verify if a ILM/ISM policy exists
-func (i ILMClient) Exists(name string) (bool, error) {
+func (i ILMClient) Exists(ctx context.Context, name string) (bool, error) {
 	endpoint := "_ilm/policy/" + name
 	if i.UseOpenSearchISM {
 		endpoint = "_plugins/_ism/policies/" + name
 	}
 	operation := func() ([]byte, error) {
-		bytes, err := i.request(elasticRequest{
+		bytes, err := i.request(ctx, elasticRequest{
 			endpoint: endpoint,
 			method:   http.MethodGet,
 		})
@@ -54,7 +54,7 @@ func (i ILMClient) Exists(name string) (bool, error) {
 	}
 
 	_, err := backoff.Retry(
-		context.TODO(),
+		ctx,
 		operation,
 		backoff.WithMaxTries(maxTries),
 		backoff.WithMaxElapsedTime(maxElapsedTime),

--- a/internal/storage/elasticsearch/client/ilm_client_test.go
+++ b/internal/storage/elasticsearch/client/ilm_client_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -60,7 +61,7 @@ func TestExists(t *testing.T) {
 				},
 				Logger: zap.NewNop(),
 			}
-			result, err := c.Exists("jaeger-ilm-policy")
+			result, err := c.Exists(context.Background(), "jaeger-ilm-policy")
 			if test.errContains != "" {
 				require.ErrorContains(t, err, test.errContains)
 			}
@@ -114,7 +115,7 @@ func TestExists_OpenSearchISM(t *testing.T) {
 				Logger:           zap.NewNop(),
 				UseOpenSearchISM: true,
 			}
-			result, err := c.Exists("jaeger-ilm-policy")
+			result, err := c.Exists(context.Background(), "jaeger-ilm-policy")
 			if test.errContains != "" {
 				require.ErrorContains(t, err, test.errContains)
 			}
@@ -152,7 +153,7 @@ func TestExists_Retries(t *testing.T) {
 		Logger: zap.NewNop(),
 	}
 
-	result, err := c.Exists("jaeger-ilm-policy")
+	result, err := c.Exists(context.Background(), "jaeger-ilm-policy")
 	require.NoError(t, err)
 	assert.True(t, result)
 	assert.Equal(t, maxTries, callCount, "should retry twice before succeeding")

--- a/internal/storage/elasticsearch/client/index_client.go
+++ b/internal/storage/elasticsearch/client/index_client.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -54,10 +55,10 @@ type IndicesClient struct {
 // - indices: jaeger-span-000001, jaeger-service-000001 etc.
 // - aliases: jaeger-span-archive-read, jaeger-span-archive-write
 // - indices: jaeger-span-archive-000001
-func (i *IndicesClient) GetJaegerIndices(prefix string) ([]Index, error) {
+func (i *IndicesClient) GetJaegerIndices(ctx context.Context, prefix string) ([]Index, error) {
 	prefix += "jaeger-*"
 
-	body, err := i.request(elasticRequest{
+	body, err := i.request(ctx, elasticRequest{
 		endpoint: prefix + "?flat_settings=true&filter_path=*.aliases,*.settings",
 		method:   http.MethodGet,
 	})
@@ -93,8 +94,8 @@ func (i *IndicesClient) GetJaegerIndices(prefix string) ([]Index, error) {
 }
 
 // execute delete request
-func (i *IndicesClient) indexDeleteRequest(concatIndices string) error {
-	_, err := i.request(elasticRequest{
+func (i *IndicesClient) indexDeleteRequest(ctx context.Context, concatIndices string) error {
+	_, err := i.request(ctx, elasticRequest{
 		endpoint: fmt.Sprintf("%s?master_timeout=%ds&ignore_unavailable=%t", concatIndices,
 			i.MasterTimeoutSeconds, i.IgnoreUnavailableIndex),
 		method: http.MethodDelete,
@@ -112,7 +113,7 @@ func (i *IndicesClient) indexDeleteRequest(concatIndices string) error {
 }
 
 // DeleteIndices deletes specified set of indices.
-func (i *IndicesClient) DeleteIndices(indices []Index) error {
+func (i *IndicesClient) DeleteIndices(ctx context.Context, indices []Index) error {
 	concatIndices := ""
 	for j, index := range indices {
 		// verify the length of the concatIndices
@@ -120,7 +121,7 @@ func (i *IndicesClient) DeleteIndices(indices []Index) error {
 		// a line contains other than concatIndices data in the request, ie: master_timeout
 		// for a safer side check the line length should not exceed 4000
 		if (len(concatIndices) + len(index.Index)) > 4000 {
-			err := i.indexDeleteRequest(concatIndices)
+			err := i.indexDeleteRequest(ctx, concatIndices)
 			if err != nil {
 				return err
 			}
@@ -132,15 +133,15 @@ func (i *IndicesClient) DeleteIndices(indices []Index) error {
 
 		// if it is last index, delete request should be executed
 		if j == len(indices)-1 {
-			return i.indexDeleteRequest(concatIndices)
+			return i.indexDeleteRequest(ctx, concatIndices)
 		}
 	}
 	return nil
 }
 
 // CreateIndex an ES index
-func (i *IndicesClient) CreateIndex(index string) error {
-	_, err := i.request(elasticRequest{
+func (i *IndicesClient) CreateIndex(ctx context.Context, index string) error {
+	_, err := i.request(ctx, elasticRequest{
 		endpoint: index,
 		method:   http.MethodPut,
 	})
@@ -157,8 +158,8 @@ func (i *IndicesClient) CreateIndex(index string) error {
 }
 
 // CreateAlias an ES specific set of index aliases
-func (i *IndicesClient) CreateAlias(aliases []Alias) error {
-	err := i.aliasAction("add", aliases)
+func (i *IndicesClient) CreateAlias(ctx context.Context, aliases []Alias) error {
+	err := i.aliasAction(ctx, "add", aliases)
 	if err != nil {
 		var responseError ResponseError
 		if errors.As(err, &responseError) {
@@ -172,8 +173,8 @@ func (i *IndicesClient) CreateAlias(aliases []Alias) error {
 }
 
 // DeleteAlias an ES specific set of index aliases
-func (i *IndicesClient) DeleteAlias(aliases []Alias) error {
-	err := i.aliasAction("remove", aliases)
+func (i *IndicesClient) DeleteAlias(ctx context.Context, aliases []Alias) error {
+	err := i.aliasAction(ctx, "remove", aliases)
 	if err != nil {
 		var responseError ResponseError
 		if errors.As(err, &responseError) {
@@ -187,8 +188,8 @@ func (i *IndicesClient) DeleteAlias(aliases []Alias) error {
 }
 
 // AliasExists check whether an alias exists or not
-func (i *IndicesClient) AliasExists(alias string) (bool, error) {
-	_, err := i.request(elasticRequest{
+func (i *IndicesClient) AliasExists(ctx context.Context, alias string) (bool, error) {
+	_, err := i.request(ctx, elasticRequest{
 		endpoint: "_alias/" + alias,
 		method:   http.MethodHead,
 	})
@@ -205,8 +206,8 @@ func (i *IndicesClient) AliasExists(alias string) (bool, error) {
 }
 
 // IndexExists check whether an index exists or not
-func (i *IndicesClient) IndexExists(index string) (bool, error) {
-	_, err := i.request(elasticRequest{
+func (i *IndicesClient) IndexExists(ctx context.Context, index string) (bool, error) {
+	_, err := i.request(ctx, elasticRequest{
 		endpoint: index,
 		method:   http.MethodHead,
 	})
@@ -231,7 +232,7 @@ func (*IndicesClient) aliasesString(aliases []Alias) string {
 	return strings.Trim(concatAliases, ",")
 }
 
-func (i *IndicesClient) aliasAction(action string, aliases []Alias) error {
+func (i *IndicesClient) aliasAction(ctx context.Context, action string, aliases []Alias) error {
 	actions := []map[string]any{}
 
 	for _, alias := range aliases {
@@ -255,7 +256,7 @@ func (i *IndicesClient) aliasAction(action string, aliases []Alias) error {
 	if err != nil {
 		return err
 	}
-	_, err = i.request(elasticRequest{
+	_, err = i.request(ctx, elasticRequest{
 		endpoint: "_aliases",
 		method:   http.MethodPost,
 		body:     bodyBytes,
@@ -265,15 +266,15 @@ func (i *IndicesClient) aliasAction(action string, aliases []Alias) error {
 }
 
 // CreateTemplate an ES index template
-func (i IndicesClient) CreateTemplate(template, name string) error {
+func (i IndicesClient) CreateTemplate(ctx context.Context, template, name string) error {
 	endpointFmt := "_template/%s"
 	cl := ClusterClient{Client: i.Client}
-	if v, err := cl.Version(); err != nil {
+	if v, err := cl.Version(ctx); err != nil {
 		return err
 	} else if v.UsesV8API() {
 		endpointFmt = "_index_template/%s"
 	}
-	_, err := i.request(elasticRequest{
+	_, err := i.request(ctx, elasticRequest{
 		endpoint: fmt.Sprintf(endpointFmt, name),
 		method:   http.MethodPut,
 		body:     []byte(template),
@@ -291,7 +292,7 @@ func (i IndicesClient) CreateTemplate(template, name string) error {
 }
 
 // Rollover create a rollover for certain index/alias
-func (i IndicesClient) Rollover(rolloverTarget string, conditions map[string]any) error {
+func (i IndicesClient) Rollover(ctx context.Context, rolloverTarget string, conditions map[string]any) error {
 	esReq := elasticRequest{
 		endpoint: rolloverTarget + "/_rollover/",
 		method:   http.MethodPost,
@@ -306,7 +307,7 @@ func (i IndicesClient) Rollover(rolloverTarget string, conditions map[string]any
 		}
 		esReq.body = bodyBytes
 	}
-	_, err := i.request(esReq)
+	_, err := i.request(ctx, esReq)
 	if err != nil {
 		var responseError ResponseError
 		if errors.As(err, &responseError) {

--- a/internal/storage/elasticsearch/client/index_client_test.go
+++ b/internal/storage/elasticsearch/client/index_client_test.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -150,7 +151,7 @@ func TestClientGetIndices(t *testing.T) {
 				},
 			}
 
-			indices, err := c.GetJaegerIndices(test.prefix)
+			indices, err := c.GetJaegerIndices(context.Background(), test.prefix)
 			if test.errContains != "" {
 				require.ErrorContains(t, err, test.errContains)
 				assert.Nil(t, indices)
@@ -272,7 +273,7 @@ func TestClientDeleteIndices(t *testing.T) {
 				IgnoreUnavailableIndex: ignoreUnavailableIndex,
 			}
 
-			err := c.DeleteIndices(test.indices)
+			err := c.DeleteIndices(context.Background(), test.indices)
 			assert.Equal(t, test.triggerAPI, apiTriggered)
 
 			if test.errContains != "" {
@@ -355,9 +356,9 @@ func testIndexOrAliasExistence(t *testing.T, existence string) {
 			var err error
 			switch existence {
 			case "index":
-				exists, err = c.IndexExists("jaeger-span")
+				exists, err = c.IndexExists(context.Background(), "jaeger-span")
 			case "alias":
-				exists, err = c.AliasExists("jaeger-span")
+				exists, err = c.AliasExists(context.Background(), "jaeger-span")
 			default:
 			}
 			if test.expectedErr != "" {
@@ -377,7 +378,7 @@ func TestClientRequestError(t *testing.T) {
 			Endpoint: "%",
 		},
 	}
-	indices, err := c.GetJaegerIndices("")
+	indices, err := c.GetJaegerIndices(context.Background(), "")
 	require.Error(t, err)
 	assert.Nil(t, indices)
 }
@@ -390,7 +391,7 @@ func TestClientDoError(t *testing.T) {
 		},
 	}
 
-	indices, err := c.GetJaegerIndices("")
+	indices, err := c.GetJaegerIndices(context.Background(), "")
 	require.Error(t, err)
 	assert.Nil(t, indices)
 }
@@ -432,7 +433,7 @@ func TestClientCreateIndex(t *testing.T) {
 					BasicAuth: "foobar",
 				},
 			}
-			err := c.CreateIndex(indexName)
+			err := c.CreateIndex(context.Background(), indexName)
 			if test.errContains != "" {
 				assert.ErrorContains(t, err, test.errContains)
 			}
@@ -492,7 +493,7 @@ func TestClientCreateAliases(t *testing.T) {
 					BasicAuth: "foobar",
 				},
 			}
-			err := c.CreateAlias(aliases)
+			err := c.CreateAlias(context.Background(), aliases)
 			if test.errContains != "" {
 				assert.ErrorContains(t, err, test.errContains)
 			}
@@ -551,7 +552,7 @@ func TestClientDeleteAliases(t *testing.T) {
 					BasicAuth: "foobar",
 				},
 			}
-			err := c.DeleteAlias(aliases)
+			err := c.DeleteAlias(context.Background(), aliases)
 			if test.errContains != "" {
 				assert.ErrorContains(t, err, test.errContains)
 			}
@@ -614,7 +615,7 @@ func TestClientCreateTemplate(t *testing.T) {
 					BasicAuth: "foobar",
 				},
 			}
-			err := c.CreateTemplate(templateContent, templateName)
+			err := c.CreateTemplate(context.Background(), templateContent, templateName)
 			if test.errContains != "" {
 				assert.ErrorContains(t, err, test.errContains)
 			}
@@ -667,7 +668,7 @@ func TestRollover(t *testing.T) {
 					BasicAuth: "foobar",
 				},
 			}
-			err := c.Rollover("jaeger-span", mapConditions)
+			err := c.Rollover(context.Background(), "jaeger-span", mapConditions)
 			if test.errContains != "" {
 				assert.ErrorContains(t, err, test.errContains)
 			}

--- a/internal/storage/elasticsearch/client/interfaces.go
+++ b/internal/storage/elasticsearch/client/interfaces.go
@@ -3,24 +3,28 @@
 
 package client
 
-import es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
+import (
+	"context"
+
+	es "github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
+)
 
 type IndexAPI interface {
-	GetJaegerIndices(prefix string) ([]Index, error)
-	IndexExists(index string) (bool, error)
-	AliasExists(alias string) (bool, error)
-	DeleteIndices(indices []Index) error
-	CreateIndex(index string) error
-	CreateAlias(aliases []Alias) error
-	DeleteAlias(aliases []Alias) error
-	CreateTemplate(template, name string) error
-	Rollover(rolloverTarget string, conditions map[string]any) error
+	GetJaegerIndices(ctx context.Context, prefix string) ([]Index, error)
+	IndexExists(ctx context.Context, index string) (bool, error)
+	AliasExists(ctx context.Context, alias string) (bool, error)
+	DeleteIndices(ctx context.Context, indices []Index) error
+	CreateIndex(ctx context.Context, index string) error
+	CreateAlias(ctx context.Context, aliases []Alias) error
+	DeleteAlias(ctx context.Context, aliases []Alias) error
+	CreateTemplate(ctx context.Context, template, name string) error
+	Rollover(ctx context.Context, rolloverTarget string, conditions map[string]any) error
 }
 
 type ClusterAPI interface {
-	Version() (es.BackendVersion, error)
+	Version(ctx context.Context) (es.BackendVersion, error)
 }
 
 type IndexManagementLifecycleAPI interface {
-	Exists(name string) (bool, error)
+	Exists(ctx context.Context, name string) (bool, error)
 }

--- a/internal/storage/elasticsearch/client/mocks/mocks.go
+++ b/internal/storage/elasticsearch/client/mocks/mocks.go
@@ -10,6 +10,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/client"
 	mock "github.com/stretchr/testify/mock"
@@ -43,8 +45,8 @@ func (_m *IndexAPI) EXPECT() *IndexAPI_Expecter {
 }
 
 // AliasExists provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) AliasExists(alias string) (bool, error) {
-	ret := _mock.Called(alias)
+func (_mock *IndexAPI) AliasExists(ctx context.Context, alias string) (bool, error) {
+	ret := _mock.Called(ctx, alias)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AliasExists")
@@ -52,16 +54,16 @@ func (_mock *IndexAPI) AliasExists(alias string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(alias)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, alias)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(alias)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, alias)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(alias)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, alias)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -74,170 +76,17 @@ type IndexAPI_AliasExists_Call struct {
 }
 
 // AliasExists is a helper method to define mock.On call
+//   - ctx context.Context
 //   - alias string
-func (_e *IndexAPI_Expecter) AliasExists(alias interface{}) *IndexAPI_AliasExists_Call {
-	return &IndexAPI_AliasExists_Call{Call: _e.mock.On("AliasExists", alias)}
+func (_e *IndexAPI_Expecter) AliasExists(ctx interface{}, alias interface{}) *IndexAPI_AliasExists_Call {
+	return &IndexAPI_AliasExists_Call{Call: _e.mock.On("AliasExists", ctx, alias)}
 }
 
-func (_c *IndexAPI_AliasExists_Call) Run(run func(alias string)) *IndexAPI_AliasExists_Call {
+func (_c *IndexAPI_AliasExists_Call) Run(run func(ctx context.Context, alias string)) *IndexAPI_AliasExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *IndexAPI_AliasExists_Call) Return(b bool, err error) *IndexAPI_AliasExists_Call {
-	_c.Call.Return(b, err)
-	return _c
-}
-
-func (_c *IndexAPI_AliasExists_Call) RunAndReturn(run func(alias string) (bool, error)) *IndexAPI_AliasExists_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateAlias provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) CreateAlias(aliases []client.Alias) error {
-	ret := _mock.Called(aliases)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateAlias")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func([]client.Alias) error); ok {
-		r0 = returnFunc(aliases)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// IndexAPI_CreateAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAlias'
-type IndexAPI_CreateAlias_Call struct {
-	*mock.Call
-}
-
-// CreateAlias is a helper method to define mock.On call
-//   - aliases []client.Alias
-func (_e *IndexAPI_Expecter) CreateAlias(aliases interface{}) *IndexAPI_CreateAlias_Call {
-	return &IndexAPI_CreateAlias_Call{Call: _e.mock.On("CreateAlias", aliases)}
-}
-
-func (_c *IndexAPI_CreateAlias_Call) Run(run func(aliases []client.Alias)) *IndexAPI_CreateAlias_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []client.Alias
-		if args[0] != nil {
-			arg0 = args[0].([]client.Alias)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *IndexAPI_CreateAlias_Call) Return(err error) *IndexAPI_CreateAlias_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *IndexAPI_CreateAlias_Call) RunAndReturn(run func(aliases []client.Alias) error) *IndexAPI_CreateAlias_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateIndex provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) CreateIndex(index string) error {
-	ret := _mock.Called(index)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateIndex")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(index)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// IndexAPI_CreateIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateIndex'
-type IndexAPI_CreateIndex_Call struct {
-	*mock.Call
-}
-
-// CreateIndex is a helper method to define mock.On call
-//   - index string
-func (_e *IndexAPI_Expecter) CreateIndex(index interface{}) *IndexAPI_CreateIndex_Call {
-	return &IndexAPI_CreateIndex_Call{Call: _e.mock.On("CreateIndex", index)}
-}
-
-func (_c *IndexAPI_CreateIndex_Call) Run(run func(index string)) *IndexAPI_CreateIndex_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *IndexAPI_CreateIndex_Call) Return(err error) *IndexAPI_CreateIndex_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *IndexAPI_CreateIndex_Call) RunAndReturn(run func(index string) error) *IndexAPI_CreateIndex_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateTemplate provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) CreateTemplate(template string, name string) error {
-	ret := _mock.Called(template, name)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateTemplate")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(template, name)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// IndexAPI_CreateTemplate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateTemplate'
-type IndexAPI_CreateTemplate_Call struct {
-	*mock.Call
-}
-
-// CreateTemplate is a helper method to define mock.On call
-//   - template string
-//   - name string
-func (_e *IndexAPI_Expecter) CreateTemplate(template interface{}, name interface{}) *IndexAPI_CreateTemplate_Call {
-	return &IndexAPI_CreateTemplate_Call{Call: _e.mock.On("CreateTemplate", template, name)}
-}
-
-func (_c *IndexAPI_CreateTemplate_Call) Run(run func(template string, name string)) *IndexAPI_CreateTemplate_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -251,27 +100,204 @@ func (_c *IndexAPI_CreateTemplate_Call) Run(run func(template string, name strin
 	return _c
 }
 
+func (_c *IndexAPI_AliasExists_Call) Return(b bool, err error) *IndexAPI_AliasExists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *IndexAPI_AliasExists_Call) RunAndReturn(run func(ctx context.Context, alias string) (bool, error)) *IndexAPI_AliasExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateAlias provides a mock function for the type IndexAPI
+func (_mock *IndexAPI) CreateAlias(ctx context.Context, aliases []client.Alias) error {
+	ret := _mock.Called(ctx, aliases)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAlias")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []client.Alias) error); ok {
+		r0 = returnFunc(ctx, aliases)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// IndexAPI_CreateAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAlias'
+type IndexAPI_CreateAlias_Call struct {
+	*mock.Call
+}
+
+// CreateAlias is a helper method to define mock.On call
+//   - ctx context.Context
+//   - aliases []client.Alias
+func (_e *IndexAPI_Expecter) CreateAlias(ctx interface{}, aliases interface{}) *IndexAPI_CreateAlias_Call {
+	return &IndexAPI_CreateAlias_Call{Call: _e.mock.On("CreateAlias", ctx, aliases)}
+}
+
+func (_c *IndexAPI_CreateAlias_Call) Run(run func(ctx context.Context, aliases []client.Alias)) *IndexAPI_CreateAlias_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []client.Alias
+		if args[1] != nil {
+			arg1 = args[1].([]client.Alias)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IndexAPI_CreateAlias_Call) Return(err error) *IndexAPI_CreateAlias_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *IndexAPI_CreateAlias_Call) RunAndReturn(run func(ctx context.Context, aliases []client.Alias) error) *IndexAPI_CreateAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateIndex provides a mock function for the type IndexAPI
+func (_mock *IndexAPI) CreateIndex(ctx context.Context, index string) error {
+	ret := _mock.Called(ctx, index)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateIndex")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, index)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// IndexAPI_CreateIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateIndex'
+type IndexAPI_CreateIndex_Call struct {
+	*mock.Call
+}
+
+// CreateIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - index string
+func (_e *IndexAPI_Expecter) CreateIndex(ctx interface{}, index interface{}) *IndexAPI_CreateIndex_Call {
+	return &IndexAPI_CreateIndex_Call{Call: _e.mock.On("CreateIndex", ctx, index)}
+}
+
+func (_c *IndexAPI_CreateIndex_Call) Run(run func(ctx context.Context, index string)) *IndexAPI_CreateIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IndexAPI_CreateIndex_Call) Return(err error) *IndexAPI_CreateIndex_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *IndexAPI_CreateIndex_Call) RunAndReturn(run func(ctx context.Context, index string) error) *IndexAPI_CreateIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateTemplate provides a mock function for the type IndexAPI
+func (_mock *IndexAPI) CreateTemplate(ctx context.Context, template string, name string) error {
+	ret := _mock.Called(ctx, template, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateTemplate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, template, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// IndexAPI_CreateTemplate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateTemplate'
+type IndexAPI_CreateTemplate_Call struct {
+	*mock.Call
+}
+
+// CreateTemplate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - template string
+//   - name string
+func (_e *IndexAPI_Expecter) CreateTemplate(ctx interface{}, template interface{}, name interface{}) *IndexAPI_CreateTemplate_Call {
+	return &IndexAPI_CreateTemplate_Call{Call: _e.mock.On("CreateTemplate", ctx, template, name)}
+}
+
+func (_c *IndexAPI_CreateTemplate_Call) Run(run func(ctx context.Context, template string, name string)) *IndexAPI_CreateTemplate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *IndexAPI_CreateTemplate_Call) Return(err error) *IndexAPI_CreateTemplate_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *IndexAPI_CreateTemplate_Call) RunAndReturn(run func(template string, name string) error) *IndexAPI_CreateTemplate_Call {
+func (_c *IndexAPI_CreateTemplate_Call) RunAndReturn(run func(ctx context.Context, template string, name string) error) *IndexAPI_CreateTemplate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteAlias provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) DeleteAlias(aliases []client.Alias) error {
-	ret := _mock.Called(aliases)
+func (_mock *IndexAPI) DeleteAlias(ctx context.Context, aliases []client.Alias) error {
+	ret := _mock.Called(ctx, aliases)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAlias")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func([]client.Alias) error); ok {
-		r0 = returnFunc(aliases)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []client.Alias) error); ok {
+		r0 = returnFunc(ctx, aliases)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -284,19 +310,25 @@ type IndexAPI_DeleteAlias_Call struct {
 }
 
 // DeleteAlias is a helper method to define mock.On call
+//   - ctx context.Context
 //   - aliases []client.Alias
-func (_e *IndexAPI_Expecter) DeleteAlias(aliases interface{}) *IndexAPI_DeleteAlias_Call {
-	return &IndexAPI_DeleteAlias_Call{Call: _e.mock.On("DeleteAlias", aliases)}
+func (_e *IndexAPI_Expecter) DeleteAlias(ctx interface{}, aliases interface{}) *IndexAPI_DeleteAlias_Call {
+	return &IndexAPI_DeleteAlias_Call{Call: _e.mock.On("DeleteAlias", ctx, aliases)}
 }
 
-func (_c *IndexAPI_DeleteAlias_Call) Run(run func(aliases []client.Alias)) *IndexAPI_DeleteAlias_Call {
+func (_c *IndexAPI_DeleteAlias_Call) Run(run func(ctx context.Context, aliases []client.Alias)) *IndexAPI_DeleteAlias_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []client.Alias
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]client.Alias)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []client.Alias
+		if args[1] != nil {
+			arg1 = args[1].([]client.Alias)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -307,22 +339,22 @@ func (_c *IndexAPI_DeleteAlias_Call) Return(err error) *IndexAPI_DeleteAlias_Cal
 	return _c
 }
 
-func (_c *IndexAPI_DeleteAlias_Call) RunAndReturn(run func(aliases []client.Alias) error) *IndexAPI_DeleteAlias_Call {
+func (_c *IndexAPI_DeleteAlias_Call) RunAndReturn(run func(ctx context.Context, aliases []client.Alias) error) *IndexAPI_DeleteAlias_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteIndices provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) DeleteIndices(indices []client.Index) error {
-	ret := _mock.Called(indices)
+func (_mock *IndexAPI) DeleteIndices(ctx context.Context, indices []client.Index) error {
+	ret := _mock.Called(ctx, indices)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteIndices")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func([]client.Index) error); ok {
-		r0 = returnFunc(indices)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []client.Index) error); ok {
+		r0 = returnFunc(ctx, indices)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -335,19 +367,25 @@ type IndexAPI_DeleteIndices_Call struct {
 }
 
 // DeleteIndices is a helper method to define mock.On call
+//   - ctx context.Context
 //   - indices []client.Index
-func (_e *IndexAPI_Expecter) DeleteIndices(indices interface{}) *IndexAPI_DeleteIndices_Call {
-	return &IndexAPI_DeleteIndices_Call{Call: _e.mock.On("DeleteIndices", indices)}
+func (_e *IndexAPI_Expecter) DeleteIndices(ctx interface{}, indices interface{}) *IndexAPI_DeleteIndices_Call {
+	return &IndexAPI_DeleteIndices_Call{Call: _e.mock.On("DeleteIndices", ctx, indices)}
 }
 
-func (_c *IndexAPI_DeleteIndices_Call) Run(run func(indices []client.Index)) *IndexAPI_DeleteIndices_Call {
+func (_c *IndexAPI_DeleteIndices_Call) Run(run func(ctx context.Context, indices []client.Index)) *IndexAPI_DeleteIndices_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []client.Index
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]client.Index)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []client.Index
+		if args[1] != nil {
+			arg1 = args[1].([]client.Index)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -358,14 +396,14 @@ func (_c *IndexAPI_DeleteIndices_Call) Return(err error) *IndexAPI_DeleteIndices
 	return _c
 }
 
-func (_c *IndexAPI_DeleteIndices_Call) RunAndReturn(run func(indices []client.Index) error) *IndexAPI_DeleteIndices_Call {
+func (_c *IndexAPI_DeleteIndices_Call) RunAndReturn(run func(ctx context.Context, indices []client.Index) error) *IndexAPI_DeleteIndices_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetJaegerIndices provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) GetJaegerIndices(prefix string) ([]client.Index, error) {
-	ret := _mock.Called(prefix)
+func (_mock *IndexAPI) GetJaegerIndices(ctx context.Context, prefix string) ([]client.Index, error) {
+	ret := _mock.Called(ctx, prefix)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetJaegerIndices")
@@ -373,18 +411,18 @@ func (_mock *IndexAPI) GetJaegerIndices(prefix string) ([]client.Index, error) {
 
 	var r0 []client.Index
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]client.Index, error)); ok {
-		return returnFunc(prefix)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]client.Index, error)); ok {
+		return returnFunc(ctx, prefix)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) []client.Index); ok {
-		r0 = returnFunc(prefix)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []client.Index); ok {
+		r0 = returnFunc(ctx, prefix)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]client.Index)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(prefix)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, prefix)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -397,19 +435,25 @@ type IndexAPI_GetJaegerIndices_Call struct {
 }
 
 // GetJaegerIndices is a helper method to define mock.On call
+//   - ctx context.Context
 //   - prefix string
-func (_e *IndexAPI_Expecter) GetJaegerIndices(prefix interface{}) *IndexAPI_GetJaegerIndices_Call {
-	return &IndexAPI_GetJaegerIndices_Call{Call: _e.mock.On("GetJaegerIndices", prefix)}
+func (_e *IndexAPI_Expecter) GetJaegerIndices(ctx interface{}, prefix interface{}) *IndexAPI_GetJaegerIndices_Call {
+	return &IndexAPI_GetJaegerIndices_Call{Call: _e.mock.On("GetJaegerIndices", ctx, prefix)}
 }
 
-func (_c *IndexAPI_GetJaegerIndices_Call) Run(run func(prefix string)) *IndexAPI_GetJaegerIndices_Call {
+func (_c *IndexAPI_GetJaegerIndices_Call) Run(run func(ctx context.Context, prefix string)) *IndexAPI_GetJaegerIndices_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -420,14 +464,14 @@ func (_c *IndexAPI_GetJaegerIndices_Call) Return(indexs []client.Index, err erro
 	return _c
 }
 
-func (_c *IndexAPI_GetJaegerIndices_Call) RunAndReturn(run func(prefix string) ([]client.Index, error)) *IndexAPI_GetJaegerIndices_Call {
+func (_c *IndexAPI_GetJaegerIndices_Call) RunAndReturn(run func(ctx context.Context, prefix string) ([]client.Index, error)) *IndexAPI_GetJaegerIndices_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IndexExists provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) IndexExists(index string) (bool, error) {
-	ret := _mock.Called(index)
+func (_mock *IndexAPI) IndexExists(ctx context.Context, index string) (bool, error) {
+	ret := _mock.Called(ctx, index)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IndexExists")
@@ -435,16 +479,16 @@ func (_mock *IndexAPI) IndexExists(index string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(index)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, index)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(index)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, index)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(index)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, index)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -457,19 +501,25 @@ type IndexAPI_IndexExists_Call struct {
 }
 
 // IndexExists is a helper method to define mock.On call
+//   - ctx context.Context
 //   - index string
-func (_e *IndexAPI_Expecter) IndexExists(index interface{}) *IndexAPI_IndexExists_Call {
-	return &IndexAPI_IndexExists_Call{Call: _e.mock.On("IndexExists", index)}
+func (_e *IndexAPI_Expecter) IndexExists(ctx interface{}, index interface{}) *IndexAPI_IndexExists_Call {
+	return &IndexAPI_IndexExists_Call{Call: _e.mock.On("IndexExists", ctx, index)}
 }
 
-func (_c *IndexAPI_IndexExists_Call) Run(run func(index string)) *IndexAPI_IndexExists_Call {
+func (_c *IndexAPI_IndexExists_Call) Run(run func(ctx context.Context, index string)) *IndexAPI_IndexExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -480,22 +530,22 @@ func (_c *IndexAPI_IndexExists_Call) Return(b bool, err error) *IndexAPI_IndexEx
 	return _c
 }
 
-func (_c *IndexAPI_IndexExists_Call) RunAndReturn(run func(index string) (bool, error)) *IndexAPI_IndexExists_Call {
+func (_c *IndexAPI_IndexExists_Call) RunAndReturn(run func(ctx context.Context, index string) (bool, error)) *IndexAPI_IndexExists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Rollover provides a mock function for the type IndexAPI
-func (_mock *IndexAPI) Rollover(rolloverTarget string, conditions map[string]any) error {
-	ret := _mock.Called(rolloverTarget, conditions)
+func (_mock *IndexAPI) Rollover(ctx context.Context, rolloverTarget string, conditions map[string]any) error {
+	ret := _mock.Called(ctx, rolloverTarget, conditions)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Rollover")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, map[string]any) error); ok {
-		r0 = returnFunc(rolloverTarget, conditions)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]any) error); ok {
+		r0 = returnFunc(ctx, rolloverTarget, conditions)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -508,25 +558,31 @@ type IndexAPI_Rollover_Call struct {
 }
 
 // Rollover is a helper method to define mock.On call
+//   - ctx context.Context
 //   - rolloverTarget string
 //   - conditions map[string]any
-func (_e *IndexAPI_Expecter) Rollover(rolloverTarget interface{}, conditions interface{}) *IndexAPI_Rollover_Call {
-	return &IndexAPI_Rollover_Call{Call: _e.mock.On("Rollover", rolloverTarget, conditions)}
+func (_e *IndexAPI_Expecter) Rollover(ctx interface{}, rolloverTarget interface{}, conditions interface{}) *IndexAPI_Rollover_Call {
+	return &IndexAPI_Rollover_Call{Call: _e.mock.On("Rollover", ctx, rolloverTarget, conditions)}
 }
 
-func (_c *IndexAPI_Rollover_Call) Run(run func(rolloverTarget string, conditions map[string]any)) *IndexAPI_Rollover_Call {
+func (_c *IndexAPI_Rollover_Call) Run(run func(ctx context.Context, rolloverTarget string, conditions map[string]any)) *IndexAPI_Rollover_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 map[string]any
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(map[string]any)
+			arg1 = args[1].(string)
+		}
+		var arg2 map[string]any
+		if args[2] != nil {
+			arg2 = args[2].(map[string]any)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -537,7 +593,7 @@ func (_c *IndexAPI_Rollover_Call) Return(err error) *IndexAPI_Rollover_Call {
 	return _c
 }
 
-func (_c *IndexAPI_Rollover_Call) RunAndReturn(run func(rolloverTarget string, conditions map[string]any) error) *IndexAPI_Rollover_Call {
+func (_c *IndexAPI_Rollover_Call) RunAndReturn(run func(ctx context.Context, rolloverTarget string, conditions map[string]any) error) *IndexAPI_Rollover_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -570,8 +626,8 @@ func (_m *ClusterAPI) EXPECT() *ClusterAPI_Expecter {
 }
 
 // Version provides a mock function for the type ClusterAPI
-func (_mock *ClusterAPI) Version() (elasticsearch.BackendVersion, error) {
-	ret := _mock.Called()
+func (_mock *ClusterAPI) Version(ctx context.Context) (elasticsearch.BackendVersion, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Version")
@@ -579,16 +635,16 @@ func (_mock *ClusterAPI) Version() (elasticsearch.BackendVersion, error) {
 
 	var r0 elasticsearch.BackendVersion
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (elasticsearch.BackendVersion, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (elasticsearch.BackendVersion, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() elasticsearch.BackendVersion); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) elasticsearch.BackendVersion); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(elasticsearch.BackendVersion)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -601,13 +657,20 @@ type ClusterAPI_Version_Call struct {
 }
 
 // Version is a helper method to define mock.On call
-func (_e *ClusterAPI_Expecter) Version() *ClusterAPI_Version_Call {
-	return &ClusterAPI_Version_Call{Call: _e.mock.On("Version")}
+//   - ctx context.Context
+func (_e *ClusterAPI_Expecter) Version(ctx interface{}) *ClusterAPI_Version_Call {
+	return &ClusterAPI_Version_Call{Call: _e.mock.On("Version", ctx)}
 }
 
-func (_c *ClusterAPI_Version_Call) Run(run func()) *ClusterAPI_Version_Call {
+func (_c *ClusterAPI_Version_Call) Run(run func(ctx context.Context)) *ClusterAPI_Version_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -617,7 +680,7 @@ func (_c *ClusterAPI_Version_Call) Return(backendVersion elasticsearch.BackendVe
 	return _c
 }
 
-func (_c *ClusterAPI_Version_Call) RunAndReturn(run func() (elasticsearch.BackendVersion, error)) *ClusterAPI_Version_Call {
+func (_c *ClusterAPI_Version_Call) RunAndReturn(run func(ctx context.Context) (elasticsearch.BackendVersion, error)) *ClusterAPI_Version_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -650,8 +713,8 @@ func (_m *IndexManagementLifecycleAPI) EXPECT() *IndexManagementLifecycleAPI_Exp
 }
 
 // Exists provides a mock function for the type IndexManagementLifecycleAPI
-func (_mock *IndexManagementLifecycleAPI) Exists(name string) (bool, error) {
-	ret := _mock.Called(name)
+func (_mock *IndexManagementLifecycleAPI) Exists(ctx context.Context, name string) (bool, error) {
+	ret := _mock.Called(ctx, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Exists")
@@ -659,16 +722,16 @@ func (_mock *IndexManagementLifecycleAPI) Exists(name string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, name)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, name)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(name)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -681,19 +744,25 @@ type IndexManagementLifecycleAPI_Exists_Call struct {
 }
 
 // Exists is a helper method to define mock.On call
+//   - ctx context.Context
 //   - name string
-func (_e *IndexManagementLifecycleAPI_Expecter) Exists(name interface{}) *IndexManagementLifecycleAPI_Exists_Call {
-	return &IndexManagementLifecycleAPI_Exists_Call{Call: _e.mock.On("Exists", name)}
+func (_e *IndexManagementLifecycleAPI_Expecter) Exists(ctx interface{}, name interface{}) *IndexManagementLifecycleAPI_Exists_Call {
+	return &IndexManagementLifecycleAPI_Exists_Call{Call: _e.mock.On("Exists", ctx, name)}
 }
 
-func (_c *IndexManagementLifecycleAPI_Exists_Call) Run(run func(name string)) *IndexManagementLifecycleAPI_Exists_Call {
+func (_c *IndexManagementLifecycleAPI_Exists_Call) Run(run func(ctx context.Context, name string)) *IndexManagementLifecycleAPI_Exists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -704,7 +773,7 @@ func (_c *IndexManagementLifecycleAPI_Exists_Call) Return(b bool, err error) *In
 	return _c
 }
 
-func (_c *IndexManagementLifecycleAPI_Exists_Call) RunAndReturn(run func(name string) (bool, error)) *IndexManagementLifecycleAPI_Exists_Call {
+func (_c *IndexManagementLifecycleAPI_Exists_Call) RunAndReturn(run func(ctx context.Context, name string) (bool, error)) *IndexManagementLifecycleAPI_Exists_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #4708 (RFC 0004 Phase 2). Carved out per @yurishkuro's suggestion that the `request`/ctx change land as a standalone refactoring PR before the data stream client work.

## Description of the changes
- The direct-HTTP Elasticsearch client hardcoded `context.Background()` in `client.request`, and `ILMClient.Exists` used `context.TODO()` for its retry loop, so request cancellation could never be propagated.
- Threads `context.Context` through `request` and the `IndexAPI`, `ClusterAPI` and `IndexManagementLifecycleAPI` methods, and updates the call sites: `es-index-cleaner` reuses its existing root context, while the `es-rollover` actions pass `context.TODO()` (they run as one-shot CLIs with no request-scoped context). Mocks are regenerated.
- Pure refactor with no behavior change; it is the groundwork for the data stream bootstrap, which needs context-aware REST calls.

## How was this change tested?
- Existing unit tests for the ES client and the `es-rollover` / `es-index-cleaner` commands pass unchanged (only updated to pass a context); mocks regenerated with the pinned mockery version.
- `make lint test` pass locally (the only failing unit tests are pre-existing Windows-only path/errno-string quirks, unrelated to this change and green on Linux CI).

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

- [x] **Moderate**: AI helped with code generation or debugging specific parts
