### PR TITLE
fix(mcptools): mark tool errors on spans

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware.go
@@ -80,6 +80,9 @@ func createTracingMiddleware(tracerProvider trace.TracerProvider) mcp.Middleware
 				span.SetAttributes(otelsemconv.ErrorType(errorTypeTool))
 				if toolErr := callResult.GetError(); toolErr != nil {
 					span.RecordError(toolErr)
+					span.SetStatus(codes.Error, toolErr.Error())
+				} else {
+					span.SetStatus(codes.Error, "tool returned an error result")
 				}
 			}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware_test.go
@@ -104,7 +104,8 @@ func TestTracingMiddlewareToolCallResultError(t *testing.T) {
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIToolName("").Key), "get_services")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIOperationNameExecuteTool.Key), "execute_tool")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.ErrorType("").Key), errorTypeTool)
-	assert.Equal(t, codes.Unset, spanData.Status.Code)
+	assert.Equal(t, codes.Error, spanData.Status.Code)
+	assert.Equal(t, "invalid pattern", spanData.Status.Description)
 }
 
 func TestTracingMiddlewareTracesNonToolMethods(t *testing.T) {
@@ -191,7 +192,8 @@ func TestTracingMiddlewareToolCallResultErrorWithoutConcreteError(t *testing.T) 
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIToolName("").Key), "get_services")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIOperationNameExecuteTool.Key), "execute_tool")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.ErrorType("").Key), errorTypeTool)
-	assert.Equal(t, codes.Unset, spanData.Status.Code)
+	assert.Equal(t, codes.Error, spanData.Status.Code)
+	assert.Equal(t, "tool returned an error result", spanData.Status.Description)
 }
 
 func TestTracingMiddlewareUsesTraceContextFromRequestMeta(t *testing.T) {


### PR DESCRIPTION
Description

Tool-level MCP errors were being recorded with "error.type=tool_error" and an exception event, but the corresponding OTel span status remained "Unset".

This caused the tracing middleware to classify the same failed tool call differently from the metrics middleware, which already records "status="error"" for "CallToolResult{IsError: true}".

Changes

- Set the span status to "codes.Error" for MCP tool results with "IsError=true".
- Use the concrete tool error message as the span status description when available.
- Add a defensive fallback status description when "IsError=true" but no concrete error is present.
- Update the existing tracing middleware tests to reflect the corrected span status.
- Preserve the existing behavior for successful tool calls and transport-level errors.

Verification

- "gofmt"
- "git diff --check"
- Targeted tracing middleware tests
- Full "mcptools" package test suite
- "go vet ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/..."

All checks pass.

Fixes #9335