### PR TITLE
fix(mcp): Report search depth and truncation from search_traces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -73,7 +73,14 @@ outer:
 		}
 	}
 
-	output := types.SearchTracesOutput{Traces: summaries}
+	// The search depth is clamped to the server limit and is what bounds the
+	// result, so report it alongside whether the result filled it. Without both,
+	// a full page is indistinguishable from an exhaustive one.
+	output := types.SearchTracesOutput{
+		Traces:          summaries,
+		SearchDepthUsed: query.SearchDepth,
+		Truncated:       query.SearchDepth > 0 && len(summaries) >= query.SearchDepth,
+	}
 	if len(processErrs) > 0 {
 		searchErr := errors.Join(processErrs...)
 		if len(summaries) == 0 {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -627,3 +627,84 @@ func TestSearchTracesHandler_Handle_LimitEnforced(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, output.Traces, 3)
 }
+
+// yieldSummaries returns a mock that yields n identical summaries in one batch.
+func yieldSummaries(n int) *mockQueryService {
+	batch := make([]tracestore.TraceSummary, n)
+	for i := range batch {
+		batch[i] = makeTraceSummary("svc", "/op", false)
+	}
+	return &mockQueryService{
+		findTraceSummariesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			return func(yield func([]tracestore.TraceSummary, error) bool) {
+				yield(batch, nil)
+			}
+		},
+	}
+}
+
+func TestSearchTracesHandler_Handle_ReportsTruncation(t *testing.T) {
+	tests := []struct {
+		name           string
+		returned       int
+		requestedDepth int
+		maxResults     int
+		wantTraces     int
+		wantDepthUsed  int
+		wantTruncated  bool
+	}{
+		{
+			name:           "result fills the depth",
+			returned:       5,
+			requestedDepth: 5,
+			maxResults:     100,
+			wantTraces:     5,
+			wantDepthUsed:  5,
+			wantTruncated:  true,
+		},
+		{
+			name:           "result is short of the depth",
+			returned:       2,
+			requestedDepth: 5,
+			maxResults:     100,
+			wantTraces:     2,
+			wantDepthUsed:  5,
+			wantTruncated:  false,
+		},
+		{
+			name:           "requested depth is clamped to the server limit",
+			returned:       3,
+			requestedDepth: 500,
+			maxResults:     3,
+			wantTraces:     3,
+			wantDepthUsed:  3,
+			wantTruncated:  true,
+		},
+		{
+			name:           "unset depth reports the default",
+			returned:       1,
+			requestedDepth: 0,
+			maxResults:     100,
+			wantTraces:     1,
+			wantDepthUsed:  10,
+			wantTruncated:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &searchTracesHandler{
+				queryService: yieldSummaries(tt.returned),
+				maxResults:   tt.maxResults,
+			}
+
+			input := types.SearchTracesInput{ServiceName: "svc", SearchDepth: tt.requestedDepth}
+			_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+			require.NoError(t, err)
+			assert.Len(t, output.Traces, tt.wantTraces)
+			assert.Equal(t, tt.wantDepthUsed, output.SearchDepthUsed)
+			assert.Equal(t, tt.wantTruncated, output.Truncated)
+		})
+	}
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
@@ -44,6 +44,14 @@ type SearchTracesInput struct {
 type SearchTracesOutput struct {
 	Traces []TraceSummary `json:"traces,omitempty" jsonschema:"List of trace summaries matching the search criteria"`
 	Error  string         `json:"error,omitempty" jsonschema:"Error message if partial results were returned"`
+
+	// SearchDepthUsed is the depth the search actually ran with, which is the
+	// requested search_depth clamped to the server's MaxSearchResults.
+	SearchDepthUsed int `json:"search_depth_used" jsonschema:"Search depth actually used, after clamping to the server limit"`
+
+	// Truncated is true when the result filled SearchDepthUsed, so more traces
+	// may match the query.
+	Truncated bool `json:"truncated" jsonschema:"True if the result filled the search depth; more traces may match. Raise search_depth or narrow the query"`
 }
 
 // TraceSummary contains lightweight metadata about a single trace.


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9319

`search_traces` bounds its result by `search_depth`, clamped to the server's `MaxSearchResults`, and returns neither number. A result that fills the depth is indistinguishable from an exhaustive one, and a request for 500 is quietly served at 100.

The sibling tools already signal this. `get_services` returns `total_count` and `truncated`, `get_trace_errors` returns `total_error_count`. `search_traces` is the entry point and had nothing.

## Description of the changes

- `SearchTracesOutput` gains `search_depth_used` and `truncated`.
- `search_depth_used` is the depth the query actually ran with, after clamping.
- `truncated` is true when the result filled that depth, so more traces may match.

Storage applies the depth, so an exact match total is not available without a second query. These two fields are what the handler can report without guessing.

## How was this change tested?

- `TestSearchTracesHandler_Handle_ReportsTruncation` covers a result that fills the depth, one short of it, a requested depth clamped by the server limit, and an unset depth reporting the default of 10.
- The tests fail with the change backed out. `go test ./cmd/jaeger/internal/extension/jaegerquery/...` passes.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully