### PR TITLE
fix(storage): Sanitize remote storage exports

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/internal/jptrace"
+	"github.com/jaegertracing/jaeger/internal/jptrace/sanitizer"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
@@ -201,7 +202,7 @@ func (h *Handler) Export(ctx context.Context, request ptraceotlp.ExportRequest) 
 	ptraceotlp.ExportResponse,
 	error,
 ) {
-	err := h.traceWriter.WriteTraces(ctx, request.Traces())
+	err := h.traceWriter.WriteTraces(ctx, sanitizer.Sanitize(request.Traces()))
 	if err != nil {
 		return ptraceotlp.NewExportResponse(), err
 	}

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/internal/jptrace"
+	"github.com/jaegertracing/jaeger/internal/jptrace/sanitizer"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore"
 	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
@@ -423,9 +424,9 @@ func TestHandler_Export(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			reader := new(tracestoremocks.Reader)
-			writer := new(tracestoremocks.Writer)
+			writer := tracestoremocks.NewWriter(t)
 			depReader := new(depstoremocks.Reader)
-			writer.On("WriteTraces", mock.Anything, makeTestTrace()).Return(test.writeTracesErr).Once()
+			writer.On("WriteTraces", mock.Anything, sanitizer.Sanitize(makeTestTrace())).Return(test.writeTracesErr).Once()
 			server := NewHandler(reader, writer, depReader)
 
 			response, err := server.Export(context.Background(), ptraceotlp.NewExportRequestFromTraces(makeTestTrace()))


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #9061 
- The remote-storage OTLP `Export` handler bypasses the trace sanitization used by the local storage exporter. As a result, malformed traces, including those without `service.name`, can be persisted differently depending on deployment topology.

## Description of the changes
- Apply `jptrace/sanitizer.Sanitize` at the remote-storage gRPC export boundary before passing traces to the configured writer.
- Add a regression test that verifies the writer receives the canonical sanitized trace and that the write is invoked.

## How was this change tested?
- `make fmt` / `int` / `test`
- Started `jaeger-remote-storage` with its default memory backend using `go run ./cmd/remote-storage`.
- Sent an OTLP gRPC `Export` request for a trace without `service.name`, then retrieved it through the remote-storage `TraceReader/GetTraces` API. The persisted resource attributes contained `service.name: missing-service-name`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
