### PR TITLE
fix: use <= in findLastFinishingChildSpan to handle back-to-back sequential spans

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
@@ -27,8 +27,9 @@ func findLastFinishingChildSpan(
 		childEndTime := childSpan.StartTime + childSpan.Duration
 
 		if returningChildStartTime != nil {
-			// Find child that finishes just before the returning child's start time
-			if childEndTime < *returningChildStartTime {
+			// Find child that finishes just before or exactly at the returning child's start time.
+			// Using <= handles back-to-back sequential spans where one ends exactly when the next begins.
+			if childEndTime <= *returningChildStartTime {
 				if childEndTime > maxEndTime {
 					maxEndTime = childEndTime
 					childSpanCopy := childSpan

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
@@ -154,6 +154,29 @@ func TestFindLastFinishingChildSpan(t *testing.T) {
 			expectedSpanID: nil,
 		},
 		{
+			name: "back-to-back spans: child ends exactly at next child start time",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 100,
+					Duration:  50, // ends at 150
+				},
+				spanID(3): {
+					SpanID:    spanID(3),
+					StartTime: 150,
+					Duration:  50, // ends at 200
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2), spanID(3)},
+			},
+			returningChildStartTime: new(uint64(150)), // span 3 starts at 150; span 2 ends at exactly 150
+			expectedSpanID:          &pcommon.SpanID{2}, // span 2 ends at 150 <= 150, should be found
+		},
+		{
 			name: "with returningChildStartTime selects best among multiple valid children",
 			spanMap: map[pcommon.SpanID]CPSpan{
 				spanID(2): {


### PR DESCRIPTION
Fixes #9173

findLastFinishingChildSpan used a strict < to find the predecessor span before a given returningChildStartTime.

When two spans are perfectly back-to-back, one ending at exactly the nanosecond the next begins, childEndTime < returningChildStartTime evaluates to false and the predecessor is silently skipped.

This produces an incomplete critical path: the skipped span's duration disappears, the tool reports a phantom time gap, and an LLM agent diagnosing latency will hallucinate a bottleneck that does not exist.

**Fix:** change `<` to `<=` so spans that end exactly at the boundary are correctly included.

Added a regression test covering the exact boundary case.