### PR TITLE
fix(query): Default search_depth in api_v3 gRPC handler

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -82,7 +82,10 @@ func (h *Handler) internalFindTraces(
 }
 
 // traceQueryParams converts a proto TraceQueryParameters to querysvc.TraceQueryParams,
-// validating that the required time range fields are present.
+// validating that the required time range fields are present. An unset (or
+// non-positive) search_depth defaults to defaultSearchDepth, mirroring the
+// HTTP gateway: proto3 cannot distinguish an omitted field from 0, and a
+// literal 0 is rejected by some storage backends (e.g. the in-memory store).
 func traceQueryParams(query *api_v3.TraceQueryParameters) (querysvc.TraceQueryParams, error) {
 	if query == nil {
 		return querysvc.TraceQueryParams{}, status.Error(codes.InvalidArgument, "missing query")
@@ -90,12 +93,16 @@ func traceQueryParams(query *api_v3.TraceQueryParameters) (querysvc.TraceQueryPa
 	if query.GetStartTimeMin().IsZero() || query.GetStartTimeMax().IsZero() {
 		return querysvc.TraceQueryParams{}, status.Error(codes.InvalidArgument, "start time min and max are required parameters")
 	}
+	searchDepth := int(query.GetSearchDepth())
+	if searchDepth <= 0 {
+		searchDepth = defaultSearchDepth
+	}
 	queryParams := querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
 			Attributes:    jptrace.PlainMapToPcommonMap(query.GetAttributes()),
-			SearchDepth:   int(query.GetSearchDepth()),
+			SearchDepth:   searchDepth,
 			StartTimeMin:  query.GetStartTimeMin(),
 			StartTimeMax:  query.GetStartTimeMax(),
 			DurationMin:   query.GetDurationMin(),

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -261,6 +261,60 @@ func TestFindTraces(t *testing.T) {
 	require.Equal(t, 1, td.SpanCount())
 }
 
+func TestTraceQueryParamsSearchDepth(t *testing.T) {
+	baseQuery := func() *api_v3.TraceQueryParameters {
+		return &api_v3.TraceQueryParameters{
+			StartTimeMin: time.Now().Add(-2 * time.Hour),
+			StartTimeMax: time.Now(),
+		}
+	}
+	tests := []struct {
+		name        string
+		searchDepth int32
+		expected    int
+	}{
+		{name: "unset defaults", searchDepth: 0, expected: defaultSearchDepth},
+		{name: "negative defaults", searchDepth: -1, expected: defaultSearchDepth},
+		{name: "explicit value preserved", searchDepth: 42, expected: 42},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query := baseQuery()
+			query.SearchDepth = test.searchDepth
+			params, err := traceQueryParams(query)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, params.SearchDepth)
+		})
+	}
+}
+
+func TestFindTracesDefaultsSearchDepth(t *testing.T) {
+	// A FindTraces request without search_depth (proto3 default 0) must reach
+	// the storage backend with the default search depth, matching the HTTP
+	// gateway. Some backends (e.g. the in-memory store) reject a literal 0.
+	tsc := newTestServerClient(t)
+	tsc.reader.On("FindTraces", matchContext, mock.MatchedBy(func(q tracestore.TraceQueryParams) bool {
+		return q.SearchDepth == defaultSearchDepth
+	})).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield([]ptrace.Traces{makeTestTrace()}, nil)
+		})).Once()
+
+	responseStream, err := tsc.client.FindTraces(context.Background(), &api_v3.FindTracesRequest{
+		Query: &api_v3.TraceQueryParameters{
+			ServiceName:  "myservice",
+			StartTimeMin: time.Now().Add(-2 * time.Hour),
+			StartTimeMax: time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	recv, err := responseStream.Recv()
+	require.NoError(t, err)
+	td := recv.ToTraces()
+	require.Equal(t, 1, td.SpanCount())
+	tsc.reader.AssertExpectations(t)
+}
+
 func TestFindTracesSendError(t *testing.T) {
 	reader := new(tracestoremocks.Reader)
 	reader.On("FindTraces", mock.Anything, mock.AnythingOfType("tracestore.TraceQueryParams")).


### PR DESCRIPTION
## Summary

- Default unset, zero, or negative `search_depth` to `defaultSearchDepth` (100) in the api_v3 gRPC `traceQueryParams` converter
- Matches existing HTTP gateway behavior
- Prevents `FindTraces` failures against in-memory storage when `search_depth` is omitted

Fixes #9099

## Test plan

- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...`
- [x] Added `TestTraceQueryParamsSearchDepth` and `TestFindTracesDefaultsSearchDepth`