### PR TITLE
fix(mcp): Report total_count and truncated on get_services and get_span_names

### DIFF
--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_services.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_services.go
@@ -69,16 +69,22 @@ func (h *getServicesHandler) handle(
 	// Sort services for consistent ordering
 	slices.Sort(services)
 
-	// Apply limit
+	// Apply limit, recording the pre-truncation total so the caller can detect
+	// that results were cut (see issue #8901).
 	limit := input.Limit
 	if limit <= 0 {
 		limit = defaultServiceLimit
 	}
+	totalCount := len(services)
+	truncated := false
 	if len(services) > limit {
 		services = services[:limit]
+		truncated = true
 	}
 
 	return nil, types.GetServicesOutput{
-		Services: services,
+		Services:   services,
+		TotalCount: totalCount,
+		Truncated:  truncated,
 	}, nil
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_services_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_services_test.go
@@ -138,6 +138,47 @@ func TestGetServicesHandler_Success_WithLimit(t *testing.T) {
 	require.Len(t, output.Services, 3)
 	// After sorting, should return first 3 alphabetically
 	assert.Equal(t, []string{"service-1", "service-2", "service-3"}, output.Services)
+	// Truncation must be reported so the caller knows results were cut (issue #8901).
+	assert.Equal(t, 5, output.TotalCount)
+	assert.True(t, output.Truncated)
+}
+
+func TestGetServicesHandler_Truncation_ReportsTotalAndFlag(t *testing.T) {
+	testServices := []string{"a", "b", "c", "d"}
+
+	mock := &mockGetServicesQueryService{
+		getServicesFunc: func(_ context.Context) ([]string, error) {
+			return testServices, nil
+		},
+	}
+
+	handler := &getServicesHandler{queryService: mock}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, types.GetServicesInput{Limit: 2})
+
+	require.NoError(t, err)
+	require.Len(t, output.Services, 2)
+	assert.Equal(t, 4, output.TotalCount, "total_count must reflect all matches before the limit")
+	assert.True(t, output.Truncated, "truncated must be true when the limit drops results")
+}
+
+func TestGetServicesHandler_NoTruncation_FlagFalse(t *testing.T) {
+	testServices := []string{"a", "b", "c"}
+
+	mock := &mockGetServicesQueryService{
+		getServicesFunc: func(_ context.Context) ([]string, error) {
+			return testServices, nil
+		},
+	}
+
+	handler := &getServicesHandler{queryService: mock}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, types.GetServicesInput{Limit: 10})
+
+	require.NoError(t, err)
+	require.Len(t, output.Services, 3)
+	assert.Equal(t, 3, output.TotalCount)
+	assert.False(t, output.Truncated, "truncated must be false when everything fits")
 }
 
 func TestGetServicesHandler_Success_WithPatternAndLimit(t *testing.T) {
@@ -194,6 +235,9 @@ func TestGetServicesHandler_Success_DefaultLimit(t *testing.T) {
 	require.NoError(t, err)
 	// Should apply default limit of 100
 	assert.Len(t, output.Services, defaultServiceLimit)
+	// And report that the other 50 were dropped (issue #8901).
+	assert.Equal(t, 150, output.TotalCount)
+	assert.True(t, output.Truncated)
 }
 
 func TestGetServicesHandler_Error_InvalidPattern(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names.go
@@ -96,9 +96,13 @@ func (h *getSpanNamesHandler) handle(
 		return cmp.Compare(a.Name, b.Name)
 	})
 
-	// Apply limit
+	// Apply limit, recording the pre-truncation total so the caller can detect
+	// that results were cut (see issue #8901).
+	totalCount := len(filteredOps)
+	truncated := false
 	if len(filteredOps) > limit {
 		filteredOps = filteredOps[:limit]
+		truncated = true
 	}
 
 	// Build output - initialize as empty slice to ensure JSON serialization as []
@@ -110,5 +114,9 @@ func (h *getSpanNamesHandler) handle(
 		})
 	}
 
-	return nil, types.GetSpanNamesOutput{SpanNames: spanNames}, nil
+	return nil, types.GetSpanNamesOutput{
+		SpanNames:  spanNames,
+		TotalCount: totalCount,
+		Truncated:  truncated,
+	}, nil
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names_test.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/handlers/get_span_names_test.go
@@ -54,6 +54,7 @@ func TestGetSpanNamesHandler_Handle(t *testing.T) {
 					{Name: "GET /api/users", SpanKind: "SERVER"},
 					{Name: "POST /api/checkout", SpanKind: "SERVER"},
 				},
+				TotalCount: 3,
 			},
 		},
 		{
@@ -79,6 +80,7 @@ func TestGetSpanNamesHandler_Handle(t *testing.T) {
 					{Name: "GET /api/orders", SpanKind: "SERVER"},
 					{Name: "GET /api/users", SpanKind: "SERVER"},
 				},
+				TotalCount: 2,
 			},
 		},
 		{
@@ -96,6 +98,7 @@ func TestGetSpanNamesHandler_Handle(t *testing.T) {
 					{Name: "call-backend", SpanKind: "CLIENT"},
 					{Name: "call-database", SpanKind: "CLIENT"},
 				},
+				TotalCount: 2,
 			},
 		},
 		{
@@ -115,6 +118,8 @@ func TestGetSpanNamesHandler_Handle(t *testing.T) {
 					{Name: "op1", SpanKind: "SERVER"},
 					{Name: "op2", SpanKind: "SERVER"},
 				},
+				TotalCount: 4,
+				Truncated:  true,
 			},
 		},
 		{
@@ -124,7 +129,9 @@ func TestGetSpanNamesHandler_Handle(t *testing.T) {
 			},
 			mockOps: generateOperations(150),
 			expectedOutput: types.GetSpanNamesOutput{
-				SpanNames: generateSpanNameInfos(100),
+				SpanNames:  generateSpanNameInfos(100),
+				TotalCount: 150,
+				Truncated:  true,
 			},
 		},
 		{

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_services.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_services.go
@@ -16,4 +16,10 @@ type GetServicesInput struct {
 // GetServicesOutput defines the output of the get_services MCP tool.
 type GetServicesOutput struct {
 	Services []string `json:"services" jsonschema:"List of service names"`
+
+	// TotalCount is the number of services that matched before the limit was applied.
+	TotalCount int `json:"total_count" jsonschema:"Total number of matching services before the limit was applied"`
+
+	// Truncated is true when the limit dropped some matching services from the result.
+	Truncated bool `json:"truncated" jsonschema:"True if results were truncated by the limit; raise limit or refine pattern to see more"`
 }

--- a/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_span_names.go
+++ b/cmd/jaeger/internal/extension/jaegermcp/internal/types/get_span_names.go
@@ -21,6 +21,12 @@ type GetSpanNamesInput struct {
 // GetSpanNamesOutput defines the output of the get_span_names MCP tool.
 type GetSpanNamesOutput struct {
 	SpanNames []SpanNameInfo `json:"span_names" jsonschema:"List of span names for the service"`
+
+	// TotalCount is the number of span names that matched before the limit was applied.
+	TotalCount int `json:"total_count" jsonschema:"Total number of matching span names before the limit was applied"`
+
+	// Truncated is true when the limit dropped some matching span names from the result.
+	Truncated bool `json:"truncated" jsonschema:"True if results were truncated by the limit; raise limit or refine pattern to see more"`
 }
 
 // SpanNameInfo contains information about a span name.


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #8901. `get_services` and `get_span_names` cap their results at 100 (`defaultServiceLimit` / `defaultSpanNameLimit`) and return the trimmed slice with no indication anything was cut, so a caller cannot tell whether it got everything.

## Description of the changes

- Added `total_count` (number of matches before the limit) and a `truncated` flag to `GetServicesOutput` and `GetSpanNamesOutput`, mirroring what `get_trace_topology` (#8489) and `search_traces` (#8491) already expose.
- Both handlers now record the pre-truncation total and set `truncated` when the limit drops results.

## How was this change tested?

- New/updated unit tests assert `total_count` and `truncated` for truncated, non-truncated, and default-limit cases; they fail without the handler change.
- `go test` on the affected packages, `gofmt`, and `go vet` all pass.

Out of scope (per the issue): switching the hardcoded 100 to the configurable `max_search_results` — left as the noted separate follow-up.

---
*Disclosure: this change was authored with AI assistance (Claude Code); I have reviewed it and will shepherd it through review.*