### PR TITLE
fix(query): Harden api_v3 gRPC and HTTP query APIs

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -4,9 +4,11 @@
 package apiv3
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"iter"
+	"slices"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"google.golang.org/grpc/codes"
@@ -82,7 +84,10 @@ func (h *Handler) internalFindTraces(
 }
 
 // traceQueryParams converts a proto TraceQueryParameters to querysvc.TraceQueryParams,
-// validating that the required time range fields are present.
+// validating that the required time range fields are present. An unset (or
+// non-positive) search_depth defaults to defaultSearchDepth, mirroring the
+// HTTP gateway: proto3 cannot distinguish an omitted field from 0, and a
+// literal 0 is rejected by some storage backends (e.g. the in-memory store).
 func traceQueryParams(query *api_v3.TraceQueryParameters) (querysvc.TraceQueryParams, error) {
 	if query == nil {
 		return querysvc.TraceQueryParams{}, status.Error(codes.InvalidArgument, "missing query")
@@ -90,12 +95,16 @@ func traceQueryParams(query *api_v3.TraceQueryParameters) (querysvc.TraceQueryPa
 	if query.GetStartTimeMin().IsZero() || query.GetStartTimeMax().IsZero() {
 		return querysvc.TraceQueryParams{}, status.Error(codes.InvalidArgument, "start time min and max are required parameters")
 	}
+	searchDepth := int(query.GetSearchDepth())
+	if searchDepth <= 0 {
+		searchDepth = defaultSearchDepth
+	}
 	queryParams := querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
 			Attributes:    jptrace.PlainMapToPcommonMap(query.GetAttributes()),
-			SearchDepth:   int(query.GetSearchDepth()),
+			SearchDepth:   searchDepth,
 			StartTimeMin:  query.GetStartTimeMin(),
 			StartTimeMax:  query.GetStartTimeMax(),
 			DurationMin:   query.GetDurationMin(),
@@ -204,6 +213,14 @@ func (h *Handler) GetDependencies(ctx context.Context, request *api_v3.GetDepend
 	if err != nil {
 		return nil, err
 	}
+	// Sort the links so the response order is deterministic; the storage layer
+	// builds dependency links from a map, whose iteration order is not stable.
+	slices.SortFunc(deps, func(a, b model.DependencyLink) int {
+		if c := cmp.Compare(a.Parent, b.Parent); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Child, b.Child)
+	})
 	links := make([]*api_v3.Dependency, len(deps))
 	for i, dep := range deps {
 		links[i] = &api_v3.Dependency{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -261,6 +261,60 @@ func TestFindTraces(t *testing.T) {
 	require.Equal(t, 1, td.SpanCount())
 }
 
+func TestTraceQueryParamsSearchDepth(t *testing.T) {
+	baseQuery := func() *api_v3.TraceQueryParameters {
+		return &api_v3.TraceQueryParameters{
+			StartTimeMin: time.Now().Add(-2 * time.Hour),
+			StartTimeMax: time.Now(),
+		}
+	}
+	tests := []struct {
+		name        string
+		searchDepth int32
+		expected    int
+	}{
+		{name: "unset defaults", searchDepth: 0, expected: defaultSearchDepth},
+		{name: "negative defaults", searchDepth: -1, expected: defaultSearchDepth},
+		{name: "explicit value preserved", searchDepth: 42, expected: 42},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query := baseQuery()
+			query.SearchDepth = test.searchDepth
+			params, err := traceQueryParams(query)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, params.SearchDepth)
+		})
+	}
+}
+
+func TestFindTracesDefaultsSearchDepth(t *testing.T) {
+	// A FindTraces request without search_depth (proto3 default 0) must reach
+	// the storage backend with the default search depth, matching the HTTP
+	// gateway. Some backends (e.g. the in-memory store) reject a literal 0.
+	tsc := newTestServerClient(t)
+	tsc.reader.On("FindTraces", matchContext, mock.MatchedBy(func(q tracestore.TraceQueryParams) bool {
+		return q.SearchDepth == defaultSearchDepth
+	})).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{makeTestTrace()}, nil)
+		})).Once()
+
+	responseStream, err := tsc.client.FindTraces(context.Background(), &api_v3.FindTracesRequest{
+		Query: &api_v3.TraceQueryParameters{
+			ServiceName:  "myservice",
+			StartTimeMin: time.Now().Add(-2 * time.Hour),
+			StartTimeMax: time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	recv, err := responseStream.Recv()
+	require.NoError(t, err)
+	td := recv.ToTraces()
+	require.Equal(t, 1, td.SpanCount())
+	tsc.reader.AssertExpectations(t)
+}
+
 func TestFindTracesSendError(t *testing.T) {
 	reader := new(tracestoremocks.Reader)
 	reader.On("FindTraces", mock.Anything, mock.AnythingOfType("tracestore.TraceQueryParams")).
@@ -490,6 +544,39 @@ func TestGetDependencies(t *testing.T) {
 	assert.Equal(t, "frontend", response.GetDependencies()[0].Parent)
 	assert.Equal(t, "backend", response.GetDependencies()[0].Child)
 	assert.Equal(t, uint64(100), response.GetDependencies()[0].CallCount)
+}
+
+func TestGetDependenciesSortsLinks(t *testing.T) {
+	tsc := newTestServerClient(t)
+	endTime := time.Now().UTC()
+	lookback := 24 * time.Hour
+
+	// Returned in an order that is not sorted, mimicking the unstable map
+	// iteration order the storage layer builds dependency links from.
+	unsortedDeps := []model.DependencyLink{
+		{Parent: "frontend", Child: "redis", CallCount: 1},
+		{Parent: "backend", Child: "mysql", CallCount: 2},
+		{Parent: "frontend", Child: "backend", CallCount: 3},
+	}
+	tsc.depsReader.On("GetDependencies", matchContext, mock.Anything).
+		Return(unsortedDeps, nil).Once()
+
+	response, err := tsc.client.GetDependencies(context.Background(), &api_v3.GetDependenciesRequest{
+		StartTime: endTime.Add(-lookback),
+		EndTime:   endTime,
+	})
+	require.NoError(t, err)
+
+	got := make([][2]string, 0, len(response.GetDependencies()))
+	for _, d := range response.GetDependencies() {
+		got = append(got, [2]string{d.Parent, d.Child})
+	}
+	want := [][2]string{
+		{"backend", "mysql"},
+		{"frontend", "backend"},
+		{"frontend", "redis"},
+	}
+	assert.Equal(t, want, got)
 }
 
 func TestGetDependenciesStorageError(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -5,7 +5,6 @@ package apiv3
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/jiter"
 	"github.com/jaegertracing/jaeger/internal/jptrace"
@@ -85,9 +85,14 @@ func (h *HTTPGateway) tryHandleError(w http.ResponseWriter, err error, statusCod
 			Message:  err.Error(),
 		},
 	}
-	resp, _ := json.Marshal(&errorResponse)
-	http.Error(w, string(resp), statusCode)
+	h.writeError(w, statusCode, &errorResponse)
 	return true
+}
+
+func (h *HTTPGateway) writeError(w http.ResponseWriter, statusCode int, response any) {
+	if err := httpjson.WriteError(w, statusCode, response); err != nil {
+		h.Logger.Error("Failed to write HTTP error response", zap.Error(err))
+	}
 }
 
 // tryParamError is similar to tryHandleError but specifically for reporting malformed params.
@@ -117,8 +122,7 @@ func (h *HTTPGateway) returnTraces(traces []ptrace.Traces, err error, w http.Res
 				Message:  "No traces found",
 			},
 		}
-		resp, _ := json.Marshal(&errorResponse)
-		http.Error(w, string(resp), http.StatusNotFound)
+		h.writeError(w, http.StatusNotFound, &errorResponse)
 		return
 	}
 	// TODO: the response should be streamed back to the client

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -102,7 +102,11 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.False(t, gw.tryHandleError(nil, nil, 0), "returns false if no error")
 
 	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
 	assert.True(t, gw.tryHandleError(w, spanstore.ErrTraceNotFound, 0), "returns true if error")
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 	assert.Equal(t, http.StatusNotFound, w.Code, "sets status code to 404")
 
 	logger, log := testutils.NewLogger()
@@ -112,6 +116,28 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.True(t, gw.tryHandleError(w, errors.New(e), http.StatusInternalServerError))
 	assert.Contains(t, log.String(), e, "logs error if status code is 500")
 	assert.Contains(t, string(w.Body.String()), e, "writes error message to body")
+}
+
+func TestHTTPGatewayLogsErrorResponseWriteFailure(t *testing.T) {
+	logger, log := testutils.NewLogger()
+	gw := &HTTPGateway{Logger: logger}
+
+	gw.writeError(&httpResponseErrWriter{}, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	assert.Contains(t, log.String(), "Failed to write HTTP error response")
+	assert.Contains(t, log.String(), "failed to write")
+}
+
+type httpResponseErrWriter struct{}
+
+func (*httpResponseErrWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (*httpResponseErrWriter) WriteHeader(int) {}
+
+func (*httpResponseErrWriter) Write([]byte) (int, error) {
+	return 0, errors.New("failed to write")
 }
 
 func TestHTTPGatewayGetTrace(t *testing.T) {
@@ -246,6 +272,7 @@ func TestHTTPGatewayGetTraceEmptyResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	assert.Contains(t, w.Body.String(), "No traces found")
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -6,7 +6,6 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +23,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3"
 	deepdependencies "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/qualitymetrics"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
@@ -555,8 +555,9 @@ func (aH *APIHandler) handleError(w http.ResponseWriter, err error, statusCode i
 			},
 		},
 	}
-	resp, _ := json.Marshal(&structuredResp)
-	http.Error(w, string(resp), statusCode)
+	if err := httpjson.WriteError(w, statusCode, &structuredResp); err != nil {
+		aH.logger.Error("Failed to write HTTP error response", zap.Error(err))
+	}
 	return true
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -44,6 +44,7 @@ import (
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"github.com/jaegertracing/jaeger/internal/testutils"
 	ui "github.com/jaegertracing/jaeger/internal/uimodel"
 )
 
@@ -281,6 +282,30 @@ func TestLogOnServerError(t *testing.T) {
 	assert.Equal(t, "HTTP handler, Internal Server Error", log.Message)
 	require.Len(t, log.Context, 1)
 	assert.Equal(t, e, log.Context[0].Interface)
+}
+
+func TestHandleErrorWritesJSONContentType(t *testing.T) {
+	h := NewAPIHandler(nil)
+	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
+
+	h.handleError(w, errors.New("test error"), http.StatusBadRequest)
+
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.JSONEq(t, `{"data":null,"errors":[{"code":400,"msg":"test error"}],"total":0,"limit":0,"offset":0}`, w.Body.String())
+}
+
+func TestHandleErrorLogsWriteFailure(t *testing.T) {
+	logger, log := testutils.NewLogger()
+	h := NewAPIHandler(nil, HandlerOptions.Logger(logger))
+
+	h.handleError(&httpResponseErrWriter{}, errors.New("test error"), http.StatusBadRequest)
+
+	assert.Contains(t, log.String(), "Failed to write HTTP error response")
+	assert.Contains(t, log.String(), "failed to write")
 }
 
 // httpResponseErrWriter implements the http.ResponseWriter interface that returns an error on Write.
@@ -667,6 +692,19 @@ func TestSearchFailures(t *testing.T) {
 		{
 			`/api/traces?service=service&start=0&end=0&operation=operation&maxDuration=10ms&limit=200&minDuration=20ms`,
 			parsedError(400, "'maxDuration' should be greater than 'minDuration'"),
+		},
+		{
+			`/api/traces?service=service&start=0&end=0&operation=operation&limit=0`,
+			parsedError(400, "parameter 'limit' must be greater than 0"),
+		},
+		{
+			`/api/traces?service=service&start=0&end=0&operation=operation&limit=-1`,
+			parsedError(400, "parameter 'limit' must be greater than 0"),
+		},
+		{
+			// start=1000 microseconds after epoch is after end=0 (epoch)
+			`/api/traces?service=service&start=1000&end=0&operation=operation&limit=200`,
+			parsedError(400, "'start' must not be later than 'end'"),
 		},
 	}
 	for _, test := range tests {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpjson provides JSON response helpers for Jaeger Query HTTP APIs.
+package httpjson
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// WriteError writes an error response with a JSON body. It must be called before
+// the response is committed.
+func WriteError(w http.ResponseWriter, statusCode int, response any) error {
+	body, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON error response: %w", err)
+	}
+	body = append(body, '\n')
+
+	w.Header().Del("Content-Length")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(statusCode)
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("failed to write JSON error response: %w", err)
+	}
+	return nil
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package httpjson
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}
+
+func TestWriteError(t *testing.T) {
+	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
+
+	err := WriteError(w, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	require.NoError(t, err)
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.JSONEq(t, `{"error":"test error"}`, w.Body.String())
+}
+
+func TestWriteErrorMarshalFailureDoesNotCommitResponse(t *testing.T) {
+	w := &failingResponseWriter{header: http.Header{"Content-Length": []string{"1"}}}
+
+	err := WriteError(w, http.StatusBadRequest, make(chan int))
+
+	require.ErrorContains(t, err, "failed to marshal JSON error response")
+	assert.Zero(t, w.statusCode)
+	assert.Equal(t, "1", w.Header().Get("Content-Length"))
+	assert.Empty(t, w.Header().Get("Content-Type"))
+}
+
+func TestWriteErrorWriteFailure(t *testing.T) {
+	writeErr := errors.New("write failed")
+	w := &failingResponseWriter{header: make(http.Header), writeErr: writeErr}
+
+	err := WriteError(w, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	require.ErrorIs(t, err, writeErr)
+	assert.Equal(t, http.StatusBadRequest, w.statusCode)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+}
+
+type failingResponseWriter struct {
+	header     http.Header
+	statusCode int
+	writeErr   error
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	return 0, w.writeErr
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -42,6 +42,12 @@ var (
 
 	// errServiceParameterRequired occurs when no service name is defined.
 	errServiceParameterRequired = fmt.Errorf("parameter '%s' is required", serviceParam)
+
+	// errLimitMustBePositive occurs when the limit parameter is zero or negative.
+	errLimitMustBePositive = fmt.Errorf("parameter '%s' must be greater than 0", limitParam)
+
+	// errStartTimeAfterEnd occurs when the start time is after the end time.
+	errStartTimeAfterEnd = fmt.Errorf("'%s' must not be later than '%s'", startTimeParam, endTimeParam)
 )
 
 type (
@@ -361,6 +367,12 @@ func mapSpanKindsToOpenTelemetry(spanKinds []string) ([]string, error) {
 func (*queryParser) validateQuery(traceQuery *traceQueryParameters) error {
 	if len(traceQuery.TraceIDs) == 0 && traceQuery.ServiceName == "" {
 		return errServiceParameterRequired
+	}
+	if len(traceQuery.TraceIDs) == 0 && traceQuery.SearchDepth <= 0 {
+		return errLimitMustBePositive
+	}
+	if len(traceQuery.TraceIDs) == 0 && traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {
+		return errStartTimeAfterEnd
 	}
 	if traceQuery.DurationMin != 0 && traceQuery.DurationMax != 0 {
 		if traceQuery.DurationMax < traceQuery.DurationMin {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -39,6 +39,10 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", `unable to parse param 'maxDuration': time: missing unit in duration "?30"?$`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `malformed 'tag' parameter, expecting key:value, received: k`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=25s&maxDuration=1s", `'maxDuration' should be greater than 'minDuration'`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=0", `parameter 'limit' must be greater than 0`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=-1", `parameter 'limit' must be greater than 0`, nil},
+		// start=1000 (1ms since epoch) is after end=0 (epoch)
+		{"x?service=service&start=1000&end=0&operation=operation&limit=200", `'start' must not be later than 'end'`, nil},
 		{
 			"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
 			&traceQueryParameters{
@@ -219,6 +223,17 @@ func TestParseTraceQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateQuerySkipsLimitAndTimeChecksForTraceIDOnly(t *testing.T) {
+	timeNow := time.Now()
+	request, err := http.NewRequest(http.MethodGet, "x?traceID=abc123", http.NoBody)
+	require.NoError(t, err)
+
+	parser := &queryParser{timeNow: func() time.Time { return timeNow }}
+	query, err := parser.parseTraceQueryParams(request)
+	require.NoError(t, err)
+	require.Len(t, query.TraceIDs, 1)
 }
 
 func TestParseBool(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR bundles four related query API fixes:

- **api_v3 GetDependencies ordering** (#9126): Sort dependency links by `(parent, child)` before returning so gRPC responses are deterministic regardless of storage map iteration order.
- **api_v3 gRPC search_depth default** (#9099): Default unset/zero/negative `search_depth` to `defaultSearchDepth` (100), matching the HTTP gateway and preventing in-memory storage from rejecting literal `0`.
- **HTTP JSON error content-type** (#9051): Introduce a shared `httpjson.WriteError` helper so legacy `/api/*` and `/api/v3/*` error responses use `Content-Type: application/json` instead of `text/plain` from `http.Error`.
- **HTTP query parameter validation** (#8436): Return HTTP 400 for invalid `limit` (≤ 0) and inverted time ranges (`start > end`) before requests reach storage.

## Test plan

- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...`
- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/...`
- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/...`
- [x] New unit tests for dependency sorting, search_depth defaulting, JSON error headers, and query parser validation