### PR TITLE
test(integration): Initialize Attributes and SearchDepth in the unexpected-services diagnostic

### DIFF
--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -213,10 +213,16 @@ func (s *StorageIntegration) testGetServices(t *testing.T) {
 			// If the storage backend returns more services than expected, let's log traces for those
 			t.Log("🛑 Found unexpected services!")
 			for _, service := range actual {
+				// Attributes and SearchDepth are not optional: readers dereference the map
+				// before anything else, where a zero value panics, and the memory store
+				// rejects a non-positive depth. 100 is what Cassandra and Elasticsearch
+				// default to when the field is unset, and it exceeds the whole corpus.
 				iterTraces := s.TraceReader.FindTraces(context.Background(), tracestore.TraceQueryParams{
 					ServiceName:  service,
+					Attributes:   pcommon.NewMap(),
 					StartTimeMin: time.Now().Add(-2 * time.Hour),
 					StartTimeMax: time.Now(),
+					SearchDepth:  100,
 				})
 				for traces, err := range iterTraces {
 					if err != nil {

--- a/internal/storage/integration/integration_test.go
+++ b/internal/storage/integration/integration_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore"
+	tracestoremocks "github.com/jaegertracing/jaeger/internal/storage/v2/api/tracestore/mocks"
+	"github.com/jaegertracing/jaeger/internal/telemetry/otelsemconv"
+)
+
+// maxSearchDepth is the tightest ceiling the suite's backends put on SearchDepth: the memory
+// store refuses a depth above its MaxTraces, which every memory-backed harness sets to 10000,
+// and ClickHouse refuses one above its own MaxSearchDepth, which defaults to the same number.
+const maxSearchDepth = 10_000
+
+// TestGetServicesUnexpectedServiceDiagnostic drives testGetServices into the branch that only
+// runs when the backend reports more services than the corpus wrote, which is where the
+// diagnostic search lives. That search is a Reader call like any other, so it owes the Reader
+// contract: Attributes initialized with pcommon.NewMap(), because readers dereference it before
+// they do anything else, and an explicit SearchDepth, because the memory store rejects a
+// non-positive one and so never reached the dereference that panicked elsewhere.
+func TestGetServicesUnexpectedServiceDiagnostic(t *testing.T) {
+	const (
+		corpusService     = "corpus-service"
+		unexpectedService = "unexpected-service"
+	)
+
+	trace := ptrace.NewTraces()
+	resource := trace.ResourceSpans().AppendEmpty()
+	resource.Resource().Attributes().PutStr(otelsemconv.ServiceNameKey, corpusService)
+	resource.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+
+	reader := new(tracestoremocks.Reader)
+	// The first read reports a service the corpus never wrote, which is the only way into the
+	// diagnostic; every later read agrees with the corpus so the assertion settles immediately
+	// instead of spending the full waitForCondition budget.
+	reader.EXPECT().GetServices(mock.Anything).
+		Return([]string{corpusService, unexpectedService}, nil).Once()
+	reader.EXPECT().GetServices(mock.Anything).
+		Return([]string{corpusService}, nil)
+
+	var queries []tracestore.TraceQueryParams
+	reader.EXPECT().FindTraces(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, query tracestore.TraceQueryParams) iter.Seq2[[]ptrace.Traces, error] {
+			// Reading Attributes is the first thing the Cassandra and Elasticsearch readers do
+			// with a query, and a zero-value pcommon.Map panics there rather than reading as
+			// empty, so this stands in for them.
+			require.Equal(t, 0, query.Attributes.Len())
+			queries = append(queries, query)
+			return func(func([]ptrace.Traces, error) bool) {}
+		},
+	)
+
+	s := &StorageIntegration{
+		TraceReader: reader,
+		Corpus:      &Corpus{Example: trace},
+	}
+	s.testGetServices(t)
+
+	require.Len(t, queries, 2, "the diagnostic searches once per reported service")
+	for _, query := range queries {
+		assert.Positive(t, query.SearchDepth, "the memory store rejects a non-positive search depth")
+		assert.LessOrEqual(t, query.SearchDepth, maxSearchDepth, "the search depth must stay under every backend's ceiling")
+	}
+	assert.Equal(t, []string{corpusService, unexpectedService},
+		[]string{queries[0].ServiceName, queries[1].ServiceName})
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9485 
- The unexpected-services diagnostic in `testGetServices` panics instead of logging, and the panic takes the rest of the suite down with it.

## Description of the changes
- `testGetServices` logs the traces behind each unexpected service when a backend reports more services than the corpus wrote. The query it builds leaves `Attributes` at its zero value, which readers dereference before doing anything else, so the branch panics instead of logging.
- Initializes `Attributes` with `pcommon.NewMap()` and sets an explicit `SearchDepth`. Both are needed: the memory store rejects a non-positive depth at `internal/storage/v2/memory/tenant.go:125` before it reads attributes, so setting only `SearchDepth` would turn a silent no-op there into a panic.
- `SearchDepth: 100` is what Cassandra (`spanstore/reader.go:58`) and Elasticsearch (`tracestore/core/reader.go:49`) already substitute when the field is unset, and what the harness uses for its own broad searches (`filters.go:40`). It stays well inside the tightest ceiling in play, a `MaxTraces` and `MaxSearchDepth` of 10000.
- Test code only. This was the last construction of `TraceQueryParams` in the repo leaving `Attributes` uninitialized, and no production entry point can build one.

## How was this change tested?
- Added `TestGetServicesUnexpectedServiceDiagnostic`, which enters the branch by having `GetServices` over-report once. It panics at `pcommon.Map.Len` without this change and passes with it.
- `make lint` reports 0 issues and `make test` passes with no failures.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)