### PR TITLE
docs(jaeger): CONTRIBUTING.md: Include Docker and uv in prereqs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,15 @@ make install-tools
 make test
 ```
 
+If you are regenerating protobuf code via `make proto`, you will also need to have Docker installed and running as well
+as `uv` for the Python SDK stubs (see [`sdk/python/README.md`](sdk/python/README.md)).
+
+To install `uv` on macOS, run:
+
+```
+brew install uv
+```
+
 ### Contributing Code
 
 We accept new changes as pull requests on GitHub. Please make sure the following conditions are met before submitting PRs:


### PR DESCRIPTION
## Which problem is this PR solving?
When I was setting up my dev env, I was missing a couple prerequisites that were not in the contrib docs. Adding a note about them so others don't run into the same.

## Description of the changes
- Add a note about how `make proto` requires Docker and uv.

## How was this change tested?
It's a doc fix. I proofread it. I also installed `uv` following the instructions in it.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
