### PR TITLE
fix(memory): Skip same-service parents when building dependency links

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -797,6 +797,49 @@ func TestGetDependencies(t *testing.T) {
 	assert.Empty(t, emptyDeps)
 }
 
+func TestGetDependencies_SameService(t *testing.T) {
+	store, err := NewStore(Configuration{
+		MaxTraces: 10,
+	})
+	require.NoError(t, err)
+	traceId := fromString(t, "00000000000000010000000000000000")
+	td := ptrace.NewTraces()
+	resourceSpans := td.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr(string(conventions.ServiceNameKey), "service-x")
+	startTime := time.Now()
+	parent := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	parent.SetTraceID(traceId)
+	parent.SetSpanID(spanIdFromString(t, "0000000000000001"))
+	parent.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
+	parent.SetEndTimestamp(pcommon.NewTimestampFromTime(startTime.Add(2 * time.Second)))
+	child := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	child.SetTraceID(traceId)
+	child.SetSpanID(spanIdFromString(t, "0000000000000002"))
+	child.SetParentSpanID(spanIdFromString(t, "0000000000000001"))
+	child.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
+	child.SetEndTimestamp(pcommon.NewTimestampFromTime(startTime.Add(1 * time.Second)))
+	otherResourceSpans := td.ResourceSpans().AppendEmpty()
+	otherResourceSpans.Resource().Attributes().PutStr(string(conventions.ServiceNameKey), "service-y")
+	remoteChild := otherResourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	remoteChild.SetTraceID(traceId)
+	remoteChild.SetSpanID(spanIdFromString(t, "0000000000000003"))
+	remoteChild.SetParentSpanID(spanIdFromString(t, "0000000000000001"))
+	remoteChild.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
+	remoteChild.SetEndTimestamp(pcommon.NewTimestampFromTime(startTime.Add(1 * time.Second)))
+	err = store.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+	deps, err := store.GetDependencies(context.Background(), depstore.QueryParameters{
+		StartTime: startTime.Add(-1 * time.Second),
+		EndTime:   startTime.Add(3 * time.Second),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []model.DependencyLink{{
+		Parent:    "service-x",
+		Child:     "service-y",
+		CallCount: 1,
+	}}, deps)
+}
+
 func TestGetDependencies_Err(t *testing.T) {
 	store, err := NewStore(Configuration{
 		MaxTraces: 10,

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -180,7 +180,7 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 					}
 					spanServiceName := getServiceNameFromResource(resourceSpan.Resource())
 					parentSpanServiceName, found := findServiceNameWithSpanId(traceWithTime.trace, span.ParentSpanID())
-					if !found {
+					if !found || parentSpanServiceName == spanServiceName {
 						continue
 					}
 					depKey := parentSpanServiceName + "&&&" + spanServiceName


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #9089

## Description of the changes

Skip dependency links where the parent and child span belong to the same service, matching the Badger dependency store and the v1 memory store this code was ported from.

## How was this change tested?

- New `TestGetDependencies_SameService`: one trace with an internal parent/child pair in `service-x` plus a cross-service call to `service-y`, asserting only `service-x -> service-y` is returned. On `main` it also returns `service-x -> service-x`.
- Existing `TestGetDependencies*` cases are unaffected.

Note: #8767 and #9003 also have open changes to `getDependencies`. Happy to rebase behind whichever lands first.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
