### PR TITLE
fix(mcp): Stop read_skill from sending the skill body twice

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill.go
@@ -57,13 +57,21 @@ func (h *readSkillHandler) handle(
 		return nil, types.ReadSkillOutput{}, fmt.Errorf("cannot read %q: %w", input.Path, err)
 	}
 	content := string(buf[:n])
-	if n > int(h.maxFileSize) {
+	truncated := n > int(h.maxFileSize)
+	if truncated {
 		content += fmt.Sprintf("\n\nfile content truncated after %d bytes\n", h.maxFileSize)
 	}
 
-	return &mcp.CallToolResult{
+	// The body belongs in the content block alone. The SDK copies the returned
+	// output into StructuredContent, so returning the body there too would send
+	// it twice — once as markdown, once JSON-escaped.
+	result := &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: content}},
-	}, types.ReadSkillOutput{Instructions: content}, nil
+	}
+	return result, types.ReadSkillOutput{
+		Path:      input.Path,
+		Truncated: truncated,
+	}, nil
 }
 
 // open routes p to the custom tree when it names the custom/ prefix and to the

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/read_skill_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"io/fs"
 	"testing"
 	"testing/fstest"
@@ -31,19 +32,35 @@ func newTestHandler() *readSkillHandler {
 	return &readSkillHandler{builtins: testSkillsFS(), maxFileSize: testMaxFileSize}
 }
 
+// skillText returns the markdown an agent actually receives: the result's
+// content block, which is the only place the skill body is carried.
+func skillText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	return tc.Text
+}
+
 func TestReadSkillHandler_RootSkillMD(t *testing.T) {
 	h := newTestHandler()
-	_, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "SKILL.md"})
+	result, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "SKILL.md"})
 	require.NoError(t, err)
-	assert.Contains(t, output.Instructions, "# Skills")
-	assert.Contains(t, output.Instructions, "skill-a")
+	body := skillText(t, result)
+	assert.Contains(t, body, "# Skills")
+	assert.Contains(t, body, "skill-a")
+	assert.Equal(t, "SKILL.md", output.Path)
+	assert.False(t, output.Truncated)
 }
 
 func TestReadSkillHandler_SubSkillMD(t *testing.T) {
 	h := newTestHandler()
-	_, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
+	result, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
 	require.NoError(t, err)
-	assert.Equal(t, "# Skill A\n\nContent here.", output.Instructions)
+	assert.Equal(t, "# Skill A\n\nContent here.", skillText(t, result))
+	assert.Equal(t, "skill-a/SKILL.md", output.Path)
+	assert.False(t, output.Truncated)
 }
 
 func TestReadSkillHandler_InvalidPaths(t *testing.T) {
@@ -80,20 +97,33 @@ func TestReadSkillHandler_Directory(t *testing.T) {
 
 func TestReadSkillHandler_FileTooLarge(t *testing.T) {
 	h := newTestHandler()
-	_, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "large.bin"})
+	result, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "large.bin"})
 	require.NoError(t, err)
-	assert.Contains(t, output.Instructions, "truncated after")
+	assert.Contains(t, skillText(t, result), "truncated after")
+	assert.True(t, output.Truncated)
 }
 
 func TestReadSkillHandler_RawTextInContent(t *testing.T) {
 	h := newTestHandler()
-	result, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "SKILL.md"})
+	result, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "SKILL.md"})
 	require.NoError(t, err)
-	require.NotNil(t, result)
-	tc, ok := result.Content[0].(*mcp.TextContent)
-	require.True(t, ok)
-	assert.Contains(t, tc.Text, "# Skills")
-	assert.Equal(t, tc.Text, output.Instructions)
+	assert.Contains(t, skillText(t, result), "# Skills")
+}
+
+// Regression test for #9290. The SDK marshals the returned output into
+// StructuredContent verbatim, so a body carried there as well as in the content
+// block would travel twice — once as markdown, once JSON-escaped.
+func TestReadSkillHandler_BodyNotRepeatedInStructuredOutput(t *testing.T) {
+	h := newTestHandler()
+	result, output, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "# Skill A\n\nContent here.", skillText(t, result))
+
+	structured, err := json.Marshal(output)
+	require.NoError(t, err)
+	assert.NotContains(t, string(structured), "Content here.")
+	assert.JSONEq(t, `{"path":"skill-a/SKILL.md","truncated":false}`, string(structured))
 }
 
 func TestNewReadSkillHandler(t *testing.T) {
@@ -124,21 +154,22 @@ func TestReadSkillHandler_DispatchesByPrefix(t *testing.T) {
 	h := &readSkillHandler{builtins: testSkillsFS(), custom: testCustomFS(), maxFileSize: testMaxFileSize}
 
 	t.Run("custom prefix reaches the custom tree", func(t *testing.T) {
-		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/slow-db-call/SKILL.md"})
+		result, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/slow-db-call/SKILL.md"})
 		require.NoError(t, err)
-		assert.Equal(t, "# Slow DB Call", out.Instructions)
+		assert.Equal(t, "# Slow DB Call", skillText(t, result))
+		assert.Equal(t, "custom/slow-db-call/SKILL.md", out.Path)
 	})
 
 	t.Run("custom entry point is served", func(t *testing.T) {
-		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/SKILL.md"})
+		result, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "custom/SKILL.md"})
 		require.NoError(t, err)
-		assert.Equal(t, "# Operator catalog", out.Instructions)
+		assert.Equal(t, "# Operator catalog", skillText(t, result))
 	})
 
 	t.Run("built-ins still reachable at the root", func(t *testing.T) {
-		_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
+		result, _, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.ReadSkillInput{Path: "skill-a/SKILL.md"})
 		require.NoError(t, err)
-		assert.Equal(t, "# Skill A\n\nContent here.", out.Instructions)
+		assert.Equal(t, "# Skill A\n\nContent here.", skillText(t, result))
 	})
 
 	t.Run("traversal out of custom is rejected", func(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/read_skill.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/read_skill.go
@@ -8,7 +8,16 @@ type ReadSkillInput struct {
 	Path string `json:"path" jsonschema:"Relative path within the skills directory (e.g. SKILL.md or detect-n-plus-one/SKILL.md)."`
 }
 
-// ReadSkillOutput defines the output of the read_skill MCP tool.
+// ReadSkillOutput defines the output of the read_skill MCP tool. It carries
+// only metadata: the skill body travels in the result's content block as
+// unescaped markdown, which is the form an agent reads. Repeating it here would
+// put the same bytes on the wire a second time, JSON-escaped, because the SDK
+// marshals this struct into StructuredContent verbatim.
 type ReadSkillOutput struct {
-	Instructions string `json:"instructions"`
+	// Path echoes the skill that was served, so a caller reading several skills
+	// can attribute a result without tracking request ids.
+	Path string `json:"path"`
+	// Truncated reports that the file exceeded the server's max_read_file_size
+	// and the content block holds only its leading bytes.
+	Truncated bool `json:"truncated"`
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #9290.

`read_skill` is the only one of the nine MCP tools that sets `CallToolResult.Content` itself. The SDK also copies the typed output into `StructuredContent`, so every response carried the skill body twice — once as unescaped markdown, once JSON-escaped.

Across the three embedded skills that is 7987 bytes on the wire for 3762 bytes of markdown, and `INSTRUCTIONS.md` routes agents through at least two `read_skill` calls before they reach any telemetry.

## Description of the changes

- Keep the markdown in the content block, which is where an agent reads it.
- Reduce `ReadSkillOutput` to metadata: the path that was served, and whether the file was truncated.

`truncated` also replaces having to match the `file content truncated after N bytes` notice out of the prose, and follows the `Truncated` field being added to `GetTraceErrorsOutput` in #9240.

Measured through the MCP round trip against the embedded skills:

| skill | file | before | after | saved |
|---|---|---|---|---|
| `SKILL.md` | 800 B | 1723 | 919 | 47% |
| `error-root-cause/SKILL.md` | 1427 B | 3021 | 1585 | 48% |
| `detect-n-plus-one/SKILL.md` | 1535 B | 3243 | 1697 | 48% |
| **total** | 3762 B | **7987** | **4201** | **47%** |

Both columns are measured over the MCP round trip, registering the old and new handler
shapes side by side on one server and marshalling each `CallToolResult`. An earlier
revision of this description derived the `before` column arithmetically instead and
overstated it by 140 bytes; the reproducer is in the thread.

Out of scope, deliberately: the `n > maxFileSize` boundary (#8911, with #8993 open on it), and the other eight tools, whose duplication comes from the MCP spec's backward-compat guidance rather than from our code — that side is measured in #9135.

## This is a schema change, and it needs an explicit ack

`read_skill`'s advertised output schema changes: `instructions` is replaced by `path` and `truncated`. A client reading `structuredContent.instructions` has to move to the content block. The body is unchanged for clients that already read `content`, which is where the MCP spec puts human-readable output.

#9290 laid out four options and this implements the fourth. That choice was argued in the issue thread by non-maintainers, including me, largely from the fact that `TestReadSkillHandler_RawTextInContent` looks like a deliberate decision to serve raw markdown. As @aryangorde8 pointed out there, that is an inference from a test name rather than a ratified decision, so I would rather this not merge without @yurishkuro or @jkowall confirming the shape. Happy to switch to one of the other options; the tests are the only part that would need real rework.

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegerquery/...` passes.
- `go vet`, `gofmt` and `gofumpt` are clean.
- `read_skill.go` is at 100% statement coverage on all three functions.
- `TestReadSkillHandler_BodyNotRepeatedInStructuredOutput` is the regression test: it marshals the typed output and asserts the body is absent. It fails against the previous shape with `"...\"instructions\":\"# Skill A\\n\\nContent here.\"}" should not contain "Content here."`.
- The existing body assertions were kept rather than dropped — they moved onto `result.Content`, via a small `skillText` helper, so the tests still fail if the handler stops serving the right file.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
