### PR TITLE
fix(query): Reject inverted/zero time range in apiv2 GetDependencies

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler.go
@@ -234,6 +234,9 @@ func (g *GRPCHandler) GetDependencies(ctx context.Context, r *api_v2.GetDependen
 	if startTime.IsZero() || endTime.IsZero() {
 		return nil, status.Errorf(codes.InvalidArgument, "StartTime and EndTime must be initialized.")
 	}
+	if !endTime.After(startTime) {
+		return nil, status.Errorf(codes.InvalidArgument, "end_time must be after start_time")
+	}
 
 	dependencies, err := g.queryService.GetDependencies(ctx, endTime, endTime.Sub(startTime))
 	if err != nil {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/grpc_handler_test.go
@@ -619,6 +619,31 @@ func TestGetDependenciesFailureUninitializedTimeGRPC(t *testing.T) {
 	}
 }
 
+func TestGetDependenciesFailureInvertedTimeRangeGRPC(t *testing.T) {
+	now := time.Now().UTC()
+	timeInputs := []struct {
+		name      string
+		startTime time.Time
+		endTime   time.Time
+	}{
+		{"end before start", now, now.Add(-time.Hour)},
+		{"end equal to start", now, now},
+	}
+
+	for _, input := range timeInputs {
+		t.Run(input.name, func(t *testing.T) {
+			withServerAndClient(t, func(_ *grpcServer, client *grpcClient) {
+				_, err := client.GetDependencies(context.Background(), &api_v2.GetDependenciesRequest{
+					StartTime: input.startTime,
+					EndTime:   input.endTime,
+				})
+
+				assertGRPCError(t, err, codes.InvalidArgument, "end_time must be after start_time")
+			})
+		})
+	}
+}
+
 // test from GRPCHandler and not grpcClient as Generated Go client panics with `nil` request
 func TestGetDependenciesNilRequestOnHandlerGRPC(t *testing.T) {
 	grpcHandler := &GRPCHandler{}


### PR DESCRIPTION
## Summary
- The apiv2 gRPC `GetDependencies` handler never validated that `end_time` is strictly after `start_time`, so an inverted or zero-length range reached the storage layer.
- Depending on the backend this produced either a misleading `Internal` error (in-memory) or a silent, empty 200 response (ES/OpenSearch) instead of a clear `InvalidArgument`.
- Added the same guard already present in the apiv3 handler (`!endTime.After(startTime)` → `codes.InvalidArgument`) so both API versions agree, rejecting the request before computing the lookback duration.

Fixes #9237

## Test plan
- [x] Added `TestGetDependenciesFailureInvertedTimeRangeGRPC` covering `end_time < start_time` and `end_time == start_time`, asserting `codes.InvalidArgument`.
- [x] `make fmt`
- [x] `make lint` (0 issues)
- [x] `make test` (all tests pass)
- [x] 100% patch coverage on the changed handler function

🤖 Generated with [Claude Code](https://claude.com/claude-code)