### PR TITLE
fix(deps): Upgrade js-yaml in CI scripts

### DIFF
--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -3349,9 +3349,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes #9028

## What changed

- Update the CI scripts lockfile from `js-yaml` 3.14.2 to 3.15.0.
- Keep the transitive dependency within `@istanbuljs/load-nyc-config`'s existing `^3.13.1` range.

## Why

Dependabot alerts [#65](https://github.com/jaegertracing/jaeger/security/dependabot/65) and [#69](https://github.com/jaegertracing/jaeger/security/dependabot/69) report:

- [GHSA-h67p-54hq-rp68 / CVE-2026-53550](https://github.com/advisories/GHSA-h67p-54hq-rp68)
- [GHSA-52cp-r559-cp3m / CVE-2026-59869](https://github.com/advisories/GHSA-52cp-r559-cp3m)

Both advisories are fixed by `js-yaml` 3.15.0 on the existing 3.x release line, so a 4.x override is not needed.

This only changes the development lockfile used by `.github/scripts`; production Jaeger dependencies are unaffected.

## Validation

- `npm ci`
- `npm ls js-yaml --all` resolves 3.15.0
- `npm test -- --runInBand` passes all 97 tests
- `npm audit --package-lock-only --omit=optional` reports only the separate `brace-expansion` findings in alerts [#67](https://github.com/jaegertracing/jaeger/security/dependabot/67) and [#68](https://github.com/jaegertracing/jaeger/security/dependabot/68), tracked by #9106
- `make fmt`
- `make lint` reports 0 issues
- `make test` passes 4,049 tests with 37 skipped
