### PR TITLE
fix(mcp): cap get_critical_path segments, keeping highest self time

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
@@ -200,15 +200,15 @@ func (h *getCriticalPathHandler) buildOutput(
 // path. When capping is needed, the segments with the highest self_time_us are
 // kept, since those are the ones the tool description tells callers to look at
 // first, and a stable sort preserves their original chronological order among
-// ties and within the kept set.
+// ties. segments is freshly built by the caller for this response and held
+// nowhere else, so it is safe to sort in place instead of cloning.
 func (h *getCriticalPathHandler) capSegments(segments []types.CriticalPathSegment) []types.CriticalPathSegment {
 	if h.maxSpanDetailsPerRequest <= 0 || len(segments) <= h.maxSpanDetailsPerRequest {
 		return segments
 	}
 
-	kept := slices.Clone(segments)
-	slices.SortStableFunc(kept, func(a, b types.CriticalPathSegment) int {
+	slices.SortStableFunc(segments, func(a, b types.CriticalPathSegment) int {
 		return cmp.Compare(b.SelfTimeUs, a.SelfTimeUs) // descending
 	})
-	return kept[:h.maxSpanDetailsPerRequest]
+	return segments[:h.maxSpanDetailsPerRequest]
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
@@ -4,10 +4,12 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -28,15 +30,18 @@ type queryServiceGetCriticalPathInterface interface {
 // This tool identifies the sequence of spans forming the critical latency path
 // (the blocking execution path) in a distributed trace.
 type getCriticalPathHandler struct {
-	queryService queryServiceGetCriticalPathInterface
+	queryService             queryServiceGetCriticalPathInterface
+	maxSpanDetailsPerRequest int
 }
 
 // NewGetCriticalPathHandler creates a new get_critical_path handler and returns the handler function.
 func NewGetCriticalPathHandler(
 	queryService *querysvc.QueryService,
+	maxSpanDetailsPerRequest int,
 ) mcp.ToolHandlerFor[types.GetCriticalPathInput, types.GetCriticalPathOutput] {
 	h := &getCriticalPathHandler{
-		queryService: queryService,
+		queryService:             queryService,
+		maxSpanDetailsPerRequest: maxSpanDetailsPerRequest,
 	}
 	return h.handle
 }
@@ -108,7 +113,7 @@ func (*getCriticalPathHandler) buildQuery(input types.GetCriticalPathInput) (que
 }
 
 // buildOutput constructs the GetCriticalPathOutput from the trace and critical path sections.
-func (*getCriticalPathHandler) buildOutput(
+func (h *getCriticalPathHandler) buildOutput(
 	traceIDStr string,
 	trace ptrace.Traces,
 	criticalPathSections []criticalpath.Section,
@@ -176,10 +181,34 @@ func (*getCriticalPathHandler) buildOutput(
 		})
 	}
 
+	totalSegmentCount := len(segments)
+	segments = h.capSegments(segments)
+
 	return types.GetCriticalPathOutput{
 		TraceID:                traceIDStr,
 		TotalDurationUs:        traceEndTime - traceStartTime,
 		CriticalPathDurationUs: criticalPathDuration,
+		TotalSegmentCount:      totalSegmentCount,
 		Segments:               segments,
 	}
+}
+
+// capSegments bounds the number of segments returned to the caller. The critical
+// path and its total duration are always computed over the full trace (see
+// buildOutput); only the segments slice itself is capped here, so truncating a
+// deep trace can never change which spans are considered part of the critical
+// path. When capping is needed, the segments with the highest self_time_us are
+// kept, since those are the ones the tool description tells callers to look at
+// first, and a stable sort preserves their original chronological order among
+// ties and within the kept set.
+func (h *getCriticalPathHandler) capSegments(segments []types.CriticalPathSegment) []types.CriticalPathSegment {
+	if h.maxSpanDetailsPerRequest <= 0 || len(segments) <= h.maxSpanDetailsPerRequest {
+		return segments
+	}
+
+	kept := slices.Clone(segments)
+	slices.SortStableFunc(kept, func(a, b types.CriticalPathSegment) int {
+		return cmp.Compare(b.SelfTimeUs, a.SelfTimeUs) // descending
+	})
+	return kept[:h.maxSpanDetailsPerRequest]
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
@@ -67,7 +67,7 @@ func createCriticalPathTestTrace() ptrace.Traces {
 
 func TestNewGetCriticalPathHandler(t *testing.T) {
 	// We can pass nil because we only check if it returns a handler function
-	handler := NewGetCriticalPathHandler(nil)
+	handler := NewGetCriticalPathHandler(nil, 20)
 	assert.NotNil(t, handler)
 }
 
@@ -314,4 +314,82 @@ func TestGetCriticalPathHandler_BuildOutput_MissingSpan(t *testing.T) {
 	// Should only have 1 segment for the existing span
 	assert.Len(t, output.Segments, 1)
 	assert.Equal(t, span.SpanID().String(), output.Segments[0].SpanID)
+}
+
+func TestGetCriticalPathHandler_BuildOutput_SegmentsCappedByLargestSelfTime(t *testing.T) {
+	// buildOutput must cap the returned segments to the configured limit while
+	// TotalSegmentCount still reflects every segment on the full critical path,
+	// and critical_path_duration_us (summed before capping, in the handle method)
+	// is unaffected by which segments get truncated here.
+	handler := &getCriticalPathHandler{maxSpanDetailsPerRequest: 2}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "test-service")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	small := ss.Spans().AppendEmpty()
+	small.SetSpanID([8]byte{1})
+	small.SetTraceID([16]byte{1})
+	small.SetName("small")
+	small.SetStartTimestamp(pcommon.Timestamp(0))
+	small.SetEndTimestamp(pcommon.Timestamp(1000))
+
+	medium := ss.Spans().AppendEmpty()
+	medium.SetSpanID([8]byte{2})
+	medium.SetTraceID([16]byte{1})
+	medium.SetName("medium")
+	medium.SetStartTimestamp(pcommon.Timestamp(0))
+	medium.SetEndTimestamp(pcommon.Timestamp(1000))
+
+	large := ss.Spans().AppendEmpty()
+	large.SetSpanID([8]byte{3})
+	large.SetTraceID([16]byte{1})
+	large.SetName("large")
+	large.SetStartTimestamp(pcommon.Timestamp(0))
+	large.SetEndTimestamp(pcommon.Timestamp(1000))
+
+	traceID := small.TraceID().String()
+
+	// Three sections with distinct self times: 10us, 30us, 20us.
+	sections := []criticalpath.Section{
+		{SpanID: small.SpanID().String(), SectionStart: 0, SectionEnd: 10},
+		{SpanID: medium.SpanID().String(), SectionStart: 10, SectionEnd: 40}, // self time 30
+		{SpanID: large.SpanID().String(), SectionStart: 40, SectionEnd: 60},  // self time 20
+	}
+
+	output := handler.buildOutput(traceID, traces, sections)
+
+	assert.Equal(t, 3, output.TotalSegmentCount, "total should reflect every computed segment")
+	require.Len(t, output.Segments, 2, "segments should be capped to the configured limit")
+
+	// The two largest self times (30, 20) must be kept; the smallest (10) dropped,
+	// and the kept segments returned with the largest self time first.
+	require.Equal(t, uint64(30), output.Segments[0].SelfTimeUs)
+	require.Equal(t, uint64(20), output.Segments[1].SelfTimeUs)
+}
+
+func TestGetCriticalPathHandler_BuildOutput_SegmentsNotCappedWhenUnderLimit(t *testing.T) {
+	// A limit of 0 means unlimited, matching the convention used by the other MCP tools.
+	handler := &getCriticalPathHandler{maxSpanDetailsPerRequest: 0}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetSpanID([8]byte{1})
+	span.SetTraceID([16]byte{1})
+	span.SetName("only-span")
+	span.SetStartTimestamp(pcommon.Timestamp(0))
+	span.SetEndTimestamp(pcommon.Timestamp(1000))
+
+	traceID := span.TraceID().String()
+	sections := []criticalpath.Section{
+		{SpanID: span.SpanID().String(), SectionStart: 0, SectionEnd: 10},
+	}
+
+	output := handler.buildOutput(traceID, traces, sections)
+
+	assert.Equal(t, 1, output.TotalSegmentCount)
+	assert.Len(t, output.Segments, 1)
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
@@ -14,7 +14,8 @@ type GetCriticalPathOutput struct {
 	TraceID                string                `json:"trace_id" jsonschema:"Unique identifier for the trace"`
 	TotalDurationUs        uint64                `json:"total_duration_us" jsonschema:"Total trace duration in microseconds"`
 	CriticalPathDurationUs uint64                `json:"critical_path_duration_us" jsonschema:"Total duration of critical path in microseconds"`
-	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Ordered list of span segments on the critical path"`
+	TotalSegmentCount      int                   `json:"total_segment_count" jsonschema:"Total number of segments on the critical path (may exceed the size of the segments list due to per-request limits)"`
+	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Span segments on the critical path, ordered chronologically unless truncated, in which case the highest self_time_us segments are kept (possibly truncated to server-configured limit)"`
 }
 
 // CriticalPathSegment represents a span segment on the critical path.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/get_critical_path.go
@@ -15,7 +15,7 @@ type GetCriticalPathOutput struct {
 	TotalDurationUs        uint64                `json:"total_duration_us" jsonschema:"Total trace duration in microseconds"`
 	CriticalPathDurationUs uint64                `json:"critical_path_duration_us" jsonschema:"Total duration of critical path in microseconds"`
 	TotalSegmentCount      int                   `json:"total_segment_count" jsonschema:"Total number of segments on the critical path (may exceed the size of the segments list due to per-request limits)"`
-	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Span segments on the critical path, ordered chronologically unless truncated, in which case the highest self_time_us segments are kept (possibly truncated to server-configured limit)"`
+	Segments               []CriticalPathSegment `json:"segments" jsonschema:"Span segments on the critical path, ordered chronologically unless truncated to the server-configured limit, in which case the highest self_time_us segments are kept and returned in descending self_time_us order"`
 }
 
 // CriticalPathSegment represents a span segment on the critical path.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -162,8 +162,11 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 		Name: "get_critical_path",
 		Description: "Identify the critical latency path through a trace: the chain of spans " +
 			"that determined end-to-end duration. " +
-			"Higher self_time_us values indicate where time is concentrated on the critical path.",
-	}, handlers.NewGetCriticalPathHandler(s.queryAPI))
+			"Higher self_time_us values indicate where time is concentrated on the critical path. " +
+			"total_duration_us and critical_path_duration_us always reflect the full trace; only the " +
+			"segments list may be truncated to the server limit, keeping the highest self_time_us " +
+			"entries first. Compare total_segment_count with the number of returned segments to detect truncation.",
+	}, handlers.NewGetCriticalPathHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_service_dependencies",


### PR DESCRIPTION
## What changed

get_critical_path was the only trace shaped MCP tool with no response bound. get_span_details, get_trace_errors and get_trace_topology all respect max_span_details_per_request (default 20), but get_critical_path had no limit at all, and its segments list grows linearly with trace size. A trace of a few thousand spans could already push around 100KB of JSON into an agent's context window.

total_duration_us and critical_path_duration_us are still computed from the full trace. Capping the input would change which spans are considered part of the critical path, so that computation is untouched. Only the returned segments list is capped, and it keeps the entries with the highest self_time_us rather than simply the first N encountered, since those are the entries the tool description already tells callers to look at first.

A new total_segment_count field lets callers detect truncation, the same pattern get_trace_errors uses with total_error_count.

## Testing

Added two tests in get_critical_path_test.go:
- one confirming that when segments exceed the limit, the highest self_time_us entries are kept and total_segment_count still reflects the full count
- one confirming nothing is capped when the limit is 0 (unlimited), matching the convention used by the other MCP tools

Ran the full mcptools package test suite locally, all relevant tests pass.

Fixes #9175