### PR TITLE
es tracestore: set Flags("NONE") on tag RegexpQuery (#9387)

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_01.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_01.json
@@ -6,6 +6,7 @@
           "must":{
             "regexp":{
               "tag.bat@foo":{
+                "flags":"NONE",
                 "value":"spook"
               }
             }
@@ -17,6 +18,7 @@
           "must":{
             "regexp":{
               "process.tag.bat@foo":{
+                "flags":"NONE",
                 "value":"spook"
               }
             }
@@ -39,6 +41,7 @@
                 {
                   "regexp":{
                     "tags.value":{
+                      "flags":"NONE",
                       "value":"spook"
                     }
                   }
@@ -64,6 +67,7 @@
                 {
                   "regexp":{
                     "process.tags.value":{
+                      "flags":"NONE",
                       "value":"spook"
                     }
                   }
@@ -89,6 +93,7 @@
                 {
                   "regexp":{
                     "logs.fields.value":{
+                      "flags":"NONE",
                       "value":"spook"
                     }
                   }

--- a/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_02.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_02.json
@@ -6,6 +6,7 @@
           "must":{
             "regexp":{
               "tag.bat@foo":{
+                "flags":"NONE",
                 "value":"spo.*"
               }
             }
@@ -17,6 +18,7 @@
           "must":{
             "regexp":{
               "process.tag.bat@foo":{
+                "flags":"NONE",
                 "value":"spo.*"
               }
             }
@@ -39,6 +41,7 @@
                 {
                   "regexp":{
                     "tags.value":{
+                      "flags":"NONE",
                       "value":"spo.*"
                     }
                   }
@@ -64,6 +67,7 @@
                 {
                   "regexp":{
                     "process.tags.value":{
+                      "flags":"NONE",
                       "value":"spo.*"
                     }
                   }
@@ -89,6 +93,7 @@
                 {
                   "regexp":{
                     "logs.fields.value":{
+                      "flags":"NONE",
                       "value":"spo.*"
                     }
                   }

--- a/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_03.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/fixtures/query_03.json
@@ -6,6 +6,7 @@
           "must":{
             "regexp":{
               "tag.bat@foo":{
+                "flags":"NONE",
                 "value":"spo\\*"
               }
             }
@@ -17,6 +18,7 @@
           "must":{
             "regexp":{
               "process.tag.bat@foo":{
+                "flags":"NONE",
                 "value":"spo\\*"
               }
             }
@@ -39,6 +41,7 @@
                 {
                   "regexp":{
                     "tags.value":{
+                      "flags":"NONE",
                       "value":"spo\\*"
                     }
                   }
@@ -64,6 +67,7 @@
                 {
                   "regexp":{
                     "process.tags.value":{
+                      "flags":"NONE",
                       "value":"spo\\*"
                     }
                   }
@@ -89,6 +93,7 @@
                 {
                   "regexp":{
                     "logs.fields.value":{
+                      "flags":"NONE",
                       "value":"spo\\*"
                     }
                   }

--- a/internal/storage/v2/elasticsearch/tracestore/core/reader.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/reader.go
@@ -608,14 +608,14 @@ func (*SpanReader) buildNestedQuery(field string, k string, v string) esquery.Qu
 	keyField := fmt.Sprintf("%s.%s", field, tagKeyField)
 	valueField := fmt.Sprintf("%s.%s", field, tagValueField)
 	keyQuery := esquery.NewMatchQuery(keyField, k)
-	valueQuery := esquery.NewRegexpQuery(valueField, v)
+	valueQuery := esquery.NewRegexpQuery(valueField, v).Flags("NONE")
 	tagBoolQuery := esquery.NewBoolQuery().Must(keyQuery, valueQuery)
 	return esquery.NewNestedQuery(field, tagBoolQuery)
 }
 
 func (*SpanReader) buildObjectQuery(field string, k string, v string) esquery.Query {
 	keyField := fmt.Sprintf("%s.%s", field, k)
-	keyQuery := esquery.NewRegexpQuery(keyField, v)
+	keyQuery := esquery.NewRegexpQuery(keyField, v).Flags("NONE")
 	return esquery.NewBoolQuery().Must(keyQuery)
 }
 

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_ids.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_ids.json
@@ -71,6 +71,7 @@
                     "must": {
                       "regexp": {
                         "tag.httpstatus_code": {
+                          "flags": "NONE",
                           "value": "200"
                         }
                       }
@@ -82,6 +83,7 @@
                     "must": {
                       "regexp": {
                         "process.tag.httpstatus_code": {
+                          "flags": "NONE",
                           "value": "200"
                         }
                       }
@@ -104,6 +106,7 @@
                           {
                             "regexp": {
                               "tags.value": {
+                                "flags": "NONE",
                                 "value": "200"
                               }
                             }
@@ -129,6 +132,7 @@
                           {
                             "regexp": {
                               "process.tags.value": {
+                                "flags": "NONE",
                                 "value": "200"
                               }
                             }
@@ -154,6 +158,7 @@
                           {
                             "regexp": {
                               "logs.fields.value": {
+                                "flags": "NONE",
                                 "value": "200"
                               }
                             }

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_summaries.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/find_trace_summaries.json
@@ -22,6 +22,7 @@
                       "must": {
                         "regexp": {
                           "tag.error": {
+                            "flags": "NONE",
                             "value": "true"
                           }
                         }
@@ -33,6 +34,7 @@
                       "must": {
                         "regexp": {
                           "process.tag.error": {
+                            "flags": "NONE",
                             "value": "true"
                           }
                         }
@@ -55,6 +57,7 @@
                             {
                               "regexp": {
                                 "tags.value": {
+                                  "flags": "NONE",
                                   "value": "true"
                                 }
                               }
@@ -80,6 +83,7 @@
                             {
                               "regexp": {
                                 "process.tags.value": {
+                                  "flags": "NONE",
                                   "value": "true"
                                 }
                               }
@@ -105,6 +109,7 @@
                             {
                               "regexp": {
                                 "logs.fields.value": {
+                                  "flags": "NONE",
                                   "value": "true"
                                 }
                               }
@@ -177,6 +182,7 @@
                           "must": {
                             "regexp": {
                               "tag.error": {
+                                "flags": "NONE",
                                 "value": "true"
                               }
                             }
@@ -188,6 +194,7 @@
                           "must": {
                             "regexp": {
                               "process.tag.error": {
+                                "flags": "NONE",
                                 "value": "true"
                               }
                             }
@@ -210,6 +217,7 @@
                                 {
                                   "regexp": {
                                     "tags.value": {
+                                      "flags": "NONE",
                                       "value": "true"
                                     }
                                   }
@@ -235,6 +243,7 @@
                                 {
                                   "regexp": {
                                     "process.tags.value": {
+                                      "flags": "NONE",
                                       "value": "true"
                                     }
                                   }
@@ -260,6 +269,7 @@
                                 {
                                   "regexp": {
                                     "logs.fields.value": {
+                                      "flags": "NONE",
                                       "value": "true"
                                     }
                                   }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9387

## Description of the changes
- Added `.Flags("NONE")` to `esquery.NewRegexpQuery` calls in `reader.go` so tag search values don't trigger Lucene regex operators.

## How was this change tested?
- Ran `go test` in `internal/storage/v2/elasticsearch/tracestore/core`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes