### PR TITLE
fix(es): Treat index date separator as literal

### DIFF
--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -41,7 +41,8 @@ func (i *IndexFilter) filterByPattern(indices []esclient.Index) []esclient.Index
 	case i.Rollover:
 		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{6}", i.IndexPrefix))
 	default:
-		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{4}%s\\d{2}%s\\d{2}", i.IndexPrefix, i.IndexDateSeparator, i.IndexDateSeparator))
+		dateSeparator := regexp.QuoteMeta(i.IndexDateSeparator)
+		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{4}%s\\d{2}%s\\d{2}", i.IndexPrefix, dateSeparator, dateSeparator))
 	}
 
 	var filtered []esclient.Index

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -64,6 +64,16 @@ func runIndexFilterTest(t *testing.T, prefix string) {
 			Aliases:      map[string]bool{},
 		},
 		{
+			Index:        prefix + "jaeger-span-2020.08.05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        prefix + "jaeger-span-2020x08x05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
 			Index:        prefix + "jaeger-span-archive",
 			CreationTime: time.Date(2020, time.August, 1, 15, 0, 0, 0, time.UTC),
 			Aliases:      map[string]bool{},
@@ -187,6 +197,23 @@ func runIndexFilterTest(t *testing.T, prefix string) {
 				},
 				{
 					Index:        prefix + "jaeger-sampling-2020-08-05",
+					CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
+				},
+			},
+		},
+		{
+			name: "normal indices with dot separator match separator literally",
+			filter: &IndexFilter{
+				IndexPrefix:          prefix,
+				IndexDateSeparator:   ".",
+				Archive:              false,
+				Rollover:             false,
+				DeleteBeforeThisDate: time20200807.Add(-time.Hour * 24 * time.Duration(1)),
+			},
+			expected: []esclient.Index{
+				{
+					Index:        prefix + "jaeger-span-2020.08.05",
 					CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
 					Aliases:      map[string]bool{},
 				},


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9120 

## Description of the changes

- Escape the configured index date separator before interpolating it into the index cleaner's regular expression.
- Add a regression case proving that a dot separator matches `2020.08.05` but not `2020x08x05`, with and without an index prefix.

## How was this change tested?

- `make fmt / lint / test`

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
