### PR TITLE
fix(query): prevent archiving archive-only traces

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -306,25 +306,28 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query tracestore.GetTra
 	if qs.options.ArchiveTraceWriter == nil {
 		return errNoArchiveSpanStorage
 	}
-	getTracesIter := qs.interceptResults(ctx, qs.traceReader.GetTraces(ctx, query))
 	var (
 		found      bool
 		archiveErr error
 	)
-	getTracesIter(func(traces []ptrace.Traces, err error) bool {
-		if err != nil {
-			archiveErr = err
-			return false
-		}
-		for _, trace := range traces {
-			found = true
-			err = qs.options.ArchiveTraceWriter.WriteTraces(ctx, trace)
+	qs.receiveTraces(
+		qs.interceptResults(ctx, qs.traceReader.GetTraces(ctx, query)),
+		func(traces []ptrace.Traces, err error) bool {
 			if err != nil {
-				archiveErr = errors.Join(archiveErr, err)
+				archiveErr = err
+				return false
 			}
-		}
-		return true
-	})
+			for _, trace := range traces {
+				found = true
+				err = qs.options.ArchiveTraceWriter.WriteTraces(ctx, trace)
+				if err != nil {
+					archiveErr = errors.Join(archiveErr, err)
+				}
+			}
+			return true
+		},
+		false,
+	)
 	if archiveErr == nil && !found {
 		return spanstore.ErrTraceNotFound
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -306,9 +306,7 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query tracestore.GetTra
 	if qs.options.ArchiveTraceWriter == nil {
 		return errNoArchiveSpanStorage
 	}
-	getTracesIter := qs.GetTraces(
-		ctx, GetTraceParams{TraceIDs: []tracestore.GetTraceParams{query}},
-	)
+	getTracesIter := qs.interceptResults(ctx, qs.traceReader.GetTraces(ctx, query))
 	var (
 		found      bool
 		archiveErr error

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go
@@ -314,7 +314,7 @@ func (qs QueryService) ArchiveTrace(ctx context.Context, query tracestore.GetTra
 		qs.interceptResults(ctx, qs.traceReader.GetTraces(ctx, query)),
 		func(traces []ptrace.Traces, err error) bool {
 			if err != nil {
-				archiveErr = err
+				archiveErr = errors.Join(archiveErr, err)
 				return false
 			}
 			for _, trace := range traces {

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
@@ -694,6 +694,23 @@ func TestArchiveTrace(t *testing.T) {
 			},
 			expectedError: spanstore.ErrTraceNotFound,
 		},
+		{
+			name:    "archive only trace is not re-archived",
+			options: []testOption{withArchiveTraceReader(), withArchiveTraceWriter()},
+			setupMocks: func(tqs *testQueryService) {
+				primaryIter := iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+					yield([]ptrace.Traces{}, nil)
+				})
+				archiveIter := iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
+					yield([]ptrace.Traces{makeTestTrace()}, nil)
+				})
+				tqs.traceReader.On("GetTraces", mock.Anything, paramsTraceIDs).
+					Return(primaryIter).Once()
+				tqs.archiveTraceReader.On("GetTraces", mock.Anything, paramsTraceIDs).
+					Return(archiveIter).Maybe()
+			},
+			expectedError: spanstore.ErrTraceNotFound,
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go
@@ -701,13 +701,8 @@ func TestArchiveTrace(t *testing.T) {
 				primaryIter := iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
 					yield([]ptrace.Traces{}, nil)
 				})
-				archiveIter := iter.Seq2[[]ptrace.Traces, error](func(yield func([]ptrace.Traces, error) bool) {
-					yield([]ptrace.Traces{makeTestTrace()}, nil)
-				})
 				tqs.traceReader.On("GetTraces", mock.Anything, paramsTraceIDs).
 					Return(primaryIter).Once()
-				tqs.archiveTraceReader.On("GetTraces", mock.Anything, paramsTraceIDs).
-					Return(archiveIter).Maybe()
 			},
 			expectedError: spanstore.ErrTraceNotFound,
 		},


### PR DESCRIPTION
## Summary

Fixes a bug where `ArchiveTrace` could rewrite traces that only existed in archive storage.

This closes #9390.

## Problem

`ArchiveTrace` was using the general trace lookup path, which includes archive fallback. When a trace was missing from primary storage but still existed in archive storage, the trace was read from archive and then written back to archive again.

This caused:
- an unnecessary second archive write
- possible refresh of backend expiration metadata
- duplicate archive documents in some backends

## Fix

The fix keeps archive fallback behavior for normal read queries, but makes `ArchiveTrace` read only from primary storage before writing. If the trace is not found in primary storage, it returns `ErrTraceNotFound` without reading from or writing to archive storage.

## Files changed

- `cmd/jaeger/internal/extension/jaegerquery/querysvc/service.go`
- `cmd/jaeger/internal/extension/jaegerquery/querysvc/service_test.go`

## Testing

Added a regression test covering the archive-only trace scenario and verified it with:

```bash
go test ./cmd/jaeger/internal/extension/jaegerquery/querysvc -run 'TestArchiveTrace/archive_only_trace_is_not_re-archived|TestArchiveTrace' -count=1