### PR TITLE
fix(es): Bound service and operation query lookback

### DIFF
--- a/internal/storage/v1/elasticsearch/factory.go
+++ b/internal/storage/v1/elasticsearch/factory.go
@@ -141,15 +141,16 @@ func (f *FactoryBase) GetSpanReaderParams() esspanstore.SpanReaderParams {
 		maxSpanAge = esspanstore.DawnOfTimeSpanAge
 	}
 	return esspanstore.SpanReaderParams{
-		Searcher:          f.searcher,
-		MaxDocCount:       f.config.MaxDocCount,
-		MaxSpanAge:        maxSpanAge,
-		MaxTraceDuration:  f.config.MaxTraceDuration,
-		TagDotReplacement: f.config.Tags.DotReplacement,
-		Logger:            f.logger,
-		Tracer:            f.tracer.Tracer("esspanstore.SpanReader"),
-		SpanRotation:      spanRotation,
-		ServiceRotation:   serviceRotation,
+		Searcher:            f.searcher,
+		MaxDocCount:         f.config.MaxDocCount,
+		MaxSpanAge:          maxSpanAge,
+		ServicesMaxLookback: f.config.MaxSpanAge,
+		MaxTraceDuration:    f.config.MaxTraceDuration,
+		TagDotReplacement:   f.config.Tags.DotReplacement,
+		Logger:              f.logger,
+		Tracer:              f.tracer.Tracer("esspanstore.SpanReader"),
+		SpanRotation:        spanRotation,
+		ServiceRotation:     serviceRotation,
 	}
 }
 

--- a/internal/storage/v1/elasticsearch/factory_test.go
+++ b/internal/storage/v1/elasticsearch/factory_test.go
@@ -799,6 +799,7 @@ func TestGetSpanReaderParams_NonPeriodicMaxSpanAge(t *testing.T) {
 	f := &FactoryBase{config: &cfg, logger: zap.NewNop(), tracer: otel.GetTracerProvider()}
 	params := f.GetSpanReaderParams()
 	assert.Equal(t, core.DawnOfTimeSpanAge, params.MaxSpanAge)
+	assert.Equal(t, 72*time.Hour, params.ServicesMaxLookback)
 }
 
 func TestGetSpanReaderParams_MaxTraceDuration(t *testing.T) {

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -102,10 +102,11 @@ var (
 
 // SpanReader can query for and load traces from ElasticSearch
 type SpanReader struct {
-	searcher esclient.Searcher
-	// The age of the oldest service/operation we will look for. Because indices in ElasticSearch are by day,
-	// this will be rounded down to UTC 00:00 of that day.
-	maxSpanAge              time.Duration
+	searcher   esclient.Searcher
+	maxSpanAge time.Duration
+	// servicesMaxLookback bounds GetServices/GetOperations independently from maxSpanAge,
+	// which may be widened to DawnOfTimeSpanAge for trace reads through an alias or data stream.
+	servicesMaxLookback     time.Duration
 	maxTraceDuration        time.Duration
 	serviceOperationStorage *ServiceOperationStorage
 	spanRotation            indices.Rotation
@@ -120,15 +121,17 @@ type SpanReader struct {
 type SpanReaderParams struct {
 	// Searcher is the esclient data-plane search client backing every read path:
 	// service/operation reads, trace-ID and trace lookups, and native summaries.
-	Searcher          esclient.Searcher
-	MaxSpanAge        time.Duration
-	MaxTraceDuration  time.Duration
-	MaxDocCount       int
-	TagDotReplacement string
-	Logger            *zap.Logger
-	Tracer            trace.Tracer
-	SpanRotation      indices.Rotation
-	ServiceRotation   indices.Rotation
+	Searcher   esclient.Searcher
+	MaxSpanAge time.Duration
+	// ServicesMaxLookback bounds GetServices/GetOperations.
+	ServicesMaxLookback time.Duration
+	MaxTraceDuration    time.Duration
+	MaxDocCount         int
+	TagDotReplacement   string
+	Logger              *zap.Logger
+	Tracer              trace.Tracer
+	SpanRotation        indices.Rotation
+	ServiceRotation     indices.Rotation
 }
 
 // NewSpanReader returns a new SpanReader with a metrics.
@@ -136,6 +139,7 @@ func NewSpanReader(p SpanReaderParams) *SpanReader {
 	return &SpanReader{
 		searcher:                p.Searcher,
 		maxSpanAge:              p.MaxSpanAge,
+		servicesMaxLookback:     p.ServicesMaxLookback,
 		maxTraceDuration:        p.MaxTraceDuration,
 		serviceOperationStorage: NewServiceOperationStorage(p.Searcher, p.Logger, 0), // read-only; the decorator takes care of metrics
 		spanRotation:            p.SpanRotation,
@@ -224,7 +228,7 @@ func (s *SpanReader) GetServices(ctx context.Context) ([]string, error) {
 	ctx, span := s.tracer.Start(ctx, "GetService")
 	defer span.End()
 	currentTime := time.Now()
-	jaegerIndices := s.serviceRotation.ReadTargets(currentTime.Add(-s.maxSpanAge), currentTime)
+	jaegerIndices := s.serviceRotation.ReadTargets(currentTime.Add(-s.servicesMaxLookback), currentTime)
 	return s.serviceOperationStorage.getServices(ctx, jaegerIndices, s.maxDocCount)
 }
 
@@ -236,7 +240,7 @@ func (s *SpanReader) GetOperations(
 	ctx, span := s.tracer.Start(ctx, "GetOperations")
 	defer span.End()
 	currentTime := time.Now()
-	jaegerIndices := s.serviceRotation.ReadTargets(currentTime.Add(-s.maxSpanAge), currentTime)
+	jaegerIndices := s.serviceRotation.ReadTargets(currentTime.Add(-s.servicesMaxLookback), currentTime)
 	operations, err := s.serviceOperationStorage.getOperations(ctx, jaegerIndices, query.ServiceName, s.maxDocCount)
 	if err != nil {
 		return nil, err

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -102,7 +102,7 @@ var (
 
 // SpanReader can query for and load traces from ElasticSearch
 type SpanReader struct {
-	searcher   esclient.Searcher
+	searcher esclient.Searcher
 	// maxSpanAge is how far back (in terms of timestamped indices)
 	// we look when loading trace by ID (a query without a time range).
 	maxSpanAge time.Duration

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -103,6 +103,8 @@ var (
 // SpanReader can query for and load traces from ElasticSearch
 type SpanReader struct {
 	searcher   esclient.Searcher
+	// maxSpanAge is how far back (in terms of timestamped indices)
+	// we look when loading trace by ID (a query without a time range).
 	maxSpanAge time.Duration
 	// servicesMaxLookback bounds GetServices/GetOperations independently from maxSpanAge,
 	// which may be widened to DawnOfTimeSpanAge for trace reads through an alias or data stream.

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader_test.go
@@ -177,6 +177,36 @@ func TestNewSpanReader(t *testing.T) {
 	assert.Equal(t, time.Hour*72, reader.maxSpanAge)
 }
 
+func TestSpanReader_ServiceQueriesUseBoundedLookback(t *testing.T) {
+	searcher := esclientmocks.NewSearcher(t)
+	searcher.On(
+		"Search",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		assert.Len(t, args.Get(1).([]string), 4)
+	}).Return(&esclient.SearchResponse{Aggregations: termsAggregations(map[string]esclient.AggregationResult{
+		servicesAggregation:   {},
+		operationsAggregation: {},
+	})}, nil).Twice()
+
+	reader := NewSpanReader(SpanReaderParams{
+		Searcher:            searcher,
+		MaxSpanAge:          DawnOfTimeSpanAge,
+		ServicesMaxLookback: 72 * time.Hour,
+		MaxDocCount:         defaultMaxDocCount,
+		Logger:              zap.NewNop(),
+		Tracer:              noop.NewTracerProvider().Tracer("test"),
+		ServiceRotation:     indices.NewPeriodicRotation(config.ServiceIndexName, "2006-01-02", 24*time.Hour),
+	})
+
+	_, err := reader.GetServices(context.Background())
+	require.NoError(t, err)
+	_, err = reader.GetOperations(context.Background(), dbmodel.OperationQueryParameters{ServiceName: "service"})
+	require.NoError(t, err)
+}
+
 func TestSpanReaderRotations(t *testing.T) {
 	date := time.Date(2019, 10, 10, 5, 0, 0, 0, time.UTC)
 


### PR DESCRIPTION

## Which problem is this PR solving?

Part of [#4708](https://github.com/jaegertracing/jaeger/issues/4708).

For alias and data-stream span rotations, Jaeger internally expands the trace lookup window (MaxSpanAge) to 50 years so `GetTrace` does not exclude older retained traces. `GetServices` and `GetOperations` accidentally reused that trace-only window.

When services use periodic daily indices, this generates thousands of explicit index names and OpenSearch rejects the oversized request. Services should continue using the configured `max_span_age`, which represents the retention window. Alias-based service rotations remain unchanged because they query their single read alias.

## Description of the changes

- Keep the 50-year fallback for trace reads.
- Use the configured `max_span_age` for service and operation reads.
- Add no new user-facing configuration.

## How was this change tested?

- `make fmt`
- `make lint`
- `make test`
- Verified against local OpenSearch: the failing service request succeeds with the bounded service lookback.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`