### PR TITLE
fix(mcptools): Cap get_critical_path segments and report total_segment_count

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
@@ -4,10 +4,12 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -29,14 +31,22 @@ type queryServiceGetCriticalPathInterface interface {
 // (the blocking execution path) in a distributed trace.
 type getCriticalPathHandler struct {
 	queryService queryServiceGetCriticalPathInterface
+	// maxSegments bounds the number of segments returned to the caller; 0 means
+	// unlimited. The critical path itself is always computed over the complete
+	// trace — truncating the input spans would change which path is critical —
+	// so only the response is capped, keeping the segments with the largest
+	// self time.
+	maxSegments int
 }
 
 // NewGetCriticalPathHandler creates a new get_critical_path handler and returns the handler function.
 func NewGetCriticalPathHandler(
 	queryService *querysvc.QueryService,
+	maxSegments int,
 ) mcp.ToolHandlerFor[types.GetCriticalPathInput, types.GetCriticalPathOutput] {
 	h := &getCriticalPathHandler{
 		queryService: queryService,
+		maxSegments:  maxSegments,
 	}
 	return h.handle
 }
@@ -108,7 +118,7 @@ func (*getCriticalPathHandler) buildQuery(input types.GetCriticalPathInput) (que
 }
 
 // buildOutput constructs the GetCriticalPathOutput from the trace and critical path sections.
-func (*getCriticalPathHandler) buildOutput(
+func (h *getCriticalPathHandler) buildOutput(
 	traceIDStr string,
 	trace ptrace.Traces,
 	criticalPathSections []criticalpath.Section,
@@ -180,6 +190,39 @@ func (*getCriticalPathHandler) buildOutput(
 		TraceID:                traceIDStr,
 		TotalDurationUs:        traceEndTime - traceStartTime,
 		CriticalPathDurationUs: criticalPathDuration,
-		Segments:               segments,
+		TotalSegmentCount:      len(segments),
+		Segments:               h.capSegments(segments),
 	}
+}
+
+// capSegments bounds the response to maxSegments entries. The segments dropped
+// are the ones contributing the least latency: the survivors are chosen by
+// largest self time and then re-sorted back into the path's native order,
+// which walks from the end of the trace backwards (see the section order in
+// computeCriticalPath), so capped and uncapped responses read the same way.
+// Ties break by start offset and span ID, making both comparators total orders
+// so the selection is deterministic. A maxSegments of zero (or below) means
+// unlimited.
+func (h *getCriticalPathHandler) capSegments(segments []types.CriticalPathSegment) []types.CriticalPathSegment {
+	if h.maxSegments <= 0 || len(segments) <= h.maxSegments {
+		return segments
+	}
+	bySelfTime := slices.Clone(segments)
+	slices.SortFunc(bySelfTime, func(a, b types.CriticalPathSegment) int {
+		if a.SelfTimeUs != b.SelfTimeUs {
+			return cmp.Compare(b.SelfTimeUs, a.SelfTimeUs) // descending
+		}
+		if a.StartOffsetUs != b.StartOffsetUs {
+			return cmp.Compare(b.StartOffsetUs, a.StartOffsetUs)
+		}
+		return cmp.Compare(a.SpanID, b.SpanID)
+	})
+	kept := bySelfTime[:h.maxSegments]
+	slices.SortFunc(kept, func(a, b types.CriticalPathSegment) int {
+		if a.StartOffsetUs != b.StartOffsetUs {
+			return cmp.Compare(b.StartOffsetUs, a.StartOffsetUs) // trace end first
+		}
+		return cmp.Compare(a.SpanID, b.SpanID)
+	})
+	return kept
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"math"
+	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,8 +70,151 @@ func createCriticalPathTestTrace() ptrace.Traces {
 
 func TestNewGetCriticalPathHandler(t *testing.T) {
 	// We can pass nil because we only check if it returns a handler function
-	handler := NewGetCriticalPathHandler(nil)
+	handler := NewGetCriticalPathHandler(nil, 20)
 	assert.NotNil(t, handler)
+}
+
+// buildNestedChainTrace returns a strictly nested chain of n+1 spans: span i
+// covers [i ms, (2n+2-i) ms] and is the parent of span i+1, so every child is
+// fully inside its parent. The critical path walk then produces a section on
+// both sides of each child plus the innermost span, more than 2n sections in
+// total, without relying on the sibling-walk behavior of the algorithm.
+func buildNestedChainTrace(n int) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "svc")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	span := ss.Spans().AppendEmpty()
+	span.SetTraceID(pcommon.TraceID([16]byte{1}))
+	span.SetSpanID(pcommon.SpanID([8]byte{0xFF}))
+	span.SetName("root")
+	const base = 1_000_000 // 1ms; a zero start trips buildOutput's traceStartTime==0 guard
+	span.SetStartTimestamp(pcommon.Timestamp(base))
+	span.SetEndTimestamp(pcommon.Timestamp(base + uint64(2*n+2)*1_000_000))
+
+	parentID := span.SpanID()
+	for i := 1; i <= n; i++ {
+		child := ss.Spans().AppendEmpty()
+		child.SetTraceID(span.TraceID())
+		child.SetSpanID(pcommon.SpanID([8]byte{byte(i), 2}))
+		child.SetParentSpanID(parentID)
+		child.SetName("child")
+		child.SetStartTimestamp(pcommon.Timestamp(base + uint64(i)*1_000_000))
+		child.SetEndTimestamp(pcommon.Timestamp(base + uint64(2*n+2-i)*1_000_000))
+		parentID = child.SpanID()
+	}
+	return traces
+}
+
+func TestGetCriticalPathHandler_SegmentCap_KeepsLargestSelfTime(t *testing.T) {
+	const spans, limit = 30, 5
+	mockQS := &mockGetCriticalPathQueryService{
+		traces: []ptrace.Traces{buildNestedChainTrace(spans)},
+	}
+	handler := &getCriticalPathHandler{queryService: mockQS, maxSegments: limit}
+
+	_, output, err := handler.handle(context.Background(), nil, types.GetCriticalPathInput{
+		TraceID: "00000000000000000000000000000001",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, output.Segments, limit)
+	assert.Greater(t, output.TotalSegmentCount, limit,
+		"total must reflect the uncapped path so truncation is detectable")
+
+	// Survivors are the largest-self-time segments: every returned segment must
+	// have self time >= the largest segment that was dropped.
+	uncapped := &getCriticalPathHandler{queryService: mockQS, maxSegments: 0}
+	_, full, err := uncapped.handle(context.Background(), nil, types.GetCriticalPathInput{
+		TraceID: "00000000000000000000000000000001",
+	})
+	require.NoError(t, err)
+	require.Len(t, full.Segments, full.TotalSegmentCount)
+	assert.Equal(t, full.TotalSegmentCount, output.TotalSegmentCount)
+	assert.Equal(t, full.CriticalPathDurationUs, output.CriticalPathDurationUs,
+		"critical path duration must be computed over the full path")
+
+	kept := make(map[string]bool, limit)
+	minKept := uint64(math.MaxUint64)
+	for _, s := range output.Segments {
+		kept[s.SpanID+"/"+strconv.FormatUint(s.StartOffsetUs, 10)] = true
+		if s.SelfTimeUs < minKept {
+			minKept = s.SelfTimeUs
+		}
+	}
+	for _, s := range full.Segments {
+		if !kept[s.SpanID+"/"+strconv.FormatUint(s.StartOffsetUs, 10)] {
+			assert.LessOrEqual(t, s.SelfTimeUs, minKept,
+				"a dropped segment must not out-rank a kept one")
+		}
+	}
+
+	// Returned segments keep the path's native order: trace end first,
+	// matching the uncapped response (see section order in criticalpath tests).
+	for i := 1; i < len(output.Segments); i++ {
+		assert.GreaterOrEqual(t, output.Segments[i-1].StartOffsetUs, output.Segments[i].StartOffsetUs)
+	}
+	for i := 1; i < len(full.Segments); i++ {
+		assert.GreaterOrEqual(t, full.Segments[i-1].StartOffsetUs, full.Segments[i].StartOffsetUs,
+			"uncapped output must have the same ordering the cap preserves")
+	}
+}
+
+func TestCapSegments_DeterministicTiebreaks(t *testing.T) {
+	// Equal self times force the start-offset tiebreak, and equal start offsets
+	// force the span-ID tiebreak, in both sort passes.
+	segs := []types.CriticalPathSegment{
+		{SpanID: "dd", SelfTimeUs: 10, StartOffsetUs: 40},
+		{SpanID: "bb", SelfTimeUs: 10, StartOffsetUs: 20},
+		{SpanID: "aa", SelfTimeUs: 10, StartOffsetUs: 20},
+		{SpanID: "cc", SelfTimeUs: 5, StartOffsetUs: 30},
+	}
+	h := &getCriticalPathHandler{maxSegments: 3}
+
+	got := h.capSegments(slices.Clone(segs))
+
+	// The three self-time-10 segments survive; cc (5us) is dropped. Survivors
+	// keep the native trace-end-first order, with the aa/bb tie at offset 20
+	// broken by span ID.
+	want := []types.CriticalPathSegment{
+		{SpanID: "dd", SelfTimeUs: 10, StartOffsetUs: 40},
+		{SpanID: "aa", SelfTimeUs: 10, StartOffsetUs: 20},
+		{SpanID: "bb", SelfTimeUs: 10, StartOffsetUs: 20},
+	}
+	assert.Equal(t, want, got)
+
+	// Same input in a different order produces the identical result.
+	shuffled := []types.CriticalPathSegment{segs[3], segs[0], segs[2], segs[1]}
+	assert.Equal(t, want, h.capSegments(shuffled))
+}
+
+func TestGetCriticalPathHandler_SegmentCap_ZeroMeansUnlimited(t *testing.T) {
+	mockQS := &mockGetCriticalPathQueryService{
+		traces: []ptrace.Traces{buildNestedChainTrace(30)},
+	}
+	handler := &getCriticalPathHandler{queryService: mockQS, maxSegments: 0}
+
+	_, output, err := handler.handle(context.Background(), nil, types.GetCriticalPathInput{
+		TraceID: "00000000000000000000000000000001",
+	})
+	require.NoError(t, err)
+	assert.Len(t, output.Segments, output.TotalSegmentCount)
+	assert.Greater(t, output.TotalSegmentCount, 20)
+}
+
+func TestGetCriticalPathHandler_SegmentCap_UnderLimitUntouched(t *testing.T) {
+	mockQS := &mockGetCriticalPathQueryService{
+		traces: []ptrace.Traces{createCriticalPathTestTrace()},
+	}
+	handler := &getCriticalPathHandler{queryService: mockQS, maxSegments: 20}
+
+	_, output, err := handler.handle(context.Background(), nil, types.GetCriticalPathInput{
+		TraceID: "00000000000000000000000000000001",
+	})
+	require.NoError(t, err)
+	assert.Len(t, output.Segments, output.TotalSegmentCount)
+	assert.LessOrEqual(t, output.TotalSegmentCount, 20)
 }
 
 func TestGetCriticalPathHandler_Handle_Success(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
@@ -13,8 +13,9 @@ type GetCriticalPathInput struct {
 type GetCriticalPathOutput struct {
 	TraceID                string                `json:"trace_id" jsonschema:"Unique identifier for the trace"`
 	TotalDurationUs        uint64                `json:"total_duration_us" jsonschema:"Total trace duration in microseconds"`
-	CriticalPathDurationUs uint64                `json:"critical_path_duration_us" jsonschema:"Total duration of critical path in microseconds"`
-	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Ordered list of span segments on the critical path"`
+	CriticalPathDurationUs uint64                `json:"critical_path_duration_us" jsonschema:"Total duration of critical path in microseconds, computed over the full path even when segments are truncated"`
+	TotalSegmentCount      int                   `json:"total_segment_count" jsonschema:"Total number of segments on the critical path before truncation; compare with the number of returned segments to detect truncation"`
+	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Segments on the critical path, ordered from the end of the trace backwards; when truncated to the server limit only the segments with the largest self_time_us are kept"`
 }
 
 // CriticalPathSegment represents a span segment on the critical path.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -162,8 +162,10 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 		Name: "get_critical_path",
 		Description: "Identify the critical latency path through a trace: the chain of spans " +
 			"that determined end-to-end duration. " +
-			"Higher self_time_us values indicate where time is concentrated on the critical path.",
-	}, handlers.NewGetCriticalPathHandler(s.queryAPI))
+			"Higher self_time_us values indicate where time is concentrated on the critical path. " +
+			"Segments may be truncated to the server limit, keeping the largest self_time_us; " +
+			"compare total_segment_count with the number of returned segments to detect truncation.",
+	}, handlers.NewGetCriticalPathHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_service_dependencies",


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #9175. `get_critical_path` was the only trace tool with no response bound, measured at 282 KB of JSON for a 5,000 span trace, while the other trace tools cap at `max_span_details_per_request`.

## Description of the changes
- The path is still computed over the complete trace, since truncating the input would change which path is critical. Only the response is capped.
- `NewGetCriticalPathHandler` reuses the existing `MaxSpanDetailsPerRequest` limit, with 0 meaning unlimited.
- Over the limit, the segments with the largest `self_time_us` are kept and re-sorted back into the path's native order (trace end first, the same order the uncapped response has, see the section order in `criticalpath` tests). Ties break by start offset then span ID, so the selection is deterministic.
- `total_segment_count` and `critical_path_duration_us` always reflect the full path, so truncation is detectable like `total_error_count` in `get_trace_errors`.
- Per-tool limits were raised in #9135 and are left to that benchmark work. The limit is the built-in default for all capped tools today (#8926 tracks restoring the config surface).

## How was this change tested?
- Unit tests for the cap: largest self-time segments kept in the uncapped order, deterministic tiebreaks, 0 means unlimited, under-limit untouched.
- Changed functions are at 100% coverage.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR
- [x] **Moderate**: AI helped with code generation or debugging specific parts