### PR TITLE
fix(examples): Upgrade OTel demo OpenSearch

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -35,13 +35,14 @@ on:
           - otel
           - all
       otel_deploy_scope:
-        description: 'OTel demo deploy scope. Use otel-demo for an app-only upgrade or all to refresh the full stack.'
+        description: 'OTel demo deploy scope. Use otel-demo or opensearch for an isolated upgrade, or all for the full stack.'
         required: false
         default: jaeger
         type: choice
         options:
           - jaeger
           - otel-demo
+          - opensearch
           - all
 
 permissions: read-all
@@ -83,7 +84,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     - name: Resolve and verify snapshot image tags
-      if: env.JAEGER_DEMO_STACK != 'otel' || env.JAEGER_OTEL_DEMO_DEPLOY_SCOPE != 'otel-demo' || env.JAEGER_DEMO_DEPLOY_MODE == 'clean'
+      if: env.JAEGER_DEMO_STACK != 'otel' || (env.JAEGER_OTEL_DEMO_DEPLOY_SCOPE != 'otel-demo' && env.JAEGER_OTEL_DEMO_DEPLOY_SCOPE != 'opensearch') || env.JAEGER_DEMO_DEPLOY_MODE == 'clean'
       run: bash scripts/utils/resolve-demo-snapshot-tags.sh
 
     - name: Deploy using appropriate script

--- a/docker-compose/opensearch/v2/docker-compose.yml
+++ b/docker-compose/opensearch/v2/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.0@sha256:1f8b88245a6af61e7aa500afe0e87d43401e4b33140bb47230a919428ce3f7cb
+    image: opensearchproject/opensearch:2.19.6@sha256:8690b204fe914c60ca76d451ac73bc0481e034d32d3779944c8caca56a2b003f
     environment:
       - discovery.type=single-node
       - cluster.routing.allocation.disk.threshold_enabled=false

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -19,6 +19,10 @@ RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
 DEPLOY_SCOPE="${JAEGER_OTEL_DEMO_DEPLOY_SCOPE:-jaeger}"
 # renovate: datasource=helm depName=opentelemetry-demo registryUrl=https://open-telemetry.github.io/opentelemetry-helm-charts
 OTEL_DEMO_CHART_VERSION="0.40.9"
+# renovate: datasource=helm depName=opensearch registryUrl=https://opensearch-project.github.io/helm-charts
+OPENSEARCH_CHART_VERSION="2.38.0"
+# renovate: datasource=helm depName=opensearch-dashboards registryUrl=https://opensearch-project.github.io/helm-charts
+OPENSEARCH_DASHBOARDS_CHART_VERSION="2.34.0"
 
 log() { echo "[$(date +"%F %T")] $*"; }
 err() { echo "[$(date +"%F %T")] ERROR: $*" >&2; exit 1; }
@@ -36,11 +40,11 @@ validate_options() {
   esac
 
   case "$DEPLOY_SCOPE" in
-    jaeger|otel-demo|all)
+    jaeger|otel-demo|opensearch|all)
       ;;
     *)
       echo "Error: Invalid deploy scope '$DEPLOY_SCOPE'" >&2
-      echo "Expected JAEGER_OTEL_DEMO_DEPLOY_SCOPE to be 'jaeger', 'otel-demo', or 'all'" >&2
+      echo "Expected JAEGER_OTEL_DEMO_DEPLOY_SCOPE to be 'jaeger', 'otel-demo', 'opensearch', or 'all'" >&2
       return 1
       ;;
   esac
@@ -260,6 +264,10 @@ deploy_full_stack() {
   [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" == "all" ]]
 }
 
+deploy_opensearch_stack() {
+  deploy_full_stack || [[ "$DEPLOY_SCOPE" == "opensearch" ]]
+}
+
 deploy_jaeger_stack() {
   [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" == "jaeger" || "$DEPLOY_SCOPE" == "all" ]]
 }
@@ -269,7 +277,25 @@ deploy_otel_demo() {
 }
 
 reconcile_ingress() {
-  [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" != "otel-demo" ]]
+  [[ "$MODE" == "clean" || "$DEPLOY_SCOPE" == "jaeger" || "$DEPLOY_SCOPE" == "all" ]]
+}
+
+deploy_opensearch_releases() {
+  log "Deploying OpenSearch chart $OPENSEARCH_CHART_VERSION"
+  helm upgrade --install opensearch opensearch/opensearch \
+    --namespace opensearch --create-namespace \
+    --version "$OPENSEARCH_CHART_VERSION" \
+    -f "$SCRIPT_DIR/opensearch-values.yaml" \
+    --wait --timeout 10m
+  wait_for_statefulset opensearch opensearch-cluster-single "${ROLLOUT_TIMEOUT}s"
+
+  log "Deploying OpenSearch Dashboards chart $OPENSEARCH_DASHBOARDS_CHART_VERSION"
+  helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards \
+    --namespace opensearch \
+    --version "$OPENSEARCH_DASHBOARDS_CHART_VERSION" \
+    -f "$SCRIPT_DIR/opensearch-dashboard-values.yaml" \
+    --wait --timeout 10m
+  wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
 }
 
 cleanup() {
@@ -422,22 +448,8 @@ main() {
     log "Skipping Jaeger Helm chart preparation in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
   fi
 
-  if deploy_full_stack; then
-    log "Deploying OpenSearch"
-    helm upgrade --install opensearch opensearch/opensearch \
-      --namespace opensearch --create-namespace \
-      --version 2.19.0 \
-      --set image.tag=2.11.0 \
-      -f "$SCRIPT_DIR/opensearch-values.yaml" \
-      --wait --timeout 10m
-    wait_for_statefulset opensearch opensearch-cluster-single "${ROLLOUT_TIMEOUT}s"
-
-    log "Deploying OpenSearch Dashboards"
-    helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards \
-      --namespace opensearch \
-      -f "$SCRIPT_DIR/opensearch-dashboard-values.yaml" \
-      --wait --timeout 10m
-    wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
+  if deploy_opensearch_stack; then
+    deploy_opensearch_releases
   else
     log "Skipping OpenSearch refresh in '$MODE' mode with deploy scope '$DEPLOY_SCOPE'"
   fi

--- a/examples/otel-demo/deploy-all.test.sh
+++ b/examples/otel-demo/deploy-all.test.sh
@@ -36,6 +36,7 @@ assertRouteDisabled() {
 
 testJaegerUpgradeRouting() {
   assertRouteDisabled upgrade jaeger deploy_full_stack
+  assertRouteDisabled upgrade jaeger deploy_opensearch_stack
   assertRouteEnabled upgrade jaeger deploy_jaeger_stack
   assertRouteDisabled upgrade jaeger deploy_otel_demo
   assertRouteEnabled upgrade jaeger reconcile_ingress
@@ -43,13 +44,23 @@ testJaegerUpgradeRouting() {
 
 testOtelDemoOnlyUpgradeRouting() {
   assertRouteDisabled upgrade otel-demo deploy_full_stack
+  assertRouteDisabled upgrade otel-demo deploy_opensearch_stack
   assertRouteDisabled upgrade otel-demo deploy_jaeger_stack
   assertRouteEnabled upgrade otel-demo deploy_otel_demo
   assertRouteDisabled upgrade otel-demo reconcile_ingress
 }
 
+testOpenSearchOnlyUpgradeRouting() {
+  assertRouteDisabled upgrade opensearch deploy_full_stack
+  assertRouteEnabled upgrade opensearch deploy_opensearch_stack
+  assertRouteDisabled upgrade opensearch deploy_jaeger_stack
+  assertRouteDisabled upgrade opensearch deploy_otel_demo
+  assertRouteDisabled upgrade opensearch reconcile_ingress
+}
+
 testAllUpgradeRouting() {
   assertRouteEnabled upgrade all deploy_full_stack
+  assertRouteEnabled upgrade all deploy_opensearch_stack
   assertRouteEnabled upgrade all deploy_jaeger_stack
   assertRouteEnabled upgrade all deploy_otel_demo
   assertRouteEnabled upgrade all reconcile_ingress
@@ -57,6 +68,7 @@ testAllUpgradeRouting() {
 
 testCleanAlwaysUsesFullStackRouting() {
   assertRouteEnabled clean otel-demo deploy_full_stack
+  assertRouteEnabled clean otel-demo deploy_opensearch_stack
   assertRouteEnabled clean otel-demo deploy_jaeger_stack
   assertRouteEnabled clean otel-demo deploy_otel_demo
   assertRouteEnabled clean otel-demo reconcile_ingress
@@ -89,6 +101,29 @@ testMainIsGuardedWhenSourced() {
 testPinsCompatibleOtelDemoChart() {
   output=$(bash -c 'source "$1"; printf "%s" "$OTEL_DEMO_CHART_VERSION"' _ "$SCRIPT")
   assertEquals "0.40.9" "$output"
+}
+
+testPinsCompatibleOpenSearchCharts() {
+  output=$(bash -c 'source "$1"; printf "%s|%s" "$OPENSEARCH_CHART_VERSION" "$OPENSEARCH_DASHBOARDS_CHART_VERSION"' _ "$SCRIPT")
+  assertEquals "2.38.0|2.34.0" "$output"
+}
+
+testDeploysPinnedOpenSearchChartsInOrder() {
+  output=$(bash -c '
+    source "$1"
+    log() { :; }
+    helm() { printf "helm"; printf " %s" "$@"; printf "\n"; }
+    wait_for_statefulset() { printf "wait-for-statefulset"; printf " %s" "$@"; printf "\n"; }
+    wait_for_deployment() { printf "wait-for-deployment"; printf " %s" "$@"; printf "\n"; }
+    deploy_opensearch_releases
+  ' _ "$SCRIPT")
+
+  expected="helm upgrade --install opensearch opensearch/opensearch --namespace opensearch --create-namespace --version 2.38.0 -f $(dirname "$SCRIPT")/opensearch-values.yaml --wait --timeout 10m
+wait-for-statefulset opensearch opensearch-cluster-single 600s
+helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards --namespace opensearch --version 2.34.0 -f $(dirname "$SCRIPT")/opensearch-dashboard-values.yaml --wait --timeout 10m"
+  expected="$expected
+wait-for-deployment opensearch opensearch-dashboards 600s"
+  assertEquals "$expected" "$output"
 }
 
 # shellcheck disable=SC1091

--- a/examples/otel-demo/opensearch-dashboard-values.yaml
+++ b/examples/otel-demo/opensearch-dashboard-values.yaml
@@ -4,7 +4,6 @@
 
 image:
   repository: docker.io/opensearchproject/opensearch-dashboards
-  tag: "2.11.0"
 
 opensearchHosts: "http://opensearch-cluster-single:9200"
 
@@ -20,4 +19,3 @@ config:
     opensearch.password: "admin123"
     opensearch.ssl.verificationMode: none
     opensearch_security.enabled: false
-

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,24 @@
       "automerge": false
     },
     {
+      "description": "Keep the OTel demo OpenSearch charts on supported 2.x releases and update them together",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "opensearch",
+        "opensearch-dashboards"
+      ],
+      "groupName": "OTel demo OpenSearch Helm charts",
+      "groupSlug": "otel-demo-opensearch-helm",
+      "minimumGroupSize": 2,
+      "allowedVersions": "/^2\\./",
+      "automerge": false
+    },
+    {
       "description": "CI Python deps are hash-pinned in .github/requirements/*requirements.txt for OpenSSF Scorecard. Renovate bumps the version but NOT the --hash line, so the bump PR will fail --require-hashes until the hash is regenerated (see the comment in the requirements file). Label these so they are easy to spot and complete.",
       "matchManagers": [
         "pip_requirements"


### PR DESCRIPTION
Fixes #9244

#9245 has merged; this PR now contains only the OpenSearch upgrade.

## Why

There is no documented Jaeger/OpenSearch compatibility reason for the demo's `2.11.0` pin. It entered with the original demo in #7516 and remained as shell/YAML image overrides that Renovate could not see. The pinned OpenSearch chart `2.19.0` actually defaults to application `2.13.0`, while the Dashboards chart was unpinned, so the deployment combined chart drift with an image downgrade.

OpenSearch `2.19.6` is the maintained 2.x release and is the required staging line before a later 3.x upgrade. The official upgrade guidance requires at least `2.19.0` before 3.x.

## What changed

- pin OpenSearch chart [`2.38.0`](https://github.com/opensearch-project/helm-charts/releases/tag/opensearch-2.38.0-1) and Dashboards chart [`2.34.0`](https://github.com/opensearch-project/helm-charts/releases/tag/opensearch-dashboards-2.34.0-1), both with `appVersion: 2.19.6`;
- remove both `2.11.0` tag overrides so chart `appVersion` is the single image-tag source;
- add an `opensearch` upgrade scope that changes only OpenSearch, waits for its StatefulSet, and then changes matching Dashboards;
- skip Jaeger, HotROD, generators, the OTel Demo, ingress reconciliation, and snapshot-image resolution for that isolated scope;
- group both Helm chart pins in Renovate, require both packages in a group, constrain automation to 2.x, and disable auto-merge;
- extend shunit2 coverage for `jaeger`, `otel-demo`, `opensearch`, `all`, invalid scope, and full-stack `clean` routing; and
- pin the repository's 2.x direct/E2E fixture to the immutable `2.19.6` multi-arch digest so those CI cells test the exact target rather than `2.19.0`.

The existing one-replica topology, StatefulSet/service/PVC names, `oci-bv` 10Gi volume, `-Xms3g -Xmx3g`, `1000m` CPU request, `6Gi/6Gi` memory, disabled security, and Jaeger `1Gi/3Gi` preferred anti-affinity guardrails are unchanged.

## Validation

- `make fmt`
- `make lint`
- `make test`: 4,180 tests passed, 38 skipped
- `bash -n examples/otel-demo/deploy-all.sh examples/otel-demo/deploy-all.test.sh scripts/utils/run-tests.sh`
- focused shunit2 routing/command suite: 11/11 passed
- Renovate config validator and annotated-variable extraction
- exact Helm lint/template for:
  - OTel Demo chart `0.40.9`
  - OpenSearch chart `2.38.0`
  - Dashboards chart `2.34.0`
  - the Jaeger `v2` chart at commit `28017780d96b`
- rendered assertions for both `2.19.6` images, exactly one 3g JVM option, OpenSearch resources/topology/storage/security, and Jaeger resources/anti-affinity
- parsed old/new StatefulSet comparison: immutable fields unchanged
- `git diff --check`

The direct and E2E OpenSearch jobs require Docker, which is not available in this local workspace. The existing CI matrix will run both modes against the new exact `2.19.6` fixture and the existing exact `3.7.0` fixture; this draft should not be made ready until those cells pass.

Expected chart deltas are limited to labels/checksums/images, a config-copy init-container security context, and a mutable `metrics` port `9600` on the primary Service. Client ports `9200`/`9300`, service names, and immutable StatefulSet fields remain stable.

## Rollout gates

This PR does not deploy anything. A merge also does not deploy the OTel stack.

Before dispatching:

1. run the isolated OTel recovery delivered by #9245;
2. complete the investigation tracked in #9243 and hold the collector DaemonSet at 2/2 ready;
3. capture live `helm history`, `helm get values -a`, and `helm get manifest` for both releases, because the prior Dashboards chart floated;
4. verify node allocatable/request headroom, cluster health, shards, plugins, pending tasks, breaker counters, and the unchanged discovery configuration;
5. require a successful external snapshot and a tested restore; stop if no snapshot repository exists.

After separate approval, dispatch `demo_stack=otel`, `deploy_mode=upgrade`, `otel_deploy_scope=opensearch`. Never use `clean`. The script upgrades OpenSearch first, waits for readiness, then upgrades Dashboards. Expect one OpenSearch pod restart and a temporary single-node query/ingest outage; Jaeger stays running but storage operations can fail during the restart.

Soak `2.19.6` for seven days, including a daily rollover, with no new circuit-breaker trips, 429s, OOMs, or evictions before proposing 3.x.

## Rollback and follow-ups

OpenSearch does not support direct downgrades, so `helm rollback` is not a safe database rollback. Recovery is a fresh installation of the prior version with a fresh/recovered PVC followed by restoration of the verified pre-upgrade snapshot; Dashboards must then match that OpenSearch version. See the [official upgrade guidance](https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/) and [release policy](https://opensearch.org/releases/).

OpenSearch 3.7.0 remains a separate post-soak issue/PR. Retention also remains unchanged: the repository declares daily index layout/rollover settings but no ISM/ILM deletion policy. Any retention policy needs a separate snapshot-tested design issue; this change does not disable generators or delete data.
