### PR TITLE
fix(docker): Upgrade Alpine packages in base image at build time

### DIFF
--- a/scripts/build/docker/base/Dockerfile
+++ b/scripts/build/docker/base/Dockerfile
@@ -5,5 +5,7 @@ FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6ee
 RUN apk add --update --no-cache ca-certificates mailcap
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+# hadolint ignore=DL3017
+RUN apk upgrade --no-cache
 COPY --from=cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=cert /etc/mime.types /etc/mime.types


### PR DESCRIPTION
## Summary
- Add `apk upgrade --no-cache` to the final stage of `scripts/build/docker/base/Dockerfile`
- Ensures `jaegertracing/all-in-one` images include patched Alpine OS packages at build time
- Alpine 3.24.1 base digest was already updated in #8794; this hardens against stale base layers
- `# hadolint ignore=DL3017` documents intentional use of `apk upgrade` for security patching
## Context
Fixes #8420. Reported CVEs were in OS packages bundled with the Docker image, not Jaeger Go code.
Reporter's `openssl 3.5.4-r0` / `zlib 1.3.1-r2` matched alpine 3.23.0-era images; #8794 already moved main to patched alpine 3.24.1.
## Test plan
- [x] `make fmt`
- [x] `make lint`
- [x] `make test`
- [x] Built base image and verified `libcrypto3-3.5.7-r0`, `libssl3-3.5.7-r0`, `zlib-1.3.2-r0`
- [x] Trivy scan: 0 HIGH/CRITICAL unfixed CVEs

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`
<img width="3072" height="1920" alt="image" src="https://github.com/user-attachments/assets/c7394a15-6f4d-49e2-8d10-b94e9512e109" />


## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
