### PR TITLE
fix(ai-gateway): Propagate tenant header to MCP sidecar

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 	"github.com/jaegertracing/jaeger/internal/version"
 )
 
@@ -39,6 +40,7 @@ type chatEndpoint struct {
 	// endpoint. NewHandler sets it only when that endpoint is actually mounted and
 	// a reachable address is known, so empty means announce nothing.
 	mcpBaseURL         string
+	tenancyMgr         *tenancy.Manager
 	sidecarWSURL       string
 	basePath           string
 	maxRequestBodySize int64
@@ -57,16 +59,24 @@ const mcpServerName = "jaeger"
 // requires an agent to opt into each McpServer variant, and announcing one it cannot
 // consume would make it fail the session. Streamable HTTP is the only variant the
 // gateway offers today.
-func (h *chatEndpoint) announceMCP(caps acp.AgentCapabilities, mcpRouteID string) []acp.McpServer {
+func (h *chatEndpoint) announceMCP(ctx context.Context, caps acp.AgentCapabilities, mcpRouteID string) []acp.McpServer {
 	if mcpRouteID == "" || h.mcpBaseURL == "" || !caps.McpCapabilities.Http {
 		return []acp.McpServer{}
+	}
+	headers := []acp.HttpHeader{}
+	if h.tenancyMgr != nil && h.tenancyMgr.Enabled {
+		tenant := tenancy.GetTenant(ctx)
+		if tenant == "" {
+			return []acp.McpServer{}
+		}
+		headers = append(headers, acp.HttpHeader{Name: h.tenancyMgr.Header, Value: tenant})
 	}
 	return []acp.McpServer{{
 		Http: &acp.McpServerHttpInline{
 			Type:    "http",
 			Name:    mcpServerName,
 			Url:     h.mcpBaseURL + h.basePath + routeMCPPrefix + mcpRouteID + "/",
-			Headers: []acp.HttpHeader{},
+			Headers: headers,
 		},
 	}}
 }
@@ -206,7 +216,7 @@ func (h *chatEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Cwd: "/",
 		// Point the sidecar at this turn's turn-scoped MCP endpoint, on the
 		// transports it advertised support for in Initialize.
-		McpServers: h.announceMCP(init.AgentCapabilities, mcpRouteID),
+		McpServers: h.announceMCP(ctx, init.AgentCapabilities, mcpRouteID),
 	}
 	if len(prefixedTools) > 0 {
 		newSessionReq.Meta = map[string]any{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+	"github.com/jaegertracing/jaeger/internal/tenancy"
 	"github.com/jaegertracing/jaeger/internal/version"
 )
 
@@ -421,19 +422,72 @@ func announceEndpoint(baseURL, basePath string) *chatEndpoint {
 }
 
 func TestAnnounceMCPOverHTTP(t *testing.T) {
-	got := announceEndpoint(testBaseURL, "").announceMCP(httpCaps(true), "route-1")
+	got := announceEndpoint(testBaseURL, "").announceMCP(context.Background(), httpCaps(true), "route-1")
 	require.Len(t, got, 1)
 	require.NotNil(t, got[0].Http)
 	assert.Equal(t, "http", got[0].Http.Type)
 	assert.Equal(t, mcpServerName, got[0].Http.Name)
 	assert.Equal(t, testBaseURL+"/api/ai/mcp/route-1/", got[0].Http.Url)
+	assert.Empty(t, got[0].Http.Headers)
+}
+
+func TestAnnounceMCPPropagatesTenantHeader(t *testing.T) {
+	tenantCtx := tenancy.WithTenant(context.Background(), "acme")
+	tests := []struct {
+		name             string
+		tenancyMgr       *tenancy.Manager
+		ctx              context.Context
+		wantAnnouncement bool
+		wantHeaders      []acp.HttpHeader
+	}{
+		{
+			name:             "default header",
+			tenancyMgr:       tenancy.NewManager(&tenancy.Options{Enabled: true}),
+			ctx:              tenantCtx,
+			wantAnnouncement: true,
+			wantHeaders:      []acp.HttpHeader{{Name: "x-tenant", Value: "acme"}},
+		},
+		{
+			name:             "custom header",
+			tenancyMgr:       tenancy.NewManager(&tenancy.Options{Enabled: true, Header: "X-Scope-OrgID"}),
+			ctx:              tenantCtx,
+			wantAnnouncement: true,
+			wantHeaders:      []acp.HttpHeader{{Name: "X-Scope-OrgID", Value: "acme"}},
+		},
+		{
+			name:       "missing tenant",
+			tenancyMgr: tenancy.NewManager(&tenancy.Options{Enabled: true}),
+			ctx:        context.Background(),
+		},
+		{
+			name:             "tenancy disabled",
+			tenancyMgr:       tenancy.NewManager(&tenancy.Options{}),
+			ctx:              tenantCtx,
+			wantAnnouncement: true,
+			wantHeaders:      []acp.HttpHeader{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint := announceEndpoint(testBaseURL, "")
+			endpoint.tenancyMgr = test.tenancyMgr
+			got := endpoint.announceMCP(test.ctx, httpCaps(true), "route-1")
+			if !test.wantAnnouncement {
+				assert.Empty(t, got)
+				return
+			}
+			require.Len(t, got, 1)
+			assert.Equal(t, test.wantHeaders, got[0].Http.Headers)
+		})
+	}
 }
 
 // TestAnnounceMCPRequiresHTTPCapability is the core contract: ACP requires an agent
 // to opt into each McpServer variant, so announcing HTTP to an agent that cannot
 // consume it would make it fail the session.
 func TestAnnounceMCPRequiresHTTPCapability(t *testing.T) {
-	got := announceEndpoint(testBaseURL, "").announceMCP(httpCaps(false), "route-1")
+	got := announceEndpoint(testBaseURL, "").announceMCP(context.Background(), httpCaps(false), "route-1")
 	assert.Empty(t, got, "an agent that did not advertise mcpCapabilities.http is offered nothing")
 }
 
@@ -441,17 +495,17 @@ func TestAnnounceMCPRequiresHTTPCapability(t *testing.T) {
 // turn-scoped endpoint is not mounted at all, or it is mounted but no reachable
 // address is known (see AIConfig.resolveMCPBaseURL).
 func TestAnnounceMCPRequiresBaseURL(t *testing.T) {
-	got := announceEndpoint("", "").announceMCP(httpCaps(true), "route-1")
+	got := announceEndpoint("", "").announceMCP(context.Background(), httpCaps(true), "route-1")
 	assert.Empty(t, got, "with no reachable base URL the endpoint is not announced")
 }
 
 func TestAnnounceMCPRequiresRouteID(t *testing.T) {
-	got := announceEndpoint(testBaseURL, "").announceMCP(httpCaps(true), "")
+	got := announceEndpoint(testBaseURL, "").announceMCP(context.Background(), httpCaps(true), "")
 	assert.Empty(t, got, "without a route id there is no turn-scoped endpoint to announce")
 }
 
 func TestAnnounceMCPEmbedsBasePath(t *testing.T) {
-	got := announceEndpoint("http://127.0.0.1:16686", "/jaeger").announceMCP(httpCaps(true), "u-1")
+	got := announceEndpoint("http://127.0.0.1:16686", "/jaeger").announceMCP(context.Background(), httpCaps(true), "u-1")
 	require.Len(t, got, 1)
 	assert.Equal(t, "http://127.0.0.1:16686/jaeger/api/ai/mcp/u-1/", got[0].Http.Url,
 		"the announced URL must carry the query server's base path")
@@ -472,10 +526,12 @@ func TestChatEndpointAnnouncesMCPEndpoint(t *testing.T) {
 
 	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
 	handler.mcpBaseURL = "https://jaeger.example.com:16686"
+	handler.tenancyMgr = tenancy.NewManager(&tenancy.Options{Enabled: true})
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(reqBody))
+	req = req.WithContext(tenancy.WithTenant(req.Context(), "acme"))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
@@ -484,6 +540,7 @@ func TestChatEndpointAnnouncesMCPEndpoint(t *testing.T) {
 	require.NotNil(t, sessionReq)
 	require.Len(t, sessionReq.McpServers, 1, "the endpoint must be announced")
 	require.NotNil(t, sessionReq.McpServers[0].Http)
+	assert.Equal(t, []acp.HttpHeader{{Name: "x-tenant", Value: "acme"}}, sessionReq.McpServers[0].Http.Headers)
 
 	url := sessionReq.McpServers[0].Http.Url
 	assert.True(t, strings.HasPrefix(url, "https://jaeger.example.com:16686/jaeger/api/ai/mcp/"),

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
@@ -70,6 +70,7 @@ func NewHandler(p HandlerParams) *Handler {
 	h := &Handler{basePath: basePath, chat: chat}
 	if p.EnableMCP {
 		h.mcp = newTurnScopedEndpoint(p.Telset, p.QueryService, p.TenancyMgr, turns, basePath, p.Logger)
+		chat.tenancyMgr = p.TenancyMgr
 		// Hand the chat endpoint the endpoint's reachable base URL so each turn
 		// announces it to the sidecar (see chatEndpoint.announceMCP). Setting it only
 		// here is what keeps the announcement off when no endpoint is mounted.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler_test.go
@@ -94,12 +94,14 @@ func TestNewHandlerNormalizesMCPBaseURL(t *testing.T) {
 		"http://127.0.0.1:16686/",
 		"http://127.0.0.1:16686//",
 	} {
+		tenancyMgr := tenancy.NewManager(&tenancy.Options{})
 		h := NewHandler(HandlerParams{
 			Logger: zap.NewNop(), AgentURL: "ws://x", MaxRequestBodySize: 1,
-			EnableMCP: true, QueryService: svc, TenancyMgr: tenancy.NewManager(&tenancy.Options{}),
+			EnableMCP: true, QueryService: svc, TenancyMgr: tenancyMgr,
 			Telset: telemetry.NoopSettings(), MCPBaseURL: base,
 		})
-		got := h.chat.announceMCP(httpCaps(true), "SID")
+		assert.Same(t, tenancyMgr, h.chat.tenancyMgr)
+		got := h.chat.announceMCP(context.Background(), httpCaps(true), "SID")
 		require.Len(t, got, 1)
 		assert.Equal(t, "http://127.0.0.1:16686/api/ai/mcp/SID/", got[0].Http.Url,
 			"base URL %q must normalize to a single slash", base)


### PR DESCRIPTION
## Which issue is this PR closing?

Resolves #9155.

## What does this PR do?

Propagates the validated tenant from the incoming chat request context through the HTTP MCP server announcement sent to the sidecar. The sidecar can then replay the configured tenant header when calling the turn-scoped MCP endpoint, instead of receiving `401 missing tenant header` for every tool call.

The change uses `tenancy.GetTenant(ctx)`, so it forwards the value already validated by the query router rather than rereading the raw request header. It preserves the configured header name, including custom headers, and leaves single-tenant announcements unchanged. If tenancy is enabled but the context unexpectedly has no tenant, the gateway announces no unusable MCP endpoint.

The implementation remains scoped to the announcement path; it does not place tenant identity in the URL or change tenancy validation.

## Testing

- Default `x-tenant` propagation
- Custom tenant-header propagation
- Missing-tenant fail-safe behavior
- Disabled-tenancy behavior
- ACP `session/new` payload verification
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai -run "Test(AnnounceMCP|ChatEndpointAnnouncesMCPEndpoint|NewHandler)" -count=1`
- `go test -covermode=atomic ./cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai` (100.0%)
- `make fmt`
- `make lint`
- `make test` (4,122 passed, 38 environment-dependent skips)


The implementation and test results were manually reviewed and verified.