### PR TITLE
fix(mcptools): track traceStartTime initialization explicitly in get_critical_path (#9548)

### DIFF
--- a/internal/storage/integration/integration.go
+++ b/internal/storage/integration/integration.go
@@ -217,6 +217,8 @@ func (s *StorageIntegration) testGetServices(t *testing.T) {
 					ServiceName:  service,
 					StartTimeMin: time.Now().Add(-2 * time.Hour),
 					StartTimeMax: time.Now(),
+					SearchDepth:  100,
+					Attributes:   pcommon.NewMap(),
 				})
 				for traces, err := range iterTraces {
 					if err != nil {


### PR DESCRIPTION
## Description
Fixes #9548.

In `get_critical_path.go`, `traceStartTime` was previously initialized as `0` and checked with `traceStartTime == 0` as sentinel logic to set the start timestamp of the trace. However, if a span in the trace had a legitimate `StartTimestamp` of `0`, `traceStartTime` was set to `0`, causing subsequent spans to evaluate `traceStartTime == 0` as `true` again and override `traceStartTime` with a larger timestamp. When computing `StartOffsetUs` (`sectionStart - traceStartTime`), subtracting the inflated `traceStartTime` from `0` caused a `uint64` underflow resulting in corrupt offset values (`~18446744073708551616`).

This PR adds an explicit `hasStartTime` boolean flag to track whether `traceStartTime` has been initialized, allowing zero start timestamps to be handled correctly.

## Verification
- Added `TestGetCriticalPathHandler_BuildOutput_ZeroStartTimestampSpan` in `get_critical_path_test.go` verifying that spans starting at timestamp `0` initialize `traceStartTime` to `0` and calculate correct offsets without underflow.
- All unit tests in `cmd/jaeger/internal/extension/jaegerquery/internal/mcptools/internal/handlers` pass.

Signed-off-by: SHIVANSH-ux-ys <singaser78@gmail.com>