### PR TITLE
fix(ci): Skip unused ES image builds

### DIFF
--- a/.github/workflows/ci-e2e-elasticsearch.yml
+++ b/.github/workflows/ci-e2e-elasticsearch.yml
@@ -56,7 +56,6 @@ jobs:
         date
         echo TZ="$TZ"
 
-    - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
     - name: Run ${{ matrix.version.distribution }} integration tests
       id: test-execution
       run: bash scripts/e2e/elasticsearch.sh ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.storage_test }}
@@ -72,4 +71,3 @@ jobs:
       with:
         files: cover.out
         flag: ${{ matrix.version.distribution }}-${{ matrix.version.major }}-${{ matrix.version.storage_test }}
-

--- a/.github/workflows/ci-e2e-opensearch.yml
+++ b/.github/workflows/ci-e2e-opensearch.yml
@@ -51,8 +51,6 @@ jobs:
       with:
         go-version: 1.26.x
 
-    - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
     - name: Run ${{ matrix.version.distribution }} integration tests
       id: test-execution
       run: bash scripts/e2e/elasticsearch.sh ${{ matrix.version.distribution }} ${{ matrix.version.major }} ${{ matrix.version.storage_test }}

--- a/scripts/e2e/elasticsearch.sh
+++ b/scripts/e2e/elasticsearch.sh
@@ -134,10 +134,10 @@ main() {
   set -x
 
   bring_up_storage "${distro}" "${es_version}"
-  build_local_img
   if [[ "${storage_test}" == "e2e" ]]; then
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
   elif [[ "${storage_test}" == "direct" ]]; then
+    build_local_img
     echo "::group::⬇️ Pre-pull test docker images"
     docker pull localhost:5000/jaegertracing/jaeger-es-index-cleaner:local-test
     docker pull localhost:5000/jaegertracing/jaeger-es-rollover:local-test

--- a/scripts/makefiles/IntegrationTests.mk
+++ b/scripts/makefiles/IntegrationTests.mk
@@ -18,7 +18,7 @@ jaeger-v2-storage-integration-test: $(GOTESTSUM)
 	# Expire tests results for jaeger storage integration tests since the environment
 	# might have changed even though the code remains the same.
 	go clean -testcache
-	$(GOTESTSUM) $(INTEGRATION_TEST_FLAGS) -- $(RACE) -coverpkg=./... -coverprofile $(COVEROUT) $(JAEGER_V2_STORAGE_PKGS)
+	$(GOTESTSUM) $(INTEGRATION_TEST_FLAGS) -- $(RACE) -coverprofile $(COVEROUT) $(JAEGER_V2_STORAGE_PKGS)
 
 .PHONY: storage-integration-test
 storage-integration-test: $(GOTESTSUM)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9084

## Description of the changes
- build local es-index-cleaner and es-rollover images only for `storage_test=direct`
- skip those image builds for ES/OpenSearch `e2e` jobs because they do not consume the local images
- remove whole-module `-coverpkg=./...` instrumentation from `jaeger-v2-storage-integration-test` while still writing `cover.out`
- remove unused QEMU setup from the ES/OpenSearch e2e workflows, which build native `linux/$(go env GOARCH)` images

## How was this change tested?
- `bash -n scripts/e2e/elasticsearch.sh`
- `STORAGE=memory_v2 make jaeger-v2-storage-integration-test`
- `make fmt`
- `make lint`
- `make test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes