### PR TITLE
fix(examples): Pin the OTel Demo chart

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -35,12 +35,13 @@ on:
           - otel
           - all
       otel_deploy_scope:
-        description: 'OTel demo deploy scope. Use all to refresh OpenSearch and the OTel app.'
+        description: 'OTel demo deploy scope. Use otel-demo for an app-only upgrade or all to refresh the full stack.'
         required: false
         default: jaeger
         type: choice
         options:
           - jaeger
+          - otel-demo
           - all
 
 permissions: read-all
@@ -82,6 +83,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     - name: Resolve and verify snapshot image tags
+      if: env.JAEGER_DEMO_STACK != 'otel' || env.JAEGER_OTEL_DEMO_DEPLOY_SCOPE != 'otel-demo' || env.JAEGER_DEMO_DEPLOY_MODE == 'clean'
       run: bash scripts/utils/resolve-demo-snapshot-tags.sh
 
     - name: Deploy using appropriate script

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -17,45 +17,43 @@ IMAGE_PULL_POLICY="${JAEGER_DEMO_IMAGE_PULL_POLICY:-IfNotPresent}"
 PUBLIC_JAEGER_URL="${JAEGER_DEMO_PUBLIC_JAEGER_URL:-${JAEGER_OTEL_DEMO_JAEGER_URL:-https://jaeger.demo.jaegertracing.io}}"
 RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
 DEPLOY_SCOPE="${JAEGER_OTEL_DEMO_DEPLOY_SCOPE:-jaeger}"
-
-case "$MODE" in
-  upgrade|clean)
-    echo " Running in '$MODE' mode..."
-    ;;
-  *)
-    echo "Error: Invalid mode '$MODE'"
-    echo "Usage: $0 [upgrade|clean] [image-tag]"
-    echo ""
-    echo "Modes:"
-    echo "  upgrade  - Upgrade existing deployment or install if not present (default)"
-    echo "  clean    - Clean install (removes existing deployment first)"
-    echo ""
-    echo "Examples:"
-    echo "  $0                    # Upgrade mode with latest tag"
-    echo "  $0 clean              # Clean install"
-    exit 1
-    ;;
- esac
-
-case "$DEPLOY_SCOPE" in
-  jaeger|all)
-    ;;
-  *)
-    echo "Error: Invalid deploy scope '$DEPLOY_SCOPE'"
-    echo "Expected JAEGER_OTEL_DEMO_DEPLOY_SCOPE to be 'jaeger' or 'all'"
-    exit 1
-    ;;
-esac
-
-if [[ "$MODE" == "upgrade" ]]; then
-  HELM_JAEGER_CMD="upgrade --install --wait --atomic"
-else
-  # For clean mode, use install after cleanup
-  HELM_JAEGER_CMD="install --wait"
-fi
+# renovate: datasource=helm depName=opentelemetry-demo registryUrl=https://open-telemetry.github.io/opentelemetry-helm-charts
+OTEL_DEMO_CHART_VERSION="0.40.9"
 
 log() { echo "[$(date +"%F %T")] $*"; }
 err() { echo "[$(date +"%F %T")] ERROR: $*" >&2; exit 1; }
+
+validate_options() {
+  case "$MODE" in
+    upgrade|clean)
+      ;;
+    *)
+      echo "Error: Invalid mode '$MODE'" >&2
+      echo "Usage: $0 [upgrade|clean] [image-tag]" >&2
+      echo "Expected mode to be 'upgrade' or 'clean'" >&2
+      return 1
+      ;;
+  esac
+
+  case "$DEPLOY_SCOPE" in
+    jaeger|otel-demo|all)
+      ;;
+    *)
+      echo "Error: Invalid deploy scope '$DEPLOY_SCOPE'" >&2
+      echo "Expected JAEGER_OTEL_DEMO_DEPLOY_SCOPE to be 'jaeger', 'otel-demo', or 'all'" >&2
+      return 1
+      ;;
+  esac
+}
+
+configure_jaeger_helm_command() {
+  if [[ "$MODE" == "upgrade" ]]; then
+    HELM_JAEGER_CMD="upgrade --install --wait --atomic"
+  else
+    # For clean mode, use install after cleanup.
+    HELM_JAEGER_CMD="install --wait"
+  fi
+}
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -123,8 +121,24 @@ diagnose_deployment_failure() {
   kubectl -n "$namespace" get events --sort-by=.lastTimestamp | tail -80 || true
 }
 
+collect_otel_collector_logs() {
+  local pod
+
+  while IFS= read -r pod; do
+    [[ -n "$pod" ]] || continue
+    log "Collecting current logs for otel-demo/$pod"
+    kubectl -n otel-demo logs "$pod" --all-containers --tail=300 --prefix || true
+    log "Collecting previous logs for otel-demo/$pod"
+    kubectl -n otel-demo logs "$pod" --all-containers --previous --tail=300 --prefix || true
+  done < <(kubectl -n otel-demo get pods \
+    -l app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/instance=otel-demo \
+    -o name 2>/dev/null || true)
+}
+
 diagnose_otel_demo_failure() {
   log "Collecting diagnostics for namespace otel-demo"
+  helm status otel-demo -n otel-demo || true
+  helm history otel-demo -n otel-demo || true
   kubectl -n otel-demo get deploy,daemonset,replicaset,pods,svc,endpoints -o wide || true
   kubectl -n otel-demo describe svc otel-collector || true
   kubectl -n otel-demo get endpoints otel-collector -o yaml || true
@@ -134,7 +148,7 @@ diagnose_otel_demo_failure() {
   kubectl -n otel-demo describe deployment load-generator || true
   kubectl -n otel-demo describe deployment postgresql || true
   kubectl -n otel-demo describe deployment product-catalog || true
-  kubectl -n otel-demo logs -l app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/instance=otel-demo --all-containers --tail=300 --prefix || true
+  collect_otel_collector_logs
   kubectl -n otel-demo logs -l opentelemetry.io/name=frontend --all-containers --tail=200 --prefix || true
   kubectl -n otel-demo logs -l opentelemetry.io/name=frontend-proxy --all-containers --tail=200 --prefix || true
   kubectl -n otel-demo logs -l opentelemetry.io/name=load-generator --all-containers --tail=200 --prefix || true
@@ -244,6 +258,18 @@ smoke_expect() {
 
 deploy_full_stack() {
   [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" == "all" ]]
+}
+
+deploy_jaeger_stack() {
+  [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" == "jaeger" || "$DEPLOY_SCOPE" == "all" ]]
+}
+
+deploy_otel_demo() {
+  [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" == "otel-demo" || "$DEPLOY_SCOPE" == "all" ]]
+}
+
+reconcile_ingress() {
+  [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" != "otel-demo" ]]
 }
 
 cleanup() {
@@ -368,6 +394,9 @@ clone_jaeger_v2() {
 
 
 main() {
+  validate_options || exit 1
+  configure_jaeger_helm_command
+  echo " Running in '$MODE' mode..."
   log "Starting CI deploy (weekly refresh)"
   need bash
   need git
@@ -387,7 +416,11 @@ main() {
   helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts >/dev/null 2>&1 || true
   helm repo add jaegertracing https://jaegertracing.github.io/helm-charts >/dev/null 2>&1 || true
   helm repo update >/dev/null
-  clone_jaeger_v2
+  if deploy_jaeger_stack; then
+    clone_jaeger_v2
+  else
+    log "Skipping Jaeger Helm chart preparation in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
+  fi
 
   if deploy_full_stack; then
     log "Deploying OpenSearch"
@@ -409,55 +442,62 @@ main() {
     log "Skipping OpenSearch refresh in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
   fi
 
-  if [[ "$MODE" == "upgrade" ]]; then
-    adopt_resource_for_helm_release jaeger serviceaccount jaeger-hotrod jaeger
-    adopt_resource_for_helm_release jaeger service jaeger-hotrod jaeger
-    delete_deployment_before_helm_upgrade jaeger jaeger-hotrod
+  if deploy_jaeger_stack; then
+    if [[ "$MODE" == "upgrade" ]]; then
+      adopt_resource_for_helm_release jaeger serviceaccount jaeger-hotrod jaeger
+      adopt_resource_for_helm_release jaeger service jaeger-hotrod jaeger
+      delete_deployment_before_helm_upgrade jaeger jaeger-hotrod
+    fi
+
+    log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"
+    log "Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${HOTROD_IMAGE_TAG}"
+    if ! helm $HELM_JAEGER_CMD jaeger "$SCRIPT_DIR/helm-charts/charts/jaeger" \
+      --namespace jaeger --create-namespace \
+      --set allInOne.enabled=true \
+      --set storage.type=elasticsearch \
+      --set storage.elasticsearch.anonymous=true \
+      --set storage.elasticsearch.usePassword=false \
+      --set storage.elasticsearch.host=opensearch-cluster-single.opensearch.svc.cluster.local \
+      --set storage.elasticsearch.port=9200 \
+      --set allInOne.image.repository="${JAEGER_IMAGE_REPOSITORY}" \
+      --set allInOne.image.tag="${JAEGER_IMAGE_TAG}" \
+      --set allInOne.image.pullPolicy="${IMAGE_PULL_POLICY}" \
+      --set hotrod.image.repository="${HOTROD_IMAGE_REPOSITORY}" \
+      --set hotrod.image.tag="${HOTROD_IMAGE_TAG}" \
+      --set hotrod.image.pullPolicy="${IMAGE_PULL_POLICY}" \
+      --set-file userconfig="$SCRIPT_DIR/jaeger-config.yaml" \
+      -f "$SCRIPT_DIR/jaeger-values.yaml" \
+      --timeout 10m; then
+      diagnose_deployment_failure jaeger jaeger
+      err "Helm release jaeger failed"
+    fi
+    wait_for_deployment jaeger jaeger "${ROLLOUT_TIMEOUT}s"
+
+    log "Creating Jaeger query ClusterIP service..."
+    kubectl apply -n jaeger -f "$SCRIPT_DIR/jaeger-query-service.yaml"
+    log "Jaeger query ClusterIP service created"
+
+    log "Ensuring Jaeger Collector service endpoints are ready"
+    wait_for_service_endpoints jaeger jaeger-collector 180
+
+    log "Ensuring HotROD service endpoints are ready"
+    wait_for_service_endpoints jaeger jaeger-hotrod 180
+
+    log "Deploying HotROD trace generator"
+    kubectl -n jaeger create configmap trace-script --from-file="$SCRIPT_DIR/generate_traces.py" --dry-run=client -o yaml | kubectl apply -f -
+    kubectl apply -n jaeger -f "$SCRIPT_DIR/load-generator.yaml"
+    wait_for_deployment jaeger trace-generator "${ROLLOUT_TIMEOUT}s"
+  else
+    log "Skipping Jaeger, HotROD, and trace generator refresh in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
   fi
 
-  log "Deploying Jaeger image ${JAEGER_IMAGE_REPOSITORY}:${JAEGER_IMAGE_TAG}"
-  log "Deploying HotROD image ${HOTROD_IMAGE_REPOSITORY}:${HOTROD_IMAGE_TAG}"
-  if ! helm $HELM_JAEGER_CMD jaeger "$SCRIPT_DIR/helm-charts/charts/jaeger" \
-    --namespace jaeger --create-namespace \
-    --set allInOne.enabled=true \
-    --set storage.type=elasticsearch \
-    --set storage.elasticsearch.anonymous=true \
-    --set storage.elasticsearch.usePassword=false \
-    --set storage.elasticsearch.host=opensearch-cluster-single.opensearch.svc.cluster.local \
-    --set storage.elasticsearch.port=9200 \
-    --set allInOne.image.repository="${JAEGER_IMAGE_REPOSITORY}" \
-    --set allInOne.image.tag="${JAEGER_IMAGE_TAG}" \
-    --set allInOne.image.pullPolicy="${IMAGE_PULL_POLICY}" \
-    --set hotrod.image.repository="${HOTROD_IMAGE_REPOSITORY}" \
-    --set hotrod.image.tag="${HOTROD_IMAGE_TAG}" \
-    --set hotrod.image.pullPolicy="${IMAGE_PULL_POLICY}" \
-    --set-file userconfig="$SCRIPT_DIR/jaeger-config.yaml" \
-    -f "$SCRIPT_DIR/jaeger-values.yaml" \
-    --timeout 10m; then
-    diagnose_deployment_failure jaeger jaeger
-    err "Helm release jaeger failed"
-  fi
-  wait_for_deployment jaeger jaeger "${ROLLOUT_TIMEOUT}s"
+  if deploy_otel_demo; then
+    log "Ensuring Jaeger Collector service endpoints are ready before deploying the demo"
+    wait_for_service_endpoints jaeger jaeger-collector 180
 
-
-  log "Creating Jaeger query ClusterIP service..."
-  kubectl apply -n jaeger -f "$SCRIPT_DIR/jaeger-query-service.yaml"
-  log "Jaeger query ClusterIP service created"
-
-  log "Ensuring Jaeger Collector service endpoints are ready before deploying the demo"
-  wait_for_service_endpoints jaeger jaeger-collector 180
-
-  log "Ensuring HotROD service endpoints are ready"
-  wait_for_service_endpoints jaeger jaeger-hotrod 180
-
-  log "Deploying HotROD trace generator"
-  kubectl -n jaeger create configmap trace-script --from-file="$SCRIPT_DIR/generate_traces.py" --dry-run=client -o yaml | kubectl apply -f -
-  kubectl apply -n jaeger -f "$SCRIPT_DIR/load-generator.yaml"
-  wait_for_deployment jaeger trace-generator "${ROLLOUT_TIMEOUT}s"
-
-  if deploy_full_stack; then
-    log "Deploying OpenTelemetry Demo (with in-cluster Collector)"
+    log "Deploying OpenTelemetry Demo chart $OTEL_DEMO_CHART_VERSION (with in-cluster Collector)"
     if ! helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
+      --version "$OTEL_DEMO_CHART_VERSION" \
       -f "$SCRIPT_DIR/otel-demo-values.yaml" \
       --namespace otel-demo --create-namespace \
       --wait --timeout 15m; then
@@ -474,7 +514,11 @@ main() {
   log "All components deployed successfully"
 
   # Deploy HTTPS ingress
-  deploy_ingress
+  if reconcile_ingress; then
+    deploy_ingress
+  else
+    log "Skipping ingress reconciliation in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
+  fi
 
   if [[ "$RUN_PUBLIC_SMOKE_TESTS" == "true" ]]; then
     log "Verifying public OTel demo endpoints..."
@@ -492,4 +536,6 @@ main() {
 
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/examples/otel-demo/deploy-all.test.sh
+++ b/examples/otel-demo/deploy-all.test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/deploy-all.sh"
+
+run_route() {
+  local mode=$1
+  local scope=$2
+  local predicate=$3
+
+  bash -c 'source "$1"; MODE="$2"; DEPLOY_SCOPE="$3"; "$4"' \
+    _ "$SCRIPT" "$mode" "$scope" "$predicate"
+}
+
+assertRouteEnabled() {
+  local mode=$1
+  local scope=$2
+  local predicate=$3
+
+  run_route "$mode" "$scope" "$predicate" >/dev/null 2>&1
+  assertEquals "$mode/$scope should enable $predicate" 0 $?
+}
+
+assertRouteDisabled() {
+  local mode=$1
+  local scope=$2
+  local predicate=$3
+
+  run_route "$mode" "$scope" "$predicate" >/dev/null 2>&1
+  assertEquals "$mode/$scope should disable $predicate" 1 $?
+}
+
+testJaegerUpgradeRouting() {
+  assertRouteDisabled upgrade jaeger deploy_full_stack
+  assertRouteEnabled upgrade jaeger deploy_jaeger_stack
+  assertRouteDisabled upgrade jaeger deploy_otel_demo
+  assertRouteEnabled upgrade jaeger reconcile_ingress
+}
+
+testOtelDemoOnlyUpgradeRouting() {
+  assertRouteDisabled upgrade otel-demo deploy_full_stack
+  assertRouteDisabled upgrade otel-demo deploy_jaeger_stack
+  assertRouteEnabled upgrade otel-demo deploy_otel_demo
+  assertRouteDisabled upgrade otel-demo reconcile_ingress
+}
+
+testAllUpgradeRouting() {
+  assertRouteEnabled upgrade all deploy_full_stack
+  assertRouteEnabled upgrade all deploy_jaeger_stack
+  assertRouteEnabled upgrade all deploy_otel_demo
+  assertRouteEnabled upgrade all reconcile_ingress
+}
+
+testCleanAlwaysUsesFullStackRouting() {
+  assertRouteEnabled clean otel-demo deploy_full_stack
+  assertRouteEnabled clean otel-demo deploy_jaeger_stack
+  assertRouteEnabled clean otel-demo deploy_otel_demo
+  assertRouteEnabled clean otel-demo reconcile_ingress
+}
+
+testInvalidScopeIsRejected() {
+  output=$(bash -c 'source "$1"; MODE=upgrade; DEPLOY_SCOPE=invalid; validate_options' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertEquals "invalid scope should fail" 1 $rc
+  assertContains "$output" "Invalid deploy scope 'invalid'"
+}
+
+testInvalidModeIsRejected() {
+  output=$(bash -c 'source "$1"; MODE=invalid; DEPLOY_SCOPE=jaeger; validate_options' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertEquals "invalid mode should fail" 1 $rc
+  assertContains "$output" "Invalid mode 'invalid'"
+}
+
+testMainIsGuardedWhenSourced() {
+  output=$(bash -c 'source "$1"; printf sourced-only' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertEquals "source should succeed without running main" 0 $rc
+  assertEquals "sourced-only" "$output"
+}
+
+testPinsCompatibleOtelDemoChart() {
+  output=$(bash -c 'source "$1"; printf "%s" "$OTEL_DEMO_CHART_VERSION"' _ "$SCRIPT")
+  assertEquals "0.40.9" "$output"
+}
+
+# shellcheck disable=SC1091
+source "${SHUNIT2}/shunit2"

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 The Jaeger Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-# official schema for otel demo is at https://raw.githubusercontent.com/open-telemetry/opentelemetry-helm-charts/main/charts/opentelemetry-demo/values.yaml
+# Official values for the pinned chart are at https://raw.githubusercontent.com/open-telemetry/opentelemetry-helm-charts/opentelemetry-demo-0.40.9/charts/opentelemetry-demo/values.yaml
 
 # Keep bundled infra disabled (we deploy Jaeger/OpenSearch separately)
 jaeger:

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,29 @@
       "on the first day of the month"
     ]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update annotated Helm chart version variables in shell scripts",
+      "managerFilePatterns": [
+        "/\\.sh$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>helm) depName=(?<depName>\\S+) registryUrl=(?<registryUrl>\\S+)\\s+[A-Z][A-Z0-9_]*_CHART_VERSION=\"(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
   "packageRules": [
+    {
+      "description": "Require review for OTel Demo Helm chart upgrades",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "opentelemetry-demo"
+      ],
+      "automerge": false
+    },
     {
       "description": "CI Python deps are hash-pinned in .github/requirements/*requirements.txt for OpenSSF Scorecard. Renovate bumps the version but NOT the --hash line, so the bump PR will fail --require-hashes until the hash is regenerated (see the comment in the requirements file). Label these so they are easy to spot and complete.",
       "matchManagers": [

--- a/scripts/utils/run-tests.sh
+++ b/scripts/utils/run-tests.sh
@@ -12,6 +12,7 @@ TEST_FILES=(
     "$UTILS_DIR/compute-tags.test.sh"
     "$UTILS_DIR/retry.test.sh"
     "$UTILS_DIR/resolve-demo-snapshot-tags.test.sh"
+    "$REPO_ROOT/examples/otel-demo/deploy-all.test.sh"
     "$REPO_ROOT/internal/storage/v1/cassandra/schema/create.test.sh"
 )
 


### PR DESCRIPTION
Fixes #9242

## Why

The OTel Demo deployment was not pinning its Helm chart, so `helm repo update` could select a schema-incompatible release without any repository change. The live recovery attempt selected `0.41.0`, which rejected the committed `0.40.9` values before changing the release.

## What changed

- pin the OTel Demo chart to the known-compatible `0.40.9` release;
- expose an `otel-demo` upgrade scope that verifies the existing Jaeger collector endpoint and upgrades only the OTel Demo release;
- skip OpenSearch, Dashboards, Jaeger, HotROD, the standalone generator, ingress reconciliation, and snapshot-image resolution for that isolated scope;
- preserve the existing `jaeger`, `all`, and full-stack `clean` behavior;
- collect Helm state plus current and previous logs from every OTel collector pod on failure;
- track the chart pin with Renovate while explicitly disabling auto-merge; and
- add shunit2 coverage for the routing matrix and version pin.

## Validation

- `make fmt`
- `make lint`
- `bash -n examples/otel-demo/deploy-all.sh examples/otel-demo/deploy-all.test.sh scripts/utils/run-tests.sh`
- focused shunit2 suite: 8/8 passed
- Helm `lint` and `template` against exact chart `0.40.9`
- rendered chart version, PostgreSQL `17.6`, and the existing PostgreSQL URL asserted
- `renovate-config-validator renovate.json`
- `git diff --check`

`make test` ran 4,180 tests and failed only the known macOS `internal/storage/v2/grpc` goleak around a gRPC dial. The exact package failure reproduces on unchanged upstream `main` at `3adad6e6`.

The full shunit2 runner reaches and passes the new suite. Its pre-existing `compute-tags.test.sh` fails on macOS because BSD `grep` does not support shunit2's `grep -P` assertion implementation.

## Rollout

This PR does not deploy anything. After merge and separate approval, recovery is a manual workflow dispatch with `demo_stack=otel`, `deploy_mode=upgrade`, and `otel_deploy_scope=otel-demo`. Do not use `clean`.

The pre-existing one-node collector CrashLoop remains separately tracked in #9243 and must be diagnosed from evidence before any collector-specific remediation.
