### PR TITLE
docs: update threat model evidence URL

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -31,7 +31,7 @@ security-artifacts:
   threat-model:
     threat-model-created: true
     evidence-url:
-    - https://github.com/jaegertracing/jaeger/blob/main/THREAT-MODEL.md
+    - https://github.com/jaegertracing/jaeger/blob/main/docs/security/threat-model.md
   self-assessment:
     self-assessment-created: true
     evidence-url:


### PR DESCRIPTION
Fixes #9013.

## Summary

- update SECURITY-INSIGHTS.yml threat-model evidence-url to point at the existing complete threat model under docs/security/threat-model.md
- leave the root placeholder file untouched

## Validation

- PATH=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/.toolchains/go1.25.7/bin:$PATH make fmt
- PATH=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/.toolchains/go1.25.7/bin:$PATH make lint
- PATH=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/.toolchains/go1.25.7/bin:$PATH make test
- git diff --check
