### PR TITLE
Fix exclusive time-bound filtering in memory storage GetDependencies 

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -838,7 +838,10 @@ func TestGetDependencies(t *testing.T) {
 		EndTime:   span1StartTime.Add(5 * time.Second),
 	})
 	require.NoError(t, err)
-	assert.Len(t, boundaryDeps, 2)
+	assert.ElementsMatch(t, []model.DependencyLink{
+		{Parent: "service-y", Child: "service-x", CallCount: 2},
+		{Parent: "service-z", Child: "service-y", CallCount: 1},
+	}, boundaryDeps)
 
 	// A query whose window falls strictly inside the trace's span, so the trace is excluded.
 	emptyDeps, err := store.GetDependencies(context.Background(), depstore.QueryParameters{

--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -833,9 +833,17 @@ func TestGetDependencies(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Len(t, newDeps2, 2)
-	emptyDeps, err := store.GetDependencies(context.Background(), depstore.QueryParameters{
+	boundaryDeps, err := store.GetDependencies(context.Background(), depstore.QueryParameters{
 		StartTime: span1StartTime.Add(-4 * time.Second),
 		EndTime:   span1StartTime.Add(5 * time.Second),
+	})
+	require.NoError(t, err)
+	assert.Len(t, boundaryDeps, 2)
+
+	// A query whose window falls strictly inside the trace's span, so the trace is excluded.
+	emptyDeps, err := store.GetDependencies(context.Background(), depstore.QueryParameters{
+		StartTime: span1StartTime.Add(-3 * time.Second),
+		EndTime:   span1StartTime.Add(4 * time.Second),
 	})
 	require.NoError(t, err)
 	assert.Empty(t, emptyDeps)

--- a/internal/storage/v2/memory/sampling_test.go
+++ b/internal/storage/v2/memory/sampling_test.go
@@ -42,7 +42,7 @@ func TestInsertThroughtput(t *testing.T) {
 			{Service: "our-svc", Operation: "op2"},
 		}
 		require.NoError(t, samplingStore.InsertThroughput(throughputs))
-		ret, _ := samplingStore.GetThroughput(start, start.Add(time.Second*time.Duration(1)))
+		ret, _ := samplingStore.GetThroughput(start.Add(-time.Second), start.Add(time.Second*time.Duration(1)))
 		assert.Len(t, ret, 2)
 
 		for i := range 10 {

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -42,9 +42,9 @@ type traceAndId struct {
 
 func (t traceAndId) traceIsBetweenStartAndEnd(startTime time.Time, endTime time.Time) bool {
 	if endTime.IsZero() {
-		return t.startTime.After(startTime)
+		return !t.startTime.Before(startTime)
 	}
-	return t.startTime.After(startTime) && t.endTime.Before(endTime)
+	return !t.startTime.Before(startTime) && !t.endTime.After(endTime)
 }
 
 func newTenant(cfg *Configuration) *Tenant {


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9002

## Description of the changes

- `traceIsBetweenStartAndEnd` in the memory storage backend used strict `.After()`/`.Before()` comparisons, silently excluding traces whose start/end time exactly matched a `GetDependencies` query's boundary. Changed both comparisons to inclusive bounds (`!Before`/`!After`), aligning with the Elasticsearch backend's inclusive `Gte`/`Lte` semantics and this package's own `validSpan` inclusive checks. The `endTime.IsZero()` no-upper-bound branch is preserved unchanged.

## How was this change tested?

- Corrected the existing `emptyDeps` case in `TestGetDependencies`, which was querying exactly on the trace's boundary and asserting an empty result — that assertion was encoding the exclusive-bounds bug. Its query window now falls strictly inside the trace's span to test genuine exclusion.
- Added a new `boundaryDeps` case asserting a query with `StartTime`/`EndTime` set exactly to the trace's boundary now returns the expected dependency link.
- Ran `go test -v ./internal/storage/v2/memory -run TestGetDependencies` — all cases pass.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR

- [x] **Moderate**: AI helped with code generation or debugging specific parts