### PR TITLE
fix(storage): Cap Elasticsearch _msearch to avoid proxy 502s

### DIFF
--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -28,6 +28,12 @@ const (
 	ServiceIndexName    = "jaeger-service"
 	DependencyIndexName = "jaeger-dependencies"
 	SamplingIndexName   = "jaeger-sampling"
+
+	// DefaultMaxMsearchItems is the default cap on sub-searches packed into one
+	// Elasticsearch/OpenSearch _msearch request. Chosen below the ~60-item
+	// threshold that triggered Envoy 502s in issue #5825. Raise toward 100 only
+	// when there is no size-limiting proxy and extra round-trips dominate latency.
+	DefaultMaxMsearchItems = 32
 )
 
 // WriteMode selects how the Elasticsearch/OpenSearch trace writer persists spans.
@@ -262,6 +268,12 @@ type Configuration struct {
 	// ---- jaeger-specific configs ----
 	// MaxDocCount Defines maximum number of results to fetch from storage per query.
 	MaxDocCount int `mapstructure:"max_doc_count"`
+	// MaxMsearchItems is the maximum number of sub-searches packed into one
+	// Elasticsearch/OpenSearch _msearch request when loading traces by ID.
+	// Requests larger than this are split into sequential chunks. 0 means use
+	// DefaultMaxMsearchItems (32). There is no hard maximum; keep this at or
+	// below ~100 unless the cluster is reached without a buffering proxy.
+	MaxMsearchItems int `mapstructure:"max_msearch_items"`
 	// MaxSpanAge configures the maximum lookback on span reads.
 	// For alias-based rotation (manual_rollover/auto_rollover), this should be set
 	// to match the ILM/ISM data retention policy so that GetTraces can find traces
@@ -423,6 +435,9 @@ func (c *Configuration) Validate() error {
 	// values so they don't silently become an Unknown version. 0 means auto-detect.
 	if c.Version != 0 && !es.IsSupportedVersion(c.Version) {
 		return fmt.Errorf("unsupported version %d: set 0 to auto-detect, or use 7/8/9 (Elasticsearch) or 101/102/103 (OpenSearch 1/2/3)", c.Version)
+	}
+	if c.MaxMsearchItems < 0 {
+		return errors.New("max_msearch_items must not be negative")
 	}
 
 	// Ensure at most one auth method is configured (they all set the Authorization header).

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -159,6 +159,15 @@ func TestValidate(t *testing.T) {
 			expectedError: "unsupported version 10",
 		},
 		{
+			name:          "negative max_msearch_items rejected",
+			config:        &Configuration{Servers: []string{"localhost:8000/dummyserver"}, MaxMsearchItems: -1},
+			expectedError: "max_msearch_items must not be negative",
+		},
+		{
+			name:   "zero max_msearch_items uses default at construction",
+			config: &Configuration{Servers: []string{"localhost:8000/dummyserver"}, MaxMsearchItems: 0},
+		},
+		{
 			name:          "no valid input are set",
 			config:        &Configuration{},
 			expectedError: "Servers: non zero value required",

--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -143,6 +143,7 @@ func (f *FactoryBase) GetSpanReaderParams() esspanstore.SpanReaderParams {
 	return esspanstore.SpanReaderParams{
 		Searcher:          f.searcher,
 		MaxDocCount:       f.config.MaxDocCount,
+		MaxMsearchItems:   f.config.MaxMsearchItems,
 		MaxSpanAge:        maxSpanAge,
 		MaxTraceDuration:  f.config.MaxTraceDuration,
 		TagDotReplacement: f.config.Tags.DotReplacement,

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -823,11 +823,13 @@ func TestGetSpanReaderParams_MaxTraceDuration(t *testing.T) {
 		},
 		MaxSpanAge:       72 * time.Hour,
 		MaxTraceDuration: 2 * time.Hour,
+		MaxMsearchItems:  16,
 	}
 	f := &FactoryBase{config: &cfg, logger: zap.NewNop(), tracer: otel.GetTracerProvider()}
 	params := f.GetSpanReaderParams()
 	assert.Equal(t, 72*time.Hour, params.MaxSpanAge)
 	assert.Equal(t, 2*time.Hour, params.MaxTraceDuration)
+	assert.Equal(t, 16, params.MaxMsearchItems)
 }
 
 // mockHTTPAuthenticator implements extensionauth.HTTPClient for testing

--- a/internal/storage/v1/elasticsearch/options.go
+++ b/internal/storage/v1/elasticsearch/options.go
@@ -64,6 +64,7 @@ func DefaultConfig() config.Configuration {
 		Servers:              []string{"http://127.0.0.1:9200"},
 		RemoteReadClusters:   []string{},
 		MaxDocCount:          10_000,
+		MaxMsearchItems:      config.DefaultMaxMsearchItems,
 		LogLevel:             "error",
 		CreateIndexTemplates: true,
 		HTTPCompression:      true,

--- a/internal/storage/v1/elasticsearch/options_test.go
+++ b/internal/storage/v1/elasticsearch/options_test.go
@@ -697,6 +697,12 @@ func TestMaxDocCount(t *testing.T) {
 	}
 }
 
+func TestMaxMsearchItems(t *testing.T) {
+	assert.Equal(t, escfg.DefaultMaxMsearchItems, DefaultConfig().MaxMsearchItems)
+	assert.Equal(t, 32, DefaultConfig().MaxMsearchItems)
+	assert.Equal(t, 16, escfg.Configuration{MaxMsearchItems: 16}.MaxMsearchItems)
+}
+
 func TestIndexDateSeparator(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/config"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/esclient"
 	"github.com/jaegertracing/jaeger/internal/storage/elasticsearch/indices"
 	esquery "github.com/jaegertracing/jaeger/internal/storage/elasticsearch/query"
@@ -111,6 +112,7 @@ type SpanReader struct {
 	spanRotation            indices.Rotation
 	serviceRotation         indices.Rotation
 	maxDocCount             int
+	maxMsearchItems         int
 	logger                  *zap.Logger
 	tracer                  trace.Tracer
 	dotReplacer             dbmodel.DotReplacer
@@ -124,6 +126,7 @@ type SpanReaderParams struct {
 	MaxSpanAge        time.Duration
 	MaxTraceDuration  time.Duration
 	MaxDocCount       int
+	MaxMsearchItems   int
 	TagDotReplacement string
 	Logger            *zap.Logger
 	Tracer            trace.Tracer
@@ -133,6 +136,10 @@ type SpanReaderParams struct {
 
 // NewSpanReader returns a new SpanReader with a metrics.
 func NewSpanReader(p SpanReaderParams) *SpanReader {
+	maxMsearchItems := p.MaxMsearchItems
+	if maxMsearchItems <= 0 {
+		maxMsearchItems = config.DefaultMaxMsearchItems
+	}
 	return &SpanReader{
 		searcher:                p.Searcher,
 		maxSpanAge:              p.MaxSpanAge,
@@ -141,6 +148,7 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 		spanRotation:            p.SpanRotation,
 		serviceRotation:         p.ServiceRotation,
 		maxDocCount:             p.MaxDocCount,
+		maxMsearchItems:         maxMsearchItems,
 		logger:                  p.Logger,
 		tracer:                  p.Tracer,
 		dotReplacer:             dbmodel.NewDotReplacer(p.TagDotReplacement),
@@ -309,8 +317,17 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 	totalDocumentsFetched := make(map[dbmodel.TraceID]int)
 	tracesMap := make(map[dbmodel.TraceID]*dbmodel.Trace)
 	for len(traceIDs) != 0 {
-		searchRequests := make([]esclient.MultiSearchRequest, len(traceIDs))
-		for i, traceID := range traceIDs {
+		// Cap each _msearch at maxMsearchItems so a large FindTraces/GetTraces
+		// cannot pack every remaining ID into one HTTP body (issue #5825).
+		n := s.maxMsearchItems
+		if n > len(traceIDs) {
+			n = len(traceIDs)
+		}
+		chunk := traceIDs[:n]
+		rest := traceIDs[n:]
+
+		searchRequests := make([]esclient.MultiSearchRequest, len(chunk))
+		for i, traceID := range chunk {
 			traceQuery := buildTraceByIDQuery(traceID)
 			startTimeRangeQuery := s.buildStartTimeQuery(startTime.Add(-s.maxTraceDuration), endTime.Add(s.maxTraceDuration))
 			query := esquery.NewBoolQuery().
@@ -329,8 +346,6 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 				Search:  s.buildTraceReadRequest(query, cursor),
 			}
 		}
-		// set traceIDs to empty
-		traceIDs = nil
 		responses, err := s.searcher.MultiSearch(ctx, searchRequests)
 		if err != nil {
 			logErrorToSpan(childSpan, err)
@@ -341,6 +356,7 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 			break
 		}
 
+		var requeued []dbmodel.TraceID
 		for _, result := range responses {
 			// A failed _msearch item carries an error payload and no hits; skipping it
 			// like an empty result would silently drop the trace (or truncate it, when
@@ -371,13 +387,14 @@ func (s *SpanReader) multiRead(ctx context.Context, traceIDs []dbmodel.TraceID, 
 
 			totalDocumentsFetched[lastSpan.TraceID] += len(result.Hits.Hits)
 			if totalDocumentsFetched[lastSpan.TraceID] < result.Hits.Total.Value {
-				traceIDs = append(traceIDs, lastSpan.TraceID)
+				requeued = append(requeued, lastSpan.TraceID)
 				searchAfter[lastSpan.TraceID] = traceReadCursor{
 					startTime: lastSpan.StartTime,
 					spanID:    string(lastSpan.SpanID),
 				}
 			}
 		}
+		traceIDs = append(rest, requeued...)
 	}
 	return traces, nil
 }

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -175,6 +175,10 @@ func TestNewSpanReader(t *testing.T) {
 	reader := NewSpanReader(params)
 	require.NotNil(t, reader)
 	assert.Equal(t, time.Hour*72, reader.maxSpanAge)
+	assert.Equal(t, config.DefaultMaxMsearchItems, reader.maxMsearchItems)
+
+	custom := NewSpanReader(SpanReaderParams{MaxMsearchItems: 8, Logger: zaptest.NewLogger(t)})
+	assert.Equal(t, 8, custom.maxMsearchItems)
 }
 
 func TestSpanReaderRotations(t *testing.T) {
@@ -337,6 +341,54 @@ func TestSpanReader_multiRead_followUp_query(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, string(expectedData), string(actualData))
 		}
+	})
+}
+
+func recordMsearchSizes(r *spanReaderTest) *[]int {
+	sizes := make([]int, 0, 4)
+	r.searcher.On("MultiSearch", mock.Anything, mock.Anything).Return(
+		func(_ context.Context, reqs []esclient.MultiSearchRequest) ([]esclient.SearchResponse, error) {
+			sizes = append(sizes, len(reqs))
+			return make([]esclient.SearchResponse, len(reqs)), nil
+		},
+	)
+	return &sizes
+}
+
+func traceIDs(n int) []dbmodel.TraceID {
+	ids := make([]dbmodel.TraceID, n)
+	for i := range ids {
+		ids[i] = dbmodel.TraceID(fmt.Sprintf("id-%02d", i))
+	}
+	return ids
+}
+
+func TestSpanReader_multiRead_chunksWhenOverCap(t *testing.T) {
+	withSpanReader(t, func(r *spanReaderTest) {
+		assert.Equal(t, config.DefaultMaxMsearchItems, r.reader.maxMsearchItems)
+		sizes := recordMsearchSizes(r)
+		_, err := r.reader.multiRead(context.Background(), traceIDs(70), time.Now(), time.Now())
+		require.NoError(t, err)
+		assert.Equal(t, []int{32, 32, 6}, *sizes)
+	})
+}
+
+func TestSpanReader_multiRead_singleCallUnderCap(t *testing.T) {
+	withSpanReader(t, func(r *spanReaderTest) {
+		sizes := recordMsearchSizes(r)
+		_, err := r.reader.multiRead(context.Background(), traceIDs(20), time.Now(), time.Now())
+		require.NoError(t, err)
+		assert.Equal(t, []int{20}, *sizes)
+	})
+}
+
+func TestSpanReader_multiRead_customCap(t *testing.T) {
+	withSpanReader(t, func(r *spanReaderTest) {
+		r.reader.maxMsearchItems = 10
+		sizes := recordMsearchSizes(r)
+		_, err := r.reader.multiRead(context.Background(), traceIDs(25), time.Now(), time.Now())
+		require.NoError(t, err)
+		assert.Equal(t, []int{10, 10, 5}, *sizes)
 	})
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Closes: #5825

Jaeger loads traces with one Elasticsearch/OpenSearch `_msearch`: one sub-search per trace ID, all in a single HTTP body. Around 60 traces, a proxy in front of the cluster (Envoy in the original report) returns 502. OpenSearch itself is fine — a direct `_msearch` of 500 traces returned 200. The proxy times out or hits a max body size; the giant request is what fails.

`SpanReader.multiRead` (`internal/storage/v2/elasticsearch/tracestore/core/reader.go`) is the shared loader for `FindTraces` and `GetTraces`. It packed every remaining trace ID into one `_msearch` with no outer cap. `search_after` paging inside a single large trace already exists and is not this bug (#9048 / spanID tie-breaker is already landed).

Removing the proxy is an ops choice, not a Jaeger fix. The proxy is still useful for TLS, auth, and load balancing. Jaeger should keep requests small enough to pass through it.

## Description of the changes

- Cap how many sub-searches go in one `_msearch` (`max_msearch_items`, default **32**, below the ~60 that failed and below default search depth of 100).
- If N ≤ 32, keep one request. If N > 32, send sequential chunks of 32, last chunk leftover (e.g. 70 traces → 32 + 32 + 6).
- Re-queue `search_after` follow-ups after the remaining IDs so paging inside a trace is unchanged.
- Apply the cap only on `_msearch` paths (`FindTraces`, `GetTraces`). `FindTraceIDs`, summaries, services, and operations stay ordinary `_search`.
- Wire `max_msearch_items` through ES/OS config and the span-reader factory. `0` means 32; negative is rejected. No hard maximum: if 32 still 502, lower it; if there is no proxy and extra round-trips hurt, raise toward 100.

## How was this change tested?

- `TestSpanReader_multiRead_chunksWhenOverCap`: 70 IDs at default 32 → call sizes `32, 32, 6`.
- `TestSpanReader_multiRead_singleCallUnderCap`: 20 IDs at default 32 → one call of `20`.
- `TestSpanReader_multiRead_customCap`: 25 IDs at cap 10 → `10, 10, 5`.
- `TestNewSpanReader` asserts default 32 and a custom cap.
- Config/factory tests: default 32, custom value wired through, negative `max_msearch_items` rejected, `0` accepted (becomes 32 at construction).
- Existing `multiRead` / `search_after` tests still pass.
- `make fmt lint test` passes locally (4204 tests, 38 skipped integration tests that need a live backend).

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [[AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy)](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

* [ ] **None**: No AI tools were used in creating this PR
* [] **Light**: AI provided minor assistance (formatting, simple suggestions)
* [x] **Moderate**: AI helped with code generation or debugging specific parts
* [ ] **Heavy**: AI generated most or all of the code changes