### PR TITLE
fix(ci): Skip es-index-cleaner/es-rollover image build for e2e cells

### DIFF
--- a/scripts/e2e/elasticsearch.sh
+++ b/scripts/e2e/elasticsearch.sh
@@ -134,10 +134,15 @@ main() {
   set -x
 
   bring_up_storage "${distro}" "${es_version}"
-  build_local_img
   if [[ "${storage_test}" == "e2e" ]]; then
     STORAGE=${distro} SPAN_STORAGE_TYPE=${distro} make jaeger-v2-storage-integration-test
   elif [[ "${storage_test}" == "direct" ]]; then
+    # build_local_img produces the es-index-cleaner/es-rollover linux binaries and
+    # their Docker images, which only the direct storage-integration test consumes
+    # (es_index_cleaner_test.go pulls localhost:5000/.../jaeger-es-{index-cleaner,rollover}:local-test).
+    # The e2e path builds es-rollover from source at test time (go run ./cmd/es-rollover),
+    # so building the images for e2e cells is pure waste — see #9084.
+    build_local_img
     echo "::group::⬇️ Pre-pull test docker images"
     docker pull localhost:5000/jaegertracing/jaeger-es-index-cleaner:local-test
     docker pull localhost:5000/jaegertracing/jaeger-es-rollover:local-test


### PR DESCRIPTION
## Which problem is this PR solving?

- Addresses finding 1 of #9084.

The ES/OpenSearch e2e CI jobs run a large amount of Go compilation and image building that the `e2e` matrix cells never consume. `scripts/e2e/elasticsearch.sh` `main()` calls `build_local_img` unconditionally, but only the `direct`
storage-integration test uses its output.

## Description of the changes

- Move `build_local_img` out of the unconditional path in `main()` and into the `direct` branch, so only `storage_test == direct` cells build the es-index-cleaner/es-rollover linux binaries and their Docker images.

Why this is safe -> only `direct` consumes those artifacts:
- The `direct` test pulls and uses `localhost:5000/jaegertracing/jaeger-es-{index-cleaner,rollover}:local-test` (`internal/storage/integration/es_index_cleaner_test.go`).
- The `e2e` path (`cmd/jaeger/internal/integration`) builds es-rollover from source at test time instead -`es_rotation_helpers_test.go` runs `go run ./cmd/es-rollover ...` — and never references the local-test images.

So for the two `e2e` matrix cells, the cold ~59s `es-index-cleaner` build, `create-baseimg`, and both `docker buildx` image builds were pure waste (~80s/cell). This applies across both the `ci-e2e-elasticsearch.yml` and `ci-e2e-opensearch.yml` matrices, since both drive this same script.

This PR intentionally scopes to finding #1 only. Findings #2/#3 (the doubled jaeger-v2 compile and `-coverpkg` cost) touch coverage measurement and a make target shared by other jobs, so they're better addressed separately.

## How was this change tested?

- This is a CI-only change with no product-code impact, so it has no unit test; the real validation is the e2e jobs still   passing on this PR while skipping the redundant build for `e2e` cells.
- `bash -n scripts/e2e/elasticsearch.sh` - passes.
- `shellcheck scripts/e2e/elasticsearch.sh` - clean (matches the `ci-lint-checks` workflow's `shellcheck    scripts/**/*.sh`).
- Verified the `e2e` path's independence from the built images by tracing `es_rotation_helpers_test.go` (`go run ./cmd/es-rollover`) and the `jaeger-v2-storage-integration-test` make target (no image references).

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
