### PR TITLE
fix(es): Add spanID tie-breaker to trace search_after pagination

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -29,6 +29,7 @@ const (
 	indexPrefixSeparator = "-"
 
 	traceIDField           = "traceID"
+	spanIDField            = "spanID"
 	durationField          = "duration"
 	startTimeField         = "startTime"
 	startTimeMillisField   = "startTimeMillis"
@@ -147,16 +148,29 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 	}
 }
 
+// searchAfterCursor is the search_after pagination cursor multiRead carries between
+// pages of the same trace. startTime alone is not a unique sort key -> spans sharing
+// a startTime (common with ms-precision SDKs or batched writes) would be skipped or
+// truncated across a page boundary. spanID is a unique keyword field within a trace
+// and acts as a tie-breaker, per ES's search_after documentation.
+type searchAfterCursor struct {
+	startTime uint64
+	spanID    string
+}
+
 // buildTraceReadRequest builds the per-trace search body multiRead pages through:
-// the trace's query, ordered by startTime ascending, with search_after for the
-// pagination cursor and track_total_hits so the loop knows when a trace is fully
+// the trace's query, ordered by (startTime, spanID) ascending, with search_after for
+// the pagination cursor and track_total_hits so the loop knows when a trace is fully
 // fetched.
-func (s *SpanReader) buildTraceReadRequest(q esquery.Query, nextTime uint64) esclient.SearchRequest {
+func (s *SpanReader) buildTraceReadRequest(q esquery.Query, cursor searchAfterCursor) esclient.SearchRequest {
 	return esclient.SearchRequest{
-		Query:          q,
-		Size:           s.maxDocCount,
-		Sort:           []esclient.SortOrder{{Field: startTimeField, Order: esquery.Ascending}},
-		SearchAfter:    []any{nextTime},
+		Query: q,
+		Size:  s.maxDocCount,
+		Sort: []esclient.SortOrder{
+			{Field: startTimeField, Order: esquery.Ascending},
+			{Field: spanIDField, Order: esquery.Ascending},
+		},
+		SearchAfter:    []any{cursor.startTime, cursor.spanID},
 		TrackTotalHits: true,
 	}
 }
@@ -283,8 +297,8 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 
 	// See timeRangeDesign above for context on the padding and the alias filter.
 	idxList := s.spanRotation.ReadTargets(startTime.Add(-s.maxTraceDuration), endTime.Add(s.maxTraceDuration))
-	nextTime := model.TimeAsEpochMicroseconds(startTime.Add(-s.maxTraceDuration))
-	searchAfterTime := make(map[dbmodel.TraceID]uint64)
+	initialCursor := searchAfterCursor{startTime: model.TimeAsEpochMicroseconds(startTime.Add(-s.maxTraceDuration))}
+	searchAfterCursors := make(map[dbmodel.TraceID]searchAfterCursor)
 	totalDocumentsFetched := make(map[dbmodel.TraceID]int)
 	tracesMap := make(map[dbmodel.TraceID]*dbmodel.Trace)
 	for len(traceIDs) != 0 {
@@ -296,13 +310,14 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 				Must(traceQuery).
 				Must(startTimeRangeQuery)
 
-			if val, ok := searchAfterTime[traceID]; ok {
-				nextTime = val
+			cursor := initialCursor
+			if val, ok := searchAfterCursors[traceID]; ok {
+				cursor = val
 			}
 
 			searchRequests[i] = esclient.MultiSearchRequest{
 				Indices: idxList,
-				Search:  s.buildTraceReadRequest(query, nextTime),
+				Search:  s.buildTraceReadRequest(query, cursor),
 			}
 		}
 		// set traceIDs to empty
@@ -348,7 +363,7 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 			totalDocumentsFetched[lastSpan.TraceID] += len(result.Hits.Hits)
 			if totalDocumentsFetched[lastSpan.TraceID] < result.Hits.Total.Value {
 				traceIDs = append(traceIDs, lastSpan.TraceID)
-				searchAfterTime[lastSpan.TraceID] = lastSpan.StartTime
+				searchAfterCursors[lastSpan.TraceID] = searchAfterCursor{startTime: lastSpan.StartTime, spanID: string(lastSpan.SpanID)}
 			}
 		}
 	}

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -297,23 +297,27 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 			{Hits: esclient.HitsResult{Total: esclient.TotalHits{Value: 2}, Hits: []esclient.SearchHit{{Source: spanBytesID1}}}},
 		}
 
-		// Every sub-request must page startTime-ascending, track total hits, and carry
-		// the expected search_after cursor: the padded window start on round 1, and
-		// the last span's startTime on the follow-up.
-		initialCursor := model.TimeAsEpochMicroseconds(date.Add(-24 * time.Hour))
-		paginates := func(req esclient.MultiSearchRequest, wantCursor uint64) bool {
+		// Every sub-request must page (startTime, spanID)-ascending, track total hits,
+		// and carry the expected search_after cursor: the padded window start (with an
+		// empty spanID tie-breaker) on round 1, and the last span's (startTime, spanID)
+		// on the follow-up.
+		initialCursor := searchAfterCursor{startTime: model.TimeAsEpochMicroseconds(date.Add(-24 * time.Hour))}
+		paginates := func(req esclient.MultiSearchRequest, wantCursor searchAfterCursor) bool {
 			s := req.Search
-			return len(s.Sort) == 1 &&
+			return len(s.Sort) == 2 &&
 				s.Sort[0] == esclient.SortOrder{Field: startTimeField, Order: esquery.Ascending} &&
+				s.Sort[1] == esclient.SortOrder{Field: spanIDField, Order: esquery.Ascending} &&
 				s.TrackTotalHits &&
-				len(s.SearchAfter) == 1 && s.SearchAfter[0] == any(wantCursor)
+				len(s.SearchAfter) == 2 &&
+				s.SearchAfter[0] == any(wantCursor.startTime) &&
+				s.SearchAfter[1] == any(wantCursor.spanID)
 		}
 
 		r.searcher.On("MultiSearch", mock.Anything, mock.MatchedBy(func(reqs []esclient.MultiSearchRequest) bool {
 			return len(reqs) == 2 && paginates(reqs[0], initialCursor) && paginates(reqs[1], initialCursor)
 		})).Return(firstRound, nil).Once()
 		r.searcher.On("MultiSearch", mock.Anything, mock.MatchedBy(func(reqs []esclient.MultiSearchRequest) bool {
-			return len(reqs) == 1 && paginates(reqs[0], spanID1.StartTime)
+			return len(reqs) == 1 && paginates(reqs[0], searchAfterCursor{startTime: spanID1.StartTime, spanID: string(spanID1.SpanID)})
 		})).Return(secondRound, nil).Once()
 
 		traces, err := r.reader.multiRead(context.Background(), []dbmodel.TraceID{traceID1, traceID2}, date, date)
@@ -330,6 +334,75 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, string(expectedData), string(actualData))
 		}
+	})
+}
+
+// TestSpanReader_multiRead_sharedStartTime_usesSpanIDTieBreaker is a regression
+// test for https://github.com/jaegertracing/jaeger/issues/9048: search_after
+// pagination must carry a unique tie-breaker (spanID) alongside startTime.
+// Elasticsearch's search_after resumes strictly after the cursor value, so a
+// cursor of startTime alone would (with a page boundary landing inside a run of
+// spans sharing one startTime, as ms-precision SDKs and batched writes commonly
+// produce) skip the remaining same-timestamp spans on the next page — the reader
+// would return an incomplete trace with a nil error. This test fails if the
+// follow-up request's search_after ever regresses to a bare startTime.
+func TestSpanReader_multiRead_sharedStartTime_usesSpanIDTieBreaker(t *testing.T) {
+	withSpanReader(t, func(r *spanReaderTest) {
+		traceID := dbmodel.TraceID(testingTraceId)
+		date := time.Date(2019, 10, 10, 5, 0, 0, 0, time.UTC)
+		sameStartTime := model.TimeAsEpochMicroseconds(date)
+
+		newSpan := func(spanID dbmodel.SpanID) dbmodel.Span {
+			return dbmodel.Span{
+				SpanID:    spanID,
+				TraceID:   traceID,
+				StartTime: sameStartTime,
+				Tags:      []dbmodel.KeyValue{},
+				Process:   dbmodel.Process{Tags: []dbmodel.KeyValue{}},
+			}
+		}
+		spans := []dbmodel.Span{newSpan("0"), newSpan("1"), newSpan("2"), newSpan("3")}
+		hitsFor := func(idx ...int) []esclient.SearchHit {
+			hits := make([]esclient.SearchHit, len(idx))
+			for i, s := range idx {
+				b, err := json.Marshal(spans[s])
+				require.NoError(t, err)
+				hits[i] = esclient.SearchHit{Source: b}
+			}
+			return hits
+		}
+
+		// Page 1: 3 of the 4 spans sharing one startTime, total reports a 4th remains.
+		firstRound := []esclient.SearchResponse{
+			{Hits: esclient.HitsResult{Total: esclient.TotalHits{Value: 4}, Hits: hitsFor(0, 1, 2)}},
+		}
+		// Page 2: the remaining span, now fully fetched.
+		secondRound := []esclient.SearchResponse{
+			{Hits: esclient.HitsResult{Total: esclient.TotalHits{Value: 4}, Hits: hitsFor(3)}},
+		}
+
+		wantCursor := func(req esclient.MultiSearchRequest, cursor searchAfterCursor) bool {
+			s := req.Search
+			return len(s.SearchAfter) == 2 &&
+				s.SearchAfter[0] == any(cursor.startTime) &&
+				s.SearchAfter[1] == any(cursor.spanID)
+		}
+
+		initialCursor := searchAfterCursor{startTime: model.TimeAsEpochMicroseconds(date.Add(-24 * time.Hour))}
+		r.searcher.On("MultiSearch", mock.Anything, mock.MatchedBy(func(reqs []esclient.MultiSearchRequest) bool {
+			return len(reqs) == 1 && wantCursor(reqs[0], initialCursor)
+		})).Return(firstRound, nil).Once()
+		// The follow-up cursor must be (sameStartTime, "2") — the last span of page 1 —
+		// not a bare sameStartTime, or the 4th span (also at sameStartTime) would be
+		// skipped by Elasticsearch's search_after semantics.
+		r.searcher.On("MultiSearch", mock.Anything, mock.MatchedBy(func(reqs []esclient.MultiSearchRequest) bool {
+			return len(reqs) == 1 && wantCursor(reqs[0], searchAfterCursor{startTime: sameStartTime, spanID: "2"})
+		})).Return(secondRound, nil).Once()
+
+		traces, err := r.reader.multiRead(context.Background(), []dbmodel.TraceID{traceID}, date, date)
+		require.NoError(t, err)
+		require.Len(t, traces, 1)
+		require.Len(t, traces[0].Spans, 4, "all 4 same-startTime spans must be returned, none skipped")
 	})
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/get_traces.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/get_traces.json
@@ -27,12 +27,18 @@
         }
       },
       "search_after": [
-        1577847845000000
+        1577847845000000,
+        ""
       ],
       "size": 100,
       "sort": [
         {
           "startTime": {
+            "order": "asc"
+          }
+        },
+        {
+          "spanID": {
             "order": "asc"
           }
         }


### PR DESCRIPTION
Motivation:
SpanReader.multiRead pages through large traces using Elasticsearch's
search_after, sorted by startTime ascending, but the cursor carried
only that single, non-unique value. search_after resumes strictly
after the cursor, so per ES's own documentation a unique tie-breaker
field is required "otherwise hits with the same sort values could be
skipped". Since startTime has microsecond granularity and is not
unique (bursty batch writes, ms-precision SDKs that collapse many
distinct spans onto one timestamp), a page boundary landing inside a
run of same-startTime spans could drop them from the returned trace,
or - when >= max_doc_count spans share one timestamp - truncate the
trace outright. Both failure modes return nil error, so the UI shows
an incomplete trace with nothing logged.

Approach:
Add spanID (a keyword field in the span mapping, unique within a
trace) as a secondary sort key, and carry a two-value search_after
cursor (startTime, spanID) instead of a bare timestamp. This needed
no esclient API changes, since SearchRequest.Sort/SearchAfter already
accept multiple entries. buildTraceReadRequest and multiRead's
per-traceID cursor tracking were updated accordingly.

Validation:
go test -covermode=atomic -coverprofile=cover.out \
  ./internal/storage/v2/elasticsearch/tracestore/core/... && \
  go tool cover -func=cover.out
=> ok, 100.0% of statements covered in the changed package.

Added TestSpanReader_multiRead_sharedStartTime_usesSpanIDTieBreaker,
a regression test that mocks two search_after pages of spans sharing
one startTime and asserts the follow-up request's cursor is
(startTime, lastSpanID) rather than a bare startTime; it fails to
even compile against the pre-fix single-value cursor. Regenerated
the ES/OpenSearch request-snapshot fixture
(testdata/get_traces.json) via REGENERATE_SNAPSHOTS=true to reflect
the new two-field sort/search_after shape.

make lint and make fmt were also run clean.

Fixes #9048

Co-authored-by: Claude <noreply@anthropic.com>
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
