### PR TITLE
fix(badger): Remove stale operations entries on service expiry

### DIFF
--- a/internal/storage/v1/badger/spanstore/cache.go
+++ b/internal/storage/v1/badger/spanstore/cache.go
@@ -122,8 +122,9 @@ func (c *CacheStore) GetServices() ([]string, error) {
 		if v > t {
 			services = append(services, k)
 		} else {
-			// Service has expired, remove it
+			// Service has expired, remove it along with its operations
 			delete(c.services, k)
+			delete(c.operations, k)
 		}
 	}
 	c.cacheLock.Unlock()

--- a/internal/storage/v1/badger/spanstore/cache_test.go
+++ b/internal/storage/v1/badger/spanstore/cache_test.go
@@ -53,6 +53,21 @@ func TestExpiredItems(t *testing.T) {
 	})
 }
 
+func TestGetServicesRemovesExpiredOperations(t *testing.T) {
+	runWithBadger(t, func(store *badger.DB, t *testing.T) {
+		cache := NewCacheStore(store, time.Duration(-1*time.Hour))
+
+		expireTime := uint64(time.Now().Add(cache.ttl).Unix())
+		cache.Update("service1", "op1", expireTime)
+
+		services, err := cache.GetServices()
+		require.NoError(t, err)
+		assert.Empty(t, services)
+
+		assert.Empty(t, cache.operations, "GetServices must remove operations for services it expires")
+	})
+}
+
 // func runFactoryTest(tb testing.TB, test func(tb testing.TB, sw spanstore.Writer, sr spanstore.Reader)) {
 func runWithBadger(t *testing.T, test func(store *badger.DB, t *testing.T)) {
 	opts := badger.DefaultOptions("")


### PR DESCRIPTION
Resolves #9004

What this changes

GetServices in internal/storage/v1/badger/spanstore/cache.go removed an expired key from the services map but left the matching entry in the operations map untouched. That cleanup only happened inside GetOperations, and only for the one service passed to it.

If a service was only ever looked up through GetServices, its entry in the operations map, and every operation recorded under it, stayed in memory for the life of the process.

Fix

When GetServices removes an expired service from the services map, it now also removes that service's entry from the operations map, the same way GetOperations already does.

Testing

Added TestGetServicesRemovesExpiredOperations in cache_test.go. It adds a service with an already expired TTL, calls GetServices, and checks the operations map no longer holds an entry for it. This test fails without the fix and passes with it.

Ran:
- go test ./internal/storage/v1/badger/spanstore/...
- go vet ./internal/storage/v1/badger/spanstore/...

Both pass. gofumpt and golangci-lint are not available in my environment (make and the tool binaries are not installed on this machine), so I checked formatting manually with gofmt on the changed files instead.
