### PR TITLE
fix(mcptools): Fix the mcptools trace details code to reject invalid all-zero trace IDs, just like it already rejects invalid all-zero span IDs.

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details.go
@@ -282,6 +282,11 @@ func parseTraceID(traceIDStr string) (pcommon.TraceID, error) {
 	}
 
 	copy(traceID[:], bytes)
+	// The all-zero trace ID can never identify a real trace: TraceID.String()
+	// returns "" for it, so it would silently never match in storage.
+	if traceID.IsEmpty() {
+		return pcommon.TraceID{}, errors.New("trace ID must not be all zero")
+	}
 	return traceID, nil
 }
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_span_details_test.go
@@ -542,6 +542,11 @@ func TestParseTraceID(t *testing.T) {
 			input:     "",
 			wantError: true,
 		},
+		{
+			name:      "invalid trace ID - all zero",
+			input:     "00000000000000000000000000000000",
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -555,6 +560,24 @@ func TestParseTraceID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSpanDetailsHandler_Handle_ZeroTraceID(t *testing.T) {
+	// The all-zero trace_id is syntactically valid hex but can never identify a
+	// real trace, so it must be rejected before any backend query runs. A nil
+	// queryService is safe here: reaching it would panic.
+	handler := NewGetSpanDetailsHandler(nil, 50)
+
+	input := types.GetSpanDetailsInput{
+		TraceID: "00000000000000000000000000000000",
+		SpanIDs: []string{spanIDToHex("span001")},
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid trace_id")
+	assert.Contains(t, err.Error(), "trace ID must not be all zero")
 }
 
 func TestGetSpanDetailsHandler_Handle_UppercaseSpanID(t *testing.T) {


### PR DESCRIPTION

## Which problem is this PR solving?
`parseTraceID` in the `get_span_details` MCP tool accepts the all-zero trace ID (`00000000000000000000000000000000`), while `parseSpanID` in the same file already rejects the equivalent all-zero span ID. `pcommon.TraceID` exposes the same `IsEmpty()` method `pcommon.SpanID` does, so there's no reason for the two to behave differently.

This isn't a crash or data-corruption bug — a zero trace_id currently just fails later with a generic "trace not found" after a wasted backend query, instead of failing fast at validation with a clear "invalid trace_id". Small correctness/consistency fix, not a functional regression.

## Description of the changes
- Added an `IsEmpty()` check in `parseTraceID`, mirroring the existing guard in `parseSpanID`. Same error style, same place in the function, same pattern — no new logic introduced.
- Added a table case for the all-zero trace ID to `TestParseTraceID`
- Added `TestGetSpanDetailsHandler_Handle_ZeroTraceID`, mirroring the existing`TestGetSpanDetailsHandler_Handle_ZeroSpanID`.

## How was this change tested?
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/... -v`
  — full package passes, including the two new tests.
- `go vet ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/...`
  — clean.
- Confirmed the new tests fail without the implementation change and pass with it.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
