### PR TITLE
Align search_traces with_errors description with span-scoped behavior

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -176,8 +176,9 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	// The error filter is expressed as a span attribute because the span-level
 	// criteria (service name, span name, attributes) are conjunctive on a single
 	// span: only traces whose matching span has error status are returned, not
-	// traces with errors anywhere. Trace-level filters (time window, duration)
-	// still apply to the trace as a whole.
+	// traces with errors anywhere. Only the criteria actually provided apply.
+	// Trace-level filters (time window, duration) still apply to the trace as
+	// a whole.
 	if input.WithErrors {
 		attributes.PutStr("error", "true")
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -173,9 +173,11 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	for key, value := range input.Attributes {
 		attributes.PutStr(key, value)
 	}
-	// The error filter is expressed as a span attribute because storage backends
-	// apply all search criteria to a single span: only traces whose matching span
-	// has error status are returned, not traces with errors anywhere.
+	// The error filter is expressed as a span attribute because the span-level
+	// criteria (service name, span name, attributes) are conjunctive on a single
+	// span: only traces whose matching span has error status are returned, not
+	// traces with errors anywhere. Trace-level filters (time window, duration)
+	// still apply to the trace as a whole.
 	if input.WithErrors {
 		attributes.PutStr("error", "true")
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -173,6 +173,9 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	for key, value := range input.Attributes {
 		attributes.PutStr(key, value)
 	}
+	// The error filter is expressed as a span attribute because storage backends
+	// apply all search criteria to a single span: only traces whose matching span
+	// has error status are returned, not traces with errors anywhere.
 	if input.WithErrors {
 		attributes.PutStr("error", "true")
 	}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
@@ -24,8 +24,12 @@ type SearchTracesInput struct {
 	// Example: {"http.status_code": "500", "user.id": "12345"}
 	Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
 
-	// WithErrors filters to only return traces containing error spans (optional).
-	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true only return traces containing error spans"`
+	// WithErrors filters to traces whose matching span has error status (optional).
+	// Storage backends apply all search criteria to a single span, so the error
+	// status must be on the same span that matches the other criteria (service
+	// name, span name, attributes); errors on other spans of the trace do not
+	// match. Use HasErrors in the output to check for errors anywhere in a trace.
+	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true, only return traces where the span matching the other criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match. Use has_errors in the output to check whether a trace contains any error span"`
 
 	// DurationMin is the minimum duration filter (optional, e.g., "2s", "100ms").
 	DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
@@ -25,10 +25,12 @@ type SearchTracesInput struct {
 	Attributes map[string]string `json:"attributes,omitempty" jsonschema:"Key-value pairs to match against span/resource attributes"`
 
 	// WithErrors filters to traces whose matching span has error status (optional).
-	// Storage backends apply all search criteria to a single span, so the error
-	// status must be on the same span that matches the other criteria (service
-	// name, span name, attributes); errors on other spans of the trace do not
-	// match. Use HasErrors in the output to check for errors anywhere in a trace.
+	// The span-level criteria (service name, span name, attributes — including
+	// this error filter) are conjunctive on a single span, so the error status
+	// must be on the same span that matches the other span-level criteria;
+	// errors on other spans of the trace do not match. Trace-level filters
+	// (time window, duration) still apply to the trace as a whole. Use
+	// HasErrors in the output to check for errors anywhere in a trace.
 	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true, only return traces where the span matching the other criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match. Use has_errors in the output to check whether a trace contains any error span"`
 
 	// DurationMin is the minimum duration filter (optional, e.g., "2s", "100ms").

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types/search_traces.go
@@ -27,11 +27,11 @@ type SearchTracesInput struct {
 	// WithErrors filters to traces whose matching span has error status (optional).
 	// The span-level criteria (service name, span name, attributes — including
 	// this error filter) are conjunctive on a single span, so the error status
-	// must be on the same span that matches the other span-level criteria;
-	// errors on other spans of the trace do not match. Trace-level filters
-	// (time window, duration) still apply to the trace as a whole. Use
+	// must be on the same span that matches the other provided span-level
+	// criteria; errors on other spans of the trace do not match. Trace-level
+	// filters (time window, duration) still apply to the trace as a whole. Use
 	// HasErrors in the output to check for errors anywhere in a trace.
-	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true, only return traces where the span matching the other criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match. Use has_errors in the output to check whether a trace contains any error span"`
+	WithErrors bool `json:"with_errors,omitempty" jsonschema:"If true, only return traces where the span matching the other provided criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match. Use has_errors in the output to check whether a trace contains any error span"`
 
 	// DurationMin is the minimum duration filter (optional, e.g., "2s", "100ms").
 	DurationMin string `json:"duration_min,omitempty" jsonschema:"Minimum duration filter (e.g. 2s 100ms)"`

--- a/docs/rfc/0012-mcp-server-extension.md
+++ b/docs/rfc/0012-mcp-server-extension.md
@@ -94,7 +94,7 @@ tools:
       service_name: string (required) - Filter by service name. Use get_services to discover valid names.
       span_name: string (optional) - Filter by span name. Use get_span_names to discover valid names.
       attributes: object (optional) - Key-value pairs to match against span/resource attributes (e.g., {"http.status_code": "500"})
-      with_errors: boolean (optional) - If true, only return traces where the span matching the other provided criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match; use has_errors in the output to check whether a trace contains any error span
+      with_errors: boolean (optional) - If true, only return traces containing error spans
       duration_min: duration string (optional, e.g., "2s", "100ms")
       duration_max: duration string (optional)
       search_depth: integer (optional, default: 10, max: server-configured via MaxSearchResults) - Maximum search depth. Depending on the storage backend, this may behave like a limit, but it is not guaranteed to be an exact SQL-style LIMIT.
@@ -165,7 +165,7 @@ Find traces matching criteria. Returns lightweight metadata only (no attributes/
     "http.status_code": "500",
     "user.id": "12345"
   },
-  "with_errors": true,               // optional: matching span must have error status
+  "with_errors": true,               // optional: filter to error traces
   "duration_min": "2s",              // optional
   "duration_max": "10s",             // optional
   "search_depth": 10                 // optional: default 10, max server-configured MaxSearchResults

--- a/docs/rfc/0012-mcp-server-extension.md
+++ b/docs/rfc/0012-mcp-server-extension.md
@@ -94,7 +94,7 @@ tools:
       service_name: string (required) - Filter by service name. Use get_services to discover valid names.
       span_name: string (optional) - Filter by span name. Use get_span_names to discover valid names.
       attributes: object (optional) - Key-value pairs to match against span/resource attributes (e.g., {"http.status_code": "500"})
-      with_errors: boolean (optional) - If true, only return traces containing error spans
+      with_errors: boolean (optional) - If true, only return traces where the span matching the other criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match; use has_errors in the output to check whether a trace contains any error span
       duration_min: duration string (optional, e.g., "2s", "100ms")
       duration_max: duration string (optional)
       search_depth: integer (optional, default: 10, max: server-configured via MaxSearchResults) - Maximum search depth. Depending on the storage backend, this may behave like a limit, but it is not guaranteed to be an exact SQL-style LIMIT.
@@ -165,7 +165,7 @@ Find traces matching criteria. Returns lightweight metadata only (no attributes/
     "http.status_code": "500",
     "user.id": "12345"
   },
-  "with_errors": true,               // optional: filter to error traces
+  "with_errors": true,               // optional: matching span must have error status
   "duration_min": "2s",              // optional
   "duration_max": "10s",             // optional
   "search_depth": 10                 // optional: default 10, max server-configured MaxSearchResults

--- a/docs/rfc/0012-mcp-server-extension.md
+++ b/docs/rfc/0012-mcp-server-extension.md
@@ -94,7 +94,7 @@ tools:
       service_name: string (required) - Filter by service name. Use get_services to discover valid names.
       span_name: string (optional) - Filter by span name. Use get_span_names to discover valid names.
       attributes: object (optional) - Key-value pairs to match against span/resource attributes (e.g., {"http.status_code": "500"})
-      with_errors: boolean (optional) - If true, only return traces where the span matching the other criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match; use has_errors in the output to check whether a trace contains any error span
+      with_errors: boolean (optional) - If true, only return traces where the span matching the other provided criteria (service name, span name, attributes) has error status. Errors on other spans of the trace do not match; use has_errors in the output to check whether a trace contains any error span
       duration_min: duration string (optional, e.g., "2s", "100ms")
       duration_max: duration string (optional)
       search_depth: integer (optional, default: 10, max: server-configured via MaxSearchResults) - Maximum search depth. Depending on the storage backend, this may behave like a limit, but it is not guaranteed to be an exact SQL-style LIMIT.


### PR DESCRIPTION
## Which problem is this PR addressing?

The `search_traces` MCP tool describes `with_errors` as trace-scoped ("only return traces containing error spans"), but the implementation adds `error=true` to the span attribute filter. Storage backends apply all search criteria to a single span, so the parameter actually means "the error status must be on the same span that matches service_name, span_name and attributes." When errors are on a downstream service's spans, the query returns empty, which an LLM agent cannot distinguish from "this service has no errors." This is exactly the mismatch reported in #9334, including the captured HotROD session where `service_name: driver` + `with_errors: true` returned `{}` while the same query without the flag returned traces with `has_errors: true`.

The output side is trace-scoped (`has_errors` counts error spans across the whole trace), while the input filter is span-scoped. Making the filter genuinely trace-scoped would be a cross-backend semantics decision; the issue proposes the low-risk fix of aligning the description with the behavior, which is what this PR does:

- Reword the `with_errors` jsonschema description and doc comment in `SearchTracesInput` to state the span-scoped semantics and point at `has_errors` in the output for trace-scoped error presence.
- Add a comment at the handler explaining why the filter is expressed as a span attribute.
- Update the matching wording in `docs/rfc/0012-mcp-server-extension.md` (input schema and example).

No behavior change.

Resolves #9334

## How was this change tested?

- `go build ./cmd/jaeger/internal/extension/jaegerquery/...`
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/...` — handlers and types packages pass. (`TestOpenCustomSkillsDir_ServesDirectoryContents` fails only during Windows temp-dir cleanup with a file-lock error; it fails identically on unmodified `main` and is unrelated.)

## AI usage declaration

AI tools were used to help draft the wording of this change. I read and verified every change, ran the tests above, and take responsibility for the content per the project's AI usage policy.
