### PR TITLE
fix(mcp): Include back-to-back sibling spans in the critical path walk

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc.go
@@ -27,8 +27,12 @@ func findLastFinishingChildSpan(
 		childEndTime := childSpan.StartTime + childSpan.Duration
 
 		if returningChildStartTime != nil {
-			// Find child that finishes just before the returning child's start time
-			if childEndTime < *returningChildStartTime {
+			// Find child that finishes just before the returning child's start time.
+			// The bound is inclusive: back-to-back siblings, where one ends on the
+			// exact microsecond the next begins, are the common shape for sequential
+			// work and belong on the critical path. A strict bound dropped them,
+			// truncating the walk at the first such boundary.
+			if childEndTime <= *returningChildStartTime {
 				if childEndTime > maxEndTime {
 					maxEndTime = childEndTime
 					childSpanCopy := childSpan

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/criticalpath/find_lfc_test.go
@@ -181,6 +181,73 @@ func TestFindLastFinishingChildSpan(t *testing.T) {
 			returningChildStartTime: new(uint64(155)),
 			expectedSpanID:          &pcommon.SpanID{4}, // ends at 150 < 155, closest to returningChildStartTime
 		},
+		{
+			// Regression: back-to-back sequential siblings. The predecessor ends on
+			// the exact microsecond the returning child starts, which is the normal
+			// shape for sequential work and must stay on the critical path.
+			name: "child ending exactly at returningChildStartTime is included",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 100,
+					Duration:  50, // ends at 150, exactly when the returning child starts
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          &pcommon.SpanID{2},
+		},
+		{
+			// The exact-boundary sibling is also the *best* answer when an earlier
+			// sibling also qualifies — it is the one immediately preceding the
+			// returning child.
+			name: "exact-boundary child wins over an earlier finishing sibling",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 100,
+					Duration:  20, // ends at 120
+				},
+				spanID(3): {
+					SpanID:    spanID(3),
+					StartTime: 120,
+					Duration:  30, // ends at 150, exactly at the boundary
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2), spanID(3)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          &pcommon.SpanID{3},
+		},
+		{
+			// The bound stays exclusive on the other side: a sibling still running
+			// when the returning child starts overlaps it and is not a predecessor.
+			name: "child ending after returningChildStartTime is still excluded",
+			spanMap: map[pcommon.SpanID]CPSpan{
+				spanID(2): {
+					SpanID:    spanID(2),
+					StartTime: 100,
+					Duration:  51, // ends at 151, one past the boundary
+				},
+			},
+			currentSpan: CPSpan{
+				SpanID:       spanID(1),
+				StartTime:    100,
+				Duration:     100,
+				ChildSpanIDs: []pcommon.SpanID{spanID(2)},
+			},
+			returningChildStartTime: new(uint64(150)),
+			expectedSpanID:          nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9173
- Resolves #9148

## Description of the changes

`findLastFinishingChildSpan` required a child to end *strictly* before the
returning child started, so a sibling finishing on the exact microsecond the next
one began was never selected. Sequential work commonly produces those exact
boundaries, and the walk truncated at the first one, leaving `get_critical_path`
silently short.

The bound becomes inclusive. The other side stays exclusive: a sibling still
running when the returning child starts overlaps it and is not a predecessor.

This also resolves #9148, which describes the same boundary from the
predecessor-sibling side.

**On the existing PRs:** #9174, #9214 and #9218 all propose the same one-character
change, and #9174 got there first. I am not claiming novelty on the fix. The only
thing this adds is two regression cases that none of the three currently pin:

1. When an earlier sibling *also* qualifies, the exact-boundary child must win —
   it is the immediate predecessor. Siblings ending at 120 and 150 against
   `returningChildStartTime = 150` pin the *selection*, not just the inclusion.
2. A sibling ending at 151 against the same boundary must still be excluded.
   Without this, `<=` could drift to `<= +1` unnoticed.

**Maintainers: if you would rather merge #9174, please do — I am happy to close
this and send those two test cases as a follow-up against it instead.** I opened
it as a PR rather than a review comment only so the cases are runnable.

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/...`
- Three new table cases in `find_lfc_test.go`: the inclusive boundary, the
  selection among multiple qualifying siblings, and the still-exclusive far side.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
