### PR TITLE
fix(es): Return non-error traces for error=false search

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -43,6 +44,7 @@ const (
 	nestedLogFieldsField   = "logs.fields"
 	tagKeyField            = "key"
 	tagValueField          = "value"
+	errorTag               = "error"
 
 	defaultSearchDepth = 100
 
@@ -526,6 +528,21 @@ func (s *SpanReader) buildFindTraceIDsQuery(traceQuery dbmodel.TraceQueryParamet
 	}
 
 	for k, v := range traceQuery.Tags {
+		// The error tag is only written for error spans (error=true; see
+		// getTagFromStatusCode in to_dbmodel.go). A non-error span carries no error
+		// tag at all, so a literal error=false tag match returns nothing. Treat
+		// error=false as the complement of error=true — every non-error span — by
+		// excluding error=true instead, mirroring the in-memory store (#9096).
+		if k == errorTag {
+			if isError, parseErr := strconv.ParseBool(v); parseErr == nil {
+				if isError {
+					boolQuery.Must(s.buildTagQuery(errorTag, "true"))
+				} else {
+					boolQuery.MustNot(s.buildTagQuery(errorTag, "true"))
+				}
+				continue
+			}
+		}
 		tagQuery := s.buildTagQuery(k, v)
 		boolQuery.Must(tagQuery)
 	}

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -962,6 +962,42 @@ func TestSpanReader_buildFindTraceIDsQuery(t *testing.T) {
 	})
 }
 
+// TestSpanReader_buildFindTraceIDsQuery_errorTag covers the error tag special
+// case. Non-error spans carry no error tag (only error spans get error=true), so a
+// literal error=false match finds nothing; error=false must instead exclude
+// error=true. See #9096 for the same fix in the in-memory store.
+func TestSpanReader_buildFindTraceIDsQuery_errorTag(t *testing.T) {
+	withSpanReader(t, func(r *spanReaderTest) {
+		start := time.Time{}
+		end := time.Time{}.Add(time.Second)
+		base := func() *esquery.BoolQuery {
+			return esquery.NewBoolQuery().Must(r.reader.buildStartTimeQuery(start, end))
+		}
+		build := func(errorValue string) any {
+			q, err := r.reader.buildFindTraceIDsQuery(dbmodel.TraceQueryParameters{
+				StartTimeMin: start,
+				StartTimeMax: end,
+				Tags:         map[string]string{"error": errorValue},
+			}).Source()
+			require.NoError(t, err)
+			return q
+		}
+		wantSource := func(q *esquery.BoolQuery) any {
+			src, err := q.Source()
+			require.NoError(t, err)
+			return src
+		}
+
+		// error=true still matches the error=true tag.
+		assert.Equal(t, wantSource(base().Must(r.reader.buildTagQuery("error", "true"))), build("true"))
+		// error=false excludes error=true (the complement), instead of a literal
+		// error=false tag match that no span carries.
+		assert.Equal(t, wantSource(base().MustNot(r.reader.buildTagQuery("error", "true"))), build("false"))
+		// A non-boolean error value falls back to a literal tag match.
+		assert.Equal(t, wantSource(base().Must(r.reader.buildTagQuery("error", "oops"))), build("oops"))
+	})
+}
+
 func TestSpanReader_buildDurationQuery(t *testing.T) {
 	expectedStr := `{ "range":
 			{ "duration": {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -965,7 +965,10 @@ func TestSpanReader_buildFindTraceIDsQuery(t *testing.T) {
 // TestSpanReader_buildFindTraceIDsQuery_errorTag covers the error tag special
 // case. Non-error spans carry no error tag (only error spans get error=true), so a
 // literal error=false match finds nothing; error=false must instead exclude
-// error=true. See #9096 for the same fix in the in-memory store.
+// error=true. The value is parsed with strconv.ParseBool so every boolean form is
+// accepted, matching the in-memory store's error handling exactly (#9096, which
+// also uses strconv.ParseBool). A non-boolean value keeps the previous literal
+// tag match.
 func TestSpanReader_buildFindTraceIDsQuery_errorTag(t *testing.T) {
 	withSpanReader(t, func(r *spanReaderTest) {
 		start := time.Time{}
@@ -973,28 +976,44 @@ func TestSpanReader_buildFindTraceIDsQuery_errorTag(t *testing.T) {
 		base := func() *esquery.BoolQuery {
 			return esquery.NewBoolQuery().Must(r.reader.buildStartTimeQuery(start, end))
 		}
-		build := func(errorValue string) any {
-			q, err := r.reader.buildFindTraceIDsQuery(dbmodel.TraceQueryParameters{
-				StartTimeMin: start,
-				StartTimeMax: end,
-				Tags:         map[string]string{"error": errorValue},
-			}).Source()
-			require.NoError(t, err)
-			return q
-		}
 		wantSource := func(q *esquery.BoolQuery) any {
 			src, err := q.Source()
 			require.NoError(t, err)
 			return src
 		}
+		errorTrueMatch := wantSource(base().Must(r.reader.buildTagQuery("error", "true")))
+		errorTrueExcluded := wantSource(base().MustNot(r.reader.buildTagQuery("error", "true")))
 
-		// error=true still matches the error=true tag.
-		assert.Equal(t, wantSource(base().Must(r.reader.buildTagQuery("error", "true"))), build("true"))
-		// error=false excludes error=true (the complement), instead of a literal
-		// error=false tag match that no span carries.
-		assert.Equal(t, wantSource(base().MustNot(r.reader.buildTagQuery("error", "true"))), build("false"))
-		// A non-boolean error value falls back to a literal tag match.
-		assert.Equal(t, wantSource(base().Must(r.reader.buildTagQuery("error", "oops"))), build("oops"))
+		for _, tt := range []struct {
+			value string
+			want  any
+		}{
+			// Truthy forms match error=true.
+			{"true", errorTrueMatch},
+			{"True", errorTrueMatch},
+			{"TRUE", errorTrueMatch},
+			{"1", errorTrueMatch},
+			{"t", errorTrueMatch},
+			// Falsy forms exclude error=true (the complement).
+			{"false", errorTrueExcluded},
+			{"False", errorTrueExcluded},
+			{"FALSE", errorTrueExcluded},
+			{"0", errorTrueExcluded},
+			{"f", errorTrueExcluded},
+			// Non-boolean values keep the literal tag match.
+			{"oops", wantSource(base().Must(r.reader.buildTagQuery("error", "oops")))},
+			{"2", wantSource(base().Must(r.reader.buildTagQuery("error", "2")))},
+		} {
+			t.Run("error="+tt.value, func(t *testing.T) {
+				got, err := r.reader.buildFindTraceIDsQuery(dbmodel.TraceQueryParameters{
+					StartTimeMin: start,
+					StartTimeMax: end,
+					Tags:         map[string]string{"error": tt.value},
+				}).Source()
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #9205 

Searching traces with the tag filter `error=false` on the Elasticsearch/OpenSearch backend returns zero results, even when non-error traces exist. `error=true`works correctly.

Root cause: the v2 writer emits an `error` tag only for error spans (`error=true`, via `getTagFromStatusCode` in `to_dbmodel.go`); Ok and Unset spans carry no `error` tag at all. So the reader's literal `error=false` tag match never
matches anything.

This is the Elasticsearch/OpenSearch counterpart of #9096, which fixed the same defect in the in-memory store — where `error=false` means "not an error" (Ok and Unset), the complement of `error=true`.

## Description of the changes

- In `buildFindTraceIDsQuery` (`internal/storage/v2/elasticsearch/tracestore/core/reader.go`), special-case the `error` tag: `error=false` now excludes `error=true` (`MustNot`) instead of matching a non-existent `error=false` tag, so every
  non-error span (Ok and Unset) is returned. `error=true` and non-boolean `error`values are unchanged.

## How was this change tested?

- Added `TestSpanReader_buildFindTraceIDsQuery_errorTag`, asserting `error=false` builds a `MustNot(error=true)`  clause, `error=true` keeps the `Must(error=true)`match, and a non-boolean value falls back to a literal tag match. It fails on
`main` and passes with the fix.
- Verified end-to-end against a real OpenSearch 3.7 cluster with jaeger-v2: after sending one Unset, one Ok, and one Error span to a service, `error=false` returned 0 traces before the change and the 2 non-error traces after; `error=true`
  stayed at 1.
- `make fmt`, `make lint`, `make test` all pass.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
