### PR TITLE
test(e2e): assert core metrics golden list

### DIFF
--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -47,6 +47,13 @@ type E2EStorageIntegration struct {
 	MetricsPort     int // overridable, default to 8888
 	HealthCheckPort int // overridable for tests (e.g. Kafka, query) which run two binaries and need different ports
 
+	// RequireCoreMetrics enables a golden-list check on the scraped /metrics
+	// body after the test finishes. Enable for full all-in-one / storage e2e
+	// binaries that exercise receive → export → storage. Partial deployments
+	// (query-only, remote backends, kafka split) should leave this false.
+	// See metrics_compat.go and jaegertracing/jaeger#6278.
+	RequireCoreMetrics bool
+
 	// EnvVarOverrides contains a map of environment variables to set.
 	// The key in the map is the environment variable to override and the value
 	// is the value of the environment variable to set.
@@ -148,6 +155,9 @@ func (s *E2EStorageIntegration) scrapeMetrics(t *testing.T, storage string) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
 	outputDir := "../../../../.metrics"
 	require.NoError(t, os.MkdirAll(outputDir, os.ModePerm))
 
@@ -155,8 +165,12 @@ func (s *E2EStorageIntegration) scrapeMetrics(t *testing.T, storage string) {
 	require.NoError(t, err)
 	defer metricsFile.Close()
 
-	_, err = io.Copy(metricsFile, resp.Body)
+	_, err = metricsFile.Write(body)
 	require.NoError(t, err)
+
+	if s.RequireCoreMetrics {
+		assertCoreMetricsPresent(t, string(body))
+	}
 }
 
 func createStorageCleanerConfig(t *testing.T, configFile string, storage string) string {

--- a/cmd/jaeger/internal/integration/memory_test.go
+++ b/cmd/jaeger/internal/integration/memory_test.go
@@ -13,7 +13,8 @@ func TestMemoryStorage(t *testing.T) {
 	integration.SkipUnlessEnv(t, integration.StorageMemoryV2)
 
 	s := &E2EStorageIntegration{
-		ConfigFile: "../../config.yaml",
+		ConfigFile:         "../../config.yaml",
+		RequireCoreMetrics: true, // golden-list BC check; see metrics_compat.go / #6278
 		StorageIntegration: integration.StorageIntegration{
 			CleanUp: purge,
 		},

--- a/cmd/jaeger/internal/integration/metrics_compat.go
+++ b/cmd/jaeger/internal/integration/metrics_compat.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// coreMetricFamilies is a golden list of metric family names that form a stable
+// public monitoring surface for Jaeger v2 all-in-one / storage e2e binaries.
+// These families are what monitoring/jaeger-mixin dashboards and production
+// operators rely on; removing or renaming them is a backwards-incompatible change.
+//
+// Names match the Prometheus text exposition produced by the v2 binary (see
+// scrapeMetrics). The Grafana mixin historically used slightly different
+// suffixes (e.g. _total); the exposition names below are the source of truth.
+//
+// This is an incremental slice of https://github.com/jaegertracing/jaeger/issues/6278:
+// full snapshot diffing already exists in CI; this check fails the e2e test
+// immediately when a core family disappears.
+var coreMetricFamilies = []string{
+	"otelcol_receiver_accepted_spans",
+	"otelcol_exporter_sent_spans",
+	"jaeger_storage_requests",
+	"jaeger_storage_latency",
+}
+
+// corePositiveCounters are counter families that must have at least one sample
+// with value > 0 after a full span-store e2e run has exercised the pipeline.
+// This catches regressions where a metric is registered but never incremented
+// (see https://github.com/jaegertracing/jaeger/issues/7125).
+var corePositiveCounters = []string{
+	"otelcol_receiver_accepted_spans",
+	"jaeger_storage_requests",
+}
+
+// metricExposition holds a parsed subset of a Prometheus text scrape.
+type metricExposition struct {
+	// families maps family name (from "# TYPE <name> ...") to its type string.
+	families map[string]string
+	// maxSampleValue maps sample metric name (may include _total/_count/_sum/_bucket
+	// suffixes for some exporters) to the maximum observed sample value.
+	maxSampleValue map[string]float64
+}
+
+func parseMetricExposition(body string) metricExposition {
+	exp := metricExposition{
+		families:       make(map[string]string),
+		maxSampleValue: make(map[string]float64),
+	}
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	// Metrics lines can be long when many labels are present.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "# HELP ") {
+			continue
+		}
+		if strings.HasPrefix(line, "# TYPE ") {
+			// # TYPE <name> <type>
+			fields := strings.Fields(line)
+			if len(fields) >= 4 {
+				exp.families[fields[2]] = fields[3]
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, value, ok := parseSampleLine(line)
+		if !ok {
+			continue
+		}
+		if prev, exists := exp.maxSampleValue[name]; !exists || value > prev {
+			exp.maxSampleValue[name] = value
+		}
+	}
+	return exp
+}
+
+// parseSampleLine extracts the metric name and value from a Prometheus sample line.
+// Supports both "name{labels} value" and "name value" forms; timestamps are ignored.
+func parseSampleLine(line string) (name string, value float64, ok bool) {
+	// Strip optional timestamp by taking the last whitespace-separated field as
+	// value when two trailing numbers exist is ambiguous; Prometheus format is:
+	//   metric_name[{labels}] value [timestamp]
+	// Find the metric name first.
+	rest := line
+	if i := strings.IndexByte(line, '{'); i >= 0 {
+		name = line[:i]
+		end := strings.LastIndexByte(line, '}')
+		if end < 0 {
+			return "", 0, false
+		}
+		rest = strings.TrimSpace(line[end+1:])
+	} else {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return "", 0, false
+		}
+		name = fields[0]
+		rest = strings.Join(fields[1:], " ")
+	}
+	if name == "" || rest == "" {
+		return "", 0, false
+	}
+	fields := strings.Fields(rest)
+	if len(fields) < 1 {
+		return "", 0, false
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return name, v, true
+}
+
+// sampleValueForFamily returns the max sample value for a family name, accepting
+// common Prometheus suffixes that may appear on sample names (_total, _count).
+func (e metricExposition) sampleValueForFamily(family string) (float64, bool) {
+	candidates := []string{
+		family,
+		family + "_total",
+		family + "_count",
+	}
+	var (
+		max   float64
+		found bool
+	)
+	for _, c := range candidates {
+		if v, ok := e.maxSampleValue[c]; ok {
+			if !found || v > max {
+				max = v
+				found = true
+			}
+		}
+	}
+	// Also consider histogram/summary bucket/sum samples under the family prefix.
+	prefix := family + "_"
+	for name, v := range e.maxSampleValue {
+		if strings.HasPrefix(name, prefix) {
+			if !found || v > max {
+				max = v
+				found = true
+			}
+		}
+	}
+	return max, found
+}
+
+// checkCoreMetrics returns an error when required metric families are missing
+// from a Prometheus scrape, or when counters that should have been exercised are zero.
+func checkCoreMetrics(body string) error {
+	exp := parseMetricExposition(body)
+
+	var missing []string
+	for _, family := range coreMetricFamilies {
+		if _, ok := exp.families[family]; !ok {
+			missing = append(missing, family)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"core metrics missing from /metrics scrape (backwards-compat regression toward jaeger#6278): %v (present families: %d)",
+			missing, len(exp.families))
+	}
+
+	var nonPositive []string
+	for _, family := range corePositiveCounters {
+		v, ok := exp.sampleValueForFamily(family)
+		if !ok || v <= 0 {
+			nonPositive = append(nonPositive, fmt.Sprintf("%s (max=%v present=%v)", family, v, ok))
+		}
+	}
+	if len(nonPositive) > 0 {
+		return fmt.Errorf("core metrics present but never incremented after e2e traffic: %v", nonPositive)
+	}
+	return nil
+}
+
+// assertCoreMetricsPresent fails the test when checkCoreMetrics reports a problem.
+func assertCoreMetricsPresent(t *testing.T, body string) {
+	t.Helper()
+	require.NoError(t, checkCoreMetrics(body))
+}

--- a/cmd/jaeger/internal/integration/metrics_compat_test.go
+++ b/cmd/jaeger/internal/integration/metrics_compat_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleScrape = `
+# HELP otelcol_receiver_accepted_spans Number of spans accepted
+# TYPE otelcol_receiver_accepted_spans counter
+otelcol_receiver_accepted_spans{receiver="otlp",transport="grpc"} 42
+# HELP otelcol_exporter_sent_spans Number of spans sent
+# TYPE otelcol_exporter_sent_spans counter
+otelcol_exporter_sent_spans{exporter="jaeger_storage_exporter"} 42
+# HELP jaeger_storage_requests Storage requests
+# TYPE jaeger_storage_requests counter
+jaeger_storage_requests{operation="get_trace",result="ok"} 7
+# HELP jaeger_storage_latency Storage latency
+# TYPE jaeger_storage_latency histogram
+jaeger_storage_latency_bucket{operation="get_trace",le="+Inf"} 7
+jaeger_storage_latency_sum{operation="get_trace"} 0.01
+jaeger_storage_latency_count{operation="get_trace"} 7
+# HELP target_info Target metadata
+# TYPE target_info gauge
+target_info{service_name="jaeger"} 1
+`
+
+func TestParseMetricExposition_FamiliesAndValues(t *testing.T) {
+	exp := parseMetricExposition(sampleScrape)
+
+	assert.Equal(t, "counter", exp.families["otelcol_receiver_accepted_spans"])
+	assert.Equal(t, "counter", exp.families["jaeger_storage_requests"])
+	assert.Equal(t, "histogram", exp.families["jaeger_storage_latency"])
+	assert.NotContains(t, exp.families, "not_a_metric")
+
+	v, ok := exp.sampleValueForFamily("otelcol_receiver_accepted_spans")
+	require.True(t, ok)
+	assert.Equal(t, 42.0, v)
+
+	v, ok = exp.sampleValueForFamily("jaeger_storage_latency")
+	require.True(t, ok)
+	assert.Equal(t, 7.0, v) // max of bucket/sum/count samples
+}
+
+func TestParseSampleLine(t *testing.T) {
+	tests := []struct {
+		line      string
+		wantName  string
+		wantValue float64
+		wantOK    bool
+	}{
+		{`otelcol_receiver_accepted_spans{receiver="otlp"} 12`, "otelcol_receiver_accepted_spans", 12, true},
+		{`jaeger_storage_requests 3`, "jaeger_storage_requests", 3, true},
+		{`jaeger_storage_requests 3 1395066363000`, "jaeger_storage_requests", 3, true},
+		{`# TYPE foo counter`, "", 0, false},
+		{``, "", 0, false},
+	}
+	for _, tc := range tests {
+		name, value, ok := parseSampleLine(tc.line)
+		assert.Equal(t, tc.wantOK, ok, tc.line)
+		if tc.wantOK {
+			assert.Equal(t, tc.wantName, name, tc.line)
+			assert.Equal(t, tc.wantValue, value, tc.line)
+		}
+	}
+}
+
+func TestCheckCoreMetrics_OK(t *testing.T) {
+	require.NoError(t, checkCoreMetrics(sampleScrape))
+}
+
+func TestCheckCoreMetrics_MissingFamily(t *testing.T) {
+	body := strings.ReplaceAll(sampleScrape, "otelcol_exporter_sent_spans", "other_exporter_spans")
+	err := checkCoreMetrics(body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "otelcol_exporter_sent_spans")
+	assert.Contains(t, err.Error(), "core metrics missing")
+}
+
+func TestCheckCoreMetrics_ZeroCounter(t *testing.T) {
+	body := `
+# TYPE otelcol_receiver_accepted_spans counter
+otelcol_receiver_accepted_spans{receiver="otlp"} 0
+# TYPE otelcol_exporter_sent_spans counter
+otelcol_exporter_sent_spans{exporter="jaeger_storage_exporter"} 1
+# TYPE jaeger_storage_requests counter
+jaeger_storage_requests{operation="get_trace"} 0
+# TYPE jaeger_storage_latency histogram
+jaeger_storage_latency_count{operation="get_trace"} 0
+`
+	err := checkCoreMetrics(body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "never incremented")
+	assert.Contains(t, err.Error(), "otelcol_receiver_accepted_spans")
+}
+
+func TestAssertCoreMetricsPresent_OK(t *testing.T) {
+	assertCoreMetricsPresent(t, sampleScrape)
+}


### PR DESCRIPTION
## Summary

**Partial toward #6278** — does **not** close the issue.

Most of the metrics backwards-compatibility pipeline from #6278 is already in place (scrape → artifact → diff vs main → PR summary). Those diffs are **informational only** (non-blocking), so a core metric can still disappear without failing CI.

This PR adds a **blocking golden-list check** in the memory v2 e2e path:

1. After `scrapeMetrics` captures `/metrics`, optionally run `assertCoreMetricsPresent`.
2. `RequireCoreMetrics: true` is enabled for `TestMemoryStorage` only (full receive → export → storage path).
3. Required families (aligned with `monitoring/jaeger-mixin` and real CI snapshots):
   - `otelcol_receiver_accepted_spans`
   - `otelcol_exporter_sent_spans`
   - `jaeger_storage_requests`
   - `jaeger_storage_latency`
4. Additionally requires `otelcol_receiver_accepted_spans` and `jaeger_storage_requests` to have **at least one sample > 0** after e2e traffic (catches “registered but never incremented” regressions like #7125).

Out of scope (follow-ups):
- Enable `RequireCoreMetrics` on other full-stack backends (badger, ES, …)
- Wire remaining workflows that still lack `verify-metrics-snapshot` (query / tailsampling / SPM)
- Documentation-site metrics report (remaining unchecked task on #6278; belongs in the documentation repo per maintainer feedback)

## Test plan

- [x] `go test ./cmd/jaeger/internal/integration/ -run 'TestParse|TestCheckCore|TestAssertCore'`
- [x] Validated golden list against a recent `metrics_snapshot_memory` artifact from main CI (all four families present; counters > 0)
- [ ] CI: memory_v2 e2e job with `RequireCoreMetrics`

## AI Usage

- [x] **Moderate**: AI helped with code generation and debugging specific parts