### PR TITLE
test(elasticsearch): validate NDJSON request wire format

### DIFF
--- a/internal/storage/elasticsearch/esclient/bulk_test.go
+++ b/internal/storage/elasticsearch/esclient/bulk_test.go
@@ -49,6 +49,7 @@ func TestBulkIndexerWritesNDJSON(t *testing.T) {
 	require.Len(t, reqs, 1)
 	assert.Equal(t, http.MethodPost, reqs[0].Method)
 	assert.Contains(t, reqs[0].Path, "_bulk")
+	assert.Equal(t, "application/x-ndjson", reqs[0].ContentType)
 	body := string(reqs[0].Body)
 	assert.Contains(t, body, `"_index":"jaeger-span-000001"`)
 	assert.Contains(t, body, `"_id":"abc"`)

--- a/internal/storage/elasticsearch/esclient/client.go
+++ b/internal/storage/elasticsearch/esclient/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/extension/extensionauth"
@@ -133,6 +134,15 @@ func newResponseError(err error, code int, body []byte) ResponseError {
 // Perform neither builds the request nor interprets the status code — the caller
 // owns those (esutil writes and parses the _bulk protocol itself).
 func (c *Client) Perform(req *http.Request) (*http.Response, error) {
+	// BulkIndexer sends requests directly through the esapi.Transport interface
+	// and defaults their header to application/json. Normalize the bulk wire
+	// format here so all callers send the content type required by the bulk API.
+	if strings.HasSuffix(req.URL.Path, "/_bulk") {
+		if req.Header == nil {
+			req.Header = make(http.Header)
+		}
+		req.Header.Set("Content-Type", "application/x-ndjson")
+	}
 	// A caller may submit a request with no deadline — esutil.BulkIndexer builds
 	// its _bulk flushes (and its shutdown Close flush) from a background context.
 	// Apply the client's QueryTimeout so those writes can't hang forever, matching

--- a/internal/storage/elasticsearch/snapshottest/snapshottest.go
+++ b/internal/storage/elasticsearch/snapshottest/snapshottest.go
@@ -59,13 +59,15 @@ import (
 var Regenerate = os.Getenv("REGENERATE_SNAPSHOTS") == "true"
 
 // CapturedRequest is a faithful record of a single HTTP request as received: the
-// method, path, parsed query, and the raw body bytes exactly as sent. Turning it
-// into a canonical, diffable snapshot happens in Marshal, not here.
+// method, path, parsed query, content type, and the raw body bytes exactly as
+// sent. Turning it into a canonical, diffable snapshot happens in Marshal, not
+// here.
 type CapturedRequest struct {
-	Method string
-	Path   string
-	Query  url.Values
-	Body   []byte
+	Method      string
+	Path        string
+	Query       url.Values
+	ContentType string
+	Body        []byte
 }
 
 // Recorder is an http.Handler that records every request it receives and
@@ -95,9 +97,10 @@ func (rec *Recorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	captured := CapturedRequest{
-		Method: r.Method,
-		Path:   r.URL.Path,
-		Body:   body,
+		Method:      r.Method,
+		Path:        r.URL.Path,
+		ContentType: r.Header.Get("Content-Type"),
+		Body:        body,
 	}
 	if q := r.URL.Query(); len(q) > 0 {
 		captured.Query = q
@@ -150,9 +153,10 @@ func (rec *Recorder) Assert(t testing.TB, prefix string) {
 // body, to NDJSON documents). Marshaling sorts object keys, so the output is
 // deterministic regardless of the order the client emitted fields in.
 type snapshotRequest struct {
-	Method string     `json:"method"`
-	Path   string     `json:"path"`
-	Query  url.Values `json:"query,omitempty"`
+	Method      string     `json:"method"`
+	Path        string     `json:"path"`
+	Query       url.Values `json:"query,omitempty"`
+	ContentType string     `json:"content_type,omitempty"`
 	// Body is a single JSON body, which may be any JSON value.
 	Body any `json:"body,omitempty"`
 	// NDJSON is the documents of a newline-delimited body, each a JSON object (an
@@ -185,8 +189,24 @@ func Marshal(t testing.TB, requests []CapturedRequest) string {
 func toSnapshot(t testing.TB, r CapturedRequest) snapshotRequest {
 	t.Helper()
 	s := snapshotRequest{Method: r.Method, Path: r.Path, Query: canonicalQuery(r.Query)}
-	body := bytes.TrimRight(r.Body, "\n")
+	ndjson := isNDJSONPath(r.Path)
+	if ndjson {
+		require.NoError(t, validateNDJSON(r.ContentType, r.Body))
+		s.ContentType = r.ContentType
+	}
+	body := r.Body
+	if ndjson {
+		body = body[:len(body)-1]
+	} else {
+		body = bytes.TrimRight(body, "\n")
+	}
 	if len(body) == 0 {
+		return s
+	}
+	if ndjson {
+		docs, err := parseNDJSON(body)
+		require.NoErrorf(t, err, "request body is not valid NDJSON: %s", r.Body)
+		s.NDJSON = docs
 		return s
 	}
 	// A single JSON document parses whole; a newline-delimited body does not.
@@ -221,9 +241,6 @@ func parseNDJSON(body []byte) ([]map[string]any, error) {
 	lines := bytes.Split(body, []byte("\n"))
 	docs := make([]map[string]any, 0, len(lines))
 	for _, line := range lines {
-		if len(bytes.TrimSpace(line)) == 0 {
-			continue
-		}
 		var doc map[string]any
 		if err := json.Unmarshal(line, &doc); err != nil {
 			return nil, err
@@ -231,6 +248,29 @@ func parseNDJSON(body []byte) ([]map[string]any, error) {
 		docs = append(docs, doc)
 	}
 	return docs, nil
+}
+
+func isNDJSONPath(path string) bool {
+	return strings.HasSuffix(path, "/_bulk") || strings.HasSuffix(path, "/_msearch")
+}
+
+func validateNDJSON(contentType string, body []byte) error {
+	if contentType != "application/x-ndjson" {
+		return fmt.Errorf("NDJSON request must use Content-Type application/x-ndjson, got %q", contentType)
+	}
+	if !bytes.HasSuffix(body, []byte("\n")) {
+		return errors.New("NDJSON request body must end with a newline")
+	}
+	if bytes.HasSuffix(body, []byte("\n\n")) {
+		return errors.New("NDJSON request body must end with exactly one newline")
+	}
+	if len(body) == 1 {
+		return errors.New("NDJSON request body must not be empty")
+	}
+	if _, err := parseNDJSON(body[:len(body)-1]); err != nil {
+		return fmt.Errorf("request body is not valid NDJSON: %w", err)
+	}
+	return nil
 }
 
 // Assert compares content against the single snapshot "<prefix>.json", for a

--- a/internal/storage/elasticsearch/snapshottest/snapshottest_test.go
+++ b/internal/storage/elasticsearch/snapshottest/snapshottest_test.go
@@ -61,6 +61,7 @@ func TestRecorderCapturesNDJSON(t *testing.T) {
 	sentBody := []byte(`{"index":{"_index":"jaeger-span","_id":"1"}}` + "\n" + `{"traceID":"abc"}` + "\n")
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/_bulk", bytes.NewReader(sentBody))
 	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-ndjson")
 	resp, err := server.Client().Do(req)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
@@ -69,12 +70,32 @@ func TestRecorderCapturesNDJSON(t *testing.T) {
 	require.Len(t, requests, 1)
 	got := requests[0]
 	assert.Equal(t, "/_bulk", got.Path)
+	assert.Equal(t, "application/x-ndjson", got.ContentType)
 	// The newline-delimited body is recorded verbatim.
 	assert.Equal(t, sentBody, got.Body)
 
 	// Marshal splits it into one canonicalized document per line.
 	snapshot := Marshal(t, requests)
 	assert.Contains(t, snapshot, `"ndjson"`)
+	assert.Contains(t, snapshot, `"content_type": "application/x-ndjson"`)
+}
+
+func TestMarshalRejectsInvalidNDJSONWireFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		ct   string
+	}{
+		{name: "missing trailing newline", body: []byte(`{"index":{}}` + "\n" + `{"doc":1}`), ct: "application/x-ndjson"},
+		{name: "extra trailing newline", body: []byte(`{"index":{}}` + "\n" + `{"doc":1}` + "\n\n"), ct: "application/x-ndjson"},
+		{name: "blank line", body: []byte(`{"index":{}}` + "\n\n" + `{"doc":1}` + "\n"), ct: "application/x-ndjson"},
+		{name: "wrong content type", body: []byte(`{"index":{}}` + "\n" + `{"doc":1}` + "\n"), ct: "application/json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Error(t, validateNDJSON(tt.ct, tt.body))
+		})
+	}
 }
 
 func TestRecorderCapturesEmptyBody(t *testing.T) {
@@ -334,7 +355,6 @@ func TestMarshalMultipleRequests(t *testing.T) {
 }
 
 func TestParseNDJSONMalformed(t *testing.T) {
-	// The leading blank line is skipped; the malformed line surfaces the error.
 	_, err := parseNDJSON([]byte("\n{not json}"))
 	assert.Error(t, err)
 }

--- a/internal/storage/v1/elasticsearch/samplingstore/testdata/write_probabilities.json
+++ b/internal/storage/v1/elasticsearch/samplingstore/testdata/write_probabilities.json
@@ -1,6 +1,7 @@
 {
   "method": "POST",
   "path": "/_bulk",
+  "content_type": "application/x-ndjson",
   "ndjson": [
     {
       "index": {

--- a/internal/storage/v1/elasticsearch/samplingstore/testdata/write_throughput.json
+++ b/internal/storage/v1/elasticsearch/samplingstore/testdata/write_throughput.json
@@ -1,6 +1,7 @@
 {
   "method": "POST",
   "path": "/_bulk",
+  "content_type": "application/x-ndjson",
   "ndjson": [
     {
       "index": {

--- a/internal/storage/v2/elasticsearch/depstore/testdata/write_dependencies.json
+++ b/internal/storage/v2/elasticsearch/depstore/testdata/write_dependencies.json
@@ -1,6 +1,7 @@
 {
   "method": "POST",
   "path": "/_bulk",
+  "content_type": "application/x-ndjson",
   "ndjson": [
     {
       "index": {

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/get_traces.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/get_traces.json
@@ -1,6 +1,7 @@
 {
   "method": "GET",
   "path": "/_msearch",
+  "content_type": "application/x-ndjson",
   "ndjson": [
     {
       "ignore_unavailable": true,

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/write_service.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/write_service.json
@@ -1,6 +1,7 @@
 {
   "method": "POST",
   "path": "/_bulk",
+  "content_type": "application/x-ndjson",
   "ndjson": [
     {
       "index": {

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/write_span.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/write_span.json
@@ -1,6 +1,7 @@
 {
   "method": "POST",
   "path": "/_bulk",
+  "content_type": "application/x-ndjson",
   "ndjson": [
     {
       "index": {


### PR DESCRIPTION
## Summary

Closes #9038.

The snapshot harness now validates the raw wire requirements that canonicalized fixtures previously hid:

- captures and snapshots `Content-Type` for NDJSON requests;
- requires `application/x-ndjson` for `/_bulk` and `/_msearch` requests;
- requires exactly one trailing newline and rejects blank NDJSON lines;
- recognizes bulk paths with an index prefix;
- normalizes direct `BulkIndexer` transport requests to the required NDJSON content type;
- adds regression coverage and updates affected fixtures.

## Testing

- `go test ./internal/storage/elasticsearch/snapshottest ./internal/storage/elasticsearch/esclient`
- `go test ./internal/storage/v1/elasticsearch/samplingstore ./internal/storage/v2/elasticsearch/depstore ./internal/storage/v2/elasticsearch/tracestore/core`
- `go test ./internal/storage/elasticsearch/... ./internal/storage/v1/elasticsearch/... ./internal/storage/v2/elasticsearch/...`
- `git diff --check`

Signed-off-by: Solaris-star <820622658@qq.com>
