### PR TITLE
feat(ai-gateway): Add session-scoped MCP endpoint and session-stream registry

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
@@ -12,6 +12,7 @@ import (
 
 	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	acp "github.com/coder/acp-go-sdk"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/version"
@@ -27,8 +28,12 @@ type ChatRequest = aguitypes.RunAgentInput
 // resulting ACP notifications are streamed back to the caller as AG-UI SSE
 // events.
 type ChatHandler struct {
-	Logger             *zap.Logger
-	ctxTools           *ContextualToolsStore
+	Logger   *zap.Logger
+	ctxTools *ContextualToolsStore
+	// streams registers this turn's SSE streaming client under a session id so
+	// the session-scoped MCP endpoint can confirm the id belongs to an active
+	// turn. May be nil in tests that do not exercise session registration.
+	streams            *sessionStreams
 	sidecarWSURL       string
 	basePath           string
 	maxRequestBodySize int64
@@ -115,6 +120,18 @@ func (h *ChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer adapter.Close()
 
 	clientImpl := newStreamingClient(ctx, w, req.ThreadID, req.RunID)
+
+	// Register this turn's stream under a freshly-minted session id so the
+	// session-scoped MCP endpoint (/api/ai/mcp/<id>/) can confirm the id
+	// belongs to an active turn. The id is minted here rather than reusing the
+	// ACP session id because the endpoint URL must be constructible before
+	// session/new returns; announcing that URL to the sidecar is a follow-up.
+	if h.streams != nil {
+		mcpSessionID := uuid.NewString()
+		h.streams.set(mcpSessionID, clientImpl)
+		defer h.streams.delete(mcpSessionID)
+	}
+
 	// Build the ACP connection ourselves so the inbound dispatcher can
 	// route both standard ACP methods (session/update etc.) and our
 	// extension method (ExtMethodJaegerToolCall) — the SDK's

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler.go
@@ -15,8 +15,84 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 	"github.com/jaegertracing/jaeger/internal/version"
 )
+
+// Handler is the entry point for the jaeger-query AI gateway. It owns the
+// per-turn contextual tools store, the session-stream registry, and the chat
+// handler, and registers them on the caller-provided mux (see RegisterRoutes in
+// routes.go).
+//
+// Callers construct a Handler once (in jaegerquery's Start path), then call
+// RegisterRoutes when wiring the HTTP mux. This mirrors the APIHandler /
+// HTTPGateway pattern used by sibling jaeger-query subsystems and keeps all
+// AI dependencies inside the jaegerai package.
+type Handler struct {
+	logger *zap.Logger
+	// store and streams are two per-session registries that are separate only
+	// during this transition, because they're keyed differently: store by the
+	// ACP session id (read by the ext-method tool-call dispatch), streams by the
+	// gateway-minted UUID in the session-scoped MCP URL — and there is no bridge
+	// between the two ids. Once UI tools are served over the MCP endpoint and the
+	// ext-method path is retired, they collapse into one session container keyed
+	// by the UUID.
+	store              *ContextualToolsStore
+	streams            *sessionStreams
+	agentURL           string
+	basePath           string
+	maxRequestBodySize int64
+	// mcpHandler serves the session-scoped MCP endpoint. Non-nil only when the
+	// operator enabled MCP (HandlerParams.EnableMCP); otherwise the endpoint is
+	// not mounted and the gateway advertises AI chat only.
+	mcpHandler http.Handler
+}
+
+// HandlerParams carries the dependencies for the AI gateway Handler. Grouping
+// them in a struct keeps the constructor readable as the gateway gains MCP
+// wiring (query service, tenancy, telemetry) on top of the chat parameters.
+type HandlerParams struct {
+	Logger             *zap.Logger
+	AgentURL           string
+	BasePath           string
+	MaxRequestBodySize int64
+	// EnableMCP mounts the session-scoped telemetry MCP endpoint. When false,
+	// only the chat endpoint is registered.
+	EnableMCP    bool
+	QueryService *querysvc.QueryService
+	TenancyMgr   *tenancy.Manager
+	Telset       telemetry.Settings
+}
+
+// NewHandler constructs a jaegerai.Handler with a freshly-allocated
+// ContextualToolsStore and sessionStreams. basePath is normalized once so the
+// registered mux patterns use a single canonical prefix. When p.EnableMCP is
+// set, the session-scoped MCP handler is built from the supplied query service,
+// tenancy manager, and telemetry settings.
+func NewHandler(p HandlerParams) *Handler {
+	basePath := normalizeBasePath(p.BasePath)
+	h := &Handler{
+		logger:             p.Logger,
+		store:              NewContextualToolsStore(),
+		streams:            newSessionStreams(),
+		agentURL:           p.AgentURL,
+		basePath:           basePath,
+		maxRequestBodySize: p.MaxRequestBodySize,
+	}
+	if p.EnableMCP {
+		mcpHandler := mcptools.NewHandler(p.Telset, p.QueryService, p.TenancyMgr, mcptools.DefaultConfig())
+		h.mcpHandler = &mcpSessionHandler{
+			telemetryHandler: mcpHandler,
+			streams:          h.streams,
+			basePath:         basePath,
+			logger:           p.Logger,
+		}
+	}
+	return h
+}
 
 // ChatRequest is the AG-UI payload accepted by the chat endpoint. It is the
 // AG-UI RunAgentInput shape — messages, tools, context, thread/run ids — so

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/handler_test.go
@@ -235,6 +235,34 @@ func TestChatHandlerSendsACPProtocolRequests(t *testing.T) {
 	require.Empty(t, rr.Header().Get("Connection"), "Connection is a hop-by-hop header managed by net/http")
 }
 
+func TestChatHandlerRegistersSessionStreamForTurn(t *testing.T) {
+	streams := newSessionStreams()
+	var duringTurn int
+	agent := &mockACPAgent{
+		// Observe the registry mid-turn: by the time Prompt runs, the chat
+		// handler has registered this turn's stream.
+		promptHook: func(context.Context, *acp.AgentSideConnection, acp.PromptRequest) {
+			duringTurn = streams.count()
+		},
+	}
+	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
+	defer cleanup()
+
+	handler := NewChatHandler(zap.NewNop(), nil, wsURL, "", 1<<20)
+	handler.streams = streams
+
+	reqBody, err := json.Marshal(newAGUIRequest("where is the latency"))
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(reqBody))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body=%q", rr.Body.String())
+	assert.Equal(t, 1, duringTurn, "the turn's stream must be registered while the turn is in flight")
+	assert.Equal(t, 0, streams.count(), "the stream must be removed at end of turn")
+}
+
 func TestChatHandlerAppendsContextEntriesToPromptBlocks(t *testing.T) {
 	agent := &mockACPAgent{}
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint.go
@@ -5,16 +5,27 @@ package jaegerai
 
 import (
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 )
 
-// routeMCPSession is the session-scoped MCP path. The trailing {sessionID}
-// wildcard makes it strictly more specific than the session-free
-// "/api/ai/mcp/" pattern jaeger-query mounts, so the two coexist on the same
-// mux without conflict: a bare "/api/ai/mcp/" hits the session-free handler,
-// while "/api/ai/mcp/<id>/..." hits this one.
-const routeMCPSession = "/api/ai/mcp/{sessionID}/"
+// routeMCPSession and routeMCPSessionNoSlash are the session-scoped MCP
+// patterns. Both are strictly more specific than the session-free
+// "/api/ai/mcp/" pattern jaeger-query mounts, so all three coexist on one mux:
+//
+//	/api/ai/mcp/           → session-free handler (jaeger-query)
+//	/api/ai/mcp/<id>       → session-scoped (this handler)
+//	/api/ai/mcp/<id>/...   → session-scoped (this handler)
+//
+// Registering both the slash and no-slash forms is deliberate: without the
+// no-slash pattern, a client dialing "/api/ai/mcp/<id>" (no trailing slash)
+// would fall through to the session-free subtree pattern instead of reaching
+// the session-scoped handler.
+const (
+	routeMCPSession        = "/api/ai/mcp/{sessionID}/"
+	routeMCPSessionNoSlash = "/api/ai/mcp/{sessionID}"
+)
 
 // mcpSessionHandler serves the session-scoped MCP endpoint. It advertises the
 // same telemetry tools as the session-free endpoint, but only for a session id
@@ -22,12 +33,13 @@ const routeMCPSession = "/api/ai/mcp/{sessionID}/"
 // to an active turn is what will let a later change layer that turn's UI tools
 // on top; for now it gates access and returns telemetry tools.
 type mcpSessionHandler struct {
-	// telemetry is the shared telemetry MCP handler (mcptools.NewHandler). It is
-	// path-agnostic, so we strip the session prefix and hand it a clean root.
-	telemetry http.Handler
-	streams   *sessionStreams
-	basePath  string
-	logger    *zap.Logger
+	// telemetryHandler is the shared telemetry MCP handler (mcptools.NewHandler).
+	// It is path-agnostic, so we strip the session prefix and hand it a clean
+	// root.
+	telemetryHandler http.Handler
+	streams          *sessionStreams
+	basePath         string
+	logger           *zap.Logger
 }
 
 func (h *mcpSessionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +52,16 @@ func (h *mcpSessionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Strip "<basePath>/api/ai/mcp/<sessionID>" so the wrapped MCP handler sees
-	// its own root (matching how the session-free endpoint is mounted).
+	// its own root. The no-slash form strips to "", which we normalize to "/".
+	// Our routes carry no percent-encoding past the UUID, so Path is canonical
+	// and RawPath is cleared.
 	prefix := h.basePath + "/api/ai/mcp/" + sessionID
-	http.StripPrefix(prefix, h.telemetry).ServeHTTP(w, r)
+	rest := strings.TrimPrefix(r.URL.Path, prefix)
+	if rest == "" {
+		rest = "/"
+	}
+	rewritten := r.Clone(r.Context())
+	rewritten.URL.Path = rest
+	rewritten.URL.RawPath = ""
+	h.telemetryHandler.ServeHTTP(w, rewritten)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerai
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// routeMCPSession is the session-scoped MCP path. The trailing {sessionID}
+// wildcard makes it strictly more specific than the session-free
+// "/api/ai/mcp/" pattern jaeger-query mounts, so the two coexist on the same
+// mux without conflict: a bare "/api/ai/mcp/" hits the session-free handler,
+// while "/api/ai/mcp/<id>/..." hits this one.
+const routeMCPSession = "/api/ai/mcp/{sessionID}/"
+
+// mcpSessionHandler serves the session-scoped MCP endpoint. It advertises the
+// same telemetry tools as the session-free endpoint, but only for a session id
+// that belongs to an active chat turn (registered in sessionStreams). Scoping
+// to an active turn is what will let a later change layer that turn's UI tools
+// on top; for now it gates access and returns telemetry tools.
+type mcpSessionHandler struct {
+	// telemetry is the shared telemetry MCP handler (mcptools.NewHandler). It is
+	// path-agnostic, so we strip the session prefix and hand it a clean root.
+	telemetry http.Handler
+	streams   *sessionStreams
+	basePath  string
+	logger    *zap.Logger
+}
+
+func (h *mcpSessionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("sessionID")
+	if h.streams.get(sessionID) == nil {
+		// Unknown or expired session id: the scoped endpoint is only valid
+		// during an active chat turn, so a missing entry is a client error.
+		h.logger.Debug("session-scoped MCP request for unknown session", zap.String("session_id", sessionID))
+		http.NotFound(w, r)
+		return
+	}
+	// Strip "<basePath>/api/ai/mcp/<sessionID>" so the wrapped MCP handler sees
+	// its own root (matching how the session-free endpoint is mounted).
+	prefix := h.basePath + "/api/ai/mcp/" + sessionID
+	http.StripPrefix(prefix, h.telemetry).ServeHTTP(w, r)
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint_test.go
@@ -13,8 +13,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// newTestMCPMux mounts an mcpSessionHandler on a mux at the given base path,
-// backed by a stub telemetry handler that records the (post-strip) path it saw.
+// newTestMCPMux mounts an mcpSessionHandler on a mux (both the slash and
+// no-slash session patterns, as RegisterRoutes does), backed by a stub
+// telemetry handler that records the (post-strip) path it saw.
 func newTestMCPMux(t *testing.T, basePath string, streams *sessionStreams) (*http.ServeMux, *string) {
 	t.Helper()
 	var seenPath string
@@ -23,27 +24,39 @@ func newTestMCPMux(t *testing.T, basePath string, streams *sessionStreams) (*htt
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("telemetry"))
 	})
-	h := &mcpSessionHandler{telemetry: stub, streams: streams, basePath: basePath, logger: zap.NewNop()}
+	h := &mcpSessionHandler{telemetryHandler: stub, streams: streams, basePath: basePath, logger: zap.NewNop()}
 	mux := http.NewServeMux()
 	mux.Handle(basePath+routeMCPSession, h)
+	mux.Handle(basePath+routeMCPSessionNoSlash, h)
 	return mux, &seenPath
 }
 
 func TestMCPSessionHandlerServesActiveSession(t *testing.T) {
+	// The session prefix must be stripped so the telemetry handler sees its own
+	// root, for the trailing-slash, subpath, and no-slash forms alike.
+	cases := []struct {
+		reqSuffix    string
+		wantSeenPath string
+	}{
+		{"/api/ai/mcp/sess-1/mcp", "/mcp"},
+		{"/api/ai/mcp/sess-1/", "/"},
+		{"/api/ai/mcp/sess-1", "/"}, // no trailing slash normalizes to root
+	}
 	for _, basePath := range []string{"", "/jaeger"} {
-		t.Run("base path "+basePath, func(t *testing.T) {
-			streams := newSessionStreams()
-			streams.set("sess-1", testStreamingClient())
-			mux, seenPath := newTestMCPMux(t, basePath, streams)
+		for _, tc := range cases {
+			t.Run(basePath+tc.reqSuffix, func(t *testing.T) {
+				streams := newSessionStreams()
+				streams.set("sess-1", testStreamingClient())
+				mux, seenPath := newTestMCPMux(t, basePath, streams)
 
-			rr := httptest.NewRecorder()
-			mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, basePath+"/api/ai/mcp/sess-1/mcp", http.NoBody))
+				rr := httptest.NewRecorder()
+				mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, basePath+tc.reqSuffix, http.NoBody))
 
-			require.Equal(t, http.StatusOK, rr.Code)
-			assert.Equal(t, "telemetry", rr.Body.String())
-			// Session prefix stripped: the telemetry handler sees a clean root.
-			assert.Equal(t, "/mcp", *seenPath)
-		})
+				require.Equal(t, http.StatusOK, rr.Code)
+				assert.Equal(t, "telemetry", rr.Body.String())
+				assert.Equal(t, tc.wantSeenPath, *seenPath)
+			})
+		}
 	}
 }
 
@@ -51,9 +64,12 @@ func TestMCPSessionHandlerRejectsUnknownSession(t *testing.T) {
 	streams := newSessionStreams() // empty: no active sessions
 	mux, seenPath := newTestMCPMux(t, "", streams)
 
-	rr := httptest.NewRecorder()
-	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/ghost/mcp", http.NoBody))
-
-	require.Equal(t, http.StatusNotFound, rr.Code)
-	assert.Empty(t, *seenPath, "telemetry handler must not be reached for an unknown session")
+	for _, reqPath := range []string{"/api/ai/mcp/ghost/mcp", "/api/ai/mcp/ghost"} {
+		t.Run(reqPath, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, reqPath, http.NoBody))
+			require.Equal(t, http.StatusNotFound, rr.Code)
+			assert.Empty(t, *seenPath, "telemetry handler must not be reached for an unknown session")
+		})
+	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/mcp_endpoint_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerai
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// newTestMCPMux mounts an mcpSessionHandler on a mux at the given base path,
+// backed by a stub telemetry handler that records the (post-strip) path it saw.
+func newTestMCPMux(t *testing.T, basePath string, streams *sessionStreams) (*http.ServeMux, *string) {
+	t.Helper()
+	var seenPath string
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("telemetry"))
+	})
+	h := &mcpSessionHandler{telemetry: stub, streams: streams, basePath: basePath, logger: zap.NewNop()}
+	mux := http.NewServeMux()
+	mux.Handle(basePath+routeMCPSession, h)
+	return mux, &seenPath
+}
+
+func TestMCPSessionHandlerServesActiveSession(t *testing.T) {
+	for _, basePath := range []string{"", "/jaeger"} {
+		t.Run("base path "+basePath, func(t *testing.T) {
+			streams := newSessionStreams()
+			streams.set("sess-1", testStreamingClient())
+			mux, seenPath := newTestMCPMux(t, basePath, streams)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, basePath+"/api/ai/mcp/sess-1/mcp", http.NoBody))
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, "telemetry", rr.Body.String())
+			// Session prefix stripped: the telemetry handler sees a clean root.
+			assert.Equal(t, "/mcp", *seenPath)
+		})
+	}
+}
+
+func TestMCPSessionHandlerRejectsUnknownSession(t *testing.T) {
+	streams := newSessionStreams() // empty: no active sessions
+	mux, seenPath := newTestMCPMux(t, "", streams)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/ghost/mcp", http.NoBody))
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Empty(t, *seenPath, "telemetry handler must not be reached for an unknown session")
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
@@ -6,13 +6,6 @@ package jaegerai
 import (
 	"net/http"
 	"strings"
-
-	"go.uber.org/zap"
-
-	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
-	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
-	"github.com/jaegertracing/jaeger/internal/telemetry"
-	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 const routeChat = "/api/ai/chat"
@@ -26,70 +19,6 @@ func normalizeBasePath(basePath string) string {
 		return ""
 	}
 	return strings.TrimSuffix(basePath, "/")
-}
-
-// Handler is the entry point for the jaeger-query AI gateway. It owns the
-// per-turn contextual tools store, the session-stream registry, and the chat
-// handler, and registers them on the caller-provided mux.
-//
-// Callers construct a Handler once (in jaegerquery's Start path), then call
-// RegisterRoutes when wiring the HTTP mux. This mirrors the APIHandler /
-// HTTPGateway pattern used by sibling jaeger-query subsystems and keeps all
-// AI dependencies inside the jaegerai package.
-type Handler struct {
-	logger             *zap.Logger
-	store              *ContextualToolsStore
-	streams            *sessionStreams
-	agentURL           string
-	basePath           string
-	maxRequestBodySize int64
-	// mcpHandler serves the session-scoped MCP endpoint. Non-nil only when the
-	// operator enabled MCP (Deps.EnableMCP); otherwise the endpoint is not
-	// mounted and the gateway advertises AI chat only.
-	mcpHandler http.Handler
-}
-
-// Deps carries the dependencies for the AI gateway Handler. Grouping them in a
-// struct keeps the constructor readable as the gateway gains MCP wiring
-// (query service, tenancy, telemetry) on top of the chat parameters.
-type Deps struct {
-	Logger             *zap.Logger
-	AgentURL           string
-	BasePath           string
-	MaxRequestBodySize int64
-	// EnableMCP mounts the session-scoped telemetry MCP endpoint. When false,
-	// only the chat endpoint is registered.
-	EnableMCP    bool
-	QueryService *querysvc.QueryService
-	TenancyMgr   *tenancy.Manager
-	Telset       telemetry.Settings
-}
-
-// NewHandler constructs a jaegerai.Handler with a freshly-allocated
-// ContextualToolsStore and sessionStreams. basePath is normalized once so the
-// registered mux patterns use a single canonical prefix. When d.EnableMCP is
-// set, the session-scoped MCP handler is built from the supplied query service,
-// tenancy manager, and telemetry settings.
-func NewHandler(d Deps) *Handler {
-	basePath := normalizeBasePath(d.BasePath)
-	h := &Handler{
-		logger:             d.Logger,
-		store:              NewContextualToolsStore(),
-		streams:            newSessionStreams(),
-		agentURL:           d.AgentURL,
-		basePath:           basePath,
-		maxRequestBodySize: d.MaxRequestBodySize,
-	}
-	if d.EnableMCP {
-		mcpHandler := mcptools.NewHandler(d.Telset, d.QueryService, d.TenancyMgr, mcptools.DefaultConfig())
-		h.mcpHandler = &mcpSessionHandler{
-			telemetryHandler: mcpHandler,
-			streams:          h.streams,
-			basePath:         basePath,
-			logger:           d.Logger,
-		}
-	}
-	return h
 }
 
 // RegisterRoutes mounts the AI gateway endpoints on the provided mux:

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
@@ -83,10 +83,10 @@ func NewHandler(d Deps) *Handler {
 	if d.EnableMCP {
 		telemetryHandler := mcptools.NewHandler(d.Telset, d.QueryService, d.TenancyMgr, mcptools.DefaultConfig())
 		h.mcpHandler = &mcpSessionHandler{
-			telemetry: telemetryHandler,
-			streams:   h.streams,
-			basePath:  basePath,
-			logger:    d.Logger,
+			telemetryHandler: telemetryHandler,
+			streams:          h.streams,
+			basePath:         basePath,
+			logger:           d.Logger,
 		}
 	}
 	return h
@@ -95,9 +95,10 @@ func NewHandler(d Deps) *Handler {
 // RegisterRoutes mounts the AI gateway endpoints on the provided mux:
 //
 //   - <basePath>/api/ai/chat              — streams ACP turns to/from the sidecar.
-//   - <basePath>/api/ai/mcp/<id>/         — session-scoped MCP endpoint (only
-//     when MCP is enabled). The {sessionID} wildcard is more specific than the
-//     session-free "/api/ai/mcp/" pattern jaeger-query mounts, so both coexist.
+//   - <basePath>/api/ai/mcp/<id>[/...]    — session-scoped MCP endpoint (only
+//     when MCP is enabled). Both the slash and no-slash forms are mounted; the
+//     {sessionID} wildcard is more specific than the session-free
+//     "/api/ai/mcp/" pattern jaeger-query mounts, so all coexist.
 func (h *Handler) RegisterRoutes(router *http.ServeMux) {
 	chat := NewChatHandler(h.logger, h.store, h.agentURL, h.basePath, h.maxRequestBodySize)
 	chat.streams = h.streams
@@ -105,5 +106,6 @@ func (h *Handler) RegisterRoutes(router *http.ServeMux) {
 
 	if h.mcpHandler != nil {
 		router.Handle(h.basePath+routeMCPSession, h.mcpHandler)
+		router.Handle(h.basePath+routeMCPSessionNoSlash, h.mcpHandler)
 	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
@@ -81,9 +81,9 @@ func NewHandler(d Deps) *Handler {
 		maxRequestBodySize: d.MaxRequestBodySize,
 	}
 	if d.EnableMCP {
-		telemetryHandler := mcptools.NewHandler(d.Telset, d.QueryService, d.TenancyMgr, mcptools.DefaultConfig())
+		mcpHandler := mcptools.NewHandler(d.Telset, d.QueryService, d.TenancyMgr, mcptools.DefaultConfig())
 		h.mcpHandler = &mcpSessionHandler{
-			telemetryHandler: telemetryHandler,
+			telemetryHandler: mcpHandler,
 			streams:          h.streams,
 			basePath:         basePath,
 			logger:           d.Logger,

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 const routeChat = "/api/ai/chat"
@@ -24,8 +29,8 @@ func normalizeBasePath(basePath string) string {
 }
 
 // Handler is the entry point for the jaeger-query AI gateway. It owns the
-// per-turn contextual tools store and the chat handler, and registers them
-// on the caller-provided mux.
+// per-turn contextual tools store, the session-stream registry, and the chat
+// handler, and registers them on the caller-provided mux.
 //
 // Callers construct a Handler once (in jaegerquery's Start path), then call
 // RegisterRoutes when wiring the HTTP mux. This mirrors the APIHandler /
@@ -34,30 +39,71 @@ func normalizeBasePath(basePath string) string {
 type Handler struct {
 	logger             *zap.Logger
 	store              *ContextualToolsStore
+	streams            *sessionStreams
 	agentURL           string
 	basePath           string
 	maxRequestBodySize int64
+	// mcpHandler serves the session-scoped MCP endpoint. Non-nil only when the
+	// operator enabled MCP (Deps.EnableMCP); otherwise the endpoint is not
+	// mounted and the gateway advertises AI chat only.
+	mcpHandler http.Handler
+}
+
+// Deps carries the dependencies for the AI gateway Handler. Grouping them in a
+// struct keeps the constructor readable as the gateway gains MCP wiring
+// (query service, tenancy, telemetry) on top of the chat parameters.
+type Deps struct {
+	Logger             *zap.Logger
+	AgentURL           string
+	BasePath           string
+	MaxRequestBodySize int64
+	// EnableMCP mounts the session-scoped telemetry MCP endpoint. When false,
+	// only the chat endpoint is registered.
+	EnableMCP    bool
+	QueryService *querysvc.QueryService
+	TenancyMgr   *tenancy.Manager
+	Telset       telemetry.Settings
 }
 
 // NewHandler constructs a jaegerai.Handler with a freshly-allocated
-// ContextualToolsStore. agentURL is the WebSocket endpoint of the ACP
-// sidecar; basePath is the jaeger-query base path used to prefix the AI
-// routes. maxRequestBodySize bounds the chat request body to prevent abuse.
-//
-// basePath is normalized once so the registered mux pattern uses a single
-// canonical prefix.
-func NewHandler(logger *zap.Logger, agentURL, basePath string, maxRequestBodySize int64) *Handler {
-	return &Handler{
-		logger:             logger,
+// ContextualToolsStore and sessionStreams. basePath is normalized once so the
+// registered mux patterns use a single canonical prefix. When d.EnableMCP is
+// set, the session-scoped MCP handler is built from the supplied query service,
+// tenancy manager, and telemetry settings.
+func NewHandler(d Deps) *Handler {
+	basePath := normalizeBasePath(d.BasePath)
+	h := &Handler{
+		logger:             d.Logger,
 		store:              NewContextualToolsStore(),
-		agentURL:           agentURL,
-		basePath:           normalizeBasePath(basePath),
-		maxRequestBodySize: maxRequestBodySize,
+		streams:            newSessionStreams(),
+		agentURL:           d.AgentURL,
+		basePath:           basePath,
+		maxRequestBodySize: d.MaxRequestBodySize,
 	}
+	if d.EnableMCP {
+		telemetryHandler := mcptools.NewHandler(d.Telset, d.QueryService, d.TenancyMgr, mcptools.DefaultConfig())
+		h.mcpHandler = &mcpSessionHandler{
+			telemetry: telemetryHandler,
+			streams:   h.streams,
+			basePath:  basePath,
+			logger:    d.Logger,
+		}
+	}
+	return h
 }
 
-// RegisterRoutes mounts the AI gateway endpoints on the provided mux. The
-// chat endpoint streams ACP turns to/from the sidecar.
+// RegisterRoutes mounts the AI gateway endpoints on the provided mux:
+//
+//   - <basePath>/api/ai/chat              — streams ACP turns to/from the sidecar.
+//   - <basePath>/api/ai/mcp/<id>/         — session-scoped MCP endpoint (only
+//     when MCP is enabled). The {sessionID} wildcard is more specific than the
+//     session-free "/api/ai/mcp/" pattern jaeger-query mounts, so both coexist.
 func (h *Handler) RegisterRoutes(router *http.ServeMux) {
-	router.HandleFunc(h.basePath+routeChat, NewChatHandler(h.logger, h.store, h.agentURL, h.basePath, h.maxRequestBodySize).ServeHTTP)
+	chat := NewChatHandler(h.logger, h.store, h.agentURL, h.basePath, h.maxRequestBodySize)
+	chat.streams = h.streams
+	router.HandleFunc(h.basePath+routeChat, chat.ServeHTTP)
+
+	if h.mcpHandler != nil {
+		router.Handle(h.basePath+routeMCPSession, h.mcpHandler)
+	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewHandlerInitialisesStore(t *testing.T) {
-	h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://example", BasePath: "/jaeger", MaxRequestBodySize: 1 << 20})
+	h := NewHandler(HandlerParams{Logger: zap.NewNop(), AgentURL: "ws://example", BasePath: "/jaeger", MaxRequestBodySize: 1 << 20})
 	require.NotNil(t, h.store, "NewHandler must allocate a ContextualToolsStore")
 	require.NotNil(t, h.streams, "NewHandler must allocate a sessionStreams")
 	assert.Equal(t, "ws://example", h.agentURL)
@@ -61,7 +61,7 @@ func TestRegisterRoutesMountsChatEndpoint(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: tc.basePath, MaxRequestBodySize: 1 << 20})
+			h := NewHandler(HandlerParams{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: tc.basePath, MaxRequestBodySize: 1 << 20})
 			mux := http.NewServeMux()
 			h.RegisterRoutes(mux)
 
@@ -78,14 +78,14 @@ func TestRegisterRoutesMountsChatEndpoint(t *testing.T) {
 }
 
 func TestNewHandlerNormalizesTrailingSlash(t *testing.T) {
-	h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: "/jaeger/", MaxRequestBodySize: 1 << 20})
+	h := NewHandler(HandlerParams{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: "/jaeger/", MaxRequestBodySize: 1 << 20})
 	assert.Equal(t, "/jaeger", h.basePath, "NewHandler must trim the trailing slash")
 }
 
 func mcpEnabledHandler(t *testing.T, basePath string) *Handler {
 	t.Helper()
 	svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
-	return NewHandler(Deps{
+	return NewHandler(HandlerParams{
 		Logger:             zap.NewNop(),
 		AgentURL:           "ws://127.0.0.1:1",
 		BasePath:           basePath,
@@ -124,7 +124,7 @@ func TestRegisterRoutesMountsSessionScopedMCPWhenEnabled(t *testing.T) {
 }
 
 func TestRegisterRoutesOmitsMCPEndpointWhenDisabled(t *testing.T) {
-	h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: "", MaxRequestBodySize: 1 << 20})
+	h := NewHandler(HandlerParams{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: "", MaxRequestBodySize: 1 << 20})
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 	h.streams.set("sess-1", testStreamingClient())

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
@@ -11,14 +11,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
+	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
 
 func TestNewHandlerInitialisesStore(t *testing.T) {
-	h := NewHandler(zap.NewNop(), "ws://example", "/jaeger", 1<<20)
+	h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://example", BasePath: "/jaeger", MaxRequestBodySize: 1 << 20})
 	require.NotNil(t, h.store, "NewHandler must allocate a ContextualToolsStore")
+	require.NotNil(t, h.streams, "NewHandler must allocate a sessionStreams")
 	assert.Equal(t, "ws://example", h.agentURL)
 	assert.Equal(t, "/jaeger", h.basePath)
 	assert.Equal(t, int64(1<<20), h.maxRequestBodySize)
+	assert.Nil(t, h.mcpHandler, "MCP handler must be nil when EnableMCP is false")
 }
 
 func TestRegisterRoutesMountsChatEndpoint(t *testing.T) {
@@ -53,7 +61,7 @@ func TestRegisterRoutesMountsChatEndpoint(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewHandler(zap.NewNop(), "ws://127.0.0.1:1", tc.basePath, 1<<20)
+			h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: tc.basePath, MaxRequestBodySize: 1 << 20})
 			mux := http.NewServeMux()
 			h.RegisterRoutes(mux)
 
@@ -70,6 +78,52 @@ func TestRegisterRoutesMountsChatEndpoint(t *testing.T) {
 }
 
 func TestNewHandlerNormalizesTrailingSlash(t *testing.T) {
-	h := NewHandler(zap.NewNop(), "ws://127.0.0.1:1", "/jaeger/", 1<<20)
+	h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: "/jaeger/", MaxRequestBodySize: 1 << 20})
 	assert.Equal(t, "/jaeger", h.basePath, "NewHandler must trim the trailing slash")
+}
+
+func mcpEnabledHandler(t *testing.T, basePath string) *Handler {
+	t.Helper()
+	svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
+	return NewHandler(Deps{
+		Logger:             zap.NewNop(),
+		AgentURL:           "ws://127.0.0.1:1",
+		BasePath:           basePath,
+		MaxRequestBodySize: 1 << 20,
+		EnableMCP:          true,
+		QueryService:       svc,
+		TenancyMgr:         tenancy.NewManager(&tenancy.Options{}),
+		Telset:             telemetry.NoopSettings(),
+	})
+}
+
+func TestRegisterRoutesMountsSessionScopedMCPWhenEnabled(t *testing.T) {
+	h := mcpEnabledHandler(t, "")
+	require.NotNil(t, h.mcpHandler, "MCP handler must be built when EnableMCP is true")
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	h.streams.set("sess-1", testStreamingClient()) // active turn
+
+	t.Run("active session is served", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/sess-1/mcp", http.NoBody))
+		assert.NotEqual(t, http.StatusNotFound, rr.Code, "registered session must reach the MCP handler")
+	})
+
+	t.Run("unknown session is rejected", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/ghost/mcp", http.NoBody))
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+}
+
+func TestRegisterRoutesOmitsMCPEndpointWhenDisabled(t *testing.T) {
+	h := NewHandler(Deps{Logger: zap.NewNop(), AgentURL: "ws://127.0.0.1:1", BasePath: "", MaxRequestBodySize: 1 << 20})
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	h.streams.set("sess-1", testStreamingClient())
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/sess-1/mcp", http.NoBody))
+	assert.Equal(t, http.StatusNotFound, rr.Code, "session-scoped MCP endpoint must not be mounted when disabled")
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/routes_test.go
@@ -110,6 +110,12 @@ func TestRegisterRoutesMountsSessionScopedMCPWhenEnabled(t *testing.T) {
 		assert.NotEqual(t, http.StatusNotFound, rr.Code, "registered session must reach the MCP handler")
 	})
 
+	t.Run("active session is served without a trailing slash", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/sess-1", http.NoBody))
+		assert.NotEqual(t, http.StatusNotFound, rr.Code, "no-slash form must also reach the MCP handler")
+	})
+
 	t.Run("unknown session is rejected", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/ghost/mcp", http.NoBody))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerai
+
+import "sync"
+
+// sessionStreams maps a per-turn session id to the live SSE streaming client
+// for that chat turn. The chat handler mints a session id when it opens a turn,
+// registers the `*streamingClient` here, and removes it when the turn ends. The
+// session-scoped MCP endpoint (`/api/ai/mcp/<sessionId>/`) looks the id up to
+// confirm it belongs to an active turn before serving.
+//
+// It is the join key between the two halves of a session: the browser's SSE
+// stream (held by the chat handler) and the sidecar's MCP connection (dialed at
+// the session-scoped URL). Today it gates the endpoint to active turns; the UI
+// tool dispatch that pushes TOOL_CALL_* events onto the looked-up stream lands
+// in a follow-up.
+//
+// The registry is in-memory and tied to the process lifetime — ACP sessions are
+// scoped to a single HTTP chat request and the streaming client wraps a live
+// http.ResponseWriter, so there is nothing meaningful to persist.
+//
+// Methods are safe for concurrent use: the chat handler writes from the request
+// goroutine while the MCP endpoint reads from per-request goroutines. The map is
+// small (one entry per active chat) so a plain RWMutex is ample.
+type sessionStreams struct {
+	mu      sync.RWMutex
+	streams map[string]*streamingClient
+}
+
+// newSessionStreams returns an empty registry.
+func newSessionStreams() *sessionStreams {
+	return &sessionStreams{
+		streams: make(map[string]*streamingClient),
+	}
+}
+
+// set records the streaming client for sessionID. No-op on empty id or nil
+// client. Session ids are never reused across turns, so an overwrite indicates
+// a caller bug rather than a normal interleaving.
+func (s *sessionStreams) set(sessionID string, client *streamingClient) {
+	if sessionID == "" || client == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.streams[sessionID] = client
+}
+
+// get returns the streaming client for sessionID, or nil when no turn is active
+// for it. Returning nil (rather than an error) keeps the endpoint's call site
+// cheap: an unknown or expired id is a "not an active session" case, which the
+// endpoint maps to 404.
+func (s *sessionStreams) get(sessionID string) *streamingClient {
+	if sessionID == "" {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.streams[sessionID]
+}
+
+// delete removes sessionID. Idempotent: it runs from the chat handler's defer,
+// so it must not panic if set never ran (e.g. session/new failed).
+func (s *sessionStreams) delete(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.streams, sessionID)
+}
+
+// count returns the number of active sessions. Used by tests to observe the
+// register/deregister lifecycle without reaching into the guarded map.
+func (s *sessionStreams) count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.streams)
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerai
+
+import (
+	"context"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testStreamingClient() *streamingClient {
+	return newStreamingClient(context.Background(), httptest.NewRecorder(), "thread", "run")
+}
+
+func TestSessionStreamsSetGetDelete(t *testing.T) {
+	s := newSessionStreams()
+	client := testStreamingClient()
+
+	assert.Nil(t, s.get("missing"), "unknown id returns nil")
+
+	s.set("sess-1", client)
+	assert.Same(t, client, s.get("sess-1"), "get returns the registered client")
+
+	s.delete("sess-1")
+	assert.Nil(t, s.get("sess-1"), "get returns nil after delete")
+}
+
+func TestSessionStreamsIgnoresEmptyOrNil(t *testing.T) {
+	s := newSessionStreams()
+
+	s.set("", testStreamingClient()) // empty id: no-op
+	s.set("sess", nil)               // nil client: no-op
+	assert.Nil(t, s.get(""))
+	assert.Nil(t, s.get("sess"))
+
+	// delete is idempotent and safe when set never ran.
+	require.NotPanics(t, func() { s.delete("never-set") })
+	require.NotPanics(t, func() { s.delete("") })
+}
+
+func TestSessionStreamsConcurrent(t *testing.T) {
+	s := newSessionStreams()
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Go(func() {
+			id := strconv.Itoa(i)
+			s.set(id, testStreamingClient())
+			s.get(id)
+			s.delete(id)
+		})
+	}
+	wg.Wait()
+	// All entries deleted; nothing left behind.
+	assert.Equal(t, 0, s.count())
+	for i := 0; i < n; i++ {
+		assert.Nil(t, s.get(strconv.Itoa(i)))
+	}
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams_test.go
@@ -48,7 +48,7 @@ func TestSessionStreamsConcurrent(t *testing.T) {
 	s := newSessionStreams()
 	const n = 50
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
+	for i := range n {
 		id := strconv.Itoa(i) // precompute per iteration so each goroutine uses a distinct id
 		wg.Go(func() {
 			s.set(id, testStreamingClient())

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/session_streams_test.go
@@ -49,8 +49,8 @@ func TestSessionStreamsConcurrent(t *testing.T) {
 	const n = 50
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
+		id := strconv.Itoa(i) // precompute per iteration so each goroutine uses a distinct id
 		wg.Go(func() {
-			id := strconv.Itoa(i)
 			s.set(id, testStreamingClient())
 			s.get(id)
 			s.delete(id)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -214,14 +214,23 @@ func initRouter(
 				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
 			} else {
 				if aiCfg.AgentURL != "" {
-					jaegerai.NewHandler(
-						telset.Logger,
-						aiCfg.AgentURL,
-						queryOpts.BasePath,
-						aiCfg.MaxRequestBodySize,
-					).RegisterRoutes(r)
+					// When AI chat is enabled, jaegerai owns the chat endpoint and,
+					// if MCP is also enabled, the session-scoped MCP endpoint
+					// (/api/ai/mcp/<id>/).
+					jaegerai.NewHandler(jaegerai.Deps{
+						Logger:             telset.Logger,
+						AgentURL:           aiCfg.AgentURL,
+						BasePath:           queryOpts.BasePath,
+						MaxRequestBodySize: aiCfg.MaxRequestBodySize,
+						EnableMCP:          aiCfg.EnableMCP,
+						QueryService:       querySvc,
+						TenancyMgr:         tenancyMgr,
+						Telset:             telset,
+					}).RegisterRoutes(r)
 				}
 				if aiCfg.EnableMCP {
+					// Session-free telemetry endpoint (/api/ai/mcp/). Coexists with
+					// the wildcard session-scoped pattern above.
 					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, telset)
 				}
 			}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -217,7 +217,7 @@ func initRouter(
 					// When AI chat is enabled, jaegerai owns the chat endpoint and,
 					// if MCP is also enabled, the session-scoped MCP endpoint
 					// (/api/ai/mcp/<id>/).
-					jaegerai.NewHandler(jaegerai.Deps{
+					jaegerai.NewHandler(jaegerai.HandlerParams{
 						Logger:             telset.Logger,
 						AgentURL:           aiCfg.AgentURL,
 						BasePath:           queryOpts.BasePath,

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -1186,6 +1186,38 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 		require.NotEqual(t, http.StatusNotFound, rr.Code)
 	})
+
+	t.Run("chat and MCP both enabled: session-free and session-scoped endpoints coexist", func(t *testing.T) {
+		opts := DefaultQueryOptions()
+		opts.AI = configoptional.Some(AIConfig{AgentURL: "ws://127.0.0.1:1", EnableMCP: true, MaxRequestBodySize: 1 << 20})
+
+		// initRouter registers both /api/ai/mcp/ (session-free, jaeger-query)
+		// and /api/ai/mcp/{sessionID}/ (session-scoped, jaegerai) on the same
+		// mux. ServeMux panics on conflicting patterns, so a clean return here
+		// is itself the coexistence assertion.
+		handler, closer, err := initRouter(querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, closer.Close())
+		})
+
+		// Session-free endpoint is mounted.
+		freeRR := httptest.NewRecorder()
+		handler.ServeHTTP(freeRR, httptest.NewRequest(http.MethodGet, "/api/ai/mcp/", http.NoBody))
+		require.NotEqual(t, http.StatusNotFound, freeRR.Code, "session-free endpoint must be mounted")
+
+		// Session-scoped endpoint is mounted and takes precedence: an unknown
+		// session id reaches the session-scoped handler and is rejected (404).
+		// If it were NOT mounted, the session-free subtree pattern would match
+		// this path and serve telemetry (not 404) instead. Both the slash and
+		// no-slash forms must behave this way.
+		for _, scopedPath := range []string{"/api/ai/mcp/ghost/mcp", "/api/ai/mcp/ghost"} {
+			scopedRR := httptest.NewRecorder()
+			handler.ServeHTTP(scopedRR, httptest.NewRequest(http.MethodGet, scopedPath, http.NoBody))
+			require.Equal(t, http.StatusNotFound, scopedRR.Code,
+				"session-scoped endpoint must be mounted and reject unknown session at %s", scopedPath)
+		}
+	})
 }
 
 // TestRegisterMCPTools_BasePathNormalization checks the mount prefix directly

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gogo/googleapis v1.4.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/gnostic-models v0.7.1
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jaegertracing/jaeger-idl v0.9.0
@@ -185,7 +186,6 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #8890 (and #8874): unify AI agent tool dispatch through a
  gateway-side MCP server. #8894 added the session-free telemetry endpoint
  (`/api/ai/mcp/`); this PR adds the **session-scoped** endpoint
  (`/api/ai/mcp/<sessionId>/`) and the session-stream registry it hangs off,
  which later lets the gateway layer a chat turn's UI tools onto the telemetry
  tools and dispatch them back to the browser.

## Description of the changes
- Add a package-private `sessionStreams` registry (`jaegerai`): maps a
  per-turn session id to that turn's SSE `*streamingClient`. The chat handler
  mints a UUID per turn, registers the stream, and removes it when the turn
  ends. It is the join key between the browser's SSE stream and the sidecar's
  MCP connection.
- Add the session-scoped MCP endpoint `mcpSessionHandler`. It serves the same
  telemetry tools as the session-free endpoint, but only for a session id that
  belongs to an active chat turn (present in `sessionStreams`); an unknown or
  expired id returns 404. The `{sessionID}` wildcard pattern is strictly more
  specific than the session-free `/api/ai/mcp/` pattern, so the two coexist on
  the same mux.
- Wire it in: `jaegerai.NewHandler` takes a `Deps` struct and, when
  `enable_mcp` is set, mounts the session-scoped endpoint; jaeger-query threads
  its query service, tenancy manager, and telemetry settings through.
- The endpoint is gated on `enable_mcp && agent_url` (it lives in the AI chat
  handler's package). The session-free endpoint continues to be mounted
  independently whenever `enable_mcp` is set.

Out of scope (follow-ups): announcing the endpoint URL to the sidecar via
`NewSessionRequest.mcpServers`, layering per-session UI tools, and MCP-over-ACP.
The endpoint therefore serves telemetry tools identically to the session-free
one for now; it is the routing + registry foundation those changes build on.

## How was this change tested?
- New unit tests: `sessionStreams` (set/get/delete, empty/nil, concurrency);
  the endpoint (active session served with the session prefix stripped, unknown
  session → 404, base-path variants); the chat handler registers the stream
  during a turn and removes it at end of turn; and `NewHandler`/`RegisterRoutes`
  mount/omit the endpoint per `enable_mcp`.
- `go build ./...`, `golangci-lint`, goleak/nocover, and the full
  `cmd/jaeger/...` suite pass. Coverage: `jaegerai` 100%, `jaegerquery/internal`
  98.9%.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
