### PR TITLE
fix(jaegermcp): Enforce max_read_file_size exactly in read_skill

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -45,8 +45,13 @@ func (h *readSkillHandler) handle(
 	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, types.ReadSkillOutput{}, fmt.Errorf("cannot read %q: %w", input.Path, err)
 	}
+
+	truncated := n > int(h.maxFileSize)
+	if truncated {
+		n = int(h.maxFileSize)
+	}
 	content := string(buf[:n])
-	if n > int(h.maxFileSize) {
+	if truncated {
 		content += fmt.Sprintf("\n\nfile content truncated after %d bytes\n", h.maxFileSize)
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -5,6 +5,8 @@ package handlers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -82,6 +84,31 @@ func TestReadSkillHandler_FileTooLarge(t *testing.T) {
 	_, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "large.bin"})
 	require.NoError(t, err)
 	assert.Contains(t, output.Instructions, "truncated after")
+
+	body, _, found := strings.Cut(output.Instructions, "\n\nfile content truncated after")
+	require.True(t, found)
+	assert.Len(t, body, testMaxFileSize)
+}
+
+func TestReadSkillHandler_SizeLimitBoundary(t *testing.T) {
+	notice := fmt.Sprintf("\n\nfile content truncated after %d bytes\n", testMaxFileSize)
+	tests := []struct {
+		name string
+		size int
+		want string
+	}{
+		{"exactly at limit is not truncated", testMaxFileSize, strings.Repeat("x", testMaxFileSize)},
+		{"one byte over limit is truncated to the limit", testMaxFileSize + 1, strings.Repeat("x", testMaxFileSize) + notice},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fsys := fstest.MapFS{"f.md": &fstest.MapFile{Data: []byte(strings.Repeat("x", tt.size))}}
+			h := &readSkillHandler{skillsFS: fsys, maxFileSize: testMaxFileSize}
+			_, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "f.md"})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, output.Instructions)
+		})
+	}
 }
 
 func TestReadSkillHandler_RawTextInContent(t *testing.T) {


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #8911

## Description of the changes
- `read_skill` reads `maxFileSize+1` bytes as a sentinel to detect oversized files, but never trimmed the extra byte — so it served `maxFileSize+1` bytes and flagged files exactly one byte over the limit as truncated even though the whole file was returned.
- Trim the content back to `maxFileSize` when the sentinel byte is read, so the served size honors `max_read_file_size` exactly and the notice only appears when data is actually dropped.


## How was this change tested?
- Strengthened `TestReadSkillHandler_FileTooLarge` to assert the served body is exactly `maxFileSize` bytes.
- Added `TestReadSkillHandler_SizeLimitBoundary`: a file at the limit is returned whole; a file one byte over is capped to the limit plus the notice. Both fail against the pre-fix code.
- `go test ./cmd/jaeger/internal/extension/jaegermcp/...`, `go vet`, and `gofmt` all pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
