### PR TITLE
fix(status): accept successful health responses

### DIFF
--- a/cmd/internal/status/command.go
+++ b/cmd/internal/status/command.go
@@ -38,7 +38,7 @@ func Command(v *viper.Viper, adminPort int) *cobra.Command {
 			defer resp.Body.Close()
 			body, _ := io.ReadAll(resp.Body)
 			fmt.Println(string(body))
-			if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 				return fmt.Errorf("abnormal value of http status code: %v", resp.StatusCode)
 			}
 			return nil

--- a/cmd/internal/status/command_test.go
+++ b/cmd/internal/status/command_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
+	statusflags "github.com/jaegertracing/jaeger/cmd/internal/flags"
 	"github.com/jaegertracing/jaeger/internal/testutils"
 )
 
@@ -31,6 +32,20 @@ func TestReady(t *testing.T) {
 	v := viper.New()
 	cmd := Command(v, 80)
 	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://")})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+func TestReadyAgainstHealthHost(t *testing.T) {
+	healthHost := statusflags.NewHealthHost()
+	healthHost.Ready()
+
+	ts := httptest.NewServer(healthHost.Handler())
+	defer ts.Close()
+
+	v := viper.New()
+	cmd := Command(v, 80)
+	cmd.ParseFlags([]string{"--status.http.host-port=" + strings.TrimPrefix(ts.URL, "http://")})
+
 	err := cmd.Execute()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- accept all successful 2xx health check responses in `status`
- add a regression test using the actual `HealthHost` handler

## Testing

- `go test ./cmd/internal/status`
- `go test ./cmd/internal/flags`
- `go test ./cmd/internal/status ./cmd/internal/flags`

Fixes #9295