### PR TITLE
fix(examples): Add OpenSearch and Jaeger memory guardrails

### DIFF
--- a/examples/otel-demo/jaeger-values.yaml
+++ b/examples/otel-demo/jaeger-values.yaml
@@ -7,6 +7,23 @@ global:
 allInOne:
   enabled: true
   extraEnv: []
+  resources:
+    requests:
+      memory: "1Gi"
+    limits:
+      memory: "3Gi"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            namespaces:
+              - opensearch
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: opensearch
+                app.kubernetes.io/name: opensearch
 
 
 # Enable HotROD demo application

--- a/examples/otel-demo/opensearch-values.yaml
+++ b/examples/otel-demo/opensearch-values.yaml
@@ -14,7 +14,14 @@ persistence:
   size: "10Gi"
   storageClass: "oci-bv" # Using Oracle Cloud Block Volume storage class
 
-opensearchJavaOpts: "-Xmx1g -Xms1g"
+opensearchJavaOpts: "-Xms3g -Xmx3g"
+
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "6Gi"
+  limits:
+    memory: "6Gi"
 
 securityConfig:
   enabled: false
@@ -37,4 +44,3 @@ config:
 service:
   type: ClusterIP
   port: 9200
-


### PR DESCRIPTION
Fixes #9230

## Summary

- increase the OTel demo OpenSearch heap from 1 GiB to 3 GiB
- reserve and cap OpenSearch memory at 6 GiB while preserving its 1 CPU request
- add a 1 GiB request and 3 GiB limit to the Jaeger all-in-one pod
- prefer scheduling Jaeger away from the OpenSearch hostname without making scheduling mandatory

## Why

The single-node OpenSearch instance reached about 97% heap utilization and repeatedly tripped its parent circuit breaker. OpenSearch returned 429 responses, which surfaced as HTTP 500 responses from Jaeger's `/api/services` endpoint. Jaeger also previously had an abnormal backpressure-related memory spike and eviction, so it needs an explicit guardrail rather than sizing that spike as normal demand.

The 6 GiB OpenSearch request fits within each approximately 16 GiB worker described for this cluster. The preferred anti-affinity encourages the two memory-heavy pods onto separate workers while still allowing co-location if current scheduler capacity requires it.

## Rendered result

- OpenSearch `OPENSEARCH_JAVA_OPTS`: `-Xms3g -Xmx3g`, defined once
- OpenSearch requests: `cpu: 1000m`, `memory: 6Gi`
- OpenSearch limits: `memory: 6Gi`
- Jaeger requests: `memory: 1Gi`
- Jaeger limits: `memory: 3Gi`
- Jaeger pod anti-affinity: `preferredDuringSchedulingIgnoredDuringExecution`, weight 100, hostname topology, matching the OpenSearch release labels in the `opensearch` namespace

## Rollout and rollback

Roll out the OpenSearch release first, then confirm the StatefulSet is ready and circuit-breaker rejections have stopped before rolling out Jaeger. Updating OpenSearch restarts its only StatefulSet pod, so storage-backed Jaeger reads and writes will be unavailable until that pod rejoins with its existing PVC. Updating the single Jaeger all-in-one Deployment also restarts its pod and may briefly interrupt collection and query traffic.

If either change cannot schedule or stabilize, inspect `helm history` and roll back only that release with `helm rollback opensearch <revision> -n opensearch` or `helm rollback jaeger <revision> -n jaeger`. The rollback does not delete the OpenSearch PVC, though reverting OpenSearch also restores the undersized 1 GiB heap.

No live-cluster commands or deployments are part of this PR.

## Validation

- OpenSearch chart `opensearch-2.19.0` (`0e215f05e587cf2b20a9dce6bbb23fe99037f310`): `helm lint` and `helm template` passed; rendered JVM and resource assertions passed
- Jaeger Helm v2 (`28017780d96bd42f371bef635e2d4bbf938170e7`, chart 4.0.0): `helm lint` and `helm template` passed; rendered resource and anti-affinity assertions passed
- `make fmt` passed
- `make lint` passed
- `git diff --check upstream/main...HEAD` passed
- `make test` ran 4,178 tests with 38 skipped; it failed only in untouched `internal/storage/v2/grpc` because gRPC cleanup goroutines outlived the goleak timeout on macOS. The failure reproduces on unchanged `main`; the [Linux unit-test job at the same base commit](https://github.com/jaegertracing/jaeger/actions/runs/30951527417/job/92134536160) passed.

## Deliberately unchanged

- OpenSearch and Jaeger versions
- OpenSearch replica count, discovery, cluster-manager, storage, and shard allocation
- circuit-breaker settings
- load generators, trace generators, batching, and exporters
- index retention, ISM, and existing data

The demo currently uses daily indices with one shard and zero replicas but has no declarative retention/ISM policy. A bounded retention policy should be proposed separately with an explicit retention window and snapshot/restore validation; this PR does not introduce automatic deletion.
