### PR TITLE
fix: escape IndexDateSeparator in ES index cleaner regex (#9120)

### DIFF
--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -41,7 +41,7 @@ func (i *IndexFilter) filterByPattern(indices []esclient.Index) []esclient.Index
 	case i.Rollover:
 		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{6}", i.IndexPrefix))
 	default:
-		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{4}%s\\d{2}%s\\d{2}", i.IndexPrefix, i.IndexDateSeparator, i.IndexDateSeparator))
+		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{4}%s\\d{2}%s\\d{2}", i.IndexPrefix, regexp.QuoteMeta(i.IndexDateSeparator), regexp.QuoteMeta(i.IndexDateSeparator)))
 	}
 
 	var filtered []esclient.Index

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -64,6 +64,26 @@ func runIndexFilterTest(t *testing.T, prefix string) {
 			Aliases:      map[string]bool{},
 		},
 		{
+			Index:        prefix + "jaeger-span-2020.08.05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        prefix + "jaeger-service-2020.08.05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        prefix + "jaeger-dependencies-2020.08.05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        prefix + "jaeger-sampling-2020.08.05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
 			Index:        prefix + "jaeger-span-archive",
 			CreationTime: time.Date(2020, time.August, 1, 15, 0, 0, 0, time.UTC),
 			Aliases:      map[string]bool{},
@@ -350,6 +370,38 @@ func runIndexFilterTest(t *testing.T, prefix string) {
 					Aliases: map[string]bool{
 						prefix + "jaeger-span-archive-read": true,
 					},
+				},
+			},
+		},
+		{
+			name: "normal indices with dot separator, remove older 1 days",
+			filter: &IndexFilter{
+				IndexPrefix:          prefix,
+				IndexDateSeparator:   ".",
+				Archive:              false,
+				Rollover:             false,
+				DeleteBeforeThisDate: time20200807.Add(-time.Hour * 24 * time.Duration(1)),
+			},
+			expected: []esclient.Index{
+				{
+					Index:        prefix + "jaeger-span-2020.08.05",
+					CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
+				},
+				{
+					Index:        prefix + "jaeger-service-2020.08.05",
+					CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
+				},
+				{
+					Index:        prefix + "jaeger-dependencies-2020.08.05",
+					CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
+				},
+				{
+					Index:        prefix + "jaeger-sampling-2020.08.05",
+					CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+					Aliases:      map[string]bool{},
 				},
 			},
 		},


### PR DESCRIPTION
## Description

### Which problem is being solved?

When `IndexDateSeparator` is configured with a regex special character (e.g., `.`), the ES index cleaner's pattern filter treats it as a regex metacharacter, causing it to match unintended index names. For example, a `.` separator would match any character between date components.

### What does this PR do?

Uses `regexp.QuoteMeta()` to escape the `IndexDateSeparator` before inserting it into the compiled regex pattern, ensuring the separator is matched literally.

### Steps to reproduce the problem

1. Configure `IndexDateSeparator: .`
2. Supply `jaeger-span-2020.01.01` and `jaeger-span-2020x01y01` to `IndexFilter.Filter`
3. Before fix: both match (unexpected)
4. After fix: only `jaeger-span-2020.01.01` matches (correct)

### Testing

- Added test case `"normal indices with dot separator, remove older 1 days"` with `.` as the separator
- All existing tests continue to pass
- Both `TestIndexFilter` and `TestIndexFilterWithPrefix` pass the new test
