### PR TITLE
fix: translate error attribute to status_code in ClickHouse query builder (#9184)

### DIFF
--- a/internal/storage/v2/clickhouse/tracestore/query_builder.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder.go
@@ -185,6 +185,41 @@ func buildAttributeConditions(q *strings.Builder, args []any, attributes pcommon
 	for key, attr := range attributes.All() {
 		appendAnd(q, "(")
 
+		// Special handling for the "error" attribute: it should match the span's
+		// status_code column, not a literal attribute. OTLP spans carry error state
+		// in span status, not in a literal "error" attribute. The error=true filter
+		// is the existing Jaeger convention that works across storage backends.
+		if key == "error" {
+			var errorVal bool
+			switch attr.Type() {
+			case pcommon.ValueTypeBool:
+				errorVal = attr.Bool()
+			case pcommon.ValueTypeStr:
+				var parseErr error
+				errorVal, parseErr = strconv.ParseBool(attr.Str())
+				if parseErr != nil {
+					// Could not parse as boolean, fall through to normal attribute matching
+					goto normalAttribute
+				}
+			default:
+				// Not a bool or string, fall through to normal attribute matching
+				goto normalAttribute
+			}
+			if errorVal {
+				appendNewlineAndIndent(q, 2)
+				q.WriteString("s.status_code = ?")
+				args = append(args, "Error")
+			} else {
+				appendNewlineAndIndent(q, 2)
+				q.WriteString("s.status_code != ?")
+				args = append(args, "Error")
+			}
+			appendNewlineAndIndent(q, 1)
+			q.WriteString(")")
+			continue
+		}
+
+	normalAttribute:
 		var err error
 		switch attr.Type() {
 		case pcommon.ValueTypeBool:

--- a/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
+++ b/internal/storage/v2/clickhouse/tracestore/query_builder_test.go
@@ -190,3 +190,97 @@ func TestBuildStringAttributeCondition_MultipleTypes(t *testing.T) {
 	assert.Contains(t, query, "str_attributes")
 	assert.Len(t, args, 4)
 }
+
+func TestBuildAttributeConditions_ErrorAttribute(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupAttr     func() pcommon.Value
+		expectStatus  *bool // true = expect status_code =, false = expect status_code !=, nil = expect normal attribute matching
+		expectArgs    int
+	}{
+		{
+			name: "error=true bool",
+			setupAttr: func() pcommon.Value {
+				return pcommon.NewValueBool(true)
+			},
+			expectStatus: ptr(true),
+			expectArgs:   1,
+		},
+		{
+			name: "error=false bool",
+			setupAttr: func() pcommon.Value {
+				return pcommon.NewValueBool(false)
+			},
+			expectStatus: ptr(false),
+			expectArgs:   1,
+		},
+		{
+			name: "error=true string",
+			setupAttr: func() pcommon.Value {
+				return pcommon.NewValueStr("true")
+			},
+			expectStatus: ptr(true),
+			expectArgs:   1,
+		},
+		{
+			name: "error=false string",
+			setupAttr: func() pcommon.Value {
+				return pcommon.NewValueStr("false")
+			},
+			expectStatus: ptr(false),
+			expectArgs:   1,
+		},
+		{
+			name: "error=not-a-bool string falls through to normal attribute matching",
+			setupAttr: func() pcommon.Value {
+				return pcommon.NewValueStr("not-a-bool")
+			},
+			expectStatus: nil,
+			expectArgs:   10, // 5 key-value pairs from appendStringAttributeFallback
+		},
+		{
+			name: "error=int falls through to normal attribute matching",
+			setupAttr: func() pcommon.Value {
+				return pcommon.NewValueInt(42)
+			},
+			expectStatus: nil,
+			expectArgs:   10, // 5 key-value pairs from buildSimpleAttributeCondition
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			attrs := pcommon.NewMap()
+			attr := tc.setupAttr()
+			attr.CopyTo(attrs.PutEmpty("error"))
+
+			var q strings.Builder
+			var args []any
+			metadata := attributeMetadata{}
+
+			args, err := buildAttributeConditions(&q, args, attrs, metadata)
+			require.NoError(t, err)
+			require.Len(t, args, tc.expectArgs)
+
+			query := q.String()
+
+			if tc.expectStatus != nil {
+				// Error attribute was handled specially via status_code
+				if *tc.expectStatus {
+					assert.Contains(t, query, "s.status_code = ?")
+				} else {
+					assert.Contains(t, query, "s.status_code != ?")
+				}
+				assert.Equal(t, "Error", args[0])
+			} else {
+				// Error attribute fell through to normal attribute matching
+				assert.NotContains(t, query, "s.status_code = ?")
+				assert.NotContains(t, query, "s.status_code != ?")
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #9184

## Description
The ClickHouse query builder routes the `error` attribute through ordinary attribute matching, generating `arrayExists` conditions over the stored attribute maps. OTLP spans carry error state in the span `status_code` column, not in a literal `error` attribute, so both `error=true` and `error=false` return nothing.

This fix intercepts the `error` key in `buildAttributeConditions` and generates a condition on `s.status_code` instead:
- `error=true` → `s.status_code = 'Error'`
- `error=false` → `s.status_code != 'Error'`

Non-boolean values for `error` (e.g. `"not-a-bool"`, int) fall through to normal attribute matching, preserving backward compatibility.

## How was this change tested?
Added `TestBuildAttributeConditions_ErrorAttribute` with 6 sub-tests covering:
- `error=true` as bool
- `error=false` as bool
- `error="true"` as string
- `error="false"` as string
- `error="not-a-bool"` falls through to normal attribute matching
- `error=42` (int) falls through to normal attribute matching

All 48 tests in the package pass.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have signed the CNCF CLA.
- [x] I have added tests that prove my fix is effective.