### PR TITLE
fix(badger): Return DB.Update error in sampling store writes

### DIFF
--- a/internal/storage/v1/badger/samplingstore/storage.go
+++ b/internal/storage/v1/badger/samplingstore/storage.go
@@ -55,7 +55,7 @@ func (s *SamplingStore) InsertThroughput(throughput []*model.Throughput) error {
 		return nil
 	})
 
-	return nil
+	return err
 }
 
 func (s *SamplingStore) GetThroughput(start, end time.Time) ([]*model.Throughput, error) {
@@ -121,7 +121,7 @@ func (s *SamplingStore) InsertProbabilitiesAndQPS(hostname string,
 		return nil
 	})
 
-	return nil
+	return err
 }
 
 // GetLatestProbabilities implements samplingstore.Reader#GetLatestProbabilities.

--- a/internal/storage/v1/badger/samplingstore/storage_test.go
+++ b/internal/storage/v1/badger/samplingstore/storage_test.go
@@ -31,6 +31,15 @@ func TestInsertThroughput(t *testing.T) {
 	})
 }
 
+func TestInsertThroughputError(t *testing.T) {
+	store := newClosedSamplingStore(t)
+	throughputs := []*samplemodel.Throughput{
+		{Service: "my-svc", Operation: "op"},
+	}
+	err := store.InsertThroughput(throughputs)
+	require.ErrorIs(t, err, badger.ErrDBClosed)
+}
+
 func TestGetThroughput(t *testing.T) {
 	runWithBadger(t, func(t *testing.T, store *SamplingStore) {
 		start := time.Now()
@@ -56,6 +65,16 @@ func TestInsertProbabilitiesAndQPS(t *testing.T) {
 		)
 		require.NoError(t, err)
 	})
+}
+
+func TestInsertProbabilitiesAndQPSError(t *testing.T) {
+	store := newClosedSamplingStore(t)
+	err := store.InsertProbabilitiesAndQPS(
+		"dell11eg843d",
+		samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
+		samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
+	)
+	require.ErrorIs(t, err, badger.ErrDBClosed)
 }
 
 func TestGetLatestProbabilities(t *testing.T) {
@@ -128,6 +147,21 @@ func runWithBadger(t *testing.T, test func(t *testing.T, store *SamplingStore)) 
 	}()
 	ss := newTestSamplingStore(store)
 	test(t, ss)
+}
+
+// newClosedSamplingStore returns a SamplingStore backed by a closed Badger DB so
+// that any write transaction fails with badger.ErrDBClosed.
+func newClosedSamplingStore(t *testing.T) *SamplingStore {
+	opts := badger.DefaultOptions("")
+	opts.SyncWrites = false
+	dir := t.TempDir()
+	opts.Dir = dir
+	opts.ValueDir = dir
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	return newTestSamplingStore(db)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION

## What this PR does

`InsertThroughput` and `InsertProbabilitiesAndQPS` in the Badger sampling store
(`internal/storage/v1/badger/samplingstore/storage.go`) assigned the result of
`s.store.Update(...)` to `err` but then returned `nil` unconditionally, so a
failed or conflicting write (for example when the underlying DB is closed) was
reported to the caller as success. Both methods now return the error from
`s.store.Update`, matching the sibling `WriteSpan` in the same Badger backend
(`internal/storage/v1/badger/spanstore/writer.go`).

Because the v2 Badger backend's `CreateSamplingStore`
(`internal/storage/v2/badger/factory.go`) delegates to the v1 factory, which
constructs this same `SamplingStore`, the single v1 fix covers both v1 and v2.

Resolves #NNNN

## How was this change tested

Added two regression tests plus a small helper in
`internal/storage/v1/badger/samplingstore/storage_test.go`:

- `TestInsertThroughputError` and `TestInsertProbabilitiesAndQPSError` back the
  store with a closed Badger DB (via a new `newClosedSamplingStore(t)` helper)
  and assert the methods surface `badger.ErrDBClosed`
  (`require.ErrorIs(t, err, badger.ErrDBClosed)`).
- Both tests fail without the fix (the methods return `nil`) and pass with it.

Checks (run on the changed package):

- [x] `make fmt` (gofumpt) - clean
- [x] `make lint` (golangci-lint) - 0 issues
- [x] `go test -race ./internal/storage/v1/badger/samplingstore/...` - ok
- [x] Regression tests fail before the fix, pass after
