### PR TITLE
fix: cascade descendant deletion when dropping overflowing spans in sanitize.go

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize.go
@@ -7,6 +7,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
+// deleteWithDescendants deletes a span and all of its descendants from the spanMap.
+// This prevents orphaned grandchildren when a parent span is dropped.
+func deleteWithDescendants(spanMap map[pcommon.SpanID]CPSpan, spanID pcommon.SpanID) {
+	span, ok := spanMap[spanID]
+	if !ok {
+		return
+	}
+	for _, childID := range span.ChildSpanIDs {
+		deleteWithDescendants(spanMap, childID)
+	}
+	delete(spanMap, spanID)
+}
+
 // removeOverflowingChildren removes or adjusts child spans that overflow their parent's time range.
 // An overflowing child span is one whose time range falls outside its parent span's time range.
 // The function adjusts the start time and duration of overflowing child spans
@@ -37,10 +50,10 @@ func removeOverflowingChildren(spanMap map[pcommon.SpanID]CPSpan) map[pcommon.Sp
 
 		if span.StartTime >= parentSpan.StartTime {
 			if span.StartTime >= parentEndTime {
-				// child outside of parent range => drop the child span
+				// child outside of parent range => drop the child span and all its descendants
 				//      |----parent----|
 				//                        |----child--|
-				delete(spanMap, span.SpanID)
+				deleteWithDescendants(spanMap, span.SpanID)
 
 				// Remove the childSpanId from its parent span
 				filteredChildren := make([]pcommon.SpanID, 0, len(parentSpan.ChildSpanIDs))
@@ -69,10 +82,10 @@ func removeOverflowingChildren(spanMap map[pcommon.SpanID]CPSpan) map[pcommon.Sp
 
 		switch {
 		case childEndTime <= parentSpan.StartTime:
-			// child outside of parent range => drop the child span
+			// child outside of parent range => drop the child span and all its descendants
 			//                      |----parent----|
 			//       |----child--|
-			delete(spanMap, span.SpanID)
+			deleteWithDescendants(spanMap, span.SpanID)
 
 			// Remove the childSpanId from its parent span
 			filteredChildren := make([]pcommon.SpanID, 0, len(parentSpan.ChildSpanIDs))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/sanitize_test.go
@@ -192,6 +192,40 @@ func TestSanitizeOverFlowingChildren(t *testing.T) {
 			},
 		},
 		{
+			name: "grandchild of overflowing span is also dropped",
+			// Root A: [0..200], Child B: [210..300] overflows A, Grandchild C: [220..280] child of B.
+			// B and C must both be dropped regardless of map iteration order.
+			input: map[pcommon.SpanID]CPSpan{
+				[8]byte{1}: {
+					SpanID:       [8]byte{1},
+					StartTime:    0,
+					Duration:     200,
+					ChildSpanIDs: []pcommon.SpanID{[8]byte{2}},
+				},
+				[8]byte{2}: {
+					SpanID:       [8]byte{2},
+					ParentSpanID: [8]byte{1},
+					StartTime:    210,
+					Duration:     90,
+					ChildSpanIDs: []pcommon.SpanID{[8]byte{3}},
+				},
+				[8]byte{3}: {
+					SpanID:       [8]byte{3},
+					ParentSpanID: [8]byte{2},
+					StartTime:    220,
+					Duration:     60,
+				},
+			},
+			expected: map[pcommon.SpanID]CPSpan{
+				[8]byte{1}: {
+					SpanID:       [8]byte{1},
+					StartTime:    0,
+					Duration:     200,
+					ChildSpanIDs: []pcommon.SpanID{},
+				},
+			},
+		},
+		{
 			name: "child with dropped parent - should be dropped",
 			input: map[pcommon.SpanID]CPSpan{
 				[8]byte{2}: {


### PR DESCRIPTION
Fixes #9158

`removeOverflowingChildren` ranges over a slice built from a Go map, which has non-deterministic iteration order. 
When a span B overflow its parent A and is dropped, B's children (e.g. grandchild C) are only removed if they happen to be iterated *after* B. 
If C is visited first, it sees B still in the map and passes all checks; B is then deleted, leaving C as an orphan with a dangling parent reference.

Example (from the issue):
- Root A: [0..200]
- Child B: [210..300] — overflows A, must be dropped
- Grandchild C: [220..280] — child of B

If C is processed before B, C survives the pass. B is then deleted. C remains in the spanMap with a non-existent parent.

**Fix:** Add `deleteWithDescendants`, a recursive helper that deletes a span and all its children depth-first before removing the span itself.
Replace the two bare `delete` calls in the drop branches with this helper so the entire subtree is removed atomically regardless of iteration order.

Added a regression test covering the A→B→C cascaded drop scenario.