### PR TITLE
Fix ClickHouse ID length validation

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/from.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/from.go
@@ -66,25 +66,47 @@ func convertScope(sr *SpanRow, spanForWarnings ptrace.Span) pcommon.Instrumentat
 	return scope
 }
 
+func decodeTraceID(s string) (pcommon.TraceID, error) {
+	decoded, err := hex.DecodeString(s)
+	if err != nil {
+		return pcommon.TraceID{}, err
+	}
+	if len(decoded) != len(pcommon.TraceID{}) {
+		return pcommon.TraceID{}, fmt.Errorf("invalid length: got %d bytes, want %d bytes", len(decoded), len(pcommon.TraceID{}))
+	}
+	return pcommon.TraceID(decoded), nil
+}
+
+func decodeSpanID(s string) (pcommon.SpanID, error) {
+	decoded, err := hex.DecodeString(s)
+	if err != nil {
+		return pcommon.SpanID{}, err
+	}
+	if len(decoded) != len(pcommon.SpanID{}) {
+		return pcommon.SpanID{}, fmt.Errorf("invalid length: got %d bytes, want %d bytes", len(decoded), len(pcommon.SpanID{}))
+	}
+	return pcommon.SpanID(decoded), nil
+}
+
 func convertSpan(sr *SpanRow) (ptrace.Span, error) {
 	span := ptrace.NewSpan()
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(sr.StartTime))
-	traceId, err := hex.DecodeString(sr.TraceID)
+	traceID, err := decodeTraceID(sr.TraceID)
 	if err != nil {
 		return span, fmt.Errorf("failed to decode trace ID: %w", err)
 	}
-	span.SetTraceID(pcommon.TraceID(traceId))
-	spanId, err := hex.DecodeString(sr.ID)
+	span.SetTraceID(traceID)
+	spanID, err := decodeSpanID(sr.ID)
 	if err != nil {
 		return span, fmt.Errorf("failed to decode span ID: %w", err)
 	}
-	span.SetSpanID(pcommon.SpanID(spanId))
-	parentSpanId, err := hex.DecodeString(sr.ParentSpanID)
-	if err != nil {
-		return span, fmt.Errorf("failed to decode parent span ID: %w", err)
-	}
-	if len(parentSpanId) != 0 {
-		span.SetParentSpanID(pcommon.SpanID(parentSpanId))
+	span.SetSpanID(spanID)
+	if sr.ParentSpanID != "" {
+		parentSpanID, err := decodeSpanID(sr.ParentSpanID)
+		if err != nil {
+			return span, fmt.Errorf("failed to decode parent span ID: %w", err)
+		}
+		span.SetParentSpanID(parentSpanID)
 	}
 	span.TraceState().FromRaw(sr.TraceState)
 	span.SetName(sr.Name)
@@ -108,18 +130,18 @@ func convertSpan(sr *SpanRow) (ptrace.Span, error) {
 
 	for i, l := range sr.LinkTraceIDs {
 		link := span.Links().AppendEmpty()
-		traceID, err := hex.DecodeString(l)
+		traceID, err := decodeTraceID(l)
 		if err != nil {
 			jptrace.AddWarnings(span, fmt.Sprintf("failed to decode link trace ID: %v", err))
 			continue
 		}
-		link.SetTraceID(pcommon.TraceID(traceID))
-		spanID, err := hex.DecodeString(sr.LinkSpanIDs[i])
+		link.SetTraceID(traceID)
+		spanID, err := decodeSpanID(sr.LinkSpanIDs[i])
 		if err != nil {
 			jptrace.AddWarnings(span, fmt.Sprintf("failed to decode link span ID: %v", err))
 			continue
 		}
-		link.SetSpanID(pcommon.SpanID(spanID))
+		link.SetSpanID(spanID)
 		link.TraceState().FromRaw(sr.LinkTraceStates[i])
 
 		putAttributes2D(link.Attributes(), &sr.LinkAttributes, i, span)

--- a/internal/storage/v2/clickhouse/tracestore/dbmodel/from_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/dbmodel/from_test.go
@@ -40,12 +40,39 @@ func TestFromRow_DecodeID(t *testing.T) {
 			want: "failed to decode trace ID: encoding/hex: invalid byte: U+0078 'x'",
 		},
 		{
+			name: "empty span trace id failed",
+			arg:  &SpanRow{},
+			want: "failed to decode trace ID: invalid length: got 0 bytes, want 16 bytes",
+		},
+		{
+			name: "short span trace id failed",
+			arg: &SpanRow{
+				TraceID: "0001",
+			},
+			want: "failed to decode trace ID: invalid length: got 2 bytes, want 16 bytes",
+		},
+		{
 			name: "decode span id failed",
 			arg: &SpanRow{
 				TraceID: "00010001000100010001000100010001",
 				ID:      "0x",
 			},
 			want: "failed to decode span ID: encoding/hex: invalid byte: U+0078 'x'",
+		},
+		{
+			name: "empty span id failed",
+			arg: &SpanRow{
+				TraceID: "00010001000100010001000100010001",
+			},
+			want: "failed to decode span ID: invalid length: got 0 bytes, want 8 bytes",
+		},
+		{
+			name: "short span id failed",
+			arg: &SpanRow{
+				TraceID: "00010001000100010001000100010001",
+				ID:      "0001",
+			},
+			want: "failed to decode span ID: invalid length: got 2 bytes, want 8 bytes",
 		},
 		{
 			name: "decode span parent id failed",
@@ -55,6 +82,15 @@ func TestFromRow_DecodeID(t *testing.T) {
 				ParentSpanID: "0x",
 			},
 			want: "failed to decode parent span ID: encoding/hex: invalid byte: U+0078 'x'",
+		},
+		{
+			name: "short span parent id failed",
+			arg: &SpanRow{
+				TraceID:      "00010001000100010001000100010001",
+				ID:           "0001000100010001",
+				ParentSpanID: "0001",
+			},
+			want: "failed to decode parent span ID: invalid length: got 2 bytes, want 8 bytes",
 		},
 		{
 			name: "decode link trace id failed",
@@ -67,6 +103,26 @@ func TestFromRow_DecodeID(t *testing.T) {
 			want: "failed to decode link trace ID: encoding/hex: invalid byte: U+0078 'x'",
 		},
 		{
+			name: "empty link trace id failed",
+			arg: &SpanRow{
+				TraceID:      "00010001000100010001000100010001",
+				ID:           "0001000100010001",
+				ParentSpanID: "0001000100010001",
+				LinkTraceIDs: []string{""},
+			},
+			want: "failed to decode link trace ID: invalid length: got 0 bytes, want 16 bytes",
+		},
+		{
+			name: "short link trace id failed",
+			arg: &SpanRow{
+				TraceID:      "00010001000100010001000100010001",
+				ID:           "0001000100010001",
+				ParentSpanID: "0001000100010001",
+				LinkTraceIDs: []string{"0001"},
+			},
+			want: "failed to decode link trace ID: invalid length: got 2 bytes, want 16 bytes",
+		},
+		{
 			name: "decode link span id failed",
 			arg: &SpanRow{
 				TraceID:      "00010001000100010001000100010001",
@@ -77,11 +133,36 @@ func TestFromRow_DecodeID(t *testing.T) {
 			},
 			want: "failed to decode link span ID: encoding/hex: invalid byte: U+0078 'x'",
 		},
+		{
+			name: "empty link span id failed",
+			arg: &SpanRow{
+				TraceID:      "00010001000100010001000100010001",
+				ID:           "0001000100010001",
+				ParentSpanID: "0001000100010001",
+				LinkTraceIDs: []string{"00010001000100010001000100010001"},
+				LinkSpanIDs:  []string{""},
+			},
+			want: "failed to decode link span ID: invalid length: got 0 bytes, want 8 bytes",
+		},
+		{
+			name: "short link span id failed",
+			arg: &SpanRow{
+				TraceID:      "00010001000100010001000100010001",
+				ID:           "0001000100010001",
+				ParentSpanID: "0001000100010001",
+				LinkTraceIDs: []string{"00010001000100010001000100010001"},
+				LinkSpanIDs:  []string{"0001"},
+			},
+			want: "failed to decode link span ID: invalid length: got 2 bytes, want 8 bytes",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			trace := FromRow(tt.arg)
+			var trace ptrace.Traces
+			require.NotPanics(t, func() {
+				trace = FromRow(tt.arg)
+			})
 			span := trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 			require.Contains(t, jptrace.GetWarnings(span), tt.want)
 		})


### PR DESCRIPTION
## Summary
- Validate decoded ClickHouse trace/span ID lengths before converting slices to fixed-size OpenTelemetry IDs.
- Preserve absent parent span IDs while surfacing malformed trace/span/link IDs as warnings instead of panicking.
- Add regression coverage for empty and short TraceID/SpanID values on rows and links.

## Testing
- `go test ./internal/storage/v2/clickhouse/tracestore/dbmodel`
- `go test ./internal/storage/v2/clickhouse/tracestore/...`

Note: AI helped draft this change; I reviewed and tested it locally.

Fixes #8933
