### PR TITLE
fix(examples): Set max_span_age in OpenSearch demo

### DIFF
--- a/examples/otel-demo/jaeger-config.yaml
+++ b/examples/otel-demo/jaeger-config.yaml
@@ -28,6 +28,7 @@ extensions:
         opensearch:
           server_urls:
             - http://opensearch-cluster-single.opensearch.svc.cluster.local:9200
+          max_span_age: 720h
           indices:
             index_prefix: "jaeger-main"
             spans:


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #8331

## Description of the changes

The `otel-demo` OpenSearch config uses periodic daily index rotation but never set `max_span_age`, so it defaulted to 72h. `GetTrace` by ID computes its index-date window from `max_span_age`, so traces older than ~3-4 days 404 even though the data is intact in OpenSearch and still shows up in search results.

Sets `max_span_age: 720h` (30 days) on `some_storage` to match the demo's intended retention window. This is the exact fix confirmed by @yurishkuro in the issue.

## How was this verified?

No Go code changed, so no unit test applies. Verified manually end-to-end:

- [x] Ran real OpenSearch (`docker-compose/opensearch/v2`) + Jaeger v2 (`jaegertracing/jaeger:latest`) against this config
- [x] Sent traces backdated 10/20/30 days via OTLP, all resolved correctly by trace ID with the fix in place
- [x] Regression check: reverted `max_span_age`, restarted Jaeger, the same stored trace (unchanged in OpenSearch) 404'd again, reproducing the exact error shape from the issue's screenshots