### PR TITLE
fix(mcp): Reject negative durations in search_traces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -156,6 +156,13 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 		}
 	}
 
+	if durationMin < 0 {
+		return querysvc.TraceQueryParams{}, errors.New("invalid duration_min: duration cannot be negative")
+	}
+	if durationMax < 0 {
+		return querysvc.TraceQueryParams{}, errors.New("invalid duration_max: duration cannot be negative")
+	}
+
 	if durationMin > 0 && durationMax > 0 && durationMax < durationMin {
 		return querysvc.TraceQueryParams{}, errors.New("duration_max must be greater than duration_min")
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -513,6 +513,96 @@ func TestSearchTracesHandler_Handle_DurationMaxLessThanMin(t *testing.T) {
 	assert.Contains(t, err.Error(), "duration_max must be greater than duration_min")
 }
 
+func TestSearchTracesHandler_Handle_NegativeDurations(t *testing.T) {
+	tests := []struct {
+		name        string
+		durationMin string
+		durationMax string
+		wantErr     string
+	}{
+		{
+			name:        "negative duration_min",
+			durationMin: "-5s",
+			wantErr:     "invalid duration_min: duration cannot be negative",
+		},
+		{
+			name:        "negative duration_max",
+			durationMax: "-10s",
+			wantErr:     "invalid duration_max: duration cannot be negative",
+		},
+		{
+			name:        "both negative",
+			durationMin: "-5s",
+			durationMax: "-10s",
+			wantErr:     "invalid duration_min: duration cannot be negative",
+		},
+		{
+			name:        "negative duration_min with valid duration_max",
+			durationMin: "-5s",
+			durationMax: "10s",
+			wantErr:     "invalid duration_min: duration cannot be negative",
+		},
+		{
+			name:        "negative duration_max with valid duration_min",
+			durationMin: "2s",
+			durationMax: "-10s",
+			wantErr:     "invalid duration_max: duration cannot be negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockQueryService{
+				findTraceSummariesFunc: func(_ context.Context, _ querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+					t.Error("storage must not be queried when durations are invalid")
+					return func(_ func([]tracestore.TraceSummary, error) bool) {}
+				},
+			}
+
+			handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+
+			input := types.SearchTracesInput{
+				StartTimeMin: "-1h",
+				ServiceName:  "test",
+				DurationMin:  tt.durationMin,
+				DurationMax:  tt.durationMax,
+			}
+
+			_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestSearchTracesHandler_Handle_ZeroDurations(t *testing.T) {
+	want := makeTraceSummary("test-service", "/test", false)
+
+	mock := &mockQueryService{
+		findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			assert.Zero(t, query.DurationMin)
+			assert.Zero(t, query.DurationMax)
+			return func(yield func([]tracestore.TraceSummary, error) bool) {
+				yield([]tracestore.TraceSummary{want}, nil)
+			}
+		},
+	}
+
+	handler := &searchTracesHandler{queryService: mock, maxResults: 100}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "test-service",
+		DurationMin:  "0s",
+		DurationMax:  "0s",
+	}
+
+	_, output, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+
+	require.NoError(t, err)
+	require.Len(t, output.Traces, 1)
+}
+
 func TestParseTimeParam(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Which problem is this PR solving?
Closes: #8856

search_traces accepts negative `duration_min` / `duration_max`. `time.ParseDuration` is able to parse -5s, and the existing check is guarded on `durationMin > 0 && durationMax > 0`, so negative values skip it entirely and reach the storage backend. The query then returns an empty result set, which reads to the caller as "no traces match" rather than "your input was invalid", which is a bad failure mode for an MCP tool, whose caller is an LLM agent that will otherwise reason on from the false premise.

`buildQuery` already rejects `start_time_max` before `start_time_min`, and `duration_max` below `duration_min`. This closes the remaining gap in that same validation block.


## Description of the changes
- reject negative `duration_min` / `duration_max` in `buildQuery`, after parsing and before the min/max comparison. The existing > 0 guards on that comparison are left as-is, since 0 there means unset.
- added tests for negative durations (table-driven; the mock fails if storage is queried) and for 0s still meaning unset.


## How was this change tested?
- New tests fail on main, pass with the fix.
- make fmt lint test pass locally, and buildQuery is at 100% coverage.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
