### PR TITLE
Reject all-zero trace ID in v2 in-memory store

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -683,6 +683,34 @@ func TestWriteTraces_WriteTraceWithTwoResourceSpans(t *testing.T) {
 	assert.Equal(t, td, tenant.traces[traceIndex].trace)
 }
 
+func TestWriteTraces_IgnoresEmptyTraceID(t *testing.T) {
+	store, err := NewStore(Configuration{
+		MaxTraces: 10,
+	})
+	require.NoError(t, err)
+	writeSpan := func(traceId pcommon.TraceID) {
+		td := ptrace.NewTraces()
+		td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetTraceID(traceId)
+		require.NoError(t, store.WriteTraces(context.Background(), td))
+	}
+	writeSpan(fromString(t, "00000000000000010000000000000000"))
+	writeSpan(fromString(t, "00000000000000020000000000000000"))
+	// an all-zero trace ID must be dropped: stored, it would collide with the
+	// ring buffer's empty-slot sentinel and hide the two traces above
+	writeSpan(pcommon.NewTraceIDEmpty())
+	writeSpan(fromString(t, "00000000000000030000000000000000"))
+
+	tenant := store.getTenant(tenancy.GetTenant(context.Background()))
+	assert.NotContains(t, tenant.ids, pcommon.NewTraceIDEmpty())
+	iterLength := 0
+	for traces, err := range store.FindTraces(context.Background(), tracestore.TraceQueryParams{SearchDepth: 10, Attributes: pcommon.NewMap()}) {
+		require.NoError(t, err)
+		assert.Len(t, traces, 1)
+		iterLength++
+	}
+	assert.Equal(t, 3, iterLength)
+}
+
 func TestNewStore_TracesLimit(t *testing.T) {
 	maxTraces := 8
 	store, err := NewStore(Configuration{

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -62,6 +62,13 @@ func (t *Tenant) storeTraces(tracesById map[pcommon.TraceID]ptrace.ResourceSpans
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for traceId, sameTraceIDResourceSpan := range tracesById {
+		if traceId.IsEmpty() {
+			// An all-zero trace ID is invalid and would collide with the
+			// ring buffer's empty-slot sentinel: findTraceAndIds treats an
+			// empty-ID slot as the end of stored traces, and the eviction
+			// cleanup above skips empty IDs, leaving a stale ids entry.
+			continue
+		}
 		var startTime time.Time
 		var endTime time.Time
 		for _, resourceSpan := range sameTraceIDResourceSpan.All() {


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9019

The v2 in-memory trace store did not reject spans with an all-zero trace ID (`00000000000000000000000000000000`). That value collides with the sentinel the ring buffer uses for empty slots, corrupting reads two ways:

1. `findTraceAndIds` scans the ring backward and treats a slot whose `id.IsEmpty()` is true as an unfilled gap, breaking the loop — so a single zero-ID span hides every older trace from `FindTraces` / `FindTraceIDs`.
2. On wrap-around, the eviction cleanup skips deleting the `ids` entry for an empty ID, leaving `ids[zeroTraceID]` pointing at a recycled slot, so `GetTraces` returns an unrelated trace.

OTLP receivers do not enforce non-zero trace IDs and the storage sanitizer chain does not either, so one malformed client span was enough to trigger this.

## Description of the changes

- Skip spans with an all-zero trace ID in `Tenant.storeTraces`.

## How was this change tested?

- Added `TestWriteTraces_IgnoresEmptyTraceID`: writes valid traces around a zero-ID span, asserts the zero ID never enters the `ids` map and all valid traces stay queryable.
- `go test ./internal/storage/v2/memory/` passes.

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md) guidelines.
- [x] I have signed all commits (DCO).
- [x] I have added unit tests for the new functionality.
