### PR TITLE
fix(mcp): Reject negative durations in search_traces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -144,11 +144,17 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 		if err != nil {
 			return querysvc.TraceQueryParams{}, fmt.Errorf("invalid duration_min: %w", err)
 		}
+		if durationMin < 0 {
+			return querysvc.TraceQueryParams{}, errors.New("invalid duration_min: duration cannot be negative")
+		}
 	}
 	if input.DurationMax != "" {
 		durationMax, err = time.ParseDuration(input.DurationMax)
 		if err != nil {
 			return querysvc.TraceQueryParams{}, fmt.Errorf("invalid duration_max: %w", err)
+		}
+		if durationMax < 0 {
+			return querysvc.TraceQueryParams{}, errors.New("invalid duration_max: duration cannot be negative")
 		}
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -475,6 +475,81 @@ func TestSearchTracesHandler_Handle_DurationMaxLessThanMin(t *testing.T) {
 	assert.Contains(t, err.Error(), "duration_max must be greater than duration_min")
 }
 
+func TestSearchTracesHandler_Handle_DurationValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		durationMin string
+		durationMax string
+		wantErr     string
+	}{
+		{
+			name:        "negative duration_min",
+			durationMin: "-5s",
+			wantErr:     "invalid duration_min: duration cannot be negative",
+		},
+		{
+			name:        "negative duration_max",
+			durationMax: "-10s",
+			wantErr:     "invalid duration_max: duration cannot be negative",
+		},
+		{
+			name:        "both negative",
+			durationMin: "-5s",
+			durationMax: "-10s",
+			wantErr:     "invalid duration_min: duration cannot be negative",
+		},
+		{
+			name:        "max less than min",
+			durationMin: "10s",
+			durationMax: "5s",
+			wantErr:     "duration_max must be greater than duration_min",
+		},
+		{
+			name:        "only min provided",
+			durationMin: "5s",
+		},
+		{
+			name:        "only max provided",
+			durationMax: "10s",
+		},
+		{
+			name:        "valid range",
+			durationMin: "2s",
+			durationMax: "10s",
+		},
+		{
+			name:        "zero durations",
+			durationMin: "0s",
+			durationMax: "0s",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockQueryService{
+				findTraceSummariesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+					return func(yield func([]tracestore.TraceSummary, error) bool) {
+						yield(nil, nil)
+					}
+				},
+			}
+			handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+			input := types.SearchTracesInput{
+				StartTimeMin: "-1h",
+				ServiceName:  "test",
+				DurationMin:  tt.durationMin,
+				DurationMax:  tt.durationMax,
+			}
+			_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestParseTimeParam(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

Fixes #8856.

The `search_traces` MCP tool accepted negative `duration_min` / `duration_max` values (e.g. `"-5s"`). Because the existing range check only runs when both durations are `> 0`, negative values bypassed validation and were passed to storage.

This adds fail-fast validation immediately after `time.ParseDuration` succeeds.

## Changes

- Reject negative `duration_min` with `invalid duration_min: duration cannot be negative`
- Reject negative `duration_max` with `invalid duration_max: duration cannot be negative`
- Add table-driven `TestSearchTracesHandler_Handle_DurationValidation` (8 cases)

## Test plan

- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/... -run Duration`

## Note

Related open PR: #8962 (same fix). Happy to defer to that one if maintainers prefer — either works for me.