### PR TITLE
fix(examples): Add an OTel collector startup probe

### DIFF
--- a/.github/workflows/ci-lint-checks.yaml
+++ b/.github/workflows/ci-lint-checks.yaml
@@ -129,6 +129,9 @@ jobs:
         repository: kward/shunit2
         path: .tools/shunit2
 
+    - name: Install Helm
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+
     - name: Run unit tests for scripts
       run: |
         SHUNIT2=.tools/shunit2 bash scripts/utils/run-tests.sh

--- a/examples/otel-demo/deploy-all.test.sh
+++ b/examples/otel-demo/deploy-all.test.sh
@@ -103,6 +103,62 @@ testPinsCompatibleOtelDemoChart() {
   assertEquals "0.40.9" "$output"
 }
 
+testPinnedChartRendersCollectorStartupProbe() {
+  local chart_version
+  local rendered
+  local render_rc
+  local startup_probe_count
+  local startup_probe
+  local liveness_probe
+  local readiness_probe
+  local resources
+
+  chart_version=$(bash -c \
+    'source "$1"; printf "%s" "$OTEL_DEMO_CHART_VERSION"' \
+    _ "$SCRIPT")
+
+  rendered=$(helm template otel-demo opentelemetry-demo \
+    --repo https://open-telemetry.github.io/opentelemetry-helm-charts \
+    --version "$chart_version" \
+    --namespace otel-demo \
+    --values "$(dirname "$SCRIPT")/otel-demo-values.yaml" \
+    --show-only charts/opentelemetry-collector/templates/daemonset.yaml)
+  render_rc=$?
+
+  assertEquals "pinned OTel Demo chart should render" 0 "$render_rc"
+  [[ "$render_rc" -eq 0 ]] || return
+
+  assertContains "$rendered" "kind: DaemonSet"
+  assertContains "$rendered" "name: otel-collector-agent"
+  assertContains "$rendered" "- name: opentelemetry-collector"
+
+  startup_probe_count=$(printf '%s\n' "$rendered" | grep -c '^[[:space:]]*startupProbe:$' || true)
+  assertEquals "collector should render exactly one startup probe" 1 "$startup_probe_count"
+
+  startup_probe=$(printf '%s\n' "$rendered" |
+    sed -n '/^[[:space:]]*startupProbe:$/,/^[[:space:]]*resources:$/p')
+  assertContains "$startup_probe" "periodSeconds: 10"
+  assertContains "$startup_probe" "timeoutSeconds: 1"
+  assertContains "$startup_probe" "failureThreshold: 30"
+  assertContains "$startup_probe" "httpGet:"
+  assertContains "$startup_probe" "path: /"
+  assertContains "$startup_probe" "port: 13133"
+
+  liveness_probe=$(printf '%s\n' "$rendered" |
+    sed -n '/^[[:space:]]*livenessProbe:$/,/^[[:space:]]*readinessProbe:$/p')
+  assertContains "$liveness_probe" "path: /"
+  assertContains "$liveness_probe" "port: 13133"
+
+  readiness_probe=$(printf '%s\n' "$rendered" |
+    sed -n '/^[[:space:]]*readinessProbe:$/,/^[[:space:]]*startupProbe:$/p')
+  assertContains "$readiness_probe" "path: /"
+  assertContains "$readiness_probe" "port: 13133"
+
+  resources=$(printf '%s\n' "$rendered" |
+    sed -n '/^[[:space:]]*resources:$/,/^[[:space:]]*volumeMounts:$/p')
+  assertContains "$resources" "memory: 200Mi"
+}
+
 testPinsCompatibleOpenSearchCharts() {
   output=$(bash -c 'source "$1"; printf "%s|%s" "$OPENSEARCH_CHART_VERSION" "$OPENSEARCH_DASHBOARDS_CHART_VERSION"' _ "$SCRIPT")
   assertEquals "2.38.0|2.34.0" "$output"

--- a/examples/otel-demo/otel-demo-values.yaml
+++ b/examples/otel-demo/otel-demo-values.yaml
@@ -133,6 +133,14 @@ components:
 opentelemetry-collector:
   image:
     repository: docker.io/otel/opentelemetry-collector-contrib
+  # Allow initialization to complete before the existing liveness probe takes over.
+  startupProbe:
+    httpGet:
+      port: 13133
+      path: /
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 30
   presets:
     hostMetrics:
       enabled: false


### PR DESCRIPTION
Fixes #9266.

Related to #9243.

## Why

The OTel Demo recovery run [31214976357](https://github.com/jaegertracing/jaeger/actions/runs/31214976357) successfully selected the pinned `0.40.9` chart, then timed out because `otel-collector-agent` remained 1/2 ready.

Diagnostics show the failing collector repeatedly exits after about 30 seconds when its health endpoint is still unavailable. The current liveness probe starts immediately and has a 30-second failure window. The healthy and failing pods use the same image, controller revision, configuration checksum, and `200Mi` resource limit; neither was OOM-killed. This is consistent with a startup race, not evidence for increasing collector resources.

## What changed

- Add a startup probe to the collector with a five-minute initialization budget.
- Leave the existing liveness/readiness probes, resources, configuration, and deployment topology unchanged.
- Add an automated test that templates the pinned chart and asserts the collector DaemonSet's startup, liveness, readiness, and resource blocks.
- After startup succeeds, the existing liveness probe resumes responsibility.

## Validation

- `make fmt`
- `make lint`
- `make test` (`4177` passed, `38` skipped)
- Shell suite (`12` tests) including the exact chart render regression
- `helm lint` with the exact OTel Demo chart `0.40.9`
- `helm template` with the exact OTel Demo chart `0.40.9`
- Confirmed the regression assertion fails against the `main` values without this probe
- Compared the rendered collector DaemonSet: only the `startupProbe` block changes

## Rollout

Merging this PR does not deploy it. After approval, manually dispatch `ci-deploy-demo.yml` with `deploy_mode=upgrade`, `demo_stack=otel`, and `otel_deploy_scope=otel-demo`. Do not use `clean`.

The pod-template change will roll the collector DaemonSet. Confirm it reaches 2/2 ready and that `/api/services` includes `checkout` before dispatching the `opensearch` scope. If the affected node still cannot pass the startup probe within five minutes, continue #9243 with node/kubelet/CNI investigation rather than extending the probe or adding resources.
