### PR TITLE
test(mcptools): close SkillsFS so TempDir cleanup succeeds on Windows

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills_fs_test.go
@@ -28,6 +28,10 @@ func TestOpenCustomSkillsDir_ServesDirectoryContents(t *testing.T) {
 
 	custom, err := OpenCustomSkillsDir(dir)
 	require.NoError(t, err)
+	// The tree holds an open OS handle. Leaving it open makes t.TempDir's
+	// cleanup fail on Windows, which cannot remove a directory that is still
+	// in use; on Linux the unlink succeeds and the leak goes unnoticed.
+	t.Cleanup(func() { require.NoError(t, custom.Close()) })
 
 	catalog, err := fs.ReadFile(custom, "SKILL.md")
 	require.NoError(t, err)
@@ -96,6 +100,7 @@ func TestOpenCustomSkillsDir_BlocksSymlinkEscape(t *testing.T) {
 
 	custom, err := OpenCustomSkillsDir(dir)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, custom.Close()) })
 
 	// os.OpenRoot refuses to follow a symlink out of skills_dir.
 	_, err = custom.Open("evil/secret.txt")


### PR DESCRIPTION
## Which problem is this PR solving

Two tests in `skills_fs_test.go` open a skills tree and never close it. `SkillsFS` wraps an `os.Root`, so the OS handle stays open for the rest of the process.

On Linux the temp directory unlinks regardless and the leak is invisible. On Windows a directory that is still in use cannot be removed, so `t.TempDir`'s cleanup fails the test:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat
C:\...\TestOpenCustomSkillsDir_ServesDirectoryContents3855688764\001:
The process cannot access the file because it is being used by another process.
--- FAIL: TestOpenCustomSkillsDir_ServesDirectoryContents (1.81s)
FAIL	github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools
```

Reproducible on `main` on Windows with no local changes. `TestOpenCustomSkillsDir_BlocksSymlinkEscape` has the same leak but skips on Windows already, so it does not surface there.

The file's own `TestOpenCustomSkillsDir_CloseReleasesTheRoot` closes correctly, and the symlink test already guards for Windows, so this reads as an oversight rather than an intentional omission.

## Description of the changes

Register `Close` with `t.Cleanup` in both tests. Cleanups run last-in-first-out, and `t.TempDir` registers its removal when it is called — earlier than these — so the handle is released before the directory is removed.

This also exercises the ownership contract `SkillsFS` documents: *"Whoever mounts it owns closing it when the server it was mounted on shuts down."*

## How was this change tested?

Before, on Windows:

```
--- FAIL: TestOpenCustomSkillsDir_ServesDirectoryContents (1.81s)
FAIL
```

After:

```
$ go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/ -count=1
ok  	.../mcptools	7.524s
```

No production code changed; behaviour on Linux is unaffected.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully
