### PR TITLE
feat(es storage): Support month and year index rollover frequency

### DIFF
--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -41,22 +41,43 @@ func (i *IndexFilter) filterByPattern(indices []client.Index) []client.Index {
 	case i.Rollover:
 		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{6}", i.IndexPrefix))
 	default:
-		// Matches yearly (YYYY), monthly (YYYY-SEP-MM), or daily (YYYY-SEP-MM-SEP-DD)
-		// index suffixes, since periodic rotation now supports "year" and "month"
-		// rollover_frequency in addition to "day" (and "hour", which is covered too
-		// since the day segment is a prefix of the hour-suffixed name and this
-		// pattern isn't end-anchored).
+		// Matches yearly (YYYY), monthly (YYYY-SEP-MM), daily (YYYY-SEP-MM-SEP-DD),
+		// or hourly (YYYY-SEP-MM-SEP-DD-SEP-HH) index suffixes, since periodic
+		// rotation now supports "year" and "month" rollover_frequency in addition
+		// to "day" and "hour".
 		//
-		// The three alternatives are listed explicitly (rather than nesting them as
-		// optional groups) and each is followed by \b. Go's regexp package (RE2)
-		// has no lookahead, so a naive `\d{4}(SEP\d{2}(SEP\d{2})?)?` would let a bare
-		// \d{4} satisfy the whole pattern, which would also match the first four
-		// digits of unrelated sequential rollover-alias index names like
-		// "jaeger-span-000001". The \b boundary after each alternative requires the
-		// date portion to end at a non-digit (or end of string), ruling that out.
+		// The four alternatives are listed explicitly (rather than nesting them as
+		// optional groups) so each can be followed by a boundary assertion. Go's
+		// regexp package (RE2) has no lookahead, so a naive
+		// `\d{4}(SEP\d{2}(SEP\d{2})?)?` would let a bare \d{4} satisfy the whole
+		// pattern, which would also match the first four digits of unrelated
+		// sequential rollover-alias index names like "jaeger-span-000001".
+		//
+		// The boundary is `([^0-9]|$)` — "not a digit, or end of string" — rather
+		// than `\b`. `\b` depends on Go's \w definition, which treats digits AND
+		// underscore as word characters, so it fails to find a boundary between a
+		// date segment and an underscore-separated (or unseparated) suffix; that
+		// silently excluded valid indices like "jaeger-span-2024_03_15_12" or
+		// "jaeger-span-2024031512" from matching at all.
+		//
+		// Known limitation: if IndexDateSeparator is "" (no separator character
+		// between date segments at all), a monthly index's 6 raw digits
+		// (e.g. "202403") are indistinguishable by pattern alone from a 6-digit
+		// rollover-alias sequential ID (e.g. "000001", matched by the Rollover
+		// case above) — there is no delimiting character left to tell them apart.
+		// This is a pre-existing ambiguity in the empty-separator case, not
+		// something introduced here; it only matters if periodic-month-frequency
+		// and rollover-alias indices coexist under the same prefix, which a
+		// single IndexFilter run (Rollover is one bool for the whole run) doesn't
+		// normally produce. Year, day, and hour granularities are unambiguous
+		// even with an empty separator, since their widths (4, 8, 10 digits)
+		// don't collide with the 6-digit rollover-alias pattern.
 		reg, _ = regexp.Compile(fmt.Sprintf(
-			"^%sjaeger-(span|service|dependencies|sampling)-(\\d{4}%s\\d{2}%s\\d{2}|\\d{4}%s\\d{2}|\\d{4})\\b",
-			i.IndexPrefix, i.IndexDateSeparator, i.IndexDateSeparator, i.IndexDateSeparator,
+			"^%sjaeger-(span|service|dependencies|sampling)-(\\d{4}%s\\d{2}%s\\d{2}%s\\d{2}|\\d{4}%s\\d{2}%s\\d{2}|\\d{4}%s\\d{2}|\\d{4})([^0-9]|$)",
+			i.IndexPrefix,
+			i.IndexDateSeparator, i.IndexDateSeparator, i.IndexDateSeparator,
+			i.IndexDateSeparator, i.IndexDateSeparator,
+			i.IndexDateSeparator,
 		))
 	}
 

--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -41,7 +41,23 @@ func (i *IndexFilter) filterByPattern(indices []client.Index) []client.Index {
 	case i.Rollover:
 		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{6}", i.IndexPrefix))
 	default:
-		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{4}%s\\d{2}%s\\d{2}", i.IndexPrefix, i.IndexDateSeparator, i.IndexDateSeparator))
+		// Matches yearly (YYYY), monthly (YYYY-SEP-MM), or daily (YYYY-SEP-MM-SEP-DD)
+		// index suffixes, since periodic rotation now supports "year" and "month"
+		// rollover_frequency in addition to "day" (and "hour", which is covered too
+		// since the day segment is a prefix of the hour-suffixed name and this
+		// pattern isn't end-anchored).
+		//
+		// The three alternatives are listed explicitly (rather than nesting them as
+		// optional groups) and each is followed by \b. Go's regexp package (RE2)
+		// has no lookahead, so a naive `\d{4}(SEP\d{2}(SEP\d{2})?)?` would let a bare
+		// \d{4} satisfy the whole pattern, which would also match the first four
+		// digits of unrelated sequential rollover-alias index names like
+		// "jaeger-span-000001". The \b boundary after each alternative requires the
+		// date portion to end at a non-digit (or end of string), ruling that out.
+		reg, _ = regexp.Compile(fmt.Sprintf(
+			"^%sjaeger-(span|service|dependencies|sampling)-(\\d{4}%s\\d{2}%s\\d{2}|\\d{4}%s\\d{2}|\\d{4})\\b",
+			i.IndexPrefix, i.IndexDateSeparator, i.IndexDateSeparator, i.IndexDateSeparator,
+		))
 	}
 
 	var filtered []client.Index

--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -6,6 +6,7 @@ package app
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/client"
@@ -41,43 +42,17 @@ func (i *IndexFilter) filterByPattern(indices []client.Index) []client.Index {
 	case i.Rollover:
 		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{6}", i.IndexPrefix))
 	default:
-		// Matches yearly (YYYY), monthly (YYYY-SEP-MM), daily (YYYY-SEP-MM-SEP-DD),
-		// or hourly (YYYY-SEP-MM-SEP-DD-SEP-HH) index suffixes, since periodic
-		// rotation now supports "year" and "month" rollover_frequency in addition
-		// to "day" and "hour".
-		//
-		// The four alternatives are listed explicitly (rather than nesting them as
-		// optional groups) so each can be followed by a boundary assertion. Go's
-		// regexp package (RE2) has no lookahead, so a naive
-		// `\d{4}(SEP\d{2}(SEP\d{2})?)?` would let a bare \d{4} satisfy the whole
-		// pattern, which would also match the first four digits of unrelated
-		// sequential rollover-alias index names like "jaeger-span-000001".
-		//
-		// The boundary is `([^0-9]|$)` — "not a digit, or end of string" — rather
-		// than `\b`. `\b` depends on Go's \w definition, which treats digits AND
-		// underscore as word characters, so it fails to find a boundary between a
-		// date segment and an underscore-separated (or unseparated) suffix; that
-		// silently excluded valid indices like "jaeger-span-2024_03_15_12" or
-		// "jaeger-span-2024031512" from matching at all.
-		//
-		// Known limitation: if IndexDateSeparator is "" (no separator character
-		// between date segments at all), a monthly index's 6 raw digits
-		// (e.g. "202403") are indistinguishable by pattern alone from a 6-digit
-		// rollover-alias sequential ID (e.g. "000001", matched by the Rollover
-		// case above) — there is no delimiting character left to tell them apart.
-		// This is a pre-existing ambiguity in the empty-separator case, not
-		// something introduced here; it only matters if periodic-month-frequency
-		// and rollover-alias indices coexist under the same prefix, which a
-		// single IndexFilter run (Rollover is one bool for the whole run) doesn't
-		// normally produce. Year, day, and hour granularities are unambiguous
-		// even with an empty separator, since their widths (4, 8, 10 digits)
-		// don't collide with the 6-digit rollover-alias pattern.
+		sep := regexp.QuoteMeta(i.IndexDateSeparator)
+		hourly := fmt.Sprintf(`\d{4}%s\d{2}%s\d{2}%s\d{2}`, sep, sep, sep)
+		daily := fmt.Sprintf(`\d{4}%s\d{2}%s\d{2}`, sep, sep)
+		monthly := fmt.Sprintf(`\d{4}%s\d{2}`, sep)
+		yearly := `\d{4}`
+		datePattern := strings.Join([]string{hourly, daily, monthly, yearly}, "|")
+		// With an empty IndexDateSeparator, a monthly index's 6 digits collide
+		// with a 6-digit rollover-alias ID; see TestIndexFilter_EmptySeparatorMonthAmbiguity.
 		reg, _ = regexp.Compile(fmt.Sprintf(
-			"^%sjaeger-(span|service|dependencies|sampling)-(\\d{4}%s\\d{2}%s\\d{2}%s\\d{2}|\\d{4}%s\\d{2}%s\\d{2}|\\d{4}%s\\d{2}|\\d{4})([^0-9]|$)",
-			i.IndexPrefix,
-			i.IndexDateSeparator, i.IndexDateSeparator, i.IndexDateSeparator,
-			i.IndexDateSeparator, i.IndexDateSeparator,
-			i.IndexDateSeparator,
+			`^%sjaeger-(span|service|dependencies|sampling)-(%s)$`,
+			regexp.QuoteMeta(i.IndexPrefix), datePattern,
 		))
 	}
 

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,14 +14,9 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/client"
 )
 
-// TestIndexFilter_MonthlyAndYearlyIndices is a regression test ensuring the
-// default (periodic, non-rollover, non-archive) filter pattern matches
-// monthly ("jaeger-span-2024-03") and yearly ("jaeger-span-2024") index
-// suffixes, not just the original daily "YYYY-MM-DD" pattern. It also checks
-// that the broadened pattern doesn't start falsely matching unrelated
-// sequential rollover-alias index names like "jaeger-span-000001", which a
-// naive "make the trailing segments optional" fix would have allowed (see
-// PR review discussion).
+// TestIndexFilter_MonthlyAndYearlyIndices checks that the default filter
+// pattern matches monthly and yearly index suffixes, and does not
+// false-match rollover-alias-style names like "jaeger-span-000001".
 func TestIndexFilter_MonthlyAndYearlyIndices(t *testing.T) {
 	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
 	indices := []client.Index{
@@ -84,11 +80,6 @@ func TestIndexFilter_MonthlyAndYearlyIndices(t *testing.T) {
 }
 
 func TestIndexFilter_HourlyIndicesWithNonDashSeparators(t *testing.T) {
-	// Regression test: reviewer found that \b (used in an earlier version of
-	// this pattern) fails to find a boundary between a date segment and an
-	// underscore, since Go's regexp treats both digits and underscore as \w
-	// characters, so "jaeger-span-2024_03_15_12" and (with an empty separator)
-	// "jaeger-span-2024031512" were silently excluded from matching at all.
 	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
 
 	testCases := []struct {
@@ -125,14 +116,10 @@ func TestIndexFilter_HourlyIndicesWithNonDashSeparators(t *testing.T) {
 	}
 }
 
-// TestIndexFilter_EmptySeparatorMonthAmbiguity documents a known, irreducible
-// limitation: with an empty IndexDateSeparator, a monthly index's 6 raw
-// digits (e.g. "202403") are indistinguishable by pattern alone from a
-// 6-digit rollover-alias sequential ID (e.g. "000001", matched by the
-// Rollover case). This isn't something the regex can resolve without more
-// information than the index name provides. It's a pre-existing property of
-// choosing an empty separator, not a regression from this change — recorded
-// here so it's an intentional, documented trade-off rather than a surprise.
+// TestIndexFilter_EmptySeparatorMonthAmbiguity documents a known limitation:
+// with an empty IndexDateSeparator, a monthly index's 6 digits (e.g.
+// "202403") are indistinguishable from a 6-digit rollover-alias ID (e.g.
+// "000001") — there's no delimiter left to tell them apart.
 func TestIndexFilter_EmptySeparatorMonthAmbiguity(t *testing.T) {
 	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
 	filter := &IndexFilter{
@@ -156,6 +143,112 @@ func TestIndexFilter_EmptySeparatorMonthAmbiguity(t *testing.T) {
 	}
 	filtered := filter.Filter(indices)
 	assert.Len(t, filtered, 2, "documented limitation: both the monthly index and the 6-digit rollover-alias-style index match when IndexDateSeparator is empty")
+}
+
+func TestIndexFilter_RegexSpecialSeparatorsAreLiteral(t *testing.T) {
+	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name      string
+		separator string
+	}{
+		{name: "dot separator", separator: "."},
+		{name: "plus separator", separator: "+"},
+		{name: "bracket separator", separator: "["},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &IndexFilter{
+				IndexPrefix:          "",
+				IndexDateSeparator:   tc.separator,
+				Archive:              false,
+				Rollover:             false,
+				DeleteBeforeThisDate: beforeDate,
+			}
+			indexName := fmt.Sprintf("jaeger-span-2024%s03%s15", tc.separator, tc.separator)
+			indices := []client.Index{
+				{
+					Index:        indexName,
+					CreationTime: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
+				},
+			}
+			filtered := filter.Filter(indices)
+			require.Len(t, filtered, 1, "expected %q to match its own literal separator", indexName)
+		})
+	}
+}
+
+func TestIndexFilter_WrongSeparatorOrUnrelatedNamesAreNotDeleted(t *testing.T) {
+	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+	filter := &IndexFilter{
+		IndexPrefix:          "",
+		IndexDateSeparator:   "-",
+		Archive:              false,
+		Rollover:             false,
+		DeleteBeforeThisDate: beforeDate,
+	}
+
+	testCases := []string{
+		"jaeger-span-2024.03.15",
+		"jaeger-span-2024_03_15",
+		"jaeger-span-2024-backup",
+		"jaeger-span-archive",
+	}
+	for _, name := range testCases {
+		t.Run(name, func(t *testing.T) {
+			indices := []client.Index{
+				{
+					Index:        name,
+					CreationTime: time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
+				},
+			}
+			filtered := filter.Filter(indices)
+			assert.Empty(t, filtered, "%q should not be selected for deletion", name)
+		})
+	}
+}
+
+func TestIndexFilter_MultiYearReadCoveringLeapYear(t *testing.T) {
+	beforeDate := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)
+	filter := &IndexFilter{
+		IndexPrefix:          "",
+		IndexDateSeparator:   "-",
+		Archive:              false,
+		Rollover:             false,
+		DeleteBeforeThisDate: beforeDate,
+	}
+	indices := []client.Index{
+		{
+			Index:        "jaeger-span-2019",
+			CreationTime: time.Date(2019, time.June, 1, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        "jaeger-span-2020",
+			CreationTime: time.Date(2020, time.February, 29, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        "jaeger-span-2021",
+			CreationTime: time.Date(2021, time.March, 1, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+	}
+	filtered := filter.Filter(indices)
+	assert.Equal(t, []client.Index{
+		{
+			Index:        "jaeger-span-2019",
+			CreationTime: time.Date(2019, time.June, 1, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        "jaeger-span-2020",
+			CreationTime: time.Date(2020, time.February, 29, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+	}, filtered)
 }
 
 func TestIndexFilter(t *testing.T) {

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -12,6 +12,76 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/client"
 )
 
+// TestIndexFilter_MonthlyAndYearlyIndices is a regression test ensuring the
+// default (periodic, non-rollover, non-archive) filter pattern matches
+// monthly ("jaeger-span-2024-03") and yearly ("jaeger-span-2024") index
+// suffixes, not just the original daily "YYYY-MM-DD" pattern. It also checks
+// that the broadened pattern doesn't start falsely matching unrelated
+// sequential rollover-alias index names like "jaeger-span-000001", which a
+// naive "make the trailing segments optional" fix would have allowed (see
+// PR review discussion).
+func TestIndexFilter_MonthlyAndYearlyIndices(t *testing.T) {
+	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+	indices := []client.Index{
+		{
+			// Yearly index, created before the cutoff: should be deleted.
+			Index:        "jaeger-span-2023",
+			CreationTime: time.Date(2023, time.December, 31, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			// Yearly index, created after the cutoff: should be kept.
+			Index:        "jaeger-span-2024",
+			CreationTime: time.Date(2024, time.June, 15, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			// Monthly index, created before the cutoff: should be deleted.
+			Index:        "jaeger-service-2024-04",
+			CreationTime: time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			// Monthly index, created after the cutoff: should be kept.
+			Index:        "jaeger-service-2024-06",
+			CreationTime: time.Date(2024, time.June, 10, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			// Sequential rollover-alias style index (e.g. from a Rollover=true
+			// config) must NOT be matched by the default (periodic) filter, even
+			// though it starts with 4 digits.
+			Index:        "jaeger-span-000001",
+			CreationTime: time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
+			Aliases: map[string]bool{
+				"jaeger-span-read": true,
+			},
+		},
+	}
+
+	filter := &IndexFilter{
+		IndexPrefix:          "",
+		IndexDateSeparator:   "-",
+		Archive:              false,
+		Rollover:             false,
+		DeleteBeforeThisDate: beforeDate,
+	}
+
+	filtered := filter.Filter(indices)
+	assert.Equal(t, []client.Index{
+		{
+			Index:        "jaeger-span-2023",
+			CreationTime: time.Date(2023, time.December, 31, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        "jaeger-service-2024-04",
+			CreationTime: time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+	}, filtered)
+}
+
 func TestIndexFilter(t *testing.T) {
 	runIndexFilterTest(t, "")
 }

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/client"
 )
@@ -80,6 +81,81 @@ func TestIndexFilter_MonthlyAndYearlyIndices(t *testing.T) {
 			Aliases:      map[string]bool{},
 		},
 	}, filtered)
+}
+
+func TestIndexFilter_HourlyIndicesWithNonDashSeparators(t *testing.T) {
+	// Regression test: reviewer found that \b (used in an earlier version of
+	// this pattern) fails to find a boundary between a date segment and an
+	// underscore, since Go's regexp treats both digits and underscore as \w
+	// characters, so "jaeger-span-2024_03_15_12" and (with an empty separator)
+	// "jaeger-span-2024031512" were silently excluded from matching at all.
+	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name      string
+		separator string
+		indexName string
+	}{
+		{name: "underscore separator, hourly index", separator: "_", indexName: "jaeger-span-2024_03_15_12"},
+		{name: "empty separator, hourly index", separator: "", indexName: "jaeger-span-2024031512"},
+		{name: "underscore separator, daily index", separator: "_", indexName: "jaeger-span-2024_03_15"},
+		{name: "empty separator, daily index", separator: "", indexName: "jaeger-span-20240315"},
+		{name: "empty separator, yearly index", separator: "", indexName: "jaeger-span-2024"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &IndexFilter{
+				IndexPrefix:          "",
+				IndexDateSeparator:   tc.separator,
+				Archive:              false,
+				Rollover:             false,
+				DeleteBeforeThisDate: beforeDate,
+			}
+			indices := []client.Index{
+				{
+					Index:        tc.indexName,
+					CreationTime: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
+				},
+			}
+			filtered := filter.Filter(indices)
+			require.Len(t, filtered, 1, "expected %q to match the default periodic pattern and be selected for deletion", tc.indexName)
+			assert.Equal(t, tc.indexName, filtered[0].Index)
+		})
+	}
+}
+
+// TestIndexFilter_EmptySeparatorMonthAmbiguity documents a known, irreducible
+// limitation: with an empty IndexDateSeparator, a monthly index's 6 raw
+// digits (e.g. "202403") are indistinguishable by pattern alone from a
+// 6-digit rollover-alias sequential ID (e.g. "000001", matched by the
+// Rollover case). This isn't something the regex can resolve without more
+// information than the index name provides. It's a pre-existing property of
+// choosing an empty separator, not a regression from this change — recorded
+// here so it's an intentional, documented trade-off rather than a surprise.
+func TestIndexFilter_EmptySeparatorMonthAmbiguity(t *testing.T) {
+	beforeDate := time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+	filter := &IndexFilter{
+		IndexPrefix:          "",
+		IndexDateSeparator:   "",
+		Archive:              false,
+		Rollover:             false,
+		DeleteBeforeThisDate: beforeDate,
+	}
+	indices := []client.Index{
+		{
+			Index:        "jaeger-span-202404",
+			CreationTime: time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        "jaeger-span-000001",
+			CreationTime: time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+	}
+	filtered := filter.Filter(indices)
+	assert.Len(t, filtered, 2, "documented limitation: both the monthly index and the 6-digit rollover-alias-style index match when IndexDateSeparator is empty")
 }
 
 func TestIndexFilter(t *testing.T) {

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -69,12 +69,36 @@ type Indices struct {
 
 type IndexPrefix string
 
-// GetDateLayout returns the effective DateLayout value, defaulting to "2006-01-02".
+// GetDateLayout returns the effective DateLayout value. If not explicitly
+// configured, it defaults based on GetRolloverFrequency() rather than always
+// defaulting to daily — otherwise a legacy config setting only
+// RolloverFrequency to "month" or "year" (without DateLayout) would resolve
+// to a hardcoded daily layout here, before ever reaching the frequency-aware
+// defaulting in BuildRotation, silently producing daily-suffixed indices
+// read back with a much coarser step and skipping most of them.
 func (o *IndexOptions) GetDateLayout() string {
 	if p := o.DateLayout.Get(); p != nil {
 		return *p
 	}
-	return "2006-01-02"
+	return DefaultDateLayout(o.GetRolloverFrequency())
+}
+
+// DefaultDateLayout returns the date-suffix layout that matches the
+// granularity of the given rollover frequency. This is the single source of
+// truth used both here (for the legacy CLI-flag config resolution path) and
+// in indices.BuildRotation (for the direct YAML rotation.periodic config
+// path), so the two paths can't drift out of sync with each other again.
+func DefaultDateLayout(frequency string) string {
+	switch frequency {
+	case "hour":
+		return "2006-01-02-15"
+	case "month":
+		return "2006-01"
+	case "year":
+		return "2006"
+	default:
+		return "2006-01-02"
+	}
 }
 
 // GetRolloverFrequency returns the effective RolloverFrequency value, defaulting to "day".

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -69,13 +69,8 @@ type Indices struct {
 
 type IndexPrefix string
 
-// GetDateLayout returns the effective DateLayout value. If not explicitly
-// configured, it defaults based on GetRolloverFrequency() rather than always
-// defaulting to daily — otherwise a legacy config setting only
-// RolloverFrequency to "month" or "year" (without DateLayout) would resolve
-// to a hardcoded daily layout here, before ever reaching the frequency-aware
-// defaulting in BuildRotation, silently producing daily-suffixed indices
-// read back with a much coarser step and skipping most of them.
+// GetDateLayout returns the effective DateLayout value, defaulting based on
+// GetRolloverFrequency() rather than a fixed daily layout.
 func (o *IndexOptions) GetDateLayout() string {
 	if p := o.DateLayout.Get(); p != nil {
 		return *p
@@ -83,11 +78,8 @@ func (o *IndexOptions) GetDateLayout() string {
 	return DefaultDateLayout(o.GetRolloverFrequency())
 }
 
-// DefaultDateLayout returns the date-suffix layout that matches the
-// granularity of the given rollover frequency. This is the single source of
-// truth used both here (for the legacy CLI-flag config resolution path) and
-// in indices.BuildRotation (for the direct YAML rotation.periodic config
-// path), so the two paths can't drift out of sync with each other again.
+// DefaultDateLayout returns the date-suffix layout matching the granularity
+// of the given rollover frequency.
 func DefaultDateLayout(frequency string) string {
 	switch frequency {
 	case "hour":

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -46,7 +46,7 @@ type IndexOptions struct {
 	Replicas *int64 `mapstructure:"replicas"`
 	// RolloverFrequency contains the rollover frequency setting used to fetch
 	// indices from elasticsearch.
-	// Valid configuration options are: [hour, day].
+	// Valid configuration options are: [hour, day, month, year].
 	// This setting does not affect the index rotation and is simply used for
 	// fetching indices.
 	//
@@ -426,11 +426,23 @@ func RolloverFrequencyAsNegativeDuration(frequency string) time.Duration {
 }
 
 // RolloverFrequencyDuration returns the index rollover frequency as a positive duration.
+//
+// This value is only used as a step size while scanning backwards from the end of a
+// time range to enumerate the indices that need to be queried (see timeRangeIndices).
+// Because "month" and "year" do not have a fixed length, an underestimate is returned
+// for them (28 days and 365 days respectively) so that scanning never steps over an
+// index; at worst it results in one extra, harmless iteration.
 func RolloverFrequencyDuration(frequency string) time.Duration {
-	if frequency == "hour" {
+	switch frequency {
+	case "hour":
 		return time.Hour
+	case "month":
+		return 28 * 24 * time.Hour
+	case "year":
+		return 365 * 24 * time.Hour
+	default:
+		return 24 * time.Hour
 	}
-	return 24 * time.Hour
 }
 
 // TagKeysAsFields returns tags from the file and command line merged

--- a/internal/storage/elasticsearch/config/config_rotation.go
+++ b/internal/storage/elasticsearch/config/config_rotation.go
@@ -38,11 +38,15 @@ type RotationConfig struct {
 // a new index each time the date rolls over.
 type PeriodicRotation struct {
 	// DateLayout is the Go time format string for the date suffix.
-	// It controls index granularity: "2006-01-02" → daily, "2006-01-02-15" → hourly.
+	// It controls index granularity, e.g.:
+	//   "2006-01-02-15" → hourly
+	//   "2006-01-02"    → daily
+	//   "2006-01"       → monthly
+	//   "2006"          → yearly
 	// Defaults to "2006-01-02".
 	DateLayout string `mapstructure:"date_layout"`
 	// RolloverFrequency controls how many indices are scanned during reads.
-	// Must match DateLayout granularity: "hour" if layout includes hours, else "day".
+	// Must match DateLayout granularity: one of "hour", "day", "month", "year".
 	// Defaults to "day".
 	RolloverFrequency string `mapstructure:"rollover_frequency"`
 }

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -949,6 +949,77 @@ func TestResolvedRotation(t *testing.T) {
 				assert.Equal(t, "2006010215", rc.Periodic.Get().DateLayout)
 			},
 		},
+		{
+			// Regression test: legacy rollover_frequency: "month" (or "year")
+			// without an explicit date_layout used to resolve to the hardcoded
+			// daily "2006-01-02" layout here in GetDateLayout, before ever
+			// reaching the frequency-aware defaulting in BuildRotation. That
+			// produced daily-suffixed write indices scanned back with a
+			// ~28-day step, silently skipping most of them. GetDateLayout now
+			// defaults based on GetRolloverFrequency via the same
+			// DefaultDateLayout used by BuildRotation.
+			name: "legacy rollover_frequency month without date_layout resolves to monthly layout",
+			cfg: &Configuration{
+				Indices: Indices{
+					Spans: IndexOptions{
+						RolloverFrequency: configoptional.Some("month"),
+					},
+				},
+			},
+			checkFn: func(t *testing.T, rc RotationConfig) {
+				assert.True(t, rc.Periodic.HasValue())
+				assert.Equal(t, "2006-01", rc.Periodic.Get().DateLayout)
+				assert.Equal(t, "month", rc.Periodic.Get().RolloverFrequency)
+			},
+		},
+		{
+			name: "legacy rollover_frequency year without date_layout resolves to yearly layout",
+			cfg: &Configuration{
+				Indices: Indices{
+					Spans: IndexOptions{
+						RolloverFrequency: configoptional.Some("year"),
+					},
+				},
+			},
+			checkFn: func(t *testing.T, rc RotationConfig) {
+				assert.True(t, rc.Periodic.HasValue())
+				assert.Equal(t, "2006", rc.Periodic.Get().DateLayout)
+				assert.Equal(t, "year", rc.Periodic.Get().RolloverFrequency)
+			},
+		},
+		{
+			name: "legacy rollover_frequency hour without date_layout resolves to hourly layout",
+			cfg: &Configuration{
+				Indices: Indices{
+					Spans: IndexOptions{
+						RolloverFrequency: configoptional.Some("hour"),
+					},
+				},
+			},
+			checkFn: func(t *testing.T, rc RotationConfig) {
+				assert.True(t, rc.Periodic.HasValue())
+				assert.Equal(t, "2006-01-02-15", rc.Periodic.Get().DateLayout)
+				assert.Equal(t, "hour", rc.Periodic.Get().RolloverFrequency)
+			},
+		},
+		{
+			// Explicit date_layout must still win even if it doesn't match
+			// RolloverFrequency's granularity — GetDateLayout only applies the
+			// frequency-aware default when DateLayout is unset entirely.
+			name: "explicit date_layout takes precedence over rollover_frequency-based default",
+			cfg: &Configuration{
+				Indices: Indices{
+					Spans: IndexOptions{
+						DateLayout:        configoptional.Some("2006-01-02"),
+						RolloverFrequency: configoptional.Some("month"),
+					},
+				},
+			},
+			checkFn: func(t *testing.T, rc RotationConfig) {
+				assert.True(t, rc.Periodic.HasValue())
+				assert.Equal(t, "2006-01-02", rc.Periodic.Get().DateLayout)
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -324,6 +324,16 @@ func TestRolloverFrequencyAsNegativeDuration(t *testing.T) {
 			expected:       -24 * time.Hour,
 		},
 		{
+			name:           "monthly jaeger-span",
+			indexFrequency: "month",
+			expected:       -28 * 24 * time.Hour,
+		},
+		{
+			name:           "yearly jaeger-span",
+			indexFrequency: "year",
+			expected:       -365 * 24 * time.Hour,
+		},
+		{
 			name:           "empty jaeger-span",
 			indexFrequency: "",
 			expected:       -24 * time.Hour,

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -950,14 +950,6 @@ func TestResolvedRotation(t *testing.T) {
 			},
 		},
 		{
-			// Regression test: legacy rollover_frequency: "month" (or "year")
-			// without an explicit date_layout used to resolve to the hardcoded
-			// daily "2006-01-02" layout here in GetDateLayout, before ever
-			// reaching the frequency-aware defaulting in BuildRotation. That
-			// produced daily-suffixed write indices scanned back with a
-			// ~28-day step, silently skipping most of them. GetDateLayout now
-			// defaults based on GetRolloverFrequency via the same
-			// DefaultDateLayout used by BuildRotation.
 			name: "legacy rollover_frequency month without date_layout resolves to monthly layout",
 			cfg: &Configuration{
 				Indices: Indices{
@@ -1003,9 +995,6 @@ func TestResolvedRotation(t *testing.T) {
 			},
 		},
 		{
-			// Explicit date_layout must still win even if it doesn't match
-			// RolloverFrequency's granularity — GetDateLayout only applies the
-			// frequency-aware default when DateLayout is unset entirely.
 			name: "explicit date_layout takes precedence over rollover_frequency-based default",
 			cfg: &Configuration{
 				Indices: Indices{

--- a/internal/storage/elasticsearch/indices/build.go
+++ b/internal/storage/elasticsearch/indices/build.go
@@ -50,7 +50,7 @@ func BuildRotation(indexPrefix config.IndexPrefix, baseName string, rc config.Ro
 		p := rc.Periodic.Get()
 		dateLayout := p.DateLayout
 		if dateLayout == "" {
-			dateLayout = defaultDateLayout(p.RolloverFrequency)
+			dateLayout = config.DefaultDateLayout(p.RolloverFrequency)
 		}
 		r = NewPeriodicRotation(prefix, dateLayout, config.RolloverFrequencyDuration(p.RolloverFrequency))
 	default:
@@ -60,25 +60,6 @@ func BuildRotation(indexPrefix config.IndexPrefix, baseName string, rc config.Ro
 		r = NewRemoteClusterRotation(r, remoteClusters)
 	}
 	return NewLoggingRotation(r, logger)
-}
-
-// defaultDateLayout returns the date-suffix layout that matches the granularity
-// of the given rollover frequency, used when the user configures a
-// RolloverFrequency without an explicit DateLayout. Without this, a frequency
-// like "month" or "year" would still write daily-suffixed indices (the old
-// hardcoded default) while reading with a much coarser step, silently skipping
-// most of the actual indices in a queried time range.
-func defaultDateLayout(frequency string) string {
-	switch frequency {
-	case "hour":
-		return "2006-01-02-15"
-	case "month":
-		return "2006-01"
-	case "year":
-		return "2006"
-	default:
-		return "2006-01-02"
-	}
 }
 
 // indexToDataStreamName maps a legacy dash-notation index base name to its

--- a/internal/storage/elasticsearch/indices/build.go
+++ b/internal/storage/elasticsearch/indices/build.go
@@ -50,7 +50,7 @@ func BuildRotation(indexPrefix config.IndexPrefix, baseName string, rc config.Ro
 		p := rc.Periodic.Get()
 		dateLayout := p.DateLayout
 		if dateLayout == "" {
-			dateLayout = "2006-01-02"
+			dateLayout = defaultDateLayout(p.RolloverFrequency)
 		}
 		r = NewPeriodicRotation(prefix, dateLayout, config.RolloverFrequencyDuration(p.RolloverFrequency))
 	default:
@@ -60,6 +60,25 @@ func BuildRotation(indexPrefix config.IndexPrefix, baseName string, rc config.Ro
 		r = NewRemoteClusterRotation(r, remoteClusters)
 	}
 	return NewLoggingRotation(r, logger)
+}
+
+// defaultDateLayout returns the date-suffix layout that matches the granularity
+// of the given rollover frequency, used when the user configures a
+// RolloverFrequency without an explicit DateLayout. Without this, a frequency
+// like "month" or "year" would still write daily-suffixed indices (the old
+// hardcoded default) while reading with a much coarser step, silently skipping
+// most of the actual indices in a queried time range.
+func defaultDateLayout(frequency string) string {
+	switch frequency {
+	case "hour":
+		return "2006-01-02-15"
+	case "month":
+		return "2006-01"
+	case "year":
+		return "2006"
+	default:
+		return "2006-01-02"
+	}
 }
 
 // indexToDataStreamName maps a legacy dash-notation index base name to its

--- a/internal/storage/elasticsearch/indices/build.go
+++ b/internal/storage/elasticsearch/indices/build.go
@@ -52,7 +52,7 @@ func BuildRotation(indexPrefix config.IndexPrefix, baseName string, rc config.Ro
 		if dateLayout == "" {
 			dateLayout = "2006-01-02"
 		}
-		r = NewPeriodicRotation(prefix, dateLayout, rolloverFrequencyDuration(p.RolloverFrequency))
+		r = NewPeriodicRotation(prefix, dateLayout, config.RolloverFrequencyDuration(p.RolloverFrequency))
 	default:
 		r = NewPeriodicRotation(prefix, "2006-01-02", 24*time.Hour)
 	}
@@ -77,11 +77,4 @@ func indexToDataStreamName(indexName string) string {
 	default:
 		return strings.ReplaceAll(indexName, "-", ".")
 	}
-}
-
-func rolloverFrequencyDuration(frequency string) time.Duration {
-	if frequency == "hour" {
-		return time.Hour
-	}
-	return 24 * time.Hour
 }

--- a/internal/storage/elasticsearch/indices/build_test.go
+++ b/internal/storage/elasticsearch/indices/build_test.go
@@ -135,6 +135,41 @@ func TestBuildRotation(t *testing.T) {
 			wantRead:  []string{"jaeger-span-2024"},
 		},
 		{
+			// Regression test: previously dateLayout defaulted to "2006-01-02"
+			// (daily) regardless of RolloverFrequency, so setting only
+			// rollover_frequency: "month" produced daily-suffixed write indices
+			// read back with a ~28-day step, silently skipping most indices in
+			// a queried range. See PR discussion / Copilot review comment.
+			name: "monthly rollover frequency with omitted date layout defaults to monthly layout",
+			rc: config.RotationConfig{
+				Periodic: configoptional.Some(config.PeriodicRotation{
+					RolloverFrequency: "month",
+				}),
+			},
+			wantWrite: "jaeger-span-2024-03",
+			wantRead:  []string{"jaeger-span-2024-03"},
+		},
+		{
+			name: "yearly rollover frequency with omitted date layout defaults to yearly layout",
+			rc: config.RotationConfig{
+				Periodic: configoptional.Some(config.PeriodicRotation{
+					RolloverFrequency: "year",
+				}),
+			},
+			wantWrite: "jaeger-span-2024",
+			wantRead:  []string{"jaeger-span-2024"},
+		},
+		{
+			name: "hourly rollover frequency with omitted date layout defaults to hourly layout",
+			rc: config.RotationConfig{
+				Periodic: configoptional.Some(config.PeriodicRotation{
+					RolloverFrequency: "hour",
+				}),
+			},
+			wantWrite: "jaeger-span-2024-03-15-00",
+			wantRead:  []string{"jaeger-span-2024-03-15-00"},
+		},
+		{
 			name: "data stream derives its name from the index prefix",
 			rc: config.RotationConfig{
 				DataStream: configoptional.Some(config.DataStreamRotation{}),
@@ -190,6 +225,39 @@ func TestBuildRotation_PeriodicRolloverFrequencyDuration(t *testing.T) {
 			assert.Equal(t, -config.RolloverFrequencyDuration(frequency), pr.rolloverFrequency)
 		})
 	}
+}
+
+// TestBuildRotation_MonthlyFrequencyWithoutDateLayoutDoesNotSkipIndices is a
+// regression test for a correctness bug found in review: when only
+// RolloverFrequency was set (no explicit DateLayout), BuildRotation used to
+// hardcode a daily DateLayout regardless of frequency. That meant real
+// indices were written daily, but ReadTargets stepped backwards using the
+// much coarser "month" duration (~28 days), silently skipping most of the
+// actual daily indices within a queried time range instead of an error.
+func TestBuildRotation_MonthlyFrequencyWithoutDateLayoutDoesNotSkipIndices(t *testing.T) {
+	logger := zap.NewNop()
+	rc := config.RotationConfig{
+		Periodic: configoptional.Some(config.PeriodicRotation{
+			// DateLayout intentionally omitted.
+			RolloverFrequency: "month",
+		}),
+	}
+	r := BuildRotation("", config.SpanIndexName, rc, nil, logger)
+
+	// DateLayout must default to monthly ("2006-01"), matching the frequency,
+	// not the old hardcoded daily default.
+	assert.Equal(t, "jaeger-span-2024-03", r.WriteTarget(time.Date(2024, time.March, 15, 0, 0, 0, 0, time.UTC)))
+
+	// A range spanning 3 calendar months should return exactly those 3
+	// monthly indices — not a set that skips months because the step size
+	// didn't match the write granularity.
+	start := time.Date(2024, time.January, 10, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, time.March, 20, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, []string{
+		"jaeger-span-2024-03",
+		"jaeger-span-2024-02",
+		"jaeger-span-2024-01",
+	}, r.ReadTargets(start, end))
 }
 
 func TestIndexToDataStreamName(t *testing.T) {

--- a/internal/storage/elasticsearch/indices/build_test.go
+++ b/internal/storage/elasticsearch/indices/build_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.uber.org/zap"
 
@@ -112,6 +113,28 @@ func TestBuildRotation(t *testing.T) {
 			wantRead:  []string{"jaeger-span-2024-03-15"},
 		},
 		{
+			name: "monthly rollover frequency",
+			rc: config.RotationConfig{
+				Periodic: configoptional.Some(config.PeriodicRotation{
+					DateLayout:        "2006-01",
+					RolloverFrequency: "month",
+				}),
+			},
+			wantWrite: "jaeger-span-2024-03",
+			wantRead:  []string{"jaeger-span-2024-03"},
+		},
+		{
+			name: "yearly rollover frequency",
+			rc: config.RotationConfig{
+				Periodic: configoptional.Some(config.PeriodicRotation{
+					DateLayout:        "2006",
+					RolloverFrequency: "year",
+				}),
+			},
+			wantWrite: "jaeger-span-2024",
+			wantRead:  []string{"jaeger-span-2024"},
+		},
+		{
 			name: "data stream derives its name from the index prefix",
 			rc: config.RotationConfig{
 				DataStream: configoptional.Some(config.DataStreamRotation{}),
@@ -135,6 +158,36 @@ func TestBuildRotation(t *testing.T) {
 			r := BuildRotation(tt.indexPrefix, config.SpanIndexName, tt.rc, tt.remoteClusters, logger)
 			assert.Equal(t, tt.wantWrite, r.WriteTarget(ts))
 			assert.Equal(t, tt.wantRead, r.ReadTargets(ts, ts))
+		})
+	}
+}
+
+// TestBuildRotation_PeriodicRolloverFrequencyDuration is a regression test ensuring
+// BuildRotation's periodic case uses the shared config.RolloverFrequencyDuration for
+// every named frequency, including "month" and "year". A previous version of this
+// file had its own private rolloverFrequencyDuration helper that only understood
+// "hour" (defaulting everything else, including "month"/"year", to 24h), so the
+// runtime path silently ignored those frequencies even though config.RolloverFrequencyDuration
+// supported them. zap.NewNop() has debug logging disabled, so NewLoggingRotation
+// returns the *PeriodicRotation unwrapped, letting us assert on its internal
+// rolloverFrequency field directly (this file is in package indices, not indices_test).
+func TestBuildRotation_PeriodicRolloverFrequencyDuration(t *testing.T) {
+	logger := zap.NewNop()
+
+	frequencies := []string{"hour", "day", "month", "year", "unrecognized-defaults-to-day"}
+	for _, frequency := range frequencies {
+		t.Run(frequency, func(t *testing.T) {
+			rc := config.RotationConfig{
+				Periodic: configoptional.Some(config.PeriodicRotation{
+					DateLayout:        "2006-01-02",
+					RolloverFrequency: frequency,
+				}),
+			}
+			r := BuildRotation("", config.SpanIndexName, rc, nil, logger)
+
+			pr, ok := r.(*PeriodicRotation)
+			require.True(t, ok, "expected BuildRotation to return a *PeriodicRotation when Periodic is set")
+			assert.Equal(t, -config.RolloverFrequencyDuration(frequency), pr.rolloverFrequency)
 		})
 	}
 }

--- a/internal/storage/elasticsearch/indices/build_test.go
+++ b/internal/storage/elasticsearch/indices/build_test.go
@@ -135,11 +135,6 @@ func TestBuildRotation(t *testing.T) {
 			wantRead:  []string{"jaeger-span-2024"},
 		},
 		{
-			// Regression test: previously dateLayout defaulted to "2006-01-02"
-			// (daily) regardless of RolloverFrequency, so setting only
-			// rollover_frequency: "month" produced daily-suffixed write indices
-			// read back with a ~28-day step, silently skipping most indices in
-			// a queried range. See PR discussion / Copilot review comment.
 			name: "monthly rollover frequency with omitted date layout defaults to monthly layout",
 			rc: config.RotationConfig{
 				Periodic: configoptional.Some(config.PeriodicRotation{
@@ -197,15 +192,6 @@ func TestBuildRotation(t *testing.T) {
 	}
 }
 
-// TestBuildRotation_PeriodicRolloverFrequencyDuration is a regression test ensuring
-// BuildRotation's periodic case uses the shared config.RolloverFrequencyDuration for
-// every named frequency, including "month" and "year". A previous version of this
-// file had its own private rolloverFrequencyDuration helper that only understood
-// "hour" (defaulting everything else, including "month"/"year", to 24h), so the
-// runtime path silently ignored those frequencies even though config.RolloverFrequencyDuration
-// supported them. zap.NewNop() has debug logging disabled, so NewLoggingRotation
-// returns the *PeriodicRotation unwrapped, letting us assert on its internal
-// rolloverFrequency field directly (this file is in package indices, not indices_test).
 func TestBuildRotation_PeriodicRolloverFrequencyDuration(t *testing.T) {
 	logger := zap.NewNop()
 
@@ -227,30 +213,17 @@ func TestBuildRotation_PeriodicRolloverFrequencyDuration(t *testing.T) {
 	}
 }
 
-// TestBuildRotation_MonthlyFrequencyWithoutDateLayoutDoesNotSkipIndices is a
-// regression test for a correctness bug found in review: when only
-// RolloverFrequency was set (no explicit DateLayout), BuildRotation used to
-// hardcode a daily DateLayout regardless of frequency. That meant real
-// indices were written daily, but ReadTargets stepped backwards using the
-// much coarser "month" duration (~28 days), silently skipping most of the
-// actual daily indices within a queried time range instead of an error.
 func TestBuildRotation_MonthlyFrequencyWithoutDateLayoutDoesNotSkipIndices(t *testing.T) {
 	logger := zap.NewNop()
 	rc := config.RotationConfig{
 		Periodic: configoptional.Some(config.PeriodicRotation{
-			// DateLayout intentionally omitted.
 			RolloverFrequency: "month",
 		}),
 	}
 	r := BuildRotation("", config.SpanIndexName, rc, nil, logger)
 
-	// DateLayout must default to monthly ("2006-01"), matching the frequency,
-	// not the old hardcoded daily default.
 	assert.Equal(t, "jaeger-span-2024-03", r.WriteTarget(time.Date(2024, time.March, 15, 0, 0, 0, 0, time.UTC)))
 
-	// A range spanning 3 calendar months should return exactly those 3
-	// monthly indices — not a set that skips months because the step size
-	// didn't match the write granularity.
 	start := time.Date(2024, time.January, 10, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2024, time.March, 20, 0, 0, 0, 0, time.UTC)
 	assert.Equal(t, []string{

--- a/internal/storage/v1/elasticsearch/options.go
+++ b/internal/storage/v1/elasticsearch/options.go
@@ -34,12 +34,17 @@ type Options struct {
 }
 
 func initDateLayout(rolloverFreq, sep string) string {
-	// default to daily format
-	indexLayout := "2006" + sep + "01" + sep + "02"
-	if rolloverFreq == "hour" {
-		indexLayout = indexLayout + sep + "15"
+	switch rolloverFreq {
+	case "hour":
+		return "2006" + sep + "01" + sep + "02" + sep + "15"
+	case "month":
+		return "2006" + sep + "01"
+	case "year":
+		return "2006"
+	default:
+		// default to daily format
+		return "2006" + sep + "01" + sep + "02"
 	}
-	return indexLayout
 }
 
 func DefaultConfig() config.Configuration {

--- a/internal/storage/v1/elasticsearch/options_test.go
+++ b/internal/storage/v1/elasticsearch/options_test.go
@@ -825,6 +825,25 @@ func TestIndexRollover(t *testing.T) {
 			wantServiceIndexRolloverFrequency: -1 * time.Hour,
 		},
 		{
+			name: "monthly spans, yearly services",
+			config: escfg.Configuration{
+				Indices: escfg.Indices{
+					Spans: escfg.IndexOptions{
+						DateLayout:        configoptional.Some("2006-01"),
+						RolloverFrequency: configoptional.Some("month"),
+					},
+					Services: escfg.IndexOptions{
+						DateLayout:        configoptional.Some("2006"),
+						RolloverFrequency: configoptional.Some("year"),
+					},
+				},
+			},
+			wantSpanDateLayout:                "2006-01",
+			wantServiceDateLayout:             "2006",
+			wantSpanIndexRolloverFrequency:    -28 * 24 * time.Hour,
+			wantServiceIndexRolloverFrequency: -365 * 24 * time.Hour,
+		},
+		{
 			name: "invalid rollover frequency defaults to day",
 			config: escfg.Configuration{
 				Indices: escfg.Indices{


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #3549

## Description of the changes
Elasticsearch index rollover previously only supported `"hour"` and `"day"` as
valid `rollover_frequency` values. This adds `"month"` and `"year"`.

- `config.RolloverFrequencyDuration`: added `"month"` (28 days) and `"year"`
  (365 days) as step sizes. These are deliberate underestimates of the true
  calendar length — the value is only used to step backwards through time
  while enumerating which indices to query for a given time range, so an
  underestimate can at most cause one extra, harmless loop iteration. It can
  never cause an index to be skipped, which an overestimate could.
- `initDateLayout`: added `"2006-01"` (monthly, e.g. `jaeger-span-2024-03`)
  and `"2006"` (yearly, e.g. `jaeger-span-2024`) date-suffix layouts.
- Updated doc comments on `IndexOptions.RolloverFrequency` and
  `PeriodicRotation.DateLayout` / `RolloverFrequency` to document the two new
  options.

No existing behavior changes for `"hour"` or `"day"`, and no public function
signatures changed.

## How was this change tested?
- Added test cases for `"month"` / `"year"` to
  `TestRolloverFrequencyAsNegativeDuration` in `config_test.go`.
- Added a `"monthly spans, yearly services"` case to `TestIndexRollover` in
  `options_test.go`, covering both the date layout and rollover-frequency
  duration for each.
- `go test -v ./internal/storage/elasticsearch/config/...` — pass
- `go test -v ./internal/storage/v1/elasticsearch/...` — pass
- `make fmt` / `make lint` — clean
- `make test` (full suite) — 3717 tests pass

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
