### PR TITLE
fix(query): Include scope identity in span dedup hash

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/hash.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/hash.go
@@ -43,11 +43,17 @@ func (s *SpanHashDeduper) Adjust(traces ptrace.Traces) {
 		hashResourceSpan := hashTrace.ResourceSpans().AppendEmpty()
 		hashScopeSpan := hashResourceSpan.ScopeSpans().AppendEmpty()
 		hashSpan := hashScopeSpan.Spans().AppendEmpty()
-		rs.Resource().Attributes().CopyTo(hashResourceSpan.Resource().Attributes())
+		// Include the full resource identity (attributes and schema URL) so spans
+		// that differ only by resource are not treated as duplicates.
+		rs.Resource().CopyTo(hashResourceSpan.Resource())
+		hashResourceSpan.SetSchemaUrl(rs.SchemaUrl())
 		for j := 0; j < scopeSpans.Len(); j++ {
 			ss := scopeSpans.At(j)
 			spans := ss.Spans()
-			ss.Scope().Attributes().CopyTo(hashScopeSpan.Scope().Attributes())
+			// Include the full scope identity (name, version, attributes) and its
+			// schema URL for the same reason.
+			ss.Scope().CopyTo(hashScopeSpan.Scope())
+			hashScopeSpan.SetSchemaUrl(ss.SchemaUrl())
 			dedupedSpans := ptrace.NewSpanSlice()
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/hash_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/hash_test.go
@@ -289,6 +289,99 @@ func TestSpanHash_DuplicateSpansDifferentResourceAttributes(t *testing.T) {
 	assert.Equal(t, expected(), i)
 }
 
+func TestSpanHash_DuplicateSpansDifferentScopeName(t *testing.T) {
+	adjuster := DeduplicateSpans()
+	makeTraces := func() ptrace.Traces {
+		traces := ptrace.NewTraces()
+		rs := traces.ResourceSpans().AppendEmpty()
+
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.Scope().SetName("scope-a")
+		span1 := ss.Spans().AppendEmpty()
+		span1.SetName("span1")
+		span1.SetTraceID([16]byte{1})
+		span1.SetSpanID([8]byte{1})
+
+		ss2 := rs.ScopeSpans().AppendEmpty()
+		ss2.Scope().SetName("scope-b")
+		span2 := ss2.Spans().AppendEmpty()
+		span2.SetName("span1")
+		span2.SetTraceID([16]byte{1})
+		span2.SetSpanID([8]byte{1})
+
+		return traces
+	}
+
+	i := makeTraces()
+	adjuster.Adjust(i)
+	// The two spans belong to different instrumentation scopes, so they are
+	// distinct and must both be preserved.
+	assert.Equal(t, makeTraces(), i)
+}
+
+func TestSpanHash_DuplicateSpansDifferentScopeVersion(t *testing.T) {
+	adjuster := DeduplicateSpans()
+	makeTraces := func() ptrace.Traces {
+		traces := ptrace.NewTraces()
+		rs := traces.ResourceSpans().AppendEmpty()
+
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.Scope().SetName("scope")
+		ss.Scope().SetVersion("v1")
+		span1 := ss.Spans().AppendEmpty()
+		span1.SetName("span1")
+		span1.SetTraceID([16]byte{1})
+		span1.SetSpanID([8]byte{1})
+
+		ss2 := rs.ScopeSpans().AppendEmpty()
+		ss2.Scope().SetName("scope")
+		ss2.Scope().SetVersion("v2")
+		span2 := ss2.Spans().AppendEmpty()
+		span2.SetName("span1")
+		span2.SetTraceID([16]byte{1})
+		span2.SetSpanID([8]byte{1})
+
+		return traces
+	}
+
+	i := makeTraces()
+	adjuster.Adjust(i)
+	assert.Equal(t, makeTraces(), i)
+}
+
+func TestSpanHash_DuplicateSpansDifferentSchemaURL(t *testing.T) {
+	adjuster := DeduplicateSpans()
+	makeTraces := func() ptrace.Traces {
+		traces := ptrace.NewTraces()
+
+		rs := traces.ResourceSpans().AppendEmpty()
+		rs.SetSchemaUrl("https://example.com/schema/1")
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.SetSchemaUrl("https://example.com/scope/1")
+		span1 := ss.Spans().AppendEmpty()
+		span1.SetName("span1")
+		span1.SetTraceID([16]byte{1})
+		span1.SetSpanID([8]byte{1})
+
+		rs2 := traces.ResourceSpans().AppendEmpty()
+		rs2.SetSchemaUrl("https://example.com/schema/2")
+		ss2 := rs2.ScopeSpans().AppendEmpty()
+		ss2.SetSchemaUrl("https://example.com/scope/2")
+		span2 := ss2.Spans().AppendEmpty()
+		span2.SetName("span1")
+		span2.SetTraceID([16]byte{1})
+		span2.SetSpanID([8]byte{1})
+
+		return traces
+	}
+
+	i := makeTraces()
+	adjuster.Adjust(i)
+	// Spans carrying different resource/scope schema URLs are distinct and must
+	// both survive.
+	assert.Equal(t, makeTraces(), i)
+}
+
 type errorMarshaler struct{}
 
 func (*errorMarshaler) MarshalTraces(ptrace.Traces) ([]byte, error) {


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9035

## Description of the changes

`DeduplicateSpans` hashes each span together with its resource and scope attributes to decide whether two spans are duplicates, but it omitted the instrumentation scope **name** and **version** and both the resource and scope **schema URLs**. Spans that were identical except for those fields collided on the same hash, so one was silently dropped from the returned trace.

These fields are part of a span's identity in OTLP. The package already asserts that spans differing by resource or scope *attributes* are preserved (`TestSpanHash_DuplicateSpansDifferentScopeAttributes`, `TestSpanHash_DuplicateSpansDifferentResourceAttributes`); this change extends the same guarantee to the remaining identity fields by copying the full resource and scope (name, version, attributes) and both schema URLs into the hash input.

The change is strictly safer: it never prevents removing a genuine duplicate (a true duplicate shares these fields too) — it only stops distinct spans from being dropped.

## How was this change tested?

- Added `TestSpanHash_DuplicateSpansDifferentScopeName`, `TestSpanHash_DuplicateSpansDifferentScopeVersion`, and `TestSpanHash_DuplicateSpansDifferentSchemaURL`. Each fails on `main` and passes with this change.
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/...` passes; the package is at 100% statement coverage.
- `gofumpt` and `golangci-lint` (v2.12.2, repo config) report no issues on the package.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
