### PR TITLE
feat(es): Denormalize endTime into span to drop Painless script dependency

### DIFF
--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-6.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-6.json
@@ -70,6 +70,9 @@
         "duration":{
           "type":"long"
         },
+        "endTime":{
+          "type":"long"
+        },
         "flags":{
           "type":"integer"
         },

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-7-opensearch.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-7-opensearch.json
@@ -67,6 +67,9 @@
       "duration":{
         "type":"long"
       },
+      "endTime":{
+        "type":"long"
+      },
       "flags":{
         "type":"integer"
       },

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-7.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-7.json
@@ -70,6 +70,9 @@
       "duration":{
         "type":"long"
       },
+      "endTime":{
+        "type":"long"
+      },
       "flags":{
         "type":"integer"
       },

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-8-opensearch.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-8-opensearch.json
@@ -69,6 +69,9 @@
         "duration": {
           "type": "long"
         },
+        "endTime": {
+          "type": "long"
+        },
         "flags": {
           "type": "integer"
         },

--- a/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-8.json
+++ b/internal/storage/v1/elasticsearch/mappings/fixtures/jaeger-span-8.json
@@ -72,6 +72,9 @@
         "duration": {
           "type": "long"
         },
+        "endTime": {
+          "type": "long"
+        },
         "flags": {
           "type": "integer"
         },

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-6.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-6.json
@@ -70,6 +70,9 @@
         "duration":{
           "type":"long"
         },
+        "endTime":{
+          "type":"long"
+        },
         "flags":{
           "type":"integer"
         },

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-7.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-7.json
@@ -78,6 +78,9 @@
       "duration":{
         "type":"long"
       },
+      "endTime":{
+        "type":"long"
+      },
       "flags":{
         "type":"integer"
       },

--- a/internal/storage/v1/elasticsearch/mappings/jaeger-span-8.json
+++ b/internal/storage/v1/elasticsearch/mappings/jaeger-span-8.json
@@ -81,6 +81,9 @@
         "duration": {
           "type": "long"
         },
+        "endTime": {
+          "type": "long"
+        },
         "flags": {
           "type": "integer"
         },

--- a/internal/storage/v2/elasticsearch/factory.go
+++ b/internal/storage/v2/elasticsearch/factory.go
@@ -38,8 +38,7 @@ var nativeTraceSummariesGate = featuregate.GlobalRegistry().MustRegister(
 	featuregate.WithRegisterFromVersion("v2.20.0"),
 	featuregate.WithRegisterDescription(
 		"Computes trace summaries natively in Elasticsearch/OpenSearch via aggregations "+
-			"instead of loading full traces and aggregating in the query service. Requires "+
-			"inline (Painless) scripts to be enabled on the cluster.",
+			"instead of loading full traces and aggregating in the query service.",
 	),
 )
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
@@ -53,9 +53,12 @@ type Span struct {
 	// ElasticSearch does not support a UNIX Epoch timestamp in microseconds,
 	// so Jaeger maps StartTime to a 'long' type. This extra StartTimeMillis field
 	// works around this issue, enabling timerange queries.
-	StartTimeMillis uint64     `json:"startTimeMillis"`
-	Duration        uint64     `json:"duration"` // microseconds
-	Tags            []KeyValue `json:"tags"`
+	StartTimeMillis uint64 `json:"startTimeMillis"`
+	Duration        uint64 `json:"duration"` // microseconds
+	// EndTime is the denormalized end time (StartTime + Duration) in microseconds,
+	// stored so summary aggregations avoid a Painless script for max end time.
+	EndTime uint64     `json:"endTime"`
+	Tags    []KeyValue `json:"tags"`
 	// Alternative representation of tags for better kibana support
 	Tag     map[string]any `json:"tag,omitempty"`
 	Logs    []Log          `json:"logs"`

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -33,6 +33,7 @@ const (
 
 	traceIDField           = "traceID"
 	durationField          = "duration"
+	endTimeField           = "endTime"
 	startTimeField         = "startTime"
 	startTimeMillisField   = "startTimeMillis"
 	serviceNameField       = "process.serviceName"

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_iface.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_iface.go
@@ -21,8 +21,7 @@ type Reader interface {
 	GetServices(ctx context.Context) ([]string, error)
 	// GetTraces takes a traceID and returns a Trace associated with that traceID
 	GetTraces(ctx context.Context, query []dbmodel.TraceID) ([]dbmodel.Trace, error)
-	// FindTraceSummaries natively computes per-trace summaries for traces matching
-	// the query. It returns errors.ErrUnsupported when the backend cannot compute
-	// them (e.g. Painless scripting is disabled).
+	// FindTraceSummaries natively computes per-trace summaries for the traces
+	// matching the query by aggregating over their spans.
 	FindTraceSummaries(ctx context.Context, traceQuery dbmodel.TraceQueryParameters) ([]dbmodel.TraceSummary, error)
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/summary.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/summary.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/olivere/elastic/v7"
@@ -77,12 +76,6 @@ func (s *SpanReader) FindTraceSummaries(
 		Query(boolQuery).
 		Do(ctx)
 	if err != nil {
-		if isScriptingDisabledError(err) {
-			// The max_end aggregation needs Painless scripting. When it is disabled,
-			// returning ErrUnsupported lets the query service fall back to client-side
-			// summary computation instead of failing the request.
-			return nil, fmt.Errorf("native trace summaries require Painless scripting enabled on the cluster: %w", errors.ErrUnsupported)
-		}
 		err = es.DetailedError(err)
 		s.logger.Info("es search for trace summaries failed", zap.Any("traceQuery", traceQuery), zap.Error(err))
 		return nil, fmt.Errorf("search for trace summaries failed: %w", err)
@@ -94,29 +87,6 @@ func (s *SpanReader) FindTraceSummaries(
 	}
 	// Buckets arrive most-recent-first, ordered by the aggregation's max_start sort.
 	return parseTraceSummaries(buckets)
-}
-
-// isScriptingDisabledError reports whether an Elasticsearch/OpenSearch error was
-// caused by inline (Painless) scripting being disabled on the cluster, which the
-// max_end aggregation depends on. The cluster surfaces this as an
-// illegal_argument_exception whose reason mentions scripts being disabled.
-func isScriptingDisabledError(err error) bool {
-	var esErr *elastic.Error
-	if !errors.As(err, &esErr) || esErr.Details == nil {
-		return false
-	}
-	causes := append([]*elastic.ErrorDetails{esErr.Details}, esErr.Details.RootCause...)
-	for _, c := range causes {
-		if c == nil {
-			continue
-		}
-		reason := strings.ToLower(c.Reason)
-		if strings.Contains(reason, "script") &&
-			(strings.Contains(reason, "disabled") || strings.Contains(reason, "cannot execute")) {
-			return true
-		}
-	}
-	return false
 }
 
 // buildTraceSummariesByIDsQuery selects every span belonging to the given traces
@@ -165,9 +135,8 @@ func (s *SpanReader) buildTraceSummariesAggregation(numOfTraces int) elastic.Agg
 		Order("max_start", false). // most recent traces first
 		SubAggregation("min_start", elastic.NewMinAggregation().Field(startTimeField)).
 		SubAggregation("max_start", elastic.NewMaxAggregation().Field(startTimeField)).
-		// max_end is derived by script: ES persists no end-time field (end = start + duration).
-		SubAggregation("max_end", elastic.NewMaxAggregation().
-			Script(elastic.NewScript("doc['"+startTimeField+"'].value + doc['"+durationField+"'].value"))).
+		// max_end reads the denormalized endTime field, so no Painless script is needed.
+		SubAggregation("max_end", elastic.NewMaxAggregation().Field(endTimeField)).
 		SubAggregation("error_count", elastic.NewFilterAggregation().Filter(errorFilter)).
 		SubAggregation("services", services).
 		SubAggregation("root_span", rootSpan)

--- a/internal/storage/v2/elasticsearch/tracestore/core/summary_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/summary_test.go
@@ -237,31 +237,6 @@ func TestSpanReader_FindTraceSummaries_SearchError(t *testing.T) {
 	})
 }
 
-// TestSpanReader_FindTraceSummaries_ScriptingDisabled verifies that a phase-2
-// failure caused by inline scripting being disabled is reported as
-// errors.ErrUnsupported, so the query service can fall back to client-side
-// aggregation instead of failing the request.
-func TestSpanReader_FindTraceSummaries_ScriptingDisabled(t *testing.T) {
-	withSpanReader(t, func(r *spanReaderTest) {
-		scriptErr := &elastic.Error{
-			Status: 400,
-			Details: &elastic.ErrorDetails{
-				Type:   "search_phase_execution_exception",
-				Reason: "all shards failed",
-				RootCause: []*elastic.ErrorDetails{
-					{Type: "illegal_argument_exception", Reason: "cannot execute [inline] scripts"},
-				},
-			},
-		}
-		ss := mockSummarySearchServiceObj(r)
-		ss.On("Do", mock.Anything).Return(traceIDsResult(), nil).Once()
-		ss.On("Do", mock.Anything).Return(nil, scriptErr).Once()
-
-		_, err := r.reader.FindTraceSummaries(context.Background(), validSummaryQuery())
-		require.ErrorIs(t, err, errors.ErrUnsupported)
-	})
-}
-
 // TestSpanReader_FindTraceSummaries_PreMigrationRoot covers traces written before
 // #8859, where no span stores a parentSpanID so every span matches the parentless
 // filter; Elasticsearch's startTime-ascending sort then makes the earliest span

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01.json
@@ -24,6 +24,7 @@
   "startTime": 1485467191639875,
   "startTimeMillis": 1485467191639,
   "duration": 5,
+  "endTime": 1485467191639880,
   "tags": [
     {
       "key": "otel.scope.name",

--- a/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
+++ b/internal/storage/v2/elasticsearch/tracestore/fixtures/es_01_string_tags.json
@@ -24,6 +24,7 @@
   "startTime": 1485467191639875,
   "startTimeMillis": 1485467191639,
   "duration": 5,
+  "endTime": 1485467191639880,
   "tags": [
     {
       "key": "otel.scope.name",

--- a/internal/storage/v2/elasticsearch/tracestore/summary.go
+++ b/internal/storage/v2/elasticsearch/tracestore/summary.go
@@ -35,9 +35,7 @@ func NewReaderWithSummaries(p core.SpanReaderParams) *ReaderWithSummaries {
 }
 
 // FindTraceSummaries implements tracestore.SummaryReader by delegating to the
-// core reader's native aggregation. When the backend cannot compute summaries
-// (e.g. Painless scripting is disabled) the core yields errors.ErrUnsupported,
-// and the query service falls back to client-side aggregation.
+// core reader's native aggregation and converting the results to the domain model.
 func (t *ReaderWithSummaries) FindTraceSummaries(ctx context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
 	return func(yield func([]tracestore.TraceSummary, error) bool) {
 		// The aggregation returns all matching summaries in a single ES response,

--- a/internal/storage/v2/elasticsearch/tracestore/summary_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/summary_test.go
@@ -92,9 +92,9 @@ func TestTraceReader_FindTraceSummaries_AggregatorError(t *testing.T) {
 }
 
 func TestTraceReader_FindTraceSummaries_PropagatesUnsupported(t *testing.T) {
-	// When the core reader reports the backend cannot compute summaries (e.g.
-	// scripting disabled), the wrapper propagates errors.ErrUnsupported so the
-	// query service falls back to client-side aggregation.
+	// The wrapper propagates errors.ErrUnsupported from the core unchanged, so the
+	// query service can fall back to client-side aggregation for any backend that
+	// signals it.
 	reader := ReaderWithSummaries{TraceReader: TraceReader{spanReader: stubSummaryReader{Reader: &mocks.Reader{}, err: errors.ErrUnsupported}}}
 	_, err := collectSummaries(reader.FindTraceSummaries(context.Background(), emptyQuery()))
 	require.ErrorIs(t, err, errors.ErrUnsupported)

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -127,6 +127,8 @@ func spanToDbSpan(span ptrace.Span, libraryTags pcommon.InstrumentationScope, pr
 	traceID := dbmodel.TraceID(span.TraceID().String())
 	parentSpanID := dbmodel.SpanID(span.ParentSpanID().String())
 	startTime := span.StartTimestamp().AsTime()
+	startMicros := model.TimeAsEpochMicroseconds(startTime)
+	durationMicros := model.DurationAsMicroseconds(span.EndTimestamp().AsTime().Sub(startTime))
 	return dbmodel.Span{
 		TraceID:       traceID,
 		SpanID:        dbmodel.SpanID(span.SpanID().String()),
@@ -136,9 +138,10 @@ func spanToDbSpan(span ptrace.Span, libraryTags pcommon.InstrumentationScope, pr
 		// only write actual span links here. Kept for now so older readers that
 		// derive the parent from references still work against the same index.
 		References:      linksToDbSpanRefs(span.Links(), parentSpanID, traceID),
-		StartTime:       model.TimeAsEpochMicroseconds(startTime),
-		StartTimeMillis: model.TimeAsEpochMicroseconds(startTime) / 1000,
-		Duration:        model.DurationAsMicroseconds(span.EndTimestamp().AsTime().Sub(startTime)),
+		StartTime:       startMicros,
+		StartTimeMillis: startMicros / 1000,
+		Duration:        durationMicros,
+		EndTime:         startMicros + durationMicros,
 		Tags:            getDbSpanTags(span, libraryTags),
 		Logs:            spanEventsToDbSpanLogs(span.Events()),
 		Process:         process,


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #8811 (parent issue #8606), addressing @yurishkuro's review comment https://github.com/jaegertracing/jaeger/pull/8812#issuecomment-4845876327: the native trace-summary aggregation derives each span's max end time with an inline Painless script (`startTime + duration`) because ES stores no end-time field. That makes the whole native path depend on inline scripting being enabled on the cluster, and requires an `ErrUnsupported` fallback for clusters where it is disabled.

## Description of the changes
- **Denormalize `endTime` onto the span at write time.** `spanToDbSpan` now sets `EndTime = StartTime + Duration` (microseconds), computed from the same values as the previous script so the aggregated result is unchanged.
- **Aggregate `max_end` over the field instead of a script.** `max_end` is now `max(endTime)`, removing the sole Painless dependency. The `isScriptingDisabledError` helper and the scripting-disabled `ErrUnsupported` branch are deleted, since that failure mode no longer exists.
- **Mappings.** Added `endTime` (`type: long`) to the span mappings (`jaeger-span-6/7/8` + OpenSearch variants) and their fixtures.
- **Docs/comments.** Updated the feature-gate description (dropped the "requires inline Painless scripts" note) and the related interface/wrapper comments.
- **Backward compatibility:** existing indices written before this change have no `endTime`, so their summaries report `MaxEndTime = 0`. This self-heals as indices rotate out on retention, so it's handled by graceful degradation rather than keeping a legacy script fallback.

## How was this change tested?
- Updated golden fixtures (`es_01.json`, `es_01_string_tags.json`) now assert the marshaled `endTime`; the mapping fixture tests (`TestMappingBuilderGetMapping` / `_OpenSearch`) assert the new field across all ES/OpenSearch versions.
- Unit tests pass for the changed packages (`internal/storage/v2/elasticsearch/...`, `internal/storage/v1/elasticsearch/mappings`).
- The shared integration test `testFindTraceSummaries` exercises the field-based `max_end` end-to-end (writes a fresh trace, asserts a non-zero `MaxEndTime`).
- `make lint` (golangci-lint) is clean.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)