### PR TITLE
fix(storage/grpc): Apply the configured Timeout to gRPC storage v2 client calls

### DIFF
--- a/internal/storage/v2/grpc/factory.go
+++ b/internal/storage/v2/grpc/factory.go
@@ -142,6 +142,11 @@ func (f *Factory) initializeConnections(
 		streamInterceptors = append(streamInterceptors, headerforwarding.NewStreamClientInterceptor())
 	}
 
+	if f.config.Timeout > 0 {
+		unaryInterceptors = append(unaryInterceptors, newTimeoutUnaryClientInterceptor(f.config.Timeout))
+		streamInterceptors = append(streamInterceptors, newTimeoutStreamClientInterceptor(f.config.Timeout))
+	}
+
 	baseOpts := []grpc.DialOption{
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -30,6 +30,9 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/jaegertracing/jaeger/internal/headerforwarding"
+	"github.com/jaegertracing/jaeger/internal/jiter"
+	"github.com/jaegertracing/jaeger/internal/proto-gen/storage/v2"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 	"github.com/jaegertracing/jaeger/internal/telemetry"
 	"github.com/jaegertracing/jaeger/internal/tenancy"
 )
@@ -183,6 +186,59 @@ func TestNewFactory_MaxRecvMsgSize(t *testing.T) {
 	optsWithSize := capture(withSize)
 
 	assert.Greater(t, len(optsWithSize), len(optsBase), "MaxRecvMsgSizeMiB > 0 should add a WithDefaultCallOptions dial option")
+}
+
+func TestNewFactory_Timeout(t *testing.T) {
+	lis, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "failed to listen")
+
+	// The server sleeps far longer than the configured Timeout, so a passing
+	// test proves calls fail at the configured Timeout rather than blocking
+	// on the server (or an absent parent-context deadline). server.Stop()
+	// closes lis, so it is the only cleanup needed for the listener.
+	server := grpc.NewServer()
+	storage.RegisterTraceReaderServer(server, &testServer{delay: 500 * time.Millisecond})
+	t.Cleanup(server.Stop)
+	go func() { _ = server.Serve(lis) }()
+
+	const configuredTimeout = 20 * time.Millisecond
+	cfg := Config{
+		ClientConfig: configgrpc.ClientConfig{
+			Endpoint: lis.Addr().String(),
+			TLS: configtls.ClientConfig{
+				Insecure: true,
+			},
+		},
+		TimeoutConfig: exporterhelper.TimeoutConfig{
+			Timeout: configuredTimeout,
+		},
+	}
+	f, err := NewFactory(context.Background(), cfg, telemetry.NoopSettings())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
+	reader, err := f.CreateTraceReader()
+	require.NoError(t, err)
+
+	// slack is how much longer than configuredTimeout a call is allowed to take
+	// before we conclude the deadline was not actually enforced.
+	const slack = 300 * time.Millisecond
+
+	t.Run("unary call fails fast at configured timeout", func(t *testing.T) {
+		start := time.Now()
+		_, err := reader.GetServices(context.Background())
+		elapsed := time.Since(start)
+		require.Error(t, err)
+		assert.Less(t, elapsed, configuredTimeout+slack)
+	})
+
+	t.Run("streaming call fails fast at configured timeout", func(t *testing.T) {
+		start := time.Now()
+		_, err := jiter.FlattenWithErrors(reader.GetTraces(context.Background(), tracestore.GetTraceParams{}))
+		elapsed := time.Since(start)
+		require.Error(t, err)
+		assert.Less(t, elapsed, configuredTimeout+slack)
+	})
 }
 
 func TestInitializeConnections_ClientError(t *testing.T) {

--- a/internal/storage/v2/grpc/factory_test.go
+++ b/internal/storage/v2/grpc/factory_test.go
@@ -229,6 +229,7 @@ func TestNewFactory_Timeout(t *testing.T) {
 		_, err := reader.GetServices(context.Background())
 		elapsed := time.Since(start)
 		require.Error(t, err)
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
 		assert.Less(t, elapsed, configuredTimeout+slack)
 	})
 
@@ -237,6 +238,7 @@ func TestNewFactory_Timeout(t *testing.T) {
 		_, err := jiter.FlattenWithErrors(reader.GetTraces(context.Background(), tracestore.GetTraceParams{}))
 		elapsed := time.Since(start)
 		require.Error(t, err)
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
 		assert.Less(t, elapsed, configuredTimeout+slack)
 	})
 }

--- a/internal/storage/v2/grpc/timeout_interceptor.go
+++ b/internal/storage/v2/grpc/timeout_interceptor.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpc
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// newTimeoutUnaryClientInterceptor returns a gRPC unary client interceptor that bounds
+// every call by the given timeout, so a slow or hung storage backend fails fast with a
+// deadline-exceeded error instead of blocking indefinitely (or until an unrelated parent
+// context is cancelled).
+func newTimeoutUnaryClientInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// newTimeoutStreamClientInterceptor returns a gRPC streaming client interceptor that bounds
+// stream creation and the lifetime of the stream by the given timeout.
+func newTimeoutStreamClientInterceptor(timeout time.Duration) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		stream, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		return &timeoutClientStream{ClientStream: stream, cancel: cancel}, nil
+	}
+}
+
+// timeoutClientStream wraps grpc.ClientStream so the timeout context is released once the
+// stream finishes (its first Send/Recv/CloseSend error, including io.EOF) rather than
+// immediately after the streamer call returns, while the stream is still being consumed.
+type timeoutClientStream struct {
+	grpc.ClientStream
+	cancel context.CancelFunc
+}
+
+func (s *timeoutClientStream) RecvMsg(m any) error {
+	err := s.ClientStream.RecvMsg(m)
+	if err != nil {
+		s.cancel()
+	}
+	return err
+}
+
+func (s *timeoutClientStream) SendMsg(m any) error {
+	err := s.ClientStream.SendMsg(m)
+	if err != nil {
+		s.cancel()
+	}
+	return err
+}
+
+func (s *timeoutClientStream) CloseSend() error {
+	err := s.ClientStream.CloseSend()
+	if err != nil {
+		s.cancel()
+	}
+	return err
+}

--- a/internal/storage/v2/grpc/timeout_interceptor_test.go
+++ b/internal/storage/v2/grpc/timeout_interceptor_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestNewTimeoutUnaryClientInterceptor(t *testing.T) {
+	interceptor := newTimeoutUnaryClientInterceptor(20 * time.Millisecond)
+	invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	err := interceptor(context.Background(), "method", nil, nil, nil, invoker)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestNewTimeoutUnaryClientInterceptor_Success(t *testing.T) {
+	interceptor := newTimeoutUnaryClientInterceptor(time.Second)
+	invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		_, ok := ctx.Deadline()
+		assert.True(t, ok, "context passed to invoker should carry the configured timeout as a deadline")
+		return nil
+	}
+	err := interceptor(context.Background(), "method", nil, nil, nil, invoker)
+	require.NoError(t, err)
+}
+
+func TestNewTimeoutStreamClientInterceptor(t *testing.T) {
+	t.Run("streamer error cancels the timeout context", func(t *testing.T) {
+		interceptor := newTimeoutStreamClientInterceptor(time.Second)
+		streamer := func(context.Context, *grpc.StreamDesc, *grpc.ClientConn, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+			return nil, assert.AnError
+		}
+		stream, err := interceptor(context.Background(), &grpc.StreamDesc{}, nil, "method", streamer)
+		require.Nil(t, stream)
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("streamer success wraps the stream with the timeout context", func(t *testing.T) {
+		interceptor := newTimeoutStreamClientInterceptor(time.Second)
+		fake := &fakeClientStream{}
+		streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok, "context passed to streamer should carry the configured timeout as a deadline")
+			require.WithinDuration(t, time.Now().Add(time.Second), deadline, 200*time.Millisecond)
+			return fake, nil
+		}
+		stream, err := interceptor(context.Background(), &grpc.StreamDesc{}, nil, "method", streamer)
+		require.NoError(t, err)
+		wrapped, ok := stream.(*timeoutClientStream)
+		require.True(t, ok)
+		require.Same(t, fake, wrapped.ClientStream)
+	})
+}
+
+type fakeClientStream struct {
+	recvErr  error
+	sendErr  error
+	closeErr error
+}
+
+func (*fakeClientStream) Header() (metadata.MD, error) { return nil, nil }
+func (*fakeClientStream) Trailer() metadata.MD         { return nil }
+func (*fakeClientStream) Context() context.Context     { return context.Background() }
+func (f *fakeClientStream) CloseSend() error           { return f.closeErr }
+func (f *fakeClientStream) SendMsg(any) error          { return f.sendErr }
+func (f *fakeClientStream) RecvMsg(any) error          { return f.recvErr }
+
+func TestTimeoutClientStream(t *testing.T) {
+	tests := []struct {
+		name       string
+		underlying *fakeClientStream
+		call       func(s *timeoutClientStream) error
+		wantCancel bool
+	}{
+		{
+			name:       "RecvMsg success does not cancel",
+			underlying: &fakeClientStream{},
+			call:       func(s *timeoutClientStream) error { return s.RecvMsg(nil) },
+			wantCancel: false,
+		},
+		{
+			name:       "RecvMsg error cancels",
+			underlying: &fakeClientStream{recvErr: assert.AnError},
+			call:       func(s *timeoutClientStream) error { return s.RecvMsg(nil) },
+			wantCancel: true,
+		},
+		{
+			name:       "SendMsg success does not cancel",
+			underlying: &fakeClientStream{},
+			call:       func(s *timeoutClientStream) error { return s.SendMsg(nil) },
+			wantCancel: false,
+		},
+		{
+			name:       "SendMsg error cancels",
+			underlying: &fakeClientStream{sendErr: assert.AnError},
+			call:       func(s *timeoutClientStream) error { return s.SendMsg(nil) },
+			wantCancel: true,
+		},
+		{
+			name:       "CloseSend success does not cancel",
+			underlying: &fakeClientStream{},
+			call:       func(s *timeoutClientStream) error { return s.CloseSend() },
+			wantCancel: false,
+		},
+		{
+			name:       "CloseSend error cancels",
+			underlying: &fakeClientStream{closeErr: assert.AnError},
+			call:       func(s *timeoutClientStream) error { return s.CloseSend() },
+			wantCancel: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cancelled := false
+			s := &timeoutClientStream{ClientStream: test.underlying, cancel: func() { cancelled = true }}
+			_ = test.call(s)
+			assert.Equal(t, test.wantCancel, cancelled)
+		})
+	}
+}

--- a/internal/storage/v2/grpc/tracereader_test.go
+++ b/internal/storage/v2/grpc/tracereader_test.go
@@ -38,9 +38,26 @@ type testServer struct {
 	traceIDs   []*storage.FoundTraceID
 	summaries  []*storage.TraceSummary
 	err        error
+	// delay, if set, is how long GetServices and GetTraces sleep before
+	// responding, to simulate a slow/hung backend in timeout tests.
+	delay time.Duration
+}
+
+// sleep blocks for the configured delay, or until ctx is cancelled (e.g. the
+// caller's deadline expires and the client disconnects), whichever comes
+// first, so a timed-out test does not leave this goroutine sleeping behind.
+func (ts *testServer) sleep(ctx context.Context) {
+	if ts.delay <= 0 {
+		return
+	}
+	select {
+	case <-time.After(ts.delay):
+	case <-ctx.Done():
+	}
 }
 
 func (ts *testServer) GetTraces(_ *storage.GetTracesRequest, s storage.TraceReader_GetTracesServer) error {
+	ts.sleep(s.Context())
 	for _, trace := range ts.traces {
 		s.Send(trace)
 	}
@@ -48,9 +65,10 @@ func (ts *testServer) GetTraces(_ *storage.GetTracesRequest, s storage.TraceRead
 }
 
 func (ts *testServer) GetServices(
-	context.Context,
-	*storage.GetServicesRequest,
+	ctx context.Context,
+	_ *storage.GetServicesRequest,
 ) (*storage.GetServicesResponse, error) {
+	ts.sleep(ctx)
 	return &storage.GetServicesResponse{
 		Services: ts.services,
 	}, ts.err


### PR DESCRIPTION
Motivation:
The gRPC storage v2 Config embeds exporterhelper.TimeoutConfig (a Timeout
field defaulting to 5s), but initializeConnections in factory.go never
added it to the client interceptor chain. Reader/writer gRPC calls forwarded
whatever context.Context they received unchanged, so a hung or slow storage
backend could block reads/writes indefinitely (or until an unrelated parent
context was cancelled) instead of failing fast at the configured timeout.

Approach:
Add newTimeoutUnaryClientInterceptor and newTimeoutStreamClientInterceptor
in a new timeout_interceptor.go, appended to the existing unary/stream
interceptor chains in initializeConnections whenever Timeout > 0 (matching
the existing conditional-interceptor pattern used for header forwarding).
Because these interceptors run at connection-dial time, they cover every
RPC on both the reader and writer connections (GetTraces/FindTraces/
FindTraceSummaries/GetServices/GetOperations/FindTraceIDs, Export, and
GetDependencies), not just one call site.

The unary interceptor wraps the context with context.WithTimeout before
invoking. The stream interceptor does the same for stream creation, but
wraps the returned grpc.ClientStream so cancel() is deferred until the
stream's first RecvMsg/SendMsg/CloseSend error (including io.EOF) rather
than cancelled immediately after the streamer call returns - otherwise the
timeout context would be cancelled while the stream is still being
consumed, breaking normal streaming reads.

Validation:
- go test ./internal/storage/v2/grpc/... -race -count=1: passes.
- go tool cover -func shows 100% coverage on every new function in
  timeout_interceptor.go.
- Added TestNewFactory_Timeout in factory_test.go: starts a real gRPC
  server whose GetServices (unary) and GetTraces (stream) handlers sleep
  500ms before responding, configures the factory with a 20ms Timeout, and
  asserts both calls return an error within configuredTimeout+300ms slack
  instead of waiting out the server's 500ms delay. This is a genuine
  failing-before/passing-after regression test: reverting only the
  factory.go interceptor wiring and re-running it makes both subtests fail
  ("An error is expected but got nil", each taking the full ~500ms),
  confirming the test exercises the fixed code path.
- make lint (full repo): 0 issues.
- make test (full repo): 4205 tests, 38 skipped, 0 failures.
- go build ./...: passes.

Report: https://github.com/jaegertracing/jaeger/issues/9104
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #9104