### PR TITLE
fix: reject inverted/zero time range in apiv2 gRPC GetDependencies

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler.go
@@ -234,6 +234,9 @@ func (g *GRPCHandler) GetDependencies(ctx context.Context, r *api_v2.GetDependen
 	if startTime.IsZero() || endTime.IsZero() {
 		return nil, status.Errorf(codes.InvalidArgument, "StartTime and EndTime must be initialized.")
 	}
+	if !endTime.After(startTime) {
+		return nil, status.Errorf(codes.InvalidArgument, "end_time must be after start_time")
+	}
 
 	dependencies, err := g.queryService.GetDependencies(ctx, endTime, endTime.Sub(startTime))
 	if err != nil {


### PR DESCRIPTION
## What

Add time range validation to the apiv2 gRPC GetDependencies handler to reject inverted/zero time ranges (end_time <= start_time).

## Why

The apiv2 GetDependencies handler never validates that end_time is after start_time. When a client sends end_time <= start_time:
- `endTime.Sub(startTime)` produces a negative or zero lookback
- The invalid window reaches the storage layer
- In-memory store returns misleading Internal error (code 13)
- ES/OpenSearch silently returns empty 200 OK — operators may mistake "no dependencies" for "no traffic"

The apiv3 handler already has this guard; this fix makes apiv2 consistent with apiv3.

## Fix

Add the same validation already present in the apiv3 handler (`internal/apiv3/grpc_handler.go:198-200`) before computing the lookback duration.

Fixes #9237

## Testing

- [x] Validates that the existing zero-check still passes
- [x] Validates that end_time > start_time passes through
- [x] Validates that end_time <= start_time returns InvalidArgument
- [x] All existing tests continue to pass (no behavior change for valid inputs)