### PR TITLE
fix(storage/es): Accept non-string index settings in GetJaegerIndices

### DIFF
--- a/internal/storage/elasticsearch/esclient/index_client.go
+++ b/internal/storage/elasticsearch/esclient/index_client.go
@@ -75,8 +75,8 @@ func (i *IndicesClient) GetJaegerIndices(ctx context.Context, prefix string) ([]
 	}
 
 	type indexInfo struct {
-		Aliases  map[string]any    `json:"aliases"`
-		Settings map[string]string `json:"settings"`
+		Aliases  map[string]any `json:"aliases"`
+		Settings map[string]any `json:"settings"`
 	}
 	var indicesInfo map[string]indexInfo
 	if err = json.Unmarshal(body, &indicesInfo); err != nil {
@@ -90,7 +90,8 @@ func (i *IndicesClient) GetJaegerIndices(ctx context.Context, prefix string) ([]
 			aliases[alias] = true
 		}
 		// ignoring error, ES should return valid date
-		creationDate, _ := strconv.ParseInt(v.Settings["index.creation_date"], 10, 64)
+		creationDateStr, _ := v.Settings["index.creation_date"].(string)
+		creationDate, _ := strconv.ParseInt(creationDateStr, 10, 64)
 
 		indices = append(indices, Index{
 			Index:        k,

--- a/internal/storage/elasticsearch/esclient/index_client.go
+++ b/internal/storage/elasticsearch/esclient/index_client.go
@@ -76,7 +76,9 @@ func (i *IndicesClient) GetJaegerIndices(ctx context.Context, prefix string) ([]
 
 	type indexInfo struct {
 		Aliases  map[string]any `json:"aliases"`
-		Settings map[string]any `json:"settings"`
+		Settings struct {
+			CreationDate string `json:"index.creation_date"`
+		} `json:"settings"`
 	}
 	var indicesInfo map[string]indexInfo
 	if err = json.Unmarshal(body, &indicesInfo); err != nil {
@@ -90,8 +92,7 @@ func (i *IndicesClient) GetJaegerIndices(ctx context.Context, prefix string) ([]
 			aliases[alias] = true
 		}
 		// ignoring error, ES should return valid date
-		creationDateStr, _ := v.Settings["index.creation_date"].(string)
-		creationDate, _ := strconv.ParseInt(creationDateStr, 10, 64)
+		creationDate, _ := strconv.ParseInt(v.Settings.CreationDate, 10, 64)
 
 		indices = append(indices, Index{
 			Index:        k,

--- a/internal/storage/elasticsearch/esclient/index_client_test.go
+++ b/internal/storage/elasticsearch/esclient/index_client_test.go
@@ -70,6 +70,37 @@ const esIndexResponse = `
   }
 }`
 
+// esIndexResponseWithArraySettings mirrors a response from a cluster where the
+// index template sorts on multiple fields (OpenSearch 3.3+ / Elasticsearch
+// 8.15+ "index.sort" settings), which flattens to JSON arrays rather than
+// strings.
+const esIndexResponseWithArraySettings = `
+{
+  "%sjaeger-service-2021-08-06" : {
+    "aliases" : { },
+    "settings" : {
+      "index.creation_date" : "1628259381266"
+    }
+  },
+  "%sjaeger-span-2021-08-06" : {
+    "aliases" : { },
+    "settings" : {
+      "index.creation_date" : "1628259381326"
+    }
+  },
+  "%sjaeger-span-000001" : {
+    "aliases" : {
+      "jaeger-span-read" : { },
+      "jaeger-span-write" : { }
+    },
+    "settings" : {
+      "index.creation_date" : "1628259381326",
+      "index.sort.field" : ["traceID", "startTimeMillis"],
+      "index.sort.order" : ["asc", "desc"]
+    }
+  }
+}`
+
 const esErrResponse = `{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/jaeger-*] contains unrecognized parameter: [help]"}],"type":"illegal_argument_exception","reason":"request [/jaeger-*] contains unrecognized parameter: [help]"},"status":400}`
 
 func TestClientGetIndices(t *testing.T) {
@@ -121,6 +152,28 @@ func TestClientGetIndices(t *testing.T) {
 				},
 				{
 					Index:        "foo-jaeger-span-2021-08-06",
+					CreationTime: time.Unix(0, int64(time.Millisecond)*1628259381326),
+					Aliases:      map[string]bool{},
+				},
+			},
+		},
+		{
+			name:         "settings with array values",
+			responseCode: http.StatusOK,
+			response:     esIndexResponseWithArraySettings,
+			indices: []Index{
+				{
+					Index:        "jaeger-service-2021-08-06",
+					CreationTime: time.Unix(0, int64(time.Millisecond)*1628259381266),
+					Aliases:      map[string]bool{},
+				},
+				{
+					Index:        "jaeger-span-000001",
+					CreationTime: time.Unix(0, int64(time.Millisecond)*1628259381326),
+					Aliases:      map[string]bool{"jaeger-span-read": true, "jaeger-span-write": true},
+				},
+				{
+					Index:        "jaeger-span-2021-08-06",
 					CreationTime: time.Unix(0, int64(time.Millisecond)*1628259381326),
 					Aliases:      map[string]bool{},
 				},


### PR DESCRIPTION
Motivation:
jaeger-es-rollover crashes with "json: cannot unmarshal array into Go
struct field indexInfo.settings of type string" when a cluster's index
template defines multi-field index sort settings (OpenSearch 3.3+ /
Elasticsearch 8.15+ "index.sort.field" / "index.sort.order"). ES's
flat_settings response flattens those into JSON arrays rather than
strings, but GetJaegerIndices declared the settings map as
map[string]string, so any array-valued setting made the whole
unmarshal fail and the rollover command exit with an error before
processing any index.

Approach:
Change the indexInfo.Settings field in GetJaegerIndices from
map[string]string to map[string]any, matching the pattern already
used by TestsOnlyGetSettings for the same response shape elsewhere in
this file. The only place that reads a specific setting value
(index.creation_date, used to compute Index.CreationTime) is updated
to type-assert to string before parsing it as an int64; a missing or
non-string value falls back to the same zero CreationTime as before,
so existing behavior for well-formed responses is unchanged.

Validation:
Added a regression test case ("settings with array values") to
TestClientGetIndices in index_client_test.go with a response fixture
containing array-valued "index.sort.field" / "index.sort.order"
settings alongside the normal string settings. Confirmed the test
fails without the fix, reproducing the exact error from the issue
report, and passes with it:
  go test ./internal/storage/elasticsearch/esclient/... -run TestClientGetIndices -v
Also ran:
  go build ./...
  go test ./internal/storage/elasticsearch/esclient/...
  make fmt
  make lint (0 issues)

Report: https://github.com/jaegertracing/jaeger/issues/9251
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #9251