### PR TITLE
chore(lint): Enable revive package-directory-mismatch rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,9 +108,9 @@ linters:
           arguments:
             - 80
           disabled: true
-        # this should be enabled after fixing or disabling in a few packages
+        # storage/v1/api and storage/v2/api intentionally use package names that
+        # differ from the "api" directory; those are excluded via exclusions.rules below.
         - name: package-directory-mismatch
-          disabled: true
         # would be ok if we could exclude the test files, but otherwise too noisy
         - name: add-constant
           disabled: true
@@ -183,6 +183,12 @@ linters:
           - revive
         text: "unhandled-error"
         path: _test\.go
+      # storage/v1/api (package "storage") and storage/v2/api (package "storage_v2")
+      # intentionally keep package names that differ from the "api" directory.
+      - linters:
+          - revive
+        text: "package-directory-mismatch"
+        path: internal/storage/v(1|2)/api/
     paths:
       - .*.pb.go$
       - mocks

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/ddg/deep_dependencies.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/ddg/deep_dependencies.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package deepdependencies
+package ddg
 
 type TDdgPayloadEntry struct {
 	Service   string `json:"service"`

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/ddg/deep_dependencies_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/ddg/deep_dependencies_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package deepdependencies
+package ddg
 
 import (
 	"testing"

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3"
-	deepdependencies "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/qualitymetrics"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
@@ -345,7 +345,7 @@ func (aH *APIHandler) dependencies(w http.ResponseWriter, r *http.Request) {
 
 func (aH *APIHandler) deepDependencies(w http.ResponseWriter, r *http.Request) {
 	focalService := r.URL.Query().Get("service")
-	data := deepdependencies.GetData(focalService)
+	data := ddg.GetData(focalService)
 	aH.writeJSON(w, r, &data)
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
-	deepdependencies "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/qualitymetrics"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
@@ -967,7 +967,7 @@ func TestGetDeepDependenciesData(t *testing.T) {
 	handler.deepDependencies(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	var resp deepdependencies.TDdgPayload
+	var resp ddg.TDdgPayload
 	err := json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Part of #5506 — re-enabling disabled `revive` rules one at a time. This PR enables `package-directory-mismatch`, which the config already marks as "should be enabled after fixing or disabling in a few packages".

## Description of the changes

- Running the rule on master flags only two spots:
  1. `cmd/jaeger/internal/extension/jaegerquery/internal/ddg` — package `deepdependencies` did not match its `ddg` directory. Renamed the package to `ddg` and updated its two importers in the jaegerquery extension (dropping the now-redundant import alias).
  2. `internal/storage/v1/api` (package `storage`) and `internal/storage/v2/api` (package `storage_v2`) — these intentionally keep a package name that differs from the `api` directory.
- Per the discussion on #5506 about avoiding `//nolint` comments scattered across the v1/v2 storage packages, the intentional cases are suppressed with a single path-scoped `exclusions.rules` entry rather than inline directives.

## How was this change tested?

- `go build ./...` passes.
- `go test` passes for the renamed package, its importer (`jaegerquery`), and the `internal/storage/v1/api` / `internal/storage/v2/api` trees.
- With the rule enabled, `golangci-lint run` reports zero `package-directory-mismatch` violations.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits (DCO)
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully