### PR TITLE
docs: document e2e integration test assumptions

### DIFF
--- a/cmd/jaeger/internal/integration/README.md
+++ b/cmd/jaeger/internal/integration/README.md
@@ -150,6 +150,28 @@ subgraph Remote Storage Backend
 end
 ```
 
+## Assumptions
+
+These e2e tests start the `jaeger-e2e` binary (not the user-facing `jaeger`
+binary) so the `storagecleaner` extension is available. Unless a storage test
+overrides ports, the following defaults apply:
+
+| Endpoint | Default port | Role |
+|----------|--------------|------|
+| OTLP gRPC receiver | `4317` | Span writes from the test process |
+| Query gRPC (`jaeger_query`) | see `ports` package / storage config | Span reads |
+| Metrics | `8888` (`MetricsPort`) | Collector metrics scrape |
+| Storage cleaner | HTTP `POST /purge` on the cleaner extension | Wipe storage between cases |
+
+Storage-specific tests may run extra processes (for example Kafka, remote
+storage, or a second binary) and override `MetricsPort`, `HealthCheckPort`,
+`ConfigFile`, or `BinaryPath` on `E2EStorageIntegration`. Prefer the defaults
+in each `*_test.go` file when debugging a single backend.
+
+Configs under `/cmd/jaeger/` are used as the base collector configuration; the
+test harness injects the storage cleaner extension into that config before
+starting the binary.
+
 ## Running tests locally
 
 You can run integration tests locally with the following command:
@@ -166,3 +188,6 @@ where the storage name can be one of the following:
 * kafka
 * memory_v2
 * query
+
+CI also exercises these flows via the `ci-e2e-*.yml` workflows under
+`.github/workflows/`. Shell helpers used by some jobs live in `scripts/e2e/`.

--- a/cmd/jaeger/internal/integration/README.md
+++ b/cmd/jaeger/internal/integration/README.md
@@ -159,9 +159,9 @@ overrides ports, the following defaults apply:
 | Endpoint | Default port | Role |
 |----------|--------------|------|
 | OTLP gRPC receiver | `4317` | Span writes from the test process |
-| Query gRPC (`jaeger_query`) | see `ports` package / storage config | Span reads |
+| Query gRPC (`jaeger_query`) | `16685` (`ports.QueryGRPC`) | Span reads |
 | Metrics | `8888` (`MetricsPort`) | Collector metrics scrape |
-| Storage cleaner | HTTP `POST /purge` on the cleaner extension | Wipe storage between cases |
+| Storage cleaner | `9231` (`POST /purge`) | Wipe storage between cases |
 
 Storage-specific tests may run extra processes (for example Kafka, remote
 storage, or a second binary) and override `MetricsPort`, `HealthCheckPort`,

--- a/cmd/jaeger/internal/integration/README.md
+++ b/cmd/jaeger/internal/integration/README.md
@@ -168,9 +168,9 @@ storage, or a second binary) and override `MetricsPort`, `HealthCheckPort`,
 `ConfigFile`, or `BinaryPath` on `E2EStorageIntegration`. Prefer the defaults
 in each `*_test.go` file when debugging a single backend.
 
-Configs under `/cmd/jaeger/` are used as the base collector configuration; the
-test harness injects the storage cleaner extension into that config before
-starting the binary.
+Configs under `cmd/jaeger/` are used as the base collector configuration. Unless
+`SkipStorageCleaner` is set, the test harness injects the storage cleaner
+extension into that config before starting the binary.
 
 ## Running tests locally
 

--- a/cmd/jaeger/internal/integration/README.md
+++ b/cmd/jaeger/internal/integration/README.md
@@ -153,15 +153,19 @@ end
 ## Assumptions
 
 These e2e tests start the `jaeger-e2e` binary (not the user-facing `jaeger`
-binary) so the `storagecleaner` extension is available. Unless a storage test
-overrides ports, the following defaults apply:
+binary) so the `storagecleaner` extension is available when needed. However,
+`e2eInitialize` skips configuration injection when `SkipStorageCleaner` is set
+(e.g., query, gRPC collector, and Kafka collector test processes), so
+developers should not expect the `/purge` endpoint on those processes. Unless a
+storage test overrides ports or skips cleaner injection, the following defaults
+apply:
 
 | Endpoint | Default port | Role |
 |----------|--------------|------|
 | OTLP gRPC receiver | `4317` | Span writes from the test process |
 | Query gRPC (`jaeger_query`) | `16685` (`ports.QueryGRPC`) | Span reads |
 | Metrics | `8888` (`MetricsPort`) | Collector metrics scrape |
-| Storage cleaner | `9231` (`POST /purge`) | Wipe storage between cases |
+| Storage cleaner | `9231` (`POST /purge`) | Wipe storage between cases (omitted when `SkipStorageCleaner` is set) |
 
 Storage-specific tests may run extra processes (for example Kafka, remote
 storage, or a second binary) and override `MetricsPort`, `HealthCheckPort`,


### PR DESCRIPTION
## Summary
Document e2e integration test assumptions (ports, binaries, configs).

The historical crossdock suite is gone; this expands the current Jaeger v2 e2e README with defaults and how CI/scripts relate.

Fixes #205