### PR TITLE
fix(otel-demo): Expand OpenSearch volume online

### DIFF
--- a/.github/workflows/ci-opensearch-volume-expand.yml
+++ b/.github/workflows/ci-opensearch-volume-expand.yml
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Expand OTel Demo OpenSearch Volume
+
+on:
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: jaeger-otel-demo-opensearch-recovery
+  cancel-in-progress: false
+
+jobs:
+  require-main:
+    name: Require protected main branch
+    runs-on: ubuntu-latest
+    steps:
+    - name: Reject non-main dispatches
+      env:
+        DISPATCH_REF: ${{ github.ref }}
+      run: test "$DISPATCH_REF" = 'refs/heads/main'
+
+  expand:
+    name: Expand the existing OpenSearch PVC to 100Gi
+    needs: require-main
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+
+    steps:
+    - name: Configure kubectl with OKE
+      uses: oracle-actions/configure-kubectl-oke@77a733d79446dabe7bf0e58eb56197d33ce4dc58 # v1.5.0
+      with:
+        cluster: ${{ secrets.OKE_CLUSTER_OCID }}
+        enablePrivateEndpoint: false
+
+    - name: Checkout Jaeger repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        ref: ${{ github.sha }}
+
+    - name: Expand and verify the OpenSearch volume
+      run: bash examples/otel-demo/opensearch-expand-volume.sh

--- a/examples/otel-demo/README.md
+++ b/examples/otel-demo/README.md
@@ -127,6 +127,22 @@ data-recovery path if the existing persistent data becomes unusable.
 The waiver does not waive cluster-capacity checks. Confirm sufficient memory
 and disk headroom separately before dispatching the upgrade.
 
+### OpenSearch volume expansion
+
+The manual `Expand OTel Demo OpenSearch Volume` workflow expands only the
+existing OpenSearch PVC to 100Gi. It verifies the expected StatefulSet, pod,
+PVC, StorageClass, and OCI CSI driver, then uses a preconditioned JSON Patch and
+waits for both Kubernetes and OpenSearch to report the expanded filesystem. It
+does not restart or replace the workload and is idempotent after a successful
+expansion.
+
+The live PVC intentionally remains larger than the 10Gi StatefulSet claim
+template after this operation. Kubernetes does not permit updating that
+template in place, and changing it during the OpenSearch Helm upgrade would
+fail on an immutable StatefulSet field. Reconcile the template separately only
+after the staged version upgrade and soak. PVC expansion cannot be rolled back
+or shrunk.
+
 The Jaeger deployment uses `jaeger-config.yaml` to configure the Jaeger v2
 `jaeger_storage` extension against the in-cluster OpenSearch service. The Helm
 chart storage type is set to `elasticsearch` for compatibility with the chart's

--- a/examples/otel-demo/opensearch-expand-volume.sh
+++ b/examples/otel-demo/opensearch-expand-volume.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+NAMESPACE="opensearch"
+STATEFULSET="opensearch-cluster-single"
+POD="opensearch-cluster-single-0"
+CONTAINER="opensearch"
+DATA_PATH="/usr/share/opensearch/data"
+STORAGE_CLASS="oci-bv"
+CSI_DRIVER="blockvolume.csi.oraclecloud.com"
+TARGET_STORAGE="100Gi"
+TIMEOUT_SECONDS="${OPENSEARCH_EXPAND_TIMEOUT_SECONDS:-3000}"
+JAEGER_URL="${JAEGER_OTEL_DEMO_JAEGER_URL:-https://jaeger.demo.jaegertracing.io}"
+
+log() { echo "[$(date -u +"%F %T UTC")] $*"; }
+err() { echo "[$(date -u +"%F %T UTC")] ERROR: $*" >&2; exit 1; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || err "$1 is required but not installed"
+}
+
+get_pod_json() {
+  kubectl -n "$NAMESPACE" get pod "$POD" -o json
+}
+
+get_statefulset_json() {
+  kubectl -n "$NAMESPACE" get statefulset "$STATEFULSET" -o json
+}
+
+get_bound_pv_json() {
+  local pv=$1
+  local pv_json
+
+  pv_json=$(kubectl get pv "$pv" -o json 2>/dev/null) ||
+    err "Cannot read the bound OpenSearch PV"
+  printf '%s\n' "$pv_json"
+}
+
+get_source_pvc() {
+  local pod_json=$1
+  local data_volume
+
+  data_volume=$(jq -r --arg container "$CONTAINER" --arg path "$DATA_PATH" '
+    .spec.containers[]
+    | select(.name == $container)
+    | .volumeMounts[]
+    | select(.mountPath == $path)
+    | .name
+  ' <<<"$pod_json")
+  [[ -n "$data_volume" && "$data_volume" != "null" ]] || err "Cannot resolve the OpenSearch data volume"
+
+  jq -r --arg volume "$data_volume" '
+    .spec.volumes[]
+    | select(.name == $volume)
+    | .persistentVolumeClaim.claimName
+  ' <<<"$pod_json"
+}
+
+verify_pod_owner() {
+  local pod_json=$1
+  local statefulset_json=$2
+  local expected_uid
+  local owner_uid
+
+  expected_uid=$(jq -r '.metadata.uid' <<<"$statefulset_json")
+  owner_uid=$(jq -r --arg name "$STATEFULSET" '
+    (.metadata.ownerReferences // [])[]
+    | select(.kind == "StatefulSet" and .name == $name and .controller == true)
+    | .uid
+  ' <<<"$pod_json")
+  [[ -n "$expected_uid" && "$owner_uid" == "$expected_uid" ]] ||
+    err "OpenSearch pod is not controlled by the expected StatefulSet"
+}
+
+verify_pvc_identity() {
+  local pvc_json=$1
+  local expected_pvc_uid=$2
+  local expected_volume_name=$3
+
+  jq -e --arg pvc_uid "$expected_pvc_uid" --arg volume_name "$expected_volume_name" '
+    .metadata.uid == $pvc_uid
+    and .spec.volumeName == $volume_name
+  ' >/dev/null <<<"$pvc_json" || err "OpenSearch PVC identity or binding changed"
+}
+
+get_pod_identity() {
+  local pod_json=$1
+
+  jq -er --arg container "$CONTAINER" '
+    . as $pod
+    | ([.status.containerStatuses[]? | select(.name == $container)] | first) as $status
+    | select(($pod.metadata.uid // "") | length > 0)
+    | select(($status.containerID // "") | length > 0)
+    | select(($status.restartCount // -1) >= 0)
+    | [$pod.metadata.uid, $status.containerID, ($status.restartCount | tostring)]
+    | @tsv
+  ' <<<"$pod_json"
+}
+
+verify_pod_identity() {
+  local pod_json=$1
+  local expected_pod_uid=$2
+  local expected_container_id=$3
+  local expected_restart_count=$4
+  local identity
+
+  identity=$(get_pod_identity "$pod_json") || err "Cannot resolve the OpenSearch pod identity"
+  [[ "$identity" == "$expected_pod_uid"$'\t'"$expected_container_id"$'\t'"$expected_restart_count" ]] ||
+    err "OpenSearch pod or container restarted or was replaced during expansion"
+}
+
+verify_statefulset_identity() {
+  local statefulset_json=$1
+  local expected_uid=$2
+
+  [[ "$(jq -r '.metadata.uid // empty' <<<"$statefulset_json")" == "$expected_uid" ]] ||
+    err "OpenSearch StatefulSet was replaced during expansion"
+}
+
+verify_opensearch_health() {
+  local response
+
+  response=$(kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+    curl --fail --silent --show-error \
+      'http://127.0.0.1:9200/_cluster/health?filter_path=status,number_of_nodes,initializing_shards,relocating_shards')
+  jq -e '
+    (.status == "yellow" or .status == "green")
+    and .number_of_nodes == 1
+    and .initializing_shards == 0
+    and .relocating_shards == 0
+  ' >/dev/null <<<"$response" || err "OpenSearch is not healthy enough for online expansion"
+}
+
+verify_jaeger_health() {
+  curl --fail --silent --show-error --max-time 20 "$JAEGER_URL/api/v3/services" |
+    jq -e '.. | strings | select(. == "checkout")' >/dev/null ||
+    err "Jaeger cannot query the checkout service"
+}
+
+verify_storage() {
+  local pvc_json=$1
+  local storage_class_json=$2
+  local pv_json=$3
+  local pvc_name
+  local pvc_namespace
+  local pvc_uid
+
+  pvc_name=$(jq -r '.metadata.name // empty' <<<"$pvc_json")
+  pvc_namespace=$(jq -r '.metadata.namespace // empty' <<<"$pvc_json")
+  pvc_uid=$(jq -r '.metadata.uid // empty' <<<"$pvc_json")
+
+  jq -e --arg class "$STORAGE_CLASS" '
+    .status.phase == "Bound"
+    and ((.spec.volumeMode // "Filesystem") == "Filesystem")
+    and .spec.storageClassName == $class
+    and ((.spec.volumeName // "") | length > 0)
+  ' >/dev/null <<<"$pvc_json" || err "OpenSearch PVC is not the expected bound filesystem claim"
+  jq -e --arg driver "$CSI_DRIVER" '
+    .provisioner == $driver and .allowVolumeExpansion == true
+  ' >/dev/null <<<"$storage_class_json" || err "The oci-bv StorageClass does not support expected CSI expansion"
+  jq -e --arg driver "$CSI_DRIVER" '
+    .status.phase == "Bound" and .spec.csi.driver == $driver
+  ' >/dev/null <<<"$pv_json" || err "OpenSearch is not backed by the expected OCI CSI Block Volume"
+  jq -e \
+    --arg name "$pvc_name" \
+    --arg namespace "$pvc_namespace" \
+    --arg uid "$pvc_uid" '
+      .spec.claimRef.name == $name
+      and .spec.claimRef.namespace == $namespace
+      and .spec.claimRef.uid == $uid
+    ' >/dev/null <<<"$pv_json" || err "OpenSearch PVC and PV binding do not match"
+}
+
+classify_capacity_state() {
+  local requested=$1
+  local capacity=$2
+
+  case "$requested|$capacity" in
+    10Gi\|50Gi|50Gi\|50Gi)
+      printf 'patch\n'
+      ;;
+    100Gi\|50Gi)
+      printf 'wait\n'
+      ;;
+    100Gi\|100Gi)
+      printf 'verify\n'
+      ;;
+    *)
+      err "Unexpected OpenSearch PVC capacity state; refusing to modify it"
+      ;;
+  esac
+}
+
+render_storage_patch() {
+  local uid=$1
+  local resource_version=$2
+  local requested=$3
+
+  jq -nc \
+    --arg uid "$uid" \
+    --arg resourceVersion "$resource_version" \
+    --arg requested "$requested" \
+    --arg target "$TARGET_STORAGE" '[
+      {"op":"test","path":"/metadata/uid","value":$uid},
+      {"op":"test","path":"/metadata/resourceVersion","value":$resourceVersion},
+      {"op":"test","path":"/spec/resources/requests/storage","value":$requested},
+      {"op":"replace","path":"/spec/resources/requests/storage","value":$target}
+    ]'
+}
+
+apply_capacity_state() {
+  local state=$1
+  local pvc=$2
+  local pvc_json=$3
+  local requested=$4
+  local patch
+
+  case "$state" in
+    patch)
+      patch=$(render_storage_patch \
+        "$(jq -r '.metadata.uid' <<<"$pvc_json")" \
+        "$(jq -r '.metadata.resourceVersion' <<<"$pvc_json")" \
+        "$requested")
+      log "Requesting online expansion of the existing OpenSearch PVC to $TARGET_STORAGE"
+      kubectl -n "$NAMESPACE" patch pvc "$pvc" --type=json -p "$patch" >/dev/null 2>&1 ||
+        err "OpenSearch PVC expansion request was rejected"
+      log "Expansion request accepted; if this run stops before verification, inspect the CSI resize state and do not retry blindly"
+      ;;
+    wait)
+      log "The online expansion request already exists; waiting for completion"
+      ;;
+    verify)
+      log "The OpenSearch PVC is already expanded; verifying capacity and health"
+      ;;
+    *)
+      err "Unknown OpenSearch PVC expansion state"
+      ;;
+  esac
+}
+
+wait_for_expansion() {
+  local pvc=$1
+  local elapsed=0
+  local pvc_json
+  local capacity
+  local requested
+  local conditions
+
+  while ((elapsed < TIMEOUT_SECONDS)); do
+    pvc_json=$(kubectl -n "$NAMESPACE" get pvc "$pvc" -o json)
+    capacity=$(jq -r '.status.capacity.storage // empty' <<<"$pvc_json")
+    requested=$(jq -r '.spec.resources.requests.storage // empty' <<<"$pvc_json")
+    conditions=$(jq -r '[.status.conditions[]? | select(.status == "True")] | length' <<<"$pvc_json")
+    if [[ "$requested" == "$TARGET_STORAGE" && "$capacity" == "$TARGET_STORAGE" && "$conditions" == "0" ]]; then
+      return 0
+    fi
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+
+  err "OpenSearch PVC did not finish expanding within ${TIMEOUT_SECONDS}s"
+}
+
+verify_filesystem_headroom() {
+  local response
+
+  response=$(kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+    curl --fail --silent --show-error \
+      'http://127.0.0.1:9200/_nodes/stats/fs?filter_path=nodes.*.fs.total.total_in_bytes,nodes.*.fs.total.available_in_bytes')
+  jq -e '
+    [.nodes[].fs.total
+      | select(.total_in_bytes >= 96636764160)
+      | select((.available_in_bytes / .total_in_bytes) >= 0.30)]
+    | length == 1
+  ' >/dev/null <<<"$response" || err "Expanded OpenSearch filesystem does not have at least 30% free capacity"
+}
+
+main() {
+  local pod_json
+  local statefulset_json
+  local pvc
+  local pvc_json
+  local expected_pvc_uid
+  local pv
+  local pv_json
+  local storage_class_json
+  local requested
+  local capacity
+  local state
+  local expected_statefulset_uid
+  local expected_pod_uid
+  local expected_container_id
+  local expected_restart_count
+  local pod_identity
+  local final_pvc
+
+  need kubectl
+  need jq
+  need curl
+  pod_json=$(get_pod_json)
+  statefulset_json=$(get_statefulset_json)
+  expected_statefulset_uid=$(jq -r '.metadata.uid // empty' <<<"$statefulset_json")
+  [[ -n "$expected_statefulset_uid" ]] || err "Cannot resolve the OpenSearch StatefulSet identity"
+  verify_pod_owner "$pod_json" "$statefulset_json"
+  pod_identity=$(get_pod_identity "$pod_json") || err "Cannot resolve the OpenSearch pod identity"
+  IFS=$'\t' read -r expected_pod_uid expected_container_id expected_restart_count <<<"$pod_identity"
+  pvc=$(get_source_pvc "$pod_json")
+  [[ -n "$pvc" && "$pvc" != "null" ]] || err "Cannot resolve the OpenSearch PVC"
+  pvc_json=$(kubectl -n "$NAMESPACE" get pvc "$pvc" -o json)
+  expected_pvc_uid=$(jq -r '.metadata.uid' <<<"$pvc_json")
+  pv=$(jq -r '.spec.volumeName' <<<"$pvc_json")
+  [[ -n "$expected_pvc_uid" && -n "$pv" && "$pv" != "null" ]] ||
+    err "Cannot resolve the OpenSearch PVC identity and binding"
+  verify_pvc_identity "$pvc_json" "$expected_pvc_uid" "$pv"
+  storage_class_json=$(kubectl get storageclass "$STORAGE_CLASS" -o json)
+  pv_json=$(get_bound_pv_json "$pv")
+  verify_storage "$pvc_json" "$storage_class_json" "$pv_json"
+  requested=$(jq -r '.spec.resources.requests.storage' <<<"$pvc_json")
+  capacity=$(jq -r '.status.capacity.storage' <<<"$pvc_json")
+  state=$(classify_capacity_state "$requested" "$capacity")
+
+  verify_opensearch_health
+  verify_jaeger_health
+  apply_capacity_state "$state" "$pvc" "$pvc_json" "$requested"
+
+  wait_for_expansion "$pvc"
+  pod_json=$(get_pod_json)
+  statefulset_json=$(get_statefulset_json)
+  verify_statefulset_identity "$statefulset_json" "$expected_statefulset_uid"
+  verify_pod_owner "$pod_json" "$statefulset_json"
+  verify_pod_identity "$pod_json" "$expected_pod_uid" "$expected_container_id" "$expected_restart_count"
+  final_pvc=$(get_source_pvc "$pod_json")
+  [[ "$final_pvc" == "$pvc" ]] || err "OpenSearch pod data claim changed during expansion"
+  pvc_json=$(kubectl -n "$NAMESPACE" get pvc "$pvc" -o json)
+  verify_pvc_identity "$pvc_json" "$expected_pvc_uid" "$pv"
+  pv_json=$(get_bound_pv_json "$pv")
+  verify_storage "$pvc_json" "$storage_class_json" "$pv_json"
+  verify_filesystem_headroom
+  verify_opensearch_health
+  verify_jaeger_health
+  log "OpenSearch PVC expansion verified at $TARGET_STORAGE with at least 30% filesystem headroom"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/examples/otel-demo/opensearch-expand-volume.test.sh
+++ b/examples/otel-demo/opensearch-expand-volume.test.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+SHUNIT2="${SHUNIT2:?'expecting SHUNIT2 env var pointing to a dir with https://github.com/kward/shunit2 clone'}"
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/opensearch-expand-volume.sh"
+
+testResolvesDataPvcFromExpectedContainerMount() {
+  pod_json='{
+    "spec": {
+      "containers": [{
+        "name": "opensearch",
+        "volumeMounts": [{"name": "data", "mountPath": "/usr/share/opensearch/data"}]
+      }],
+      "volumes": [{"name": "data", "persistentVolumeClaim": {"claimName": "data-opensearch-0"}}]
+    }
+  }'
+
+  output=$(bash -c 'source "$1"; get_source_pvc "$2"' _ "$SCRIPT" "$pod_json")
+  assertEquals "data-opensearch-0" "$output"
+}
+
+testVerifiesPodControllerUid() {
+  pod_json='{
+    "metadata": {"ownerReferences": [{
+      "kind": "StatefulSet", "name": "opensearch-cluster-single",
+      "controller": true, "uid": "expected"
+    }]}
+  }'
+  statefulset_json='{"metadata":{"uid":"expected"}}'
+
+  bash -c 'source "$1"; verify_pod_owner "$2" "$3"' \
+    _ "$SCRIPT" "$pod_json" "$statefulset_json"
+  assertEquals 0 $?
+}
+
+testRejectsUnexpectedPodController() {
+  pod_json='{
+    "metadata": {"ownerReferences": [{
+      "kind": "StatefulSet", "name": "opensearch-cluster-single",
+      "controller": true, "uid": "wrong"
+    }]}
+  }'
+  statefulset_json='{"metadata":{"uid":"expected"}}'
+
+  output=$(bash -c 'source "$1"; verify_pod_owner "$2" "$3"' \
+    _ "$SCRIPT" "$pod_json" "$statefulset_json" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "not controlled by the expected StatefulSet"
+}
+
+testRejectsPodWithoutOwnerReferencesWithSanitizedMessage() {
+  pod_json='{"metadata":{}}'
+  statefulset_json='{"metadata":{"uid":"expected"}}'
+
+  output=$(bash -c 'source "$1"; verify_pod_owner "$2" "$3"' \
+    _ "$SCRIPT" "$pod_json" "$statefulset_json" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "not controlled by the expected StatefulSet"
+  assertNotContains "$output" "Cannot iterate over null"
+}
+
+testVerifiesPvcIdentityAndBinding() {
+  pvc_json='{
+    "metadata":{"uid":"pvc-uid"},
+    "spec":{"volumeName":"pv-name"}
+  }'
+
+  bash -c 'source "$1"; verify_pvc_identity "$2" pvc-uid pv-name' \
+    _ "$SCRIPT" "$pvc_json"
+  assertEquals 0 $?
+}
+
+testRejectsChangedPvcIdentity() {
+  pvc_json='{
+    "metadata":{"uid":"new-pvc-uid"},
+    "spec":{"volumeName":"new-pv-name"}
+  }'
+
+  output=$(bash -c 'source "$1"; verify_pvc_identity "$2" pvc-uid pv-name' \
+    _ "$SCRIPT" "$pvc_json" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "PVC identity or binding changed"
+}
+
+testVerifiesExpectedCsiStorage() {
+  pvc_json='{
+    "metadata":{"name":"data","namespace":"opensearch","uid":"pvc-uid"},
+    "spec": {"storageClassName":"oci-bv","volumeMode":"Filesystem","volumeName":"redacted"},
+    "status":{"phase":"Bound"}
+  }'
+  storage_class_json='{
+    "provisioner":"blockvolume.csi.oraclecloud.com","allowVolumeExpansion":true
+  }'
+  pv_json='{
+    "spec":{
+      "csi":{"driver":"blockvolume.csi.oraclecloud.com"},
+      "claimRef":{"name":"data","namespace":"opensearch","uid":"pvc-uid"}
+    },
+    "status":{"phase":"Bound"}
+  }'
+
+  bash -c 'source "$1"; verify_storage "$2" "$3" "$4"' \
+    _ "$SCRIPT" "$pvc_json" "$storage_class_json" "$pv_json"
+  assertEquals 0 $?
+}
+
+testRejectsStorageClassWithoutExpansion() {
+  pvc_json='{
+    "metadata":{"name":"data","namespace":"opensearch","uid":"pvc-uid"},
+    "spec": {"storageClassName":"oci-bv","volumeMode":"Filesystem","volumeName":"redacted"},
+    "status":{"phase":"Bound"}
+  }'
+  storage_class_json='{
+    "provisioner":"blockvolume.csi.oraclecloud.com","allowVolumeExpansion":false
+  }'
+  pv_json='{
+    "spec":{
+      "csi":{"driver":"blockvolume.csi.oraclecloud.com"},
+      "claimRef":{"name":"data","namespace":"opensearch","uid":"pvc-uid"}
+    },
+    "status":{"phase":"Bound"}
+  }'
+
+  output=$(bash -c 'source "$1"; verify_storage "$2" "$3" "$4"' \
+    _ "$SCRIPT" "$pvc_json" "$storage_class_json" "$pv_json" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "does not support expected CSI expansion"
+}
+
+testRejectsMismatchedPvClaimRef() {
+  pvc_json='{
+    "metadata":{"name":"data","namespace":"opensearch","uid":"pvc-uid"},
+    "spec":{"storageClassName":"oci-bv","volumeMode":"Filesystem","volumeName":"redacted"},
+    "status":{"phase":"Bound"}
+  }'
+  storage_class_json='{
+    "provisioner":"blockvolume.csi.oraclecloud.com","allowVolumeExpansion":true
+  }'
+  pv_json='{
+    "spec":{
+      "csi":{"driver":"blockvolume.csi.oraclecloud.com"},
+      "claimRef":{"name":"other","namespace":"opensearch","uid":"other-uid"}
+    },
+    "status":{"phase":"Bound"}
+  }'
+
+  output=$(bash -c 'source "$1"; verify_storage "$2" "$3" "$4"' \
+    _ "$SCRIPT" "$pvc_json" "$storage_class_json" "$pv_json" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "PVC and PV binding do not match"
+}
+
+testPodIdentityDetectsRestartOrReplacement() {
+  pod_json='{
+    "metadata":{"uid":"pod-uid"},
+    "status":{"containerStatuses":[{
+      "name":"opensearch","containerID":"containerd://one","restartCount":2
+    }]}
+  }'
+  assertEquals $'pod-uid\tcontainerd://one\t2' \
+    "$(bash -c 'source "$1"; get_pod_identity "$2"' _ "$SCRIPT" "$pod_json")"
+
+  output=$(bash -c 'source "$1"; verify_pod_identity "$2" pod-uid containerd://one 1' \
+    _ "$SCRIPT" "$pod_json" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "restarted or was replaced"
+}
+
+testOpenSearchHealthAcceptsYellowWithoutShardMovement() {
+  output=$(bash -c '
+    source "$1"
+    fixture=$2
+    kubectl() { printf "%s" "$fixture"; }
+    verify_opensearch_health
+  ' _ "$SCRIPT" '{"status":"yellow","number_of_nodes":1,"initializing_shards":0,"relocating_shards":0}' 2>&1)
+  assertEquals "" "$output"
+}
+
+testOpenSearchHealthRejectsRelocatingShards() {
+  output=$(bash -c '
+    source "$1"
+    fixture=$2
+    kubectl() { printf "%s" "$fixture"; }
+    verify_opensearch_health
+  ' _ "$SCRIPT" '{"status":"yellow","number_of_nodes":1,"initializing_shards":0,"relocating_shards":1}' 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "not healthy enough"
+}
+
+testJaegerHealthRequiresCheckout() {
+  bash -c '
+    source "$1"
+    fixture=$2
+    curl() { printf "%s" "$fixture"; }
+    verify_jaeger_health
+  ' _ "$SCRIPT" '{"services":[{"name":"checkout"}]}'
+  assertEquals 0 $?
+
+  output=$(bash -c '
+    source "$1"
+    fixture=$2
+    curl() { printf "%s" "$fixture"; }
+    verify_jaeger_health
+  ' _ "$SCRIPT" '{"services":[{"name":"frontend"}]}' 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "cannot query the checkout service"
+}
+
+testWaitForExpansionRequiresRequestCapacityAndNoConditions() {
+  output=$(bash -c '
+    source "$1"
+    TIMEOUT_SECONDS=1
+    fixture=$2
+    kubectl() { printf "%s" "$fixture"; }
+    sleep() { :; }
+    wait_for_expansion data
+  ' _ "$SCRIPT" '{
+    "spec":{"resources":{"requests":{"storage":"100Gi"}}},
+    "status":{"capacity":{"storage":"100Gi"},"conditions":[]}
+  }' 2>&1)
+  assertEquals "" "$output"
+
+  output=$(bash -c '
+    source "$1"
+    TIMEOUT_SECONDS=1
+    fixture=$2
+    kubectl() { printf "%s" "$fixture"; }
+    sleep() { :; }
+    wait_for_expansion data
+  ' _ "$SCRIPT" '{
+    "spec":{"resources":{"requests":{"storage":"100Gi"}}},
+    "status":{"capacity":{"storage":"100Gi"},"conditions":[{"status":"True"}]}
+  }' 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "did not finish expanding"
+}
+
+testFilesystemHeadroomRequiresSizeAndThirtyPercentFree() {
+  bash -c '
+    source "$1"
+    fixture=$2
+    kubectl() { printf "%s" "$fixture"; }
+    verify_filesystem_headroom
+  ' _ "$SCRIPT" '{"nodes":{"one":{"fs":{"total":{"total_in_bytes":107374182400,"available_in_bytes":32212254720}}}}}'
+  assertEquals 0 $?
+
+  output=$(bash -c '
+    source "$1"
+    fixture=$2
+    kubectl() { printf "%s" "$fixture"; }
+    verify_filesystem_headroom
+  ' _ "$SCRIPT" '{"nodes":{"one":{"fs":{"total":{"total_in_bytes":107374182400,"available_in_bytes":21474836480}}}}}' 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "does not have at least 30% free capacity"
+}
+
+testPvReadFailureIsSanitized() {
+  output=$(bash -c '
+    source "$1"
+    kubectl() { printf "forbidden: secret-pv-name\n" >&2; return 1; }
+    get_bound_pv_json secret-pv-name
+  ' _ "$SCRIPT" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "Cannot read the bound OpenSearch PV"
+  assertNotContains "$output" "secret-pv-name"
+}
+
+testClassifiesKnownCapacityStates() {
+  assertEquals "patch" "$(bash -c 'source "$1"; classify_capacity_state 10Gi 50Gi' _ "$SCRIPT")"
+  assertEquals "patch" "$(bash -c 'source "$1"; classify_capacity_state 50Gi 50Gi' _ "$SCRIPT")"
+  assertEquals "wait" "$(bash -c 'source "$1"; classify_capacity_state 100Gi 50Gi' _ "$SCRIPT")"
+  assertEquals "verify" "$(bash -c 'source "$1"; classify_capacity_state 100Gi 100Gi' _ "$SCRIPT")"
+}
+
+testRejectsUnknownCapacityState() {
+  output=$(bash -c 'source "$1"; classify_capacity_state 75Gi 60Gi' _ "$SCRIPT" 2>&1)
+  rc=$?
+  assertNotEquals 0 "$rc"
+  assertContains "$output" "Unexpected OpenSearch PVC capacity state"
+}
+
+testPatchUsesIdentityVersionAndCurrentSizePreconditions() {
+  output=$(bash -c 'source "$1"; render_storage_patch uid-1 rv-2 50Gi' _ "$SCRIPT")
+
+  assertEquals "uid-1" "$(jq -r '.[0].value' <<<"$output")"
+  assertEquals "/metadata/uid" "$(jq -r '.[0].path' <<<"$output")"
+  assertEquals "rv-2" "$(jq -r '.[1].value' <<<"$output")"
+  assertEquals "50Gi" "$(jq -r '.[2].value' <<<"$output")"
+  assertEquals "replace" "$(jq -r '.[3].op' <<<"$output")"
+  assertEquals "/spec/resources/requests/storage" "$(jq -r '.[3].path' <<<"$output")"
+  assertEquals "100Gi" "$(jq -r '.[3].value' <<<"$output")"
+}
+
+testWaitAndVerifyStatesNeverPatch() {
+  pvc_json='{
+    "metadata":{"uid":"pvc-uid","resourceVersion":"rv-1"},
+    "spec":{"resources":{"requests":{"storage":"100Gi"}}}
+  }'
+
+  output=$(bash -c '
+    source "$1"
+    kubectl() { printf "unsafe patch\n"; }
+    apply_capacity_state wait data "$2" 100Gi
+    apply_capacity_state verify data "$2" 100Gi
+  ' _ "$SCRIPT" "$pvc_json")
+  assertNotContains "$output" "unsafe patch"
+  assertContains "$output" "request already exists"
+  assertContains "$output" "already expanded"
+}
+
+testPatchStateCallsOnlyPreconditionedPvcPatch() {
+  pvc_json='{
+    "metadata":{"uid":"pvc-uid","resourceVersion":"rv-1"},
+    "spec":{"resources":{"requests":{"storage":"50Gi"}}}
+  }'
+
+  output=$(bash -c '
+    source "$1"
+    called=0
+    arguments=""
+    kubectl() { called=1; arguments=$*; }
+    apply_capacity_state patch data "$2" 50Gi
+    printf "called=%s\narguments=%s\n" "$called" "$arguments"
+  ' _ "$SCRIPT" "$pvc_json")
+  assertContains "$output" "called=1"
+  assertContains "$output" "patch pvc data --type=json"
+  assertContains "$output" '"path":"/metadata/uid","value":"pvc-uid"'
+  assertContains "$output" '"path":"/metadata/resourceVersion","value":"rv-1"'
+  assertContains "$output" '"path":"/spec/resources/requests/storage","value":"100Gi"'
+  assertContains "$output" "do not retry blindly"
+}
+
+testScriptAllowsOnlyPvcPatchMutation() {
+  contents=$(cat "$SCRIPT")
+
+  # shellcheck disable=SC2016
+  assertContains "$contents" 'patch pvc "$pvc" --type=json'
+  assertNotContains "$contents" "kubectl delete"
+  assertNotContains "$contents" "kubectl create"
+  assertNotContains "$contents" "kubectl apply"
+  assertNotContains "$contents" "helm "
+  assertNotContains "$contents" "oci "
+  assertNotContains "$contents" "volumeHandle"
+  assertNotContains "$contents" "describe"
+  assertNotContains "$contents" "events"
+  assertNotContains "$contents" "set -x"
+}
+
+testScriptKeepsTargetFixedAt100Gi() {
+  contents=$(cat "$SCRIPT")
+
+  assertContains "$contents" 'TARGET_STORAGE="100Gi"'
+  assertContains "$contents" "at least 30% free capacity"
+  # shellcheck disable=SC2016
+  assertNotContains "$contents" 'TARGET_STORAGE="${'
+}
+
+# shellcheck disable=SC1091
+source "${SHUNIT2}/shunit2"

--- a/examples/otel-demo/opensearch-values.yaml
+++ b/examples/otel-demo/opensearch-values.yaml
@@ -11,6 +11,8 @@ replicas: 1
 
 persistence:
   enabled: true
+  # OCI rounds this request up to 50Gi. The live PVC is expanded separately
+  # because StatefulSet volume claim templates cannot be updated in place.
   size: "10Gi"
   storageClass: "oci-bv" # Using Oracle Cloud Block Volume storage class
 

--- a/scripts/utils/run-tests.sh
+++ b/scripts/utils/run-tests.sh
@@ -13,6 +13,7 @@ TEST_FILES=(
     "$UTILS_DIR/retry.test.sh"
     "$UTILS_DIR/resolve-demo-snapshot-tags.test.sh"
     "$REPO_ROOT/examples/otel-demo/deploy-all.test.sh"
+    "$REPO_ROOT/examples/otel-demo/opensearch-expand-volume.test.sh"
     "$REPO_ROOT/examples/otel-demo/opensearch-recovery.test.sh"
     "$REPO_ROOT/internal/storage/v1/cassandra/schema/create.test.sh"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9314.

The OTel demo OpenSearch filesystem is approximately 94% used. OCI rounded the
chart's 10Gi request up to its 50Gi minimum, and the live PVC needs more
headroom before the staged OpenSearch 2.19.6 upgrade.

## Description of the changes

- adds a manual, main-only workflow serialized with the deployment and recovery
  workflows;
- discovers the existing data PVC from the live OpenSearch pod mount;
- verifies StatefulSet, pod, container, PVC, reciprocal PV binding,
  StorageClass, and OCI CSI identities before mutation;
- applies one preconditioned JSON Patch that requests a fixed 100Gi capacity;
- supports initial, in-progress, and already-expanded states idempotently;
- waits for Kubernetes and OpenSearch to report 100Gi with at least 30% free;
- proves the StatefulSet, pod, container ID/restart count, PVC UID, and PV
  binding did not change; and
- rechecks OpenSearch and Jaeger service health.

The script suppresses private PV diagnostics. It never deletes, creates, or
replaces a workload, PVC, PV, namespace, index, or snapshot. It does not deploy
OpenSearch or change the immutable StatefulSet volume claim template.

## How was this change tested?

- `make fmt`
- `make lint`
- `SHUNIT2=/tmp/jaeger-shunit2 bash examples/otel-demo/opensearch-expand-volume.test.sh` (23 tests)
- `actionlint .github/workflows/ci-opensearch-volume-expand.yml`
- `bash -n examples/otel-demo/opensearch-expand-volume.sh examples/otel-demo/opensearch-expand-volume.test.sh`
- `shellcheck examples/otel-demo/opensearch-expand-volume.sh examples/otel-demo/opensearch-expand-volume.test.sh`
- `git diff --check`
- `make test` passed all 4,200 tests (38 integration/configuration skips)

The full registered shell suite also passed every suite except the existing
`compute-tags.test.sh`, whose assertions use GNU `grep -P` and fail on macOS
BSD grep. The new expansion suite passed within that run.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have signed the commit and included a DCO sign-off
