### PR TITLE
fix: sort span events by timestamp instead of name

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort.go
@@ -4,11 +4,11 @@
 package adjuster
 
 import (
-	"cmp"
-	"slices"
+ 	"cmp"
+	 "slices"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/ptrace"
+	 "opentelemetry.io/collector/pdata/pcommon"
+	 "opentelemetry.io/collector/pdata/ptrace"
 )
 
 var _ Adjuster = (*SortAttributesAndEventsAdjuster)(nil)
@@ -17,7 +17,7 @@ var _ Adjuster = (*SortAttributesAndEventsAdjuster)(nil)
 // - Resource attributes are sorted lexicographically by their keys.
 // - Scope attributes are sorted lexicographically by their keys.
 // - Span attributes are sorted lexicographically by their keys.
-// - Span events are sorted lexicographically by their names.
+// - Span events are sorted chronologically by their timestamps.
 // - Attributes within each span event are sorted lexicographically by their keys.
 // - Attributes within each span link are sorted lexicographically by their keys.
 func SortCollections() SortAttributesAndEventsAdjuster {
@@ -79,7 +79,7 @@ func (SortAttributesAndEventsAdjuster) sortAttributes(attributes pcommon.Map) {
 
 func (s SortAttributesAndEventsAdjuster) sortEvents(events ptrace.SpanEventSlice) {
 	events.Sort(func(a, b ptrace.SpanEvent) bool {
-		return a.Name() < b.Name()
+		return a.Timestamp() < b.Timestamp()
 	})
 	for i := 0; i < events.Len(); i++ {
 		event := events.At(i)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort_test.go
@@ -5,8 +5,10 @@ package adjuster
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -33,11 +35,13 @@ func TestSortAttributesAndEventsAdjuster(t *testing.T) {
 
 		event2 := span.Events().AppendEmpty()
 		event2.SetName("event2")
+		event2.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 100)))
 		event2.Attributes().PutStr("attributeU", "valE")
 		event2.Attributes().PutStr("attributeT", "valF")
 
 		event1 := span.Events().AppendEmpty()
 		event1.SetName("event1")
+		event1.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 200)))
 		event1.Attributes().PutStr("attributeR", "valE")
 		event1.Attributes().PutStr("attributeS", "valF")
 
@@ -72,6 +76,7 @@ func TestSortAttributesAndEventsAdjuster(t *testing.T) {
 
 		event1 := span.Events().AppendEmpty()
 		event1.SetName("event1")
+		event1.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, 200)))
 		event1.Attributes().PutStr("attributeR", "valE")
 		event1.Attributes().PutStr("attributeS", "valF")
 


### PR DESCRIPTION
## Description

**What**: Span events are currently sorted lexicographically by their name. This causes the chronological order of events to be lost.

**Why**: OTLP span events are a chronological sequence. Consumers that render events in the order received (e.g., timeline UI) display them out of sequence when sorted by name.

**Fix**: Sort span events by their `Timestamp()` instead of their `Name()`, preserving the chronological order.

## Changes

- `sort.go`: Changed `sortEvents()` to sort by `a.Timestamp() < b.Timestamp()` instead of `a.Name() < b.Name()`
- `sort_test.go`: Updated test to set timestamps on events and verify the chronological sort order

Closes #9212
