### PR TITLE
chore(renovate): Add 7-day minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,11 @@
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
+  "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security", "changelog:dependencies"]
+    "labels": ["security", "changelog:dependencies"],
+    "minimumReleaseAge": "0 days"
   },
   "suppressNotifications": [
     "prEditedNotification"


### PR DESCRIPTION
Wait at least one week before proposing a dependency upgrade, avoiding broken or low-confidence releases. Security alerts bypass this delay via their own minimumReleaseAge override.
