### PR TITLE
fix(mcp): include back-to-back child spans in critical path walk

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
@@ -27,8 +27,10 @@ func findLastFinishingChildSpan(
 		childEndTime := childSpan.StartTime + childSpan.Duration
 
 		if returningChildStartTime != nil {
-			// Find child that finishes just before the returning child's start time
-			if childEndTime < *returningChildStartTime {
+			// Find child that finishes just before (or exactly when) the returning child's start time.
+			// Back-to-back sequential spans commonly share an end/start boundary, so this must be
+			// inclusive or the predecessor span is silently dropped from the critical path.
+			if childEndTime <= *returningChildStartTime {
 				if childEndTime > maxEndTime {
 					maxEndTime = childEndTime
 					childSpanCopy := childSpan

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
@@ -154,6 +154,24 @@ func TestFindLastFinishingChildSpan(t *testing.T) {
 			expectedSpanID: nil,
 		},
 		{
+			name: "with returningChildStartTime child ending exactly at boundary is included",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 100,
+					Duration:  50, // ends at 150, exactly at returningChildStartTime
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          &pcommon.SpanID{2}, // back-to-back sequential span must not be dropped
+		},
+		{
 			name: "with returningChildStartTime selects best among multiple valid children",
 			spanMap: map[pcommon.SpanID]CPSpan{
 				spanID(2): {


### PR DESCRIPTION
## What changed

`findLastFinishingChildSpan` used a strict less-than comparison when looking for the child span that finished immediately before a returning child's start time:

```go
if childEndTime < *returningChildStartTime {
```

When two spans are perfectly sequential (one ends exactly when the next one starts, which is common in synchronous pipelines and runtimes with millisecond-resolution clocks), `childEndTime` equals `returningChildStartTime`, so the strict inequality excludes the predecessor. The predecessor span is then silently dropped from the `get_critical_path` output, producing a fake gap in the reconstructed timeline.

This PR changes the comparison to less-than-or-equal so an exact boundary match is treated as immediately preceding:

```go
if childEndTime <= *returningChildStartTime {
```

## Testing

Added a regression test in `find_lfc_test.go` covering a child span whose end time exactly equals `returningChildStartTime`. This test fails against the old strict comparison and passes with the fix.

Ran the full `mcptools` and `criticalpath` package test suites locally, all relevant tests pass.

Fixes #9173