### PR TITLE
docs(jaegerquery): Correct the skills README on how skills are selected

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/README.md
@@ -37,10 +37,11 @@ custom/your-skill/SKILL.md     # your skill      , mounts <skills_dir>/your-skil
 ```
 
 `<skills_dir>/SKILL.md` is required: an agent reads it first, and without it
-nothing below is reachable. It is an ordinary skill — if your instructions are
-short it can be all you write. Anything longer belongs in a sub-skill, one
-directory per skill, that the entry point links to and the agent opens only when
-the description matches the task at hand.
+nothing below is reachable. It is also your index. An agent chooses what to read
+next from the links it finds there and from nothing else, so the line you write
+beside each link is what decides whether that skill is ever opened. If your
+instructions are short, the entry point can be all you write. Anything longer
+belongs in a file of its own that the index links to.
 
 Write those links relative to the **skills root**, not to the linking file's own
 directory — an agent passes the link text straight back to `read_skill`:
@@ -49,15 +50,15 @@ directory — an agent passes the link text straight back to `read_skill`:
 - [your-skill](custom/your-skill/SKILL.md) — one line on when to use it.
 ```
 
-Every `SKILL.md` opens with YAML frontmatter following the
-[agent skills specification](https://agentskills.io/specification):
+A link may point at any file, under any name; `SKILL.md` is required only at the
+root. The names above are a convention, not a rule.
+
+A skill is markdown. Jaeger serves it as-is and parses nothing inside it:
 
 ```markdown
 ---
 name: your-skill
-description: >-
-  When to use this skill. Agents read this to decide whether to open the
-  skill at all, so say when it applies, not just what it does.
+description: One line on what this skill does.
 ---
 
 # Your Skill
@@ -68,6 +69,13 @@ description: >-
 ## Procedure
 1. ...
 ```
+
+Frontmatter like the block above is optional. It travels well — both the
+[Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing)
+and the [agent skills specification](https://agentskills.io/specification) use
+one, so a skill written for either stays readable here — but Jaeger reads no
+field of it, and a `description` there is no substitute for the line beside the
+link in your index.
 
 A `skills_dir` that cannot be opened, or whose `SKILL.md` cannot be read, is
 broken configuration, and Jaeger refuses to start rather than quietly serving an


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #8440. Follow-up to #9195, documentation only.

The skills README makes two claims about how skills get chosen that the code does
not implement, as @yurishkuro pointed out in
https://github.com/jaegertracing/jaeger/pull/9195#discussion_r3713560863:

- "Every `SKILL.md` opens with YAML frontmatter following the agent skills
  specification" — nothing in the read path parses frontmatter.
- of the frontmatter `description`, "Agents read this to decide whether to open the
  skill at all" — an agent selects from the links in the root index and nothing else.

An operator following this guidance spends their effort on a field that has no
reader, and writes a thin line in the index — the one thing that does decide whether
their skill is opened. If the skill then goes unused, the README points them at the
frontmatter to debug, which will never be the cause.

## Description of the changes
- Names the entry point as what it is: the index. The line beside each link is what
  decides whether that skill is ever read.
- Frontmatter is described as optional and portable — the
  [Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing)
  and [agent skills](https://agentskills.io/specification) both use one, so skills
  written for either stay readable here — rather than required and enforced.
- States that a link may point at any file under any name; `SKILL.md` is required
  only at the root.

No code changes. The `ai` config example is untouched, so this does not overlap #9194.

## How was this change tested?
- `make fmt` and `make lint` clean. Markdown only, no code paths affected.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
