### PR TITLE
fix(es-rollover): Reject unknown --unit values in lookback

### DIFF
--- a/cmd/es-rollover/app/lookback/action.go
+++ b/cmd/es-rollover/app/lookback/action.go
@@ -36,6 +36,11 @@ func (a *Action) Do() error {
 }
 
 func (a *Action) lookback(ctx context.Context, indexSet app.IndexOption) error {
+	timeReference, err := getTimeReference(timeNow(), a.Unit, a.UnitCount)
+	if err != nil {
+		return err
+	}
+
 	jaegerIndex, err := a.IndicesClient.GetJaegerIndices(ctx, a.Config.IndexPrefix)
 	if err != nil {
 		return err
@@ -44,7 +49,7 @@ func (a *Action) lookback(ctx context.Context, indexSet app.IndexOption) error {
 	readAliasName := indexSet.ReadAliasName()
 	readAliasIndices := filter.ByAlias(jaegerIndex, []string{readAliasName})
 	excludedWriteIndex := filter.ByAliasExclude(readAliasIndices, []string{indexSet.WriteAliasName()})
-	finalIndices := filter.ByDate(excludedWriteIndex, getTimeReference(timeNow(), a.Unit, a.UnitCount))
+	finalIndices := filter.ByDate(excludedWriteIndex, timeReference)
 
 	if len(finalIndices) == 0 {
 		a.Logger.Info("No indices to remove from alias", zap.String("readAliasName", readAliasName))

--- a/cmd/es-rollover/app/lookback/action_test.go
+++ b/cmd/es-rollover/app/lookback/action_test.go
@@ -121,6 +121,22 @@ func TestLookBackAction(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			name: "unknown unit",
+			setupCallExpectations: func(_ *mocks.IndexAPI) {
+				// No calls expected: an unknown unit must be rejected before any
+				// indices are read or removed from the alias.
+			},
+			config: Config{
+				Unit:      "dayss",
+				UnitCount: 1,
+				Config: app.Config{
+					Archive: true,
+					UseILM:  true,
+				},
+			},
+			expectedErr: errors.New(`unknown unit "dayss", expected one of: seconds, minutes, hours, days, weeks, months, years`),
+		},
 	}
 
 	logger, _ := zap.NewProduction()

--- a/cmd/es-rollover/app/lookback/flags.go
+++ b/cmd/es-rollover/app/lookback/flags.go
@@ -5,6 +5,8 @@ package lookback
 
 import (
 	"flag"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -27,7 +29,7 @@ type Config struct {
 
 // AddFlags adds flags for TLS to the FlagSet.
 func (*Config) AddFlags(flags *flag.FlagSet) {
-	flags.String(unit, defaultUnit, "used with lookback to remove indices from read alias e.g, days, weeks, months, years")
+	flags.String(unit, defaultUnit, fmt.Sprintf("used with lookback to remove indices from read alias, one of: %s", strings.Join(validUnits, ", ")))
 	flags.Int(unitCount, defaultUnitCount, "count of UNITs")
 }
 

--- a/cmd/es-rollover/app/lookback/flags.go
+++ b/cmd/es-rollover/app/lookback/flags.go
@@ -5,7 +5,6 @@ package lookback
 
 import (
 	"flag"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -29,7 +28,7 @@ type Config struct {
 
 // AddFlags adds flags for TLS to the FlagSet.
 func (*Config) AddFlags(flags *flag.FlagSet) {
-	flags.String(unit, defaultUnit, fmt.Sprintf("used with lookback to remove indices from read alias, one of: %s", strings.Join(validUnits, ", ")))
+	flags.String(unit, defaultUnit, "used with lookback to remove indices from read alias, one of: "+strings.Join(validUnits, ", "))
 	flags.Int(unitCount, defaultUnitCount, "count of UNITs")
 }
 

--- a/cmd/es-rollover/app/lookback/time_reference.go
+++ b/cmd/es-rollover/app/lookback/time_reference.go
@@ -3,29 +3,38 @@
 
 package lookback
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
-func getTimeReference(currentTime time.Time, units string, unitCount int) time.Time {
+// validUnits are the only values getTimeReference accepts for the --unit flag.
+var validUnits = []string{"seconds", "minutes", "hours", "days", "weeks", "months", "years"}
+
+func getTimeReference(currentTime time.Time, units string, unitCount int) (time.Time, error) {
 	switch units {
+	case "seconds":
+		return currentTime.Truncate(time.Second).Add(-time.Duration(unitCount) * time.Second), nil
 	case "minutes":
-		return currentTime.Truncate(time.Minute).Add(-time.Duration(unitCount) * time.Minute)
+		return currentTime.Truncate(time.Minute).Add(-time.Duration(unitCount) * time.Minute), nil
 	case "hours":
-		return currentTime.Truncate(time.Hour).Add(-time.Duration(unitCount) * time.Hour)
+		return currentTime.Truncate(time.Hour).Add(-time.Duration(unitCount) * time.Hour), nil
 	case "days":
 		year, month, day := currentTime.Date()
 		tomorrowMidnight := time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location()).AddDate(0, 0, 1)
-		return tomorrowMidnight.Add(-time.Hour * 24 * time.Duration(unitCount))
+		return tomorrowMidnight.Add(-time.Hour * 24 * time.Duration(unitCount)), nil
 	case "weeks":
 		year, month, day := currentTime.Date()
 		tomorrowMidnight := time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location()).AddDate(0, 0, 1)
-		return tomorrowMidnight.Add(-time.Hour * 24 * time.Duration(7*unitCount))
+		return tomorrowMidnight.Add(-time.Hour * 24 * time.Duration(7*unitCount)), nil
 	case "months":
 		year, month, day := currentTime.Date()
-		return time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location()).AddDate(0, -1*unitCount, 0)
+		return time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location()).AddDate(0, -1*unitCount, 0), nil
 	case "years":
 		year, month, day := currentTime.Date()
-		return time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location()).AddDate(-1*unitCount, 0, 0)
+		return time.Date(year, month, day, 0, 0, 0, 0, currentTime.Location()).AddDate(-1*unitCount, 0, 0), nil
 	default:
-		return currentTime.Truncate(time.Second).Add(-time.Duration(unitCount) * time.Second)
+		return time.Time{}, fmt.Errorf("unknown unit %q, expected one of: %s", units, strings.Join(validUnits, ", "))
 	}
 }

--- a/cmd/es-rollover/app/lookback/time_reference_test.go
+++ b/cmd/es-rollover/app/lookback/time_reference_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTimeReference(t *testing.T) {
@@ -65,25 +66,23 @@ func TestGetTimeReference(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ref := getTimeReference(now, test.unit, test.unitCount)
+			ref, err := getTimeReference(now, test.unit, test.unitCount)
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedTime, ref)
 		})
 	}
 }
 
-func TestGetTimeReference_DefaultCase(t *testing.T) {
+func TestGetTimeReference_UnknownUnit(t *testing.T) {
 	now := time.Date(2021, time.October, 10, 10, 10, 10, 10, time.UTC)
-
-	unknownUnit := "unknown-unit"
 	unitCount := 30
 
-	ref := getTimeReference(now, unknownUnit, unitCount)
-
-	expectedTime := time.Date(2021, time.October, 10, 10, 9, 40, 0, time.UTC)
-	assert.Equal(t, expectedTime, ref)
-
-	anotherUnknownUnit := "milliseconds"
-	ref2 := getTimeReference(now, anotherUnknownUnit, unitCount)
-
-	assert.Equal(t, expectedTime, ref2)
+	for _, unknownUnit := range []string{"unknown-unit", "milliseconds", "day", "dayss"} {
+		t.Run(unknownUnit, func(t *testing.T) {
+			ref, err := getTimeReference(now, unknownUnit, unitCount)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), unknownUnit)
+			assert.Equal(t, time.Time{}, ref)
+		})
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #9439.

`es-rollover lookback`'s `--unit` flag documented only `days`, `weeks`, `months` and `years`, but the value was never validated. `getTimeReference()` fell through to a `default` case that silently computed the window in **seconds** for any unrecognized value. A typo like `--unit=day` (singular, instead of `days`) built a lookback window of a few seconds instead of days, so the command removed nearly every index from the read alias with no error or warning — a silent, hard-to-notice way to lose data availability.

## Description of the changes

- `getTimeReference()` now returns `(time.Time, error)`. `seconds` is promoted to its own explicit case (previously only reachable through the same silent fallback the bug used), and the `default` case now returns an error listing the valid units instead of guessing.
- `Action.lookback()` checks that error **before** calling `GetJaegerIndices`, so an invalid unit is rejected before any Elasticsearch call is made or index touched.
- The `--unit` flag's help text is generated from the same `validUnits` list the validation uses, so the two can't drift out of sync the way the old hardcoded help text had (it never mentioned `minutes`/`hours`, which were already implemented).
- Updated `TestGetTimeReference_DefaultCase` (which pinned the old silent-fallback behavior, as flagged in the issue) into `TestGetTimeReference_UnknownUnit`, asserting an error for `unknown-unit`, `milliseconds`, `day`, and `dayss`.
- Added an `"unknown unit"` case to `TestLookBackAction` asserting `Do()` returns the validation error and that `GetJaegerIndices`/`DeleteAlias` are never called (the mock has no expectations set for that case, so an unexpected call panics the test).

## How was this change tested?

```
$ go build ./cmd/es-rollover/...
$ go test ./cmd/es-rollover/app/lookback/... -v
...
--- PASS: TestLookBackAction (0.00s)
    --- PASS: TestLookBackAction/success (0.00s)
    --- PASS: TestLookBackAction/get_indices_error (0.00s)
    --- PASS: TestLookBackAction/empty_indices (0.00s)
    --- PASS: TestLookBackAction/unknown_unit (0.00s)
--- PASS: TestBindFlags (0.00s)
--- PASS: TestGetTimeReference (0.00s)
    (all seven valid units)
--- PASS: TestGetTimeReference_UnknownUnit (0.00s)
    (unknown-unit, milliseconds, day, dayss)
PASS
ok  	github.com/jaegertracing/jaeger/cmd/es-rollover/app/lookback	1.150s

$ go test ./cmd/es-rollover/app/lookback/... -covermode=atomic -coverprofile=cover.out && go tool cover -func=cover.out
ok  	.../lookback	coverage: 100.0% of statements
total:						(statements)		100.0%

$ go vet ./cmd/es-rollover/...
(clean)
```

`gofmt` is clean on every changed file.

**On `make fmt`/`make lint`/`make test` specifically:** I installed `make` after initially not having it, but couldn't get any of these three to run to completion in my Windows environment, for reasons unrelated to this change:
- `make fmt`/`make lint` (via `lint-imports`) invoke a single shell command listing every `.go` file in the repository as arguments; Windows has a ~32KB command-line length limit, so the command is rejected outright (`make (e=87): The parameter is incorrect`) before it reaches any of my files.
- `make test` runs `./...` across the whole repository rather than being scoped to changed packages; I didn't run it end-to-end given the size of the repo, and used the equivalent scoped `go test` instead (shown above), which is what actually exercises this change.

`go build`, `go vet`, and `gofmt -l` on the actual changed files are clean, and `go test ./cmd/es-rollover/app/lookback/...` passes with 100% patch coverage — I'm confident in the change, just not claiming a full-repo `make` run I couldn't complete.

## Checklist

- [x] I have read [CONTRIBUTING_GUIDELINES.md](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - Leaving this unchecked: `make fmt`/`make lint`/`make test` don't complete in my Windows environment for the unrelated reasons explained above. `go build`, `go vet`, `gofmt -l`, and the scoped `go test` for the changed package all pass (output above).

