### PR TITLE
ai-sidecar: fix tool_output double-wrap in gemini sidecar raw output path

### DIFF
--- a/scripts/ai-sidecar/gemini/sidecar.py
+++ b/scripts/ai-sidecar/gemini/sidecar.py
@@ -306,7 +306,7 @@ class JaegerSidecarAgent(Agent):
                         tool_call_id,
                         status="completed",
                         content=[tool_content(text_block(output_text))],
-                        raw_output={"content": tool_output},
+                        raw_output=tool_output,
                     ),
                 )
 

--- a/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
+++ b/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
@@ -347,7 +347,11 @@ def test_execute_tool_truncates_oversized_result_on_span_only(
     agent = _new_jaeger_sidecar_agent()
     conn = FakeConn()
     agent.on_connect(conn)  # pyright: ignore[reportArgumentType]
-    huge_output = {"text": "x" * (MAX_SPAN_ATTR_CHARS * 2)}
+    huge_output = {
+        "content": [{"type": "text", "text": "x" * (MAX_SPAN_ATTR_CHARS * 2)}],
+        "isError": False,
+        "structuredContent": {"traces": []},
+    }
     monkeypatch.setattr(agent._mcp, "call_tool", _fake_call_tool(huge_output))
 
     result = asyncio.run(agent._execute_tool("sess-1", "search_traces", {}, "call-3"))
@@ -355,7 +359,7 @@ def test_execute_tool_truncates_oversized_result_on_span_only(
     # The full, untruncated payload still reaches the AG-UI wire.
     assert result == huge_output
     completed_update = conn.session_updates[-1]
-    assert completed_update.raw_output == {"content": huge_output}
+    assert completed_update.raw_output == huge_output
 
     # Only the span attribute is capped, to protect OTLP export from
     # arbitrarily large tool payloads.


### PR DESCRIPTION
Forward tool_output directly in sidecar.py instead of wrapping it in an extra content layer. Update test_sidecar_workflow.py to use a realistic MCP envelope and verify exact pass-through. Resolves the TOOL_CALL_RESULT.content double-nesting reported in issue #9289.

<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

Resolves issue #9289 

## Description of the changes
- 
translation.go : flattenToolResultContent correctly extracts text blocks from envelope["content"].([]any), joining multiple blocks with \n.
streaming_client.go : passes u.ToolCallUpdate.RawOutput directly (not double-wrapped) to the flattener.

## How was this change tested?
- I've tested it on a personal repo.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
