### PR TITLE
fix(mcp): fix search depth clamping when max results is unlimited

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -161,7 +161,7 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	if searchDepth <= 0 {
 		searchDepth = defaultSearchDepth
 	}
-	if searchDepth > h.maxResults {
+	if h.maxResults > 0 && searchDepth > h.maxResults {
 		searchDepth = h.maxResults
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -302,7 +302,7 @@ func TestSearchTracesHandler_Handle_SearchDepthMax(t *testing.T) {
 	input := types.SearchTracesInput{
 		StartTimeMin: "-1h",
 		ServiceName:  "test",
-		SearchDepth:  200, // capped at maxResults=100
+		SearchDepth:  200,
 	}
 
 	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
@@ -310,10 +310,6 @@ func TestSearchTracesHandler_Handle_SearchDepthMax(t *testing.T) {
 }
 
 func TestSearchTracesHandler_Handle_SearchDepthUnboundedWhenMaxResultsZero(t *testing.T) {
-	// maxResults == 0 means "unlimited" (see handle()'s `h.maxResults > 0 && ...`
-	// guard). buildQuery must honor that same semantics when clamping
-	// SearchDepth: a requested depth larger than the default must NOT be
-	// zeroed out just because maxResults is 0.
 	want := makeTraceSummary("test", "/test", false)
 
 	mock := &mockQueryService{
@@ -338,8 +334,6 @@ func TestSearchTracesHandler_Handle_SearchDepthUnboundedWhenMaxResultsZero(t *te
 }
 
 func TestSearchTracesHandler_Handle_SearchDepthDefaultWhenMaxResultsZero(t *testing.T) {
-	// Same as above, but relying on the default search depth (10) rather
-	// than an explicit input value.
 	want := makeTraceSummary("test", "/test", false)
 
 	mock := &mockQueryService{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -302,7 +302,7 @@ func TestSearchTracesHandler_Handle_SearchDepthMax(t *testing.T) {
 	input := types.SearchTracesInput{
 		StartTimeMin: "-1h",
 		ServiceName:  "test",
-		SearchDepth:  200,
+		SearchDepth:  200, // capped at maxResults=100
 	}
 
 	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -309,6 +309,59 @@ func TestSearchTracesHandler_Handle_SearchDepthMax(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSearchTracesHandler_Handle_SearchDepthUnboundedWhenMaxResultsZero(t *testing.T) {
+	// maxResults == 0 means "unlimited" (see handle()'s `h.maxResults > 0 && ...`
+	// guard). buildQuery must honor that same semantics when clamping
+	// SearchDepth: a requested depth larger than the default must NOT be
+	// zeroed out just because maxResults is 0.
+	want := makeTraceSummary("test", "/test", false)
+
+	mock := &mockQueryService{
+		findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			assert.Equal(t, 500, query.SearchDepth)
+			return func(yield func([]tracestore.TraceSummary, error) bool) {
+				yield([]tracestore.TraceSummary{want}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 0}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "test",
+		SearchDepth:  500,
+	}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+}
+
+func TestSearchTracesHandler_Handle_SearchDepthDefaultWhenMaxResultsZero(t *testing.T) {
+	// Same as above, but relying on the default search depth (10) rather
+	// than an explicit input value.
+	want := makeTraceSummary("test", "/test", false)
+
+	mock := &mockQueryService{
+		findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			assert.Equal(t, 10, query.SearchDepth)
+			return func(yield func([]tracestore.TraceSummary, error) bool) {
+				yield([]tracestore.TraceSummary{want}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 0}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "test",
+	}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+}
+
 func TestSearchTracesHandler_Handle_QueryError(t *testing.T) {
 	want := makeTraceSummary("test-service", "/api/test", false)
 


### PR DESCRIPTION
## Which problem is this PR solving?
* Fixes an inconsistency in `search_traces` when `maxResults` is configured as `0` (unlimited).
* `handle()` treats `maxResults == 0` as unlimited, but `buildQuery()` clamps `SearchDepth` to `0`. This can cause `search_traces` requests to fail against storage backends that require a positive search depth.

## Description of the changes
* Update the search depth clamping logic in `buildQuery()` to only apply when `maxResults > 0`, matching the semantics already used in `handle()`.
* Add regression tests covering the `maxResults == 0` configuration:
  * Verify that an explicitly provided `SearchDepth` is preserved when `maxResults` is unlimited.
  * Verify that the default search depth remains `10` when no `SearchDepth` is provided.

## How was this change tested?
* Added regression tests covering the `maxResults == 0` scenario.
* Ran `go build ./...` — passes.
* Ran `go vet ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/...` — passes.
* Ran `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/...` — passes.
* Ran `gofmt -l` on the changed files — clean.

## Checklist
* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test` — ran `go build`/`go vet`/`go test` locally instead; full `make lint test` not run, deferring to CI

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
* [ ] **None**: No AI tools were used in creating this PR
* [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
* [x] **Moderate**: AI helped with code generation or debugging specific parts
* [ ] **Heavy**: AI generated most or all of the code changes