### PR TITLE
fix(deps): Upgrade pydantic-settings in AI sidecar lockfile

### DIFF
--- a/scripts/ai-sidecar/gemini/uv.lock
+++ b/scripts/ai-sidecar/gemini/uv.lock
@@ -967,16 +967,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade the Gemini AI sidecar lockfile from pydantic-settings 2.14.1 to 2.14.2
- address Dependabot security alert 64 / GHSA-4xgf-cpjx-pc3j
- keep the change scoped to the generated uv lock entry for the affected transitive dependency

## Why

Dependabot reports pydantic-settings 2.14.1 as vulnerable in scripts/ai-sidecar/gemini/uv.lock. Version 2.14.2 is the first patched release for the NestedSecretsSettingsSource symlink traversal issue.

## Validation

- /tmp/codex-uv-venv-jaeger-dependabot-64/bin/uv run --locked pytest -q test_sidecar_workflow.py
- make fmt
- make lint
- make test