### PR TITLE
fix(deps): Update js-yaml to 3.15.1

### DIFF
--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -3349,9 +3349,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes #9346.

## Summary

- update the transitive `js-yaml` lock entry from 3.15.0 to 3.15.1
- address [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)
- keep `package.json` unchanged; 3.15.1 remains within the existing `^3.13.1` range

## Risk

`js-yaml` is a development-only dependency reached through Jest coverage tooling, not a Jaeger runtime dependency. The normal CI test path does not load a YAML NYC configuration. This is a three-line lockfile-only update to the upstream patched release.

## Testing

- `make fmt`
- `make lint`
- `make test` (4,198 tests, 38 skipped)
- `npm ci --offline`
- `npm ls js-yaml --all` (resolves `js-yaml@3.15.1`)
- `npm test -- --runInBand` (2 suites, 100 tests)
- `npm run test:coverage -- --runInBand` (2 suites, 100 tests)
- `npm audit --offline --json` (0 vulnerabilities)
- `git diff --check`
