### PR TITLE
feat(featuregate): Normalize Jaeger gate names

### DIFF
--- a/cmd/es-index-cleaner/main.go
+++ b/cmd/es-index-cleaner/main.go
@@ -30,7 +30,7 @@ func init() {
 		featuregate.GlobalRegistry().MustRegister(
 			"jaeger.es.index.relativeTimeIndexDeletion",
 			featuregate.StageBeta,
-			featuregate.WithRegisterFromVersion("v2.20.0"),
+			featuregate.WithRegisterFromVersion("v2.21.0"),
 			featuregate.WithRegisterDescription("Controls whether the indices will be deleted relative to the current time or tomorrow midnight."),
 			featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/6236"),
 		),

--- a/cmd/es-index-cleaner/main.go
+++ b/cmd/es-index-cleaner/main.go
@@ -19,18 +19,28 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/es-index-cleaner/app"
 	"github.com/jaegertracing/jaeger/internal/config"
+	jaegerfeaturegate "github.com/jaegertracing/jaeger/internal/featuregate"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/esclient"
 )
 
-var relativeIndexCleaner *featuregate.Gate
+var relativeIndexCleaner *jaegerfeaturegate.RenamedGate
 
 func init() {
-	relativeIndexCleaner = featuregate.GlobalRegistry().MustRegister(
-		"es.index.relativeTimeIndexDeletion",
-		featuregate.StageBeta,
-		featuregate.WithRegisterFromVersion("v2.5.0"),
-		featuregate.WithRegisterDescription("Controls whether the indices will be deleted relative to the current time or tomorrow midnight."),
-		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/6236"),
+	relativeIndexCleaner = jaegerfeaturegate.NewRenamedGate(
+		featuregate.GlobalRegistry().MustRegister(
+			"jaeger.es.index.relativeTimeIndexDeletion",
+			featuregate.StageBeta,
+			featuregate.WithRegisterFromVersion("v2.20.0"),
+			featuregate.WithRegisterDescription("Controls whether the indices will be deleted relative to the current time or tomorrow midnight."),
+			featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/6236"),
+		),
+		featuregate.GlobalRegistry().MustRegister(
+			"es.index.relativeTimeIndexDeletion",
+			featuregate.StageBeta,
+			featuregate.WithRegisterFromVersion("v2.5.0"),
+			featuregate.WithRegisterDescription("Deprecated alias for jaeger.es.index.relativeTimeIndexDeletion."),
+			featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/9016"),
+		),
 	)
 }
 

--- a/cmd/internal/storageconfig/package_test.go
+++ b/cmd/internal/storageconfig/package_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if err := featuregate.GlobalRegistry().Set("storage.clickhouse", true); err != nil {
+	if err := featuregate.GlobalRegistry().Set("jaeger.clickhouse", true); err != nil {
 		panic(err)
 	}
 	testutils.VerifyGoLeaks(m)

--- a/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
+++ b/cmd/jaeger/internal/extension/jaegerstorage/package_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if err := featuregate.GlobalRegistry().Set("storage.clickhouse", true); err != nil {
+	if err := featuregate.GlobalRegistry().Set("jaeger.clickhouse", true); err != nil {
 		panic(err)
 	}
 	testutils.VerifyGoLeaks(m)

--- a/cmd/jaeger/internal/integration/clickhouse_test.go
+++ b/cmd/jaeger/internal/integration/clickhouse_test.go
@@ -16,7 +16,7 @@ func TestClickHouseStorage(t *testing.T) {
 		StorageIntegration: integration.StorageIntegration{
 			CleanUp: purge,
 		},
-		FeatureGates: []string{"storage.clickhouse"},
+		FeatureGates: []string{"jaeger.clickhouse"},
 	}
 	s.e2eInitialize(t, "clickhouse")
 	s.RunSpanStoreTests(t)

--- a/docker-compose/monitor/docker-compose-clickhouse.yml
+++ b/docker-compose/monitor/docker-compose-clickhouse.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - "./jaeger-ui.json:/etc/jaeger/jaeger-ui.json"
       - "../../cmd/jaeger/config-spm-clickhouse.yaml:/etc/jaeger/config.yml"
-    command: ["--config", "/etc/jaeger/config.yml", "--feature-gates=storage.clickhouse"]
+    command: ["--config", "/etc/jaeger/config.yml", "--feature-gates=jaeger.clickhouse"]
     ports:
       - "16686:16686"
       - "8888:8888"

--- a/internal/featuregate/package_test.go
+++ b/internal/featuregate/package_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package featuregate
+
+import (
+	"testing"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}

--- a/internal/featuregate/renamed.go
+++ b/internal/featuregate/renamed.go
@@ -32,8 +32,10 @@ func NewRenamedGate(current, legacy *collectorfeaturegate.Gate) *RenamedGate {
 		panic("only Alpha and Beta feature gates can be renamed")
 	}
 	return &RenamedGate{
-		current:  current,
-		legacy:   legacy,
+		current: current,
+		legacy:  legacy,
+		// Feature gates can be evaluated during configuration validation,
+		// before an application logger is available.
 		warnings: os.Stderr,
 	}
 }

--- a/internal/featuregate/renamed.go
+++ b/internal/featuregate/renamed.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package featuregate contains helpers for Jaeger feature gates.
+package featuregate
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	collectorfeaturegate "go.opentelemetry.io/collector/featuregate"
+)
+
+// RenamedGate keeps a legacy feature gate ID working while users migrate to a
+// replacement ID. Alpha gates combine the IDs with OR because they default to
+// disabled. Beta gates combine them with AND because they default to enabled.
+type RenamedGate struct {
+	current  *collectorfeaturegate.Gate
+	legacy   *collectorfeaturegate.Gate
+	warnings io.Writer
+	warnOnce sync.Once
+}
+
+// NewRenamedGate creates a feature gate backed by current and legacy IDs.
+func NewRenamedGate(current, legacy *collectorfeaturegate.Gate) *RenamedGate {
+	if current.Stage() != legacy.Stage() {
+		panic("renamed feature gate IDs must use the same stage")
+	}
+	if current.Stage() != collectorfeaturegate.StageAlpha && current.Stage() != collectorfeaturegate.StageBeta {
+		panic("only Alpha and Beta feature gates can be renamed")
+	}
+	return &RenamedGate{
+		current:  current,
+		legacy:   legacy,
+		warnings: os.Stderr,
+	}
+}
+
+// ID returns the replacement feature gate ID.
+func (g *RenamedGate) ID() string {
+	return g.current.ID()
+}
+
+// LegacyID returns the deprecated feature gate ID.
+func (g *RenamedGate) LegacyID() string {
+	return g.legacy.ID()
+}
+
+// IsEnabled returns the effective state across the replacement and legacy IDs.
+func (g *RenamedGate) IsEnabled() bool {
+	currentEnabled := g.current.IsEnabled()
+	legacyEnabled := g.legacy.IsEnabled()
+
+	var enabled, legacySelected bool
+	if g.current.Stage() == collectorfeaturegate.StageAlpha {
+		enabled = currentEnabled || legacyEnabled
+		legacySelected = legacyEnabled && !currentEnabled
+	} else {
+		enabled = currentEnabled && legacyEnabled
+		legacySelected = !legacyEnabled && currentEnabled
+	}
+
+	if legacySelected {
+		g.warnOnce.Do(func() {
+			fmt.Fprintf(g.warnings, "Feature gate %q has been renamed to %q; the legacy ID will be removed in a future release.\n", g.LegacyID(), g.ID())
+		})
+	}
+	return enabled
+}

--- a/internal/featuregate/renamed_test.go
+++ b/internal/featuregate/renamed_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package featuregate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	collectorfeaturegate "go.opentelemetry.io/collector/featuregate"
+)
+
+func TestRenamedGate(t *testing.T) {
+	tests := []struct {
+		name           string
+		stage          collectorfeaturegate.Stage
+		currentEnabled bool
+		legacyEnabled  bool
+		expected       bool
+		expectWarning  bool
+	}{
+		{name: "Alpha defaults disabled", stage: collectorfeaturegate.StageAlpha},
+		{name: "Alpha current enabled", stage: collectorfeaturegate.StageAlpha, currentEnabled: true, expected: true},
+		{name: "Alpha legacy enabled", stage: collectorfeaturegate.StageAlpha, legacyEnabled: true, expected: true, expectWarning: true},
+		{name: "Alpha both enabled", stage: collectorfeaturegate.StageAlpha, currentEnabled: true, legacyEnabled: true, expected: true},
+		{name: "Beta defaults enabled", stage: collectorfeaturegate.StageBeta, currentEnabled: true, legacyEnabled: true, expected: true},
+		{name: "Beta current disabled", stage: collectorfeaturegate.StageBeta, legacyEnabled: true},
+		{name: "Beta legacy disabled", stage: collectorfeaturegate.StageBeta, currentEnabled: true, expectWarning: true},
+		{name: "Beta both disabled", stage: collectorfeaturegate.StageBeta},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := collectorfeaturegate.NewRegistry()
+			current := registry.MustRegister("jaeger.test", test.stage)
+			legacy := registry.MustRegister("test", test.stage)
+			require.NoError(t, registry.Set(current.ID(), test.currentEnabled))
+			require.NoError(t, registry.Set(legacy.ID(), test.legacyEnabled))
+
+			gate := NewRenamedGate(current, legacy)
+			var warnings bytes.Buffer
+			gate.warnings = &warnings
+
+			assert.Equal(t, "jaeger.test", gate.ID())
+			assert.Equal(t, "test", gate.LegacyID())
+			assert.Equal(t, test.expected, gate.IsEnabled())
+			assert.Equal(t, test.expectWarning, warnings.Len() > 0)
+			if test.expectWarning {
+				assert.Equal(t, "Feature gate \"test\" has been renamed to \"jaeger.test\"; the legacy ID will be removed in a future release.\n", warnings.String())
+			}
+			warningLength := warnings.Len()
+			assert.Equal(t, test.expected, gate.IsEnabled())
+			assert.Equal(t, warningLength, warnings.Len())
+		})
+	}
+}
+
+func TestNewRenamedGatePanics(t *testing.T) {
+	t.Run("different stages", func(t *testing.T) {
+		registry := collectorfeaturegate.NewRegistry()
+		current := registry.MustRegister("jaeger.test", collectorfeaturegate.StageAlpha)
+		legacy := registry.MustRegister("test", collectorfeaturegate.StageBeta)
+		assert.PanicsWithValue(t, "renamed feature gate IDs must use the same stage", func() {
+			NewRenamedGate(current, legacy)
+		})
+	})
+
+	t.Run("unsupported stage", func(t *testing.T) {
+		registry := collectorfeaturegate.NewRegistry()
+		current := registry.MustRegister("jaeger.test", collectorfeaturegate.StageStable, collectorfeaturegate.WithRegisterToVersion("v3.0.0"))
+		legacy := registry.MustRegister("test", collectorfeaturegate.StageStable, collectorfeaturegate.WithRegisterToVersion("v3.0.0"))
+		assert.PanicsWithValue(t, "only Alpha and Beta feature gates can be renamed", func() {
+			NewRenamedGate(current, legacy)
+		})
+	})
+}

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -502,7 +502,7 @@ func (c *Configuration) Validate() error {
 			"deprecated ES rotation flags (%s) "+
 				"are no longer supported; migrate to 'indices.<type>.rotation' config "+
 				"(see https://github.com/jaegertracing/jaeger/pull/8823); "+
-				"to temporarily disable this check, use --feature-gates=-es.config.rejectLegacyRotationFlags",
+				"to temporarily disable this check, use --feature-gates=-jaeger.es.config.rejectLegacyRotationFlags",
 			legacyRotationFlagsList,
 		)
 	}

--- a/internal/storage/elasticsearch/config/config_legacy.go
+++ b/internal/storage/elasticsearch/config/config_legacy.go
@@ -7,6 +7,8 @@ import (
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
+
+	jaegerfeaturegate "github.com/jaegertracing/jaeger/internal/featuregate"
 )
 
 // RejectLegacyRotationFlags is a feature gate that, when enabled, causes validation
@@ -15,14 +17,22 @@ import (
 // It is enabled by default (Beta): setting any of these flags is a validation error
 // unless the gate is explicitly disabled. Once promoted to Stable, the gate can no
 // longer be disabled and users must migrate to the new rotation config.
-var RejectLegacyRotationFlags = featuregate.GlobalRegistry().MustRegister(
-	"es.config.rejectLegacyRotationFlags",
-	featuregate.StageBeta,
-	featuregate.WithRegisterFromVersion("v2.9.0"),
-	featuregate.WithRegisterDescription(
-		"When enabled, the use of deprecated ES rotation flags "+
-			"(use_aliases, use_ilm, span_read_alias, etc.) "+
-			"becomes a validation error instead of a deprecation warning.",
+var RejectLegacyRotationFlags = jaegerfeaturegate.NewRenamedGate(
+	featuregate.GlobalRegistry().MustRegister(
+		"jaeger.es.config.rejectLegacyRotationFlags",
+		featuregate.StageBeta,
+		featuregate.WithRegisterFromVersion("v2.20.0"),
+		featuregate.WithRegisterDescription(
+			"When enabled, the use of deprecated ES rotation flags "+
+				"(use_aliases, use_ilm, span_read_alias, etc.) "+
+				"becomes a validation error instead of a deprecation warning.",
+		),
+	),
+	featuregate.GlobalRegistry().MustRegister(
+		"es.config.rejectLegacyRotationFlags",
+		featuregate.StageBeta,
+		featuregate.WithRegisterFromVersion("v2.9.0"),
+		featuregate.WithRegisterDescription("Deprecated alias for jaeger.es.config.rejectLegacyRotationFlags."),
 	),
 )
 

--- a/internal/storage/elasticsearch/config/config_legacy.go
+++ b/internal/storage/elasticsearch/config/config_legacy.go
@@ -21,7 +21,7 @@ var RejectLegacyRotationFlags = jaegerfeaturegate.NewRenamedGate(
 	featuregate.GlobalRegistry().MustRegister(
 		"jaeger.es.config.rejectLegacyRotationFlags",
 		featuregate.StageBeta,
-		featuregate.WithRegisterFromVersion("v2.20.0"),
+		featuregate.WithRegisterFromVersion("v2.21.0"),
 		featuregate.WithRegisterDescription(
 			"When enabled, the use of deprecated ES rotation flags "+
 				"(use_aliases, use_ilm, span_read_alias, etc.) "+

--- a/internal/storage/elasticsearch/config/config_legacy.go
+++ b/internal/storage/elasticsearch/config/config_legacy.go
@@ -27,12 +27,14 @@ var RejectLegacyRotationFlags = jaegerfeaturegate.NewRenamedGate(
 				"(use_aliases, use_ilm, span_read_alias, etc.) "+
 				"becomes a validation error instead of a deprecation warning.",
 		),
+		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/9016"),
 	),
 	featuregate.GlobalRegistry().MustRegister(
 		"es.config.rejectLegacyRotationFlags",
 		featuregate.StageBeta,
 		featuregate.WithRegisterFromVersion("v2.9.0"),
 		featuregate.WithRegisterDescription("Deprecated alias for jaeger.es.config.rejectLegacyRotationFlags."),
+		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/9016"),
 	),
 )
 

--- a/internal/storage/integration/clickhouse_test.go
+++ b/internal/storage/integration/clickhouse_test.go
@@ -24,9 +24,9 @@ type ClickHouseStorageIntegration struct {
 }
 
 func (s *ClickHouseStorageIntegration) initialize(t *testing.T) {
-	require.NoError(t, featuregate.GlobalRegistry().Set("storage.clickhouse", true))
+	require.NoError(t, featuregate.GlobalRegistry().Set("jaeger.clickhouse", true))
 	t.Cleanup(func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set("storage.clickhouse", false))
+		require.NoError(t, featuregate.GlobalRegistry().Set("jaeger.clickhouse", false))
 	})
 
 	cfg := ch.Configuration{

--- a/internal/storage/v2/clickhouse/factory.go
+++ b/internal/storage/v2/clickhouse/factory.go
@@ -34,7 +34,7 @@ var clickhouseStorageGate = jaegerfeaturegate.NewRenamedGate(
 	featuregate.GlobalRegistry().MustRegister(
 		"jaeger.clickhouse",
 		featuregate.StageAlpha,
-		featuregate.WithRegisterFromVersion("v2.20.0"),
+		featuregate.WithRegisterFromVersion("v2.21.0"),
 		featuregate.WithRegisterDescription("Enables ClickHouse as a storage backend."),
 		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/9016"),
 	),

--- a/internal/storage/v2/clickhouse/factory.go
+++ b/internal/storage/v2/clickhouse/factory.go
@@ -36,6 +36,7 @@ var clickhouseStorageGate = jaegerfeaturegate.NewRenamedGate(
 		featuregate.StageAlpha,
 		featuregate.WithRegisterFromVersion("v2.20.0"),
 		featuregate.WithRegisterDescription("Enables ClickHouse as a storage backend."),
+		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/9016"),
 	),
 	featuregate.GlobalRegistry().MustRegister(
 		"storage.clickhouse",

--- a/internal/storage/v2/clickhouse/factory.go
+++ b/internal/storage/v2/clickhouse/factory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"go.opentelemetry.io/collector/featuregate"
 
+	jaegerfeaturegate "github.com/jaegertracing/jaeger/internal/featuregate"
 	"github.com/jaegertracing/jaeger/internal/storage/v1"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore/metricstoremetrics"
@@ -29,12 +30,19 @@ import (
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 )
 
-var clickhouseStorageGate = featuregate.GlobalRegistry().MustRegister(
-	"storage.clickhouse",
-	featuregate.StageAlpha,
-	featuregate.WithRegisterFromVersion("v2.18.0"),
-	featuregate.WithRegisterDescription(
-		"Enables ClickHouse as a storage backend.",
+var clickhouseStorageGate = jaegerfeaturegate.NewRenamedGate(
+	featuregate.GlobalRegistry().MustRegister(
+		"jaeger.clickhouse",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterFromVersion("v2.20.0"),
+		featuregate.WithRegisterDescription("Enables ClickHouse as a storage backend."),
+	),
+	featuregate.GlobalRegistry().MustRegister(
+		"storage.clickhouse",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterFromVersion("v2.18.0"),
+		featuregate.WithRegisterDescription("Deprecated alias for jaeger.clickhouse."),
+		featuregate.WithRegisterReferenceURL("https://github.com/jaegertracing/jaeger/issues/9016"),
 	),
 )
 
@@ -116,7 +124,7 @@ func NewFactory(ctx context.Context, cfg Configuration, telset telemetry.Setting
 		return nil, errors.New(
 			"ClickHouse storage is experimental and must be explicitly enabled. " +
 				"The schema is subject to breaking changes. " +
-				"Enable it with --feature-gates=storage.clickhouse",
+				"Enable it with --feature-gates=jaeger.clickhouse",
 		)
 	}
 	fmt.Fprint(os.Stderr, `


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #9016.

Jaeger registers feature gates in the same global registry as OpenTelemetry Collector components. Three older gates lacked the `jaeger.` namespace, creating inconsistent public IDs and a future collision risk.

## Description of the changes

- Add the prefixed IDs `jaeger.es.config.rejectLegacyRotationFlags`, `jaeger.es.index.relativeTimeIndexDeletion`, and `jaeger.clickhouse`
- Keep the existing IDs as deprecated aliases
- Preserve Alpha enable and Beta disable behavior across both IDs during the migration window
- Emit a one-time warning when a legacy ID determines the gate state
- Update internal ClickHouse configuration and guidance to use the new ID
- Add exhaustive tests for alias behavior and warnings

## How was this change tested?

- `make fmt`
- `make lint`
- `make test` (3,943 tests passed; 34 environment-dependent tests skipped)
- `go test -covermode=atomic -coverprofile=/tmp/featuregate-cover.out ./internal/featuregate` (100% statement coverage)

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes

I reviewed the implementation, verified the migration semantics, and ran the complete required test suite locally.