### PR TITLE
fix(mcp): Respect search_depth when maxResults is unlimited (0)

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -165,7 +165,7 @@ func (h *searchTracesHandler) buildQuery(input types.SearchTracesInput) (querysv
 	if searchDepth <= 0 {
 		searchDepth = defaultSearchDepth
 	}
-	if searchDepth > h.maxResults {
+	if h.maxResults > 0 && searchDepth > h.maxResults {
 		searchDepth = h.maxResults
 	}
 

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -309,6 +309,31 @@ func TestSearchTracesHandler_Handle_SearchDepthMax(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSearchTracesHandler_Handle_SearchDepthUnlimitedMaxResults(t *testing.T) {
+	want := makeTraceSummary("test", "/test", false)
+
+	mock := &mockQueryService{
+		findTraceSummariesFunc: func(_ context.Context, query querysvc.TraceQueryParams) iter.Seq2[[]tracestore.TraceSummary, error] {
+			assert.Equal(t, 25, query.SearchDepth)
+			return func(yield func([]tracestore.TraceSummary, error) bool) {
+				yield([]tracestore.TraceSummary{want}, nil)
+			}
+		},
+	}
+
+	// maxResults == 0 means "no global cap", so an explicit search_depth must be preserved.
+	handler := &searchTracesHandler{queryService: mock, maxResults: 0}
+
+	input := types.SearchTracesInput{
+		StartTimeMin: "-1h",
+		ServiceName:  "test",
+		SearchDepth:  25,
+	}
+
+	_, _, err := handler.handle(context.Background(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+}
+
 func TestSearchTracesHandler_Handle_QueryError(t *testing.T) {
 	want := makeTraceSummary("test-service", "/api/test", false)
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9516 — when the MCP extension is configured with `maxResults: 0` ("unlimited"), an explicit `search_depth` passed to `search_traces` is silently discarded and replaced with `0` before the query reaches the storage backend. Because `0` is the storage layer's sentinel for "no limit", the backend performs an unbounded scan — the opposite of what the caller requested — with no error, warning, or log.

## Description of the changes

- Guarded the `search_depth` clamp in `buildQuery()` with `h.maxResults > 0`, so it only fires when a concrete global cap is configured. This mirrors the correct guard already present on line 70 of the same file.
- Added a regression test (`TestSearchTracesHandler_Handle_SearchDepthUnlimitedMaxResults`) asserting an explicit `search_depth` of 25 is preserved when `maxResults == 0`.

## How was this change tested?

```
go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/...
```

All tests pass, including the new regression test (which fails without the one-line fix).

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
