### PR TITLE
Replace ai.enable_mcp with an optional ai.mcp config block

### DIFF
--- a/cmd/jaeger/config.yaml
+++ b/cmd/jaeger/config.yaml
@@ -44,12 +44,11 @@ extensions:
       agent_url: ws://localhost:16688
       # Serve the Jaeger telemetry MCP tools in-process at /api/ai/mcp/ on the
       # query port (replaces the retired standalone jaeger_mcp extension).
-      enable_mcp: true
-      # Optional directory of operator-supplied skills, served by the read_skill
-      # MCP tool under custom/. Requires enable_mcp: true. See
-      # cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/SKILLS.md
-      # for the layout it expects.
-      # skills_dir: /etc/jaeger/skills
+      # Present enables the endpoint; remove the block to disable it.
+      # Optional keys: mcp_base_url, and skills_dir for operator-supplied skills
+      # served by the read_skill tool under custom/ (see
+      # cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md).
+      mcp: {}
     # Accept OTLP/HTTP spans from the UI same-origin at /api/otlp/v1/*
     # and forward to the OTLP HTTP receiver above.
     otlp_proxy:

--- a/cmd/jaeger/config.yaml
+++ b/cmd/jaeger/config.yaml
@@ -45,7 +45,7 @@ extensions:
       # Serve the Jaeger telemetry MCP tools in-process at /api/ai/mcp/ on the
       # query port (replaces the retired standalone jaeger_mcp extension).
       # Present enables the endpoint; remove the block to disable it.
-      # Optional keys: mcp_base_url, and skills_dir for operator-supplied skills
+      # Optional keys: base_url, and skills_dir for operator-supplied skills
       # served by the read_skill tool under custom/ (see
       # cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md).
       mcp: {}

--- a/cmd/jaeger/internal/all-in-one.yaml
+++ b/cmd/jaeger/internal/all-in-one.yaml
@@ -30,7 +30,7 @@ extensions:
       traces: some_storage
     ai:
       # Serve the Jaeger MCP tools /api/ai/mcp/
-      enable_mcp: true
+      mcp: {}
 
   jaeger_storage:
     backends:

--- a/cmd/jaeger/internal/extension/jaegerquery/config_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/config_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/confmap/xconfmap"
 
 	queryapp "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal"
 )
@@ -89,4 +91,25 @@ func Test_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The collector validates a component's config with xconfmap.Validate, which
+// recurses into nested Validate methods — that recursion, not Config.Validate,
+// is what carries ai.mcp's own rules in production. Asserting it here keeps
+// MCPConfig.Validate from becoming a method nothing ever calls.
+func TestValidateRecursesIntoMCPConfig(t *testing.T) {
+	cfg := &Config{
+		Storage:      Storage{TracesPrimary: "some-storage"},
+		QueryOptions: queryapp.DefaultQueryOptions(),
+	}
+	cfg.AI = configoptional.Some(queryapp.AIConfig{
+		AgentURL:           queryapp.DefaultAIAgentURL,
+		MaxRequestBodySize: queryapp.DefaultAIMaxRequestBodySize,
+		MCP:                configoptional.Some(queryapp.MCPConfig{BaseURL: "not-a-url"}),
+	})
+
+	err := xconfmap.Validate(cfg)
+	// "mcp:" names the block at fault; Config.Validate alone reports nothing here.
+	require.ErrorContains(t, err, "mcp: ai.mcp.base_url must be an absolute URL")
+	require.NoError(t, cfg.Validate())
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -51,14 +51,31 @@ type AIConfig struct {
 	// AgentURL is the WebSocket endpoint of an ACP-compatible agent sidecar.
 	// For example, ws://localhost:16688
 	// See https://agentclientprotocol.com/
-	// Optional: leave empty (and set EnableMCP) to expose the telemetry MCP
+	// Optional: leave empty (and set the mcp block) to expose the telemetry MCP
 	// endpoint without the AI chat surface.
 	AgentURL string `mapstructure:"agent_url" valid:"optional"`
-	// EnableMCP exposes the Jaeger telemetry MCP server at
-	// <basePath>/api/ai/mcp/ on the query port. Off by default. It replaces the
-	// retired standalone jaeger_mcp extension (which served :16687); point
-	// Cursor/IDE MCP clients at the query port instead. Independent of AgentURL.
-	EnableMCP bool `mapstructure:"enable_mcp" valid:"optional"`
+	// MCP exposes the Jaeger telemetry MCP server at <basePath>/api/ai/mcp/ on
+	// the query port. Present enables it, absent disables it — an empty block
+	// (`mcp: {}`) is enough. It replaces the retired standalone jaeger_mcp
+	// extension (which served :16687); point Cursor/IDE MCP clients at the query
+	// port instead. Independent of AgentURL.
+	MCP configoptional.Optional[MCPConfig] `mapstructure:"mcp"`
+	// MaxRequestBodySize limits the chat-handler request body. Must be positive.
+	MaxRequestBodySize int64 `mapstructure:"max_request_body_size" valid:"optional"`
+	// HealthCheckInterval controls how often the AI health checker contacts
+	// the sidecar to determine if the chat surface should be advertised to
+	// the UI. Set to 0 to disable the health checker (advertised capability
+	// stays at false); negative values are rejected.
+	HealthCheckInterval time.Duration `mapstructure:"health_check_interval" valid:"optional"`
+	// HealthCheckTimeout is the per-check timeout. Must be positive when
+	// HealthCheckInterval > 0; ignored when the checker is disabled.
+	HealthCheckTimeout time.Duration `mapstructure:"health_check_timeout" valid:"optional"`
+}
+
+// MCPConfig configures the telemetry MCP endpoint. Its presence on AIConfig is
+// what enables the endpoint, so both fields are optional and an empty block is
+// the common case.
+type MCPConfig struct {
 	// MCPBaseURL is the externally-reachable scheme+authority a sidecar uses to
 	// dial the turn-scoped MCP endpoint, e.g. "https://jaeger.example.com:16686".
 	// The gateway announces "<MCPBaseURL><basePath>/api/ai/mcp/<mcpRouteID>/" to
@@ -71,24 +88,29 @@ type AIConfig struct {
 	// resolveMCPBaseURL). Set this whenever the sidecar reaches the gateway at
 	// some other address — behind a proxy, in another network namespace, with TLS
 	// terminated elsewhere, or forwarded into a container — none of which the
-	// query server can infer. Ignored unless both AgentURL and EnableMCP are set.
+	// query server can infer. Ignored unless AgentURL is also set.
 	MCPBaseURL string `mapstructure:"mcp_base_url" valid:"optional"`
 	// SkillsDir is a directory of operator-supplied skill playbooks on the query
 	// server's disk, served by the read_skill MCP tool under custom/ beside the
 	// built-in skills, so an installation can add its own without rebuilding
-	// Jaeger. See mcptools/README.md for the layout it expects. Requires
-	// EnableMCP. Empty (the default) serves the built-in skills only.
+	// Jaeger. See mcptools/README.md for the layout it expects. Empty (the
+	// default) serves the built-in skills only.
 	SkillsDir string `mapstructure:"skills_dir" valid:"optional"`
-	// MaxRequestBodySize limits the chat-handler request body. Must be positive.
-	MaxRequestBodySize int64 `mapstructure:"max_request_body_size" valid:"optional"`
-	// HealthCheckInterval controls how often the AI health checker contacts
-	// the sidecar to determine if the chat surface should be advertised to
-	// the UI. Set to 0 to disable the health checker (advertised capability
-	// stays at false); negative values are rejected.
-	HealthCheckInterval time.Duration `mapstructure:"health_check_interval" valid:"optional"`
-	// HealthCheckTimeout is the per-check timeout. Must be positive when
-	// HealthCheckInterval > 0; ignored when the checker is disabled.
-	HealthCheckTimeout time.Duration `mapstructure:"health_check_timeout" valid:"optional"`
+}
+
+func (c *MCPConfig) Validate() error {
+	if c.MCPBaseURL == "" {
+		return nil
+	}
+	// Reject anything we cannot turn into a dialable absolute URL. A relative
+	// or scheme-less value would be announced verbatim and fail at the
+	// sidecar, which is exactly the mid-turn failure this field exists to
+	// avoid — so fail fast at config load instead.
+	u, err := url.Parse(c.MCPBaseURL)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return errors.New("ai.mcp.mcp_base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686")
+	}
+	return nil
 }
 
 // DefaultOTLPProxyTarget is the loopback endpoint of the bundled OTel-collector
@@ -115,11 +137,8 @@ func (c *OTLPProxyConfig) Validate() error {
 // (see the AIConfig type-level comment) so by the time Validate runs the
 // caller's struct already has sensible values for any field they omitted.
 func (c *AIConfig) Validate() error {
-	if c.AgentURL == "" && !c.EnableMCP {
-		return errors.New("ai requires agent_url (AI chat) or enable_mcp (telemetry MCP tools)")
-	}
-	if c.SkillsDir != "" && !c.EnableMCP {
-		return errors.New("ai.skills_dir requires ai.enable_mcp to be true")
+	if c.AgentURL == "" && !c.MCP.HasValue() {
+		return errors.New("ai requires agent_url (AI chat) or mcp (telemetry MCP tools)")
 	}
 	if c.MaxRequestBodySize <= 0 {
 		return errors.New("ai.max_request_body_size must be a positive integer")
@@ -130,15 +149,10 @@ func (c *AIConfig) Validate() error {
 	if c.HealthCheckInterval > 0 && c.HealthCheckTimeout <= 0 {
 		return errors.New("ai.health_check_timeout must be positive when health_check_interval is positive")
 	}
-	if c.MCPBaseURL != "" {
-		// Reject anything we cannot turn into a dialable absolute URL. A relative
-		// or scheme-less value would be announced verbatim and fail at the
-		// sidecar, which is exactly the mid-turn failure this field exists to
-		// avoid — so fail fast at config load instead.
-		u, err := url.Parse(c.MCPBaseURL)
-		if err != nil || !u.IsAbs() || u.Host == "" {
-			return errors.New("ai.mcp_base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686")
-		}
+	// Reached through the collector's config walk as well, but AI config is also
+	// validated directly (see initRouter), so delegate rather than rely on that.
+	if mcp := c.MCP.Get(); mcp != nil {
+		return mcp.Validate()
 	}
 	return nil
 }
@@ -171,8 +185,12 @@ func (c *AIConfig) Validate() error {
 // httpEndpoint is the query server's own HTTP host:port and tlsEnabled its own TLS
 // setting; neither is derived from AgentURL, which only gates the inference.
 func (c *AIConfig) resolveMCPBaseURL(ctx context.Context, httpEndpoint string, tlsEnabled bool) string {
-	if c.MCPBaseURL != "" {
-		return c.MCPBaseURL
+	mcp := c.MCP.Get()
+	if mcp == nil {
+		return "" // MCP is off, so there is no endpoint to announce
+	}
+	if mcp.MCPBaseURL != "" {
+		return mcp.MCPBaseURL
 	}
 	if tlsEnabled {
 		return ""

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -54,7 +54,7 @@ type AIConfig struct {
 	// Optional: leave empty (and set the mcp block) to expose the telemetry MCP
 	// endpoint without the AI chat surface.
 	AgentURL string `mapstructure:"agent_url" valid:"optional"`
-	// MCP exposes the Jaeger telemetry MCP server at <basePath>/api/ai/mcp/ on
+	// MCP exposes Jaeger telemetry MCP server at <basePath>/api/ai/mcp/ on
 	// the query port. Present enables it, absent disables it — an empty block
 	// (`mcp: {}`) is enough. It replaces the retired standalone jaeger_mcp
 	// extension (which served :16687); point Cursor/IDE MCP clients at the query

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -149,11 +149,9 @@ func (c *AIConfig) Validate() error {
 	if c.HealthCheckInterval > 0 && c.HealthCheckTimeout <= 0 {
 		return errors.New("ai.health_check_timeout must be positive when health_check_interval is positive")
 	}
-	// Reached through the collector's config walk as well, but AI config is also
-	// validated directly (see initRouter), so delegate rather than rely on that.
-	if mcp := c.MCP.Get(); mcp != nil {
-		return mcp.Validate()
-	}
+	// MCPConfig.Validate is reached by the collector's config walk on its own,
+	// the same way OTLPProxyConfig's is; delegating to it here would only
+	// duplicate the check and drop the "mcp:" path segment from the message.
 	return nil
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -76,9 +76,9 @@ type AIConfig struct {
 // what enables the endpoint, so both fields are optional and an empty block is
 // the common case.
 type MCPConfig struct {
-	// MCPBaseURL is the externally-reachable scheme+authority a sidecar uses to
+	// BaseURL is the externally-reachable scheme+authority a sidecar uses to
 	// dial the turn-scoped MCP endpoint, e.g. "https://jaeger.example.com:16686".
-	// The gateway announces "<MCPBaseURL><basePath>/api/ai/mcp/<mcpRouteID>/" to
+	// The gateway announces "<BaseURL><basePath>/api/ai/mcp/<mcpRouteID>/" to
 	// the sidecar in the session/new request.
 	//
 	// Optional override. If left empty, the gateway infers its own loopback address
@@ -89,7 +89,7 @@ type MCPConfig struct {
 	// some other address — behind a proxy, in another network namespace, with TLS
 	// terminated elsewhere, or forwarded into a container — none of which the
 	// query server can infer. Ignored unless AgentURL is also set.
-	MCPBaseURL string `mapstructure:"mcp_base_url" valid:"optional"`
+	BaseURL string `mapstructure:"base_url" valid:"optional"`
 	// SkillsDir is a directory of operator-supplied skill playbooks on the query
 	// server's disk, served by the read_skill MCP tool under custom/ beside the
 	// built-in skills, so an installation can add its own without rebuilding
@@ -99,16 +99,16 @@ type MCPConfig struct {
 }
 
 func (c *MCPConfig) Validate() error {
-	if c.MCPBaseURL == "" {
+	if c.BaseURL == "" {
 		return nil
 	}
 	// Reject anything we cannot turn into a dialable absolute URL. A relative
 	// or scheme-less value would be announced verbatim and fail at the
 	// sidecar, which is exactly the mid-turn failure this field exists to
 	// avoid — so fail fast at config load instead.
-	u, err := url.Parse(c.MCPBaseURL)
+	u, err := url.Parse(c.BaseURL)
 	if err != nil || !u.IsAbs() || u.Host == "" {
-		return errors.New("ai.mcp.mcp_base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686")
+		return errors.New("ai.mcp.base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686")
 	}
 	return nil
 }
@@ -158,7 +158,7 @@ func (c *AIConfig) Validate() error {
 }
 
 // resolveMCPBaseURL returns the base URL the gateway announces for the turn-scoped
-// MCP endpoint, or "" to announce no HTTP transport. An explicit MCPBaseURL always
+// MCP endpoint, or "" to announce no HTTP transport. An explicit base_url always
 // wins. Otherwise the gateway infers its own loopback address, which requires every
 // leg of the round trip to hold:
 //
@@ -171,7 +171,7 @@ func (c *AIConfig) Validate() error {
 //     dial the gateway by, essentially never for an inferred loopback host, so an
 //     inferred https:// URL fails certificate verification at the sidecar.
 //
-// If any leg is unmet, nothing is announced until an operator sets MCPBaseURL. The
+// If any leg is unmet, nothing is announced until an operator sets base_url. The
 // gateway declines rather than guessing: a specific-interface bind or TLS is positive
 // evidence that an inferred loopback URL is wrong, and there is nothing else here to
 // derive a correct one from.
@@ -180,7 +180,7 @@ func (c *AIConfig) Validate() error {
 // container published with "-p 127.0.0.1:16688:16688", or "kubectl port-forward").
 // The gateway reaches the sidecar over loopback, but the sidecar's loopback is its
 // own namespace, where the gateway is not listening. That is indistinguishable from
-// genuine co-location here, and needs an explicit MCPBaseURL.
+// genuine co-location here, and needs an explicit base_url.
 //
 // httpEndpoint is the query server's own HTTP host:port and tlsEnabled its own TLS
 // setting; neither is derived from AgentURL, which only gates the inference.
@@ -189,8 +189,8 @@ func (c *AIConfig) resolveMCPBaseURL(ctx context.Context, httpEndpoint string, t
 	if mcp == nil {
 		return "" // MCP is off, so there is no endpoint to announce
 	}
-	if mcp.MCPBaseURL != "" {
-		return mcp.MCPBaseURL
+	if mcp.BaseURL != "" {
+		return mcp.BaseURL
 	}
 	if tlsEnabled {
 		return ""

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -85,24 +85,21 @@ func TestAIConfigValidateRejectsNonPositiveBodySize(t *testing.T) {
 	}
 }
 
-func TestAIConfigValidateAcceptsAbsentOrAbsoluteMCPBaseURL(t *testing.T) {
+func TestMCPConfigValidateAcceptsAbsentOrAbsoluteBaseURL(t *testing.T) {
 	// Empty is valid — the announced URL is then resolved from AgentURL
 	// (see resolveMCPBaseURL); only an explicit override is validated here.
-	cfg := validAIConfig()
-	require.NoError(t, cfg.Validate())
+	require.NoError(t, (&MCPConfig{}).Validate())
 
 	for _, u := range []string{
 		"http://127.0.0.1:16686",
 		"https://jaeger.example.com:16686",
 		"https://jaeger.example.com",
 	} {
-		cfg := validAIConfig()
-		cfg.MCP = configoptional.Some(MCPConfig{BaseURL: u})
-		require.NoError(t, cfg.Validate(), "absolute URL %q must be accepted", u)
+		require.NoError(t, (&MCPConfig{BaseURL: u}).Validate(), "absolute URL %q must be accepted", u)
 	}
 }
 
-func TestAIConfigValidateRejectsRelativeMCPBaseURL(t *testing.T) {
+func TestMCPConfigValidateRejectsRelativeBaseURL(t *testing.T) {
 	// A scheme-less or relative value would be announced verbatim and fail at the
 	// sidecar mid-turn — exactly what this field exists to prevent — so it must
 	// fail at config load instead.
@@ -113,9 +110,7 @@ func TestAIConfigValidateRejectsRelativeMCPBaseURL(t *testing.T) {
 		"http://",                  // no host
 		"://nonsense",              // unparseable
 	} {
-		cfg := validAIConfig()
-		cfg.MCP = configoptional.Some(MCPConfig{BaseURL: u})
-		require.EqualError(t, cfg.Validate(), want, "relative/invalid URL %q must be rejected", u)
+		require.EqualError(t, (&MCPConfig{BaseURL: u}).Validate(), want, "relative/invalid URL %q must be rejected", u)
 	}
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configoptional"
 )
 
 func TestDefaultQueryOptions(t *testing.T) {
@@ -60,26 +61,19 @@ func TestAIConfigValidateAcceptsDefaults(t *testing.T) {
 func TestAIConfigValidateRejectsEmptyAgentURLWithoutMCP(t *testing.T) {
 	cfg := validAIConfig()
 	cfg.AgentURL = ""
-	require.EqualError(t, cfg.Validate(), "ai requires agent_url (AI chat) or enable_mcp (telemetry MCP tools)")
+	require.EqualError(t, cfg.Validate(), "ai requires agent_url (AI chat) or mcp (telemetry MCP tools)")
 }
 
 func TestAIConfigValidateAcceptsMCPOnly(t *testing.T) {
 	cfg := validAIConfig()
 	cfg.AgentURL = ""
-	cfg.EnableMCP = true
+	cfg.MCP = configoptional.Some(MCPConfig{})
 	require.NoError(t, cfg.Validate())
 }
 
-func TestAIConfigValidateRejectsSkillsDirWithoutMCP(t *testing.T) {
+func TestAIConfigValidateAcceptsSkillsDir(t *testing.T) {
 	cfg := validAIConfig()
-	cfg.SkillsDir = "/etc/jaeger/skills"
-	require.EqualError(t, cfg.Validate(), "ai.skills_dir requires ai.enable_mcp to be true")
-}
-
-func TestAIConfigValidateAcceptsSkillsDirWithMCP(t *testing.T) {
-	cfg := validAIConfig()
-	cfg.EnableMCP = true
-	cfg.SkillsDir = "/etc/jaeger/skills"
+	cfg.MCP = configoptional.Some(MCPConfig{SkillsDir: "/etc/jaeger/skills"})
 	require.NoError(t, cfg.Validate())
 }
 
@@ -103,7 +97,7 @@ func TestAIConfigValidateAcceptsAbsentOrAbsoluteMCPBaseURL(t *testing.T) {
 		"https://jaeger.example.com",
 	} {
 		cfg := validAIConfig()
-		cfg.MCPBaseURL = u
+		cfg.MCP = configoptional.Some(MCPConfig{MCPBaseURL: u})
 		require.NoError(t, cfg.Validate(), "absolute URL %q must be accepted", u)
 	}
 }
@@ -112,7 +106,7 @@ func TestAIConfigValidateRejectsRelativeMCPBaseURL(t *testing.T) {
 	// A scheme-less or relative value would be announced verbatim and fail at the
 	// sidecar mid-turn — exactly what this field exists to prevent — so it must
 	// fail at config load instead.
-	const want = "ai.mcp_base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686"
+	const want = "ai.mcp.mcp_base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686"
 	for _, u := range []string{
 		"jaeger.example.com:16686", // no scheme
 		"/api/ai/mcp",              // path only
@@ -120,7 +114,7 @@ func TestAIConfigValidateRejectsRelativeMCPBaseURL(t *testing.T) {
 		"://nonsense",              // unparseable
 	} {
 		cfg := validAIConfig()
-		cfg.MCPBaseURL = u
+		cfg.MCP = configoptional.Some(MCPConfig{MCPBaseURL: u})
 		require.EqualError(t, cfg.Validate(), want, "relative/invalid URL %q must be rejected", u)
 	}
 }
@@ -268,7 +262,10 @@ func TestAIConfigResolveMCPBaseURL(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := AIConfig{AgentURL: tc.agentURL, MCPBaseURL: tc.mcpBaseURL}
+			cfg := AIConfig{
+				AgentURL: tc.agentURL,
+				MCP:      configoptional.Some(MCPConfig{MCPBaseURL: tc.mcpBaseURL}),
+			}
 			assert.Equal(t, tc.want, cfg.resolveMCPBaseURL(context.Background(), tc.endpoint, tc.tls))
 		})
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -97,7 +97,7 @@ func TestAIConfigValidateAcceptsAbsentOrAbsoluteMCPBaseURL(t *testing.T) {
 		"https://jaeger.example.com",
 	} {
 		cfg := validAIConfig()
-		cfg.MCP = configoptional.Some(MCPConfig{MCPBaseURL: u})
+		cfg.MCP = configoptional.Some(MCPConfig{BaseURL: u})
 		require.NoError(t, cfg.Validate(), "absolute URL %q must be accepted", u)
 	}
 }
@@ -106,7 +106,7 @@ func TestAIConfigValidateRejectsRelativeMCPBaseURL(t *testing.T) {
 	// A scheme-less or relative value would be announced verbatim and fail at the
 	// sidecar mid-turn — exactly what this field exists to prevent — so it must
 	// fail at config load instead.
-	const want = "ai.mcp.mcp_base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686"
+	const want = "ai.mcp.base_url must be an absolute URL including scheme and host, e.g. https://jaeger.example.com:16686"
 	for _, u := range []string{
 		"jaeger.example.com:16686", // no scheme
 		"/api/ai/mcp",              // path only
@@ -114,7 +114,7 @@ func TestAIConfigValidateRejectsRelativeMCPBaseURL(t *testing.T) {
 		"://nonsense",              // unparseable
 	} {
 		cfg := validAIConfig()
-		cfg.MCP = configoptional.Some(MCPConfig{MCPBaseURL: u})
+		cfg.MCP = configoptional.Some(MCPConfig{BaseURL: u})
 		require.EqualError(t, cfg.Validate(), want, "relative/invalid URL %q must be rejected", u)
 	}
 }
@@ -264,7 +264,7 @@ func TestAIConfigResolveMCPBaseURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := AIConfig{
 				AgentURL: tc.agentURL,
-				MCP:      configoptional.Some(MCPConfig{MCPBaseURL: tc.mcpBaseURL}),
+				MCP:      configoptional.Some(MCPConfig{BaseURL: tc.mcpBaseURL}),
 			}
 			assert.Equal(t, tc.want, cfg.resolveMCPBaseURL(context.Background(), tc.endpoint, tc.tls))
 		})

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
@@ -13,18 +13,18 @@ Jaeger binary. Operators can add their own without rebuilding, via
 
 ## Adding installation-specific skills
 
-Point `ai.skills_dir` at a directory on the query server's disk:
+Point `ai.mcp.skills_dir` at a directory on the query server's disk:
 
 ```yaml
 extensions:
   jaeger_query:
     ai:
-      enable_mcp: true          # required — skills are served over MCP
-      skills_dir: /etc/jaeger/skills
+      mcp:                      # skills are served over MCP
+        skills_dir: /etc/jaeger/skills
 ```
 
 The all-in-one config is not externally configurable, but the field can still be
-set on it with `--set extensions.jaeger_query.ai.skills_dir={path}`.
+set on it with `--set extensions.jaeger_query.ai.mcp.skills_dir={path}`.
 
 Its contents are served under `custom/`, beside the built-in skills:
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
@@ -19,7 +19,7 @@ Point `ai.mcp.skills_dir` at a directory on the query server's disk:
 extensions:
   jaeger_query:
     ai:
-      mcp:                      # skills are served over MCP
+      mcp:                      # skills served over MCP
         skills_dir: /etc/jaeger/skills
 ```
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -237,20 +237,24 @@ func initRouter(
 			if err := aiCfg.Validate(); err != nil {
 				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
 			} else {
+				mcpEnabled := aiCfg.MCP.HasValue()
 				// One config for both MCP endpoints so they cannot drift. The
 				// skills directory is opened once here, so both share the handle
 				// and a broken path is reported once, at startup.
 				mcpCfg := mcptools.DefaultConfig()
-				customSkills, err := mcptools.OpenCustomSkillsDir(aiCfg.SkillsDir)
-				if err != nil {
-					return nil, nil, err
+				if mcpEnabled {
+					customSkills, err := mcptools.OpenCustomSkillsDir(aiCfg.MCP.Get().SkillsDir)
+					if err != nil {
+						return nil, nil, err
+					}
+					if customSkills != nil {
+						// It holds skills_dir open for as long as it serves, so
+						// it is released with the server rather than at process
+						// exit.
+						cs = append(cs, customSkills)
+					}
+					mcpCfg.CustomSkillsFS = customSkills
 				}
-				if customSkills != nil {
-					// It holds skills_dir open for as long as it serves, so it
-					// is released with the server rather than at process exit.
-					cs = append(cs, customSkills)
-				}
-				mcpCfg.CustomSkillsFS = customSkills
 				if aiCfg.AgentURL != "" {
 					// When AI chat is enabled, jaegerai owns the chat endpoint and,
 					// if MCP is also enabled, the turn-scoped MCP endpoint
@@ -265,7 +269,7 @@ func initRouter(
 						AgentURL:           aiCfg.AgentURL,
 						BasePath:           queryOpts.BasePath,
 						MaxRequestBodySize: aiCfg.MaxRequestBodySize,
-						EnableMCP:          aiCfg.EnableMCP,
+						EnableMCP:          mcpEnabled,
 						MCPBaseURL:         aiCfg.resolveMCPBaseURL(ctx, queryOpts.HTTP.NetAddr.Endpoint, queryOpts.HTTP.TLS.HasValue()),
 						QueryService:       querySvc,
 						TenancyMgr:         tenancyMgr,
@@ -274,7 +278,7 @@ func initRouter(
 					})
 					aiGateway.RegisterRoutes(r)
 				}
-				if aiCfg.EnableMCP {
+				if mcpEnabled {
 					// Shared telemetry endpoint (/api/ai/mcp/). Coexists with the
 					// wildcard turn-scoped pattern above.
 					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, mcpCfg, telset)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -230,61 +230,12 @@ func initRouter(
 		apiNotFoundPattern = queryOpts.BasePath + apiNotFoundPattern
 	}
 
-	// AI Gateway Endpoints
-	var aiGateway *jaegerai.Handler
 	if queryOpts.AI.HasValue() {
-		if aiCfg := queryOpts.AI.Get(); aiCfg != nil {
-			if err := aiCfg.Validate(); err != nil {
-				telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
-			} else {
-				mcpEnabled := aiCfg.MCP.HasValue()
-				// One config for both MCP endpoints so they cannot drift. The
-				// skills directory is opened once here, so both share the handle
-				// and a broken path is reported once, at startup.
-				mcpCfg := mcptools.DefaultConfig()
-				if mcpEnabled {
-					customSkills, err := mcptools.OpenCustomSkillsDir(aiCfg.MCP.Get().SkillsDir)
-					if err != nil {
-						return nil, nil, err
-					}
-					if customSkills != nil {
-						// It holds skills_dir open for as long as it serves, so
-						// it is released with the server rather than at process
-						// exit.
-						cs = append(cs, customSkills)
-					}
-					mcpCfg.CustomSkillsFS = customSkills
-				}
-				if aiCfg.AgentURL != "" {
-					// When AI chat is enabled, jaegerai owns the chat endpoint and,
-					// if MCP is also enabled, the turn-scoped MCP endpoint
-					// (/api/ai/mcp/<id>/). It holds MCP sessions past the request
-					// that opened them, so it joins the closers returned below.
-					//
-					// The announced base URL is resolved here because inferring the
-					// gateway's own localhost address needs the query HTTP endpoint
-					// and TLS setting, which live on QueryOptions, not AIConfig.
-					aiGateway = jaegerai.NewHandler(jaegerai.HandlerParams{
-						Logger:             telset.Logger,
-						AgentURL:           aiCfg.AgentURL,
-						BasePath:           queryOpts.BasePath,
-						MaxRequestBodySize: aiCfg.MaxRequestBodySize,
-						EnableMCP:          mcpEnabled,
-						MCPBaseURL:         aiCfg.resolveMCPBaseURL(ctx, queryOpts.HTTP.NetAddr.Endpoint, queryOpts.HTTP.TLS.HasValue()),
-						QueryService:       querySvc,
-						TenancyMgr:         tenancyMgr,
-						Telset:             telset,
-						MCPConfig:          mcpCfg,
-					})
-					aiGateway.RegisterRoutes(r)
-				}
-				if mcpEnabled {
-					// Shared telemetry endpoint (/api/ai/mcp/). Coexists with the
-					// wildcard turn-scoped pattern above.
-					registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, mcpCfg, telset)
-				}
-			}
+		aiClosers, err := registerAIRoutes(ctx, r, queryOpts, querySvc, tenancyMgr, telset)
+		if err != nil {
+			return nil, nil, errors.Join(err, cs.Close())
 		}
+		cs = append(cs, aiClosers...)
 	}
 
 	if queryOpts.OTLPProxy.HasValue() {
@@ -298,9 +249,6 @@ func initRouter(
 	})
 
 	cs = append(cs, RegisterStaticHandler(r, telset.Logger, queryOpts, caps, aiHealthCheck))
-	if aiGateway != nil {
-		cs = append(cs, aiGateway)
-	}
 
 	var handler http.Handler = r
 	if queryOpts.BearerTokenPropagation {
@@ -314,6 +262,73 @@ func initRouter(
 	}
 	handler = traceResponseHandler(handler)
 	return handler, cs, nil
+}
+
+// registerAIRoutes mounts the AI chat gateway and the telemetry MCP endpoint,
+// and returns the closers for whatever it mounted. Invalid AI config disables
+// the AI surface rather than stopping the query server, which also serves the
+// UI and the trace APIs.
+func registerAIRoutes(
+	ctx context.Context,
+	r *http.ServeMux,
+	queryOpts *QueryOptions,
+	querySvc *querysvc.QueryService,
+	tenancyMgr *tenancy.Manager,
+	telset telemetry.Settings,
+) (closers, error) {
+	aiCfg := queryOpts.AI.Get()
+	if err := aiCfg.Validate(); err != nil {
+		telset.Logger.Error("Invalid AI config, AI handler disabled", zap.Error(err))
+		return nil, nil
+	}
+
+	var cs closers
+	// One config for both MCP endpoints so they cannot drift, and the zero value
+	// when MCP is off — the gateway ignores it then.
+	var mcpCfg mcptools.Config
+	if mcp := aiCfg.MCP.Get(); mcp != nil {
+		mcpCfg = mcptools.DefaultConfig()
+		// Opened once, so both endpoints share the handle and a broken path is
+		// reported once, at startup. It stays open for as long as it serves, so
+		// it is released with the server rather than at process exit.
+		customSkills, err := mcptools.OpenCustomSkillsDir(mcp.SkillsDir)
+		if err != nil {
+			return nil, err
+		}
+		if customSkills != nil {
+			cs = append(cs, customSkills)
+		}
+		mcpCfg.CustomSkillsFS = customSkills
+		// Shared telemetry endpoint (/api/ai/mcp/). Coexists with the wildcard
+		// turn-scoped pattern the gateway registers below.
+		registerMCPTools(r, querySvc, tenancyMgr, queryOpts.BasePath, mcpCfg, telset)
+	}
+
+	if aiCfg.AgentURL != "" {
+		// jaegerai owns the chat endpoint and, when MCP is on, the turn-scoped
+		// endpoint (/api/ai/mcp/<id>/) — which is why mcpCfg is built above
+		// rather than inside this branch. It holds MCP sessions past the request
+		// that opened them, so it joins the closers.
+		//
+		// The announced base URL is resolved here because inferring the
+		// gateway's own localhost address needs the query HTTP endpoint and TLS
+		// setting, which live on QueryOptions, not AIConfig.
+		aiGateway := jaegerai.NewHandler(jaegerai.HandlerParams{
+			Logger:             telset.Logger,
+			AgentURL:           aiCfg.AgentURL,
+			BasePath:           queryOpts.BasePath,
+			MaxRequestBodySize: aiCfg.MaxRequestBodySize,
+			EnableMCP:          aiCfg.MCP.HasValue(),
+			MCPBaseURL:         aiCfg.resolveMCPBaseURL(ctx, queryOpts.HTTP.NetAddr.Endpoint, queryOpts.HTTP.TLS.HasValue()),
+			QueryService:       querySvc,
+			TenancyMgr:         tenancyMgr,
+			Telset:             telset,
+			MCPConfig:          mcpCfg,
+		})
+		aiGateway.RegisterRoutes(r)
+		cs = append(cs, aiGateway)
+	}
+	return cs, nil
 }
 
 func otlpProxyPathPrefix(basePath string) string {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server_test.go
@@ -1155,8 +1155,7 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 	t.Run("unusable skills_dir aborts startup", func(t *testing.T) {
 		opts := DefaultQueryOptions()
 		opts.AI = configoptional.Some(AIConfig{
-			EnableMCP:          true,
-			SkillsDir:          filepath.Join(t.TempDir(), "no-such-dir"),
+			MCP:                configoptional.Some(MCPConfig{SkillsDir: filepath.Join(t.TempDir(), "no-such-dir")}),
 			MaxRequestBodySize: 1 << 20,
 		})
 
@@ -1171,8 +1170,7 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("catalog"), 0o600))
 		opts := DefaultQueryOptions()
 		opts.AI = configoptional.Some(AIConfig{
-			EnableMCP:          true,
-			SkillsDir:          dir,
+			MCP:                configoptional.Some(MCPConfig{SkillsDir: dir}),
 			MaxRequestBodySize: 1 << 20,
 		})
 
@@ -1183,7 +1181,7 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 
 	t.Run("mcp endpoint mounted in MCP-only mode", func(t *testing.T) {
 		opts := DefaultQueryOptions()
-		opts.AI = configoptional.Some(AIConfig{EnableMCP: true, MaxRequestBodySize: 1 << 20})
+		opts.AI = configoptional.Some(AIConfig{MCP: configoptional.Some(MCPConfig{}), MaxRequestBodySize: 1 << 20})
 
 		handler, cs, err := initRouter(context.Background(), querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
 		require.NoError(t, err)
@@ -1207,7 +1205,7 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 	t.Run("mcp endpoint mounted with base path", func(t *testing.T) {
 		opts := DefaultQueryOptions()
 		opts.BasePath = "/jaeger"
-		opts.AI = configoptional.Some(AIConfig{EnableMCP: true, MaxRequestBodySize: 1 << 20})
+		opts.AI = configoptional.Some(AIConfig{MCP: configoptional.Some(MCPConfig{}), MaxRequestBodySize: 1 << 20})
 
 		handler, cs, err := initRouter(context.Background(), querySvc.qs, nil, &opts, querysvc.StorageCapabilities{}, nil, tenancyMgr, telset)
 		require.NoError(t, err)
@@ -1223,7 +1221,7 @@ func TestInitRouterAIHandlerRegistration(t *testing.T) {
 
 	t.Run("chat and MCP both enabled: session-free and session-scoped endpoints coexist", func(t *testing.T) {
 		opts := DefaultQueryOptions()
-		opts.AI = configoptional.Some(AIConfig{AgentURL: "ws://127.0.0.1:1", EnableMCP: true, MaxRequestBodySize: 1 << 20})
+		opts.AI = configoptional.Some(AIConfig{AgentURL: "ws://127.0.0.1:1", MCP: configoptional.Some(MCPConfig{}), MaxRequestBodySize: 1 << 20})
 
 		// initRouter registers both /api/ai/mcp/ (session-free, jaeger-query)
 		// and /api/ai/mcp/{sessionID}/ (session-scoped, jaegerai) on the same

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -173,7 +173,7 @@ func buildAIHealthChecker(opts *queryapp.QueryOptions, logger *zap.Logger) *aihe
 	}
 	aiCfg := opts.AI.Get() // cannot be nil when HasValue is true
 	if aiCfg.AgentURL == "" {
-		// MCP-only mode (enable_mcp without agent_url): there is no chat
+		// MCP-only mode (ai.mcp without agent_url): there is no chat
 		// sidecar to probe, so the health checker has nothing to do.
 		logger.Info("AI Assistant health check disabled (no agent_url)")
 		return nil

--- a/cmd/jaeger/internal/extension/jaegerquery/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server_test.go
@@ -518,7 +518,7 @@ func TestBuildAIHealthChecker(t *testing.T) {
 		{
 			name: "MCP-only mode (no agent_url) disables the checker",
 			ai: configoptional.Some(app.AIConfig{
-				EnableMCP:           true,
+				MCP:                 configoptional.Some(app.MCPConfig{}),
 				MaxRequestBodySize:  app.DefaultAIMaxRequestBodySize,
 				HealthCheckInterval: 5 * time.Second,
 				HealthCheckTimeout:  2 * time.Second,

--- a/docs/adr/002-mcp-server.md
+++ b/docs/adr/002-mcp-server.md
@@ -18,7 +18,7 @@ Jaeger serves an MCP endpoint whose tools wrap the existing `QueryService`, rath
 
 ### 2. Run as a standalone `jaeger_mcp` extension on its own port ⚠️ superseded
 
-Shipped that way in [#8423](https://github.com/jaegertracing/jaeger/pull/8423), serving `:16687`, then retired by [RFC 0008](../rfc/0008-ai-gateway-mcp-tool-routing.md) M1 ([#8894](https://github.com/jaegertracing/jaeger/pull/8894)). The tools are now a library — [`mcptools`](../../cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/) — inside the query extension, served under `<base_path>/api/ai/mcp/` on the **query port** and gated by `enable_mcp` (off by default). One MCP implementation now backs both that endpoint and the turn-scoped one the AI gateway announces.
+Shipped that way in [#8423](https://github.com/jaegertracing/jaeger/pull/8423), serving `:16687`, then retired by [RFC 0008](../rfc/0008-ai-gateway-mcp-tool-routing.md) M1 ([#8894](https://github.com/jaegertracing/jaeger/pull/8894)). The tools are now a library — [`mcptools`](../../cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/) — inside the query extension, served under `<base_path>/api/ai/mcp/` on the **query port** and gated by the presence of the `ai.mcp` config block (absent by default). One MCP implementation now backs both that endpoint and the turn-scoped one the AI gateway announces.
 
 ### 3. Obtain `QueryService` from the `jaegerquery` extension ⚠️ superseded
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9190.

`AIConfig` gated the MCP endpoint with a standalone `enable_mcp` boolean sittingbeside the fields it governs (`mcp_base_url`, and `skills_dir` from #9169). That let the config express states that make no sense — `skills_dir` set with
`enable_mcp: false` — which #9169 had to reject with a hand-written check.

## Description of the changes

`enable_mcp` is gone. The MCP fields move into an optional nested block whose presence is the enable signal:

```yaml
ai:
  agent_url: ws://localhost:16688
  mcp: {}                          # present ⇒ MCP endpoint served
```

```yaml
ai:
  mcp:
    skills_dir: /etc/jaeger/skills # optional
    mcp_base_url: https://jaeger.example.com:16686
```

```go
MCP configoptional.Optional[MCPConfig] `mapstructure:"mcp"`

type MCPConfig struct {
	MCPBaseURL string `mapstructure:"mcp_base_url" valid:"optional"`
	SkillsDir  string `mapstructure:"skills_dir" valid:"optional"`
}
```

The `ai.skills_dir requires ai.enable_mcp` check is deleted rather than moved —the invalid state is no longer constructible. URL validation moves to `MCPConfig.Validate`, which the collector's config walk reaches on its own;
`AIConfig.Validate` delegates to it as well, because `initRouter` validates AI  config directly.

`ai.agent_url` alone (chat with no telemetry tools) stays valid, and `ai.mcp` alone (MCP-only, no chat) stays valid.

## Breaking change

`enable_mcp: true` no longer parses. Replace it with `mcp: {}`, and move `mcp_base_url` / `skills_dir` under that block. Both shipped sample configs are updated.

## How was this change tested?

- `make lint` + full `go test ./cmd/... ./internal/...`; the four touched  functions in `flags.go` are at 100% statement coverage.
- Ran the built binary against the updated `cmd/jaeger/config.yaml`:  `Jaeger telemetry MCP endpoint enabled {"path": "/api/ai/mcp/"}`, and an  `initialize` POST to `/api/ai/mcp/` returns 200.- With `skills_dir` nested under `mcp:`, `tools/call read_skill` for  `custom/slow-db-call/SKILL.md` returned the operator file verbatim.
- With the `mcp:` block removed, the endpoint is not mounted — the route 404s  and no "endpoint enabled" line is logged.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
