### PR TITLE
integration: initialize SearchDepth and Attributes in testGetServices diagnostic query (#9485)

### DIFF
--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -217,6 +217,8 @@ func (s *StorageIntegration) testGetServices(t *testing.T) {
 					ServiceName:  service,
 					StartTimeMin: time.Now().Add(-2 * time.Hour),
 					StartTimeMax: time.Now(),
+					SearchDepth:  100,
+					Attributes:   pcommon.NewMap(),
 				})
 				for traces, err := range iterTraces {
 					if err != nil {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9485

## Description of the changes
- Initialized `SearchDepth: 100` and `Attributes: pcommon.NewMap()` on `tracestore.TraceQueryParams` in `testGetServices` diagnostic query (`internal/storage/integration/integration.go`).
- Prevents `testGetServices` from panicking due to nil pointer dereference on uninitialized `Attributes` when logging unexpected storage services.

## How was this change tested?
- Ran `STORAGE=memory go test -v -run TestMemoryStorage ./internal/storage/integration`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully

## AI Usage in this PR
- [x] **Light**: AI provided minor assistance