### PR TITLE
feat(es): Make the `data_stream` rotation reachable for spans

### DIFF
--- a/cmd/jaeger/config-elasticsearch-data-stream.yaml
+++ b/cmd/jaeger/config-elasticsearch-data-stream.yaml
@@ -49,8 +49,7 @@ extensions:
               shards: 1
               replicas: 0
               rotation:
-                data_stream:
-                  policy_name: "jaeger-spans-lifecycle"
+                data_stream: {}
             services:
               shards: 1
               replicas: 0

--- a/cmd/jaeger/config-opensearch-data-stream.yaml
+++ b/cmd/jaeger/config-opensearch-data-stream.yaml
@@ -49,8 +49,7 @@ extensions:
               shards: 1
               replicas: 0
               rotation:
-                data_stream:
-                  policy_name: "jaeger-spans-lifecycle"
+                data_stream: {}
             services:
               shards: 1
               replicas: 0

--- a/cmd/jaeger/internal/integration/elasticsearch_test.go
+++ b/cmd/jaeger/internal/integration/elasticsearch_test.go
@@ -43,8 +43,6 @@ func TestElasticsearchStorage_AutoRollover(t *testing.T) {
 }
 
 func TestElasticsearchStorage_DataStream(t *testing.T) {
-	t.Skip("data_stream rotation not yet implemented (see RFC 0004 Phase 2)")
-
 	// No setup helper is needed because data streams auto-create on first write
 	// once the composable template is in place.
 	integration.SkipUnlessEnv(t, integration.StorageElasticsearch)

--- a/cmd/jaeger/internal/integration/opensearch_test.go
+++ b/cmd/jaeger/internal/integration/opensearch_test.go
@@ -85,7 +85,7 @@ func TestOpenSearchStorage_AutoRollover(t *testing.T) {
 }
 
 func TestOpenSearchStorage_DataStream(t *testing.T) {
-	t.Skip("data_stream rotation not yet implemented (see RFC 0004 Phase 2)")
+	// See TestElasticsearchStorage_DataStream for why no setup helper is needed.
 	integration.SkipUnlessEnv(t, integration.StorageOpenSearch)
 	runRotationSmokeTest(t, "../../config-opensearch-data-stream.yaml", "opensearch", func(*testing.T) {})
 }

--- a/docs/rfc/0004-elasticsearch-data-streams.md
+++ b/docs/rfc/0004-elasticsearch-data-streams.md
@@ -882,14 +882,14 @@ PR: [#8823](https://github.com/jaegertracing/jaeger/pull/8823)
 Make data streams functional for writes. Reads still go to the data stream name directly (no migration alias yet).
 
 8. ✅ **Add `@timestamp` field (date_nanos) to span document at write time.** Delivered in [#8833](https://github.com/jaegertracing/jaeger/pull/8833), with the value corrected to an RFC 3339 string in [#9363](https://github.com/jaegertracing/jaeger/pull/9363) (§3.3)
-9. Implement `DataStreamStrategy.CreateTemplates()`: composable index template + component templates (§3.2) — partially delivered by [#8991](https://github.com/jaegertracing/jaeger/pull/8991), which renders and installs them as `esclient.IndicesClient.CreateSpanDataStreamTemplates`. Still open: `FactoryBase.createTemplates` must call it when the span rotation is a data stream instead of installing the rotation-path template unconditionally, and `RotationConfig.validate` must narrow its `data_stream` rejection to non-span indices
+9. ✅ **Implement `DataStreamStrategy.CreateTemplates()`: composable index template + component templates (§3.2).** Rendered and installed by `esclient.IndicesClient.CreateSpanDataStreamTemplates` in [#8991](https://github.com/jaegertracing/jaeger/pull/8991). `FactoryBase.createTemplates` calls it in place of the rotation-path template when the span rotation is a data stream, and `RotationConfig.validate` accepts `data_stream` for spans while still rejecting it for the index types that update documents in place (§2.1)
 10. ✅ **Implement `DataStreamStrategy.WriteTarget()`: return data stream name.** Delivered in [#8833](https://github.com/jaegertracing/jaeger/pull/8833) as `DataStreamRotation.WriteTarget`
 11. ✅ **Implement `DataStreamStrategy.OpType()`: return `"create"`.** Delivered in [#8833](https://github.com/jaegertracing/jaeger/pull/8833) as `DataStreamRotation.WriteOpType`
 12. Implement ISM policy creation for OpenSearch, ILM for Elasticsearch (§3.6)
 13. ✅ **Implement `DataStreamStrategy.ReadTargets()`: return data stream name (no migration alias yet).** Delivered in [#8833](https://github.com/jaegertracing/jaeger/pull/8833) as `DataStreamRotation.ReadTargets`
-14. **CI**: Integration test — write spans via data stream, read them back, verify end-to-end on both OS and ES
+14. ✅ **CI**: Integration test — write spans via data stream, read them back, verify end-to-end on both OS and ES. Runs as `TestElasticsearchStorage_DataStream` and `TestOpenSearchStorage_DataStream`, driving the full binary through `config-{elasticsearch,opensearch}-data-stream.yaml`
 
-Deliverable: `rotation.data_stream` is fully functional for fresh installations (no legacy data).
+Deliverable: `rotation.data_stream` is fully functional for fresh installations (no legacy data). Until milestone 12 lands, the stream is created without a lifecycle policy, so its backing indices grow until an operator attaches one.
 
 ### Phase 3: Migration Support
 

--- a/internal/storage/elasticsearch/config/config_rotation.go
+++ b/internal/storage/elasticsearch/config/config_rotation.go
@@ -11,6 +11,10 @@ import (
 
 const legacyRotationFlagsList = "use_aliases, use_ilm, span_read_alias, span_write_alias, service_read_alias, service_write_alias"
 
+// spansIndexType names the span indices in rotation validation errors. Spans are
+// the only index type that can use the data_stream strategy.
+const spansIndexType = "spans"
+
 // RotationConfig defines how Jaeger manages index naming and lookup for a given
 // index type (spans, services, etc.). Exactly one variant should be set.
 // If none is set, legacy flags (use_aliases, use_ilm, etc.) determine behavior.
@@ -28,8 +32,9 @@ type RotationConfig struct {
 	// State Management) policy attached to the index template. Jaeger embeds the
 	// policy name into the template so ES/OpenSearch can manage the lifecycle.
 	AutoRollover configoptional.Optional[AutoRolloverRotation] `mapstructure:"auto_rollover"`
-	// DataStream uses ES/OpenSearch data streams for append-only span storage.
-	// Not yet implemented.
+	// DataStream stores spans in an ES/OpenSearch data stream, which is
+	// append-only and rolls its own backing indices over. Spans only: the other
+	// index types are updated in place (RFC 0004 §2.1).
 	DataStream configoptional.Optional[DataStreamRotation] `mapstructure:"data_stream"`
 }
 
@@ -77,15 +82,18 @@ type AutoRolloverRotation struct {
 	PolicyName string `mapstructure:"policy_name"`
 }
 
-// DataStreamRotation configures data stream-based storage (not yet implemented).
+// DataStreamRotation configures data stream-based storage for spans.
 type DataStreamRotation struct {
-	// PolicyName is embedded into the data stream's index template so that
-	// ES/OpenSearch manages the lifecycle (rollover, retention) automatically.
-	// If empty, the cluster's default lifecycle policy applies.
+	// PolicyName is the ILM/ISM policy that manages the data stream's lifecycle
+	// (rollover, retention).
+	//
+	// Not honored yet: the data stream is created without a lifecycle policy, so
+	// its backing indices grow until an operator attaches one. Wiring it up is
+	// RFC 0004 Phase 2 milestone 12.
 	PolicyName string `mapstructure:"policy_name"`
-	// PolicyFile is a path to a JSON file containing the ILM/ISM policy definition.
-	// When set, Jaeger creates or updates the policy at startup before creating
-	// the data stream. If empty, the policy must already exist in the cluster.
+	// PolicyFile is a path to a JSON file containing the ILM/ISM policy definition,
+	// which Jaeger creates at startup. Not honored yet, for the same reason as
+	// PolicyName.
 	PolicyFile string `mapstructure:"policy_file"`
 	// ReadAlias is an optional alias layered on top of the data stream for reads.
 	// Useful for cross-cluster search or to decouple consumer queries from the
@@ -119,7 +127,7 @@ func (c *Configuration) validateRotationConfig() error {
 		rotation *RotationConfig
 	}
 	entries := []rotationEntry{
-		{"spans", &c.Indices.Spans, &c.Indices.Spans.Rotation},
+		{spansIndexType, &c.Indices.Spans, &c.Indices.Spans.Rotation},
 		{"services", &c.Indices.Services, &c.Indices.Services.Rotation},
 		{"dependencies", &c.Indices.Dependencies, &c.Indices.Dependencies.Rotation},
 		{"sampling", &c.Indices.Sampling, &c.Indices.Sampling.Rotation},
@@ -160,9 +168,11 @@ func (r *RotationConfig) validate(indexType string) error {
 			indexType, count,
 		)
 	}
-	if r.DataStream.HasValue() {
+	// Only spans are append-only. Services and dependencies deduplicate by
+	// rewriting documents, which a data stream does not allow (RFC 0004 §2.1).
+	if r.DataStream.HasValue() && indexType != spansIndexType {
 		return fmt.Errorf(
-			"indices.%s.rotation: data_stream is not yet implemented",
+			"indices.%s.rotation: data_stream is supported only for spans",
 			indexType,
 		)
 	}

--- a/internal/storage/elasticsearch/config/config_test.go
+++ b/internal/storage/elasticsearch/config/config_test.go
@@ -626,12 +626,19 @@ func TestRotationConfig_Validate(t *testing.T) {
 			indexType: "spans",
 		},
 		{
-			name: "data_stream is not yet implemented",
+			name: "data_stream is valid for spans",
 			rotation: RotationConfig{
 				DataStream: configoptional.Some(DataStreamRotation{PolicyName: "test"}),
 			},
-			indexType:   "spans",
-			expectedErr: "data_stream is not yet implemented",
+			indexType: "spans",
+		},
+		{
+			name: "data_stream is rejected for services",
+			rotation: RotationConfig{
+				DataStream: configoptional.Some(DataStreamRotation{PolicyName: "test"}),
+			},
+			indexType:   "services",
+			expectedErr: "indices.services.rotation: data_stream is supported only for spans",
 		},
 		{
 			name: "multiple rotations set",

--- a/internal/storage/elasticsearch/esclient/data_stream_template.go
+++ b/internal/storage/elasticsearch/esclient/data_stream_template.go
@@ -29,6 +29,7 @@ const (
 	// composable choice (templateEndpoint) tracks UsesV8API.
 	componentTemplateAPI = "_component_template"
 	indexTemplateAPI     = "_index_template"
+	dataStreamAPI        = "_data_stream"
 
 	// dataStreamPriority is the composable index template priority from RFC 0004
 	// §3.2, high enough that Jaeger's template wins over a cluster's default
@@ -133,6 +134,19 @@ func (i IndicesClient) putComposableTemplate(ctx context.Context, api, name, que
 		return fmt.Errorf("failed to create data stream template %q: %w", name, err)
 	}
 	return nil
+}
+
+// DeleteSpanDataStream deletes the span data stream and the backing indices it
+// owns, tolerating a stream that does not exist.
+//
+// Purge cannot reach it through DeleteAllIndices: a data stream's backing indices
+// are hidden, so the "*" wildcard leaves them in place and every span written
+// before the purge is still searchable through the stream afterwards. Verified on
+// Elasticsearch 7.17 and 9.4 and OpenSearch 1.3 and 3.7, which all acknowledge the
+// wildcard delete and all keep the stream.
+func (i IndicesClient) DeleteSpanDataStream(ctx context.Context) error {
+	name := i.Indices.IndexPrefix.DataStreamName(spanDataStreamBase)
+	return i.deleteIfPresent(ctx, dataStreamAPI, name)
 }
 
 // TestsOnlyDeleteSpanDataStreamObjects removes every template

--- a/internal/storage/v2/elasticsearch/factory_base.go
+++ b/internal/storage/v2/elasticsearch/factory_base.go
@@ -260,12 +260,18 @@ func (f *FactoryBase) Close() error {
 	return errors.Join(errs...)
 }
 
-// Purge resets the storage to empty: it deletes the indices and clears the span
-// writers' service:operation cache, which is part of that state. A cache entry left
-// behind suppresses the service document for the next write, so the emptied index
-// would not get it back until the entry expired (12 hours by default).
+// Purge resets the storage to empty: it deletes the indices and any span data
+// stream, and clears the span writers' service:operation cache, which is part of
+// that state. A cache entry left behind suppresses the service document for the
+// next write, so the emptied index would not get it back until the entry expired
+// (12 hours by default).
 func (f *FactoryBase) Purge(ctx context.Context) error {
-	err := f.indicesClient().DeleteAllIndices(ctx)
+	ic := f.indicesClient()
+	err := ic.DeleteAllIndices(ctx)
+	// The span data stream outlives DeleteAllIndices, so it is deleted by name.
+	if f.config.ResolvedSpanRotation().DataStream.HasValue() {
+		err = errors.Join(err, ic.DeleteSpanDataStream(ctx))
+	}
 	f.serviceOperations.ClearCache()
 	return err
 }
@@ -310,16 +316,28 @@ func (f *FactoryBase) buildRotations() (spanRotation, serviceRotation indices.Ro
 	return spanRotation, serviceRotation
 }
 
+// createTemplates installs the index templates the configured rotation needs.
+// Spans get the rotation path's jaeger-span-* template, or the composable template
+// that declares the data stream (RFC 0004 §3.2), never both. Services keep theirs
+// either way: their documents are updated in place, so they stay on standard
+// indices even when spans do not (§2.1).
 func (f *FactoryBase) createTemplates(ctx context.Context) error {
 	if !f.config.CreateIndexTemplates {
 		return nil
 	}
 	ic := f.indicesClient()
-	jaegerSpanIdx := f.config.Indices.IndexPrefix.Apply(config.SpanIndexName)
-	jaegerServiceIdx := f.config.Indices.IndexPrefix.Apply(config.ServiceIndexName)
-	if err := ic.CreateTemplate(ctx, jaegerSpanIdx, esclient.SpanMapping); err != nil {
-		return fmt.Errorf("failed to create template %q: %w", jaegerSpanIdx, err)
+	if f.config.ResolvedSpanRotation().DataStream.HasValue() {
+		// The error already names the object that could not be created.
+		if err := ic.CreateSpanDataStreamTemplates(ctx); err != nil {
+			return err
+		}
+	} else {
+		jaegerSpanIdx := f.config.Indices.IndexPrefix.Apply(config.SpanIndexName)
+		if err := ic.CreateTemplate(ctx, jaegerSpanIdx, esclient.SpanMapping); err != nil {
+			return fmt.Errorf("failed to create template %q: %w", jaegerSpanIdx, err)
+		}
 	}
+	jaegerServiceIdx := f.config.Indices.IndexPrefix.Apply(config.ServiceIndexName)
 	if err := ic.CreateTemplate(ctx, jaegerServiceIdx, esclient.ServiceMapping); err != nil {
 		return fmt.Errorf("failed to create template %q: %w", jaegerServiceIdx, err)
 	}

--- a/internal/storage/v2/elasticsearch/factory_base_test.go
+++ b/internal/storage/v2/elasticsearch/factory_base_test.go
@@ -136,6 +136,53 @@ func TestFactoryBase_Purge(t *testing.T) {
 	}
 }
 
+// TestFactoryBase_PurgeDataStream covers what DeleteAllIndices cannot reach: a
+// data stream survives DELETE /*, because its backing indices are hidden and the
+// wildcard does not match them, so purging has to name the stream as well.
+// Asserting both DELETEs in order is the point — dropping either one leaves spans
+// from the previous run readable.
+func TestFactoryBase_PurgeDataStream(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		deletes []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			mu.Lock()
+			deletes = append(deletes, r.URL.Path)
+			mu.Unlock()
+			w.Write([]byte("{}"))
+			return
+		}
+		w.Write(mockEsServerResponse)
+	}))
+	defer server.Close()
+
+	esClient, err := esclient.NewClient(context.Background(),
+		&escfg.Configuration{Servers: []string{server.URL}, Version: uint(es.ElasticV7)}, zap.NewNop(), nil)
+	require.NoError(t, err)
+	f := &FactoryBase{
+		esClient: esClient,
+		logger:   zap.NewNop(),
+		config: &escfg.Configuration{
+			Indices: escfg.Indices{
+				IndexPrefix: "prod",
+				Spans: escfg.IndexOptions{
+					Rotation: escfg.RotationConfig{
+						DataStream: configoptional.Some(escfg.DataStreamRotation{}),
+					},
+				},
+			},
+		},
+		serviceOperations: core.NewServiceOperationStorage(nil, zap.NewNop(), 0),
+	}
+
+	require.NoError(t, f.Purge(context.Background()))
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"/*", "/_data_stream/prod.jaeger.spans"}, deletes)
+}
+
 // countingBatchWriter records how many service documents the span writer sends,
 // which is what the dedup cache suppresses.
 type countingBatchWriter struct {
@@ -319,6 +366,93 @@ func TestCreateTemplates(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, []string{"/_template/jaeger-span", "/_template/jaeger-service"}, puts)
 			}
+		})
+	}
+}
+
+// dataStreamFactory builds a factory whose spans are configured for a data stream,
+// pointed at the given test server.
+func dataStreamFactory(t *testing.T, serverURL string) *FactoryBase {
+	esClient, err := esclient.NewClient(context.Background(),
+		&escfg.Configuration{Servers: []string{serverURL}, Version: uint(es.ElasticV7)}, zap.NewNop(), nil)
+	require.NoError(t, err)
+	return &FactoryBase{
+		esClient: esClient,
+		logger:   zap.NewNop(),
+		config: &escfg.Configuration{
+			CreateIndexTemplates: true,
+			Indices: escfg.Indices{
+				Spans: escfg.IndexOptions{
+					Shards:   3,
+					Replicas: new(int64(1)),
+					Rotation: escfg.RotationConfig{
+						DataStream: configoptional.Some(escfg.DataStreamRotation{}),
+					},
+				},
+				Services: escfg.IndexOptions{Shards: 3, Replicas: new(int64(1))},
+			},
+		},
+	}
+}
+
+// TestCreateTemplatesDataStream pins the rotation branch: spans configured for a
+// data stream get the composable objects and not the jaeger-span-* rotation
+// template, while services keep theirs. Asserting the exact PUT list is what makes
+// the "and not" half of that checkable — a wiring that installed both would still
+// create a working data stream, and pass any assertion that only looked for one.
+//
+// The cluster answers the "@custom" probe with 404, so both cases also cover the
+// fresh-install path where Jaeger has to create that component itself. When the
+// PUTs fail, startup must fail with them rather than leave spans pointed at a
+// stream the cluster has no template for.
+func TestCreateTemplatesDataStream(t *testing.T) {
+	tests := []struct {
+		name      string
+		putStatus int
+		expectErr string
+		expectPut []string
+	}{
+		{
+			name:      "installs data stream objects instead of the span template",
+			putStatus: http.StatusOK,
+			expectPut: []string{
+				"/_component_template/jaeger.spans@custom",
+				"/_component_template/jaeger.spans@mappings",
+				"/_component_template/jaeger.spans@settings",
+				"/_index_template/jaeger.spans",
+				"/_template/jaeger-service",
+			},
+		},
+		{
+			name:      "template error fails startup",
+			putStatus: http.StatusInternalServerError,
+			expectErr: "jaeger.spans@custom",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var puts []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPut:
+					puts = append(puts, r.URL.Path)
+					w.WriteHeader(test.putStatus)
+					w.Write([]byte("{}"))
+				case strings.HasPrefix(r.URL.Path, "/_component_template/"):
+					w.WriteHeader(http.StatusNotFound)
+				default:
+					w.Write(mockEsServerResponse)
+				}
+			}))
+			defer server.Close()
+
+			err := dataStreamFactory(t, server.URL).createTemplates(context.Background())
+			if test.expectErr != "" {
+				require.ErrorContains(t, err, test.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expectPut, puts)
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #4708 (RFC 0004 Phase 2, milestones 9 and 14).

#8991 added `IndicesClient.CreateSpanDataStreamTemplates`, but nothing calls it: the only caller today is a test. `FactoryBase.createTemplates` installs the `jaeger-span-*` rotation template unconditionally, and `RotationConfig.validate` still rejects `data_stream` for every index type, so the strategy cannot be configured at all. This makes it reachable.

## Description of the changes

**`createTemplates` picks a span template by rotation.** When the resolved span rotation is a data stream, it installs the composable objects instead of the rotation-path template, never both. Services keep their template either way: service documents are updated in place, so they stay on standard indices even when spans do not (§2.1).

**The validation gate narrows to non-span indices.** `data_stream` is now accepted for spans. It is still rejected elsewhere, and the message says why it will stay that way rather than calling it unimplemented, since services and dependencies deduplicate by rewriting documents.

**Purge deletes the span data stream by name.** This is the part that was not in the milestone description. A data stream's backing indices are hidden, so the `*` wildcard does not match them and `DELETE /*` leaves the stream intact. I confirmed on all four backends that both documents written before a purge are still returned by a search afterwards, which would have made the e2e suite read the previous run's spans.

**The two e2e tests are unskipped.** `TestElasticsearchStorage_DataStream` and `TestOpenSearchStorage_DataStream` already existed as `t.Skip` stubs with their config files in place, so this only removes the skips.

**`policy_name` is dropped from the two e2e configs**, and `PolicyName`/`PolicyFile` are documented as not yet honored. `renderSpanDataStreamTemplates` deliberately asks for no lifecycle settings, so those fields do nothing until milestone 12. Leaving them in the example configs would advertise behavior that does not exist.

## How was this change tested?

**Against real clusters.** Before writing the wiring I probed Elasticsearch 7.17.22 and 9.4.0 and OpenSearch 1.3.17 and 3.7.0, the exact images in the CI matrix, to settle three things I did not want to assume:

| | OS 1.3 | ES 7.17 | ES 9.4 | OS 3.7 |
|---|---|---|---|---|
| Accepts the three template PUTs | yes | yes | yes | yes |
| Bulk `create` with Jaeger's custom `_id` | 201 | 201 | 201 | 201 |
| Auto-creates the stream on first write | yes | yes | yes | yes |
| `DELETE /*` removes the stream | **no** | **no** | **no** | **no** |

The first three mean no writer change and no version skip are needed, including on OpenSearch 1.3. The fourth is why Purge changed.

**Unit.** `TestCreateTemplatesDataStream` asserts the exact PUT list rather than merely looking for the data-stream objects, because wiring that installed both templates would still produce a working data stream and would pass a weaker assertion. It also covers the fresh-install path where `@custom` is absent, and the error case that must fail startup. `TestFactoryBase_PurgeDataStream` asserts both DELETEs in order, since dropping either leaves spans from the previous run readable.

I checked that each new test fails when its production change is reverted, rather than assuming it. Reverting the `createTemplates` branch gives:

```
expected: []string{"/_component_template/jaeger.spans@custom", ...}
actual  : []string{"/_template/jaeger-span", "/_template/jaeger-service"}
```

**One thing worth flagging.** `data_stream: {}` unmarshals to `HasValue() == true`, but a bare `data_stream:` with no value yields `false` and silently falls back to periodic. That is why the e2e configs use `{}`. It is pre-existing `configoptional` behavior shared by every rotation variant, so I have not changed it here.

## Follow-up

Milestone 12 attaches the ILM/ISM policy. Until then the stream is created without one and its backing indices grow until an operator attaches a policy, which the RFC's Phase 2 deliverable now states.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)

