### PR TITLE
fix(es): set ignore_unmapped=true on nested queries to tolerate missing mappings

### DIFF
--- a/internal/storage/elasticsearch/query/nested_query.go
+++ b/internal/storage/elasticsearch/query/nested_query.go
@@ -4,8 +4,12 @@
 package query
 
 // NestedQuery runs an inner query against a nested-field path. It renders to
-// {"nested": {"path": path, "query": <inner>}}, matching what the storage layer
-// previously produced.
+// {"nested": {"path": path, "query": <inner>, "ignore_unmapped": true}},
+// matching what the storage layer previously produced.
+//
+// ignore_unmapped is set to true so that searches against indices whose
+// mapping does not contain the nested path (e.g. spans stored with
+// tags-as-fields enabled) do not return a 400 error but simply yield no hits.
 type NestedQuery struct {
 	path  string
 	query Query
@@ -23,8 +27,9 @@ func (q *NestedQuery) Source() (any, error) {
 	}
 	return map[string]any{
 		"nested": map[string]any{
-			"path":  q.path,
-			"query": inner,
+			"path":             q.path,
+			"query":            inner,
+			"ignore_unmapped": true,
 		},
 	}, nil
 }

--- a/internal/storage/elasticsearch/query/nested_query_test.go
+++ b/internal/storage/elasticsearch/query/nested_query_test.go
@@ -20,6 +20,8 @@ func TestNestedQuerySource(t *testing.T) {
 	nested := src.(map[string]any)["nested"].(map[string]any)
 	assert.Equal(t, "tags", nested["path"])
 	assert.Contains(t, nested, "query")
+	assert.Equal(t, true, nested["ignore_unmapped"],
+		"ignore_unmapped must be true to tolerate indices without nested tag mappings")
 }
 
 func TestNestedQueryPropagatesInnerError(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3900

When Jaeger is configured with `es.tags-as-fields.all=true`, span tags are stored as top-level fields rather than in a nested `tags` array. Indices created in this mode do not have a nested `tags` mapping. Searching with a nested query against such an index causes Elasticsearch to return a 400 error:

```
failed to create query: [nested] failed to find nested object under path [tags]
```

This surfaces as an internal server error in the Jaeger query service, making tag-based searches completely broken for users running mixed configurations (e.g. some indices with nested tags and some without).

## Short description of the changes

Set `ignore_unmapped: true` on `NestedQuery.Source()` in `internal/storage/elasticsearch/query/nested_query.go`.

This tells Elasticsearch to silently skip the nested clause on indices where the path is not mapped as nested (returning no hits from those indices), rather than failing the entire search request with a 400. Indices that do have a nested mapping continue to work exactly as before.

**Before:**
```json
{"nested": {"path": "tags", "query": {...}}}
```

**After:**
```json
{"nested": {"path": "tags", "query": {...}, "ignore_unmapped": true}}
```

A regression test asserting `ignore_unmapped: true` is present in the rendered query has been added to `nested_query_test.go`.