### PR TITLE
fix(es-rollover): Use backend-aware ILM/ISM policy error messages

### DIFF
--- a/cmd/es-rollover/app/init/action.go
+++ b/cmd/es-rollover/app/init/action.go
@@ -55,7 +55,7 @@ func (c Action) Do() error {
 			return err
 		}
 		if !policyExist {
-			return fmt.Errorf("ILM policy %s doesn't exist in Elasticsearch. Please create it and re-run init", c.Config.ILMPolicyName)
+			return fmt.Errorf("ILM/ISM policy %s doesn't exist in %s. Please create it and re-run init", c.Config.ILMPolicyName, version)
 		}
 	}
 	rolloverIndices := app.RolloverIndices(c.Config.Archive, c.Config.SkipDependencies, c.Config.AdaptiveSampling, c.Config.Config.IndexPrefix)

--- a/cmd/es-rollover/app/init/action_test.go
+++ b/cmd/es-rollover/app/init/action_test.go
@@ -135,12 +135,27 @@ func TestRolloverAction(t *testing.T) {
 				clusterClient.On("Version", mock.Anything).Return(es.ElasticV7, nil)
 				ilmClient.On("Exists", mock.Anything, "myilmpolicy").Return(false, nil)
 			},
-			expectedErr: errors.New("ILM policy myilmpolicy doesn't exist in Elasticsearch. Please create it and re-run init"),
+			expectedErr: errors.New("ILM/ISM policy myilmpolicy doesn't exist in Elasticsearch 7.x. Please create it and re-run init"),
 			config: Config{
 				Config: app.Config{
 					Archive:       true,
 					UseILM:        true,
 					ILMPolicyName: "myilmpolicy",
+				},
+			},
+		},
+		{
+			name: "ism doesnt exist on opensearch",
+			setupCallExpectations: func(_ *mocks.IndexAPI, clusterClient *mocks.ClusterAPI, ilmClient *mocks.IndexManagementLifecycleAPI) {
+				clusterClient.On("Version", mock.Anything).Return(es.OpenSearch3, nil)
+				ilmClient.On("Exists", mock.Anything, "myismpolicy").Return(false, nil)
+			},
+			expectedErr: errors.New("ILM/ISM policy myismpolicy doesn't exist in OpenSearch 3.x. Please create it and re-run init"),
+			config: Config{
+				Config: app.Config{
+					Archive:       true,
+					UseILM:        true,
+					ILMPolicyName: "myismpolicy",
 				},
 			},
 		},
@@ -293,44 +308,48 @@ func TestRolloverAction(t *testing.T) {
 func TestRolloverAction_OpenSearchUsesISMEndpoint(t *testing.T) {
 	// Verify that when the backend is OpenSearch, the concrete ILMClient
 	// gets UseOpenSearchISM=true and queries the ISM endpoint.
-	var ismEndpointCalled atomic.Bool
-	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		if strings.Contains(req.URL.String(), "_plugins/_ism/policies/") {
-			ismEndpointCalled.Store(true)
-		}
-		res.WriteHeader(http.StatusOK)
-	}))
-	defer testServer.Close()
+	for _, version := range []es.BackendVersion{es.OpenSearch2, es.OpenSearch3} {
+		t.Run(version.String(), func(t *testing.T) {
+			var ismEndpointCalled atomic.Bool
+			testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				if strings.Contains(req.URL.String(), "_plugins/_ism/policies/") {
+					ismEndpointCalled.Store(true)
+				}
+				res.WriteHeader(http.StatusOK)
+			}))
+			defer testServer.Close()
 
-	clusterClient := &mocks.ClusterAPI{}
-	clusterClient.On("Version", mock.Anything).Return(es.OpenSearch2, nil)
+			clusterClient := &mocks.ClusterAPI{}
+			clusterClient.On("Version", mock.Anything).Return(version, nil)
 
-	ilmClient := &client.ILMClient{
-		Client: client.Client{
-			Client:   testServer.Client(),
-			Endpoint: testServer.URL,
-		},
-		Logger: zap.NewNop(),
+			ilmClient := &client.ILMClient{
+				Client: client.Client{
+					Client:   testServer.Client(),
+					Endpoint: testServer.URL,
+				},
+				Logger: zap.NewNop(),
+			}
+
+			cfg := Config{Config: app.Config{UseILM: true, ILMPolicyName: "test-policy"}}
+			applyTestDefaults(&cfg)
+
+			indexClient := &mocks.IndexAPI{}
+			indexClient.On("CreateTemplate", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			indexClient.On("IndexExists", mock.Anything, mock.Anything).Return(true, nil)
+			indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, nil)
+			indexClient.On("CreateAlias", mock.Anything, mock.Anything).Return(nil)
+
+			action := Action{
+				Config:        cfg,
+				IndicesClient: indexClient,
+				ClusterClient: clusterClient,
+				ILMClient:     ilmClient,
+			}
+
+			err := action.Do()
+			require.NoError(t, err)
+			assert.True(t, ilmClient.UseOpenSearchISM)
+			assert.True(t, ismEndpointCalled.Load(), "expected ISM endpoint to be called")
+		})
 	}
-
-	cfg := Config{Config: app.Config{UseILM: true, ILMPolicyName: "test-policy"}}
-	applyTestDefaults(&cfg)
-
-	indexClient := &mocks.IndexAPI{}
-	indexClient.On("CreateTemplate", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	indexClient.On("IndexExists", mock.Anything, mock.Anything).Return(true, nil)
-	indexClient.On("GetJaegerIndices", mock.Anything, "").Return([]client.Index{}, nil)
-	indexClient.On("CreateAlias", mock.Anything, mock.Anything).Return(nil)
-
-	action := Action{
-		Config:        cfg,
-		IndicesClient: indexClient,
-		ClusterClient: clusterClient,
-		ILMClient:     ilmClient,
-	}
-
-	err := action.Do()
-	require.NoError(t, err)
-	assert.True(t, ilmClient.UseOpenSearchISM)
-	assert.True(t, ismEndpointCalled.Load(), "expected ISM endpoint to be called")
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7121

## Description of the changes
- Updates the missing ILM/ISM policy error in `jaeger-es-rollover init` to name the real backend (e.g. `OpenSearch 3.x`) instead of hardcoding `Elasticsearch`
- Adds tests for OpenSearch 3.x missing ISM policy and ISM endpoint routing

OpenSearch compatibility (version detection, ISM endpoint switching, ISM rollover templates) was already fixed in #8830. This PR closes the remaining misleading error message.

<img width="416" height="1075" alt="image" src="https://github.com/user-attachments/assets/738bcb28-cc09-42fb-a1a5-3c907297dabb" />


## How was this change tested?
- `go test ./cmd/es-rollover/app/init/... -v -run 'TestRolloverAction'` — **14 subtests passed** (12 in `TestRolloverAction`, 2 in `TestRolloverAction_OpenSearchUsesISMEndpoint` including OpenSearch 3.x)
- `make fmt`
- `make lint`
- `make test` — **3699 tests passed**, 34 skipped
<img width="1170" height="858" alt="image" src="https://github.com/user-attachments/assets/cbc80e51-0351-4676-a1ba-d35ce1fc1dd7" />
---
<img width="1436" height="986" alt="image" src="https://github.com/user-attachments/assets/789065fa-5a48-4974-9828-5aa14c388944" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes