### PR TITLE
fix(storage): Stop inferring span status from HTTP attributes

### DIFF
--- a/internal/storage/v2/cassandra/tracestore/from_dbmodel.go
+++ b/internal/storage/v2/cassandra/tracestore/from_dbmodel.go
@@ -7,9 +7,7 @@
 package tracestore
 
 import (
-	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	idutils "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils"
@@ -20,8 +18,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v1/cassandra/spanstore/dbmodel"
 	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
 )
-
-var errType = errors.New("invalid type")
 
 // FromDBModel converts dbmodel.Span to ptrace.Traces
 func FromDBModel(spans []dbmodel.Span) ptrace.Traces {
@@ -134,8 +130,6 @@ func setSpanStatus(attrs pcommon.Map, span ptrace.Span) {
 
 			if desc, ok := extractStatusDescFromAttr(attrs); ok {
 				statusMessage = desc
-			} else if descAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
-				statusMessage = descAttr.Str()
 			}
 		}
 	}
@@ -159,20 +153,6 @@ func setSpanStatus(attrs pcommon.Map, span ptrace.Span) {
 		// otel.status_message tag will have already been removed if
 		// statusExists is true.
 		attrs.Remove(otelsemconv.OtelStatusCode)
-	} else if httpCodeAttr, ok := attrs.Get(otelsemconv.HTTPResponseStatusCodeKey); !statusExists && ok {
-		// Fallback to introspecting if this span represents a failed HTTP
-		// request or response, but again, only do so if the `error` tag was
-		// not set to true and no explicit status was sent.
-		if code, err := getStatusCodeFromHTTPStatusAttr(httpCodeAttr, span.Kind()); err == nil {
-			if code != ptrace.StatusCodeUnset {
-				statusExists = true
-				statusCode = code
-			}
-
-			if msgAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
-				statusMessage = msgAttr.Str()
-			}
-		}
 	}
 
 	if statusExists {
@@ -192,57 +172,6 @@ func extractStatusDescFromAttr(attrs pcommon.Map) (string, bool) {
 		return msg, true
 	}
 	return "", false
-}
-
-// codeFromAttr returns the integer code value from attrVal. An error is
-// returned if the code is not represented by an integer or string value in
-// the attrVal or the value is outside the bounds of an int representation.
-func codeFromAttr(attrVal pcommon.Value) (int64, error) {
-	var val int64
-	switch attrVal.Type() {
-	case pcommon.ValueTypeInt:
-		val = attrVal.Int()
-	case pcommon.ValueTypeStr:
-		var err error
-		val, err = strconv.ParseInt(attrVal.Str(), 10, 0)
-		if err != nil {
-			return 0, err
-		}
-	default:
-		return 0, fmt.Errorf("%w: %s", errType, attrVal.Type().String())
-	}
-	return val, nil
-}
-
-func getStatusCodeFromHTTPStatusAttr(attrVal pcommon.Value, kind ptrace.SpanKind) (ptrace.StatusCode, error) {
-	statusCode, err := codeFromAttr(attrVal)
-	if err != nil {
-		return ptrace.StatusCodeUnset, err
-	}
-
-	// For HTTP status codes in the 4xx range span status MUST be left unset
-	// in case of SpanKind.SERVER and MUST be set to Error in case of SpanKind.CLIENT.
-	// For HTTP status codes in the 5xx range, as well as any other code the client
-	// failed to interpret, span status MUST be set to Error.
-	if statusCode >= 400 && statusCode < 500 {
-		switch kind {
-		case ptrace.SpanKindClient:
-			return ptrace.StatusCodeError, nil
-		case ptrace.SpanKindServer:
-			return ptrace.StatusCodeUnset, nil
-		}
-	}
-
-	return statusCodeFromHTTP(statusCode), nil
-}
-
-// StatusCodeFromHTTP takes an HTTP status code and return the appropriate OpenTelemetry status code
-// See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status
-func statusCodeFromHTTP(httpStatusCode int64) ptrace.StatusCode {
-	if httpStatusCode >= 100 && httpStatusCode < 399 {
-		return ptrace.StatusCodeUnset
-	}
-	return ptrace.StatusCodeError
 }
 
 func jSpanKindToInternal(spanKind string) ptrace.SpanKind {

--- a/internal/storage/v2/cassandra/tracestore/from_dbmodel_test.go
+++ b/internal/storage/v2/cassandra/tracestore/from_dbmodel_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -25,53 +24,6 @@ import (
 
 // Use timestamp with microsecond granularity to work well with jaeger thrift translation
 var testSpanEventTime = time.Date(2020, 2, 11, 20, 26, 13, 123000, time.UTC).UnixMicro()
-
-func TestCodeFromAttr(t *testing.T) {
-	tests := []struct {
-		name string
-		attr pcommon.Value
-		code int64
-		err  error
-	}{
-		{
-			name: "ok-string",
-			attr: pcommon.NewValueStr("0"),
-			code: 0,
-		},
-
-		{
-			name: "ok-int",
-			attr: pcommon.NewValueInt(1),
-			code: 1,
-		},
-
-		{
-			name: "wrong-type",
-			attr: pcommon.NewValueBool(true),
-			code: 0,
-			err:  errType,
-		},
-
-		{
-			name: "invalid-string",
-			attr: pcommon.NewValueStr("inf"),
-			code: 0,
-			err:  strconv.ErrSyntax,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			code, err := codeFromAttr(test.attr)
-			if test.err != nil {
-				require.ErrorIs(t, err, test.err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, test.code, code)
-		})
-	}
-}
 
 func TestZeroBatchLength(t *testing.T) {
 	trace := FromDBModel([]dbmodel.Span{})
@@ -125,74 +77,6 @@ func Test_dbSpansToSpans_EmptySpans(t *testing.T) {
 	rss := traceData.ResourceSpans()
 	dbSpansToSpans(spans, rss)
 	assert.Equal(t, 1, rss.Len())
-}
-
-func TestGetStatusCodeFromHTTPStatusAttr(t *testing.T) {
-	tests := []struct {
-		name string
-		attr pcommon.Value
-		kind ptrace.SpanKind
-		code ptrace.StatusCode
-		err  string
-	}{
-		{
-			name: "string-unknown",
-			attr: pcommon.NewValueStr("10"),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-
-		{
-			name: "string-ok",
-			attr: pcommon.NewValueStr("101"),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeUnset,
-		},
-
-		{
-			name: "int-not-found",
-			attr: pcommon.NewValueInt(404),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-		{
-			name: "int-not-found-client-span",
-			attr: pcommon.NewValueInt(404),
-			kind: ptrace.SpanKindServer,
-			code: ptrace.StatusCodeUnset,
-		},
-		{
-			name: "int-invalid-arg",
-			attr: pcommon.NewValueInt(408),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-		{
-			name: "int-internal",
-			attr: pcommon.NewValueInt(500),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-		{
-			name: "wrong value",
-			attr: pcommon.NewValueBool(true),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeUnset,
-			err:  "invalid type: Bool",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			code, err := getStatusCodeFromHTTPStatusAttr(test.attr, test.kind)
-			if test.err != "" {
-				require.ErrorContains(t, err, test.err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, test.code, code)
-		})
-	}
 }
 
 func Test_dbLogsToSpanEvents(t *testing.T) {
@@ -310,6 +194,15 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			attrsModifiedLen: 0,
 		},
 		{
+			name: "status.code and status.description are set without an error tag",
+			attrs: map[string]any{
+				otelsemconv.OtelStatusCode:        statusError,
+				otelsemconv.OtelStatusDescription: "Error: Invalid argument",
+			},
+			status:           errorStatusWithMessage,
+			attrsModifiedLen: 0,
+		},
+		{
 			name: "status.code, status.message and error tags are set",
 			attrs: map[string]any{
 				tagError:                          true,
@@ -320,21 +213,21 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			attrsModifiedLen: 0,
 		},
 		{
-			name: "http.status_code tag is set as string",
+			name: "an HTTP status attribute alone leaves the status unset",
 			attrs: map[string]any{
 				otelsemconv.HTTPResponseStatusCodeKey: "404",
 			},
-			status:           errorStatus,
+			status:           emptyStatus,
 			attrsModifiedLen: 1,
 		},
 		{
-			name: "http.status_code, http.status_message and error tags are set",
+			name: "error tag set, the HTTP message is not adopted as the status message",
 			attrs: map[string]any{
 				tagError:                              true,
 				otelsemconv.HTTPResponseStatusCodeKey: 404,
-				tagHTTPStatusMsg:                      "HTTP 404: Not Found",
+				"http.status_message":                 "HTTP 404: Not Found",
 			},
-			status:           errorStatusWith404Message,
+			status:           errorStatus,
 			attrsModifiedLen: 2,
 		},
 		{
@@ -342,7 +235,7 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			attrs: map[string]any{
 				otelsemconv.OtelStatusCode:            statusOk,
 				otelsemconv.HTTPResponseStatusCodeKey: 500,
-				tagHTTPStatusMsg:                      "Server Error",
+				"http.status_message":                 "Server Error",
 			},
 			status:           okStatus,
 			attrsModifiedLen: 2,
@@ -361,7 +254,7 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			attrs: map[string]any{
 				otelsemconv.OtelStatusCode:            statusError,
 				otelsemconv.HTTPResponseStatusCodeKey: 500,
-				tagHTTPStatusMsg:                      "Server Error",
+				"http.status_message":                 "Server Error",
 			},
 			status:           errorStatus,
 			attrsModifiedLen: 2,
@@ -377,12 +270,12 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			attrsModifiedLen: 2,
 		},
 		{
-			name: "whether tagHttpStatusMsg is set as string",
+			name: "an HTTP status attribute is left in place for the user to filter on",
 			attrs: map[string]any{
 				otelsemconv.HTTPResponseStatusCodeKey: 404,
-				tagHTTPStatusMsg:                      "HTTP 404: Not Found",
+				"http.status_message":                 "HTTP 404: Not Found",
 			},
-			status:           errorStatusWith404Message,
+			status:           emptyStatus,
 			attrsModifiedLen: 2,
 		},
 	}

--- a/internal/storage/v2/cassandra/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/cassandra/tracestore/to_dbmodel.go
@@ -25,7 +25,6 @@ const (
 	statusOk         = "OK"
 	tagError         = "error"
 	tagW3CTraceState = "w3c.tracestate"
-	tagHTTPStatusMsg = "http.status_message"
 )
 
 // ToDBModel translates internal trace data into the DB Spans.

--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel.go
@@ -9,7 +9,6 @@ package tracestore
 import (
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -21,8 +20,6 @@ import (
 	"github.com/jaegertracing/jaeger/internal/storage/v2/elasticsearch/tracestore/core/dbmodel"
 	conventions "github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
 )
-
-var errType = errors.New("invalid type")
 
 // FromDBModel converts multiple ES DB Spans to internal traces
 func FromDBModel(spans []dbmodel.Span) (ptrace.Traces, error) {
@@ -235,8 +232,6 @@ func setSpanStatus(attrs pcommon.Map, span ptrace.Span) {
 			statusExists = true
 			if desc, ok := extractStatusDescFromAttr(attrs); ok {
 				statusMessage = desc
-			} else if descAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
-				statusMessage = descAttr.Str()
 			}
 		}
 	}
@@ -264,20 +259,6 @@ func setSpanStatus(attrs pcommon.Map, span ptrace.Span) {
 		// otel.status_message tag will have already been removed if
 		// statusExists is true.
 		attrs.Remove(conventions.OtelStatusCode)
-	} else if httpCodeAttr, ok := attrs.Get(string(conventions.HTTPResponseStatusCodeKey)); !statusExists && ok {
-		// Fallback to introspecting if this span represents a failed HTTP
-		// request or response, but again, only do so if the `error` tag was
-		// not set to true and no explicit status was sent.
-		if code, err := getStatusCodeFromHTTPStatusAttr(httpCodeAttr, span.Kind()); err == nil {
-			if code != ptrace.StatusCodeUnset {
-				statusExists = true
-				statusCode = code
-			}
-
-			if msgAttr, ok := attrs.Get(tagHTTPStatusMsg); ok {
-				statusMessage = msgAttr.Str()
-			}
-		}
 	}
 
 	if statusExists {
@@ -297,57 +278,6 @@ func extractStatusDescFromAttr(attrs pcommon.Map) (string, bool) {
 		return msg, true
 	}
 	return "", false
-}
-
-// codeFromAttr returns the integer code inputValue from attrVal. An error is
-// returned if the code is not represented by an integer or string inputValue in
-// the attrVal or the inputValue is outside the bounds of an int representation.
-func codeFromAttr(attrVal pcommon.Value) (int64, error) {
-	var val int64
-	switch attrVal.Type() {
-	case pcommon.ValueTypeInt:
-		val = attrVal.Int()
-	case pcommon.ValueTypeStr:
-		var err error
-		val, err = strconv.ParseInt(attrVal.Str(), 10, 0)
-		if err != nil {
-			return 0, err
-		}
-	default:
-		return 0, fmt.Errorf("%w: %s", errType, attrVal.Type().String())
-	}
-	return val, nil
-}
-
-func getStatusCodeFromHTTPStatusAttr(attrVal pcommon.Value, kind ptrace.SpanKind) (ptrace.StatusCode, error) {
-	statusCode, err := codeFromAttr(attrVal)
-	if err != nil {
-		return ptrace.StatusCodeUnset, err
-	}
-
-	// For HTTP status codes in the 4xx range span status MUST be left unset
-	// in case of SpanKind.SERVER and MUST be set to Error in case of SpanKind.CLIENT.
-	// For HTTP status codes in the 5xx range, as well as any other code the client
-	// failed to interpret, span status MUST be set to Error.
-	if statusCode >= 400 && statusCode < 500 {
-		switch kind {
-		case ptrace.SpanKindServer:
-			return ptrace.StatusCodeUnset, nil
-		default:
-			return ptrace.StatusCodeError, nil
-		}
-	}
-
-	return statusCodeFromHTTP(statusCode), nil
-}
-
-// StatusCodeFromHTTP takes an HTTP status code and return the appropriate OpenTelemetry status code
-// See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status
-func statusCodeFromHTTP(httpStatusCode int64) ptrace.StatusCode {
-	if httpStatusCode >= 100 && httpStatusCode < 399 {
-		return ptrace.StatusCodeUnset
-	}
-	return ptrace.StatusCodeError
 }
 
 func dbSpanKindToOTELSpanKind(spanKind string) ptrace.SpanKind {

--- a/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/from_dbmodel_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -25,50 +24,6 @@ import (
 
 var testSpanEventTime = time.Date(2020, 2, 11, 20, 26, 13, 123000, time.UTC)
 
-func TestCodeFromAttr(t *testing.T) {
-	tests := []struct {
-		name string
-		attr pcommon.Value
-		code int64
-		err  error
-	}{
-		{
-			name: "ok-string",
-			attr: pcommon.NewValueStr("0"),
-			code: 0,
-		},
-		{
-			name: "ok-int",
-			attr: pcommon.NewValueInt(1),
-			code: 1,
-		},
-		{
-			name: "wrong-type",
-			attr: pcommon.NewValueBool(true),
-			code: 0,
-			err:  errType,
-		},
-		{
-			name: "invalid-string",
-			attr: pcommon.NewValueStr("inf"),
-			code: 0,
-			err:  strconv.ErrSyntax,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			code, err := codeFromAttr(test.attr)
-			if test.err != nil {
-				require.ErrorIs(t, err, test.err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, test.code, code)
-		})
-	}
-}
-
 func TestZeroBatchLength(t *testing.T) {
 	trace, err := FromDBModel([]dbmodel.Span{})
 	require.NoError(t, err)
@@ -79,88 +34,6 @@ func TestEmptySpansAndProcess(t *testing.T) {
 	trace, err := FromDBModel([]dbmodel.Span{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, trace.ResourceSpans().Len())
-}
-
-func TestGetStatusCodeFromHTTPStatusAttr(t *testing.T) {
-	tests := []struct {
-		name string
-		attr pcommon.Value
-		kind ptrace.SpanKind
-		code ptrace.StatusCode
-		err  string
-	}{
-		{
-			name: "string-unknown",
-			attr: pcommon.NewValueStr("10"),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-		{
-			name: "string-ok",
-			attr: pcommon.NewValueStr("101"),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeUnset,
-		},
-		{
-			name: "int-not-found",
-			attr: pcommon.NewValueInt(404),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-		{
-			name: "int-not-found-client-span",
-			attr: pcommon.NewValueInt(404),
-			kind: ptrace.SpanKindServer,
-			code: ptrace.StatusCodeUnset,
-		},
-		{
-			name: "int-invalid-arg",
-			attr: pcommon.NewValueInt(408),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-		{
-			name: "int-internal",
-			attr: pcommon.NewValueInt(500),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeError,
-		},
-		{
-			name: "wrong inputValue",
-			attr: pcommon.NewValueBool(true),
-			kind: ptrace.SpanKindClient,
-			code: ptrace.StatusCodeUnset,
-			err:  "invalid type: Bool",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			code, err := getStatusCodeFromHTTPStatusAttr(test.attr, test.kind)
-			if test.err != "" {
-				require.ErrorContains(t, err, test.err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, test.code, code)
-		})
-	}
-}
-
-func TestGetStatusCodeFromHTTPStatusAttr_DefaultSpanKind(t *testing.T) {
-	value := pcommon.NewValueInt(404)
-
-	statusCode, err := getStatusCodeFromHTTPStatusAttr(value, ptrace.SpanKindInternal)
-	require.NoError(t, err)
-	assert.Equal(t, ptrace.StatusCodeError, statusCode)
-
-	statusCode, err = getStatusCodeFromHTTPStatusAttr(value, ptrace.SpanKindProducer)
-	require.NoError(t, err)
-	assert.Equal(t, ptrace.StatusCodeError, statusCode)
-
-	statusCode, err = getStatusCodeFromHTTPStatusAttr(value, ptrace.SpanKindConsumer)
-	require.NoError(t, err)
-	assert.Equal(t, ptrace.StatusCodeError, statusCode)
 }
 
 func Test_SetSpanEventsFromDbSpanLogs(t *testing.T) {
@@ -673,9 +546,7 @@ func TestSetInternalSpanStatus(t *testing.T) {
 	errorStatusWithMessage := ptrace.NewStatus()
 	errorStatusWithMessage.SetCode(ptrace.StatusCodeError)
 	errorStatusWithMessage.SetMessage("Error: Invalid argument")
-	errorStatusWith404Message := ptrace.NewStatus()
-	errorStatusWith404Message.SetCode(ptrace.StatusCodeError)
-	errorStatusWith404Message.SetMessage("HTTP 404: Not Found")
+	unsetStatus := ptrace.NewStatus()
 
 	tests := []struct {
 		name             string
@@ -702,49 +573,40 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			attrsModifiedLen: 0,
 		},
 		{
-			name: "http.status_code tag is set as string",
+			name: "an HTTP status attribute alone leaves the status unset",
 			attrs: map[string]any{
 				conventions.HTTPResponseStatusCodeKey: "404",
 			},
-			status:           errorStatus,
+			status:           unsetStatus,
 			attrsModifiedLen: 1,
 		},
 		{
-			name: "http.status_code, http.status_message and error tags are set",
+			name: "an HTTP status attribute is left in place for the user to filter on",
 			attrs: map[string]any{
 				conventions.HTTPResponseStatusCodeKey: 404,
-				tagHTTPStatusMsg:                      "HTTP 404: Not Found",
+				"http.status_message":                 "HTTP 404: Not Found",
 			},
-			status:           errorStatusWith404Message,
+			status:           unsetStatus,
 			attrsModifiedLen: 2,
 		},
 		{
-			name: "status.code has precedence over http.status_code.",
+			name: "an explicit OK status is not overridden by a 5xx attribute",
 			attrs: map[string]any{
 				conventions.OtelStatusCode:            statusOk,
 				conventions.HTTPResponseStatusCodeKey: 500,
-				tagHTTPStatusMsg:                      "Server Error",
+				"http.status_message":                 "Server Error",
 			},
 			status:           okStatus,
 			attrsModifiedLen: 2,
 		},
 		{
-			name: "status.error has precedence over http.status_error.",
+			name: "an explicit error status carries no message from the HTTP attribute",
 			attrs: map[string]any{
 				conventions.OtelStatusCode:            statusError,
 				conventions.HTTPResponseStatusCodeKey: 500,
-				tagHTTPStatusMsg:                      "Server Error",
+				"http.status_message":                 "Server Error",
 			},
 			status:           errorStatus,
-			attrsModifiedLen: 2,
-		},
-		{
-			name: "whether tagHttpStatusMsg is set as string",
-			attrs: map[string]any{
-				conventions.HTTPResponseStatusCodeKey: 404,
-				tagHTTPStatusMsg:                      "HTTP 404: Not Found",
-			},
-			status:           errorStatusWith404Message,
 			attrsModifiedLen: 2,
 		},
 		{
@@ -757,12 +619,12 @@ func TestSetInternalSpanStatus(t *testing.T) {
 			attrsModifiedLen: 0,
 		},
 		{
-			name: "error tag set and http tag message present",
+			name: "error tag set and only an HTTP message present",
 			attrs: map[string]any{
-				tagError:         true,
-				tagHTTPStatusMsg: "HTTP 404: Not Found",
+				tagError:              true,
+				"http.status_message": "HTTP 404: Not Found",
 			},
-			status:           errorStatusWith404Message,
+			status:           errorStatus,
 			attrsModifiedLen: 1,
 		},
 	}

--- a/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
+++ b/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go
@@ -24,7 +24,6 @@ const (
 	statusError      = "ERROR"
 	statusOk         = "OK"
 	tagW3CTraceState = "w3c.tracestate"
-	tagHTTPStatusMsg = "http.status_message"
 	tagError         = "error"
 )
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #9385

## Description of the changes

The Elasticsearch and Cassandra v2 readers manufactured a span `Status` from the user's own `http.response.status_code` attribute whenever a span carried neither `error` nor `otel.status_code`, and took the status *message* from `http.status_message`. No writer in this repo produces either key, so the reader was guessing at attributes the user's instrumentation happened to set.

Deleted from both `from_dbmodel.go` files:

- the HTTP fallback branch in `setSpanStatus`, plus `getStatusCodeFromHTTPStatusAttr` and `statusCodeFromHTTP`
- the two `http.status_message` reads, including the one inside the `error` branch, and the now unused `tagHTTPStatusMsg` constant

The `error` and `otel.status_code` branches are untouched. Those decode exactly what `to_dbmodel.go` encoded, which is the permitted encoding of a wire concept the DB model has no field for.

One thing the issue didn't mention: `codeFromAttr` had no caller other than `getStatusCodeFromHTTPStatusAttr`, so it goes too, and with it `errType` and the `errors` import in both files. `strconv` follows in the Cassandra file, which used it nowhere else.

## How was this change tested?

Before touching anything I pinned the current behaviour with a temporary table test against `setSpanStatus` in both packages, then re-ran it after the deletion. Four of the six cases flipped and two did not, which is the change landing where it should:

| case | before | after |
| --- | --- | --- |
| `http.response.status_code=500` alone | `Error` | `Unset` |
| `404` on a `SERVER` span | `Unset` | `Unset` |
| the same document on a `CLIENT` span | `Error` | `Unset` |
| `500` plus `http.status_message` | `Error` / `"Server Error"` | `Unset` / `""` |
| `error=true` plus `http.status_message` | `Error` / `"HTTP 404: Not Found"` | `Error` / `""` |
| the pre-#7318 `http.status_code=500` | `Unset` | `Unset` |

That last row is worth keeping in mind for the compatibility question: #7318 already moved this branch to the newer semconv key, so a span stored under the older convention stopped being inferred some time ago. The blast radius is spans written with `http.response.status_code` and no explicit status.

The harness was deleted afterwards; the committed test files are the existing `from_dbmodel_test.go` cases, rewritten for the new behaviour, with `TestCodeFromAttr` and the two `TestGetStatusCodeFromHTTPStatusAttr` tests removed since their subjects are gone.

`go test ./internal/...` passes. Package coverage: Elasticsearch stays at 99.4% with `setSpanStatus` at 100%; Cassandra goes from 97.9% to 98.0%, and `setSpanStatus` from 97.0% to 100%, because deleting the branch exposed that no case covered `otel.status_code` with a description and no `error` tag, so I added one. `make lint-fmt lint-license lint-imports lint-semconv` and `make lint-go` are clean.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
