### PR TITLE
[query] Add ErrAccessDenied sentinel for query interceptor access-control errors

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -5,6 +5,7 @@ package apiv3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/components/extension/jaegerquery/queryinterceptor"
 	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
 	expressionproto "github.com/jaegertracing/jaeger/internal/proto/expression/v1"
@@ -237,6 +239,9 @@ func (h *Handler) GetDependencies(ctx context.Context, request *api_v3.GetDepend
 func asStatusError(err error) error {
 	if querysvc.IsBadRequest(err) {
 		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	if errors.Is(err, queryinterceptor.ErrAccessDenied) {
+		return status.Error(codes.PermissionDenied, err.Error())
 	}
 	return err
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	expression "github.com/jaegertracing/jaeger-idl/query/expression/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/components/extension/jaegerquery/queryinterceptor"
 	_ "github.com/jaegertracing/jaeger/internal/gogocodec" // force gogo codec registration
 	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
@@ -755,4 +756,34 @@ func TestFindTraceSummariesServiceNameRequired(t *testing.T) {
 	_, err = responseStream.Recv()
 	require.ErrorContains(t, err, "requires a service name")
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestAsStatusError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode codes.Code
+	}{
+		{
+			name:     "access denied maps to PermissionDenied",
+			err:      fmt.Errorf("acl: denied: %w", queryinterceptor.ErrAccessDenied),
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name:     "bad request maps to InvalidArgument",
+			err:      querysvc.ErrServiceNameRequired,
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "generic error passes through",
+			err:      errors.New("something broke"),
+			wantCode: codes.Unknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := asStatusError(tt.err)
+			assert.Equal(t, tt.wantCode, status.Code(got))
+		})
+	}
 }

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/components/extension/jaegerquery/queryinterceptor"
 	"github.com/jaegertracing/jaeger/internal/jiter"
 	"github.com/jaegertracing/jaeger/internal/jptrace"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
@@ -79,6 +80,9 @@ func (h *HTTPGateway) tryHandleError(w http.ResponseWriter, err error, statusCod
 	if querysvc.IsBadRequest(err) {
 		// Either the query needs changing, or this deployment's storage cannot serve it.
 		statusCode = http.StatusBadRequest
+	}
+	if errors.Is(err, queryinterceptor.ErrAccessDenied) {
+		statusCode = http.StatusForbidden
 	}
 	if statusCode == http.StatusInternalServerError {
 		h.Logger.Error("HTTP handler, Internal Server Error", zap.Error(err))

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/http_gateway_test.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/querysvc"
+	"github.com/jaegertracing/jaeger/components/extension/jaegerquery/queryinterceptor"
 	"github.com/jaegertracing/jaeger/internal/proto/api_v3"
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 	dependencystoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/depstore/mocks"
@@ -114,6 +115,10 @@ func TestHTTPGatewayTryHandleError(t *testing.T) {
 	assert.True(t, gw.tryHandleError(w, querysvc.ErrServiceNameRequired, http.StatusInternalServerError))
 	assert.Equal(t, http.StatusBadRequest, w.Code, "sets status code to 400")
 	assert.Contains(t, w.Body.String(), "requires a service name", "explains the limitation")
+
+	w = httptest.NewRecorder()
+	assert.True(t, gw.tryHandleError(w, fmt.Errorf("denied: %w", queryinterceptor.ErrAccessDenied), http.StatusInternalServerError))
+	assert.Equal(t, http.StatusForbidden, w.Code, "ErrAccessDenied maps to 403")
 
 	logger, log := testutils.NewLogger()
 	gw.Logger = logger

--- a/components/extension/jaegerquery/queryinterceptor/interceptor.go
+++ b/components/extension/jaegerquery/queryinterceptor/interceptor.go
@@ -33,12 +33,19 @@ package queryinterceptor
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	expression "github.com/jaegertracing/jaeger-idl/query/expression/v1"
 )
+
+// ErrAccessDenied is the sentinel that interceptor implementations wrap
+// when the caller's query is refused on access-control grounds. The API
+// layers map it to HTTP 403 / gRPC PERMISSION_DENIED instead of a
+// generic server error.
+var ErrAccessDenied = errors.New("access denied")
 
 // Query is the public view of a trace-search query passed to Interceptor.OnQuery.
 //


### PR DESCRIPTION
## Which problem is this PR solving?

Interceptor errors from OnQuery/OnResult always surface as HTTP 500 / gRPC Unknown, even when the rejection is an access-control decision the caller can act on. There is no public sentinel an out-of-tree interceptor can wrap to produce a 4xx response.

## Description of the changes

Add ErrAccessDenied to the public queryinterceptor package. The HTTP gateway maps it to 403 Forbidden, the gRPC handler to PermissionDenied. Interceptors wrap it with fmt.Errorf("...: %w", queryinterceptor.ErrAccessDenied).

## Checklist
* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: make lint test (see note above — ran the ai-sidecar subproject's own pyright/pytest gate instead, since this PR doesn't touch Go code)

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).

* [ ] None: No AI tools were used in creating this PR
* [x] Light: AI provided minor assistance (formatting, simple suggestions)
* [ ] Moderate: AI helped with code generation or debugging specific parts
* [ ] Heavy: AI generated most or all of the code changes

cc: @yurishkuro 


