### PR TITLE
feat(ai-gateway): Send configurable headers on the ACP agent handshake

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags.go
@@ -7,6 +7,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/netip"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 
 	"github.com/jaegertracing/jaeger/internal/headerforwarding"
@@ -54,6 +56,17 @@ type AIConfig struct {
 	// Optional: leave empty (and set the mcp block) to expose the telemetry MCP
 	// endpoint without the AI chat surface.
 	AgentURL string `mapstructure:"agent_url" valid:"optional"`
+	// AgentHeaders are extra HTTP headers sent on the agent WebSocket
+	// handshake, for agents that require authentication. The header name is the
+	// agent's choice, not ours (Goose expects "X-Secret-Key", others expect
+	// "Authorization"), so this is a map rather than a token field: a new scheme
+	// needs configuration instead of code.
+	//
+	// The values are configopaque.String, the collector's own secret-safe type,
+	// so a credential stays out of logs and config dumps by construction rather
+	// than by everyone remembering not to print it. Prefer env expansion
+	// (${env:VAR}) over inline values. Ignored unless AgentURL is set.
+	AgentHeaders configopaque.MapList `mapstructure:"agent_headers" valid:"optional"`
 	// MCP exposes Jaeger telemetry MCP server at <basePath>/api/ai/mcp/ on
 	// the query port. Present enables it, absent disables it — an empty block
 	// (`mcp: {}`) is enough. It replaces the retired standalone jaeger_mcp
@@ -148,6 +161,11 @@ func (c *AIConfig) Validate() error {
 	}
 	if c.HealthCheckInterval > 0 && c.HealthCheckTimeout <= 0 {
 		return errors.New("ai.health_check_timeout must be positive when health_check_interval is positive")
+	}
+	// MapList permits repeated names on the wire; a duplicated header would
+	// silently keep only one value, so reject it here rather than guess which.
+	if err := c.AgentHeaders.Validate(); err != nil {
+		return fmt.Errorf("ai.agent_headers: %w", err)
 	}
 	// MCPConfig.Validate is reached by the collector's config walk on its own,
 	// the same way OTLPProxyConfig's is; delegating to it here would only

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/flags_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 )
 
@@ -320,4 +321,27 @@ func TestHostIPSkipsResolverForLocalhost(t *testing.T) {
 		require.NotNil(t, ip, "%q must resolve without the resolver", host)
 		assert.True(t, ip.IsLoopback(), "%q is loopback", host)
 	}
+}
+
+func TestAIConfigRejectsDuplicateAgentHeaders(t *testing.T) {
+	cfg := AIConfig{
+		AgentURL:           "ws://localhost:16688",
+		MaxRequestBodySize: 1 << 20,
+		AgentHeaders: configopaque.MapList{
+			{Name: "X-Secret-Key", Value: "one"},
+			{Name: "X-Secret-Key", Value: "two"},
+		},
+	}
+	require.ErrorContains(t, cfg.Validate(), "ai.agent_headers")
+}
+
+func TestAIConfigAcceptsAgentHeaders(t *testing.T) {
+	cfg := AIConfig{
+		AgentURL:           "ws://localhost:16688",
+		MaxRequestBodySize: 1 << 20,
+		AgentHeaders: configopaque.MapList{
+			{Name: "X-Secret-Key", Value: "one"},
+		},
+	}
+	require.NoError(t, cfg.Validate())
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/aihealth/acp_check.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/aihealth/acp_check.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 
 	acp "github.com/coder/acp-go-sdk"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai"
@@ -30,7 +31,7 @@ var silentACPLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 // connection to agentURL, performs one ACP `initialize` round-trip, and
 // closes. Any transport-level or protocol-level error counts as unhealthy.
 // Suitable for use as aihealth.Config.Check.
-func NewACPCheck(agentURL string, logger *zap.Logger) func(ctx context.Context) error {
+func NewACPCheck(agentURL string, agentHeaders configopaque.MapList, logger *zap.Logger) func(ctx context.Context) error {
 	// The check only sends `initialize` and immediately closes — the sidecar
 	// should never send a client-bound call in that window, but if it does we
 	// refuse it rather than crash.
@@ -38,7 +39,7 @@ func NewACPCheck(agentURL string, logger *zap.Logger) func(ctx context.Context) 
 		return nil, acp.NewMethodNotFound(method)
 	}
 	return func(ctx context.Context) error {
-		adapter, err := jaegerai.DialWsAdapter(ctx, agentURL, logger)
+		adapter, err := jaegerai.DialWsAdapter(ctx, agentURL, agentHeaders, logger)
 		if err != nil {
 			return fmt.Errorf("dial: %w", err)
 		}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/aihealth/acp_check_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/aihealth/acp_check_test.go
@@ -16,6 +16,7 @@ import (
 	acp "github.com/coder/acp-go-sdk"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai"
@@ -25,9 +26,10 @@ import (
 // only Initialize is exercised. Every other method returns a zero value and
 // nil error so the SDK does not blow up if it routes something unexpected.
 type stubAgent struct {
-	mu        sync.Mutex
-	initCount int
-	initErr   error
+	mu             sync.Mutex
+	initCount      int
+	initErr        error
+	lastAuthHeader string
 }
 
 func (*stubAgent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
@@ -79,6 +81,10 @@ func startMockACPServer(t *testing.T, agent *stubAgent) string {
 	t.Helper()
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		agent.mu.Lock()
+		agent.lastAuthHeader = r.Header.Get("X-Secret-Key")
+		agent.mu.Unlock()
+
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -102,7 +108,7 @@ func TestACPCheck_SucceedsAgainstReachableSidecar(t *testing.T) {
 	agent := &stubAgent{}
 	wsURL := startMockACPServer(t, agent)
 
-	err := NewACPCheck(wsURL, zap.NewNop())(t.Context())
+	err := NewACPCheck(wsURL, nil, zap.NewNop())(t.Context())
 	require.NoError(t, err)
 
 	agent.mu.Lock()
@@ -111,7 +117,7 @@ func TestACPCheck_SucceedsAgainstReachableSidecar(t *testing.T) {
 }
 
 func TestACPCheck_FailsWhenDialFails(t *testing.T) {
-	err := NewACPCheck("ws://127.0.0.1:1", zap.NewNop())(t.Context()) // closed port
+	err := NewACPCheck("ws://127.0.0.1:1", nil, zap.NewNop())(t.Context()) // closed port
 	require.ErrorContains(t, err, "dial:")
 }
 
@@ -119,6 +125,24 @@ func TestACPCheck_FailsWhenInitializeRejected(t *testing.T) {
 	agent := &stubAgent{initErr: errors.New("agent rejected initialize")}
 	wsURL := startMockACPServer(t, agent)
 
-	err := NewACPCheck(wsURL, zap.NewNop())(t.Context())
+	err := NewACPCheck(wsURL, nil, zap.NewNop())(t.Context())
 	require.ErrorContains(t, err, "initialize:")
+}
+
+// The health checker dials the agent independently of the chat endpoint. If it
+// were to skip the configured headers, an authenticated agent would reject it
+// and the gateway would never advertise the assistant, even though chat itself
+// works — a failure that looks like the agent being down.
+func TestACPCheck_SendsConfiguredHeaders(t *testing.T) {
+	agent := &stubAgent{}
+	wsURL := startMockACPServer(t, agent)
+
+	var headers configopaque.MapList
+	headers.Set("X-Secret-Key", "s3cret")
+
+	require.NoError(t, NewACPCheck(wsURL, headers, zap.NewNop())(t.Context()))
+
+	agent.mu.Lock()
+	defer agent.mu.Unlock()
+	require.Equal(t, "s3cret", agent.lastAuthHeader, "health check must send the configured header")
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat.go
@@ -12,6 +12,7 @@ import (
 
 	aguitypes "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	acp "github.com/coder/acp-go-sdk"
+	"go.opentelemetry.io/collector/config/configopaque"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -38,8 +39,10 @@ type chatEndpoint struct {
 	// mcpBaseURL is the scheme+authority announced for the turn-scoped MCP
 	// endpoint. NewHandler sets it only when that endpoint is actually mounted and
 	// a reachable address is known, so empty means announce nothing.
-	mcpBaseURL         string
-	sidecarWSURL       string
+	mcpBaseURL   string
+	sidecarWSURL string
+	// sidecarHeaders are sent on the agent WebSocket handshake; see AIConfig.AgentHeaders.
+	sidecarHeaders     configopaque.MapList
 	basePath           string
 	maxRequestBodySize int64
 }
@@ -77,12 +80,13 @@ func (h *chatEndpoint) announceMCP(caps acp.AgentCapabilities, mcpRouteID string
 // for consistency with sibling handlers even though ServeHTTP does not currently
 // read it. mcpBaseURL defaults to the zero value — the announcement stays off until
 // NewHandler enables it — so tests that do not exercise MCP need no extra wiring.
-func newChatEndpoint(logger *zap.Logger, ctxTools *ContextualToolsStore, turns *turnRegistry, sidecarWSURL, basePath string, maxRequestBodySize int64) *chatEndpoint {
+func newChatEndpoint(logger *zap.Logger, ctxTools *ContextualToolsStore, turns *turnRegistry, sidecarWSURL string, sidecarHeaders configopaque.MapList, basePath string, maxRequestBodySize int64) *chatEndpoint {
 	return &chatEndpoint{
 		Logger:             logger,
 		ctxTools:           ctxTools,
 		turns:              turns,
 		sidecarWSURL:       sidecarWSURL,
+		sidecarHeaders:     sidecarHeaders,
 		basePath:           normalizeBasePath(basePath),
 		maxRequestBodySize: maxRequestBodySize,
 	}
@@ -145,7 +149,7 @@ func (h *chatEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	acpCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	adapter, err := DialWsAdapter(acpCtx, h.sidecarWSURL, h.Logger)
+	adapter, err := DialWsAdapter(acpCtx, h.sidecarWSURL, h.sidecarHeaders, h.Logger)
 	if err != nil {
 		http.Error(w, "Failed to connect to agent backend", http.StatusBadGateway)
 		return

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/endpoint_chat_test.go
@@ -205,7 +205,7 @@ func TestChatEndpointSendsACPProtocolRequests(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "/jaeger", 1<<20)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -307,7 +307,7 @@ func TestChatEndpointSetsGenAISpanAttributesWithAgentInfo(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "/jaeger", 1<<20)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -331,7 +331,7 @@ func TestChatEndpointSetsGenAISpanAttributesWithoutAgentInfo(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "/jaeger", 1<<20)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -355,7 +355,7 @@ func TestChatEndpointInjectsTraceContextIntoPromptMeta(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "/jaeger", 1<<20)
 
 	reqBody, err := json.Marshal(newAGUIRequest("trace for service checkout"))
 	require.NoError(t, err, "failed to marshal request")
@@ -391,7 +391,7 @@ func TestChatEndpointRegistersTurnInRegistry(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	handler.turns = turns
 
 	reqBody, err := json.Marshal(newAGUIRequest("where is the latency"))
@@ -470,7 +470,7 @@ func TestChatEndpointAnnouncesMCPEndpoint(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "/jaeger", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "/jaeger", 1<<20)
 	handler.mcpBaseURL = "https://jaeger.example.com:16686"
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
@@ -503,7 +503,7 @@ func TestChatEndpointAnnouncesNothingWhenMCPDisabled(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20) // no mcpServer
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20) // no mcpServer
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
@@ -532,7 +532,7 @@ func TestChatEndpointAnnouncesNothingWithoutBaseURL(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	// mcpBaseURL deliberately left empty — enable_mcp without ai.mcp_base_url.
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
@@ -552,7 +552,7 @@ func TestChatEndpointAppendsContextEntriesToPromptBlocks(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "where is the latency?"}},
@@ -591,7 +591,7 @@ func TestChatEndpointAttachesContextualToolsToMetaAndStore(t *testing.T) {
 	defer cleanup()
 
 	store := NewContextualToolsStore()
-	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), wsURL, nil, "", 1<<20)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "hello"}},
@@ -634,7 +634,7 @@ func TestChatEndpointOmitsMetaWhenNoTools(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), NewContextualToolsStore(), newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), NewContextualToolsStore(), newTurnRegistry(), wsURL, nil, "", 1<<20)
 
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
@@ -656,7 +656,7 @@ func TestChatEndpointEmitsRunFinishedWithStopReasonInResult(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	reqBody, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(reqBody))
@@ -686,7 +686,7 @@ func TestChatEndpointPropagatesThreadAndRunIDs(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 
 	reqBody, err := json.Marshal(ChatRequest{
 		ThreadID: "thread-xyz",
@@ -734,7 +734,7 @@ func (*failingFlusherResponseWriter) Flush() {}
 
 func TestNewChatEndpointPassesThroughConfig(t *testing.T) {
 	store := NewContextualToolsStore()
-	h := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://localhost:1", "/jaeger", 512)
+	h := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://localhost:1", nil, "/jaeger", 512)
 	require.Equal(t, int64(512), h.maxRequestBodySize, "expected configured maxRequestBodySize")
 	require.Equal(t, "ws://localhost:1", h.sidecarWSURL, "expected configured sidecarWSURL")
 	require.Equal(t, "/jaeger", h.basePath, "expected configured basePath")
@@ -742,7 +742,7 @@ func TestNewChatEndpointPassesThroughConfig(t *testing.T) {
 }
 
 func TestChatEndpointMethodNotAllowed(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", nil, "", 1<<20)
 	req := httptest.NewRequest(http.MethodGet, "/api/ai/chat", http.NoBody)
 	rr := httptest.NewRecorder()
 
@@ -752,7 +752,7 @@ func TestChatEndpointMethodNotAllowed(t *testing.T) {
 }
 
 func TestChatEndpointBadRequest(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", nil, "", 1<<20)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader("{"))
 	rr := httptest.NewRecorder()
 
@@ -762,7 +762,7 @@ func TestChatEndpointBadRequest(t *testing.T) {
 }
 
 func TestChatEndpointEmptyPrompt(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("   "))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -775,7 +775,7 @@ func TestChatEndpointEmptyPrompt(t *testing.T) {
 }
 
 func TestChatEndpointNoUserMessage(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", nil, "", 1<<20)
 	body, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: "assistant", Content: "no user message in this run"}},
 	})
@@ -798,7 +798,7 @@ func TestChatEndpointRejectsBlankContextualToolName(t *testing.T) {
 	// validateContextualToolNames pin the function-level contract; this
 	// test pins that the handler wires the contract into the HTTP path.
 	store := NewContextualToolsStore()
-	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), store, newTurnRegistry(), "ws://127.0.0.1:1", nil, "", 1<<20)
 
 	body, err := json.Marshal(ChatRequest{
 		Messages: []aguitypes.Message{{Role: aguitypes.RoleUser, Content: "hi"}},
@@ -822,7 +822,7 @@ func TestChatEndpointRejectsBlankContextualToolName(t *testing.T) {
 }
 
 func TestChatEndpointRequestBodyTooLarge(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 10)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", nil, "", 10)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader(`{"messages":[{"role":"user","content":"this body exceeds the 10 byte limit"}]}`))
 	rr := httptest.NewRecorder()
 
@@ -832,7 +832,7 @@ func TestChatEndpointRequestBodyTooLarge(t *testing.T) {
 }
 
 func TestChatEndpointDialFailure(t *testing.T) {
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), "ws://127.0.0.1:1", nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -848,7 +848,7 @@ func TestChatEndpointInitializeError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -865,7 +865,7 @@ func TestChatEndpointNewSessionError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -885,7 +885,7 @@ func TestChatEndpointPromptError(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -922,7 +922,7 @@ func TestChatEndpointSessionUpdateStreamedBeforePromptReturns(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -944,7 +944,7 @@ func TestChatEndpointPromptErrorWriteFailure(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -971,7 +971,7 @@ func TestChatEndpointSessionCloseFiresWhenAgentAdvertisesCapability(t *testing.T
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -1003,7 +1003,7 @@ func TestChatEndpointSessionCloseErrorIsSwallowed(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
@@ -1028,7 +1028,7 @@ func TestChatEndpointSessionCloseSkippedWhenCapabilityAbsent(t *testing.T) {
 	wsURL, cleanup := startMockACPWebSocketServer(t, agent)
 	defer cleanup()
 
-	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, "", 1<<20)
+	handler := newChatEndpoint(zap.NewNop(), nil, newTurnRegistry(), wsURL, nil, "", 1<<20)
 	body, err := json.Marshal(newAGUIRequest("hello"))
 	require.NoError(t, err, "failed to marshal request")
 	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/http_handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools"
@@ -41,8 +42,11 @@ type Handler struct {
 // in a struct keeps the constructor readable as the gateway gains MCP wiring (query
 // service, tenancy, telemetry) on top of the chat parameters.
 type HandlerParams struct {
-	Logger             *zap.Logger
-	AgentURL           string
+	Logger   *zap.Logger
+	AgentURL string
+	// AgentHeaders are sent on the agent WebSocket handshake, for agents that
+	// require authentication. See AIConfig.AgentHeaders.
+	AgentHeaders       configopaque.MapList
 	BasePath           string
 	MaxRequestBodySize int64
 	// EnableMCP mounts the turn-scoped telemetry MCP endpoint. When false, only the
@@ -71,7 +75,7 @@ type HandlerParams struct {
 func NewHandler(p HandlerParams) *Handler {
 	basePath := normalizeBasePath(p.BasePath)
 	turns := newTurnRegistry()
-	chat := newChatEndpoint(p.Logger, NewContextualToolsStore(), turns, p.AgentURL, basePath, p.MaxRequestBodySize)
+	chat := newChatEndpoint(p.Logger, NewContextualToolsStore(), turns, p.AgentURL, p.AgentHeaders, basePath, p.MaxRequestBodySize)
 	h := &Handler{basePath: basePath, chat: chat}
 	if p.EnableMCP {
 		h.mcp = turnScopedEndpointBuilder{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/ws_adapter.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/ws_adapter.go
@@ -8,9 +8,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/zap"
 )
 
@@ -41,9 +43,22 @@ func NewWsAdapter(conn *websocket.Conn, logger *zap.Logger) *WsReadWriteCloser {
 // The caller must call Close() to release the connection.
 // On error, gorilla closes resp.Body internally (wraps it in io.NopCloser),
 // so we only read it here for diagnostic logging.
-func DialWsAdapter(ctx context.Context, url string, logger *zap.Logger) (*WsReadWriteCloser, error) {
+//
+// headers are sent on the upgrade request. Agents that require authentication
+// each name their own header, so the caller supplies whatever the agent expects
+// rather than this choosing a scheme. The values are credentials, which is why
+// they are configopaque.String: it keeps them out of logs and config dumps by
+// construction rather than by everyone remembering not to print them.
+func DialWsAdapter(ctx context.Context, url string, headers configopaque.MapList, logger *zap.Logger) (*WsReadWriteCloser, error) {
 	dialer := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
-	conn, resp, err := dialer.DialContext(ctx, url, nil) //nolint:bodyclose // gorilla wraps resp.Body in io.NopCloser; no close needed
+	var header http.Header
+	if len(headers) > 0 {
+		header = make(http.Header, len(headers))
+		for name, value := range headers.Iter {
+			header.Set(name, string(value))
+		}
+	}
+	conn, resp, err := dialer.DialContext(ctx, url, header) //nolint:bodyclose // gorilla wraps resp.Body in io.NopCloser; no close needed
 	if err != nil {
 		if resp != nil {
 			body, _ := io.ReadAll(resp.Body)

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/ws_adapter_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/jaegerai/ws_adapter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/zap"
 )
 
@@ -148,7 +149,7 @@ func TestDialWsAdapterSuccess(t *testing.T) {
 	defer server.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	adapter, err := DialWsAdapter(context.Background(), wsURL, zap.NewNop())
+	adapter, err := DialWsAdapter(context.Background(), wsURL, nil, zap.NewNop())
 	require.NoError(t, err, "DialWsAdapter should succeed")
 	require.NoError(t, adapter.Close(), "close should succeed")
 }
@@ -156,7 +157,7 @@ func TestDialWsAdapterSuccess(t *testing.T) {
 func TestDialWsAdapterFailure(t *testing.T) {
 	t.Parallel()
 
-	_, err := DialWsAdapter(context.Background(), "ws://127.0.0.1:1", zap.NewNop())
+	_, err := DialWsAdapter(context.Background(), "ws://127.0.0.1:1", nil, zap.NewNop())
 	require.Error(t, err, "DialWsAdapter should fail for unreachable host")
 }
 
@@ -171,7 +172,7 @@ func TestDialWsAdapterHTTPErrorLogsResponse(t *testing.T) {
 	defer server.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	_, err := DialWsAdapter(context.Background(), wsURL, zap.NewNop())
+	_, err := DialWsAdapter(context.Background(), wsURL, nil, zap.NewNop())
 	require.Error(t, err, "DialWsAdapter should fail when server rejects upgrade")
 	require.Contains(t, err.Error(), "websocket dial")
 }
@@ -508,4 +509,64 @@ func TestWsReadWriteCloserFragmentedMessageIsOneLine(t *testing.T) {
 
 	assert.Greater(t, reads, 1, "a fragmented message must span multiple Read calls")
 	assert.Equal(t, payload+"\n", got.String())
+}
+
+// Agents that require authentication name their own header, so whatever is
+// configured must reach the upgrade request verbatim.
+func TestDialWsAdapterSendsConfiguredHeaders(t *testing.T) {
+	t.Parallel()
+
+	gotHeaders := make(chan http.Header, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders <- r.Header.Clone()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	var headers configopaque.MapList
+	headers.Set("X-Secret-Key", "s3cret")
+	headers.Set("Authorization", "Bearer t0ken")
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	adapter, err := DialWsAdapter(context.Background(), wsURL, headers, zap.NewNop())
+	require.NoError(t, err, "dial should succeed")
+	defer adapter.Close()
+
+	received := <-gotHeaders
+	assert.Equal(t, "s3cret", received.Get("X-Secret-Key"))
+	assert.Equal(t, "Bearer t0ken", received.Get("Authorization"))
+}
+
+// The common deployment configures nothing, so an empty config must dial
+// exactly as before rather than sending an empty header block.
+func TestDialWsAdapterWithoutHeaders(t *testing.T) {
+	t.Parallel()
+
+	gotHeaders := make(chan http.Header, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders <- r.Header.Clone()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	adapter, err := DialWsAdapter(context.Background(), wsURL, nil, zap.NewNop())
+	require.NoError(t, err, "dial should succeed")
+	defer adapter.Close()
+
+	received := <-gotHeaders
+	assert.Empty(t, received.Get("X-Secret-Key"))
+	assert.Empty(t, received.Get("Authorization"))
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/server.go
@@ -313,6 +313,7 @@ func registerAIRoutes(
 		aiGateway := jaegerai.NewHandler(jaegerai.HandlerParams{
 			Logger:             telset.Logger,
 			AgentURL:           aiCfg.AgentURL,
+			AgentHeaders:       aiCfg.AgentHeaders,
 			BasePath:           queryOpts.BasePath,
 			MaxRequestBodySize: aiCfg.MaxRequestBodySize,
 			EnableMCP:          aiCfg.MCP.HasValue(),

--- a/cmd/jaeger/internal/extension/jaegerquery/server.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/server.go
@@ -182,7 +182,7 @@ func buildAIHealthChecker(opts *queryapp.QueryOptions, logger *zap.Logger) *aihe
 		return nil
 	}
 	return &aihealth.Checker{
-		Check:    aihealth.NewACPCheck(aiCfg.AgentURL, logger),
+		Check:    aihealth.NewACPCheck(aiCfg.AgentURL, aiCfg.AgentHeaders, logger),
 		Interval: aiCfg.HealthCheckInterval,
 		Timeout:  aiCfg.HealthCheckTimeout,
 		Logger:   logger,

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp/xconfighttp v0.155.0
 	go.opentelemetry.io/collector/config/configmiddleware v1.61.0
 	go.opentelemetry.io/collector/config/confignet v1.61.0
+	go.opentelemetry.io/collector/config/configopaque v1.61.0
 	go.opentelemetry.io/collector/config/configoptional v1.61.0
 	go.opentelemetry.io/collector/config/configretry v1.61.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.155.0
@@ -279,7 +280,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector v0.155.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.61.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.61.0 // indirect
 	go.opentelemetry.io/collector/connector/connectortest v0.155.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.155.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.155.0 // indirect


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9394

The gateway could not connect to an ACP agent that requires authentication. `DialWsAdapter` passed `nil` headers on the WebSocket upgrade, so an agent expecting a credential rejected it with 401 and the only way to use one was to turn its authentication off.

## Description of the changes

`ai.agent_headers` is an optional map sent on the agent handshake:

```yaml
ai:
  agent_url: ws://127.0.0.1:16688/acp
  agent_headers:
    X-Secret-Key: ${env:GOOSE_SECRET}
```

**A map rather than a single token field**, because the header name belongs to the agent rather than to us. Goose expects `X-Secret-Key`; another agent will expect `Authorization: Bearer`. A token field would turn each new scheme into a code change instead of configuration.

**Values are `configopaque.MapList`**, the collector's own secret-safe type, so a credential stays out of logs and config dumps by construction rather than by everyone remembering not to print it. `${env:VAR}` expansion keeps it out of the YAML.

Adopting `confighttp.ClientConfig` wholesale was considered and rejected: it has a headers map and auth-extension support and is already a direct dependency, but it is built to produce an `*http.Client`, which gorilla's WebSocket dialer is not. Its compression, timeouts, middleware and auth round-tripper would all be inert, so we would be advertising options that silently do nothing. Borrowing the value type without the struct is the useful half. Other alternatives are recorded in the issue.

**Both dial sites send the headers.** The chat endpoint and the health checker (`aihealth.NewACPCheck`) dial independently. Headers on only one would leave the health check getting 401 and the gateway never advertising the assistant to the UI, even while chat itself worked, which looks like the agent being down.

`MapList` permits repeated names on the wire and silently keeps one value, so `AIConfig.Validate` rejects duplicates rather than guessing which was meant.

Scope is the config field, the dialer, and the two call sites. No change to MCP routing, the ACP handler, or any sidecar. Orthogonal to [RFC 0008](https://github.com/jaegertracing/jaeger/blob/main/docs/rfc/0008-ai-gateway-mcp-tool-routing.md), which covers MCP tool routing rather than the gateway-to-agent handshake.

## How was this change tested?

**Unit tests:**
- configured headers reach the upgrade request verbatim
- a nil/empty config sends nothing, so existing deployments dial exactly as before
- the health checker sends them too, pinning the both-call-sites requirement
- `AIConfig.Validate` rejects duplicate header names and accepts distinct ones

**End to end against a real agent.** [Goose](https://github.com/aaif-goose/goose) `goose serve` with `GOOSE_SERVER__SECRET_KEY` set and **no** `--dangerously-unauthenticated`:

- gateway health check: 0 failures, `aiAssistant: true` advertised to the UI
- a chat turn completes a real MCP tool call (`jaeger: get services`) and answers from live trace data
- **negative control:** a dial without the header is still rejected with `HTTP 401`, so the configured header is what makes it work

Before this change that configuration was impossible; every dial got 401.

**Gates:** `make lint` clean, `go test ./cmd/jaeger/internal/extension/jaegerquery/...` passes, `make fmt` clean. `configopaque` moves from an indirect to a direct dependency in `go.mod`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
