### PR TITLE
refactor(ai-gateway): share MCP server across endpoints

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
@@ -11,9 +11,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
-	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // routeTurnMCP and routeTurnMCPNoSlash are the turn-scoped MCP
@@ -69,11 +69,18 @@ type turnScopedEndpoint struct {
 // reads the route id from the request context and, for that turn,
 // advertises its UI tools in tools/list and dispatches their tools/call to the
 // browser stream. This avoids standing up a fresh server per turn.
-func newTurnScopedEndpoint(telset telemetry.Settings, queryAPI *querysvc.QueryService, tenancyMgr *tenancy.Manager, turns *turnRegistry, basePath string, logger *zap.Logger) *turnScopedEndpoint {
-	srv := mcptools.NewServer(telset, queryAPI, mcptools.DefaultConfig())
-	srv.AddReceivingMiddleware(uiToolsMiddleware(turns, logger))
+func newTurnScopedEndpoint(
+	server *mcp.Server,
+	telset telemetry.Settings,
+	tenancyMgr *tenancy.Manager,
+	turns *turnRegistry,
+	basePath string,
+	logger *zap.Logger,
+) *turnScopedEndpoint {
+	server.AddReceivingMiddleware(uiToolsMiddleware(turns, logger))
+
 	return &turnScopedEndpoint{
-		streamable: mcptools.WrapHTTP(srv, tenancyMgr, telset),
+		streamable: mcptools.WrapHTTP(server, tenancyMgr, telset),
 		turns:      turns,
 		basePath:   basePath,
 		logger:     logger,

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
@@ -44,7 +45,17 @@ func turnMCPServer(t *testing.T, uiTools []json.RawMessage) (ts *httptest.Server
 	rec = httptest.NewRecorder()
 	routeID = registerTurn(turns, newStreamingClient(context.Background(), rec, "thread", "run"), uiTools)
 
-	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
+	telset := telemetry.NoopSettings()
+	srv := mcptools.NewServer(telset, svc, mcptools.DefaultConfig())
+
+	h := newTurnScopedEndpoint(
+		srv,
+		telset,
+		tenancy.NewManager(&tenancy.Options{}),
+		turns,
+		"",
+		zap.NewNop(),
+	)
 	mux := http.NewServeMux()
 	h.registerRoutes(mux)
 
@@ -110,7 +121,17 @@ func TestTurnScopedEndpointIsolatesTurns(t *testing.T) {
 	idA := registerTurn(turns, newStreamingClient(context.Background(), recA, "ta", "ra"), []json.RawMessage{rawUITool(t, "chart_a")})
 	idB := registerTurn(turns, newStreamingClient(context.Background(), recB, "tb", "rb"), []json.RawMessage{rawUITool(t, "chart_b")})
 
-	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
+	telset := telemetry.NoopSettings()
+	srv := mcptools.NewServer(telset, svc, mcptools.DefaultConfig())
+
+	h := newTurnScopedEndpoint(
+		srv,
+		telset,
+		tenancy.NewManager(&tenancy.Options{}),
+		turns,
+		"",
+		zap.NewNop(),
+	)
 	mux := http.NewServeMux()
 	h.registerRoutes(mux)
 	ts := httptest.NewServer(mux)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
@@ -9,9 +9,9 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const routeChat = "/api/ai/chat"
@@ -45,10 +45,10 @@ type HandlerParams struct {
 	MaxRequestBodySize int64
 	// EnableMCP mounts the turn-scoped telemetry MCP endpoint. When false, only the
 	// chat endpoint is registered.
-	EnableMCP    bool
-	QueryService *querysvc.QueryService
-	TenancyMgr   *tenancy.Manager
-	Telset       telemetry.Settings
+	EnableMCP  bool
+	TenancyMgr *tenancy.Manager
+	Telset     telemetry.Settings
+	MCPServer  *mcp.Server
 }
 
 // NewHandler constructs a jaegerai.Handler, building the endpoints it will mount.
@@ -64,9 +64,18 @@ func NewHandler(p HandlerParams) *Handler {
 		basePath: basePath,
 		chat:     newChatEndpoint(p.Logger, NewContextualToolsStore(), turns, p.AgentURL, basePath, p.MaxRequestBodySize),
 	}
+
 	if p.EnableMCP {
-		h.mcp = newTurnScopedEndpoint(p.Telset, p.QueryService, p.TenancyMgr, turns, basePath, p.Logger)
+		h.mcp = newTurnScopedEndpoint(
+			p.MCPServer,
+			p.Telset,
+			p.TenancyMgr,
+			turns,
+			basePath,
+			p.Logger,
+		)
 	}
+
 	return h
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
@@ -81,16 +82,25 @@ func TestNewHandlerNormalizesTrailingSlash(t *testing.T) {
 
 func mcpEnabledHandler(t *testing.T, basePath string) *Handler {
 	t.Helper()
-	svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
+
+	svc := querysvc.NewQueryService(
+		&tracestoremocks.Reader{},
+		&depstoremocks.Reader{},
+		querysvc.QueryServiceOptions{},
+	)
+
+	telset := telemetry.NoopSettings()
+	mcpServer := mcptools.NewServer(telset, svc, mcptools.DefaultConfig())
+
 	return NewHandler(HandlerParams{
 		Logger:             zap.NewNop(),
 		AgentURL:           "ws://127.0.0.1:1",
 		BasePath:           basePath,
 		MaxRequestBodySize: 1 << 20,
 		EnableMCP:          true,
-		QueryService:       svc,
+		MCPServer:          mcpServer,
 		TenancyMgr:         tenancy.NewManager(&tenancy.Options{}),
-		Telset:             telemetry.NoopSettings(),
+		Telset:             telset,
 	})
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -213,6 +214,11 @@ func initRouter(
 			if err := aiCfg.Validate(); err != nil {
 				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
 			} else {
+				var mcpServer *mcp.Server
+				if aiCfg.EnableMCP {
+					mcpServer = mcptools.NewServer(telset, querySvc, mcptools.DefaultConfig())
+				}
+
 				if aiCfg.AgentURL != "" {
 					// When AI chat is enabled, jaegerai owns the chat endpoint and,
 					// if MCP is also enabled, the session-scoped MCP endpoint
@@ -223,7 +229,7 @@ func initRouter(
 						BasePath:           queryOpts.BasePath,
 						MaxRequestBodySize: aiCfg.MaxRequestBodySize,
 						EnableMCP:          aiCfg.EnableMCP,
-						QueryService:       querySvc,
+						MCPServer:          mcpServer,
 						TenancyMgr:         tenancyMgr,
 						Telset:             telset,
 					}).RegisterRoutes(r)
@@ -231,7 +237,7 @@ func initRouter(
 				if aiCfg.EnableMCP {
 					// Session-free telemetry endpoint (/api/ai/mcp/). Coexists with
 					// the wildcard session-scoped pattern above.
-					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, telset)
+					registerMCPTools(r, mcpServer, tenancyMgr, queryOpts.BasePath, telset)
 				}
 			}
 		}
@@ -286,8 +292,14 @@ func otelFilterFunc(basePath string) func(*http.Request) bool {
 	}
 }
 
-func registerMCPTools(r *http.ServeMux, querySvc *querysvc.QueryService, tenancyMgr *tenancy.Manager, basePath string, telset telemetry.Settings) {
-	handler := mcptools.NewHandler(telset, querySvc, tenancyMgr, mcptools.DefaultConfig())
+func registerMCPTools(
+	r *http.ServeMux,
+	server *mcp.Server,
+	tenancyMgr *tenancy.Manager,
+	basePath string,
+	telset telemetry.Settings,
+) {
+	handler := mcptools.WrapHTTP(server, tenancyMgr, telset)
 	prefix := strings.TrimSuffix(basePath, "/") + "/api/ai/mcp"
 	r.Handle(prefix+"/", http.StripPrefix(prefix, handler))
 	telset.Logger.Info("Jaeger telemetry MCP endpoint enabled", zap.String("path", prefix+"/"))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1229,12 +1230,17 @@ func TestRegisterMCPTools_BasePathNormalization(t *testing.T) {
 	querySvc := makeQuerySvc()
 	tenancyMgr := tenancy.NewManager(&tenancy.Options{})
 
+	mcpServer := mcptools.NewServer(
+		telset,
+		querySvc.qs,
+		mcptools.DefaultConfig(),
+	)
 	for _, basePath := range []string{"", "/", "/jaeger", "/jaeger/"} {
 		t.Run("base path "+basePath, func(t *testing.T) {
 			r := http.NewServeMux()
 			// Must not panic on a double-slash pattern.
 			require.NotPanics(t, func() {
-				registerMCPTools(r, querySvc.qs, tenancyMgr, basePath, telset)
+				registerMCPTools(r, mcpServer, tenancyMgr, basePath, telset)
 			})
 
 			want := "/api/ai/mcp/"


### PR DESCRIPTION
## Which problem is this PR solving?
- Implements the single-server MCP routing design from RFC 0008.
- Avoids constructing separate MCP servers for the session-free and turn-scoped AI gateway endpoints.

## Description of the changes
- Create the telemetry MCP server once when MCP is enabled.
- Share the same MCP server between the session-free `/api/ai/mcp/` endpoint and turn-scoped `/api/ai/mcp/<id>` endpoints.
- Inject the shared MCP server into the AI gateway handler instead of constructing another server inside the turn-scoped endpoint.
- Layer turn-specific UI tool behavior onto the shared server through the existing middleware.
- Update tests to construct and pass the shared MCP server explicitly.


## How was this change tested?
Ran the relevant test suites:

- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai -count=1`
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools -count=1`
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal -run "MCP" -count=1`

All passed successfully.

Also verified:

- `git diff --check`
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal -run "^$" -count=1`

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [X] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
