### PR TITLE
fix: sort span events by timestamp instead of name

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort.go
@@ -17,7 +17,7 @@ var _ Adjuster = (*SortAttributesAndEventsAdjuster)(nil)
 // - Resource attributes are sorted lexicographically by their keys.
 // - Scope attributes are sorted lexicographically by their keys.
 // - Span attributes are sorted lexicographically by their keys.
-// - Span events are sorted lexicographically by their names.
+// - Span events are sorted by timestamp.
 // - Attributes within each span event are sorted lexicographically by their keys.
 // - Attributes within each span link are sorted lexicographically by their keys.
 func SortCollections() SortAttributesAndEventsAdjuster {
@@ -79,7 +79,7 @@ func (SortAttributesAndEventsAdjuster) sortAttributes(attributes pcommon.Map) {
 
 func (s SortAttributesAndEventsAdjuster) sortEvents(events ptrace.SpanEventSlice) {
 	events.Sort(func(a, b ptrace.SpanEvent) bool {
-		return a.Name() < b.Name()
+		return a.TimeUnixNano() < b.TimeUnixNano()
 	})
 	for i := 0; i < events.Len(); i++ {
 		event := events.At(i)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort_test.go
@@ -95,3 +95,34 @@ func TestSortAttributesAndEventsAdjuster(t *testing.T) {
 	adjuster.Adjust(i)
 	assert.Equal(t, expected(), i)
 }
+
+func TestSortEventsByTimestamp(t *testing.T) {
+	adjuster := SortCollections()
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+
+	event1 := span.Events().AppendEmpty()
+	event1.SetName("c-third")
+	event1.SetTimeUnixNano(300)
+
+	event2 := span.Events().AppendEmpty()
+	event2.SetName("a-first")
+	event2.SetTimeUnixNano(100)
+
+	event3 := span.Events().AppendEmpty()
+	event3.SetName("b-second")
+	event3.SetTimeUnixNano(200)
+
+	adjuster.Adjust(traces)
+
+	events := span.Events()
+	assert.Equal(t, 3, events.Len())
+	assert.Equal(t, "a-first", events.At(0).Name())
+	assert.Equal(t, "b-second", events.At(1).Name())
+	assert.Equal(t, "c-third", events.At(2).Name())
+	assert.Equal(t, uint64(100), uint64(events.At(0).TimeUnixNano()))
+	assert.Equal(t, uint64(200), uint64(events.At(1).TimeUnixNano()))
+	assert.Equal(t, uint64(300), uint64(events.At(2).TimeUnixNano()))
+}


### PR DESCRIPTION
## What was changed
- Changed sortEvents in cmd/jaeger/internal/extension/jaegerquery/internal/adjuster/sort.go to sort span events by timestamp (TimeUnixNano) instead of by name.
- Added unit test TestSortEventsByTimestamp to verify timestamp-based sorting.

## Why
Fixes #9212 - Span events submitted over OTLP come back sorted alphabetically by event name rather than in timestamp order. OTLP span events are a chronological sequence, so any consumer that renders them in the order received (a timeline UI being the obvious case) displays them out of sequence.

## How
- Changed .Name() < b.Name() to .TimeUnixNano() < b.TimeUnixNano() in sortEvents function
- Events are now sorted by their timestamp, preserving chronological order
- Attribute sorting remains unchanged (lexicographic by key)

## Testing
- Existing tests in sort_test.go still pass
- New test TestSortEventsByTimestamp verifies events are sorted by timestamp

Signed-off-by: Ankita Salaria <ankitasalaria21@gmail.com>