### PR TITLE
Add analyze-critical-path built-in skill

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/analyze_critical_path_skill_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/analyze_critical_path_skill_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/types"
+)
+
+// These tests follow the procedure written in skills/analyze-critical-path/SKILL.md
+// step by step against traces where the naive answer and the procedure's answer
+// differ, so they check what the skill concludes rather than only that it is
+// servable. The expected answers are derived from the span timestamps, not chosen
+// by hand.
+
+const skillTraceID = "00000000000000000000000000000001"
+
+// skillTraceBase anchors the fixtures at a real wall-clock time (2026-01-01T00:00:00Z).
+// Offsets in the assertions are relative to trace start, so the base does not
+// appear in them; it only keeps the spans off timestamp zero.
+const skillTraceBase = uint64(1_767_225_600_000)
+
+// cpSpan is one span of a hand-built trace, timed in milliseconds from trace start.
+type cpSpan struct {
+	id      byte
+	parent  byte // 0 means root
+	name    string
+	startMs uint64
+	endMs   uint64
+}
+
+func buildSkillTrace(spans []cpSpan) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "checkout")
+	ss := rs.ScopeSpans().AppendEmpty()
+	for _, s := range spans {
+		span := ss.Spans().AppendEmpty()
+		span.SetTraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+		span.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, s.id})
+		if s.parent != 0 {
+			span.SetParentSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, s.parent})
+		}
+		span.SetName(s.name)
+		span.SetStartTimestamp(pcommon.Timestamp((skillTraceBase + s.startMs) * 1_000_000))
+		span.SetEndTimestamp(pcommon.Timestamp((skillTraceBase + s.endMs) * 1_000_000))
+	}
+	return traces
+}
+
+func spanIDOf(id byte) string {
+	return pcommon.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, id}).String()
+}
+
+func criticalPathOf(t *testing.T, traces ptrace.Traces) types.GetCriticalPathOutput {
+	t.Helper()
+	h := &getCriticalPathHandler{queryService: &mockGetCriticalPathQueryService{traces: []ptrace.Traces{traces}}}
+	_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.GetCriticalPathInput{TraceID: skillTraceID})
+	require.NoError(t, err)
+	return out
+}
+
+func skillTopologyOf(t *testing.T, traces ptrace.Traces) types.GetTraceTopologyOutput {
+	t.Helper()
+	h := &getTraceTopologyHandler{queryService: newMockYieldingTraces(traces), maxSpanDetailsPerRequest: 100}
+	_, out, err := h.handle(context.Background(), &mcp.CallToolRequest{}, types.GetTraceTopologyInput{TraceID: skillTraceID})
+	require.NoError(t, err)
+	return out
+}
+
+// dominantSegment is step 2 of the skill: rank segments by self_time_us and take
+// the top one.
+func dominantSegment(out types.GetCriticalPathOutput) types.CriticalPathSegment {
+	var top types.CriticalPathSegment
+	for _, seg := range out.Segments {
+		if seg.SelfTimeUs > top.SelfTimeUs {
+			top = seg
+		}
+	}
+	return top
+}
+
+// hasDescendants is step 3 of the skill: does any other span list this span_id in
+// its ancestry path?
+func hasDescendants(topo types.GetTraceTopologyOutput, spanID string) bool {
+	for _, s := range topo.Spans {
+		if strings.Contains(s.Path, spanID+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// longestChild is the naive answer the skill exists to correct: blame the child
+// span with the longest duration.
+func longestChild(topo types.GetTraceTopologyOutput) types.TopologySpan {
+	var top types.TopologySpan
+	for _, s := range topo.Spans {
+		if strings.Contains(s.Path, "/") && s.DurationUs > top.DurationUs {
+			top = s
+		}
+	}
+	return top
+}
+
+func TestAnalyzeCriticalPathSkill_ParentGapBeatsLongestChild(t *testing.T) {
+	// Root runs 0-200ms. Child A (db.query) runs 10-60ms, child B (http.call)
+	// runs 150-190ms. Nothing is instrumented between 60ms and 150ms, so the
+	// critical path carries a 90ms root segment there, larger than either child.
+	// Naive answer: db.query, the longest child at 50ms. Procedure's answer: the
+	// root, classified as a parent scheduling or un-instrumented gap.
+	traces := buildSkillTrace([]cpSpan{
+		{id: 1, name: "POST /checkout", startMs: 0, endMs: 200},
+		{id: 2, parent: 1, name: "db.query", startMs: 10, endMs: 60},
+		{id: 3, parent: 1, name: "http.call", startMs: 150, endMs: 190},
+	})
+	cp := criticalPathOf(t, traces)
+	topo := skillTopologyOf(t, traces)
+
+	// Step 1: durations come straight from the timestamps.
+	assert.Equal(t, uint64(200_000), cp.TotalDurationUs)
+	assert.Equal(t, uint64(200_000), cp.CriticalPathDurationUs, "a single-service trace with serial children has no off-path time")
+
+	// Step 2: the dominant segment is the root's 60-150ms gap, 90ms, above the 30% threshold.
+	top := dominantSegment(cp)
+	assert.Equal(t, spanIDOf(1), top.SpanID)
+	assert.Equal(t, "POST /checkout", top.SpanName)
+	assert.Equal(t, uint64(90_000), top.SelfTimeUs)
+	assert.Equal(t, uint64(60_000), top.StartOffsetUs)
+	assert.Equal(t, uint64(150_000), top.EndOffsetUs)
+	assert.Greater(t, top.SelfTimeUs*100/cp.CriticalPathDurationUs, uint64(30))
+
+	// Step 3: the root has children listing it in their path, so this is a
+	// parent scheduling or un-instrumented gap, not a leaf bottleneck.
+	assert.True(t, hasDescendants(topo, top.SpanID))
+
+	// The naive answer differs, which is what makes the fixture worth having.
+	naive := longestChild(topo)
+	assert.Equal(t, "db.query", naive.SpanName)
+	assert.NotEqual(t, top.SpanName, naive.SpanName)
+}
+
+func TestAnalyzeCriticalPathSkill_LeafBottleneck(t *testing.T) {
+	// Root runs 0-100ms and its only child (db.query) runs 5-95ms with no
+	// children of its own. Naive answer: the root, because it has the longest
+	// duration. Procedure's answer: db.query, a 90ms leaf execution bottleneck.
+	traces := buildSkillTrace([]cpSpan{
+		{id: 1, name: "GET /orders", startMs: 0, endMs: 100},
+		{id: 2, parent: 1, name: "db.query", startMs: 5, endMs: 95},
+	})
+	cp := criticalPathOf(t, traces)
+	topo := skillTopologyOf(t, traces)
+
+	top := dominantSegment(cp)
+	assert.Equal(t, spanIDOf(2), top.SpanID)
+	assert.Equal(t, "db.query", top.SpanName)
+	assert.Equal(t, uint64(90_000), top.SelfTimeUs)
+	assert.Greater(t, top.SelfTimeUs*100/cp.CriticalPathDurationUs, uint64(30))
+
+	// No span lists db.query in its ancestry, so it is a leaf execution bottleneck.
+	assert.False(t, hasDescendants(topo, top.SpanID))
+
+	// The longest span by duration is the root, which the procedure does not blame.
+	var longest types.TopologySpan
+	for _, s := range topo.Spans {
+		if s.DurationUs > longest.DurationUs {
+			longest = s
+		}
+	}
+	assert.Equal(t, "GET /orders", longest.SpanName)
+	assert.NotEqual(t, top.SpanName, longest.SpanName)
+}
+
+func TestAnalyzeCriticalPathSkill_ParallelBranchOffPath(t *testing.T) {
+	// Gotcha "Parallel branches": child A (cache.get) runs 10-30ms and child B
+	// (db.query) runs 10-90ms concurrently. A finishes inside B's window, so it
+	// contributes nothing to the critical path even though it ran. The dominant
+	// segment is B, and A must not appear as a segment at all.
+	traces := buildSkillTrace([]cpSpan{
+		{id: 1, name: "GET /cart", startMs: 0, endMs: 100},
+		{id: 2, parent: 1, name: "cache.get", startMs: 10, endMs: 30},
+		{id: 3, parent: 1, name: "db.query", startMs: 10, endMs: 90},
+	})
+	cp := criticalPathOf(t, traces)
+
+	top := dominantSegment(cp)
+	assert.Equal(t, "db.query", top.SpanName)
+	assert.Equal(t, uint64(80_000), top.SelfTimeUs)
+	for _, seg := range cp.Segments {
+		assert.NotEqual(t, spanIDOf(2), seg.SpanID, "an off-path parallel branch must not be a critical path segment")
+	}
+}

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/server_test.go
@@ -85,6 +85,73 @@ func TestNewHandler_CallTool(t *testing.T) {
 	assert.Contains(t, text.Text, "svc-b")
 }
 
+// TestNewHandler_ReadBuiltinSkills exercises read_skill against the embedded
+// built-in skills catalog and individual sub-skills over the live MCP endpoint.
+func TestNewHandler_ReadBuiltinSkills(t *testing.T) {
+	svc := querysvc.NewQueryService(&tracestoremocks.Reader{}, &depstoremocks.Reader{}, querysvc.QueryServiceOptions{})
+	handler := NewHandler(telemetry.NoopSettings(), svc, tenancy.NewManager(&tenancy.Options{}), DefaultConfig())
+
+	session := connectTestClient(t, handler)
+	ctx := context.Background()
+
+	t.Run("root catalog lists all three built-in skills", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "read_skill",
+			Arguments: map[string]any{"path": "SKILL.md"},
+		})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		require.NotEmpty(t, res.Content)
+		text, ok := res.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, "analyze-critical-path")
+		assert.Contains(t, text.Text, "detect-n-plus-one")
+		assert.Contains(t, text.Text, "error-root-cause")
+	})
+
+	t.Run("analyze-critical-path is servable and valid", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "read_skill",
+			Arguments: map[string]any{"path": "analyze-critical-path/SKILL.md"},
+		})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		require.NotEmpty(t, res.Content)
+		text, ok := res.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, "name: analyze-critical-path")
+		assert.Contains(t, text.Text, "get_critical_path")
+		assert.Contains(t, text.Text, "self_time_us")
+		assert.Contains(t, text.Text, "get_trace_topology")
+	})
+
+	t.Run("detect-n-plus-one is servable", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "read_skill",
+			Arguments: map[string]any{"path": "detect-n-plus-one/SKILL.md"},
+		})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		require.NotEmpty(t, res.Content)
+		text, ok := res.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, "name: detect-n-plus-one")
+	})
+
+	t.Run("error-root-cause is servable", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "read_skill",
+			Arguments: map[string]any{"path": "error-root-cause/SKILL.md"},
+		})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		require.NotEmpty(t, res.Content)
+		text, ok := res.Content[0].(*mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, text.Text, "name: error-root-cause")
+	})
+}
+
 // TestNewServerDegradesWithoutMetrics covers the branch where the metrics
 // middleware fails to build: the server is still returned (metrics degraded)
 // rather than the construction failing.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills/SKILL.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills/SKILL.md
@@ -10,6 +10,11 @@ Read a sub-skill's SKILL.md before applying it.
 
 ## Available Skills
 
+- [analyze-critical-path](analyze-critical-path/SKILL.md) — Triage latency
+  bottlenecks by isolating execution time from scheduling or queue waits along
+  the critical path. Use when a trace is slow and no spans show errors, or when
+  the user asks what is slowing down a request.
+
 - [detect-n-plus-one](detect-n-plus-one/SKILL.md) — Detect N+1 query patterns where one
   parent operation triggers many near-identical child spans. Use when traces show repeated
   downstream calls or the user asks about chatty DB access.

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills/analyze-critical-path/SKILL.md
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/skills/analyze-critical-path/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: analyze-critical-path
+description: >-
+  Triage latency bottlenecks by isolating execution time from scheduling or
+  queue waits along the critical path. Use when a trace is slow and no spans
+  show errors, or when the user asks what is slowing down a request.
+license: Apache-2.0
+metadata:
+  author: jaegertracing
+  version: "1.0"
+allowed-tools: get_critical_path get_trace_topology get_span_details
+---
+
+# Analyze Critical Path
+
+## When this applies
+
+A trace is slower than expected without reporting errors, and the user wants to
+know which operations account for the elapsed wall-clock duration.
+
+## Procedure
+
+1. Call `get_critical_path` with parameter `trace_id`. Identify the total trace
+   duration (`total_duration_us`) and the critical path duration
+   (`critical_path_duration_us`).
+2. Rank the returned segments by descending `self_time_us`. Identify the dominant
+   bottleneck segment (any segment exceeding 30% of `critical_path_duration_us`,
+   or the top segment if duration is evenly distributed).
+3. Call `get_trace_topology` with parameter `trace_id` to inspect the structural
+   context of the bottleneck span:
+   - Match the bottleneck `span_id` against the `path` fields in the topology list.
+   - If no spans list this `span_id` in their ancestry path, classify it as a
+     leaf execution bottleneck (such as a database query or CPU compute loop).
+   - If other spans list this `span_id` as their parent in `path`, inspect the
+     time offsets. If a large gap precedes or separates child calls, classify it
+     as parent scheduling or un-instrumented processing wait.
+4. Call `get_span_details` with parameters `trace_id` and `span_ids: ["<bottleneck_span_id>"]`
+   to inspect attributes:
+   - For database spans, inspect `db.statement` or `db.system`.
+   - For RPC spans, inspect `rpc.service`, `rpc.method`, or `net.peer.name`.
+   - For messaging spans, inspect `messaging.operation` and queue attributes.
+5. Report:
+   - The bottleneck span ID, service name, and operation name.
+   - The self time in microseconds and its percentage of the critical path.
+   - Classification: leaf execution bottleneck versus parent scheduling gap.
+   - Concrete evidence from span attributes and recommended next diagnostic step.
+
+## Gotchas
+
+- Un-instrumented gaps: Gaps between sequential child calls are counted toward
+  the parent span's self time. If a parent span has high self time and multiple
+  children, verify whether a downstream dependency lacks tracing before blaming
+  the parent logic.
+- Parallel branches: Spans running concurrently off the critical path do not
+  constrain total trace duration, even if their individual durations are high.
+  Focus strictly on spans identified in the critical path segments.
+- Asynchronous dispatch: Producer or consumer spans linked via follow-from
+  references may record queue wait time that appears as latency; inspect
+  messaging attributes to distinguish wait time from active processing.


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9496. #8440 and #9135 name critical path latency triage as the third canonical skill next to `detect-n-plus-one` and `error-root-cause`, and `get_critical_path` has been registered for a while, but nothing in `skills/` tells an agent how to use it.

## Description of the changes
- Adds `skills/analyze-critical-path/SKILL.md`, written to `AUTHORING.md`: the index line names the symptom (a slow trace with no error spans) before the technique; every step names a measurement and what to do with each outcome; the last step says what to report.
- The procedure ranks critical path segments by `self_time_us`, then uses `get_trace_topology` to tell a leaf execution bottleneck from a parent whose self time is really an un-instrumented gap between children, which is the case the naive reading gets wrong.
- Gotchas cover the three places I have seen that reading fail: gaps counted as parent self time, parallel branches that ran long but never constrained the trace, and queue wait on follow-from spans.
- Links it from the root `SKILL.md` index, keeping the frontmatter `description` identical to the index line.

## How was this change tested?
- `TestNewHandler_ReadBuiltinSkills` reads the catalog and all three skills over the live MCP endpoint and checks the new one is served with its tool names intact.
- `TestAnalyzeCriticalPathSkill_*` follows the procedure step by step on hand-built traces where the naive answer and the procedure's answer differ, per the "test it against a real trace" section of `AUTHORING.md`: a root whose 90ms un-instrumented gap outweighs its 50ms longest child, a 90ms leaf under a 100ms root, and a parallel branch that must not appear on the path. Expected numbers are derived from the span timestamps.
- Field names in the skill were checked against `internal/types/get_critical_path.go` and `get_trace_topology.go` rather than the docs.
- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/...` passes; `make lint` clean.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [x] **Moderate**: AI helped with code generation or debugging specific parts
