### PR TITLE
feat(jaegerquery): Validate skill frontmatter on each read_skill call

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
@@ -72,3 +72,28 @@ description: >-
 A `skills_dir` that cannot be opened, or whose `SKILL.md` cannot be read, is
 broken configuration, and Jaeger refuses to start rather than quietly serving an
 incomplete skill set.
+
+### Frontmatter rules
+
+| Key | Rule |
+| --- | --- |
+| `name` | Required. Lowercase letters, digits and single hyphens (no leading, trailing or doubled hyphen), at most 64 characters, and **equal to the skill's directory name**. |
+| `description` | Required, at most 1024 characters. |
+| `license` | Optional. |
+| `metadata` | Optional map of string to string. |
+| `compatibility` | Optional, at most 500 characters. |
+| `allowed-tools` | Optional, space-separated. Advisory: Jaeger records it but does not enforce it. |
+
+Anything else is an error rather than an ignored field, so a misspelled key is
+reported instead of silently doing nothing.
+
+The rules apply to `<skill>/SKILL.md`. The tree's own `SKILL.md` has no
+directory to be named after, and a `SKILL.md` nested deeper is reference
+material inside a skill rather than a skill of its own; neither is name-checked.
+
+A skill that breaks these rules fails the `read_skill` call that asks for it,
+with a message naming what is wrong. Every other skill keeps serving — one
+malformed file does not take down the tree, and it never stops Jaeger booting.
+
+Files are read from disk per request, so editing a skill takes effect on the
+next call. There is no restart and no cache to invalidate.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"path"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -19,6 +20,9 @@ import (
 // customSkillsDir is the path prefix under which the operator's skills are
 // addressed, e.g. custom/<skill-name>/SKILL.md.
 const customSkillsDir = "custom"
+
+// skillFile is the name every skill's playbook goes by.
+const skillFile = "SKILL.md"
 
 type readSkillHandler struct {
 	builtins fs.FS
@@ -57,6 +61,14 @@ func (h *readSkillHandler) handle(
 		return nil, types.ReadSkillOutput{}, fmt.Errorf("cannot read %q: %w", input.Path, err)
 	}
 	content := string(buf[:n])
+	// Frontmatter is validated against what was actually read, before the
+	// truncation notice is appended; it sits at the head of the file, so a body
+	// long enough to be truncated does not affect the check.
+	if dir, ok := skillDirName(input.Path); ok {
+		if err := validateSkillFrontmatter(buf[:n], dir); err != nil {
+			return nil, types.ReadSkillOutput{}, fmt.Errorf("invalid skill %q: %w", input.Path, err)
+		}
+	}
 	if n > int(h.maxFileSize) {
 		content += fmt.Sprintf("\n\nfile content truncated after %d bytes\n", h.maxFileSize)
 	}
@@ -64,6 +76,21 @@ func (h *readSkillHandler) handle(
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: content}},
 	}, types.ReadSkillOutput{Instructions: content}, nil
+}
+
+// skillDirName returns the directory a skill at p is named after, and whether p
+// names a skill at all. Only <dir>/SKILL.md is one: a tree's root SKILL.md has
+// no directory to take its name from, and a SKILL.md nested deeper is
+// documentation inside a skill rather than a skill of its own. The custom/
+// prefix is stripped first so operator and built-in skills are judged alike.
+func skillDirName(p string) (string, bool) {
+	rest, _ := strings.CutPrefix(p, customSkillsDir+"/")
+	dir, file := path.Split(rest)
+	dir = strings.TrimSuffix(dir, "/")
+	if file != skillFile || dir == "" || strings.Contains(dir, "/") {
+		return "", false
+	}
+	return dir, true
 }
 
 // open routes p to the custom tree when it names the custom/ prefix and to the

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -18,11 +18,18 @@ import (
 
 const testMaxFileSize = 100
 
+// skillDoc builds a SKILL.md with valid frontmatter naming dir.
+func skillDoc(dir, body string) *fstest.MapFile {
+	return &fstest.MapFile{Data: []byte(
+		"---\nname: " + dir + "\ndescription: When to use " + dir + ".\n---\n\n" + body,
+	)}
+}
+
 func testSkillsFS() fstest.MapFS {
 	return fstest.MapFS{
 		"SKILL.md":         &fstest.MapFile{Data: []byte("# Skills\n\n- skill-a\n- skill-b\n")},
-		"skill-a/SKILL.md": &fstest.MapFile{Data: []byte("# Skill A\n\nContent here.")},
-		"skill-b/SKILL.md": &fstest.MapFile{Data: []byte("# Skill B\n\nMore content.")},
+		"skill-a/SKILL.md": skillDoc("skill-a", "# Skill A\n\nContent here."),
+		"skill-b/SKILL.md": skillDoc("skill-b", "# Skill B\n\nMore content."),
 		"large.bin":        &fstest.MapFile{Data: make([]byte, testMaxFileSize+10)},
 	}
 }
@@ -43,7 +50,7 @@ func TestReadSkillHandler_SubSkillMD(t *testing.T) {
 	h := newTestHandler()
 	_, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
 	require.NoError(t, err)
-	assert.Equal(t, "# Skill A\n\nContent here.", output.Instructions)
+	assert.Contains(t, output.Instructions, "# Skill A")
 }
 
 func TestReadSkillHandler_InvalidPaths(t *testing.T) {
@@ -103,8 +110,8 @@ func TestNewReadSkillHandler(t *testing.T) {
 
 func testCustomFS() fstest.MapFS {
 	return fstest.MapFS{
-		"SKILL.md":              &fstest.MapFile{Data: []byte("# Operator catalog")},
-		"slow-db-call/SKILL.md": &fstest.MapFile{Data: []byte("# Slow DB Call")},
+		"SKILL.md":              &fstest.MapFile{Data: []byte("# Operator entry point")},
+		"slow-db-call/SKILL.md": skillDoc("slow-db-call", "# Slow DB Call"),
 	}
 }
 
@@ -126,23 +133,130 @@ func TestReadSkillHandler_DispatchesByPrefix(t *testing.T) {
 	t.Run("custom prefix reaches the custom tree", func(t *testing.T) {
 		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/slow-db-call/SKILL.md"})
 		require.NoError(t, err)
-		assert.Equal(t, "# Slow DB Call", out.Instructions)
+		assert.Contains(t, out.Instructions, "# Slow DB Call")
 	})
 
 	t.Run("custom entry point is served", func(t *testing.T) {
 		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/SKILL.md"})
 		require.NoError(t, err)
-		assert.Equal(t, "# Operator catalog", out.Instructions)
+		assert.Equal(t, "# Operator entry point", out.Instructions)
 	})
 
 	t.Run("built-ins still reachable at the root", func(t *testing.T) {
 		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
 		require.NoError(t, err)
-		assert.Equal(t, "# Skill A\n\nContent here.", out.Instructions)
+		assert.Contains(t, out.Instructions, "# Skill A")
 	})
 
 	t.Run("traversal out of custom is rejected", func(t *testing.T) {
 		_, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/../etc/passwd"})
 		require.Error(t, err)
 	})
+}
+
+// An invalid skill must fail the read that asked for it, not the whole tree:
+// every other skill keeps serving.
+func TestReadSkillHandler_RejectsInvalidSkillOnRead(t *testing.T) {
+	custom := fstest.MapFS{
+		"SKILL.md":                &fstest.MapFile{Data: []byte("# Operator entry point")},
+		"good/SKILL.md":           skillDoc("good", "# Good"),
+		"mismatched/SKILL.md":     skillDoc("something-else", "# Mismatched"),
+		"no-frontmatter/SKILL.md": &fstest.MapFile{Data: []byte("# No frontmatter")},
+		"typo/SKILL.md":           &fstest.MapFile{Data: []byte("---\nname: typo\nunknown_key: oops\n---\n")},
+	}
+	h := &readSkillHandler{builtins: testSkillsFS(), custom: custom, maxFileSize: 1 << 16}
+
+	tests := []struct {
+		path    string
+		wantErr string
+	}{
+		{"custom/mismatched/SKILL.md", `must match its directory name "mismatched"`},
+		{"custom/no-frontmatter/SKILL.md", `missing "---" frontmatter block`},
+		{"custom/typo/SKILL.md", "unknown_key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			_, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: tt.path})
+			require.ErrorContains(t, err, tt.wantErr)
+			require.ErrorContains(t, err, "invalid skill")
+		})
+	}
+
+	t.Run("the valid skill beside them still serves", func(t *testing.T) {
+		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/good/SKILL.md"})
+		require.NoError(t, err)
+		assert.Contains(t, out.Instructions, "# Good")
+	})
+}
+
+// Only <dir>/SKILL.md is a skill in its own right. An entry point has no
+// directory to be named after, and a file nested deeper is documentation
+// inside a skill — neither carries the name/directory rule.
+func TestReadSkillHandler_ValidatesOnlyTopLevelSkills(t *testing.T) {
+	custom := fstest.MapFS{
+		// No frontmatter at all: fine for both, an error for a skill.
+		"SKILL.md":                    &fstest.MapFile{Data: []byte("# Entry point")},
+		"a-skill/SKILL.md":            skillDoc("a-skill", "# A"),
+		"a-skill/reference/SKILL.md":  &fstest.MapFile{Data: []byte("# Nested reference")},
+		"a-skill/examples/queries.md": &fstest.MapFile{Data: []byte("# Examples")},
+	}
+	h := &readSkillHandler{builtins: testSkillsFS(), custom: custom, maxFileSize: 1 << 16}
+
+	for _, p := range []string{
+		"custom/SKILL.md",
+		"custom/a-skill/reference/SKILL.md",
+		"custom/a-skill/examples/queries.md",
+	} {
+		t.Run(p, func(t *testing.T) {
+			_, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: p})
+			require.NoError(t, err)
+		})
+	}
+}
+
+// Skills are read from disk per request, so an edit takes effect without a
+// restart — the reason validation lives here rather than in a startup scan.
+func TestReadSkillHandler_PicksUpEditsWithoutRestart(t *testing.T) {
+	file := skillDoc("live", "# Before")
+	h := &readSkillHandler{
+		builtins:    testSkillsFS(),
+		custom:      fstest.MapFS{"live/SKILL.md": file},
+		maxFileSize: 1 << 16,
+	}
+
+	_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/live/SKILL.md"})
+	require.NoError(t, err)
+	assert.Contains(t, out.Instructions, "# Before")
+
+	file.Data = skillDoc("live", "# After").Data
+	_, out, err = h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/live/SKILL.md"})
+	require.NoError(t, err)
+	assert.Contains(t, out.Instructions, "# After")
+
+	// An edit that breaks the frontmatter is caught on the next read too.
+	file.Data = skillDoc("renamed", "# Broken").Data
+	_, _, err = h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/live/SKILL.md"})
+	require.ErrorContains(t, err, "invalid skill")
+}
+
+func TestSkillDirName(t *testing.T) {
+	tests := []struct {
+		path    string
+		wantDir string
+		wantOK  bool
+	}{
+		{"skill-a/SKILL.md", "skill-a", true},
+		{"custom/skill-a/SKILL.md", "skill-a", true},
+		{"SKILL.md", "", false},
+		{"custom/SKILL.md", "", false},
+		{"skill-a/nested/SKILL.md", "", false},
+		{"skill-a/notes.md", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			dir, ok := skillDirName(tt.path)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantDir, dir)
+		})
+	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/skill_frontmatter.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/skill_frontmatter.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"unicode/utf8"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Frontmatter limits from the agent skills specification,
+// https://agentskills.io/specification.
+const (
+	maxSkillNameLen          = 64
+	maxSkillDescriptionLen   = 1024
+	maxSkillCompatibilityLen = 500
+)
+
+// skillNamePattern enforces the spec's naming rules: lowercase letters, digits,
+// and hyphens only, with no leading or trailing hyphen and no doubled hyphen.
+var skillNamePattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// skillFrontmatter is the YAML frontmatter of a SKILL.md, per
+// https://agentskills.io/specification.
+type skillFrontmatter struct {
+	Name          string            `yaml:"name"`
+	Description   string            `yaml:"description"`
+	License       string            `yaml:"license"`
+	Metadata      map[string]string `yaml:"metadata"`
+	Compatibility string            `yaml:"compatibility"`
+	AllowedTools  string            `yaml:"allowed-tools"`
+}
+
+// validateSkillFrontmatter decodes a SKILL.md's frontmatter and checks it
+// against the directory holding it. Skills are validated on every read rather
+// than once at startup, so a skills_dir edited while Jaeger runs takes effect
+// without a restart.
+func validateSkillFrontmatter(data []byte, dirName string) error {
+	fm, err := decodeSkillFrontmatter(data)
+	if err != nil {
+		return err
+	}
+	return fm.validate(dirName)
+}
+
+// decodeSkillFrontmatter extracts the leading "---" block and strict-decodes it,
+// so an unknown or misspelled key is an error rather than a silently ignored
+// field.
+func decodeSkillFrontmatter(data []byte) (skillFrontmatter, error) {
+	var fm skillFrontmatter
+	// Normalize CRLF so a Windows-authored file still matches the delimiters.
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	after, ok := bytes.CutPrefix(data, []byte("---\n"))
+	if !ok {
+		return fm, errors.New(`missing "---" frontmatter block`)
+	}
+	// Require a full delimiter line; a bare "\n---" only ends the block at end
+	// of file, so a YAML value whose own text contains a line starting with
+	// "---" cannot truncate the frontmatter early.
+	block, _, ok := bytes.Cut(after, []byte("\n---\n"))
+	if !ok {
+		var rest []byte
+		block, rest, ok = bytes.Cut(after, []byte("\n---"))
+		if !ok || len(rest) != 0 {
+			return fm, errors.New(`frontmatter not terminated by "---"`)
+		}
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(block))
+	dec.KnownFields(true)
+	if err := dec.Decode(&fm); err != nil {
+		return fm, fmt.Errorf("invalid frontmatter: %w", err)
+	}
+	// KnownFields guards only the first document. A "..." terminator inside the
+	// block starts a second one whose keys strict decoding would never see, so
+	// anything a typo'd key was meant to catch could ride along in it. Decoding
+	// again therefore has to reach end of stream.
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		return fm, errors.New("frontmatter must be a single YAML document")
+	}
+	return fm, nil
+}
+
+// validate checks fm against the spec's rules, joining every violation so one
+// error names everything wrong with a skill instead of only the first thing.
+func (fm skillFrontmatter) validate(dirName string) error {
+	var errs []error
+	switch {
+	case fm.Name == "":
+		errs = append(errs, errors.New("name is required"))
+	case utf8.RuneCountInString(fm.Name) > maxSkillNameLen:
+		errs = append(errs, fmt.Errorf("name exceeds %d characters", maxSkillNameLen))
+	case !skillNamePattern.MatchString(fm.Name):
+		errs = append(errs, fmt.Errorf("name %q must be lowercase letters, digits, and single hyphens with no leading/trailing hyphen", fm.Name))
+	case fm.Name != dirName:
+		errs = append(errs, fmt.Errorf("name %q must match its directory name %q", fm.Name, dirName))
+	default:
+	}
+	if fm.Description == "" {
+		errs = append(errs, errors.New("description is required"))
+	} else if utf8.RuneCountInString(fm.Description) > maxSkillDescriptionLen {
+		errs = append(errs, fmt.Errorf("description exceeds %d characters", maxSkillDescriptionLen))
+	}
+	if utf8.RuneCountInString(fm.Compatibility) > maxSkillCompatibilityLen {
+		errs = append(errs, fmt.Errorf("compatibility exceeds %d characters", maxSkillCompatibilityLen))
+	}
+	return errors.Join(errs...)
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/skill_frontmatter_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/skill_frontmatter_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeSkillFrontmatter(t *testing.T) {
+	t.Run("valid with all spec fields", func(t *testing.T) {
+		fm, err := decodeSkillFrontmatter([]byte(`---
+name: slow-db-call
+description: Finds slow database calls.
+license: Apache-2.0
+metadata:
+  author: jaeger
+compatibility: requires Jaeger v2 with MCP enabled
+allowed-tools: search_traces read_skill
+---
+
+# Body
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "slow-db-call", fm.Name)
+		assert.Equal(t, "Finds slow database calls.", fm.Description)
+		assert.Equal(t, "Apache-2.0", fm.License)
+		assert.Equal(t, map[string]string{"author": "jaeger"}, fm.Metadata)
+		assert.Equal(t, "requires Jaeger v2 with MCP enabled", fm.Compatibility)
+		assert.Equal(t, "search_traces read_skill", fm.AllowedTools)
+	})
+
+	t.Run("missing frontmatter block", func(t *testing.T) {
+		_, err := decodeSkillFrontmatter([]byte("# Just markdown\n"))
+		require.ErrorContains(t, err, "missing")
+	})
+
+	t.Run("unterminated frontmatter", func(t *testing.T) {
+		_, err := decodeSkillFrontmatter([]byte("---\nname: x\n"))
+		require.ErrorContains(t, err, "not terminated")
+	})
+
+	t.Run("unknown key rejected by strict decoding", func(t *testing.T) {
+		_, err := decodeSkillFrontmatter([]byte("---\nname: x\nnot_a_real_field: oops\n---\nbody\n"))
+		require.ErrorContains(t, err, "not_a_real_field")
+	})
+
+	t.Run("CRLF line endings are normalized", func(t *testing.T) {
+		fm, err := decodeSkillFrontmatter([]byte("---\r\nname: crlf-skill\r\ndescription: Authored on Windows.\r\n---\r\n\r\nBody\r\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "crlf-skill", fm.Name)
+		assert.Equal(t, "Authored on Windows.", fm.Description)
+	})
+
+	t.Run("a --- inside a value does not end the block early", func(t *testing.T) {
+		// A double-quoted YAML string folds across raw lines; one of them starts
+		// with "---" but carries trailing content, so it is not a delimiter line
+		// and must not be mistaken for the real terminator that follows.
+		fm, err := decodeSkillFrontmatter([]byte("---\nname: x\ndescription: \"line1\n---trailing\nline2\"\n---\n\nbody\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "line1 ---trailing line2", fm.Description)
+	})
+
+	// KnownFields guards only the first document, so a "..." terminator inside
+	// the block would otherwise let a second document carry keys strict decoding
+	// never sees — here "unknown" would be silently accepted.
+	t.Run("second YAML document after ... is rejected", func(t *testing.T) {
+		_, err := decodeSkillFrontmatter([]byte("---\nname: good\ndescription: good\n...\nunknown: ignored\n---\nbody\n"))
+		require.Error(t, err)
+	})
+
+	t.Run("unparseable second document is reported", func(t *testing.T) {
+		_, err := decodeSkillFrontmatter([]byte("---\nname: good\ndescription: good\n...\n[unbalanced\n---\nbody\n"))
+		require.ErrorContains(t, err, "single YAML document")
+	})
+}
+
+func TestValidateSkillFrontmatter(t *testing.T) {
+	doc := string(skillDoc("good-skill", "# Body\n").Data)
+
+	t.Run("valid frontmatter passes decode and validation", func(t *testing.T) {
+		require.NoError(t, validateSkillFrontmatter([]byte(doc), "good-skill"))
+	})
+
+	// Decoding alone is not enough: the same document is invalid under a
+	// different directory, and that has to surface.
+	t.Run("decodable but invalid frontmatter still fails", func(t *testing.T) {
+		err := validateSkillFrontmatter([]byte(doc), "other-dir")
+		require.ErrorContains(t, err, `must match its directory name "other-dir"`)
+	})
+
+	t.Run("undecodable frontmatter fails before validation", func(t *testing.T) {
+		err := validateSkillFrontmatter([]byte("no frontmatter here\n"), "any")
+		require.ErrorContains(t, err, "missing")
+	})
+}
+
+func TestSkillFrontmatterValidate(t *testing.T) {
+	valid := skillFrontmatter{Name: "good-skill", Description: "d"}
+
+	tests := []struct {
+		name    string
+		mutate  func(*skillFrontmatter)
+		dirName string
+		wantErr string
+	}{
+		{name: "valid", mutate: func(*skillFrontmatter) {}, dirName: "good-skill"},
+		{
+			name:    "missing name",
+			mutate:  func(fm *skillFrontmatter) { fm.Name = "" },
+			dirName: "good-skill", wantErr: "name is required",
+		},
+		{
+			name:    "missing description",
+			mutate:  func(fm *skillFrontmatter) { fm.Description = "" },
+			dirName: "good-skill", wantErr: "description is required",
+		},
+		{
+			name:    "oversize name",
+			mutate:  func(fm *skillFrontmatter) { fm.Name = strings.Repeat("a", maxSkillNameLen+1) },
+			dirName: "good-skill", wantErr: "name exceeds",
+		},
+		{
+			name:    "uppercase in name",
+			mutate:  func(fm *skillFrontmatter) { fm.Name = "Good-Skill" },
+			dirName: "good-skill", wantErr: "lowercase",
+		},
+		{
+			name:    "leading hyphen",
+			mutate:  func(fm *skillFrontmatter) { fm.Name = "-good" },
+			dirName: "good-skill", wantErr: "lowercase",
+		},
+		{
+			name:    "doubled hyphen",
+			mutate:  func(fm *skillFrontmatter) { fm.Name = "good--skill" },
+			dirName: "good-skill", wantErr: "lowercase",
+		},
+		{
+			name:    "name differs from directory",
+			mutate:  func(*skillFrontmatter) {},
+			dirName: "other-dir", wantErr: `must match its directory name "other-dir"`,
+		},
+		{
+			name:    "oversize description",
+			mutate:  func(fm *skillFrontmatter) { fm.Description = strings.Repeat("d", maxSkillDescriptionLen+1) },
+			dirName: "good-skill", wantErr: "description exceeds",
+		},
+		{
+			// Comfortably inside the character limit but past it in bytes, so a
+			// byte-length check would wrongly reject it.
+			name:    "multi-byte description within the character limit",
+			mutate:  func(fm *skillFrontmatter) { fm.Description = strings.Repeat("日", maxSkillDescriptionLen/2) },
+			dirName: "good-skill",
+		},
+		{
+			name:    "compatibility at the limit",
+			mutate:  func(fm *skillFrontmatter) { fm.Compatibility = strings.Repeat("c", maxSkillCompatibilityLen) },
+			dirName: "good-skill",
+		},
+		{
+			name:    "oversize compatibility",
+			mutate:  func(fm *skillFrontmatter) { fm.Compatibility = strings.Repeat("c", maxSkillCompatibilityLen+1) },
+			dirName: "good-skill", wantErr: "compatibility exceeds",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fm := valid
+			tc.mutate(&fm)
+			err := fm.validate(tc.dirName)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+
+	t.Run("every problem is reported, not just the first", func(t *testing.T) {
+		err := skillFrontmatter{Compatibility: strings.Repeat("c", maxSkillCompatibilityLen+1)}.validate("d")
+		require.ErrorContains(t, err, "name is required")
+		require.ErrorContains(t, err, "description is required")
+		require.ErrorContains(t, err, "compatibility exceeds")
+	})
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #8440. Follows #9169, which served operator skills but never checked them.

An operator skill with malformed frontmatter — a misspelled key, or a `name` that does notmatch its directory — was handed to agents as-is.

## Description of the changes
- `read_skill` parses and validates frontmatter on every call, per the  [agent skills specification](https://agentskills.io/specification):

  | Key | Rule |
  | --- | --- |
  | `name` | Required; lowercase/digits/single hyphens, ≤64 chars, equal to the directory name |
  | `description` | Required, ≤1024 chars |
  | `license`, `metadata`, `compatibility`, `allowed-tools` | Optional; `compatibility` ≤500 chars |

  Unknown keys are errors rather than ignored fields, so a typo is reported instead of silently  doing nothing.

- **Per read, not a startup scan** (thanks @yurishkuro). Skills stay live on disk: editing one  takes effect on the next call, with no restart and no cache to invalidate. An invalid skill  fails only the call that asked for it — the rest keep serving, and Jaeger still boots.

- Only `<skill>/SKILL.md` carries the name rule. A tree's own `SKILL.md` has no directory to be  named after, and a `SKILL.md` nested deeper is reference material inside a skill. Built-in and  operator skills are judged alike.

- `KnownFields(true)` guards only the *first* YAML document, so a `...` terminator inside the  frontmatter could smuggle keys past strict decoding. Decoding now has to reach end of stream.

## How was this change tested?
- Unit tests. `read_skill.go` and `skill_frontmatter.go` are both at 100% statement coverage.
- Live E2E against a real Gemini ACP sidecar (`gemini-2.5-flash`) with a three-skill  `skills_dir`, one of which is deliberately invalid.

  Six `read_skill` calls in a single turn — full progressive disclosure:

  ```
  2026-08-02 03:33:07,980 INFO sidecar: Gemini requested MCP tool call: read_skill (call_id=read_skill-1)
  2026-08-02 03:33:10,242 INFO sidecar: Gemini requested MCP tool call: read_skill (call_id=read_skill-2)
  2026-08-02 03:33:10,247 INFO sidecar: Gemini requested MCP tool call: read_skill (call_id=read_skill-3)
  2026-08-02 03:33:10,252 INFO sidecar: Gemini requested MCP tool call: read_skill (call_id=read_skill-4)
  2026-08-02 03:33:12,314 INFO sidecar: Gemini requested MCP tool call: read_skill (call_id=read_skill-5)
  2026-08-02 03:33:12,324 INFO sidecar: Gemini requested MCP tool call: read_skill (call_id=read_skill-6)
  ```

  | # | path | result |
  |---|---|---|
  | 1 | `SKILL.md` | built-in root catalog |
  | 2–3 | `detect-n-plus-one/SKILL.md`, `error-root-cause/SKILL.md` | built-in skills |
  | 4 | `custom/SKILL.md` | operator entry point |
  | 5 | `custom/slow-db-call/SKILL.md` | served |
  | 6 | `custom/broken/SKILL.md` | rejected |

  The rejection, as the agent received it:

  ```
  invalid skill "custom/broken/SKILL.md": name "totally-different" must match its directory name "broken"
  ```

  The agent reported that verbatim and answered normally from the other five.

- **Hot reload, no restart.** With the server still running (same PID), the broken file was  repaired on disk and the next turn read it:

  ```
  ---
  name: broken
  description: Now the name matches its directory.
  ---

  # Fixed Skill

  This was repaired on disk without restarting Jaeger.
  ```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
