### PR TITLE
fix(mcp): keep real zero start time in get_critical_path

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -120,7 +121,7 @@ func (*getCriticalPathHandler) buildOutput(
 
 	// Build a map of span ID to service name
 	serviceMap := make(map[string]string)
-	var traceStartTime uint64
+	traceStartTime := uint64(math.MaxUint64)
 	var traceEndTime uint64
 
 	for i := 0; i < trace.ResourceSpans().Len(); i++ {
@@ -140,7 +141,7 @@ func (*getCriticalPathHandler) buildOutput(
 				startTime := uint64(span.StartTimestamp()) / 1000 // Convert to microseconds
 				endTime := uint64(span.EndTimestamp()) / 1000
 
-				if traceStartTime == 0 || startTime < traceStartTime {
+				if startTime < traceStartTime {
 					traceStartTime = startTime
 				}
 				if endTime > traceEndTime {
@@ -148,6 +149,10 @@ func (*getCriticalPathHandler) buildOutput(
 				}
 			}
 		}
+	}
+
+	if traceStartTime == math.MaxUint64 {
+		traceStartTime = 0
 	}
 
 	// Convert critical path sections to output format

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/get_critical_path_test.go
@@ -315,3 +315,49 @@ func TestGetCriticalPathHandler_BuildOutput_MissingSpan(t *testing.T) {
 	assert.Len(t, output.Segments, 1)
 	assert.Equal(t, span.SpanID().String(), output.Segments[0].SpanID)
 }
+
+func TestGetCriticalPathHandler_BuildOutput_ZeroStartTime(t *testing.T) {
+	// A span starting at timestamp 0 is a real start time, not an unset sentinel.
+	handler := &getCriticalPathHandler{}
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "test-service")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	span0 := ss.Spans().AppendEmpty()
+	span0.SetSpanID([8]byte{1})
+	span0.SetTraceID([16]byte{1})
+	span0.SetStartTimestamp(pcommon.Timestamp(0))
+	span0.SetEndTimestamp(pcommon.Timestamp(200 * 1000)) // 200us
+	span0.SetName("span-at-zero")
+
+	span1 := ss.Spans().AppendEmpty()
+	span1.SetSpanID([8]byte{2})
+	span1.SetTraceID([16]byte{1})
+	span1.SetStartTimestamp(pcommon.Timestamp(100 * 1000)) // 100us
+	span1.SetEndTimestamp(pcommon.Timestamp(200 * 1000))   // 200us
+	span1.SetName("span-at-100")
+
+	sections := []criticalpath.Section{
+		{
+			SpanID:       span0.SpanID().String(),
+			SectionStart: 0,
+			SectionEnd:   100,
+		},
+		{
+			SpanID:       span1.SpanID().String(),
+			SectionStart: 100,
+			SectionEnd:   200,
+		},
+	}
+
+	output := handler.buildOutput(span0.TraceID().String(), traces, sections)
+
+	require.Len(t, output.Segments, 2)
+	assert.Equal(t, uint64(200), output.TotalDurationUs)
+	assert.Equal(t, uint64(0), output.Segments[0].StartOffsetUs)
+	assert.Equal(t, uint64(100), output.Segments[0].EndOffsetUs)
+	assert.Equal(t, uint64(100), output.Segments[1].StartOffsetUs)
+	assert.Equal(t, uint64(200), output.Segments[1].EndOffsetUs)
+}


### PR DESCRIPTION
## Summary
`get_critical_path` initialized `traceStartTime` to `0` and treated that as unset, so a real span starting at timestamp `0` was overwritten by any later span. Offsets and `TotalDurationUs` were then wrong.

Initialize to `math.MaxUint64` and compare with `<` only (fall back to `0` when the trace has no spans).

Fixes #9339

## Test plan
- [x] `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/ -count=1`
- [x] New `TestGetCriticalPathHandler_BuildOutput_ZeroStartTime` covers span start at `0` plus a later span