### PR TITLE
fix: correct traceStartTime tracking in get_critical_path MCP tool

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -120,7 +121,7 @@ func (*getCriticalPathHandler) buildOutput(
 
 	// Build a map of span ID to service name
 	serviceMap := make(map[string]string)
-	var traceStartTime uint64
+	traceStartTime := uint64(math.MaxUint64)
 	var traceEndTime uint64
 
 	for i := 0; i < trace.ResourceSpans().Len(); i++ {
@@ -140,7 +141,7 @@ func (*getCriticalPathHandler) buildOutput(
 				startTime := uint64(span.StartTimestamp()) / 1000 // Convert to microseconds
 				endTime := uint64(span.EndTimestamp()) / 1000
 
-				if traceStartTime == 0 || startTime < traceStartTime {
+				if startTime < traceStartTime {
 					traceStartTime = startTime
 				}
 				if endTime > traceEndTime {
@@ -148,6 +149,10 @@ func (*getCriticalPathHandler) buildOutput(
 				}
 			}
 		}
+	}
+
+	if traceStartTime == math.MaxUint64 {
+		traceStartTime = 0
 	}
 
 	// Convert critical path sections to output format


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9339
## Description of the changes
- Fixed a bug in the `get_critical_path` MCP tool where `traceStartTime` was incorrectly initialized to `0`. 
- Changed the initialization to `math.MaxUint64` so that spans legitimately starting at exactly `0` (common in mock unit tests) are correctly tracked as the minimum.

## How was this change tested?
- Tested locally.
- Verified that all existing unit tests in `mcptools` continue to pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
