### PR TITLE
test(e2e): Shut down the spawned binary with SIGTERM instead of SIGKILL

### DIFF
--- a/cmd/jaeger/internal/integration/binary.go
+++ b/cmd/jaeger/internal/integration/binary.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -21,6 +22,10 @@ import (
 
 	"github.com/jaegertracing/jaeger/ports"
 )
+
+// stopTimeout is how long Stop waits for the process to exit after SIGTERM
+// before escalating to SIGKILL. Overridden in tests.
+var stopTimeout = 5 * time.Second
 
 // Binary is a wrapper around exec.Cmd to help running binaries in tests.
 type Binary struct {
@@ -73,17 +78,46 @@ func (b *Binary) Start(t *testing.T) {
 	t.Logf("%s is ready", b.Name)
 }
 
-// Stop kills the process and waits for it to exit. It is safe to call more than
-// once (and after the process has already exited): once the process has been
-// reaped, Kill returns os.ErrProcessDone, which is treated as a successful stop.
+// Stop terminates the process and waits for it to exit. SIGTERM lets the binary
+// exit through its normal shutdown path, which flushes buffered work and, for
+// `-cover` builds, coverage counters; SIGKILL flushes neither. A process that has
+// not exited within stopTimeout is killed so it cannot hang the test run. Safe to
+// call more than once: signalling a reaped process returns os.ErrProcessDone,
+// which is treated as a successful stop.
 func (b *Binary) Stop(t *testing.T) {
+	t.Helper()
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		b.Process.Wait()
+	}()
+
+	if err := b.Process.Signal(syscall.SIGTERM); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			<-exited
+			return
+		}
+		// Windows supports no signal other than Kill.
+		t.Logf("Failed to send SIGTERM to %s (%v), killing it instead", b.Name, err)
+		b.kill(t)
+	}
+
+	t.Logf("Waiting for %s to exit", b.Name)
+	select {
+	case <-exited:
+	case <-time.After(stopTimeout):
+		t.Logf("%s did not exit within %v after SIGTERM, killing it", b.Name, stopTimeout)
+		b.kill(t)
+		<-exited
+	}
+	t.Logf("%s exited", b.Name)
+}
+
+func (b *Binary) kill(t *testing.T) {
 	t.Helper()
 	if err := b.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 		t.Errorf("Failed to kill %s process: %v", b.Name, err)
 	}
-	t.Logf("Waiting for %s to exit", b.Name)
-	b.Process.Wait()
-	t.Logf("%s exited", b.Name)
 }
 
 func (b *Binary) doHealthCheck(t *testing.T, client *http.Client) bool {

--- a/cmd/jaeger/internal/integration/binary_test.go
+++ b/cmd/jaeger/internal/integration/binary_test.go
@@ -4,8 +4,11 @@
 package integration
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +30,60 @@ func TestBinaryStop_Idempotent(t *testing.T) {
 	require.NoError(t, b.Cmd.Start())
 
 	b.Stop(t)
-	b.Stop(t) // second call must not fail the test (Kill returns os.ErrProcessDone)
+	b.Stop(t) // second call must not fail the test (Signal returns os.ErrProcessDone)
 	_, err = b.Process.Wait()
 	assert.Error(t, err, "process should have already been waited on by Stop()")
+}
+
+func TestBinaryStop_SendsSIGTERM(t *testing.T) {
+	b, termFile := startTrapShell(t, "test-handles-sigterm", `trap ': > "$TERM_FILE"; exit 0' TERM`)
+
+	b.Stop(t)
+
+	assert.FileExists(t, termFile, "process should have exited through its SIGTERM handler")
+}
+
+func TestBinaryStop_KillsProcessIgnoringSIGTERM(t *testing.T) {
+	orig := stopTimeout
+	stopTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { stopTimeout = orig })
+
+	b, termFile := startTrapShell(t, "test-ignores-sigterm", `trap "" TERM`)
+
+	start := time.Now()
+	b.Stop(t)
+
+	assert.GreaterOrEqual(t, time.Since(start), stopTimeout,
+		"Stop() should have waited out stopTimeout before escalating to SIGKILL")
+	assert.NoFileExists(t, termFile, "process should have ignored SIGTERM")
+	_, err := b.Process.Wait()
+	assert.Error(t, err, "process should have been killed and reaped by Stop()")
+}
+
+// startTrapShell starts a shell that installs the given TERM trap and then idles.
+// It returns once the trap is in place, since signalling before that would hit the
+// default handler instead, and the path the trap writes to on SIGTERM.
+func startTrapShell(t *testing.T, name, trap string) (*Binary, string) {
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh binary not found; this test requires a POSIX environment")
+	}
+
+	dir := t.TempDir()
+	readyFile := filepath.Join(dir, "ready")
+	termFile := filepath.Join(dir, "term")
+	b := &Binary{
+		Name: name,
+		Cmd: exec.Cmd{
+			Path: shPath,
+			Args: []string{"sh", "-c", trap + `; : > "$READY_FILE"; while true; do sleep 0.1; done`},
+			Env:  append(os.Environ(), "READY_FILE="+readyFile, "TERM_FILE="+termFile),
+		},
+	}
+	require.NoError(t, b.Cmd.Start())
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyFile)
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond, "shell did not install its TERM trap")
+	return b, termFile
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- RFC 0013 M3 (#9131). The e2e harness stops the spawned binary with `Process.Kill()`, and SIGKILL is uncatchable, so the collector never runs its shutdown path. Storage `Close()` is skipped on every e2e run, and a binary built with `-cover` flushes no counters at all, which is what blocks M4.

## Description of the changes
- `Binary.Stop` now sends SIGTERM and waits up to 5s, falling back to SIGKILL so a wedged binary cannot hang CI. Signalling an already reaped process still returns `os.ErrProcessDone` and counts as a successful stop, and a platform that supports no signal other than Kill falls back to killing.

## How was this change tested?
- `TestBinaryStop_SendsSIGTERM` asserts the process exits through its own TERM handler, and `TestBinaryStop_KillsProcessIgnoringSIGTERM` covers the escalation. Both fail if the signal is switched back to SIGKILL.
- Ran the kafka 3.x (two binaries), elasticsearch 8.x, cassandra 5.x, clickhouse, badger and memory-v2 e2e legs locally: 14 binary stops, zero escalations, no failures.
- With a `-cover` build, SIGTERM writes `covcounters` and reports 86.4% for `cmd/jaeger/internal`, while SIGKILL writes only `covmeta` and everything reads 0.0%. Shutdown itself takes about 20ms, so the bounded wait is never reached in practice.
- Two notes: the wait after the fallback SIGKILL is deliberately unbounded, since a process in uninterruptible sleep keeps the goroutine alive either way (per the discussion in #8822), and the no-signal-support branch has no test because it cannot be reached on POSIX.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
