### PR TITLE
fix(storage): Clear ServiceOperation cache in Purge to fix flaky tests

### DIFF
--- a/internal/storage/integration/elasticsearch_test.go
+++ b/internal/storage/integration/elasticsearch_test.go
@@ -85,7 +85,6 @@ func (s *ESStorageIntegration) initSpanstore(t *testing.T, allTagsAsFields bool)
 	}
 	cfg.WriteMode = s.writeMode
 	cfg.Tags.AllAsFields = allTagsAsFields
-	cfg.ServiceCacheTTL = 1 * time.Second
 	cfg.Indices.IndexPrefix = indexPrefix
 	var err error
 	f, err := esv2.NewFactory(context.Background(), cfg, telemetry.NoopSettings(), nil)

--- a/internal/storage/v2/elasticsearch/factory_base.go
+++ b/internal/storage/v2/elasticsearch/factory_base.go
@@ -55,6 +55,11 @@ type FactoryBase struct {
 	searcher        esclient.Searcher
 	asyncBulkWriter *esclient.BulkIndexer
 
+	// serviceOpStorage is the service:operation cache used by the span writer.
+	// The factory owns it so that Purge can clear it — without this, Purge
+	// deletes the ES indices but the stale cache suppresses the next writes.
+	serviceOpStorage *esspanstore.ServiceOperationStorage
+
 	tags []string
 }
 
@@ -171,6 +176,11 @@ func (f *FactoryBase) spanBatchWriter() esclient.BatchWriter {
 // GetSpanWriterParams returns the SpanWriterParams which can be used to initialize the v1 and v2 writers.
 func (f *FactoryBase) GetSpanWriterParams() esspanstore.SpanWriterParams {
 	spanRotation, serviceRotation := f.buildRotations()
+	serviceCacheTTL := f.config.ServiceCacheTTL
+	if serviceCacheTTL == 0 {
+		serviceCacheTTL = esspanstore.ServiceCacheTTLDefault
+	}
+	f.serviceOpStorage = esspanstore.NewServiceOperationStorage(nil, f.logger, serviceCacheTTL)
 	return esspanstore.SpanWriterParams{
 		BatchWriter:       f.spanBatchWriter(),
 		AllTagsAsFields:   f.config.Tags.AllAsFields,
@@ -178,7 +188,7 @@ func (f *FactoryBase) GetSpanWriterParams() esspanstore.SpanWriterParams {
 		TagDotReplacement: f.config.Tags.DotReplacement,
 		Logger:            f.logger,
 		MetricsFactory:    f.metricsFactory,
-		ServiceCacheTTL:   f.config.ServiceCacheTTL,
+		ServiceOpStorage:  f.serviceOpStorage,
 		SpanRotation:      spanRotation,
 		ServiceRotation:   serviceRotation,
 	}
@@ -254,6 +264,9 @@ func (f *FactoryBase) Close() error {
 }
 
 func (f *FactoryBase) Purge(ctx context.Context) error {
+	if f.serviceOpStorage != nil {
+		f.serviceOpStorage.ClearCache()
+	}
 	return f.indicesClient().DeleteAllIndices(ctx)
 }
 

--- a/internal/storage/v2/elasticsearch/factory_base_test.go
+++ b/internal/storage/v2/elasticsearch/factory_base_test.go
@@ -110,6 +110,7 @@ func TestFactoryBase_Purge(t *testing.T) {
 				&escfg.Configuration{Servers: []string{server.URL}, Version: uint(es.ElasticV7)}, zap.NewNop(), nil)
 			require.NoError(t, err)
 			f := &FactoryBase{esClient: esClient, logger: zap.NewNop(), config: &escfg.Configuration{}}
+			f.serviceOpStorage = core.NewServiceOperationStorage(nil, zap.NewNop(), time.Hour)
 
 			err = f.Purge(context.Background())
 			mu.Lock()

--- a/internal/storage/v2/elasticsearch/tracestore/core/service_operation.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/service_operation.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -37,7 +38,9 @@ var errNoSearcher = errors.New("service/operation reads require a searcher, but 
 type ServiceOperationStorage struct {
 	searcher     esclient.Searcher
 	logger       *zap.Logger
+	mu           sync.RWMutex
 	serviceCache cache.Cache
+	cacheTTL     time.Duration
 }
 
 // NewServiceOperationStorage returns a new ServiceOperationStorage. searcher is
@@ -52,6 +55,7 @@ func NewServiceOperationStorage(
 	return &ServiceOperationStorage{
 		searcher: searcher,
 		logger:   logger,
+		cacheTTL: cacheTTL,
 		serviceCache: cache.NewLRUWithOptions(
 			100000,
 			&cache.Options{
@@ -59,6 +63,20 @@ func NewServiceOperationStorage(
 			},
 		),
 	}
+}
+
+// ClearCache replaces the service cache with a fresh empty instance, preserving
+// the original TTL. Called by Purge to ensure the in-memory cache does not
+// suppress writes to a freshly emptied index.
+func (s *ServiceOperationStorage) ClearCache() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.serviceCache = cache.NewLRUWithOptions(
+		100000,
+		&cache.Options{
+			TTL: s.cacheTTL,
+		},
+	)
 }
 
 // toUpsertItem returns the service:operation document to upsert for a span and its
@@ -73,7 +91,12 @@ func (s *ServiceOperationStorage) toUpsertItem(indexName string, jsonSpan *dbmod
 		OperationName: jsonSpan.OperationName,
 	}
 	cacheKey := hashCode(service)
-	if s.serviceCache.Get(cacheKey) != nil {
+
+	s.mu.RLock()
+	inCache := s.serviceCache.Get(cacheKey) != nil
+	s.mu.RUnlock()
+
+	if inCache {
 		return esclient.BulkItem{}, "", false
 	}
 	return esclient.BulkItem{Index: indexName, ID: cacheKey, Body: service}, cacheKey, true
@@ -81,8 +104,10 @@ func (s *ServiceOperationStorage) toUpsertItem(indexName string, jsonSpan *dbmod
 
 // commitToCache records that a service:operation document is durably written, so it
 // is not re-sent until the cache entry expires. Called only after a successful flush.
-func (s *ServiceOperationStorage) commitToCache(cacheKey string) {
-	s.serviceCache.Put(cacheKey, cacheKey)
+func (s *ServiceOperationStorage) commitToCache(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.serviceCache.Put(key, key)
 }
 
 // serviceOperationBatch accumulates the new service:operation documents for one write

--- a/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/service_operation_test.go
@@ -54,6 +54,31 @@ func TestToUpsertItem(t *testing.T) {
 	assert.False(t, ok, "must be cached after confirm")
 }
 
+func TestClearCache(t *testing.T) {
+	indexName := "jaeger-1995-04-21"
+	jsonSpan := &dbmodel.Span{
+		OperationName: "operation",
+		Process:       dbmodel.Process{ServiceName: "service"},
+	}
+	s := NewServiceOperationStorage(nil, zap.NewNop(), time.Hour)
+
+	// Write and commit to cache.
+	_, key, ok := s.toUpsertItem(indexName, jsonSpan)
+	require.True(t, ok)
+	s.commitToCache(key)
+
+	// Verify cached.
+	_, _, ok = s.toUpsertItem(indexName, jsonSpan)
+	assert.False(t, ok)
+
+	// Clear cache.
+	s.ClearCache()
+
+	// Verify cache is cleared and write is permitted again.
+	_, _, ok = s.toUpsertItem(indexName, jsonSpan)
+	assert.True(t, ok, "must be permitted after clearing cache")
+}
+
 // oneBucketResponse is a search response with a single terms-aggregation bucket
 // keyed "123", used to assert getServices/getOperations extract the bucket keys.
 func oneBucketResponse(aggName string) *esclient.SearchResponse {

--- a/internal/storage/v2/elasticsearch/tracestore/core/writer.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/writer.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	serviceCacheTTLDefault = 12 * time.Hour
+	ServiceCacheTTLDefault = 12 * time.Hour
 	indexCacheTTLDefault   = 48 * time.Hour
 )
 
@@ -64,16 +64,25 @@ type SpanWriterParams struct {
 	AllTagsAsFields   bool
 	TagKeysAsFields   []string
 	TagDotReplacement string
-	ServiceCacheTTL   time.Duration
-	SpanRotation      indices.Rotation
-	ServiceRotation   indices.Rotation
+	// ServiceOpStorage is the shared service:operation cache. When non-nil the
+	// writer uses this instance (letting the factory clear it on Purge). When nil
+	// the writer creates its own from ServiceCacheTTL — backward-compatible for
+	// tests that don't need Purge semantics.
+	ServiceOpStorage *ServiceOperationStorage
+	ServiceCacheTTL  time.Duration
+	SpanRotation     indices.Rotation
+	ServiceRotation  indices.Rotation
 }
 
 // NewSpanWriter creates a new SpanWriter for use
 func NewSpanWriter(p SpanWriterParams) *SpanWriter {
-	serviceCacheTTL := p.ServiceCacheTTL
-	if p.ServiceCacheTTL == 0 {
-		serviceCacheTTL = serviceCacheTTLDefault
+	serviceOp := p.ServiceOpStorage
+	if serviceOp == nil {
+		serviceCacheTTL := p.ServiceCacheTTL
+		if serviceCacheTTL == 0 {
+			serviceCacheTTL = ServiceCacheTTLDefault
+		}
+		serviceOp = NewServiceOperationStorage(nil, p.Logger, serviceCacheTTL) // write-only: no searcher
 	}
 
 	tags := map[string]bool{}
@@ -83,7 +92,7 @@ func NewSpanWriter(p SpanWriterParams) *SpanWriter {
 
 	return &SpanWriter{
 		batchWriter:       p.BatchWriter,
-		serviceOp:         NewServiceOperationStorage(nil, p.Logger, serviceCacheTTL), // write-only: no searcher
+		serviceOp:         serviceOp,
 		logger:            p.Logger,
 		writerMetrics:     spanstoremetrics.NewWriter(p.MetricsFactory, "spans"),
 		spanRotation:      p.SpanRotation,


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9411

## Description of the changes
- Added `ClearCache()` to `ServiceOperationStorage` to reset the LRU cache while keeping the configured TTL.
- Added `sync.RWMutex` to safely protect cache access and replacement.
- Updated `SpanWriterParams` to optionally use the shared `ServiceOpStorage` managed by the factory.
- Updated `FactoryBase.Purge()` to clear the service-operation cache after purging the Elasticsearch indices.
- Removed the `ServiceCacheTTL = 1 * time.Second` workaround from the integration tests so they run with the normal cache configuration.

## How was this change tested?
- Added `TestClearCache` to verify that cached service-operation entries are removed and subsequent writes are allowed.
- Updated `TestFactoryBase_Purge` to verify that `Purge()` clears the service-operation cache.
- Ran the relevant Elasticsearch storage tests and integration tests.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes