### PR TITLE
Length-prefix Badger index key fields to prevent collisions

### DIFF
--- a/docs/adr/005-badger-storage-record-layouts.md
+++ b/docs/adr/005-badger-storage-record-layouts.md
@@ -2,6 +2,7 @@
 
 * **Status**: Documented existing implementation
 * **Date**: 2026-03-12
+* **Updated**: 2026-08-04 — corrected the Operation Name Index section's claim that the reader guards against concatenation-collision ambiguity (it doesn't: the check only rejects partial-prefix mismatches, not two field splits that concatenate to identical bytes). Documented the length-prefixed field encoding (`encodeIndexFields`/`decodeIndexField` in `index_encoding.go`) that fixes the underlying issue in the Service Name, Operation Name, and Tag indexes.
 
 ## Context
 
@@ -73,16 +74,16 @@ An index entry is written for each span, keyed by the service name of the span's
 
 **Key** (variable size):
 ```
-[0x81][serviceName: variable][startTime: 8B][traceID.High: 8B][traceID.Low: 8B]
+[0x81][encodeIndexFields(serviceName): variable][startTime: 8B][traceID.High: 8B][traceID.Low: 8B]
 ```
 
-- `serviceName` — UTF-8 bytes of the service name, no length prefix or separator
+- `encodeIndexFields(serviceName)` — the service name as a single length-prefixed field: a 2-byte big-endian length followed by that many bytes (see `encodeIndexFields` in `index_encoding.go`). A field longer than 65535 bytes is truncated before encoding. A lone field can't collide with itself, so this index doesn't strictly need the length prefix for correctness, but it goes through the same encoding as the Operation Name and Tag indexes below so that every composite index key is built by one function.
 - `startTime` — `uint64`, microseconds since Unix epoch
 - `traceID` — the 16-byte trace ID (High then Low, big-endian)
 
 **Value**: empty (`nil`)
 
-**Purpose**: enables scanning all trace IDs associated with a given service within a time range. The reader seeks to `[0x81][serviceName]` and iterates in reverse (latest first), extracting the trailing 16 bytes of each key as the trace ID.
+**Purpose**: enables scanning all trace IDs associated with a given service within a time range. The reader seeks to `[0x81][encodeIndexFields(serviceName)]` and iterates in reverse (latest first), extracting the trailing 16 bytes of each key as the trace ID.
 
 **TTL**: same as the corresponding primary span record.
 
@@ -90,20 +91,20 @@ An index entry is written for each span, keyed by the service name of the span's
 
 ### 3. Operation Name Index (`0x82`)
 
-An index entry is written for each span, keyed by the concatenation of service name and operation name.
+An index entry is written for each span, keyed by the service name and operation name, each encoded as its own length-prefixed field.
 
 **Key** (variable size):
 ```
-[0x82][serviceName + operationName: variable][startTime: 8B][traceID.High: 8B][traceID.Low: 8B]
+[0x82][encodeIndexFields(serviceName, operationName): variable][startTime: 8B][traceID.High: 8B][traceID.Low: 8B]
 ```
 
-- `serviceName + operationName` — the two strings concatenated directly, no separator
+- `encodeIndexFields(serviceName, operationName)` — each string prefixed with its own 2-byte big-endian length, then concatenated (see `index_encoding.go`)
 
 **Value**: empty (`nil`)
 
 **Purpose**: enables finding trace IDs for a specific service + operation pair within a time range.
 
-**Note**: because the service name and operation name are concatenated without a separator, a service named `"foo"` with operation `"bar"` produces the same prefix as a service named `"foobar"` with operation `""`. The reader guards against this ambiguity by checking that the full key prefix (up to the timestamp) matches exactly.
+**Note**: this index used to concatenate `serviceName + operationName` directly with no separator or length prefix, so a service named `"foo"` with operation `"bar"` produced the same bytes as a service named `"foobar"` with operation `""` — and, more generally, any two `(service, operation)` pairs whose concatenations happened to collide. An earlier version of this ADR claimed the reader guarded against that ambiguity by checking that the full key prefix (up to the timestamp) matched exactly. That claim was wrong: the check only rejects a *partial* prefix match (e.g. a stored key for `"foobarextra"` while querying `"foobar"`); it cannot distinguish two prefixes that are byte-for-byte identical, which is exactly what a concatenation collision produces, so the check passed colliding entries straight through. Queries could silently return trace IDs belonging to the wrong `(service, operation)` pair. Encoding each field with an explicit length prefix removes the ambiguity at the encoding level instead: two different field splits can no longer produce identical bytes, so no prefix-matching guard is needed to compensate.
 
 **TTL**: same as the corresponding primary span record.
 
@@ -115,15 +116,17 @@ For each searchable tag key-value pair associated with a span, a separate index 
 
 **Key** (variable size):
 ```
-[0x83][serviceName + tagKey + tagValue: variable][startTime: 8B][traceID.High: 8B][traceID.Low: 8B]
+[0x83][encodeIndexFields(serviceName, tagKey, tagValue): variable][startTime: 8B][traceID.High: 8B][traceID.Low: 8B]
 ```
 
-- `serviceName + tagKey + tagValue` — all three strings concatenated directly, no separators
-- Tag values are converted to their string representation via `kv.AsString()` before being embedded in the key
+- `encodeIndexFields(serviceName, tagKey, tagValue)` — each of the three strings prefixed with its own 2-byte big-endian length, then concatenated
+- Tag values are converted to their string representation via `kv.AsString()` before being encoded
 
 **Value**: empty (`nil`)
 
 **Purpose**: enables finding trace IDs for spans that carry a specific tag key-value pair within a given service.
+
+**Note**: this index used to concatenate `serviceName + tagKey + tagValue` directly with no separators, so e.g. a `checkout` service with tag `id=123` produced the same bytes as a `checkout` service with tag `id1=23`. Unlike the Operation Name Index above, this path had no prefix-matching guard at all — nothing stood between a collision and a wrong query result. Fixed by the same length-prefix encoding.
 
 **TTL**: same as the corresponding primary span record.
 
@@ -264,7 +267,7 @@ The record layouts described above were chosen to satisfy the following requirem
 
 - **Not distributed**: Badger is a single-node store. It is not suitable for high-throughput or multi-instance deployments.
 - **No spanKind in operations**: the operation name index does not encode span kind, so `GetOperations` returns operations without span kind information (tracked in [issue #1922](https://github.com/jaegertracing/jaeger/issues/1922)).
-- **String concatenation without separators**: the absence of separators between service name, tag key, and tag value in composite index keys means that a suffix of one component can collide with a prefix of the next. The implementation handles this with exact-prefix length checks but it is a latent source of subtle bugs if the key format is extended.
+- **Length-prefixed composite index keys**: the Service Name, Operation Name, and Tag indexes above encode each field with an explicit 2-byte length prefix (`encodeIndexFields`/`decodeIndexField` in `index_encoding.go`) rather than concatenating strings directly, which is what previously let different field combinations collide onto identical key bytes. A field longer than 65535 bytes is truncated before encoding, so two very long fields can still collide with each other, though this is unreachable in practice for typical service/operation/tag names. This changed the on-disk format of these three index types: pre-existing entries written in the old, unprefixed format are not decodable under the new format and are skipped (not misread) during cache prefill, so a persisted (non-ephemeral) data directory upgraded in place will simply miss search results for spans indexed before the upgrade until their TTL expires.
 - **No dependency index**: the dependency store computes dependency links via a full trace scan on every request rather than maintaining a dedicated index, which may be slow for large datasets.
 - **Sampling entries have no TTL**: throughput and probabilities records are not automatically expired and accumulate indefinitely unless explicitly pruned.
 - **Ephemeral by default**: the default configuration (`Ephemeral: true`) stores data in a temporary directory that is deleted on process exit, which may surprise users who expect data to persist across restarts.
@@ -274,6 +277,7 @@ The record layouts described above were chosen to satisfy the following requirem
 - [`internal/storage/v1/badger/spanstore/writer.go`](../../internal/storage/v1/badger/spanstore/writer.go) — `createTraceKV`, `createIndexKey`, `WriteSpan`
 - [`internal/storage/v1/badger/spanstore/reader.go`](../../internal/storage/v1/badger/spanstore/reader.go) — `FindTraceIDs`, `scanIndexKeys`, `scanRangeIndex`, `scanTimeRange`, `getTraces`
 - [`internal/storage/v1/badger/spanstore/cache.go`](../../internal/storage/v1/badger/spanstore/cache.go) — `CacheStore`
+- [`internal/storage/v1/badger/spanstore/index_encoding.go`](../../internal/storage/v1/badger/spanstore/index_encoding.go) — `encodeIndexFields`, `decodeIndexField`
 - [`internal/storage/v1/badger/samplingstore/storage.go`](../../internal/storage/v1/badger/samplingstore/storage.go) — `createThroughputKV`, `createProbabilitiesKV`
 - [`internal/storage/v1/badger/config.go`](../../internal/storage/v1/badger/config.go) — `Config`, `DefaultConfig`
 - [Badger documentation](https://dgraph.io/docs/badger/)

--- a/internal/storage/v1/badger/spanstore/index_encoding.go
+++ b/internal/storage/v1/badger/spanstore/index_encoding.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package spanstore
+
+import "encoding/binary"
+
+// maxIndexFieldLen is the largest field length that fits in the 2-byte
+// big-endian length prefix used by encodeIndexFields.
+const maxIndexFieldLen = 65535
+
+// encodeIndexFields concatenates fields into a single byte slice, prefixing each
+// field with its own 2-byte big-endian length so that field boundaries are
+// recoverable. Without explicit boundaries, different field combinations can
+// concatenate to identical bytes -- e.g. ("A","Bc") and ("AB","c") both produce
+// "ABc" -- making them indistinguishable once written into an index key, so a
+// query for one pair can silently match spans belonging to the other.
+//
+// A field longer than maxIndexFieldLen is truncated before encoding, and the
+// encoded length always matches the truncated bytes. Truncation can only cause
+// two very long fields to collide with each other; it cannot corrupt or misalign
+// any other index key, since every field's length is explicit in the encoding.
+func encodeIndexFields(fields ...string) []byte {
+	total := 0
+	for _, f := range fields {
+		total += 2 + truncatedLen(f)
+	}
+
+	out := make([]byte, 0, total)
+	for _, f := range fields {
+		b := []byte(f)
+		if len(b) > maxIndexFieldLen {
+			b = b[:maxIndexFieldLen]
+		}
+		var lenBuf [2]byte
+		//nolint:gosec // G115: len(b) <= maxIndexFieldLen (65535) by the truncation above
+		binary.BigEndian.PutUint16(lenBuf[:], uint16(len(b)))
+		out = append(out, lenBuf[:]...)
+		out = append(out, b...)
+	}
+	return out
+}
+
+func truncatedLen(f string) int {
+	if len(f) > maxIndexFieldLen {
+		return maxIndexFieldLen
+	}
+	return len(f)
+}
+
+// decodeIndexField reads a single length-prefixed field encoded by
+// encodeIndexFields, starting at offset in b. It returns the field's bytes and
+// the offset immediately following the field, so callers can decode a sequence
+// of fields by chaining calls.
+//
+// ok is false if b does not contain a valid length-prefixed field at offset --
+// too few bytes remain to hold the 2-byte length, or the declared length runs
+// past the end of b. This is not just defensive: it is the only thing standing
+// between a stray badger entry in the old, unprefixed key format (e.g. left over
+// from before this encoding existed) and an out-of-range panic, since the first
+// two bytes of arbitrary old-format data are read as a length and used as a
+// slice bound. Callers must treat ok==false as "not decodable", not as an empty
+// field.
+func decodeIndexField(b []byte, offset int) (field []byte, next int, ok bool) {
+	if offset < 0 || offset+2 > len(b) {
+		return nil, 0, false
+	}
+	length := binary.BigEndian.Uint16(b[offset : offset+2])
+	start := offset + 2
+	end := start + int(length)
+	if end > len(b) {
+		return nil, 0, false
+	}
+	return b[start:end], end, true
+}

--- a/internal/storage/v1/badger/spanstore/index_encoding_test.go
+++ b/internal/storage/v1/badger/spanstore/index_encoding_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package spanstore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeIndexFields_CollidingConcatenationsDiffer(t *testing.T) {
+	// "A"+"Bc" and "AB"+"c" both concatenate to "ABc" with plain string
+	// concatenation; encodeIndexFields must keep them distinct.
+	a := encodeIndexFields("A", "Bc")
+	b := encodeIndexFields("AB", "c")
+	assert.NotEqual(t, a, b)
+
+	// "checkout"+"id"+"123" and "checkout"+"id1"+"23" both concatenate to
+	// "checkoutid123".
+	c := encodeIndexFields("checkout", "id", "123")
+	d := encodeIndexFields("checkout", "id1", "23")
+	assert.NotEqual(t, c, d)
+}
+
+func TestEncodeIndexFields_SameFieldsProduceSameBytes(t *testing.T) {
+	first := encodeIndexFields("A", "Bc")
+	second := encodeIndexFields("A", "Bc")
+	assert.Equal(t, first, second)
+}
+
+func TestEncodeIndexFields_DecodeRoundTrip(t *testing.T) {
+	fields := []string{"checkout", "id", "123"}
+	encoded := encodeIndexFields(fields...)
+
+	offset := 0
+	for _, want := range fields {
+		var got []byte
+		var ok bool
+		got, offset, ok = decodeIndexField(encoded, offset)
+		require.True(t, ok)
+		assert.Equal(t, want, string(got))
+	}
+	assert.Len(t, encoded, offset, "decoding should consume exactly the encoded bytes")
+}
+
+func TestDecodeIndexField_RejectsOldUnprefixedFormat(t *testing.T) {
+	// Old-format index entries concatenated fields directly, with no length
+	// prefix, e.g. raw "service1". The first two bytes ('s','e' = 0x7365)
+	// decode as a bogus length far past the buffer; decodeIndexField must
+	// report failure instead of slicing out of range.
+	old := []byte("service1")
+
+	_, _, ok := decodeIndexField(old, 0)
+	assert.False(t, ok)
+}
+
+func TestDecodeIndexField_RejectsTruncatedInput(t *testing.T) {
+	// Fewer than 2 bytes remain to hold the length prefix at all.
+	_, _, ok := decodeIndexField([]byte{0x00}, 0)
+	assert.False(t, ok)
+
+	// A valid-looking length prefix whose declared length runs past the end
+	// of the buffer (declares 10 bytes, only 3 are present).
+	truncated := []byte{0x00, 0x0A, 'a', 'b', 'c'}
+	_, _, ok = decodeIndexField(truncated, 0)
+	assert.False(t, ok)
+
+	// Offset itself is past the end of the buffer.
+	_, _, ok = decodeIndexField([]byte{0x00, 0x01, 'a'}, 10)
+	assert.False(t, ok)
+}
+
+func TestEncodeIndexFields_SingleFieldIsPrefixOfMultiField(t *testing.T) {
+	// preloadOperations relies on encodeIndexFields(service) being an exact byte
+	// prefix of encodeIndexFields(service, operation), for any operation, so it
+	// can use the former as a Badger iterator seek prefix.
+	serviceOnly := encodeIndexFields("checkout")
+	serviceAndOp := encodeIndexFields("checkout", "place-order")
+	assert.True(t, strings.HasPrefix(string(serviceAndOp), string(serviceOnly)))
+}
+
+func TestEncodeIndexFields_EmptyFields(t *testing.T) {
+	encoded := encodeIndexFields("", "x", "")
+	offset := 0
+	var got []byte
+	var ok bool
+	got, offset, ok = decodeIndexField(encoded, offset)
+	require.True(t, ok)
+	assert.Empty(t, got)
+	got, offset, ok = decodeIndexField(encoded, offset)
+	require.True(t, ok)
+	assert.Equal(t, "x", string(got))
+	got, offset, ok = decodeIndexField(encoded, offset)
+	require.True(t, ok)
+	assert.Empty(t, got)
+	assert.Len(t, encoded, offset)
+}
+
+func TestEncodeIndexFields_TruncatesOverlongFieldsWithoutDrift(t *testing.T) {
+	long := strings.Repeat("a", maxIndexFieldLen+100)
+	encoded := encodeIndexFields(long, "next")
+
+	field, offset, ok := decodeIndexField(encoded, 0)
+	require.True(t, ok)
+	require.Len(t, field, maxIndexFieldLen, "field must be truncated to the max length")
+
+	// The encoded length must match the truncated bytes exactly, so decoding the
+	// next field still lands in the right place.
+	next, _, ok := decodeIndexField(encoded, offset)
+	require.True(t, ok)
+	assert.Equal(t, "next", string(next))
+}

--- a/internal/storage/v1/badger/spanstore/read_write_test.go
+++ b/internal/storage/v1/badger/spanstore/read_write_test.go
@@ -277,6 +277,118 @@ func TestIndexSeeks(t *testing.T) {
 	})
 }
 
+// TestFindTraceIDs_TagIndexKeyCollision is a regression test for a bug where the
+// tag index key was built by concatenating ServiceName+TagKey+TagValue with no
+// delimiter, so two different (tag key, tag value) pairs under the same service
+// whose concatenation collided byte-for-byte became indistinguishable in the
+// index, and a query for one pair silently returned trace IDs belonging to the
+// other. Fixed by encoding each field with an explicit length prefix
+// (encodeIndexFields in index_encoding.go) instead of raw concatenation.
+func TestFindTraceIDs_TagIndexKeyCollision(t *testing.T) {
+	runFactoryTest(t, func(_ testing.TB, sw spanstore.Writer, sr spanstore.Reader) {
+		now := time.Now()
+
+		// trace1: service="checkout", tag id="123"      -> concat "checkout"+"id"+"123" = "checkoutid123"
+		trace1 := model.TraceID{Low: 1, High: 1}
+		span1 := model.Span{
+			TraceID:       trace1,
+			SpanID:        model.SpanID(1),
+			OperationName: "op",
+			Process:       &model.Process{ServiceName: "checkout"},
+			StartTime:     now,
+			Duration:      time.Millisecond,
+			Tags: model.KeyValues{
+				{Key: "id", VStr: "123", VType: model.StringType},
+			},
+		}
+		require.NoError(t, sw.WriteSpan(context.Background(), &span1))
+
+		// trace2: service="checkout", tag id1="23"       -> concat "checkout"+"id1"+"23" = "checkoutid123"
+		// Same concatenated bytes as trace1's index entry, but a genuinely different
+		// (tag key, tag value) pair.
+		trace2 := model.TraceID{Low: 2, High: 1}
+		span2 := model.Span{
+			TraceID:       trace2,
+			SpanID:        model.SpanID(2),
+			OperationName: "op",
+			Process:       &model.Process{ServiceName: "checkout"},
+			StartTime:     now.Add(time.Microsecond),
+			Duration:      time.Millisecond,
+			Tags: model.KeyValues{
+				{Key: "id1", VStr: "23", VType: model.StringType},
+			},
+		}
+		require.NoError(t, sw.WriteSpan(context.Background(), &span2))
+
+		ids, err := sr.FindTraceIDs(context.Background(), &spanstore.TraceQueryParameters{
+			ServiceName:  "checkout",
+			Tags:         map[string]string{"id": "123"},
+			StartTimeMin: now.Add(-time.Minute),
+			StartTimeMax: now.Add(time.Minute),
+			NumTraces:    10,
+		})
+		require.NoError(t, err)
+
+		// EXPECTED: only trace1 (tag id=123) should be returned.
+		// trace2 belongs to tag id1=23 and must not match.
+		assert.NotContains(t, ids, trace2,
+			"query for tag id=123 incorrectly matched tag id1=23 due to delimiter-less tag index key concatenation")
+		assert.Len(t, ids, 1, "expected exactly 1 trace id (trace1) to match")
+	})
+}
+
+// TestFindTraceIDs_OperationIndexKeyCollision is the operation-name analogue of
+// TestFindTraceIDs_TagIndexKeyCollision: the operation-name index key used to
+// concatenate ServiceName+OperationName with no delimiter, so a query could match
+// a trace from an unrelated (service, operation) pair whose names happened to
+// concatenate identically. Same fix, same root cause.
+func TestFindTraceIDs_OperationIndexKeyCollision(t *testing.T) {
+	runFactoryTest(t, func(_ testing.TB, sw spanstore.Writer, sr spanstore.Reader) {
+		now := time.Now()
+
+		// trace1: service="A", operation="Bc"  -> concat "A"+"Bc" = "ABc"
+		trace1 := model.TraceID{Low: 1, High: 1}
+		span1 := model.Span{
+			TraceID:       trace1,
+			SpanID:        model.SpanID(1),
+			OperationName: "Bc",
+			Process:       &model.Process{ServiceName: "A"},
+			StartTime:     now,
+			Duration:      time.Millisecond,
+		}
+		require.NoError(t, sw.WriteSpan(context.Background(), &span1))
+
+		// trace2: service="AB", operation="c"  -> concat "AB"+"c" = "ABc"
+		// Same concatenated bytes as trace1's index entry, but a genuinely different
+		// (service, operation) pair.
+		trace2 := model.TraceID{Low: 2, High: 1}
+		span2 := model.Span{
+			TraceID:       trace2,
+			SpanID:        model.SpanID(2),
+			OperationName: "c",
+			Process:       &model.Process{ServiceName: "AB"},
+			StartTime:     now.Add(time.Microsecond),
+			Duration:      time.Millisecond,
+		}
+		require.NoError(t, sw.WriteSpan(context.Background(), &span2))
+
+		ids, err := sr.FindTraceIDs(context.Background(), &spanstore.TraceQueryParameters{
+			ServiceName:   "A",
+			OperationName: "Bc",
+			StartTimeMin:  now.Add(-time.Minute),
+			StartTimeMax:  now.Add(time.Minute),
+			NumTraces:     10,
+		})
+		require.NoError(t, err)
+
+		// EXPECTED: only trace1 (service=A, operation=Bc) should be returned.
+		// trace2 belongs to service=AB, operation=c and must not match.
+		assert.NotContains(t, ids, trace2,
+			"query for service=A,operation=Bc incorrectly matched service=AB,operation=c due to delimiter-less operation index key concatenation")
+		assert.Len(t, ids, 1, "expected exactly 1 trace id (trace1) to match")
+	})
+}
+
 func TestFindNothing(t *testing.T) {
 	runFactoryTest(t, func(_ testing.TB, _ spanstore.Writer, sr spanstore.Reader) {
 		startT := time.Now()

--- a/internal/storage/v1/badger/spanstore/reader.go
+++ b/internal/storage/v1/badger/spanstore/reader.go
@@ -264,7 +264,7 @@ func serviceQueries(query *spanstore.TraceQueryParameters, indexSeeks [][]byte) 
 		indexSearchKey := make([]byte, 0, 64) // 64 is a magic guess
 		tagQueryUsed := false
 		for k, v := range query.Tags {
-			tagSearch := []byte(query.ServiceName + k + v)
+			tagSearch := encodeIndexFields(query.ServiceName, k, v)
 			tagSearchKey := make([]byte, 0, len(tagSearch)+1)
 			tagSearchKey = append(tagSearchKey, tagIndexKey)
 			tagSearchKey = append(tagSearchKey, tagSearch...)
@@ -274,10 +274,10 @@ func serviceQueries(query *spanstore.TraceQueryParameters, indexSeeks [][]byte) 
 
 		if query.OperationName != "" {
 			indexSearchKey = append(indexSearchKey, operationNameIndexKey)
-			indexSearchKey = append(indexSearchKey, []byte(query.ServiceName+query.OperationName)...)
+			indexSearchKey = append(indexSearchKey, encodeIndexFields(query.ServiceName, query.OperationName)...)
 		} else if !tagQueryUsed { // Tag query already reduces the search set with a serviceName
 			indexSearchKey = append(indexSearchKey, serviceNameIndexKey)
-			indexSearchKey = append(indexSearchKey, []byte(query.ServiceName)...)
+			indexSearchKey = append(indexSearchKey, encodeIndexFields(query.ServiceName)...)
 		}
 
 		if len(indexSearchKey) > 0 {
@@ -630,8 +630,13 @@ func (r *TraceReader) preloadServices() []string {
 
 		// Seek all the services first
 		for it.Seek(serviceKey); it.ValidForPrefix(serviceKey); it.Next() {
-			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
-			serviceName := string(it.Item().Key()[len(serviceKey):timestampStartIndex])
+			serviceNameBytes, _, ok := decodeIndexField(it.Item().Key(), len(serviceKey))
+			if !ok {
+				// Not a valid length-prefixed field, e.g. a leftover entry in the
+				// old unprefixed key format. Skip rather than misread it.
+				continue
+			}
+			serviceName := string(serviceNameBytes)
 			keyTTL := it.Item().ExpiresAt()
 			services[serviceName] = struct{}{}
 			r.cache.AddService(serviceName, keyTTL)
@@ -648,14 +653,20 @@ func (r *TraceReader) preloadOperations(service string) {
 		it := txn.NewIterator(opts)
 		defer it.Close()
 
-		serviceKey := make([]byte, len(service)+1)
+		encodedService := encodeIndexFields(service)
+		serviceKey := make([]byte, len(encodedService)+1)
 		serviceKey[0] = operationNameIndexKey
-		copy(serviceKey[1:], service)
+		copy(serviceKey[1:], encodedService)
 
-		// Seek all the services first
+		// Seek all the operations for this service
 		for it.Seek(serviceKey); it.ValidForPrefix(serviceKey); it.Next() {
-			timestampStartIndex := len(it.Item().Key()) - (sizeOfTraceID + 8) // 8 = sizeof(uint64)
-			operationName := string(it.Item().Key()[len(serviceKey):timestampStartIndex])
+			operationNameBytes, _, ok := decodeIndexField(it.Item().Key(), len(serviceKey))
+			if !ok {
+				// Not a valid length-prefixed field, e.g. a leftover entry in the
+				// old unprefixed key format. Skip rather than misread it.
+				continue
+			}
+			operationName := string(operationNameBytes)
 			keyTTL := it.Item().ExpiresAt()
 			r.cache.AddOperation(service, operationName, keyTTL)
 		}

--- a/internal/storage/v1/badger/spanstore/rw_internal_test.go
+++ b/internal/storage/v1/badger/spanstore/rw_internal_test.go
@@ -193,8 +193,8 @@ func TestMergeJoin(t *testing.T) {
 func TestOldReads(t *testing.T) {
 	runWithBadger(t, func(store *badger.DB, t *testing.T) {
 		timeNow := model.TimeAsEpochMicroseconds(time.Now())
-		s1Key := createIndexKey(serviceNameIndexKey, []byte("service1"), timeNow, model.TraceID{High: 0, Low: 0})
-		s1o1Key := createIndexKey(operationNameIndexKey, []byte("service1operation1"), timeNow, model.TraceID{High: 0, Low: 0})
+		s1Key := createIndexKey(serviceNameIndexKey, encodeIndexFields("service1"), timeNow, model.TraceID{High: 0, Low: 0})
+		s1o1Key := createIndexKey(operationNameIndexKey, encodeIndexFields("service1", "operation1"), timeNow, model.TraceID{High: 0, Low: 0})
 
 		tid := time.Now().Add(1 * time.Minute)
 

--- a/internal/storage/v1/badger/spanstore/writer.go
+++ b/internal/storage/v1/badger/spanstore/writer.go
@@ -70,8 +70,8 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	entriesToStore = append(
 		entriesToStore,
 		trace,
-		w.createBadgerEntry(createIndexKey(serviceNameIndexKey, []byte(span.Process.ServiceName), startTime, span.TraceID), nil, expireTime),
-		w.createBadgerEntry(createIndexKey(operationNameIndexKey, []byte(span.Process.ServiceName+span.OperationName), startTime, span.TraceID), nil, expireTime),
+		w.createBadgerEntry(createIndexKey(serviceNameIndexKey, encodeIndexFields(span.Process.ServiceName), startTime, span.TraceID), nil, expireTime),
+		w.createBadgerEntry(createIndexKey(operationNameIndexKey, encodeIndexFields(span.Process.ServiceName, span.OperationName), startTime, span.TraceID), nil, expireTime),
 	)
 
 	// It doesn't matter if we overwrite Duration index keys, everything is read at Trace level in any case
@@ -82,16 +82,16 @@ func (w *SpanWriter) WriteSpan(_ context.Context, span *model.Span) error {
 	for _, kv := range span.Tags {
 		// Convert everything to string since queries are done that way also
 		// KEY: it<serviceName><tagsKey><traceId> VALUE: <tagsValue>
-		entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(tagIndexKey, []byte(span.Process.ServiceName+kv.Key+kv.AsString()), startTime, span.TraceID), nil, expireTime))
+		entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(tagIndexKey, encodeIndexFields(span.Process.ServiceName, kv.Key, kv.AsString()), startTime, span.TraceID), nil, expireTime))
 	}
 
 	for _, kv := range span.Process.Tags {
-		entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(tagIndexKey, []byte(span.Process.ServiceName+kv.Key+kv.AsString()), startTime, span.TraceID), nil, expireTime))
+		entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(tagIndexKey, encodeIndexFields(span.Process.ServiceName, kv.Key, kv.AsString()), startTime, span.TraceID), nil, expireTime))
 	}
 
 	for _, log := range span.Logs {
 		for _, kv := range log.Fields {
-			entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(tagIndexKey, []byte(span.Process.ServiceName+kv.Key+kv.AsString()), startTime, span.TraceID), nil, expireTime))
+			entriesToStore = append(entriesToStore, w.createBadgerEntry(createIndexKey(tagIndexKey, encodeIndexFields(span.Process.ServiceName, kv.Key, kv.AsString()), startTime, span.TraceID), nil, expireTime))
 		}
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

* Resolves #9222 

## Description of the changes

### The bug

Badger's secondary index keys are built by concatenating fields with no delimiter or length prefix:

* Operation index: `ServiceName + OperationName` (`writer.go:74`), seeked at `reader.go:277`
* Tag index: `ServiceName + kv.Key + kv.AsString()` (`writer.go:85,89,94`), seeked at `reader.go:267`

Because field boundaries are not encoded, distinct field combinations can produce identical key bytes, and a query for one silently returns trace IDs belonging to another. No error is returned and nothing is logged.

* `service="checkout"` with tag `id="123"` and `service="checkout"` with tag `id1="23"` both encode to `checkoutid123`.
* `service="A", operation="Bc"` and `service="AB", operation="c"` both encode to `ABc`.

### Why the documented guard does not prevent this

ADR-005 states the reader guards against this ambiguity by checking that the full key prefix up to the timestamp matches exactly. That check exists (`reader.go:547`, `bytes.Equal` on the key prefix), but it cannot catch this case: collided fields produce byte-identical prefixes rather than a mismatch, so `bytes.Equal` returns true and the entry passes through. The ADR's own worked example, `"foo"+"bar"` vs `"foobar"+""`, concatenates identically and would also pass. For the tag index the ADR makes no correctness claim at all, which matches the code — no equivalent check exists on that path.

ADR-005 is corrected in place: the false guard claim is removed, the length-prefixed encoding is described in the service, operation, and tag index sections, and the stale "latent bug" limitation bullet is replaced with the fix and its remaining constraints.

### The fix

A new `index_encoding.go` provides `encodeIndexFields`, which length-prefixes each field with a 2-byte big-endian length before concatenation:

```text
encodeIndexFields("checkout", "id", "123")  ->  [0,8]checkout[0,2]id[0,3]123
```

Both the writer and the reader call this single helper, so the two encodings cannot drift apart — a mismatch would silently break every Badger query, so sharing one implementation is deliberate rather than incidental.

Applied to the operation and tag indexes, and to the service name index for consistency (that one has a single field and cannot collide, so this is not a bug fix there). The duration index and primary span key are untouched, as neither concatenates strings.

2-byte lengths were chosen over 1-byte or varint. A 1-byte length caps fields at 255 bytes, which would silently misencode longer tag values and reintroduce a quieter version of the same bug; no length cap exists anywhere in this package today. Varints would be more compact but appear nowhere else in `spanstore`, whereas fixed-width `binary.BigEndian` matches the existing style (8-byte timestamps, 16-byte trace IDs). Fields longer than 65535 bytes are truncated to that length.

`timestampStartIndex` is unaffected: the reader computes it as `len(key) - (sizeOfTraceID + 8)`, working backward from the fixed-size suffix rather than assuming anything about the value portion's length.

### Avoiding a crash on upgrade

The on-disk index key format changes. Cache prefill against a pre-existing non-ephemeral data directory would encounter old-format keys, and a decoder that reads two arbitrary bytes as a length and slices with it panics on such input — `"se"` from a raw `"service1"` key decodes as length 29541. That would turn a wrong-results bug into a crash on startup, which is strictly worse than the original problem.

`decodeIndexField` is therefore bounds-checked and returns an `ok` flag rather than panicking. `preloadServices` and `preloadOperations` skip undecodable entries instead of failing. This was surfaced by `TestOldReads`, a white-box test that hand-builds raw index keys.

### On feature gates

`CONTRIBUTING.md` asks that breaking changes go through an OTel feature gate, and an on-disk format change qualifies by the letter of that policy. I have not added one here, for these reasons — happy to add a gate if maintainers prefer:

* `Ephemeral` defaults to `true`, so the default configuration writes to a temp directory that is removed on process exit and never sees old-format keys.
* `TTL.Spans` defaults to 72 hours even when non-ephemeral, so old-format index entries age out within one TTL window without operator action.
* The failure mode during that window is that old entries stop matching, not corruption or a crash. Stale index entries pointing at expired primary records already fail closed in the existing code.
* There is no key-format version byte or migration path anywhere in `internal/storage/v1/badger` or `internal/storage/v2/badger`, so a gate would have nothing to switch between without also introducing dual-format read support, which seems disproportionate for a backend documented as unsuitable for high-throughput or multi-instance deployments.

## How was this change tested?

* `TestFindTraceIDs_TagIndexKeyCollision` and `TestFindTraceIDs_OperationIndexKeyCollision` in `read_write_test.go` fail on `main` and pass with this change.
* New `index_encoding_test.go` covers determinism, collision resistance, round-trip, the prefix property `preloadOperations` depends on, and malformed input including the exact old-format bytes that surfaced the panic.
* `TestOldReads` updated to build keys via `encodeIndexFields`. It is a white-box test of unrelated cache-TTL behaviour that simply needed the current format.
* Full Badger suite passes across all four sub-packages.
* `make fmt`, `make lint`, and `make test` are clean (4188 tests, 38 skipped — all environment-gated integration tests).

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully

AI assistance was used for slight debugging while exploring the codebase. I verified the behavior against running code and wrote the change myself.
