### PR TITLE
fix(safeexpvar): Prevent panic on concurrent first use of SetInt

### DIFF
--- a/internal/safeexpvar/safeexpvar.go
+++ b/internal/safeexpvar/safeexpvar.go
@@ -5,12 +5,28 @@ package safeexpvar
 
 import (
 	"expvar"
+	"sync"
 )
 
+// createMu serializes the get-or-create step. expvar offers no atomic
+// equivalent: Get and NewInt are individually safe, but between them two
+// goroutines can both observe nil for the same name and both call NewInt, and
+// the second panics with "Reuse of exported var name". Publishing a var is rare
+// and happens on startup paths, so a package-level mutex costs nothing.
+var createMu sync.Mutex
+
+// SetInt publishes value under name, creating the expvar.Int on first use.
+// It is safe for concurrent use, including concurrent first use of the same name.
 func SetInt(name string, value int64) {
 	v := expvar.Get(name)
 	if v == nil {
-		v = expvar.NewInt(name)
+		createMu.Lock()
+		// Re-check under the lock: another goroutine may have published name
+		// while this one was blocked, and NewInt would panic on the duplicate.
+		if v = expvar.Get(name); v == nil {
+			v = expvar.NewInt(name)
+		}
+		createMu.Unlock()
 	}
 	v.(*expvar.Int).Set(value)
 }

--- a/internal/safeexpvar/safeexpvar_test.go
+++ b/internal/safeexpvar/safeexpvar_test.go
@@ -5,6 +5,7 @@ package safeexpvar
 
 import (
 	"expvar"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,37 @@ func TestSetInt(t *testing.T) {
 	expInt, ok := v.(*expvar.Int)
 	require.True(t, ok, "expected variable %s to be of type *expvar.Int", name)
 	assert.Equal(t, value, expInt.Value())
+}
+
+// Regression: concurrent first use of the same name used to let two goroutines
+// both see nil from expvar.Get and both call expvar.NewInt, panicking the second
+// with "Reuse of exported var name". Run with -race for the full signal.
+func TestSetIntConcurrentFirstUse(t *testing.T) {
+	name := "metrics-test-concurrent"
+	const goroutines = 32
+
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	done.Add(goroutines)
+
+	for i := range goroutines {
+		go func() {
+			defer done.Done()
+			start.Wait() // release everyone at once to widen the race window
+			assert.NotPanics(t, func() { SetInt(name, int64(i)) })
+		}()
+	}
+
+	start.Done()
+	done.Wait()
+
+	v := expvar.Get(name)
+	require.NotNil(t, v, "expected variable %s to be created exactly once", name)
+	expInt, ok := v.(*expvar.Int)
+	require.True(t, ok, "expected variable %s to be of type *expvar.Int", name)
+	// The winning writer is nondeterministic; only publication matters here.
+	assert.Less(t, expInt.Value(), int64(goroutines))
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9282

## Description of the changes

`expvar.Get` and `expvar.NewInt` are each safe, but `SetInt` used them as a
non-atomic get-or-create: two goroutines publishing the same name for the first
time could both observe `nil` and both call `NewInt`, panicking the second with
"Reuse of exported var name".

The create step is now guarded by a package-level mutex with a re-check under the
lock. Publishing is rare and confined to startup paths, so the lock is not on any
hot path — the common case still takes the unlocked `Get`.

**On the existing PR:** #9284 already fixes this with the same double-checked
locking approach and got there first. I am not claiming novelty. This adds a
concurrency regression test (32 goroutines released simultaneously on the same
unpublished name) that asserts no panic and exactly one publication.

**Maintainers: #9284 is the one to merge — I am happy to close this and send the
test as a follow-up against it.** Opened as a PR only so the test is runnable.

## How was this change tested?

- `go test ./internal/safeexpvar/...`
- New `TestSetIntConcurrentFirstUse`. Note it was **not** verified under `-race`
  locally (no 64-bit C toolchain on my machine); the test still fails on the panic
  itself, which is the actual defect, and CI will cover the race detector.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
