### PR TITLE
feat(query): Support serving UI assets from a .tar.gz archive

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -22,6 +22,8 @@ type UIConfig struct {
 	// ConfigFile is the path to a configuration file for the UI.
 	ConfigFile string `mapstructure:"config_file" valid:"optional"`
 	// AssetsPath is the path for the static assets for the UI (https://github.com/uber/jaeger-ui).
+	// It may be either a directory or the assets.tar.gz bundle published on the
+	// jaeger-ui releases page, in which case the archive is read directly.
 	AssetsPath string `mapstructure:"assets_path" valid:"optional" `
 	// LogAccess tells static handler to log access to static assets, useful in debugging.
 	LogAccess bool `mapstructure:"log_access" valid:"optional"`

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/static_handler.go
@@ -88,7 +88,11 @@ type loadedConfig struct {
 func newStaticAssetsHandler(qOpts *QueryOptions, storageCaps querysvc.StorageCapabilities, aiHealthCheck func() bool, logger *zap.Logger) (*staticAssetsHandler, error) {
 	assetsFS := ui.GetStaticFiles(logger)
 	if qOpts.UIConfig.AssetsPath != "" {
-		assetsFS = http.Dir(qOpts.UIConfig.AssetsPath)
+		var err error
+		assetsFS, err = newAssetsFS(qOpts.UIConfig.AssetsPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 	raw, err := loadIndexHTML(assetsFS.Open)
 	if err != nil {
@@ -117,6 +121,29 @@ func newStaticAssetsHandler(qOpts *QueryOptions, storageCaps querysvc.StorageCap
 		logger.Info("Using UI configuration", zap.String("path", h.uiConfigFile))
 	}
 	return h, nil
+}
+
+// newAssetsFS resolves ui.assets_path to a file system. The path is normally a
+// directory, but it may also be the jaeger-ui assets.tar.gz bundle as
+// published on the releases page, which saves a custom distribution from
+// having to unpack the archive at image-build time.
+//
+// A path that merely looks like an archive but cannot be stat'ed, or that is a
+// directory despite the suffix, falls through to http.Dir so the existing
+// "cannot load index.html" error still describes the real problem.
+func newAssetsFS(assetsPath string) (http.FileSystem, error) {
+	if !strings.HasSuffix(strings.ToLower(assetsPath), tarGzSuffix) {
+		return http.Dir(assetsPath), nil
+	}
+	info, err := os.Stat(assetsPath)
+	if err != nil || info.IsDir() {
+		return http.Dir(assetsPath), nil
+	}
+	fsys, err := newTarGzFS(assetsPath)
+	if err != nil {
+		return nil, err
+	}
+	return http.FS(fsys), nil
 }
 
 // getUIConfig returns the cached parsed UI config, re-reading it from disk

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/targz.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/targz.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// tarGzSuffix marks an assets path as an archive rather than a directory.
+// It matches the name of the assets bundle published on the jaeger-ui
+// releases page, so a distribution can point ui.assets_path straight at the
+// downloaded file without unpacking it first.
+const tarGzSuffix = ".tar.gz"
+
+// tarGzFS is a read-only fs.FS over a gzipped tar archive.
+//
+// The archive is expanded into memory once at construction rather than being
+// decompressed per request: tar is a sequential format with no index, so
+// serving a single asset from disk would mean re-scanning the archive from the
+// start every time. The UI bundle is a few megabytes, which is the same order
+// as the assets already embedded in the binary by ui.GetStaticFiles.
+type tarGzFS struct {
+	// entries is keyed by fs.FS path — slash-separated, unrooted, with the
+	// archive root stored as ".".
+	entries map[string]*tarGzEntry
+}
+
+type tarGzEntry struct {
+	name     string // base name, as reported by FileInfo.Name
+	data     []byte // nil for directories
+	mode     fs.FileMode
+	modTime  time.Time
+	isDir    bool
+	children []*tarGzEntry // populated for directories only
+}
+
+// newTarGzFS reads the archive at archivePath into memory.
+func newTarGzFS(archivePath string) (fs.FS, error) {
+	f, err := os.Open(filepath.Clean(archivePath))
+	if err != nil {
+		return nil, fmt.Errorf("cannot open assets archive %s: %w", archivePath, err)
+	}
+	defer f.Close()
+	return readTarGz(f, archivePath)
+}
+
+// readTarGz builds the in-memory tree from a gzipped tar stream. name is used
+// only to give errors a useful subject.
+func readTarGz(r io.Reader, name string) (fs.FS, error) {
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read assets archive %s: %w", name, err)
+	}
+	defer gr.Close()
+
+	fsys := &tarGzFS{entries: make(map[string]*tarGzEntry)}
+	fsys.entries["."] = &tarGzEntry{
+		name:  ".",
+		mode:  fs.ModeDir | 0o555,
+		isDir: true,
+	}
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("cannot read assets archive %s: %w", name, err)
+		}
+
+		entryPath := path.Clean(strings.TrimPrefix(filepath.ToSlash(hdr.Name), "./"))
+		// Skip the root itself and any entry whose name escapes the archive
+		// root (e.g. "../evil"). A read-only FS has nothing to gain from
+		// honouring traversal, and fs.FS forbids such paths outright.
+		if entryPath == "." || !fs.ValidPath(entryPath) {
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			fsys.mkdirAll(entryPath, hdr.ModTime)
+		case tar.TypeReg:
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("cannot read %s from assets archive %s: %w", entryPath, name, err)
+			}
+			fsys.addFile(entryPath, data, hdr)
+		default:
+			// Symlinks, devices and the like have no meaning for the UI
+			// bundle; ignore them rather than failing the whole archive.
+		}
+	}
+
+	// Directory listings must be ordered by filename to satisfy fs.ReadDirFile.
+	for _, e := range fsys.entries {
+		if e.isDir {
+			sort.Slice(e.children, func(i, j int) bool {
+				return e.children[i].name < e.children[j].name
+			})
+		}
+	}
+	return fsys, nil
+}
+
+// addFile inserts a regular file, creating any missing parent directories.
+func (fsys *tarGzFS) addFile(entryPath string, data []byte, hdr *tar.Header) {
+	if existing, ok := fsys.entries[entryPath]; ok && !existing.isDir {
+		// Later entries win, mirroring how an extraction to disk would end up.
+		existing.data = data
+		existing.modTime = hdr.ModTime
+		return
+	}
+	parent := fsys.mkdirAll(path.Dir(entryPath), hdr.ModTime)
+	e := &tarGzEntry{
+		name:    path.Base(entryPath),
+		data:    data,
+		mode:    fs.FileMode(hdr.Mode).Perm(),
+		modTime: hdr.ModTime,
+	}
+	fsys.entries[entryPath] = e
+	parent.children = append(parent.children, e)
+}
+
+// mkdirAll returns the directory entry for dir, creating it and any missing
+// ancestors. Archives are not required to contain explicit directory entries.
+func (fsys *tarGzFS) mkdirAll(dir string, modTime time.Time) *tarGzEntry {
+	if dir == "." || dir == "" {
+		return fsys.entries["."]
+	}
+	if e, ok := fsys.entries[dir]; ok && e.isDir {
+		return e
+	}
+	parent := fsys.mkdirAll(path.Dir(dir), modTime)
+	e := &tarGzEntry{
+		name:    path.Base(dir),
+		mode:    fs.ModeDir | 0o555,
+		modTime: modTime,
+		isDir:   true,
+	}
+	fsys.entries[dir] = e
+	parent.children = append(parent.children, e)
+	return e
+}
+
+func (fsys *tarGzFS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	e, ok := fsys.entries[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	if e.isDir {
+		return &tarGzDir{entry: e}, nil
+	}
+	return &tarGzFile{Reader: bytes.NewReader(e.data), entry: e}, nil
+}
+
+// tarGzFile embeds *bytes.Reader so the file satisfies io.Seeker, which
+// http.ServeContent needs for range requests.
+type tarGzFile struct {
+	*bytes.Reader
+	entry *tarGzEntry
+}
+
+func (f *tarGzFile) Stat() (fs.FileInfo, error) { return tarGzInfo{f.entry}, nil }
+
+func (*tarGzFile) Close() error { return nil }
+
+type tarGzDir struct {
+	entry  *tarGzEntry
+	offset int
+}
+
+func (d *tarGzDir) Stat() (fs.FileInfo, error) { return tarGzInfo{d.entry}, nil }
+
+func (*tarGzDir) Close() error { return nil }
+
+func (d *tarGzDir) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.entry.name, Err: fs.ErrInvalid}
+}
+
+func (d *tarGzDir) ReadDir(n int) ([]fs.DirEntry, error) {
+	remaining := d.entry.children[d.offset:]
+	if n <= 0 {
+		d.offset = len(d.entry.children)
+		return toDirEntries(remaining), nil
+	}
+	if len(remaining) == 0 {
+		return nil, io.EOF
+	}
+	if n > len(remaining) {
+		n = len(remaining)
+	}
+	d.offset += n
+	return toDirEntries(remaining[:n]), nil
+}
+
+func toDirEntries(entries []*tarGzEntry) []fs.DirEntry {
+	out := make([]fs.DirEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, fs.FileInfoToDirEntry(tarGzInfo{e}))
+	}
+	return out
+}
+
+type tarGzInfo struct{ entry *tarGzEntry }
+
+func (i tarGzInfo) Name() string       { return i.entry.name }
+func (i tarGzInfo) Size() int64        { return int64(len(i.entry.data)) }
+func (i tarGzInfo) Mode() fs.FileMode  { return i.entry.mode }
+func (i tarGzInfo) ModTime() time.Time { return i.entry.modTime }
+func (i tarGzInfo) IsDir() bool        { return i.entry.isDir }
+func (tarGzInfo) Sys() any             { return nil }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/targz_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/targz_test.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+)
+
+// buildFixtureArchive packs the existing "fixture" directory into a
+// .tar.gz in a temp dir, so the archive and the directory cases are served
+// from byte-identical sources.
+func buildFixtureArchive(t *testing.T) string {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "fixture.tar.gz")
+	out, err := os.Create(archivePath)
+	require.NoError(t, err)
+	defer out.Close()
+
+	gw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gw)
+
+	const root = "fixture"
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if d.IsDir() {
+			hdr.Name += "/"
+			return tw.WriteHeader(hdr)
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		_, err = tw.Write(data)
+		return err
+	})
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	return archivePath
+}
+
+func serveFromAssets(t *testing.T, assetsPath, target string) (int, string) {
+	t.Helper()
+	r := http.NewServeMux()
+	closer := RegisterStaticHandler(
+		r, zap.NewNop(),
+		&QueryOptions{UIConfig: UIConfig{AssetsPath: assetsPath}},
+		querysvc.StorageCapabilities{},
+		nil,
+	)
+	defer closer.Close()
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, target, http.NoBody))
+	return rr.Code, rr.Body.String()
+}
+
+// TestAssetsFromArchiveMatchDirectory is the core guarantee: pointing
+// assets_path at the archive serves exactly what the directory serves.
+func TestAssetsFromArchiveMatchDirectory(t *testing.T) {
+	archive := buildFixtureArchive(t)
+
+	for _, target := range []string{"/", "/static/asset.txt"} {
+		t.Run(target, func(t *testing.T) {
+			dirCode, dirBody := serveFromAssets(t, "fixture", target)
+			arcCode, arcBody := serveFromAssets(t, archive, target)
+
+			assert.Equal(t, http.StatusOK, dirCode)
+			assert.Equal(t, dirCode, arcCode)
+			assert.Equal(t, dirBody, arcBody)
+		})
+	}
+}
+
+func TestNewAssetsFSFallsBackToDir(t *testing.T) {
+	// A directory that merely ends in .tar.gz is still a directory.
+	dir := filepath.Join(t.TempDir(), "assets.tar.gz")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"plain directory", "fixture"},
+		{"directory named like an archive", dir},
+		{"archive that does not exist", filepath.Join(t.TempDir(), "missing.tar.gz")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assetsFS, err := newAssetsFS(tt.path)
+			require.NoError(t, err)
+			assert.IsType(t, http.Dir(""), assetsFS)
+		})
+	}
+}
+
+func TestNewAssetsFSRejectsMalformedArchive(t *testing.T) {
+	bad := filepath.Join(t.TempDir(), "broken.tar.gz")
+	require.NoError(t, os.WriteFile(bad, []byte("not gzip at all"), 0o600))
+
+	_, err := newAssetsFS(bad)
+	require.ErrorContains(t, err, "cannot read assets archive")
+}
+
+func TestNewStaticAssetsHandlerMalformedArchive(t *testing.T) {
+	bad := filepath.Join(t.TempDir(), "broken.tar.gz")
+	require.NoError(t, os.WriteFile(bad, []byte("not gzip at all"), 0o600))
+
+	handler, err := newStaticAssetsHandler(
+		&QueryOptions{UIConfig: UIConfig{AssetsPath: bad}},
+		querysvc.StorageCapabilities{},
+		nil,
+		zap.NewNop(),
+	)
+	require.ErrorContains(t, err, "cannot read assets archive")
+	assert.Nil(t, handler)
+}
+
+func TestNewTarGzFSUnreadableArchive(t *testing.T) {
+	_, err := newTarGzFS(filepath.Join(t.TempDir(), "nope.tar.gz"))
+	require.ErrorContains(t, err, "cannot open assets archive")
+}
+
+func TestTarGzFSTruncatedArchive(t *testing.T) {
+	// Valid gzip wrapper, truncated tar payload.
+	full, err := os.ReadFile(buildFixtureArchive(t))
+	require.NoError(t, err)
+
+	truncated := filepath.Join(t.TempDir(), "truncated.tar.gz")
+	require.NoError(t, os.WriteFile(truncated, full[:len(full)/2], 0o600))
+
+	_, err = newTarGzFS(truncated)
+	require.Error(t, err)
+}
+
+func TestTarGzFSTruncatedFileContent(t *testing.T) {
+	const content = "some index.html content"
+
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "index.html", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(content)),
+	}))
+	_, err := tw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	// Keep the 512-byte header block but cut the payload short, so gzip and the
+	// tar header both parse and the failure surfaces while reading the entry.
+	partial := tarBuf.Bytes()[:512+len(content)/2]
+
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	_, err = gw.Write(partial)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+
+	_, err = readTarGz(bytes.NewReader(gzBuf.Bytes()), "partial.tar.gz")
+	require.ErrorContains(t, err, "cannot read index.html from assets archive")
+}
+
+// TestTarGzFSCompliance leans on the stdlib's own fs.FS conformance suite,
+// which exercises Open, Stat, ReadDir and path validation far more thoroughly
+// than hand-written cases would.
+func TestTarGzFSCompliance(t *testing.T) {
+	f, err := os.Open(buildFixtureArchive(t))
+	require.NoError(t, err)
+	defer f.Close()
+
+	fsys, err := readTarGz(f, "fixture.tar.gz")
+	require.NoError(t, err)
+	require.NoError(t, fstest.TestFS(fsys, "index.html", "static/asset.txt"))
+}
+
+func TestTarGzFSOpenErrors(t *testing.T) {
+	f, err := os.Open(buildFixtureArchive(t))
+	require.NoError(t, err)
+	defer f.Close()
+
+	fsys, err := readTarGz(f, "fixture.tar.gz")
+	require.NoError(t, err)
+
+	t.Run("invalid path", func(t *testing.T) {
+		_, err := fsys.Open("../escape")
+		require.ErrorIs(t, err, fs.ErrInvalid)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := fsys.Open("does/not/exist")
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	t.Run("read on a directory", func(t *testing.T) {
+		d, err := fsys.Open("static")
+		require.NoError(t, err)
+		defer d.Close()
+
+		_, err = d.Read(make([]byte, 1))
+		require.ErrorIs(t, err, fs.ErrInvalid)
+	})
+}
+
+func TestTarGzFSDirectoryListing(t *testing.T) {
+	f, err := os.Open(buildFixtureArchive(t))
+	require.NoError(t, err)
+	defer f.Close()
+
+	fsys, err := readTarGz(f, "fixture.tar.gz")
+	require.NoError(t, err)
+
+	d, err := fsys.Open("static")
+	require.NoError(t, err)
+	defer d.Close()
+
+	info, err := d.Stat()
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+	assert.Equal(t, "static", info.Name())
+	assert.Nil(t, info.Sys())
+
+	dir, ok := d.(fs.ReadDirFile)
+	require.True(t, ok, "directories must satisfy fs.ReadDirFile")
+
+	// Paged reads drain the listing and then report io.EOF.
+	first, err := dir.ReadDir(1)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "asset.txt", first[0].Name())
+
+	_, err = dir.ReadDir(1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestTarGzFSSkipsUnsupportedEntries(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "odd.tar.gz")
+	out, err := os.Create(archivePath)
+	require.NoError(t, err)
+
+	gw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gw)
+
+	// A symlink and a traversal attempt are both ignored; the regular file
+	// alongside them is still served. The nested file also proves that parent
+	// directories are synthesised when the archive omits them.
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "link", Typeflag: tar.TypeSymlink, Linkname: "index.html", Mode: 0o777,
+	}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "../escape.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 3,
+	}))
+	_, err = tw.Write([]byte("bad"))
+	require.NoError(t, err)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "./nested/deep/ok.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 2,
+	}))
+	_, err = tw.Write([]byte("ok"))
+	require.NoError(t, err)
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	require.NoError(t, out.Close())
+
+	fsys, err := newTarGzFS(archivePath)
+	require.NoError(t, err)
+
+	data, err := fs.ReadFile(fsys, "nested/deep/ok.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(data))
+
+	_, err = fsys.Open("link")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+
+	_, err = fsys.Open("escape.txt")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestTarGzFSDuplicateEntriesLastWins(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "dupes.tar.gz")
+	out, err := os.Create(archivePath)
+	require.NoError(t, err)
+
+	gw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gw)
+
+	// tar allows the same path to appear twice; extracting to disk would leave
+	// the later copy in place, so the FS view must agree.
+	for _, content := range []string{"first", "last!"} {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: "index.html", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(content)),
+		}))
+		_, err = tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	require.NoError(t, out.Close())
+
+	fsys, err := newTarGzFS(archivePath)
+	require.NoError(t, err)
+
+	data, err := fs.ReadFile(fsys, "index.html")
+	require.NoError(t, err)
+	assert.Equal(t, "last!", string(data))
+
+	// The duplicate must not be listed twice in its parent directory.
+	entries, err := fs.ReadDir(fsys, ".")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "index.html", entries[0].Name())
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9065

`ui.assets_path` was passed straight to `http.Dir`, so it had to be a **directory**. A custom Jaeger distribution that serves the UI from disk rather than embedding it had to unpack the published `jaeger-ui` `assets.tar.gz` into a directory at image-build time before the binary could use it.

## Description of the changes

- `ui.assets_path` now also accepts the published `assets.tar.gz` directly — same property, no new option. When the path is a **regular file** (not a directory) whose name ends in `.tar.gz`, it is served through an `fs.FS` backed by `compress/gzip` + `archive/tar`; otherwise the existing `http.Dir` behaviour is unchanged.

```yaml
extensions:
  jaeger_query:
    ui:
      assets_path: /var/lib/jaeger/ui                # directory (unchanged)
      # assets_path: /var/lib/jaeger/assets.tar.gz   # archive (new)
```

Notes on the implementation:

- **The archive is expanded into memory once at construction.** tar is a sequential format with no index, so serving a single asset straight from the file would mean re-scanning the archive from the start on every request. The UI bundle is the same order of size as the assets already embedded in the binary by `ui.GetStaticFiles`.
- **`tarGzFile` embeds `*bytes.Reader`** so files satisfy `io.Seeker`, which `http.ServeContent` needs to answer range requests.
- **Parent directories are synthesised** when an archive omits explicit directory entries.
- **Entries that escape the archive root** (e.g. `../evil`) and non-regular entries (symlinks, devices) are skipped rather than failing the whole archive.
- **A path that only looks like an archive** — a directory carrying the suffix, or one that cannot be stat'ed — falls through to `http.Dir`, so the existing `cannot load index.html` error still describes the real problem rather than being masked by an archive-specific one.

Only `static_handler.go` (resolution of `assets_path`), a doc comment on the `AssetsPath` field, and the new `targz.go` / `targz_test.go` are touched.

## How was this change tested?

New tests in `cmd/jaeger/internal/extension/jaegerquery/internal/targz_test.go`. The fixture archive is built at test time by packing the existing `fixture/` directory, so the directory and archive cases are served from byte-identical sources rather than from a committed binary blob.

- `TestAssetsFromArchiveMatchDirectory` — the core guarantee: `/` and `/static/asset.txt` return identical status and body whether `assets_path` points at `fixture` or at `fixture.tar.gz`.
- `TestTarGzFSCompliance` — runs the stdlib's own `fstest.TestFS` conformance suite against the archive FS.
- Error paths — malformed gzip, unreadable archive, gzip-valid but truncated tar, and a tar entry whose payload is cut short.
- Fallbacks — plain directory, a directory named `*.tar.gz`, and a `.tar.gz` that does not exist.
- FS semantics — invalid path, missing file, `Read` on a directory, paged `ReadDir` draining to `io.EOF`, skipped symlink/traversal entries, and duplicate entries where the last one wins.

Verification run locally:

- `go vet ./cmd/jaeger/internal/extension/jaegerquery/internal/` — clean
- `gofmt` — clean
- Coverage: **100% of statements on every new function**, measured with `go test -covermode=atomic -coverprofile` over the changed package.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits (DCO)
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
