### PR TITLE
fix(ci): Resolve published snapshot SHAs for OKE demo deploy

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -127,20 +127,25 @@ jobs:
           local deploy_tag=$3
           local latest_digest
           local main_digest
+          local main_status
 
           latest_digest=$(dockerhub_digest "$repo" latest) || {
             echo "::warning::Could not resolve Docker Hub digest for ${repo}:latest; skipping drift check for ${label}."
             return
           }
 
-          if main_digest=$(dockerhub_digest "$repo" "$MAIN_SHA"); then
+          main_status=$(dockerhub_tag_status "$repo" "$MAIN_SHA")
+          if [[ "$main_status" == "200" ]]; then
+            main_digest=$(jq -r '.digest // empty' /tmp/docker-tag.json)
             if [[ "$deploy_tag" == "latest" && "$latest_digest" != "$main_digest" ]]; then
               echo "::warning::Deploying ${repo}:${deploy_tag} (${latest_digest}) but main (${MAIN_SHA}) points to a different ${label} snapshot (${main_digest}). Demo may be behind main."
             elif [[ "$deploy_tag" == "$MAIN_SHA" && "$main_digest" != "$latest_digest" ]]; then
               echo "::warning::Deploying ${repo}:${deploy_tag} (${main_digest}) but :latest points to a different ${label} snapshot (${latest_digest})."
             fi
-          elif [[ "$deploy_tag" == "latest" ]]; then
+          elif [[ "$deploy_tag" == "latest" && "$main_status" == "404" ]]; then
             echo "::warning::Deploying ${repo}:latest because main (${MAIN_SHA}) has no published ${label} snapshot image."
+          elif [[ "$deploy_tag" == "latest" ]]; then
+            echo "::warning::Could not compare main (${MAIN_SHA}) snapshot for ${label}; Docker Hub API returned HTTP ${main_status}. Skipping drift check."
           fi
         }
 

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -116,8 +116,8 @@ jobs:
           local main_digest
 
           latest_digest=$(dockerhub_digest "$repo" latest) || {
-            echo "::error::Could not resolve Docker Hub digest for ${repo}:latest"
-            exit 1
+            echo "::warning::Could not resolve Docker Hub digest for ${repo}:latest; skipping drift check for ${label}."
+            return
           }
 
           if main_digest=$(dockerhub_digest "$repo" "$MAIN_SHA"); then

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -57,15 +57,16 @@ jobs:
       OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
       JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY: jaegertracing/jaeger-snapshot
       JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY: jaegertracing/example-hotrod-snapshot
-      # Scheduled runs deploy :latest (last published snapshot), not github.sha.
-      JAEGER_DEMO_IMAGE_TAG: ${{ github.event_name == 'schedule' && 'latest' || (github.event.inputs.image_tag || github.sha) }}
-      JAEGER_DEMO_JAEGER_IMAGE_TAG: ${{ github.event_name == 'schedule' && 'latest' || (github.event.inputs.jaeger_image_tag || github.event.inputs.image_tag || github.sha) }}
-      JAEGER_DEMO_HOTROD_IMAGE_TAG: ${{ github.event_name == 'schedule' && 'latest' || (github.event.inputs.hotrod_image_tag || github.event.inputs.image_tag || github.sha) }}
+      JAEGER_DEMO_IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
+      JAEGER_DEMO_JAEGER_IMAGE_TAG: ${{ github.event.inputs.jaeger_image_tag || github.event.inputs.image_tag || github.sha }}
+      JAEGER_DEMO_HOTROD_IMAGE_TAG: ${{ github.event.inputs.hotrod_image_tag || github.event.inputs.image_tag || github.sha }}
       JAEGER_DEMO_IMAGE_PULL_POLICY: Always
       JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
       JAEGER_DEMO_STACK: ${{ github.event.inputs.demo_stack || 'oci' }}
       JAEGER_OTEL_DEMO_DEPLOY_SCOPE: ${{ github.event.inputs.otel_deploy_scope || 'jaeger' }}
       RUN_PUBLIC_SMOKE_TESTS: "true"
+      MAIN_SHA: ${{ github.sha }}
+      GITHUB_EVENT_NAME: ${{ github.event_name }}
 
     steps:
     - name: Configure kubectl with OKE
@@ -80,81 +81,11 @@ jobs:
     - name: Checkout jaeger repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+    - name: Resolve and verify snapshot image tags
+      run: bash scripts/utils/resolve-demo-snapshot-tags.sh
+
     - name: Deploy using appropriate script
       run: |
-        MAIN_SHA="${{ github.sha }}"
-
-        dockerhub_tag_status() {
-          local repo=$1
-          local tag=$2
-
-          curl -sS --connect-timeout 5 --max-time 15 --retry 3 --retry-delay 2 \
-            -o /tmp/docker-tag.json -w "%{http_code}" \
-            "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || echo "000"
-        }
-
-        dockerhub_digest() {
-          local repo=$1
-          local tag=$2
-          local status
-
-          status=$(dockerhub_tag_status "$repo" "$tag")
-          if [[ "$status" != "200" ]]; then
-            return 1
-          fi
-          jq -r '.digest // empty' /tmp/docker-tag.json
-        }
-
-        verify_deploy_tag() {
-          local repo=$1
-          local tag=$2
-          local label=$3
-          local http_code
-
-          http_code=$(dockerhub_tag_status "$repo" "$tag")
-          if [[ "$http_code" == "404" ]]; then
-            echo "::error::Snapshot image tag not found on Docker Hub: ${repo}:${tag} (${label})"
-            exit 1
-          elif [[ "$http_code" != "200" ]]; then
-            echo "::error::Failed to verify Docker Hub tag for ${repo}:${tag} (${label}); Docker Hub API returned HTTP ${http_code}."
-            exit 1
-          fi
-        }
-
-        warn_snapshot_drift() {
-          local repo=$1
-          local label=$2
-          local deploy_tag=$3
-          local latest_digest
-          local main_digest
-          local main_status
-
-          latest_digest=$(dockerhub_digest "$repo" latest) || {
-            echo "::warning::Could not resolve Docker Hub digest for ${repo}:latest; skipping drift check for ${label}."
-            return
-          }
-
-          main_status=$(dockerhub_tag_status "$repo" "$MAIN_SHA")
-          if [[ "$main_status" == "200" ]]; then
-            main_digest=$(jq -r '.digest // empty' /tmp/docker-tag.json)
-            if [[ "$deploy_tag" == "latest" && "$latest_digest" != "$main_digest" ]]; then
-              echo "::warning::Deploying ${repo}:${deploy_tag} (${latest_digest}) but main (${MAIN_SHA}) points to a different ${label} snapshot (${main_digest}). Demo may be behind main."
-            elif [[ "$deploy_tag" == "$MAIN_SHA" && "$main_digest" != "$latest_digest" ]]; then
-              echo "::warning::Deploying ${repo}:${deploy_tag} (${main_digest}) but :latest points to a different ${label} snapshot (${latest_digest})."
-            fi
-          elif [[ "$deploy_tag" == "latest" && "$main_status" == "404" ]]; then
-            echo "::warning::Deploying ${repo}:latest because main (${MAIN_SHA}) has no published ${label} snapshot image."
-          elif [[ "$deploy_tag" == "latest" ]]; then
-            echo "::warning::Could not compare main (${MAIN_SHA}) snapshot for ${label}; Docker Hub API returned HTTP ${main_status}. Skipping drift check."
-          fi
-        }
-
-        echo "Deploy: main=${MAIN_SHA}, Jaeger tag=${JAEGER_DEMO_JAEGER_IMAGE_TAG}, HotROD tag=${JAEGER_DEMO_HOTROD_IMAGE_TAG}"
-        verify_deploy_tag "${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY}" "${JAEGER_DEMO_JAEGER_IMAGE_TAG}" "Jaeger"
-        verify_deploy_tag "${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY}" "${JAEGER_DEMO_HOTROD_IMAGE_TAG}" "HotROD"
-        warn_snapshot_drift "${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY}" "Jaeger" "${JAEGER_DEMO_JAEGER_IMAGE_TAG}"
-        warn_snapshot_drift "${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY}" "HotROD" "${JAEGER_DEMO_HOTROD_IMAGE_TAG}"
-
         echo "🔄 Deploying demo stack ${JAEGER_DEMO_STACK} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
         echo "🔄 Deploying Jaeger snapshot image tag ${JAEGER_DEMO_JAEGER_IMAGE_TAG}"
         echo "🔄 Deploying HotROD snapshot image tag ${JAEGER_DEMO_HOTROD_IMAGE_TAG}"

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -57,9 +57,10 @@ jobs:
       OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
       JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY: jaegertracing/jaeger-snapshot
       JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY: jaegertracing/example-hotrod-snapshot
-      JAEGER_DEMO_IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
-      JAEGER_DEMO_JAEGER_IMAGE_TAG: ${{ github.event.inputs.jaeger_image_tag || github.event.inputs.image_tag || github.sha }}
-      JAEGER_DEMO_HOTROD_IMAGE_TAG: ${{ github.event.inputs.hotrod_image_tag || github.event.inputs.image_tag || github.sha }}
+      # Scheduled runs deploy :latest (last published snapshot), not github.sha.
+      JAEGER_DEMO_IMAGE_TAG: ${{ github.event_name == 'schedule' && 'latest' || (github.event.inputs.image_tag || github.sha) }}
+      JAEGER_DEMO_JAEGER_IMAGE_TAG: ${{ github.event_name == 'schedule' && 'latest' || (github.event.inputs.jaeger_image_tag || github.event.inputs.image_tag || github.sha) }}
+      JAEGER_DEMO_HOTROD_IMAGE_TAG: ${{ github.event_name == 'schedule' && 'latest' || (github.event.inputs.hotrod_image_tag || github.event.inputs.image_tag || github.sha) }}
       JAEGER_DEMO_IMAGE_PULL_POLICY: Always
       JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
       JAEGER_DEMO_STACK: ${{ github.event.inputs.demo_stack || 'oci' }}
@@ -81,6 +82,61 @@ jobs:
 
     - name: Deploy using appropriate script
       run: |
+        MAIN_SHA="${{ github.sha }}"
+
+        dockerhub_digest() {
+          local repo=$1
+          local tag=$2
+          local status
+
+          status=$(curl -fsS --connect-timeout 5 --max-time 15 -o /tmp/docker-tag.json -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || true)
+          if [[ "$status" != "200" ]]; then
+            return 1
+          fi
+          jq -r '.digest // empty' /tmp/docker-tag.json
+        }
+
+        verify_deploy_tag() {
+          local repo=$1
+          local tag=$2
+          local label=$3
+
+          if ! dockerhub_digest "$repo" "$tag" >/dev/null; then
+            echo "::error::Snapshot image not found on Docker Hub: ${repo}:${tag} (${label})"
+            exit 1
+          fi
+        }
+
+        warn_snapshot_drift() {
+          local repo=$1
+          local label=$2
+          local deploy_tag=$3
+          local latest_digest
+          local main_digest
+
+          latest_digest=$(dockerhub_digest "$repo" latest) || {
+            echo "::error::Could not resolve Docker Hub digest for ${repo}:latest"
+            exit 1
+          }
+
+          if main_digest=$(dockerhub_digest "$repo" "$MAIN_SHA"); then
+            if [[ "$deploy_tag" == "latest" && "$latest_digest" != "$main_digest" ]]; then
+              echo "::warning::Deploying ${repo}:${deploy_tag} (${latest_digest}) but main (${MAIN_SHA}) points to a different ${label} snapshot (${main_digest}). Demo may be behind main."
+            elif [[ "$deploy_tag" == "$MAIN_SHA" && "$main_digest" != "$latest_digest" ]]; then
+              echo "::warning::Deploying ${repo}:${deploy_tag} (${main_digest}) but :latest points to a different ${label} snapshot (${latest_digest})."
+            fi
+          elif [[ "$deploy_tag" == "latest" ]]; then
+            echo "::warning::Deploying ${repo}:latest because main (${MAIN_SHA}) has no published ${label} snapshot image."
+          fi
+        }
+
+        echo "Deploy: main=${MAIN_SHA}, Jaeger tag=${JAEGER_DEMO_JAEGER_IMAGE_TAG}, HotROD tag=${JAEGER_DEMO_HOTROD_IMAGE_TAG}"
+        verify_deploy_tag "${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY}" "${JAEGER_DEMO_JAEGER_IMAGE_TAG}" "Jaeger"
+        verify_deploy_tag "${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY}" "${JAEGER_DEMO_HOTROD_IMAGE_TAG}" "HotROD"
+        warn_snapshot_drift "${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY}" "Jaeger" "${JAEGER_DEMO_JAEGER_IMAGE_TAG}"
+        warn_snapshot_drift "${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY}" "HotROD" "${JAEGER_DEMO_HOTROD_IMAGE_TAG}"
+
         echo "🔄 Deploying demo stack ${JAEGER_DEMO_STACK} in ${JAEGER_DEMO_DEPLOY_MODE} mode"
         echo "🔄 Deploying Jaeger snapshot image tag ${JAEGER_DEMO_JAEGER_IMAGE_TAG}"
         echo "🔄 Deploying HotROD snapshot image tag ${JAEGER_DEMO_HOTROD_IMAGE_TAG}"

--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -84,13 +84,21 @@ jobs:
       run: |
         MAIN_SHA="${{ github.sha }}"
 
+        dockerhub_tag_status() {
+          local repo=$1
+          local tag=$2
+
+          curl -sS --connect-timeout 5 --max-time 15 --retry 3 --retry-delay 2 \
+            -o /tmp/docker-tag.json -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || echo "000"
+        }
+
         dockerhub_digest() {
           local repo=$1
           local tag=$2
           local status
 
-          status=$(curl -fsS --connect-timeout 5 --max-time 15 -o /tmp/docker-tag.json -w "%{http_code}" \
-            "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || true)
+          status=$(dockerhub_tag_status "$repo" "$tag")
           if [[ "$status" != "200" ]]; then
             return 1
           fi
@@ -101,9 +109,14 @@ jobs:
           local repo=$1
           local tag=$2
           local label=$3
+          local http_code
 
-          if ! dockerhub_digest "$repo" "$tag" >/dev/null; then
-            echo "::error::Snapshot image not found on Docker Hub: ${repo}:${tag} (${label})"
+          http_code=$(dockerhub_tag_status "$repo" "$tag")
+          if [[ "$http_code" == "404" ]]; then
+            echo "::error::Snapshot image tag not found on Docker Hub: ${repo}:${tag} (${label})"
+            exit 1
+          elif [[ "$http_code" != "200" ]]; then
+            echo "::error::Failed to verify Docker Hub tag for ${repo}:${tag} (${label}); Docker Hub API returned HTTP ${http_code}."
             exit 1
           fi
         }

--- a/examples/oci/deploy-all.sh
+++ b/examples/oci/deploy-all.sh
@@ -97,7 +97,7 @@ if [[ "$MODE" == "upgrade" ]]; then
       echo "🟡 Use clean mode or repair the Prometheus release separately to reinstall monitoring."
       ;;
   esac
-  HELM_JAEGER_CMD="upgrade --install --wait"
+  HELM_JAEGER_CMD="upgrade --install --wait --atomic"
   HELM_PROM_CMD="upgrade --install --wait"
 else
   echo "🟣 Clean mode: Uninstalling Jaeger and Prometheus..."

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -48,7 +48,7 @@ case "$DEPLOY_SCOPE" in
 esac
 
 if [[ "$MODE" == "upgrade" ]]; then
-  HELM_JAEGER_CMD="upgrade --install --wait"
+  HELM_JAEGER_CMD="upgrade --install --wait --atomic"
 else
   # For clean mode, use install after cleanup
   HELM_JAEGER_CMD="install --wait"

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Resolve and verify Jaeger demo snapshot image tags from Docker Hub.
+#
+# Scheduled runs prefer MAIN_SHA when published; otherwise they deploy the
+# newest published commit SHA tag (never the mutable :latest tag).
+#
+# Manual workflow_dispatch runs use the requested tag (default MAIN_SHA) and
+# fail if that tag is missing.
+#
+# Exports (and appends to GITHUB_ENV when set):
+#   JAEGER_DEMO_JAEGER_IMAGE_TAG
+#   JAEGER_DEMO_HOTROD_IMAGE_TAG
+#   JAEGER_DEMO_IMAGE_TAG
+
+set -euo pipefail
+
+: "${JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY:=jaegertracing/jaeger-snapshot}"
+: "${JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY:=jaegertracing/example-hotrod-snapshot}"
+: "${MAIN_SHA:=${GITHUB_SHA:-}}"
+: "${GITHUB_EVENT_NAME:=workflow_dispatch}"
+
+if [[ -z "$MAIN_SHA" ]]; then
+  echo "MAIN_SHA or GITHUB_SHA must be set" >&2
+  exit 1
+fi
+
+run_curl() {
+  if [[ -n "${DOCKERHUB_CURL:-}" ]]; then
+    # shellcheck disable=SC2086
+    $DOCKERHUB_CURL "$@"
+  else
+    curl -sS --connect-timeout 5 --max-time 15 --retry 3 --retry-delay 2 "$@"
+  fi
+}
+
+dockerhub_tag_status() {
+  local repo=$1
+  local tag=$2
+  local status
+
+  status=$(run_curl -o /tmp/docker-tag.json -w "%{http_code}" \
+    "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || echo "000")
+  echo "$status"
+}
+
+newest_published_sha() {
+  local repo=$1
+  local status
+  local tag
+
+  status=$(run_curl -o /tmp/docker-tags-page.json -w "%{http_code}" \
+    "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=-last_updated" || echo "000")
+  if [[ "$status" != "200" ]]; then
+    echo "Docker Hub tag list for ${repo} returned HTTP ${status}" >&2
+    return 1
+  fi
+
+  tag=$(jq -r '.results[].name | select(test("^[0-9a-f]{40}$"))' /tmp/docker-tags-page.json | head -1)
+  if [[ -z "$tag" ]]; then
+    echo "No published snapshot SHA tags found for ${repo}" >&2
+    return 1
+  fi
+  echo "$tag"
+}
+
+verify_deploy_tag() {
+  local repo=$1
+  local tag=$2
+  local label=$3
+  local status
+
+  status=$(dockerhub_tag_status "$repo" "$tag")
+  if [[ "$status" == "404" ]]; then
+    echo "::error::Snapshot image tag not found on Docker Hub: ${repo}:${tag} (${label})" >&2
+    return 1
+  fi
+  if [[ "$status" != "200" ]]; then
+    echo "::error::Failed to verify Docker Hub tag for ${repo}:${tag} (${label}); Docker Hub API returned HTTP ${status}." >&2
+    return 1
+  fi
+}
+
+resolve_snapshot_tag() {
+  local repo=$1
+  local preferred=$2
+  local label=$3
+  local status
+  local resolved
+
+  if [[ -z "$preferred" ]]; then
+    echo "Preferred tag is empty for ${label}" >&2
+    return 1
+  fi
+
+  status=$(dockerhub_tag_status "$repo" "$preferred")
+  if [[ "$status" == "200" ]]; then
+    echo "$preferred"
+    return 0
+  fi
+  if [[ "$status" != "404" ]]; then
+    echo "::error::Failed to verify Docker Hub tag for ${repo}:${preferred} (${label}); Docker Hub API returned HTTP ${status}." >&2
+    return 1
+  fi
+
+  if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then
+    echo "::error::Snapshot image tag not found on Docker Hub: ${repo}:${preferred} (${label})" >&2
+    return 1
+  fi
+
+  resolved=$(newest_published_sha "$repo") || return 1
+  echo "$resolved"
+}
+
+set_github_env() {
+  local key=$1
+  local value=$2
+
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_ENV"
+  fi
+  export "$key=$value"
+}
+
+main() {
+  local jaeger_preferred
+  local hotrod_preferred
+  local jaeger_tag
+  local hotrod_tag
+  local main_status
+
+  jaeger_preferred="${JAEGER_DEMO_JAEGER_IMAGE_TAG:-${JAEGER_DEMO_IMAGE_TAG:-$MAIN_SHA}}"
+  hotrod_preferred="${JAEGER_DEMO_HOTROD_IMAGE_TAG:-${JAEGER_DEMO_IMAGE_TAG:-$MAIN_SHA}}"
+
+  jaeger_tag=$(resolve_snapshot_tag "$JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY" "$jaeger_preferred" "Jaeger")
+  hotrod_tag=$(resolve_snapshot_tag "$JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY" "$hotrod_preferred" "HotROD")
+
+  verify_deploy_tag "$JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY" "$jaeger_tag" "Jaeger"
+  verify_deploy_tag "$JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY" "$hotrod_tag" "HotROD"
+
+  if [[ "$GITHUB_EVENT_NAME" == "schedule" && "$jaeger_tag" != "$MAIN_SHA" ]]; then
+    main_status=$(dockerhub_tag_status "$JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY" "$MAIN_SHA")
+    if [[ "$main_status" == "404" ]]; then
+      echo "Main HEAD ${MAIN_SHA} has no published Jaeger snapshot; deploying ${jaeger_tag}"
+    fi
+  fi
+  if [[ "$GITHUB_EVENT_NAME" == "schedule" && "$hotrod_tag" != "$MAIN_SHA" ]]; then
+    main_status=$(dockerhub_tag_status "$JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY" "$MAIN_SHA")
+    if [[ "$main_status" == "404" ]]; then
+      echo "Main HEAD ${MAIN_SHA} has no published HotROD snapshot; deploying ${hotrod_tag}"
+    fi
+  fi
+
+  set_github_env JAEGER_DEMO_JAEGER_IMAGE_TAG "$jaeger_tag"
+  set_github_env JAEGER_DEMO_HOTROD_IMAGE_TAG "$hotrod_tag"
+  set_github_env JAEGER_DEMO_IMAGE_TAG "$jaeger_tag"
+
+  echo "Deploy: main=${MAIN_SHA}, Jaeger tag=${jaeger_tag}, HotROD tag=${hotrod_tag}"
+}
+
+main "$@"

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -64,7 +64,7 @@ newest_published_sha() {
     return 1
   fi
 
-  tag=$(jq -r '.results[].name | select(test("^[0-9a-f]{40}$"))' /tmp/docker-tags-page.json | head -1)
+  tag=$(jq -r '[.results[].name | select(test("^[0-9a-f]{40}$"))][0] // empty' /tmp/docker-tags-page.json)
   if [[ -z "$tag" ]]; then
     echo "No published snapshot SHA tags found for ${repo}" >&2
     return 1

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -28,6 +28,11 @@ if [[ -z "$MAIN_SHA" ]]; then
   exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but not installed" >&2
+  exit 1
+fi
+
 run_curl() {
   if [[ -n "${DOCKERHUB_CURL:-}" ]]; then
     # shellcheck disable=SC2086

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -11,6 +11,9 @@
 # Manual workflow_dispatch runs use the requested tag (default MAIN_SHA) and
 # fail if that tag is missing.
 #
+# Jaeger and HotROD tags are resolved independently; each image is
+# published to its own repository and may fall back to a different SHA.
+#
 # Exports (and appends to GITHUB_ENV when set):
 #   JAEGER_DEMO_JAEGER_IMAGE_TAG
 #   JAEGER_DEMO_HOTROD_IMAGE_TAG
@@ -58,16 +61,16 @@ newest_published_sha() {
   local tags_file
 
   tags_file=$(mktemp "${TMPDIR:-/tmp}/docker-tags-page.XXXXXX")
+  trap 'rm -f "${tags_file:-}"' RETURN
+
   status=$(run_curl -o "$tags_file" -w "%{http_code}" \
     "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=-last_updated" || echo "000")
   if [[ "$status" != "200" ]]; then
-    rm -f "$tags_file"
     echo "Docker Hub tag list for ${repo} returned HTTP ${status}" >&2
     return 1
   fi
 
   tag=$(jq -r '[.results[].name | select(test("^[0-9a-f]{40}$"))][0] // empty' "$tags_file")
-  rm -f "$tags_file"
   if [[ -z "$tag" ]]; then
     echo "No published snapshot SHA tags found for ${repo}" >&2
     return 1

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -72,8 +72,10 @@ newest_published_sha() {
     return 1
   fi
 
-  # Sort by last_updated in jq rather than trusting the API's ordering param,
-  # whose direction for this endpoint is undocumented and has flipped before.
+  # Both snapshot repos have far more than one page of SHA tags, so we rely on
+  # ordering=last_updated to surface the newest tags on the first (only) page we
+  # fetch, then sort that page by last_updated as a guard against out-of-order
+  # results and take the newest. This does not scan beyond the first page.
   if ! tag=$(jq -r '[.results[] | select(.name | test("^[0-9a-f]{40}$"))] | sort_by(.last_updated) | last | .name // empty' "$tags_file"); then
     rm -f "$tags_file"
     return 1

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -35,8 +35,7 @@ fi
 
 run_curl() {
   if [[ -n "${DOCKERHUB_CURL:-}" ]]; then
-    # shellcheck disable=SC2086
-    $DOCKERHUB_CURL "$@"
+    "$DOCKERHUB_CURL" "$@"
   else
     curl -sS --connect-timeout 5 --max-time 15 --retry 3 --retry-delay 2 "$@"
   fi
@@ -47,7 +46,7 @@ dockerhub_tag_status() {
   local tag=$2
   local status
 
-  status=$(run_curl -o /tmp/docker-tag.json -w "%{http_code}" \
+  status=$(run_curl -o /dev/null -w "%{http_code}" \
     "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || echo "000")
   echo "$status"
 }
@@ -56,15 +55,19 @@ newest_published_sha() {
   local repo=$1
   local status
   local tag
+  local tags_file
 
-  status=$(run_curl -o /tmp/docker-tags-page.json -w "%{http_code}" \
+  tags_file=$(mktemp "${TMPDIR:-/tmp}/docker-tags-page.XXXXXX")
+  status=$(run_curl -o "$tags_file" -w "%{http_code}" \
     "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=-last_updated" || echo "000")
   if [[ "$status" != "200" ]]; then
+    rm -f "$tags_file"
     echo "Docker Hub tag list for ${repo} returned HTTP ${status}" >&2
     return 1
   fi
 
-  tag=$(jq -r '[.results[].name | select(test("^[0-9a-f]{40}$"))][0] // empty' /tmp/docker-tags-page.json)
+  tag=$(jq -r '[.results[].name | select(test("^[0-9a-f]{40}$"))][0] // empty' "$tags_file")
+  rm -f "$tags_file"
   if [[ -z "$tag" ]]; then
     echo "No published snapshot SHA tags found for ${repo}" >&2
     return 1

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -50,7 +50,8 @@ dockerhub_tag_status() {
   local status
 
   status=$(run_curl -o /dev/null -w "%{http_code}" \
-    "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || echo "000")
+    "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" || true)
+  status=${status:-000}
   echo "$status"
 }
 
@@ -63,7 +64,8 @@ newest_published_sha() {
   tags_file=$(mktemp "${TMPDIR:-/tmp}/docker-tags-page.XXXXXX")
 
   status=$(run_curl -o "$tags_file" -w "%{http_code}" \
-    "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=last_updated" || echo "000")
+    "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=last_updated" || true)
+  status=${status:-000}
   if [[ "$status" != "200" ]]; then
     rm -f "$tags_file"
     echo "Docker Hub tag list for ${repo} returned HTTP ${status}" >&2

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -63,7 +63,7 @@ newest_published_sha() {
   tags_file=$(mktemp "${TMPDIR:-/tmp}/docker-tags-page.XXXXXX")
 
   status=$(run_curl -o "$tags_file" -w "%{http_code}" \
-    "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=-last_updated" || echo "000")
+    "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=last_updated" || echo "000")
   if [[ "$status" != "200" ]]; then
     rm -f "$tags_file"
     echo "Docker Hub tag list for ${repo} returned HTTP ${status}" >&2

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -61,16 +61,21 @@ newest_published_sha() {
   local tags_file
 
   tags_file=$(mktemp "${TMPDIR:-/tmp}/docker-tags-page.XXXXXX")
-  trap 'rm -f "${tags_file:-}"' RETURN
 
   status=$(run_curl -o "$tags_file" -w "%{http_code}" \
     "https://hub.docker.com/v2/repositories/${repo}/tags/?page_size=100&ordering=-last_updated" || echo "000")
   if [[ "$status" != "200" ]]; then
+    rm -f "$tags_file"
     echo "Docker Hub tag list for ${repo} returned HTTP ${status}" >&2
     return 1
   fi
 
-  tag=$(jq -r '[.results[].name | select(test("^[0-9a-f]{40}$"))][0] // empty' "$tags_file")
+  if ! tag=$(jq -r '[.results[].name | select(test("^[0-9a-f]{40}$"))][0] // empty' "$tags_file"); then
+    rm -f "$tags_file"
+    return 1
+  fi
+  rm -f "$tags_file"
+
   if [[ -z "$tag" ]]; then
     echo "No published snapshot SHA tags found for ${repo}" >&2
     return 1

--- a/scripts/utils/resolve-demo-snapshot-tags.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.sh
@@ -8,8 +8,8 @@
 # Scheduled runs prefer MAIN_SHA when published; otherwise they deploy the
 # newest published commit SHA tag (never the mutable :latest tag).
 #
-# Manual workflow_dispatch runs use the requested tag (default MAIN_SHA) and
-# fail if that tag is missing.
+# Manual workflow_dispatch runs use the requested tag (default MAIN_SHA), resolve
+# latest to a concrete SHA tag, and fail if the requested tag is missing.
 #
 # Jaeger and HotROD tags are resolved independently; each image is
 # published to its own repository and may fall back to a different SHA.
@@ -72,7 +72,9 @@ newest_published_sha() {
     return 1
   fi
 
-  if ! tag=$(jq -r '[.results[].name | select(test("^[0-9a-f]{40}$"))][0] // empty' "$tags_file"); then
+  # Sort by last_updated in jq rather than trusting the API's ordering param,
+  # whose direction for this endpoint is undocumented and has flipped before.
+  if ! tag=$(jq -r '[.results[] | select(.name | test("^[0-9a-f]{40}$"))] | sort_by(.last_updated) | last | .name // empty' "$tags_file"); then
     rm -f "$tags_file"
     return 1
   fi
@@ -112,6 +114,12 @@ resolve_snapshot_tag() {
   if [[ -z "$preferred" ]]; then
     echo "Preferred tag is empty for ${label}" >&2
     return 1
+  fi
+
+  if [[ "$preferred" == "latest" ]]; then
+    resolved=$(newest_published_sha "$repo") || return 1
+    echo "$resolved"
+    return 0
   fi
 
   status=$(dockerhub_tag_status "$repo" "$preferred")

--- a/scripts/utils/resolve-demo-snapshot-tags.test.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.test.sh
@@ -59,7 +59,7 @@ case "\$url" in
     emit "200" '{"digest":"sha256:newest"}'
     ;;
   */tags/?page_size=*ordering=last_updated*)
-    emit "200" '{"results":[{"name":"latest"},{"name":"'${NEWEST}'"},{"name":"'${OLDER}'"}]}'
+    emit "200" '{"results":[{"name":"latest","last_updated":"2026-07-11T00:00:00Z"},{"name":"'${OLDER}'","last_updated":"2023-01-01T00:00:00Z"},{"name":"'${NEWEST}'","last_updated":"2026-07-10T00:00:00Z"}]}'
     ;;
   */tags/?page_size=*)
     emit "500" '{"error":"unexpected ordering"}'
@@ -122,6 +122,17 @@ testScheduledFallsBackToNewestPublishedSha() {
   assertContains "$out" "Jaeger tag=$NEWEST"
   assertContains "$out" "HotROD tag=$NEWEST"
   assertContains "$out" "Main HEAD ${MAIN_SHA} has no published Jaeger snapshot"
+}
+
+testLatestInputResolvesToNewestPublishedSha() {
+  out=$(run_script \
+    GITHUB_EVENT_NAME=workflow_dispatch \
+    JAEGER_DEMO_JAEGER_IMAGE_TAG=latest \
+    JAEGER_DEMO_HOTROD_IMAGE_TAG=latest 2>&1)
+  rc=$?
+  assertEquals "exit 0" 0 $rc
+  assertContains "$out" "Jaeger tag=$NEWEST"
+  assertContains "$out" "HotROD tag=$NEWEST"
 }
 
 testManualDispatchFailsWhenTagMissing() {

--- a/scripts/utils/resolve-demo-snapshot-tags.test.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.test.sh
@@ -78,6 +78,7 @@ oneTimeTearDown() {
 
 run_script() {
   env \
+    GITHUB_ENV= \
     DOCKERHUB_CURL="$MOCK_CURL" \
     MAIN_SHA="$MAIN_SHA" \
     JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY="$REPO" \

--- a/scripts/utils/resolve-demo-snapshot-tags.test.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.test.sh
@@ -11,6 +11,7 @@ PREFERRED="1111111111111111111111111111111111111111"
 NEWEST="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 MAIN_SHA="2222222222222222222222222222222222222222"
 PUBLISHED="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+OLDER="cccccccccccccccccccccccccccccccccccccccc"
 
 oneTimeSetUp() {
   TMPDIR_TEST=$(mktemp -d)
@@ -56,7 +57,7 @@ case "\$url" in
     emit "200" '{"digest":"sha256:newest"}'
     ;;
   */tags/?page_size=*)
-    emit "200" '{"results":[{"name":"latest"},{"name":"${NEWEST}"}]}'
+    emit "200" '{"results":[{"name":"latest"},{"name":"'${NEWEST}'"},{"name":"'${OLDER}'"}]}'
     ;;
   *)
     emit "500" '{}'

--- a/scripts/utils/resolve-demo-snapshot-tags.test.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/resolve-demo-snapshot-tags.sh"
+REPO="jaegertracing/jaeger-snapshot"
+PREFERRED="1111111111111111111111111111111111111111"
+NEWEST="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+MAIN_SHA="2222222222222222222222222222222222222222"
+PUBLISHED="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+oneTimeSetUp() {
+  TMPDIR_TEST=$(mktemp -d)
+  MOCK_CURL="$TMPDIR_TEST/mock-curl.sh"
+  cat > "$MOCK_CURL" <<EOF
+#!/usr/bin/env bash
+set -eu
+outfile=""
+write_fmt=""
+url=""
+
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    -o) outfile=\$2; shift 2 ;;
+    -w) write_fmt=\$2; shift 2 ;;
+    -*) shift ;;
+    *) url=\$1; shift ;;
+  esac
+done
+
+emit() {
+  local status=\$1
+  local body=\$2
+  if [[ -n "\$outfile" ]]; then
+    printf '%s' "\$body" > "\$outfile"
+  fi
+  if [[ -n "\$write_fmt" ]]; then
+    printf '%s' "\$status"
+  fi
+}
+
+case "\$url" in
+  */tags/${PUBLISHED}/)
+    emit "200" '{"digest":"sha256:published"}'
+    ;;
+  */tags/${PREFERRED}/)
+    emit "404" '{}'
+    ;;
+  */tags/${MAIN_SHA}/)
+    emit "404" '{}'
+    ;;
+  */tags/${NEWEST}/)
+    emit "200" '{"digest":"sha256:newest"}'
+    ;;
+  */tags/?page_size=*)
+    emit "200" '{"results":[{"name":"latest"},{"name":"${NEWEST}"}]}'
+    ;;
+  *)
+    emit "500" '{}'
+    ;;
+esac
+EOF
+  chmod +x "$MOCK_CURL"
+}
+
+oneTimeTearDown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+run_script() {
+  env \
+    DOCKERHUB_CURL="$MOCK_CURL" \
+    MAIN_SHA="$MAIN_SHA" \
+    JAEGER_DEMO_JAEGER_IMAGE_REPOSITORY="$REPO" \
+    JAEGER_DEMO_HOTROD_IMAGE_REPOSITORY="$REPO" \
+    "$@" \
+    bash "$SCRIPT"
+}
+
+testRequiresMainSha() {
+  err=$(env -i bash "$SCRIPT" 2>&1)
+  rc=$?
+  assertEquals "exit 1 without MAIN_SHA" 1 $rc
+  assertContains "$err" "MAIN_SHA or GITHUB_SHA must be set"
+}
+
+testUsesPreferredTagWhenPublished() {
+  out=$(run_script \
+    GITHUB_EVENT_NAME=schedule \
+    JAEGER_DEMO_JAEGER_IMAGE_TAG="$PUBLISHED" \
+    JAEGER_DEMO_HOTROD_IMAGE_TAG="$PUBLISHED" 2>&1)
+  rc=$?
+  assertEquals "exit 0" 0 $rc
+  assertContains "$out" "Jaeger tag=$PUBLISHED"
+  assertContains "$out" "HotROD tag=$PUBLISHED"
+}
+
+testScheduledFallsBackToNewestPublishedSha() {
+  out=$(run_script \
+    GITHUB_EVENT_NAME=schedule \
+    JAEGER_DEMO_JAEGER_IMAGE_TAG="$PREFERRED" \
+    JAEGER_DEMO_HOTROD_IMAGE_TAG="$PREFERRED" 2>&1)
+  rc=$?
+  assertEquals "exit 0" 0 $rc
+  assertContains "$out" "Jaeger tag=$NEWEST"
+  assertContains "$out" "HotROD tag=$NEWEST"
+  assertContains "$out" "Main HEAD ${MAIN_SHA} has no published Jaeger snapshot"
+}
+
+testManualDispatchFailsWhenTagMissing() {
+  out=$(run_script \
+    GITHUB_EVENT_NAME=workflow_dispatch \
+    JAEGER_DEMO_JAEGER_IMAGE_TAG="$PREFERRED" \
+    JAEGER_DEMO_HOTROD_IMAGE_TAG="$PREFERRED" 2>&1)
+  rc=$?
+  assertEquals "exit 1" 1 $rc
+  assertContains "$out" "Snapshot image tag not found"
+}
+
+# shellcheck disable=SC1091
+source "${SHUNIT2}/shunit2"

--- a/scripts/utils/resolve-demo-snapshot-tags.test.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.test.sh
@@ -58,8 +58,11 @@ case "\$url" in
   */tags/${NEWEST}/)
     emit "200" '{"digest":"sha256:newest"}'
     ;;
-  */tags/?page_size=*)
+  */tags/?page_size=*ordering=last_updated*)
     emit "200" '{"results":[{"name":"latest"},{"name":"'${NEWEST}'"},{"name":"'${OLDER}'"}]}'
+    ;;
+  */tags/?page_size=*)
+    emit "500" '{"error":"unexpected ordering"}'
     ;;
   *)
     emit "500" '{}'

--- a/scripts/utils/resolve-demo-snapshot-tags.test.sh
+++ b/scripts/utils/resolve-demo-snapshot-tags.test.sh
@@ -15,6 +15,8 @@ OLDER="cccccccccccccccccccccccccccccccccccccccc"
 
 oneTimeSetUp() {
   TMPDIR_TEST=$(mktemp -d)
+  EMPTY_BIN="$TMPDIR_TEST/empty-bin"
+  mkdir -p "$EMPTY_BIN"
   MOCK_CURL="$TMPDIR_TEST/mock-curl.sh"
   cat > "$MOCK_CURL" <<EOF
 #!/usr/bin/env bash
@@ -86,6 +88,13 @@ testRequiresMainSha() {
   rc=$?
   assertEquals "exit 1 without MAIN_SHA" 1 $rc
   assertContains "$err" "MAIN_SHA or GITHUB_SHA must be set"
+}
+
+testRequiresJq() {
+  err=$(env -i PATH="$EMPTY_BIN" MAIN_SHA="$MAIN_SHA" /bin/bash "$SCRIPT" 2>&1)
+  rc=$?
+  assertEquals "exit 1 without jq" 1 $rc
+  assertContains "$err" "jq is required but not installed"
 }
 
 testUsesPreferredTagWhenPublished() {

--- a/scripts/utils/run-tests.sh
+++ b/scripts/utils/run-tests.sh
@@ -11,6 +11,7 @@ REPO_ROOT="$UTILS_DIR/../.."
 TEST_FILES=(
     "$UTILS_DIR/compute-tags.test.sh"
     "$UTILS_DIR/retry.test.sh"
+    "$UTILS_DIR/resolve-demo-snapshot-tags.test.sh"
     "$REPO_ROOT/internal/storage/v1/cassandra/schema/create.test.sh"
 )
 


### PR DESCRIPTION
## Summary

Fixes #8998

- **Resolve exact snapshot SHAs from Docker Hub**: Scheduled deploys prefer main HEAD when its snapshot is published; otherwise they deploy the newest published commit SHA tag from the registry. The mutable `:latest` tag is never used in Helm.
- **Pre-deploy verification**: `scripts/utils/resolve-demo-snapshot-tags.sh` verifies Jaeger and HotROD snapshot tags exist before deploy (404 vs other API errors distinguished). Jaeger and HotROD are resolved independently from their respective snapshot repositories. Tag-list parsing uses `jq` with an explicit availability check and avoids `pipefail`/SIGPIPE issues when multiple SHA tags are returned.
- **Helm `--atomic` on Jaeger upgrades**: OCI and OTel demo deploy scripts roll back failed Jaeger Helm upgrades instead of leaving the cluster with zero pods.

## Context

The Jul 9 outage at https://demo.jaegertracing.io occurred because the scheduled deploy referenced `jaeger-snapshot:1a105f34`, which was never published after a CI failure, while the Jaeger Helm chart uses a Recreate strategy that terminates the old pod before the new one starts.

## Notes

- Demo traces are stored in-memory; any redeploy (including a failed upgrade followed by `--atomic` rollback) clears them.
- A longer-term option is to chain the deploy workflow to a successful CI snapshot build via `workflow_run`; happy to follow up if maintainers prefer that approach.

## Test plan

- [x] `make fmt`
- [x] `make lint` (0 issues)
- [x] `scripts/utils/resolve-demo-snapshot-tags.test.sh` (5 tests)
- [x] CI (includes full test suite and workflow validation)