### PR TITLE
refactor(ai-gateway): Pass mcptools.Config into the turn-scoped MCP endpoint

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
@@ -72,11 +72,9 @@ type turnScopedEndpoint struct {
 	logger   *zap.Logger
 }
 
-// turnScopedEndpointBuilder collects the endpoint's dependencies so callers
-// assign named fields instead of threading a positional argument list that grows
-// with every new dependency. mcpConfig is supplied ready-made by the caller:
-// deciding MCP configuration belongs with the rest of the gateway's config
-// handling, not in this constructor.
+// turnScopedEndpointBuilder collects the endpoint's dependencies. mcpConfig
+// arrives ready-made: deciding MCP configuration belongs with the gateway's
+// other config handling, not in this constructor.
 type turnScopedEndpointBuilder struct {
 	telset     telemetry.Settings
 	queryAPI   *querysvc.QueryService
@@ -86,12 +84,10 @@ type turnScopedEndpointBuilder struct {
 	mcpConfig  mcptools.Config
 }
 
-// build assembles the turn-scoped handler around a single shared MCP server. The
-// telemetry tools are a fixed capability, so they are registered once; the
-// per-turn UI tools are layered on via uiToolsMiddleware, which reads the route
-// id from the request context and, for that turn, advertises its UI tools in
-// tools/list and dispatches their tools/call to the browser stream. This avoids
-// standing up a fresh server per turn.
+// build assembles the turn-scoped handler around a single shared MCP server:
+// the telemetry tools are a fixed capability registered once, and each turn's
+// UI tools are layered on per-request by uiToolsMiddleware, so no server has to
+// be stood up per turn.
 func (b turnScopedEndpointBuilder) build() *turnScopedEndpoint {
 	srv := mcptools.NewServer(b.telset, b.queryAPI, b.mcpConfig)
 	srv.AddReceivingMiddleware(uiToolsMiddleware(b.turns, b.telset.Logger))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp.go
@@ -72,21 +72,35 @@ type turnScopedEndpoint struct {
 	logger   *zap.Logger
 }
 
-// newTurnScopedEndpoint builds the turn-scoped handler around a single shared
-// MCP server. The telemetry tools are a fixed capability, so they are registered
-// once; the per-turn UI tools are layered on via uiToolsMiddleware, which
-// reads the route id from the request context and, for that turn,
-// advertises its UI tools in tools/list and dispatches their tools/call to the
-// browser stream. This avoids standing up a fresh server per turn.
-func newTurnScopedEndpoint(telset telemetry.Settings, queryAPI *querysvc.QueryService, tenancyMgr *tenancy.Manager, turns *turnRegistry, basePath string, logger *zap.Logger) *turnScopedEndpoint {
-	srv := mcptools.NewServer(telset, queryAPI, mcptools.DefaultConfig())
-	srv.AddReceivingMiddleware(uiToolsMiddleware(turns, logger))
+// turnScopedEndpointBuilder collects the endpoint's dependencies so callers
+// assign named fields instead of threading a positional argument list that grows
+// with every new dependency. mcpConfig is supplied ready-made by the caller:
+// deciding MCP configuration belongs with the rest of the gateway's config
+// handling, not in this constructor.
+type turnScopedEndpointBuilder struct {
+	telset     telemetry.Settings
+	queryAPI   *querysvc.QueryService
+	tenancyMgr *tenancy.Manager
+	turns      *turnRegistry
+	basePath   string
+	mcpConfig  mcptools.Config
+}
+
+// build assembles the turn-scoped handler around a single shared MCP server. The
+// telemetry tools are a fixed capability, so they are registered once; the
+// per-turn UI tools are layered on via uiToolsMiddleware, which reads the route
+// id from the request context and, for that turn, advertises its UI tools in
+// tools/list and dispatches their tools/call to the browser stream. This avoids
+// standing up a fresh server per turn.
+func (b turnScopedEndpointBuilder) build() *turnScopedEndpoint {
+	srv := mcptools.NewServer(b.telset, b.queryAPI, b.mcpConfig)
+	srv.AddReceivingMiddleware(uiToolsMiddleware(b.turns, b.telset.Logger))
 	return &turnScopedEndpoint{
-		streamable: mcptools.WrapHTTP(srv, tenancyMgr, telset),
+		streamable: mcptools.WrapHTTP(srv, b.tenancyMgr, b.telset),
 		server:     srv,
-		turns:      turns,
-		basePath:   basePath,
-		logger:     logger,
+		turns:      b.turns,
+		basePath:   b.basePath,
+		logger:     b.telset.Logger,
 	}
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_turn_mcp_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
@@ -44,7 +44,13 @@ func turnMCPServer(t *testing.T, uiTools []json.RawMessage) (ts *httptest.Server
 	rec = httptest.NewRecorder()
 	routeID = registerTurn(turns, newStreamingClient(context.Background(), rec, "thread", "run"), uiTools)
 
-	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
+	h := turnScopedEndpointBuilder{
+		telset:     telemetry.NoopSettings(),
+		queryAPI:   svc,
+		tenancyMgr: tenancy.NewManager(&tenancy.Options{}),
+		turns:      turns,
+		mcpConfig:  mcptools.DefaultConfig(),
+	}.build()
 	mux := http.NewServeMux()
 	h.registerRoutes(mux)
 
@@ -110,7 +116,13 @@ func TestTurnScopedEndpointIsolatesTurns(t *testing.T) {
 	idA := registerTurn(turns, newStreamingClient(context.Background(), recA, "ta", "ra"), []json.RawMessage{rawUITool(t, "chart_a")})
 	idB := registerTurn(turns, newStreamingClient(context.Background(), recB, "tb", "rb"), []json.RawMessage{rawUITool(t, "chart_b")})
 
-	h := newTurnScopedEndpoint(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), turns, "", zap.NewNop())
+	h := turnScopedEndpointBuilder{
+		telset:     telemetry.NoopSettings(),
+		queryAPI:   svc,
+		tenancyMgr: tenancy.NewManager(&tenancy.Options{}),
+		turns:      turns,
+		mcpConfig:  mcptools.DefaultConfig(),
+	}.build()
 	mux := http.NewServeMux()
 	h.registerRoutes(mux)
 	ts := httptest.NewServer(mux)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
@@ -55,6 +56,11 @@ type HandlerParams struct {
 	QueryService *querysvc.QueryService
 	TenancyMgr   *tenancy.Manager
 	Telset       telemetry.Settings
+	// MCPConfig configures the MCP server behind the turn-scoped endpoint. The
+	// caller builds it and passes the same value it uses for the shared endpoint,
+	// so an agent sees an identical tool set whichever one it dials. Read only
+	// when EnableMCP is set.
+	MCPConfig mcptools.Config
 }
 
 // NewHandler constructs a jaegerai.Handler, building the endpoints it will mount.
@@ -69,7 +75,14 @@ func NewHandler(p HandlerParams) *Handler {
 	chat := newChatEndpoint(p.Logger, NewContextualToolsStore(), turns, p.AgentURL, basePath, p.MaxRequestBodySize)
 	h := &Handler{basePath: basePath, chat: chat}
 	if p.EnableMCP {
-		h.mcp = newTurnScopedEndpoint(p.Telset, p.QueryService, p.TenancyMgr, turns, basePath, p.Logger)
+		h.mcp = turnScopedEndpointBuilder{
+			telset:     p.Telset,
+			queryAPI:   p.QueryService,
+			tenancyMgr: p.TenancyMgr,
+			turns:      turns,
+			basePath:   basePath,
+			mcpConfig:  p.MCPConfig,
+		}.build()
 		// Hand the chat endpoint the endpoint's reachable base URL so each turn
 		// announces it to the sidecar (see chatEndpoint.announceMCP). Setting it only
 		// here is what keeps the announcement off when no endpoint is mounted.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
@@ -57,9 +57,8 @@ type HandlerParams struct {
 	TenancyMgr   *tenancy.Manager
 	Telset       telemetry.Settings
 	// MCPConfig configures the MCP server behind the turn-scoped endpoint. The
-	// caller builds it and passes the same value it uses for the shared endpoint,
-	// so an agent sees an identical tool set whichever one it dials. Read only
-	// when EnableMCP is set.
+	// caller passes the same value it gives the shared endpoint, so the two
+	// cannot drift. Read only when EnableMCP is set.
 	MCPConfig mcptools.Config
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -236,9 +236,7 @@ func initRouter(
 			if err := aiCfg.Validate(); err != nil {
 				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
 			} else {
-				// One MCP config for both endpoints: the shared one mounted below
-				// and the turn-scoped one jaegerai mounts, so an agent sees the
-				// same tools whichever it dials.
+				// One config for both MCP endpoints so they cannot drift.
 				mcpCfg := mcptools.DefaultConfig()
 				if aiCfg.AgentURL != "" {
 					// When AI chat is enabled, jaegerai owns the chat endpoint and,

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -236,6 +236,10 @@ func initRouter(
 			if err := aiCfg.Validate(); err != nil {
 				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
 			} else {
+				// One MCP config for both endpoints: the shared one mounted below
+				// and the turn-scoped one jaegerai mounts, so an agent sees the
+				// same tools whichever it dials.
+				mcpCfg := mcptools.DefaultConfig()
 				if aiCfg.AgentURL != "" {
 					// When AI chat is enabled, jaegerai owns the chat endpoint and,
 					// if MCP is also enabled, the turn-scoped MCP endpoint
@@ -255,13 +259,14 @@ func initRouter(
 						QueryService:       querySvc,
 						TenancyMgr:         tenancyMgr,
 						Telset:             telset,
+						MCPConfig:          mcpCfg,
 					})
 					aiGateway.RegisterRoutes(r)
 				}
 				if aiCfg.EnableMCP {
 					// Shared telemetry endpoint (/api/ai/mcp/). Coexists with the
 					// wildcard turn-scoped pattern above.
-					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, telset)
+					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, mcpCfg, telset)
 				}
 			}
 		}
@@ -319,8 +324,8 @@ func otelFilterFunc(basePath string) func(*http.Request) bool {
 	}
 }
 
-func registerMCPTools(r *http.ServeMux, querySvc *querysvc.QueryService, tenancyMgr *tenancy.Manager, basePath string, telset telemetry.Settings) {
-	handler := mcptools.NewHandler(telset, querySvc, tenancyMgr, mcptools.DefaultConfig())
+func registerMCPTools(r *http.ServeMux, querySvc *querysvc.QueryService, tenancyMgr *tenancy.Manager, basePath string, cfg mcptools.Config, telset telemetry.Settings) {
+	handler := mcptools.NewHandler(telset, querySvc, tenancyMgr, cfg)
 	prefix := strings.TrimSuffix(basePath, "/") + "/api/ai/mcp"
 	r.Handle(prefix+"/", http.StripPrefix(prefix, handler))
 	telset.Logger.Info("Jaeger telemetry MCP endpoint enabled", zap.String("path", prefix+"/"))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/grpctest"
 	"github.com/jaegertracing/jaeger/internal/headerforwarding"
@@ -1234,7 +1235,7 @@ func TestRegisterMCPTools_BasePathNormalization(t *testing.T) {
 			r := http.NewServeMux()
 			// Must not panic on a double-slash pattern.
 			require.NotPanics(t, func() {
-				registerMCPTools(r, querySvc.qs, tenancyMgr, basePath, telset)
+				registerMCPTools(r, querySvc.qs, tenancyMgr, basePath, mcptools.DefaultConfig(), telset)
 			})
 
 			want := "/api/ai/mcp/"


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #8440. This is the first of three PRs carved out of #9010, which  mixed a refactor, a feature, and its validation into one ~1,300-line change. Per review feedback there, each lands separately; this is the behaviour-preserving refactor that the other two build on.

## Description of the changes

**No behaviour change.** Purely how the turn-scoped MCP endpoint is constructed. - `newTurnScopedEndpoint` took six positional arguments and grew one per new  dependency. Replaced with a `turnScopedEndpointBuilder` struct plus a
  `build()` method, so callers assign named fields:

  ```go
  h.mcp = turnScopedEndpointBuilder{
      telset:     p.Telset,
      queryAPI:   p.QueryService,
      tenancyMgr: p.TenancyMgr,
      turns:      turns,
      basePath:   basePath,
      mcpConfig:  p.MCPConfig,
  }.build()
```
The endpoint no longer calls mcptools.DefaultConfig() itself. It takes anmcptools.Config via the new HandlerParams.MCPConfig, and jaeger-querybuilds that config once in initRouter and passes the same value to both the shared endpoint and the turn-scoped one. Deciding MCP configuration belongs with the rest of the gateway's config handling, not inside the constructor of the object that consumes it — and sharing one value is what keeps the two
endpoints from drifting as config grows.

Dropped the separate logger parameter: telemetry.Settings already carries a Logger, and passing both invited them to disagree.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
