### PR TITLE
ci: Run ysh-bot PRs in parallel CI alongside the dependency bots

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,7 +25,7 @@ The `setup` job determines whether to use parallel execution based on these **OR
 | `merge_group` event | Merge Queue entry, high confidence |
 | PR author is an org member (`MEMBER` or `OWNER`) | Trusted maintainer |
 | PR author has 5+ merged PRs in this repo | Established contributor. Covers private org members whose `author_association` is incorrectly reported as `CONTRIBUTOR` when they lack direct team access. |
-| PR author login is `dependabot[bot]`, `renovate-bot`, or `Copilot` | Dependency automation bots and the Copilot coding agent (`Copilot` is the `user.login` for `copilot-swe-agent[bot]`; GitHub Search API returns 422 for that login so the merged-PR fallback cannot detect it) |
+| PR author login is `dependabot[bot]`, `renovate-bot`, `Copilot`, or `ysh-bot` | Dependency automation bots, the Copilot coding agent, and the `ysh-bot` maintainer automation account (`Copilot` is the `user.login` for `copilot-swe-agent[bot]`; GitHub Search API returns 422 for that login so the merged-PR fallback cannot detect it) |
 | PR has the `ci:parallel` label | Explicit opt-in |
 
 #### Stage Workflows (DRY Encapsulation)

--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -92,10 +92,11 @@ jobs:
               fi
             fi
 
-            # Parallel for known bots (dependency update automation and Copilot agent).
+            # Parallel for known bots (dependency update automation, Copilot agent, and
+            # the ysh-bot maintainer automation account that authors agent-generated PRs).
             # "Copilot" is the user.login for the copilot-swe-agent[bot] GitHub App; GitHub
             # Search API returns 422 for that login so the merged-PR fallback cannot detect it.
-            if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "renovate-bot" || "$PR_AUTHOR" == "Copilot" ]]; then
+            if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "renovate-bot" || "$PR_AUTHOR" == "Copilot" || "$PR_AUTHOR" == "ysh-bot" ]]; then
               echo "Parallel: bot PR author ($PR_AUTHOR)"
               PARALLEL=true
             else


### PR DESCRIPTION
## Which problem is this PR solving?
- `ysh-bot` is a maintainer automation account that authors agent-generated PRs. Its PRs currently run CI in the slower sequential mode because the account is new (no 5+ merged PRs) and isn't matched by the orchestrator's known-bot list.

## Description of the changes
- Add `ysh-bot` to the CI orchestrator's known-bot check (`ci-orchestrator.yml`) so its PRs use the parallel (fast-track) execution mode, alongside `dependabot[bot]`, `renovate-bot`, and `Copilot`.
- Document it in the execution-mode table in `.github/workflows/README.md`.

Note: `ysh-bot` commits are DCO-signed, so it is intentionally **not** added to the `dependabot`-only DCO-check skip in `ci-lint-checks.yaml` — only to the parallel-execution fast-track.

## How was this change tested?
- Config-only change to workflow gating; no code paths affected. The condition mirrors the existing bot entries exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)