### PR TITLE
feat(mcptools): Add get_service_metrics MCP tool for SPM RED metrics

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
@@ -69,8 +70,8 @@ type turnScopedEndpoint struct {
 // reads the route id from the request context and, for that turn,
 // advertises its UI tools in tools/list and dispatches their tools/call to the
 // browser stream. This avoids standing up a fresh server per turn.
-func newTurnScopedEndpoint(telset telemetry.Settings, queryAPI *querysvc.QueryService, tenancyMgr *tenancy.Manager, turns *turnRegistry, basePath string, logger *zap.Logger) *turnScopedEndpoint {
-	srv := mcptools.NewServer(telset, queryAPI, mcptools.DefaultConfig())
+func newTurnScopedEndpoint(telset telemetry.Settings, queryAPI *querysvc.QueryService, metricsQuerySvc metricstore.Reader, tenancyMgr *tenancy.Manager, turns *turnRegistry, basePath string, logger *zap.Logger) *turnScopedEndpoint {
+	srv := mcptools.NewServer(telset, queryAPI, metricsQuerySvc, mcptools.DefaultConfig())
 	srv.AddReceivingMiddleware(uiToolsMiddleware(turns, logger))
 	return &turnScopedEndpoint{
 		streamable: mcptools.WrapHTTP(srv, tenancyMgr, telset),

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp_test.go
@@ -44,7 +44,7 @@ func turnMCPServer(t *testing.T, uiTools []json.RawMessage) (ts *httptest.Server
 	rec = httptest.NewRecorder()
 	routeID = registerTurn(turns, newStreamingClient(context.Background(), rec, "thread", "run"), uiTools)
 
-	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
+	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, nil, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
 	mux := http.NewServeMux()
 	h.registerRoutes(mux)
 
@@ -110,7 +110,7 @@ func TestTurnScopedEndpointIsolatesTurns(t *testing.T) {
 	idA := registerTurn(turns, newStreamingClient(context.Background(), recA, "ta", "ra"), []json.RawMessage{rawUITool(t, "chart_a")})
 	idB := registerTurn(turns, newStreamingClient(context.Background(), recB, "tb", "rb"), []json.RawMessage{rawUITool(t, "chart_b")})
 
-	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
+	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, nil, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
 	mux := http.NewServeMux()
 	h.registerRoutes(mux)
 	ts := httptest.NewServer(mux)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
@@ -47,8 +48,11 @@ type HandlerParams struct {
 	// chat endpoint is registered.
 	EnableMCP    bool
 	QueryService *querysvc.QueryService
-	TenancyMgr   *tenancy.Manager
-	Telset       telemetry.Settings
+	// MetricsQuerySvc backs the get_service_metrics MCP tool; the tool is not
+	// registered when this is nil or the disabled reader.
+	MetricsQuerySvc metricstore.Reader
+	TenancyMgr      *tenancy.Manager
+	Telset          telemetry.Settings
 }
 
 // NewHandler constructs a jaegerai.Handler, building the endpoints it will mount.
@@ -65,7 +69,7 @@ func NewHandler(p HandlerParams) *Handler {
 		chat:     newChatEndpoint(p.Logger, NewContextualToolsStore(), turns, p.AgentURL, basePath, p.MaxRequestBodySize),
 	}
 	if p.EnableMCP {
-		h.mcp = newTurnScopedEndpoint(p.Telset, p.QueryService, p.TenancyMgr, turns, basePath, p.Logger)
+		h.mcp = newTurnScopedEndpoint(p.Telset, p.QueryService, p.MetricsQuerySvc, p.TenancyMgr, turns, basePath, p.Logger)
 	}
 	return h
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types"
+	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
+)
+
+const (
+	metricTypeLatency   = "latency"
+	metricTypeCallRate  = "call_rate"
+	metricTypeErrorRate = "error_rate"
+
+	defaultQuantile = 0.95
+	defaultLookback = time.Hour
+	// The step default is coarser than the HTTP API's 5s: at 5s a 1h window is
+	// ~720 points per series, which is costly as model context (see the format
+	// benchmark on issue #8409). 1m keeps a 1h window at 60 points.
+	defaultStep    = time.Minute
+	defaultRatePer = 10 * time.Minute
+
+	// maxDataPointsPerSeries bounds lookback/step so a single call cannot
+	// request an unbounded number of points per series.
+	maxDataPointsPerSeries = 1500
+)
+
+// spanKindNames maps the accepted lowercase span kind names to the
+// SpanKind enum names the metricstore expects.
+var spanKindNames = map[string]string{
+	"unspecified": metrics.SpanKind_SPAN_KIND_UNSPECIFIED.String(),
+	"internal":    metrics.SpanKind_SPAN_KIND_INTERNAL.String(),
+	"server":      metrics.SpanKind_SPAN_KIND_SERVER.String(),
+	"client":      metrics.SpanKind_SPAN_KIND_CLIENT.String(),
+	"producer":    metrics.SpanKind_SPAN_KIND_PRODUCER.String(),
+	"consumer":    metrics.SpanKind_SPAN_KIND_CONSUMER.String(),
+}
+
+// getServiceMetricsHandler implements the get_service_metrics MCP tool. It
+// exposes the RED metrics (latency, call rate, error rate) that Service
+// Performance Monitoring already computes, as per-bucket time series.
+type getServiceMetricsHandler struct {
+	metricsReader metricstore.Reader
+}
+
+// NewGetServiceMetricsHandler creates a new get_service_metrics handler and
+// returns the handler function.
+func NewGetServiceMetricsHandler(
+	metricsReader metricstore.Reader,
+) mcp.ToolHandlerFor[types.GetServiceMetricsInput, types.GetServiceMetricsOutput] {
+	h := &getServiceMetricsHandler{
+		metricsReader: metricsReader,
+	}
+	return h.handle
+}
+
+// handle processes the get_service_metrics tool request.
+func (h *getServiceMetricsHandler) handle(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input types.GetServiceMetricsInput,
+) (*mcp.CallToolResult, types.GetServiceMetricsOutput, error) {
+	params, quantile, err := buildQueryParams(input)
+	if err != nil {
+		return nil, types.GetServiceMetricsOutput{}, err
+	}
+
+	var family *metrics.MetricFamily
+	switch input.MetricType {
+	case metricTypeLatency:
+		family, err = h.metricsReader.GetLatencies(ctx, &metricstore.LatenciesQueryParameters{
+			BaseQueryParameters: params,
+			Quantile:            quantile,
+		})
+	case metricTypeCallRate:
+		family, err = h.metricsReader.GetCallRates(ctx, &metricstore.CallRateQueryParameters{
+			BaseQueryParameters: params,
+		})
+	case metricTypeErrorRate:
+		family, err = h.metricsReader.GetErrorRates(ctx, &metricstore.ErrorRateQueryParameters{
+			BaseQueryParameters: params,
+		})
+	default:
+		return nil, types.GetServiceMetricsOutput{}, fmt.Errorf(
+			"invalid metric_type %q: must be one of %s, %s, %s",
+			input.MetricType, metricTypeLatency, metricTypeCallRate, metricTypeErrorRate,
+		)
+	}
+	if err != nil {
+		return nil, types.GetServiceMetricsOutput{}, fmt.Errorf("failed to get %s metrics: %w", input.MetricType, err)
+	}
+
+	output := types.GetServiceMetricsOutput{
+		MetricType: input.MetricType,
+		Metrics:    buildSeries(family),
+	}
+	if input.MetricType == metricTypeLatency {
+		output.Quantile = quantile
+	}
+	if family != nil {
+		output.MetricName = family.Name
+		output.Description = family.Help
+	}
+	return nil, output, nil
+}
+
+// buildQueryParams validates the input and assembles the metricstore query
+// parameters, returning the effective latency quantile alongside them.
+func buildQueryParams(input types.GetServiceMetricsInput) (metricstore.BaseQueryParameters, float64, error) {
+	var zero metricstore.BaseQueryParameters
+	if len(input.Services) == 0 {
+		return zero, 0, errors.New("at least one service is required")
+	}
+
+	quantile := input.Quantile
+	if quantile == 0 {
+		quantile = defaultQuantile
+	}
+	if quantile < 0 || quantile > 1 {
+		return zero, 0, fmt.Errorf("invalid quantile %v: must be in (0, 1]", input.Quantile)
+	}
+
+	endTime := time.Now()
+	if input.EndTime != "" {
+		t, err := time.Parse(time.RFC3339, input.EndTime)
+		if err != nil {
+			return zero, 0, fmt.Errorf("invalid end_time: %w", err)
+		}
+		endTime = t
+	}
+
+	lookback, err := parsePositiveDuration("lookback", input.Lookback, defaultLookback)
+	if err != nil {
+		return zero, 0, err
+	}
+	step, err := parsePositiveDuration("step", input.Step, defaultStep)
+	if err != nil {
+		return zero, 0, err
+	}
+	ratePer, err := parsePositiveDuration("rate_per", input.RatePer, defaultRatePer)
+	if err != nil {
+		return zero, 0, err
+	}
+	if points := int64(lookback / step); points > maxDataPointsPerSeries {
+		return zero, 0, fmt.Errorf(
+			"lookback/step yields %d data points per series, exceeding the limit of %d: use a coarser step or a shorter lookback",
+			points, maxDataPointsPerSeries,
+		)
+	}
+
+	spanKinds, err := normalizeSpanKinds(input.SpanKinds)
+	if err != nil {
+		return zero, 0, err
+	}
+
+	return metricstore.BaseQueryParameters{
+		ServiceNames:     input.Services,
+		GroupByOperation: input.GroupByOperation,
+		EndTime:          &endTime,
+		Lookback:         &lookback,
+		Step:             &step,
+		RatePer:          &ratePer,
+		SpanKinds:        spanKinds,
+	}, quantile, nil
+}
+
+// parsePositiveDuration parses value as a Go duration, applying def when value
+// is empty and rejecting non-positive results.
+func parsePositiveDuration(name, value string, def time.Duration) (time.Duration, error) {
+	if value == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid %s %q: must be positive", name, value)
+	}
+	return d, nil
+}
+
+// normalizeSpanKinds maps the accepted lowercase span kind names to the enum
+// names the metricstore expects, defaulting to server, matching the HTTP API.
+func normalizeSpanKinds(kinds []string) ([]string, error) {
+	if len(kinds) == 0 {
+		return []string{metrics.SpanKind_SPAN_KIND_SERVER.String()}, nil
+	}
+	normalized := make([]string, 0, len(kinds))
+	for _, kind := range kinds {
+		mapped, ok := spanKindNames[strings.ToLower(kind)]
+		if !ok {
+			return nil, fmt.Errorf("invalid span kind %q: must be one of unspecified, internal, server, client, producer, consumer", kind)
+		}
+		normalized = append(normalized, mapped)
+	}
+	return normalized, nil
+}
+
+// buildSeries converts a MetricFamily into the tool's output series. A NaN
+// gauge value, which the metricstore reports when the backend has no data for
+// a timestamp, becomes a null value rather than a fake zero.
+func buildSeries(family *metrics.MetricFamily) []types.ServiceMetricSeries {
+	series := []types.ServiceMetricSeries{}
+	if family == nil {
+		return series
+	}
+	for _, metric := range family.Metrics {
+		if metric == nil {
+			continue
+		}
+		s := types.ServiceMetricSeries{
+			DataPoints: []types.MetricDataPoint{},
+		}
+		for _, label := range metric.GetLabels() {
+			switch label.Name {
+			case "service_name":
+				s.ServiceName = label.Value
+			case "operation":
+				s.OperationName = label.Value
+			case "span_kind":
+				s.SpanKind = label.Value
+			default:
+				// other labels are not part of the tool's output
+			}
+		}
+		for _, point := range metric.GetMetricPoints() {
+			if point == nil {
+				continue
+			}
+			dp := types.MetricDataPoint{}
+			if ts := point.GetTimestamp(); ts != nil {
+				dp.TimestampMs = ts.Seconds*1000 + int64(ts.Nanos)/1_000_000
+			}
+			if gauge := point.GetGaugeValue(); gauge != nil {
+				if v := gauge.GetDoubleValue(); !math.IsNaN(v) {
+					dp.Value = &v
+				}
+			}
+			s.DataPoints = append(s.DataPoints, dp)
+		}
+		series = append(series, s)
+	}
+	return series
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics.go
@@ -208,9 +208,10 @@ func normalizeSpanKinds(kinds []string) ([]string, error) {
 	return normalized, nil
 }
 
-// buildSeries converts a MetricFamily into the tool's output series. A NaN
-// gauge value, which the metricstore reports when the backend has no data for
-// a timestamp, becomes a null value rather than a fake zero.
+// buildSeries converts a MetricFamily into the tool's output series. Non-finite
+// gauge values become null: NaN is what the metricstore reports when the
+// backend has no data for a timestamp, and +/-Inf can come out of quantile
+// calculations; neither is JSON-encodable, and a fake number would be worse.
 func buildSeries(family *metrics.MetricFamily) []types.ServiceMetricSeries {
 	series := []types.ServiceMetricSeries{}
 	if family == nil {
@@ -244,7 +245,7 @@ func buildSeries(family *metrics.MetricFamily) []types.ServiceMetricSeries {
 				dp.TimestampMs = ts.Seconds*1000 + int64(ts.Nanos)/1_000_000
 			}
 			if gauge := point.GetGaugeValue(); gauge != nil {
-				if v := gauge.GetDoubleValue(); !math.IsNaN(v) {
+				if v := gauge.GetDoubleValue(); !math.IsNaN(v) && !math.IsInf(v, 0) {
 					dp.Value = &v
 				}
 			}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types"
+	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
+	metricstoremocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore/mocks"
+)
+
+func makeTestMetricFamily() *metrics.MetricFamily {
+	return &metrics.MetricFamily{
+		Name: "service_latencies",
+		Help: "0.95th quantile latency, grouped by service, in milliseconds",
+		Metrics: []*metrics.Metric{
+			nil, // a nil metric entry must be skipped, not panic
+			{
+				Labels: []*metrics.Label{
+					{Name: "service_name", Value: "frontend"},
+					{Name: "operation", Value: "GET /dispatch"},
+					{Name: "span_kind", Value: "SPAN_KIND_SERVER"},
+				},
+				MetricPoints: []*metrics.MetricPoint{
+					nil, // a nil point must be skipped, not panic
+					{
+						Value:     &metrics.MetricPoint_GaugeValue{GaugeValue: &metrics.GaugeValue{Value: &metrics.GaugeValue_DoubleValue{DoubleValue: 42.5}}},
+						Timestamp: &gogotypes.Timestamp{Seconds: 1700000000, Nanos: 500_000_000},
+					},
+					{
+						// NaN is what the metricstore reports when the backend
+						// has no data for this timestamp.
+						Value:     &metrics.MetricPoint_GaugeValue{GaugeValue: &metrics.GaugeValue{Value: &metrics.GaugeValue_DoubleValue{DoubleValue: math.NaN()}}},
+						Timestamp: &gogotypes.Timestamp{Seconds: 1700000060},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGetServiceMetrics_Latency(t *testing.T) {
+	reader := &metricstoremocks.Reader{}
+	reader.On("GetLatencies", mock.Anything, mock.MatchedBy(func(p *metricstore.LatenciesQueryParameters) bool {
+		return p.Quantile == 0.95 && // default applied
+			len(p.ServiceNames) == 1 && p.ServiceNames[0] == "frontend" &&
+			*p.Lookback == time.Hour && *p.Step == time.Minute && *p.RatePer == 10*time.Minute &&
+			len(p.SpanKinds) == 1 && p.SpanKinds[0] == "SPAN_KIND_SERVER"
+	})).Return(makeTestMetricFamily(), nil).Once()
+
+	handler := NewGetServiceMetricsHandler(reader)
+	_, output, err := handler(context.Background(), nil, types.GetServiceMetricsInput{
+		Services:   []string{"frontend"},
+		MetricType: "latency",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "latency", output.MetricType)
+	assert.InDelta(t, 0.95, output.Quantile, 1e-9)
+	assert.Equal(t, "service_latencies", output.MetricName)
+	assert.Equal(t, "0.95th quantile latency, grouped by service, in milliseconds", output.Description)
+	require.Len(t, output.Metrics, 1)
+
+	series := output.Metrics[0]
+	assert.Equal(t, "frontend", series.ServiceName)
+	assert.Equal(t, "GET /dispatch", series.OperationName)
+	assert.Equal(t, "SPAN_KIND_SERVER", series.SpanKind)
+	require.Len(t, series.DataPoints, 2)
+	assert.Equal(t, int64(1700000000500), series.DataPoints[0].TimestampMs)
+	require.NotNil(t, series.DataPoints[0].Value)
+	assert.InDelta(t, 42.5, *series.DataPoints[0].Value, 1e-9)
+	assert.Equal(t, int64(1700000060000), series.DataPoints[1].TimestampMs)
+	assert.Nil(t, series.DataPoints[1].Value, "NaN from the backend must become null, not a fake number")
+}
+
+func TestGetServiceMetrics_CallRateAndErrorRate(t *testing.T) {
+	tests := []struct {
+		metricType string
+		mockMethod string
+	}{
+		{metricType: "call_rate", mockMethod: "GetCallRates"},
+		{metricType: "error_rate", mockMethod: "GetErrorRates"},
+	}
+	for _, test := range tests {
+		t.Run(test.metricType, func(t *testing.T) {
+			reader := &metricstoremocks.Reader{}
+			reader.On(test.mockMethod, mock.Anything, mock.Anything).Return(makeTestMetricFamily(), nil).Once()
+
+			handler := NewGetServiceMetricsHandler(reader)
+			_, output, err := handler(context.Background(), nil, types.GetServiceMetricsInput{
+				Services:   []string{"frontend"},
+				MetricType: test.metricType,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, test.metricType, output.MetricType)
+			assert.Zero(t, output.Quantile, "quantile applies to latency only")
+			require.Len(t, output.Metrics, 1)
+			reader.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetServiceMetrics_CustomParameters(t *testing.T) {
+	endTime := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	reader := &metricstoremocks.Reader{}
+	reader.On("GetLatencies", mock.Anything, mock.MatchedBy(func(p *metricstore.LatenciesQueryParameters) bool {
+		return p.Quantile == 0.99 &&
+			p.EndTime.Equal(endTime) &&
+			*p.Lookback == 30*time.Minute && *p.Step == 5*time.Second && *p.RatePer == time.Minute &&
+			p.GroupByOperation &&
+			len(p.SpanKinds) == 2 && p.SpanKinds[0] == "SPAN_KIND_CLIENT" && p.SpanKinds[1] == "SPAN_KIND_PRODUCER"
+	})).Return(&metrics.MetricFamily{}, nil).Once()
+
+	handler := NewGetServiceMetricsHandler(reader)
+	_, output, err := handler(context.Background(), nil, types.GetServiceMetricsInput{
+		Services:         []string{"frontend"},
+		MetricType:       "latency",
+		Quantile:         0.99,
+		EndTime:          "2026-07-28T10:00:00Z",
+		Lookback:         "30m",
+		Step:             "5s",
+		RatePer:          "1m",
+		GroupByOperation: true,
+		SpanKinds:        []string{"CLIENT", "producer"},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, output.Metrics, "empty result must be an empty list, not null")
+	assert.Empty(t, output.Metrics)
+	reader.AssertExpectations(t)
+}
+
+func TestGetServiceMetrics_InputValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       types.GetServiceMetricsInput
+		expectedErr string
+	}{
+		{
+			name:        "missing services",
+			input:       types.GetServiceMetricsInput{MetricType: "latency"},
+			expectedErr: "at least one service is required",
+		},
+		{
+			name:        "invalid metric type",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "throughput"},
+			expectedErr: "invalid metric_type",
+		},
+		{
+			name:        "invalid quantile",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "latency", Quantile: 1.5},
+			expectedErr: "invalid quantile",
+		},
+		{
+			name:        "invalid end time",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "latency", EndTime: "yesterday"},
+			expectedErr: "invalid end_time",
+		},
+		{
+			name:        "negative lookback",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "latency", Lookback: "-1h"},
+			expectedErr: "invalid lookback",
+		},
+		{
+			name:        "malformed step",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "latency", Step: "fast"},
+			expectedErr: "invalid step",
+		},
+		{
+			name:        "negative rate_per",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "latency", RatePer: "-1m"},
+			expectedErr: "invalid rate_per",
+		},
+		{
+			name:        "invalid span kind",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "latency", SpanKinds: []string{"sideways"}},
+			expectedErr: "invalid span kind",
+		},
+		{
+			name:        "too many data points",
+			input:       types.GetServiceMetricsInput{Services: []string{"a"}, MetricType: "latency", Lookback: "48h", Step: "1m"},
+			expectedErr: "data points per series",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := NewGetServiceMetricsHandler(&metricstoremocks.Reader{})
+			_, _, err := handler(context.Background(), nil, test.input)
+			require.ErrorContains(t, err, test.expectedErr)
+		})
+	}
+}
+
+func TestGetServiceMetrics_ReaderError(t *testing.T) {
+	reader := &metricstoremocks.Reader{}
+	reader.On("GetCallRates", mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
+
+	handler := NewGetServiceMetricsHandler(reader)
+	_, _, err := handler(context.Background(), nil, types.GetServiceMetricsInput{
+		Services:   []string{"frontend"},
+		MetricType: "call_rate",
+	})
+	require.ErrorContains(t, err, "failed to get call_rate metrics")
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_service_metrics_test.go
@@ -44,6 +44,12 @@ func makeTestMetricFamily() *metrics.MetricFamily {
 						Value:     &metrics.MetricPoint_GaugeValue{GaugeValue: &metrics.GaugeValue{Value: &metrics.GaugeValue_DoubleValue{DoubleValue: math.NaN()}}},
 						Timestamp: &gogotypes.Timestamp{Seconds: 1700000060},
 					},
+					{
+						// +/-Inf can come out of quantile calculations and is
+						// not JSON-encodable either.
+						Value:     &metrics.MetricPoint_GaugeValue{GaugeValue: &metrics.GaugeValue{Value: &metrics.GaugeValue_DoubleValue{DoubleValue: math.Inf(1)}}},
+						Timestamp: &gogotypes.Timestamp{Seconds: 1700000120},
+					},
 				},
 			},
 		},
@@ -51,7 +57,7 @@ func makeTestMetricFamily() *metrics.MetricFamily {
 }
 
 func TestGetServiceMetrics_Latency(t *testing.T) {
-	reader := &metricstoremocks.Reader{}
+	reader := metricstoremocks.NewReader(t)
 	reader.On("GetLatencies", mock.Anything, mock.MatchedBy(func(p *metricstore.LatenciesQueryParameters) bool {
 		return p.Quantile == 0.95 && // default applied
 			len(p.ServiceNames) == 1 && p.ServiceNames[0] == "frontend" &&
@@ -76,12 +82,14 @@ func TestGetServiceMetrics_Latency(t *testing.T) {
 	assert.Equal(t, "frontend", series.ServiceName)
 	assert.Equal(t, "GET /dispatch", series.OperationName)
 	assert.Equal(t, "SPAN_KIND_SERVER", series.SpanKind)
-	require.Len(t, series.DataPoints, 2)
+	require.Len(t, series.DataPoints, 3)
 	assert.Equal(t, int64(1700000000500), series.DataPoints[0].TimestampMs)
 	require.NotNil(t, series.DataPoints[0].Value)
 	assert.InDelta(t, 42.5, *series.DataPoints[0].Value, 1e-9)
 	assert.Equal(t, int64(1700000060000), series.DataPoints[1].TimestampMs)
 	assert.Nil(t, series.DataPoints[1].Value, "NaN from the backend must become null, not a fake number")
+	assert.Equal(t, int64(1700000120000), series.DataPoints[2].TimestampMs)
+	assert.Nil(t, series.DataPoints[2].Value, "Inf from the backend must become null; json.Marshal cannot encode it")
 }
 
 func TestGetServiceMetrics_CallRateAndErrorRate(t *testing.T) {
@@ -94,7 +102,7 @@ func TestGetServiceMetrics_CallRateAndErrorRate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.metricType, func(t *testing.T) {
-			reader := &metricstoremocks.Reader{}
+			reader := metricstoremocks.NewReader(t)
 			reader.On(test.mockMethod, mock.Anything, mock.Anything).Return(makeTestMetricFamily(), nil).Once()
 
 			handler := NewGetServiceMetricsHandler(reader)
@@ -106,14 +114,13 @@ func TestGetServiceMetrics_CallRateAndErrorRate(t *testing.T) {
 			assert.Equal(t, test.metricType, output.MetricType)
 			assert.Zero(t, output.Quantile, "quantile applies to latency only")
 			require.Len(t, output.Metrics, 1)
-			reader.AssertExpectations(t)
 		})
 	}
 }
 
 func TestGetServiceMetrics_CustomParameters(t *testing.T) {
 	endTime := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
-	reader := &metricstoremocks.Reader{}
+	reader := metricstoremocks.NewReader(t)
 	reader.On("GetLatencies", mock.Anything, mock.MatchedBy(func(p *metricstore.LatenciesQueryParameters) bool {
 		return p.Quantile == 0.99 &&
 			p.EndTime.Equal(endTime) &&
@@ -137,7 +144,6 @@ func TestGetServiceMetrics_CustomParameters(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, output.Metrics, "empty result must be an empty list, not null")
 	assert.Empty(t, output.Metrics)
-	reader.AssertExpectations(t)
 }
 
 func TestGetServiceMetrics_InputValidation(t *testing.T) {
@@ -202,7 +208,7 @@ func TestGetServiceMetrics_InputValidation(t *testing.T) {
 }
 
 func TestGetServiceMetrics_ReaderError(t *testing.T) {
-	reader := &metricstoremocks.Reader{}
+	reader := metricstoremocks.NewReader(t)
 	reader.On("GetCallRates", mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
 
 	handler := NewGetServiceMetricsHandler(reader)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_service_metrics.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_service_metrics.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// GetServiceMetricsInput defines the input parameters for the get_service_metrics tool.
+type GetServiceMetricsInput struct {
+	// Services to fetch metrics for.
+	Services []string `json:"services" jsonschema:"One or more service names to fetch metrics for"`
+
+	// MetricType selects which RED metric to fetch.
+	MetricType string `json:"metric_type" jsonschema:"Metric to fetch. One of: latency, call_rate, error_rate"`
+
+	// Quantile applies to latency only.
+	Quantile float64 `json:"quantile,omitempty" jsonschema:"Latency quantile in (0, 1], e.g. 0.95 for P95. Only used when metric_type is latency. Default: 0.95"`
+
+	// EndTime is the end of the query range.
+	EndTime string `json:"end_time,omitempty" jsonschema:"End of the time range as RFC3339, e.g. 2026-07-28T10:00:00Z. Default: now"`
+
+	// Lookback is the window ending at end_time.
+	Lookback string `json:"lookback,omitempty" jsonschema:"Query window ending at end_time, as a Go duration, e.g. 1h, 30m. Default: 1h"`
+
+	// Step is the interval between data points.
+	Step string `json:"step,omitempty" jsonschema:"Interval between data points, as a Go duration. Default: 1m. Smaller steps return more points and cost more context"`
+
+	// RatePer is the sliding window for rate calculations.
+	RatePer string `json:"rate_per,omitempty" jsonschema:"Sliding window over which per-second rates are computed, as a Go duration. Default: 10m"`
+
+	// GroupByOperation splits each service's series per operation.
+	GroupByOperation bool `json:"group_by_operation,omitempty" jsonschema:"If true, return one series per service+operation instead of one per service. Default: false"`
+
+	// SpanKinds limits which span kinds are aggregated.
+	SpanKinds []string `json:"span_kinds,omitempty" jsonschema:"Span kinds to include: server, client, internal, producer, consumer, unspecified. Default: [server]"`
+}
+
+// GetServiceMetricsOutput defines the output of the get_service_metrics tool.
+type GetServiceMetricsOutput struct {
+	// MetricType echoes the requested metric type.
+	MetricType string `json:"metric_type" jsonschema:"The metric type that was queried"`
+
+	// Quantile echoes the applied latency quantile, when relevant.
+	Quantile float64 `json:"quantile,omitempty" jsonschema:"Latency quantile applied (latency only)"`
+
+	// MetricName is the backend's name for this metric family.
+	MetricName string `json:"metric_name,omitempty" jsonschema:"Backend metric family name"`
+
+	// Description is the backend's help text, which states the metric semantics and units.
+	Description string `json:"description,omitempty" jsonschema:"Backend description of the metric, including units"`
+
+	// Metrics holds one time series per service (or service+operation).
+	Metrics []ServiceMetricSeries `json:"metrics" jsonschema:"One time series per service, or per service+operation when group_by_operation is true"`
+}
+
+// ServiceMetricSeries is one labeled time series.
+type ServiceMetricSeries struct {
+	ServiceName   string            `json:"service_name" jsonschema:"Service the series belongs to"`
+	OperationName string            `json:"operation_name,omitempty" jsonschema:"Operation, set when group_by_operation is true"`
+	SpanKind      string            `json:"span_kind,omitempty" jsonschema:"Span kind the series was aggregated over"`
+	DataPoints    []MetricDataPoint `json:"data_points" jsonschema:"Chronological data points"`
+}
+
+// MetricDataPoint is a single point in a series. Value is null when the backend
+// has no data for that timestamp, as opposed to a measured zero.
+type MetricDataPoint struct {
+	TimestampMs int64    `json:"timestamp_ms" jsonschema:"Unix timestamp in milliseconds"`
+	Value       *float64 `json:"value" jsonschema:"Metric value; null means no data at this timestamp, which is different from a measured 0"`
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/storage/metricstore/disabled"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
@@ -48,7 +50,11 @@ var skillsEmbedFS embed.FS
 // session-scoped endpoint that advertises per-session UI tools via receiving
 // middleware) build a server here, add their middleware, and serve it with
 // WrapHTTP.
-func NewServer(telset telemetry.Settings, queryAPI *querysvc.QueryService, cfg Config) *mcp.Server {
+// metricsReader supplies the SPM RED metrics behind the get_service_metrics
+// tool. Pass nil (or the disabled reader) when no metrics backend is
+// configured; the tool is then not registered, so agents never see a tool
+// that can only return errors.
+func NewServer(telset telemetry.Settings, queryAPI *querysvc.QueryService, metricsReader metricstore.Reader, cfg Config) *mcp.Server {
 	server := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    cfg.ServerName,
@@ -58,7 +64,7 @@ func NewServer(telset telemetry.Settings, queryAPI *querysvc.QueryService, cfg C
 			Instructions: serverInstructions,
 		},
 	)
-	registerTools(server, queryAPI, cfg)
+	registerTools(server, queryAPI, metricsReader, cfg)
 
 	mw := []mcp.Middleware{
 		createTracingMiddleware(telset.TracerProvider),
@@ -102,14 +108,14 @@ func WrapHTTP(server *mcp.Server, tenancyMgr *tenancy.Manager, telset telemetry.
 // over streamable HTTP, backed by the given QueryService — the session-free
 // endpoint (e.g. jaeger-query at /api/ai/mcp/). It is a thin composition of
 // NewServer and WrapHTTP around a single shared server.
-func NewHandler(telset telemetry.Settings, queryAPI *querysvc.QueryService, tenancyMgr *tenancy.Manager, cfg Config) http.Handler {
-	return WrapHTTP(NewServer(telset, queryAPI, cfg), tenancyMgr, telset)
+func NewHandler(telset telemetry.Settings, queryAPI *querysvc.QueryService, metricsReader metricstore.Reader, tenancyMgr *tenancy.Manager, cfg Config) http.Handler {
+	return WrapHTTP(NewServer(telset, queryAPI, metricsReader, cfg), tenancyMgr, telset)
 }
 
 // RegisterTools registers all Jaeger telemetry MCP tools on the given server,
 // wiring each handler to the supplied QueryService. cfg supplies the per-tool
 // limits (search results, span details, read-file size).
-func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Config) {
+func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, metricsReader metricstore.Reader, cfg Config) {
 	s := struct { // alias to minimize code diff during move
 		mcpServer *mcp.Server
 		config    Config
@@ -164,6 +170,20 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 			"that determined end-to-end duration. " +
 			"Higher self_time_us values indicate where time is concentrated on the critical path.",
 	}, handlers.NewGetCriticalPathHandler(s.queryAPI))
+
+	// Only expose the metrics tool when a metrics backend is actually
+	// configured; the disabled reader is the sentinel jaeger_query installs
+	// when storage.metrics is not set, and a tool that can only return
+	// "metrics disabled" errors is worse for an agent than no tool.
+	if _, metricsDisabled := metricsReader.(*disabled.MetricsReader); metricsReader != nil && !metricsDisabled {
+		mcp.AddTool(s.mcpServer, &mcp.Tool{
+			Name: "get_service_metrics",
+			Description: "Get RED metrics (latency percentile, call rate, error rate) for services " +
+				"as time series from Service Performance Monitoring. " +
+				"Each series is per-bucket data points over the query window; " +
+				"a null value means no data at that timestamp, as opposed to a measured 0.",
+		}, handlers.NewGetServiceMetricsHandler(metricsReader))
+	}
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_service_dependencies",

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/storage/metricstore/disabled"
+	"github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore"
+	metricstoremocks "github.com/jaegertracing/jaeger/internal/storage/v1/api/metricstore/mocks"
 	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
@@ -48,7 +51,7 @@ func connectTestClient(t *testing.T, handler http.Handler) *mcp.ClientSession {
 // backed by empty mocks.
 func TestNewHandler_ListTools(t *testing.T) {
 	svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
-	handler := NewHandler(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), DefaultConfig())
+	handler := NewHandler(telemetry.NoopSettings(), svc, nil, tenancy.NewManager(&tenancy.Options{}), DefaultConfig())
 
 	session := connectTestClient(t, handler)
 	listed, err := session.ListTools(context.Background(), &mcp.ListToolsParams{})
@@ -65,13 +68,46 @@ func TestNewHandler_ListTools(t *testing.T) {
 	}, got)
 }
 
+// TestNewHandler_MetricsToolRegistration asserts get_service_metrics is only
+// advertised when a real metrics backend is behind the reader: present with a
+// working reader, absent with the disabled sentinel jaeger_query installs when
+// storage.metrics is not configured (nil is covered by TestNewHandler_ListTools).
+func TestNewHandler_MetricsToolRegistration(t *testing.T) {
+	tests := []struct {
+		name          string
+		metricsReader metricstore.Reader
+		expectTool    bool
+	}{
+		{name: "configured reader registers the tool", metricsReader: &metricstoremocks.Reader{}, expectTool: true},
+		{name: "disabled reader does not register the tool", metricsReader: &disabled.MetricsReader{}, expectTool: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
+			handler := NewHandler(telemetry.NoopSettings(), svc, test.metricsReader, tenancy.NewManager(&tenancy.Options{}), DefaultConfig())
+
+			session := connectTestClient(t, handler)
+			listed, err := session.ListTools(context.Background(), &mcp.ListToolsParams{})
+			require.NoError(t, err)
+
+			found := false
+			for _, tool := range listed.Tools {
+				if tool.Name == "get_service_metrics" {
+					found = true
+				}
+			}
+			assert.Equal(t, test.expectTool, found)
+		})
+	}
+}
+
 // TestNewHandler_CallTool exercises a tool end-to-end through the HTTP stack,
 // confirming the handler reaches the QueryService and returns a result.
 func TestNewHandler_CallTool(t *testing.T) {
 	reader := &tracestoremocks.Reader{}
 	reader.On("GetServices", mock.Anything).Return([]string{"svc-a", "svc-b"}, nil)
 	svc := querysvc.NewQueryService(reader, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
-	handler := NewHandler(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), DefaultConfig())
+	handler := NewHandler(telemetry.NoopSettings(), svc, nil, tenancy.NewManager(&tenancy.Options{}), DefaultConfig())
 
 	session := connectTestClient(t, handler)
 	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "get_services"})
@@ -93,7 +129,7 @@ func TestNewServerDegradesWithoutMetrics(t *testing.T) {
 	telset := telemetry.NoopSettings()
 	telset.MeterProvider = &failingMeterProvider{failCounter: true}
 
-	srv := NewServer(telset, svc, DefaultConfig())
+	srv := NewServer(telset, svc, nil, DefaultConfig())
 	require.NotNil(t, srv)
 }
 
@@ -104,7 +140,7 @@ func TestRegisterTools(t *testing.T) {
 	svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
-	registerTools(server, svc, DefaultConfig())
+	registerTools(server, svc, nil, DefaultConfig())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -224,6 +224,7 @@ func initRouter(
 						MaxRequestBodySize: aiCfg.MaxRequestBodySize,
 						EnableMCP:          aiCfg.EnableMCP,
 						QueryService:       querySvc,
+						MetricsQuerySvc:    metricsQuerySvc,
 						TenancyMgr:         tenancyMgr,
 						Telset:             telset,
 					}).RegisterRoutes(r)
@@ -231,7 +232,7 @@ func initRouter(
 				if aiCfg.EnableMCP {
 					// Session-free telemetry endpoint (/api/ai/mcp/). Coexists with
 					// the wildcard session-scoped pattern above.
-					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, telset)
+					registerMCPTools(r, querySvc, metricsQuerySvc, tenancyMgr, queryOpts.BasePath, telset)
 				}
 			}
 		}
@@ -286,8 +287,8 @@ func otelFilterFunc(basePath string) func(*http.Request) bool {
 	}
 }
 
-func registerMCPTools(r *http.ServeMux, querySvc *querysvc.QueryService, tenancyMgr *tenancy.Manager, basePath string, telset telemetry.Settings) {
-	handler := mcptools.NewHandler(telset, querySvc, tenancyMgr, mcptools.DefaultConfig())
+func registerMCPTools(r *http.ServeMux, querySvc *querysvc.QueryService, metricsQuerySvc metricstore.Reader, tenancyMgr *tenancy.Manager, basePath string, telset telemetry.Settings) {
+	handler := mcptools.NewHandler(telset, querySvc, metricsQuerySvc, tenancyMgr, mcptools.DefaultConfig())
 	prefix := strings.TrimSuffix(basePath, "/") + "/api/ai/mcp"
 	r.Handle(prefix+"/", http.StripPrefix(prefix, handler))
 	telset.Logger.Info("Jaeger telemetry MCP endpoint enabled", zap.String("path", prefix+"/"))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -1234,7 +1234,7 @@ func TestRegisterMCPTools_BasePathNormalization(t *testing.T) {
 			r := http.NewServeMux()
 			// Must not panic on a double-slash pattern.
 			require.NotPanics(t, func() {
-				registerMCPTools(r, querySvc.qs, tenancyMgr, basePath, telset)
+				registerMCPTools(r, querySvc.qs, nil, tenancyMgr, basePath, telset)
 			})
 
 			want := "/api/ai/mcp/"


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #8409

## Description of the changes

Adds a `get_service_metrics` MCP tool exposing the RED metrics (latency quantile, call rate, error rate) that SPM already computes. Output is per-bucket time series, the format the A/B benchmark on #8409 supported: summary rows discard the time axis agents need for spike, correlation and trend questions.

Details worth reviewer attention:

- The tool registers only when a metrics backend is configured; with the `disabled` sentinel reader it is omitted entirely, per the note on #8409.
- NaN values from the metricstore become `null` data points rather than fake zeros, and the backend's metric name and help text pass through so units stay unambiguous.
- `step` defaults to 1m rather than the HTTP API's 5s: at 5s a 1h window is ~720 points per series, which is costly as model context. Flagging this divergence explicitly in case you'd rather mirror the HTTP default.
- Wired into both the session-free endpoint and the jaegerai session-scoped endpoint.
- #8477 took a first pass at this tool before the jaegermcp/jaeger_query merge; it now conflicts with the moved tree. This is a fresh implementation in the new location.

## How was this change tested?

- Unit tests for the handler (defaults, validation, NaN handling, dispatch per metric type) and for conditional registration through the full HTTP stack. `make lint` (0 issues), `make test` (4091 tests, 0 failures), mcptools package coverage 99.2%.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
