### PR TITLE
fix(anonymizer): Handle empty span captures without panicking

### DIFF
--- a/cmd/anonymizer/app/uiconv/reader.go
+++ b/cmd/anonymizer/app/uiconv/reader.go
@@ -62,6 +62,13 @@ func (r *spanReader) NextSpan() (*uimodel.Span, error) {
 		r.eofReached = true
 		return nil, fmt.Errorf("cannot read file: %w", err)
 	}
+	if len(s) < 2 {
+		r.eofReached = true
+		if r.spansRead == 0 {
+			return nil, errNoMoreSpans
+		}
+		return nil, errors.New("unexpected empty line in captured file")
+	}
 	if s[len(s)-2] == ',' { // all but last span lines end with ,\n
 		s = s[0 : len(s)-2]
 	} else {

--- a/cmd/anonymizer/app/uiconv/reader_test.go
+++ b/cmd/anonymizer/app/uiconv/reader_test.go
@@ -4,6 +4,8 @@
 package uiconv
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +53,35 @@ func TestReaderTraceEmpty(t *testing.T) {
 	require.ErrorContains(t, err, "cannot read file")
 	assert.Equal(t, 0, r.spansRead)
 	assert.True(t, r.eofReached)
+}
+
+func TestReaderTraceNoSpans(t *testing.T) {
+	inputFile := filepath.Join(t.TempDir(), "trace.json")
+	require.NoError(t, os.WriteFile(inputFile, []byte("[\n]\n"), 0o600))
+
+	r, err := newSpanReader(inputFile, zap.NewNop())
+	require.NoError(t, err)
+	defer r.capturedFile.Close()
+
+	_, err = r.NextSpan()
+	require.Equal(t, errNoMoreSpans, err)
+	assert.Equal(t, 0, r.spansRead)
+	assert.True(t, r.eofReached)
+}
+
+func TestReaderTraceBlankLine(t *testing.T) {
+	inputFile := filepath.Join(t.TempDir(), "trace.json")
+	require.NoError(t, os.WriteFile(inputFile, []byte("[{},\n\n]\n"), 0o600))
+
+	r, err := newSpanReader(inputFile, zap.NewNop())
+	require.NoError(t, err)
+	defer r.capturedFile.Close()
+
+	_, err = r.NextSpan()
+	require.NoError(t, err)
+
+	_, err = r.NextSpan()
+	require.EqualError(t, err, "unexpected empty line in captured file")
 }
 
 func TestReaderTraceWrongFormat(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

The anonymizer crashes when a captured file has no spans. The writer always writes `[\n]\n` for an empty trace, and the reader indexes into the 1-character line without checking its length, panicking with `index out of range [-1]`.

Fixes #9225

## Description of the changes

- Return `errNoMoreSpans` from `spanReader.NextSpan` when a short line is the very first line of the capture.
- If a blank line appears after some spans, return an error instead of silently stopping, so spans are not silently dropped.
- Added tests for both cases.

## How was this change tested?

- `go test ./cmd/anonymizer/app/uiconv/` - the new tests panic/fail before the fix and pass after; the other tests in the package pass as well.
- `go test ./cmd/anonymizer/...` - the other anonymizer packages pass.
- `gofmt -s`, `gofumpt`, `go vet`, and the repo's import-order check pass on the changed files.
- `make lint` / `make test` were not run locally: this is a Windows machine without cgo (`-race` is unavailable), git's autocrlf turns the checkout into CRLF which the repo's line-ending lint rejects, and Docker is not available here. The full suite will run on Linux CI.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)