### PR TITLE
feat(tracestoremetrics): Forward SummaryReader when underlying reader supports it

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -172,7 +172,7 @@ func (qs QueryService) FindTraceSummaries(
 	ctx context.Context,
 	query TraceQueryParams,
 ) iter.Seq2[[]tracestore.TraceSummary, error] {
-	if sr := findSummaryReader(qs.traceReader); sr != nil {
+	if sr, ok := qs.traceReader.(tracestore.SummaryReader); ok {
 		return func(yield func([]tracestore.TraceSummary, error) bool) {
 			for batch, err := range sr.FindTraceSummaries(ctx, query.TraceQueryParams) {
 				if err != nil {
@@ -195,11 +195,6 @@ func (qs QueryService) FindTraceSummaries(
 		}
 	}
 	return computeSummaries(qs.traceReader.FindTraces(ctx, query.TraceQueryParams), qs.adjuster)
-}
-
-func findSummaryReader(r tracestore.Reader) tracestore.SummaryReader {
-	sr, _ := r.(tracestore.SummaryReader)
-	return sr
 }
 
 // ArchiveTrace archives a trace specified by the given query parameters.

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -197,23 +197,9 @@ func (qs QueryService) FindTraceSummaries(
 	return computeSummaries(qs.traceReader.FindTraces(ctx, query.TraceQueryParams), qs.adjuster)
 }
 
-// findSummaryReader walks the reader chain (via Unwrap) to find a SummaryReader,
-// allowing decorators that wrap the underlying reader to remain transparent.
 func findSummaryReader(r tracestore.Reader) tracestore.SummaryReader {
-	type unwrapper interface {
-		Unwrap() tracestore.Reader
-	}
-	for r != nil {
-		if sr, ok := r.(tracestore.SummaryReader); ok {
-			return sr
-		}
-		u, ok := r.(unwrapper)
-		if !ok {
-			break
-		}
-		r = u.Unwrap()
-	}
-	return nil
+	sr, _ := r.(tracestore.SummaryReader)
+	return sr
 }
 
 // ArchiveTrace archives a trace specified by the given query parameters.

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
@@ -880,15 +880,6 @@ func (m *mockSummaryReader) FindTraceSummaries(_ context.Context, _ tracestore.T
 	}
 }
 
-// wrappingReader wraps a tracestore.Reader and exposes Unwrap, simulating
-// decorators like ReadMetricsDecorator that may hide the underlying SummaryReader.
-type wrappingReader struct {
-	tracestoremocks.Reader
-	inner tracestore.Reader
-}
-
-func (w *wrappingReader) Unwrap() tracestore.Reader { return w.inner }
-
 func TestFindTraceSummaries_Fallback(t *testing.T) {
 	tqs := initializeTestService()
 	qp := tracestore.TraceQueryParams{
@@ -923,22 +914,6 @@ func TestFindTraceSummaries_NativePath(t *testing.T) {
 	assert.Equal(t, want, got)
 	// FindTraces should NOT have been called on the native reader.
 	nativeReader.AssertNotCalled(t, "FindTraces")
-}
-
-func TestFindTraceSummaries_NativePath_ThroughWrapper(t *testing.T) {
-	want := []tracestore.TraceSummary{{RootServiceName: "wrapped-native"}}
-	nativeReader := &mockSummaryReader{summaries: want}
-	wrapped := &wrappingReader{inner: nativeReader}
-
-	depsMock := initializeTestService().depsReader
-	qs := NewQueryService(wrapped, depsMock, QueryServiceOptions{})
-
-	got, err := jiter.FlattenWithErrors(qs.FindTraceSummaries(context.Background(), TraceQueryParams{
-		TraceQueryParams: tracestore.TraceQueryParams{Attributes: pcommon.NewMap()},
-	}))
-	require.NoError(t, err)
-	assert.Equal(t, want, got)
-	wrapped.AssertNotCalled(t, "FindTraces")
 }
 
 // TestFindTraceSummaries_NativeError verifies that a non-ErrUnsupported error

--- a/docs/adr/010-trace-summary-api.md
+++ b/docs/adr/010-trace-summary-api.md
@@ -2,7 +2,7 @@
 
 * **Status**: In progress (✅ Milestones 1, 2, 3, and 4 complete; ⏳ Milestone 5 pending)
 * **Date**: 2026-05-21
-* **Last updated**: 2026-05-26
+* **Last updated**: 2026-06-29
 
 ## Context
 
@@ -287,7 +287,7 @@ internal packages.
 
 ```go
 // In QueryService.FindTraceSummaries (simplified):
-if sr := findSummaryReader(qs.traceReader); sr != nil {
+if sr, ok := qs.traceReader.(tracestore.SummaryReader); ok {
     return func(yield func([]tracestore.TraceSummary, error) bool) {
         for batch, err := range sr.FindTraceSummaries(ctx, query) {
             if errors.Is(err, errors.ErrUnsupported) {
@@ -554,10 +554,10 @@ the HTTP contract before touching other repositories.
 **Delivered:**
 1. `tracestore.ServiceSummary`, `tracestore.TraceSummary`, and the optional `tracestore.SummaryReader` interface (`internal/storage/v2/api/tracestore/summary.go`).
 2. `computeSummaries` fallback aggregation in `querysvc/summary.go`, using `jptrace.AggregateTraces` to reassemble multi-chunk traces before summarizing.
-3. `querysvc.QueryService.FindTraceSummaries` with both the `SummaryReader` native path and the fallback path. The `SummaryReader` discovery uses a chain-walker (`findSummaryReader`) that traverses `Unwrap()` on decorator types (e.g. `ReadMetricsDecorator`). If the `SummaryReader` yields `errors.ErrUnsupported`, `QueryService` falls back transparently to `computeSummaries` (see §6).
+3. `querysvc.QueryService.FindTraceSummaries` with both the `SummaryReader` native path and the fallback path. `SummaryReader` discovery is a direct `ok`-guarded type assertion on `qs.traceReader`; `ReadMetricsDecorator` surfaces `SummaryReader` directly when the wrapped reader implements it (see §5 below). If the `SummaryReader` yields `errors.ErrUnsupported`, `QueryService` falls back transparently to `computeSummaries` (see §6).
 4. `GET /api/v3/trace-summaries` in the HTTP gateway, reusing `parseFindTracesQuery`. Response is plain JSON; timestamps encoded as decimal strings per proto3 JSON convention.
 5. `query.search_depth` is the canonical query parameter (matching the proto field); `query.num_traces` is accepted as a deprecated alias (jaegertracing/jaeger#8617). Defaults to 100 when omitted.
-6. Unit tests for `computeSummaries` (empty, error, multi-service, multi-chunk, orphan spans), `FindTraceSummaries` (fallback path, native `SummaryReader`, `SummaryReader` through decorator chain, `ErrUnsupported` fallback), HTTP handler (success, storage error, deprecated alias).
+6. Unit tests for `computeSummaries` (empty, error, multi-service, multi-chunk, orphan spans), `FindTraceSummaries` (fallback path, native `SummaryReader`, `ErrUnsupported` fallback), HTTP handler (success, storage error, deprecated alias).
 7. Integration test: `FindTraceSummaries` added to `RunSpanStoreTests`, exercised end-to-end via `TestJaegerQueryService` (see §9).
 
 ---
@@ -627,7 +627,7 @@ changes.
 1. ~~**`jaeger-idl`**: Add `ServiceSummary`, `TraceSummary`, `FindTraceSummariesRequest`,
    `FindTraceSummariesResponse`, and the optional `FindTraceSummaries` RPC to `storage/v2/trace_storage.proto`.~~ ✅ Already done in `jaeger-idl` main (same PR #203).
 2. ✅ **`jaeger`**: `Handler.FindTraceSummaries` in the gRPC storage server (`internal/storage/v2/grpc/handler.go`) forwards to the underlying `tracestore.SummaryReader` if available, otherwise returns `codes.Unimplemented`.
-3. ✅ **`jaeger`**: `TraceReader.FindTraceSummaries` in the gRPC storage client (`internal/storage/v2/grpc/tracereader.go`) implements `tracestore.SummaryReader` as a plain iterator (matching the `FindTraces` signature). `codes.Unimplemented` from the server (delivered via the first `Recv()`) is yielded as `errors.ErrUnsupported`; `QueryService` detects it and falls back to `computeSummaries` automatically via the existing `findSummaryReader` chain-walker (already shipped in Milestone 1).
+3. ✅ **`jaeger`**: `TraceReader.FindTraceSummaries` in the gRPC storage client (`internal/storage/v2/grpc/tracereader.go`) implements `tracestore.SummaryReader` as a plain iterator (matching the `FindTraces` signature). `codes.Unimplemented` from the server (delivered via the first `Recv()`) is yielded as `errors.ErrUnsupported`; `QueryService` detects it and falls back to `computeSummaries` automatically.
 4. ✅ Storage backends that don't implement `SummaryReader` opt out via `Capabilities.SkipList` — the `FindTraceSummaries` integration test is only run for backends that implement it (currently the e2e `traceReader` in `cmd/jaeger/internal/integration/`).
 
 ---

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics.go
@@ -14,7 +14,11 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
-var _ tracestore.Reader = (*ReadMetricsDecorator)(nil)
+var (
+	_ tracestore.Reader        = (*ReadMetricsDecorator)(nil)
+	_ tracestore.Reader        = (*ReadMetricsDecoratorWithSummary)(nil)
+	_ tracestore.SummaryReader = (*ReadMetricsDecoratorWithSummary)(nil)
+)
 
 // ReadMetricsDecorator wraps a tracestore.Reader and collects metrics around each read operation.
 type ReadMetricsDecorator struct {
@@ -24,6 +28,13 @@ type ReadMetricsDecorator struct {
 	getTraceMetrics      *queryMetrics
 	getServicesMetrics   *queryMetrics
 	getOperationsMetrics *queryMetrics
+}
+
+// ReadMetricsDecoratorWithSummary extends ReadMetricsDecorator with tracestore.SummaryReader support.
+// It is returned by NewReaderDecorator when the wrapped reader also implements SummaryReader.
+type ReadMetricsDecoratorWithSummary struct {
+	ReadMetricsDecorator
+	findTraceSummariesMetrics *queryMetrics
 }
 
 type queryMetrics struct {
@@ -45,9 +56,11 @@ func (q *queryMetrics) emit(err error, latency time.Duration, responses int) {
 	}
 }
 
-// NewReaderDecorator returns a new ReadMetricsDecorator.
-func NewReaderDecorator(traceReader tracestore.Reader, metricsFactory metrics.Factory) *ReadMetricsDecorator {
-	return &ReadMetricsDecorator{
+// NewReaderDecorator returns a ReadMetricsDecorator that instruments all tracestore.Reader
+// methods with metrics. If traceReader also implements tracestore.SummaryReader, the returned
+// value will implement it too, forwarding calls with the same metrics instrumentation.
+func NewReaderDecorator(traceReader tracestore.Reader, metricsFactory metrics.Factory) tracestore.Reader {
+	base := &ReadMetricsDecorator{
 		traceReader:          traceReader,
 		findTracesMetrics:    buildQueryMetrics("find_traces", metricsFactory),
 		findTraceIDsMetrics:  buildQueryMetrics("find_trace_ids", metricsFactory),
@@ -55,6 +68,13 @@ func NewReaderDecorator(traceReader tracestore.Reader, metricsFactory metrics.Fa
 		getServicesMetrics:   buildQueryMetrics("get_services", metricsFactory),
 		getOperationsMetrics: buildQueryMetrics("get_operations", metricsFactory),
 	}
+	if _, ok := traceReader.(tracestore.SummaryReader); ok {
+		return &ReadMetricsDecoratorWithSummary{
+			ReadMetricsDecorator:      *base,
+			findTraceSummariesMetrics: buildQueryMetrics("find_trace_summaries", metricsFactory),
+		}
+	}
+	return base
 }
 
 func buildQueryMetrics(operation string, metricsFactory metrics.Factory) *queryMetrics {
@@ -148,4 +168,24 @@ func (m *ReadMetricsDecorator) GetOperations(
 	retMe, err := m.traceReader.GetOperations(ctx, query)
 	m.getOperationsMetrics.emit(err, time.Since(start), len(retMe))
 	return retMe, err
+}
+
+// FindTraceSummaries implements tracestore.SummaryReader#FindTraceSummaries
+func (m *ReadMetricsDecoratorWithSummary) FindTraceSummaries(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+	return func(yield func([]tracestore.TraceSummary, error) bool) {
+		start := time.Now()
+		var err error
+		length := 0
+		defer func() {
+			m.findTraceSummariesMetrics.emit(err, time.Since(start), length)
+		}()
+		summaryReader := m.traceReader.(tracestore.SummaryReader)
+		for summaries, iterErr := range summaryReader.FindTraceSummaries(ctx, query) {
+			err = iterErr
+			length += len(summaries)
+			if !yield(summaries, iterErr) {
+				return
+			}
+		}
+	}
 }

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics.go
@@ -152,13 +152,6 @@ func (m *ReadMetricsDecorator) GetServices(ctx context.Context) ([]string, error
 	return retMe, err
 }
 
-// Unwrap returns the underlying tracestore.Reader, allowing callers to
-// discover optional interfaces (e.g. tracestore.SummaryReader) that the
-// wrapped reader may implement but the decorator does not forward.
-func (m *ReadMetricsDecorator) Unwrap() tracestore.Reader {
-	return m.traceReader
-}
-
 // GetOperations implements tracestore.Reader#GetOperations
 func (m *ReadMetricsDecorator) GetOperations(
 	ctx context.Context,

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/jaegertracing/jaeger/internal/metricstest"
@@ -178,5 +179,56 @@ func TestReadMetricsDecorator_Unwrap(t *testing.T) {
 	mf := metricstest.NewFactory(0)
 	inner := &mocks.Reader{}
 	d := NewReaderDecorator(inner, mf)
-	assert.Same(t, inner, d.Unwrap())
+	decorated, ok := d.(*ReadMetricsDecorator)
+	require.True(t, ok)
+	assert.Same(t, inner, decorated.Unwrap())
+}
+
+func TestNewReaderDecorator_WithSummaryReader(t *testing.T) {
+	mf := metricstest.NewFactory(0)
+
+	type readerWithSummary struct {
+		mocks.Reader
+		mocks.SummaryReader
+	}
+	inner := &readerWithSummary{}
+	d := NewReaderDecorator(inner, mf)
+	_, ok := d.(tracestore.SummaryReader)
+	assert.True(t, ok, "expected returned decorator to implement tracestore.SummaryReader")
+}
+
+func TestNewReaderDecorator_WithoutSummaryReader(t *testing.T) {
+	mf := metricstest.NewFactory(0)
+	inner := &mocks.Reader{}
+	d := NewReaderDecorator(inner, mf)
+	_, ok := d.(tracestore.SummaryReader)
+	assert.False(t, ok, "expected returned decorator to not implement tracestore.SummaryReader")
+}
+
+func TestReadMetricsDecoratorWithSummary_FindTraceSummaries(t *testing.T) {
+	mf := metricstest.NewFactory(0)
+
+	type readerWithSummary struct {
+		mocks.Reader
+		mocks.SummaryReader
+	}
+	inner := &readerWithSummary{}
+	summaries := []tracestore.TraceSummary{{RootServiceName: "svc-a"}, {RootServiceName: "svc-b"}}
+	inner.SummaryReader.On("FindTraceSummaries", context.Background(), tracestore.TraceQueryParams{}).
+		Return(emptyIter[tracestore.TraceSummary](summaries, nil))
+
+	d := NewReaderDecorator(inner, mf)
+	sr, ok := d.(tracestore.SummaryReader)
+	require.True(t, ok)
+
+	var got []tracestore.TraceSummary
+	for batch, err := range sr.FindTraceSummaries(context.Background(), tracestore.TraceQueryParams{}) {
+		require.NoError(t, err)
+		got = append(got, batch...)
+	}
+	assert.Len(t, got, len(summaries))
+
+	counters, _ := mf.Snapshot()
+	assert.Equal(t, int64(1), counters["requests|operation=find_trace_summaries|result=ok"])
+	assert.Equal(t, int64(int64(len(summaries))), counters["responses|operation=find_trace_summaries"])
 }

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
@@ -175,15 +175,6 @@ func emptyIter[T any](td []T, err error) iter.Seq2[[]T, error] {
 	}
 }
 
-func TestReadMetricsDecorator_Unwrap(t *testing.T) {
-	mf := metricstest.NewFactory(0)
-	inner := &mocks.Reader{}
-	d := NewReaderDecorator(inner, mf)
-	decorated, ok := d.(*ReadMetricsDecorator)
-	require.True(t, ok)
-	assert.Same(t, inner, decorated.Unwrap())
-}
-
 func TestNewReaderDecorator_WithSummaryReader(t *testing.T) {
 	mf := metricstest.NewFactory(0)
 

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
@@ -237,6 +237,7 @@ func TestReadMetricsDecoratorWithSummary_FindTraceSummaries_Error(t *testing.T) 
 	require.True(t, ok)
 
 	for range sr.FindTraceSummaries(context.Background(), tracestore.TraceQueryParams{}) {
+		t.Log("FindTraceSummaries error iteration")
 	}
 
 	counters, _ := mf.Snapshot()

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
@@ -196,13 +196,14 @@ func TestNewReaderDecorator_WithoutSummaryReader(t *testing.T) {
 	assert.False(t, ok, "expected returned decorator to not implement tracestore.SummaryReader")
 }
 
+type readerWithSummary struct {
+	mocks.Reader
+	mocks.SummaryReader
+}
+
 func TestReadMetricsDecoratorWithSummary_FindTraceSummaries(t *testing.T) {
 	mf := metricstest.NewFactory(0)
 
-	type readerWithSummary struct {
-		mocks.Reader
-		mocks.SummaryReader
-	}
 	inner := &readerWithSummary{}
 	summaries := []tracestore.TraceSummary{{RootServiceName: "svc-a"}, {RootServiceName: "svc-b"}}
 	inner.SummaryReader.On("FindTraceSummaries", context.Background(), tracestore.TraceQueryParams{}).
@@ -222,4 +223,43 @@ func TestReadMetricsDecoratorWithSummary_FindTraceSummaries(t *testing.T) {
 	counters, _ := mf.Snapshot()
 	assert.Equal(t, int64(1), counters["requests|operation=find_trace_summaries|result=ok"])
 	assert.Equal(t, int64(int64(len(summaries))), counters["responses|operation=find_trace_summaries"])
+}
+
+func TestReadMetricsDecoratorWithSummary_FindTraceSummaries_Error(t *testing.T) {
+	mf := metricstest.NewFactory(0)
+
+	inner := &readerWithSummary{}
+	inner.SummaryReader.On("FindTraceSummaries", context.Background(), tracestore.TraceQueryParams{}).
+		Return(emptyIter[tracestore.TraceSummary](nil, assert.AnError))
+
+	d := NewReaderDecorator(inner, mf)
+	sr, ok := d.(tracestore.SummaryReader)
+	require.True(t, ok)
+
+	for range sr.FindTraceSummaries(context.Background(), tracestore.TraceQueryParams{}) {
+	}
+
+	counters, _ := mf.Snapshot()
+	assert.Equal(t, int64(1), counters["requests|operation=find_trace_summaries|result=err"])
+}
+
+func TestReadMetricsDecoratorWithSummary_FindTraceSummaries_EarlyExit(t *testing.T) {
+	mf := metricstest.NewFactory(0)
+
+	inner := &readerWithSummary{}
+	summaries := []tracestore.TraceSummary{{RootServiceName: "svc-a"}, {RootServiceName: "svc-b"}}
+	inner.SummaryReader.On("FindTraceSummaries", context.Background(), tracestore.TraceQueryParams{}).
+		Return(emptyIter[tracestore.TraceSummary](summaries, nil))
+
+	d := NewReaderDecorator(inner, mf)
+	sr, ok := d.(tracestore.SummaryReader)
+	require.True(t, ok)
+
+	count := 0
+	for range sr.FindTraceSummaries(context.Background(), tracestore.TraceQueryParams{}) {
+		if count != 0 {
+			break
+		}
+		count++
+	}
 }

--- a/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
+++ b/internal/storage/v2/api/tracestore/tracestoremetrics/reader_metrics_test.go
@@ -248,7 +248,13 @@ func TestReadMetricsDecoratorWithSummary_FindTraceSummaries_EarlyExit(t *testing
 	mf := metricstest.NewFactory(0)
 
 	inner := &readerWithSummary{}
-	summaries := []tracestore.TraceSummary{{RootServiceName: "svc-a"}, {RootServiceName: "svc-b"}}
+	// Three summaries: break after the second so the third is never yielded,
+	// exercising the !yield early-exit path inside FindTraceSummaries.
+	summaries := []tracestore.TraceSummary{
+		{RootServiceName: "svc-a"},
+		{RootServiceName: "svc-b"},
+		{RootServiceName: "svc-c"},
+	}
 	inner.SummaryReader.On("FindTraceSummaries", context.Background(), tracestore.TraceQueryParams{}).
 		Return(emptyIter[tracestore.TraceSummary](summaries, nil))
 


### PR DESCRIPTION
## Summary

- `NewReaderDecorator` now returns a `ReadMetricsDecoratorWithSummary` (embedding `ReadMetricsDecorator` by value + implementing `tracestore.SummaryReader`) when the wrapped reader implements that optional interface; otherwise it returns a plain `*ReadMetricsDecorator` as before.
- `FindTraceSummaries` on the new type instruments the delegated call with the same metrics pattern used by all other operations (`find_trace_summaries` operation label).
- `Unwrap()` removed from `ReadMetricsDecorator` — no longer needed since the decorator surfaces `SummaryReader` directly.
- `findSummaryReader` in `querysvc` removed; inlined as a direct `if sr, ok := qs.traceReader.(tracestore.SummaryReader); ok` at the single call site.
- `wrappingReader` test helper and `TestFindTraceSummaries_NativePath_ThroughWrapper` removed.
- ADR-010 updated to reflect the new approach.

> **Note:** This PR has no linked issue. The change is a targeted enhancement to the metrics decorator identified during work on the `SummaryReader` feature.

## Test plan

- [ ] `go test ./internal/storage/v2/api/tracestore/tracestoremetrics/...` passes
- [ ] `go test ./cmd/jaeger/internal/extension/jaegerquery/querysvc/...` passes
- [ ] New tests cover: detection when underlying reader has `SummaryReader`, detection when it does not, and metrics counters on `FindTraceSummaries`
- [ ] `make lint` and `make fmt` clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)