### PR TITLE
feat(hotrod): Add standard OTEL DB semconv attributes to HotRod spans

### DIFF
--- a/examples/hotrod/services/customer/database.go
+++ b/examples/hotrod/services/customer/database.go
@@ -69,9 +69,11 @@ func (d *database) Get(ctx context.Context, customerID int) (*Customer, error) {
 
 	ctx, span := d.tracer.Start(ctx, "SQL SELECT", trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(
+		otelsemconv.DBSystemAttribute("mysql"),
+		otelsemconv.DBOperationNameAttribute("SELECT"),
 		otelsemconv.PeerServiceAttribute("mysql"),
 		attribute.
-			Key("sql.query").
+			Key(otelsemconv.DBQueryTextKey).
 			String(fmt.Sprintf("SELECT * FROM customer WHERE customer_id=%d", customerID)),
 	)
 	defer span.End()

--- a/examples/hotrod/services/driver/redis.go
+++ b/examples/hotrod/services/driver/redis.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jaegertracing/jaeger/examples/hotrod/pkg/tracing"
 	"github.com/jaegertracing/jaeger/examples/hotrod/services/config"
 	"github.com/jaegertracing/jaeger/internal/metrics"
+	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
 )
 
 // Redis is a simulator of remote Redis cache
@@ -41,7 +42,11 @@ func newRedis(otelExporter string, metricsFactory metrics.Factory, logger log.Fa
 // FindDriverIDs finds IDs of drivers who are near the location.
 func (r *Redis) FindDriverIDs(ctx context.Context, location string) []string {
 	ctx, span := r.tracer.Start(ctx, "FindDriverIDs", trace.WithSpanKind(trace.SpanKindClient))
-	span.SetAttributes(attribute.Key("param.driver.location").String(location))
+	span.SetAttributes(
+		otelsemconv.DBSystemAttribute("redis"),
+		otelsemconv.DBOperationNameAttribute("FindDriverIDs"),
+		attribute.Key("param.driver.location").String(location),
+	)
 	defer span.End()
 
 	// simulate RPC delay
@@ -59,7 +64,11 @@ func (r *Redis) FindDriverIDs(ctx context.Context, location string) []string {
 // GetDriver returns driver and the current car location
 func (r *Redis) GetDriver(ctx context.Context, driverID string) (Driver, error) {
 	ctx, span := r.tracer.Start(ctx, "GetDriver", trace.WithSpanKind(trace.SpanKindClient))
-	span.SetAttributes(attribute.Key("param.driverID").String(driverID))
+	span.SetAttributes(
+		otelsemconv.DBSystemAttribute("redis"),
+		otelsemconv.DBOperationNameAttribute("GetDriver"),
+		attribute.Key("param.driverID").String(driverID),
+	)
 	defer span.End()
 
 	// simulate RPC delay

--- a/examples/hotrod/services/driver/redis.go
+++ b/examples/hotrod/services/driver/redis.go
@@ -44,7 +44,7 @@ func (r *Redis) FindDriverIDs(ctx context.Context, location string) []string {
 	ctx, span := r.tracer.Start(ctx, "FindDriverIDs", trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(
 		otelsemconv.DBSystemAttribute("redis"),
-		otelsemconv.DBOperationNameAttribute("FindDriverIDs"),
+		otelsemconv.DBOperationNameAttribute("GET"),
 		attribute.Key("param.driver.location").String(location),
 	)
 	defer span.End()
@@ -66,7 +66,7 @@ func (r *Redis) GetDriver(ctx context.Context, driverID string) (Driver, error) 
 	ctx, span := r.tracer.Start(ctx, "GetDriver", trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(
 		otelsemconv.DBSystemAttribute("redis"),
-		otelsemconv.DBOperationNameAttribute("GetDriver"),
+		otelsemconv.DBOperationNameAttribute("GET"),
 		attribute.Key("param.driverID").String(driverID),
 	)
 	defer span.End()

--- a/internal/telemetry/otelsemconv/semconv.go
+++ b/internal/telemetry/otelsemconv/semconv.go
@@ -69,6 +69,11 @@ func DBSystemAttribute(value string) attribute.KeyValue {
 	return semconv.DBSystemNameKey.String(value)
 }
 
+// DBOperationName creates a key-value pair for the DB operation name attribute.
+func DBOperationNameAttribute(value string) attribute.KeyValue {
+	return semconv.DBOperationNameKey.String(value)
+}
+
 // HTTPStatusCode creates a key-value pair for the HTTP status code attribute.
 func HTTPStatusCodeAttribute(value int) attribute.KeyValue {
 	return semconv.HTTPResponseStatusCodeKey.Int(value)


### PR DESCRIPTION
Add db.system.name, db.operation.name, and db.query.text attributes to the simulated Redis and MySQL client spans in the HotROD example, and expose a DBOperationNameAttribute helper in the otelsemconv package.
