### PR TITLE
fix(mcp): clarify trace error root cause

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server.go
@@ -146,6 +146,9 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_trace_errors",
 		Description: "Get full details for all error-status spans in a trace. " +
+			"An error-status span is not necessarily the root cause: a caller or proxy may report an error " +
+			"because a child span failed or timed out even when that child has no error status. " +
+			"Inspect the trace topology and child spans before identifying the failing service or operation. " +
 			"Results may be truncated to the server limit; " +
 			"compare total_error_count with the number of returned spans to detect truncation.",
 	}, handlers.NewGetTraceErrorsHandler(s.queryAPI, s.config.MaxSpanDetailsPerRequest))
@@ -153,6 +156,8 @@ func registerTools(server *mcp.Server, queryAPI *querysvc.QueryService, cfg Conf
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "get_trace_topology",
 		Description: "Get the structural overview of a trace as a flat, depth-first span list. " +
+			"Use this to inspect parent-child relationships when an error-status span may only be a caller or proxy " +
+			"that timed out or gave up waiting for a child; the actual cause may be a descendant without error status. " +
 			"Each span includes a 'path' field encoding ancestry as slash-delimited span IDs " +
 			"(e.g. 'rootID/parentID/spanID'). " +
 			"Does NOT include attributes, events, or links.",

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server_test.go
@@ -122,14 +122,16 @@ func TestRegisterTools(t *testing.T) {
 	listed, err := clientSession.ListTools(ctx, &mcp.ListToolsParams{})
 	require.NoError(t, err)
 
-	got := make([]string, 0, len(listed.Tools))
+	got := make(map[string]string, len(listed.Tools))
 	for _, tool := range listed.Tools {
-		got = append(got, tool.Name)
+		got[tool.Name] = tool.Description
 	}
 
-	assert.ElementsMatch(t, []string{
-		"get_services", "get_span_names", "search_traces", "get_span_details",
-		"get_trace_errors", "get_trace_topology", "get_critical_path", "get_service_dependencies",
-		"read_skill",
-	}, got)
+	assert.Contains(t, got, "get_trace_errors")
+	assert.Contains(t, got, "get_trace_topology")
+
+	assert.Contains(t, got["get_trace_errors"], "not necessarily the root cause")
+	assert.Contains(t, got["get_trace_errors"], "Inspect the trace topology and child spans")
+	assert.Contains(t, got["get_trace_topology"], "parent-child relationships")
+	assert.Contains(t, got["get_trace_topology"], "actual cause may be a descendant without error status")
 }


### PR DESCRIPTION
## Summary

Fixes #9336 by adding disambiguating guidance to the `get_trace_errors` and `get_trace_topology` MCP tool descriptions.

An error-status span does not necessarily represent the root cause of a failure. A caller or proxy may report an error because a child span failed or timed out, while the child itself has no error status.

The tool descriptions now make this distinction explicit and direct the agent toward inspecting trace topology and child spans before identifying the failing service or operation.

## Changes

* Updated `get_trace_errors` to clarify that an error-status span may not be the root cause.
* Updated `get_trace_topology` to highlight parent-child inspection for this case.
* Extended `TestRegisterTools` to verify that the new guidance is actually exposed through the MCP tool descriptions.

## Testing

Ran:

```text
go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools -run '^(TestNewHandler_ListTools|TestNewHandler_CallTool|TestRegisterTools)$' -count=1
```

Result:

```text
ok
```

The full package test was also attempted. It encountered an unrelated Windows temporary-directory cleanup failure in `TestOpenCustomSkillsDir_ServesDirectoryContents`; the targeted tests covering the changed functionality pass successfully.

## Related Issue

Fixes #9336
