### PR TITLE
fix(query): Default search_depth in api_v3 gRPC handler

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -71,7 +71,10 @@ func (h *Handler) internalFindTraces(
 }
 
 // traceQueryParams converts a proto TraceQueryParameters to querysvc.TraceQueryParams,
-// validating that the required time range fields are present.
+// validating that the required time range fields are present. An unset (or
+// non-positive) search_depth defaults to defaultSearchDepth, mirroring the
+// HTTP gateway: proto3 cannot distinguish an omitted field from 0, and a
+// literal 0 is rejected by some storage backends (e.g. the in-memory store).
 func traceQueryParams(query *api_v3.TraceQueryParameters) (querysvc.TraceQueryParams, error) {
 	if query == nil {
 		return querysvc.TraceQueryParams{}, status.Error(codes.InvalidArgument, "missing query")
@@ -79,12 +82,16 @@ func traceQueryParams(query *api_v3.TraceQueryParameters) (querysvc.TraceQueryPa
 	if query.GetStartTimeMin().IsZero() || query.GetStartTimeMax().IsZero() {
 		return querysvc.TraceQueryParams{}, status.Error(codes.InvalidArgument, "start time min and max are required parameters")
 	}
+	searchDepth := int(query.GetSearchDepth())
+	if searchDepth <= 0 {
+		searchDepth = defaultSearchDepth
+	}
 	queryParams := querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
 			Attributes:    jptrace.PlainMapToPcommonMap(query.GetAttributes()),
-			SearchDepth:   int(query.GetSearchDepth()),
+			SearchDepth:   searchDepth,
 			StartTimeMin:  query.GetStartTimeMin(),
 			StartTimeMax:  query.GetStartTimeMax(),
 			DurationMin:   query.GetDurationMin(),

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -199,6 +199,60 @@ func TestFindTraces(t *testing.T) {
 	require.Equal(t, 1, td.SpanCount())
 }
 
+func TestTraceQueryParamsSearchDepth(t *testing.T) {
+	baseQuery := func() *api_v3.TraceQueryParameters {
+		return &api_v3.TraceQueryParameters{
+			StartTimeMin: time.Now().Add(-2 * time.Hour),
+			StartTimeMax: time.Now(),
+		}
+	}
+	tests := []struct {
+		name        string
+		searchDepth int32
+		expected    int
+	}{
+		{name: "unset defaults", searchDepth: 0, expected: defaultSearchDepth},
+		{name: "negative defaults", searchDepth: -1, expected: defaultSearchDepth},
+		{name: "explicit value preserved", searchDepth: 42, expected: 42},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query := baseQuery()
+			query.SearchDepth = test.searchDepth
+			params, err := traceQueryParams(query)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, params.SearchDepth)
+		})
+	}
+}
+
+func TestFindTracesDefaultsSearchDepth(t *testing.T) {
+	// A FindTraces request without search_depth (proto3 default 0) must reach
+	// the storage backend with the default search depth, matching the HTTP
+	// gateway. Some backends (e.g. the in-memory store) reject a literal 0.
+	tsc := newTestServerClient(t)
+	tsc.reader.On("FindTraces", matchContext, mock.MatchedBy(func(q tracestore.TraceQueryParams) bool {
+		return q.SearchDepth == defaultSearchDepth
+	})).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{makeTestTrace()}, nil)
+		})).Once()
+
+	responseStream, err := tsc.client.FindTraces(context.Background(), &api_v3.FindTracesRequest{
+		Query: &api_v3.TraceQueryParameters{
+			ServiceName:  "myservice",
+			StartTimeMin: time.Now().Add(-2 * time.Hour),
+			StartTimeMax: time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	recv, err := responseStream.Recv()
+	require.NoError(t, err)
+	td := recv.ToTraces()
+	require.Equal(t, 1, td.SpanCount())
+	tsc.reader.AssertExpectations(t)
+}
+
 func TestFindTracesSendError(t *testing.T) {
 	reader := new(tracestoremocks.Reader)
 	reader.On("FindTraces", mock.Anything, mock.AnythingOfType("tracestore.TraceQueryParams")).


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9099

## Description of the changes
- The api_v3 HTTP gateway defaults an absent `query.searchDepth` to 100 (`query_parser.go`), but the gRPC handler passed the proto field through as-is. proto3 cannot distinguish an omitted `search_depth` from an explicit 0, so storage received `SearchDepth: 0` — which the v2 in-memory store rejects (`search depth must be greater than 0 and less than max traces`). Net: `FindTraces`/`FindTraceSummaries` over gRPC failed on the default all-in-one backend for any client that does not set `search_depth`, while the identical HTTP query succeeds. ES/Cassandra/Badger readers already default 0 → 100 internally, so the gRPC entry point was the odd one out (details and backend matrix in #9099).
- `traceQueryParams` in `grpc_handler.go` now defaults a non-positive `search_depth` to the package's existing `defaultSearchDepth` (100), mirroring the HTTP gateway. This covers both `FindTraces` and `FindTraceSummaries`, which share the helper. The in-memory store's own validation is deliberately unchanged — this is an API-transport consistency fix.

## How was this change tested?
- New `TestTraceQueryParamsSearchDepth` (table-driven: unset → 100, negative → 100, explicit 42 preserved) and `TestFindTracesDefaultsSearchDepth` (gRPC round-trip against a mock reader matched on `SearchDepth == defaultSearchDepth`). Both fail on `main` — the mock test with `SearchDepth: 0` reaching the reader — and pass with the fix.
- Verified the end-to-end failure and fix against the real v2 memory store: same handler call errors on `main` and returns the trace after this change.
- `make fmt`, `make lint` (clean), `make test` (full suite: 4054 tests, all green).

## Disclosure
Per the AI Usage Policy: this change was developed with AI assistance (Claude Code). I have read and can explain every line; the repro, tests, and full local verification above were all run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)