### PR TITLE
fix(otel-demo): Allow explicit OpenSearch recovery waiver

### DIFF
--- a/.github/workflows/ci-deploy-demo.yml
+++ b/.github/workflows/ci-deploy-demo.yml
@@ -44,6 +44,14 @@ on:
           - otel-demo
           - opensearch
           - all
+      opensearch_recovery:
+        description: 'OpenSearch recovery policy. Waive only for disposable data in an isolated upgrade.'
+        required: false
+        default: required
+        type: choice
+        options:
+          - required
+          - waive
 
 permissions: read-all
 
@@ -70,11 +78,33 @@ jobs:
       JAEGER_DEMO_DEPLOY_MODE: ${{ github.event.inputs.deploy_mode || 'upgrade' }}
       JAEGER_DEMO_STACK: ${{ github.event.inputs.demo_stack || 'oci' }}
       JAEGER_OTEL_DEMO_DEPLOY_SCOPE: ${{ github.event.inputs.otel_deploy_scope || 'jaeger' }}
+      JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY: ${{ github.event.inputs.opensearch_recovery || 'required' }}
       RUN_PUBLIC_SMOKE_TESTS: "true"
       MAIN_SHA: ${{ github.sha }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
 
     steps:
+    - name: Validate OpenSearch recovery policy
+      run: |
+        case "${JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY}" in
+          required)
+            ;;
+          waive)
+            if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ||
+              "${GITHUB_REF}" != "refs/heads/main" ||
+              "${JAEGER_DEMO_STACK}" != "otel" ||
+              "${JAEGER_DEMO_DEPLOY_MODE}" != "upgrade" ||
+              "${JAEGER_OTEL_DEMO_DEPLOY_SCOPE}" != "opensearch" ]]; then
+              echo "OpenSearch recovery may be waived only by a manual isolated otel/upgrade/opensearch run from main" >&2
+              exit 1
+            fi
+            ;;
+          *)
+            echo "Invalid OpenSearch recovery policy: ${JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY}" >&2
+            exit 1
+            ;;
+        esac
+
     - name: Configure kubectl with OKE
       uses: oracle-actions/configure-kubectl-oke@77a733d79446dabe7bf0e58eb56197d33ce4dc58 # v1.5.0
       with:

--- a/examples/otel-demo/README.md
+++ b/examples/otel-demo/README.md
@@ -115,6 +115,18 @@ instead. See the
 [OpenSearch recovery procedure](./OPENSEARCH_RECOVERY.md) for both intact- and
 replaced-namespace recovery.
 
+If the trace data is disposable, a maintainer may explicitly select
+`opensearch_recovery=waive` for a manual workflow dispatch from `main` whose
+other inputs are exactly `demo_stack=otel`, `deploy_mode=upgrade`, and
+`otel_deploy_scope=opensearch`. No other event, branch, stack, mode, or scope
+accepts the waiver. This skips only the recovery-point check: it does not run
+`clean`, delete data or storage, change the OpenSearch-before-Dashboards rollout
+order, or remove health waits. The waived upgrade has no tested rollback or
+data-recovery path if the existing persistent data becomes unusable.
+
+The waiver does not waive cluster-capacity checks. Confirm sufficient memory
+and disk headroom separately before dispatching the upgrade.
+
 The Jaeger deployment uses `jaeger-config.yaml` to configure the Jaeger v2
 `jaeger_storage` extension against the in-cluster OpenSearch service. The Helm
 chart storage type is set to `elasticsearch` for compatibility with the chart's

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -17,6 +17,7 @@ IMAGE_PULL_POLICY="${JAEGER_DEMO_IMAGE_PULL_POLICY:-IfNotPresent}"
 PUBLIC_JAEGER_URL="${JAEGER_DEMO_PUBLIC_JAEGER_URL:-${JAEGER_OTEL_DEMO_JAEGER_URL:-https://jaeger.demo.jaegertracing.io}}"
 RUN_PUBLIC_SMOKE_TESTS="${RUN_PUBLIC_SMOKE_TESTS:-false}"
 DEPLOY_SCOPE="${JAEGER_OTEL_DEMO_DEPLOY_SCOPE:-jaeger}"
+OPENSEARCH_RECOVERY="${JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY:-required}"
 # renovate: datasource=helm depName=opentelemetry-demo registryUrl=https://open-telemetry.github.io/opentelemetry-helm-charts
 OTEL_DEMO_CHART_VERSION="0.40.9"
 # renovate: datasource=helm depName=opensearch registryUrl=https://opensearch-project.github.io/helm-charts
@@ -48,6 +49,26 @@ validate_options() {
       return 1
       ;;
   esac
+
+  case "$OPENSEARCH_RECOVERY" in
+    required|waive)
+      ;;
+    *)
+      echo "Error: Invalid OpenSearch recovery policy '$OPENSEARCH_RECOVERY'" >&2
+      echo "Expected JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY to be 'required' or 'waive'" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ "$OPENSEARCH_RECOVERY" == "waive" ]] &&
+    { [[ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]] ||
+      [[ "${GITHUB_REF:-}" != "refs/heads/main" ]] ||
+      [[ "${JAEGER_DEMO_STACK:-}" != "otel" ]] ||
+      [[ "$MODE" != "upgrade" ]] ||
+      [[ "$DEPLOY_SCOPE" != "opensearch" ]]; }; then
+    echo "Error: OpenSearch recovery may be waived only by a manual isolated otel/upgrade/opensearch run from main" >&2
+    return 1
+  fi
 }
 
 configure_jaeger_helm_command() {
@@ -285,8 +306,18 @@ reconcile_ingress() {
 
 deploy_opensearch_releases() {
   if [[ "$MODE" == "upgrade" ]]; then
-    log "Verifying a recent tested OpenSearch recovery point"
-    bash "$SCRIPT_DIR/opensearch-recovery.sh" verify
+    case "$OPENSEARCH_RECOVERY" in
+      required)
+        log "Verifying a recent tested OpenSearch recovery point"
+        bash "$SCRIPT_DIR/opensearch-recovery.sh" verify
+        ;;
+      waive)
+        log "WARNING: OpenSearch recovery was explicitly waived; this upgrade has no tested rollback or data-recovery path"
+        ;;
+      *)
+        err "Invalid OpenSearch recovery policy '$OPENSEARCH_RECOVERY'"
+        ;;
+    esac
   fi
 
   log "Deploying OpenSearch chart $OPENSEARCH_CHART_VERSION"

--- a/examples/otel-demo/deploy-all.test.sh
+++ b/examples/otel-demo/deploy-all.test.sh
@@ -90,6 +90,58 @@ testInvalidModeIsRejected() {
   assertContains "$output" "Invalid mode 'invalid'"
 }
 
+testInvalidOpenSearchRecoveryPolicyIsRejected() {
+  output=$(bash -c '
+    source "$1"
+    MODE=upgrade
+    DEPLOY_SCOPE=opensearch
+    OPENSEARCH_RECOVERY=invalid
+    validate_options
+  ' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertEquals "invalid recovery policy should fail" 1 $rc
+  assertContains "$output" "Invalid OpenSearch recovery policy 'invalid'"
+}
+
+testOpenSearchRecoveryWaiverAcceptsOnlyManualMainIsolatedUpgrade() {
+  output=$(GITHUB_EVENT_NAME=workflow_dispatch \
+    GITHUB_REF=refs/heads/main \
+    JAEGER_DEMO_STACK=otel \
+    JAEGER_OTEL_DEMO_DEPLOY_SCOPE=opensearch \
+    JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY=waive \
+    bash -c 'source "$1"; MODE=upgrade; DEPLOY_SCOPE=opensearch; validate_options' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertEquals "exact manual waiver route should pass" 0 $rc
+  assertEquals "" "$output"
+}
+
+testOpenSearchRecoveryWaiverRejectsOtherRoutes() {
+  local cases=(
+    "schedule|refs/heads/main|otel|upgrade|opensearch"
+    "workflow_dispatch|refs/heads/feature|otel|upgrade|opensearch"
+    "workflow_dispatch|refs/heads/main|oci|upgrade|opensearch"
+    "workflow_dispatch|refs/heads/main|otel|clean|opensearch"
+    "workflow_dispatch|refs/heads/main|otel|upgrade|all"
+  )
+  local values
+
+  for values in "${cases[@]}"; do
+    IFS='|' read -r event ref stack mode scope <<<"$values"
+    output=$(GITHUB_EVENT_NAME="$event" \
+      GITHUB_REF="$ref" \
+      JAEGER_DEMO_STACK="$stack" \
+      JAEGER_OTEL_DEMO_DEPLOY_SCOPE="$scope" \
+      JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY=waive \
+      bash -c 'source "$1"; MODE="$2"; validate_options' _ "$SCRIPT" "$mode" 2>&1)
+    rc=$?
+
+    assertEquals "$values should reject the waiver" 1 $rc
+    assertContains "$output" "OpenSearch recovery may be waived only"
+  done
+}
+
 testMainIsGuardedWhenSourced() {
   output=$(bash -c 'source "$1"; printf sourced-only' _ "$SCRIPT" 2>&1)
   rc=$?
@@ -198,6 +250,43 @@ testRecoveryGatePrecedesOpenSearchUpgrade() {
 
   assertNotEquals "missing recovery point must stop deployment" 0 "$rc"
   assertContains "$output" "recovery $(dirname "$SCRIPT")/opensearch-recovery.sh verify"
+  assertNotContains "$output" "unsafe helm call"
+}
+
+testRecoveryWaiverSkipsOnlyRecoveryGate() {
+  output=$(bash -c '
+    source "$1"
+    MODE=upgrade
+    OPENSEARCH_RECOVERY=waive
+    log() { printf "log %s\n" "$*"; }
+    bash() { printf "unsafe recovery call\n"; }
+    helm() { printf "helm"; printf " %s" "$@"; printf "\n"; }
+    wait_for_statefulset() { printf "wait-for-statefulset"; printf " %s" "$@"; printf "\n"; }
+    wait_for_deployment() { printf "wait-for-deployment"; printf " %s" "$@"; printf "\n"; }
+    deploy_opensearch_releases
+  ' _ "$SCRIPT")
+
+  assertContains "$output" "WARNING: OpenSearch recovery was explicitly waived"
+  assertNotContains "$output" "unsafe recovery call"
+  assertContains "$output" "helm upgrade --install opensearch opensearch/opensearch"
+  assertContains "$output" "wait-for-statefulset opensearch opensearch-cluster-single 600s"
+  assertContains "$output" "helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards"
+  assertContains "$output" "wait-for-deployment opensearch opensearch-dashboards 600s"
+}
+
+testInvalidRecoveryPolicyCannotCallHelm() {
+  output=$(bash -c '
+    source "$1"
+    MODE=upgrade
+    OPENSEARCH_RECOVERY=invalid
+    log() { :; }
+    helm() { printf "unsafe helm call\n"; }
+    deploy_opensearch_releases
+  ' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertNotEquals "invalid recovery policy must stop deployment" 0 "$rc"
+  assertContains "$output" "Invalid OpenSearch recovery policy 'invalid'"
   assertNotContains "$output" "unsafe helm call"
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9312.

The OTel demo OpenSearch upgrade path currently requires a tested recovery
point. That is the safe default, but the current cluster does not expose the CSI
VolumeSnapshot API and the demo trace data is disposable. There was no narrow,
auditable way for an operator to accept that data-recovery risk.

## Description of the changes

- adds an `opensearch_recovery` workflow choice that defaults to `required`;
- accepts `waive` only for a manual dispatch from `main` whose route is exactly
  `otel / upgrade / opensearch`;
- enforces the same restriction again in `deploy-all.sh`;
- logs the missing rollback and data-recovery path before a waived upgrade;
- retains OpenSearch-before-Dashboards ordering, health waits, recovery tooling,
  and shared deployment concurrency; and
- documents that the waiver does not waive capacity checks or delete anything.

This PR does not deploy OpenSearch, resize storage, create a backup, use
`clean`, or delete any cluster resource.

## How was this change tested?

- `make fmt`
- `make lint`
- `SHUNIT2=/tmp/jaeger-shunit2 bash examples/otel-demo/deploy-all.test.sh`
- `actionlint .github/workflows/ci-deploy-demo.yml`
- `bash -n examples/otel-demo/deploy-all.sh examples/otel-demo/deploy-all.test.sh`
- `git diff --check`
- `make test` ran 4,194 tests; one unrelated `internal/storage/v2/grpc`
  goleak race failed and reproduced when rerun in isolation. The changed shell
  and workflow tests pass.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have signed the commit and included a DCO sign-off
