### PR TITLE
test(es): Remove obsolete olivere-era goroutine-leak exceptions

### DIFF
--- a/internal/storage/integration/elasticsearch_test.go
+++ b/internal/storage/integration/elasticsearch_test.go
@@ -141,14 +141,14 @@ func runElasticsearchTest(t *testing.T, allTagsAsFields bool) {
 
 func TestElasticsearchStorage(t *testing.T) {
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	runElasticsearchTest(t, false)
 }
 
 func TestElasticsearchStorage_AllTagsAsObjectFields(t *testing.T) {
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	runElasticsearchTest(t, true)
 }
@@ -156,7 +156,7 @@ func TestElasticsearchStorage_AllTagsAsObjectFields(t *testing.T) {
 func TestElasticsearchStorage_IndexTemplates(t *testing.T) {
 	SkipUnlessEnv(t, StorageElasticsearch, StorageOpenSearch)
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	c := getESHttpClient(t)
 	require.NoError(t, healthCheck(c))

--- a/internal/storage/integration/es_index_cleaner_test.go
+++ b/internal/storage/integration/es_index_cleaner_test.go
@@ -30,7 +30,7 @@ const (
 func TestIndexCleaner_doNotFailOnEmptyStorage(t *testing.T) {
 	SkipUnlessEnv(t, StorageElasticsearch, StorageOpenSearch)
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	client := createESClient(t)
 	client.deleteAllIndices(t)
@@ -51,7 +51,7 @@ func TestIndexCleaner_doNotFailOnEmptyStorage(t *testing.T) {
 func TestIndexCleaner_doNotFailOnFullStorage(t *testing.T) {
 	SkipUnlessEnv(t, StorageElasticsearch, StorageOpenSearch)
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	client := createESClient(t)
 	tests := []struct {
@@ -74,7 +74,7 @@ func TestIndexCleaner_doNotFailOnFullStorage(t *testing.T) {
 func TestIndexCleaner(t *testing.T) {
 	SkipUnlessEnv(t, StorageElasticsearch, StorageOpenSearch)
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	client := createESClient(t)
 

--- a/internal/storage/integration/es_index_rollover_test.go
+++ b/internal/storage/integration/es_index_rollover_test.go
@@ -20,7 +20,7 @@ const (
 func TestIndexRollover_FailIfILMNotPresent(t *testing.T) {
 	SkipUnlessEnv(t, StorageElasticsearch, StorageOpenSearch)
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	client := createESClient(t)
 	// make sure ES is clean
@@ -36,7 +36,7 @@ func TestIndexRollover_FailIfILMNotPresent(t *testing.T) {
 func TestIndexRollover_Idempotency(t *testing.T) {
 	SkipUnlessEnv(t, StorageElasticsearch, StorageOpenSearch)
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	client := createESClient(t)
 	// Make sure that es is clean before the test!
@@ -52,7 +52,7 @@ func TestIndexRollover_Idempotency(t *testing.T) {
 func TestIndexRollover_CreateIndicesWithILM(t *testing.T) {
 	SkipUnlessEnv(t, StorageElasticsearch, StorageOpenSearch)
 	t.Cleanup(func() {
-		testutils.VerifyGoLeaksOnceForES(t)
+		testutils.VerifyGoLeaksOnce(t)
 	})
 	// Test using the default ILM Policy Name, i.e. do not pass the ES_ILM_POLICY_NAME env var to the rollover script.
 	t.Run("DefaultPolicyName", func(t *testing.T) {

--- a/internal/storage/integration/package_test.go
+++ b/internal/storage/integration/package_test.go
@@ -4,16 +4,11 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/jaegertracing/jaeger/internal/testutils"
 )
 
 func TestMain(m *testing.M) {
-	if os.Getenv("STORAGE") == "elasticsearch" || os.Getenv("STORAGE") == "opensearch" {
-		testutils.VerifyGoLeaksForES(m)
-	} else {
-		testutils.VerifyGoLeaks(m)
-	}
+	testutils.VerifyGoLeaks(m)
 }

--- a/internal/testutils/leakcheck.go
+++ b/internal/testutils/leakcheck.go
@@ -34,30 +34,6 @@ func IgnoreGoMetricsMeterLeak() goleak.Option {
 	return goleak.IgnoreTopFunction("github.com/rcrowley/go-metrics.(*meterArbiter).tick")
 }
 
-// Don't use this in any other method other than leaks for ElasticSearch and OpenSearch.
-// These are idle-connection goroutines from the net/http transport that backs
-// the ES/OpenSearch HTTP clients, not leaks in Jaeger itself.
-// See this PR for context: https://github.com/jaegertracing/jaeger/pull/6339
-func ignoreHttpTransportWriteLoopLeak() goleak.Option {
-	return goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop")
-}
-
-// Don't use this in any other method other than leaks for ElasticSearch and OpenSearch.
-// These are idle-connection goroutines from the net/http transport that backs
-// the ES/OpenSearch HTTP clients, not leaks in Jaeger itself.
-// See this PR for context: https://github.com/jaegertracing/jaeger/pull/6339
-func ignoreHttpTransportPollRuntimeLeak() goleak.Option {
-	return goleak.IgnoreTopFunction("internal/poll.runtime_pollWait")
-}
-
-// Don't use this in any other method other than leaks for ElasticSearch and OpenSearch.
-// These are idle-connection goroutines from the net/http transport that backs
-// the ES/OpenSearch HTTP clients, not leaks in Jaeger itself.
-// See this PR for context: https://github.com/jaegertracing/jaeger/pull/6339
-func ignoreHttpTransportReadLoopLeak() goleak.Option {
-	return goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop")
-}
-
 // VerifyGoLeaks verifies that unit tests do not leak any goroutines.
 // It should be called in TestMain.
 func VerifyGoLeaks(m *testing.M) {
@@ -72,16 +48,4 @@ func VerifyGoLeaks(m *testing.M) {
 //	defer testutils.VerifyGoLeaksOnce(t)
 func VerifyGoLeaksOnce(t *testing.T) {
 	goleak.VerifyNone(t, IgnoreGlogFlushDaemonLeak(), IgnoreOpenCensusWorkerLeak(), IgnoreGoMetricsMeterLeak())
-}
-
-// VerifyGoLeaksOnceForES is go leak check for ElasticSearch integration tests (v1)
-// This must not be used anywhere else other than integration package for v1
-func VerifyGoLeaksOnceForES(t *testing.T) {
-	goleak.VerifyNone(t, ignoreHttpTransportWriteLoopLeak(), ignoreHttpTransportPollRuntimeLeak(), ignoreHttpTransportReadLoopLeak())
-}
-
-// VerifyGoLeaksForES is go leak check for integration package in ElasticSearch Environment
-// This must not be used anywhere else other than integration package in ES environment for v1
-func VerifyGoLeaksForES(m *testing.M) {
-	goleak.VerifyTestMain(m, ignoreHttpTransportWriteLoopLeak(), ignoreHttpTransportPollRuntimeLeak(), ignoreHttpTransportReadLoopLeak())
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #8984

`internal/testutils/leakcheck.go` carried three goleak "ignore" options used only by the Elasticsearch/OpenSearch integration tests (via `VerifyGoLeaksForES` / `VerifyGoLeaksOnceForES`):

- `net/http.(*persistConn).writeLoop`
- `net/http.(*persistConn).readLoop`
- `internal/poll.runtime_pollWait`

They were added in #6339 to paper over idle-connection goroutines left behind because the storage factory built the `olivere/elastic` client but never closed it.

## Description of the changes
These exceptions are now obsolete:
- The `olivere/elastic` client stack has been deleted (#8982); the only remaining `olivere` references are explanatory comments.
- #8974 wired `esclient.Close()` → `http.Transport.CloseIdleConnections` into the factory's `Close` — exactly the gap #6339 worked around.
- The `esclient` package's own tests already run under the plain `VerifyGoLeaks` (no exceptions) and pass, despite opening/closing keep-alive connections against `httptest` servers.

Changes:
- Delete the three `ignoreHttpTransport*` helpers.
- Remove the `VerifyGoLeaksForES` / `VerifyGoLeaksOnceForES` variants and switch the integration call sites to the plain `VerifyGoLeaks` / `VerifyGoLeaksOnce`.
- Collapse the now-identical ES/non-ES branches in the integration `TestMain`.

The ES integration tests now use the same ignore set as everything else (glog / opencensus / go-metrics). If an integration-only path still lingers a goroutine, that is a real leak worth surfacing rather than ignoring.

## How was this change tested?
- `go test ./internal/testutils/` passes; the integration package compiles.
- The real proof-of-safety is the **ES 7–9 / OpenSearch 1–3 integration matrix** (live clusters) in CI, which now runs these tests without the transport-leak exceptions.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality (N/A — test-infra cleanup; covered by existing goleak checks)
- [x] I have run lint and test steps successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)