### PR TITLE
fix: Query HTTP APIs send JSON error bodies with application/json content type (#9051)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -86,7 +86,9 @@ func (h *HTTPGateway) tryHandleError(w http.ResponseWriter, err error, statusCod
 		},
 	}
 	resp, _ := json.Marshal(&errorResponse)
-	http.Error(w, string(resp), statusCode)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	w.Write(resp)
 	return true
 }
 
@@ -118,7 +120,9 @@ func (h *HTTPGateway) returnTraces(traces []ptrace.Traces, err error, w http.Res
 			},
 		}
 		resp, _ := json.Marshal(&errorResponse)
-		http.Error(w, string(resp), http.StatusNotFound)
+		w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	w.Write(resp)
 		return
 	}
 	// TODO: the response should be streamed back to the client

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go
@@ -556,7 +556,9 @@ func (aH *APIHandler) handleError(w http.ResponseWriter, err error, statusCode i
 		},
 	}
 	resp, _ := json.Marshal(&structuredResp)
-	http.Error(w, string(resp), statusCode)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	w.Write(resp)
 	return true
 }
 


### PR DESCRIPTION
## Description

Fixes #9051

Query HTTP APIs (both legacy and v3) send JSON error responses but with  because  hardcodes that type.

This PR replaces  with explicit  header +  +  so that standard HTTP clients can parse errors consistently.

## Changes

1. **cmd/jaeger/internal/extension/jaegerquery/internal/http_handler.go** — : replaced  with proper JSON content type
2. **cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go** —  and : same fix in two locations

## Verification

- Error responses still return the same JSON body and status code
- Content-Type header is now  instead of 