### PR TITLE
fix(ai-sidecar): Forward MCP server instructions to Gemini

### DIFF
--- a/scripts/ai-sidecar/gemini/mcp_bridge.py
+++ b/scripts/ai-sidecar/gemini/mcp_bridge.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from google.adk.tools.mcp_tool import MCPToolset, StreamableHTTPConnectionParams
 from google.genai import types
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_TOOL_NAME
 from opentelemetry.semconv.attributes.url_attributes import URL_FULL
 from opentelemetry.trace import Status, StatusCode
@@ -29,6 +31,7 @@ class JaegerMCPBridge:
         )
         self._tools_by_name: dict[str, Any] = {}
         self._gemini_tools: list[types.Tool] = []
+        self._instructions: str = ""
         self._initialized = False
 
     async def initialize(self) -> None:
@@ -83,6 +86,42 @@ class JaegerMCPBridge:
                 self._gemini_tools = []
 
             self._initialized = True
+
+        await self._fetch_instructions()
+
+    async def _fetch_instructions(self) -> None:
+        """Perform a lightweight MCP initialize handshake to retrieve the
+        server's `instructions` field, if any.
+
+        This is separate from tool discovery because MCPToolset does not
+        surface the initialize response. Failure here is non-fatal: tool
+        discovery has already succeeded by the time this runs, so we log a
+        warning and continue with no additional instructions rather than
+        aborting the request.
+        """
+        with tracer().start_as_current_span("mcp.fetch_instructions", attributes={
+            URL_FULL: self._mcp_url,
+        }) as span:
+            try:
+                async with asyncio.timeout(self._timeout_sec):
+                    async with streamablehttp_client(self._mcp_url) as (read, write, _):
+                        async with ClientSession(read, write) as session:
+                            result = await session.initialize()
+                            self._instructions = result.instructions or ""
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, description=str(exc)))
+                logger.warning(
+                    "Unable to retrieve MCP server instructions from %s; continuing without them. Error: %s",
+                    self._mcp_url,
+                    exc,
+                )
+                self._instructions = ""
+
+    @property
+    def instructions(self) -> str:
+        """The MCP server's `instructions` field, or empty string if unavailable."""
+        return self._instructions
 
     async def get_gemini_tools(self) -> list[types.Tool]:
         await self.initialize()

--- a/scripts/ai-sidecar/gemini/mcp_bridge.py
+++ b/scripts/ai-sidecar/gemini/mcp_bridge.py
@@ -85,9 +85,9 @@ class JaegerMCPBridge:
             else:
                 self._gemini_tools = []
 
-            self._initialized = True
+            await self._fetch_instructions()
 
-        await self._fetch_instructions()
+            self._initialized = True
 
     async def _fetch_instructions(self) -> None:
         """Perform a lightweight MCP initialize handshake to retrieve the

--- a/scripts/ai-sidecar/gemini/sidecar.py
+++ b/scripts/ai-sidecar/gemini/sidecar.py
@@ -312,7 +312,7 @@ class JaegerSidecarAgent(Agent):
             GEN_AI_REQUEST_MODEL: "gemini-2.5-flash",
         }):
             logger.info("Starting agentic Gemini loop for session %s", session_id)
-            system_instruction = (
+            base_system_instruction = (
                 "You are Jaeger AI, an assistant for distributed tracing investigations. "
                 "You will be given telemetry information from MCP tool results; treat that data as your source of truth. "
                 "When telemetry evidence is needed, request the MCP tool instead of answering from assumptions. "
@@ -327,6 +327,14 @@ class JaegerSidecarAgent(Agent):
             for tool in mcp_tools:
                 if tool.function_declarations:
                     mcp_tool_names.update(fd.name for fd in tool.function_declarations if fd.name)
+
+            # The MCP server's `instructions` field (from its initialize response),
+            # if any, is appended so Gemini sees tool-usage guidance the server
+            # itself provides, in addition to our base instruction.
+            if self._mcp.instructions:
+                system_instruction = f"{base_system_instruction}\n\n{self._mcp.instructions}"
+            else:
+                system_instruction = base_system_instruction
 
             contextual_tools = self._contextual_tools.get(session_id, [])
             contextual_tool_names = {t["name"] for t in contextual_tools if t.get("name")}

--- a/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
+++ b/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
@@ -4,19 +4,24 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from pathlib import Path
 from typing import Any
 from functools import partial
+from unittest.mock import patch
 
 import pytest
 import websockets
+from mcp.types import Implementation as MCPImplementation
+from mcp.types import InitializeResult, ServerCapabilities
 
 from acp import Agent, PROTOCOL_VERSION
 from acp.schema import AgentCapabilities, Implementation, ListSessionsResponse, LoadSessionResponse, NewSessionResponse, PromptResponse
 from acp.helpers import text_block, update_agent_message
 
 import sidecar
+from mcp_bridge import JaegerMCPBridge
 
 END_OF_TURN_MARKER = "__END_OF_TURN__"
 DEFAULT_PROMPT = "hello"
@@ -242,4 +247,102 @@ async def run_workflow_test(prompt: str, cwd: str) -> None:
 
 def test_complete_acp_workflow_with_fake_agent() -> None:
     asyncio.run(run_workflow_test(DEFAULT_PROMPT, DEFAULT_CWD))
+
+
+class _FakeInitializeSession:
+    """Stands in for mcp.ClientSession, returning a canned initialize result."""
+
+    def __init__(self, instructions: str | None) -> None:
+        self._instructions = instructions
+
+    async def __aenter__(self) -> "_FakeInitializeSession":
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def initialize(self) -> InitializeResult:
+        return InitializeResult(
+            protocolVersion="2025-06-18",
+            capabilities=ServerCapabilities(),
+            serverInfo=MCPImplementation(name="fake-mcp-server", version="0"),
+            instructions=self._instructions,
+        )
+
+
+@contextlib.asynccontextmanager
+async def _fake_streamablehttp_client(url: str, **kwargs: Any):
+    yield (None, None, None)
+
+
+def _patch_tool_discovery(bridge: JaegerMCPBridge) -> Any:
+    """Bypasses the real MCPToolset connection; tool discovery is not under test here."""
+
+    async def fake_get_tools() -> list[Any]:
+        return []
+
+    return patch.object(bridge._toolset, "get_tools", side_effect=fake_get_tools)
+
+
+def test_mcp_bridge_exposes_server_instructions() -> None:
+    """Regression test for #8897: JaegerMCPBridge must surface the MCP
+    server's `instructions` field from its initialize response, since
+    MCPToolset's tool discovery does not expose it."""
+
+    async def run() -> None:
+        bridge = JaegerMCPBridge("http://example.invalid/mcp", timeout_sec=5.0)
+        expected = "Always call list_traces before summarizing a service."
+
+        with (
+            _patch_tool_discovery(bridge),
+            patch("mcp_bridge.streamablehttp_client", _fake_streamablehttp_client),
+            patch("mcp_bridge.ClientSession", lambda *args, **kwargs: _FakeInitializeSession(expected)),
+        ):
+            await bridge.initialize()
+
+        assert bridge.instructions == expected
+
+    asyncio.run(run())
+
+
+def test_mcp_bridge_instructions_default_to_empty_string() -> None:
+    """An MCP server with no `instructions` field should not break the bridge."""
+
+    async def run() -> None:
+        bridge = JaegerMCPBridge("http://example.invalid/mcp", timeout_sec=5.0)
+
+        with (
+            _patch_tool_discovery(bridge),
+            patch("mcp_bridge.streamablehttp_client", _fake_streamablehttp_client),
+            patch("mcp_bridge.ClientSession", lambda *args, **kwargs: _FakeInitializeSession(None)),
+        ):
+            await bridge.initialize()
+
+        assert bridge.instructions == ""
+
+    asyncio.run(run())
+
+
+def test_mcp_bridge_instructions_handshake_failure_is_non_fatal() -> None:
+    """If the extra initialize handshake fails, tool discovery must still
+    succeed and `instructions` should fall back to an empty string rather
+    than raising."""
+
+    async def run() -> None:
+        bridge = JaegerMCPBridge("http://example.invalid/mcp", timeout_sec=5.0)
+
+        @contextlib.asynccontextmanager
+        async def _broken_streamablehttp_client(url: str, **kwargs: Any):
+            raise RuntimeError("connection refused")
+            yield  # pragma: no cover - unreachable, keeps this an async generator
+
+        with (
+            _patch_tool_discovery(bridge),
+            patch("mcp_bridge.streamablehttp_client", _broken_streamablehttp_client),
+        ):
+            await bridge.initialize()
+
+        assert bridge.instructions == ""
+
+    asyncio.run(run())
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #8897

## Description of the changes
- `JaegerMCPBridge` (mcp_bridge.py) now performs a separate, lightweight MCP `initialize` handshake via the `mcp` SDK's `streamablehttp_client` + `ClientSession`, since `MCPToolset` (used for tool discovery) does not surface the server's `initialize` response.
- The retrieved `instructions` field is stored and exposed via a new read-only `instructions` property on `JaegerMCPBridge`.
- If the handshake fails, it's logged as a warning and `instructions` falls back to `""`; this does not block tool discovery or the request.
- `sidecar.py`'s `_run_agentic_gemini_loop` now appends `self._mcp.instructions` (when non-empty) to the base Gemini system instruction, so server-provided tool-usage guidance actually reaches the model.

## How was this change tested?
- Added three regression tests in `test_sidecar_workflow.py`:
  - `test_mcp_bridge_exposes_server_instructions` — verifies instructions are captured and exposed when the server provides them.
  - `test_mcp_bridge_instructions_default_to_empty_string` — verifies a server with no `instructions` field doesn't break the bridge.
  - `test_mcp_bridge_instructions_handshake_failure_is_non_fatal` — verifies a failed handshake still lets initialization succeed, with `instructions` defaulting to `""`.
- Confirmed all three tests fail on the pre-fix code and pass after the fix (true regression tests).
- Ran `uv run pyright ./` → 0 errors.
- Ran `uv run pytest -q test_sidecar_workflow.py` → 4 passed.
- Ran `make fmt`, `make lint`, `make test` from repo root → all clean, full test suite passing.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes