### PR TITLE
fix(jaegerai): enforce model context limit for massive trace context (#8801)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -40,6 +40,7 @@ const (
 	DefaultAIMaxRequestBodySize  int64 = 1 << 20 // 1 MiB
 	DefaultAIHealthCheckInterval       = 30 * time.Second
 	DefaultAIHealthCheckTimeout        = 2 * time.Second
+	DefaultAIModelContextLimit         = 8192
 )
 
 // AIConfig is the AI-related slice of QueryOptions. All defaults are seeded
@@ -83,6 +84,10 @@ type AIConfig struct {
 	// HealthCheckTimeout is the per-check timeout. Must be positive when
 	// HealthCheckInterval > 0; ignored when the checker is disabled.
 	HealthCheckTimeout time.Duration `mapstructure:"health_check_timeout" valid:"optional"`
+	// ModelContextLimit is the maximum number of tokens the gateway estimates
+	// for the user prompt plus AG-UI context before rejecting or pruning trace
+	// payloads. Zero means use DefaultAIModelContextLimit.
+	ModelContextLimit int `mapstructure:"model_context_limit" valid:"optional"`
 }
 
 // DefaultOTLPProxyTarget is the loopback endpoint of the bundled OTel-collector
@@ -120,6 +125,9 @@ func (c *AIConfig) Validate() error {
 	}
 	if c.HealthCheckInterval > 0 && c.HealthCheckTimeout <= 0 {
 		return errors.New("ai.health_check_timeout must be positive when health_check_interval is positive")
+	}
+	if c.ModelContextLimit < 0 {
+		return errors.New("ai.model_context_limit must not be negative")
 	}
 	if c.MCPBaseURL != "" {
 		// Reject anything we cannot turn into a dialable absolute URL. A relative
@@ -301,6 +309,7 @@ func DefaultQueryOptions() QueryOptions {
 			MaxRequestBodySize:  DefaultAIMaxRequestBodySize,
 			HealthCheckInterval: DefaultAIHealthCheckInterval,
 			HealthCheckTimeout:  DefaultAIHealthCheckTimeout,
+			ModelContextLimit:   DefaultAIModelContextLimit,
 		}),
 		OTLPProxy: configoptional.Default(OTLPProxyConfig{
 			Target: DefaultOTLPProxyTarget,

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -26,6 +26,7 @@ func TestDefaultQueryOptions(t *testing.T) {
 	require.Equal(t, DefaultAIMaxRequestBodySize, aiCfg.MaxRequestBodySize)
 	require.Equal(t, DefaultAIHealthCheckInterval, aiCfg.HealthCheckInterval)
 	require.Equal(t, DefaultAIHealthCheckTimeout, aiCfg.HealthCheckTimeout)
+	require.Equal(t, DefaultAIModelContextLimit, aiCfg.ModelContextLimit)
 	require.NoError(t, aiCfg.Validate())
 
 	require.False(t, qo.OTLPProxy.HasValue())
@@ -49,6 +50,7 @@ func validAIConfig() AIConfig {
 		MaxRequestBodySize:  DefaultAIMaxRequestBodySize,
 		HealthCheckInterval: DefaultAIHealthCheckInterval,
 		HealthCheckTimeout:  DefaultAIHealthCheckTimeout,
+		ModelContextLimit:   DefaultAIModelContextLimit,
 	}
 }
 
@@ -284,6 +286,12 @@ func TestAIConfigValidateRejectsNonPositiveHealthCheckTimeoutWhenEnabled(t *test
 		require.EqualError(t, cfg.Validate(),
 			"ai.health_check_timeout must be positive when health_check_interval is positive")
 	}
+}
+
+func TestAIConfigValidateRejectsNegativeModelContextLimit(t *testing.T) {
+	cfg := validAIConfig()
+	cfg.ModelContextLimit = -1
+	require.EqualError(t, cfg.Validate(), "ai.model_context_limit must not be negative")
 }
 
 // TestHostIPUsesFirstResolvedAddress covers the name-resolution path. "localhost" is

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat.go
@@ -42,6 +42,7 @@ type chatEndpoint struct {
 	sidecarWSURL       string
 	basePath           string
 	maxRequestBodySize int64
+	modelContextLimit  int
 }
 
 // mcpServerName is the human-readable name the gateway gives its MCP server in the
@@ -77,7 +78,7 @@ func (h *chatEndpoint) announceMCP(caps acp.AgentCapabilities, mcpRouteID string
 // for consistency with sibling handlers even though ServeHTTP does not currently
 // read it. mcpBaseURL defaults to the zero value — the announcement stays off until
 // NewHandler enables it — so tests that do not exercise MCP need no extra wiring.
-func newChatEndpoint(logger *zap.Logger, ctxTools *ContextualToolsStore, turns *turnRegistry, sidecarWSURL, basePath string, maxRequestBodySize int64) *chatEndpoint {
+func newChatEndpoint(logger *zap.Logger, ctxTools *ContextualToolsStore, turns *turnRegistry, sidecarWSURL, basePath string, maxRequestBodySize int64, modelContextLimit int) *chatEndpoint {
 	return &chatEndpoint{
 		Logger:             logger,
 		ctxTools:           ctxTools,
@@ -85,6 +86,7 @@ func newChatEndpoint(logger *zap.Logger, ctxTools *ContextualToolsStore, turns *
 		sidecarWSURL:       sidecarWSURL,
 		basePath:           normalizeBasePath(basePath),
 		maxRequestBodySize: maxRequestBodySize,
+		modelContextLimit:  modelContextLimit,
 	}
 }
 
@@ -111,6 +113,12 @@ func (h *chatEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	prompt, err := latestUserMessageText(req.Messages)
 	if err != nil {
 		http.Error(w, "messages must include a user message with text content", http.StatusBadRequest)
+		return
+	}
+
+	req.Context, err = enforceModelContextLimit(prompt, req.Context, h.modelContextLimit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+	"github.com/jaegertracing/jaeger/internal/uimodel"
 	"github.com/jaegertracing/jaeger/internal/version"
 )
 
@@ -205,7 +206,7 @@ func TestChatEndpointSendsACPProtocolRequests(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -307,7 +308,7 @@ func TestChatEndpointSetsGenAISpanAttributesWithAgentInfo(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -331,7 +332,7 @@ func TestChatEndpointSetsGenAISpanAttributesWithoutAgentInfo(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -355,7 +356,7 @@ func TestChatEndpointInjectsTraceContextIntoPromptMeta(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -391,7 +392,7 @@ func TestChatEndpointRegistersTurnInRegistry(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	handler.turns = turns
 
 	reqBody, err := json.Marshal(newAGUIRequest("where is the latency"))
@@ -470,7 +471,7 @@ func TestChatEndpointAnnouncesMCPEndpoint(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20, DefaultModelContextLimit)
 	handler.mcpBaseURL = "https://jaeger.example.com:16686"
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
@@ -503,7 +504,7 @@ func TestChatEndpointAnnouncesNothingWhenMCPDisabled(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20) // no mcpServer
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit) // no mcpServer
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
@@ -532,7 +533,7 @@ func TestChatEndpointAnnouncesNothingWithoutBaseURL(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	// mcpBaseURL deliberately left empty — enable_mcp without ai.mcp_base_url.
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
@@ -552,7 +553,7 @@ func TestChatEndpointAppendsContextEntriesToPromptBlocks(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "where is the latency?"}},
@@ -591,7 +592,7 @@ func TestChatEndpointAttachesContextualToolsToMetaAndStore(t *testing.T) {
 	defer cleanup()
 
 	store := NewContextualToolsStore()
-	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "hello"}},
@@ -634,7 +635,7 @@ func TestChatEndpointOmitsMetaWhenNoTools(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), NewContextualToolsStore(), newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), NewContextualToolsStore(), newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
@@ -656,7 +657,7 @@ func TestChatEndpointEmitsRunFinishedWithStopReasonInResult(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(reqBody))
@@ -686,7 +687,7 @@ func TestChatEndpointPropagatesThreadAndRunIDs(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		ThreadID: "thread-xyz",
@@ -734,15 +735,16 @@ func (*failingFlusherResponseWriter) Flush() {}
 
 func TestNewChatEndpointPassesThroughConfig(t *testing.T) {
 	store := NewContextualToolsStore()
-	h := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://localhost:1", "/jaeger", 512)
+	h := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://localhost:1", "/jaeger", 512, DefaultModelContextLimit)
 	require.Equal(t, int64(512), h.maxRequestBodySize, "expected configured maxRequestBodySize")
 	require.Equal(t, "ws://localhost:1", h.sidecarWSURL, "expected configured sidecarWSURL")
 	require.Equal(t, "/jaeger", h.basePath, "expected configured basePath")
+	require.Equal(t, DefaultModelContextLimit, h.modelContextLimit, "expected configured modelContextLimit")
 	require.Same(t, store, h.ctxTools, "expected configured ctxTools store")
 }
 
 func TestChatEndpointMethodNotAllowed(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20, DefaultModelContextLimit)
 	req := httptest.NewRequest(http.MethodGet, "/api/ai/chat", http.NoBody)
 	rr := httptest.NewRecorder()
 
@@ -752,7 +754,7 @@ func TestChatEndpointMethodNotAllowed(t *testing.T) {
 }
 
 func TestChatEndpointBadRequest(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20, DefaultModelContextLimit)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader("{"))
 	rr := httptest.NewRecorder()
 
@@ -762,7 +764,7 @@ func TestChatEndpointBadRequest(t *testing.T) {
 }
 
 func TestChatEndpointEmptyPrompt(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("   "))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -775,7 +777,7 @@ func TestChatEndpointEmptyPrompt(t *testing.T) {
 }
 
 func TestChatEndpointNoUserMessage(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: "assistant", Content: "no user message in this run"}},
 	})
@@ -798,7 +800,7 @@ func TestChatEndpointRejectsBlankContextualToolName(t *testing.T) {
 	// validateContextualToolNames pin the function-level contract; this
 	// test pins that the handler wires the contract into the HTTP path.
 	store := NewContextualToolsStore()
-	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20, DefaultModelContextLimit)
 
 	body, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "hi"}},
@@ -822,7 +824,7 @@ func TestChatEndpointRejectsBlankContextualToolName(t *testing.T) {
 }
 
 func TestChatEndpointRequestBodyTooLarge(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 10)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 10, DefaultModelContextLimit)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader(`{"messages":[{"role":"user","content":"this body exceeds the 10 byte limit"}]}`))
 	rr := httptest.NewRecorder()
 
@@ -832,7 +834,7 @@ func TestChatEndpointRequestBodyTooLarge(t *testing.T) {
 }
 
 func TestChatEndpointDialFailure(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -848,7 +850,7 @@ func TestChatEndpointInitializeError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -865,7 +867,7 @@ func TestChatEndpointNewSessionError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -885,7 +887,7 @@ func TestChatEndpointPromptError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -922,7 +924,7 @@ func TestChatEndpointSessionUpdateStreamedBeforePromptReturns(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -944,7 +946,7 @@ func TestChatEndpointPromptErrorWriteFailure(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -971,7 +973,7 @@ func TestChatEndpointSessionCloseFiresWhenAgentAdvertisesCapability(t *testing.T
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -1003,7 +1005,7 @@ func TestChatEndpointSessionCloseErrorIsSwallowed(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -1028,7 +1030,7 @@ func TestChatEndpointSessionCloseSkippedWhenCapabilityAbsent(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, DefaultModelContextLimit)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -1038,4 +1040,50 @@ func TestChatEndpointSessionCloseSkippedWhenCapabilityAbsent(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "unexpected status code, body=%q", rr.Body.String())
 	require.Nil(t, agent.capturedCloseRequest(), "session/close must not fire when agent does not advertise the capability")
+}
+
+func TestChatEndpointModelContextLimitAndPruning(t *testing.T) {
+	agent := &mockACPAgent{}
+	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
+	defer cleanup()
+
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, 10)
+
+	body, err := json.Marshal(ChatRequest{
+		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "this user prompt is long and exceeds ten tokens"}},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), ErrModelContextExceeded.Error())
+
+	handlerOk := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20, 70)
+
+	trace := uimodel.Trace{
+		TraceID: "t1",
+		Spans: []uimodel.Span{
+			{SpanID: "root"},
+			{SpanID: "child", ParentSpanID: "root", Duration: 100},
+		},
+	}
+	traceBytes, err := json.Marshal(trace)
+	require.NoError(t, err)
+
+	body, err = json.Marshal(ChatRequest{
+		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "short prompt"}},
+		Context: []aguitypes.Context{
+			{Value: string(traceBytes)},
+		},
+	})
+	require.NoError(t, err)
+
+	req = httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	rr = httptest.NewRecorder()
+	handlerOk.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "pruned trace context should fit within limit, body=%q", rr.Body.String())
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
@@ -44,6 +44,7 @@ type HandlerParams struct {
 	AgentURL           string
 	BasePath           string
 	MaxRequestBodySize int64
+	ModelContextLimit  int
 	// EnableMCP mounts the turn-scoped telemetry MCP endpoint. When false, only the
 	// chat endpoint is registered.
 	EnableMCP bool
@@ -66,7 +67,7 @@ type HandlerParams struct {
 func NewHandler(p HandlerParams) *Handler {
 	basePath := normalizeBasePath(p.BasePath)
 	turns := newTurnRegistry()
-	chat := newChatEndpoint(p.Logger, NewContextualToolsStore(), turns, p.AgentURL, basePath, p.MaxRequestBodySize)
+	chat := newChatEndpoint(p.Logger, NewContextualToolsStore(), turns, p.AgentURL, basePath, p.MaxRequestBodySize, p.ModelContextLimit)
 	h := &Handler{basePath: basePath, chat: chat}
 	if p.EnableMCP {
 		h.mcp = newTurnScopedEndpoint(p.Telset, p.QueryService, p.TenancyMgr, turns, basePath, p.Logger)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation.go
@@ -11,6 +11,8 @@ import (
 
 	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/coder/acp-go-sdk"
+
+	"github.com/jaegertracing/jaeger/internal/uimodel"
 )
 
 // latestUserMessageText returns the text content of the most recent user
@@ -288,4 +290,152 @@ func flattenToolResultContent(raw any) string {
 		return fmt.Sprintf("%v", raw)
 	}
 	return string(payload)
+}
+
+// DefaultModelContextLimit is the fallback token budget when the gateway is not
+// configured with ai.model_context_limit. It matches DefaultAIModelContextLimit in
+// the query flags package.
+const DefaultModelContextLimit = 8192
+
+// ErrModelContextExceeded is returned when the estimated prompt plus AG-UI context
+// still exceeds the configured model context limit after trace pruning.
+var ErrModelContextExceeded = errors.New("trace too large for local model. Please filter or prune spans first")
+
+// estimateTokens returns an estimated token count using a 1 token ≈ 4 characters heuristic.
+func estimateTokens(text string) int {
+	return (len(text) + 3) / 4
+}
+
+// enforceModelContextLimit estimates prompt and context size against limit. When the
+// estimate exceeds limit it prunes low-value spans from trace-shaped context entries
+// and re-estimates; if still over limit it returns ErrModelContextExceeded.
+func enforceModelContextLimit(prompt string, context []aguitypes.Context, limit int) ([]aguitypes.Context, error) {
+	if limit <= 0 {
+		limit = DefaultModelContextLimit
+	}
+	total := estimatedPromptTokens(prompt, context)
+	if total <= limit {
+		return context, nil
+	}
+
+	prunedContext := make([]aguitypes.Context, len(context))
+	copy(prunedContext, context)
+	anyPruned := false
+	for i, entry := range prunedContext {
+		if newVal, pruned := tryPruneTraceContext(entry.Value); pruned {
+			prunedContext[i].Value = newVal
+			anyPruned = true
+		}
+	}
+	if anyPruned && estimatedPromptTokens(prompt, prunedContext) <= limit {
+		return prunedContext, nil
+	}
+	return nil, ErrModelContextExceeded
+}
+
+func estimatedPromptTokens(prompt string, context []aguitypes.Context) int {
+	total := estimateTokens(prompt)
+	for _, ctxText := range contextTextEntries(context) {
+		total += estimateTokens(ctxText)
+	}
+	return total
+}
+
+// isLowValueSpan reports whether a span can be dropped when shrinking trace context.
+// Root spans, spans at or above 1ms, and spans with error signals are kept.
+func isLowValueSpan(span uimodel.Span) bool {
+	if span.ParentSpanID == "" && len(span.References) == 0 {
+		return false
+	}
+	if span.Duration >= 1000 {
+		return false
+	}
+	for _, kv := range span.Tags {
+		if kv.Key == "error" {
+			if b, ok := kv.Value.(bool); ok && b {
+				return false
+			}
+			if s, ok := kv.Value.(string); ok && (s == "true" || s == "1") {
+				return false
+			}
+			if i, ok := kv.Value.(int64); ok && i != 0 {
+				return false
+			}
+			if f, ok := kv.Value.(float64); ok && f != 0 {
+				return false
+			}
+		}
+		if kv.Key == "http.status_code" {
+			if i, ok := kv.Value.(int64); ok && i >= 400 {
+				return false
+			}
+			if f, ok := kv.Value.(float64); ok && f >= 400 {
+				return false
+			}
+			if s, ok := kv.Value.(string); ok {
+				var code int
+				if n, err := fmt.Sscanf(s, "%d", &code); err == nil && n == 1 && code >= 400 {
+					return false
+				}
+			}
+		}
+	}
+	for _, log := range span.Logs {
+		for _, kv := range log.Fields {
+			if kv.Key == "error" {
+				return false
+			}
+			if kv.Key == "event" && kv.Value == "error" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// tryPruneTraceContext unmarshals a context value as trace JSON, drops low-value spans,
+// and returns the updated JSON when anything was removed.
+func tryPruneTraceContext(contextValue string) (string, bool) {
+	var trace uimodel.Trace
+	if err := json.Unmarshal([]byte(contextValue), &trace); err == nil && len(trace.Spans) > 0 {
+		prunedSpans := make([]uimodel.Span, 0, len(trace.Spans))
+		for _, span := range trace.Spans {
+			if !isLowValueSpan(span) {
+				prunedSpans = append(prunedSpans, span)
+			}
+		}
+		if len(prunedSpans) < len(trace.Spans) {
+			trace.Spans = prunedSpans
+			if updatedBytes, err := json.Marshal(trace); err == nil {
+				return string(updatedBytes), true
+			}
+		}
+		return contextValue, false
+	}
+
+	type envelope struct {
+		Data []uimodel.Trace `json:"data"`
+	}
+	var env envelope
+	if err := json.Unmarshal([]byte(contextValue), &env); err == nil && len(env.Data) > 0 {
+		prunedAny := false
+		for i, t := range env.Data {
+			prunedSpans := make([]uimodel.Span, 0, len(t.Spans))
+			for _, span := range t.Spans {
+				if !isLowValueSpan(span) {
+					prunedSpans = append(prunedSpans, span)
+				}
+			}
+			if len(prunedSpans) < len(t.Spans) {
+				env.Data[i].Spans = prunedSpans
+				prunedAny = true
+			}
+		}
+		if prunedAny {
+			if updatedBytes, err := json.Marshal(env); err == nil {
+				return string(updatedBytes), true
+			}
+		}
+	}
+	return contextValue, false
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/translation_test.go
@@ -10,6 +10,8 @@ import (
 	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/internal/uimodel"
 )
 
 func TestLatestUserMessageTextPicksMostRecentUser(t *testing.T) {
@@ -298,4 +300,85 @@ func TestValidateContextualToolNamesReportsFirstOffendingIndex(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tools[2].name",
 		"the index of the first invalid tool must be in the error so frontend devs can locate it")
+}
+
+func TestEstimateTokens(t *testing.T) {
+	assert.Equal(t, 0, estimateTokens(""))
+	assert.Equal(t, 1, estimateTokens("a"))
+	assert.Equal(t, 1, estimateTokens("abcd"))
+	assert.Equal(t, 2, estimateTokens("abcde"))
+	assert.Equal(t, 2, estimateTokens("abcdefgh"))
+}
+
+func TestIsLowValueSpan(t *testing.T) {
+	rootSpan := uimodel.Span{SpanID: "root"}
+	assert.False(t, isLowValueSpan(rootSpan))
+
+	longSpan := uimodel.Span{SpanID: "child", ParentSpanID: "root", Duration: 1000}
+	assert.False(t, isLowValueSpan(longSpan))
+
+	shortSpan := uimodel.Span{SpanID: "child", ParentSpanID: "root", Duration: 500}
+	assert.True(t, isLowValueSpan(shortSpan))
+
+	errSpanBool := uimodel.Span{
+		SpanID: "child", ParentSpanID: "root", Duration: 500,
+		Tags: []uimodel.KeyValue{{Key: "error", Value: true}},
+	}
+	assert.False(t, isLowValueSpan(errSpanBool))
+
+	errSpanStr := uimodel.Span{
+		SpanID: "child", ParentSpanID: "root", Duration: 500,
+		Tags: []uimodel.KeyValue{{Key: "error", Value: "true"}},
+	}
+	assert.False(t, isLowValueSpan(errSpanStr))
+
+	httpErrSpan := uimodel.Span{
+		SpanID: "child", ParentSpanID: "root", Duration: 500,
+		Tags: []uimodel.KeyValue{{Key: "http.status_code", Value: int64(500)}},
+	}
+	assert.False(t, isLowValueSpan(httpErrSpan))
+}
+
+func TestTryPruneTraceContext(t *testing.T) {
+	trace := uimodel.Trace{
+		TraceID: "t1",
+		Spans: []uimodel.Span{
+			{SpanID: "root"},
+			{SpanID: "child", ParentSpanID: "root", Duration: 100},
+			{SpanID: "err", ParentSpanID: "root", Duration: 100, Tags: []uimodel.KeyValue{{Key: "error", Value: true}}},
+		},
+	}
+	traceBytes, err := json.Marshal(trace)
+	require.NoError(t, err)
+
+	pruned, ok := tryPruneTraceContext(string(traceBytes))
+	require.True(t, ok)
+
+	var result uimodel.Trace
+	require.NoError(t, json.Unmarshal([]byte(pruned), &result))
+	require.Len(t, result.Spans, 2)
+	assert.Equal(t, uimodel.SpanID("root"), result.Spans[0].SpanID)
+	assert.Equal(t, uimodel.SpanID("err"), result.Spans[1].SpanID)
+}
+
+func TestEnforceModelContextLimitRejectsOversizedPrompt(t *testing.T) {
+	_, err := enforceModelContextLimit("this prompt is definitely longer than ten tokens", nil, 10)
+	require.ErrorIs(t, err, ErrModelContextExceeded)
+}
+
+func TestEnforceModelContextLimitPrunesTraceContext(t *testing.T) {
+	trace := uimodel.Trace{
+		TraceID: "t1",
+		Spans: []uimodel.Span{
+			{SpanID: "root"},
+			{SpanID: "child", ParentSpanID: "root", Duration: 100},
+		},
+	}
+	traceBytes, err := json.Marshal(trace)
+	require.NoError(t, err)
+
+	context := []aguitypes.Context{{Value: string(traceBytes)}}
+	pruned, err := enforceModelContextLimit("short", context, 70)
+	require.NoError(t, err)
+	require.NotEqual(t, context[0].Value, pruned[0].Value)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -250,6 +250,7 @@ func initRouter(
 						AgentURL:           aiCfg.AgentURL,
 						BasePath:           queryOpts.BasePath,
 						MaxRequestBodySize: aiCfg.MaxRequestBodySize,
+						ModelContextLimit:  aiCfg.ModelContextLimit,
 						EnableMCP:          aiCfg.EnableMCP,
 						MCPBaseURL:         aiCfg.resolveMCPBaseURL(ctx, queryOpts.HTTP.NetAddr.Endpoint, queryOpts.HTTP.TLS.HasValue()),
 						QueryService:       querySvc,


### PR DESCRIPTION
## Summary
- Adds `ai.model_context_limit` config (default 8192 tokens) to bound estimated prompt + AG-UI context size before the gateway dials the sidecar.
- When over limit, prunes low-value spans from trace-shaped context entries (non-root, <1ms, no error signals) and retries the estimate.
- Returns HTTP 400 with a clear message when the payload still exceeds the limit after pruning.

Ports the fix for #8801 onto the current `jaegerai` package layout (`endpoint_chat.go` / `http_handler.go`). This supersedes the stale approach in #8821, which targeted the pre-refactor `handler.go`.

## Test plan
- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/...`
- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/...`
- [ ] Manual: open a large trace in Jaeger UI, invoke AI Assistant with a low `ai.model_context_limit`, confirm 400 with pruning guidance instead of sidecar context-length crash

Resolves #8801