### PR TITLE
fix(safeexpvar): prevent panic on concurrent SetInt initialization

### DIFF
--- a/internal/safeexpvar/safeexpvar.go
+++ b/internal/safeexpvar/safeexpvar.go
@@ -5,12 +5,20 @@ package safeexpvar
 
 import (
 	"expvar"
+	"sync"
 )
+
+var mu sync.Mutex
 
 func SetInt(name string, value int64) {
 	v := expvar.Get(name)
 	if v == nil {
-		v = expvar.NewInt(name)
+		mu.Lock()
+		v = expvar.Get(name)
+		if v == nil {
+			v = expvar.NewInt(name)
+		}
+		mu.Unlock()
 	}
 	v.(*expvar.Int).Set(value)
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Prevents a panic (`Reuse of exported var name`) caused by a TOCTOU race condition during concurrent initialization in `safeexpvar.SetInt`.
- Resolves #9282 

## Description of the changes

- Added a package-level `sync.Mutex` and double-checked locking inside `safeexpvar.SetInt` in `internal/safeexpvar/safeexpvar.go` to ensure `expvar.NewInt` is never invoked concurrently for the same variable name.
- Added `TestSetIntConcurrent` in `internal/safeexpvar/safeexpvar_test.go` to test concurrent variable registration.

## How was this change tested?

- Ran race-enabled unit tests:
  ```bash
  go test -v -race ./internal/safeexpvar/...

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
