### PR TITLE
fix(mcp): Set span status to Error on failed tool calls

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware.go
@@ -80,6 +80,9 @@ func createTracingMiddleware(tracerProvider trace.TracerProvider) mcp.Middleware
 				span.SetAttributes(otelsemconv.ErrorType(errorTypeTool))
 				if toolErr := callResult.GetError(); toolErr != nil {
 					span.RecordError(toolErr)
+					span.SetStatus(codes.Error, toolErr.Error())
+				} else {
+					span.SetStatus(codes.Error, "tool returned an error result")
 				}
 			}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware_repro_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware_repro_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcptools
+
+import (
+	"context"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/internal/metrics"
+	depstoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
+	"github.com/jaegertracing/jaeger/internal/telemetry"
+	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+)
+
+// TestToolErrorSpanStatusVsMetricStatus drives a real mcptools server, real
+// handlers, both middlewares, in-memory transport, and calls get_trace_topology
+// for a trace the store does not have. The handler returns
+// errors.New("trace not found"), which the MCP SDK converts into
+// CallToolResult{IsError: true} with a nil Go error.
+//
+// Tracing and metrics must agree: jaeger.mcp.tool.calls{status="error"} and
+// span Status.Code = Error.
+func TestToolErrorSpanStatusVsMetricStatus(t *testing.T) {
+	traceCap := newTraceCapture(t)
+	metricCap := newMetricsCapture(t)
+
+	reader := &tracestoremocks.Reader{}
+	reader.EXPECT().GetTraces(mock.Anything, mock.Anything).RunAndReturn(
+		func(context.Context, ...tracestore.GetTraceParams) iter.Seq2[[]ptrace.Traces, error] {
+			return func(func([]ptrace.Traces, error) bool) {}
+		},
+	)
+	svc := querysvc.NewQueryService(reader, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
+
+	server := NewServer(telemetry.Settings{
+		Logger:         zap.NewNop(),
+		Metrics:        metrics.NullFactory,
+		MeterProvider:  metricCap.provider,
+		TracerProvider: traceCap.provider,
+	}, svc, DefaultConfig())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "repro-client", Version: "0.0.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer clientSession.Close()
+
+	res, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "get_trace_topology",
+		Arguments: map[string]any{"trace_id": "00000000000000000000000000000abc"},
+	})
+	require.NoError(t, err, "no transport-level error: the failure is carried in the result")
+	require.True(t, res.IsError, "the tool call failed")
+
+	require.NoError(t, traceCap.provider.ForceFlush(ctx))
+	spans := traceCap.exporter.GetSpans()
+	require.NotEmpty(t, spans)
+
+	toolSpanName := mcpMethodToolsCall + " get_trace_topology"
+	var toolSpan tracetest.SpanStub
+	found := false
+	for _, s := range spans {
+		if s.Name == toolSpanName {
+			toolSpan = s
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected a span named %q", toolSpanName)
+
+	rm := metricCap.collect(t)
+	counter := findMetricDataPoint[metricdata.Sum[int64]](t, rm, "jaeger.mcp.tool.calls")
+
+	var toolCallStatus string
+	for _, p := range counter.DataPoints {
+		status, _ := p.Attributes.Value("status")
+		toolName, _ := p.Attributes.Value("gen_ai.tool.name")
+		if toolName.AsString() == "get_trace_topology" {
+			toolCallStatus = status.AsString()
+			break
+		}
+	}
+
+	assert.Equal(t, metricStatusError, toolCallStatus,
+		"metrics middleware classifies the failed call as an error")
+	assert.Equal(t, codes.Error, toolSpan.Status.Code,
+		"tracing middleware must mark the same failed call as Error")
+	assertHasStringAttribute(t, toolSpan.Attributes,
+		string(otelsemconv.ErrorType("").Key), errorTypeTool)
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/middleware_test.go
@@ -104,7 +104,8 @@ func TestTracingMiddlewareToolCallResultError(t *testing.T) {
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIToolName("").Key), "get_services")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIOperationNameExecuteTool.Key), "execute_tool")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.ErrorType("").Key), errorTypeTool)
-	assert.Equal(t, codes.Unset, spanData.Status.Code)
+	assert.Equal(t, codes.Error, spanData.Status.Code)
+	assert.Equal(t, "invalid pattern", spanData.Status.Description)
 }
 
 func TestTracingMiddlewareTracesNonToolMethods(t *testing.T) {
@@ -191,7 +192,8 @@ func TestTracingMiddlewareToolCallResultErrorWithoutConcreteError(t *testing.T) 
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIToolName("").Key), "get_services")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.GenAIOperationNameExecuteTool.Key), "execute_tool")
 	assertHasStringAttribute(t, spanData.Attributes, string(otelsemconv.ErrorType("").Key), errorTypeTool)
-	assert.Equal(t, codes.Unset, spanData.Status.Code)
+	assert.Equal(t, codes.Error, spanData.Status.Code)
+	assert.Equal(t, "tool returned an error result", spanData.Status.Description)
 }
 
 func TestTracingMiddlewareUsesTraceContextFromRequestMeta(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Closes: #9332

The MCP tracing middleware leaves span status `Unset` on failed `tools/call` when the handler returns `CallToolResult{IsError: true}`. The metrics middleware correctly classifies the same call as `status="error"`, but the tracing middleware only sets the `error.type` attribute and records the exception event without calling `span.SetStatus(codes.Error, ...)`.

This makes failed tool calls invisible to status-code-based error queries in Jaeger (e.g., `search_traces(with_errors: true)` and `get_trace_errors`), since they filter on `StatusCodeError`.

The MCP Go SDK converts every plain handler error into `CallToolResult{IsError: true}` with a nil Go error, so the `err != nil` branch (which does set status) is never reached for handler errors. This routes all handler error returns across the tools through the `Unset` path.

## Description of the changes

* Add `span.SetStatus(codes.Error, ...)` in the `callResult.IsError` branch of `createTracingMiddleware`, after `span.RecordError`.
* When a concrete error is present, the status description carries the error text; otherwise it falls back to `"tool returned an error result"`.
* Update `TestTracingMiddlewareToolCallResultError` and `TestTracingMiddlewareToolCallResultErrorWithoutConcreteError` to expect `codes.Error` instead of `codes.Unset`. The distinction from transport errors is still carried by `error.type=tool_error`, which both tests already assert.
* Leave `TestTracingMiddlewareToolCallSuccess` untouched — the success path still correctly yields `codes.Unset`.
* Add regression test `TestToolErrorSpanStatusVsMetricStatus` that drives a real `mcptools` server with both middlewares over in-memory transport, triggers a handler error, and asserts that the metric and span status agree (both error).

## How was this change tested?

* New regression test `TestToolErrorSpanStatusVsMetricStatus` fails on main (asserts `codes.Error` against the current `codes.Unset`) and passes with the fix.
* Existing middleware tests updated and all pass: `go test -run TestTracingMiddleware -v -count=1`.
* Full package suite passes: `go test ./... -count=1`.
* `make fmt lint test` passes locally.

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [[AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy)](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

* [ ] **None**: No AI tools were used in creating this PR
* [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
* [ ] **Moderate**: AI helped with code generation or debugging specific parts
* [ ] **Heavy**: AI generated most or all of the code changes