### PR TITLE
fix: disable disk allocation threshold on ES/OpenSearch CI test clusters

### DIFF
--- a/docker-compose/elasticsearch/v7/docker-compose.yml
+++ b/docker-compose/elasticsearch/v7/docker-compose.yml
@@ -11,5 +11,6 @@ services:
       - xpack.security.enabled=false  # Disable security features
       - xpack.security.http.ssl.enabled=false  # Disable HTTPS
       - xpack.monitoring.enabled=false  # Disable monitoring features
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ports:
       - "9200:9200"

--- a/docker-compose/elasticsearch/v8/docker-compose.yml
+++ b/docker-compose/elasticsearch/v8/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - xpack.security.http.ssl.enabled=false  # Disable HTTPS
       - action.destructive_requires_name=false
       - xpack.monitoring.collection.enabled=false  # Disable monitoring features
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ports:
       - "9200:9200"
-

--- a/docker-compose/elasticsearch/v9/docker-compose.yml
+++ b/docker-compose/elasticsearch/v9/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - xpack.security.http.ssl.enabled=false  # Disable HTTPS
       - action.destructive_requires_name=false
       - xpack.monitoring.collection.enabled=false  # Disable monitoring features
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ports:
       - "9200:9200"
-

--- a/docker-compose/opensearch/v1/docker-compose.yml
+++ b/docker-compose/opensearch/v1/docker-compose.yml
@@ -9,5 +9,6 @@ services:
       - plugins.security.disabled=true
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ports:
       - "9200:9200"

--- a/docker-compose/opensearch/v2/docker-compose.yml
+++ b/docker-compose/opensearch/v2/docker-compose.yml
@@ -10,5 +10,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=passRT%^#234
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ports:
       - "9200:9200"

--- a/docker-compose/opensearch/v3/docker-compose.yml
+++ b/docker-compose/opensearch/v3/docker-compose.yml
@@ -10,5 +10,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=passRT%^#234
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ports:
       - "9200:9200"


### PR DESCRIPTION
## Problem

The Elasticsearch/OpenSearch e2e jobs intermittently fail with HTTP 403 (`FORBIDDEN/10/cluster create-index blocked`) under CI runner disk pressure. As diagnosed in #9083, this is the OpenSearch/Elasticsearch disk-watermark mechanism (`DiskThresholdMonitor`) reacting to the runner's baseline disk fill, not a race condition or product bug.

## Fix

The ephemeral test clusters are torn down after every run and never need to enforce disk-based allocation limits, so this disables disk-threshold-based allocation blocking for them by adding one environment variable to each test compose file:

```yaml
- cluster.routing.allocation.disk.threshold_enabled=false
```

Applied to all 6 files called out in the issue:
- `docker-compose/opensearch/v1/docker-compose.yml`
- `docker-compose/opensearch/v2/docker-compose.yml`
- `docker-compose/opensearch/v3/docker-compose.yml`
- `docker-compose/elasticsearch/v7/docker-compose.yml`
- `docker-compose/elasticsearch/v8/docker-compose.yml`
- `docker-compose/elasticsearch/v9/docker-compose.yml`

I checked `docker-compose/monitor/docker-compose-{opensearch,elasticsearch}.yml` as well (mentioned as optional in the issue) — they're not referenced anywhere under `.github/`, so they don't run in CI and are left unchanged.

## Verification

Ran the full CI suite on a fork (allocsys/jaeger#1) to sanity-check the clusters still start correctly and the e2e suites pass with the setting in place — `stage3-fast / e2e-tests / elasticsearch / elasticsearch 9.x direct` and all other e2e/unit/lint jobs passed.

Fixes #9083

## Checklist
- [x] Tests updated and GenAI-assistance both checked
- [ ] Documentation/Config converters — not applicable (test-infra-only change)