### PR TITLE
fix: Reject nil query in storage v2 gRPC search handlers (#9156)

### DIFF
--- a/internal/storage/v2/grpc/handler.go
+++ b/internal/storage/v2/grpc/handler.go
@@ -119,6 +119,9 @@ func (h *Handler) FindTraces(
 	req *storage.FindTracesRequest,
 	srv storage.TraceReader_FindTracesServer,
 ) error {
+	if req.Query == nil {
+		return status.Errorf(codes.InvalidArgument, "missing query")
+	}
 	for traces, err := range h.traceReader.FindTraces(srv.Context(), toTraceQueryParams(req.Query)) {
 		if err != nil {
 			return err
@@ -138,6 +141,9 @@ func (h *Handler) FindTraceSummaries(
 	req *storage.FindTraceSummariesRequest,
 	srv storage.TraceReader_FindTraceSummariesServer,
 ) error {
+	if req.Query == nil {
+		return status.Errorf(codes.InvalidArgument, "missing query")
+	}
 	for summaries, err := range h.traceReader.FindTraceSummaries(srv.Context(), toTraceQueryParams(req.Query)) {
 		if err != nil {
 			// A backend that cannot compute summaries natively signals this with
@@ -182,6 +188,9 @@ func (h *Handler) FindTraceIDs(
 	ctx context.Context,
 	req *storage.FindTraceIDsRequest,
 ) (*storage.FindTraceIDsResponse, error) {
+	if req.Query == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "missing query")
+	}
 	foundTraceIDs := []*storage.FoundTraceID{}
 	for traceIDs, err := range h.traceReader.FindTraceIDs(ctx, toTraceQueryParams(req.Query)) {
 		if err != nil {

--- a/internal/storage/v2/grpc/handler_test.go
+++ b/internal/storage/v2/grpc/handler_test.go
@@ -329,6 +329,16 @@ func TestHandler_FindTraces(t *testing.T) {
 	}
 }
 
+func TestHandler_FindTraces_NilQuery(t *testing.T) {
+	reader := new(tracestoremocks.Reader)
+	writer := new(tracestoremocks.Writer)
+	depReader := new(depstoremocks.Reader)
+	server := NewHandler(reader, writer, depReader)
+	stream := &testStream{}
+	err := server.FindTraces(&storage.FindTracesRequest{Query: nil}, stream)
+	require.ErrorIs(t, err, status.Errorf(codes.InvalidArgument, "missing query"))
+}
+
 func TestHandler_FindTraceIDs(t *testing.T) {
 	query := tracestore.TraceQueryParams{
 		ServiceName:   "service",
@@ -407,6 +417,15 @@ func TestHandler_FindTraceIDs(t *testing.T) {
 			require.Equal(t, test.expectedTraceIDs, response.TraceIds)
 		}
 	}
+}
+
+func TestHandler_FindTraceIDs_NilQuery(t *testing.T) {
+	reader := new(tracestoremocks.Reader)
+	writer := new(tracestoremocks.Writer)
+	depReader := new(depstoremocks.Reader)
+	server := NewHandler(reader, writer, depReader)
+	_, err := server.FindTraceIDs(context.Background(), &storage.FindTraceIDsRequest{Query: nil})
+	require.ErrorIs(t, err, status.Errorf(codes.InvalidArgument, "missing query"))
 }
 
 func TestHandler_Export(t *testing.T) {
@@ -843,4 +862,13 @@ func TestHandler_FindTraceSummaries_SendError(t *testing.T) {
 		Query: &storage.TraceQueryParameters{},
 	}, &summaryStream{sendErr: assert.AnError})
 	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestHandler_FindTraceSummaries_NilQuery(t *testing.T) {
+	reader := new(tracestoremocks.Reader)
+	writer := new(tracestoremocks.Writer)
+	depReader := new(depstoremocks.Reader)
+	handler := NewHandler(reader, writer, depReader)
+	err := handler.FindTraceSummaries(&storage.FindTraceSummariesRequest{Query: nil}, &summaryStream{})
+	require.ErrorIs(t, err, status.Errorf(codes.InvalidArgument, "missing query"))
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #9156.

Storage v2 gRPC search handlers (`FindTraces`, `FindTraceSummaries`, `FindTraceIDs`) panic with a nil pointer dereference when the request omits the nested `query` message. Protobuf permits `query` to be omitted, but `toTraceQueryParams()` dereferences the pointer without checking it.

## Description of the changes

- Added nil checks for `req.Query` in all three handlers
- Return gRPC status `codes.InvalidArgument` with message `"missing query"` instead of panicking
- Added three new test functions: `TestHandler_FindTraces_NilQuery`, `TestHandler_FindTraceIDs_NilQuery`, `TestHandler_FindTraceSummaries_NilQuery`

This matches the existing API v3 gRPC query handler, which already returns `codes.InvalidArgument` when its query message is missing.

## How was this change tested?

- `go test ./internal/storage/v2/grpc/ -run "TestHandler_FindTraces|TestHandler_FindTraceIDs|TestHandler_FindTraceSummaries" -v` — all 12 tests pass