### PR TITLE
docs: clarify with_errors scope in search_traces MCP tool

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
@@ -24,8 +24,8 @@ type SearchTracesInput struct {
 	// Example: {"http.status_code": "500", "user.id": "12345"}
 	Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
 
-	// WithErrors filters to only return traces containing error spans (optional).
-	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only return traces containing error spans"`
+	// WithErrors filters to only return traces where the span matching the other criteria also has an error status (optional).
+	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true, the span matching the other search criteria must also have an error status. To find traces with errors anywhere, omit this and check has_errors in the results."`
 
 	// DurationMin is the minimum duration filter (optional, e.g., "2s", "100ms").
 	DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9334

## Description of the changes
- Updated the JSON schema documentation for the `WithErrors` field in the `search_traces` MCP tool. 
- The description now accurately reflects its span-scoped behavior (that the error status must be on the exact same span that matches the other search criteria), aligning the description with the actual backend implementation across storage backends.

## How was this change tested?
- This is a documentation/schema tag update only. No functional logic was changed.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality (N/A)
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
