### PR TITLE
fix: cap get_critical_path segments to configurable limit with truncation signal [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/config.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/config.go
@@ -13,10 +13,11 @@ import (
 // Default tunables for the telemetry MCP server, preserved from the retired
 // jaeger_mcp extension.
 const (
-	DefaultServerName               = "jaeger"
-	DefaultMaxSpanDetailsPerRequest = 20
-	DefaultMaxSearchResults         = 100
-	DefaultMaxReadFileSize          = 512 * 1024
+	DefaultServerName                   = "jaeger"
+	DefaultMaxSpanDetailsPerRequest     = 20
+	DefaultMaxSearchResults             = 100
+	DefaultMaxCriticalPathSegments      = 20
+	DefaultMaxReadFileSize              = 512 * 1024
 
 	// mcpSessionTimeout caps an idle MCP session. The streamable handler keeps
 	// per-MCP-session state for SSE resumption and stream-id correlation.
@@ -27,17 +28,21 @@ const (
 // non-transport slice of the retired jaeger_mcp extension's config — the HTTP
 // listener is gone because the handler now mounts on jaeger-query's own mux.
 type Config struct {
-	ServerName               string
-	ServerVersion            string
-	MaxSpanDetailsPerRequest int
-	MaxSearchResults         int
+	ServerName                   string
+	ServerVersion                string
+	MaxSpanDetailsPerRequest     int
+	MaxSearchResults             int
+	// MaxCriticalPathSegments bounds the number of segments returned by
+	// get_critical_path. The critical path is computed over the full trace,
+	// and only the top-N segments with the largest self_time_us are returned.
+	MaxCriticalPathSegments      int
 	// MaxReadFileSize bounds the size (bytes) of a file served by read_skill.
-	MaxReadFileSize int64
+	MaxReadFileSize              int64
 	// CustomSkillsFS is the operator's skills directory (ai.skills_dir),
 	// already opened by the caller, served by read_skill under custom/ beside
 	// the built-in skills. Nil means none is configured, and only the built-ins
 	// are served.
-	CustomSkillsFS fs.FS
+	CustomSkillsFS               fs.FS
 }
 
 // DefaultConfig returns the Config the standalone jaeger_mcp extension used, so
@@ -48,10 +53,11 @@ func DefaultConfig() Config {
 		ver = "dev"
 	}
 	return Config{
-		ServerName:               DefaultServerName,
-		ServerVersion:            ver,
-		MaxSpanDetailsPerRequest: DefaultMaxSpanDetailsPerRequest,
-		MaxSearchResults:         DefaultMaxSearchResults,
-		MaxReadFileSize:          DefaultMaxReadFileSize,
+		ServerName:                DefaultServerName,
+		ServerVersion:             ver,
+		MaxSpanDetailsPerRequest:  DefaultMaxSpanDetailsPerRequest,
+		MaxSearchResults:          DefaultMaxSearchResults,
+		MaxCriticalPathSegments:   DefaultMaxCriticalPathSegments,
+		MaxReadFileSize:           DefaultMaxReadFileSize,
 	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"sort"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -28,15 +29,18 @@ type queryServiceGetCriticalPathInterface interface {
 // This tool identifies the sequence of spans forming the critical latency path
 // (the blocking execution path) in a distributed trace.
 type getCriticalPathHandler struct {
-	queryService queryServiceGetCriticalPathInterface
+	queryService             queryServiceGetCriticalPathInterface
+	maxCriticalPathSegments  int
 }
 
 // NewGetCriticalPathHandler creates a new get_critical_path handler and returns the handler function.
 func NewGetCriticalPathHandler(
 	queryService *querysvc.QueryService,
+	maxCriticalPathSegments int,
 ) mcp.ToolHandlerFor[types.GetCriticalPathInput, types.GetCriticalPathOutput] {
 	h := &getCriticalPathHandler{
-		queryService: queryService,
+		queryService:            queryService,
+		maxCriticalPathSegments: maxCriticalPathSegments,
 	}
 	return h.handle
 }
@@ -75,16 +79,25 @@ func (h *getCriticalPathHandler) handle(
 		return nil, types.GetCriticalPathOutput{}, errors.New("trace not found")
 	}
 
-	// Compute critical path
+	// Compute critical path over the full trace
 	criticalPathSections, err := criticalpath.ComputeCriticalPathFromTraces(trace)
 	if err != nil {
 		return nil, types.GetCriticalPathOutput{}, fmt.Errorf("failed to compute critical path: %w", err)
 	}
 
 	// Build output
-	output := h.buildOutput(input.TraceID, trace, criticalPathSections)
+	output := h.buildOutput(input.TraceID, trace, criticalPathSections, h.effectiveMaxSegments(input))
 
 	return nil, output, nil
+}
+
+// effectiveMaxSegments returns the max segments to use, preferring the
+// caller-provided value over the server default.
+func (h *getCriticalPathHandler) effectiveMaxSegments(input types.GetCriticalPathInput) int {
+	if input.MaxSegments != nil && *input.MaxSegments > 0 {
+		return *input.MaxSegments
+	}
+	return h.maxCriticalPathSegments
 }
 
 // buildQuery converts GetCriticalPathInput to querysvc.GetTraceParams.
@@ -112,6 +125,7 @@ func (*getCriticalPathHandler) buildOutput(
 	traceIDStr string,
 	trace ptrace.Traces,
 	criticalPathSections []criticalpath.Section,
+	maxSegments int,
 ) types.GetCriticalPathOutput {
 	// Build a map of spans for quick lookup
 	spanMap := jptrace.SpanMap(trace, func(span ptrace.Span) string {
@@ -176,10 +190,28 @@ func (*getCriticalPathHandler) buildOutput(
 		})
 	}
 
+	totalSegmentCount := len(segments)
+
+	// Cap segments to the configured limit, keeping the ones with the largest
+	// self_time_us. This follows the same pattern as get_trace_errors which
+	// computes over the full trace and caps the returned list.
+	if maxSegments > 0 && len(segments) > maxSegments {
+		// Sort by SelfTimeUs descending so we keep the most meaningful segments
+		sort.Slice(segments, func(i, j int) bool {
+			return segments[i].SelfTimeUs > segments[j].SelfTimeUs
+		})
+		segments = segments[:maxSegments]
+		// Re-sort by StartOffsetUs to maintain chronological order
+		sort.Slice(segments, func(i, j int) bool {
+			return segments[i].StartOffsetUs < segments[j].StartOffsetUs
+		})
+	}
+
 	return types.GetCriticalPathOutput{
 		TraceID:                traceIDStr,
 		TotalDurationUs:        traceEndTime - traceStartTime,
 		CriticalPathDurationUs: criticalPathDuration,
 		Segments:               segments,
+		TotalSegmentCount:      totalSegmentCount,
 	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
@@ -67,7 +67,7 @@ func createCriticalPathTestTrace() ptrace.Traces {
 
 func TestNewGetCriticalPathHandler(t *testing.T) {
 	// We can pass nil because we only check if it returns a handler function
-	handler := NewGetCriticalPathHandler(nil)
+	handler := NewGetCriticalPathHandler(nil, 20)
 	assert.NotNil(t, handler)
 }
 
@@ -77,7 +77,8 @@ func TestGetCriticalPathHandler_Handle_Success(t *testing.T) {
 		traces: []ptrace.Traces{traces},
 	}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -91,6 +92,7 @@ func TestGetCriticalPathHandler_Handle_Success(t *testing.T) {
 	assert.Positive(t, output.TotalDurationUs)
 	assert.Positive(t, output.CriticalPathDurationUs)
 	assert.NotEmpty(t, output.Segments)
+	assert.Equal(t, len(output.Segments), output.TotalSegmentCount)
 
 	// Verify path contains span information
 	for _, span := range output.Segments {
@@ -103,7 +105,8 @@ func TestGetCriticalPathHandler_Handle_Success(t *testing.T) {
 func TestGetCriticalPathHandler_Handle_EmptyTraceID(t *testing.T) {
 	mockQS := &mockGetCriticalPathQueryService{}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -118,7 +121,8 @@ func TestGetCriticalPathHandler_Handle_EmptyTraceID(t *testing.T) {
 func TestGetCriticalPathHandler_Handle_InvalidTraceID(t *testing.T) {
 	mockQS := &mockGetCriticalPathQueryService{}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -135,7 +139,8 @@ func TestGetCriticalPathHandler_Handle_QueryServiceError(t *testing.T) {
 		err: errors.New("query service error"),
 	}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -152,7 +157,8 @@ func TestGetCriticalPathHandler_Handle_TraceNotFound(t *testing.T) {
 		traces: []ptrace.Traces{}, // empty traces
 	}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -182,7 +188,8 @@ func TestGetCriticalPathHandler_Handle_InvalidTrace(t *testing.T) {
 		traces: []ptrace.Traces{traces},
 	}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -226,7 +233,8 @@ func TestGetCriticalPathHandler_Handle_MultipleServices(t *testing.T) {
 		traces: []ptrace.Traces{traces},
 	}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -261,7 +269,8 @@ func TestGetCriticalPathHandler_Handle_UnknownService(t *testing.T) {
 		traces: []ptrace.Traces{traces},
 	}
 	handler := &getCriticalPathHandler{
-		queryService: mockQS,
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
 	}
 
 	input := types.GetCriticalPathInput{
@@ -309,9 +318,90 @@ func TestGetCriticalPathHandler_BuildOutput_MissingSpan(t *testing.T) {
 		},
 	}
 
-	output := handler.buildOutput(traceID, traces, sections)
+	output := handler.buildOutput(traceID, traces, sections, 20)
 
 	// Should only have 1 segment for the existing span
 	assert.Len(t, output.Segments, 1)
 	assert.Equal(t, span.SpanID().String(), output.Segments[0].SpanID)
+	assert.Equal(t, 1, output.TotalSegmentCount)
+}
+
+func TestGetCriticalPathHandler_SegmentCap(t *testing.T) {
+	// Test that the segment cap correctly limits the number of returned segments
+	// and sets TotalSegmentCount to the full count.
+	handler := &getCriticalPathHandler{}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	// Create 5 spans with different self times
+	for i := 0; i < 5; i++ {
+		sp := ss.Spans().AppendEmpty()
+		sp.SetSpanID([8]byte{byte(i + 1)})
+		sp.SetTraceID([16]byte{1})
+		sp.SetStartTimestamp(pcommon.Timestamp(uint64(1000+i*100) * 1000))
+		sp.SetEndTimestamp(pcommon.Timestamp(uint64(2000+i*100) * 1000))
+		sp.SetName("span")
+	}
+
+	traceID := "00000000000000000000000000000001"
+
+	sections := make([]criticalpath.Section, 5)
+	for i := 0; i < 5; i++ {
+		spanID := [8]byte{byte(i + 1)}
+		sections[i] = criticalpath.Section{
+			SpanID:       spanID.String(),
+			SectionStart: uint64(1000 + i*100),
+			SectionEnd:   uint64(2000 + i*100),
+		}
+	}
+
+	// Cap to 3 segments
+	output := handler.buildOutput(traceID, traces, sections, 3)
+
+	assert.Len(t, output.Segments, 3)
+	assert.Equal(t, 5, output.TotalSegmentCount)
+}
+
+func TestGetCriticalPathHandler_Handle_WithMaxSegmentsInput(t *testing.T) {
+	traces := createCriticalPathTestTrace()
+	mockQS := &mockGetCriticalPathQueryService{
+		traces: []ptrace.Traces{traces},
+	}
+	handler := &getCriticalPathHandler{
+		queryService:            mockQS,
+		maxCriticalPathSegments: 20,
+	}
+
+	maxSeg := 1
+	input := types.GetCriticalPathInput{
+		TraceID:     "00000000000000000000000000000001",
+		MaxSegments: &maxSeg,
+	}
+
+	_, output, err := handler.handle(context.Background(), nil, input)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(output.Segments), 1)
+	assert.Equal(t, len(output.Segments), output.TotalSegmentCount)
+}
+
+func TestGetCriticalPathHandler_EffectiveMaxSegments(t *testing.T) {
+	handler := &getCriticalPathHandler{
+		maxCriticalPathSegments: 20,
+	}
+
+	// No input override -> server default
+	input := types.GetCriticalPathInput{}
+	assert.Equal(t, 20, handler.effectiveMaxSegments(input))
+
+	// With input override
+	maxSeg := 5
+	input.MaxSegments = &maxSeg
+	assert.Equal(t, 5, handler.effectiveMaxSegments(input))
+
+	// Zero input override -> server default
+	zero := 0
+	input.MaxSegments = &zero
+	assert.Equal(t, 20, handler.effectiveMaxSegments(input))
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
@@ -7,6 +7,11 @@ package types
 type GetCriticalPathInput struct {
 	// TraceID is the unique identifier for the trace (required).
 	TraceID string `json:"trace_id" jsonschema:"Unique identifier for the trace"`
+	// MaxSegments is the maximum number of segments to return in the response.
+	// If not set, the server-configured default is used. The critical path is
+	// computed over the full trace, and only the top-N segments with the
+	// largest self_time_us are returned.
+	MaxSegments *int `json:"max_segments,omitempty" jsonschema:"Maximum number of segments to return (default: server-configured limit)"`
 }
 
 // GetCriticalPathOutput defines the output of the get_critical_path MCP tool.
@@ -14,7 +19,8 @@ type GetCriticalPathOutput struct {
 	TraceID                string                `json:"trace_id" jsonschema:"Unique identifier for the trace"`
 	TotalDurationUs        uint64                `json:"total_duration_us" jsonschema:"Total trace duration in microseconds"`
 	CriticalPathDurationUs uint64                `json:"critical_path_duration_us" jsonschema:"Total duration of critical path in microseconds"`
-	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Ordered list of span segments on the critical path"`
+	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Ordered list of span segments on the critical path (may be truncated; compare total_segment_count with the size of segments to detect truncation)"`
+	TotalSegmentCount      int                   `json:"total_segment_count" jsonschema:"Total number of segments in the critical path (may exceed the size of the segments list due to per-request limits)"`
 }
 
 // CriticalPathSegment represents a span segment on the critical path.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -162,8 +162,10 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 		Name: "get_critical_path",
 		Description: "Identify the critical latency path through a trace: the chain of spans " +
 			"that determined end-to-end duration. " +
-			"Higher self_time_us values indicate where time is concentrated on the critical path.",
-	}, handlers.NewGetCriticalPathHandler(s.queryAPI))
+			"Higher self_time_us values indicate where time is concentrated on the critical path. " +
+			"Results may be truncated to the server limit; " +
+			"compare total_segment_count with the size of segments to detect truncation.",
+	}, handlers.NewGetCriticalPathHandler(s.queryAPI, s.config.MaxCriticalPathSegments))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_service_dependencies",


### PR DESCRIPTION
## Description

Fixes #9175

The `get_critical_path` MCP tool was the only trace-shaped tool without a response bound. While `get_span_details`, `get_trace_errors`, and `get_trace_topology` all cap their responses to `MaxSpanDetailsPerRequest` (default 20), `get_critical_path` returned every segment, causing unbounded JSON output (e.g., 282 KB for 5,000 spans).

### Changes

1. **`config.go`** — Added `MaxCriticalPathSegments` config field (default: 20), following the same pattern as `MaxSpanDetailsPerRequest`.

2. **`types/get_critical_path.go`** — Added `max_segments` optional input parameter to `GetCriticalPathInput` and `total_segment_count` to `GetCriticalPathOutput`, matching the `total_error_count` truncation detection pattern used by `get_trace_errors`.

3. **`handlers/get_critical_path.go`** — The critical path is still computed over the full trace for accurate `critical_path_duration_us`. After computing all segments, the list is sorted by `self_time_us` descending, capped to the segment limit, and re-sorted chronologically. This ensures the most important (time-dominant) segments are returned. The full count is reported via `total_segment_count` so the client can detect truncation.

4. **`server.go`** — Passes `cfg.MaxCriticalPathSegments` to the handler and updates the tool description to mention truncation.

### Testing

- Added `TestGetCriticalPathHandler_SegmentCap` — verifies that segments are capped and `TotalSegmentCount` reflects the full count.
- Added `TestGetCriticalPathHandler_Handle_WithMaxSegmentsInput` — verifies the per-request `max_segments` override.
- Added `TestGetCriticalPathHandler_EffectiveMaxSegments` — verifies the precedence logic (input > server default).
- Updated existing tests to pass the new `maxCriticalPathSegments` field.