### PR TITLE
fix(query): Prevent archiving archive-only traces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -305,14 +305,12 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query tracestore.GetTra
 	if qs.options.ArchiveTraceWriter == nil {
 		return errNoArchiveSpanStorage
 	}
-	getTracesIter := qs.GetTraces(
-		ctx, GetTraceParams{TraceIDs: []tracestore.GetTraceParams{query}},
-	)
+	getTracesIter := qs.interceptResults(ctx, qs.traceReader.GetTraces(ctx, query))
 	var (
 		found      bool
 		archiveErr error
 	)
-	getTracesIter(func(traces []ptrace.Traces, err error) bool {
+	qs.receiveTraces(getTracesIter, func(traces []ptrace.Traces, err error) bool {
 		if err != nil {
 			archiveErr = err
 			return false
@@ -325,7 +323,7 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query tracestore.GetTra
 			}
 		}
 		return true
-	})
+	}, false)
 	if archiveErr == nil && !found {
 		return spanstore.ErrTraceNotFound
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -305,12 +305,13 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query tracestore.GetTra
 	if qs.options.ArchiveTraceWriter == nil {
 		return errNoArchiveSpanStorage
 	}
-	getTracesIter := qs.interceptResults(ctx, qs.traceReader.GetTraces(ctx, query))
+	// use primary reader only to avoid readArchive->archive cycle
+	getTracesIter := qs.traceReader.GetTraces(ctx, query)
 	var (
 		found      bool
 		archiveErr error
 	)
-	qs.receiveTraces(getTracesIter, func(traces []ptrace.Traces, err error) bool {
+	getTracesIter(func(traces []ptrace.Traces, err error) bool {
 		if err != nil {
 			archiveErr = err
 			return false
@@ -323,7 +324,7 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query tracestore.GetTra
 			}
 		}
 		return true
-	}, false)
+	})
 	if archiveErr == nil && !found {
 		return spanstore.ErrTraceNotFound
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
@@ -716,18 +716,20 @@ func TestArchiveTrace(t *testing.T) {
 }
 
 func TestArchiveTrace_ArchiveOnlyTraceNotFound(t *testing.T) {
-	paramsTraceIDs := []tracestore.GetTraceParams{{TraceID: testTraceID}}
+	query := tracestore.GetTraceParams{TraceID: testTraceID}
 	tqs := initializeTestService(withArchiveTraceReader(), withArchiveTraceWriter())
-	tqs.traceReader.On("GetTraces", mock.Anything, paramsTraceIDs).
+	// mocks.Reader.GetTraces packs variadic params into a single slice argument.
+	tqs.traceReader.On("GetTraces", mock.Anything, []tracestore.GetTraceParams{query}).
 		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
 			yield(nil, nil)
 		})).Once()
 
-	err := tqs.queryService.ArchiveTrace(t.Context(), paramsTraceIDs[0])
+	err := tqs.queryService.ArchiveTrace(t.Context(), query)
 
 	require.ErrorIs(t, err, spanstore.ErrTraceNotFound)
-	tqs.archiveTraceReader.AssertNotCalled(t, "GetTraces", mock.Anything, paramsTraceIDs)
-	tqs.archiveTraceWriter.AssertNotCalled(t, "WriteTraces", mock.Anything, mock.Anything)
+	tqs.traceReader.AssertExpectations(t)
+	tqs.archiveTraceReader.AssertNotCalled(t, "GetTraces")
+	tqs.archiveTraceWriter.AssertNotCalled(t, "WriteTraces")
 }
 
 func TestGetDependencies(t *testing.T) {

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
@@ -715,6 +715,21 @@ func TestArchiveTrace(t *testing.T) {
 	}
 }
 
+func TestArchiveTrace_ArchiveOnlyTraceNotFound(t *testing.T) {
+	paramsTraceIDs := []tracestore.GetTraceParams{{TraceID: testTraceID}}
+	tqs := initializeTestService(withArchiveTraceReader(), withArchiveTraceWriter())
+	tqs.traceReader.On("GetTraces", mock.Anything, paramsTraceIDs).
+		Return(iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+			yield(nil, nil)
+		})).Once()
+
+	err := tqs.queryService.ArchiveTrace(t.Context(), paramsTraceIDs[0])
+
+	require.ErrorIs(t, err, spanstore.ErrTraceNotFound)
+	tqs.archiveTraceReader.AssertNotCalled(t, "GetTraces", mock.Anything, paramsTraceIDs)
+	tqs.archiveTraceWriter.AssertNotCalled(t, "WriteTraces", mock.Anything, mock.Anything)
+}
+
 func TestGetDependencies(t *testing.T) {
 	tqs := initializeTestService()
 	expected := []model.DependencyLink{


### PR DESCRIPTION
Fixes #9390.

## Summary

- Read traces for `ArchiveTrace` only from primary storage.
- Preserve result interception and trace adjustment.
- Return not found without reading or writing archive storage when the trace is absent from primary storage.
- Add a regression test for the archive-only case.

## Verification

- `make fmt`
- `make lint`
- `GOMAXPROCS=2 make test` (4,587 tests, 38 skipped)
- Focused `TestArchiveTrace` race tests
- `git diff --check`
