### PR TITLE
fix: accept any type for index settings (#9251)

### DIFF
--- a/internal/storage/elasticsearch/esclient/index_client.go
+++ b/internal/storage/elasticsearch/esclient/index_client.go
@@ -76,7 +76,7 @@ func (i *IndicesClient) GetJaegerIndices(ctx context.Context, prefix string) ([]
 
 	type indexInfo struct {
 		Aliases  map[string]any    `json:"aliases"`
-		Settings map[string]string `json:"settings"`
+		Settings map[string]any    `json:"settings"`
 	}
 	var indicesInfo map[string]indexInfo
 	if err = json.Unmarshal(body, &indicesInfo); err != nil {
@@ -90,7 +90,15 @@ func (i *IndicesClient) GetJaegerIndices(ctx context.Context, prefix string) ([]
 			aliases[alias] = true
 		}
 		// ignoring error, ES should return valid date
-		creationDate, _ := strconv.ParseInt(v.Settings["index.creation_date"], 10, 64)
+		var creationDate int64
+		if cd, ok := v.Settings["index.creation_date"]; ok {
+			switch cdv := cd.(type) {
+			case string:
+				creationDate, _ = strconv.ParseInt(cdv, 10, 64)
+			case float64:
+				creationDate = int64(cdv)
+			}
+		}
 
 		indices = append(indices, Index{
 			Index:        k,


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #9251
- The `GetJaegerIndices` method's `indexInfo` struct uses `Settings map[string]string`, but custom index settings (e.g. `index.sort.field` with array values) are returned as JSON arrays even with `flat_settings=true`. This causes `json.Unmarshal` to fail with a type mismatch during rollover.

## Description of changes
- Change `Settings` type from `map[string]string` to `map[string]any` to accept any JSON value type
- Handle `index.creation_date` parsing with a type switch (string/float64) since it's now `any`

## How was this change tested?
- Existing tests pass unchanged
- The `TestsOnlyGetSettings` method already uses `map[string]any` for settings, confirming this is the correct pattern