### PR TITLE
fix(dep): fix nondeterministic dependency ordering

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/handler_deps_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/handler_deps_test.go
@@ -5,8 +5,6 @@
 package app
 
 import (
-	"cmp"
-	"slices"
 	"testing"
 	"time"
 
@@ -65,11 +63,6 @@ func TestDeduplicateDependencies(t *testing.T) {
 			[]ui.DependencyLink{
 				{
 					Parent:    "Dáin I",
-					Child:     "Thrór",
-					CallCount: 314,
-				},
-				{
-					Parent:    "Dáin I",
 					Child:     "Frór",
 					CallCount: 159,
 				},
@@ -77,6 +70,11 @@ func TestDeduplicateDependencies(t *testing.T) {
 					Parent:    "Dáin I",
 					Child:     "Grór",
 					CallCount: 265,
+				},
+				{
+					Parent:    "Dáin I",
+					Child:     "Thrór",
+					CallCount: 314,
 				},
 			},
 		},
@@ -96,14 +94,14 @@ func TestDeduplicateDependencies(t *testing.T) {
 			},
 			[]ui.DependencyLink{
 				{
-					Parent:    "Hador",
-					Child:     "Glóredhel",
-					CallCount: 3,
-				},
-				{
 					Parent:    "Gildis",
 					Child:     "Glóredhel",
 					CallCount: 9,
+				},
+				{
+					Parent:    "Hador",
+					Child:     "Glóredhel",
+					CallCount: 3,
 				},
 			},
 		},
@@ -129,35 +127,24 @@ func TestDeduplicateDependencies(t *testing.T) {
 			[]ui.DependencyLink{
 				{
 					Parent:    "Dáin I",
-					Child:     "Thrór",
-					CallCount: 473,
+					Child:     "Grór",
+					CallCount: 265,
 				},
 				{
 					Parent:    "Dáin I",
-					Child:     "Grór",
-					CallCount: 265,
+					Child:     "Thrór",
+					CallCount: 473,
 				},
 			},
 		},
 	}
 
 	for _, test := range tests {
-		actual := handler.deduplicateDependencies(test.input)
-		slices.SortFunc(actual, compareDependencyLinks)
-		expected := test.expected
-		slices.SortFunc(expected, compareDependencyLinks)
-		assert.Equal(t, expected, actual, test.description)
+		for range 100 {
+			actual := handler.deduplicateDependencies(test.input)
+			require.Equal(t, test.expected, actual, test.description)
+		}
 	}
-}
-
-func compareDependencyLinks(a, b ui.DependencyLink) int {
-	if a.Parent != b.Parent {
-		return cmp.Compare(a.Parent, b.Parent)
-	}
-	if a.Child != b.Child {
-		return cmp.Compare(a.Child, b.Child)
-	}
-	return cmp.Compare(a.CallCount, b.CallCount)
 }
 
 func TestFilterDependencies(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/handler_deps_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/handler_deps_test.go
@@ -140,10 +140,8 @@ func TestDeduplicateDependencies(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		for range 100 {
-			actual := handler.deduplicateDependencies(test.input)
-			require.Equal(t, test.expected, actual, test.description)
-		}
+		actual := handler.deduplicateDependencies(test.input)
+		assert.Equal(t, test.expected, actual, test.description)
 	}
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -5,6 +5,7 @@
 package app
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"time"
 
@@ -406,6 +408,12 @@ func (*APIHandler) deduplicateDependencies(dependencies []model.DependencyLink) 
 	for k, v := range links {
 		result = append(result, ui.DependencyLink{Parent: k.parent, Child: k.child, CallCount: v})
 	}
+	slices.SortFunc(result, func(a, b ui.DependencyLink) int {
+		if c := cmp.Compare(a.Parent, b.Parent); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Child, b.Child)
+	})
 
 	return result
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9118

## Description of the changes
- Sort deduplicated legacy dependency API links by parent service and then child service, removing nondeterministic Go map iteration from the response while preserving aggregated call counts.
- Update the existing table-driven tests to assert the canonical response order directly instead of sorting the actual and expected results in the test.

## How was this change tested?
- `make fmt / lint / test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes