### PR TITLE
fix(storage/v2/grpc): validate query to prevent nil pointer panic

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -119,6 +119,9 @@ func (h *Handler) FindTraces(
 	req *storage.FindTracesRequest,
 	srv storage.TraceReader_FindTracesServer,
 ) error {
+	if req.Query == nil {
+		return status.Errorf(codes.InvalidArgument, "missing query")
+	}
 	for traces, err := range h.traceReader.FindTraces(srv.Context(), toTraceQueryParams(req.Query)) {
 		if err != nil {
 			return err
@@ -138,6 +141,9 @@ func (h *Handler) FindTraceSummaries(
 	req *storage.FindTraceSummariesRequest,
 	srv storage.TraceReader_FindTraceSummariesServer,
 ) error {
+	if req.Query == nil {
+		return status.Errorf(codes.InvalidArgument, "missing query")
+	}
 	for summaries, err := range h.traceReader.FindTraceSummaries(srv.Context(), toTraceQueryParams(req.Query)) {
 		if err != nil {
 			// A backend that cannot compute summaries natively signals this with
@@ -182,6 +188,9 @@ func (h *Handler) FindTraceIDs(
 	ctx context.Context,
 	req *storage.FindTraceIDsRequest,
 ) (*storage.FindTraceIDsResponse, error) {
+	if req.Query == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "missing query")
+	}
 	foundTraceIDs := []*storage.FoundTraceID{}
 	for traceIDs, err := range h.traceReader.FindTraceIDs(ctx, toTraceQueryParams(req.Query)) {
 		if err != nil {

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -844,3 +844,25 @@ func TestHandler_FindTraceSummaries_SendError(t *testing.T) {
 	}, &summaryStream{sendErr: assert.AnError})
 	require.ErrorIs(t, err, assert.AnError)
 }
+
+func TestHandler_MissingQuery(t *testing.T) {
+	reader := new(tracestoremocks.Reader)
+	writer := new(tracestoremocks.Writer)
+	depReader := new(depstoremocks.Reader)
+	handler := NewHandler(reader, writer, depReader)
+
+	err := handler.FindTraces(&storage.FindTracesRequest{}, &testStream{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "missing query")
+
+	err = handler.FindTraceSummaries(&storage.FindTraceSummariesRequest{}, &summaryStream{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "missing query")
+
+	_, err = handler.FindTraceIDs(context.Background(), &storage.FindTraceIDsRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "missing query")
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #9156 

When using the storage v2 gRPC API, if a client omits the nested `query` message in search requests (`FindTraces`, `FindTraceIDs`, `FindTraceSummaries`), the `req.Query` pointer evaluates to `nil`. Passing this nil pointer to `toTraceQueryParams()` causes an unhandled nil-pointer panic before the storage backend is ever reached.

## Short description of the changes
- Added explicit `req.Query == nil` validation checks at the very top of all three storage v2 gRPC search handlers (`FindTraces`, `FindTraceSummaries`, and `FindTraceIDs`).
- If the query is omitted, the handlers now gracefully return a `codes.InvalidArgument` gRPC status with a `"missing query"` message (matching the behavior of the API v3 gRPC handlers).
- Added a new unit test suite (`TestHandler_MissingQuery`) in `handler_test.go` to ensure all three RPCs correctly catch the missing query and return the expected validation error instead of panicking.
