### PR TITLE
fix(es-index-cleaner): Quote index prefix in index name pattern

### DIFF
--- a/cmd/es-index-cleaner/app/index_filter.go
+++ b/cmd/es-index-cleaner/app/index_filter.go
@@ -33,15 +33,18 @@ func (i *IndexFilter) Filter(indices []esclient.Index) []esclient.Index {
 }
 
 func (i *IndexFilter) filterByPattern(indices []esclient.Index) []esclient.Index {
+	// The prefix is user input and may carry characters that are legal in an
+	// index name but meaningful in a regular expression ('.', '+', '(' ...).
+	prefix := regexp.QuoteMeta(i.IndexPrefix)
 	var reg *regexp.Regexp
 	switch {
 	case i.Archive:
 		// archive works only for rollover
-		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-span-archive-\\d{6}", i.IndexPrefix))
+		reg = regexp.MustCompile(fmt.Sprintf("^%sjaeger-span-archive-\\d{6}", prefix))
 	case i.Rollover:
-		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{6}", i.IndexPrefix))
+		reg = regexp.MustCompile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{6}", prefix))
 	default:
-		reg, _ = regexp.Compile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{4}%s\\d{2}%s\\d{2}", i.IndexPrefix, i.IndexDateSeparator, i.IndexDateSeparator))
+		reg = regexp.MustCompile(fmt.Sprintf("^%sjaeger-(span|service|dependencies|sampling)-\\d{4}%s\\d{2}%s\\d{2}", prefix, i.IndexDateSeparator, i.IndexDateSeparator))
 	}
 
 	var filtered []esclient.Index

--- a/cmd/es-index-cleaner/app/index_filter_test.go
+++ b/cmd/es-index-cleaner/app/index_filter_test.go
@@ -361,3 +361,33 @@ func runIndexFilterTest(t *testing.T, prefix string) {
 		})
 	}
 }
+
+// Elasticsearch allows '.', '+', '(' and ')' in index names, and the prefix is
+// interpolated into a regular expression, so a prefix carrying any of them
+// must still match only its own indices.
+func TestIndexFilterWithRegexMetaPrefix(t *testing.T) {
+	runIndexFilterTest(t, "v1.0+(eu)-")
+}
+
+// A prefix that is not a valid regular expression on its own must not crash
+// the cleaner; it must match its own indices like any other prefix.
+func TestIndexFilterWithUnbalancedPrefix(t *testing.T) {
+	filter := &IndexFilter{
+		IndexPrefix:          "team(a-",
+		IndexDateSeparator:   "-",
+		DeleteBeforeThisDate: time.Date(2020, time.August, 7, 0, 0, 0, 0, time.UTC),
+	}
+	indices := []esclient.Index{
+		{
+			Index:        "team(a-jaeger-span-2020-08-05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+		{
+			Index:        "other-jaeger-span-2020-08-05",
+			CreationTime: time.Date(2020, time.August, 5, 15, 0, 0, 0, time.UTC),
+			Aliases:      map[string]bool{},
+		},
+	}
+	assert.Equal(t, indices[:1], filter.Filter(indices))
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9524. `es-index-cleaner` interpolates `--index-prefix` into a regular expression unescaped and discards the compile error, so a prefix carrying characters that Elasticsearch allows in index names (`.`, `+`, `(`, `)`, `[`, `]`) either panics on a nil `*regexp.Regexp` or matches nothing and silently cleans nothing.

## Description of the changes
- `filterByPattern` runs the prefix through `regexp.QuoteMeta` before building the pattern, so it matches itself. The alias checks a few lines further down already treated the prefix literally; the pattern now agrees with them.
- `regexp.Compile` with a discarded error becomes `regexp.MustCompile`. After quoting the prefix, the only user input left in the pattern is the date separator, which #9121 quotes. Until that lands, a separator that cannot compile fails with the pattern in the message instead of a nil pointer dereference.
- The date separator is deliberately left as it is, to stay out of #9121's way.

## How was this change tested?
- `TestIndexFilterWithRegexMetaPrefix` runs the existing filter table with prefix `v1.0+(eu)-`. Before this change every case that expects a match got an empty result.
- `TestIndexFilterWithUnbalancedPrefix` uses `team(a-`, which panicked before this change and now matches only its own index.
- `go test ./cmd/es-index-cleaner/...` passes, `make lint-fmt lint-license lint-imports` pass, `make lint-go` reports 0 issues.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [x] **Moderate**: AI helped with code generation or debugging specific parts
