### PR TITLE
fix(clickhouse): Order trace search results by max(start_time) DESC

### DIFF
--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -211,7 +211,7 @@ const SelectSpansByTraceID = SelectSpansQuery + " WHERE s.trace_id = ?"
 // The query begins with a no-op predicate (`WHERE 1=1`) so that additional
 // filters can be appended unconditionally using `AND` without needing to check
 // whether this is the first WHERE clause.
-const SearchTraceIDsBase = `SELECT DISTINCT
+const SearchTraceIDsBase = `SELECT
     s.trace_id
 FROM spans s
 WHERE 1=1`
@@ -229,7 +229,8 @@ FROM (
 %s
 ) l
 LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
-GROUP BY l.trace_id`
+GROUP BY l.trace_id
+ORDER BY end DESC, l.trace_id`
 
 const SelectServices = `
 SELECT

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -206,7 +206,9 @@ FROM
 
 const SelectSpansByTraceID = SelectSpansQuery + " WHERE s.trace_id = ?"
 
-// SearchTraceIDsBase is the inner SQL fragment for finding distinct trace IDs.
+// SearchTraceIDsBase is the inner SQL fragment for finding trace IDs.
+// Deduplication and ordering are applied in the query builder via
+// GROUP BY s.trace_id ORDER BY max(s.start_time) DESC.
 //
 // The query begins with a no-op predicate (`WHERE 1=1`) so that additional
 // filters can be appended unconditionally using `AND` without needing to check

--- a/internal/storage/v2/clickhouse/sql/queries.go
+++ b/internal/storage/v2/clickhouse/sql/queries.go
@@ -208,13 +208,17 @@ const SelectSpansByTraceID = SelectSpansQuery + " WHERE s.trace_id = ?"
 
 // SearchTraceIDsBase is the inner SQL fragment for finding trace IDs.
 // Deduplication and ordering are applied in the query builder via
-// GROUP BY s.trace_id ORDER BY max(s.start_time) DESC.
+// GROUP BY s.trace_id ORDER BY max(s.start_time) DESC. The max(s.start_time)
+// aggregate is surfaced as start_time so the outer query can order by it
+// independently of the trace_id_timestamps view (whose end column is
+// non-nullable and defaults to the epoch when the JOIN misses).
 //
 // The query begins with a no-op predicate (`WHERE 1=1`) so that additional
 // filters can be appended unconditionally using `AND` without needing to check
 // whether this is the first WHERE clause.
 const SearchTraceIDsBase = `SELECT
-    s.trace_id
+    s.trace_id,
+    max(s.start_time) AS start_time
 FROM spans s
 WHERE 1=1`
 
@@ -232,7 +236,7 @@ FROM (
 ) l
 LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 GROUP BY l.trace_id
-ORDER BY end DESC, l.trace_id`
+ORDER BY l.start_time DESC, l.trace_id`
 
 const SelectServices = `
 SELECT

--- a/internal/storage/v2/clickhouse/tracestore/query_builder.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder.go
@@ -171,7 +171,7 @@ func (r *Reader) buildFindTraceIDsQuery(
 		return "", nil, err
 	}
 
-	inner.WriteString("\nLIMIT ?")
+	inner.WriteString("\nGROUP BY s.trace_id\nORDER BY max(s.start_time) DESC, s.trace_id\nLIMIT ?")
 	args = append(args, limit)
 
 	// Wrap the inner subquery with a JOIN to trace_id_timestamps

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
@@ -3,7 +3,7 @@ SELECT
     min(t.start) AS start,
     max(t.end) AS end
 FROM (
-	SELECT DISTINCT
+	SELECT
 	    s.trace_id
 	FROM spans s
 	WHERE 1=1
@@ -114,7 +114,10 @@ FROM (
 		AND (
 			arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.str_attributes.key, x.str_attributes.value), s.events)
 		)
+	GROUP BY s.trace_id
+	ORDER BY max(s.start_time) DESC, s.trace_id
 	LIMIT ?
 ) l
 LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 GROUP BY l.trace_id
+ORDER BY end DESC, l.trace_id

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraceIDs_2.sql
@@ -4,7 +4,8 @@ SELECT
     max(t.end) AS end
 FROM (
 	SELECT
-	    s.trace_id
+	    s.trace_id,
+	    max(s.start_time) AS start_time
 	FROM spans s
 	WHERE 1=1
 		AND s.service_name = ?
@@ -120,4 +121,4 @@ FROM (
 ) l
 LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 GROUP BY l.trace_id
-ORDER BY end DESC, l.trace_id
+ORDER BY l.start_time DESC, l.trace_id

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/multiple_spans_1.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/multiple_spans_1.sql
@@ -76,14 +76,17 @@ WHERE s.trace_id IN (
 		    min(t.start) AS start,
 		    max(t.end) AS end
 		FROM (
-			SELECT DISTINCT
+			SELECT
 			    s.trace_id
 			FROM spans s
 			WHERE 1=1
+			GROUP BY s.trace_id
+			ORDER BY max(s.start_time) DESC, s.trace_id
 			LIMIT ?
 		) l
 		LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 		GROUP BY l.trace_id
+		ORDER BY end DESC, l.trace_id
 	)
 )
 ORDER BY s.trace_id

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/multiple_spans_1.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/multiple_spans_1.sql
@@ -77,7 +77,8 @@ WHERE s.trace_id IN (
 		    max(t.end) AS end
 		FROM (
 			SELECT
-			    s.trace_id
+			    s.trace_id,
+			    max(s.start_time) AS start_time
 			FROM spans s
 			WHERE 1=1
 			GROUP BY s.trace_id
@@ -86,7 +87,7 @@ WHERE s.trace_id IN (
 		) l
 		LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 		GROUP BY l.trace_id
-		ORDER BY end DESC, l.trace_id
+		ORDER BY l.start_time DESC, l.trace_id
 	)
 )
 ORDER BY s.trace_id

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/single_span_1.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/single_span_1.sql
@@ -76,14 +76,17 @@ WHERE s.trace_id IN (
 		    min(t.start) AS start,
 		    max(t.end) AS end
 		FROM (
-			SELECT DISTINCT
+			SELECT
 			    s.trace_id
 			FROM spans s
 			WHERE 1=1
+			GROUP BY s.trace_id
+			ORDER BY max(s.start_time) DESC, s.trace_id
 			LIMIT ?
 		) l
 		LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 		GROUP BY l.trace_id
+		ORDER BY end DESC, l.trace_id
 	)
 )
 ORDER BY s.trace_id

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/single_span_1.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_Success/single_span_1.sql
@@ -77,7 +77,8 @@ WHERE s.trace_id IN (
 		    max(t.end) AS end
 		FROM (
 			SELECT
-			    s.trace_id
+			    s.trace_id,
+			    max(s.start_time) AS start_time
 			FROM spans s
 			WHERE 1=1
 			GROUP BY s.trace_id
@@ -86,7 +87,7 @@ WHERE s.trace_id IN (
 		) l
 		LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 		GROUP BY l.trace_id
-		ORDER BY end DESC, l.trace_id
+		ORDER BY l.start_time DESC, l.trace_id
 	)
 )
 ORDER BY s.trace_id

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
@@ -76,7 +76,7 @@ WHERE s.trace_id IN (
 		    min(t.start) AS start,
 		    max(t.end) AS end
 		FROM (
-			SELECT DISTINCT
+			SELECT
 			    s.trace_id
 			FROM spans s
 			WHERE 1=1
@@ -187,10 +187,13 @@ WHERE s.trace_id IN (
 				AND (
 					arrayExists(x -> arrayExists((key, value) -> key = ? AND value = ?, x.str_attributes.key, x.str_attributes.value), s.events)
 				)
+			GROUP BY s.trace_id
+			ORDER BY max(s.start_time) DESC, s.trace_id
 			LIMIT ?
 		) l
 		LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 		GROUP BY l.trace_id
+		ORDER BY end DESC, l.trace_id
 	)
 )
 ORDER BY s.trace_id

--- a/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
+++ b/internal/storage/v2/clickhouse/tracestore/snapshots/TestFindTraces_WithFilters_2.sql
@@ -77,7 +77,8 @@ WHERE s.trace_id IN (
 		    max(t.end) AS end
 		FROM (
 			SELECT
-			    s.trace_id
+			    s.trace_id,
+			    max(s.start_time) AS start_time
 			FROM spans s
 			WHERE 1=1
 				AND s.service_name = ?
@@ -193,7 +194,7 @@ WHERE s.trace_id IN (
 		) l
 		LEFT JOIN trace_id_timestamps t ON l.trace_id = t.trace_id
 		GROUP BY l.trace_id
-		ORDER BY end DESC, l.trace_id
+		ORDER BY l.start_time DESC, l.trace_id
 	)
 )
 ORDER BY s.trace_id


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #8996 — ClickHouse trace search returns an arbitrary, unstable set of traces rather than the most recent ones.

The inner subquery (`SearchTraceIDsBase`) used `SELECT DISTINCT ... LIMIT ?` without any `ORDER BY`, so ClickHouse was free to return whichever rows it found first. This depended on table layout, number of parts, and `max_threads` — the same query on the same data could return different traces. The other three backends (Elasticsearch, badger, memory) all return the newest matches.

## Description of the changes

1. **`sql/queries.go`**: Remove `DISTINCT` from `SearchTraceIDsBase` (replaced by `GROUP BY`)
2. **`query_builder.go`**: Append `GROUP BY s.trace_id ORDER BY max(s.start_time) DESC` before `LIMIT ?` in `buildFindTraceIDsQuery`, after all filter conditions are appended
3. **Snapshots**: Update 4 SQL snapshot files to match the new query shape

The GROUP BY/ORDER BY is placed in the query builder rather than the base SQL fragment so that dynamically-appended filter clauses (service, operation, time, duration, attributes) stay before the grouping, producing valid SQL for both filtered and unfiltered queries.

## How was this change tested?

- `go test -run "TestFindTraceIDs|TestFindTraces" ./internal/storage/v2/clickhouse/tracestore/` — all passed
- `gofmt` — no formatting issues
- Codex review — approved

## Checklist

- [x] The problem is described in the PR description
- [x] The change is scoped to one issue
- [x] All commits are signed (`git commit -s`)
- [x] Tests pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>