### PR TITLE
fix(apiv3): Sort dependency links for deterministic ordering

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -4,9 +4,11 @@
 package apiv3
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"iter"
+	"slices"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"google.golang.org/grpc/codes"
@@ -204,6 +206,14 @@ func (h *Handler) GetDependencies(ctx context.Context, request *api_v3.GetDepend
 	if err != nil {
 		return nil, err
 	}
+	// Sort the links so the response order is deterministic; the storage layer
+	// builds dependency links from a map, whose iteration order is not stable.
+	slices.SortFunc(deps, func(a, b model.DependencyLink) int {
+		if c := cmp.Compare(a.Parent, b.Parent); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Child, b.Child)
+	})
 	links := make([]*api_v3.Dependency, len(deps))
 	for i, dep := range deps {
 		links[i] = &api_v3.Dependency{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -492,6 +492,39 @@ func TestGetDependencies(t *testing.T) {
 	assert.Equal(t, uint64(100), response.GetDependencies()[0].CallCount)
 }
 
+func TestGetDependenciesSortsLinks(t *testing.T) {
+	tsc := newTestServerClient(t)
+	endTime := time.Now().UTC()
+	lookback := 24 * time.Hour
+
+	// Returned in an order that is not sorted, mimicking the unstable map
+	// iteration order the storage layer builds dependency links from.
+	unsortedDeps := []model.DependencyLink{
+		{Parent: "frontend", Child: "redis", CallCount: 1},
+		{Parent: "backend", Child: "mysql", CallCount: 2},
+		{Parent: "frontend", Child: "backend", CallCount: 3},
+	}
+	tsc.depsReader.On("GetDependencies", matchContext, mock.Anything).
+		Return(unsortedDeps, nil).Once()
+
+	response, err := tsc.client.GetDependencies(context.Background(), &api_v3.GetDependenciesRequest{
+		StartTime: endTime.Add(-lookback),
+		EndTime:   endTime,
+	})
+	require.NoError(t, err)
+
+	got := make([][2]string, 0, len(response.GetDependencies()))
+	for _, d := range response.GetDependencies() {
+		got = append(got, [2]string{d.Parent, d.Child})
+	}
+	want := [][2]string{
+		{"backend", "mysql"},
+		{"frontend", "backend"},
+		{"frontend", "redis"},
+	}
+	assert.Equal(t, want, got)
+}
+
 func TestGetDependenciesStorageError(t *testing.T) {
 	tsc := newTestServerClient(t)
 	tsc.depsReader.On("GetDependencies", matchContext, mock.Anything).Return(


### PR DESCRIPTION
## Summary

- Sort `GetDependencies` response links by `(parent, child)` before returning
- Storage builds links from a map with unstable iteration order, causing nondeterministic gRPC responses

Fixes #9126

## Test plan

- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/... -run GetDependencies`
- [x] Added `TestGetDependenciesSortsLinks`