### PR TITLE
fix: detect conflicting attributes.error filter when with_errors is true

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -170,6 +170,10 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 		attributes.PutStr(key, value)
 	}
 	if input.WithErrors {
+		if v, ok := input.Attributes["error"]; ok && v != "true" {
+			return querysvc.TraceQueryParams{}, fmt.Errorf(
+				"with_errors=true conflicts with attributes.error=%q: set attributes.error=\"true\" or remove with_errors", v)
+		}
 		attributes.PutStr("error", "true")
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -589,3 +589,81 @@ func TestSearchTracesHandler_Handle_LimitEnforced(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, output.Traces, 3)
 }
+
+func TestSearchTracesHandler_Handle_WithErrorsConflict(t *testing.T) {
+	tests := []struct {
+		name      string
+		errorVal  string
+		wantError string
+	}{
+		{
+			name:      "error=false conflicts with with_errors=true",
+			errorVal:  "false",
+			wantError: `with_errors=true conflicts with attributes.error="false"`,
+		},
+		{
+			name:      "error=0 conflicts with with_errors=true",
+			errorVal:  "0",
+			wantError: `with_errors=true conflicts with attributes.error="0"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &searchTracesHandler{queryService: nil, maxResults: 100}
+			_, err := handler.buildQuery(types.SearchTracesInput{
+				StartTimeMin: "-1h",
+				ServiceName:  "test",
+				Attributes:   map[string]string{"error": tt.errorVal},
+				WithErrors:   true,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+}
+
+func TestSearchTracesHandler_Handle_WithErrorsNoConflict(t *testing.T) {
+	tests := []struct {
+		name     string
+		errorVal string
+	}{
+		{
+			name:     "error=true with with_errors=true is allowed",
+			errorVal: "true",
+		},
+		{
+			name:     "no error attribute with with_errors=true is allowed",
+			errorVal: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockQueryService{
+				findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+					errorAttr, ok := query.Attributes.Get("error")
+					require.True(t, ok)
+					assert.Equal(t, "true", errorAttr.Str())
+					return func(yield func([]tracestore.TraceSummary, error) bool) {
+						yield([]tracestore.TraceSummary{makeTraceSummary("test", "/op", true)}, nil)
+					}
+				},
+			}
+
+			handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+			input := types.SearchTracesInput{
+				StartTimeMin: "-1h",
+				ServiceName:  "test",
+				WithErrors:   true,
+			}
+			if tt.errorVal != "" {
+				input.Attributes = map[string]string{"error": tt.errorVal}
+			}
+
+			_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+			require.NoError(t, err)
+			require.Len(t, output.Traces, 1)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #9176

When `WithErrors` is true, `buildQuery()` unconditionally calls `attributes.PutStr("error", "true")`, silently overwriting any user-provided error attribute filter. This means a user who provides `attributes: {"error": "false"}` alongside `with_errors: true` will get error traces without any warning that their filter was ignored.

### Fix

Added a validation check: if `WithErrors` is true and the user explicitly provided an `error` attribute with a value other than `"true"`, return a clear validation error instead of silently overwriting.

### Tests

- `TestSearchTracesHandler_Handle_WithErrorsConflict` — verifies that `error=false` and `error=0` with `with_errors=true` both return validation errors
- `TestSearchTracesHandler_Handle_WithErrorsNoConflict` — verifies that `error=true` with `with_errors=true` works, and that no error attribute with `with_errors=true` continues to work
