### PR TITLE
fix: reject nil query in storage v2 gRPC search handlers to prevent panic

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -119,6 +119,9 @@ func (h *Handler) FindTraces(
 	req *storage.FindTracesRequest,
 	srv storage.TraceReader_FindTracesServer,
 ) error {
+	if req.Query == nil {
+		return status.Error(codes.InvalidArgument, "missing query")
+	}
 	for traces, err := range h.traceReader.FindTraces(srv.Context(), toTraceQueryParams(req.Query)) {
 		if err != nil {
 			return err
@@ -138,6 +141,9 @@ func (h *Handler) FindTraceSummaries(
 	req *storage.FindTraceSummariesRequest,
 	srv storage.TraceReader_FindTraceSummariesServer,
 ) error {
+	if req.Query == nil {
+		return status.Error(codes.InvalidArgument, "missing query")
+	}
 	for summaries, err := range h.traceReader.FindTraceSummaries(srv.Context(), toTraceQueryParams(req.Query)) {
 		if err != nil {
 			// A backend that cannot compute summaries natively signals this with
@@ -182,6 +188,9 @@ func (h *Handler) FindTraceIDs(
 	ctx context.Context,
 	req *storage.FindTraceIDsRequest,
 ) (*storage.FindTraceIDsResponse, error) {
+	if req.Query == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing query")
+	}
 	foundTraceIDs := []*storage.FoundTraceID{}
 	for traceIDs, err := range h.traceReader.FindTraceIDs(ctx, toTraceQueryParams(req.Query)) {
 		if err != nil {

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -753,6 +753,30 @@ func (s *summaryStream) Send(r *storage.FindTraceSummariesResponse) error {
 	return nil
 }
 
+func TestHandler_FindTraces_NilQuery(t *testing.T) {
+	handler := NewHandler(new(tracestoremocks.Reader), new(tracestoremocks.Writer), new(depstoremocks.Reader))
+	err := handler.FindTraces(&storage.FindTracesRequest{}, &testStream{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "missing query")
+}
+
+func TestHandler_FindTraceIDs_NilQuery(t *testing.T) {
+	handler := NewHandler(new(tracestoremocks.Reader), new(tracestoremocks.Writer), new(depstoremocks.Reader))
+	_, err := handler.FindTraceIDs(context.Background(), &storage.FindTraceIDsRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "missing query")
+}
+
+func TestHandler_FindTraceSummaries_NilQuery(t *testing.T) {
+	handler := NewHandler(new(tracestoremocks.Reader), new(tracestoremocks.Writer), new(depstoremocks.Reader))
+	err := handler.FindTraceSummaries(&storage.FindTraceSummariesRequest{}, &summaryStream{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "missing query")
+}
+
 func TestHandler_FindTraceSummaries_NotImplemented(t *testing.T) {
 	// A backend that cannot compute summaries natively yields errors.ErrUnsupported;
 	// the handler must translate that into gRPC Unimplemented.


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9156

Three storage v2 gRPC handlers (FindTraces, FindTraceIDs, FindTraceSummaries) panic when the request omits the nested `query` message. Protobuf permits this message to be omitted, in which case `req.Query` is nil and `toTraceQueryParams()` dereferences a nil pointer.

## Description of the changes

- Added nil check for `req.Query` at the top of `FindTraces`, `FindTraceIDs`, and `FindTraceSummaries`
- Returns gRPC status `codes.InvalidArgument` with message `"missing query"` — matching the existing API v3 handler pattern
- Added three regression tests (`TestHandler_FindTraces_NilQuery`, `TestHandler_FindTraceIDs_NilQuery`, `TestHandler_FindTraceSummaries_NilQuery`) confirming each RPC returns the expected error without invoking the storage backend

## How was this PR tested

- Unit tests: `go test ./internal/storage/v2/grpc/ -run TestHandler_Find -v`
- All existing tests continue to pass

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md)
- [x] I have signed the [CNCF CLA](https://github.com/jaegertracing/jaeger/blob/main/README.md#contributing)
- [x] Existing tests are passing
- [x] I have added tests for the changes