### PR TITLE
fix(mcptools): fix sequential predecessor check in critical path calculation

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -73,6 +73,7 @@ jobs:
       uses: oracle-actions/configure-kubectl-oke@77a733d79446dabe7bf0e58eb56197d33ce4dc58 # v1.5.0
       with:
         cluster: ${{ secrets.OKE_CLUSTER_OCID }}
+        region: ${{ secrets.OCI_CLI_REGION }}
         enablePrivateEndpoint: false
 
     - name: Install Helm

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
@@ -27,8 +27,8 @@ func findLastFinishingChildSpan(
 		childEndTime := childSpan.StartTime + childSpan.Duration
 
 		if returningChildStartTime != nil {
-			// Find child that finishes just before the returning child's start time
-			if childEndTime < *returningChildStartTime {
+			// Find child that finishes just before or exactly at the returning child's start time
+			if childEndTime <= *returningChildStartTime {
 				if childEndTime > maxEndTime {
 					maxEndTime = childEndTime
 					childSpanCopy := childSpan

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
@@ -181,6 +181,129 @@ func TestFindLastFinishingChildSpan(t *testing.T) {
 			returningChildStartTime: new(uint64(155)),
 			expectedSpanID:          &pcommon.SpanID{4}, // ends at 150 < 155, closest to returningChildStartTime
 		},
+		{
+			name: "Exact boundary match - sibling ends exactly when returning child starts",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 110,
+					Duration:  40, // ends at 150
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          &pcommon.SpanID{2},
+		},
+		{
+			name: "Multiple candidates at/before boundary - picks the one with latest end time",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 100,
+					Duration:  30, // ends at 130
+				},
+				spanID(3): {
+					SpanID:    spanID(3),
+					StartTime: 100,
+					Duration:  50, // ends at 150
+				},
+				spanID(4): {
+					SpanID:    spanID(4),
+					StartTime: 100,
+					Duration:  40, // ends at 140
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2), spanID(3), spanID(4)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          &pcommon.SpanID{3}, // ends at 150 (latest <= 150)
+		},
+		{
+			name: "Zero-duration span exactly at the boundary",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 150,
+					Duration:  0, // ends at 150
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          &pcommon.SpanID{2}, // zero duration ends at 150 <= 150
+		},
+		{
+			name: "Sibling ending exactly 1 nanosecond after returningChildStartTime is excluded",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 110,
+					Duration:  41, // ends at 151
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          nil, // 151 > 150, must be excluded
+		},
+		{
+			name: "No candidates at all - all start/end after the window",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 160,
+					Duration:  10, // ends at 170
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          nil,
+		},
+		{
+			name: "Realistic large int64 nanosecond timestamps",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 1716943800000000000,
+					Duration:  5000000000, // ends at 1716943805000000000
+				},
+				spanID(3): {
+					SpanID:    spanID(3),
+					StartTime: 1716943805000000000,
+					Duration:  5000000000, // ends at 1716943810000000000
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    1716943800000000000,
+				Duration:     10000000000,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2), spanID(3)},
+			},
+			returningChildStartTime: new(uint64(1716943805000000000)),
+			expectedSpanID:          &pcommon.SpanID{2}, // ends at exactly 1716943805000000000
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What changed
Changed the comparison in `findLastFinishingChildSpan` from strict less-than to less-than-or-equal:

```diff
- if childEndTime < *returningChildStartTime {
+ if childEndTime <= *returningChildStartTime {
```

## Why
`findLastFinishingChildSpan` searches for the sibling span that finishes just before a given "returning" child span starts, in order to correctly attribute execution time on the critical path. For strictly sequential siblings — where one span ends at the exact timestamp the next begins — the previous strict `<` check excluded the earlier sibling entirely, causing that time window to be wrongly attributed to the parent span instead of the sibling that actually executed during it.

Example: Child 1 `[100,150]`, Child 2 `[150,200]`. Reconstructing backward from Child 2 (`returningChildStartTime = 150`), Child 1's end time (150) failed `150 < 150`, so it was skipped.

## Testing
Added 6 edge-case tests to `find_lfc_test.go`:
- Exact boundary match (core fix case)
- Multiple candidates at/before the boundary — verifies latest end time wins
- Zero-duration span exactly at the boundary
- Sibling ending 1ns after the boundary — verifies correct exclusion (no over-correction)
- No candidates at all — verifies graceful nil return
- Realistic large int64 nanosecond timestamps

All 19 tests in the `criticalpath` package pass. `go vet` and `gofmt` clean.

## Related
Fixes #9148