### PR TITLE
fix(es): Write the data stream @timestamp as an RFC 3339 string

### DIFF
--- a/docs/rfc/0004-elasticsearch-data-streams.md
+++ b/docs/rfc/0004-elasticsearch-data-streams.md
@@ -192,10 +192,11 @@ This overrides Jaeger's default policy without touching any Jaeger config or ris
 
 Data streams require a `@timestamp` field mapped as `date` or `date_nanos`.
 
-Recommendation: Add `@timestamp` as a field in the document at write time (in Go code), derived from the span's start time. No ingest pipeline needed.
+Recommendation: Add `@timestamp` as a field in the document at write time (in Go code), derived from the OTLP `StartTimestamp` at nanosecond precision. No ingest pipeline needed.
 
 Rationale:
-- Jaeger stores `startTime` as epoch microseconds, and a plain `date` field is millisecond precision, so it would truncate. `date_nanos` keeps the microseconds.
+- OTLP defines timestamps in nanoseconds; truncating to milliseconds loses precision unnecessarily.
+- ES/OpenSearch `date_nanos` type stores nanosecond precision; `date` stores milliseconds.
 - Ingest pipelines add operational complexity and a failure point.
 - Avoids dependency on ES ingest nodes (relevant for cost in licensed ES/ECK deployments).
 
@@ -211,7 +212,9 @@ The field is added to the mapping component template:
 }
 ```
 
-The value is written as an RFC 3339 string rather than a number. `date_nanos` defaults to `strict_date_optional_time_nanos||epoch_millis` on Elasticsearch and `strict_date_optional_time||epoch_millis` on OpenSearch, and both read a bare number as epoch *milliseconds*: the epoch-nanosecond value this RFC originally proposed lands far past the type's 2262 upper bound and gets the document rejected. Both defaults accept an RFC 3339 string at full precision, so no explicit `format` restriction is needed and users can still index documents manually or query with human-readable timestamps in Kibana/Grafana.
+The value is written as an RFC 3339 string rather than a number. `date_nanos` defaults to `strict_date_optional_time_nanos||epoch_millis` on Elasticsearch and `strict_date_optional_time||epoch_millis` on OpenSearch, and neither engine has an `epoch_nanos` format at all, so a bare number is always read as epoch *milliseconds*. That is why this RFC's original proposal to write epoch nanoseconds does not work: such a value lands far past the type's 2262 upper bound and the document is rejected.
+
+Both defaults accept an RFC 3339 string at full precision, so no explicit `format` restriction is needed and users can still index documents manually or query with human-readable timestamps in Kibana/Grafana.
 
 Note: The existing `startTime` (microseconds) and `startTimeMillis` fields remain for backward compatibility with queries. `@timestamp` is used exclusively by the data stream machinery for rollover and time-based partitioning.
 

--- a/docs/rfc/0004-elasticsearch-data-streams.md
+++ b/docs/rfc/0004-elasticsearch-data-streams.md
@@ -192,17 +192,16 @@ This overrides Jaeger's default policy without touching any Jaeger config or ris
 
 Data streams require a `@timestamp` field mapped as `date` or `date_nanos`.
 
-Recommendation: Add `@timestamp` as a field in the document at write time (in Go code), derived from the OTLP `StartTimestamp` at nanosecond precision. No ingest pipeline needed.
+Recommendation: Add `@timestamp` as a field in the document at write time (in Go code), derived from the span's start time. No ingest pipeline needed.
 
 Rationale:
-- OTLP defines timestamps in nanoseconds; truncating to milliseconds loses precision unnecessarily.
-- ES/OpenSearch `date_nanos` type supports epoch nanoseconds natively.
+- Jaeger stores `startTime` as epoch microseconds, and a plain `date` field is millisecond precision, so it would truncate. `date_nanos` keeps the microseconds.
 - Ingest pipelines add operational complexity and a failure point.
 - Avoids dependency on ES ingest nodes (relevant for cost in licensed ES/ECK deployments).
 
 ```go
-// In the span-to-dbmodel conversion
-doc["@timestamp"] = span.StartTimestamp().AsTime().UnixNano()
+// In SpanWriter.WriteSpans, on the data stream path only
+span.Timestamp = spanStartTime.Format(time.RFC3339Nano)
 ```
 
 The field is added to the mapping component template:
@@ -212,7 +211,7 @@ The field is added to the mapping component template:
 }
 ```
 
-The `date_nanos` type accepts both epoch nanoseconds (what Jaeger writes) and ISO-8601 strings by default. No explicit `format` restriction is needed — keeping the default allows users to index documents manually or query with human-readable timestamps in Kibana/Grafana.
+The value is written as an RFC 3339 string rather than a number. `date_nanos` defaults to `strict_date_optional_time_nanos||epoch_millis` on Elasticsearch and `strict_date_optional_time||epoch_millis` on OpenSearch, and both read a bare number as epoch *milliseconds*: the epoch-nanosecond value this RFC originally proposed lands far past the type's 2262 upper bound and gets the document rejected. Both defaults accept an RFC 3339 string at full precision, so no explicit `format` restriction is needed and users can still index documents manually or query with human-readable timestamps in Kibana/Grafana.
 
 Note: The existing `startTime` (microseconds) and `startTimeMillis` fields remain for backward compatibility with queries. `@timestamp` is used exclusively by the data stream machinery for rollover and time-based partitioning.
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
@@ -60,10 +60,9 @@ type Span struct {
 	Tag     map[string]any `json:"tag,omitempty"`
 	Logs    []Log          `json:"logs"`
 	Process Process        `json:"process"`
-	// Timestamp is an RFC 3339 nanosecond string, written only for data streams
-	// (mapped as date_nanos). The format is load-bearing: date_nanos reads a bare
-	// number as epoch *milliseconds*, so epoch nanoseconds land past the type's 2262
-	// ceiling and the document is rejected. Legacy strategies leave it empty.
+	// Timestamp is the span's start time as an RFC 3339 string, written only on the
+	// data stream path; other rotation strategies leave it empty. It has to be the
+	// string form rather than a number (RFC 0004 §3.3).
 	Timestamp string `json:"@timestamp,omitempty"`
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/dbmodel/model.go
@@ -60,9 +60,10 @@ type Span struct {
 	Tag     map[string]any `json:"tag,omitempty"`
 	Logs    []Log          `json:"logs"`
 	Process Process        `json:"process"`
-	// Timestamp is epoch nanoseconds as a decimal string, written only for data
-	// streams (mapped as date_nanos). Using a string avoids JSON float64 truncation
-	// of large int64 nanosecond values; legacy strategies leave it empty.
+	// Timestamp is an RFC 3339 nanosecond string, written only for data streams
+	// (mapped as date_nanos). The format is load-bearing: date_nanos reads a bare
+	// number as epoch *milliseconds*, so epoch nanoseconds land past the type's 2262
+	// ceiling and the document is rejected. Legacy strategies leave it empty.
 	Timestamp string `json:"@timestamp,omitempty"`
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer.go
@@ -114,7 +114,7 @@ func (s *SpanWriter) WriteSpans(ctx context.Context, spans []dbmodel.Span) error
 		// Span doc.
 		s.convertNestedTagsToFieldTags(span)
 		if s.spanRotation.RequiresDocumentTimestamp() {
-			span.Timestamp = strconv.FormatInt(spanStartTime.UnixNano(), 10)
+			span.Timestamp = spanStartTime.Format(time.RFC3339Nano)
 		}
 		item, err := s.buildSpanItem(s.spanRotation.WriteTarget(spanStartTime), span)
 		if err != nil {

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
@@ -409,7 +409,10 @@ func TestSpanDocID(t *testing.T) {
 }
 
 func TestWriteSpan_DataStreamTimestamp(t *testing.T) {
-	date := time.Date(2024, time.June, 18, 10, 0, 0, 0, time.UTC)
+	// The sub-second digits are the point of the fixture: they survive
+	// TimeAsEpochMicroseconds exactly (123456000 nanoseconds is 123456 microseconds),
+	// and a whole-second format would pass against a fixture that had none.
+	date := time.Date(2024, time.June, 18, 10, 0, 0, 123456000, time.UTC)
 
 	logger, _ := testutils.NewLogger()
 	metricsFactory := metricstest.NewFactory(0)
@@ -424,13 +427,12 @@ func TestWriteSpan_DataStreamTimestamp(t *testing.T) {
 	spans := []dbmodel.Span{{TraceID: "abc", SpanID: "def", StartTime: model.TimeAsEpochMicroseconds(date)}}
 	require.NoError(t, writer.WriteSpans(context.Background(), spans))
 
-	// The exact format is load-bearing rather than cosmetic; see the reason on
-	// dbmodel.Span.Timestamp. Pinning it here is what makes a revert to epoch
-	// nanoseconds fail without needing a live backend.
-	assert.Equal(t, date.Format(time.RFC3339Nano), spans[0].Timestamp)
+	// Literals rather than Format calls, so the assertion can disagree with the
+	// implementation instead of restating its formula.
+	assert.Equal(t, "2024-06-18T10:00:00.123456Z", spans[0].Timestamp)
 	out, err := json.Marshal(spans[0])
 	require.NoError(t, err)
-	assert.Contains(t, string(out), `"@timestamp":"`+date.Format(time.RFC3339Nano)+`"`)
+	assert.Contains(t, string(out), `"@timestamp":"2024-06-18T10:00:00.123456Z"`)
 }
 
 func TestWriteSpan_LegacyOmitsTimestamp(t *testing.T) {

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"math"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
@@ -425,11 +424,13 @@ func TestWriteSpan_DataStreamTimestamp(t *testing.T) {
 	spans := []dbmodel.Span{{TraceID: "abc", SpanID: "def", StartTime: model.TimeAsEpochMicroseconds(date)}}
 	require.NoError(t, writer.WriteSpans(context.Background(), spans))
 
-	// The data stream write path stamps @timestamp as epoch nanoseconds.
-	assert.Equal(t, strconv.FormatInt(date.UnixNano(), 10), spans[0].Timestamp)
+	// The exact format is load-bearing rather than cosmetic; see the reason on
+	// dbmodel.Span.Timestamp. Pinning it here is what makes a revert to epoch
+	// nanoseconds fail without needing a live backend.
+	assert.Equal(t, date.Format(time.RFC3339Nano), spans[0].Timestamp)
 	out, err := json.Marshal(spans[0])
 	require.NoError(t, err)
-	assert.Contains(t, string(out), `"@timestamp":"`+strconv.FormatInt(date.UnixNano(), 10)+`"`)
+	assert.Contains(t, string(out), `"@timestamp":"`+date.Format(time.RFC3339Nano)+`"`)
 }
 
 func TestWriteSpan_LegacyOmitsTimestamp(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #4708 (RFC 0004, Elasticsearch/OpenSearch data streams).

The data stream write path added in #8833 stamps `@timestamp` as epoch nanoseconds. `date_nanos` cannot read that as intended: its default format is `strict_date_optional_time_nanos||epoch_millis` on Elasticsearch and `strict_date_optional_time||epoch_millis` on OpenSearch, and neither engine ships an `epoch_nanos` format at all, so a bare number is always parsed as epoch **milliseconds**. An epoch-nanosecond value therefore lands far past the type's 2262 upper bound and the document is rejected.

Split out of #8991 at @yurishkuro's ask, so the write-path fix lands independently of the template work.

## Description of the changes

`SpanWriter.WriteSpans` emits an RFC 3339 nanosecond string instead of epoch nanoseconds. Both engines' default formats accept it at full precision, so the `format`-free mapping in RFC 0004 §3.3 stands unchanged.

RFC 0004 §3.3 is rewritten rather than annotated. The RFC's status is Partially Implemented, and per #9352 a live RFC states what is true now rather than narrating its own history, so the section describes the string format with one clause recording that it reverses the original epoch-nanosecond proposal. The stale Go snippet and the "`date_nanos` supports epoch nanoseconds natively" rationale went with it. The OTLP rationale is untouched: the input is OTLP, so that is still what decides the mapping type.

## How was this change tested?

`TestWriteSpan_DataStreamTimestamp` pins the exact string. The fixture carries microseconds (`123456000` nanoseconds, which `TimeAsEpochMicroseconds` round-trips exactly to `123456` microseconds) and the expectations are literals rather than `Format` calls, so the assertion can disagree with the implementation instead of restating its formula.

That makes it fail on both regressions on this path:

```
# span.Timestamp = spanStartTime.Format(time.RFC3339)
--- FAIL: TestWriteSpan_DataStreamTimestamp
    expected: "2024-06-18T10:00:00.123456Z"
    actual  : "2024-06-18T10:00:00Z"

# span.Timestamp = strconv.FormatInt(spanStartTime.UnixNano(), 10)
--- FAIL: TestWriteSpan_DataStreamTimestamp
    expected: "2024-06-18T10:00:00.123456Z"
    actual  : "1718704800123456000"
```

The whole-second case matters most: `time.RFC3339` discards exactly the sub-second precision `date_nanos` is chosen for, and it is the one a zero-nanosecond fixture cannot see.

The change is write-only, so nothing else needed adjusting. The only other `Timestamp` references in the package are `Log.Timestamp` in `from_dbmodel.go` and `to_dbmodel.go`, a different field; `Span.Timestamp` is never read back.

`go vet` is clean and the storage packages pass: `internal/storage/v2/elasticsearch/...` including `tracestore`, `tracestore/core` and `tracestore/core/dbmodel`.

A live backend check is not in this PR. It arrives with the data stream templates in #8991, whose integration test writes through this same `SpanWriter`; the unit test pins the format meanwhile.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully