### PR TITLE
fix(cassandra): add missing continue after CSV read error in parseString

### DIFF
--- a/internal/storage/v1/cassandra/samplingstore/storage.go
+++ b/internal/storage/v1/cassandra/samplingstore/storage.go
@@ -252,6 +252,7 @@ func (s *SamplingStore) parseString(str string, numColumns int, appendFunc func(
 		}
 		if err != nil {
 			s.logger.Error("failed to read csv", zap.Error(err))
+			continue
 		}
 		if len(csvFields) != numColumns {
 			s.logger.Warn("incomplete throughput data", zap.Int("expected_columns", numColumns), zap.Any("entries", csvFields))


### PR DESCRIPTION
## Summary

In the `parseString` method (`internal/storage/v1/cassandra/samplingstore/storage.go:253`), when `csv.Reader.Read()` returns a non-EOF error, the code logs the error but does **not** `continue` to the next iteration.

Go's `csv.Reader.Read()` can return partial records alongside errors. If the partial record happens to have the right number of columns (or more), it will be appended to the store as valid data via `appendFunc(csvFields)`, silently corrupting sampling throughput data in Cassandra.

**Fix**: Added the missing `continue` statement after the error log to skip the corrupted record.

### Regression test

A test should be added that provides a malformed CSV string to `parseString` and verifies that:
1. The error is logged
2. No records are appended for the malformed line
3. Valid lines after the malformed one are still processed correctly