### PR TITLE
fix(es): Disable disk thresholds in test stacks

### DIFF
--- a/docker-compose/elasticsearch/v7/docker-compose.yml
+++ b/docker-compose/elasticsearch/v7/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.22@sha256:a0e01a200a316bac8d661e1acae368fd40c9c618847205a12f443c09c36e6eb3
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - xpack.security.enabled=false  # Disable security features

--- a/docker-compose/elasticsearch/v8/docker-compose.yml
+++ b/docker-compose/elasticsearch/v8/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0@sha256:e1e66bfabae0fd03a0a36651a9bb198e7f061e0c99f457a6203b116e053e9cdb
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - xpack.security.enabled=false  # Disable security features

--- a/docker-compose/elasticsearch/v9/docker-compose.yml
+++ b/docker-compose/elasticsearch/v9/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:9.4.0@sha256:754c3d8ca6f74acba58eb0610b8479a13c36df09ac1a4e0f2667dc167d377b84
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - xpack.security.enabled=false  # Disable security features

--- a/docker-compose/monitor/docker-compose-elasticsearch.yml
+++ b/docker-compose/monitor/docker-compose-elasticsearch.yml
@@ -8,6 +8,7 @@ services:
       - backend
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - xpack.security.enabled=false  # Disable security features

--- a/docker-compose/monitor/docker-compose-opensearch.yml
+++ b/docker-compose/monitor/docker-compose-opensearch.yml
@@ -8,6 +8,7 @@ services:
       - backend
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - plugins.security.disabled=true
       - http.host=0.0.0.0
       - transport.host=127.0.0.1

--- a/docker-compose/opensearch/v1/docker-compose.yml
+++ b/docker-compose/opensearch/v1/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: opensearchproject/opensearch:1.3.17@sha256:749c568af3106a12b1600673ab8dd2d1980d1c699a09f10cbcf6a003d8e38aed
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - plugins.security.disabled=true
       - http.host=0.0.0.0
       - transport.host=127.0.0.1

--- a/docker-compose/opensearch/v2/docker-compose.yml
+++ b/docker-compose/opensearch/v2/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: opensearchproject/opensearch:2.19.0@sha256:1f8b88245a6af61e7aa500afe0e87d43401e4b33140bb47230a919428ce3f7cb
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - plugins.security.disabled=true
       - http.host=0.0.0.0
       - transport.host=127.0.0.1

--- a/docker-compose/opensearch/v3/docker-compose.yml
+++ b/docker-compose/opensearch/v3/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: opensearchproject/opensearch:3.7.0@sha256:123e6591a47b1d54686890551bdb35739c85193ecded381219fc9e059e18128f
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - plugins.security.disabled=true
       - http.host=0.0.0.0
       - transport.host=127.0.0.1


### PR DESCRIPTION
Resolves #9083

## Summary

- Disable disk-based allocation thresholds in the ephemeral Elasticsearch and OpenSearch test stacks so CI disk pressure cannot block index creation.
- Apply the same setting to the Elasticsearch and OpenSearch monitor stacks exercised by the SPM end-to-end tests.

## Testing

- make fmt
- make lint
- make test (4,031 tests passed; 35 expected integration skips)
- Parsed all eight changed files with docker compose config --quiet and verified the rendered setting.
- Started OpenSearch 3.7 and Elasticsearch 9.4 from the changed Compose files; both reported cluster.routing.allocation.disk.threshold_enabled=false via the cluster settings API.

The original failure depends on a CI runner crossing a disk watermark, so it is not deterministic to reproduce locally. The existing storage and rollover end-to-end jobs exercise these Compose stacks in CI.

## AI assistance

Codex assisted with issue discovery, the repetitive YAML edit, and local validation. I reviewed the complete patch and test results.