### PR TITLE
docs: Add v2 equivalent for jaeger_collector_spans_received_total

### DIFF
--- a/cmd/jaeger/docs/migration/all-in-one-metrics.md
+++ b/cmd/jaeger/docs/migration/all-in-one-metrics.md
@@ -82,5 +82,66 @@
 
 | V1 Metric | V1 Labels | V2 Metric | V2 Labels |
 |-----------|---------------|-----------|---------------|
+| jaeger_collector_spans_received_total | debug, format, svc, transport | receiver_accepted_spans | receiver, service_instance_id, service_name, service_version, transport |
 | jaeger_collector_spans_rejected_total | debug, format, svc, transport | receiver_refused_spans | receiver, service_instance_id, service_name, service_version, transport |
 | jaeger_build_info | build_date, revision,  version | target_info | service_instance_id, service_name, service_version |
+
+### Notes
+
+#### Prometheus metric naming
+
+The V2 metric names in this table use OTel semantic names (no prefix, no `_total` suffix).
+On the Prometheus scrape endpoint (default `:8888`), counters appear with the `otelcol_` prefix
+and `_total` suffix:
+
+| Table name | Prometheus endpoint name |
+|---|---|
+| `receiver_accepted_spans` | `otelcol_receiver_accepted_spans_total` |
+| `receiver_refused_spans` | `otelcol_receiver_refused_spans_total` |
+
+#### Why `svc` label is not available in v2
+
+In V1, the collector parsed each span's payload to extract the application's service name
+and attach it as the `svc` label. In V2, the OTel Collector deliberately does not parse
+trace payloads for its own internal telemetry — this avoids metric cardinality explosions
+when thousands of microservices each generate a new time series.
+
+The `service_name` label on `receiver_accepted_spans` refers to the **Jaeger collector's own**
+`service.name` resource attribute (typically `"jaeger"`), not the downstream application.
+
+#### Per-service span counts via spanmetrics connector
+
+To regain per-application-service span counts, add the `spanmetrics` connector to your pipeline:
+
+```yaml
+connectors:
+  spanmetrics:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter, spanmetrics]
+    metrics/spanmetrics:
+      receivers: [spanmetrics]
+      exporters: [prometheus]
+```
+
+The spanmetrics Prometheus endpoint (default `:8889`) exports per-service call counters.
+The exact metric name depends on connector namespace configuration:
+
+- Default (no namespace): `calls_total`
+- With namespace `traces_span_metrics` (Jaeger SPM default): `traces_span_metrics_calls_total`
+
+```promql
+# Total collector ingestion (port :8888)
+sum(rate(otelcol_receiver_accepted_spans_total[5m]))
+
+# Per-application service counts (port :8889, requires spanmetrics pipeline)
+sum(rate(traces_span_metrics_calls_total[5m])) by (service_name)
+# or, if no namespace is configured:
+sum(rate(calls_total[5m])) by (service_name)
+```
+
+Reference config: [`cmd/jaeger/config-spm.yaml`](../../config-spm.yaml).

--- a/scripts/utils/metrics-md.py
+++ b/scripts/utils/metrics-md.py
@@ -92,12 +92,14 @@ class ConvertJson:
         )
 
         filtered_v1_metrics = {
+       "jaeger_collector_spans_received_total": {"debug": "false", "format": "", "svc": "", "transport": ""},
        "jaeger_collector_spans_rejected_total": {"debug": "false", "format": "","svc": "","transport":""},
        "jaeger_build_info": {"build_date": "","revision": ""," version": ""}  # Add more metrics as needed
        }
 
         # Hardcoding filtered v2 metrics
         filtered_v2_metrics = {
+       "receiver_accepted_spans": {"receiver": "", "service_instance_id": "", "service_name": "", "service_version": "", "transport": ""},
        "receiver_refused_spans": {"receiver": "","service_instance_id": "","service_name": "","service_version": "","transport": ""},
        "target_info": {"service_instance_id": "","service_name": "","service_version": ""}  # Add more metrics as needed
         }


### PR DESCRIPTION
Fixes #8433

## Which problem is this PR solving?
- Resolves #8433 — users migrating from Jaeger v1 to v2 could not find documentation for the v1 metric `jaeger_collector_spans_received_total`. The migration guide listed it as `N/A` in the Combined Metrics table and had no Equivalent Metrics mapping, unlike `jaeger_collector_spans_rejected_total`.

## Description of the changes
- Add `jaeger_collector_spans_received_total` → `receiver_accepted_spans` mapping to the **Equivalent Metrics** table in `cmd/jaeger/docs/migration/all-in-one-metrics.md` (consistent with how `spans_rejected_total` is documented; Combined table unchanged).
- Add a **Notes** section explaining:
  - OTel table names vs Prometheus scrape names (`otelcol_receiver_accepted_spans_total` on `:8888`)
  - Why the V1 `svc` label is not available on receiver telemetry in v2
  - How to regain per-service span counts using the `spanmetrics` connector (`calls_total` / `traces_span_metrics_calls_total` on `:8889`)
- Update `scripts/utils/metrics-md.py` hardcoded dicts so doc regeneration preserves the new mapping.

## How was this change tested?
- `make fmt`
- `make lint`
- `make test` (3696 tests passed locally)
- Manual review of `cmd/jaeger/docs/migration/all-in-one-metrics.md` for table alignment and accuracy
<img width="1472" height="993" alt="image" src="https://github.com/user-attachments/assets/72f234de-afa1-49dd-9f3e-51fec51e5700" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality *(N/A — documentation-only change)*
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes