### PR TITLE
feat(query): Make MCP tool limits configurable in jaeger-query

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -6,6 +6,7 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -13,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configoptional"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/internal/headerforwarding"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 	"github.com/jaegertracing/jaeger/ports"
@@ -37,6 +39,14 @@ const (
 	DefaultAIHealthCheckTimeout        = 2 * time.Second
 )
 
+// Upper bounds for the configurable MCP tool limits, mirroring the ranges the
+// retired jaeger_mcp extension enforced. A value of 0 means "use the default".
+const (
+	mcpMaxReadFileSizeLimit          int64 = 10 * 1024 * 1024 // 10 MiB
+	mcpMaxSearchResultsLimit               = 1000
+	mcpMaxSpanDetailsPerRequestLimit       = 100
+)
+
 // AIConfig is the AI-related slice of QueryOptions. All defaults are seeded
 // by DefaultQueryOptions via configoptional.Default, and a user's partial
 // YAML block overlays only the fields they specify (configoptional unmarshals
@@ -54,6 +64,15 @@ type AIConfig struct {
 	// retired standalone jaeger_mcp extension (which served :16687); point
 	// Cursor/IDE MCP clients at the query port instead. Independent of AgentURL.
 	EnableMCP bool `mapstructure:"enable_mcp" valid:"optional"`
+	// MCPMaxReadFileSize bounds the size (bytes) of a file served by the read_skill
+	// MCP tool. 0 uses the default (512 KiB). Only applies when EnableMCP is set.
+	MCPMaxReadFileSize int64 `mapstructure:"mcp_max_read_file_size" valid:"optional"`
+	// MCPMaxSearchResults caps the results returned by the search_traces MCP tool.
+	// 0 uses the default (100). Only applies when EnableMCP is set.
+	MCPMaxSearchResults int `mapstructure:"mcp_max_search_results" valid:"optional"`
+	// MCPMaxSpanDetailsPerRequest caps the spans returned per get_span_details and
+	// get_trace_* MCP request. 0 uses the default (20). Only applies when EnableMCP is set.
+	MCPMaxSpanDetailsPerRequest int `mapstructure:"mcp_max_span_details_per_request" valid:"optional"`
 	// MaxRequestBodySize limits the chat-handler request body. Must be positive.
 	MaxRequestBodySize int64 `mapstructure:"max_request_body_size" valid:"optional"`
 	// HealthCheckInterval controls how often the AI health checker contacts
@@ -102,7 +121,32 @@ func (c *AIConfig) Validate() error {
 	if c.HealthCheckInterval > 0 && c.HealthCheckTimeout <= 0 {
 		return errors.New("ai.health_check_timeout must be positive when health_check_interval is positive")
 	}
+	if c.MCPMaxReadFileSize < 0 || c.MCPMaxReadFileSize > mcpMaxReadFileSizeLimit {
+		return fmt.Errorf("ai.mcp_max_read_file_size must be between 0 and %d", mcpMaxReadFileSizeLimit)
+	}
+	if c.MCPMaxSearchResults < 0 || c.MCPMaxSearchResults > mcpMaxSearchResultsLimit {
+		return fmt.Errorf("ai.mcp_max_search_results must be between 0 and %d", mcpMaxSearchResultsLimit)
+	}
+	if c.MCPMaxSpanDetailsPerRequest < 0 || c.MCPMaxSpanDetailsPerRequest > mcpMaxSpanDetailsPerRequestLimit {
+		return fmt.Errorf("ai.mcp_max_span_details_per_request must be between 0 and %d", mcpMaxSpanDetailsPerRequestLimit)
+	}
 	return nil
+}
+
+// MCPConfig returns the mcptools.Config for the in-process MCP server: the
+// defaults with any explicit (non-zero) overrides from the AI config applied.
+func (c *AIConfig) MCPConfig() mcptools.Config {
+	cfg := mcptools.DefaultConfig()
+	if c.MCPMaxReadFileSize > 0 {
+		cfg.MaxReadFileSize = c.MCPMaxReadFileSize
+	}
+	if c.MCPMaxSearchResults > 0 {
+		cfg.MaxSearchResults = c.MCPMaxSearchResults
+	}
+	if c.MCPMaxSpanDetailsPerRequest > 0 {
+		cfg.MaxSpanDetailsPerRequest = c.MCPMaxSpanDetailsPerRequest
+	}
+	return cfg
 }
 
 // QueryOptions holds configuration for query service shared with jaeger-v2

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 )
 
 func TestDefaultQueryOptions(t *testing.T) {
@@ -73,6 +75,62 @@ func TestAIConfigValidateRejectsNonPositiveBodySize(t *testing.T) {
 		cfg.MaxRequestBodySize = size
 		require.EqualError(t, cfg.Validate(), "ai.max_request_body_size must be a positive integer")
 	}
+}
+
+func TestAIConfigValidateAcceptsMCPLimits(t *testing.T) {
+	cfg := validAIConfig()
+	cfg.EnableMCP = true
+	// Zero means "use the default".
+	require.NoError(t, cfg.Validate())
+	// Explicit in-range values are accepted.
+	cfg.MCPMaxReadFileSize = 1 << 20
+	cfg.MCPMaxSearchResults = 250
+	cfg.MCPMaxSpanDetailsPerRequest = 50
+	require.NoError(t, cfg.Validate())
+}
+
+func TestAIConfigValidateRejectsInvalidMCPLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*AIConfig)
+		wantErr string
+	}{
+		{"read file size negative", func(c *AIConfig) { c.MCPMaxReadFileSize = -1 }, "ai.mcp_max_read_file_size must be between 0 and 10485760"},
+		{"read file size over limit", func(c *AIConfig) { c.MCPMaxReadFileSize = 10485761 }, "ai.mcp_max_read_file_size must be between 0 and 10485760"},
+		{"search results negative", func(c *AIConfig) { c.MCPMaxSearchResults = -1 }, "ai.mcp_max_search_results must be between 0 and 1000"},
+		{"search results over limit", func(c *AIConfig) { c.MCPMaxSearchResults = 1001 }, "ai.mcp_max_search_results must be between 0 and 1000"},
+		{"span details negative", func(c *AIConfig) { c.MCPMaxSpanDetailsPerRequest = -1 }, "ai.mcp_max_span_details_per_request must be between 0 and 100"},
+		{"span details over limit", func(c *AIConfig) { c.MCPMaxSpanDetailsPerRequest = 101 }, "ai.mcp_max_span_details_per_request must be between 0 and 100"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validAIConfig()
+			tt.mutate(&cfg)
+			require.EqualError(t, cfg.Validate(), tt.wantErr)
+		})
+	}
+}
+
+func TestAIConfigMCPConfigAppliesOverrides(t *testing.T) {
+	defaults := mcptools.DefaultConfig()
+
+	// Zero limits keep the mcptools defaults.
+	zeroCfg := validAIConfig()
+	got := zeroCfg.MCPConfig()
+	require.Equal(t, defaults.MaxReadFileSize, got.MaxReadFileSize)
+	require.Equal(t, defaults.MaxSearchResults, got.MaxSearchResults)
+	require.Equal(t, defaults.MaxSpanDetailsPerRequest, got.MaxSpanDetailsPerRequest)
+
+	// Non-zero limits override only their own field.
+	cfg := validAIConfig()
+	cfg.MCPMaxReadFileSize = 1 << 20
+	cfg.MCPMaxSearchResults = 250
+	cfg.MCPMaxSpanDetailsPerRequest = 50
+	got = cfg.MCPConfig()
+	require.Equal(t, int64(1<<20), got.MaxReadFileSize)
+	require.Equal(t, 250, got.MaxSearchResults)
+	require.Equal(t, 50, got.MaxSpanDetailsPerRequest)
+	require.Equal(t, defaults.ServerName, got.ServerName)
 }
 
 func TestAIConfigValidateAcceptsZeroHealthCheckIntervalAsDisable(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -222,7 +222,7 @@ func initRouter(
 					).RegisterRoutes(r)
 				}
 				if aiCfg.EnableMCP {
-					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, telset)
+					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, telset, aiCfg.MCPConfig())
 				}
 			}
 		}
@@ -277,8 +277,8 @@ func otelFilterFunc(basePath string) func(*http.Request) bool {
 	}
 }
 
-func registerMCPTools(r *http.ServeMux, querySvc *querysvc.QueryService, tenancyMgr *tenancy.Manager, basePath string, telset telemetry.Settings) {
-	handler := mcptools.NewHandler(telset, querySvc, tenancyMgr, mcptools.DefaultConfig())
+func registerMCPTools(r *http.ServeMux, querySvc *querysvc.QueryService, tenancyMgr *tenancy.Manager, basePath string, telset telemetry.Settings, cfg mcptools.Config) {
+	handler := mcptools.NewHandler(telset, querySvc, tenancyMgr, cfg)
 	prefix := strings.TrimSuffix(basePath, "/") + "/api/ai/mcp"
 	r.Handle(prefix+"/", http.StripPrefix(prefix, handler))
 	telset.Logger.Info("Jaeger telemetry MCP endpoint enabled", zap.String("path", prefix+"/"))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/grpctest"
 	"github.com/jaegertracing/jaeger/internal/headerforwarding"
@@ -1202,7 +1203,7 @@ func TestRegisterMCPTools_BasePathNormalization(t *testing.T) {
 			r := http.NewServeMux()
 			// Must not panic on a double-slash pattern.
 			require.NotPanics(t, func() {
-				registerMCPTools(r, querySvc.qs, tenancyMgr, basePath, telset)
+				registerMCPTools(r, querySvc.qs, tenancyMgr, basePath, telset, mcptools.DefaultConfig())
 			})
 
 			want := "/api/ai/mcp/"


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #8926


## Description of the changes
- Adds `mcp_max_read_file_size`, `mcp_max_search_results`, and `mcp_max_span_details_per_request` to the `jaeger_query` `ai:` config, restoring the MCP tool limits that became non-configurable after #8894 (which hardcoded `mcptools.DefaultConfig()`).
- `0` keeps the current default (so existing configs are unaffected); values are validated against the same bounds the retired `jaeger_mcp` extension used (10 MiB / 1000 / 100).

## How was this change tested?
- Added unit tests for the new validation and the `MCPConfig` override logic; `make lint test` pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
