### PR TITLE
fix: use <= in findLastFinishingChildSpan to include back-to-back sequential spans (#9173)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
@@ -27,8 +27,11 @@ func findLastFinishingChildSpan(
 		childEndTime := childSpan.StartTime + childSpan.Duration
 
 		if returningChildStartTime != nil {
-			// Find child that finishes just before the returning child's start time
-			if childEndTime < *returningChildStartTime {
+			// Find child that finishes just before the returning child's start time.
+			// Use <= to include back-to-back sequential spans where the predecessor
+			// ends at exactly the same time the next span starts (e.g. synchronous
+			// pipelines with millisecond-resolution clocks).
+			if childEndTime <= *returningChildStartTime {
 				if childEndTime > maxEndTime {
 					maxEndTime = childEndTime
 					childSpanCopy := childSpan


### PR DESCRIPTION
## What changed?

Changed the strict inequality `<` to `<=` in `findLastFinishingChildSpan` so that perfectly sequential spans (where one child ends at exactly the same time the next starts) are included in the critical path.

## Why?

The `get_critical_path` MCP tool uses `findLastFinishingChildSpan` to reconstruct the critical path of a trace by walking backwards from the latest-finishing span. When two spans are perfectly sequential — which is extremely common in synchronous pipelines or runtimes with millisecond-resolution clocks (like Node.js) — the previous span's end time equals the next span's start time. With the strict `<` check, `50 < 50` evaluates to `false`, causing the predecessor span to be skipped entirely. This breaks the contiguous chain and causes the AI assistant to hallucinate large time gaps, failing to identify the true root-cause bottlenecks.

## Verification

- [x] `go vet ./...` passes
- [x] Existing tests in `find_lfc_test.go` and `criticalpath_test.go` still pass

## Related issue

Fixes #9173