### PR TITLE
fix(mcptools): treat get_span_details limit of 0 as unlimited

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details.go
@@ -131,8 +131,10 @@ func (h *getSpanDetailsHandler) buildQuery(input types.GetSpanDetailsInput) (que
 		return querysvc.GetTraceParams{}, nil, errors.New("span_ids is required and must not be empty")
 	}
 
-	// Validate span count against configured limit
-	if len(input.SpanIDs) > h.maxSpanDetailsPerRequest {
+	// Validate span count against configured limit. A limit of 0 means unlimited,
+	// matching the convention get_trace_errors and get_trace_topology use for the
+	// same config value.
+	if h.maxSpanDetailsPerRequest > 0 && len(input.SpanIDs) > h.maxSpanDetailsPerRequest {
 		return querysvc.GetTraceParams{}, nil, fmt.Errorf(
 			"span_ids exceeds maximum limit: requested %d, max allowed %d",
 			len(input.SpanIDs),

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details_test.go
@@ -516,6 +516,34 @@ func TestGetSpanDetailsHandler_ExceedsLimit(t *testing.T) {
 	assert.Contains(t, err.Error(), "max allowed 2")
 }
 
+func TestGetSpanDetailsHandler_Handle_ZeroLimitIsUnlimited(t *testing.T) {
+	// maxSpanDetailsPerRequest == 0 must mean unlimited, matching the convention
+	// get_trace_errors and get_trace_topology use for the same config value,
+	// instead of rejecting every non-empty request.
+	traceID := testTraceID
+	spanConfigs := []spanConfig{
+		{spanID: "span001", operation: "/api/test1"},
+		{spanID: "span002", operation: "/api/test2"},
+		{spanID: "span003", operation: "/api/test3"},
+	}
+
+	testTrace := createTestTraceWithSpans(traceID, spanConfigs)
+
+	mock := newMockYieldingTraces(testTrace)
+
+	handler := &getSpanDetailsHandler{queryService: mock, maxSpanDetailsPerRequest: 0}
+
+	input := types.GetSpanDetailsInput{
+		TraceID: traceID,
+		SpanIDs: []string{spanIDToHex("span001"), spanIDToHex("span002"), spanIDToHex("span003")},
+	}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	assert.Len(t, output.Spans, 3)
+}
+
 func TestParseTraceID(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Which problem is this PR solving?

Read through `cmd/jaeger/internal/extension/jaegerquery/internal/mcptools` for #9135. The truncation gap named in that issue (`get_trace_topology` dropping its warning / missing `total_span_count`) is already covered by #8530, so I looked for a different defect in the same package.

Found one in `get_span_details.go`'s `buildQuery`: it does not treat `MaxSpanDetailsPerRequest == 0` as unlimited, unlike `get_trace_errors` and `get_trace_topology`, which both use the same config field with that convention.

## Description of the changes

The `span_ids` bound check was `len(input.SpanIDs) > h.maxSpanDetailsPerRequest`. Since `span_ids` is required to be non-empty, this rejects every request once the limit is 0, instead of removing the cap as the sibling handlers do:
- `get_trace_errors`: `h.maxSpanDetailsPerRequest == 0 || len(errorSpans) < h.maxSpanDetailsPerRequest`
- `get_trace_topology`: `h.maxSpanDetailsPerRequest > 0 && len(spans) >= h.maxSpanDetailsPerRequest`

Changed the check to `h.maxSpanDetailsPerRequest > 0 && len(input.SpanIDs) > h.maxSpanDetailsPerRequest`, matching that convention.

## How was this change tested?

- `go build ./...`
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/...`
- Added `TestGetSpanDetailsHandler_Handle_ZeroLimitIsUnlimited`, which was missing before this change (no test exercised the zero-limit case for this handler).
