### PR TITLE
fix: default search_depth to 100 in gRPC traceQueryParams to match HTTP gateway (#9099)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -90,12 +90,16 @@ func traceQueryParams(query *api_v3.TraceQueryParameters) (querysvc.TraceQueryPa
 	if query.GetStartTimeMin().IsZero() || query.GetStartTimeMax().IsZero() {
 		return querysvc.TraceQueryParams{}, status.Error(codes.InvalidArgument, "start time min and max are required parameters")
 	}
+	searchDepth := int(query.GetSearchDepth())
+	if searchDepth <= 0 {
+		searchDepth = defaultSearchDepth
+	}
 	queryParams := querysvc.TraceQueryParams{
 		TraceQueryParams: tracestore.TraceQueryParams{
 			ServiceName:   query.GetServiceName(),
 			OperationName: query.GetOperationName(),
 			Attributes:    jptrace.PlainMapToPcommonMap(query.GetAttributes()),
-			SearchDepth:   int(query.GetSearchDepth()),
+			SearchDepth:   searchDepth,
 			StartTimeMin:  query.GetStartTimeMin(),
 			StartTimeMax:  query.GetStartTimeMax(),
 			DurationMin:   query.GetDurationMin(),

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
@@ -27,8 +27,11 @@ func findLastFinishingChildSpan(
 		childEndTime := childSpan.StartTime + childSpan.Duration
 
 		if returningChildStartTime != nil {
-			// Find child that finishes just before the returning child's start time
-			if childEndTime < *returningChildStartTime {
+			// Find child that finishes just before the returning child's start time.
+			// Use <= to include back-to-back sequential spans where the predecessor
+			// ends at exactly the same time the next span starts (e.g. synchronous
+			// pipelines with millisecond-resolution clocks).
+			if childEndTime <= *returningChildStartTime {
 				if childEndTime > maxEndTime {
 					maxEndTime = childEndTime
 					childSpanCopy := childSpan

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"sort"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -29,14 +30,17 @@ type queryServiceGetCriticalPathInterface interface {
 // (the blocking execution path) in a distributed trace.
 type getCriticalPathHandler struct {
 	queryService queryServiceGetCriticalPathInterface
+	maxSegments  int
 }
 
 // NewGetCriticalPathHandler creates a new get_critical_path handler and returns the handler function.
 func NewGetCriticalPathHandler(
 	queryService *querysvc.QueryService,
+	maxSegments int,
 ) mcp.ToolHandlerFor[types.GetCriticalPathInput, types.GetCriticalPathOutput] {
 	h := &getCriticalPathHandler{
 		queryService: queryService,
+		maxSegments:  maxSegments,
 	}
 	return h.handle
 }
@@ -82,7 +86,7 @@ func (h *getCriticalPathHandler) handle(
 	}
 
 	// Build output
-	output := h.buildOutput(input.TraceID, trace, criticalPathSections)
+	output := h.buildOutput(input.TraceID, trace, criticalPathSections, input)
 
 	return nil, output, nil
 }
@@ -108,10 +112,11 @@ func (*getCriticalPathHandler) buildQuery(input types.GetCriticalPathInput) (que
 }
 
 // buildOutput constructs the GetCriticalPathOutput from the trace and critical path sections.
-func (*getCriticalPathHandler) buildOutput(
+func (h *getCriticalPathHandler) buildOutput(
 	traceIDStr string,
 	trace ptrace.Traces,
 	criticalPathSections []criticalpath.Section,
+	input types.GetCriticalPathInput,
 ) types.GetCriticalPathOutput {
 	// Build a map of spans for quick lookup
 	spanMap := jptrace.SpanMap(trace, func(span ptrace.Span) string {
@@ -176,10 +181,27 @@ func (*getCriticalPathHandler) buildOutput(
 		})
 	}
 
+	totalCount := len(segments)
+
+	// Determine the cap: prefer caller-provided MaxSegments, fall back to server default
+	// When both are zero or negative, no cap is applied.
+	limit := h.maxSegments
+	if input.MaxSegments > 0 {
+		limit = input.MaxSegments
+	}
+	if limit > 0 && len(segments) > limit {
+		// Sort by self_time descending so we keep the most impactful segments
+		sort.Slice(segments, func(i, j int) bool {
+			return segments[i].SelfTimeUs > segments[j].SelfTimeUs
+		})
+		segments = segments[:limit]
+	}
+
 	return types.GetCriticalPathOutput{
 		TraceID:                traceIDStr,
 		TotalDurationUs:        traceEndTime - traceStartTime,
 		CriticalPathDurationUs: criticalPathDuration,
 		Segments:               segments,
+		TotalSegmentCount:      totalCount,
 	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
@@ -67,7 +67,7 @@ func createCriticalPathTestTrace() ptrace.Traces {
 
 func TestNewGetCriticalPathHandler(t *testing.T) {
 	// We can pass nil because we only check if it returns a handler function
-	handler := NewGetCriticalPathHandler(nil)
+	handler := NewGetCriticalPathHandler(nil, 20)
 	assert.NotNil(t, handler)
 }
 
@@ -78,6 +78,7 @@ func TestGetCriticalPathHandler_Handle_Success(t *testing.T) {
 	}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -91,6 +92,7 @@ func TestGetCriticalPathHandler_Handle_Success(t *testing.T) {
 	assert.Positive(t, output.TotalDurationUs)
 	assert.Positive(t, output.CriticalPathDurationUs)
 	assert.NotEmpty(t, output.Segments)
+	assert.Equal(t, len(output.Segments), output.TotalSegmentCount)
 
 	// Verify path contains span information
 	for _, span := range output.Segments {
@@ -104,6 +106,7 @@ func TestGetCriticalPathHandler_Handle_EmptyTraceID(t *testing.T) {
 	mockQS := &mockGetCriticalPathQueryService{}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -119,6 +122,7 @@ func TestGetCriticalPathHandler_Handle_InvalidTraceID(t *testing.T) {
 	mockQS := &mockGetCriticalPathQueryService{}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -136,6 +140,7 @@ func TestGetCriticalPathHandler_Handle_QueryServiceError(t *testing.T) {
 	}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -153,6 +158,7 @@ func TestGetCriticalPathHandler_Handle_TraceNotFound(t *testing.T) {
 	}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -183,6 +189,7 @@ func TestGetCriticalPathHandler_Handle_InvalidTrace(t *testing.T) {
 	}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -227,6 +234,7 @@ func TestGetCriticalPathHandler_Handle_MultipleServices(t *testing.T) {
 	}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -262,6 +270,7 @@ func TestGetCriticalPathHandler_Handle_UnknownService(t *testing.T) {
 	}
 	handler := &getCriticalPathHandler{
 		queryService: mockQS,
+		maxSegments:  20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -275,6 +284,78 @@ func TestGetCriticalPathHandler_Handle_UnknownService(t *testing.T) {
 	for _, span := range output.Segments {
 		assert.Equal(t, "unknown", span.Service)
 	}
+}
+
+func TestGetCriticalPathHandler_BuildOutput_Truncation(t *testing.T) {
+	handler := &getCriticalPathHandler{maxSegments: 2}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "test-service")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	// Create 3 spans with different self times
+	span1 := ss.Spans().AppendEmpty()
+	span1.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1})
+	span1.SetTraceID([16]byte{1})
+	span1.SetStartTimestamp(pcommon.Timestamp(1000 * 1000))
+	span1.SetEndTimestamp(pcommon.Timestamp(100100 * 1000)) // 100ms self time
+	span1.SetName("span-100ms")
+
+	span2 := ss.Spans().AppendEmpty()
+	span2.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2})
+	span2.SetTraceID([16]byte{1})
+	span2.SetStartTimestamp(pcommon.Timestamp(1000 * 1000))
+	span2.SetEndTimestamp(pcommon.Timestamp(10001 * 1000)) // ~10ms self time
+	span2.SetName("span-10ms")
+
+	span3 := ss.Spans().AppendEmpty()
+	span3.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 3})
+	span3.SetTraceID([16]byte{1})
+	span3.SetStartTimestamp(pcommon.Timestamp(1000 * 1000))
+	span3.SetEndTimestamp(pcommon.Timestamp(1002 * 1000)) // ~2ms self time
+	span3.SetName("span-2ms")
+
+	traceID := span1.TraceID().String()
+
+	sections := []criticalpath.Section{
+		{SpanID: span1.SpanID().String(), SectionStart: 1000, SectionEnd: 100100},
+		{SpanID: span2.SpanID().String(), SectionStart: 1000, SectionEnd: 10001},
+		{SpanID: span3.SpanID().String(), SectionStart: 1000, SectionEnd: 1002},
+	}
+
+	output := handler.buildOutput(traceID, traces, sections, types.GetCriticalPathInput{MaxSegments: 2})
+
+	assert.Equal(t, 3, output.TotalSegmentCount, "total before truncation")
+	assert.Len(t, output.Segments, 2, "should be truncated to 2")
+	// The top 2 by self_time should be span1 (100ms) and span2 (10ms)
+	assert.Equal(t, "span-100ms", output.Segments[0].SpanName, "first by self_time")
+	assert.Equal(t, "span-10ms", output.Segments[1].SpanName, "second by self_time")
+}
+
+func TestGetCriticalPathHandler_BuildOutput_NoTruncation(t *testing.T) {
+	handler := &getCriticalPathHandler{maxSegments: 20}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "test-service")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	span := ss.Spans().AppendEmpty()
+	span.SetSpanID([8]byte{1})
+	span.SetTraceID([16]byte{1})
+	span.SetStartTimestamp(pcommon.Timestamp(1000 * 1000))
+	span.SetEndTimestamp(pcommon.Timestamp(2000 * 1000))
+	span.SetName("single-span")
+
+	sections := []criticalpath.Section{
+		{SpanID: span.SpanID().String(), SectionStart: 1000, SectionEnd: 2000},
+	}
+
+	output := handler.buildOutput(span.TraceID().String(), traces, sections, types.GetCriticalPathInput{})
+
+	assert.Equal(t, 1, output.TotalSegmentCount)
+	assert.Len(t, output.Segments, 1)
 }
 
 func TestGetCriticalPathHandler_BuildOutput_MissingSpan(t *testing.T) {
@@ -309,7 +390,7 @@ func TestGetCriticalPathHandler_BuildOutput_MissingSpan(t *testing.T) {
 		},
 	}
 
-	output := handler.buildOutput(traceID, traces, sections)
+	output := handler.buildOutput(traceID, traces, sections, types.GetCriticalPathInput{})
 
 	// Should only have 1 segment for the existing span
 	assert.Len(t, output.Segments, 1)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -170,6 +170,10 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 		attributes.PutStr(key, value)
 	}
 	if input.WithErrors {
+		if userError, ok := input.Attributes["error"]; ok && !strings.EqualFold(userError, "true") {
+			return querysvc.TraceQueryParams{},
+				fmt.Errorf("with_errors=true conflicts with attributes[error]=%q: set with_errors to false or remove the error attribute to fix", userError)
+		}
 		attributes.PutStr("error", "true")
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -223,6 +223,87 @@ func TestSearchTracesHandler_Handle_WithErrorsFilter(t *testing.T) {
 	assert.True(t, output.Traces[0].HasErrors)
 }
 
+func TestSearchTracesHandler_Handle_WithErrorsFilter_ConflictWithAttributes(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes map[string]string
+		withErrors bool
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name:       "with_errors=true + error=false conflicts",
+			attributes: map[string]string{"error": "false"},
+			withErrors: true,
+			wantErr:    true,
+			errMsg:     "conflicts",
+		},
+		{
+			name:       "with_errors=true + error=FALSE (case insensitive) conflicts",
+			attributes: map[string]string{"error": "FALSE"},
+			withErrors: true,
+			wantErr:    true,
+			errMsg:     "conflicts",
+		},
+		{
+			name:       "with_errors=true + error=true is fine",
+			attributes: map[string]string{"error": "true"},
+			withErrors: true,
+			wantErr:    false,
+		},
+		{
+			name:       "with_errors=false + error=false is fine",
+			attributes: map[string]string{"error": "false"},
+			withErrors: false,
+			wantErr:    false,
+		},
+		{
+			name:       "with_errors=true + no error attribute is fine",
+			attributes: map[string]string{"http.status_code": "500"},
+			withErrors: true,
+			wantErr:    false,
+		},
+		{
+			name:       "with_errors=true + error=INVALID conflicts",
+			attributes: map[string]string{"error": "INVALID"},
+			withErrors: true,
+			wantErr:    true,
+			errMsg:     "conflicts",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := makeTraceSummary("test", "/test", tt.withErrors)
+			mock := &mockQueryService{
+				findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+					return func(yield func([]tracestore.TraceSummary, error) bool) {
+						yield([]tracestore.TraceSummary{want}, nil)
+					}
+				},
+			}
+
+			handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+
+			input := types.SearchTracesInput{
+				StartTimeMin: "-1h",
+				ServiceName:  "test",
+				Attributes:   tt.attributes,
+				WithErrors:   tt.withErrors,
+			}
+
+			_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestSearchTracesHandler_Handle_WithErrorsFilter_UsingMemoryStore(t *testing.T) {
 	store, err := memory.NewStore(memory.Configuration{MaxTraces: 10})
 	require.NoError(t, err)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
@@ -7,6 +7,9 @@ package types
 type GetCriticalPathInput struct {
 	// TraceID is the unique identifier for the trace (required).
 	TraceID string `json:"trace_id" jsonschema:"Unique identifier for the trace"`
+	// MaxSegments limits the number of segments returned. When zero, the server-configured default is used.
+	// Segments are selected by highest self_time_us when the total exceeds the limit.
+	MaxSegments int `json:"max_segments,omitempty" jsonschema:"Maximum number of critical path segments to return (optional, server-configured default used when unset)"`
 }
 
 // GetCriticalPathOutput defines the output of the get_critical_path MCP tool.
@@ -14,7 +17,8 @@ type GetCriticalPathOutput struct {
 	TraceID                string                `json:"trace_id" jsonschema:"Unique identifier for the trace"`
 	TotalDurationUs        uint64                `json:"total_duration_us" jsonschema:"Total trace duration in microseconds"`
 	CriticalPathDurationUs uint64                `json:"critical_path_duration_us" jsonschema:"Total duration of critical path in microseconds"`
-	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Ordered list of span segments on the critical path"`
+	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Ordered list of span segments on the critical path (may be truncated; compare total_segment_count to detect truncation)"`
+	TotalSegmentCount      int                   `json:"total_segment_count" jsonschema:"Total number of critical path segments before truncation"`
 }
 
 // CriticalPathSegment represents a span segment on the critical path.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -163,7 +163,7 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 		Description: "Identify the critical latency path through a trace: the chain of spans " +
 			"that determined end-to-end duration. " +
 			"Higher self_time_us values indicate where time is concentrated on the critical path.",
-	}, handlers.NewGetCriticalPathHandler(s.queryAPI))
+	}, handlers.NewGetCriticalPathHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_service_dependencies",


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #9099 — api_v3 gRPC FindTraces with unset search_depth fails on in-memory storage.

## Description of the changes

The gRPC handler passes  from the proto3 field directly, and proto3 cannot distinguish between an omitted field (0) and an explicit 0. When  is omitted, the in-memory store rejects the query with .

The HTTP gateway already defaults to  (100) in the query parser. This change applies the same default in the gRPC  function, making both transports consistent.

## How was this change tested?

- Existing tests pass: , 
- Memory store tests pass: , 