### PR TITLE
fix(es): Surface failed _msearch items instead of dropping traces silently.

### DIFF
--- a/internal/storage/elasticsearch/esclient/search.go
+++ b/internal/storage/elasticsearch/esclient/search.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -73,8 +74,26 @@ func (r SearchRequest) body() ([]byte, error) {
 // matched documents (hits) and aggregation buckets; other aggregation shapes are
 // added by later migration slices as their callers need them.
 type SearchResponse struct {
+	// Error and Status report a failed _msearch item; see Err. A failed item
+	// carries an error object and a non-2xx status instead of hits, inside an
+	// overall HTTP 200 _msearch response.
+	Error  json.RawMessage `json:"error,omitempty"`
+	Status int             `json:"status,omitempty"`
+
 	Hits         HitsResult   `json:"hits"`
 	Aggregations Aggregations `json:"aggregations"`
+}
+
+// Err returns the response's server-reported failure, or nil if it succeeded.
+// Only a MultiSearch item can fail this way: _msearch reports a failed item as
+// {"error": ..., "status": N} with no hits inside an overall HTTP 200, so
+// without this check a failed item is indistinguishable from empty hits. (A
+// failed single Search surfaces as a transport-level error instead.)
+func (r *SearchResponse) Err() error {
+	if len(r.Error) == 0 || bytes.Equal(r.Error, []byte("null")) {
+		return nil
+	}
+	return fmt.Errorf("search failed with status %d: %s", r.Status, r.Error)
 }
 
 // HitsResult holds the documents a search matched and, when the request asked for
@@ -201,10 +220,9 @@ func (s SearchClient) MultiSearch(ctx context.Context, reqs []MultiSearchRequest
 		return nil, err
 	}
 	// A per-sub-response error (an item carrying an "error"/non-2xx "status" while
-	// the overall _msearch is HTTP 200) is not surfaced here: such an item decodes
-	// to empty hits, which the caller skips — matching the previous MultiSearch path
-	// this replaced. Turning those into a hard error is a behavior change left to a
-	// follow-up, not this wire-preserving migration.
+	// the overall _msearch is HTTP 200) is decoded into the item's Error/Status
+	// fields; callers must check Err() per item, because a failed item carries no
+	// hits and would otherwise be indistinguishable from an empty result.
 	var resp struct {
 		Responses []SearchResponse `json:"responses"`
 	}

--- a/internal/storage/elasticsearch/esclient/search_test.go
+++ b/internal/storage/elasticsearch/esclient/search_test.go
@@ -200,6 +200,45 @@ func TestMultiSearchNDJSONAndResponse(t *testing.T) {
 	require.Len(t, resps[0].Hits.Hits, 1)
 }
 
+// TestMultiSearchDecodesPerItemError covers a failed _msearch item: the overall
+// response is HTTP 200 but the item carries {"error": ..., "status": N} and no
+// hits. The error must be decoded and reported by Err(), not swallowed as an
+// empty result.
+func TestMultiSearchDecodesPerItemError(t *testing.T) {
+	const respBody = `{"responses":[` +
+		`{"error":{"type":"search_phase_execution_exception","reason":"all shards failed"},"status":503},` +
+		`{"status":200,"hits":{"total":1,"hits":[{"_source":{"traceID":"abc"}}]}}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(respBody))
+	}))
+	defer server.Close()
+
+	sc := SearchClient{Client: makeClient(t, server.URL, "", "", es.ElasticV7)}
+	resps, err := sc.MultiSearch(context.Background(), []MultiSearchRequest{
+		{Indices: []string{"idx-a"}},
+		{Indices: []string{"idx-b"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, resps, 2)
+
+	itemErr := resps[0].Err()
+	require.ErrorContains(t, itemErr, "status 503")
+	require.ErrorContains(t, itemErr, "search_phase_execution_exception")
+
+	require.NoError(t, resps[1].Err())
+	assert.Equal(t, 1, resps[1].Hits.Total.Value)
+}
+
+func TestSearchResponseErr(t *testing.T) {
+	var ok SearchResponse
+	require.NoError(t, json.Unmarshal([]byte(`{"status":200,"hits":{"total":0,"hits":[]}}`), &ok))
+	require.NoError(t, ok.Err())
+
+	var nullErr SearchResponse
+	require.NoError(t, json.Unmarshal([]byte(`{"error":null,"status":200}`), &nullErr))
+	require.NoError(t, nullErr.Err())
+}
+
 func TestMultiSearchMultipleIndicesRenderAsArray(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -318,6 +318,14 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 		}
 
 		for _, result := range responses {
+			// A failed _msearch item carries an error payload and no hits; skipping it
+			// like an empty result would silently drop the trace (or truncate it, when
+			// a later search_after page fails and the trace is never re-queued).
+			if itemErr := result.Err(); itemErr != nil {
+				err := fmt.Errorf("multi-search item failed: %w", itemErr)
+				logErrorToSpan(childSpan, err)
+				return nil, err
+			}
 			// Hits is a value (esclient.HitsResult), not a pointer, so there's no nil
 			// to guard — only the inner slice can be empty.
 			if len(result.Hits.Hits) == 0 {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -385,6 +385,28 @@ func TestSpanReader_GetTraceNilHits(t *testing.T) {
 	})
 }
 
+// TestSpanReader_GetTraceMultiSearchItemError verifies that a failed _msearch
+// item (an error payload inside an overall HTTP 200) surfaces as an error
+// instead of being skipped like an empty result — which would silently report
+// an existing trace as not found, or return a truncated trace as complete when
+// a search_after continuation page fails.
+func TestSpanReader_GetTraceMultiSearchItemError(t *testing.T) {
+	withSpanReader(t, func(r *spanReaderTest) {
+		mockMultiSearchService(r).Return([]esclient.SearchResponse{
+			{
+				Error:  json.RawMessage(`{"type":"search_phase_execution_exception","reason":"all shards failed"}`),
+				Status: 503,
+			},
+		}, nil)
+
+		query := []dbmodel.TraceID{dbmodel.TraceID(testingTraceId)}
+		trace, err := r.reader.GetTraces(context.Background(), query)
+		require.NotEmpty(t, r.traceBuffer.GetSpans(), "Spans recorded")
+		require.ErrorContains(t, err, "status 503")
+		require.Nil(t, trace)
+	})
+}
+
 func TestSpanReader_GetTraceInvalidSpanError(t *testing.T) {
 	withSpanReader(t, func(r *spanReaderTest) {
 		data := []byte(`{"TraceID": "123"asdf fadsg}`)


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9007

## Description of the changes

A failed `_msearch` item arrives inside an overall HTTP 200 as
`{"error": ..., "status": N}` with no `hits` key. `esclient.SearchResponse` had
no fields to decode it, so a failed item was indistinguishable from an empty
result and `SpanReader.multiRead` skipped it - silently reporting an existing
trace as not found, or returning a truncated trace as complete when a
`search_after` continuation page failed.

- `esclient.SearchResponse` now decodes the item's `error`/`status` and exposes
  the failure via a new `Err()` method; the `MultiSearch` comment that deferred
  this to "a follow-up" is replaced with the new contract (callers must check
  `Err()` per item).
- `SpanReader.multiRead` returns the error instead of treating the failed item
  as empty hits.

Strict failure was chosen over per-trace degradation, consistent with the
contract-fidelity direction of RFC 0007; per-trace leniency can be discussed
separately in #8899, which concerns a different layer (dbmodel conversion).

## How was this change tested?

- New `TestSpanReader_GetTraceMultiSearchItemError` reproduces the bug
  end-to-end: without the fix it fails with `GetTraces` returning
  `(nil, nil)` for a failed item; with the fix the error surfaces.
- New `TestMultiSearchDecodesPerItemError` covers the client-level decode with
  a failed and a successful item side by side, and `TestSearchResponseErr`
  covers the absent/`null` error edge cases.
- `make fmt`, `make lint`, `make test` all pass (3931 tests).

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
