### PR TITLE
fix(mcp): Preserve sub-second precision in search_traces start_time

### DIFF
--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces.go
@@ -97,7 +97,7 @@ func toMCPTraceSummary(s tracestore.TraceSummary) types.TraceSummary {
 	}
 	var startTime string
 	if !s.MinStartTime.IsZero() {
-		startTime = s.MinStartTime.Format(time.RFC3339)
+		startTime = s.MinStartTime.Format(time.RFC3339Nano)
 	}
 	var durationUs int64
 	if !s.MinStartTime.IsZero() && !s.MaxEndTime.IsZero() {

--- a/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
+++ b/cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/search_traces_test.go
@@ -69,6 +69,23 @@ func TestToMCPTraceSummary_WithErrors(t *testing.T) {
 	assert.True(t, out.HasErrors)
 }
 
+func TestToMCPTraceSummary_PreservesSubSecondPrecision(t *testing.T) {
+	s := tracestore.TraceSummary{
+		TraceID:           testTraceIDBytes,
+		RootServiceName:   "frontend",
+		RootOperationName: "/api/checkout",
+		MinStartTime:      time.Date(2025, time.July, 14, 10, 30, 0, 750123456, time.UTC),
+		MaxEndTime:        time.Date(2025, time.July, 14, 10, 30, 1, 0, time.UTC),
+		SpanCount:         1,
+		Services: []tracestore.ServiceSummary{
+			{Name: "frontend", SpanCount: 1},
+		},
+	}
+	out := toMCPTraceSummary(s)
+
+	assert.Equal(t, "2025-07-14T10:30:00.750123456Z", out.StartTime)
+}
+
 func TestToMCPTraceSummary_MultipleServices(t *testing.T) {
 	s := tracestore.TraceSummary{
 		TraceID:           testTraceIDBytes,


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #9529 — `search_traces` drops sub-second precision from the `start_time` of returned trace summaries.

The MCP `search_traces` tool formatted trace start times with `time.RFC3339`, which truncates to second precision. The sibling tools `get_span_details` and `get_trace_topology` both use `time.RFC3339Nano`, so trace summaries were inconsistent with span-level timestamps and two traces starting within the same second became indistinguishable by `start_time` alone.

## Description of the changes

- Format `MinStartTime` with `time.RFC3339Nano` in `toMCPTraceSummary`, matching the precision the other MCP tools already preserve.
- Add `TestToMCPTraceSummary_PreservesSubSecondPrecision`, which asserts a trace starting at `2025-07-14T10:30:00.750123456Z` round-trips its nanoseconds (fails against the old `RFC3339` formatting).

## How was this change tested?

- `go test ./cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers/ -count=1`
- Confirmed the new regression test fails when the formatting is reverted to `time.RFC3339`.

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] Signed-off-by is present (DCO)
