### PR TITLE
Reject unrecognized span.status and span.kind filter values in memory store

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -1088,6 +1088,14 @@ func TestFindTraces_OTLPFields(t *testing.T) {
 			expectedIDs:    []pcommon.TraceID{traceID5, traceID4, traceID3},
 		},
 		{
+			// An unrecognized status must not fall back to Unset, which would
+			// match the three Unset traces above.
+			name:           "Filter by span.status=INVALID (no match)",
+			queryAttrs:     map[string]string{"span.status": "INVALID"},
+			expectedTraces: 0,
+			expectedIDs:    []pcommon.TraceID{},
+		},
+		{
 			name:           "Filter by span.kind=SERVER",
 			queryAttrs:     map[string]string{"span.kind": "SERVER"},
 			expectedTraces: 1,
@@ -1237,6 +1245,87 @@ func TestFindTraces_OTLPFields(t *testing.T) {
 					assert.Equal(t, expectedID, actualID)
 				}
 			}
+		})
+	}
+}
+
+// TestFindTraces_InvalidOTLPEnumFilters covers a span carrying the default
+// Unset status and Unspecified kind, which TestFindTraces_OTLPFields does not.
+// Without validation, an unrecognized span.status or span.kind value parses as
+// the enum's zero value and matches such spans, even though every other
+// non-matching filter returns no traces.
+func TestFindTraces_InvalidOTLPEnumFilters(t *testing.T) {
+	store, err := NewStore(Configuration{
+		MaxTraces: 10,
+	})
+	require.NoError(t, err)
+
+	traceID := fromString(t, "00000000000000010000000000000000")
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(conventions.ServiceNameKey, "service1")
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetTraceID(traceID)
+	span.SetSpanID(spanIdFromString(t, "0000000000000001"))
+	span.SetName("operation1")
+	span.SetKind(ptrace.SpanKindUnspecified)
+	span.Status().SetCode(ptrace.StatusCodeUnset)
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
+
+	require.NoError(t, store.WriteTraces(context.Background(), td))
+
+	tests := []struct {
+		name           string
+		queryAttrs     map[string]string
+		expectedTraces int
+	}{
+		{
+			name:           "span.status=UNSET matches the Unset span",
+			queryAttrs:     map[string]string{"span.status": "UNSET"},
+			expectedTraces: 1,
+		},
+		{
+			name:           "span.kind=UNSPECIFIED matches the Unspecified span",
+			queryAttrs:     map[string]string{"span.kind": "UNSPECIFIED"},
+			expectedTraces: 1,
+		},
+		{
+			name:           "unrecognized span.status does not match the Unset span",
+			queryAttrs:     map[string]string{"span.status": "NOT_A_STATUS"},
+			expectedTraces: 0,
+		},
+		{
+			name:           "unrecognized span.kind does not match the Unspecified span",
+			queryAttrs:     map[string]string{"span.kind": "NOT_A_KIND"},
+			expectedTraces: 0,
+		},
+		{
+			name:           "a typo in span.status is not treated as Unset",
+			queryAttrs:     map[string]string{"span.status": "UNSETT"},
+			expectedTraces: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := pcommon.NewMap()
+			for k, v := range tt.queryAttrs {
+				attrs.PutStr(k, v)
+			}
+
+			query := tracestore.TraceQueryParams{
+				Attributes:  attrs,
+				SearchDepth: 10,
+			}
+
+			var foundTraces []ptrace.Traces
+			for traces, err := range store.FindTraces(context.Background(), query) {
+				require.NoError(t, err)
+				foundTraces = append(foundTraces, traces...)
+			}
+
+			assert.Len(t, foundTraces, tt.expectedTraces, "query: %v", tt.queryAttrs)
 		})
 	}
 }

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -275,15 +275,15 @@ func validSpan(resourceAttributes pcommon.Map, scope pcommon.InstrumentationScop
 	}
 
 	if statusAttr, ok := query.Attributes.Get("span.status"); ok {
-		expectedStatus := spanStatusFromString(statusAttr.AsString())
-		if expectedStatus != span.Status().Code() {
+		expectedStatus, valid := spanStatusFromString(statusAttr.AsString())
+		if !valid || expectedStatus != span.Status().Code() {
 			return false
 		}
 	}
 
 	if kindAttr, ok := query.Attributes.Get("span.kind"); ok {
-		expectedKind := spanKindFromString(kindAttr.AsString())
-		if expectedKind != span.Kind() {
+		expectedKind, valid := spanKindFromString(kindAttr.AsString())
+		if !valid || expectedKind != span.Kind() {
 			return false
 		}
 	}
@@ -371,30 +371,42 @@ func errorQueryValue(attr pcommon.Value) (value bool, valid bool) {
 	}
 }
 
-func spanStatusFromString(statusStr string) ptrace.StatusCode {
+// spanStatusFromString parses a span.status filter value. The second return
+// value reports whether the string is a recognized status. An unrecognized
+// value must not be reported as Unset, otherwise the filter would match every
+// span carrying the default status.
+func spanStatusFromString(statusStr string) (ptrace.StatusCode, bool) {
 	switch strings.ToUpper(statusStr) {
+	case "UNSET":
+		return ptrace.StatusCodeUnset, true
 	case "OK":
-		return ptrace.StatusCodeOk
+		return ptrace.StatusCodeOk, true
 	case "ERROR":
-		return ptrace.StatusCodeError
+		return ptrace.StatusCodeError, true
 	default:
-		return ptrace.StatusCodeUnset
+		return ptrace.StatusCodeUnset, false
 	}
 }
 
-func spanKindFromString(kindStr string) ptrace.SpanKind {
+// spanKindFromString parses a span.kind filter value. As with
+// spanStatusFromString, the second return value distinguishes a recognized
+// kind from an unrecognized one, so that an unrecognized value does not match
+// every span with the default Unspecified kind.
+func spanKindFromString(kindStr string) (ptrace.SpanKind, bool) {
 	switch strings.ToUpper(kindStr) {
+	case "UNSPECIFIED":
+		return ptrace.SpanKindUnspecified, true
 	case "CLIENT":
-		return ptrace.SpanKindClient
+		return ptrace.SpanKindClient, true
 	case "SERVER":
-		return ptrace.SpanKindServer
+		return ptrace.SpanKindServer, true
 	case "PRODUCER":
-		return ptrace.SpanKindProducer
+		return ptrace.SpanKindProducer, true
 	case "CONSUMER":
-		return ptrace.SpanKindConsumer
+		return ptrace.SpanKindConsumer, true
 	case "INTERNAL":
-		return ptrace.SpanKindInternal
+		return ptrace.SpanKindInternal, true
 	default:
-		return ptrace.SpanKindUnspecified
+		return ptrace.SpanKindUnspecified, false
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9152

In the v2 in-memory store, `spanStatusFromString` and `spanKindFromString` mapped any unrecognized string onto the enum's zero value through their `default:` branch. A filter such as `span.status=Sucess` therefore matched every span carrying the default `Unset` status rather than matching nothing, and since `Unset` is the default for the large majority of spans, a typo returned a large set of unrelated traces.

Two things made this look unintended:

1. `errorQueryValue`, in the same file and used a few lines above, already returns a `valid` flag so that `error=notabool` matches nothing. The two enum filters had no equivalent check.
2. Every other non-matching filter in this store returns zero traces, which `TestFindTraces_OTLPFields` asserts for `scope.name`, `scope.version` and `resource.deployment.environment`.

## Description of the changes

- `spanStatusFromString` and `spanKindFromString` now return `(value, valid)`, following the existing `errorQueryValue` pattern, and `validSpan` rejects the span when the filter value was not recognized.
- `UNSET` and `UNSPECIFIED` are now matched explicitly so they remain valid values a caller can pass. Previously they worked only by falling through to the default branch.

I went with rejecting the value, so the query returns no traces, because it keeps the change local to `validSpan`, matches how every other filter in this store behaves, and adds no new error to the API surface. The alternative discussed in #9152 was to surface a validation error to the caller instead. Happy to switch if you would rather have that.

## How was this change tested?

- Added `TestFindTraces_InvalidOTLPEnumFilters`, which uses a span with the default `Unset` status and `Unspecified` kind. The existing `TestFindTraces_OTLPFields` fixture has no `Unspecified`-kind span, which is why its `span.kind=INVALID` case passed before this change without protecting against the bug.
- Added a `span.status=INVALID (no match)` case to `TestFindTraces_OTLPFields`, which returned 3 traces before this change because that fixture has three `Unset` traces.
- Confirmed the new tests fail without the change to `tenant.go` and pass with it.
- `go test ./internal/storage/v2/memory/` passes, and `go vet` and `gofmt` are clean.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
