### PR TITLE
feat(es): Add optional index.mapping.total_fields.limit to the span index template

### DIFF
--- a/cmd/es-rollover/app/init/flags.go
+++ b/cmd/es-rollover/app/init/flags.go
@@ -19,6 +19,7 @@ const (
 	priorityServiceTemplate      = "priority-service-template"
 	priorityDependenciesTemplate = "priority-dependencies-template"
 	prioritySamplingTemplate     = "priority-sampling-template"
+	spanTotalFieldsLimit         = "span-total-fields-limit"
 )
 
 // Config holds configuration for index cleaner binary.
@@ -36,6 +37,7 @@ func (*Config) AddFlags(flags *flag.FlagSet) {
 	flags.Int(priorityServiceTemplate, 0, "Priority of jaeger-service index template (ESv8 only)")
 	flags.Int(priorityDependenciesTemplate, 0, "Priority of jaeger-dependencies index template (ESv8 only)")
 	flags.Int(prioritySamplingTemplate, 0, "Priority of jaeger-sampling index template (ESv8 only)")
+	flags.Int64(spanTotalFieldsLimit, 0, "Sets index.mapping.total_fields.limit on the jaeger-span index template. If unset, no limit is set and Elasticsearch's own default applies")
 }
 
 // InitFromViper initializes config from viper.Viper.
@@ -55,6 +57,10 @@ func (c *Config) InitFromViper(v *viper.Viper) {
 	c.Indices.Services.Priority = v.GetInt64(priorityServiceTemplate)
 	c.Indices.Dependencies.Priority = v.GetInt64(priorityDependenciesTemplate)
 	c.Indices.Sampling.Priority = v.GetInt64(prioritySamplingTemplate)
+
+	if v.IsSet(spanTotalFieldsLimit) {
+		c.Indices.Spans.TotalFieldsLimit = new(v.GetInt64(spanTotalFieldsLimit))
+	}
 
 	// Config.IndexPrefix supersedes Indices.IndexPrefix: the client renders the
 	// templates from Indices, so reconcile the prefix onto it here.

--- a/cmd/es-rollover/app/init/flags_test.go
+++ b/cmd/es-rollover/app/init/flags_test.go
@@ -29,6 +29,7 @@ func TestBindFlags(t *testing.T) {
 		"--priority-service-template=301",
 		"--priority-dependencies-template=302",
 		"--priority-sampling-template=303",
+		"--span-total-fields-limit=2000",
 	})
 	require.NoError(t, err)
 
@@ -40,4 +41,22 @@ func TestBindFlags(t *testing.T) {
 	assert.EqualValues(t, 301, c.Indices.Services.Priority)
 	assert.EqualValues(t, 302, c.Indices.Dependencies.Priority)
 	assert.EqualValues(t, 303, c.Indices.Sampling.Priority)
+	require.NotNil(t, c.Indices.Spans.TotalFieldsLimit)
+	assert.EqualValues(t, 2000, *c.Indices.Spans.TotalFieldsLimit)
+}
+
+func TestBindFlagsTotalFieldsLimitUnset(t *testing.T) {
+	v := viper.New()
+	c := &Config{}
+	command := cobra.Command{}
+	flags := &flag.FlagSet{}
+	c.AddFlags(flags)
+	command.PersistentFlags().AddGoFlagSet(flags)
+	v.BindPFlags(command.PersistentFlags())
+
+	err := command.ParseFlags([]string{})
+	require.NoError(t, err)
+
+	c.InitFromViper(v)
+	assert.Nil(t, c.Indices.Spans.TotalFieldsLimit)
 }

--- a/internal/storage/elasticsearch/config/config.go
+++ b/internal/storage/elasticsearch/config/config.go
@@ -74,6 +74,10 @@ type IndexOptions struct {
 	Shards int64 `mapstructure:"shards"`
 	// Replicas is the number of replicas per index in Elasticsearch.
 	Replicas *int64 `mapstructure:"replicas"`
+	// TotalFieldsLimit sets index.mapping.total_fields.limit on the span index
+	// template (the maximum number of fields an index mapping may have). Left
+	// unset, no limit is set on the index and Elasticsearch's own default applies.
+	TotalFieldsLimit *int64 `mapstructure:"total_fields_limit"`
 	// RolloverFrequency contains the rollover frequency setting used to fetch
 	// indices from elasticsearch.
 	// Valid configuration options are: [hour, day].

--- a/internal/storage/elasticsearch/esclient/index_template.go
+++ b/internal/storage/elasticsearch/esclient/index_template.go
@@ -130,6 +130,10 @@ type innerParams struct {
 	IndexPrefix string
 	Shards      int64
 	Replicas    int64
+	// TotalFieldsLimit is left nil when unconfigured, so the template omits
+	// "index.mapping.total_fields.limit" entirely rather than rendering a
+	// default.
+	TotalFieldsLimit *int64
 }
 
 // renderBackendNeutralBody executes the embedded template for one mapping type and
@@ -148,10 +152,11 @@ func renderBackendNeutralBody(m MappingType, indices config.Indices, lifecycle l
 
 	var buf bytes.Buffer
 	if err := indexTemplates.ExecuteTemplate(&buf, file, innerParams{
-		lifecycleParams: lifecycle,
-		IndexPrefix:     indices.IndexPrefix.Apply(""),
-		Shards:          opts.Shards,
-		Replicas:        *opts.Replicas,
+		lifecycleParams:  lifecycle,
+		IndexPrefix:      indices.IndexPrefix.Apply(""),
+		Shards:           opts.Shards,
+		Replicas:         *opts.Replicas,
+		TotalFieldsLimit: opts.TotalFieldsLimit,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to render %s index template: %w", m, err)
 	}

--- a/internal/storage/elasticsearch/esclient/index_template_test.go
+++ b/internal/storage/elasticsearch/esclient/index_template_test.go
@@ -52,6 +52,40 @@ func TestRenderIndexTemplateNilReplicas(t *testing.T) {
 	require.ErrorContains(t, err, "no replica count configured")
 }
 
+func TestRenderIndexTemplateTotalFieldsLimit(t *testing.T) {
+	reps := int64(1)
+	limit := int64(2000)
+	tests := []struct {
+		name             string
+		totalFieldsLimit *int64
+		wantContains     string
+	}{
+		{
+			name:             "configured",
+			totalFieldsLimit: &limit,
+			wantContains:     `"index.mapping.total_fields.limit":2000`,
+		},
+		{
+			name:             "unconfigured",
+			totalFieldsLimit: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			indices := config.Indices{
+				Spans: config.IndexOptions{Replicas: &reps, TotalFieldsLimit: test.totalFieldsLimit},
+			}
+			rendered, err := RenderIndexTemplate(SpanMapping, indices, false, "", es.ElasticV8)
+			require.NoError(t, err)
+			if test.wantContains != "" {
+				assert.Contains(t, rendered, test.wantContains)
+			} else {
+				assert.NotContains(t, rendered, "index.mapping.total_fields.limit")
+			}
+		})
+	}
+}
+
 func TestRenderIndexTemplateInvalidJSON(t *testing.T) {
 	// A prefix carrying a double quote makes the rendered template invalid JSON
 	// (the prefix appears in the ILM alias name), exercising the parse-failure branch.

--- a/internal/storage/elasticsearch/esclient/index_templates/jaeger-span.json
+++ b/internal/storage/elasticsearch/esclient/index_templates/jaeger-span.json
@@ -9,6 +9,9 @@
       "index.number_of_replicas": {{ .Replicas }},
       "index.mapping.nested_fields.limit": 50,
       "index.requests.cache.enable": true
+      {{- if .TotalFieldsLimit }},
+      "index.mapping.total_fields.limit": {{ .TotalFieldsLimit }}
+      {{- end }}
       {{- if .UseILM }},
       {{- if .IsOpenSearch }}
       "plugins.index_state_management.rollover_alias": "{{ .IndexPrefix }}jaeger-span-write"


### PR DESCRIPTION
## Summary
- Adds `config.IndexOptions.TotalFieldsLimit` (`mapstructure:"total_fields_limit"`), threaded through to the `jaeger-span` index template's `settings`. When unset, the template omits `index.mapping.total_fields.limit` entirely so Elasticsearch/OpenSearch's own default applies.
- Exposes the same setting on `es-rollover init` via a new `--span-total-fields-limit` flag, set only when explicitly passed.

## Test plan
- [x] `go test ./internal/storage/elasticsearch/... ./cmd/es-rollover/...` passes
- [x] Added unit tests covering both the "configured" and "unconfigured" (field omitted) rendering paths in `index_template_test.go`
- [x] Added unit tests covering the flag being set vs. unset in `flags_test.go`
- [x] `make lint` reports 0 issues
- [x] Verified existing `CreateTemplate` request snapshots (`testdata/create_template/*.json`) are unaffected, since the new field defaults to unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)