### PR TITLE
fix(grpc): skip nil-valued KeyValue entries in convertMapToKeyValueList

### DIFF
--- a/internal/storage/v2/grpc/tracereader.go
+++ b/internal/storage/v2/grpc/tracereader.go
@@ -288,9 +288,16 @@ func toProtoQueryParameters(t tracestore.TraceQueryParams) (*storage.TraceQueryP
 func convertMapToKeyValueList(m pcommon.Map) []*storage.KeyValue {
 	keyValues := make([]*storage.KeyValue, 0, m.Len())
 	m.Range(func(k string, v pcommon.Value) bool {
+		av := convertValueToAnyValue(v)
+		if av == nil {
+			// Skip attributes with unsupported value types (e.g. ValueTypeEmpty)
+			// rather than emitting a KeyValue with a nil Value field that would be
+			// silently dropped by the server-side nil guard in convertKeyValueListToMap.
+			return true
+		}
 		keyValues = append(keyValues, &storage.KeyValue{
 			Key:   k,
-			Value: convertValueToAnyValue(v),
+			Value: av,
 		})
 		return true
 	})

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -585,12 +585,7 @@ func TestConvertMapToKeyValueList(t *testing.T) {
 				m.PutEmpty("key1")
 				return m
 			}(),
-			expected: []*storage.KeyValue{
-				{
-					Key:   "key1",
-					Value: nil,
-				},
-			},
+			expected: []*storage.KeyValue{},
 		},
 		{
 			name: "primitive types",
@@ -1027,4 +1022,40 @@ func TestToProtoQueryParameters_SearchDepth(t *testing.T) {
 			assert.ErrorContains(t, err, "SearchDepth must be in [0,")
 		}
 	})
+}
+
+func TestConvertMapToKeyValueList_SkipsEmptyValueType(t *testing.T) {
+	m := pcommon.NewMap()
+	m.PutStr("valid_key", "hello")
+	// PutEmpty inserts an attribute whose Type() == pcommon.ValueTypeEmpty.
+	m.PutEmpty("empty_key")
+
+	kvList := convertMapToKeyValueList(m)
+
+	// Only the well-formed string attribute should survive; the empty-typed one
+	// must not appear as a KeyValue with a nil Value field.
+	require.Len(t, kvList, 1, "empty-typed attribute must be skipped, not emitted with nil Value")
+	assert.Equal(t, "valid_key", kvList[0].Key)
+	assert.NotNil(t, kvList[0].Value, "surviving KeyValue must have a non-nil Value")
+}
+
+func TestConvertMapToKeyValueList_NoNilValues(t *testing.T) {
+	m := pcommon.NewMap()
+	m.PutStr("s", "str")
+	m.PutBool("b", true)
+	m.PutInt("i", 42)
+	m.PutDouble("d", 3.14)
+	m.PutEmptyBytes("by").FromRaw([]byte{1, 2, 3})
+	m.PutEmptySlice("arr")
+	m.PutEmptyMap("nested")
+	// Also insert an empty-typed value that must be filtered out.
+	m.PutEmpty("empty_typed")
+
+	kvList := convertMapToKeyValueList(m)
+
+	// Seven well-typed entries should survive; the empty-typed one must be absent.
+	assert.Len(t, kvList, 7, "empty-typed entry must not appear in the output")
+	for _, kv := range kvList {
+		assert.NotNil(t, kv.Value, "every KeyValue in the output must have a non-nil Value (key: %s)", kv.Key)
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9285

When building trace search queries via the storage v2 gRPC client (`TraceReader`), passing a `pcommon.Map` attribute with type `ValueTypeEmpty` (the zero value of `pcommon.Value`) causes `convertValueToAnyValue()` in `tracereader.go` to return `nil`.

`convertMapToKeyValueList()` was unconditionally appending these as `&storage.KeyValue{Key: k, Value: nil}` — emitting a `KeyValue` entry with a `nil Value` field to the wire payload.

On the server side, `convertKeyValueListToMap()` in `handler.go` already guards against nil values (`if kv == nil || kv.Value == nil { continue }`), causing such attributes to be silently dropped from the query. A client searching for traces with an empty-typed attribute gets results as if that attribute was never specified, with no warning or error.

## Description of the changes

In `convertMapToKeyValueList()` (`internal/storage/v2/grpc/tracereader.go`):
- Check the return value of `convertValueToAnyValue()` before appending.
- Skip emitting the `KeyValue` entry entirely when the converted value is `nil`, rather than sending a `KeyValue` with a `nil Value` field over gRPC.

## How was this change tested?

Added two new regression unit tests in `internal/storage/v2/grpc/tracereader_test.go`:
- `TestConvertMapToKeyValueList_SkipsEmptyValueType`: Confirms that an `Empty`-typed attribute is skipped and not emitted with a `nil Value`.
- `TestConvertMapToKeyValueList_NoNilValues`: Confirms that all 7 supported value types survive conversion and every emitted `KeyValue` has a non-nil `Value`, while an inserted `Empty`-typed attribute is filtered out.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

