### PR TITLE
fix(ai-sidecar): join ACP prompt blocks with delimiter to prevent token fusion

### DIFF
--- a/scripts/ai-sidecar/gemini/sidecar.py
+++ b/scripts/ai-sidecar/gemini/sidecar.py
@@ -23,6 +23,7 @@ from sidecar_config import SidecarConfig
 from sidecar_helpers import (
     _build_gemini_contextual_tool,
     _extract_contextual_tools,
+    _extract_prompt_text,
     _to_tool_text,
     _truncate_for_span,
     _validate_function_call,
@@ -410,10 +411,7 @@ class JaegerSidecarAgent(Agent):
             logger.info("Received prompt request for session %s", session_id)
 
             # Extract text from prompt blocks
-            user_text = ""
-            for block in prompt:
-                if hasattr(block, "text"):
-                    user_text += block.text
+            user_text = _extract_prompt_text(prompt)
 
             try:
                 conn = self._require_conn()

--- a/scripts/ai-sidecar/gemini/sidecar_helpers.py
+++ b/scripts/ai-sidecar/gemini/sidecar_helpers.py
@@ -142,3 +142,18 @@ def _extract_function_declaration(tool: Any) -> types.FunctionDeclaration | None
         return cast(types.FunctionDeclaration, private_get_declaration())
 
     return None
+
+
+def _extract_prompt_text(prompt: list[Any]) -> str:
+    """Extract and combine text from ACP prompt content blocks.
+
+    Separates discrete content blocks (e.g. user prompt and contextual metadata
+    entries such as active trace IDs or service names) with blank lines to
+    prevent words and hex identifiers from fusing across block boundaries.
+    """
+    return "\n\n".join(
+        stripped
+        for block in prompt
+        if isinstance(text := getattr(block, "text", None), str)
+        and (stripped := text.strip())
+    )

--- a/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
+++ b/scripts/ai-sidecar/gemini/test_sidecar_workflow.py
@@ -21,6 +21,7 @@ from acp.helpers import text_block, update_agent_message
 
 import sidecar
 from sidecar_config import SidecarConfig
+from sidecar_helpers import _extract_prompt_text
 
 END_OF_TURN_MARKER = "__END_OF_TURN__"
 DEFAULT_PROMPT = "hello"
@@ -106,7 +107,7 @@ class FakeAgent(Agent):
         return ListSessionsResponse(sessions=[])
 
     async def prompt(self, prompt: list[Any], session_id: str, message_id: str | None = None, **kwargs: Any) -> PromptResponse:
-        user_text = "".join(block.text for block in prompt if hasattr(block, "text"))
+        user_text = _extract_prompt_text(prompt)
         self.received_prompts.append((session_id, user_text))
 
         assert self._conn is not None
@@ -167,10 +168,23 @@ async def send_request(
         raise
 
 
-async def run_workflow_test(prompt: str, cwd: str) -> None:
+async def run_workflow_test(
+    prompt: str | list[dict[str, Any]],
+    cwd: str,
+    expected_user_text: str | None = None,
+) -> None:
     pending = PendingRequests()
     received_messages: list[dict[str, Any]] = []
     stop_event = asyncio.Event()
+
+    if isinstance(prompt, str):
+        prompt_blocks = [{"type": "text", "text": prompt}]
+        expected_text = expected_user_text if expected_user_text is not None else prompt
+    else:
+        prompt_blocks = prompt
+        if expected_user_text is None:
+            raise ValueError("expected_user_text is required when prompt is a list of blocks")
+        expected_text = expected_user_text
 
     async with websockets.serve(partial(sidecar.handle_websocket, agent_factory=FakeAgent), "127.0.0.1", 0) as server:
         port = next(iter(server.sockets)).getsockname()[1]
@@ -221,12 +235,7 @@ async def run_workflow_test(prompt: str, cwd: str) -> None:
                     "session/prompt",
                     {
                         "sessionId": session_id,
-                        "prompt": [
-                            {
-                                "type": "text",
-                                "text": prompt,
-                            }
-                        ],
+                        "prompt": prompt_blocks,
                     },
                 )
                 prompt_result = prompt_response.get("result", prompt_response)
@@ -240,12 +249,78 @@ async def run_workflow_test(prompt: str, cwd: str) -> None:
 
     fake_agent = FakeAgent.last_instance
     assert fake_agent is not None
-    assert fake_agent.received_prompts == [(session_id, prompt)]
+    assert fake_agent.received_prompts == [(session_id, expected_text)]
     assert any(END_OF_TURN_MARKER in json.dumps(message) for message in received_messages)
     assert any("echo: " in json.dumps(message) for message in received_messages)
 
+
 def test_complete_acp_workflow_with_fake_agent() -> None:
     asyncio.run(run_workflow_test(DEFAULT_PROMPT, DEFAULT_CWD))
+
+
+def test_complete_acp_workflow_multi_block_prompt() -> None:
+    # Regression test: verify ACP prompt content blocks (user prompt + telemetry context)
+    # are separated with paragraph delimiters over the complete WS wire.
+    prompt_blocks = [
+        {"type": "text", "text": "Investigate latency in this trace"},
+        {"type": "text", "text": "Active Trace ID:\n4bc972776e103118"},
+        {"type": "text", "text": "Active Service:\nfrontend"},
+    ]
+    expected_text = (
+        "Investigate latency in this trace\n\n"
+        "Active Trace ID:\n4bc972776e103118\n\n"
+        "Active Service:\nfrontend"
+    )
+    asyncio.run(run_workflow_test(prompt_blocks, DEFAULT_CWD, expected_user_text=expected_text))
+
+
+def test_extract_prompt_text_empty_list() -> None:
+    assert _extract_prompt_text([]) == ""
+
+
+def test_extract_prompt_text_single_block() -> None:
+    assert _extract_prompt_text([type("Block", (), {"text": "hello world"})()]) == "hello world"
+
+
+def test_extract_prompt_text_multi_block_prevents_identifier_fusion() -> None:
+    prompt = [
+        type("Block", (), {"text": "Investigate latency in this trace"})(),
+        type("Block", (), {"text": "Active Trace ID:\n4bc972776e103118"})(),
+        type("Block", (), {"text": "Active Service:\nfrontend"})(),
+    ]
+    result = _extract_prompt_text(prompt)
+    expected = (
+        "Investigate latency in this trace\n\n"
+        "Active Trace ID:\n4bc972776e103118\n\n"
+        "Active Service:\nfrontend"
+    )
+    assert result == expected
+    assert "traceActive" not in result
+    assert "4bc972776e103118Active" not in result
+
+
+def test_extract_prompt_text_skips_empty_and_whitespace_blocks() -> None:
+    prompt = [
+        type("Block", (), {"text": "First"})(),
+        type("Block", (), {"text": ""})(),
+        type("Block", (), {"text": "   \n\t  "})(),
+        type("Block", (), {"text": "Second"})(),
+    ]
+    assert _extract_prompt_text(prompt) == "First\n\nSecond"
+
+
+def test_extract_prompt_text_skips_non_text_and_invalid_blocks() -> None:
+    class ImageBlock:
+        pass
+
+    prompt = [
+        type("Block", (), {"text": "Text prompt"})(),
+        ImageBlock(),
+        type("Block", (), {"text": 12345})(),  # Non-string .text
+        type("Block", (), {"text": "Final text"})(),
+    ]
+    assert _extract_prompt_text(prompt) == "Text prompt\n\nFinal text"
+
 
 
 class FakeConn:


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9510

When the Gemini sidecar receives multiple ACP prompt content blocks (user query + context entries like active trace ID and service name), it concatenated them with `user_text += block.text` without any delimiter, fusing words (`"traceActive"`) and corrupting hex trace IDs (`"4bc972776e103118Active"`). This caused MCP tool calls like `get_span_details` to fail hex decoding and abort.

## Description of the changes
- Added `_extract_prompt_text(prompt: list[Any]) -> str` in `sidecar_helpers.py` — trims outer whitespace, joins non-empty blocks with `\n\n`
- Updated `JaegerSidecarAgent.prompt()` in `sidecar.py` to use `_extract_prompt_text`
- Updated `FakeAgent.prompt` in `test_sidecar_workflow.py` to mirror production behavior
- Generalized `run_workflow_test` to accept multi-block payloads
- Added `test_complete_acp_workflow_multi_block_prompt` (end-to-end WebSocket)
- Added unit tests covering empty list, single block, fusion prevention, whitespace skipping, non-text blocks

## How was this change tested?
- `uv run pytest -v` — 15/15 passed
- `uv run pyright` — 0 errors, 0 warnings
- `make fmt && make lint-license lint-line-endings` — clean

## Checklist
- [x] I have read CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage
- [x] **Moderate**: AI helped with debugging and code generation for specific parts