### PR TITLE
fix(mcp): Reject conflicting with_errors and error attribute in search_traces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -19,6 +19,11 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
 )
 
+// errorAttributeKey is the attribute the with_errors shorthand expands to. It is
+// also a key callers may set directly through attributes, which is why the two
+// have to be reconciled rather than blindly merged.
+const errorAttributeKey = "error"
+
 // queryServiceInterface defines the interface we need from QueryService for testing.
 type queryServiceInterface interface {
 	FindTraceSummaries(ctx context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error]
@@ -169,12 +174,22 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 		searchDepth = h.maxResults
 	}
 
+	// with_errors is sugar for the "error" attribute, so the two can express
+	// contradictory filters through different channels. Silently letting one win
+	// hands the agent results that do not match what it asked for, and nothing in
+	// the response reveals the substitution — so reject the ambiguity instead.
+	if userError, ok := input.Attributes[errorAttributeKey]; ok && input.WithErrors && userError != "true" {
+		return querysvc.TraceQueryParams{}, fmt.Errorf(
+			"conflicting filters: with_errors=true implies attributes[%q]=\"true\", but %q was given; drop one of them",
+			errorAttributeKey, userError)
+	}
+
 	attributes := pcommon.NewMap()
 	for key, value := range input.Attributes {
 		attributes.PutStr(key, value)
 	}
 	if input.WithErrors {
-		attributes.PutStr("error", "true")
+		attributes.PutStr(errorAttributeKey, "true")
 	}
 
 	return querysvc.TraceQueryParams{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -223,6 +223,92 @@ func TestSearchTracesHandler_Handle_WithErrorsFilter(t *testing.T) {
 	assert.True(t, output.Traces[0].HasErrors)
 }
 
+func TestSearchTracesHandler_Handle_WithErrorsConflictsWithErrorAttribute(t *testing.T) {
+	// The query must never reach storage: the caller asked for two different
+	// things and the tool cannot pick one for them.
+	mock := &mockQueryService{
+		findTraceSummariesFunc: func(context.Context, querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			t.Fatal("storage must not be queried when the filters conflict")
+			return nil
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "test",
+		WithErrors:   true,
+		Attributes:   map[string]string{"error": "false"},
+	}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "conflicting filters")
+}
+
+func TestSearchTracesHandler_Handle_WithErrorsAgreesWithErrorAttribute(t *testing.T) {
+	// Redundant but consistent: both channels ask for errored traces, so there is
+	// no ambiguity to reject.
+	want := makeTraceSummary("test", "/error", true)
+
+	mock := &mockQueryService{
+		findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			errorAttr, ok := query.Attributes.Get("error")
+			assert.True(t, ok)
+			assert.Equal(t, "true", errorAttr.Str())
+			return func(yield func([]tracestore.TraceSummary, error) bool) {
+				yield([]tracestore.TraceSummary{want}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "test",
+		WithErrors:   true,
+		Attributes:   map[string]string{"error": "true"},
+	}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	require.Len(t, output.Traces, 1)
+}
+
+func TestSearchTracesHandler_Handle_ErrorAttributeAloneIsPreserved(t *testing.T) {
+	// Without with_errors there is nothing to reconcile, and an explicit
+	// error=false filter must survive to storage rather than being overwritten.
+	want := makeTraceSummary("test", "/ok", false)
+
+	mock := &mockQueryService{
+		findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			errorAttr, ok := query.Attributes.Get("error")
+			assert.True(t, ok)
+			assert.Equal(t, "false", errorAttr.Str())
+			return func(yield func([]tracestore.TraceSummary, error) bool) {
+				yield([]tracestore.TraceSummary{want}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "test",
+		Attributes:   map[string]string{"error": "false"},
+	}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	require.Len(t, output.Traces, 1)
+}
+
 func TestSearchTracesHandler_Handle_WithErrorsFilter_UsingMemoryStore(t *testing.T) {
 	store, err := memory.NewStore(memory.Configuration{MaxTraces: 10})
 	require.NoError(t, err)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
@@ -25,7 +25,9 @@ type SearchTracesInput struct {
 	Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
 
 	// WithErrors filters to only return traces containing error spans (optional).
-	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only return traces containing error spans"`
+	// It is shorthand for attributes["error"]="true"; setting both to conflicting
+	// values is rejected rather than silently resolved.
+	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only return traces containing error spans. Shorthand for attributes[error]=true; do not also pass a conflicting error attribute"`
 
 	// DurationMin is the minimum duration filter (optional, e.g., "2s", "100ms").
 	DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9176

## Description of the changes

`with_errors` is shorthand for `attributes["error"]="true"`, and the handler
applied it *after* copying the caller's attributes — so an explicit
`attributes["error"]="false"` was silently overwritten. The agent then received
errored traces while believing it had filtered them out, and nothing in the
response disclosed the substitution. For an assistant reasoning over the result, a
silently different query is worse than an error.

- Conflicting values are rejected, with a message naming both inputs.
- **Agreeing values stay valid.** `with_errors: true` together with
  `attributes: {error: "true"}` is redundant but unambiguous — both ask for the
  same filter. Failing there costs the agent a retry for no correctness gain. An
  error should mean "I cannot tell what you want", not "you were repetitive".
- An `error` attribute passed *without* `with_errors` reaches storage unchanged.
- The tool schema now states the relationship, so callers can avoid the conflict
  up front rather than discovering it through an error.

**On the existing PRs:** #9177 and #9236 both address this issue and predate this
one. The design question I would flag for maintainers regardless of which lands is
the agreeing-values case above — whether redundant-but-consistent input should be
rejected or accepted. This PR accepts it; if the preference is strict rejection,
that is a one-line change.

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/...`
- Three new tests: the conflict is rejected *before* storage is touched (the mock
  fails the test if queried), the agreeing case still queries, and a lone
  `error=false` survives to storage unmodified.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
