### PR TITLE
fix(integration): Check type assertions in config helper

### DIFF
--- a/cmd/jaeger/internal/integration/e2e_integration.go
+++ b/cmd/jaeger/internal/integration/e2e_integration.go
@@ -199,20 +199,29 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 
 	serviceAny, ok := config["service"]
 	require.True(t, ok)
-	service := serviceAny.(map[string]any)
-	service["extensions"] = append(service["extensions"].([]any), "storage_cleaner")
+	service, ok := serviceAny.(map[string]any)
+	require.True(t, ok, "expecting 'service' to be a map, found: %T", serviceAny)
+	serviceExtensions, ok := service["extensions"].([]any)
+	require.True(t, ok, "expecting 'service.extensions' to be a list, found: %T", service["extensions"])
+	service["extensions"] = append(serviceExtensions, "storage_cleaner")
 
 	extensionsAny, ok := config["extensions"]
 	require.True(t, ok)
-	extensions := extensionsAny.(map[string]any)
+	extensions, ok := extensionsAny.(map[string]any)
+	require.True(t, ok, "expecting 'extensions' to be a map, found: %T", extensionsAny)
 
 	var traceStorage string
 
 	// Try to get the storage from jaeger_query first
 	if queryAny, found := extensions["jaeger_query"]; found {
-		if storageAny, found := queryAny.(map[string]any)["storage"]; found {
-			if traceStorageAny, found := storageAny.(map[string]any)["traces"]; found {
-				traceStorage = traceStorageAny.(string)
+		query, isMap := queryAny.(map[string]any)
+		require.True(t, isMap, "expecting 'jaeger_query' to be a map, found: %T", queryAny)
+		if storageAny, found := query["storage"]; found {
+			storage, isMap := storageAny.(map[string]any)
+			require.True(t, isMap, "expecting 'jaeger_query.storage' to be a map, found: %T", storageAny)
+			if traceStorageAny, found := storage["traces"]; found {
+				traceStorage, ok = traceStorageAny.(string)
+				require.True(t, ok, "expecting 'jaeger_query.storage.traces' to be a string, found: %T", traceStorageAny)
 			}
 		}
 	}
@@ -220,8 +229,11 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 	// If jaeger_query not found or no storage, fallback to remote_storage
 	if traceStorage == "" {
 		if remoteAny, found := extensions["remote_storage"]; found {
-			if storageNameAny, found := remoteAny.(map[string]any)["storage"]; found {
-				traceStorage = storageNameAny.(string)
+			remote, isMap := remoteAny.(map[string]any)
+			require.True(t, isMap, "expecting 'remote_storage' to be a map, found: %T", remoteAny)
+			if storageNameAny, found := remote["storage"]; found {
+				traceStorage, ok = storageNameAny.(string)
+				require.True(t, ok, "expecting 'remote_storage.storage' to be a string, found: %T", storageNameAny)
 			}
 		}
 	}
@@ -232,19 +244,23 @@ func createStorageCleanerConfig(t *testing.T, configFile string, storage string)
 
 	jaegerStorageAny, ok := extensions["jaeger_storage"]
 	require.True(t, ok)
-	jaegerStorage := jaegerStorageAny.(map[string]any)
+	jaegerStorage, ok := jaegerStorageAny.(map[string]any)
+	require.True(t, ok, "expecting 'jaeger_storage' to be a map, found: %T", jaegerStorageAny)
 	backendsAny, ok := jaegerStorage["backends"]
 	require.True(t, ok)
-	backends := backendsAny.(map[string]any)
+	backends, ok := backendsAny.(map[string]any)
+	require.True(t, ok, "expecting 'backends' to be a map, found: %T", backendsAny)
 
 	switch storage {
 	case "elasticsearch", "opensearch":
 		someStoreAny, ok := backends["some_storage"]
 		require.True(t, ok, "expecting 'some_storage' entry, found: %v", jaegerStorage)
-		someStore := someStoreAny.(map[string]any)
+		someStore, ok := someStoreAny.(map[string]any)
+		require.True(t, ok, "expecting 'some_storage' to be a map, found: %T", someStoreAny)
 		esMainAny, ok := someStore[storage]
 		require.True(t, ok, "expecting '%s' entry, found %v", storage, someStore)
-		esMain := esMainAny.(map[string]any)
+		esMain, ok := esMainAny.(map[string]any)
+		require.True(t, ok, "expecting '%s' to be a map, found: %T", storage, esMainAny)
 		esMain["service_cache_ttl"] = "1ms"
 	default:
 		// Do Nothing


### PR DESCRIPTION
## Problem

`createStorageCleanerConfig` in `cmd/jaeger/internal/integration/e2e_integration.go` walks the parsed YAML config with bare type assertions at every level:

```go
service := serviceAny.(map[string]any)
extensions := extensionsAny.(map[string]any)
traceStorage = traceStorageAny.(string)
```

A malformed or unexpected config panics with a raw runtime error rather than failing with a message that identifies which key was wrong. The surrounding code already uses `require.True` for the map key lookups, so the assertions were the odd ones out.

## Changes

Converted each bare assertion to the comma-ok form guarded by `require.True`, matching the pattern already used in the same function. Failures now name the offending key and report the actual type, for example:

```
expecting 'jaeger_query.storage.traces' to be a string, found: map[string]interface {}
```

This takes the file from 8 `unchecked-type-assertion` violations to 0.

## Testing

- `make lint` passes with 0 issues
- `make fmt` produces no further changes
- `go test ./cmd/jaeger/internal/integration/...` passes, both packages
- Verified with the revive `unchecked-type-assertion` rule temporarily enabled locally: this file drops from 8 violations to 0, and the repo total goes from 118 to 110

No new functionality is added, so there are no new tests. The change converts panics into assertion failures inside existing test scaffolding, and this directory is in the `.codecov.yml` ignore list.

## Scope

This is a standalone robustness fix. It does **not** enable the revive rule, since 110 violations remain elsewhere in the repo. I have asked in #5506 how you would prefer to scope the remainder, in particular the `internal/cache/lru.go` cases, which are safe by construction and sit in a package at 100% coverage.

Relates to #5506

---

AI assistance disclosure, per the AI Usage Policy in `CONTRIBUTING_GUIDELINES.md`: I used AI assistance while analyzing the revive output and preparing this change.
