### PR TITLE
fix(cassandra): use consistent float formatting in the tag index

### DIFF
--- a/internal/storage/v1/cassandra/spanstore/dbmodel/model.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/model.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 )
 
@@ -139,7 +141,9 @@ func (t *KeyValue) AsString() string {
 	case Int64Type:
 		return strconv.FormatInt(t.ValueInt64, 10)
 	case Float64Type:
-		return strconv.FormatFloat(t.ValueFloat64, 'g', 10, 64)
+		// SpanReader.queryByTagsAndLogs looks up tag_index with
+		// pcommon.Value.AsString(), so the index must be written the same way.
+		return pcommon.NewValueDouble(t.ValueFloat64).AsString()
 	case BinaryType:
 		return hex.EncodeToString(t.ValueBinary)
 	default:

--- a/internal/storage/v1/cassandra/spanstore/dbmodel/model_test.go
+++ b/internal/storage/v1/cassandra/spanstore/dbmodel/model_test.go
@@ -6,6 +6,7 @@ package dbmodel
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -330,6 +331,44 @@ func TestKeyValueAsString(t *testing.T) {
 				ValueFloat64: 12.34,
 			},
 			expect: "12.34",
+		},
+		{
+			// tag_index rows must be searchable, and SpanReader builds the query
+			// with pcommon.Value.AsString(), so these must be the same strings.
+			name: "Float64TypeMaxFloat64",
+			kv: KeyValue{
+				Key:          "k",
+				ValueType:    Float64Type,
+				ValueFloat64: math.MaxFloat64,
+			},
+			expect: "1.7976931348623157e+308",
+		},
+		{
+			name: "Float64TypeFullPrecision",
+			kv: KeyValue{
+				Key:          "k",
+				ValueType:    Float64Type,
+				ValueFloat64: 0.30000000000000004,
+			},
+			expect: "0.30000000000000004",
+		},
+		{
+			name: "Float64TypeLargeInteger",
+			kv: KeyValue{
+				Key:          "k",
+				ValueType:    Float64Type,
+				ValueFloat64: 1e20,
+			},
+			expect: "100000000000000000000",
+		},
+		{
+			name: "Float64TypeSmallMagnitude",
+			kv: KeyValue{
+				Key:          "k",
+				ValueType:    Float64Type,
+				ValueFloat64: 1e-7,
+			},
+			expect: "1e-7",
 		},
 		{
 			name: "BinaryType",


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #2476

## Description of the changes
- The Cassandra tag index is written and read by different float formatters. `KeyValue.AsString()` used `strconv.FormatFloat(v, 'g', 10, 64)`, while `SpanReader.queryByTagsAndLogs` builds the lookup from `pcommon.Value.AsString()`. They disagree past 10 significant digits, so those rows are written under a key no query generates. `1e20` becomes `1e+20` vs `100000000000000000000`.
- At the extreme, `math.MaxFloat64` is written as `1.797693135e+308`, which is larger than `MaxFloat64` and will not parse back. That is the error in the issue title.
- Fixed at the shared `AsString()`. Both callers, the index writer and the reader, want the reader-compatible string.
- The Elasticsearch half named in the issue was already fixed by the v2 ES model.

## How was this change tested?
- 4 regression cases, verified failing without the fix.
- All 8 cassandra packages green.

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
- [ ] **None**
- [ ] **Light**
- [X] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**

Note: existing high-precision index rows written before this change will stop matching. Only rows with more than 10 significant digits are affected, and those are unqueryable today.