### PR TITLE
fix(query): Return JSON HTTP errors and validate query parameters

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -5,7 +5,6 @@ package apiv3
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/jiter"
 	"github.com/jaegertracing/jaeger/internal/jptrace"
@@ -85,9 +85,14 @@ func (h *HTTPGateway) tryHandleError(w http.ResponseWriter, err error, statusCod
 			Message:  err.Error(),
 		},
 	}
-	resp, _ := json.Marshal(&errorResponse)
-	http.Error(w, string(resp), statusCode)
+	h.writeError(w, statusCode, &errorResponse)
 	return true
+}
+
+func (h *HTTPGateway) writeError(w http.ResponseWriter, statusCode int, response any) {
+	if err := httpjson.WriteError(w, statusCode, response); err != nil {
+		h.Logger.Error("Failed to write HTTP error response", zap.Error(err))
+	}
 }
 
 // tryParamError is similar to tryHandleError but specifically for reporting malformed params.
@@ -117,8 +122,7 @@ func (h *HTTPGateway) returnTraces(traces []ptrace.Traces, err error, w http.Res
 				Message:  "No traces found",
 			},
 		}
-		resp, _ := json.Marshal(&errorResponse)
-		http.Error(w, string(resp), http.StatusNotFound)
+		h.writeError(w, http.StatusNotFound, &errorResponse)
 		return
 	}
 	// TODO: the response should be streamed back to the client

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -102,7 +102,11 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.False(t, gw.tryHandleError(nil, nil, 0), "returns false if no error")
 
 	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
 	assert.True(t, gw.tryHandleError(w, spanstore.ErrTraceNotFound, 0), "returns true if error")
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 	assert.Equal(t, http.StatusNotFound, w.Code, "sets status code to 404")
 
 	logger, log := testutils.NewLogger()
@@ -112,6 +116,28 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.True(t, gw.tryHandleError(w, errors.New(e), http.StatusInternalServerError))
 	assert.Contains(t, log.String(), e, "logs error if status code is 500")
 	assert.Contains(t, string(w.Body.String()), e, "writes error message to body")
+}
+
+func TestHTTPGatewayLogsErrorResponseWriteFailure(t *testing.T) {
+	logger, log := testutils.NewLogger()
+	gw := &HTTPGateway{Logger: logger}
+
+	gw.writeError(&httpResponseErrWriter{}, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	assert.Contains(t, log.String(), "Failed to write HTTP error response")
+	assert.Contains(t, log.String(), "failed to write")
+}
+
+type httpResponseErrWriter struct{}
+
+func (*httpResponseErrWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (*httpResponseErrWriter) WriteHeader(int) {}
+
+func (*httpResponseErrWriter) Write([]byte) (int, error) {
+	return 0, errors.New("failed to write")
 }
 
 func TestHTTPGatewayGetTrace(t *testing.T) {
@@ -246,6 +272,7 @@ func TestHTTPGatewayGetTraceEmptyResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 	gw.router.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	assert.Contains(t, w.Body.String(), "No traces found")
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -6,7 +6,6 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +23,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3"
 	deepdependencies "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/ddg"
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/qualitymetrics"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
 	"github.com/jaegertracing/jaeger/internal/proto-gen/api_v2/metrics"
@@ -555,8 +555,9 @@ func (aH *APIHandler) handleError(w http.ResponseWriter, err error, statusCode i
 			},
 		},
 	}
-	resp, _ := json.Marshal(&structuredResp)
-	http.Error(w, string(resp), statusCode)
+	if err := httpjson.WriteError(w, statusCode, &structuredResp); err != nil {
+		aH.logger.Error("Failed to write HTTP error response", zap.Error(err))
+	}
 	return true
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler_test.go
@@ -44,6 +44,7 @@ import (
 	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/v1adapter"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
+	"github.com/jaegertracing/jaeger/internal/testutils"
 	ui "github.com/jaegertracing/jaeger/internal/uimodel"
 )
 
@@ -281,6 +282,30 @@ func TestLogOnServerError(t *testing.T) {
 	assert.Equal(t, "HTTP handler, Internal Server Error", log.Message)
 	require.Len(t, log.Context, 1)
 	assert.Equal(t, e, log.Context[0].Interface)
+}
+
+func TestHandleErrorWritesJSONContentType(t *testing.T) {
+	h := NewAPIHandler(nil)
+	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
+
+	h.handleError(w, errors.New("test error"), http.StatusBadRequest)
+
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.JSONEq(t, `{"data":null,"errors":[{"code":400,"msg":"test error"}],"total":0,"limit":0,"offset":0}`, w.Body.String())
+}
+
+func TestHandleErrorLogsWriteFailure(t *testing.T) {
+	logger, log := testutils.NewLogger()
+	h := NewAPIHandler(nil, HandlerOptions.Logger(logger))
+
+	h.handleError(&httpResponseErrWriter{}, errors.New("test error"), http.StatusBadRequest)
+
+	assert.Contains(t, log.String(), "Failed to write HTTP error response")
+	assert.Contains(t, log.String(), "failed to write")
 }
 
 // httpResponseErrWriter implements the http.ResponseWriter interface that returns an error on Write.
@@ -667,6 +692,19 @@ func TestSearchFailures(t *testing.T) {
 		{
 			`/api/traces?service=service&start=0&end=0&operation=operation&maxDuration=10ms&limit=200&minDuration=20ms`,
 			parsedError(400, "'maxDuration' should be greater than 'minDuration'"),
+		},
+		{
+			`/api/traces?service=service&start=0&end=0&operation=operation&limit=0`,
+			parsedError(400, "parameter 'limit' must be greater than 0"),
+		},
+		{
+			`/api/traces?service=service&start=0&end=0&operation=operation&limit=-1`,
+			parsedError(400, "parameter 'limit' must be greater than 0"),
+		},
+		{
+			// start=1000 microseconds after epoch is after end=0 (epoch)
+			`/api/traces?service=service&start=1000&end=0&operation=operation&limit=200`,
+			parsedError(400, "'start' must not be later than 'end'"),
 		},
 	}
 	for _, test := range tests {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpjson provides JSON response helpers for Jaeger Query HTTP APIs.
+package httpjson
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// WriteError writes an error response with a JSON body. It must be called before
+// the response is committed.
+func WriteError(w http.ResponseWriter, statusCode int, response any) error {
+	body, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON error response: %w", err)
+	}
+	body = append(body, '\n')
+
+	w.Header().Del("Content-Length")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(statusCode)
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("failed to write JSON error response: %w", err)
+	}
+	return nil
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/error_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package httpjson
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.VerifyGoLeaks(m)
+}
+
+func TestWriteError(t *testing.T) {
+	w := httptest.NewRecorder()
+	w.Header().Set("Content-Length", "1")
+
+	err := WriteError(w, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	require.NoError(t, err)
+	assert.Empty(t, w.Header().Get("Content-Length"))
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.JSONEq(t, `{"error":"test error"}`, w.Body.String())
+}
+
+func TestWriteErrorMarshalFailureDoesNotCommitResponse(t *testing.T) {
+	w := &failingResponseWriter{header: http.Header{"Content-Length": []string{"1"}}}
+
+	err := WriteError(w, http.StatusBadRequest, make(chan int))
+
+	require.ErrorContains(t, err, "failed to marshal JSON error response")
+	assert.Zero(t, w.statusCode)
+	assert.Equal(t, "1", w.Header().Get("Content-Length"))
+	assert.Empty(t, w.Header().Get("Content-Type"))
+}
+
+func TestWriteErrorWriteFailure(t *testing.T) {
+	writeErr := errors.New("write failed")
+	w := &failingResponseWriter{header: make(http.Header), writeErr: writeErr}
+
+	err := WriteError(w, http.StatusBadRequest, map[string]string{"error": "test error"})
+
+	require.ErrorIs(t, err, writeErr)
+	assert.Equal(t, http.StatusBadRequest, w.statusCode)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+}
+
+type failingResponseWriter struct {
+	header     http.Header
+	statusCode int
+	writeErr   error
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	return 0, w.writeErr
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser.go
@@ -42,6 +42,12 @@ var (
 
 	// errServiceParameterRequired occurs when no service name is defined.
 	errServiceParameterRequired = fmt.Errorf("parameter '%s' is required", serviceParam)
+
+	// errLimitMustBePositive occurs when the limit parameter is zero or negative.
+	errLimitMustBePositive = fmt.Errorf("parameter '%s' must be greater than 0", limitParam)
+
+	// errStartTimeAfterEnd occurs when the start time is after the end time.
+	errStartTimeAfterEnd = fmt.Errorf("'%s' must not be later than '%s'", startTimeParam, endTimeParam)
 )
 
 type (
@@ -361,6 +367,12 @@ func mapSpanKindsToOpenTelemetry(spanKinds []string) ([]string, error) {
 func (*queryParser) validateQuery(traceQuery *traceQueryParameters) error {
 	if len(traceQuery.TraceIDs) == 0 && traceQuery.ServiceName == "" {
 		return errServiceParameterRequired
+	}
+	if len(traceQuery.TraceIDs) == 0 && traceQuery.SearchDepth <= 0 {
+		return errLimitMustBePositive
+	}
+	if len(traceQuery.TraceIDs) == 0 && traceQuery.StartTimeMin.After(traceQuery.StartTimeMax) {
+		return errStartTimeAfterEnd
 	}
 	if traceQuery.DurationMin != 0 && traceQuery.DurationMax != 0 {
 		if traceQuery.DurationMax < traceQuery.DurationMin {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/query_parser_test.go
@@ -39,6 +39,10 @@ func TestParseTraceQuery(t *testing.T) {
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=20s&maxDuration=30", `unable to parse param 'maxDuration': time: missing unit in duration "?30"?$`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y&tag=k&log=k:v&log=k", `malformed 'tag' parameter, expecting key:value, received: k`, nil},
 		{"x?service=service&start=0&end=0&operation=operation&limit=200&minDuration=25s&maxDuration=1s", `'maxDuration' should be greater than 'minDuration'`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=0", `parameter 'limit' must be greater than 0`, nil},
+		{"x?service=service&start=0&end=0&operation=operation&limit=-1", `parameter 'limit' must be greater than 0`, nil},
+		// start=1000 (1ms since epoch) is after end=0 (epoch)
+		{"x?service=service&start=1000&end=0&operation=operation&limit=200", `'start' must not be later than 'end'`, nil},
 		{
 			"x?service=service&start=0&end=0&operation=operation&limit=200&tag=k:v&tag=x:y", noErr,
 			&traceQueryParameters{
@@ -219,6 +223,17 @@ func TestParseTraceQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateQuerySkipsLimitAndTimeChecksForTraceIDOnly(t *testing.T) {
+	timeNow := time.Now()
+	request, err := http.NewRequest(http.MethodGet, "x?traceID=abc123", http.NoBody)
+	require.NoError(t, err)
+
+	parser := &queryParser{timeNow: func() time.Time { return timeNow }}
+	query, err := parser.parseTraceQueryParams(request)
+	require.NoError(t, err)
+	require.Len(t, query.TraceIDs, 1)
 }
 
 func TestParseBool(t *testing.T) {


### PR DESCRIPTION
## Summary

### Fixes #9051 (complete)

Query HTTP APIs (`/api/*` and `/api/v3/*`) serialized error bodies as JSON but sent them via `http.Error`, which forces `Content-Type: text/plain`. This introduces `httpjson.WriteError` and uses it from both the legacy handler and the api_v3 HTTP gateway so error responses declare `application/json`.

### Addresses #8436 (partial — legacy `/api/traces` only)

Adds early validation in the legacy query parser so invalid client input returns HTTP 400 instead of reaching storage:

- `limit=0` or `limit=-1` → 400 (`parameter 'limit' must be greater than 0`)
- `start > end` on service-based searches → 400 (`'start' must not be later than 'end'`)

**Not in scope:** #8436 bug 3 (api_v3 HTTP inverted time range) is already handled in `apiv3/query_parser.go` (`query.startTimeMin must be before query.startTimeMax`). gRPC inverted time ranges are a separate gap.

Related open PRs: #9060 (content-type only), #8692 (validation only). This PR combines both.

## Test plan

- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/httpjson/...`
- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...`
- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/...`
- [x] Tests assert `Content-Type: application/json`, `limit` validation, and inverted time range