### PR TITLE
fix: skip same-service parent/child pairs in v2 memory store GetDependencies

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -901,6 +901,36 @@ func TestGetDependencies_WrongSpanId(t *testing.T) {
 	assert.Empty(t, deps)
 }
 
+func TestGetDependencies_SameService(t *testing.T) {
+	store, err := NewStore(Configuration{
+		MaxTraces: 10,
+	})
+	require.NoError(t, err)
+	td := ptrace.NewTraces()
+	resourceSpans := td.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr(conventions.ServiceNameKey, "service-x")
+	span1 := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span1.SetTraceID(fromString(t, "00000000000000010000000000000000"))
+	span1.SetSpanID(spanIdFromString(t, "0000000000000001"))
+	span1.SetParentSpanID(spanIdFromString(t, "0000000000000002"))
+	startTime := time.Now()
+	span1.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
+	span1.SetEndTimestamp(pcommon.NewTimestampFromTime(startTime.Add(1 * time.Second)))
+	span2 := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span2.SetTraceID(fromString(t, "00000000000000010000000000000000"))
+	span2.SetSpanID(spanIdFromString(t, "0000000000000002"))
+	span2.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime.Add(-1 * time.Second)))
+	span2.SetEndTimestamp(pcommon.NewTimestampFromTime(startTime.Add(2 * time.Second)))
+	err = store.WriteTraces(context.Background(), td)
+	require.NoError(t, err)
+	deps, err := store.GetDependencies(context.Background(), depstore.QueryParameters{
+		StartTime: startTime.Add(-2 * time.Second),
+		EndTime:   startTime.Add(3 * time.Second),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, deps, "same-service parent/child should not produce a dependency link")
+}
+
 func writeTenTraces(t *testing.T, store *Store) {
 	for i := 1; i < 10; i++ {
 		traceID := fromString(t, fmt.Sprintf("000000000000000%d0000000000000000", i))

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -183,6 +183,9 @@ func (t *Tenant) getDependencies(query depstore.QueryParameters) ([]model.Depend
 					if !found {
 						continue
 					}
+					if parentSpanServiceName == spanServiceName {
+						continue
+					}
 					depKey := parentSpanServiceName + "&&&" + spanServiceName
 					if _, ok := deps[depKey]; !ok {
 						deps[depKey] = &model.DependencyLink{


### PR DESCRIPTION
## Description

The v2 in-memory store builds dependency links without checking whether the parent and child spans belong to the same service. This causes any service with nested internal spans to produce a `service -> service` self-loop in the System Architecture graph.

The Badger dependency store has this check (see `processTrace` in `internal/storage/v1/badger/dependencystore/storage.go#L64`), and the v1 memory store had it until it was removed in #7711. The v2 implementation (#7154) did not carry it over.

## Fix

Added a same-service check in `internal/storage/v2/memory/tenant.go` — if the parent span's service name equals the child span's service name, the pair is skipped (matching the Badger store's behavior).

## Testing

- ✅ Existing `TestGetDependencies` tests pass unchanged
- ✅ New `TestGetDependencies_SameService` test verifies that a parent/child pair in the same service produces zero dependency links

Fixes #9089