### PR TITLE
fix(storage/grpc): Wire configured timeout to gRPC client interceptors

### DIFF
--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -143,6 +144,11 @@ func (f *Factory) initializeConnections(
 		streamInterceptors = append(streamInterceptors, headerforwarding.NewStreamClientInterceptor())
 	}
 
+	if f.config.Timeout > 0 {
+		unaryInterceptors = append(unaryInterceptors, timeoutUnaryClientInterceptor(f.config.Timeout))
+		streamInterceptors = append(streamInterceptors, timeoutStreamClientInterceptor(f.config.Timeout))
+	}
+
 	baseOpts := []grpc.DialOption{
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
@@ -176,4 +182,62 @@ func (f *Factory) initializeConnections(
 	f.readerConn, f.writerConn = readerConn, writerConn
 
 	return nil
+}
+
+type timeoutClientStream struct {
+	grpc.ClientStream
+	cancel context.CancelFunc
+}
+
+func (t *timeoutClientStream) RecvMsg(m any) error {
+	err := t.ClientStream.RecvMsg(m)
+	if err != nil {
+		t.cancel()
+	}
+	return err
+}
+
+func (t *timeoutClientStream) SendMsg(m any) error {
+	err := t.ClientStream.SendMsg(m)
+	if err != nil {
+		t.cancel()
+	}
+	return err
+}
+
+func timeoutUnaryClientInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func timeoutStreamClientInterceptor(timeout time.Duration) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		return &timeoutClientStream{
+			ClientStream: clientStream,
+			cancel:       cancel,
+		}, nil
+	}
 }

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -16,10 +16,16 @@ import (
 	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/jaegertracing/jaeger/internal/headerforwarding"
+	"github.com/jaegertracing/jaeger/internal/jiter"
+	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
@@ -198,4 +204,83 @@ func TestInitializeConnections_ClientError(t *testing.T) {
 		newClientFn,
 	)
 	assert.ErrorContains(t, err, "error creating reader client connection")
+}
+
+type sleepServer struct {
+	storage.UnimplementedTraceReaderServer
+	sleepDuration time.Duration
+}
+
+func (s *sleepServer) GetServices(ctx context.Context, _ *storage.GetServicesRequest) (*storage.GetServicesResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(s.sleepDuration):
+		return &storage.GetServicesResponse{Services: []string{"foo"}}, nil
+	}
+}
+
+func (s *sleepServer) GetTraces(_ *storage.GetTracesRequest, srv storage.TraceReader_GetTracesServer) error {
+	select {
+	case <-srv.Context().Done():
+		return srv.Context().Err()
+	case <-time.After(s.sleepDuration):
+		return nil
+	}
+}
+
+func TestFactory_Timeout(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	s := grpc.NewServer()
+	srv := &sleepServer{sleepDuration: 200 * time.Millisecond}
+	storage.RegisterTraceReaderServer(s, srv)
+
+	go func() {
+		_ = s.Serve(lis)
+	}()
+	defer s.Stop()
+
+	cfg := Config{
+		ClientConfig: configgrpc.ClientConfig{
+			Endpoint: lis.Addr().String(),
+			TLS: configtls.ClientConfig{
+				Insecure: true,
+			},
+		},
+		TimeoutConfig: exporterhelper.TimeoutConfig{
+			Timeout: 20 * time.Millisecond,
+		},
+	}
+
+	f, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
+	require.NoError(t, err)
+	defer f.Close()
+
+	tr, err := f.CreateTraceReader()
+	require.NoError(t, err)
+
+	t.Run("unary timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		_, err := tr.GetServices(ctx)
+		require.Error(t, err)
+		// gRPC translates context deadline exceeded into codes.DeadlineExceeded;
+		// check the status code rather than the error string to be format-agnostic.
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	})
+
+	t.Run("streaming timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		it := tr.GetTraces(ctx, tracestore.GetTraceParams{})
+		_, err := jiter.FlattenWithErrors(it)
+		require.Error(t, err)
+		// gRPC translates context deadline exceeded into codes.DeadlineExceeded;
+		// check the status code rather than the error string to be format-agnostic.
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	})
 }


### PR DESCRIPTION
The exporterhelper.TimeoutConfig embedded in Config (defaulting to 5s) was never applied: all reader/writer gRPC calls forwarded the caller's context unchanged, so the configured timeout had no effect.

Add timeoutUnaryClientInterceptor and timeoutStreamClientInterceptor in factory.go's initializeConnections, appended to the existing unary and stream interceptor chains. Both are skipped when Timeout == 0.

The stream interceptor wraps the context with context.WithTimeout but defers cancel() via a timeoutClientStream wrapper (called on the first RecvMsg/SendMsg error, including io.EOF), so the timeout context is not cancelled immediately after stream creation.

## Which problem is this PR solving?
- Fixes #9104 

## Description of the changes
- `config.go` defines `Timeout` (via embedded `exporterhelper.TimeoutConfig`, defaulting to 5s), but it was never wired into the actual gRPC client calls — reader/writer clients forwarded the caller's context unchanged, so the configured timeout had no effect.
- Added `timeoutUnaryClientInterceptor` and `timeoutStreamClientInterceptor` in `factory.go`, appended to the existing unary/stream interceptor chains (alongside bearertoken, tenancy, headerforwarding). Both are skipped when `Timeout == 0`.
- For streaming calls, a `timeoutClientStream` wrapper defers `cancel()` until the first `RecvMsg`/`SendMsg` error (including `io.EOF`), so the timeout context isn't cancelled immediately after stream creation — only once the stream actually completes or fails.

## How was this change tested?
- Added `TestFactory_Timeout` in `factory_test.go`, covering both unary (`GetServices`) and streaming (`GetTraces`) paths against a real gRPC test server that intentionally sleeps past the configured timeout. Both subtests assert a `context.DeadlineExceeded` error is returned.
- Ran `make fmt`, `make lint`, and `make test` locally — all pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [X] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes