### PR TITLE
test(integration): Add backward-compatibility suites for Cassandra and ClickHouse

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -152,7 +152,7 @@ The following workflows operate independently and are **not** part of the orches
 - **dco_merge_group.yml** - DCO verification for merge groups
 
 ### Opt-in Checks
-- **ci-backward-compatibility.yml** - Writes the integration corpus with a Jaeger built from `main` and reads it back with the one built from the pull request. A backend joins by adding a matrix entry carrying the command that stands its storage up; Elasticsearch and OpenSearch are there today, Cassandra and ClickHouse are still to come. Each job builds a second Jaeger and stands up a storage backend, so the workflow runs only on a pull request labelled `ci:backward-compat`, and it gates nothing.
+- **ci-backward-compatibility.yml** - Writes the integration corpus with a Jaeger built from `main` and reads it back with the one built from the pull request. A backend joins by adding a matrix entry carrying the command that stands its storage up. Each job builds a second Jaeger and stands up a storage backend, so the workflow runs only on a pull request labelled `ci:backward-compat`, and it gates nothing.
 
 ### Scheduled Maintenance
 - **stale.yml** - Marks and closes stale issues/PRs

--- a/.github/workflows/ci-backward-compatibility.yml
+++ b/.github/workflows/ci-backward-compatibility.yml
@@ -33,14 +33,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(#8691): add cassandra and clickhouse. Each one needs a `compat` mode in its own
-        # scripts/e2e script, the way elasticsearch.sh has one, and a BackwardCompatibility entry
-        # point in its own cmd/jaeger/internal/integration test file. Nothing else here changes.
         include:
         - backend: elasticsearch
           command: bash scripts/e2e/elasticsearch.sh elasticsearch 9.x compat
         - backend: opensearch
           command: bash scripts/e2e/elasticsearch.sh opensearch 3.x compat
+        # Cassandra is the one backend whose schema can come either from the e2e script or from
+        # Jaeger itself. The compat job takes the latter, so the earlier revision creates the
+        # schema and this revision reads back through whatever that one made, which is the shape
+        # a real upgrade has.
+        - backend: cassandra
+          command: SKIP_APPLY_SCHEMA=true bash scripts/e2e/cassandra.sh 5.x v004 compat
+        - backend: clickhouse
+          command: bash scripts/e2e/clickhouse.sh compat
     name: ${{ matrix.backend }}
     steps:
     - name: Harden Runner

--- a/cmd/jaeger/internal/integration/cassandra_test.go
+++ b/cmd/jaeger/internal/integration/cassandra_test.go
@@ -22,3 +22,13 @@ func TestCassandraStorage(t *testing.T) {
 	s.e2eInitialize(t, "cassandra")
 	s.RunSpanStoreTests(t)
 }
+
+func TestCassandraStorage_BackwardCompatibility(t *testing.T) {
+	integration.SkipUnlessEnv(t, integration.StorageCassandra)
+	runBackwardCompatibilityTests(t, "cassandra", E2EStorageIntegration{
+		ConfigFile: "../../config-cassandra.yaml",
+		StorageIntegration: integration.StorageIntegration{
+			Capabilities: capabilities.Cassandra(),
+		},
+	})
+}

--- a/cmd/jaeger/internal/integration/clickhouse_test.go
+++ b/cmd/jaeger/internal/integration/clickhouse_test.go
@@ -22,3 +22,13 @@ func TestClickHouseStorage(t *testing.T) {
 	s.e2eInitialize(t, "clickhouse")
 	s.RunSpanStoreTests(t)
 }
+
+func TestClickHouseStorage_BackwardCompatibility(t *testing.T) {
+	integration.SkipUnlessEnv(t, integration.StorageClickHouse)
+	runBackwardCompatibilityTests(t, "clickhouse", E2EStorageIntegration{
+		ConfigFile: "../../config-clickhouse.yaml",
+		StorageIntegration: integration.StorageIntegration{
+			Capabilities: capabilities.E2EWithoutNativeFilters(),
+		},
+	})
+}

--- a/scripts/e2e/cassandra.sh
+++ b/scripts/e2e/cassandra.sh
@@ -16,7 +16,7 @@ export CASSANDRA_CREATE_SCHEMA=${SKIP_APPLY_SCHEMA}
 
 usage() {
   echo $"Usage: $0 <cassandra_version> <schema_version> <storage_test>"
-  echo "  storage_test: direct | e2e"
+  echo "  storage_test: direct | e2e | compat"
   exit 1
 }
 
@@ -112,8 +112,10 @@ run_integration_test() {
     STORAGE=cassandra make storage-integration-test
   elif [ "${storageTest}" == "e2e" ]; then
     STORAGE=cassandra make jaeger-v2-storage-integration-test
+  elif [ "${storageTest}" == "compat" ]; then
+    STORAGE=cassandra make jaeger-v2-backward-compatibility-test
   else
-    echo "Unknown storage_test value $storageTest. Valid options are direct or e2e"
+    echo "Unknown storage_test value $storageTest. Valid options are direct, e2e or compat"
     exit 1
   fi
   success="true"

--- a/scripts/e2e/clickhouse.sh
+++ b/scripts/e2e/clickhouse.sh
@@ -54,10 +54,12 @@ run_integration_test() {
     healthcheck_clickhouse
     if [[ "${storage_test}" == "e2e" ]]; then
         STORAGE=clickhouse make jaeger-v2-storage-integration-test
+    elif [[ "${storage_test}" == "compat" ]]; then
+        STORAGE=clickhouse make jaeger-v2-backward-compatibility-test
     elif [[ "${storage_test}" == "direct" ]]; then
         STORAGE=clickhouse make storage-integration-test
     else
-        echo "ERROR: Invalid argument value storage_test=${storage_test}, expecting direct or e2e"
+        echo "ERROR: Invalid argument value storage_test=${storage_test}, expecting direct, e2e or compat"
         exit 1
     fi
     success="true"


### PR DESCRIPTION
## Which problem is this PR solving?

- Cassandra and ClickHouse were the two backends still missing from the backward compatibility matrix added in #9437, marked there with a `TODO(#8691)`. This PR adds both and removes the TODO. Towards #8691.

## Description of the changes

- Added a `compat` mode to `scripts/e2e/cassandra.sh` and `scripts/e2e/clickhouse.sh`, alongside their existing `direct` and `e2e` modes, which runs `make jaeger-v2-backward-compatibility-test`.
- Added `TestCassandraStorage_BackwardCompatibility` and `TestClickHouseStorage_BackwardCompatibility`, each describing itself with the same config file and capabilities as that backend's ordinary e2e suite.
- Added both as matrix entries in `ci-backward-compatibility.yml` and removed the `TODO(#8691)`.
- The cassandra entry sets `SKIP_APPLY_SCHEMA=true` so the schema comes from Jaeger rather than from the e2e script: the earlier revision creates it and this revision reads back through what that one made, which is closer to a real upgrade. Suggested by @yurishkuro on #8691.
- No changes to the Go suite, to the make target, or to any other step in the workflow.

## How was this change tested?

- Ran both matrix entries verbatim, with the earlier revision built from `main` the way the workflow builds it.
- ClickHouse: 40 tests, 3 skipped, pass. Cassandra: 41 tests, 18 skipped, pass, and every skip is an opt-out that `capabilities.Cassandra()` already declares.
- In the cassandra run the script's `apply_schema` step does not run at all, so both keyspaces are the ones the earlier revision created.
- `make fmt`, `make lint` and `make test` are clean.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)