### PR TITLE
fix: validate span.status and span.kind filter values in memory store (#9152)

### DIFF
--- a/internal/storage/v2/memory/memory_test.go
+++ b/internal/storage/v2/memory/memory_test.go
@@ -1088,6 +1088,12 @@ func TestFindTraces_OTLPFields(t *testing.T) {
 			expectedIDs:    []pcommon.TraceID{traceID5, traceID4, traceID3},
 		},
 		{
+			name:           "Filter by span.status=INVALID (default/unknown)",
+			queryAttrs:     map[string]string{"span.status": "INVALID"},
+			expectedTraces: 0,
+			expectedIDs:    []pcommon.TraceID{},
+		},
+		{
 			name:           "Filter by span.kind=SERVER",
 			queryAttrs:     map[string]string{"span.kind": "SERVER"},
 			expectedTraces: 1,

--- a/internal/storage/v2/memory/tenant.go
+++ b/internal/storage/v2/memory/tenant.go
@@ -275,14 +275,20 @@ func validSpan(resourceAttributes pcommon.Map, scope pcommon.InstrumentationScop
 	}
 
 	if statusAttr, ok := query.Attributes.Get("span.status"); ok {
-		expectedStatus := spanStatusFromString(statusAttr.AsString())
+		expectedStatus, valid := spanStatusFromString(statusAttr.AsString())
+		if !valid {
+			return false
+		}
 		if expectedStatus != span.Status().Code() {
 			return false
 		}
 	}
 
 	if kindAttr, ok := query.Attributes.Get("span.kind"); ok {
-		expectedKind := spanKindFromString(kindAttr.AsString())
+		expectedKind, valid := spanKindFromString(kindAttr.AsString())
+		if !valid {
+			return false
+		}
 		if expectedKind != span.Kind() {
 			return false
 		}
@@ -371,30 +377,34 @@ func errorQueryValue(attr pcommon.Value) (value bool, valid bool) {
 	}
 }
 
-func spanStatusFromString(statusStr string) ptrace.StatusCode {
+func spanStatusFromString(statusStr string) (ptrace.StatusCode, bool) {
 	switch strings.ToUpper(statusStr) {
 	case "OK":
-		return ptrace.StatusCodeOk
+		return ptrace.StatusCodeOk, true
 	case "ERROR":
-		return ptrace.StatusCodeError
+		return ptrace.StatusCodeError, true
+	case "UNSET":
+		return ptrace.StatusCodeUnset, true
 	default:
-		return ptrace.StatusCodeUnset
+		return ptrace.StatusCodeUnset, false
 	}
 }
 
-func spanKindFromString(kindStr string) ptrace.SpanKind {
+func spanKindFromString(kindStr string) (ptrace.SpanKind, bool) {
 	switch strings.ToUpper(kindStr) {
 	case "CLIENT":
-		return ptrace.SpanKindClient
+		return ptrace.SpanKindClient, true
 	case "SERVER":
-		return ptrace.SpanKindServer
+		return ptrace.SpanKindServer, true
 	case "PRODUCER":
-		return ptrace.SpanKindProducer
+		return ptrace.SpanKindProducer, true
 	case "CONSUMER":
-		return ptrace.SpanKindConsumer
+		return ptrace.SpanKindConsumer, true
 	case "INTERNAL":
-		return ptrace.SpanKindInternal
+		return ptrace.SpanKindInternal, true
+	case "UNSPECIFIED":
+		return ptrace.SpanKindUnspecified, true
 	default:
-		return ptrace.SpanKindUnspecified
+		return ptrace.SpanKindUnspecified, false
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9152

In the in-memory store, unrecognized `span.status` and `span.kind` filter values were silently parsed as the zero value (`StatusCodeUnset` / `SpanKindUnspecified`), causing the query to match every span with that default value instead of returning nothing.

This is inconsistent with other filters in the same store:
- `error=notabool` correctly returns zero traces (via `errorQueryValue` returning `valid=false`)
- `scope.name=nonexistent` correctly returns zero traces
- `scope.version=99.0.0` correctly returns zero traces

## Description of the changes

1. Changed `spanStatusFromString` to return `(ptrace.StatusCode, bool)` — the bool indicates whether the input was recognized
2. Changed `spanKindFromString` to return `(ptrace.SpanKind, bool)` — same pattern
3. Updated callers in `validSpan` to reject unrecognized values by returning `false`
4. Added `UNSET`/`UNSPECIFIED` as explicit valid cases alongside `OK`/`ERROR` and the kind values

## How was this change tested?

- `go test ./internal/storage/v2/memory/...` — all tests pass
- Added a new test case `Filter by span.status=INVALID (default/unknown)` to `TestFindTraces_OTLPFields` that asserts 0 results for an invalid status value