### PR TITLE
feat(jaegerquery): Serve operator skills from ai.skills_dir under custom/

### DIFF
--- a/cmd/jaeger/config.yaml
+++ b/cmd/jaeger/config.yaml
@@ -45,6 +45,11 @@ extensions:
       # Serve the Jaeger telemetry MCP tools in-process at /api/ai/mcp/ on the
       # query port (replaces the retired standalone jaeger_mcp extension).
       enable_mcp: true
+      # Optional directory of operator-supplied skills, served by the read_skill
+      # MCP tool under custom/. Requires enable_mcp: true. See
+      # cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/SKILLS.md
+      # for the layout it expects.
+      # skills_dir: /etc/jaeger/skills
     # Accept OTLP/HTTP spans from the UI same-origin at /api/otlp/v1/*
     # and forward to the OTLP HTTP receiver above.
     otlp_proxy:

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -73,6 +73,12 @@ type AIConfig struct {
 	// terminated elsewhere, or forwarded into a container — none of which the
 	// query server can infer. Ignored unless both AgentURL and EnableMCP are set.
 	MCPBaseURL string `mapstructure:"mcp_base_url" valid:"optional"`
+	// SkillsDir is a directory of operator-supplied skill playbooks on the query
+	// server's disk, served by the read_skill MCP tool under custom/ beside the
+	// built-in skills, so an installation can add its own without rebuilding
+	// Jaeger. See mcptools/SKILLS.md for the layout it expects. Requires
+	// EnableMCP. Empty (the default) serves the built-in skills only.
+	SkillsDir string `mapstructure:"skills_dir" valid:"optional"`
 	// MaxRequestBodySize limits the chat-handler request body. Must be positive.
 	MaxRequestBodySize int64 `mapstructure:"max_request_body_size" valid:"optional"`
 	// HealthCheckInterval controls how often the AI health checker contacts
@@ -111,6 +117,9 @@ func (c *OTLPProxyConfig) Validate() error {
 func (c *AIConfig) Validate() error {
 	if c.AgentURL == "" && !c.EnableMCP {
 		return errors.New("ai requires agent_url (AI chat) or enable_mcp (telemetry MCP tools)")
+	}
+	if c.SkillsDir != "" && !c.EnableMCP {
+		return errors.New("ai.skills_dir requires ai.enable_mcp to be true")
 	}
 	if c.MaxRequestBodySize <= 0 {
 		return errors.New("ai.max_request_body_size must be a positive integer")

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -76,7 +76,7 @@ type AIConfig struct {
 	// SkillsDir is a directory of operator-supplied skill playbooks on the query
 	// server's disk, served by the read_skill MCP tool under custom/ beside the
 	// built-in skills, so an installation can add its own without rebuilding
-	// Jaeger. See mcptools/SKILLS.md for the layout it expects. Requires
+	// Jaeger. See mcptools/README.md for the layout it expects. Requires
 	// EnableMCP. Empty (the default) serves the built-in skills only.
 	SkillsDir string `mapstructure:"skills_dir" valid:"optional"`
 	// MaxRequestBodySize limits the chat-handler request body. Must be positive.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -70,6 +70,19 @@ func TestAIConfigValidateAcceptsMCPOnly(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 }
 
+func TestAIConfigValidateRejectsSkillsDirWithoutMCP(t *testing.T) {
+	cfg := validAIConfig()
+	cfg.SkillsDir = "/etc/jaeger/skills"
+	require.EqualError(t, cfg.Validate(), "ai.skills_dir requires ai.enable_mcp to be true")
+}
+
+func TestAIConfigValidateAcceptsSkillsDirWithMCP(t *testing.T) {
+	cfg := validAIConfig()
+	cfg.EnableMCP = true
+	cfg.SkillsDir = "/etc/jaeger/skills"
+	require.NoError(t, cfg.Validate())
+}
+
 func TestAIConfigValidateRejectsNonPositiveBodySize(t *testing.T) {
 	for _, size := range []int64{0, -1} {
 		cfg := validAIConfig()

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
@@ -32,8 +32,8 @@ Its contents are served under `custom/`, beside the built-in skills:
 SKILL.md                       # built-in entry point
 detect-n-plus-one/SKILL.md     # built-in skill
 error-root-cause/SKILL.md      # built-in skill
-custom/SKILL.md                # your entry point   ← <skills_dir>/SKILL.md
-custom/your-skill/SKILL.md     # your skill         ← <skills_dir>/your-skill/SKILL.md
+custom/SKILL.md                # your entry point, mounts <skills_dir>/SKILL.md
+custom/your-skill/SKILL.md     # your skill      , mounts <skills_dir>/your-skill/SKILL.md
 ```
 
 `<skills_dir>/SKILL.md` is required: an agent reads it first, and without it

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
@@ -1,14 +1,15 @@
-# Skills
+# mcptools
+
+This package serves Jaeger's telemetry tools over MCP, `read_skill` among them.
 
 A *skill* is a markdown playbook an AI agent reads before attempting a task —
 how to detect an N+1 query pattern, how to walk a failed trace to its root
-cause. Agents reach them through the `read_skill` MCP tool, starting at the root
-`SKILL.md` catalog and following its links, so only the catalog is read up front
-and an individual skill only when it looks relevant.
+cause. Agents reach them through `read_skill`, starting at the root `SKILL.md`
+and following its links, so a skill is only read when it looks relevant.
 
 The `skills/` directory beside this file holds the skills compiled into the
 Jaeger binary. Operators can add their own without rebuilding, via
-`ai.skills_dir`.
+`ai.skills_dir` — the rest of this file is for them.
 
 ## Adding installation-specific skills
 
@@ -28,24 +29,27 @@ set on it with `--set extensions.jaeger_query.ai.skills_dir={path}`.
 Its contents are served under `custom/`, beside the built-in skills:
 
 ```
-SKILL.md                       # built-in root catalog
+SKILL.md                       # built-in entry point
 detect-n-plus-one/SKILL.md     # built-in skill
 error-root-cause/SKILL.md      # built-in skill
-custom/SKILL.md                # your catalog       ← <skills_dir>/SKILL.md
+custom/SKILL.md                # your entry point   ← <skills_dir>/SKILL.md
 custom/your-skill/SKILL.md     # your skill         ← <skills_dir>/your-skill/SKILL.md
 ```
 
-So `skills_dir` wants a root `SKILL.md` cataloguing your skills, plus one
-directory per skill, each with its own `SKILL.md`.
+`<skills_dir>/SKILL.md` is required: an agent reads it first, and without it
+nothing below is reachable. It is an ordinary skill — if your instructions are
+short it can be all you write. Anything longer belongs in a sub-skill, one
+directory per skill, that the entry point links to and the agent opens only when
+the description matches the task at hand.
 
-Write catalog links relative to the **skills root**, not to the catalog's own
+Write those links relative to the **skills root**, not to the linking file's own
 directory — an agent passes the link text straight back to `read_skill`:
 
 ```markdown
 - [your-skill](custom/your-skill/SKILL.md) — one line on when to use it.
 ```
 
-Each skill's `SKILL.md` opens with YAML frontmatter following the
+Every `SKILL.md` opens with YAML frontmatter following the
 [agent skills specification](https://agentskills.io/specification):
 
 ```markdown
@@ -65,8 +69,6 @@ description: >-
 1. ...
 ```
 
-Your root `custom/SKILL.md` is a hand-written catalog rather than a skill, so it
-needs no frontmatter.
-
-A `skills_dir` that cannot be opened or listed is broken configuration, and
-Jaeger refuses to start rather than quietly serving an incomplete skill set.
+A `skills_dir` that cannot be opened, or whose `SKILL.md` cannot be read, is
+broken configuration, and Jaeger refuses to start rather than quietly serving an
+incomplete skill set.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/SKILLS.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/SKILLS.md
@@ -1,0 +1,72 @@
+# Skills
+
+A *skill* is a markdown playbook an AI agent reads before attempting a task —
+how to detect an N+1 query pattern, how to walk a failed trace to its root
+cause. Agents reach them through the `read_skill` MCP tool, starting at the root
+`SKILL.md` catalog and following its links, so only the catalog is read up front
+and an individual skill only when it looks relevant.
+
+The `skills/` directory beside this file holds the skills compiled into the
+Jaeger binary. Operators can add their own without rebuilding, via
+`ai.skills_dir`.
+
+## Adding installation-specific skills
+
+Point `ai.skills_dir` at a directory on the query server's disk:
+
+```yaml
+extensions:
+  jaeger_query:
+    ai:
+      enable_mcp: true          # required — skills are served over MCP
+      skills_dir: /etc/jaeger/skills
+```
+
+The all-in-one config is not externally configurable, but the field can still be
+set on it with `--set extensions.jaeger_query.ai.skills_dir={path}`.
+
+Its contents are served under `custom/`, beside the built-in skills:
+
+```
+SKILL.md                       # built-in root catalog
+detect-n-plus-one/SKILL.md     # built-in skill
+error-root-cause/SKILL.md      # built-in skill
+custom/SKILL.md                # your catalog       ← <skills_dir>/SKILL.md
+custom/your-skill/SKILL.md     # your skill         ← <skills_dir>/your-skill/SKILL.md
+```
+
+So `skills_dir` wants a root `SKILL.md` cataloguing your skills, plus one
+directory per skill, each with its own `SKILL.md`.
+
+Write catalog links relative to the **skills root**, not to the catalog's own
+directory — an agent passes the link text straight back to `read_skill`:
+
+```markdown
+- [your-skill](custom/your-skill/SKILL.md) — one line on when to use it.
+```
+
+Each skill's `SKILL.md` opens with YAML frontmatter following the
+[agent skills specification](https://agentskills.io/specification):
+
+```markdown
+---
+name: your-skill
+description: >-
+  When to use this skill. Agents read this to decide whether to open the
+  skill at all, so say when it applies, not just what it does.
+---
+
+# Your Skill
+
+## When this applies
+...
+
+## Procedure
+1. ...
+```
+
+Your root `custom/SKILL.md` is a hand-written catalog rather than a skill, so it
+needs no frontmatter.
+
+A `skills_dir` that cannot be opened or listed is broken configuration, and
+Jaeger refuses to start rather than quietly serving an incomplete skill set.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/config.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/config.go
@@ -4,6 +4,7 @@
 package mcptools
 
 import (
+	"io/fs"
 	"time"
 
 	"github.com/jaegertracing/jaeger/internal/version"
@@ -32,6 +33,11 @@ type Config struct {
 	MaxSearchResults         int
 	// MaxReadFileSize bounds the size (bytes) of a file served by read_skill.
 	MaxReadFileSize int64
+	// OperatorSkillsFS is the operator's skills directory (ai.skills_dir),
+	// already opened by the caller, served by read_skill under custom/ beside
+	// the built-in skills. Nil means the operator configured none, and only
+	// the built-ins are served.
+	OperatorSkillsFS fs.FS
 }
 
 // DefaultConfig returns the Config the standalone jaeger_mcp extension used, so

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/config.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/config.go
@@ -33,11 +33,11 @@ type Config struct {
 	MaxSearchResults         int
 	// MaxReadFileSize bounds the size (bytes) of a file served by read_skill.
 	MaxReadFileSize int64
-	// OperatorSkillsFS is the operator's skills directory (ai.skills_dir),
+	// CustomSkillsFS is the operator's skills directory (ai.skills_dir),
 	// already opened by the caller, served by read_skill under custom/ beside
-	// the built-in skills. Nil means the operator configured none, and only
-	// the built-ins are served.
-	OperatorSkillsFS fs.FS
+	// the built-in skills. Nil means none is configured, and only the built-ins
+	// are served.
+	CustomSkillsFS fs.FS
 }
 
 // DefaultConfig returns the Config the standalone jaeger_mcp extension used, so

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -22,21 +22,21 @@ const customSkillsDir = "custom"
 
 type readSkillHandler struct {
 	builtins fs.FS
-	// operator serves the operator's skills_dir tree; nil when none is
-	// configured, in which case every custom/ path reports not-exist.
-	operator    fs.FS
+	// custom serves the skills_dir tree; nil when none is configured, in which
+	// case every custom/ path reports not-exist.
+	custom      fs.FS
 	maxFileSize int64
 }
 
 // NewReadSkillHandler creates a handler that reads skill files, choosing the
-// tree by path prefix: custom/ comes from operator, everything else from
-// builtins. operator may be nil (no skills_dir configured).
+// tree by path prefix: custom/ comes from custom, everything else from
+// builtins. custom may be nil (no skills_dir configured).
 func NewReadSkillHandler(
 	builtins fs.FS,
-	operator fs.FS,
+	custom fs.FS,
 	maxFileSize int64,
 ) mcp.ToolHandlerFor[types.ReadSkillInput, types.ReadSkillOutput] {
-	h := &readSkillHandler{builtins: builtins, operator: operator, maxFileSize: maxFileSize}
+	h := &readSkillHandler{builtins: builtins, custom: custom, maxFileSize: maxFileSize}
 	return h.handle
 }
 
@@ -66,22 +66,19 @@ func (h *readSkillHandler) handle(
 	}, types.ReadSkillOutput{Instructions: content}, nil
 }
 
-// open routes p to the operator tree when it names the custom/ prefix and to
-// the built-in tree otherwise — two filesystems and a prefix check, rather than
-// a merged view over both.
+// open routes p to the custom tree when it names the custom/ prefix and to the
+// built-in tree otherwise — two filesystems and a prefix check, rather than a
+// merged view over both.
 func (h *readSkillHandler) open(p string) (fs.File, error) {
 	if !fs.ValidPath(p) {
 		return nil, &fs.PathError{Op: "open", Path: p, Err: fs.ErrInvalid}
 	}
 	rest, isCustom := strings.CutPrefix(p, customSkillsDir+"/")
-	if p == customSkillsDir {
-		rest, isCustom = ".", true
-	}
 	if !isCustom {
 		return h.builtins.Open(p)
 	}
-	if h.operator == nil {
+	if h.custom == nil {
 		return nil, &fs.PathError{Op: "open", Path: p, Err: fs.ErrNotExist}
 	}
-	return h.operator.Open(rest)
+	return h.custom.Open(rest)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -9,23 +9,34 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types"
 )
 
+// customSkillsDir is the path prefix under which the operator's skills are
+// addressed, e.g. custom/<skill-name>/SKILL.md.
+const customSkillsDir = "custom"
+
 type readSkillHandler struct {
-	skillsFS    fs.FS
+	builtins fs.FS
+	// operator serves the operator's skills_dir tree; nil when none is
+	// configured, in which case every custom/ path reports not-exist.
+	operator    fs.FS
 	maxFileSize int64
 }
 
-// NewReadSkillHandler creates a handler that reads skill files from the given FS.
+// NewReadSkillHandler creates a handler that reads skill files, choosing the
+// tree by path prefix: custom/ comes from operator, everything else from
+// builtins. operator may be nil (no skills_dir configured).
 func NewReadSkillHandler(
-	skillsFS fs.FS,
+	builtins fs.FS,
+	operator fs.FS,
 	maxFileSize int64,
 ) mcp.ToolHandlerFor[types.ReadSkillInput, types.ReadSkillOutput] {
-	h := &readSkillHandler{skillsFS: skillsFS, maxFileSize: maxFileSize}
+	h := &readSkillHandler{builtins: builtins, operator: operator, maxFileSize: maxFileSize}
 	return h.handle
 }
 
@@ -34,7 +45,7 @@ func (h *readSkillHandler) handle(
 	_ *mcp.CallToolRequest,
 	input types.ReadSkillInput,
 ) (*mcp.CallToolResult, types.ReadSkillOutput, error) {
-	f, err := h.skillsFS.Open(input.Path)
+	f, err := h.open(input.Path)
 	if err != nil {
 		return nil, types.ReadSkillOutput{}, fmt.Errorf("cannot read %q: %w", input.Path, err)
 	}
@@ -53,4 +64,24 @@ func (h *readSkillHandler) handle(
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: content}},
 	}, types.ReadSkillOutput{Instructions: content}, nil
+}
+
+// open routes p to the operator tree when it names the custom/ prefix and to
+// the built-in tree otherwise — two filesystems and a prefix check, rather than
+// a merged view over both.
+func (h *readSkillHandler) open(p string) (fs.File, error) {
+	if !fs.ValidPath(p) {
+		return nil, &fs.PathError{Op: "open", Path: p, Err: fs.ErrInvalid}
+	}
+	rest, isCustom := strings.CutPrefix(p, customSkillsDir+"/")
+	if p == customSkillsDir {
+		rest, isCustom = ".", true
+	}
+	if !isCustom {
+		return h.builtins.Open(p)
+	}
+	if h.operator == nil {
+		return nil, &fs.PathError{Op: "open", Path: p, Err: fs.ErrNotExist}
+	}
+	return h.operator.Open(rest)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -101,18 +101,18 @@ func TestNewReadSkillHandler(t *testing.T) {
 	assert.NotNil(t, handler)
 }
 
-func testOperatorFS() fstest.MapFS {
+func testCustomFS() fstest.MapFS {
 	return fstest.MapFS{
 		"SKILL.md":              &fstest.MapFile{Data: []byte("# Operator catalog")},
 		"slow-db-call/SKILL.md": &fstest.MapFile{Data: []byte("# Slow DB Call")},
 	}
 }
 
-// Without an operator tree every custom/ path must report not-exist rather than
-// falling through to the built-ins.
+// With no skills_dir configured every custom/ path must report not-exist
+// rather than falling through to the built-ins.
 func TestReadSkillHandler_CustomPathWithoutOperatorFS(t *testing.T) {
 	h := newTestHandler()
-	for _, p := range []string{"custom", "custom/SKILL.md", "custom/slow-db-call/SKILL.md"} {
+	for _, p := range []string{"custom/SKILL.md", "custom/slow-db-call/SKILL.md"} {
 		t.Run(p, func(t *testing.T) {
 			_, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: p})
 			require.ErrorIs(t, err, fs.ErrNotExist)
@@ -121,15 +121,15 @@ func TestReadSkillHandler_CustomPathWithoutOperatorFS(t *testing.T) {
 }
 
 func TestReadSkillHandler_DispatchesByPrefix(t *testing.T) {
-	h := &readSkillHandler{builtins: testSkillsFS(), operator: testOperatorFS(), maxFileSize: testMaxFileSize}
+	h := &readSkillHandler{builtins: testSkillsFS(), custom: testCustomFS(), maxFileSize: testMaxFileSize}
 
-	t.Run("custom prefix reaches the operator tree", func(t *testing.T) {
+	t.Run("custom prefix reaches the custom tree", func(t *testing.T) {
 		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/slow-db-call/SKILL.md"})
 		require.NoError(t, err)
 		assert.Equal(t, "# Slow DB Call", out.Instructions)
 	})
 
-	t.Run("operator catalog is served", func(t *testing.T) {
+	t.Run("custom catalog is served", func(t *testing.T) {
 		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/SKILL.md"})
 		require.NoError(t, err)
 		assert.Equal(t, "# Operator catalog", out.Instructions)
@@ -139,15 +139,6 @@ func TestReadSkillHandler_DispatchesByPrefix(t *testing.T) {
 		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
 		require.NoError(t, err)
 		assert.Equal(t, "# Skill A\n\nContent here.", out.Instructions)
-	})
-
-	t.Run("bare custom lists the operator root", func(t *testing.T) {
-		f, err := h.open("custom")
-		require.NoError(t, err)
-		defer f.Close()
-		info, err := f.Stat()
-		require.NoError(t, err)
-		assert.True(t, info.IsDir())
 	})
 
 	t.Run("traversal out of custom is rejected", func(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -129,7 +129,7 @@ func TestReadSkillHandler_DispatchesByPrefix(t *testing.T) {
 		assert.Equal(t, "# Slow DB Call", out.Instructions)
 	})
 
-	t.Run("custom catalog is served", func(t *testing.T) {
+	t.Run("custom entry point is served", func(t *testing.T) {
 		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/SKILL.md"})
 		require.NoError(t, err)
 		assert.Equal(t, "# Operator catalog", out.Instructions)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"io/fs"
 	"testing"
 	"testing/fstest"
 
@@ -27,7 +28,7 @@ func testSkillsFS() fstest.MapFS {
 }
 
 func newTestHandler() *readSkillHandler {
-	return &readSkillHandler{skillsFS: testSkillsFS(), maxFileSize: testMaxFileSize}
+	return &readSkillHandler{builtins: testSkillsFS(), maxFileSize: testMaxFileSize}
 }
 
 func TestReadSkillHandler_RootSkillMD(t *testing.T) {
@@ -96,6 +97,61 @@ func TestReadSkillHandler_RawTextInContent(t *testing.T) {
 }
 
 func TestNewReadSkillHandler(t *testing.T) {
-	handler := NewReadSkillHandler(testSkillsFS(), testMaxFileSize)
+	handler := NewReadSkillHandler(testSkillsFS(), nil, testMaxFileSize)
 	assert.NotNil(t, handler)
+}
+
+func testOperatorFS() fstest.MapFS {
+	return fstest.MapFS{
+		"SKILL.md":              &fstest.MapFile{Data: []byte("# Operator catalog")},
+		"slow-db-call/SKILL.md": &fstest.MapFile{Data: []byte("# Slow DB Call")},
+	}
+}
+
+// Without an operator tree every custom/ path must report not-exist rather than
+// falling through to the built-ins.
+func TestReadSkillHandler_CustomPathWithoutOperatorFS(t *testing.T) {
+	h := newTestHandler()
+	for _, p := range []string{"custom", "custom/SKILL.md", "custom/slow-db-call/SKILL.md"} {
+		t.Run(p, func(t *testing.T) {
+			_, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: p})
+			require.ErrorIs(t, err, fs.ErrNotExist)
+		})
+	}
+}
+
+func TestReadSkillHandler_DispatchesByPrefix(t *testing.T) {
+	h := &readSkillHandler{builtins: testSkillsFS(), operator: testOperatorFS(), maxFileSize: testMaxFileSize}
+
+	t.Run("custom prefix reaches the operator tree", func(t *testing.T) {
+		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/slow-db-call/SKILL.md"})
+		require.NoError(t, err)
+		assert.Equal(t, "# Slow DB Call", out.Instructions)
+	})
+
+	t.Run("operator catalog is served", func(t *testing.T) {
+		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/SKILL.md"})
+		require.NoError(t, err)
+		assert.Equal(t, "# Operator catalog", out.Instructions)
+	})
+
+	t.Run("built-ins still reachable at the root", func(t *testing.T) {
+		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
+		require.NoError(t, err)
+		assert.Equal(t, "# Skill A\n\nContent here.", out.Instructions)
+	})
+
+	t.Run("bare custom lists the operator root", func(t *testing.T) {
+		f, err := h.open("custom")
+		require.NoError(t, err)
+		defer f.Close()
+		info, err := f.Stat()
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("traversal out of custom is rejected", func(t *testing.T) {
+		_, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/../etc/passwd"})
+		require.Error(t, err)
+	})
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -178,5 +178,5 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 		Description: "Read a skill file for trace analysis. " +
 			"Skills are organized using progressive disclosure. " +
 			"Start with SKILL.md which will guide you to more specific sub-skills.",
-	}, handlers.NewReadSkillHandler(s.skillsFS, s.config.OperatorSkillsFS, s.config.MaxReadFileSize))
+	}, handlers.NewReadSkillHandler(s.skillsFS, s.config.CustomSkillsFS, s.config.MaxReadFileSize))
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -178,5 +178,5 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 		Description: "Read a skill file for trace analysis. " +
 			"Skills are organized using progressive disclosure. " +
 			"Start with SKILL.md which will guide you to more specific sub-skills.",
-	}, handlers.NewReadSkillHandler(s.skillsFS, s.config.MaxReadFileSize))
+	}, handlers.NewReadSkillHandler(s.skillsFS, s.config.OperatorSkillsFS, s.config.MaxReadFileSize))
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills/SKILL.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills/SKILL.md
@@ -16,3 +16,7 @@ Read a sub-skill's SKILL.md before applying it.
 
 - [error-root-cause](error-root-cause/SKILL.md) — Walk a failed trace to the first
   originating error span. Use when a request failed and the user wants to know where.
+
+Installation-specific skills, if any, are listed under
+[custom/SKILL.md](custom/SKILL.md). If that file does not exist, this Jaeger
+instance has none.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
@@ -9,8 +9,8 @@ import (
 	"os"
 )
 
-// OpenOperatorSkillsDir opens the operator's skills directory for read_skill to
-// serve under custom/. It is opened with os.OpenRoot, which blocks ".."
+// OpenCustomSkillsDir opens the operator's skills directory (ai.skills_dir) for
+// read_skill to serve under custom/. It is opened with os.OpenRoot, which blocks ".."
 // traversal and symlink escapes out of the directory at the OS level, and the
 // returned fs.FS keeps that root open for its lifetime.
 //
@@ -18,7 +18,7 @@ import (
 // is broken configuration rather than a content problem, so it is a hard error
 // that aborts startup instead of degrading to serving nothing. skillsDir == ""
 // means the operator configured none: no FS, no error.
-func OpenOperatorSkillsDir(skillsDir string) (fs.FS, error) {
+func OpenCustomSkillsDir(skillsDir string) (fs.FS, error) {
 	if skillsDir == "" {
 		return nil, nil
 	}
@@ -28,13 +28,13 @@ func OpenOperatorSkillsDir(skillsDir string) (fs.FS, error) {
 	}
 	// root.FS() is a pointer type conversion of root itself, not a wrapper, so
 	// keeping the returned FS alive keeps root's directory handle open too.
-	operator := root.FS()
+	custom := root.FS()
 	// OpenRoot succeeds on a directory that cannot be listed (read permission
 	// without execute, on Unix), which would then look like an empty skills
 	// tree at serve time; check explicitly so it fails here instead.
-	if _, err := fs.ReadDir(operator, "."); err != nil {
+	if _, err := fs.ReadDir(custom, "."); err != nil {
 		_ = root.Close()
 		return nil, fmt.Errorf("cannot list skills_dir %q: %w", skillsDir, err)
 	}
-	return operator, nil
+	return custom, nil
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcptools
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// OpenOperatorSkillsDir opens the operator's skills directory for read_skill to
+// serve under custom/. It is opened with os.OpenRoot, which blocks ".."
+// traversal and symlink escapes out of the directory at the OS level, and the
+// returned fs.FS keeps that root open for its lifetime.
+//
+// An unusable skillsDir — missing, not a directory, unreadable, or unlistable —
+// is broken configuration rather than a content problem, so it is a hard error
+// that aborts startup instead of degrading to serving nothing. skillsDir == ""
+// means the operator configured none: no FS, no error.
+func OpenOperatorSkillsDir(skillsDir string) (fs.FS, error) {
+	if skillsDir == "" {
+		return nil, nil
+	}
+	root, err := os.OpenRoot(skillsDir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open skills_dir %q: %w", skillsDir, err)
+	}
+	// root.FS() is a pointer type conversion of root itself, not a wrapper, so
+	// keeping the returned FS alive keeps root's directory handle open too.
+	operator := root.FS()
+	// OpenRoot succeeds on a directory that cannot be listed (read permission
+	// without execute, on Unix), which would then look like an empty skills
+	// tree at serve time; check explicitly so it fails here instead.
+	if _, err := fs.ReadDir(operator, "."); err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("cannot list skills_dir %q: %w", skillsDir, err)
+	}
+	return operator, nil
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
@@ -9,15 +9,19 @@ import (
 	"os"
 )
 
+// entryPointSkill is the skill an agent reads first in any skills tree; it
+// links to the rest.
+const entryPointSkill = "SKILL.md"
+
 // OpenCustomSkillsDir opens the operator's skills directory (ai.skills_dir) for
 // read_skill to serve under custom/. It is opened with os.OpenRoot, which blocks ".."
 // traversal and symlink escapes out of the directory at the OS level, and the
 // returned fs.FS keeps that root open for its lifetime.
 //
-// An unusable skillsDir — missing, not a directory, unreadable, or unlistable —
-// is broken configuration rather than a content problem, so it is a hard error
-// that aborts startup instead of degrading to serving nothing. skillsDir == ""
-// means the operator configured none: no FS, no error.
+// An unusable skillsDir — missing, not a directory, or without a readable
+// entry-point skill — is broken configuration rather than a content problem, so
+// it is a hard error that aborts startup instead of degrading to serving
+// nothing. skillsDir == "" means the operator configured none: no FS, no error.
 func OpenCustomSkillsDir(skillsDir string) (fs.FS, error) {
 	if skillsDir == "" {
 		return nil, nil
@@ -29,12 +33,13 @@ func OpenCustomSkillsDir(skillsDir string) (fs.FS, error) {
 	// root.FS() is a pointer type conversion of root itself, not a wrapper, so
 	// keeping the returned FS alive keeps root's directory handle open too.
 	custom := root.FS()
-	// OpenRoot succeeds on a directory that cannot be listed (read permission
-	// without execute, on Unix), which would then look like an empty skills
-	// tree at serve time; check explicitly so it fails here instead.
-	if _, err := fs.ReadDir(custom, "."); err != nil {
+	// The entry point is what an agent reads first; without it nothing below is
+	// reachable. Reading it also catches a directory OpenRoot could open but
+	// whose contents are unreadable, which would otherwise only show up as an
+	// empty skills tree at serve time.
+	if _, err := fs.ReadFile(custom, entryPointSkill); err != nil {
 		_ = root.Close()
-		return nil, fmt.Errorf("cannot list skills_dir %q: %w", skillsDir, err)
+		return nil, fmt.Errorf("cannot read %s in skills_dir %q: %w", entryPointSkill, skillsDir, err)
 	}
 	return custom, nil
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs.go
@@ -5,6 +5,7 @@ package mcptools
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 )
@@ -13,16 +14,32 @@ import (
 // links to the rest.
 const entryPointSkill = "SKILL.md"
 
+// SkillsFS is a skills tree backed by an open OS handle. Whoever mounts it owns
+// closing it when the server it was mounted on shuts down.
+type SkillsFS interface {
+	fs.FS
+	io.Closer
+}
+
+// rootSkillsFS adapts os.Root, whose Open returns *os.File and so does not
+// satisfy fs.FS on its own: root.FS() supplies the FS view over the same handle
+// and root supplies Close.
+type rootSkillsFS struct {
+	fs.FS
+	root *os.Root
+}
+
+func (r rootSkillsFS) Close() error { return r.root.Close() }
+
 // OpenCustomSkillsDir opens the operator's skills directory (ai.skills_dir) for
 // read_skill to serve under custom/. It is opened with os.OpenRoot, which blocks ".."
-// traversal and symlink escapes out of the directory at the OS level, and the
-// returned fs.FS keeps that root open for its lifetime.
+// traversal and symlink escapes out of the directory at the OS level.
 //
 // An unusable skillsDir — missing, not a directory, or without a readable
 // entry-point skill — is broken configuration rather than a content problem, so
 // it is a hard error that aborts startup instead of degrading to serving
 // nothing. skillsDir == "" means the operator configured none: no FS, no error.
-func OpenCustomSkillsDir(skillsDir string) (fs.FS, error) {
+func OpenCustomSkillsDir(skillsDir string) (SkillsFS, error) {
 	if skillsDir == "" {
 		return nil, nil
 	}
@@ -30,15 +47,13 @@ func OpenCustomSkillsDir(skillsDir string) (fs.FS, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot open skills_dir %q: %w", skillsDir, err)
 	}
-	// root.FS() is a pointer type conversion of root itself, not a wrapper, so
-	// keeping the returned FS alive keeps root's directory handle open too.
-	custom := root.FS()
+	custom := rootSkillsFS{FS: root.FS(), root: root}
 	// The entry point is what an agent reads first; without it nothing below is
 	// reachable. Reading it also catches a directory OpenRoot could open but
 	// whose contents are unreadable, which would otherwise only show up as an
 	// empty skills tree at serve time.
 	if _, err := fs.ReadFile(custom, entryPointSkill); err != nil {
-		_ = root.Close()
+		_ = custom.Close()
 		return nil, fmt.Errorf("cannot read %s in skills_dir %q: %w", entryPointSkill, skillsDir, err)
 	}
 	return custom, nil

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
@@ -51,21 +51,23 @@ func TestOpenCustomSkillsDir_HardFailsOnUnusablePath(t *testing.T) {
 		require.ErrorContains(t, err, "cannot open skills_dir")
 	})
 
-	t.Run("directory is not listable", func(t *testing.T) {
+	t.Run("no entry-point skill", func(t *testing.T) {
+		_, err := OpenCustomSkillsDir(t.TempDir())
+		require.ErrorContains(t, err, "cannot read SKILL.md in skills_dir")
+	})
+
+	t.Run("entry-point skill is unreadable", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("permission bits are not enforced the same way on Windows")
 		}
 		if os.Geteuid() == 0 {
-			t.Skip("running as root ignores directory permission bits")
+			t.Skip("running as root ignores permission bits")
 		}
-		// Read without execute: os.OpenRoot succeeds (it can stat the
-		// directory) but its entries cannot be listed.
 		dir := t.TempDir()
-		require.NoError(t, os.Chmod(dir, 0o400))
-		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("x"), 0o000))
 
 		_, err := OpenCustomSkillsDir(dir)
-		require.ErrorContains(t, err, "cannot list skills_dir")
+		require.ErrorContains(t, err, "cannot read SKILL.md in skills_dir")
 	})
 }
 
@@ -77,6 +79,7 @@ func TestOpenCustomSkillsDir_BlocksSymlinkEscape(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600))
 
 	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("catalog"), 0o600))
 	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "evil")))
 
 	custom, err := OpenCustomSkillsDir(dir)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
@@ -38,6 +38,18 @@ func TestOpenCustomSkillsDir_ServesDirectoryContents(t *testing.T) {
 	assert.Equal(t, "skill body", string(skill))
 }
 
+func TestOpenCustomSkillsDir_CloseReleasesTheRoot(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("catalog"), 0o600))
+
+	custom, err := OpenCustomSkillsDir(dir)
+	require.NoError(t, err)
+	require.NoError(t, custom.Close())
+
+	_, err = fs.ReadFile(custom, "SKILL.md")
+	require.Error(t, err, "the tree must not still be readable once closed")
+}
+
 func TestOpenCustomSkillsDir_HardFailsOnUnusablePath(t *testing.T) {
 	t.Run("nonexistent directory", func(t *testing.T) {
 		_, err := OpenCustomSkillsDir(filepath.Join(t.TempDir(), "no-such-dir"))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
@@ -14,40 +14,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOpenOperatorSkillsDir_EmptyPathOpensNothing(t *testing.T) {
-	operator, err := OpenOperatorSkillsDir("")
+func TestOpenCustomSkillsDir_EmptyPathOpensNothing(t *testing.T) {
+	custom, err := OpenCustomSkillsDir("")
 	require.NoError(t, err)
-	assert.Nil(t, operator, "no skills_dir configured means no operator FS")
+	assert.Nil(t, custom, "no skills_dir configured means no custom FS")
 }
 
-func TestOpenOperatorSkillsDir_ServesDirectoryContents(t *testing.T) {
+func TestOpenCustomSkillsDir_ServesDirectoryContents(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("operator catalog"), 0o600))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "slow-db-call"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "slow-db-call", "SKILL.md"), []byte("skill body"), 0o600))
 
-	operator, err := OpenOperatorSkillsDir(dir)
+	custom, err := OpenCustomSkillsDir(dir)
 	require.NoError(t, err)
 
-	catalog, err := fs.ReadFile(operator, "SKILL.md")
+	catalog, err := fs.ReadFile(custom, "SKILL.md")
 	require.NoError(t, err)
 	assert.Equal(t, "operator catalog", string(catalog))
 
-	skill, err := fs.ReadFile(operator, "slow-db-call/SKILL.md")
+	skill, err := fs.ReadFile(custom, "slow-db-call/SKILL.md")
 	require.NoError(t, err)
 	assert.Equal(t, "skill body", string(skill))
 }
 
-func TestOpenOperatorSkillsDir_HardFailsOnUnusablePath(t *testing.T) {
+func TestOpenCustomSkillsDir_HardFailsOnUnusablePath(t *testing.T) {
 	t.Run("nonexistent directory", func(t *testing.T) {
-		_, err := OpenOperatorSkillsDir(filepath.Join(t.TempDir(), "no-such-dir"))
+		_, err := OpenCustomSkillsDir(filepath.Join(t.TempDir(), "no-such-dir"))
 		require.ErrorContains(t, err, "cannot open skills_dir")
 	})
 
 	t.Run("path is a file", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "not-a-dir")
 		require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
-		_, err := OpenOperatorSkillsDir(f)
+		_, err := OpenCustomSkillsDir(f)
 		require.ErrorContains(t, err, "cannot open skills_dir")
 	})
 
@@ -64,12 +64,12 @@ func TestOpenOperatorSkillsDir_HardFailsOnUnusablePath(t *testing.T) {
 		require.NoError(t, os.Chmod(dir, 0o400))
 		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 
-		_, err := OpenOperatorSkillsDir(dir)
+		_, err := OpenCustomSkillsDir(dir)
 		require.ErrorContains(t, err, "cannot list skills_dir")
 	})
 }
 
-func TestOpenOperatorSkillsDir_BlocksSymlinkEscape(t *testing.T) {
+func TestOpenCustomSkillsDir_BlocksSymlinkEscape(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires elevated privileges on Windows")
 	}
@@ -79,11 +79,11 @@ func TestOpenOperatorSkillsDir_BlocksSymlinkEscape(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "evil")))
 
-	operator, err := OpenOperatorSkillsDir(dir)
+	custom, err := OpenCustomSkillsDir(dir)
 	require.NoError(t, err)
 
 	// os.OpenRoot refuses to follow a symlink out of skills_dir.
-	_, err = operator.Open("evil/secret.txt")
+	_, err = custom.Open("evil/secret.txt")
 	require.Error(t, err, "a symlink pointing outside skills_dir must not be followed")
 
 	var pathErr *fs.PathError

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcptools
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenOperatorSkillsDir_EmptyPathOpensNothing(t *testing.T) {
+	operator, err := OpenOperatorSkillsDir("")
+	require.NoError(t, err)
+	assert.Nil(t, operator, "no skills_dir configured means no operator FS")
+}
+
+func TestOpenOperatorSkillsDir_ServesDirectoryContents(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("operator catalog"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "slow-db-call"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "slow-db-call", "SKILL.md"), []byte("skill body"), 0o600))
+
+	operator, err := OpenOperatorSkillsDir(dir)
+	require.NoError(t, err)
+
+	catalog, err := fs.ReadFile(operator, "SKILL.md")
+	require.NoError(t, err)
+	assert.Equal(t, "operator catalog", string(catalog))
+
+	skill, err := fs.ReadFile(operator, "slow-db-call/SKILL.md")
+	require.NoError(t, err)
+	assert.Equal(t, "skill body", string(skill))
+}
+
+func TestOpenOperatorSkillsDir_HardFailsOnUnusablePath(t *testing.T) {
+	t.Run("nonexistent directory", func(t *testing.T) {
+		_, err := OpenOperatorSkillsDir(filepath.Join(t.TempDir(), "no-such-dir"))
+		require.ErrorContains(t, err, "cannot open skills_dir")
+	})
+
+	t.Run("path is a file", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+		_, err := OpenOperatorSkillsDir(f)
+		require.ErrorContains(t, err, "cannot open skills_dir")
+	})
+
+	t.Run("directory is not listable", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("permission bits are not enforced the same way on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("running as root ignores directory permission bits")
+		}
+		// Read without execute: os.OpenRoot succeeds (it can stat the
+		// directory) but its entries cannot be listed.
+		dir := t.TempDir()
+		require.NoError(t, os.Chmod(dir, 0o400))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+		_, err := OpenOperatorSkillsDir(dir)
+		require.ErrorContains(t, err, "cannot list skills_dir")
+	})
+}
+
+func TestOpenOperatorSkillsDir_BlocksSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600))
+
+	dir := t.TempDir()
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "evil")))
+
+	operator, err := OpenOperatorSkillsDir(dir)
+	require.NoError(t, err)
+
+	// os.OpenRoot refuses to follow a symlink out of skills_dir.
+	_, err = operator.Open("evil/secret.txt")
+	require.Error(t, err, "a symlink pointing outside skills_dir must not be followed")
+
+	var pathErr *fs.PathError
+	require.ErrorAs(t, err, &pathErr)
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -236,8 +236,15 @@ func initRouter(
 			if err := aiCfg.Validate(); err != nil {
 				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
 			} else {
-				// One config for both MCP endpoints so they cannot drift.
+				// One config for both MCP endpoints so they cannot drift. The
+				// skills directory is opened once here, so both share the handle
+				// and a broken path is reported once, at startup.
 				mcpCfg := mcptools.DefaultConfig()
+				operatorSkills, err := mcptools.OpenOperatorSkillsDir(aiCfg.SkillsDir)
+				if err != nil {
+					return nil, nil, err
+				}
+				mcpCfg.OperatorSkillsFS = operatorSkills
 				if aiCfg.AgentURL != "" {
 					// When AI chat is enabled, jaegerai owns the chat endpoint and,
 					// if MCP is also enabled, the turn-scoped MCP endpoint

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -240,11 +240,11 @@ func initRouter(
 				// skills directory is opened once here, so both share the handle
 				// and a broken path is reported once, at startup.
 				mcpCfg := mcptools.DefaultConfig()
-				operatorSkills, err := mcptools.OpenOperatorSkillsDir(aiCfg.SkillsDir)
+				customSkills, err := mcptools.OpenCustomSkillsDir(aiCfg.SkillsDir)
 				if err != nil {
 					return nil, nil, err
 				}
-				mcpCfg.OperatorSkillsFS = operatorSkills
+				mcpCfg.CustomSkillsFS = customSkills
 				if aiCfg.AgentURL != "" {
 					// When AI chat is enabled, jaegerai owns the chat endpoint and,
 					// if MCP is also enabled, the turn-scoped MCP endpoint

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -212,6 +212,7 @@ func initRouter(
 		apiHandlerOptions...,
 	)
 	r := http.NewServeMux()
+	var cs closers
 
 	(&apiv3.HTTPGateway{
 		QueryService: querySvc,
@@ -243,6 +244,11 @@ func initRouter(
 				customSkills, err := mcptools.OpenCustomSkillsDir(aiCfg.SkillsDir)
 				if err != nil {
 					return nil, nil, err
+				}
+				if customSkills != nil {
+					// It holds skills_dir open for as long as it serves, so it
+					// is released with the server rather than at process exit.
+					cs = append(cs, customSkills)
 				}
 				mcpCfg.CustomSkillsFS = customSkills
 				if aiCfg.AgentURL != "" {
@@ -279,7 +285,7 @@ func initRouter(
 
 	if queryOpts.OTLPProxy.HasValue() {
 		if err := registerOTLPProxy(r, queryOpts, telset); err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Join(err, cs.Close())
 		}
 	}
 
@@ -287,7 +293,7 @@ func initRouter(
 		http.Error(w, "404 page not found", http.StatusNotFound)
 	})
 
-	cs := closers{RegisterStaticHandler(r, telset.Logger, queryOpts, caps, aiHealthCheck)}
+	cs = append(cs, RegisterStaticHandler(r, telset.Logger, queryOpts, caps, aiHealthCheck))
 	if aiGateway != nil {
 		cs = append(cs, aiGateway)
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1146,6 +1147,20 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		require.Equal(t, http.StatusBadGateway, rr.Code)
+	})
+
+	// An unusable skills_dir is broken configuration, so it has to stop the
+	// server coming up rather than degrade to serving no custom skills.
+	t.Run("unusable skills_dir aborts startup", func(t *testing.T) {
+		opts := DefaultQueryOptions()
+		opts.AI = configoptional.Some(AIConfig{
+			EnableMCP:          true,
+			SkillsDir:          filepath.Join(t.TempDir(), "no-such-dir"),
+			MaxRequestBodySize: 1 << 20,
+		})
+
+		_, _, err := initRouter(context.Background(), querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.ErrorContains(t, err, "cannot open skills_dir")
 	})
 
 	t.Run("mcp endpoint mounted in MCP-only mode", func(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1161,6 +1162,23 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 
 		_, _, err := initRouter(context.Background(), querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
 		require.ErrorContains(t, err, "cannot open skills_dir")
+	})
+
+	// skills_dir stays open for as long as it is served, so the server has to
+	// hand it back as a closer rather than leave it to process exit.
+	t.Run("skills_dir is closed with the server", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("catalog"), 0o600))
+		opts := DefaultQueryOptions()
+		opts.AI = configoptional.Some(AIConfig{
+			EnableMCP:          true,
+			SkillsDir:          dir,
+			MaxRequestBodySize: 1 << 20,
+		})
+
+		_, cs, err := initRouter(context.Background(), querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
+		require.NoError(t, err)
+		require.NoError(t, cs.Close())
 	})
 
 	t.Run("mcp endpoint mounted in MCP-only mode", func(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #8440. Second of the PRs split out of #9010, on top of #9162.
- PR 1 (#8849) added the `read_skill` MCP tool serving skill playbooks compiled
  into the binary. This adds the operator-extensibility half: an installation can
  ship its own skills without rebuilding Jaeger.

## Description of the changes

New `ai.skills_dir` config. Point it at a directory on the query server's disk and its contents are served by `read_skill` under `custom/`, beside the built-in skills:

```
SKILL.md                       # built-in root catalog
detect-n-plus-one/SKILL.md     # built-in skill
custom/SKILL.md                # operator catalog   ← <skills_dir>/SKILL.md
custom/your-skill/SKILL.md     # operator skill     ← <skills_dir>/your-skill/SKILL.md
```


- **No merged filesystem.** The agent already knows about `custom/`, so  `read_skill` checks the path prefix and opens from one of two plain `fs.FS`  values. There is no synthetic FS over the pair.
- **Opened once, in `initRouter`.** `Config` carries the opened `fs.FS` rather  than a path string, so the shared and turn-scoped endpoints share one handle,  the directory is walked once, and a broken path is reported once — at startup,
  where it belongs. No constructor in the chain gains an error return.
- **Path safety** comes from `os.OpenRoot`, which blocks `..` traversal and  symlink escapes out of the directory at the OS level.
- **A `skills_dir` that cannot be opened or listed aborts startup.** That is  broken configuration, not a content problem, so failing loudly beats quietly  serving an incomplete skill set. `OpenRoot` alone is not enough: it succeeds on
  a directory that cannot be listed (read permission without execute), which  would then look like an empty skills tree, so listability is checked  explicitly.
- `ai.skills_dir` requires `ai.enable_mcp` — skills are only reachable over MCP,  so the combination is rejected at config load rather than silently ignored.
- `mcptools/SKILLS.md` documents the layout, and the built-in root catalog gains  a pointer to `custom/SKILL.md`.

**No validation of skill content here.** A malformed skill is served as-is.Frontmatter validation and skipping invalid skills is the next PR, so thecontested questions there (exclude vs. warn, unknown-key strictness) do not hold
up the feature.

Not added to `all-in-one.yaml`: it is not externally configurable there, andSKILLS.md documents the `--set extensions.jaeger_query.ai.skills_dir={path}`route instead.

## How was this change tested?

- Unit tests: prefix dispatch (`custom/` → operator tree, everything else →  built-ins), `custom/` paths with no `skills_dir` configured, traversal out of  `custom/`, symlink escape blocked, and each hard-fail case — missing directory,  path is a file, directory not listable.- Config validation: `skills_dir` with and without `enable_mcp`.
- Verified end-to-end against a running Jaeger with the real Gemini sidecar: the  agent read the built-in root catalog, followed it to `custom/SKILL.md`, then  into the operator's skill, and answered from its content — three `read_skill`
  calls, correct progressive disclosure.
- `go build ./cmd/jaeger/...`, `go vet`, full `cmd/jaeger/internal/extension/jaegerquery/...` suite, `make fmt`, `make lint`
  all clean.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes

