### PR TITLE
fix(memory): Remove stale services and operations on trace eviction

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -696,6 +696,147 @@ func TestNewStore_TracesLimit(t *testing.T) {
 	assert.Len(t, tenant.ids, maxTraces)
 }
 
+func TestStoreTraces_EvictionRemovesStaleServicesAndOperations(t *testing.T) {
+	writeServiceTrace := func(t *testing.T, store *Store, traceID, service, operation string) {
+		td := ptrace.NewTraces()
+		resourceSpan := td.ResourceSpans().AppendEmpty()
+		if service != "" {
+			resourceSpan.Resource().Attributes().PutStr(conventions.ServiceNameKey, service)
+		}
+		span := resourceSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(fromString(t, traceID))
+		span.SetName(operation)
+		span.SetKind(ptrace.SpanKindServer)
+		require.NoError(t, store.WriteTraces(context.Background(), td))
+	}
+
+	store, err := NewStore(Configuration{
+		MaxTraces: 2,
+	})
+	require.NoError(t, err)
+
+	writeServiceTrace(t, store, "00000000000000010000000000000000", "evicted-service", "evicted-op")
+	services, err := store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evicted-service"}, services)
+
+	// Fill and overflow the ring buffer so the first trace is evicted. A trace
+	// without a service name is retained alongside it to ensure such spans are
+	// skipped when the evicted trace's metadata reference counts are released.
+	writeServiceTrace(t, store, "00000000000000020000000000000000", "retained-service", "retained-op")
+	writeServiceTrace(t, store, "00000000000000030000000000000000", "", "no-service-op")
+
+	// The evicted trace's service and operations must no longer be reported,
+	// because they fall outside the retention period (the ring buffer).
+	services, err = store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"retained-service"}, services)
+
+	evictedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "evicted-service",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, evictedOps)
+
+	retainedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "retained-service",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []tracestore.Operation{{Name: "retained-op", SpanKind: "server"}}, retainedOps)
+}
+
+func TestStoreTraces_EvictionKeepsMetadataReferencedByRetainedTraces(t *testing.T) {
+	writeSpan := func(t *testing.T, store *Store, traceID, service, operation string) {
+		td := ptrace.NewTraces()
+		resourceSpan := td.ResourceSpans().AppendEmpty()
+		resourceSpan.Resource().Attributes().PutStr(conventions.ServiceNameKey, service)
+		span := resourceSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(fromString(t, traceID))
+		span.SetName(operation)
+		span.SetKind(ptrace.SpanKindServer)
+		require.NoError(t, store.WriteTraces(context.Background(), td))
+	}
+
+	store, err := NewStore(Configuration{
+		MaxTraces: 2,
+	})
+	require.NoError(t, err)
+
+	// Two retained traces contribute the same "shared" service with different
+	// operations, so the service is reference-counted twice while each operation
+	// is referenced once.
+	writeSpan(t, store, "00000000000000010000000000000000", "shared", "op-evicted")
+	writeSpan(t, store, "00000000000000020000000000000000", "shared", "op-retained")
+
+	tenant := store.getTenant(tenancy.GetTenant(context.Background()))
+	assert.Equal(t, 2, tenant.services["shared"])
+
+	// Overflow the ring buffer, evicting the first trace. The "shared" service is
+	// still referenced by the second trace, so it must be retained even though the
+	// operation contributed only by the evicted trace must be dropped.
+	writeSpan(t, store, "00000000000000030000000000000000", "other", "op-other")
+
+	services, err := store.GetServices(context.Background())
+	require.NoError(t, err)
+	slices.Sort(services)
+	assert.Equal(t, []string{"other", "shared"}, services)
+	assert.Equal(t, 1, tenant.services["shared"])
+
+	sharedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "shared",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []tracestore.Operation{{Name: "op-retained", SpanKind: "server"}}, sharedOps)
+
+	otherOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "other",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []tracestore.Operation{{Name: "op-other", SpanKind: "server"}}, otherOps)
+}
+
+func TestStoreTraces_UpdatedTraceReleasesAllMetadataOnEviction(t *testing.T) {
+	writeSpan := func(t *testing.T, store *Store, traceID, service, operation string) {
+		td := ptrace.NewTraces()
+		resourceSpan := td.ResourceSpans().AppendEmpty()
+		resourceSpan.Resource().Attributes().PutStr(conventions.ServiceNameKey, service)
+		span := resourceSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(fromString(t, traceID))
+		span.SetName(operation)
+		span.SetKind(ptrace.SpanKindServer)
+		require.NoError(t, store.WriteTraces(context.Background(), td))
+	}
+
+	store, err := NewStore(Configuration{
+		MaxTraces: 1,
+	})
+	require.NoError(t, err)
+
+	// The same trace id is written twice; the second write is appended to the
+	// existing trace, so both operations must be tracked and both released once
+	// the trace is evicted.
+	writeSpan(t, store, "00000000000000010000000000000000", "svc", "op-1")
+	writeSpan(t, store, "00000000000000010000000000000000", "svc", "op-2")
+
+	ops, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "svc",
+	})
+	require.NoError(t, err)
+	assert.Len(t, ops, 2)
+
+	tenant := store.getTenant(tenancy.GetTenant(context.Background()))
+	assert.Equal(t, 2, tenant.services["svc"])
+
+	// Evict the updated trace by writing a different trace into the single slot.
+	writeSpan(t, store, "00000000000000020000000000000000", "svc2", "op-3")
+
+	services, err := store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"svc2"}, services)
+	assert.NotContains(t, tenant.services, "svc")
+	assert.NotContains(t, tenant.operations, "svc")
+}
+
 func TestNewStore_ReverseChronologicalOrder(t *testing.T) {
 	maxTraces := 8
 	store, err := NewStore(Configuration{

--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -919,6 +919,26 @@ func TestStoreTraces_UpdatedTraceReleasesAllMetadataOnEviction(t *testing.T) {
 	assert.NotContains(t, tenant.operations, "svc")
 }
 
+func TestReleaseServiceMetadata_SkipsSpansWithoutOperationEntry(t *testing.T) {
+	td := ptrace.NewTraces()
+	resourceSpan := td.ResourceSpans().AppendEmpty()
+	resourceSpan.Resource().Attributes().PutStr(conventions.ServiceNameKey, "svc")
+	span := resourceSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("op")
+	span.SetKind(ptrace.SpanKindServer)
+
+	// A service with no recorded operations cannot arise from storeTraces, but
+	// releaseServiceMetadata must tolerate it and skip the spans instead of
+	// writing to a nil map.
+	tenant := newTenant(&Configuration{MaxTraces: 1})
+	tenant.services["svc"] = 1
+
+	tenant.releaseServiceMetadata(td)
+
+	assert.NotContains(t, tenant.services, "svc")
+	assert.NotContains(t, tenant.operations, "svc")
+}
+
 func TestNewStore_ReverseChronologicalOrder(t *testing.T) {
 	maxTraces := 8
 	store, err := NewStore(Configuration{

--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -778,6 +778,147 @@ func TestNewStore_TracesLimit(t *testing.T) {
 	assert.Len(t, tenant.ids, maxTraces)
 }
 
+func TestStoreTraces_EvictionRemovesStaleServicesAndOperations(t *testing.T) {
+	writeServiceTrace := func(t *testing.T, store *Store, traceID, service, operation string) {
+		td := ptrace.NewTraces()
+		resourceSpan := td.ResourceSpans().AppendEmpty()
+		if service != "" {
+			resourceSpan.Resource().Attributes().PutStr(conventions.ServiceNameKey, service)
+		}
+		span := resourceSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(fromString(t, traceID))
+		span.SetName(operation)
+		span.SetKind(ptrace.SpanKindServer)
+		require.NoError(t, store.WriteTraces(context.Background(), td))
+	}
+
+	store, err := NewStore(Configuration{
+		MaxTraces: 2,
+	})
+	require.NoError(t, err)
+
+	writeServiceTrace(t, store, "00000000000000010000000000000000", "evicted-service", "evicted-op")
+	services, err := store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evicted-service"}, services)
+
+	// Fill and overflow the ring buffer so the first trace is evicted. A trace
+	// without a service name is retained alongside it to ensure such spans are
+	// skipped when the evicted trace's metadata reference counts are released.
+	writeServiceTrace(t, store, "00000000000000020000000000000000", "retained-service", "retained-op")
+	writeServiceTrace(t, store, "00000000000000030000000000000000", "", "no-service-op")
+
+	// The evicted trace's service and operations must no longer be reported,
+	// because they fall outside the retention period (the ring buffer).
+	services, err = store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"retained-service"}, services)
+
+	evictedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "evicted-service",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, evictedOps)
+
+	retainedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "retained-service",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []tracestore.Operation{{Name: "retained-op", SpanKind: "server"}}, retainedOps)
+}
+
+func TestStoreTraces_EvictionKeepsMetadataReferencedByRetainedTraces(t *testing.T) {
+	writeSpan := func(t *testing.T, store *Store, traceID, service, operation string) {
+		td := ptrace.NewTraces()
+		resourceSpan := td.ResourceSpans().AppendEmpty()
+		resourceSpan.Resource().Attributes().PutStr(conventions.ServiceNameKey, service)
+		span := resourceSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(fromString(t, traceID))
+		span.SetName(operation)
+		span.SetKind(ptrace.SpanKindServer)
+		require.NoError(t, store.WriteTraces(context.Background(), td))
+	}
+
+	store, err := NewStore(Configuration{
+		MaxTraces: 2,
+	})
+	require.NoError(t, err)
+
+	// Two retained traces contribute the same "shared" service with different
+	// operations, so the service is reference-counted twice while each operation
+	// is referenced once.
+	writeSpan(t, store, "00000000000000010000000000000000", "shared", "op-evicted")
+	writeSpan(t, store, "00000000000000020000000000000000", "shared", "op-retained")
+
+	tenant := store.getTenant(tenancy.GetTenant(context.Background()))
+	assert.Equal(t, 2, tenant.services["shared"])
+
+	// Overflow the ring buffer, evicting the first trace. The "shared" service is
+	// still referenced by the second trace, so it must be retained even though the
+	// operation contributed only by the evicted trace must be dropped.
+	writeSpan(t, store, "00000000000000030000000000000000", "other", "op-other")
+
+	services, err := store.GetServices(context.Background())
+	require.NoError(t, err)
+	slices.Sort(services)
+	assert.Equal(t, []string{"other", "shared"}, services)
+	assert.Equal(t, 1, tenant.services["shared"])
+
+	sharedOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "shared",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []tracestore.Operation{{Name: "op-retained", SpanKind: "server"}}, sharedOps)
+
+	otherOps, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "other",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []tracestore.Operation{{Name: "op-other", SpanKind: "server"}}, otherOps)
+}
+
+func TestStoreTraces_UpdatedTraceReleasesAllMetadataOnEviction(t *testing.T) {
+	writeSpan := func(t *testing.T, store *Store, traceID, service, operation string) {
+		td := ptrace.NewTraces()
+		resourceSpan := td.ResourceSpans().AppendEmpty()
+		resourceSpan.Resource().Attributes().PutStr(conventions.ServiceNameKey, service)
+		span := resourceSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(fromString(t, traceID))
+		span.SetName(operation)
+		span.SetKind(ptrace.SpanKindServer)
+		require.NoError(t, store.WriteTraces(context.Background(), td))
+	}
+
+	store, err := NewStore(Configuration{
+		MaxTraces: 1,
+	})
+	require.NoError(t, err)
+
+	// The same trace id is written twice; the second write is appended to the
+	// existing trace, so both operations must be tracked and both released once
+	// the trace is evicted.
+	writeSpan(t, store, "00000000000000010000000000000000", "svc", "op-1")
+	writeSpan(t, store, "00000000000000010000000000000000", "svc", "op-2")
+
+	ops, err := store.GetOperations(context.Background(), tracestore.OperationQueryParams{
+		ServiceName: "svc",
+	})
+	require.NoError(t, err)
+	assert.Len(t, ops, 2)
+
+	tenant := store.getTenant(tenancy.GetTenant(context.Background()))
+	assert.Equal(t, 2, tenant.services["svc"])
+
+	// Evict the updated trace by writing a different trace into the single slot.
+	writeSpan(t, store, "00000000000000020000000000000000", "svc2", "op-3")
+
+	services, err := store.GetServices(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"svc2"}, services)
+	assert.NotContains(t, tenant.services, "svc")
+	assert.NotContains(t, tenant.operations, "svc")
+}
+
 func TestNewStore_ReverseChronologicalOrder(t *testing.T) {
 	maxTraces := 8
 	store, err := NewStore(Configuration{

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -29,10 +29,11 @@ type Tenant struct {
 	traces     []traceAndId            // ring buffer to store traces
 	mostRecent int                     // position in traces[] of the most recently added trace
 
-	// services and operations reference-count how many retained spans contribute
-	// each service and operation. Entries are removed once their count reaches
-	// zero so that GetServices and GetOperations never report metadata whose
-	// traces have already been evicted from the ring buffer.
+	// services and operations reference-count how many retained resource spans
+	// and spans contribute each service and operation, respectively. Entries are
+	// removed once their count reaches zero so that GetServices and GetOperations
+	// never report metadata whose traces have already been evicted from the ring
+	// buffer.
 	services   map[string]int
 	operations map[string]map[tracestore.Operation]int
 }
@@ -126,11 +127,10 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 
 // releaseServiceMetadata decrements the reference count of every service and
 // operation contributed by an evicted trace, deleting an entry once its count
-// reaches zero. Because storeTraces increments the same counts for each span it
-// stores, this keeps GetServices and GetOperations proportional to the number
-// of spans in the evicted trace rather than rebuilding the metadata from every
-// retained trace, and it correctly retains a service or operation that is still
-// referenced by another trace in the ring buffer.
+// reaches zero. storeTraces increments service counts for resource spans and
+// operation counts for spans, and this function decrements them at the same
+// granularity. This correctly retains metadata that another trace in the ring
+// buffer still references.
 func (t *Tenant) releaseServiceMetadata(trace ptrace.Traces) {
 	for _, resourceSpan := range trace.ResourceSpans().All() {
 		serviceName := getServiceNameFromResource(resourceSpan.Resource())

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -29,8 +29,12 @@ type Tenant struct {
 	traces     []traceAndId            // ring buffer to store traces
 	mostRecent int                     // position in traces[] of the most recently added trace
 
-	services   map[string]struct{}
-	operations map[string]map[tracestore.Operation]struct{}
+	// services and operations reference-count how many retained spans contribute
+	// each service and operation. Entries are removed once their count reaches
+	// zero so that GetServices and GetOperations never report metadata whose
+	// traces have already been evicted from the ring buffer.
+	services   map[string]int
+	operations map[string]map[tracestore.Operation]int
 }
 
 type traceAndId struct {
@@ -53,8 +57,8 @@ func newTenant(cfg *Configuration) *Tenant {
 		ids:        make(map[pcommon.TraceID]int),
 		traces:     make([]traceAndId, cfg.MaxTraces),
 		mostRecent: -1,
-		services:   map[string]struct{}{},
-		operations: map[string]map[tracestore.Operation]struct{}{},
+		services:   map[string]int{},
+		operations: map[string]map[tracestore.Operation]int{},
 	}
 }
 
@@ -67,7 +71,7 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 		for _, resourceSpan := range sameTraceIDResourceSpan.All() {
 			serviceName := getServiceNameFromResource(resourceSpan.Resource())
 			if serviceName != "" {
-				t.services[serviceName] = struct{}{}
+				t.services[serviceName]++
 			}
 			for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
 				for _, span := range scopeSpan.Spans().All() {
@@ -77,9 +81,9 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 							SpanKind: fromOTELSpanKind(span.Kind()),
 						}
 						if _, ok := t.operations[serviceName]; !ok {
-							t.operations[serviceName] = make(map[tracestore.Operation]struct{})
+							t.operations[serviceName] = make(map[tracestore.Operation]int)
 						}
-						t.operations[serviceName][operation] = struct{}{}
+						t.operations[serviceName][operation]++
 					}
 					if startTime.IsZero() || span.StartTimestamp().AsTime().Before(startTime) {
 						startTime = span.StartTimestamp().AsTime()
@@ -103,9 +107,11 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 		traces := ptrace.NewTraces()
 		sameTraceIDResourceSpan.MoveAndAppendTo(traces.ResourceSpans())
 		t.mostRecent = (t.mostRecent + 1) % t.config.MaxTraces
-		// if there is already a trace in lastEvicted position, remove its ID from ids map
+		// if there is already a trace in lastEvicted position, remove its ID from
+		// ids map and release the service and operation metadata it contributed.
 		if !t.traces[t.mostRecent].id.IsEmpty() {
 			delete(t.ids, t.traces[t.mostRecent].id)
+			t.releaseServiceMetadata(t.traces[t.mostRecent].trace)
 		}
 		// update the ring with the trace id
 		t.ids[traceId] = t.mostRecent
@@ -114,6 +120,45 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 			trace:     traces,
 			startTime: startTime,
 			endTime:   endTime,
+		}
+	}
+}
+
+// releaseServiceMetadata decrements the reference count of every service and
+// operation contributed by an evicted trace, deleting an entry once its count
+// reaches zero. Because storeTraces increments the same counts for each span it
+// stores, this keeps GetServices and GetOperations proportional to the number
+// of spans in the evicted trace rather than rebuilding the metadata from every
+// retained trace, and it correctly retains a service or operation that is still
+// referenced by another trace in the ring buffer.
+func (t *Tenant) releaseServiceMetadata(trace ptrace.Traces) {
+	for _, resourceSpan := range trace.ResourceSpans().All() {
+		serviceName := getServiceNameFromResource(resourceSpan.Resource())
+		if serviceName == "" {
+			continue
+		}
+		t.services[serviceName]--
+		if t.services[serviceName] <= 0 {
+			delete(t.services, serviceName)
+		}
+		operations := t.operations[serviceName]
+		for _, scopeSpan := range resourceSpan.ScopeSpans().All() {
+			for _, span := range scopeSpan.Spans().All() {
+				if operations == nil {
+					continue
+				}
+				operation := tracestore.Operation{
+					Name:     span.Name(),
+					SpanKind: fromOTELSpanKind(span.Kind()),
+				}
+				operations[operation]--
+				if operations[operation] <= 0 {
+					delete(operations, operation)
+				}
+			}
+		}
+		if len(operations) == 0 {
+			delete(t.operations, serviceName)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8703

### Problem

The v2 in-memory store retained service and operation metadata after the ring buffer evicted the trace that contributed it. `GetServices` and `GetOperations` could therefore return entries with no retained traces.

### Fix

I changed the metadata maps to reference counts. Storing a trace increments service counts per resource span and operation counts per span. Eviction walks only the evicted trace, decrements at the same granularity, and removes entries when their counts reach zero.

This preserves metadata shared by retained traces and correctly releases metadata added when spans are appended to an existing trace. Store and eviction work is proportional to the resource spans and spans in the affected trace, with no scan of all retained traces.

### Tests

I added regression coverage for removing metadata from an evicted trace, preserving shared metadata, and releasing metadata from an updated trace.

Verified with `go test ./internal/storage/v2/memory` and `make lint`.