### PR TITLE
fix(deps): Upgrade brace-expansion in CI scripts

### DIFF
--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1884,9 +1884,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4208,9 +4208,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes #9106

## What changed

- Update the top-level `brace-expansion` lockfile entry from 2.1.1 to 2.1.2.
- Update Jest's nested `brace-expansion` lockfile entry from 1.1.15 to 1.1.16.

## Why

Dependabot alerts [#67](https://github.com/jaegertracing/jaeger/security/dependabot/67) and [#68](https://github.com/jaegertracing/jaeger/security/dependabot/68) report [GHSA-3jxr-9vmj-r5cp / CVE-2026-13149](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), an exponential-time denial-of-service issue in `brace-expansion`.

Both affected versions are transitive Jest development dependencies in `.github/scripts/package-lock.json`. They are not shipped in Jaeger runtime binaries.

## Validation

- `npm ci`
- `npm ls brace-expansion --all` resolves 1.1.16 and 2.1.2
- `npm test -- --runInBand` passes all 97 tests
- `npm audit --package-lock-only --omit=optional` reports only the separate `js-yaml` findings in alerts [#65](https://github.com/jaegertracing/jaeger/security/dependabot/65) and [#69](https://github.com/jaegertracing/jaeger/security/dependabot/69), covered by #8887
- `make fmt`
- `make lint` reports 0 issues
- `make test` runs 4,049 tests with 37 skipped, but hits one pre-existing `internal/storage/v2/grpc` goleak failure that reproduces on unmodified `upstream/main`
