### PR TITLE
fix(es): Reject negative index retention

### DIFF
--- a/cmd/es-index-cleaner/main.go
+++ b/cmd/es-index-cleaner/main.go
@@ -61,6 +61,9 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("could not parse NUM_OF_DAYS argument: %w", err)
 			}
+			if numOfDays < 0 {
+				return errors.New("NUM_OF_DAYS argument must be non-negative")
+			}
 
 			if err := cfg.InitFromViper(v); err != nil {
 				return fmt.Errorf("failed to initialize config: %w", err)

--- a/cmd/es-index-cleaner/main_test.go
+++ b/cmd/es-index-cleaner/main_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}
+
+func TestMainRejectsNegativeNumOfDays(t *testing.T) {
+	const helperProcess = "JAEGER_TEST_NEGATIVE_RETENTION"
+	if os.Getenv(helperProcess) == "1" {
+		os.Args = []string{"jaeger-es-index-cleaner", "--", "-1", "http://localhost:0"}
+		main()
+		return
+	}
+
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestMainRejectsNegativeNumOfDays$")
+	cmd.Env = append(os.Environ(), helperProcess+"=1")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	assert.Contains(t, string(output), "NUM_OF_DAYS argument must be non-negative")
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9122

## Description of the changes

- Reject negative `NUM_OF_DAYS` values before initializing configuration or connecting to Elasticsearch.
- Preserve the existing behavior for zero and positive retention values.
- Add a CLI regression test for negative retention.

## How was this change tested?

- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
