### PR TITLE
fix(cassandra): Validate query consistency values

### DIFF
--- a/internal/storage/cassandra/config/config.go
+++ b/internal/storage/cassandra/config/config.go
@@ -200,7 +200,11 @@ func (c *Configuration) NewCluster() (*gocql.ClusterConfig, error) {
 	if c.Query.Consistency == "" {
 		cluster.Consistency = gocql.LocalOne
 	} else {
-		cluster.Consistency = gocql.ParseConsistency(c.Query.Consistency)
+		consistency, err := parseConsistency(c.Query.Consistency)
+		if err != nil {
+			return nil, err
+		}
+		cluster.Consistency = consistency
 	}
 
 	fallbackHostSelectionPolicy := gocql.RoundRobinHostPolicy()
@@ -241,6 +245,16 @@ func isValidTTL(duration time.Duration) bool {
 	return duration == 0 || duration >= time.Second
 }
 
+func parseConsistency(consistency string) (_ gocql.Consistency, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("invalid query consistency %q: %v", consistency, recovered)
+		}
+	}()
+
+	return gocql.ParseConsistency(consistency), nil
+}
+
 func (c *Configuration) Validate() error {
 	_, err := govalidator.ValidateStruct(c)
 	if err != nil {
@@ -257,6 +271,12 @@ func (c *Configuration) Validate() error {
 
 	if c.Schema.CompactionWindow < time.Minute {
 		return errors.New("compaction_window should at least be 1 minute")
+	}
+
+	if c.Query.Consistency != "" {
+		if _, err := parseConsistency(c.Query.Consistency); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/storage/cassandra/config/config_test.go
+++ b/internal/storage/cassandra/config/config_test.go
@@ -53,6 +53,14 @@ func TestValidate_DoesNotReturnErrorWhenRequiredFieldsSet(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidate_ReturnsErrorWhenConsistencyInvalid(t *testing.T) {
+	cfg := DefaultConfiguration()
+	cfg.Query.Consistency = "garbage"
+
+	err := cfg.Validate()
+	require.EqualError(t, err, `invalid query consistency "garbage": invalid consistency "GARBAGE"`)
+}
+
 func TestNewClusterWithDefaults(t *testing.T) {
 	cfg := DefaultConfiguration()
 	cl, err := cfg.NewCluster()
@@ -117,6 +125,30 @@ func TestNewClusterWithOverrides(t *testing.T) {
 	assert.Equal(t, "password", auth.Password)
 	assert.NotNil(t, cl.SslOpts)
 	assert.True(t, cl.DisableInitialHostLookup)
+}
+
+func TestNewCluster_ReturnsErrorWhenConsistencyInvalid(t *testing.T) {
+	cfg := DefaultConfiguration()
+	cfg.Query.Consistency = "garbage"
+
+	var (
+		cl  *gocql.ClusterConfig
+		err error
+	)
+	require.NotPanics(t, func() {
+		cl, err = cfg.NewCluster()
+	})
+	require.Nil(t, cl)
+	require.EqualError(t, err, `invalid query consistency "garbage": invalid consistency "GARBAGE"`)
+}
+
+func TestNewCluster_AcceptsAnyConsistency(t *testing.T) {
+	cfg := DefaultConfiguration()
+	cfg.Query.Consistency = "ANY"
+
+	cl, err := cfg.NewCluster()
+	require.NoError(t, err)
+	assert.Equal(t, gocql.Any, cl.Consistency)
 }
 
 func TestApplyDefaults(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #9080

## Description of the changes
- add a panic-safe helper around Cassandra consistency parsing
- validate `query.consistency` during config validation and cluster creation
- add regression tests for invalid consistency input and a valid `ANY` value

## How was this change tested?
- `go test ./internal/storage/cassandra/config`
- `make fmt`
- `make lint`
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
