### PR TITLE
fix(otel-demo): Upgrade OpenSearch to 3.7.0

### DIFF
--- a/examples/otel-demo/deploy-all.sh
+++ b/examples/otel-demo/deploy-all.sh
@@ -22,9 +22,9 @@ OPENSEARCH_RECOVERY="${JAEGER_OTEL_DEMO_OPENSEARCH_RECOVERY:-required}"
 # renovate: datasource=helm depName=opentelemetry-demo registryUrl=https://open-telemetry.github.io/opentelemetry-helm-charts
 OTEL_DEMO_CHART_VERSION="0.40.9"
 # renovate: datasource=helm depName=opensearch registryUrl=https://opensearch-project.github.io/helm-charts
-OPENSEARCH_CHART_VERSION="2.38.0"
+OPENSEARCH_CHART_VERSION="3.7.0"
 # renovate: datasource=helm depName=opensearch-dashboards registryUrl=https://opensearch-project.github.io/helm-charts
-OPENSEARCH_DASHBOARDS_CHART_VERSION="2.34.0"
+OPENSEARCH_DASHBOARDS_CHART_VERSION="3.7.0"
 
 log() { echo "[$(date +"%F %T")] $*"; }
 err() { echo "[$(date +"%F %T")] ERROR: $*" >&2; exit 1; }

--- a/examples/otel-demo/deploy-all.test.sh
+++ b/examples/otel-demo/deploy-all.test.sh
@@ -213,7 +213,7 @@ testPinnedChartRendersCollectorStartupProbe() {
 
 testPinsCompatibleOpenSearchCharts() {
   output=$(bash -c 'source "$1"; printf "%s|%s" "$OPENSEARCH_CHART_VERSION" "$OPENSEARCH_DASHBOARDS_CHART_VERSION"' _ "$SCRIPT")
-  assertEquals "2.38.0|2.34.0" "$output"
+  assertEquals "3.7.0|3.7.0" "$output"
 }
 
 testDeploysPinnedOpenSearchChartsInOrder() {
@@ -229,9 +229,9 @@ testDeploysPinnedOpenSearchChartsInOrder() {
   ' _ "$SCRIPT")
 
   expected="bash $(dirname "$SCRIPT")/opensearch-recovery.sh verify
-helm upgrade --install opensearch opensearch/opensearch --namespace opensearch --create-namespace --version 2.38.0 -f $(dirname "$SCRIPT")/opensearch-values.yaml --wait --timeout 10m
+helm upgrade --install opensearch opensearch/opensearch --namespace opensearch --create-namespace --version 3.7.0 -f $(dirname "$SCRIPT")/opensearch-values.yaml --wait --timeout 10m
 wait-for-statefulset opensearch opensearch-cluster-single 600s
-helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards --namespace opensearch --version 2.34.0 -f $(dirname "$SCRIPT")/opensearch-dashboard-values.yaml --wait --timeout 60m"
+helm upgrade --install opensearch-dashboards opensearch/opensearch-dashboards --namespace opensearch --version 3.7.0 -f $(dirname "$SCRIPT")/opensearch-dashboard-values.yaml --wait --timeout 60m"
   expected="$expected
 wait-for-dashboards 600s"
   assertEquals "$expected" "$output"

--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,7 @@
       "automerge": false
     },
     {
-      "description": "Keep the OTel demo OpenSearch charts on supported 2.x releases and update them together",
+      "description": "Keep the OTel demo OpenSearch charts on supported 3.x releases and update them together",
       "matchManagers": [
         "custom.regex"
       ],
@@ -69,7 +69,7 @@
       "groupName": "OTel demo OpenSearch Helm charts",
       "groupSlug": "otel-demo-opensearch-helm",
       "minimumGroupSize": 2,
-      "allowedVersions": "/^2\\./",
+      "allowedVersions": "/^3\\./",
       "automerge": false
     },
     {


### PR DESCRIPTION
Fixes #9396

## Summary

- Pin the OTel demo OpenSearch and OpenSearch Dashboards charts to 3.7.0, which makes each chart's `appVersion` the single source for the matching 3.7.0 image.
- Update the routing regression test for the matched chart pair.
- Keep Renovate's paired review policy on supported 3.x chart releases, with auto-merge disabled.

The existing one-node topology, PVC template, 3 GiB heap, 6 GiB memory request/limit, CPU request, disabled security, and Jaeger guardrails are unchanged.

## Validation

- `GOTOOLCHAIN=go1.26.0 make fmt`
- `GOTOOLCHAIN=go1.26.0 make lint`
- `GOTOOLCHAIN=go1.26.0 make test` (4,586 tests passed; 38 integration/configuration skips)
- `examples/otel-demo/deploy-all.test.sh` (18 tests passed)
- `helm lint` and `helm template` with OpenSearch chart 3.7.0 and Dashboards chart 3.7.0
- `jq empty renovate.json`

The exact render contains matched 3.7.0 images, one `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, 6 GiB OpenSearch memory request/limit, a 1000m CPU request, one OpenSearch replica, the existing PVC/service identities, and the existing Jaeger resource and preferred anti-affinity values.

## Rollout boundary

Merging this PR does not deploy it. Land #9393 before any live 3.x rollout. Before a separately approved manual deployment, inventory every visible, hidden, and system index and reindex anything originally created before OpenSearch 2.x. Record cluster health, shard state, deprecation output, resource headroom, and either a tested recovery point or, if the disposable-data waiver is explicitly used, acceptance of having no rollback or data-recovery path.

The single-node upgrade causes a query and ingest outage. OpenSearch 3.x cannot be downgraded safely, so do not use Helm rollback or `clean` as recovery.
