### PR TITLE
fix(clickhouse): Translate the error attribute into a status_code predicate

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/query_builder.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder.go
@@ -11,12 +11,39 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/xpdata"
 
 	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
 )
+
+// errorAttributeKey is the Jaeger convention for filtering traces by error
+// state: the query attribute error=true must match spans whose OTLP status is
+// Error, regardless of whether a literal "error" attribute was ever stored
+// (#8553). The semantics of this one key mirror the memory store's, including
+// error=false matching Unset-status spans (#9096). Other synthetic query keys
+// the memory store supports (span.status, span.kind, scope.*) are not yet
+// translated here.
+const errorAttributeKey = "error"
+
+// errorQueryValue interprets the value of the error query attribute, mirroring
+// the memory store: an unparseable value is invalid and must match nothing.
+func errorQueryValue(attr pcommon.Value) (value bool, valid bool) {
+	switch attr.Type() {
+	case pcommon.ValueTypeBool:
+		return attr.Bool(), true
+	case pcommon.ValueTypeStr:
+		val, err := strconv.ParseBool(attr.Str())
+		if err != nil {
+			return false, false
+		}
+		return val, true
+	default:
+		return false, false
+	}
+}
 
 // marshalValueForQuery is a simpler wrapper around xpdata.JSONMarshaler.
 // It can be overridden in tests to simulate marshaling errors.
@@ -161,12 +188,35 @@ func (r *Reader) buildFindTraceIDsQuery(
 		args = append(args, query.StartTimeMax)
 	}
 
-	attributeMetadata, err := r.getAttributeMetadata(ctx, query.Attributes)
+	// The error attribute is a status filter, not a stored attribute
+	// (see errorAttributeKey).
+	attributes := query.Attributes
+	if errAttr, ok := attributes.Get(errorAttributeKey); ok {
+		errorVal, valid := errorQueryValue(errAttr)
+		if valid {
+			if errorVal {
+				appendAnd(&inner, "s.status_code = ?")
+			} else {
+				// Not-error includes the default Unset status, not just Ok (#9096).
+				appendAnd(&inner, "s.status_code != ?")
+			}
+			args = append(args, ptrace.StatusCodeError.String())
+			attributes = pcommon.NewMap()
+			query.Attributes.CopyTo(attributes)
+			attributes.Remove(errorAttributeKey)
+		} else {
+			// An unparseable error value matches nothing, same as the memory store.
+			appendAnd(&inner, "1 = 0")
+			attributes = pcommon.NewMap()
+		}
+	}
+
+	attributeMetadata, err := r.getAttributeMetadata(ctx, attributes)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get attribute metadata: %w", err)
 	}
 
-	args, err = buildAttributeConditions(&inner, args, query.Attributes, attributeMetadata)
+	args, err = buildAttributeConditions(&inner, args, attributes, attributeMetadata)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/clickhousetest"
 	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/sql"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/clickhouse/tracestore/dbmodel"
 )
 
 func TestBuildFindTraceIDsQuery_MarshalErrors(t *testing.T) {
@@ -189,4 +190,155 @@ func TestBuildStringAttributeCondition_MultipleTypes(t *testing.T) {
 	assert.Contains(t, query, "OR")
 	assert.Contains(t, query, "str_attributes")
 	assert.Len(t, args, 4)
+}
+
+func TestBuildFindTraceIDsQuery_ErrorAttribute(t *testing.T) {
+	tests := []struct {
+		name     string
+		setAttr  func(attrs pcommon.Map)
+		wantCond string
+		wantArgs []any
+	}{
+		{
+			name:     "true as string",
+			setAttr:  func(attrs pcommon.Map) { attrs.PutStr("error", "true") },
+			wantCond: "s.status_code = ?",
+			wantArgs: []any{"svc", "Error", 10},
+		},
+		{
+			name:     "true as bool",
+			setAttr:  func(attrs pcommon.Map) { attrs.PutBool("error", true) },
+			wantCond: "s.status_code = ?",
+			wantArgs: []any{"svc", "Error", 10},
+		},
+		{
+			name:     "false as string",
+			setAttr:  func(attrs pcommon.Map) { attrs.PutStr("error", "false") },
+			wantCond: "s.status_code != ?",
+			wantArgs: []any{"svc", "Error", 10},
+		},
+		{
+			name:     "false as bool",
+			setAttr:  func(attrs pcommon.Map) { attrs.PutBool("error", false) },
+			wantCond: "s.status_code != ?",
+			wantArgs: []any{"svc", "Error", 10},
+		},
+		{
+			name:     "invalid value matches nothing",
+			setAttr:  func(attrs pcommon.Map) { attrs.PutInt("error", 1) },
+			wantCond: "1 = 0",
+			wantArgs: []any{"svc", 10},
+		},
+		{
+			name:     "unparseable string matches nothing",
+			setAttr:  func(attrs pcommon.Map) { attrs.PutStr("error", "maybe") },
+			wantCond: "1 = 0",
+			wantArgs: []any{"svc", 10},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := pcommon.NewMap()
+			tt.setAttr(attrs)
+
+			// The bare driver proves no attribute metadata query is issued.
+			reader := NewReader(&clickhousetest.Driver{}, testReaderConfig)
+			query, args, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{
+				ServiceName: "svc",
+				Attributes:  attrs,
+				SearchDepth: 10,
+			})
+			require.NoError(t, err)
+
+			assert.Contains(t, query, tt.wantCond)
+			assert.Equal(t, tt.wantArgs, args)
+		})
+	}
+}
+
+func TestBuildFindTraceIDsQuery_ErrorAttributeAlongsideOthers(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("error", "true")
+	attrs.PutStr("http.method", "GET")
+
+	conn := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectAttributeMetadata: {
+				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+					Data:   nil,
+					ScanFn: scanAttributeMetadataFn(),
+				},
+			},
+		},
+	}
+	reader := NewReader(conn, testReaderConfig)
+	query, args, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{
+		ServiceName: "svc",
+		Attributes:  attrs,
+		SearchDepth: 10,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, query, "s.status_code = ?")
+	assert.Contains(t, query, "arrayExists")
+	assert.Equal(t, []any{
+		"svc", "Error",
+		"http.method", "GET", "http.method", "GET", "http.method", "GET",
+		"http.method", "GET", "http.method", "GET",
+		10,
+	}, args)
+}
+
+func TestBuildFindTraceIDsQuery_ErrorFalseAlongsideOthers(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutBool("error", false)
+	attrs.PutStr("http.method", "GET")
+
+	conn := &clickhousetest.Driver{
+		QueryResponses: map[string]*clickhousetest.QueryResponse{
+			sql.SelectAttributeMetadata: {
+				Rows: &clickhousetest.Rows[dbmodel.AttributeMetadata]{
+					Data:   nil,
+					ScanFn: scanAttributeMetadataFn(),
+				},
+			},
+		},
+	}
+	reader := NewReader(conn, testReaderConfig)
+	query, args, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{
+		ServiceName: "svc",
+		Attributes:  attrs,
+		SearchDepth: 10,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, query, "s.status_code != ?")
+	assert.Contains(t, query, "arrayExists")
+	assert.Equal(t, []any{
+		"svc", "Error",
+		"http.method", "GET", "http.method", "GET", "http.method", "GET",
+		"http.method", "GET", "http.method", "GET",
+		10,
+	}, args)
+}
+
+func TestBuildFindTraceIDsQuery_InvalidErrorDropsSiblings(t *testing.T) {
+	// An unparseable error value matches nothing, so the sibling attribute
+	// conditions are intentionally dropped.
+	attrs := pcommon.NewMap()
+	attrs.PutStr("error", "maybe")
+	attrs.PutStr("http.method", "GET")
+
+	reader := NewReader(&clickhousetest.Driver{}, testReaderConfig)
+	query, args, err := reader.buildFindTraceIDsQuery(t.Context(), tracestore.TraceQueryParams{
+		ServiceName: "svc",
+		Attributes:  attrs,
+		SearchDepth: 10,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, query, "1 = 0")
+	assert.NotContains(t, query, "arrayExists")
+	assert.Equal(t, []any{"svc", 10}, args)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #9184. ClickHouse matched the `error` search attribute against stored attributes, so `error=true` and `error=false` returned nothing for OTLP traces, which carry error state in span status.

## Description of the changes
- `buildFindTraceIDsQuery` translates the `error` attribute into a `status_code` predicate instead of attribute matching. `error=false` means not-Error, so `Unset` spans are included, same as the memory store after #9096.
- An unparseable value matches nothing, also mirroring the memory store.
- Known trade-off: a literal stored `error` attribute no longer matches this filter. Same as the memory reference; ES gets both because its writer materializes the tag. The other synthetic keys (`span.status`, `span.kind`, `scope.*`) and a `status_code` skip index are follow-up material.

## How was this change tested?
- Unit tests on the generated SQL for every value form, with and without other attributes.
- Verified live on docker-compose ClickHouse: the issue's repro fails on main and passes with this change.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR
- [x] **Moderate**: AI helped with code generation or debugging specific parts

