### PR TITLE
chore(storage): Remove expired feature gates

### DIFF
--- a/cmd/jaeger/internal/extension/remotesampling/config.go
+++ b/cmd/jaeger/internal/extension/remotesampling/config.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
-	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/jaegertracing/jaeger/internal/sampling/samplingstrategy/adaptive"
 )
@@ -27,15 +26,6 @@ var (
 var (
 	_ component.Config   = (*Config)(nil)
 	_ xconfmap.Validator = (*Config)(nil)
-
-	_ = featuregate.GlobalRegistry().MustRegister(
-		"jaeger.sampling.includeDefaultOpStrategies",
-		featuregate.StageStable, // can only be ON
-		featuregate.WithRegisterFromVersion("v2.2.0"),
-		featuregate.WithRegisterToVersion("v2.5.0"),
-		featuregate.WithRegisterDescription("Forces service strategy to be merged with default strategy, including per-operation overrides."),
-		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/5270"),
-	)
 )
 
 type Config struct {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -10,10 +10,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -77,20 +75,7 @@ var (
 	nestedTagFieldList = []string{nestedTagsField, nestedProcessTagsField, nestedLogFieldsField}
 
 	_ Reader = (*SpanReader)(nil) // check API conformance
-
-	disableLegacyIDs *featuregate.Gate
 )
-
-func init() {
-	disableLegacyIDs = featuregate.GlobalRegistry().MustRegister(
-		"jaeger.es.disableLegacyId",
-		featuregate.StageStable, // enabled by default and cannot be disabled
-		featuregate.WithRegisterFromVersion("v2.5.0"),
-		featuregate.WithRegisterToVersion("v2.8.0"),
-		featuregate.WithRegisterDescription("Legacy trace ids are the ids that used to be rendered with leading 0s omitted. Setting this gate to false will force the reader to search for the spans with trace ids having leading zeroes"),
-		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/1578"),
-	)
-}
 
 // Time-range design (referenced as "timeRangeDesign" in comments below):
 //
@@ -366,26 +351,7 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 }
 
 func buildTraceByIDQuery(traceID dbmodel.TraceID) esquery.Query {
-	return buildTraceByIDQueryWithLegacy(traceID, disableLegacyIDs.IsEnabled())
-}
-
-// buildTraceByIDQueryWithLegacy takes the gate value as a parameter so the
-// legacy-ID branch — unreachable in production while the stable
-// jaeger.es.disableLegacyId gate is enabled — stays testable.
-func buildTraceByIDQueryWithLegacy(traceID dbmodel.TraceID, disableLegacy bool) esquery.Query {
-	traceIDStr := string(traceID)
-	// An empty ID has no leading-zero variant (and indexing traceIDStr[0] would
-	// panic); a term query on "" simply matches nothing.
-	if traceIDStr == "" || traceIDStr[0] != '0' || disableLegacy {
-		return esquery.NewTermQuery(traceIDField, traceIDStr)
-	}
-	// https://github.com/jaegertracing/jaeger/pull/1956 added leading zeros to IDs
-	// So we need to also read IDs without leading zeros for compatibility with previously saved data.
-	legacyTraceID := strings.TrimLeft(traceIDStr, "0")
-	return esquery.NewBoolQuery().Should(
-		esquery.NewTermQuery(traceIDField, traceIDStr).Boost(2),
-		esquery.NewTermQuery(traceIDField, legacyTraceID),
-	)
+	return esquery.NewTermQuery(traceIDField, string(traceID))
 }
 
 func validateQuery(p dbmodel.TraceQueryParameters) error {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -1008,56 +1008,40 @@ func TestSpanReader_ArchiveTraces(t *testing.T) {
 
 func TestBuildTraceByIDQuery(t *testing.T) {
 	tests := []struct {
-		name          string
-		traceID       string
-		disableLegacy bool
-		expected      any
+		name     string
+		traceID  string
+		expected any
 	}{
 		{
-			name:          "leading zero, legacy disabled",
-			traceID:       "0000000000000001",
-			disableLegacy: true,
-			expected:      map[string]any{"term": map[string]any{"traceID": "0000000000000001"}},
+			name:     "leading zero",
+			traceID:  "0000000000000001",
+			expected: map[string]any{"term": map[string]any{"traceID": "0000000000000001"}},
 		},
 		{
-			name:          "long id, legacy disabled",
-			traceID:       "00000000000000010000000000000001",
-			disableLegacy: true,
-			expected:      map[string]any{"term": map[string]any{"traceID": "00000000000000010000000000000001"}},
+			name:     "long id",
+			traceID:  "00000000000000010000000000000001",
+			expected: map[string]any{"term": map[string]any{"traceID": "00000000000000010000000000000001"}},
 		},
 		{
-			name:          "no leading zero",
-			traceID:       "ffffffffffffffffffffffffffffffff",
-			disableLegacy: true,
-			expected:      map[string]any{"term": map[string]any{"traceID": "ffffffffffffffffffffffffffffffff"}},
+			name:     "no leading zero",
+			traceID:  "ffffffffffffffffffffffffffffffff",
+			expected: map[string]any{"term": map[string]any{"traceID": "ffffffffffffffffffffffffffffffff"}},
 		},
 		{
-			name:          "leading zero non-hex, legacy disabled",
-			traceID:       "0short-traceid",
-			disableLegacy: true,
-			expected:      map[string]any{"term": map[string]any{"traceID": "0short-traceid"}},
+			name:     "leading zero non-hex",
+			traceID:  "0short-traceid",
+			expected: map[string]any{"term": map[string]any{"traceID": "0short-traceid"}},
 		},
 		{
-			// Legacy branch: a 0-prefixed id also matches its leading-zeros-trimmed form.
-			name:          "leading zero, legacy enabled",
-			traceID:       "0000000000000001",
-			disableLegacy: false,
-			expected: map[string]any{"bool": map[string]any{"should": []any{
-				map[string]any{"term": map[string]any{"traceID": map[string]any{"value": "0000000000000001", "boost": float64(2)}}},
-				map[string]any{"term": map[string]any{"traceID": "1"}},
-			}}},
-		},
-		{
-			// An empty ID must not panic (traceIDStr[0]); it yields a match-nothing term.
-			name:          "empty id, legacy enabled",
-			traceID:       "",
-			disableLegacy: false,
-			expected:      map[string]any{"term": map[string]any{"traceID": ""}},
+			// An empty ID must not panic; it yields a match-nothing term.
+			name:     "empty id",
+			traceID:  "",
+			expected: map[string]any{"term": map[string]any{"traceID": ""}},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q := buildTraceByIDQueryWithLegacy(dbmodel.TraceID(test.traceID), test.disableLegacy)
+			q := buildTraceByIDQuery(dbmodel.TraceID(test.traceID))
 			actual, err := q.Source()
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, actual)


### PR DESCRIPTION
Resolves #8964

Remove the unused jaeger.sampling.includeDefaultOpStrategies and jaeger.es.disableLegacyId feature gates since their scheduled removal versions have passed.

## Which problem is this PR solving?
- Resolves #8964

## Description of the changes
- Removed the `jaeger.sampling.includeDefaultOpStrategies` feature gate registration from `cmd/jaeger/internal/extension/remotesampling/config.go` as it was an unused legacy stub.
- Removed the `jaeger.es.disableLegacyId` feature gate and the unreachable legacy logic from `internal/storage/v2/elasticsearch/tracestore/core/reader.go` since its `ToVersion` has passed and the behavior is now permanent.
- Simplified `TestBuildTraceByIDQuery` tests in `reader_test.go` to directly test the remaining code paths without the `disableLegacy` parameters.

## How was this change tested?
- Updated the existing unit tests in `reader_test.go` to ensure `buildTraceByIDQuery` functions properly with the simplified logic.
- Verified locally on a Windows environment by running:
  - `make fmt` — passed
  - `make lint` — passed, 0 issues
  - `make test` — passed, 3895 tests, 34 skipped

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
