### PR TITLE
Make "SPM not configured" error message more explicit

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -1022,7 +1022,10 @@ func TestMetricsQueryDisabled(t *testing.T) {
 	const urlPath = "/api/metrics/latencies?service=emailservice&quantile=0.95"
 	var response any
 	err = getJSON(ts.server.URL+urlPath, &response)
-	require.ErrorContains(t, err, "currently disabled")
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusNotImplemented, httpErr.StatusCode)
+	require.Contains(t, httpErr.Body, "currently disabled")
 }
 
 // getJSON fetches a JSON document from a server via HTTP GET

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -1019,26 +1019,10 @@ func TestMetricsQueryDisabled(t *testing.T) {
 	ts := initializeTestServer(t, HandlerOptions.MetricsQueryService(disabledReader))
 	defer ts.server.Close()
 
-	for _, tc := range []struct {
-		name             string
-		urlPath          string
-		wantErrorMessage string
-	}{
-		{
-			name:             "metrics query disabled error returned when fetching latency metrics",
-			urlPath:          "/api/metrics/latencies?service=emailservice&quantile=0.95",
-			wantErrorMessage: "metrics querying is currently disabled",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			// Test
-			var response any
-			err := getJSON(ts.server.URL+tc.urlPath, &response)
-
-			// Verify
-			assert.ErrorContains(t, err, tc.wantErrorMessage)
-		})
-	}
+	const urlPath = "/api/metrics/latencies?service=emailservice&quantile=0.95"
+	var response any
+	err = getJSON(ts.server.URL+urlPath, &response)
+	require.ErrorContains(t, err, "currently disabled")
 }
 
 // getJSON fetches a JSON document from a server via HTTP GET

--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -322,24 +322,24 @@ If the `groupByOperation=true` parameter is set, the response will include the o
       ],
 ```
 
-# Disabling Metrics Querying
+# Running Without Service Performance Monitoring
 
-The monitor example enables metrics querying in the Jaeger v2 YAML config mounted by the Docker Compose file.
+The SPM functionality (the Monitor tab in the UI and the `/api/metrics/*` endpoints) require a metrics backend. Jaeger advertises backend capabilities to the UI at startup; when no metrics backend is configured, Jaeger does not advertise `metricsStorage` and the Monitor tab does not appear.
 
-For example, remove or comment out the `metrics` entry under `extensions.jaeger_query.storage` in [`cmd/jaeger/config-spm.yaml`](../../cmd/jaeger/config-spm.yaml):
+To reproduce this, commend out the `metrics` key from `extensions.jaeger_query.storage` in [config-spm.yaml](../../cmd/jaeger/config-spm.yaml):
 
 ```yaml
 extensions:
   jaeger_query:
     storage:
       traces: some_storage
-      # metrics: some_metrics_storage
+      # metrics: some_metrics_storage  # comment this out
 ```
 
-Then querying metrics endpoints results in an error message:
+Then querying any metrics endpoint returns:
 
 ```
-$ curl "http://localhost:16686/api/metrics/calls?service=driver" | jq .
+$ curl http://localhost:16686/api/metrics/minstep | jq .
 {
   "data": null,
   "total": 0,
@@ -348,7 +348,7 @@ $ curl "http://localhost:16686/api/metrics/calls?service=driver" | jq .
   "errors": [
     {
       "code": 501,
-      "msg": "metrics querying is currently disabled"
+      "msg": "trace metrics are currently disabled - no metrics backend configured"
     }
   ]
 }

--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -324,7 +324,7 @@ If the `groupByOperation=true` parameter is set, the response will include the o
 
 # Running Without Service Performance Monitoring
 
-The SPM functionality (the Monitor tab in the UI and the `/api/metrics/*` endpoints) require a metrics backend. Jaeger advertises backend capabilities to the UI at startup; when no metrics backend is configured, Jaeger does not advertise `metricsStorage` and the Monitor tab does not appear.
+The SPM functionality (the Monitor tab in the UI and the `/api/metrics/*` endpoints) requires a metrics backend. Jaeger advertises backend capabilities to the UI at startup; when no metrics backend is configured, Jaeger does not advertise `metricsStorage` and the Monitor tab does not appear.
 
 To reproduce this, comment out the `metrics` key from `extensions.jaeger_query.storage` in [config-spm.yaml](../../cmd/jaeger/config-spm.yaml):
 

--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -324,14 +324,22 @@ If the `groupByOperation=true` parameter is set, the response will include the o
 
 # Disabling Metrics Querying
 
-As this is feature is opt-in only, disabling metrics querying simply involves omitting the `METRICS_STORAGE_TYPE` environment variable when starting-up jaeger-query or jaeger all-in-one.
+The monitor example enables metrics querying in the Jaeger v2 YAML config mounted by the Docker Compose file.
 
-For example, try removing the `METRICS_STORAGE_TYPE=prometheus` environment variable from the [docker-compose.yml](./docker-compose.yml) file.
+For example, remove or comment out the `metrics` entry under `extensions.jaeger_query.storage` in [`cmd/jaeger/config-spm.yaml`](../../cmd/jaeger/config-spm.yaml):
 
-Then querying any metrics endpoints results in an error message:
+```yaml
+extensions:
+  jaeger_query:
+    storage:
+      traces: some_storage
+      # metrics: some_metrics_storage
+```
+
+Then querying metrics endpoints results in an error message:
 
 ```
-$ curl http://localhost:16686/api/metrics/minstep | jq .
+$ curl "http://localhost:16686/api/metrics/calls?service=driver" | jq .
 {
   "data": null,
   "total": 0,
@@ -339,7 +347,7 @@ $ curl http://localhost:16686/api/metrics/minstep | jq .
   "offset": 0,
   "errors": [
     {
-      "code": 405,
+      "code": 501,
       "msg": "metrics querying is currently disabled"
     }
   ]

--- a/docker-compose/monitor/README.md
+++ b/docker-compose/monitor/README.md
@@ -326,7 +326,7 @@ If the `groupByOperation=true` parameter is set, the response will include the o
 
 The SPM functionality (the Monitor tab in the UI and the `/api/metrics/*` endpoints) require a metrics backend. Jaeger advertises backend capabilities to the UI at startup; when no metrics backend is configured, Jaeger does not advertise `metricsStorage` and the Monitor tab does not appear.
 
-To reproduce this, commend out the `metrics` key from `extensions.jaeger_query.storage` in [config-spm.yaml](../../cmd/jaeger/config-spm.yaml):
+To reproduce this, comment out the `metrics` key from `extensions.jaeger_query.storage` in [config-spm.yaml](../../cmd/jaeger/config-spm.yaml):
 
 ```yaml
 extensions:

--- a/internal/storage/metricstore/disabled/reader.go
+++ b/internal/storage/metricstore/disabled/reader.go
@@ -12,7 +12,7 @@ import (
 
 type (
 	// MetricsReader represents a "disabled" metricstore.Reader implementation where
-	// the METRICS_STORAGE_TYPE has not been set.
+	// no metrics backend is configured.
 	MetricsReader struct{}
 
 	// errMetricsQueryDisabledError is the error returned by disabledMetricsQueryService.

--- a/internal/storage/metricstore/disabled/reader.go
+++ b/internal/storage/metricstore/disabled/reader.go
@@ -23,7 +23,7 @@ type (
 var ErrDisabled = &errMetricsQueryDisabledError{}
 
 func (*errMetricsQueryDisabledError) Error() string {
-	return "metrics querying is currently disabled"
+	return "trace metrics are currently disabled - no metrics backend configured"
 }
 
 // NewMetricsReader returns a new Disabled MetricsReader.


### PR DESCRIPTION
## Summary

- Rename section "Disabling Metrics Querying" → "Running Without the Monitor Tab": the old heading implied turning off something already running, but the Monitor tab simply never appears when no metrics backend is configured.
- Replace stale Jaeger v1 `METRICS_STORAGE_TYPE` env var instructions with the Jaeger v2 equivalent: remove `metrics:` from `extensions.jaeger_query.storage` in `config-spm.yaml`.
- Explain that the Monitor tab visibility is driven by server-advertised capabilities (`metricsStorage`), not a UI-side toggle.

## Testing

- Docs-only change; verified diff is coherent.

Closes #8847