### PR TITLE
fix(es): make OpenSearch mapping generation discoverable

### DIFF
--- a/internal/storage/v1/elasticsearch/mappings/flags.go
+++ b/internal/storage/v1/elasticsearch/mappings/flags.go
@@ -21,10 +21,8 @@ type Options struct {
 }
 
 // BackendVersion returns the BackendVersion corresponding to the EsVersion flag.
-// TODO: This unsafe cast only works for Elasticsearch versions (6, 7, 8, 9).
-// OpenSearch cannot be specified because its enum values (101, 102, 103) are
-// internal. Add an --opensearch-version flag and use it to return the correct
-// OpenSearch BackendVersion variant.
+// Supported values are documented on the es-version flag. OpenSearch uses the
+// exported BackendVersion values 101, 102, and 103.
 func (o *Options) BackendVersion() es.BackendVersion {
 	return es.BackendVersion(o.EsVersion)
 }
@@ -51,7 +49,7 @@ func (o *Options) AddFlags(command *cobra.Command) {
 		&o.EsVersion,
 		esVersionFlag,
 		7,
-		"The major Elasticsearch version",
+		"The Elasticsearch or OpenSearch version. Use 6, 7, 8, or 9 for Elasticsearch; 101, 102, or 103 for OpenSearch 1.x, 2.x, or 3.x.",
 	)
 	command.Flags().Int64Var(
 		&o.Shards,

--- a/internal/storage/v1/elasticsearch/mappings/flags_test.go
+++ b/internal/storage/v1/elasticsearch/mappings/flags_test.go
@@ -49,3 +49,14 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "true", o.UseILM)
 	assert.Equal(t, "jaeger-test-policy", o.ILMPolicyName)
 }
+
+func TestEsVersionFlagHelpMentionsOpenSearch(t *testing.T) {
+	o := Options{}
+	c := cobra.Command{}
+	o.AddFlags(&c)
+
+	flag := c.Flags().Lookup(esVersionFlag)
+	require.NotNil(t, flag)
+	assert.Contains(t, flag.Usage, "101, 102, or 103")
+	assert.Contains(t, flag.Usage, "OpenSearch")
+}


### PR DESCRIPTION
## Summary

Fixes #8966.

This keeps the `esmapping-generator` CLI aligned with the new backend-version support by making OpenSearch values discoverable from `--es-version` help and removing the stale comment that said OpenSearch could not be specified.

Changes:
- document `--es-version` values for OpenSearch 1.x/2.x/3.x (`101`, `102`, `103`)
- update the `BackendVersion()` comment to reference the exported OpenSearch values
- add coverage for the flag help text

## Verification

- `git diff --check`

Could not run `go test ./internal/storage/v1/elasticsearch/mappings` locally because this Windows environment does not have `go` on PATH. GitHub CI should cover the Go test suite.