### PR TITLE
fix(query): Return JSON errors with correct type

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -5,7 +5,6 @@ package apiv3
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/jiter"
 	"github.com/jaegertracing/jaeger/internal/jptrace"
@@ -85,9 +85,14 @@ func (h *HTTPGateway) tryHandleError(w http.ResponseWriter, err error, statusCod
 			Message:  err.Error(),
 		},
 	}
-	resp, _ := json.Marshal(&errorResponse)
-	http.Error(w, string(resp), statusCode)
+	h.writeError(w, statusCode, &errorResponse)
 	return true
+}
+
+func (h *HTTPGateway) writeError(w http.ResponseWriter, statusCode int, response any) {
+	if err := httpjson.WriteError(w, statusCode, response); err != nil {
+		h.Logger.Error("Failed to write HTTP error response", zap.Error(err))
+	}
 }
 
 // tryParamError is similar to tryHandleError but specifically for reporting malformed params.
@@ -117,8 +122,7 @@ func (h *HTTPGateway) returnTraces(traces []ptrace.Traces, err error, w http.Res
 				Message:  "No traces found",
 			},
 		}
-		resp, _ := json.Marshal(&errorResponse)
-		http.Error(w, string(resp), http.StatusNotFound)
+		h.writeError(w, http.StatusNotFound, &errorResponse)
 		return
 	}
 	// TODO: the response should be streamed back to the client

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -83,7 +83,11 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.False(t, gw.tryHandleError(nil, nil, 0), "returns false if no error")
 
 	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
 	assert.True(t, gw.tryHandleError(w, spanstore.ErrTraceNotFound, 0), "returns true if error")
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 	assert.Equal(t, http.StatusNotFound, w.Code, "sets status code to 404")
 
 	logger, log := testutils.NewLogger()
@@ -93,6 +97,28 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.True(t, gw.tryHandleError(w, errors.New(e), http.StatusInternalServerError))
 	assert.Contains(t, log.String(), e, "logs error if status code is 500")
 	assert.Contains(t, string(w.Body.String()), e, "writes error message to body")
+}
+
+func TestHTTPGatewayLogsErrorResponseWriteFailure(t *testing.T) {
+	logger, log := testutils.NewLogger()
+	gw := &HTTPGateway{Logger: logger}
+
+	gw.writeError(&httpResponseErrWriter{}, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	assert.Contains(t, log.String(), "Failed to write HTTP error response")
+	assert.Contains(t, log.String(), "failed to write")
+}
+
+type httpResponseErrWriter struct{}
+
+func (*httpResponseErrWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (*httpResponseErrWriter) WriteHeader(int) {}
+
+func (*httpResponseErrWriter) Write([]byte) (int, error) {
+	return 0, errors.New("failed to write")
 }
 
 func TestHTTPGatewayGetTrace(t *testing.T) {
@@ -219,6 +245,7 @@ func TestHTTPGatewayGetTraceEmptyResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	assert.Contains(t, w.Body.String(), "No traces found")
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -6,7 +6,6 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +23,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3"
 	deepdependencies "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/qualitymetrics"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
@@ -555,8 +555,9 @@ func (aH *APIHandler) handleError(w http.ResponseWriter, err error, statusCode i
 			},
 		},
 	}
-	resp, _ := json.Marshal(&structuredResp)
-	http.Error(w, string(resp), statusCode)
+	if err := httpjson.WriteError(w, statusCode, &structuredResp); err != nil {
+		aH.logger.Error("Failed to write HTTP error response", zap.Error(err))
+	}
 	return true
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -44,6 +44,7 @@ import (
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"github.com/jaegertracing/jaeger/internal/testutils"
 	ui "github.com/jaegertracing/jaeger/internal/uimodel"
 )
 
@@ -281,6 +282,30 @@ func TestLogOnServerError(t *testing.T) {
 	assert.Equal(t, "HTTP handler, Internal Server Error", log.Message)
 	require.Len(t, log.Context, 1)
 	assert.Equal(t, e, log.Context[0].Interface)
+}
+
+func TestHandleErrorWritesJSONContentType(t *testing.T) {
+	h := NewAPIHandler(nil)
+	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
+
+	h.handleError(w, errors.New("test error"), http.StatusBadRequest)
+
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.JSONEq(t, `{"data":null,"errors":[{"code":400,"msg":"test error"}],"total":0,"limit":0,"offset":0}`, w.Body.String())
+}
+
+func TestHandleErrorLogsWriteFailure(t *testing.T) {
+	logger, log := testutils.NewLogger()
+	h := NewAPIHandler(nil, HandlerOptions.Logger(logger))
+
+	h.handleError(&httpResponseErrWriter{}, errors.New("test error"), http.StatusBadRequest)
+
+	assert.Contains(t, log.String(), "Failed to write HTTP error response")
+	assert.Contains(t, log.String(), "failed to write")
 }
 
 // httpResponseErrWriter implements the http.ResponseWriter interface that returns an error on Write.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpjson provides JSON response helpers for Jaeger Query HTTP APIs.
+package httpjson
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// WriteError writes an error response with a JSON body. It must be called before
+// the response is committed.
+func WriteError(w http.ResponseWriter, statusCode int, response any) error {
+	body, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON error response: %w", err)
+	}
+	body = append(body, '\n')
+
+	w.Header().Del("Content-Length")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(statusCode)
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("failed to write JSON error response: %w", err)
+	}
+	return nil
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package httpjson
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}
+
+func TestWriteError(t *testing.T) {
+	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
+
+	err := WriteError(w, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	require.NoError(t, err)
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.JSONEq(t, `{"error":"test error"}`, w.Body.String())
+}
+
+func TestWriteErrorMarshalFailureDoesNotCommitResponse(t *testing.T) {
+	w := &failingResponseWriter{header: http.Header{"Content-Length": []string{"1"}}}
+
+	err := WriteError(w, http.StatusBadRequest, make(chan int))
+
+	require.ErrorContains(t, err, "failed to marshal JSON error response")
+	assert.Zero(t, w.statusCode)
+	assert.Equal(t, "1", w.Header().Get("Content-Length"))
+	assert.Empty(t, w.Header().Get("Content-Type"))
+}
+
+func TestWriteErrorWriteFailure(t *testing.T) {
+	writeErr := errors.New("write failed")
+	w := &failingResponseWriter{header: make(http.Header), writeErr: writeErr}
+
+	err := WriteError(w, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	require.ErrorIs(t, err, writeErr)
+	assert.Equal(t, http.StatusBadRequest, w.statusCode)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+}
+
+type failingResponseWriter struct {
+	header     http.Header
+	statusCode int
+	writeErr   error
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	return 0, w.writeErr
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- closes #9051

## Description of the changes
- Add a feature-scoped JSON error writer shared by the legacy and API v3 query handlers.
- Return `Content-Type: application/json` while preserving the existing status codes, response schemas, trailing newline, stale `Content-Length` removal, and `X-Content-Type-Options: nosniff` behavior.
- Serialize error payloads before committing the response and report serialization or write failures to the handler for logging.
- Cover legacy errors, API v3 errors, no-traces responses, serialization failures, and response write failures with regression tests.

## How was this change tested?
- `make fmt` / `lint` / `test`
- Started the all-in-one service with memory storage:
  - `go run ./cmd/jaeger --set extensions.jaeger_query.http.endpoint=127.0.0.1`
- Verified live HTTP responses:
  - `GET /api/operations` returned `400`, the legacy JSON error schema, `Content-Type: application/json`, and `X-Content-Type-Options: nosniff`.
  - `GET /api/v3/traces/not-a-trace-id` returned `400`, the API v3 JSON error schema, `Content-Type: application/json`, and `X-Content-Type-Options: nosniff`.
  - `GET /api/v3/traces/00000000000000000000000000000001` returned `404`, the API v3 no-traces JSON error, `Content-Type: application/json`, and `X-Content-Type-Options: nosniff`.
  - `GET /api/services` remained successful with `200` and `Content-Type: application/json`.
- Sent an interrupt to the running service and confirmed that HTTP, gRPC, and the collector completed graceful shutdown.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
