### PR TITLE
fix(query): sort api_v3 GetDependencies links by parent then child

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler.go
@@ -4,10 +4,12 @@
 package apiv3
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"google.golang.org/grpc/codes"
@@ -221,6 +223,12 @@ func (h *Handler) GetDependencies(ctx context.Context, request *api_v3.GetDepend
 	if err != nil {
 		return nil, err
 	}
+	slices.SortFunc(deps, func(a, b model.DependencyLink) int {
+		if c := cmp.Compare(a.Parent, b.Parent); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Child, b.Child)
+	})
 	links := make([]*api_v3.Dependency, len(deps))
 	for i, dep := range deps {
 		links[i] = &api_v3.Dependency{

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/grpc_handler_test.go
@@ -561,6 +561,39 @@ func TestGetDependencies(t *testing.T) {
 	assert.Equal(t, uint64(100), response.GetDependencies()[0].CallCount)
 }
 
+func TestGetDependencies_SortedByParentThenChild(t *testing.T) {
+	tsc := newTestServerClient(t)
+	endTime := time.Now().UTC()
+	lookback := 24 * time.Hour
+
+	// Deliberately out of order, and not orderable by insertion or by
+	// CallCount, so a passing assertion can only come from an actual sort.
+	unsortedDeps := []model.DependencyLink{
+		{Parent: "b", Child: "y", CallCount: 1, Source: "traces"},
+		{Parent: "a", Child: "z", CallCount: 2, Source: "traces"},
+		{Parent: "a", Child: "x", CallCount: 3, Source: "traces"},
+	}
+
+	tsc.depsReader.On("GetDependencies", matchContext, mock.MatchedBy(func(p depstore.QueryParameters) bool {
+		return p.EndTime.Equal(endTime) && p.StartTime.Equal(endTime.Add(-lookback))
+	})).Return(unsortedDeps, nil).Once()
+
+	response, err := tsc.client.GetDependencies(context.Background(), &api_v3.GetDependenciesRequest{
+		StartTime: endTime.Add(-lookback),
+		EndTime:   endTime,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.GetDependencies(), 3)
+
+	got := response.GetDependencies()
+	assert.Equal(t, "a", got[0].Parent)
+	assert.Equal(t, "x", got[0].Child)
+	assert.Equal(t, "a", got[1].Parent)
+	assert.Equal(t, "z", got[1].Child)
+	assert.Equal(t, "b", got[2].Parent)
+	assert.Equal(t, "y", got[2].Child)
+}
+
 func TestGetDependenciesStorageError(t *testing.T) {
 	tsc := newTestServerClient(t)
 	tsc.depsReader.On("GetDependencies", matchContext, mock.Anything).Return(


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9126

## Description of the changes
- `QueryService.GetDependencies` builds its result from a Go map, so `apiv3.Handler.GetDependencies` (the gRPC api_v3 path) returned the same set of dependency links in a different order on repeated identical calls.
- The legacy HTTP handler was already fixed the same way in #9119, and the MCP `get_service_dependencies` tool in #8403. This closes the third path the issue calls out as still unsorted.
- Sorts by `Parent` then `Child` with `slices.SortFunc`/`cmp.Compare`, the same comparator shape #9119 used for the legacy handler.

## How was this change tested?
- Added `TestGetDependencies_SortedByParentThenChild`, which feeds the mock storage layer three links in an order that isn't recoverable by insertion order or by `CallCount`, so it only passes if the handler actually sorts.
- Confirmed the new test fails without the fix (reverted the source change locally, re-ran — it failed with the expected mismatch) and passes with it.
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...` — all pass, including the pre-existing `TestGetDependencies`, `TestGetDependenciesStorageError`, and `TestHTTPGateway` snapshot tests in that package.
- `golangci-lint run ./cmd/jaeger/internal/extension/jaegerquery/internal/apiv3/...` — 0 issues.
- `gofmt -l` and `go vet` on both changed files — clean.
- I ran these scoped to the changed package rather than the full `make lint test`, since the change itself only touches this one file pair.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes