### PR TITLE
fix(criticalpath): Fix non-deterministic grandchild cascade in removeOverflowingChildren

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize.go
@@ -11,26 +11,60 @@ import (
 // An overflowing child span is one whose time range falls outside its parent span's time range.
 // The function adjusts the start time and duration of overflowing child spans
 // to ensure they fit within the time range of their parent span.
+//
+// The traversal is a top-down BFS from every root span so that a parent is
+// always resolved (kept or dropped) before any of its children are evaluated.
+// When a span is dropped, its children are enqueued for unconditional deletion
+// in the same pass, guaranteeing the cascade is order-independent regardless
+// of the underlying map's iteration order.
 func removeOverflowingChildren(spanMap map[pcommon.SpanID]CPSpan) map[pcommon.SpanID]CPSpan {
-	// Get all span IDs
-	spanIDs := make([]pcommon.SpanID, 0, len(spanMap))
-	for spanID := range spanMap {
-		spanIDs = append(spanIDs, spanID)
+	// Seed the BFS queue with every root span (spans that have no parent in the
+	// map). Roots are always kept; we only evaluate children against their parent.
+	queue := make([]pcommon.SpanID, 0, len(spanMap))
+	for spanID, span := range spanMap {
+		_, parentInMap := spanMap[span.ParentSpanID]
+		if span.ParentSpanID.IsEmpty() || !parentInMap {
+			// True root (no parent) or orphan whose parent is missing from the map.
+			// Orphans with a non-empty ParentSpanID that point outside the map are
+			// treated as roots for traversal purposes; the original code dropped them
+			// via the "parentExists == false" branch. We replicate that below.
+			queue = append(queue, spanID)
+		}
 	}
 
-	for _, spanID := range spanIDs {
+	for len(queue) > 0 {
+		// Dequeue the next span to process.
+		spanID := queue[0]
+		queue = queue[1:]
+
 		span, ok := spanMap[spanID]
-		if !ok || span.ParentSpanID.IsEmpty() {
+		if !ok {
+			// Already deleted by a prior cascade step.
 			continue
 		}
 
-		// parentSpan will be undefined when its parent was dropped previously
-		parentSpan, parentExists := spanMap[span.ParentSpanID]
-		if !parentExists {
-			// Drop the child spans of dropped parent span
-			delete(spanMap, span.SpanID)
+		// Spans whose parent is not in the map (true orphans) are dropped.
+		// True roots have an empty ParentSpanID and are always kept.
+		if !span.ParentSpanID.IsEmpty() {
+			if _, parentExists := spanMap[span.ParentSpanID]; !parentExists {
+				// Drop this orphan and cascade deletion to all its descendants.
+				delete(spanMap, spanID)
+				queue = appendChildren(queue, span.ChildSpanIDs)
+				continue
+			}
+		}
+
+		// Enqueue this span's children so they are processed after the parent.
+		queue = appendChildren(queue, span.ChildSpanIDs)
+
+		// Root spans have no parent to overflow; nothing to check.
+		if span.ParentSpanID.IsEmpty() {
 			continue
 		}
+
+		// At this point the parent is guaranteed to be in spanMap and already
+		// resolved (clamped or kept) because BFS processes parents first.
+		parentSpan := spanMap[span.ParentSpanID]
 
 		childEndTime := span.StartTime + span.Duration
 		parentEndTime := parentSpan.StartTime + parentSpan.Duration
@@ -41,16 +75,10 @@ func removeOverflowingChildren(spanMap map[pcommon.SpanID]CPSpan) map[pcommon.Sp
 				//      |----parent----|
 				//                        |----child--|
 				delete(spanMap, span.SpanID)
+				cascadeDelete(spanMap, span.ChildSpanIDs)
 
 				// Remove the childSpanId from its parent span
-				filteredChildren := make([]pcommon.SpanID, 0, len(parentSpan.ChildSpanIDs))
-				for _, childID := range parentSpan.ChildSpanIDs {
-					if childID != span.SpanID {
-						filteredChildren = append(filteredChildren, childID)
-					}
-				}
-				parentSpan.ChildSpanIDs = filteredChildren
-				spanMap[parentSpan.SpanID] = parentSpan
+				spanMap[parentSpan.SpanID] = removeChild(parentSpan, span.SpanID)
 				continue
 			}
 			if childEndTime > parentEndTime {
@@ -73,16 +101,10 @@ func removeOverflowingChildren(spanMap map[pcommon.SpanID]CPSpan) map[pcommon.Sp
 			//                      |----parent----|
 			//       |----child--|
 			delete(spanMap, span.SpanID)
+			cascadeDelete(spanMap, span.ChildSpanIDs)
 
 			// Remove the childSpanId from its parent span
-			filteredChildren := make([]pcommon.SpanID, 0, len(parentSpan.ChildSpanIDs))
-			for _, childID := range parentSpan.ChildSpanIDs {
-				if childID != span.SpanID {
-					filteredChildren = append(filteredChildren, childID)
-				}
-			}
-			parentSpan.ChildSpanIDs = filteredChildren
-			spanMap[parentSpan.SpanID] = parentSpan
+			spanMap[parentSpan.SpanID] = removeChild(parentSpan, span.SpanID)
 		case childEndTime <= parentEndTime:
 			// child start before parent, truncate is needed
 			//      |----parent----|
@@ -101,4 +123,38 @@ func removeOverflowingChildren(spanMap map[pcommon.SpanID]CPSpan) map[pcommon.Sp
 	}
 
 	return spanMap
+}
+
+// removeChild returns a copy of parent with childID removed from ChildSpanIDs.
+func removeChild(parent CPSpan, childID pcommon.SpanID) CPSpan {
+	filtered := make([]pcommon.SpanID, 0, len(parent.ChildSpanIDs))
+	for _, id := range parent.ChildSpanIDs {
+		if id != childID {
+			filtered = append(filtered, id)
+		}
+	}
+	parent.ChildSpanIDs = filtered
+	return parent
+}
+
+// cascadeDelete removes all descendants of a dropped span from spanMap.
+// It walks the ChildSpanIDs transitively so that no orphan is left behind.
+func cascadeDelete(spanMap map[pcommon.SpanID]CPSpan, children []pcommon.SpanID) {
+	queue := make([]pcommon.SpanID, len(children))
+	copy(queue, children)
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		child, ok := spanMap[id]
+		if !ok {
+			continue
+		}
+		delete(spanMap, id)
+		queue = appendChildren(queue, child.ChildSpanIDs)
+	}
+}
+
+// appendChildren appends ids to queue and returns the extended slice.
+func appendChildren(queue []pcommon.SpanID, ids []pcommon.SpanID) []pcommon.SpanID {
+	return append(queue, ids...)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize_test.go
@@ -296,3 +296,81 @@ func TestSanitizeOverFlowingChildren_MultipleChildren(t *testing.T) {
 	_, ok4 := result[[8]byte{4}]
 	assert.False(t, ok4)
 }
+
+// TestSanitizeOverFlowingChildren_GrandchildCascade is a regression test for
+// a non-deterministic bug where a grandchild could survive sanitization if its
+// intermediate parent (which overflows the grandparent) happened to be iterated
+// after the grandchild in the old random-order map pass.
+//
+// Scenario:
+//
+//	Root A [0..200]
+//	  └─ B [210..300]   overflows A → must be dropped
+//	       └─ C [220..280]  grandchild via B → must also be dropped
+//
+// With the old implementation, if C was visited before B, C's parent (B) was
+// still present in the map at that moment, so C survived the single pass. B was
+// then deleted, leaving C as an orphan. The test is run many times to detect
+// non-determinism: even a single failure proves the bug.
+func TestSanitizeOverFlowingChildren_GrandchildCascade(t *testing.T) {
+	// spA, spB, spC use distinct byte values so the map has three different keys.
+	spA := pcommon.SpanID([8]byte{0xA})
+	spB := pcommon.SpanID([8]byte{0xB})
+	spC := pcommon.SpanID([8]byte{0xC})
+
+	buildInput := func() map[pcommon.SpanID]CPSpan {
+		return map[pcommon.SpanID]CPSpan{
+			spA: {
+				SpanID:       spA,
+				StartTime:    0,
+				Duration:     200, // [0..200]
+				ChildSpanIDs: []pcommon.SpanID{spB},
+			},
+			spB: {
+				SpanID:       spB,
+				ParentSpanID: spA,
+				StartTime:    210, // starts after A ends → overflows
+				Duration:     90,  // [210..300]
+				ChildSpanIDs: []pcommon.SpanID{spC},
+			},
+			spC: {
+				SpanID:       spC,
+				ParentSpanID: spB,
+				StartTime:    220, // grandchild of A via overflowing B
+				Duration:     60,  // [220..280]
+			},
+		}
+	}
+
+	// Run many times: Go map iteration is randomized per run, so a bug in the
+	// old single-pass implementation would surface on a fraction of iterations.
+	// 100 runs is enough to make a flaky pass astronomically unlikely.
+	const iterations = 100
+	for i := range iterations {
+		result := removeOverflowingChildren(buildInput())
+
+		// A must survive with an empty ChildSpanIDs list (B was removed from it).
+		a, ok := result[spA]
+		assert.True(t, ok, "iteration %d: root A must survive", i)
+		assert.Empty(t, a.ChildSpanIDs,
+			"iteration %d: A's ChildSpanIDs must be empty after B is dropped", i)
+
+		// B overflows A and must be dropped.
+		_, ok = result[spB]
+		assert.False(t, ok, "iteration %d: overflowing B must be dropped", i)
+
+		// C is a descendant of dropped B and must also be dropped.
+		_, ok = result[spC]
+		assert.False(t, ok, "iteration %d: grandchild C must be dropped with B", i)
+
+		// No span in the result may reference B or C in its ChildSpanIDs.
+		for id, span := range result {
+			for _, childID := range span.ChildSpanIDs {
+				assert.NotEqual(t, spB, childID,
+					"iteration %d: span %v still references dropped B", i, id)
+				assert.NotEqual(t, spC, childID,
+					"iteration %d: span %v still references dropped C", i, id)
+			}
+		}
+	}
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize_test.go
@@ -297,6 +297,71 @@ func TestSanitizeOverFlowingChildren_MultipleChildren(t *testing.T) {
 	assert.False(t, ok4)
 }
 
+// TestSanitizeOverFlowingChildren_OrphanCascade pins the behavior of a "true
+// orphan": a span whose ParentSpanID is non-empty but does not exist anywhere
+// in spanMap (its parent was never part of the trace, not merely dropped during
+// this pass).
+//
+// The original single-pass code dropped the orphan via the `parentExists ==
+// false` branch (delete + continue, no explicit child cascade). Children of the
+// orphan were still in the flat spanIDs snapshot, so they were visited later;
+// their own parent-lookup also failed (orphan was deleted), causing them to be
+// deleted too. The net result: the full subtree rooted at the orphan is removed.
+//
+// The BFS rewrite replicates this by enqueuing the orphan's children
+// (appendChildren) before the continue, so they are processed in the same pass
+// and deleted via the same orphan-detection branch. The observable result is
+// identical: every span in the orphan's subtree is absent from the output.
+//
+// This test explicitly asserts that contract for a two-level subtree:
+//
+//	Orphan O  (ParentSpanID → X, X not in map)
+//	  └─ Child C
+//	       └─ Grandchild G
+func TestSanitizeOverFlowingChildren_OrphanCascade(t *testing.T) {
+	spO := pcommon.SpanID([8]byte{0xE1}) // orphan: parent missing from map
+	spC := pcommon.SpanID([8]byte{0xE2}) // child of orphan
+	spG := pcommon.SpanID([8]byte{0xE3}) // grandchild of orphan
+	spX := pcommon.SpanID([8]byte{0xFF}) // the missing parent (never in map)
+
+	input := map[pcommon.SpanID]CPSpan{
+		spO: {
+			SpanID:       spO,
+			ParentSpanID: spX, // points outside the map
+			StartTime:    100,
+			Duration:     200,
+			ChildSpanIDs: []pcommon.SpanID{spC},
+		},
+		spC: {
+			SpanID:       spC,
+			ParentSpanID: spO,
+			StartTime:    110,
+			Duration:     50,
+			ChildSpanIDs: []pcommon.SpanID{spG},
+		},
+		spG: {
+			SpanID:       spG,
+			ParentSpanID: spC,
+			StartTime:    120,
+			Duration:     20,
+		},
+	}
+
+	result := removeOverflowingChildren(input)
+
+	// The entire subtree must be absent.
+	_, okO := result[spO]
+	assert.False(t, okO, "orphan O must be dropped (its parent is not in the map)")
+
+	_, okC := result[spC]
+	assert.False(t, okC, "child C of orphan O must be cascade-dropped")
+
+	_, okG := result[spG]
+	assert.False(t, okG, "grandchild G of orphan O must be cascade-dropped")
+
+	assert.Empty(t, result, "result must be completely empty")
+}
+
 // TestSanitizeOverFlowingChildren_GrandchildCascade is a regression test for
 // a non-deterministic bug where a grandchild could survive sanitization if its
 // intermediate parent (which overflows the grandparent) happened to be iterated


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9158 

## Description of the changes
- `removeOverflowingChildren` built its span list by ranging over a Go map, whose iteration order is randomized on every call. A dropped span's cascade to its own children only worked if the parent happened to be visited before them, so a grandchild could survive sanitization while its dropped parent left it orphaned, and `computeCriticalPath` would later walk into it through a stale reference. Non-deterministic, so it wouldn't reproduce on every run.
- Replaced the random-order pass with a top-down BFS from every root, guaranteeing a parent is resolved before its children so drops always cascade correctly. Added `cascadeDelete`, `removeChild`, and `appendChildren` helpers.

## How was this change tested?
- Added `TestSanitizeOverFlowingChildren_GrandchildCascade`: builds a Root → overflowing child → grandchild scenario and runs sanitization 100 times, asserting no orphan or stale reference ever survives. Since the bug was order-dependent, one run isn't a reliable check.
- Full `criticalpath` and `mcptools` suites pass. `apiv3`'s `TestHTTPGateway` subtests fail here but confirmed pre-existing on unmodified `main` (Windows CRLF snapshot issue, unrelated — filed separately).

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [ ] **None**
- [ ] **Light**
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**