### PR TITLE
fix(samplingstore): Propagate write errors in InsertThroughput and InsertProbabilitiesAndQPS

### DIFF
--- a/internal/storage/v1/badger/samplingstore/storage.go
+++ b/internal/storage/v1/badger/samplingstore/storage.go
@@ -55,7 +55,7 @@ func (s *SamplingStore) InsertThroughput(throughput []*model.Throughput) error {
 		return nil
 	})
 
-	return nil
+	return err
 }
 
 func (s *SamplingStore) GetThroughput(start, end time.Time) ([]*model.Throughput, error) {
@@ -121,7 +121,7 @@ func (s *SamplingStore) InsertProbabilitiesAndQPS(hostname string,
 		return nil
 	})
 
-	return nil
+	return err
 }
 
 // GetLatestProbabilities implements samplingstore.Reader#GetLatestProbabilities.

--- a/internal/storage/v1/badger/samplingstore/storage_test.go
+++ b/internal/storage/v1/badger/samplingstore/storage_test.go
@@ -31,6 +31,12 @@ func TestInsertThroughput(t *testing.T) {
 	})
 }
 
+func TestInsertThroughputPropagatesError(t *testing.T) {
+	store := newClosedTestSamplingStore(t)
+	err := store.InsertThroughput([]*samplemodel.Throughput{{Service: "my-svc", Operation: "op"}})
+	require.Error(t, err)
+}
+
 func TestGetThroughput(t *testing.T) {
 	runWithBadger(t, func(t *testing.T, store *SamplingStore) {
 		start := time.Now()
@@ -56,6 +62,16 @@ func TestInsertProbabilitiesAndQPS(t *testing.T) {
 		)
 		require.NoError(t, err)
 	})
+}
+
+func TestInsertProbabilitiesAndQPSPropagatesError(t *testing.T) {
+	store := newClosedTestSamplingStore(t)
+	err := store.InsertProbabilitiesAndQPS(
+		"dell11eg843d",
+		samplemodel.ServiceOperationProbabilities{"new-srv": {"op": 0.1}},
+		samplemodel.ServiceOperationQPS{"new-srv": {"op": 4}},
+	)
+	require.Error(t, err)
 }
 
 func TestGetLatestProbabilities(t *testing.T) {
@@ -128,6 +144,23 @@ func runWithBadger(t *testing.T, test func(t *testing.T, store *SamplingStore)) 
 	}()
 	ss := newTestSamplingStore(store)
 	test(t, ss)
+}
+
+// newClosedTestSamplingStore opens a Badger-backed SamplingStore and then closes
+// the underlying DB so that any subsequent write fails. It is used to verify that
+// write errors are propagated to callers instead of being silently swallowed.
+func newClosedTestSamplingStore(t *testing.T) *SamplingStore {
+	opts := badger.DefaultOptions("")
+	opts.SyncWrites = false
+	dir := t.TempDir()
+	opts.Dir = dir
+	opts.ValueDir = dir
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	return newTestSamplingStore(db)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## What

`InsertThroughput` and `InsertProbabilitiesAndQPS` in the Badger sampling store captured the error returned by `store.Update(...)` into a local `err` variable but unconditionally returned `nil`. Any failure inside the Badger transaction (disk full, transaction conflict, closed DB, etc.) was silently discarded, so callers were told a write succeeded when it didn't. This is inconsistent with `SpanWriter.WriteSpan`, which correctly propagates the same error.

## Changes

- Return the `err` from `store.Update(...)` in both `InsertThroughput` and `InsertProbabilitiesAndQPS`.
- Added two regression tests (`TestInsertThroughputPropagatesError`, `TestInsertProbabilitiesAndQPSPropagatesError`) that close the underlying Badger DB and assert the write error is propagated rather than swallowed.

## Verification

- `go test ./internal/storage/v1/badger/samplingstore/...` — passes (all tests green, including the two new regression tests).
- `gofmt` — no changes.

Fixes #9532
