### PR TITLE
fix(auth): Synchronize fallback token in TokenProviderWithTime closure

### DIFF
--- a/internal/auth/tokenloader.go
+++ b/internal/auth/tokenloader.go
@@ -58,7 +58,7 @@ func TokenProviderWithTime(path string, interval time.Duration, logger *zap.Logg
 	loader := cachedFileTokenLoader(path, interval, timeFn)
 
 	// current token load
-	token, err := loader()
+	currentToken, err := loader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token from file: %w", err)
 	}
@@ -68,10 +68,7 @@ func TokenProviderWithTime(path string, interval time.Duration, logger *zap.Logg
 	// invoked by the auth RoundTripper on every HTTP request and may run
 	// concurrently, so access is guarded by mu. A mutex (rather than an
 	// atomic.Pointer/atomic.Value) keeps this hot path allocation-free.
-	var (
-		mu           sync.Mutex
-		currentToken = token
-	)
+	var mu sync.Mutex
 
 	return func() string {
 		newToken, err := loader()

--- a/internal/auth/tokenloader.go
+++ b/internal/auth/tokenloader.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -67,19 +66,25 @@ func TokenProviderWithTime(path string, interval time.Duration, logger *zap.Logg
 	// currentToken is the last successfully loaded token, held so it can be
 	// returned as a fallback if a later reload fails. The returned closure is
 	// invoked by the auth RoundTripper on every HTTP request and may run
-	// concurrently, so access is synchronized via atomic.Pointer.
-	var currentToken atomic.Pointer[string]
-	currentToken.Store(&token)
+	// concurrently, so access is guarded by mu. A mutex (rather than an
+	// atomic.Pointer/atomic.Value) keeps this hot path allocation-free.
+	var (
+		mu           sync.Mutex
+		currentToken = token
+	)
 
 	return func() string {
 		newToken, err := loader()
+
+		mu.Lock()
+		defer mu.Unlock()
 		if err != nil {
 			logger.Warn("Token reload failed", zap.Error(err))
-			return *currentToken.Load()
+			return currentToken
 		}
 
 		// save it in case the load fails later (e.g. if file is removed)
-		currentToken.Store(&newToken)
-		return newToken
+		currentToken = newToken
+		return currentToken
 	}, nil
 }

--- a/internal/auth/tokenloader.go
+++ b/internal/auth/tokenloader.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -58,20 +59,27 @@ func TokenProviderWithTime(path string, interval time.Duration, logger *zap.Logg
 	loader := cachedFileTokenLoader(path, interval, timeFn)
 
 	// current token load
-	currentToken, err := loader()
+	token, err := loader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token from file: %w", err)
 	}
+
+	// currentToken is the last successfully loaded token, held so it can be
+	// returned as a fallback if a later reload fails. The returned closure is
+	// invoked by the auth RoundTripper on every HTTP request and may run
+	// concurrently, so access is synchronized via atomic.Pointer.
+	var currentToken atomic.Pointer[string]
+	currentToken.Store(&token)
 
 	return func() string {
 		newToken, err := loader()
 		if err != nil {
 			logger.Warn("Token reload failed", zap.Error(err))
-			return currentToken
+			return *currentToken.Load()
 		}
 
 		// save it in case the load fails later (e.g. if file is removed)
-		currentToken = newToken
-		return currentToken
+		currentToken.Store(&newToken)
+		return newToken
 	}, nil
 }

--- a/internal/auth/tokenloader_test.go
+++ b/internal/auth/tokenloader_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -274,6 +275,32 @@ func TestCachedFileTokenLoader_FilePermissions(t *testing.T) {
 	_, err = loader()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "permission denied")
+}
+
+// TestTokenProviderWithTime_ConcurrentCalls is a regression test for a data
+// race on the fallback token in the returned closure. It must be run with
+// -race to be meaningful; the token provider is invoked on every HTTP request
+// and can run concurrently across goroutines.
+func TestTokenProviderWithTime_ConcurrentCalls(t *testing.T) {
+	// A zero interval reloads on every call, maximizing writes to the
+	// fallback token and thus the chance of catching an unsynchronized access.
+	currentTime := time.Unix(0, 0)
+	timeFn := func() time.Time { return currentTime }
+	tokenFile := createTempTokenFile(t, "concurrent-token\n")
+	logger := zap.NewNop()
+
+	tokenFn, err := TokenProviderWithTime(tokenFile, 0, logger, timeFn)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			for range 100 {
+				assert.Equal(t, "concurrent-token", tokenFn())
+			}
+		})
+	}
+	wg.Wait()
 }
 
 func TestTokenProvider_Wrapper(t *testing.T) {

--- a/internal/auth/tokenloader_test.go
+++ b/internal/auth/tokenloader_test.go
@@ -282,8 +282,9 @@ func TestCachedFileTokenLoader_FilePermissions(t *testing.T) {
 // -race to be meaningful; the token provider is invoked on every HTTP request
 // and can run concurrently across goroutines.
 func TestTokenProviderWithTime_ConcurrentCalls(t *testing.T) {
-	// A zero interval reloads on every call, maximizing writes to the
-	// fallback token and thus the chance of catching an unsynchronized access.
+	// Every call writes the fallback token from the returned closure, so many
+	// concurrent callers maximize the chance of catching an unsynchronized
+	// access. The reload interval is irrelevant here (the file never changes).
 	currentTime := time.Unix(0, 0)
 	timeFn := func() time.Time { return currentTime }
 	tokenFile := createTempTokenFile(t, "concurrent-token\n")


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #8951

`internal/auth.TokenProviderWithTime` returns a `func() string` closure that
read and wrote a captured `currentToken` string **without synchronization**.
The auth `RoundTripper` invokes that closure on **every HTTP request**, so any
concurrent authenticated requests raced on `currentToken`. Because a Go
`string` is a `(pointer, length)` pair whose assignment is not atomic, a torn
read can yield a mismatched pointer/length — a corrupted token — leading to
auth failures. This affects file-based bearer-token (`--es.token-file`) and
API-key auth whenever requests overlap (the normal production case).

## Description of the changes

- Guard the fallback token with a `sync.Mutex` so the returned closure is safe
  to call concurrently. The inner `cachedFileTokenLoader` was already
  mutex-protected; only the outer fallback needed synchronization. A mutex
  (rather than an `atomic.Pointer`/`atomic.Value`) keeps this per-request hot
  path allocation-free.
- Add a `-race` regression test (`TestTokenProviderWithTime_ConcurrentCalls`)
  that drives 50 goroutines × 100 calls through one provider.

## How was this change tested?

The new test reliably reproduces the race against the old code and passes with
the fix.

**Before the fix** (test present, source reverted) — `go test -race`:

```
WARNING: DATA RACE
  github.com/jaegertracing/jaeger/internal/auth.TokenProviderWithTime.func1()
      internal/auth/tokenloader.go:74 +0x170
  github.com/jaegertracing/jaeger/internal/auth.TestTokenProviderWithTime_ConcurrentCalls.func2()
      internal/auth/tokenloader_test.go:301 +0x98
```

**After the fix** — `go test -race -run TestTokenProviderWithTime_ConcurrentCalls -v ./internal/auth/`:

```
=== RUN   TestTokenProviderWithTime_ConcurrentCalls
--- PASS: TestTokenProviderWithTime_ConcurrentCalls (0.01s)
PASS
ok  	github.com/jaegertracing/jaeger/internal/auth	1.325s
```

## Checklist

- [x] `make lint` passes
- [x] `make test` / `go test -race ./internal/auth/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

