### PR TITLE
fix(otel-demo): Harden Dashboards rollout diagnostics

### DIFF
--- a/examples/otel-demo/README.md
+++ b/examples/otel-demo/README.md
@@ -33,6 +33,7 @@ It is driven by `deploy-all.sh`, which supports both clean installs and upgrades
 
 Environment variables:
 - ROLLOUT_TIMEOUT: rollout wait timeout in seconds (default 600)
+- OPENSEARCH_DASHBOARDS_HELM_TIMEOUT: Helm wait timeout for OpenSearch Dashboards (default 60m)
 
 ```bash path=null start=null
 ROLLOUT_TIMEOUT=900 ./deploy-all.sh clean

--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-600}"
+OPENSEARCH_DASHBOARDS_HELM_TIMEOUT="${OPENSEARCH_DASHBOARDS_HELM_TIMEOUT:-60m}"
 
 MODE="${1:-upgrade}"
 IMAGE_TAG="${2:-${JAEGER_DEMO_IMAGE_TAG:-latest}}"
@@ -147,6 +148,108 @@ diagnose_deployment_failure() {
   kubectl -n "$namespace" describe pods -l app.kubernetes.io/instance=jaeger || true
   kubectl -n "$namespace" logs -l app.kubernetes.io/instance=jaeger --all-containers --tail=200 --prefix || true
   kubectl -n "$namespace" get events --sort-by=.lastTimestamp | tail -80 || true
+}
+
+summarize_opensearch_dashboards_logs() {
+  awk '
+    BEGIN {
+      lines = errors = warnings = timeouts = connection_failures = memory_failures = readiness_failures = 0
+    }
+    {
+      lines++
+      lower = tolower($0)
+      if (lower ~ /(error|exception|fatal)/) errors++
+      if (lower ~ /warn/) warnings++
+      if (lower ~ /(etimedout|timed out|timeout)/) timeouts++
+      if (lower ~ /(connection refused|econnrefused|unable to connect|unavailable)/) connection_failures++
+      if (lower ~ /(heap|oomkilled|out of memory)/) memory_failures++
+      if (lower ~ /(liveness|not ready|readiness|startup probe)/) readiness_failures++
+    }
+    END {
+      printf "lines=%d errors=%d warnings=%d timeouts=%d connection_failures=%d memory_failures=%d readiness_failures=%d\n", lines, errors, warnings, timeouts, connection_failures, memory_failures, readiness_failures
+    }
+  '
+}
+
+collect_opensearch_dashboards_logs() {
+  local pod
+  local pod_number=0
+  local logs
+
+  while IFS= read -r pod; do
+    [[ -n "$pod" ]] || continue
+    pod_number=$((pod_number + 1))
+    if logs=$(kubectl -n opensearch logs "$pod" -c dashboards --tail=300 2>/dev/null); then
+      log "Current Dashboards container log summary (pod $pod_number)"
+      printf '%s' "$logs" | summarize_opensearch_dashboards_logs
+    else
+      log "Current Dashboards container logs are unavailable (pod $pod_number)"
+    fi
+    if logs=$(kubectl -n opensearch logs "$pod" -c dashboards --previous --tail=300 2>/dev/null); then
+      log "Previous Dashboards container log summary (pod $pod_number)"
+      printf '%s' "$logs" | summarize_opensearch_dashboards_logs
+    else
+      log "Previous Dashboards container logs are unavailable (pod $pod_number)"
+    fi
+  done < <(kubectl -n opensearch get pods \
+    -l app.kubernetes.io/name=opensearch-dashboards,app.kubernetes.io/instance=opensearch-dashboards \
+    -o name 2>/dev/null || true)
+}
+
+diagnose_opensearch_dashboards_failure() {
+  log "Collecting sanitized OpenSearch Dashboards diagnostics"
+
+  if command -v jq >/dev/null 2>&1; then
+    helm status opensearch-dashboards -n opensearch -o json 2>/dev/null |
+      jq -c '
+        def string_or_null: if type == "string" then . else null end;
+        def revision_or_null: if type == "string" or type == "number" then . else null end;
+        if type == "object" then
+          {
+            revision: ((.version // .revision) | revision_or_null),
+            status: ((.info.status // .status) | string_or_null),
+            chartVersion: (if (.chart | type) == "object" then (.chart.metadata.version | string_or_null) else (.chart | string_or_null) end),
+            appVersion: (if (.chart | type) == "object" then ((.chart.metadata.appVersion // .app_version) | string_or_null) else (.app_version | string_or_null) end)
+          }
+        else
+          {revision: null, status: null, chartVersion: null, appVersion: null}
+        end
+      ' || true
+    helm history opensearch-dashboards -n opensearch -o json 2>/dev/null |
+      jq -c '
+        def string_or_null: if type == "string" then . else null end;
+        def revision_or_null: if type == "string" or type == "number" then . else null end;
+        [.[]? | select(type == "object") | {
+          revision: (.revision | revision_or_null),
+          status: (.status | string_or_null),
+          chart: (.chart | string_or_null),
+          appVersion: ((.app_version // .appVersion) | string_or_null)
+        }]
+      ' || true
+    kubectl -n opensearch get deployment opensearch-dashboards -o json 2>/dev/null |
+      jq -c '{generation: .metadata.generation, observedGeneration: .status.observedGeneration, replicas: .status.replicas, updatedReplicas: .status.updatedReplicas, readyReplicas: .status.readyReplicas, availableReplicas: .status.availableReplicas, unavailableReplicas: .status.unavailableReplicas, conditions: [.status.conditions[]? | {type, status, reason, lastTransitionTime}]}' || true
+    kubectl -n opensearch get pods \
+      -l app.kubernetes.io/name=opensearch-dashboards,app.kubernetes.io/instance=opensearch-dashboards \
+      -o json 2>/dev/null |
+      jq -c '[.items[] | {phase: .status.phase, scheduled: ([.status.conditions[]? | select(.type == "PodScheduled") | {status, reason}] | .[0] // null), dashboards: ([.status.containerStatuses[]? | select(.name == "dashboards") | {ready, started, restartCount, waitingReason: .state.waiting.reason, terminatedReason: .state.terminated.reason, exitCode: .state.terminated.exitCode, lastTerminatedReason: .lastState.terminated.reason, lastExitCode: .lastState.terminated.exitCode}] | .[0] // null)}]' || true
+    kubectl -n opensearch get events -o json 2>/dev/null |
+      jq -c '[.items[] | select((.involvedObject.name // "") | startswith("opensearch-dashboards")) | {type, reason, count, firstTimestamp, lastTimestamp, eventTime}]' || true
+  else
+    log "jq is unavailable; skipping structured Dashboards diagnostics"
+  fi
+
+  collect_opensearch_dashboards_logs
+}
+
+wait_for_opensearch_dashboards() {
+  local timeout="${1:-${ROLLOUT_TIMEOUT}s}"
+
+  log "Waiting for OpenSearch Dashboards deployment..."
+  if ! kubectl rollout status deployment/opensearch-dashboards -n opensearch --timeout="$timeout"; then
+    diagnose_opensearch_dashboards_failure
+    err "OpenSearch Dashboards failed to remain ready"
+  fi
+  log "OpenSearch Dashboards deployment is ready"
 }
 
 collect_otel_collector_logs() {
@@ -329,12 +432,15 @@ deploy_opensearch_releases() {
   wait_for_statefulset opensearch opensearch-cluster-single "${ROLLOUT_TIMEOUT}s"
 
   log "Deploying OpenSearch Dashboards chart $OPENSEARCH_DASHBOARDS_CHART_VERSION"
-  helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards \
+  if ! helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards \
     --namespace opensearch \
     --version "$OPENSEARCH_DASHBOARDS_CHART_VERSION" \
     -f "$SCRIPT_DIR/opensearch-dashboard-values.yaml" \
-    --wait --timeout 10m
-  wait_for_deployment opensearch opensearch-dashboards "${ROLLOUT_TIMEOUT}s"
+    --wait --timeout "$OPENSEARCH_DASHBOARDS_HELM_TIMEOUT"; then
+    diagnose_opensearch_dashboards_failure
+    err "Helm release opensearch-dashboards failed"
+  fi
+  wait_for_opensearch_dashboards "${ROLLOUT_TIMEOUT}s"
 }
 
 cleanup() {

--- a/examples/otel-demo/deploy-all.test.sh
+++ b/examples/otel-demo/deploy-all.test.sh
@@ -224,17 +224,136 @@ testDeploysPinnedOpenSearchChartsInOrder() {
     bash() { printf "bash"; printf " %s" "$@"; printf "\n"; }
     helm() { printf "helm"; printf " %s" "$@"; printf "\n"; }
     wait_for_statefulset() { printf "wait-for-statefulset"; printf " %s" "$@"; printf "\n"; }
-    wait_for_deployment() { printf "wait-for-deployment"; printf " %s" "$@"; printf "\n"; }
+    wait_for_opensearch_dashboards() { printf "wait-for-dashboards"; printf " %s" "$@"; printf "\n"; }
     deploy_opensearch_releases
   ' _ "$SCRIPT")
 
   expected="bash $(dirname "$SCRIPT")/opensearch-recovery.sh verify
 helm upgrade --install opensearch opensearch/opensearch --namespace opensearch --create-namespace --version 2.38.0 -f $(dirname "$SCRIPT")/opensearch-values.yaml --wait --timeout 10m
 wait-for-statefulset opensearch opensearch-cluster-single 600s
-helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards --namespace opensearch --version 2.34.0 -f $(dirname "$SCRIPT")/opensearch-dashboard-values.yaml --wait --timeout 10m"
+helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards --namespace opensearch --version 2.34.0 -f $(dirname "$SCRIPT")/opensearch-dashboard-values.yaml --wait --timeout 60m"
   expected="$expected
-wait-for-deployment opensearch opensearch-dashboards 600s"
+wait-for-dashboards 600s"
   assertEquals "$expected" "$output"
+}
+
+testDashboardsHelmTimeoutCanBeOverridden() {
+  output=$(OPENSEARCH_DASHBOARDS_HELM_TIMEOUT=75m bash -c '
+    source "$1"
+    MODE=clean
+    log() { :; }
+    helm() { printf "helm"; printf " %s" "$@"; printf "\n"; }
+    wait_for_statefulset() { :; }
+    wait_for_opensearch_dashboards() { :; }
+    deploy_opensearch_releases
+  ' _ "$SCRIPT")
+
+  assertContains "$output" "helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards"
+  assertContains "$output" "--wait --timeout 75m"
+}
+
+testDashboardsHelmFailureCollectsDiagnosticsAndStops() {
+  output=$(bash -c '
+    source "$1"
+    MODE=clean
+    log() { :; }
+    helm() {
+      if [[ "$*" == *"opensearch-dashboards opensearch/opensearch-dashboards"* ]]; then
+        return 1
+      fi
+      return 0
+    }
+    wait_for_statefulset() { printf "wait-for-statefulset\n"; }
+    wait_for_opensearch_dashboards() { printf "unsafe wait-for-deployment\n"; }
+    diagnose_opensearch_dashboards_failure() { printf "dashboards diagnostics\n"; }
+    deploy_opensearch_releases
+  ' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertNotEquals "Dashboards Helm failure should fail deployment" 0 "$rc"
+  assertContains "$output" "dashboards diagnostics"
+  assertEquals "diagnostics should run exactly once" 1 "$(grep -c '^dashboards diagnostics$' <<<"$output")"
+  assertContains "$output" "Helm release opensearch-dashboards failed"
+  assertNotContains "$output" "unsafe wait-for-deployment"
+}
+
+testDashboardsDiagnosticsAreSanitized() {
+  output=$(bash -c '
+    source "$1"
+    log() { printf "log %s\n" "$*"; }
+    helm() {
+      case "$1" in
+        status)
+          printf "%s\n" '\''{"version":12,"info":{"status":"failed"},"chart":{"values":{"password":"raw-status-value"}},"app_version":"2.19.6"}'\''
+          ;;
+        history)
+          printf "%s\n" '\''[{"revision":12,"status":"failed","chart":"opensearch-dashboards-2.34.0","app_version":"2.19.6"},{"revision":13,"status":{"value":"failed"},"chart":{"values":{"password":"raw-history-value"}},"app_version":{"token":"raw-app-value"}}]'\''
+          ;;
+      esac
+    }
+    kubectl() {
+      case "$*" in
+        *"get deployment opensearch-dashboards -o json"*)
+          printf "%s\n" '\''{"metadata":{"generation":2},"status":{"observedGeneration":2,"replicas":1,"readyReplicas":0,"conditions":[{"type":"Available","status":"False","reason":"MinimumReplicasUnavailable","lastTransitionTime":"2026-08-22T11:45:52Z"}]}}'\''
+          ;;
+        *"get pods -l app.kubernetes.io/name=opensearch-dashboards,app.kubernetes.io/instance=opensearch-dashboards -o json"*)
+          printf "%s\n" '\''{"items":[{"metadata":{"name":"opensearch-dashboards-private-id"},"spec":{"nodeName":"oke-private-node"},"status":{"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False","reason":"Unschedulable"}],"containerStatuses":[{"name":"dashboards","ready":false,"started":false,"restartCount":1,"state":{"waiting":{"reason":"ImagePullBackOff"}},"lastState":{"terminated":{"reason":"Error","exitCode":1}}}]}}]}'\''
+          ;;
+        *"get events -o json"*)
+          printf "%s\n" '\''{"items":[{"involvedObject":{"name":"opensearch-dashboards-private-id"},"type":"Warning","reason":"FailedScheduling","count":2,"lastTimestamp":"2026-08-22T11:46:00Z","message":"private event text"}]}'\''
+          ;;
+        *"get pods -l app.kubernetes.io/name=opensearch-dashboards,app.kubernetes.io/instance=opensearch-dashboards -o name"*)
+          printf "%s\n" "pod/opensearch-dashboards-abc123-def45"
+          ;;
+        *"logs pod/opensearch-dashboards-abc123-def45 -c dashboards --previous --tail=300"*)
+          printf "%s\n" "warning: startup timed out" "Basic dXNlcjpwYXNz" "HTTPS://alice:uRLp4ss@example.invalid/"
+          ;;
+        *"logs pod/opensearch-dashboards-abc123-def45 -c dashboards --tail=300"*)
+          printf "%s\n" "error: connection refused" '\''{"password":"json-value"}'\'' '\''{"scheme":"Bearer eyJhbGciOiJIUzI1NiJ9.opaque"}'\'' "endpoint 10.1.2.3" "endpoint 2001:db8::1" "pod opensearch-dashboards-abc123-def45" "node oke-private-node"
+          ;;
+      esac
+    }
+    diagnose_opensearch_dashboards_failure
+  ' _ "$SCRIPT" 2>&1)
+
+  assertContains "$output" '"chart":"opensearch-dashboards-2.34.0"'
+  assertContains "$output" '"waitingReason":"ImagePullBackOff"'
+  assertContains "$output" '"reason":"FailedScheduling"'
+  assertContains "$output" "Current Dashboards container log summary (pod 1)"
+  assertContains "$output" "lines=7 errors=1 warnings=0 timeouts=0 connection_failures=1 memory_failures=0 readiness_failures=0"
+  assertContains "$output" "Previous Dashboards container log summary (pod 1)"
+  assertContains "$output" "lines=3 errors=0 warnings=1 timeouts=1 connection_failures=0 memory_failures=0 readiness_failures=0"
+  assertNotContains "$output" "dXNlcjpwYXNz"
+  assertNotContains "$output" "uRLp4ss"
+  assertNotContains "$output" "json-value"
+  assertNotContains "$output" "eyJhbGciOiJIUzI1NiJ9.opaque"
+  assertNotContains "$output" "10.1.2.3"
+  assertNotContains "$output" "2001:db8::1"
+  assertNotContains "$output" "opensearch-dashboards-abc123-def45"
+  assertNotContains "$output" "opensearch-dashboards-private-id"
+  assertNotContains "$output" "oke-private-node"
+  assertNotContains "$output" "private event text"
+  assertNotContains "$output" "raw-status-value"
+  assertNotContains "$output" "raw-history-value"
+  assertNotContains "$output" "raw-app-value"
+}
+
+testDashboardsRolloutFailureCollectsSanitizedDiagnostics() {
+  output=$(bash -c '
+    source "$1"
+    log() { :; }
+    kubectl() { printf "kubectl"; printf " %s" "$@"; printf "\n"; return 1; }
+    diagnose_opensearch_dashboards_failure() { printf "dashboards diagnostics\n"; }
+    wait_for_opensearch_dashboards 45s
+  ' _ "$SCRIPT" 2>&1)
+  rc=$?
+
+  assertNotEquals "Dashboards rollout failure should fail deployment" 0 "$rc"
+  assertContains "$output" "kubectl rollout status deployment/opensearch-dashboards -n opensearch --timeout=45s"
+  assertContains "$output" "dashboards diagnostics"
+  assertContains "$output" "OpenSearch Dashboards failed to remain ready"
+  assertNotContains "$output" "-o wide"
+  assertNotContains "$output" "describe"
 }
 
 testRecoveryGatePrecedesOpenSearchUpgrade() {
@@ -262,7 +381,7 @@ testRecoveryWaiverSkipsOnlyRecoveryGate() {
     bash() { printf "unsafe recovery call\n"; }
     helm() { printf "helm"; printf " %s" "$@"; printf "\n"; }
     wait_for_statefulset() { printf "wait-for-statefulset"; printf " %s" "$@"; printf "\n"; }
-    wait_for_deployment() { printf "wait-for-deployment"; printf " %s" "$@"; printf "\n"; }
+    wait_for_opensearch_dashboards() { printf "wait-for-dashboards"; printf " %s" "$@"; printf "\n"; }
     deploy_opensearch_releases
   ' _ "$SCRIPT")
 
@@ -271,7 +390,7 @@ testRecoveryWaiverSkipsOnlyRecoveryGate() {
   assertContains "$output" "helm upgrade --install opensearch opensearch/opensearch"
   assertContains "$output" "wait-for-statefulset opensearch opensearch-cluster-single 600s"
   assertContains "$output" "helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards"
-  assertContains "$output" "wait-for-deployment opensearch opensearch-dashboards 600s"
+  assertContains "$output" "wait-for-dashboards 600s"
 }
 
 testInvalidRecoveryPolicyCannotCallHelm() {


### PR DESCRIPTION
## Which problem is this PR solving?

The first isolated OTel demo OpenSearch 2.19.6 rollout upgraded OpenSearch successfully, but the matching Dashboards Helm upgrade exceeded the shared 10-minute wait. Dashboards converged later, while the failed workflow lacked component-specific evidence to classify the delay.

Fixes #9392.

Operational rollout evidence is recorded in #9244.

## Description of the changes

- Give only OpenSearch Dashboards a configurable 60-minute Helm timeout, calibrated above the observed approximately 44-minute cold convergence.
- Preserve the OpenSearch-first order and OpenSearch's existing timeout.
- On either Helm or post-Helm readiness failure, emit allowlisted Helm, Deployment, pod/container, and event state.
- Read bounded current and previous Dashboards logs but publish only aggregate error-category counts, never raw log bodies or cluster identifiers.
- Add regression coverage for command order, the default and overridden timeout, both failure paths, exact selectors/container, and adversarial diagnostic data.

No chart versions, resources, replicas, probes, security settings, values, deployment routing, or destructive behavior change.

## Testing

- `make fmt`
- `make lint`
- `make test` (4,586 tests, 38 skipped)
- 21 focused `deploy-all.test.sh` cases, including all changed behavior
- `bash -n examples/otel-demo/deploy-all.sh examples/otel-demo/deploy-all.test.sh`
- `git diff --check`

The separate existing pinned OTel chart-render case could not fetch its upstream chart locally because the external Helm repository timed out; CI will rerun it.
