### PR TITLE
fix(anonymizer): Register the gogo codec

### DIFF
--- a/cmd/anonymizer/app/query/query.go
+++ b/cmd/anonymizer/app/query/query.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
+	_ "github.com/jaegertracing/jaeger/internal/gogocodec" // force gogo codec registration
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 )
 

--- a/cmd/anonymizer/app/query/query_test.go
+++ b/cmd/anonymizer/app/query/query_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/jaegertracing/jaeger-idl/model/v1"
 	"github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
-	_ "github.com/jaegertracing/jaeger/internal/gogocodec" // force gogo codec registration
 	"github.com/jaegertracing/jaeger/internal/storage/v1/api/spanstore"
 )
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #9539.
- `jaeger-anonymizer` panics on every run with `invalid Go type model.TraceID for field jaeger.api_v2.GetTraceRequest.trace_id` before it sends anything to `jaeger-query`.
- The api_v2 messages are gogo-generated, and grpc-go's stock codec cannot marshal their custom field types. `internal/gogocodec` registers the codec that can, but only the query package's test file imported it, so the unit tests passed while the binary did not link it.

## Description of the changes
- Blank-import `internal/gogocodec` from `cmd/anonymizer/app/query/query.go`, the same way `grpc_handler.go` does on the server side.
- Remove the same import from `query_test.go`, so the package tests run against the production import instead of supplying it themselves.

## How was this change tested?
- On `main` with the test-side import removed, `go test ./cmd/anonymizer/app/query/` panics with `invalid Go type model.TraceID`; with this change the package passes and `go list -deps ./cmd/anonymizer` includes `internal/gogocodec`.
- End to end against `./cmd/jaeger` built from the same commit, on one trace from `./cmd/tracegen`: the `main` binary exits 2 with the panic; this branch exits 0 and writes `.original.json`, `.anonymized.json`, `.mapping.json` and `.anonymized-ui-trace.json`, with both spans in the UI file.
- `go test ./cmd/anonymizer/...` passes; `make lint-fmt lint-license lint-imports` pass; `golangci-lint run ./cmd/anonymizer/... --new-from-rev upstream/main` reports 0 issues.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [x] **Moderate**: AI helped with code generation or debugging specific parts
