### PR TITLE
fix(anonymizer): Hash span log fields in place for hash_logs

### DIFF
--- a/cmd/anonymizer/app/anonymizer/anonymizer.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer.go
@@ -167,8 +167,10 @@ func (a *Anonymizer) AnonymizeSpan(span *model.Span) *uimodel.Span {
 
 	// when true, logs are hashed, when false, they are dropped
 	if a.options.HashLogs {
-		for _, log := range span.Logs {
-			log.Fields = hashTags(log.Fields)
+		// Index into span.Logs directly; ranging by value would hash a copy and
+		// discard the result, leaking the original log fields.
+		for i := range span.Logs {
+			span.Logs[i].Fields = hashTags(span.Logs[i].Fields)
 		}
 	} else {
 		span.Logs = nil

--- a/cmd/anonymizer/app/anonymizer/anonymizer_test.go
+++ b/cmd/anonymizer/app/anonymizer/anonymizer_test.go
@@ -187,6 +187,42 @@ func TestAnonymizer_AnonymizeSpan_AllFalse(t *testing.T) {
 	assert.Empty(t, span2.Process.Tags)
 }
 
+func TestAnonymizer_AnonymizeSpan_HashLogs(t *testing.T) {
+	anonymizer := &Anonymizer{
+		mapping: mapping{
+			Services:   make(map[string]string),
+			Operations: make(map[string]string),
+		},
+		options: Options{
+			HashLogs: true,
+		},
+	}
+	span := &model.Span{
+		TraceID:       traceID,
+		SpanID:        model.NewSpanID(1),
+		Process:       &model.Process{ServiceName: "serviceName"},
+		OperationName: "operationName",
+		Logs: []model.Log{
+			{
+				Timestamp: time.Unix(300, 0),
+				Fields: []model.KeyValue{
+					model.String("logKey", "logValue"),
+				},
+			},
+		},
+	}
+
+	_ = anonymizer.AnonymizeSpan(span)
+
+	require.Len(t, span.Logs, 1)
+	require.Len(t, span.Logs[0].Fields, 1)
+	field := span.Logs[0].Fields[0]
+	// With HashLogs enabled, both the field key and value must be hashed so no
+	// original log data leaks through.
+	assert.Equal(t, hash("logKey"), field.Key)
+	assert.Equal(t, hash("logValue"), field.AsString())
+}
+
 func TestAnonymizer_MapString_Present(t *testing.T) {
 	v := "foobar"
 	m := map[string]string{


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9029

## Description of the changes

`Span.Logs` is a `[]model.Log`, and `model.Log` is a value type. The previous code ranged over `span.Logs` **by value** and assigned to `log.Fields`, which mutated a copy that was then discarded:

```go
for _, log := range span.Logs {
    log.Fields = hashTags(log.Fields)
}
```

Because the assignment never reached `span.Logs[i]`, enabling `hash_logs` left the original, unhashed log fields on the span, so they were passed through to the anonymized output — leaking the very data the option is meant to obfuscate.

This changes the loop to index into `span.Logs` directly so the hashed fields are written back:

```go
for i := range span.Logs {
    span.Logs[i].Fields = hashTags(span.Logs[i].Fields)
}
```

## How was this change tested?

- Added `TestAnonymizer_AnonymizeSpan_HashLogs`, which asserts that the log field key and value are hashed. It fails on `main` and passes with this change. (The existing `TestAnonymizer_AnonymizeSpan_AllTrue` only checked the log count, which is why the bug went unnoticed.)
- `go test ./cmd/anonymizer/...` passes; `AnonymizeSpan` is at 100% statement coverage.
- `gofumpt` and `golangci-lint` (v2.12.2, repo config) report no issues on the package.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
