### PR TITLE
fix: handle error=false tag query in ES reader (complement of error=true)

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -526,6 +526,15 @@ func (s *SpanReader) buildFindTraceIDsQuery(traceQuery dbmodel.TraceQueryParamet
 	}
 
 	for k, v := range traceQuery.Tags {
+		// error=false is the complement of error=true. Since non-error spans
+		// (Ok and Unset status) carry no "error" tag stored in ES, searching
+		// for error=false as a literal tag value matches nothing. Instead,
+		// error=false should exclude spans that have error=true tag.
+		if k == "error" && v == "false" {
+			errorTrueQuery := s.buildTagQuery("error", "true")
+			boolQuery.MustNot(errorTrueQuery)
+			continue
+		}
 		tagQuery := s.buildTagQuery(k, v)
 		boolQuery.Must(tagQuery)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9205

## Description
Searching traces with the tag filter `error=false` on the Elasticsearch/OpenSearch backend returns zero results, even when non-error traces exist. `error=true` works correctly.

**Root cause**: `getTagFromStatusCode` writes an `error=true` tag only for `StatusCodeError` spans. Ok spans get `otel.status_code=OK` and Unset spans get no status tag. No span is ever written with `error=false`, so the reader's tag query for `error=false` matches nothing.

**Fix**: When `error=false` is in the tag filter, treat it as the complement of `error=true` — exclude spans that have the `error=true` tag — rather than searching for a literal `error=false` tag value. This mirrors the in-memory store fix (#9096) where `error=false` matches every non-error span (Ok and Unset).

## Changes
- `internal/storage/v2/elasticsearch/tracestore/core/reader.go`: In `buildFindTraceIDsQuery`, when `error=false` is encountered in the tags, build a `must_not` query for `error=true` instead of a `must` query for `error=false`.
