### PR TITLE
docs(maintainers): Update jkowall and yurishkuro employer affiliations

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,11 +3,11 @@ The current Maintainers Group for the Jaeger Project consists of:
 | Name | Employer | Responsibilities |
 | ---- | -------- | ---------------- |
 | [@albertteoh](https://github.com/albertteoh) | PackSmith | ALL |
-| [@jkowall](https://github.com/jkowall) | Paessler | ALL |
+| [@jkowall](https://github.com/jkowall) | Spacelift | ALL |
 | [@joe-elliott](https://github.com/joe-elliott) | Grafana Labs | ALL |
 | [@mahadzaryab1](https://github.com/mahadzaryab1) | Bloomberg | ALL |
 | [@pavolloffay](https://github.com/pavolloffay) | RedHat | ALL |
-| [@yurishkuro](https://github.com/yurishkuro) | Meta | ALL |
+| [@yurishkuro](https://github.com/yurishkuro) | Airbnb | ALL |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 


### PR DESCRIPTION
## Summary
- Update Jonah Kowall (`@jkowall`) employer from Paessler to Spacelift
- Update Yuri Shkuro (`@yurishkuro`) employer from Meta to Airbnb

Keeps `MAINTAINERS.md` aligned ahead of the matching CNCF `project-maintainers.csv` update.

cc @yurishkuro