### PR TITLE
fix(mcp): cap read_skill output at max_read_file_size

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -45,8 +45,14 @@ func (h *readSkillHandler) handle(
 	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, types.ReadSkillOutput{}, fmt.Errorf("cannot read %q: %w", input.Path, err)
 	}
+	truncated := n > int(h.maxFileSize)
+	if truncated {
+		// The buffer is maxFileSize+1 to detect oversize; trim back to the
+		// limit so the served content is capped at exactly maxFileSize bytes.
+		n = int(h.maxFileSize)
+	}
 	content := string(buf[:n])
-	if n > int(h.maxFileSize) {
+	if truncated {
 		content += fmt.Sprintf("\n\nfile content truncated after %d bytes\n", h.maxFileSize)
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -56,8 +56,14 @@ func (h *readSkillHandler) handle(
 	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, types.ReadSkillOutput{}, fmt.Errorf("cannot read %q: %w", input.Path, err)
 	}
+	truncated := n > int(h.maxFileSize)
+	if truncated {
+		// The buffer is maxFileSize+1 to detect oversize; trim back to the
+		// limit so the served content is capped at exactly maxFileSize bytes.
+		n = int(h.maxFileSize)
+	}
 	content := string(buf[:n])
-	if n > int(h.maxFileSize) {
+	if truncated {
 		content += fmt.Sprintf("\n\nfile content truncated after %d bytes\n", h.maxFileSize)
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -56,15 +56,12 @@ func (h *readSkillHandler) handle(
 	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, types.ReadSkillOutput{}, fmt.Errorf("cannot read %q: %w", input.Path, err)
 	}
-	truncated := n > int(h.maxFileSize)
-	if truncated {
-		// The buffer is maxFileSize+1 to detect oversize; trim back to the
-		// limit so the served content is capped at exactly maxFileSize bytes.
-		n = int(h.maxFileSize)
-	}
-	content := string(buf[:n])
-	if truncated {
-		content += fmt.Sprintf("\n\nfile content truncated after %d bytes\n", h.maxFileSize)
+	// The buffer is maxFileSize+1 so that an oversize file is detectable; the
+	// served content is capped at exactly maxFileSize bytes.
+	maxSize := int(h.maxFileSize)
+	content := string(buf[:min(n, maxSize)])
+	if n > maxSize {
+		content += fmt.Sprintf("\n\nfile content truncated after %d bytes\n", maxSize)
 	}
 
 	return &mcp.CallToolResult{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -98,4 +99,25 @@ func TestReadSkillHandler_RawTextInContent(t *testing.T) {
 func TestNewReadSkillHandler(t *testing.T) {
 	handler := NewReadSkillHandler(testSkillsFS(), testMaxFileSize)
 	assert.NotNil(t, handler)
+}
+
+func TestReadSkillHandler_SizeLimitBoundary(t *testing.T) {
+	fsys := fstest.MapFS{
+		"exactly.bin": &fstest.MapFile{Data: []byte(strings.Repeat("B", testMaxFileSize))},
+		"over.bin":    &fstest.MapFile{Data: []byte(strings.Repeat("A", testMaxFileSize+1))},
+	}
+	h := &readSkillHandler{skillsFS: fsys, maxFileSize: testMaxFileSize}
+
+	// Exactly at the limit: whole file served, no truncation notice.
+	_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "exactly.bin"})
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat("B", testMaxFileSize), out.Instructions)
+	assert.NotContains(t, out.Instructions, "truncated")
+
+	// One byte over: content capped at exactly maxFileSize, then the notice.
+	_, out, err = h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "over.bin"})
+	require.NoError(t, err)
+	idx := strings.Index(out.Instructions, "\n\nfile content truncated")
+	require.NotEqual(t, -1, idx)
+	assert.Equal(t, testMaxFileSize, idx)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"io/fs"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -145,4 +146,25 @@ func TestReadSkillHandler_DispatchesByPrefix(t *testing.T) {
 		_, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/../etc/passwd"})
 		require.Error(t, err)
 	})
+}
+
+func TestReadSkillHandler_SizeLimitBoundary(t *testing.T) {
+	fsys := fstest.MapFS{
+		"exactly.bin": &fstest.MapFile{Data: []byte(strings.Repeat("B", testMaxFileSize))},
+		"over.bin":    &fstest.MapFile{Data: []byte(strings.Repeat("A", testMaxFileSize+1))},
+	}
+	h := &readSkillHandler{builtins: fsys, maxFileSize: testMaxFileSize}
+
+	// Exactly at the limit: whole file served, no truncation notice.
+	_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "exactly.bin"})
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat("B", testMaxFileSize), out.Instructions)
+	assert.NotContains(t, out.Instructions, "truncated")
+
+	// One byte over: content capped at exactly maxFileSize, then the notice.
+	_, out, err = h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "over.bin"})
+	require.NoError(t, err)
+	idx := strings.Index(out.Instructions, "\n\nfile content truncated")
+	require.NotEqual(t, -1, idx)
+	assert.Equal(t, testMaxFileSize, idx)
 }


### PR DESCRIPTION
### Problem
`read_skill` reads into a `maxFileSize+1` buffer as an oversize sentinel, but served the whole buffer without trimming. As a result it returned `maxFileSize+1` bytes instead of `maxFileSize`, and a file that is exactly one byte over the limit was tagged `truncated` even though the entire file was returned. The size limit was off by one.

### Fix
When the sentinel byte is present (`n > maxFileSize`), trim the served content back to exactly `maxFileSize` bytes, and only append the truncation notice when content is actually dropped.

### Test
Added `TestReadSkillHandler_SizeLimitBoundary`: a file exactly at the limit is served whole with no notice; a file one byte over is capped at exactly `maxFileSize` bytes before the truncation notice. `go test`, `go vet`, `gofmt` all clean.

Resolves #8911
