### PR TITLE
fix: remove orphan spans when span-count limit truncates intermediate parents (#9178) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_trace_topology.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_trace_topology.go
@@ -94,6 +94,13 @@ func (h *getTraceTopologyHandler) handle(
 		return nil, types.GetTraceTopologyOutput{}, errors.New("trace not found")
 	}
 
+	// When the span limit was reached, remove orphan spans whose parent
+	// was truncated. This prevents structurally misleading topology output
+	// where a child span appears without its parent.
+	if h.maxSpanDetailsPerRequest > 0 && len(spans) >= h.maxSpanDetailsPerRequest {
+		spans = h.removeOrphanedSpans(spans)
+	}
+
 	// Build the flat topology list from the collected spans
 	output := types.GetTraceTopologyOutput{
 		TraceID: input.TraceID,
@@ -150,6 +157,33 @@ func extractRawSpan(pos jptrace.SpanIterPos, span ptrace.Span) rawSpan {
 		status:     span.Status().Code().String(),
 		startNano:  span.StartTimestamp().AsTime().UnixNano(),
 	}
+}
+
+// removeOrphanedSpans removes spans whose parent was truncated by the span limit.
+// When the span limit (maxSpanDetailsPerRequest) causes a parent to be excluded
+// while its child is retained, the child becomes an orphan. Removing these orphans
+// prevents structurally misleading topology output.
+func (h *getTraceTopologyHandler) removeOrphanedSpans(spans []rawSpan) []rawSpan {
+	if len(spans) == 0 {
+		return spans
+	}
+
+	// Build a set of collected span IDs
+	byID := make(map[string]bool, len(spans))
+	for _, s := range spans {
+		byID[s.spanID] = true
+	}
+
+	// Remove spans whose parent is not in the collected set
+	result := make([]rawSpan, 0, len(spans))
+	for _, s := range spans {
+		if s.parentID != "" && !byID[s.parentID] {
+			// This span's parent was truncated by the limit, skip it
+			continue
+		}
+		result = append(result, s)
+	}
+	return result
 }
 
 // buildFlatTopology converts a flat slice of rawSpans into a depth-first ordered

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_trace_topology_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_trace_topology_test.go
@@ -599,3 +599,42 @@ func TestGetTraceTopologyHandler_Handle_LimitEnforced(t *testing.T) {
 	// Exactly 3 spans returned — 6-span trace with limit=3 must truncate to exactly 3
 	assert.Len(t, output.Spans, 3)
 }
+
+func TestGetTraceTopologyHandler_Handle_LimitOutOfOrderSpans(t *testing.T) {
+	traceID := testTraceID
+
+	// Spans sorted by spanID in OTLP iteration order: grandchild, root, child.
+	// With limit=2, the first 2 spans are grandchild and root. The intermediate
+	// child span (parent of grandchild) is excluded by the limit.
+	// Without the fix, the output would contain an orphan grandchild span
+	// whose parent (child) is not present.
+	spanConfigs := []spanConfig{
+		{spanID: "grand01", parentSpanID: "child01", operation: "grandchild"},
+		{spanID: "root001", operation: "root"},
+		{spanID: "child01", parentSpanID: "root001", operation: "child"},
+	}
+
+	testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+	mock := newMockYieldingTraces(testTrace)
+
+	handler := &getTraceTopologyHandler{
+		queryService:             mock,
+		maxSpanDetailsPerRequest: 2,
+	}
+
+	input := types.GetTraceTopologyInput{TraceID: traceID}
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+
+	// Only the root span should be returned. The grandchild's parent (child)
+	// was truncated, so the grandchild should also be removed.
+	root := findSpanByName(output.Spans, "root")
+	require.NotNil(t, root)
+
+	grandchild := findSpanByName(output.Spans, "grandchild")
+	require.Nil(t, grandchild, "grandchild should be removed since its parent was truncated")
+
+	child := findSpanByName(output.Spans, "child")
+	require.Nil(t, child, "child should be truncated by the limit")
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9178

The `get_trace_topology` MCP tool limits the number of spans returned based on `maxSpanDetailsPerRequest`. When the span limit is reached, the truncation occurs by iteration order (OTLP span iteration), not by topology. If an intermediate parent span is excluded by the limit but one of its descendants is retained, the output contains an orphan span whose parent does not exist in the response.

## Description of the changes

Added a post-processing step in `getTraceTopologyHandler.handle()` that removes orphan spans whose parent was truncated by the span limit. After collecting spans with the limit, if the limit was reached, any span whose parent is not in the collected set is removed.

This ensures the topology output is structurally consistent and does not contain orphan spans.

## How was this change tested?

- Added `TestGetTraceTopologyHandler_Handle_LimitOutOfOrderSpans` regression test
- All existing tests pass unchanged

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] I have signed the required DCO (not required for this change).
- [x] The change is cleanly scoped to the topology handler.