### PR TITLE
fix(storage): Reject mutually-exclusive ES auth methods in Validate()

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -478,6 +478,21 @@ func (c *Configuration) Validate() error {
 		return fmt.Errorf("unsupported version %d: set 0 to auto-detect, or use 6/7/8/9 (Elasticsearch) or 101/102/103 (OpenSearch 1/2/3)", c.Version)
 	}
 
+	// Ensure at most one auth method is configured (they all set the Authorization header).
+	var authCount int
+	if c.Authentication.BasicAuthentication.HasValue() {
+		authCount++
+	}
+	if c.Authentication.BearerTokenAuth.HasValue() {
+		authCount++
+	}
+	if c.Authentication.APIKeyAuth.HasValue() {
+		authCount++
+	}
+	if authCount > 1 {
+		return errors.New("at most one authentication method (basic, bearer_token, api_key) may be configured; all three use the Authorization header")
+	}
+
 	// Validate rotation config for each index type
 	if err := c.validateRotationConfig(); err != nil {
 		return err

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -435,6 +435,107 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// --- auth mutual-exclusion tests ---
+		{
+			name: "single basic auth is valid",
+			config: &Configuration{
+				Servers: []string{"localhost:8000/dummyserver"},
+				Authentication: Authentication{
+					BasicAuthentication: configoptional.Some(BasicAuthentication{
+						Username: "user",
+						Password: "pass",
+					}),
+				},
+			},
+		},
+		{
+			name: "single bearer_token auth is valid",
+			config: &Configuration{
+				Servers: []string{"localhost:8000/dummyserver"},
+				Authentication: Authentication{
+					BearerTokenAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/token",
+					}),
+				},
+			},
+		},
+		{
+			name: "single api_key auth is valid",
+			config: &Configuration{
+				Servers: []string{"localhost:8000/dummyserver"},
+				Authentication: Authentication{
+					APIKeyAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/apikey",
+					}),
+				},
+			},
+		},
+		{
+			name: "basic + bearer_token auth rejected",
+			config: &Configuration{
+				Servers: []string{"localhost:8000/dummyserver"},
+				Authentication: Authentication{
+					BasicAuthentication: configoptional.Some(BasicAuthentication{
+						Username: "user",
+						Password: "pass",
+					}),
+					BearerTokenAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/token",
+					}),
+				},
+			},
+			expectedError: "at most one authentication method (basic, bearer_token, api_key) may be configured",
+		},
+		{
+			name: "basic + api_key auth rejected",
+			config: &Configuration{
+				Servers: []string{"localhost:8000/dummyserver"},
+				Authentication: Authentication{
+					BasicAuthentication: configoptional.Some(BasicAuthentication{
+						Username: "user",
+						Password: "pass",
+					}),
+					APIKeyAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/apikey",
+					}),
+				},
+			},
+			expectedError: "at most one authentication method (basic, bearer_token, api_key) may be configured",
+		},
+		{
+			name: "bearer_token + api_key auth rejected",
+			config: &Configuration{
+				Servers: []string{"localhost:8000/dummyserver"},
+				Authentication: Authentication{
+					BearerTokenAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/token",
+					}),
+					APIKeyAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/apikey",
+					}),
+				},
+			},
+			expectedError: "at most one authentication method (basic, bearer_token, api_key) may be configured",
+		},
+		{
+			name: "all three auth methods rejected",
+			config: &Configuration{
+				Servers: []string{"localhost:8000/dummyserver"},
+				Authentication: Authentication{
+					BasicAuthentication: configoptional.Some(BasicAuthentication{
+						Username: "user",
+						Password: "pass",
+					}),
+					BearerTokenAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/token",
+					}),
+					APIKeyAuth: configoptional.Some(TokenAuthentication{
+						FilePath: "/tmp/apikey",
+					}),
+				},
+			},
+			expectedError: "at most one authentication method (basic, bearer_token, api_key) may be configured",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #8940
- `config.Configuration.Validate()` does not check that at most one HTTP authentication method (`basic`, `bearer_token`, `api_key`) is configured. All three write to the same `Authorization` header, so configuring more than one silently produces a broken client with multiple `Authorization` headers that Elasticsearch/OpenSearch reject.

## Description of the changes
- Added a mutual-exclusion check in `config.Configuration.Validate()` that counts how many auth methods have a value and returns a clear error when more than one is set.
- Added 7 test cases to `TestValidate` covering all combinations: each single auth method (3 valid), each pair (3 rejected), and all three together (1 rejected).

## How was this change tested?
- `make fmt` — passed
- `make lint` — passed, 0 issues
- `make test` — passed, 3838 tests, 34 skipped

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
