### PR TITLE
fix(es): Support span.kind structured filters

### DIFF
--- a/internal/storage/v2/elasticsearch/tracestore/core/filter.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/filter.go
@@ -26,6 +26,14 @@ var eventNameAsAttribute = reference{
 	attribute: true,
 }
 
+// spanKindAsAttribute reads span.kind from the tag the write path creates for the OTLP span kind.
+// The read path promotes that tag back to the built-in field, so both spellings share one lowering.
+var spanKindAsAttribute = reference{
+	name:      model.SpanKindKey,
+	level:     expression.LevelSpan,
+	attribute: true,
+}
+
 // reference is what a lowering needs to know about a reference term: the level it names, the key or
 // field name under it, and whether it is an attribute. The AST has a distinct type per kind
 // (RFC 0005 §5.1); reading one into this shape once keeps every lowering below from switching on
@@ -289,6 +297,8 @@ func (s *SpanReader) buildComparison(
 	switch {
 	case ref.isField(expression.LevelSpan, expression.SpanFieldName):
 		return buildTextComparison(operationNameField, op, ref, text)
+	case ref.isField(expression.LevelSpan, expression.SpanFieldKind):
+		return s.buildAttributeComparison(op, spanKindAsAttribute, text)
 	case ref.isField(expression.LevelResource, expression.ResourceFieldService):
 		return buildTextComparison(serviceNameField, op, ref, text)
 	case ref.isField(expression.LevelEvent, expression.EventFieldName):
@@ -352,6 +362,8 @@ func (s *SpanReader) buildExists(ref reference) (esquery.Query, error) {
 		return s.buildAttributeExists(ref)
 	case ref.isField(expression.LevelSpan, expression.SpanFieldName):
 		return esquery.NewExistsQuery(operationNameField), nil
+	case ref.isField(expression.LevelSpan, expression.SpanFieldKind):
+		return s.buildAttributeExists(spanKindAsAttribute)
 	case ref.isField(expression.LevelResource, expression.ResourceFieldService):
 		return esquery.NewExistsQuery(serviceNameField), nil
 	case ref.isField(expression.LevelSpan, expression.SpanFieldDuration):

--- a/internal/storage/v2/elasticsearch/tracestore/core/filter_test.go
+++ b/internal/storage/v2/elasticsearch/tracestore/core/filter_test.go
@@ -108,6 +108,10 @@ func TestBuildFilterQuery(t *testing.T) {
 			filter: p.Span().Name.Eq("/api/v3/traces"),
 		},
 		{
+			name:   "span.kind reads the attribute the write path stores",
+			filter: p.Span().Kind.Eq(p.Text("server")),
+		},
+		{
 			name:   "resource.service is the service name",
 			filter: p.Resource().Service.Eq("cart"),
 		},
@@ -158,6 +162,10 @@ func TestBuildFilterQuery(t *testing.T) {
 			filter: p.Span().Attr("http.route").Matches("/api/.*"),
 		},
 		{
+			name:   "regex on span.kind reads the stored attribute",
+			filter: p.Span().Kind.Matches("serv.*"),
+		},
+		{
 			name:   "an escaped punctuation character, which both dialects read the same way",
 			filter: p.Span().Attr("http.route").Matches(`/cart\.json`),
 		},
@@ -188,6 +196,10 @@ func TestBuildFilterQuery(t *testing.T) {
 		{
 			name:   "exists on the operation name",
 			filter: p.Span().Name.Exists(),
+		},
+		{
+			name:   "exists on span.kind reads the stored attribute",
+			filter: p.Span().Kind.Exists(),
 		},
 		{
 			name:   "exists on the service name",
@@ -235,6 +247,10 @@ func TestBuildFilterQuery(t *testing.T) {
 			filter: p.Resource().Service.Ne("cart"),
 		},
 		{
+			name:   "ne on span.kind requires the stored attribute to be present",
+			filter: p.Span().Kind.Ne("server"),
+		},
+		{
 			name:   "in is the disjunction of equalities it stands for",
 			filter: p.Resource().Service.In("cart", "checkout"),
 		},
@@ -245,6 +261,14 @@ func TestBuildFilterQuery(t *testing.T) {
 		{
 			name:   "not_in requires the reference to be present, like ne",
 			filter: p.Resource().Service.NotIn("cart", "checkout"),
+		},
+		{
+			name:   "membership on span.kind reads the stored attribute",
+			filter: p.Span().Kind.In("server", "client"),
+		},
+		{
+			name:   "not_in on span.kind requires the stored attribute to be present",
+			filter: p.Span().Kind.NotIn("server", "client"),
 		},
 		{
 			// The lowering is the disjunction of equalities the membership stands for, and each
@@ -379,9 +403,9 @@ func TestBuildFilterQueryRefused(t *testing.T) {
 		},
 		{
 			name:    "a built-in field this schema has no field for",
-			filter:  p.Span().Kind.Eq("server"),
+			filter:  p.Span().Status.Eq("ok"),
 			wantErr: tracestore.ErrFilterUnsupported,
-			wantMsg: `built-in field "kind" of the "span" level`,
+			wantMsg: `built-in field "status" of the "span" level`,
 		},
 		{
 			name:    "exists on a built-in field this schema has no field for",
@@ -400,6 +424,12 @@ func TestBuildFilterQueryRefused(t *testing.T) {
 			filter:  p.Span().Name.Lte("m"),
 			wantErr: tracestore.ErrFilterUnsupported,
 			wantMsg: `indexes "name" as a keyword rather than a number`,
+		},
+		{
+			name:    "ordering span.kind",
+			filter:  p.Span().Kind.Gt("server"),
+			wantErr: tracestore.ErrFilterUnsupported,
+			wantMsg: `indexes "span.kind" as a keyword rather than a number`,
 		},
 		{
 			name:    "a pattern over the duration, which is a number",
@@ -626,7 +656,7 @@ func TestFindTraceIDsRefusesUnservableFilter(t *testing.T) {
 		_, err := r.reader.FindTraceIDs(context.Background(), dbmodel.TraceQueryParameters{
 			StartTimeMin: now,
 			StartTimeMax: now.Add(time.Hour),
-			Filter:       p.Span().Kind.Eq("server"),
+			Filter:       p.Link().Attr("k").Eq("v"),
 		})
 		require.ErrorIs(t, err, tracestore.ErrFilterUnsupported)
 	})

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/exists_on_span_kind_reads_the_stored_attribute.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/exists_on_span_kind_reads_the_stored_attribute.json
@@ -1,0 +1,21 @@
+{
+  "bool": {
+    "should": [
+      {
+        "exists": {
+          "field": "tag.span@kind"
+        }
+      },
+      {
+        "nested": {
+          "path": "tags",
+          "query": {
+            "term": {
+              "tags.key": "span.kind"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/membership_on_span_kind_reads_the_stored_attribute.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/membership_on_span_kind_reads_the_stored_attribute.json
@@ -1,0 +1,70 @@
+{
+  "bool": {
+    "should": [
+      {
+        "bool": {
+          "should": [
+            {
+              "term": {
+                "tag.span@kind": "server"
+              }
+            },
+            {
+              "nested": {
+                "path": "tags",
+                "query": {
+                  "bool": {
+                    "must": [
+                      {
+                        "term": {
+                          "tags.key": "span.kind"
+                        }
+                      },
+                      {
+                        "term": {
+                          "tags.value": "server"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "bool": {
+          "should": [
+            {
+              "term": {
+                "tag.span@kind": "client"
+              }
+            },
+            {
+              "nested": {
+                "path": "tags",
+                "query": {
+                  "bool": {
+                    "must": [
+                      {
+                        "term": {
+                          "tags.key": "span.kind"
+                        }
+                      },
+                      {
+                        "term": {
+                          "tags.value": "client"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/ne_on_span_kind_requires_the_stored_attribute_to_be_present.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/ne_on_span_kind_requires_the_stored_attribute_to_be_present.json
@@ -1,0 +1,57 @@
+{
+  "bool": {
+    "must": {
+      "bool": {
+        "should": [
+          {
+            "exists": {
+              "field": "tag.span@kind"
+            }
+          },
+          {
+            "nested": {
+              "path": "tags",
+              "query": {
+                "term": {
+                  "tags.key": "span.kind"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "must_not": {
+      "bool": {
+        "should": [
+          {
+            "term": {
+              "tag.span@kind": "server"
+            }
+          },
+          {
+            "nested": {
+              "path": "tags",
+              "query": {
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "tags.key": "span.kind"
+                      }
+                    },
+                    {
+                      "term": {
+                        "tags.value": "server"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/not_in_on_span_kind_requires_the_stored_attribute_to_be_present.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/not_in_on_span_kind_requires_the_stored_attribute_to_be_present.json
@@ -1,0 +1,95 @@
+{
+  "bool": {
+    "must": {
+      "bool": {
+        "should": [
+          {
+            "exists": {
+              "field": "tag.span@kind"
+            }
+          },
+          {
+            "nested": {
+              "path": "tags",
+              "query": {
+                "term": {
+                  "tags.key": "span.kind"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "must_not": {
+      "bool": {
+        "should": [
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "tag.span@kind": "server"
+                  }
+                },
+                {
+                  "nested": {
+                    "path": "tags",
+                    "query": {
+                      "bool": {
+                        "must": [
+                          {
+                            "term": {
+                              "tags.key": "span.kind"
+                            }
+                          },
+                          {
+                            "term": {
+                              "tags.value": "server"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "bool": {
+              "should": [
+                {
+                  "term": {
+                    "tag.span@kind": "client"
+                  }
+                },
+                {
+                  "nested": {
+                    "path": "tags",
+                    "query": {
+                      "bool": {
+                        "must": [
+                          {
+                            "term": {
+                              "tags.key": "span.kind"
+                            }
+                          },
+                          {
+                            "term": {
+                              "tags.value": "client"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/regex_on_span_kind_reads_the_stored_attribute.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/regex_on_span_kind_reads_the_stored_attribute.json
@@ -1,0 +1,38 @@
+{
+  "bool": {
+    "should": [
+      {
+        "regexp": {
+          "tag.span@kind": {
+            "flags": "NONE",
+            "value": ".*(serv.*).*"
+          }
+        }
+      },
+      {
+        "nested": {
+          "path": "tags",
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "term": {
+                    "tags.key": "span.kind"
+                  }
+                },
+                {
+                  "regexp": {
+                    "tags.value": {
+                      "flags": "NONE",
+                      "value": ".*(serv.*).*"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/span_kind_reads_the_attribute_the_write_path_stores.json
+++ b/internal/storage/v2/elasticsearch/tracestore/core/testdata/filter/span_kind_reads_the_attribute_the_write_path_stores.json
@@ -1,0 +1,32 @@
+{
+  "bool": {
+    "should": [
+      {
+        "term": {
+          "tag.span@kind": "server"
+        }
+      },
+      {
+        "nested": {
+          "path": "tags",
+          "query": {
+            "bool": {
+              "must": [
+                {
+                  "term": {
+                    "tags.key": "span.kind"
+                  }
+                },
+                {
+                  "term": {
+                    "tags.value": "server"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #9473.

* Map the built-in `span.kind` field to the tag written by the ES/OS storage path.
* Support equality, membership, existence, and regex filters for `span.kind`.
* Keep ordered comparisons unsupported because span kinds have no ordering.

## Test plan

* `make fmt`
* `make lint`
* `make test`
