### PR TITLE
feat(mcptools): Strengthen context-cost signals in tool descriptions

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -140,7 +140,8 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_span_details",
 		Description: "Fetch full span data (attributes, events, links, status) for specific spans. " +
-			"Returns verbose output per span.",
+			"Returns verbose output per span. Prefer a small, targeted set of span IDs; " +
+			"requesting an entire trace's spans produces a large response.",
 	}, handlers.NewGetSpanDetailsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
@@ -155,7 +156,8 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 		Description: "Get the structural overview of a trace as a flat, depth-first span list. " +
 			"Each span includes a 'path' field encoding ancestry as slash-delimited span IDs " +
 			"(e.g. 'rootID/parentID/spanID'). " +
-			"Does NOT include attributes, events, or links.",
+			"Does NOT include attributes, events, or links, keeping output compact " +
+			"even for large traces.",
 	}, handlers.NewGetTraceTopologyHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #9129 (phase 1)

## Description of the changes
- The draft stateless MCP revision (SEP-2575) makes server instructions best-effort: they move to `server/discover`, which clients MAY skip. #8897 shows some clients already miss instructions under the current revision.
- Phase 1 of #9129 proposed moving key usage guidance from INSTRUCTIONS.md into tool descriptions. Working through it, most of that guidance already lives in the descriptions since #8314 (output weight, data boundaries, truncation behavior, the `read_skill` entry point). What descriptions can carry beyond that without turning into workflow guidance is per-tool cost facts, so this PR is intentionally small and additive:
  - `get_span_details`: prefer a small, targeted set of span IDs; whole-trace requests produce large responses.
  - `get_trace_topology`: omitting attributes/events/links keeps output compact even for large traces.
- The cross-tool investigation strategy (broad discovery before verbose detail) intentionally stays in INSTRUCTIONS.md: ordering guidance inside descriptions would recreate workflow-in-descriptions, and would repeat across the nine tools in `tools/list` (~15KB today). This partially answers open question 1 in #9129: descriptions can absorb the per-tool facts, but the strategy layer still needs a delivery path, which is what the `server/discover` wiring in a later phase is for.

## How was this change tested?
- `make fmt`, `make lint`, `make test` pass. This is a description-only change: `TestNewHandler_ListTools` confirms all nine tools are still advertised, but description text itself is not asserted by any test.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality (description-string change; no dedicated assertion on description text, see test note above)
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
